### PR TITLE
Fix resize to 0 issue

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1941,8 +1941,20 @@ export class ComfyApp {
     const scale = Math.max(window.devicePixelRatio, 1);
 
     // Clear fixed width and height while calculating rect so it uses 100% instead
+    const { width: oldWidth, height: oldHeight } =
+      this.canvasEl.getBoundingClientRect();
+
     this.canvasEl.height = this.canvasEl.width = NaN;
     const { width, height } = this.canvasEl.getBoundingClientRect();
+
+    if (width === 0 || height === 0) {
+      // TODO(huchenlei): This is a very hacky fix. Need to find a better way to handle resize
+      // of canvas deterministically.
+      this.canvasEl.width = oldWidth;
+      this.canvasEl.height = oldHeight;
+      return;
+    }
+
     this.canvasEl.width = Math.round(width * scale);
     this.canvasEl.height = Math.round(height * scale);
     this.canvasEl.getContext("2d").scale(scale, scale);


### PR DESCRIPTION
Users have reported issue that in special setup (With some custom node scripts) will cause resize function to change height of canvas to 0.

This PR address this issue in a dumb but working way. Need to figure out a more fundamental fix later.

![image](https://github.com/user-attachments/assets/60231bd9-0e75-4212-8a13-060bc58c118b)
