### PR TITLE
Fix settings getter

### DIFF
--- a/src/components/sidebar/SideBarThemeToggleIcon.vue
+++ b/src/components/sidebar/SideBarThemeToggleIcon.vue
@@ -13,9 +13,7 @@ import SideBarIcon from './SideBarIcon.vue'
 import { useSettingStore } from '@/stores/settingStore'
 
 const previousDarkTheme = ref('dark')
-const currentTheme = computed(() =>
-  useSettingStore().get('Comfy.ColorPalette', 'dark')
-)
+const currentTheme = computed(() => useSettingStore().get('Comfy.ColorPalette'))
 const isDarkMode = computed(() => currentTheme.value !== 'light')
 const icon = computed(() => (isDarkMode.value ? 'pi pi-moon' : 'pi pi-sun'))
 


### PR DESCRIPTION
SettingStore.get now only takes 1 param, the settings id, and returns the default value of the setting if the setting value is not found.