### PR TITLE
Reduce search highlight padding

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -193,7 +193,7 @@ const setHoverSuggestion = (index: number) => {
   color: var(--p-primary-contrast-color);
   font-weight: bold;
   border-radius: 0.25rem;
-  padding: 0.125rem 0.25rem;
+  padding: 0rem 0.125rem;
   margin: -0.125rem 0.125rem;
 }
 </style>


### PR DESCRIPTION
Previously the round coner of the padding is truncated.

Before:
![image](https://github.com/user-attachments/assets/08f805d9-016c-448d-8baa-c14687b12867)


After:
![image](https://github.com/user-attachments/assets/16dfa57b-dd8f-4297-94f6-bdaca12b4829)

