### PR TITLE
Float workflow selection on top of sidebar

### DIFF
--- a/src/scripts/ui/menu/menu.css
+++ b/src/scripts/ui/menu/menu.css
@@ -261,7 +261,7 @@
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
   border-bottom-left-radius: 4px;
-  z-index: 400;
+  z-index: 1001;
 }
 
 .comfyui-workflows-panel {


### PR DESCRIPTION
The Menu has z-index of 1000. The side bar has z-index of 999. The workflow popover should have z-index bigger than both. 

Before:

![image](https://github.com/user-attachments/assets/cfd9d3a9-2731-413b-b27e-2db029d39aba)

After:

![image](https://github.com/user-attachments/assets/e791e664-2c06-4328-a025-a5ae9174ccab)
