### PR TITLE
Allow comfyui to use images as background

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,6 +1,7 @@
 :root {
   --fg-color: #000;
   --bg-color: #fff;
+  --bg-img: #fff;
   --comfy-menu-bg: #353535;
   --comfy-input-bg: #222;
   --input-text: #ddd;
@@ -24,6 +25,7 @@
   :root {
     --fg-color: #fff;
     --bg-color: #202020;
+    --bg-img: #202020;
     --content-bg: #4e4e4e;
     --content-fg: #fff;
     --content-hover-bg: #222;
@@ -38,7 +40,7 @@ body {
   overflow: hidden;
   grid-template-columns: auto 1fr auto;
   grid-template-rows: auto 1fr auto;
-  background-color: var(--bg-color);
+  background: var(--bg-img) no-repeat center /cover;
   color: var(--fg-color);
   min-height: -webkit-fill-available;
   max-height: -webkit-fill-available;

--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -57,6 +57,7 @@ const colorPalettes: ColorPalettes = {
       comfy_base: {
         'fg-color': '#fff',
         'bg-color': '#202020',
+        'bg-img': '#202020',
         'comfy-menu-bg': '#353535',
         'comfy-input-bg': '#222',
         'input-text': '#ddd',
@@ -119,6 +120,7 @@ const colorPalettes: ColorPalettes = {
       comfy_base: {
         'fg-color': '#222',
         'bg-color': '#DDD',
+        'bg-img': '#DDD',
         'comfy-menu-bg': '#F5F5F5',
         'comfy-input-bg': '#C9C9C9',
         'input-text': '#222',
@@ -179,6 +181,7 @@ const colorPalettes: ColorPalettes = {
       comfy_base: {
         'fg-color': '#fdf6e3', // Base3
         'bg-color': '#002b36', // Base03
+        'bg-img': '#002b36', 
         'comfy-menu-bg': '#073642', // Base02
         'comfy-input-bg': '#002b36', // Base03
         'input-text': '#93a1a1', // Base1
@@ -253,6 +256,7 @@ const colorPalettes: ColorPalettes = {
       comfy_base: {
         'fg-color': '#fff',
         'bg-color': '#2b2f38',
+        'bg-img': '#2b2f38',
         'comfy-menu-bg': '#242730',
         'comfy-input-bg': '#2b2f38',
         'input-text': '#ddd',
@@ -327,6 +331,7 @@ const colorPalettes: ColorPalettes = {
       comfy_base: {
         'fg-color': '#e5eaf0',
         'bg-color': '#2e3440',
+        'bg-img': '#2e3440',
         'comfy-menu-bg': '#161b22',
         'comfy-input-bg': '#2e3440',
         'input-text': '#bcc2c8',
@@ -401,6 +406,7 @@ const colorPalettes: ColorPalettes = {
       comfy_base: {
         'fg-color': '#e5eaf0',
         'bg-color': '#161b22',
+        'bg-img': '#161b22',
         'comfy-menu-bg': '#13171d',
         'comfy-input-bg': '#161b22',
         'input-text': '#bcc2c8',

--- a/src/types/colorPalette.ts
+++ b/src/types/colorPalette.ts
@@ -59,6 +59,7 @@ const litegraphBaseSchema = z
 const comfyBaseSchema = z.object({
   ['fg-color']: z.string(),
   ['bg-color']: z.string(),
+  ['bg-img']: z.string().optional(),
   ['comfy-menu-bg']: z.string(),
   ['comfy-input-bg']: z.string(),
   ['input-text']: z.string(),


### PR DESCRIPTION
### **This change allows users to use images as backgrounds by modifying the color palette configuration file.**

### How to use an image as a background:

Export a palette profile and edit it.

Set the value of `"bg-img"` to `url('your image path/background image.png')`. 

> Example:`"bg-img": "#202020"` ➡ `"bg-img": "url('Users/Mijuku/Pictures/bg.png')"`.


In addition, setting the value of `CLEAR_BACKGROUND_COLOR` to `transparent` can prevent the background from disappearing due to scaling the canvas.

Finally, import the modified configuration file in the comfyui palette and refresh the browser

![屏幕截图 2024-08-22 174630](https://github.com/user-attachments/assets/458b4f1f-1588-4e38-bef9-0489c15223ab)

_If you think it is troublesome to modify the palette configuration file, I have the modified configuration file here. 
[ImgBG.json](https://github.com/user-attachments/files/16709173/ImgBG.json)
Just import the `ImgBG.json` in the comfyui colorpalette, then rename the background image to `bg.png` and place it in the `ComfyUI/web` directory, and refresh the browser to take effect._
