### PR TITLE
Add sidebar size setting (normal/small)

### DIFF
--- a/src/components/sidebar/SideToolBar.vue
+++ b/src/components/sidebar/SideToolBar.vue
@@ -1,6 +1,6 @@
 <template>
   <teleport :to="teleportTarget">
-    <nav class="side-tool-bar-container">
+    <nav :class="'side-tool-bar-container' + (isSmall ? ' small-sidebar' : '')">
       <SideBarIcon
         v-for="tab in tabs"
         :key="tab.id"
@@ -55,6 +55,10 @@ const teleportTarget = computed(() =>
     : '.comfyui-body-right'
 )
 
+const isSmall = computed(
+  () => settingStore.get('Comfy.SideBar.Size') === 'small'
+)
+
 const tabs = computed(() => workspaceStore.getSidebarTabs())
 const selectedTab = computed<SidebarTabExtension | null>(() => {
   const tabId = workspaceStore.activeSidebarTab
@@ -81,6 +85,10 @@ onBeforeUnmount(() => {
 :root {
   --sidebar-width: 64px;
   --sidebar-icon-size: 1.5rem;
+}
+:root .small-sidebar {
+  --sidebar-width: 40px;
+  --sidebar-icon-size: 1rem;
 }
 </style>
 

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -89,6 +89,14 @@ export const useSettingStore = defineStore('setting', {
         options: ['left', 'right'],
         defaultValue: 'left'
       })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.SideBar.Size',
+        name: 'Sidebar size',
+        type: 'combo',
+        options: ['normal', 'small'],
+        defaultValue: 'normal'
+      })
     },
 
     set(key: string, value: any) {

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -95,7 +95,7 @@ export const useSettingStore = defineStore('setting', {
         name: 'Sidebar size',
         type: 'combo',
         options: ['normal', 'small'],
-        defaultValue: 'normal'
+        defaultValue: window.innerWidth < 1600 ? 'small' : 'normal'
       })
     },
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/70194160-38b8-41ad-a4b4-fdce46328f5f)

![image](https://github.com/user-attachments/assets/ff81fb6a-857e-4f02-b48e-03aca0df8a7e)

Small screen users are complaining that side bar is taking too much screen space. This PR offers small side bar option.