### PR TITLE
Truncate JSON default value in node preview

### DIFF
--- a/src/components/NodePreview.vue
+++ b/src/components/NodePreview.vue
@@ -40,7 +40,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         <div class="_sb_col">{{ widgetInput.name }}</div>
         <div class="_sb_col middle-column"></div>
         <div class="_sb_col _sb_inherit">
-          {{ widgetInput.default }}
+          {{ truncateDefaultValue(widgetInput.default) }}
         </div>
         <div class="_sb_col _sb_arrow">&#x25B6;</div>
       </div>
@@ -73,6 +73,12 @@ const slotInputDefs = allInputDefs.filter(
 const widgetInputDefs = allInputDefs.filter((input) =>
   nodeDefStore.inputIsWidget(input)
 )
+const truncateDefaultValue = (value: any): string => {
+  if (value instanceof Object) {
+    return _.truncate(JSON.stringify(value), { length: 20 })
+  }
+  return value
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
JSON default value in node preview can be very long, and not much useful to the end user, as it often is further rendered by custom JS scripts by custom nodes.

This PR truncates the JSON value so that the node preview box stays at reasonable width.

Before:

![image](https://github.com/user-attachments/assets/f0d63e41-0fe8-4220-8512-a745f41fb7e7)

After:

![image](https://github.com/user-attachments/assets/4d597fdf-c539-439f-9038-1ae2ddb22f48)
