### PR TITLE
Relax schema on node I/O link

### DIFF
--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -42,7 +42,7 @@ const zNodeOutput = z
   .object({
     name: z.string(),
     type: zDataType,
-    links: z.array(z.number()).nullable(),
+    links: z.array(z.number()).nullable().optional(),
     slot_index: zSlotIndex.optional()
   })
   .passthrough()
@@ -51,7 +51,7 @@ const zNodeInput = z
   .object({
     name: z.string(),
     type: zDataType,
-    link: z.number().nullable(),
+    link: z.number().nullable().optional(),
     slot_index: zSlotIndex.optional()
   })
   .passthrough()


### PR DESCRIPTION
It's reported that legacy workflows can have links undefined for node input and node output.