### PR TITLE
Target ES2022 in vite config to align with tsconfig target

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -114,7 +114,7 @@ export default defineConfig({
   ],
   build: {
     minify: SHOULD_MINIFY ? 'esbuild' : false,
-    target: 'es2015',
+    target: 'es2022',
     sourcemap: true,
     rollupOptions: {
       // Disabling tree-shaking


### PR DESCRIPTION
The `tsconfig` is targetting ES2022. This PR changes the build target in vite to align with the `tsconfig` target.