### PR TITLE
Fix PrimeVue ref error on adding node via searchbox

### DIFF
--- a/src/components/NodeSearchBoxPopover.vue
+++ b/src/components/NodeSearchBoxPopover.vue
@@ -65,8 +65,6 @@ const closeDialog = () => {
 }
 
 const addNode = (nodeDef: ComfyNodeDefImpl) => {
-  closeDialog()
-
   const node = app.addNodeOnGraph(nodeDef, { pos: getNewNodeLocation() })
 
   const eventDetail = triggerEvent.value.detail
@@ -75,6 +73,13 @@ const addNode = (nodeDef: ComfyNodeDefImpl) => {
       ConnectingLinkImpl.createFromPlainObject(link).connectTo(node)
     })
   }
+
+  // TODO: This is not robust timing-wise.
+  // PrimeVue complains about the dialog being closed before the event selecting
+  // item is fully processed.
+  window.setTimeout(() => {
+    closeDialog()
+  }, 100)
 }
 
 const canvasEventHandler = (e: LiteGraphCanvasEvent) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4e37efa3-3359-4929-a686-f148cc6799eb)

The root cause is that the `@option-select` event is emitted before PrimeVue process the item added to the multiple autocomplete result.

This is a temporary fix to prevent console error.