### PR TITLE
Add link release searchbox trigger mode

### DIFF
--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -425,14 +425,6 @@ export class ComfyUI {
     })
 
     this.settings.addSetting({
-      id: 'Comfy.NodeSearchBoxImpl',
-      name: 'Node Search box implementation',
-      type: 'combo',
-      options: ['default', 'litegraph (legacy)'],
-      defaultValue: 'default'
-    })
-
-    this.settings.addSetting({
       id: 'Comfy.EnableTooltips',
       name: 'Enable Tooltips',
       type: 'boolean',

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -9,6 +9,7 @@
 
 import { app } from '@/scripts/app'
 import { ComfySettingsDialog } from '@/scripts/ui/settings'
+import { LinkReleaseTriggerMode } from '@/types/searchBoxTypes'
 import { SettingParams } from '@/types/settingTypes'
 import { buildTree } from '@/utils/treeUtil'
 import { defineStore } from 'pinia'
@@ -62,6 +63,23 @@ export const useSettingStore = defineStore('setting', {
         name: 'Validate workflows',
         type: 'boolean',
         defaultValue: true
+      })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.NodeSearchBoxImpl',
+        name: 'Node Search box implementation',
+        type: 'combo',
+        options: ['default', 'litegraph (legacy)'],
+        defaultValue: 'default'
+      })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.NodeSearchBoxImpl.LinkReleaseTrigger',
+        name: 'Trigger on link release',
+        tooltip: 'Only applies to the default implementation',
+        type: 'combo',
+        options: Object.values(LinkReleaseTriggerMode),
+        defaultValue: LinkReleaseTriggerMode.ALWAYS
       })
     },
 

--- a/src/types/searchBoxTypes.ts
+++ b/src/types/searchBoxTypes.ts
@@ -1,0 +1,5 @@
+export enum LinkReleaseTriggerMode {
+  ALWAYS = 'always',
+  HOLD_SHIFT = 'hold shift',
+  NOT_HOLD_SHIFT = 'NOT hold shift'
+}


### PR DESCRIPTION
A recommendation from Jovix. We now allow user customize link release behavior.
- Hold shift: drop without holding shift simply disconnects the link
- NOT hold shift: drop holding shift simply disconnects the link
- Always: Alaways trigger the searchbox on link release
