### PR TITLE
Attach DOM widgets to canvas container instead of document body

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -264,7 +264,7 @@ LGraphNode.prototype.addDOMWidget = function (
   options = { hideOnZoom: true, selectOn: ['focus', 'click'], ...options }
 
   if (!element.parentElement) {
-    document.body.append(element)
+    app.canvasContainer.append(element)
   }
   element.hidden = true
   element.style.display = 'none'
@@ -335,8 +335,8 @@ LGraphNode.prototype.addDOMWidget = function (
       Object.assign(element.style, {
         transformOrigin: '0 0',
         transform: scale,
-        left: `${transform.a + transform.e + elRect.left}px`,
-        top: `${transform.d + transform.f + elRect.top}px`,
+        left: `${transform.a + transform.e}px`,
+        top: `${transform.d + transform.f}px`,
         width: `${widgetWidth - margin * 2}px`,
         height: `${(widget.computedHeight ?? 50) - margin * 2}px`,
         position: 'absolute',


### PR DESCRIPTION
Previously the DOM widgets were attached to document body, which has introduces clipping problem for non-chromium browsers.

This PR fixes this by attaching DOM widgets to canvas container. Canvas container is the direct parent of the LiteGraph canvas, and they have the same size. The offset is no longer necessary as now canvas and DOM widgets are under the same parent.

Previously rect offset was added in https://github.com/comfyanonymous/ComfyUI/commit/90aebb6c868d713c3e6457d1474c53808cb5f6a2.

Before fix
![image](https://github.com/user-attachments/assets/39ad5756-dafc-46ac-bf36-06d007dc5d5c)


After fix
![image](https://github.com/user-attachments/assets/ac54925a-9399-4daf-b841-7cd41dbc3233)
