### PR TITLE
Fix "undo" incorrectly undoing text input

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -110,11 +110,11 @@ export class ChangeTracker {
     window.addEventListener(
       'keydown',
       (e) => {
+        const activeEl = document.activeElement;
         requestAnimationFrame(async () => {
-          let activeEl
+          let bindInputEl
           // If we are auto queue in change mode then we do want to trigger on inputs
           if (!app.ui.autoQueueEnabled || app.ui.autoQueueMode === 'instant') {
-            activeEl = document.activeElement
             if (
               activeEl?.tagName === 'INPUT' ||
               activeEl?.['type'] === 'textarea'
@@ -122,6 +122,7 @@ export class ChangeTracker {
               // Ignore events on inputs, they have their native history
               return
             }
+            bindInputEl = activeEl
           }
 
           keyIgnored =
@@ -135,7 +136,7 @@ export class ChangeTracker {
           if (await changeTracker().undoRedo(e)) return
 
           // If our active element is some type of input then handle changes after they're done
-          if (ChangeTracker.bindInput(app, activeEl)) return
+          if (ChangeTracker.bindInput(app, bindInputEl)) return
           changeTracker().checkState()
         })
       },


### PR DESCRIPTION
Originally submitted here: https://github.com/comfyanonymous/ComfyUI/pull/4114

Fixes an issue where under certain conditions, the ComfyUI custom undo / redo functions would not run when intended to.

When trying to undo an action like deleting several nodes, instead the native browser undo runs - e.g. a textarea gets focus and the last typed text is undone. Clicking outside the `textarea` and hitting `ctrl + z` again just keeps doing the same thing.

This could use a slight refactor, but I went with "minimal changes".