### PR TITLE
Attach isLeaf info to node library tree node

### DIFF
--- a/src/components/sidebar/tabs/NodeLibrarySideBarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySideBarTab.vue
@@ -99,9 +99,8 @@ const renderedRoot = computed(() => {
   return fillNodeInfo(root.value)
 })
 const fillNodeInfo = (node: TreeNode): TreeNode => {
-  const isLeaf = node.children === undefined || node.children.length === 0
   const isExpanded = expandedKeys.value[node.key]
-  const icon = isLeaf
+  const icon = node.leaf
     ? 'pi pi-circle-fill'
     : isExpanded
       ? 'pi pi-folder-open'
@@ -112,8 +111,8 @@ const fillNodeInfo = (node: TreeNode): TreeNode => {
     ...node,
     icon,
     children,
-    type: isLeaf ? 'node' : 'folder',
-    totalNodes: isLeaf
+    type: node.leaf ? 'node' : 'folder',
+    totalNodes: node.leaf
       ? 1
       : children.reduce((acc, child) => acc + child.totalNodes, 0)
   }

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -260,6 +260,7 @@ export const useNodeDefStore = defineStore('nodeDef', {
       const root: TreeNode = {
         key: 'root',
         label: 'Nodes',
+        leaf: false,
         children: []
       }
       for (const nodeDef of Object.values(state.nodeDefsByName)) {
@@ -270,7 +271,7 @@ export const useNodeDefStore = defineStore('nodeDef', {
           key += `/${part}`
           let next = current.children.find((child) => child.label === part)
           if (!next) {
-            next = { key, label: part, children: [] }
+            next = { key, label: part, children: [], leaf: false }
             current.children.push(next)
           }
           current = next
@@ -278,7 +279,8 @@ export const useNodeDefStore = defineStore('nodeDef', {
         current.children.push({
           label: nodeDef.display_name,
           data: nodeDef,
-          key: `${key}/${nodeDef.name}`
+          key: `${key}/${nodeDef.name}`,
+          leaf: true
         })
       }
       return root


### PR DESCRIPTION
PrimeVue's TreeNode interface has a built-in field `leaf` to specify whether a node is leaf. This PR make use of that instead of determine this by inspecting whether the node has children. This can be helpful if later we decide to add an empty folder.