### PR TITLE
link release pops up searchbox by default

### DIFF
--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -27,6 +27,9 @@ test.describe('Node Interaction', () => {
 
   test('Can disconnect/connect edge', async ({ comfyPage }) => {
     await comfyPage.disconnectEdge()
+    // Close search menu poped up.
+    await comfyPage.page.keyboard.press('Escape')
+    await comfyPage.nextFrame()
     await expect(comfyPage.canvas).toHaveScreenshot(
       'disconnected-edge-with-menu.png'
     )

--- a/browser_tests/nodeSearchBox.spec.ts
+++ b/browser_tests/nodeSearchBox.spec.ts
@@ -36,8 +36,10 @@ test.describe('Node search box', () => {
       x: 5,
       y: 5
     }
-
+    await comfyPage.page.keyboard.down('Shift')
     await comfyPage.dragAndDrop(outputSlot1Pos, emptySpacePos)
+    await comfyPage.page.keyboard.up('Shift')
+
     await comfyPage.searchBox.fillAndSelectFirstNode('Load Checkpoint')
     await expect(comfyPage.canvas).toHaveScreenshot(
       'auto-linked-node-batch.png'

--- a/browser_tests/nodeSearchBox.spec.ts
+++ b/browser_tests/nodeSearchBox.spec.ts
@@ -8,14 +8,8 @@ test.describe('Node search box', () => {
   })
 
   test('Can trigger on link release', async ({ comfyPage }) => {
-    await comfyPage.page.keyboard.down('Shift')
     await comfyPage.disconnectEdge()
     await expect(comfyPage.searchBox.input).toHaveCount(1)
-  })
-
-  test('Does not trigger on link release (no shift)', async ({ comfyPage }) => {
-    await comfyPage.disconnectEdge()
-    await expect(comfyPage.searchBox.input).toHaveCount(0)
   })
 
   test('Can add node', async ({ comfyPage }) => {
@@ -26,9 +20,7 @@ test.describe('Node search box', () => {
   })
 
   test('Can auto link node', async ({ comfyPage }) => {
-    await comfyPage.page.keyboard.down('Shift')
     await comfyPage.disconnectEdge()
-    await comfyPage.page.keyboard.up('Shift')
     await comfyPage.searchBox.fillAndSelectFirstNode('CLIPTextEncode')
     await expect(comfyPage.canvas).toHaveScreenshot('auto-linked-node.png')
   })
@@ -45,10 +37,7 @@ test.describe('Node search box', () => {
       y: 5
     }
 
-    await comfyPage.page.keyboard.down('Shift')
     await comfyPage.dragAndDrop(outputSlot1Pos, emptySpacePos)
-    await comfyPage.page.keyboard.up('Shift')
-
     await comfyPage.searchBox.fillAndSelectFirstNode('Load Checkpoint')
     await expect(comfyPage.canvas).toHaveScreenshot(
       'auto-linked-node-batch.png'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      timeout: 5000
+      timeout: 15000
     }
 
     // {

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -48,6 +48,7 @@ watch(
   nodeSearchEnabled,
   (newVal) => {
     LiteGraph.release_link_on_empty_shows_menu = !newVal
+    if (comfyApp.canvas) comfyApp.canvas.allow_searchbox = !newVal
   },
   { immediate: true }
 )
@@ -70,6 +71,7 @@ onMounted(async () => {
 
   workspaceStore.spinner = true
   await comfyApp.setup(canvasRef.value)
+  comfyApp.canvas.allow_searchbox = !nodeSearchEnabled.value
   workspaceStore.spinner = false
 
   window['app'] = comfyApp

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -44,9 +44,13 @@ const betaMenuEnabled = computed(
 const nodeSearchEnabled = computed<boolean>(
   () => settingStore.get('Comfy.NodeSearchBoxImpl') === 'default'
 )
-watch(nodeSearchEnabled, (newVal) => {
-  if (comfyApp.canvas) comfyApp.canvas.allow_searchbox = !newVal
-})
+watch(
+  nodeSearchEnabled,
+  (newVal) => {
+    LiteGraph.release_link_on_empty_shows_menu = !newVal
+  },
+  { immediate: true }
+)
 
 let dropTargetCleanup = () => {}
 
@@ -66,7 +70,6 @@ onMounted(async () => {
 
   workspaceStore.spinner = true
   await comfyApp.setup(canvasRef.value)
-  comfyApp.canvas.allow_searchbox = !nodeSearchEnabled.value
   workspaceStore.spinner = false
 
   window['app'] = comfyApp

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -29,6 +29,7 @@ import { LiteGraphCanvasEvent, ConnectingLink } from '@comfyorg/litegraph'
 import { FilterAndValue } from '@/services/nodeSearchService'
 import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 import { ConnectingLinkImpl } from '@/types/litegraphTypes'
+import { LiteGraph } from '@comfyorg/litegraph'
 
 interface LiteGraphPointerEvent extends Event {
   canvasX: number
@@ -83,13 +84,6 @@ const addNode = (nodeDef: ComfyNodeDefImpl) => {
 }
 
 const canvasEventHandler = (e: LiteGraphCanvasEvent) => {
-  const shiftPressed = (e.detail.originalEvent as KeyboardEvent).shiftKey
-  // Ignore empty releases unless shift is pressed
-  // Empty release without shift is trigger right click menu
-  if (e.detail.subType === 'empty-release' && !shiftPressed) {
-    return
-  }
-
   if (e.detail.subType === 'empty-release') {
     const context = e.detail.linkReleaseContext
     if (context.links.length === 0) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1875,7 +1875,6 @@ export class ComfyApp {
     this.canvas = new LGraphCanvas(canvasEl, this.graph)
     this.ctx = canvasEl.getContext('2d')
 
-    LiteGraph.release_link_on_empty_shows_menu = true
     LiteGraph.alt_drag_do_clone_nodes = true
 
     this.graph.start()


### PR DESCRIPTION
We have a few users complaining that the search is not triggered by default when releasing link without holding shift.
- https://github.com/comfyanonymous/ComfyUI/issues/4169#issuecomment-2275929186
- https://github.com/comfyanonymous/ComfyUI/issues/4169#issuecomment-2276059139

This PR makes the searchbox becomes the default behavior on link release.