### PR TITLE
Reduce debounce delay in node searchbox

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -17,6 +17,7 @@
       append-to="self"
       :suggestions="suggestions"
       :min-length="0"
+      :delay="100"
       @complete="search($event.query)"
       @option-select="emit('addNode', $event.value)"
       @focused-option-changed="setHoverSuggestion($event)"


### PR DESCRIPTION
The default debounce delay is 300ms which is too long in the node search context. Our current fuse search generally takes ~30ms to search among ~8k nodes.

This PR reduces the delay to 100ms to make the search more responsive.