### PR TITLE
Display frontend version in settings dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@
 				font-family: 'Roboto Mono', 'Noto Color Emoji';
 			}
 		</style> -->
-		<script type="module" src="/src/main.ts"></script>
 		<script type="module">
 			window["__COMFYUI_FRONTEND_VERSION__"] = __COMFYUI_FRONTEND_VERSION__;
 			console.log("ComfyUI Front-end version:", __COMFYUI_FRONTEND_VERSION__);
 		</script>
+		<script type="module" src="/src/main.ts"></script>
 		<link rel="stylesheet" type="text/css" href="/user.css" />
 		<link rel="stylesheet" type="text/css" href="/materialdesignicons.min.css" />
 	</head>

--- a/src/scripts/ui/settings.ts
+++ b/src/scripts/ui/settings.ts
@@ -11,6 +11,7 @@ export class ComfySettingsDialog extends ComfyDialog<HTMLDialogElement> {
 
   constructor(app: ComfyApp) {
     super();
+    const frontendVersion = window["__COMFYUI_FRONTEND_VERSION__"];
     this.app = app;
     this.settingsValues = {};
     this.settingsLookup = {};
@@ -24,7 +25,7 @@ export class ComfySettingsDialog extends ComfyDialog<HTMLDialogElement> {
         $el("table.comfy-modal-content.comfy-table", [
           $el(
             "caption",
-            { textContent: "Settings" },
+            { textContent: `Settings (v${frontendVersion})` },
             $el("button.comfy-btn", {
               type: "button",
               textContent: "\u00d7",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/99f0bbbd-61ad-4908-a6f9-d09f4e1bea55)

More visual indication on what frontend version the user is using. Previously the frontend version was only printed onto the console.