### PR TITLE
Show category in node search box instead of description

### DIFF
--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -178,6 +178,7 @@ const truncateDefaultValue = (value: any, charLimit: number = 32): string => {
   font-style: italic;
   font-weight: 500;
   font-size: 0.9rem;
+  word-break: break-word;
 }
 
 ._sb_table {

--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -34,8 +34,8 @@
               :python_module="option.python_module"
             />
           </div>
-          <div v-if="option.description" class="option-description">
-            {{ option.description }}
+          <div class="option-category">
+            {{ option.category.replaceAll('/', ' > ') }}
           </div>
         </div>
       </template>
@@ -144,17 +144,11 @@ const setHoverSuggestion = (index: number) => {
   @apply flex flex-col px-4 py-2 cursor-pointer overflow-hidden w-full;
 }
 
-.option-container:hover .option-description {
-  @apply overflow-visible;
-  /* Allows text to wrap */
-  white-space: normal;
-}
-
 .option-display-name {
   @apply font-semibold;
 }
 
-.option-description {
+.option-category {
   @apply text-sm text-gray-400 overflow-hidden text-ellipsis;
   /* Keeps the text on a single line by default */
   white-space: nowrap;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f5fd9b7d-a2b2-44f4-9718-e16a821f29a0)

Since we already have description shown in the node preview, the description string in the search result item is reflaced by node category.