### PR TITLE
Make node def output class

### DIFF
--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -59,7 +59,7 @@ const nodeDefStore = useNodeDefStore()
 
 const nodeDef = props.nodeDef
 const allInputDefs = nodeDef.input.all
-const allOutputDefs = Object.values(nodeDef.output)
+const allOutputDefs = nodeDef.output.all
 const slotInputDefs = allInputDefs.filter(
   (input) => !nodeDefStore.inputIsWidget(input)
 )

--- a/tests-ui/tests/nodeDef.test.ts
+++ b/tests-ui/tests/nodeDef.test.ts
@@ -171,7 +171,7 @@ describe('ComfyNodeDefImpl', () => {
     expect(result.python_module).toBe('test_module')
     expect(result.description).toBe('A test node')
     expect(result.input).toBeInstanceOf(ComfyInputsSpec)
-    expect(result.output).toEqual({
+    expect(result.output.outputByName).toEqual({
       intOutput: {
         name: 'intOutput',
         display_name: 'intOutput',
@@ -196,7 +196,7 @@ describe('ComfyNodeDefImpl', () => {
 
     const result = plainToClass(ComfyNodeDefImpl, plainObject)
 
-    expect(result.output).toEqual({
+    expect(result.output.outputByName).toEqual({
       stringOutput: {
         name: 'stringOutput',
         display_name: 'stringOutput',
@@ -234,7 +234,7 @@ describe('ComfyNodeDefImpl', () => {
 
     const result = plainToClass(ComfyNodeDefImpl, plainObject)
 
-    expect(result.output).toEqual({
+    expect(result.output.outputByName).toEqual({
       '0': {
         name: '0',
         display_name: 'INT',
@@ -289,7 +289,7 @@ describe('ComfyNodeDefImpl', () => {
 
     const result = plainToClass(ComfyNodeDefImpl, plainObject)
 
-    expect(result.output).toEqual({})
+    expect(result.output.outputByName).toEqual({})
   })
 
   it('should handle complex input specifications', () => {


### PR DESCRIPTION
Previously the node def output is a plain JS object. This PR makes it a class to unify with the behavior with the node def input