### PR TITLE
Sort nodes by id before saving

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2395,9 +2395,9 @@ export class ComfyApp {
       }
     }
 
-    const workflow = graph.serialize();
+    const workflow = graph.serialize();  
     // links are already sorted, but nodes are not
-		workflow["nodes"] = Object.values(workflow["nodes"]).sort((a, b) => a.id - b.id);
+    workflow["nodes"] = Object.values(workflow["nodes"]).sort((a, b) => a.id - b.id);
     
     const output = {};
     // Process nodes in order of execution

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2396,6 +2396,9 @@ export class ComfyApp {
     }
 
     const workflow = graph.serialize();
+    // links are already sorted, but nodes are not
+		workflow["nodes"] = Object.values(workflow["nodes"]).sort((a, b) => a.id - b.id);
+    
     const output = {};
     // Process nodes in order of execution
     for (const outerNode of graph.computeExecutionOrder(false)) {


### PR DESCRIPTION
Reopening this PR: https://github.com/comfyanonymous/ComfyUI/pull/4052

Currently after even a minor modification of the workflow, it's saved in random order. This fix ensures that the nodes are sorted, which minimises the GIT diff after modification. And in general makes sense, given the fact that links are already sorted