### PR TITLE
Change repo reference in CI workflow

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -10,18 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout ComfyUI_frontend
+      uses: actions/checkout@v4
+      with:
+        repository: "huchenlei/ComfyUI_frontend"
+        path: "ComfyUI_frontend"
     - name: Checkout ComfyUI
       uses: actions/checkout@v4
       with:
         repository: "comfyanonymous/ComfyUI"
         path: "ComfyUI"
         ref: master
-    - name: Checkout ComfyUI_frontend
-      uses: actions/checkout@v4
-      with:
-        repository: "huchenlei/ComfyUI_frontend"
-        path: "ComfyUI_frontend"
-        ref: ${{ github.head_ref }}
     - name: Get commit message
       id: commit-message
       run: echo "::set-output name=message::$(git log -1 --pretty=%B)"

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -10,17 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout ComfyUI_frontend
-      uses: actions/checkout@v4
-      with:
-        repository: "huchenlei/ComfyUI_frontend"
-        path: "ComfyUI_frontend"
     - name: Checkout ComfyUI
       uses: actions/checkout@v4
       with:
         repository: "comfyanonymous/ComfyUI"
         path: "ComfyUI"
         ref: master
+    - name: Checkout ComfyUI_frontend
+      uses: actions/checkout@v4
+      with:
+        repository: "Comfy-Org/ComfyUI_frontend"
+        path: "ComfyUI_frontend"
     - name: Get commit message
       id: commit-message
       run: echo "::set-output name=message::$(git log -1 --pretty=%B)"


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/73.

Because of ownership transfer. Checking out huchenlei/ComfyUI_frontend always ends up with main branch. This PR fixes the issue foundamentally.