### PR TITLE
Allow input spec with extra values passthrough

### DIFF
--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -198,7 +198,7 @@ const zFloatInputSpec = inputSpec([
     min: z.number().optional(),
     max: z.number().optional(),
     step: z.number().optional(),
-    round: z.boolean().optional(),
+    round: z.union([z.number(), z.literal(false)]).optional(),
     default: z.number().optional()
   })
 ])

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -233,7 +233,12 @@ const zComboInputSpec = inputSpec(
   /* allowUpcast=*/ false
 )
 
-const zCustomInputSpec = inputSpec([z.string(), zBaseInputSpecValue])
+const excludedLiterals = new Set(['INT', 'FLOAT', 'BOOLEAN', 'STRING', 'COMBO'])
+
+const zCustomInputSpec = inputSpec([
+  z.string().refine((value) => !excludedLiterals.has(value)),
+  zBaseInputSpecValue
+])
 
 const zInputSpec = z.union([
   zIntInputSpec,

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -175,46 +175,49 @@ function inputSpec(
   ])
 }
 
+const zBaseInputSpecValue = z
+  .object({
+    default: z.any().optional(),
+    forceInput: z.boolean().optional()
+  })
+  .passthrough()
+
 const zIntInputSpec = inputSpec([
   z.literal('INT'),
-  z.object({
+  zBaseInputSpecValue.extend({
     min: z.number().optional(),
     max: z.number().optional(),
     step: z.number().optional(),
-    default: z.number().optional(),
-    forceInput: z.boolean().optional()
+    default: z.number().optional()
   })
 ])
 
 const zFloatInputSpec = inputSpec([
   z.literal('FLOAT'),
-  z.object({
+  zBaseInputSpecValue.extend({
     min: z.number().optional(),
     max: z.number().optional(),
     step: z.number().optional(),
     round: z.number().optional(),
-    default: z.number().optional(),
-    forceInput: z.boolean().optional()
+    default: z.number().optional()
   })
 ])
 
 const zBooleanInputSpec = inputSpec([
   z.literal('BOOLEAN'),
-  z.object({
+  zBaseInputSpecValue.extend({
     label_on: z.string().optional(),
     label_off: z.string().optional(),
-    default: z.boolean().optional(),
-    forceInput: z.boolean().optional()
+    default: z.boolean().optional()
   })
 ])
 
 const zStringInputSpec = inputSpec([
   z.literal('STRING'),
-  z.object({
+  zBaseInputSpecValue.extend({
     default: z.string().optional(),
     multiline: z.boolean().optional(),
-    dynamicPrompts: z.boolean().optional(),
-    forceInput: z.boolean().optional()
+    dynamicPrompts: z.boolean().optional()
   })
 ])
 
@@ -222,23 +225,15 @@ const zStringInputSpec = inputSpec([
 const zComboInputSpec = inputSpec(
   [
     z.array(z.any()),
-    z.object({
-      default: z.any().optional(),
+    zBaseInputSpecValue.extend({
       control_after_generate: z.boolean().optional(),
-      image_upload: z.boolean().optional(),
-      forceInput: z.boolean().optional()
+      image_upload: z.boolean().optional()
     })
   ],
   /* allowUpcast=*/ false
 )
 
-const zCustomInputSpec = inputSpec([
-  z.string(),
-  z.object({
-    default: z.any().optional(),
-    forceInput: z.boolean().optional()
-  })
-])
+const zCustomInputSpec = inputSpec([z.string(), zBaseInputSpecValue])
 
 const zInputSpec = z.union([
   zIntInputSpec,

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -198,7 +198,7 @@ const zFloatInputSpec = inputSpec([
     min: z.number().optional(),
     max: z.number().optional(),
     step: z.number().optional(),
-    round: z.number().optional(),
+    round: z.boolean().optional(),
     default: z.number().optional()
   })
 ])

--- a/tests-ui/tests/apiTypes.test.ts
+++ b/tests-ui/tests/apiTypes.test.ts
@@ -51,7 +51,9 @@ describe('validateNodeDef', () => {
   describe.each([
     [{ ckpt_name: { 'model1.safetensors': 'foo' } }],
     [{ ckpt_name: ['*', ''] }],
-    [{ ckpt_name: ['foo', { default: 1 }, { default: 2 }] }]
+    [{ ckpt_name: ['foo', { default: 1 }, { default: 2 }] }],
+    // Should reject incorrect default value type.
+    [{ ckpt_name: ['INT', { default: '124' }] }]
   ])(
     'validateComfyNodeDef rejects with various input spec formats',
     (inputSpec) => {

--- a/tests-ui/tests/apiTypes.test.ts
+++ b/tests-ui/tests/apiTypes.test.ts
@@ -27,7 +27,11 @@ describe('validateNodeDef', () => {
   describe.each([
     [{ ckpt_name: 'foo' }, ['foo', {}]],
     [{ ckpt_name: ['foo'] }, ['foo', {}]],
-    [{ ckpt_name: ['foo', { default: 1 }] }, ['foo', { default: 1 }]]
+    [{ ckpt_name: ['foo', { default: 1 }] }, ['foo', { default: 1 }]],
+    // Extra input spec should be preserved
+    [{ ckpt_name: ['foo', { bar: 1 }] }, ['foo', { bar: 1 }]],
+    [{ ckpt_name: ['INT', { bar: 1 }] }, ['INT', { bar: 1 }]],
+    [{ ckpt_name: [[1, 2, 3], { bar: 1 }] }, [[1, 2, 3], { bar: 1 }]]
   ])(
     'validateComfyNodeDef with various input spec formats',
     (inputSpec, expected) => {


### PR DESCRIPTION
Previously all extra fields passed with input spec dict are filtered by zod validation. This PR let these values passthrough.