### PR TITLE
Minify build

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -105,7 +105,7 @@ export default defineConfig({
     comfyAPIPlugin(),
   ],
   build: {
-    minify: false,
+    minify: true,
     sourcemap: true,
     rollupOptions: {
       // Disabling tree-shaking


### PR DESCRIPTION
Reduces index.js from 3MB to 1.7MB. We are including source map for debugging purpose already. Source minification should not affect debugbility.

![image](https://github.com/user-attachments/assets/2399cffb-39d9-4c7a-b9fb-113329ee7fde)
