### PR TITLE
Only report each unknown ws message type once

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -30,6 +30,8 @@ class ComfyApi extends EventTarget {
   socket?: WebSocket
   clientId?: string
 
+  reportedUnknownMessageTypes = new Set<string>()
+
   constructor() {
     super()
     this.api_host = location.host
@@ -206,7 +208,8 @@ class ComfyApi extends EventTarget {
                 this.dispatchEvent(
                   new CustomEvent(msg.type, { detail: msg.data })
                 )
-              } else {
+              } else if (!this.reportedUnknownMessageTypes.has(msg.type)) {
+                this.reportedUnknownMessageTypes.add(msg.type)
                 throw new Error(`Unknown message type ${msg.type}`)
               }
           }


### PR DESCRIPTION
When using dev server, the frontend custom node scripts are not loaded, while the backend still fires some extra ws events. This makes frontend browser repeatedly logging unhandled ws message warning. This PR makes that we only log the warning message once for each unknown message type.

![image](https://github.com/user-attachments/assets/90867d7b-b7a6-49d5-be14-801dd23cff5c)
