### PR TITLE
Fix type check on TaskItemImpl

### DIFF
--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -70,7 +70,7 @@ export class TaskItemImpl {
     this.flatOutputs = flatOutputs ?? this.calculateFlatOutputs()
   }
 
-  private calculateFlatOutputs(): ReadonlyArray<ResultItemImpl> {
+  calculateFlatOutputs(): ReadonlyArray<ResultItemImpl> {
     if (!this.outputs) {
       return []
     }


### PR DESCRIPTION
TypeScript checker is not satisfied with `calculateFlatOutputs` being private when `TaskItemImpl` is used in in `QueueSidebarTab`