### PR TITLE
Reduce loglevel on node def validation

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -249,11 +249,17 @@ class ComfyApi extends EventTarget {
     const objectInfoUnsafe = await resp.json()
     const objectInfo: Record<string, ComfyNodeDef> = {}
     for (const key in objectInfoUnsafe) {
-      try {
-        objectInfo[key] = validateComfyNodeDef(objectInfoUnsafe[key])
-      } catch (e) {
-        console.warn('Ignore node definition: ', key)
-        console.error(e)
+      const validatedDef = await validateComfyNodeDef(
+        objectInfoUnsafe[key],
+        /* onError=*/ (errorMessage: string) => {
+          console.warn(
+            `Skipping invalid node definition: ${key}. See debug log for more information.`
+          )
+          console.debug(errorMessage)
+        }
+      )
+      if (validatedDef !== null) {
+        objectInfo[key] = validatedDef
       }
     }
     return objectInfo

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -285,15 +285,17 @@ export type ComfyInputsSpec = z.infer<typeof zComfyInputsSpec>
 export type ComfyOutputTypesSpec = z.infer<typeof zComfyOutputTypesSpec>
 export type ComfyNodeDef = z.infer<typeof zComfyNodeDef>
 
-export function validateComfyNodeDef(data: any): ComfyNodeDef {
-  const result = zComfyNodeDef.safeParse(data)
+export async function validateComfyNodeDef(
+  data: any,
+  onError: (error: string) => void = console.warn
+): Promise<ComfyNodeDef | null> {
+  const result = await zComfyNodeDef.safeParseAsync(data)
   if (!result.success) {
     const zodError = fromZodError(result.error)
-    const error = new Error(
+    onError(
       `Invalid ComfyNodeDef: ${JSON.stringify(data)}\n${zodError.message}`
     )
-    error.cause = zodError
-    throw error
+    return null
   }
   return result.data
 }

--- a/tests-ui/tests/apiTypes.test.ts
+++ b/tests-ui/tests/apiTypes.test.ts
@@ -20,8 +20,8 @@ const EXAMPLE_NODE_DEF: ComfyNodeDef = {
 }
 
 describe('validateNodeDef', () => {
-  it('Should accept a valid node definition', () => {
-    expect(() => validateComfyNodeDef(EXAMPLE_NODE_DEF)).not.toThrow()
+  it('Should accept a valid node definition', async () => {
+    expect(await validateComfyNodeDef(EXAMPLE_NODE_DEF)).not.toBeNull()
   })
 
   describe.each([
@@ -35,14 +35,16 @@ describe('validateNodeDef', () => {
   ])(
     'validateComfyNodeDef with various input spec formats',
     (inputSpec, expected) => {
-      it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, () => {
+      it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, async () => {
         expect(
-          validateComfyNodeDef({
-            ...EXAMPLE_NODE_DEF,
-            input: {
-              required: inputSpec
-            }
-          }).input.required.ckpt_name
+          (
+            await validateComfyNodeDef({
+              ...EXAMPLE_NODE_DEF,
+              input: {
+                required: inputSpec
+              }
+            })
+          ).input.required.ckpt_name
         ).toEqual(expected)
       })
     }
@@ -57,15 +59,15 @@ describe('validateNodeDef', () => {
   ])(
     'validateComfyNodeDef rejects with various input spec formats',
     (inputSpec) => {
-      it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, () => {
-        expect(() =>
-          validateComfyNodeDef({
+      it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, async () => {
+        expect(
+          await validateComfyNodeDef({
             ...EXAMPLE_NODE_DEF,
             input: {
               required: inputSpec
             }
           })
-        ).toThrow()
+        ).toBeNull()
       })
     }
   )
@@ -76,8 +78,9 @@ describe('validateNodeDef', () => {
         fs.readFileSync(path.resolve('./tests-ui/data/object_info.json'))
       )
     )
-    nodeDefs.forEach((nodeDef) => {
-      expect(() => validateComfyNodeDef(nodeDef)).not.toThrow()
-    })
+
+    for (const nodeDef of nodeDefs) {
+      expect(await validateComfyNodeDef(nodeDef)).not.toBeNull()
+    }
   })
 })


### PR DESCRIPTION
Lower the log level as the zod validation error is giving end-user hardtime. End users often panic on the red erorr message.