### PR TITLE
Allow skipping workflow validation

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -44,6 +44,7 @@ import {
 import { Vector2 } from '@comfyorg/litegraph'
 import _ from 'lodash'
 import { showLoadWorkflowWarning } from '@/services/dialogService'
+import { useSettingStore } from '@/stores/settingStore'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
@@ -2178,8 +2179,13 @@ export class ComfyApp {
       console.error(error)
     }
 
-    graphData = await validateComfyWorkflow(graphData, /* onError=*/ alert)
-    if (!graphData) return
+    if (
+      this.vueAppReady &&
+      useSettingStore().get<boolean>('Comfy.Validation.Workflows')
+    ) {
+      graphData = await validateComfyWorkflow(graphData, /* onError=*/ alert)
+      if (!graphData) return
+    }
 
     const missingNodeTypes = []
     await this.#invokeExtensionsAsync(

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -56,6 +56,13 @@ export const useSettingStore = defineStore('setting', {
         this.settingValues[id] = value
       }
       this.settings = settings.settingsParamLookup
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.Validation.Workflows',
+        name: 'Validate workflows',
+        type: 'boolean',
+        defaultValue: true
+      })
     },
 
     set(key: string, value: any) {


### PR DESCRIPTION
Some legacy workflows is having trouble loading due to custom nodes overwriting node input type to non-string values. Offer an setting option to turn off workflow validation for backward compatibility.

![image](https://github.com/user-attachments/assets/73e01fff-7997-499e-84b5-6b1af45a4ca4)

We are not offering the option to turn off node validation as we expect people to always use latest version of node packs and it's node author's responsibility to provide correct node definition.
