### PR TITLE
Assign default category Others

### DIFF
--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -30,9 +30,23 @@ export const useSettingStore = defineStore('setting', {
   }),
   getters: {
     settingTree(): SettingTreeNode {
-      return buildTree(Object.values(this.settings), (setting: SettingParams) =>
-        setting.id.split('.')
+      const root = buildTree(
+        Object.values(this.settings),
+        (setting: SettingParams) => setting.id.split('.')
       )
+
+      const floatingSettings = root.children.filter((node) => node.leaf)
+      if (floatingSettings.length) {
+        root.children = root.children.filter((node) => !node.leaf)
+        root.children.push({
+          key: 'Others',
+          label: 'Others',
+          leaf: false,
+          children: floatingSettings
+        })
+      }
+
+      return root
     }
   },
   actions: {

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -39,8 +39,8 @@ export const useSettingStore = defineStore('setting', {
       if (floatingSettings.length) {
         root.children = root.children.filter((node) => !node.leaf)
         root.children.push({
-          key: 'Others',
-          label: 'Others',
+          key: 'Other',
+          label: 'Other',
           leaf: false,
           children: floatingSettings
         })


### PR DESCRIPTION
If an extension adds a setting with id `Random Name` that does not contain '.', automatically assigns it to `Others` category.

![image](https://github.com/user-attachments/assets/c87c41da-874b-4589-9403-687a9c1decac)
