### PR TITLE
vite relative paths fix

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -88,6 +88,7 @@ function getModuleName(id: string): string {
 const DEV_SERVER_COMFYUI_URL = process.env.DEV_SERVER_COMFYUI_URL || 'http://127.0.0.1:8188';
 
 export default defineConfig({
+  base: '',
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
same idea as https://github.com/Comfy-Org/ComfyUI_frontend/pull/447 but tells vite's autogenerated files to use relative paths as well. This should suffice to make the new frontend completely compatible on non-root paths now.