### PR TITLE
Manage searchbox imp setting in Vue app

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -14,7 +14,14 @@
 import SideToolBar from '@/components/sidebar/SideToolBar.vue'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import NodeSearchboxPopover from '@/components/NodeSearchBoxPopover.vue'
-import { ref, onMounted, computed, onUnmounted } from 'vue'
+import {
+  ref,
+  computed,
+  onUnmounted,
+  onBeforeMount,
+  watch,
+  onMounted
+} from 'vue'
 import { app as comfyApp } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'
 import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
@@ -32,6 +39,9 @@ const betaMenuEnabled = computed(
 const nodeSearchEnabled = computed<boolean>(
   () => settingStore.get('Comfy.NodeSearchBoxImpl') === 'default'
 )
+watch(nodeSearchEnabled, (newVal) => {
+  comfyApp.canvas.allow_searchbox = !newVal
+})
 
 let dropTargetCleanup = () => {}
 
@@ -40,6 +50,7 @@ onMounted(async () => {
 
   workspaceStore.spinner = true
   await comfyApp.setup(canvasRef.value)
+  comfyApp.canvas.allow_searchbox = !nodeSearchEnabled.value
   workspaceStore.spinner = false
 
   window['app'] = comfyApp

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -14,14 +14,7 @@
 import SideToolBar from '@/components/sidebar/SideToolBar.vue'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import NodeSearchboxPopover from '@/components/NodeSearchBoxPopover.vue'
-import {
-  ref,
-  computed,
-  onUnmounted,
-  onBeforeMount,
-  watch,
-  onMounted
-} from 'vue'
+import { ref, computed, onUnmounted, watch, onMounted } from 'vue'
 import { app as comfyApp } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'
 import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1881,7 +1881,6 @@ export class ComfyApp {
     this.#addAfterConfigureHandler()
 
     this.canvas = new LGraphCanvas(canvasEl, this.graph)
-    this.ui.settings.refreshSetting('Comfy.NodeSearchBoxImpl')
     this.ctx = canvasEl.getContext('2d')
 
     LiteGraph.release_link_on_empty_shows_menu = true

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -425,14 +425,7 @@ export class ComfyUI {
       name: 'Node Search box implementation',
       type: 'combo',
       options: ['default', 'litegraph (legacy)'],
-      defaultValue: 'default',
-      onChange: (value?: string) => {
-        if (!app.canvas) return
-
-        value = value || 'default'
-        const useLitegraphSearch = value === 'litegraph (legacy)'
-        app.canvas.allow_searchbox = useLitegraphSearch
-      }
+      defaultValue: 'default'
     })
 
     const fileInput = $el('input', {


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/234

Previously `app.canvas.allow_searchbox` was managed in legacy settings mechanism, which has caused inconcistency bugs where 2 search boxes both pop up in some situations. This PR moves the litegraph searchbox setting management to Vue app, so that get we better consistency on the setting.