### PR TITLE
Fix node preview widget overflow

### DIFF
--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -39,7 +39,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         <div class="_sb_col _sb_arrow">&#x25C0;</div>
         <div class="_sb_col">{{ widgetInput.name }}</div>
         <div class="_sb_col middle-column"></div>
-        <div class="_sb_col _sb_inherit _sb_hide_overflow">
+        <div class="_sb_col _sb_inherit">
           {{ widgetInput.default }}
         </div>
         <div class="_sb_col _sb_arrow">&#x25B6;</div>

--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -39,7 +39,9 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         <div class="_sb_col _sb_arrow">&#x25C0;</div>
         <div class="_sb_col">{{ widgetInput.name }}</div>
         <div class="_sb_col middle-column"></div>
-        <div class="_sb_col _sb_inherit">{{ widgetInput.default }}</div>
+        <div class="_sb_col _sb_inherit _sb_hide_overflow">
+          {{ widgetInput.default }}
+        </div>
         <div class="_sb_col _sb_arrow">&#x25B6;</div>
       </div>
     </div>
@@ -179,7 +181,6 @@ const widgetInputDefs = allInputDefs.filter((input) =>
   align-items: center;
   padding-left: 9px;
   padding-right: 9px;
-  overflow-x: hidden;
 }
 
 ._sb_row_string {


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/e1b21472-6930-4cdc-83f4-f203dafb53ab)

After:

![image](https://github.com/user-attachments/assets/3c0e9719-da1c-4699-8357-25091b0b4c86)
