### PR TITLE
Fix splitter overlay z-index

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -52,7 +52,11 @@ const gutterClass = computed(() => {
   left: 0;
   background-color: transparent;
   pointer-events: none;
-  z-index: 10;
+  /* Set it the same as the ComfyUI menu */
+  /* Note: Lite-graph DOM widgets have the same z-index as the node id, so
+  999 should be sufficient to make sure splitter overlays on node's DOM
+  widgets */
+  z-index: 999;
   border: none;
 }
 </style>


### PR DESCRIPTION
Sometimes DOM widgets can be on top of Vue splitter overlay, due to DOM widget's dynamic z-index. This PR changes splitter overlay's z-index to 999 (The same as beta menu ui) so that it always stays on top of DOM widgets.

https://github.com/Comfy-Org/ComfyUI_frontend/blob/ee6eed1c1c3a38424779217bcb8f6f7c68c77f94/src/scripts/domWidget.ts#L331-L341