### PR TITLE
Migrate settings dialog to Vue

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -33,12 +33,12 @@ import { type Component, computed, markRaw } from 'vue'
 import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import Select from 'primevue/select'
-import Slider from 'primevue/slider'
 import Chip from 'primevue/chip'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { useSettingStore } from '@/stores/settingStore'
 import { SettingParams } from '@/types/settingTypes'
 import CustomSettingValue from '@/components/dialog/content/setting/CustomSettingValue.vue'
+import InputSlider from '@/components/dialog/content/setting/InputSlider.vue'
 
 const settingStore = useSettingStore()
 const sortedSettings = computed<SettingParams[]>(() => {
@@ -83,7 +83,7 @@ function getSettingComponent(setting: SettingParams): Component {
     case 'number':
       return InputNumber
     case 'slider':
-      return Slider
+      return InputSlider
     case 'combo':
       return Select
     default:

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -59,6 +59,15 @@ function getSettingAttrs(setting: SettingParams) {
         setting.attrs
       )
   }
+  switch (setting.type) {
+    case 'combo':
+      attrs['options'] = setting.options
+      if (typeof setting.options[0] !== 'string') {
+        attrs['optionLabel'] = 'text'
+        attrs['optionValue'] = 'value'
+      }
+      break
+  }
   return attrs
 }
 

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -48,7 +48,7 @@ const sortedSettings = computed<SettingParams[]>(() => {
 })
 
 function getSettingAttrs(setting: SettingParams) {
-  const attrs = setting.attrs || {}
+  const attrs = { ...(setting.attrs || {}) }
   const settingType = setting.type
   if (typeof settingType === 'function') {
     attrs['renderFunction'] = () =>
@@ -68,6 +68,8 @@ function getSettingAttrs(setting: SettingParams) {
       }
       break
   }
+
+  attrs['class'] += ' comfy-vue-setting-input'
   return attrs
 }
 
@@ -101,6 +103,9 @@ const updateSetting = (setting: SettingParams, value: any) => {
 <style>
 .info-chip {
   background: transparent !important;
+}
+.comfy-vue-setting-input {
+  width: 100%;
 }
 </style>
 

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -1,0 +1,75 @@
+<template>
+  <table class="comfy-modal-content comfy-table">
+    <tbody>
+      <tr v-for="setting in sortedSettings" :key="setting.id">
+        <td>
+          <span>
+            {{ setting.name }}
+          </span>
+          <Chip
+            v-if="setting.tooltip"
+            icon="pi pi-info-circle"
+            severity="secondary"
+            v-tooltip="setting.tooltip"
+            class="info-chip"
+          />
+        </td>
+        <td>
+          <component
+            :is="getSettingComponent(setting)"
+            :id="setting.id"
+            :value="settingStore.get(setting.id)"
+            @update:value="settingStore.set(setting.id, $event)"
+            v-bind="setting.attrs"
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import InputText from 'primevue/inputtext'
+import InputNumber from 'primevue/inputnumber'
+import Checkbox from 'primevue/checkbox'
+import Select from 'primevue/select'
+import Slider from 'primevue/slider'
+import Chip from 'primevue/chip'
+import { useSettingStore } from '@/stores/settingStore'
+import { SettingParams } from '@/types/settingTypes'
+
+const settingStore = useSettingStore()
+const sortedSettings = computed<SettingParams[]>(() => {
+  return Object.values(settingStore.settings)
+    .filter((setting: SettingParams) => setting.type !== 'hidden')
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+function getSettingComponent(setting: SettingParams) {
+  switch (setting.type) {
+    case 'boolean':
+      return Checkbox
+    case 'number':
+      return InputNumber
+    case 'slider':
+      return Slider
+    case 'combo':
+      return Select
+    default:
+      return InputText
+  }
+}
+</script>
+
+<style>
+.info-chip {
+  background: transparent !important;
+}
+</style>
+
+<style scoped>
+.comfy-table {
+  width: 100%;
+}
+</style>

--- a/src/components/dialog/content/setting/CustomSettingValue.vue
+++ b/src/components/dialog/content/setting/CustomSettingValue.vue
@@ -1,0 +1,25 @@
+<template>
+  <div ref="container"></div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+
+const props = defineProps<{
+  renderFunction: () => HTMLElement
+}>()
+
+const container = ref<HTMLElement | null>(null)
+
+function renderContent() {
+  if (container.value) {
+    container.value.innerHTML = ''
+    const element = props.renderFunction()
+    container.value.appendChild(element)
+  }
+}
+
+onMounted(renderContent)
+
+watch(() => props.renderFunction, renderContent)
+</script>

--- a/src/components/dialog/content/setting/InputSlider.vue
+++ b/src/components/dialog/content/setting/InputSlider.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="input-slider">
+    <Slider
+      :modelValue="modelValue"
+      @update:modelValue="updateValue"
+      class="slider-part"
+      :class="sliderClass"
+      v-bind="$attrs"
+    />
+    <InputText
+      :value="modelValue"
+      @input="updateValue"
+      class="input-part"
+      :class="inputClass"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import InputText from 'primevue/inputtext'
+import Slider from 'primevue/slider'
+
+const props = defineProps<{
+  modelValue: number
+  inputClass?: string
+  sliderClass?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: number): void
+}>()
+
+const updateValue = (newValue: string | number) => {
+  const numValue =
+    typeof newValue === 'string' ? parseFloat(newValue) : newValue
+  if (!isNaN(numValue)) {
+    emit('update:modelValue', numValue)
+  }
+}
+</script>
+
+<style scoped>
+.input-slider {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  /* Adjust this value to control space between slider and input */
+}
+
+.slider-part {
+  flex-grow: 1;
+}
+
+.input-part {
+  width: 5rem;
+  /* Adjust this value to control input width */
+}
+</style>

--- a/src/components/sidebar/SideBarSettingsToggleIcon.vue
+++ b/src/components/sidebar/SideBarSettingsToggleIcon.vue
@@ -7,10 +7,16 @@
 </template>
 
 <script setup lang="ts">
-import { app } from '@/scripts/app'
 import SideBarIcon from './SideBarIcon.vue'
+import { useDialogStore } from '@/stores/dialogStore'
+import SettingDialogContent from '@/components/dialog/content/SettingDialogContent.vue'
+const frontendVersion = window['__COMFYUI_FRONTEND_VERSION__']
 
+const dialogStore = useDialogStore()
 const showSetting = () => {
-  app.ui.settings.show()
+  dialogStore.showDialog({
+    title: `Settings (v${frontendVersion})`,
+    component: SettingDialogContent
+  })
 }
 </script>

--- a/src/scripts/ui/settings.ts
+++ b/src/scripts/ui/settings.ts
@@ -185,6 +185,9 @@ export class ComfySettingsDialog extends ComfyDialog<HTMLDialogElement> {
     }
 
     this.settingsParamLookup[id] = params
+    if (this.app.vueAppReady) {
+      useSettingStore().settings[id] = params
+    }
     this.settingsLookup[id] = {
       id,
       onChange,

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -2,7 +2,7 @@
 // Currently we need to bridge between legacy app code and Vue app with a Pinia store.
 
 import { defineStore } from 'pinia'
-import { Component } from 'vue'
+import { type Component, markRaw } from 'vue'
 
 interface DialogState {
   isVisible: boolean
@@ -26,7 +26,7 @@ export const useDialogStore = defineStore('dialog', {
       props?: Record<string, any>
     }) {
       this.title = options.title
-      this.component = options.component
+      this.component = markRaw(options.component)
       this.props = options.props || {}
       this.isVisible = true
     },

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -9,15 +9,18 @@
 
 import { app } from '@/scripts/app'
 import { ComfySettingsDialog } from '@/scripts/ui/settings'
+import { SettingParams } from '@/types/settingTypes'
 import { defineStore } from 'pinia'
 
 interface State {
   settingValues: Record<string, any>
+  settings: Record<string, SettingParams>
 }
 
 export const useSettingStore = defineStore('setting', {
   state: (): State => ({
-    settingValues: {}
+    settingValues: {},
+    settings: {}
   }),
   actions: {
     addSettings(settings: ComfySettingsDialog) {
@@ -25,6 +28,7 @@ export const useSettingStore = defineStore('setting', {
         const value = settings.getSettingValue(id)
         this.settingValues[id] = value
       }
+      this.settings = settings.settingsParamLookup
     },
 
     set(key: string, value: any) {


### PR DESCRIPTION
## Settings dialog in Vue

Note: the new settings dialog only triggers when you are in beta menu UI. If you are in default menu UI, clicking the cog icon still shows the old menu dialog.

![image](https://github.com/user-attachments/assets/80058529-a99f-4ef3-b298-c980a50d7a77)
![image](https://github.com/user-attachments/assets/7df87877-8021-4c36-843c-3508a930a652)

Dialog with some custom nodes enable
![image](https://github.com/user-attachments/assets/a5b9dbff-c788-4749-9b31-eefa146e8b5c)

## Next step

Categorize setting items