### PR TITLE
Revert to sync validation on node def for better performance

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -249,7 +249,7 @@ class ComfyApi extends EventTarget {
     const objectInfoUnsafe = await resp.json()
     const objectInfo: Record<string, ComfyNodeDef> = {}
     for (const key in objectInfoUnsafe) {
-      const validatedDef = await validateComfyNodeDef(
+      const validatedDef = validateComfyNodeDef(
         objectInfoUnsafe[key],
         /* onError=*/ (errorMessage: string) => {
           console.warn(

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -285,11 +285,11 @@ export type ComfyInputsSpec = z.infer<typeof zComfyInputsSpec>
 export type ComfyOutputTypesSpec = z.infer<typeof zComfyOutputTypesSpec>
 export type ComfyNodeDef = z.infer<typeof zComfyNodeDef>
 
-export async function validateComfyNodeDef(
+export function validateComfyNodeDef(
   data: any,
   onError: (error: string) => void = console.warn
-): Promise<ComfyNodeDef | null> {
-  const result = await zComfyNodeDef.safeParseAsync(data)
+): ComfyNodeDef | null {
+  const result = zComfyNodeDef.safeParse(data)
   if (!result.success) {
     const zodError = fromZodError(result.error)
     onError(

--- a/tests-ui/tests/apiTypes.test.ts
+++ b/tests-ui/tests/apiTypes.test.ts
@@ -21,7 +21,7 @@ const EXAMPLE_NODE_DEF: ComfyNodeDef = {
 
 describe('validateNodeDef', () => {
   it('Should accept a valid node definition', async () => {
-    expect(await validateComfyNodeDef(EXAMPLE_NODE_DEF)).not.toBeNull()
+    expect(validateComfyNodeDef(EXAMPLE_NODE_DEF)).not.toBeNull()
   })
 
   describe.each([
@@ -37,14 +37,12 @@ describe('validateNodeDef', () => {
     (inputSpec, expected) => {
       it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, async () => {
         expect(
-          (
-            await validateComfyNodeDef({
-              ...EXAMPLE_NODE_DEF,
-              input: {
-                required: inputSpec
-              }
-            })
-          ).input.required.ckpt_name
+          validateComfyNodeDef({
+            ...EXAMPLE_NODE_DEF,
+            input: {
+              required: inputSpec
+            }
+          }).input.required.ckpt_name
         ).toEqual(expected)
       })
     }
@@ -61,7 +59,7 @@ describe('validateNodeDef', () => {
     (inputSpec) => {
       it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, async () => {
         expect(
-          await validateComfyNodeDef({
+          validateComfyNodeDef({
             ...EXAMPLE_NODE_DEF,
             input: {
               required: inputSpec
@@ -80,7 +78,7 @@ describe('validateNodeDef', () => {
     )
 
     for (const nodeDef of nodeDefs) {
-      expect(await validateComfyNodeDef(nodeDef)).not.toBeNull()
+      expect(validateComfyNodeDef(nodeDef)).not.toBeNull()
     }
   })
 })


### PR DESCRIPTION
`safeParseAsync` is causing extra overhead comparing to `safeParse`. Sync validation: <1s. Async validation >10s.