### PR TITLE
Fix search preview's text wrap

### DIFF
--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -214,6 +214,7 @@ const widgetInputDefs = allInputDefs.filter((input) => !!input.widgetType);
   align-items: center;
   padding-left: 9px;
   padding-right: 9px;
+  overflow-x: hidden;
 }
 
 ._sb_row_string {
@@ -240,6 +241,7 @@ const widgetInputDefs = allInputDefs.filter((input) => !!input.widgetType);
   margin: 5px 5px 0 5px;
   border-radius: 10px;
   line-height: 1.7;
+  text-wrap: nowrap;
 }
 
 ._sb_arrow {


### PR DESCRIPTION
Widget text in node previews is wrapping:

![Selection_047](https://github.com/user-attachments/assets/0a8c800f-f3be-4fad-8a52-eadf560f82ad)

After Change:

![Selection_046](https://github.com/user-attachments/assets/ae12e25e-c7ea-46d6-bb9a-14678b5154be)
