### PR TITLE
Shift node color's brightness for light mode

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,7 +15,7 @@ const jestConfig: JestConfigWithTsJest = {
 	resetModules: true,
 	testTimeout: 10000,
 	moduleNameMapper: {
-		"^src/(.*)$": "<rootDir>/src/$1",
+		"^@/(.*)$": "<rootDir>/src/$1",
 		'\\.(css|less|scss|sass)$': 'identity-obj-proxy',
 	},
 };

--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -1,3 +1,4 @@
+import { lightenColor } from "@/utils/colorUtil";
 import { app } from "../../scripts/app";
 import { $el } from "../../scripts/ui";
 import type { ColorPalettes, Palette } from "@/types/colorPalette";

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -33,6 +33,7 @@ import {
 // CSS imports. style.css must be imported later as it overwrites some litegraph styles.
 import "@comfyorg/litegraph/css/litegraph.css";
 import "../assets/css/style.css";
+import { lightenColor } from "@/utils/colorUtil";
 
 export const ANIM_PREVIEW_WIDGET = "$$comfy_animation_preview";
 
@@ -1538,7 +1539,8 @@ export class ComfyApp {
     // @ts-ignore
     LGraphCanvas.prototype.drawNode = function (node, ctx) {
       var editor_alpha = this.editor_alpha;
-      var old_color = node.bgcolor;
+      var old_color = node.color;
+      var old_bgcolor = node.bgcolor;
 
       if (node.mode === 2) {
         // never
@@ -1551,10 +1553,19 @@ export class ComfyApp {
       // 	this.editor_alpha = 0.2;
       // }
 
+      const adjustColor = (color?: string) => {
+        return color ? lightenColor(color, 0.5) : color;
+      };
+      if (app.ui.settings.getSettingValue("Comfy.ColorPalette") === "light") {
+        node.bgcolor = adjustColor(node.bgcolor);
+        node.color = adjustColor(node.color);
+      }
+
       const res = origDrawNode.apply(this, arguments);
 
       this.editor_alpha = editor_alpha;
-      node.bgcolor = old_color;
+      node.color = old_color;
+      node.bgcolor = old_bgcolor;
 
       return res;
     };

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -20,6 +20,7 @@ import {
   parseComfyWorkflow,
 } from "../types/comfyWorkflow";
 import { ComfyNodeDef } from "@/types/apiTypes";
+import { lightenColor } from "@/utils/colorUtil";
 import { ComfyAppMenu } from "./ui/menu/index";
 import { getStorageValue } from "./utils";
 import { ComfyWorkflowManager, ComfyWorkflow } from "./workflows";
@@ -33,7 +34,6 @@ import {
 // CSS imports. style.css must be imported later as it overwrites some litegraph styles.
 import "@comfyorg/litegraph/css/litegraph.css";
 import "../assets/css/style.css";
-import { lightenColor } from "@/utils/colorUtil";
 
 export const ANIM_PREVIEW_WIDGET = "$$comfy_animation_preview";
 

--- a/src/types/colorPalette.ts
+++ b/src/types/colorPalette.ts
@@ -86,6 +86,12 @@ const paletteSchema = z.object({
   id: z.string(),
   name: z.string(),
   colors: colorsSchema,
+  /**
+   * Brightens color for light theme
+   * @param color in hex format
+   * @returns color in hex format
+   */
+  shiftBgColor: z.function(z.tuple([z.string()]), z.string()).optional(),
 });
 
 const colorPalettesSchema = z.record(paletteSchema);

--- a/src/types/colorPalette.ts
+++ b/src/types/colorPalette.ts
@@ -86,12 +86,6 @@ const paletteSchema = z.object({
   id: z.string(),
   name: z.string(),
   colors: colorsSchema,
-  /**
-   * Brightens color for light theme
-   * @param color in hex format
-   * @returns color in hex format
-   */
-  shiftBgColor: z.function(z.tuple([z.string()]), z.string()).optional(),
 });
 
 const colorPalettesSchema = z.record(paletteSchema);

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -1,0 +1,100 @@
+type RGB = { r: number; g: number; b: number };
+type HSL = { h: number; s: number; l: number };
+
+function rgbToHsl({ r, g, b }: RGB): HSL {
+  (r /= 255), (g /= 255), (b /= 255);
+  const max = Math.max(r, g, b),
+    min = Math.min(r, g, b);
+  let h: number,
+    s: number,
+    l: number = (max + min) / 2;
+
+  if (max === min) {
+    h = s = 0; // achromatic
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return { h, s, l };
+}
+
+function hslToRgb({ h, s, l }: HSL): RGB {
+  let r: number, g: number, b: number;
+
+  if (s === 0) {
+    r = g = b = l; // achromatic
+  } else {
+    const hue2rgb = (p: number, q: number, t: number) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+}
+
+function hexToRgb(hex: string): RGB {
+  let r = 0,
+    g = 0,
+    b = 0;
+  // 3 digits
+  if (hex.length == 4) {
+    r = parseInt(hex[1] + hex[1], 16);
+    g = parseInt(hex[2] + hex[2], 16);
+    b = parseInt(hex[3] + hex[3], 16);
+  }
+  // 6 digits
+  else if (hex.length == 7) {
+    r = parseInt(hex.slice(1, 3), 16);
+    g = parseInt(hex.slice(3, 5), 16);
+    b = parseInt(hex.slice(5, 7), 16);
+  }
+  return { r, g, b };
+}
+
+function rgbToHex({ r, g, b }: RGB): string {
+  return (
+    "#" +
+    [r, g, b]
+      .map((x) => {
+        const hex = x.toString(16);
+        return hex.length === 1 ? "0" + hex : hex;
+      })
+      .join("")
+  );
+}
+
+export function lightenColor(hex: string, amount: number): string {
+  let rgb = hexToRgb(hex);
+  let hsl = rgbToHsl(rgb);
+  hsl.l = Math.min(1, hsl.l + amount);
+  rgb = hslToRgb(hsl);
+  return rgbToHex(rgb);
+}


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/121

The underlying non-default color value stored in the workflow is unchanged, but the color representation is brightened for node color and node bg color.

![image](https://github.com/user-attachments/assets/8a97d595-cadf-433e-9bd4-9737376fcdd1)
![image](https://github.com/user-attachments/assets/e5110359-6cbd-4ffc-987b-08e43bfdfbef)
