### PR TITLE
Add support for menu on the right

### DIFF
--- a/src/scripts/ui/components/popup.ts
+++ b/src/scripts/ui/components/popup.ts
@@ -130,10 +130,11 @@ export class ComfyPopup extends EventTarget {
     }
 
     const thisRect = this.element.getBoundingClientRect()
+    // TODO: Test if thisRect.height < this.element.scrollHeight works on all browsers
     if (thisRect.height < 30) {
       // Move up instead
       this.element.style.setProperty('--top', 'unset')
-      this.element.style.setProperty('--bottom', rect.height + 5 + 'px')
+      this.element.style.setProperty('--bottom', window.innerHeight - rect.top + 'px')
       this.element.style.setProperty('--limit', rect.height + 5 + 'px')
     }
   }

--- a/src/scripts/ui/menu/menu.css
+++ b/src/scripts/ui/menu/menu.css
@@ -143,6 +143,14 @@
   max-height: 90vh;
 }
 
+.comfyui-menu.comfyui-menu-side {
+  width: unset;
+  height: 100vh;
+  max-height: unset;
+  flex-direction: column;
+  padding: 1.5rem 0.75rem;
+}
+
 .comfyui-menu>* {
   flex-shrink: 0;
 }


### PR DESCRIPTION
Initial (fully functional) framework to allow the menu to be docked on the right of the screen.  This would likely be preferable for many users on ultrawide displays.

Also provides a solution for a workaround in `popup.ts` - anchor to the top of the parent.

Have left a TODO in `popup.ts` also, in case that test is preferred (it uses element height, rather than current render height).