### PR TITLE
Perform text replacement for SaveAnimatedWEBP in addition to SaveImage

### DIFF
--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -5,7 +5,7 @@ import { applyTextReplacements } from '../../scripts/utils'
 app.registerExtension({
   name: 'Comfy.SaveImageExtraOutput',
   async beforeRegisterNodeDef(nodeType, nodeData, app) {
-    if (nodeData.name === 'SaveImage') {
+    if (nodeData.name === 'SaveImage' || nodeData.name === 'SaveAnimatedWEBP') {
       const onNodeCreated = nodeType.prototype.onNodeCreated
       // When the SaveImage node is created we want to override the serialization of the output name widget to run our S&R
       nodeType.prototype.onNodeCreated = function () {


### PR DESCRIPTION
- Perform text replacement for ``SaveAnimatedWEBP`` in addition to ``SaveImage``
    - https://blenderneko.github.io/ComfyUI-docs/Interface/SaveFileFormatting/
- Fix https://github.com/comfyanonymous/ComfyUI/issues/2565


(This is the transferred PR of https://github.com/comfyanonymous/ComfyUI/pull/4340. )