### PR TITLE
Fix loadGraphData call when loading from json

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2699,7 +2699,12 @@ export class ComfyApp {
         } else if (this.isApiJson(jsonContent)) {
           this.loadApiJson(jsonContent, fileName)
         } else {
-          await this.loadGraphData(JSON.parse(readerResult), true, fileName)
+          await this.loadGraphData(
+            JSON.parse(readerResult),
+            true,
+            false,
+            fileName
+          )
         }
       }
       reader.readAsText(file)


### PR DESCRIPTION
The `loadGraphData` call when loading a workflow from json file is missing an arg:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/73f7889f81f3b8c49f78f4efedb0e5fb07a229c4/src/scripts/app.ts#L2702

Signature:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/73f7889f81f3b8c49f78f4efedb0e5fb07a229c4/src/scripts/app.ts#L2184-L2188

After fixing, when you load from json file, the workflow name is set to the filename as intended:


https://github.com/user-attachments/assets/e623164e-b214-4bf7-b535-ec696959e847

