### PR TITLE
Fix queue cancelled status

### DIFF
--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -137,13 +137,13 @@ export class TaskItemImpl {
       case 'Pending':
         return TaskItemDisplayStatus.Pending
       case 'History':
+        if (this.interrupted) return TaskItemDisplayStatus.Cancelled
+
         switch (this.status!.status_str) {
           case 'success':
             return TaskItemDisplayStatus.Completed
           case 'error':
-            return this.interrupted
-              ? TaskItemDisplayStatus.Cancelled
-              : TaskItemDisplayStatus.Failed
+            return TaskItemDisplayStatus.Failed
         }
     }
   }


### PR DESCRIPTION
The interrupted task can have status_str `success` after #2666.

![image](https://github.com/user-attachments/assets/8beff41c-f627-412b-a3c8-d28c9b5adc58)
