### PR TITLE
Organize setting display for new settings dialog

### DIFF
--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -1,4 +1,3 @@
-import { lightenColor } from '@/utils/colorUtil'
 import { app } from '../../scripts/app'
 import { $el } from '../../scripts/ui'
 import type { ColorPalettes, Palette } from '@/types/colorPalette'
@@ -749,12 +748,6 @@ app.registerExtension({
         ) as HTMLSelectElement
 
         return $el('tr', [
-          $el('td', [
-            $el('label', {
-              for: id.replaceAll('.', '-'),
-              textContent: 'Color palette'
-            })
-          ]),
           $el('td', [
             els.select,
             $el(

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -662,9 +662,7 @@ app.registerExtension({
   init() {
     useConversionSubmenusSetting = app.ui.settings.addSetting({
       id: 'Comfy.NodeInputConversionSubmenus',
-      name: 'Node widget/input conversion sub-menus',
-      tooltip:
-        'In the node context menu, place the entries that convert between input/widget in sub-menus.',
+      name: 'In the node context menu, place the entries that convert between input/widget in sub-menus.',
       type: 'boolean',
       defaultValue: true
     })

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -401,7 +401,7 @@ export class ComfyUI {
 
     this.settings.addSetting({
       id: 'Comfy.DisableSliders',
-      name: 'Disable sliders.',
+      name: 'Disable node widget sliders',
       type: 'boolean',
       defaultValue: false
     })
@@ -746,9 +746,9 @@ export class ComfyUI {
       })
     ]) as HTMLDivElement
 
-    const devMode = this.settings.addSetting({
+    this.settings.addSetting({
       id: 'Comfy.DevMode',
-      name: 'Enable Dev mode Options',
+      name: 'Enable dev mode options (API save, etc.)',
       type: 'boolean',
       defaultValue: false,
       onChange: function (value) {

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -347,12 +347,10 @@ function isSlider(display, app) {
 export function initWidgets(app) {
   app.ui.settings.addSetting({
     id: 'Comfy.WidgetControlMode',
-    name: 'Widget Value Control Mode',
+    name: 'Controls when widget values are updated (randomize/increment/decrement), either before the prompt is queued or after.',
     type: 'combo',
     defaultValue: 'after',
     options: ['before', 'after'],
-    tooltip:
-      'Controls when widget values are updated (randomize/increment/decrement), either before the prompt is queued or after.',
     onChange(value) {
       controlValueRunBefore = value === 'before'
       for (const n of app.graph._nodes) {


### PR DESCRIPTION
For the new settings dialog, adjust some settings entries for better visual appearance.

Before:

![image](https://github.com/user-attachments/assets/9c2f3fbf-f3fd-4949-bc2a-f1e04ecaea6b)
![image](https://github.com/user-attachments/assets/146dce27-bf75-4e12-8e3e-69357c281949)
![image](https://github.com/user-attachments/assets/20d8ae23-1262-4e09-afd3-68f59df26494)
![image](https://github.com/user-attachments/assets/4dce4a49-33e6-4c4b-9728-2b86898700e3)
![image](https://github.com/user-attachments/assets/5b8b63d4-e914-4ee0-8e56-92b444fb0d3a)

After:
![image](https://github.com/user-attachments/assets/7610bb62-e503-487e-b959-7cfe6b9761eb)
![image](https://github.com/user-attachments/assets/c823ff2e-6da2-4cd1-bca9-e2678037ec35)
![image](https://github.com/user-attachments/assets/35947e8d-e63a-419f-9015-d21fbe3753b5)
![image](https://github.com/user-attachments/assets/522a810d-b825-4587-a1e3-81811b0aed18)
![image](https://github.com/user-attachments/assets/410befc9-8302-4f1c-99b9-e3f3567ad7e9)
