### PR TITLE
Fix hotkeys triggering while editing properties panel values

### DIFF
--- a/browser_tests/propertiesPanel.spec.ts
+++ b/browser_tests/propertiesPanel.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from '@playwright/test'
+import { comfyPageFixture as test } from './ComfyPage'
+
+test.describe('Properties Panel', () => {
+  test('Can change property value', async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.rightClickEmptyLatentNode()
+    await comfyPage.page.getByText('Properties Panel').click()
+    await comfyPage.nextFrame()
+    await expect(comfyPage.canvas).toHaveScreenshot(
+      'right-click-node-properties-panel.png'
+    )
+    const propertyInput = comfyPage.page.locator('span.property_value').first()
+
+    // Ensure no keybinds are triggered while typing
+    await propertyInput.pressSequentially('abcdefghijklmnopqrstuvwxyz')
+    await expect(comfyPage.canvas).toHaveScreenshot(
+      'right-click-node-properties-panel-property-changed.png'
+    )
+
+    await propertyInput.fill('Empty Latent Image')
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
+  })
+})

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -27,7 +27,12 @@ app.registerExtension({
       }
 
       const target = event.composedPath()[0]
-      if (['INPUT', 'TEXTAREA'].includes(target.tagName)) {
+      if (
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'INPUT' ||
+        (target.tagName === 'SPAN' &&
+          target.classList.contains('property_value'))
+      ) {
         return
       }
 


### PR DESCRIPTION
The keybind handler ignores events in `TEXTAREA` and `INPUT`, but the inputs in the litegraph properties panel are `SPAN`, causing shortcuts like `q` and `r` to activate while typing there.

Issue:

- #592 