### PR TITLE
Fix github request too long issue

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -74,7 +74,8 @@ onMounted(async () => {
 })
 
 const generateReport = (systemStats: SystemStats) => {
-  const MAX_JSON_LENGTH = 50000
+  // The default JSON workflow has about 3000 characters.
+  const MAX_JSON_LENGTH = 20000
   const workflowJSONString = JSON.stringify(app.graph.serialize())
   const workflowText =
     workflowJSONString.length > MAX_JSON_LENGTH
@@ -148,11 +149,14 @@ const copyReportToClipboard = async () => {
   }
 }
 
-const openNewGithubIssue = () => {
+const openNewGithubIssue = async () => {
+  await copyReportToClipboard()
   const issueTitle = encodeURIComponent(
     `[Bug]: ${props.error.exception_type} in ${props.error.node_type}`
   )
-  const issueBody = encodeURIComponent(reportContent.value)
+  const issueBody = encodeURIComponent(
+    'The report has been copied to the clipboard. Please paste it here.'
+  )
   const url = `https://github.com/${repoOwner}/${repoName}/issues/new?title=${issueTitle}&body=${issueBody}`
   window.open(url, '_blank')
 }

--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -135,16 +135,14 @@ const copyReportToClipboard = async () => {
       toast.add({
         severity: 'error',
         summary: 'Error',
-        detail: 'Failed to copy report',
-        life: 3000
+        detail: 'Failed to copy report'
       })
     }
   } else {
     toast.add({
       severity: 'error',
       summary: 'Error',
-      detail: 'Clipboard API not supported in your browser',
-      life: 3000
+      detail: 'Clipboard API not supported in your browser'
     })
   }
 }


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/603

GitHub as pretty limited length for the GET request param if we want to attach we whole report as get request param to the body param.

This PR makes report copied to the clipboard when user clicks the new issue button. The user now need to paste the text from clipboard as the body of issue.

Note:
Error toast's life is removed as users need to see the error message if they found out the clipboard is empty and navigate back to the ComfyUI tab. If we keep a life there, the error message toast might be gone if the user navigate back.