### PR TITLE
Allow duplicated output names

### DIFF
--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -15,6 +15,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
       <div
         v-for="[slotInput, slotOutput] in _.zip(slotInputDefs, allOutputDefs)"
         class="_sb_row slot_row"
+        :key="(slotInput?.name || '') + (slotOutput?.index.toString() || '')"
       >
         <div class="_sb_col">
           <div v-if="slotInput" :class="['_sb_dot', slotInput.type]"></div>
@@ -22,7 +23,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         <div class="_sb_col">{{ slotInput ? slotInput.name : '' }}</div>
         <div class="_sb_col middle-column"></div>
         <div class="_sb_col _sb_inherit">
-          {{ slotOutput ? slotOutput.display_name : '' }}
+          {{ slotOutput ? slotOutput.name : '' }}
         </div>
         <div class="_sb_col">
           <div v-if="slotOutput" :class="['_sb_dot', slotOutput.type]"></div>
@@ -30,7 +31,11 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
       </div>
 
       <!-- Node widget inputs -->
-      <div v-for="widgetInput in widgetInputDefs" class="_sb_row _long_field">
+      <div
+        v-for="widgetInput in widgetInputDefs"
+        class="_sb_row _long_field"
+        :key="widgetInput.name"
+      >
         <div class="_sb_col _sb_arrow">&#x25C0;</div>
         <div class="_sb_col">{{ widgetInput.name }}</div>
         <div class="_sb_col middle-column"></div>

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -133,8 +133,9 @@ export class ComfyInputsSpec {
 
 export class ComfyOutputSpec {
   constructor(
+    public index: number,
+    // Name is not unique for output params
     public name: string,
-    public display_name: string,
     public type: string,
     public is_list: boolean,
     public comboOptions?: any[]
@@ -142,10 +143,10 @@ export class ComfyOutputSpec {
 }
 
 export class ComfyOutputsSpec {
-  constructor(public outputByName: Record<string, ComfyOutputSpec>) {}
+  constructor(public outputs: ComfyOutputSpec[]) {}
 
   get all() {
-    return Object.values(this.outputByName)
+    return this.outputs
   }
 }
 
@@ -164,27 +165,17 @@ export class ComfyNodeDefImpl {
 
   private static transformOutputSpec(obj: any): ComfyOutputsSpec {
     const { output, output_is_list, output_name } = obj
-    const result = {}
-
-    output.forEach((type: string | any[], index: number) => {
+    const result = output.map((type: string | any[], index: number) => {
       const typeString = Array.isArray(type) ? 'COMBO' : type
-      const display_name = output_name[index]
-      const name = display_name === typeString ? index.toString() : display_name
 
-      const outputSpec = new ComfyOutputSpec(
-        name,
-        display_name,
+      return new ComfyOutputSpec(
+        index,
+        output_name[index],
         typeString,
         output_is_list[index],
         Array.isArray(type) ? type : undefined
       )
-
-      if (name in result) {
-        throw new Error(`Duplicate output name: ${name}`)
-      }
-      result[name] = outputSpec
     })
-
     return new ComfyOutputsSpec(result)
   }
 }

--- a/tests-ui/tests/nodeDef.test.ts
+++ b/tests-ui/tests/nodeDef.test.ts
@@ -171,14 +171,14 @@ describe('ComfyNodeDefImpl', () => {
     expect(result.python_module).toBe('test_module')
     expect(result.description).toBe('A test node')
     expect(result.input).toBeInstanceOf(ComfyInputsSpec)
-    expect(result.output.outputByName).toEqual({
-      intOutput: {
+    expect(result.output.all).toEqual([
+      {
+        index: 0,
         name: 'intOutput',
-        display_name: 'intOutput',
         type: 'INT',
         is_list: false
       }
-    })
+    ])
   })
 
   it('should handle multiple outputs including COMBO type', () => {
@@ -196,27 +196,27 @@ describe('ComfyNodeDefImpl', () => {
 
     const result = plainToClass(ComfyNodeDefImpl, plainObject)
 
-    expect(result.output.outputByName).toEqual({
-      stringOutput: {
+    expect(result.output.all).toEqual([
+      {
+        index: 0,
         name: 'stringOutput',
-        display_name: 'stringOutput',
         type: 'STRING',
         is_list: true
       },
-      comboOutput: {
+      {
+        index: 1,
         name: 'comboOutput',
-        display_name: 'comboOutput',
         type: 'COMBO',
         is_list: false,
         comboOptions: ['COMBO', 'option1', 'option2']
       },
-      floatOutput: {
+      {
+        index: 2,
         name: 'floatOutput',
-        display_name: 'floatOutput',
         type: 'FLOAT',
         is_list: false
       }
-    })
+    ])
   })
 
   it('should use index for output names if matches type', () => {
@@ -234,29 +234,29 @@ describe('ComfyNodeDefImpl', () => {
 
     const result = plainToClass(ComfyNodeDefImpl, plainObject)
 
-    expect(result.output.outputByName).toEqual({
-      '0': {
-        name: '0',
-        display_name: 'INT',
+    expect(result.output.all).toEqual([
+      {
+        index: 0,
+        name: 'INT',
         type: 'INT',
         is_list: false
       },
-      '1': {
-        name: '1',
-        display_name: 'FLOAT',
+      {
+        index: 1,
+        name: 'FLOAT',
         type: 'FLOAT',
         is_list: true
       },
-      '2': {
-        name: '2',
-        display_name: 'FLOAT',
+      {
+        index: 2,
+        name: 'FLOAT',
         type: 'FLOAT',
         is_list: true
       }
-    })
+    ])
   })
 
-  it('should throw an error for duplicate output names', () => {
+  it('should handle duplicate output names', () => {
     const plainObject = {
       name: 'DuplicateOutputNode',
       display_name: 'Duplicate Output Node',
@@ -269,9 +269,27 @@ describe('ComfyNodeDefImpl', () => {
       output_name: ['output', 'output', 'uniqueOutput']
     }
 
-    expect(() => {
-      plainToClass(ComfyNodeDefImpl, plainObject)
-    }).toThrow('Duplicate output name: output')
+    const result = plainToClass(ComfyNodeDefImpl, plainObject)
+    expect(result.output.all).toEqual([
+      {
+        index: 0,
+        name: 'output',
+        type: 'INT',
+        is_list: false
+      },
+      {
+        index: 1,
+        name: 'output',
+        type: 'FLOAT',
+        is_list: false
+      },
+      {
+        index: 2,
+        name: 'uniqueOutput',
+        type: 'STRING',
+        is_list: false
+      }
+    ])
   })
 
   it('should handle empty output', () => {
@@ -289,7 +307,7 @@ describe('ComfyNodeDefImpl', () => {
 
     const result = plainToClass(ComfyNodeDefImpl, plainObject)
 
-    expect(result.output.outputByName).toEqual({})
+    expect(result.output.all).toEqual([])
   })
 
   it('should handle complex input specifications', () => {


### PR DESCRIPTION
There are custom nodes that use output name != type while still being duplicated. Previously this would cause exception. This PR allows this behavior again. Now the output is indentified by index.