### PR TITLE
Support view of gifs in queue media preview

### DIFF
--- a/src/components/sidebar/tabs/queue/ResultItem.vue
+++ b/src/components/sidebar/tabs/queue/ResultItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="result-container" ref="resultContainer">
     <Image
-      v-if="result.mediaType === 'images'"
+      v-if="result.mediaType === 'images' || result.mediaType === 'gifs'"
       :src="result.url"
       alt="Task Output"
       width="100%"


### PR DESCRIPTION
Currently the gif will just loop forever. I am not sure if this is the desired behavior, but it should be better than displaying a placeholder. We can improve the interaction later.