### PR TITLE
Fix settings dialog on mobile

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -198,4 +198,15 @@ const tabValue = computed(() =>
 .settings-content::-webkit-scrollbar-thumb {
   background-color: transparent;
 }
+
+@media (max-width: 768px) {
+  .settings-container {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+  }
+}
 </style>


### PR DESCRIPTION
Settings can't be used on mobile at the moment. I added mobile breakpoint to switch flex direction of settings content from `row` to `column`.

Before:


https://github.com/user-attachments/assets/dcc1067e-4b1c-4a5c-bc41-7628bc416afd

After:


https://github.com/user-attachments/assets/641d3a4f-d39d-4595-8420-011345186c72

