### PR TITLE
Force import DraggableList

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -6,6 +6,7 @@ import { defaultGraph } from "./defaultGraph";
 import { getPngMetadata, getWebpMetadata, importA1111, getLatentMetadata } from "./pnginfo";
 import { addDomClippingSetting } from "./domWidget";
 import { createImageHost, calculateImageGrid } from "./ui/imagePreview"
+import { DraggableList } from "./ui/draggableList";
 import { applyTextReplacements, addStylesheet } from "./utils";
 import type { ComfyExtension } from "/types/comfy";
 import type { LGraph, LGraphCanvas, LGraphNode } from "/types/litegraph";
@@ -53,9 +54,11 @@ export class ComfyApp {
 	static clipspace_return_node = null;
 
 	// Force vite to import utils.ts as part of index.
+	// Force import of DraggableList.
 	static utils = {
 		applyTextReplacements,
 		addStylesheet,
+		DraggableList,
 	};
 
 	ui: ComfyUI;

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -1,6 +1,7 @@
 import { api } from "./api";
 import { ComfyDialog as _ComfyDialog } from "./ui/dialog";
 import { toggleSwitch } from "./ui/toggleSwitch";
+import { DraggableList } from "./ui/draggableList";
 import { ComfySettingsDialog } from "./ui/settings";
 import { ComfyApp, app } from "./app";
 
@@ -193,6 +194,9 @@ function dragElement(dragEl, settings) {
 }
 
 class ComfyList {
+	// Force import of DraggableList.
+	static draggableList = DraggableList;
+
 	#type;
 	#text;
 	#reverse;

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -1,7 +1,6 @@
 import { api } from "./api";
 import { ComfyDialog as _ComfyDialog } from "./ui/dialog";
 import { toggleSwitch } from "./ui/toggleSwitch";
-import { DraggableList } from "./ui/draggableList";
 import { ComfySettingsDialog } from "./ui/settings";
 import { ComfyApp, app } from "./app";
 
@@ -194,9 +193,6 @@ function dragElement(dragEl, settings) {
 }
 
 class ComfyList {
-	// Force import of DraggableList.
-	static draggableList = DraggableList;
-
 	#type;
 	#text;
 	#reverse;

--- a/src/scripts/ui/draggableList.ts
+++ b/src/scripts/ui/draggableList.ts
@@ -25,7 +25,7 @@
     SOFTWARE.
 */
 
-import { $el } from "../ui.js";
+import { $el } from "../ui";
 
 $el("style", {
     parent: document.head,
@@ -92,7 +92,7 @@ export class DraggableList extends EventTarget {
 		return item.hasAttribute("data-is-toggled");
 	}
 
-	on(source, event, listener, options) {
+	on(source, event, listener, options?) {
 		listener = listener.bind(this);
 		source.addEventListener(event, listener, options);
 		return () => source.removeEventListener(event, listener);

--- a/src/scripts/ui/draggableList.ts
+++ b/src/scripts/ui/draggableList.ts
@@ -1,4 +1,3 @@
-// @ts-check
 /*
 	Original implementation:
     https://github.com/TahaSh/drag-to-reorder

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -88,7 +88,6 @@ export default defineConfig({
 			targets: [
 				{src: "src/lib/*", dest: "lib/"},
 				{src: "src/extensions/*", dest: "extensions/"},
-				{src: "src/scripts/ui/draggableList.js", dest: "scripts/ui/"},
 			],
 		}),
 	],


### PR DESCRIPTION
DraggableList is not reference by the main app before so it was excluded from the vite rollup build. This PR does a dummy import and reference so that DraggableList can be included in the vite build. This is to solve issue for DraggableList having ".js" suffix giving test error.