### PR TITLE
Support clicking on library entries to toggle expand/insert node

### DIFF
--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -173,7 +173,7 @@ const toggleNode = (id: string) => {
   }
 }
 
-const insertNode = (nodeDef: ComfyNodeDef) => {
+const insertNode = (nodeDef: ComfyNodeDefImpl) => {
   app.addNodeOnGraph(nodeDef, { pos: app.getCanvasCenter() })
 }
 </script>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2958,6 +2958,11 @@ export class ComfyApp {
       ([p, o1, o2]) => (p - o2) / this.canvas.ds.scale - o1
     ) as Vector2
   }
+
+  getCanvasCenter() {
+    const [x, y, w, h] = app.canvas.ds.visible_area
+    return [x + w / 2, y + h / 2]
+  }
 }
 
 export const app = new ComfyApp()


### PR DESCRIPTION
Clicking a folder expands/collapses it
Clicking a node inserts it into the canvas
Small vertical alignment fix on the node label and spacing