### PR TITLE
Fix script type

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 				font-family: 'Roboto Mono', 'Noto Color Emoji';
 			}
 		</style> -->
-		<script src="node_modules/reflect-metadata/Reflect.js"></script>
+		<script type="module" src="node_modules/reflect-metadata/Reflect.js"></script>
 		<script type="module">
 			import 'reflect-metadata';
 			window["__COMFYUI_FRONTEND_VERSION__"] = __COMFYUI_FRONTEND_VERSION__;


### PR DESCRIPTION
Fix build warning `<script src="node_modules/reflect-metadata/Reflect.js"> in "/index.html" can't be bundled without type="module" attribute`