### PR TITLE
Add error boundary on node.DrawBackground

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -657,7 +657,7 @@ export class ComfyApp {
       }
     }
 
-    node.prototype.onDrawBackground = function (ctx) {
+    function unsafeDrawBackground(ctx) {
       if (!this.flags.collapsed) {
         let imgURLs = []
         let imagesChanged = false
@@ -990,6 +990,14 @@ export class ComfyApp {
             }
           }
         }
+      }
+    }
+
+    node.prototype.onDrawBackground = function (ctx) {
+      try {
+        unsafeDrawBackground.call(this, ctx)
+      } catch (error) {
+        console.error('Error drawing node background', error)
       }
     }
   }


### PR DESCRIPTION
Reported by @ltdrdata 

> Currently, this phenomenon is also occurring in app.js of Comfy Core. Occasionally, this.imgs[imageIndex] points to a temp resource, which can result in an invalid URL upon restart. In this case, the UI freezes with crash.

This PR adds an error boundary to make sure that the error in the function does not crash the whole app.