### PR TITLE
Move error handling out of api.ts to workflows.ts

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -541,11 +541,7 @@ class ComfyApi extends EventTarget {
     const resp = await this.fetchApi(`/userdata/${encodeURIComponent(file)}`, {
       method: 'DELETE'
     })
-    if (resp.status !== 204) {
-      throw new Error(
-        `Error removing user data file '${file}': ${resp.status} ${resp.statusText}`
-      )
-    }
+    return resp
   }
 
   /**

--- a/src/scripts/workflows.ts
+++ b/src/scripts/workflows.ts
@@ -399,19 +399,21 @@ export class ComfyWorkflow {
   async delete() {
     // TODO: fix delete of current workflow - should mark workflow as unsaved and when saving use old name by default
 
-    try {
-      if (this.isFavorite) {
-        await this.favorite(false)
-      }
-      await api.deleteUserData('workflows/' + this.path)
-      this.unsaved = true
-      this.#path = null
-      this.#pathParts = null
-      this.manager.workflows.splice(this.manager.workflows.indexOf(this), 1)
-      this.manager.dispatchEvent(new CustomEvent('delete', { detail: this }))
-    } catch (error) {
-      alert(`Error deleting workflow: ${error.message || error}`)
+    if (this.isFavorite) {
+      await this.favorite(false)
     }
+    const resp = await api.deleteUserData('workflows/' + this.path)
+    if (resp.status !== 204) {
+      alert(
+        `Error removing user data file '${this.path}': ${resp.status} ${resp.statusText}`
+      )
+    }
+
+    this.unsaved = true
+    this.#path = null
+    this.#pathParts = null
+    this.manager.workflows.splice(this.manager.workflows.indexOf(this), 1)
+    this.manager.dispatchEvent(new CustomEvent('delete', { detail: this }))
   }
 
   track() {


### PR DESCRIPTION
Just like all other endpoints defined in `api.ts`, the `deleteUserData` endpoint should not handle error by itself. This PR moves the error handling to the callsite.