### PR TITLE
[Experimental] hide/show logic improvement

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -227,9 +227,13 @@ LGraphCanvas.prototype.computeVisibleNodes = function (): LGraphNode[] {
       const hidden = visibleNodes.indexOf(node) === -1
       for (const w of node.widgets) {
         if (w.element) {
-          w.element.hidden = hidden
-          w.element.style.display = hidden ? 'none' : undefined
-          if (hidden) {
+          w.element.dataset.isInVisibleNodes = hidden ? 'false' : 'true'
+          const shouldOtherwiseHide = w.element.dataset.shouldHide === 'true'
+          const wasHidden = w.element.hidden
+          const actualHidden = hidden || shouldOtherwiseHide
+          w.element.hidden = actualHidden
+          w.element.style.display = actualHidden ? 'none' : undefined
+          if (actualHidden && !wasHidden) {
             w.options.onHide?.(w)
           }
         }
@@ -313,9 +317,13 @@ LGraphNode.prototype.addDOMWidget = function (
         widget.computedHeight <= 0 ||
         widget.type === 'converted-widget' ||
         widget.type === 'hidden'
-      element.hidden = hidden
-      element.style.display = hidden ? 'none' : null
-      if (hidden) {
+      element.dataset.shouldHide = hidden ? 'true' : 'false'
+      const isInVisibleNodes = element.dataset.isInVisibleNodes === 'true'
+      const actualHidden = hidden || !isInVisibleNodes
+      const wasHidden = element.hidden
+      element.hidden = actualHidden
+      element.style.display = actualHidden ? 'none' : null
+      if (actualHidden && !wasHidden) {
         widget.options.onHide?.(widget)
         return
       }

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -229,8 +229,9 @@ LGraphCanvas.prototype.computeVisibleNodes = function (): LGraphNode[] {
         if (w.element) {
           w.element.dataset.isInVisibleNodes = hidden ? 'false' : 'true'
           const shouldOtherwiseHide = w.element.dataset.shouldHide === 'true'
+          const isCollapsed = w.element.dataset.collapsed === 'true'
           const wasHidden = w.element.hidden
-          const actualHidden = hidden || shouldOtherwiseHide
+          const actualHidden = hidden || shouldOtherwiseHide || isCollapsed
           w.element.hidden = actualHidden
           w.element.style.display = actualHidden ? 'none' : null
           if (actualHidden && !wasHidden) {
@@ -312,14 +313,14 @@ LGraphNode.prototype.addDOMWidget = function (
       }
 
       const hidden =
-        node.flags?.collapsed ||
         (!!options.hideOnZoom && app.canvas.ds.scale < 0.5) ||
         widget.computedHeight <= 0 ||
         widget.type === 'converted-widget' ||
         widget.type === 'hidden'
       element.dataset.shouldHide = hidden ? 'true' : 'false'
       const isInVisibleNodes = element.dataset.isInVisibleNodes === 'true'
-      const actualHidden = hidden || !isInVisibleNodes
+      const isCollapsed = element.dataset.collapsed === 'true'
+      const actualHidden = hidden || !isInVisibleNodes || isCollapsed
       const wasHidden = element.hidden
       element.hidden = actualHidden
       element.style.display = actualHidden ? 'none' : null
@@ -388,6 +389,7 @@ LGraphNode.prototype.addDOMWidget = function (
       element.hidden = true
       element.style.display = 'none'
     }
+    element.dataset.collapsed = this.flags?.collapsed ? 'true' : 'false'
   }
 
   const onRemoved = this.onRemoved

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -232,7 +232,7 @@ LGraphCanvas.prototype.computeVisibleNodes = function (): LGraphNode[] {
           const wasHidden = w.element.hidden
           const actualHidden = hidden || shouldOtherwiseHide
           w.element.hidden = actualHidden
-          w.element.style.display = actualHidden ? 'none' : undefined
+          w.element.style.display = actualHidden ? 'none' : null
           if (actualHidden && !wasHidden) {
             w.options.onHide?.(w)
           }

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -325,6 +325,8 @@ LGraphNode.prototype.addDOMWidget = function (
       element.style.display = actualHidden ? 'none' : null
       if (actualHidden && !wasHidden) {
         widget.options.onHide?.(widget)
+      }
+      if (actualHidden) {
         return
       }
 


### PR DESCRIPTION
for #470

Experimental tweak to track both isInVisibleNodes (ie on/off screen boundary), and shouldHide (based on scale and all) as dataset values (I'd store it on `widget`, but it appears `DOMWidget` is used for one and `LiteGraph.IWidget` is the other, which is awkward - not sure if there's a convenient way to grab the DOMWidget from a litegraph one?)

Per the description of the issue in #470 , the actual style.display value was toggling rapidly before - this change should effectively prevent that.
While editing this, I also added a change to only fire `onHide` if it's actually being hidden in that frame (as opposed to every frame while it's hidden)

There's potentially a rootmore issue that a lot of redundant calculations are being done to check the visibility state that could be skipped? Not sure if `draw` is being called when hidden but I think not, `computeVisibleNodes` could probably be simplified to not subloop if the visible state hasn't changed

Will ask #470 author to test before this is pulled