### PR TITLE
Fix vue warning on key

### DIFF
--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -55,11 +55,6 @@ const props = defineProps({
     type: Object as PropType<ComfyNodeDef>,
     required: true,
   },
-  // Make sure vue properly re-render the component when the nodeDef changes
-  key: {
-    type: String,
-    required: true,
-  },
 });
 
 const nodeDef = props.nodeDef as ComfyNodeDef;


### PR DESCRIPTION
```
[Vue warn]: Invalid prop name: "key" is a reserved property. 
  at <NodeSearchBox filters= [] onAddFilter=fn<addFilter> onRemoveFilter=fn<removeFilter>  ... > 
  at <BaseTransition onBeforeEnter=fn<onBeforeEnter> onEnter=fn onBeforeLeave=fn<bound onBeforeLeave>  ... > 
  at <Transition name="p-dialog" onBeforeEnter=fn<bound onBeforeEnter> onEnter=fn<bound onEnter>  ... > 
  at <Portal appendTo="body" > 
  at <Dialog visible=true onUpdate:visible=fn pt:root:class="invisible-dialog-root"  ... > 
  at <NodeSearchBoxPopover key=0 > 
  at <App>
```