### PR TITLE
Use DPI to calculate screen center

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2952,9 +2952,10 @@ export class ComfyApp {
     ) as Vector2
   }
 
-  getCanvasCenter() {
+  getCanvasCenter(): Vector2 {
+    const dpi = Math.max(window.devicePixelRatio ?? 1, 1)
     const [x, y, w, h] = app.canvas.ds.visible_area
-    return [x + w / 2, y + h / 2]
+    return [x + w / dpi / 2, y + h / dpi / 2]
   }
 }
 


### PR DESCRIPTION
Fixes #542 by using DPI to calculate screen center. Width/height from `app.canvas.ds.visible_area` uses physical pixels.

Before / After:


https://github.com/user-attachments/assets/80e2f95b-97e5-41ed-ab28-3a9aa9dc6ba3



https://github.com/user-attachments/assets/72861f51-7f8f-4e0f-8c75-43ae86f71364

Related:

- #511
- Comfy-Org/litegraph.js#49
- https://github.com/comfyanonymous/ComfyUI/commit/4796e61
