### PR TITLE
Add touch-action none back to canvas

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -103,6 +103,7 @@ body {
 #graph-canvas {
   width: 100%;
   height: 100%;
+  touch-action: none;
 }
 
 .comfyui-body-right {


### PR DESCRIPTION
Touch panning stopped working in 1.2.6.

https://github.com/Comfy-Org/ComfyUI_frontend/blob/c73915e31eaf2c549e4f4f6ec794561f00fb218a/src/scripts/app.ts#L1858-L1860

`touchAction` was being set to none on `mainCanvas` in app.ts. But that `mainCanvas` is longer used after #255 I think.

I don't see a good way to emulate touch panning with playwright, sorry.

Ref:

- #482 