### PR TITLE
Don't cache API requests

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -54,6 +54,9 @@ class ComfyApi extends EventTarget {
     if (!options.headers) {
       options.headers = {}
     }
+    if (!options.cache) {
+        options.cache = 'no-cache'
+    }
     options.headers['Comfy-User'] = this.user
     return fetch(this.apiURL(route), options)
   }


### PR DESCRIPTION
API requests should by default never be cached. Can still manually specify caching is desired on a request via the options. Generally API requests expect up-to-date information, otherwise you wouldn't make the API request.

Should address #352
