### PR TITLE
Fix combo input default value

### DIFF
--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -120,7 +120,8 @@ export class ComfyInputsSpec {
           name,
           type,
           ...spec,
-          comboOptions: typeRaw
+          comboOptions: typeRaw,
+          default: spec.default ?? typeRaw[0]
         })
       default:
         return plainToClass(CustomInputSpec, { name, type, ...spec })

--- a/tests-ui/afterSetup.ts
+++ b/tests-ui/afterSetup.ts
@@ -3,6 +3,25 @@ import lg from './utils/litegraph'
 
 // Load things once per test file before to ensure its all warmed up for the tests
 beforeAll(async () => {
+  const originalWarn = console.warn
+  console.error = function (...args) {
+    if (['Error: Not implemented: window.alert'].includes(args[0])) {
+      return
+    }
+  }
+  console.warn = function (...args) {
+    if (
+      [
+        "sMethod=='pointer' && !window.PointerEvent",
+        'Warning, nodes missing on pasting'
+      ].includes(args[0])
+    ) {
+      return
+    }
+    originalWarn.apply(console, args)
+  }
+  console.log = function (...args) {}
+
   lg.setup(global)
   await start({ resetEnv: true })
   lg.teardown(global)

--- a/tests-ui/tests/nodeDef.test.ts
+++ b/tests-ui/tests/nodeDef.test.ts
@@ -89,7 +89,7 @@ describe('ComfyInputsSpec', () => {
     expect(floatInput.step).toBe(0.1)
   })
 
-  it('should handle custom input specs', () => {
+  it('should handle combo input specs', () => {
     const plainObject = {
       optional: {
         comboInput: [[1, 2, 3], { default: 2 }]
@@ -101,6 +101,21 @@ describe('ComfyInputsSpec', () => {
     expect(result.optional.comboInput).toBeInstanceOf(ComboInputSpec)
     expect(result.optional.comboInput.type).toBe('COMBO')
     expect(result.optional.comboInput.default).toBe(2)
+  })
+
+  it('should handle combo input specs (auto-default)', () => {
+    const plainObject = {
+      optional: {
+        comboInput: [[1, 2, 3], {}]
+      }
+    }
+
+    const result = plainToClass(ComfyInputsSpec, plainObject)
+
+    expect(result.optional.comboInput).toBeInstanceOf(ComboInputSpec)
+    expect(result.optional.comboInput.type).toBe('COMBO')
+    // Should pick the first choice as default
+    expect(result.optional.comboInput.default).toBe(1)
   })
 
   it('should handle custom input specs', () => {

--- a/tests-ui/tests/nodeSearchService.test.ts
+++ b/tests-ui/tests/nodeSearchService.test.ts
@@ -6,7 +6,7 @@ const EXAMPLE_NODE_DEFS: ComfyNodeDefImpl[] = [
   {
     input: {
       required: {
-        ckpt_name: [['model1.safetensors', 'model2.ckpt']]
+        ckpt_name: [['model1.safetensors', 'model2.ckpt'], {}]
       }
     },
     output: ['MODEL', 'CLIP', 'VAE'],


### PR DESCRIPTION
If not specified, combo input should use first combo value as default value.