### PR TITLE
Use settingStore to access setting

### DIFF
--- a/browser_tests/assets/missing_nodes.json
+++ b/browser_tests/assets/missing_nodes.json
@@ -1,0 +1,61 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "UNKNOWN NODE",
+      "pos": [
+        48,
+        86
+      ],
+      "size": {
+        "0": 358.80780029296875,
+        "1": 314.7989501953125
+      },
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null,
+          "slot_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [],
+          "slot_index": 0,
+          "shape": 6
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNKNOWN NODE"
+      },
+      "widgets_values": [
+        "wd-v1-4-moat-tagger-v2",
+        0.35,
+        0.85,
+        false,
+        false,
+        ""
+      ]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [
+        0, 0
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test'
-import { ComfyPage, comfyPageFixture as test } from './ComfyPage'
+import { comfyPageFixture as test } from './ComfyPage'
 
 test.describe('Node Interaction', () => {
   test('Can enter prompt', async ({ comfyPage }) => {
@@ -104,10 +104,14 @@ test.describe('Node Interaction', () => {
   test('Can toggle dom widget node open/closed', async ({ comfyPage }) => {
     await expect(comfyPage.canvas).toHaveScreenshot('default.png')
     await comfyPage.clickTextEncodeNodeToggler()
-    await expect(comfyPage.canvas).toHaveScreenshot('text-encode-toggled-off.png')
+    await expect(comfyPage.canvas).toHaveScreenshot(
+      'text-encode-toggled-off.png'
+    )
     await comfyPage.delay(1000)
     await comfyPage.clickTextEncodeNodeToggler()
-    await expect(comfyPage.canvas).toHaveScreenshot('text-encode-toggled-back-open.png')
+    await expect(comfyPage.canvas).toHaveScreenshot(
+      'text-encode-toggled-back-open.png'
+    )
   })
 })
 

--- a/browser_tests/loadWorkflowWarning.spec.ts
+++ b/browser_tests/loadWorkflowWarning.spec.ts
@@ -1,0 +1,14 @@
+import { expect } from '@playwright/test'
+import { comfyPageFixture as test } from './ComfyPage'
+
+test.describe('Load workflow warning', () => {
+  test('Should display a warning when loading a workflow with missing nodes', async ({
+    comfyPage
+  }) => {
+    await comfyPage.loadWorkflow('missing_nodes')
+
+    // Wait for the element with the .comfy-missing-nodes selector to be visible
+    const missingNodesWarning = comfyPage.page.locator('.comfy-missing-nodes')
+    await expect(missingNodesWarning).toBeVisible()
+  })
+})

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2158,13 +2158,9 @@ export class ComfyApp {
 
   showMissingNodesError(missingNodeTypes, hasAddedNodes = true) {
     if (
-      !this.ui.settings.getSettingValue(
-        'Comfy.Workflow.ShowMissingNodesWarning'
-      )
-    )
-      return
-
-    if (this.vueAppReady) {
+      this.vueAppReady &&
+      useSettingStore().get('Comfy.Workflow.ShowMissingNodesWarning')
+    ) {
       showLoadWorkflowWarning({
         missingNodeTypes,
         hasAddedNodes,


### PR DESCRIPTION
Reference: https://github.com/Comfy-Org/ComfyUI_frontend/pull/569#issuecomment-2302268561

Use settingStore to access setting to ensure default value of setting is correctly handled. A playwright test is added to verify the default behavior.