### PR TITLE
Fix right-click save image in gallery (firefox)

### DIFF
--- a/src/components/sidebar/tabs/queue/ResultGallery.vue
+++ b/src/components/sidebar/tabs/queue/ResultGallery.vue
@@ -94,7 +94,10 @@ img.galleria-image {
   max-width: 100vw;
   max-height: 100vh;
   object-fit: contain;
+}
+
+.p-galleria-close-button {
   /* Set z-index so the close button doesn't get hidden behind the image when image is large */
-  z-index: -1;
+  z-index: 1;
 }
 </style>


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI_frontend/blob/8f8eac038ad98571f99f9c83fb1b4bf782b6085f/src/components/sidebar/tabs/queue/ResultGallery.vue#L97-L98

On firefox it seems that if the z-index is -1, the element cannot be the event target on right click.

Changing z-index of close-button instead of img keeps the intended positioning intact and allows right click event on img:

https://github.com/user-attachments/assets/da5c2127-b532-43e8-9038-2ba1d4493ed3

