### PR TITLE
Extension API to add toast message

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ We will support custom icons later.
 ![image](https://github.com/user-attachments/assets/7bff028a-bf91-4cab-bf97-55c243b3f5e0)
 </details>
 
+<details>
+  <summary>v1.2.27: Extension API to add toast message</summary>
+
+  Extensions can call the following API to add toast messages.
+
+```js
+  app.extensionManager.toast.add({
+    severity: 'info',
+    summary: 'Loaded!',
+    detail: 'Extension loaded!'
+  })
+```
+
+![image](https://github.com/user-attachments/assets/de02cd7e-cd81-43d1-a0b0-bccef92ff487)
+</details>
 
 ## Road Map
 

--- a/src/stores/workspaceStateStore.ts
+++ b/src/stores/workspaceStateStore.ts
@@ -1,5 +1,6 @@
-import { SidebarTabExtension } from '@/types/extensionTypes'
+import { SidebarTabExtension, ToastManager } from '@/types/extensionTypes'
 import { defineStore } from 'pinia'
+import { useToastStore } from './toastStore'
 
 interface WorkspaceState {
   spinner: boolean
@@ -13,6 +14,11 @@ export const useWorkspaceStore = defineStore('workspace', {
     activeSidebarTab: null,
     sidebarTabs: []
   }),
+  getters: {
+    toast(): ToastManager {
+      return useToastStore()
+    }
+  },
   actions: {
     updateActiveSidebarTab(tabId: string) {
       this.activeSidebarTab = tabId

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -1,3 +1,4 @@
+import type { ToastMessageOptions } from 'primevue/toast'
 import { Component } from 'vue'
 
 export interface BaseSidebarTabExtension {
@@ -24,8 +25,18 @@ export type SidebarTabExtension =
   | VueSidebarTabExtension
   | CustomSidebarTabExtension
 
+export type ToastManager = {
+  add(message: ToastMessageOptions): void
+  remove(message: ToastMessageOptions): void
+  removeAll(): void
+}
+
 export interface ExtensionManager {
+  // Sidebar tabs
   registerSidebarTab(tab: SidebarTabExtension): void
   unregisterSidebarTab(id: string): void
   getSidebarTabs(): SidebarTabExtension[]
+
+  // Toast
+  toast: ToastManager
 }


### PR DESCRIPTION
Expose toast API to extensions.

![image](https://github.com/user-attachments/assets/de02cd7e-cd81-43d1-a0b0-bccef92ff487)

```js
app.extensionManager.toast.add({
    severity: 'info',
    summary: 'Loaded!',
    detail: 'Extension loaded!'
})
```