### PR TITLE
Fix escape not resetting activeIndex in gallery

### DIFF
--- a/src/components/sidebar/tabs/queue/ResultGallery.vue
+++ b/src/components/sidebar/tabs/queue/ResultGallery.vue
@@ -65,6 +65,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
       navigateImage(1)
       break
     case 'Escape':
+      handleActiveIndexChange(-1)
       galleryVisible.value = false
       break
   }

--- a/src/components/sidebar/tabs/queue/ResultGallery.vue
+++ b/src/components/sidebar/tabs/queue/ResultGallery.vue
@@ -65,8 +65,8 @@ const handleKeyDown = (event: KeyboardEvent) => {
       navigateImage(1)
       break
     case 'Escape':
-      handleActiveIndexChange(-1)
       galleryVisible.value = false
+      handleVisibilityChange(false)
       break
   }
 }


### PR DESCRIPTION
This was not emitting when galleria closed via escape key:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/f5ce42d5d5f9ca7ffc6e2f9597310f048749346b/src/components/sidebar/tabs/queue/ResultGallery.vue#L4

Resulting in `activeIndex` not being reset to -1. Then you could not re-open image at that index, since clicking open button did not change `activeIndex`.