### PR TITLE
Fix canvas not init issue

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -33,7 +33,7 @@ const nodeSearchEnabled = computed<boolean>(
   () => settingStore.get('Comfy.NodeSearchBoxImpl') === 'default'
 )
 watch(nodeSearchEnabled, (newVal) => {
-  comfyApp.canvas.allow_searchbox = !newVal
+  if (comfyApp.canvas) comfyApp.canvas.allow_searchbox = !newVal
 })
 
 let dropTargetCleanup = () => {}


### PR DESCRIPTION
If the app loads with litegraph search box impl selected, the watch can trigger before app.canvas exist. This PR fixes that corner case.