### PR TITLE
Reverse init order

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,8 +2,8 @@
   <ProgressSpinner v-if="isLoading" class="spinner"></ProgressSpinner>
   <div v-else>
     <NodeSearchboxPopover v-if="nodeSearchEnabled" />
-    <teleport to="#graph-canvas-container">
-      <LiteGraphCanvasSplitterOverlay>
+    <teleport to=".graph-canvas-container">
+      <LiteGraphCanvasSplitterOverlay v-if="betaMenuEnabled">
         <template #side-bar-panel>
           <SideToolBar />
         </template>
@@ -21,7 +21,6 @@ import QueueSideBarTab from '@/components/sidebar/tabs/QueueSideBarTab.vue'
 import ProgressSpinner from 'primevue/progressspinner'
 import { app } from './scripts/app'
 import { useSettingStore } from './stores/settingStore'
-import { useNodeDefStore } from './stores/nodeDefStore'
 import { ExtensionManagerImpl } from './scripts/extensionManager'
 import { useI18n } from 'vue-i18n'
 
@@ -45,13 +44,15 @@ watch(
   },
   { immediate: true }
 )
+const betaMenuEnabled = computed(
+  () => useSettingStore().get('Comfy.UseNewMenu') !== 'Disabled'
+)
 
 const { t } = useI18n()
 const init = () => {
-  useNodeDefStore().addNodeDefs(Object.values(app.nodeDefs))
   useSettingStore().addSettings(app.ui.settings)
   app.vueAppReady = true
-  // Late init as extension manager needs to access pinia store.
+  // lazy init as extension manager needs to access pinia store.
   app.extensionManager = new ExtensionManagerImpl()
   app.extensionManager.registerSidebarTab({
     id: 'queue',

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -90,7 +90,7 @@ body {
   display: flex;
 }
 
-#graph-canvas-container {
+.graph-canvas-container {
   width: 100%;
   height: 100%;
   order: -3;

--- a/src/components/sidebar/SideToolBar.vue
+++ b/src/components/sidebar/SideToolBar.vue
@@ -38,8 +38,7 @@
 import SideBarIcon from './SideBarIcon.vue'
 import SideBarThemeToggleIcon from './SideBarThemeToggleIcon.vue'
 import SideBarSettingsToggleIcon from './SideBarSettingsToggleIcon.vue'
-import { computed, onBeforeUnmount, watch } from 'vue'
-import { useSettingStore } from '@/stores/settingStore'
+import { computed, onBeforeUnmount } from 'vue'
 import { app } from '@/scripts/app'
 import { useWorkspaceStore } from '@/stores/workspaceStateStore'
 import {
@@ -61,15 +60,6 @@ const onTabClick = (item: SidebarTabExtension) => {
     workspaceStateStore.activeSidebarTab === item.id ? null : item.id
   )
 }
-
-const betaMenuEnabled = computed(
-  () => useSettingStore().get('Comfy.UseNewMenu') !== 'Disabled'
-)
-watch(betaMenuEnabled, (newValue) => {
-  if (!newValue) {
-    workspaceStateStore.updateActiveSidebarTab(null)
-  }
-})
 onBeforeUnmount(() => {
   tabs.value.forEach((tab) => {
     if (tab.type === 'custom' && tab.destroy) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,28 +21,27 @@ const ComfyUIPreset = definePreset(Aura, {
 
 const app = createApp(App)
 const pinia = createPinia()
+app.directive('tooltip', Tooltip)
+app
+  .use(PrimeVue, {
+    theme: {
+      preset: ComfyUIPreset,
+      options: {
+        prefix: 'p',
+        cssLayer: false,
+        // This is a workaround for the issue with the dark mode selector
+        // https://github.com/primefaces/primevue/issues/5515
+        darkModeSelector: '.dark-theme, :root:has(.dark-theme)'
+      }
+    }
+  })
+  .use(ConfirmationService)
+  .use(ToastService)
+  .use(pinia)
+  .use(i18n)
+  .mount('#vue-app')
 
 comfyApp.setup().then(() => {
   window['app'] = comfyApp
   window['graph'] = comfyApp.graph
-
-  app.directive('tooltip', Tooltip)
-  app
-    .use(PrimeVue, {
-      theme: {
-        preset: ComfyUIPreset,
-        options: {
-          prefix: 'p',
-          cssLayer: false,
-          // This is a workaround for the issue with the dark mode selector
-          // https://github.com/primefaces/primevue/issues/5515
-          darkModeSelector: '.dark-theme, :root:has(.dark-theme)'
-        }
-      }
-    })
-    .use(ConfirmationService)
-    .use(ToastService)
-    .use(pinia)
-    .use(i18n)
-    .mount('#vue-app')
 })


### PR DESCRIPTION
Reverse init order of vue app and comfy app so that the custom node can call `app.extensionManager` when `init` hook is called.

