### PR TITLE
Add spellcheck option to Multiline widget, add Interrupt Queue keybind

### DIFF
--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -11,9 +11,9 @@ app.registerExtension({
       if (modifierPressed && event.key === 'Enter') {
         // Cancel current prompt using (ctrl or command) + alt + enter
         if(event.altKey) {
-					api.interrupt()
-					return
-				}
+          api.interrupt()
+          return
+        }
         // Queue prompt as first for generation using (ctrl or command) + shift + enter
         app.queuePrompt(event.shiftKey ? -1 : 0).then()
         return

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -1,4 +1,5 @@
 import { app } from '../../scripts/app'
+import { api } from '../../scripts/api'
 
 app.registerExtension({
   name: 'Comfy.Keybinds',
@@ -6,8 +7,14 @@ app.registerExtension({
     const keybindListener = function (event) {
       const modifierPressed = event.ctrlKey || event.metaKey
 
-      // Queue prompt using ctrl or command + enter
+      // Queue prompt using (ctrl or command) + enter
       if (modifierPressed && event.key === 'Enter') {
+        // Cancel current prompt using (ctrl or command) + alt + enter
+        if(event.altKey) {
+					api.interrupt()
+					return
+				}
+        // Queue prompt as first for generation using (ctrl or command) + shift + enter
         app.queuePrompt(event.shiftKey ? -1 : 0).then()
         return
       }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -313,6 +313,7 @@ function addMultilineWidget(node, name, opts, app) {
   inputEl.className = 'comfy-multiline-input'
   inputEl.value = opts.defaultVal
   inputEl.placeholder = opts.placeholder || name
+  inputEl.spellcheck = opts.spellcheck || false
 
   const widget = node.addDOMWidget(name, 'customtext', inputEl, {
     getValue() {


### PR DESCRIPTION
Red squigglies were annoying me in my XY lists, so this change turns off spellcheck in multiline input widgets by default. If desired, spellcheck can be toggled on for individual nodes in the node inputs options:

`"text_input":  ("STRING", {"default":"", "multiline": True, "spellcheck": True}),`

Also, I use interrupt queue a lot more than priority queue so I propose this small keybind addition for interrupt: Ctrl/Cmd + Alt + Enter