### PR TITLE
Fix custom settings with callable options property

### DIFF
--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -68,7 +68,10 @@ function getSettingAttrs(setting: SettingParams) {
   }
   switch (setting.type) {
     case 'combo':
-      attrs['options'] = setting.options
+      attrs['options'] =
+        typeof setting.options === 'function'
+          ? setting.options(settingStore.get(setting.id))
+          : setting.options
       if (typeof setting.options[0] !== 'string') {
         attrs['optionLabel'] = 'text'
         attrs['optionValue'] = 'value'


### PR DESCRIPTION
`SettingsParams.options` can be a function:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/845ab88d55a881ff64308a7a76e3634834193d0d/src/types/settingTypes.ts#L40

For combo settings, the options property is set here:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/845ab88d55a881ff64308a7a76e3634834193d0d/src/components/dialog/content/setting/SettingGroup.vue#L71

`setting.options` is not invoked automatically, and Primvue `select.options` expects `any[]`, so the option fails to render.

Examples:

- `Crystools.whichHDD`
- `pysssss.Workflows.Default Workflow`