### PR TITLE
Support node deprecated/experimental flag

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -68,6 +68,12 @@ watchEffect(() => {
   nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')
 })
 
+watchEffect(() => {
+  nodeDefStore.showExperimental = settingStore.get(
+    'Comfy.Node.ShowExperimental'
+  )
+})
+
 let dropTargetCleanup = () => {}
 
 onMounted(async () => {

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -16,7 +16,7 @@ import SideToolbar from '@/components/sidebar/SideToolbar.vue'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import NodeSearchboxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
 import NodeTooltip from '@/components/graph/NodeTooltip.vue'
-import { ref, computed, onUnmounted, watch, onMounted } from 'vue'
+import { ref, computed, onUnmounted, watch, onMounted, watchEffect } from 'vue'
 import { app as comfyApp } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'
 import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
@@ -36,6 +36,7 @@ import {
 const emit = defineEmits(['ready'])
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 const settingStore = useSettingStore()
+const nodeDefStore = useNodeDefStore()
 const workspaceStore = useWorkspaceStore()
 
 const betaMenuEnabled = computed(
@@ -62,6 +63,10 @@ watch(
   },
   { immediate: true }
 )
+
+watchEffect(() => {
+  nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')
+})
 
 let dropTargetCleanup = () => {}
 
@@ -98,7 +103,7 @@ onMounted(async () => {
       const comfyNodeName = event.source.element.getAttribute(
         'data-comfy-node-name'
       )
-      const nodeDef = useNodeDefStore().nodeDefsByName[comfyNodeName]
+      const nodeDef = nodeDefStore.nodeDefsByName[comfyNodeName]
       comfyApp.addNodeOnGraph(nodeDef, { pos })
     }
   })

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -112,6 +112,7 @@ const settingStore = useSettingStore()
 const sidebarLocation = computed<'left' | 'right'>(() =>
   settingStore.get('Comfy.Sidebar.Location')
 )
+
 const nodePreviewStyle = ref<Record<string, string>>({
   position: 'absolute',
   top: '0px',

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -166,6 +166,9 @@ export class ComfyNodeDefImpl {
   python_module: string
   description: string
 
+  @Transform(({ value, obj }) => value || obj.category === '')
+  deprecated: boolean
+
   @Type(() => ComfyInputsSpec)
   input: ComfyInputsSpec
 

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -173,6 +173,16 @@ export class ComfyNodeDefImpl {
   @Expose()
   deprecated: boolean
 
+  @Transform(
+    ({ value, obj }) => value ?? obj.category.startsWith('_for_testing'),
+    {
+      toClassOnly: true
+    }
+  )
+  @Type(() => Boolean)
+  @Expose()
+  experimental: boolean
+
   @Type(() => ComfyInputsSpec)
   input: ComfyInputsSpec
 
@@ -237,13 +247,15 @@ interface State {
   nodeDefsByName: Record<string, ComfyNodeDefImpl>
   widgets: Record<string, ComfyWidgetConstructor>
   showDeprecated: boolean
+  showExperimental: boolean
 }
 
 export const useNodeDefStore = defineStore('nodeDef', {
   state: (): State => ({
     nodeDefsByName: {},
     widgets: {},
-    showDeprecated: false
+    showDeprecated: false,
+    showExperimental: false
   }),
   getters: {
     nodeDefs(state) {
@@ -251,11 +263,11 @@ export const useNodeDefStore = defineStore('nodeDef', {
     },
     // Node defs that are not deprecated
     visibleNodeDefs(state) {
-      return state.showDeprecated
-        ? this.nodeDefs
-        : this.nodeDefs.filter(
-            (nodeDef: ComfyNodeDefImpl) => !nodeDef.deprecated
-          )
+      return this.nodeDefs.filter(
+        (nodeDef: ComfyNodeDefImpl) =>
+          (state.showDeprecated || !nodeDef.deprecated) &&
+          (state.showExperimental || !nodeDef.experimental)
+      )
     },
     nodeSearchService() {
       return new NodeSearchService(this.visibleNodeDefs)

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -151,6 +151,8 @@ export const useSettingStore = defineStore('setting', {
       app.ui.settings.addSetting({
         id: 'Comfy.Node.ShowDeprecated',
         name: 'Show deprecated nodes in search',
+        tooltip:
+          'Deprecated nodes are hidden by default in the UI, but remain functional in existing workflows that use them.',
         type: 'boolean',
         defaultValue: false
       })
@@ -158,6 +160,8 @@ export const useSettingStore = defineStore('setting', {
       app.ui.settings.addSetting({
         id: 'Comfy.Node.ShowExperimental',
         name: 'Show experimental nodes in search',
+        tooltip:
+          'Experimental nodes are marked as such in the UI and may be subject to significant changes or removal in future versions. Use with caution in production workflows',
         type: 'boolean',
         defaultValue: true
       })

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -147,6 +147,13 @@ export const useSettingStore = defineStore('setting', {
         type: 'boolean',
         defaultValue: true
       })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.Node.ShowDeprecated',
+        name: 'Show deprecated nodes in search',
+        type: 'boolean',
+        defaultValue: false
+      })
     },
 
     set<K extends keyof Settings>(key: K, value: Settings[K]) {

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -154,6 +154,13 @@ export const useSettingStore = defineStore('setting', {
         type: 'boolean',
         defaultValue: false
       })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.Node.ShowExperimental',
+        name: 'Show experimental nodes in search',
+        type: 'boolean',
+        defaultValue: true
+      })
     },
 
     set<K extends keyof Settings>(key: K, value: Settings[K]) {

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -422,6 +422,7 @@ const zSettings = z.record(z.any()).and(
       'Comfy.NodeSearchBoxImpl.ShowCategory': z.boolean(),
       'Comfy.NodeSuggestions.number': z.number(),
       'Comfy.Node.ShowDeprecated': z.boolean(),
+      'Comfy.Node.ShowExperimental': z.boolean(),
       'Comfy.PreviewFormat': z.string(),
       'Comfy.PromptFilename': z.boolean(),
       'Comfy.Sidebar.Location': z.enum(['left', 'right']),

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -420,6 +420,7 @@ const zSettings = z.record(z.any()).and(
       'Comfy.NodeSearchBoxImpl': z.enum(['default', 'simple']),
       'Comfy.NodeSearchBoxImpl.ShowCategory': z.boolean(),
       'Comfy.NodeSuggestions.number': z.number(),
+      'Comfy.Node.ShowDeprecated': z.boolean(),
       'Comfy.PreviewFormat': z.string(),
       'Comfy.PromptFilename': z.boolean(),
       'Comfy.Sidebar.Location': z.enum(['left', 'right']),

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -335,7 +335,8 @@ const zComfyNodeDef = z.object({
   description: z.string(),
   category: z.string(),
   output_node: z.boolean(),
-  python_module: z.string()
+  python_module: z.string(),
+  deprecated: z.boolean().optional()
 })
 
 // `/object_info`

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -336,7 +336,8 @@ const zComfyNodeDef = z.object({
   category: z.string(),
   output_node: z.boolean(),
   python_module: z.string(),
-  deprecated: z.boolean().optional()
+  deprecated: z.boolean().optional(),
+  experimental: z.boolean().optional()
 })
 
 // `/object_info`

--- a/tests-ui/tests/apiTypes.test.ts
+++ b/tests-ui/tests/apiTypes.test.ts
@@ -16,7 +16,9 @@ const EXAMPLE_NODE_DEF: ComfyNodeDef = {
   description: '',
   python_module: 'nodes',
   category: 'loaders',
-  output_node: false
+  output_node: false,
+  experimental: false,
+  deprecated: false
 }
 
 describe('validateNodeDef', () => {

--- a/tests-ui/tests/nodeDef.test.ts
+++ b/tests-ui/tests/nodeDef.test.ts
@@ -194,6 +194,52 @@ describe('ComfyNodeDefImpl', () => {
         is_list: false
       }
     ])
+    expect(result.deprecated).toBe(false)
+  })
+
+  it('should transform a deprecated basic node definition', () => {
+    const plainObject = {
+      name: 'TestNode',
+      display_name: 'Test Node',
+      category: 'Testing',
+      python_module: 'test_module',
+      description: 'A test node',
+      input: {
+        required: {
+          intInput: ['INT', { min: 0, max: 100, default: 50 }]
+        }
+      },
+      output: ['INT'],
+      output_is_list: [false],
+      output_name: ['intOutput'],
+      deprecated: true
+    }
+
+    const result = plainToClass(ComfyNodeDefImpl, plainObject)
+    expect(result.deprecated).toBe(true)
+  })
+
+  // Legacy way of marking a node as deprecated
+  it('should mark deprecated with empty category', () => {
+    const plainObject = {
+      name: 'TestNode',
+      display_name: 'Test Node',
+      // Empty category should be treated as deprecated
+      category: '',
+      python_module: 'test_module',
+      description: 'A test node',
+      input: {
+        required: {
+          intInput: ['INT', { min: 0, max: 100, default: 50 }]
+        }
+      },
+      output: ['INT'],
+      output_is_list: [false],
+      output_name: ['intOutput']
+    }
+
+    const result = plainToClass(ComfyNodeDefImpl, plainObject)
+    expect(result.deprecated).toBe(true)
   })
 
   it('should handle multiple outputs including COMBO type', () => {


### PR DESCRIPTION
Related issue: https://github.com/comfyanonymous/ComfyUI/pull/4506

Hide nodes from node searchbox and node library if they are marked as deprecated / experimental. The legacy way of marking node as deprecated was set a node's category to empty string. The legacy way of marking node as experimental was set a node's category to starts with `_for_testing`

![image](https://github.com/user-attachments/assets/d4601e42-869e-4ab9-b726-3a0b7c3496fb)
