### PR TITLE
Fix no task message display

### DIFF
--- a/src/components/sidebar/tabs/QueueSideBarTab.vue
+++ b/src/components/sidebar/tabs/QueueSideBarTab.vue
@@ -59,7 +59,7 @@
       </template>
     </Column>
   </DataTable>
-  <div>
+  <div v-else>
     <Message icon="pi pi-info" severity="error">
       <span class="ml-2">No tasks</span>
     </Message>


### PR DESCRIPTION
Only display the message when there is no task.