### PR TITLE
Move sidebar y-axis overflow style to container

### DIFF
--- a/src/components/sidebar/SideToolBar.vue
+++ b/src/components/sidebar/SideToolBar.vue
@@ -15,23 +15,21 @@
       </div>
     </nav>
   </teleport>
-  <div v-if="!selectedTab"></div>
-  <component
-    v-else-if="selectedTab.type === 'vue'"
-    :is="selectedTab.component"
-  />
-  <div
-    v-else
-    :ref="
-      (el) => {
-        if (el)
-          mountCustomTab(
-            selectedTab as CustomSidebarTabExtension,
-            el as HTMLElement
-          )
-      }
-    "
-  ></div>
+  <div v-if="selectedTab" class="sidebar-content-container">
+    <component v-if="selectedTab.type === 'vue'" :is="selectedTab.component" />
+    <div
+      v-else
+      :ref="
+        (el) => {
+          if (el)
+            mountCustomTab(
+              selectedTab as CustomSidebarTabExtension,
+              el as HTMLElement
+            )
+        }
+      "
+    ></div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -93,5 +91,10 @@ onBeforeUnmount(() => {
 .side-tool-bar-end {
   align-self: flex-end;
   margin-top: auto;
+}
+
+.sidebar-content-container {
+  height: 100%;
+  overflow-y: auto;
 }
 </style>

--- a/src/components/sidebar/tabs/QueueSideBarTab.vue
+++ b/src/components/sidebar/tabs/QueueSideBarTab.vue
@@ -168,9 +168,4 @@ onMounted(() => {
 .queue-time-cell-content {
   width: fit-content;
 }
-
-.queue-table {
-  height: 100%;
-  overflow-y: auto;
-}
 </style>


### PR DESCRIPTION
The y-axis overflow logic is moved from the queue tab to side bar continaer as it is universal for all side bar tabs.