### PR TITLE
Update ws message schema on reconnecting

### DIFF
--- a/src/scripts/ui/menu/interruptButton.ts
+++ b/src/scripts/ui/menu/interruptButton.ts
@@ -16,7 +16,7 @@ export function getInteruptButton(visibility: string) {
   api.addEventListener(
     'status',
     ({ detail }: CustomEvent<StatusWsMessageStatus>) => {
-      const sz = detail.exec_info.queue_remaining
+      const sz = detail?.exec_info?.queue_remaining
       btn.enabled = sz > 0
     }
   )

--- a/src/scripts/ui/menu/queueButton.ts
+++ b/src/scripts/ui/menu/queueButton.ts
@@ -85,7 +85,7 @@ export class ComfyQueueButton {
     api.addEventListener(
       'status',
       ({ detail }: CustomEvent<StatusWsMessageStatus>) => {
-        this.#internalQueueSize = detail.exec_info.queue_remaining
+        this.#internalQueueSize = detail?.exec_info?.queue_remaining
         if (this.#internalQueueSize != null) {
           if (!this.#internalQueueSize && !app.lastExecutionError) {
             if (

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -214,7 +214,7 @@ export const useQueuePendingTaskCountStore = defineStore(
     }),
     actions: {
       update(e: CustomEvent<StatusWsMessageStatus>) {
-        this.count = e.detail.exec_info.queue_remaining
+        this.count = e.detail?.exec_info?.queue_remaining || 0
       }
     }
   }

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -13,15 +13,13 @@ const zImageResult = z.object({
 
 // WS messages
 const zStatusWsMessageStatus = z.object({
-  exec_info: z
-    .object({
-      queue_remaining: z.number().int().optional()
-    })
-    .optional()
+  exec_info: z.object({
+    queue_remaining: z.number().int()
+  })
 })
 
 const zStatusWsMessage = z.object({
-  status: zStatusWsMessageStatus
+  status: zStatusWsMessageStatus.nullable().optional()
 })
 
 const zProgressWsMessage = z.object({

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -13,9 +13,11 @@ const zImageResult = z.object({
 
 // WS messages
 const zStatusWsMessageStatus = z.object({
-  exec_info: z.object({
-    queue_remaining: z.number().int()
-  })
+  exec_info: z
+    .object({
+      queue_remaining: z.number().int().optional()
+    })
+    .optional()
 })
 
 const zStatusWsMessage = z.object({


### PR DESCRIPTION
On backend server stop, the last status message does not contain `exec_info`.