### PR TITLE
Use '@' path mapping

### DIFF
--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -1,6 +1,6 @@
 import { app } from "../../scripts/app";
 import { $el } from "../../scripts/ui";
-import type { ColorPalettes } from "/types/colorPalette";
+import type { ColorPalettes } from "@/types/colorPalette";
 import { LGraphCanvas, LiteGraph } from "@comfyorg/litegraph";
 
 // Manage color palettes

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -1,8 +1,8 @@
 import { app } from "../../scripts/app";
 import { api } from "../../scripts/api";
 import type { IWidget } from "@comfyorg/litegraph";
-import type { DOMWidget } from "/scripts/domWidget";
-import { ComfyNodeDef } from "/types/apiTypes";
+import type { DOMWidget } from "@/scripts/domWidget";
+import { ComfyNodeDef } from "@/types/apiTypes";
 
 type FolderType = "input" | "output" | "temp";
 

--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -1,5 +1,5 @@
 import { app } from "../../scripts/app";
-import { ComfyNodeDef } from "/types/apiTypes";
+import { ComfyNodeDef } from "@/types/apiTypes";
 
 // Adds an upload button to the nodes
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1,10 +1,10 @@
-import { ComfyWorkflowJSON } from "types/comfyWorkflow";
+import { ComfyWorkflowJSON } from "@/types/comfyWorkflow";
 import {
   HistoryTaskItem,
   PendingTaskItem,
   RunningTaskItem,
   ComfyNodeDef,
-} from "/types/apiTypes";
+} from "@/types/apiTypes";
 
 interface QueuePromptRequestBody {
   client_id: string;

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -14,12 +14,12 @@ import { addDomClippingSetting } from "./domWidget";
 import { createImageHost, calculateImageGrid } from "./ui/imagePreview";
 import { DraggableList } from "./ui/draggableList";
 import { applyTextReplacements, addStylesheet } from "./utils";
-import type { ComfyExtension } from "/types/comfy";
+import type { ComfyExtension } from "@/types/comfy";
 import {
   type ComfyWorkflowJSON,
   parseComfyWorkflow,
 } from "../types/comfyWorkflow";
-import { ComfyNodeDef } from "/types/apiTypes";
+import { ComfyNodeDef } from "@/types/apiTypes";
 import { ComfyAppMenu } from "./ui/menu/index";
 import { getStorageValue } from "./utils";
 import { ComfyWorkflowManager, ComfyWorkflow } from "./workflows";

--- a/src/scripts/defaultGraph.ts
+++ b/src/scripts/defaultGraph.ts
@@ -1,4 +1,4 @@
-import type { ComfyWorkflowJSON } from "/types/comfyWorkflow";
+import type { ComfyWorkflowJSON } from "@/types/comfyWorkflow";
 
 export const defaultGraph: ComfyWorkflowJSON = {
   last_node_id: 9,

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -3,7 +3,7 @@ import { ComfyDialog as _ComfyDialog } from "./ui/dialog";
 import { toggleSwitch } from "./ui/toggleSwitch";
 import { ComfySettingsDialog } from "./ui/settings";
 import { ComfyApp, app } from "./app";
-import { TaskItem } from "/types/apiTypes";
+import { TaskItem } from "@/types/apiTypes";
 
 export const ComfyDialog = _ComfyDialog;
 

--- a/src/scripts/ui/components/button.ts
+++ b/src/scripts/ui/components/button.ts
@@ -3,7 +3,7 @@ import { applyClasses, ClassList, toggleElement } from "../utils";
 import { prop } from "../../utils";
 import type { ComfyPopup } from "./popup";
 import type { ComfyComponent } from ".";
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 
 type ComfyButtonProps = {
   icon?: string;

--- a/src/scripts/ui/menu/index.ts
+++ b/src/scripts/ui/menu/index.ts
@@ -1,4 +1,4 @@
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 import { api } from "../../api";
 import { $el } from "../../ui";
 import { downloadBlob } from "../../utils";

--- a/src/scripts/ui/menu/queueButton.ts
+++ b/src/scripts/ui/menu/queueButton.ts
@@ -4,7 +4,7 @@ import { api } from "../../api";
 import { ComfySplitButton } from "../components/splitButton";
 import { ComfyQueueOptions } from "./queueOptions";
 import { prop } from "../../utils";
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 
 export class ComfyQueueButton {
   element = $el("div.comfyui-queue-button");

--- a/src/scripts/ui/menu/queueOptions.ts
+++ b/src/scripts/ui/menu/queueOptions.ts
@@ -1,4 +1,4 @@
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 import { $el } from "../../ui";
 import { prop } from "../../utils";
 

--- a/src/scripts/ui/menu/viewHistory.ts
+++ b/src/scripts/ui/menu/viewHistory.ts
@@ -1,4 +1,4 @@
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 import { ComfyButton } from "../components/button";
 import { ComfyViewList, ComfyViewListButton } from "./viewList";
 

--- a/src/scripts/ui/menu/viewList.ts
+++ b/src/scripts/ui/menu/viewList.ts
@@ -2,7 +2,7 @@ import { ComfyButton } from "../components/button";
 import { $el } from "../../ui";
 import { api } from "../../api";
 import { ComfyPopup } from "../components/popup";
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 
 type ViewListMode = "Queue" | "History";
 

--- a/src/scripts/ui/menu/viewQueue.ts
+++ b/src/scripts/ui/menu/viewQueue.ts
@@ -1,7 +1,7 @@
 import { ComfyButton } from "../components/button";
 import { ComfyViewList, ComfyViewListButton } from "./viewList";
 import { api } from "../../api";
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 
 export class ComfyViewQueueButton extends ComfyViewListButton {
   constructor(app: ComfyApp) {

--- a/src/scripts/ui/menu/workflows.ts
+++ b/src/scripts/ui/menu/workflows.ts
@@ -6,7 +6,7 @@ import { ComfyPopup } from "../components/popup";
 import { createSpinner } from "../spinner";
 import { ComfyWorkflow, trimJsonExt } from "../../workflows";
 import { ComfyAsyncDialog } from "../components/asyncDialog";
-import type { ComfyApp } from "scripts/app";
+import type { ComfyApp } from "@/scripts/app";
 import type { ComfyComponent } from "../components";
 
 export class ComfyWorkflowsMenu {

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -2,7 +2,7 @@ import { api } from "./api";
 import "./domWidget";
 import type { ComfyApp } from "./app";
 import type { IWidget, LGraphNode } from "@comfyorg/litegraph";
-import { ComfyNodeDef } from "/types/apiTypes";
+import { ComfyNodeDef } from "@/types/apiTypes";
 
 export type ComfyWidgetConstructor = (
   node: LGraphNode,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "allowJs": true,
     "baseUrl": ".",
     "paths": {
-      "*": ["src/*"],
+      "@/*": ["src/*"],
     },
     "typeRoots": ["src/types", "node_modules/@types"],
     "outDir": "./dist",


### PR DESCRIPTION
> Using @ as an alias for the [src](vscode-file://vscode-app/c:/Users/hcl/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) directory is a common practice in Vue projects, especially those created with Vue CLI or using webpack for module bundling. This alias allows for cleaner and more manageable import statements, avoiding relative path hell when importing components, utilities, or assets from deeply nested directories.