### PR TITLE
Categorize setting items

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -12,7 +12,11 @@
     @unmaximize="maximized = false"
   >
     <template #header>
-      <h3>{{ dialogStore.title || ' ' }}</h3>
+      <component
+        v-if="dialogStore.headerComponent"
+        :is="dialogStore.headerComponent"
+      />
+      <h3 v-else>{{ dialogStore.title || ' ' }}</h3>
     </template>
 
     <component

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -51,6 +51,5 @@ const activeCategory = ref<SettingTreeNode | null>(null)
 
 onMounted(() => {
   activeCategory.value = categories.value[0]
-  console.log('activeCategory', activeCategory.value)
 })
 </script>

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -67,7 +67,7 @@ onMounted(() => {
 <style>
 /* Remove after we have tailwind setup */
 .border-none {
-  border: none;
+  border: none !important;
 }
 </style>
 

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -1,237 +1,56 @@
 <template>
   <div class="settings-container">
     <div class="settings-sidebar">
-      <Menu :model="topLevelCategories" />
+      <Listbox
+        v-model="activeCategory"
+        :options="categories"
+        optionLabel="label"
+      />
     </div>
-    <div class="settings-content">
-      <TabView v-model:activeIndex="activeCategory">
-        <TabPanel v-for="(category, index) in categories" :key="index">
-          <template #header>
-            <span class="sr-only">{{ category.label }}</span>
-          </template>
-          <div
-            v-for="group in category.items"
-            :key="group.label"
-            class="setting-group"
+    <div class="settings-content" v-if="activeCategory">
+      <Tabs :value="activeCategory.label">
+        <TabPanels>
+          <TabPanel
+            v-for="category in categories"
+            :key="category.key"
+            :value="category.label"
           >
-            <Card>
-              <template #title>
-                <h3>{{ group.label }}</h3>
-              </template>
-              <template #content>
-                <div
-                  v-for="setting in group.settings"
-                  :key="setting.id"
-                  class="setting-item"
-                >
-                  <div class="setting-label">
-                    <span>{{ setting.name }}</span>
-                    <Chip
-                      v-if="setting.tooltip"
-                      icon="pi pi-info-circle"
-                      severity="secondary"
-                      v-tooltip="setting.tooltip"
-                      class="info-chip"
-                    />
-                  </div>
-                  <div class="setting-input">
-                    <component
-                      :is="markRaw(getSettingComponent(setting))"
-                      :id="setting.id"
-                      :modelValue="settingStore.get(setting.id)"
-                      @update:modelValue="updateSetting(setting, $event)"
-                      v-bind="getSettingAttrs(setting)"
-                    />
-                  </div>
-                </div>
-              </template>
-            </Card>
-          </div>
-        </TabPanel>
-      </TabView>
+            <SettingGroup
+              v-for="group in category.children"
+              :key="group.label"
+              :group="{
+                label: group.label,
+                settings: flattenTree<SettingParams>(group)
+              }"
+            />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, markRaw, type Component } from 'vue'
-import Menu from 'primevue/menu'
-import TabView from 'primevue/tabview'
+import { ref, computed, onMounted } from 'vue'
+import Listbox from 'primevue/listbox'
+import Tabs from 'primevue/tabs'
+import TabPanels from 'primevue/tabpanels'
 import TabPanel from 'primevue/tabpanel'
-import Card from 'primevue/card'
-import InputText from 'primevue/inputtext'
-import InputNumber from 'primevue/inputnumber'
-import Select from 'primevue/select'
-import Chip from 'primevue/chip'
-import ToggleSwitch from 'primevue/toggleswitch'
-import { useSettingStore } from '@/stores/settingStore'
+import { SettingTreeNode, useSettingStore } from '@/stores/settingStore'
 import { SettingParams } from '@/types/settingTypes'
-import CustomSettingValue from '@/components/dialog/content/setting/CustomSettingValue.vue'
-import InputSlider from '@/components/dialog/content/setting/InputSlider.vue'
+import SettingGroup from './setting/SettingGroup.vue'
+import { flattenTree } from '@/utils/treeUtil'
 
 const settingStore = useSettingStore()
-const activeCategory = ref(0)
+const settingRoot = computed<SettingTreeNode>(() => settingStore.settingTree)
+const categories = computed<SettingTreeNode[]>(
+  () => settingRoot.value.children || []
+)
 
-const categories = computed(() => {
-  const categorizedSettings = {} as Record<string, SettingParams[]>
+const activeCategory = ref<SettingTreeNode | null>(null)
 
-  Object.values(settingStore.settings)
-    .filter((setting: SettingParams) => setting.type !== 'hidden')
-    .forEach((setting) => {
-      const category = setting.id.split('.')[0]
-      if (!categorizedSettings[category]) {
-        categorizedSettings[category] = []
-      }
-      categorizedSettings[category].push(setting)
-    })
-
-  return Object.entries(categorizedSettings).map(([category, settings]) => ({
-    label: category,
-    items: groupSettingsBySubcategory(settings)
-  }))
+onMounted(() => {
+  activeCategory.value = categories.value[0]
+  console.log('activeCategory', activeCategory.value)
 })
-
-const topLevelCategories = computed(() => {
-  return categories.value.map((category) => ({
-    label: category.label,
-    command: () => {
-      activeCategory.value = categories.value.findIndex(
-        (c) => c.label === category.label
-      )
-    }
-  }))
-})
-
-function groupSettingsBySubcategory(settings: SettingParams[]) {
-  const groups = {} as Record<string, SettingParams[]>
-  settings.forEach((setting) => {
-    const [, subcategory] = setting.id.split('.')
-    if (!groups[subcategory]) {
-      groups[subcategory] = []
-    }
-    groups[subcategory].push(setting)
-  })
-  return Object.entries(groups).map(([label, settings]) => ({
-    label,
-    settings
-  }))
-}
-
-function getSettingAttrs(setting: SettingParams) {
-  const attrs = { ...(setting.attrs || {}) }
-  const settingType = setting.type
-  if (typeof settingType === 'function') {
-    attrs['renderFunction'] = () =>
-      settingType(
-        setting.name,
-        (v) => updateSetting(setting, v),
-        settingStore.get(setting.id),
-        setting.attrs
-      )
-  }
-  switch (setting.type) {
-    case 'combo':
-      attrs['options'] = setting.options
-      if (typeof setting.options[0] !== 'string') {
-        attrs['optionLabel'] = 'text'
-        attrs['optionValue'] = 'value'
-      }
-      break
-  }
-  attrs['class'] += ' comfy-vue-setting-input'
-  return attrs
-}
-
-function getSettingComponent(setting: SettingParams): Component {
-  if (typeof setting.type === 'function') {
-    return CustomSettingValue
-  }
-  switch (setting.type) {
-    case 'boolean':
-      return ToggleSwitch
-    case 'number':
-      return InputNumber
-    case 'slider':
-      return InputSlider
-    case 'combo':
-      return Select
-    default:
-      return InputText
-  }
-}
-
-const updateSetting = (setting: SettingParams, value: any) => {
-  if (setting.onChange) setting.onChange(value, settingStore.get(setting.id))
-  settingStore.set(setting.id, value)
-}
 </script>
-
-<style scoped>
-.settings-container {
-  display: flex;
-  height: 100%;
-}
-
-.settings-sidebar {
-  width: 200px;
-  border-right: 1px solid var(--surface-border);
-}
-
-.settings-content {
-  flex: 1;
-  padding: 1rem;
-}
-
-.setting-group {
-  margin-bottom: 2rem;
-}
-
-.setting-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.setting-label {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex: 1;
-}
-
-.setting-input {
-  width: 60%;
-  display: flex;
-  justify-content: flex-end;
-}
-
-.info-chip {
-  background: transparent !important;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
-:deep(.p-card) {
-  margin-bottom: 1rem;
-}
-
-:deep(.p-card-title) {
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--surface-border);
-}
-
-:deep(.p-card-content) {
-  padding-top: 1rem;
-}
-</style>

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -5,8 +5,11 @@
         v-model="activeCategory"
         :options="categories"
         optionLabel="label"
+        scrollHeight="100%"
+        :pt="{ root: { class: 'border-none' } }"
       />
     </div>
+    <Divider layout="vertical" />
     <div class="settings-content" v-if="activeCategory">
       <Tabs :value="activeCategory.label">
         <TabPanels>
@@ -31,11 +34,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import Listbox from 'primevue/listbox'
 import Tabs from 'primevue/tabs'
 import TabPanels from 'primevue/tabpanels'
 import TabPanel from 'primevue/tabpanel'
+import Divider from 'primevue/divider'
 import { SettingTreeNode, useSettingStore } from '@/stores/settingStore'
 import { SettingParams } from '@/types/settingTypes'
 import SettingGroup from './setting/SettingGroup.vue'
@@ -49,7 +53,60 @@ const categories = computed<SettingTreeNode[]>(
 
 const activeCategory = ref<SettingTreeNode | null>(null)
 
+watch(activeCategory, (newCategory, oldCategory) => {
+  if (newCategory === null) {
+    activeCategory.value = oldCategory
+  }
+})
+
 onMounted(() => {
   activeCategory.value = categories.value[0]
 })
 </script>
+
+<style>
+/* Remove after we have tailwind setup */
+.border-none {
+  border: none;
+}
+</style>
+
+<style scoped>
+.settings-container {
+  display: flex;
+  height: 80vh;
+  width: 60vw;
+  max-width: 1000px;
+  overflow: hidden;
+  /* Prevents container from scrolling */
+}
+
+.settings-sidebar {
+  width: 250px;
+  flex-shrink: 0; /* Prevents sidebar from shrinking */
+  overflow-y: auto;
+  padding: 10px;
+}
+
+.settings-content {
+  flex-grow: 1;
+  overflow-y: auto;
+  /* Allows vertical scrolling */
+}
+
+/* Ensure the Listbox takes full width of the sidebar */
+.settings-sidebar :deep(.p-listbox) {
+  width: 100%;
+}
+
+/* Optional: Style scrollbars for webkit browsers */
+.settings-sidebar::-webkit-scrollbar,
+.settings-content::-webkit-scrollbar {
+  width: 1px;
+}
+
+.settings-sidebar::-webkit-scrollbar-thumb,
+.settings-content::-webkit-scrollbar-thumb {
+  background-color: transparent;
+}
+</style>

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -19,7 +19,7 @@
             :value="category.label"
           >
             <SettingGroup
-              v-for="group in category.children"
+              v-for="group in sortedGroups(category)"
               :key="group.label"
               :group="{
                 label: group.label,
@@ -62,6 +62,12 @@ watch(activeCategory, (newCategory, oldCategory) => {
 onMounted(() => {
   activeCategory.value = categories.value[0]
 })
+
+const sortedGroups = (category: SettingTreeNode) => {
+  return [...(category.children || [])].sort((a, b) =>
+    a.label.localeCompare(b.label)
+  )
+}
 </script>
 
 <style>
@@ -83,7 +89,8 @@ onMounted(() => {
 
 .settings-sidebar {
   width: 250px;
-  flex-shrink: 0; /* Prevents sidebar from shrinking */
+  flex-shrink: 0;
+  /* Prevents sidebar from shrinking */
   overflow-y: auto;
   padding: 10px;
 }

--- a/src/components/dialog/content/setting/InputSlider.vue
+++ b/src/components/dialog/content/setting/InputSlider.vue
@@ -20,7 +20,7 @@
 import InputText from 'primevue/inputtext'
 import Slider from 'primevue/slider'
 
-const props = defineProps<{
+defineProps<{
   modelValue: number
   inputClass?: string
   sliderClass?: string
@@ -44,7 +44,6 @@ const updateValue = (newValue: string | number) => {
   display: flex;
   align-items: center;
   gap: 1rem;
-  /* Adjust this value to control space between slider and input */
 }
 
 .slider-part {
@@ -52,7 +51,6 @@ const updateValue = (newValue: string | number) => {
 }
 
 .input-part {
-  width: 5rem;
-  /* Adjust this value to control input width */
+  width: 5rem !important;
 }
 </style>

--- a/src/components/dialog/content/setting/InputSlider.vue
+++ b/src/components/dialog/content/setting/InputSlider.vue
@@ -5,37 +5,68 @@
       @update:modelValue="updateValue"
       class="slider-part"
       :class="sliderClass"
-      v-bind="$attrs"
+      :min="min"
+      :max="max"
+      :step="step"
     />
-    <InputText
-      :value="modelValue"
-      @input="updateValue"
+    <InputNumber
+      :modelValue="modelValue"
+      @update:modelValue="updateValue"
       class="input-part"
       :class="inputClass"
+      :min="min"
+      :max="max"
+      :step="step"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import InputText from 'primevue/inputtext'
+import { ref, watch } from 'vue'
+import InputNumber from 'primevue/inputnumber'
 import Slider from 'primevue/slider'
 
-defineProps<{
+const props = defineProps<{
   modelValue: number
   inputClass?: string
   sliderClass?: string
+  min?: number
+  max?: number
+  step?: number
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: number): void
 }>()
 
-const updateValue = (newValue: string | number) => {
-  const numValue =
-    typeof newValue === 'string' ? parseFloat(newValue) : newValue
-  if (!isNaN(numValue)) {
-    emit('update:modelValue', numValue)
+const localValue = ref(props.modelValue)
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    localValue.value = newValue
   }
+)
+
+const updateValue = (newValue: number | null) => {
+  if (newValue === null) {
+    // If the input is cleared, reset to the minimum value or 0
+    newValue = Number(props.min) || 0
+  }
+
+  const min = Number(props.min) || Number.NEGATIVE_INFINITY
+  const max = Number(props.max) || Number.POSITIVE_INFINITY
+  const step = Number(props.step) || 1
+
+  // Ensure the value is within the allowed range
+  newValue = Math.max(min, Math.min(max, newValue))
+
+  // Round to the nearest step
+  newValue = Math.round(newValue / step) * step
+
+  // Update local value and emit change
+  localValue.value = newValue
+  emit('update:modelValue', newValue)
 }
 </script>
 

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -37,12 +37,11 @@ import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import Select from 'primevue/select'
 import ToggleSwitch from 'primevue/toggleswitch'
-import Chip from 'primevue/chip'
 import Divider from 'primevue/divider'
 import CustomSettingValue from '@/components/dialog/content/setting/CustomSettingValue.vue'
 import InputSlider from '@/components/dialog/content/setting/InputSlider.vue'
 
-const props = defineProps<{
+defineProps<{
   group: {
     label: string
     settings: SettingParams[]

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -1,0 +1,100 @@
+<!-- A single setting item -->
+<template>
+  <div class="setting-group">
+    <h3>{{ group.label }}</h3>
+    <div
+      v-for="setting in group.settings"
+      :key="setting.id"
+      class="setting-item"
+    >
+      <div class="setting-label">
+        <span>{{ setting.name }}</span>
+        <Chip
+          v-if="setting.tooltip"
+          icon="pi pi-info-circle"
+          severity="secondary"
+          v-tooltip="setting.tooltip"
+          class="info-chip"
+        />
+      </div>
+      <div class="setting-input">
+        <component
+          :is="markRaw(getSettingComponent(setting))"
+          :id="setting.id"
+          :modelValue="settingStore.get(setting.id)"
+          @update:modelValue="updateSetting(setting, $event)"
+          v-bind="getSettingAttrs(setting)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useSettingStore } from '@/stores/settingStore'
+import { SettingParams } from '@/types/settingTypes'
+import { markRaw, type Component } from 'vue'
+import InputText from 'primevue/inputtext'
+import InputNumber from 'primevue/inputnumber'
+import Select from 'primevue/select'
+import ToggleSwitch from 'primevue/toggleswitch'
+import Chip from 'primevue/chip'
+import CustomSettingValue from '@/components/dialog/content/setting/CustomSettingValue.vue'
+import InputSlider from '@/components/dialog/content/setting/InputSlider.vue'
+
+const props = defineProps<{
+  group: {
+    label: string
+    settings: SettingParams[]
+  }
+}>()
+
+const settingStore = useSettingStore()
+
+function getSettingAttrs(setting: SettingParams) {
+  const attrs = { ...(setting.attrs || {}) }
+  const settingType = setting.type
+  if (typeof settingType === 'function') {
+    attrs['renderFunction'] = () =>
+      settingType(
+        setting.name,
+        (v) => updateSetting(setting, v),
+        settingStore.get(setting.id),
+        setting.attrs
+      )
+  }
+  switch (setting.type) {
+    case 'combo':
+      attrs['options'] = setting.options
+      if (typeof setting.options[0] !== 'string') {
+        attrs['optionLabel'] = 'text'
+        attrs['optionValue'] = 'value'
+      }
+      break
+  }
+  return attrs
+}
+
+const updateSetting = (setting: SettingParams, value: any) => {
+  if (setting.onChange) setting.onChange(value, settingStore.get(setting.id))
+  settingStore.set(setting.id, value)
+}
+
+function getSettingComponent(setting: SettingParams): Component {
+  if (typeof setting.type === 'function') {
+    return CustomSettingValue
+  }
+  switch (setting.type) {
+    case 'boolean':
+      return ToggleSwitch
+    case 'number':
+      return InputNumber
+    case 'slider':
+      return InputSlider
+    case 'combo':
+      return Select
+    default:
+      return InputText
+  }
+}
+</script>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -8,14 +8,13 @@
       class="setting-item"
     >
       <div class="setting-label">
-        <span>{{ setting.name }}</span>
-        <Chip
-          v-if="setting.tooltip"
-          icon="pi pi-info-circle"
-          severity="secondary"
-          v-tooltip="setting.tooltip"
-          class="info-chip"
-        />
+        <span
+          >{{ setting.name }}
+          <i
+            v-if="setting.tooltip"
+            class="pi pi-info-circle info-chip"
+            v-tooltip="setting.tooltip"
+        /></span>
       </div>
       <div class="setting-input">
         <component

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -1,6 +1,6 @@
-<!-- A single setting item -->
 <template>
   <div class="setting-group">
+    <Divider />
     <h3>{{ group.label }}</h3>
     <div
       v-for="setting in group.settings"
@@ -39,6 +39,7 @@ import InputNumber from 'primevue/inputnumber'
 import Select from 'primevue/select'
 import ToggleSwitch from 'primevue/toggleswitch'
 import Chip from 'primevue/chip'
+import Divider from 'primevue/divider'
 import CustomSettingValue from '@/components/dialog/content/setting/CustomSettingValue.vue'
 import InputSlider from '@/components/dialog/content/setting/InputSlider.vue'
 
@@ -98,3 +99,46 @@ function getSettingComponent(setting: SettingParams): Component {
   }
 }
 </script>
+
+<style scoped>
+.info-chip {
+  background: transparent;
+}
+
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.setting-label {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.setting-input {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Ensure PrimeVue components take full width of their container */
+.setting-input :deep(.p-inputtext),
+.setting-input :deep(.input-slider),
+.setting-input :deep(.p-select),
+.setting-input :deep(.p-togglebutton) {
+  width: 100%;
+  max-width: 200px;
+}
+
+.setting-input :deep(.p-inputtext) {
+  max-width: unset;
+}
+
+/* Special case for ToggleSwitch to align it to the right */
+.setting-input :deep(.p-toggleswitch) {
+  margin-left: auto;
+}
+</style>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -134,6 +134,7 @@ function getSettingComponent(setting: SettingParams): Component {
 }
 
 .setting-input :deep(.p-inputtext) {
+  margin-left: 1rem;
   max-width: unset;
 }
 

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -122,6 +122,7 @@ function getSettingComponent(setting: SettingParams): Component {
   flex: 1;
   display: flex;
   justify-content: flex-end;
+  margin-left: 1rem;
 }
 
 /* Ensure PrimeVue components take full width of their container */
@@ -134,7 +135,6 @@ function getSettingComponent(setting: SettingParams): Component {
 }
 
 .setting-input :deep(.p-inputtext) {
-  margin-left: 1rem;
   max-width: unset;
 }
 

--- a/src/components/dialog/header/SettingDialogHeader.vue
+++ b/src/components/dialog/header/SettingDialogHeader.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <h2>
+      <i class="pi pi-cog"></i>
+      <span>Settings</span>
+      <Tag :value="frontendVersion" severity="secondary" class="version-tag" />
+    </h2>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Tag from 'primevue/tag'
+const frontendVersion = 'v' + window['__COMFYUI_FRONTEND_VERSION__']
+</script>
+
+<style scoped>
+.pi-cog {
+  font-size: 1.25rem;
+  margin-right: 0.5rem;
+}
+.version-tag {
+  margin-left: 0.5rem;
+}
+</style>

--- a/src/components/sidebar/SideBarSettingsToggleIcon.vue
+++ b/src/components/sidebar/SideBarSettingsToggleIcon.vue
@@ -10,12 +10,12 @@
 import SideBarIcon from './SideBarIcon.vue'
 import { useDialogStore } from '@/stores/dialogStore'
 import SettingDialogContent from '@/components/dialog/content/SettingDialogContent.vue'
-const frontendVersion = window['__COMFYUI_FRONTEND_VERSION__']
+import SettingDialogHeader from '@/components/dialog/header/SettingDialogHeader.vue'
 
 const dialogStore = useDialogStore()
 const showSetting = () => {
   dialogStore.showDialog({
-    title: `Settings (v${frontendVersion})`,
+    headerComponent: SettingDialogHeader,
     component: SettingDialogContent
   })
 }

--- a/src/scripts/ui/dialog.ts
+++ b/src/scripts/ui/dialog.ts
@@ -1,3 +1,4 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { $el } from '../ui'
 
 export class ComfyDialog<

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -7,6 +7,7 @@ import { type Component, markRaw } from 'vue'
 interface DialogState {
   isVisible: boolean
   title: string
+  headerComponent: Component | null
   component: Component | null
   props: Record<string, any>
 }
@@ -15,6 +16,7 @@ export const useDialogStore = defineStore('dialog', {
   state: (): DialogState => ({
     isVisible: false,
     title: '',
+    headerComponent: null,
     component: null,
     props: {}
   }),
@@ -22,10 +24,12 @@ export const useDialogStore = defineStore('dialog', {
   actions: {
     showDialog(options: {
       title?: string
+      headerComponent?: Component
       component: Component
       props?: Record<string, any>
     }) {
       this.title = options.title
+      this.headerComponent = markRaw(options.headerComponent)
       this.component = markRaw(options.component)
       this.props = options.props || {}
       this.isVisible = true

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -10,7 +10,13 @@
 import { app } from '@/scripts/app'
 import { ComfySettingsDialog } from '@/scripts/ui/settings'
 import { SettingParams } from '@/types/settingTypes'
+import { buildTree } from '@/utils/treeUtil'
 import { defineStore } from 'pinia'
+import type { TreeNode } from 'primevue/treenode'
+
+export interface SettingTreeNode extends TreeNode {
+  data?: SettingParams
+}
 
 interface State {
   settingValues: Record<string, any>
@@ -22,6 +28,13 @@ export const useSettingStore = defineStore('setting', {
     settingValues: {},
     settings: {}
   }),
+  getters: {
+    settingTree(): SettingTreeNode {
+      return buildTree(Object.values(this.settings), (setting: SettingParams) =>
+        setting.id.split('.')
+      )
+    }
+  },
   actions: {
     addSettings(settings: ComfySettingsDialog) {
       for (const id in settings.settingsLookup) {

--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -1,0 +1,49 @@
+import type { TreeNode } from 'primevue/treenode'
+
+export function buildTree<T>(
+  items: T[],
+  key: string | ((item: T) => string[])
+): TreeNode {
+  const root: TreeNode = {
+    key: 'root',
+    label: 'root',
+    children: []
+  }
+
+  const map: Record<string, TreeNode> = {
+    root: root
+  }
+
+  for (const item of items) {
+    const keys = typeof key === 'string' ? item[key] : key(item)
+    let parent = root
+    for (const k of keys) {
+      const id = parent.key + '/' + k
+      if (!map[id]) {
+        const node: TreeNode = {
+          key: id,
+          label: k,
+          leaf: false,
+          children: []
+        }
+        map[id] = node
+        parent.children.push(node)
+      }
+      parent = map[id]
+    }
+    parent.leaf = true
+    parent.data = item
+  }
+  return root
+}
+
+export function flattenTree<T>(tree: TreeNode): T[] {
+  const result: T[] = []
+  const stack: TreeNode[] = [tree]
+  while (stack.length) {
+    const node = stack.pop()!
+    if (node.leaf && node.data) result.push(node.data)
+    stack.push(...(node.children || []))
+  }
+  return result
+}


### PR DESCRIPTION
Setting ids are generally following the convention of `A.B.C` format in ComfyUI, so we utilize the id info for categorization. Now the setting id is devided into 3 parts: `{Category name}.{Group name}.{Rest of keys}`

Do note that we don't prevent custom node registering settings under `Comfy` category now, so the category might be a little bit misleading if some custom nodes are intentionally trying to disguise users.

![image](https://github.com/user-attachments/assets/346fad29-3bbf-45ef-90fb-7f80281c7b60)
