### PR TITLE
Update state when graph cleared via UI

### DIFF
--- a/src/scripts/changeTracker.js
+++ b/src/scripts/changeTracker.js
@@ -160,6 +160,10 @@ export class ChangeTracker {
       changeTracker().checkState();
     });
 
+    api.addEventListener("graphCleared", () => {
+      changeTracker().checkState();
+    });
+
     // Handle litegraph clicks
     // @ts-ignore
     const processMouseUp = LGraphCanvas.prototype.processMouseUp;

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -706,6 +706,7 @@ export class ComfyUI {
             app.clean();
             app.graph.clear();
             app.resetView();
+            api.dispatchEvent(new CustomEvent("graphCleared"));
           }
         },
       }),

--- a/src/scripts/ui/menu/index.js
+++ b/src/scripts/ui/menu/index.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import { api } from "../../api";
 import { $el } from "../../ui";
 import { downloadBlob } from "../../utils";
 import { ComfyButton } from "../components/button";
@@ -112,6 +113,7 @@ export class ComfyAppMenu {
           ) {
             app.clean();
             app.graph.clear();
+            api.dispatchEvent(new CustomEvent("graphCleared"));
           }
         },
       })


### PR DESCRIPTION
`ChangeTracker` is not tracking the graph being cleared via the clear-workflow buttons in the UI. Probably because clicks on the alert dialog don't trigger a state check. This is another iteration of [this issue](https://github.com/comfyanonymous/ComfyUI/issues/3885).

Here's the situation that can result from this:
1. The user accidentally clicks the clear-workflow button (and clicks confirm accidentally, or has the confirm dialog disabled via settings)
2. The user tries to Ctrl+Z undo, and it doesn't work.
3. The user believes that that workflow is now lost, so they close the program, load a new workflow, etc.

In reality, the user would just need to do something else that would trigger a state check. But on first attempt, it will fail.

This change solves the issue by dispatching a `graphCleared` event to the api when the clear-workflow button is clicked in the old or new menu, and has `ChangeTracker` listen for that event. 

I think it's maybe an unusual thing for the `api` to serve as the observer for such a thing, but that seems to be the pattern right now until there's a more clear dilineation that separates the event systems. 