### PR TITLE
No CI on direct push

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -1,8 +1,6 @@
 name: Tests CI
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 


### PR DESCRIPTION
Main branch is now protected from direct push. Disable CI on main branch push to save github CI quota.