### PR TITLE
Make workflow group color optional

### DIFF
--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -82,7 +82,7 @@ const zGroup = z
   .object({
     title: z.string(),
     bounding: z.tuple([z.number(), z.number(), z.number(), z.number()]),
-    color: z.string(),
+    color: z.string().optional(),
     font_size: z.number().optional(),
     locked: z.boolean().optional()
   })


### PR DESCRIPTION
In some legacy workflows, the color field is not populated. Mark the field as optional to be compatible with these workflows.

![image](https://github.com/user-attachments/assets/7815996a-1e63-494c-9244-cc2f5d9f857b)
