### PR TITLE
EditAttention: allow negatives

### DIFF
--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -21,7 +21,6 @@ app.registerExtension({
       const floatWeight = parseFloat(weight)
       if (isNaN(floatWeight)) return weight
       const newWeight = floatWeight + delta
-      if (newWeight < 0) return '0'
       return String(Number(newWeight.toFixed(10)))
     }
 
@@ -143,7 +142,7 @@ app.registerExtension({
       // Increment the weight
       const weightDelta = event.key === 'ArrowUp' ? delta : -delta
       const updatedText = selectedText.replace(
-        /\((.*):(\d+(?:\.\d+)?)\)/,
+        /\((.*):([+-]?\d+(?:\.\d+)?)\)/,
         (match, text, weight) => {
           weight = incrementWeight(weight, weightDelta)
           if (weight == 1) {


### PR DESCRIPTION
for #474

Tested and working as intended - can CTRL+Up/Down and go negative/positive/.. as intended just fine.

Questions:
(A) Do we actually want this at all? imo as a general rule core things should allow too much rather than restrict too much, so my vote is yes
(B) should this potentially be hidden behind a setting toggle? imo while it could make sense too, ... well it's like you're gonna be surprised by it or anything, you have to pretty intentionally hold CTRL+Down for a while to get a silly value out of it, so doesn't need a blocker.
