### PR TITLE
Fix signature of listUserData

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -581,13 +581,13 @@ class ComfyApi extends EventTarget {
    */
   async listUserData(
     dir: string,
-    recurse: true,
-    split?: boolean
+    recurse: boolean,
+    split?: true
   ): Promise<string[][]>
   async listUserData(
     dir: string,
-    recurse: false,
-    split?: boolean
+    recurse: boolean,
+    split?: false
   ): Promise<string[]>
   async listUserData(dir, recurse, split) {
     const resp = await this.fetchApi(


### PR DESCRIPTION
According to the comment, the return type should differ based on the value of `split` rather than based on the value of `recurse`