### PR TITLE
Remove double reroute pin

### DIFF
--- a/browser_tests/nodeSearchBox.spec.ts
+++ b/browser_tests/nodeSearchBox.spec.ts
@@ -37,7 +37,7 @@ test.describe('Node search box', () => {
     await comfyPage.disconnectEdge()
     // Select the second item as the first item is always reroute
     await comfyPage.searchBox.fillAndSelectFirstNode('CLIPTextEncode', {
-      suggestionIndex: 1
+      suggestionIndex: 0
     })
     await expect(comfyPage.canvas).toHaveScreenshot('auto-linked-node.png')
   })
@@ -59,7 +59,7 @@ test.describe('Node search box', () => {
 
     // Select the second item as the first item is always reroute
     await comfyPage.searchBox.fillAndSelectFirstNode('Load Checkpoint', {
-      suggestionIndex: 1
+      suggestionIndex: 0
     })
     await expect(comfyPage.canvas).toHaveScreenshot(
       'auto-linked-node-batch.png'

--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -81,11 +81,6 @@ const props = defineProps({
   searchLimit: {
     type: Number,
     default: 64
-  },
-  // TODO: Find a more flexible mechanism to add pinned nodes
-  includeReroute: {
-    type: Boolean,
-    default: false
   }
 })
 
@@ -100,9 +95,6 @@ const placeholder = computed(() => {
 const search = (query: string) => {
   currentQuery.value = query
   suggestions.value = [
-    ...(props.includeReroute
-      ? [useNodeDefStore().nodeDefsByName['Reroute']]
-      : []),
     ...useNodeDefStore().nodeSearchService.searchNode(query, props.filters, {
       limit: props.searchLimit
     })

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -20,7 +20,6 @@
       <template #container>
         <NodeSearchBox
           :filters="nodeFilters"
-          :includeReroute="includeReroute"
           @add-filter="addFilter"
           @remove-filter="removeFilter"
           @add-node="addNode"
@@ -62,7 +61,6 @@ const getNewNodeLocation = (): [number, number] => {
   return [originalEvent.canvasX, originalEvent.canvasY]
 }
 const nodeFilters = reactive([])
-const includeReroute = ref(false)
 const addFilter = (filter: FilterAndValue) => {
   nodeFilters.push(filter)
 }
@@ -102,7 +100,6 @@ const linkReleaseTriggerMode = computed(() => {
 })
 
 const canvasEventHandler = (e: LiteGraphCanvasEvent) => {
-  includeReroute.value = false
   const shiftPressed = (e.detail.originalEvent as KeyboardEvent).shiftKey
 
   if (e.detail.subType === 'empty-release') {
@@ -126,7 +123,6 @@ const canvasEventHandler = (e: LiteGraphCanvasEvent) => {
     )
     const dataType = firstLink.type
     addFilter([filter, dataType])
-    includeReroute.value = true
   }
   triggerEvent.value = e
   visible.value = true


### PR DESCRIPTION
There is double reroute in the link release drop suggestions. Reroute is added as system node which appears at first of the search result, and wildcard matches any type filter, so reroute is indeed already at the top of search result on link release.

Partially reverts https://github.com/Comfy-Org/ComfyUI_frontend/pull/469