### PR TITLE
Hide hidden settings

### DIFF
--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -33,7 +33,9 @@ export const useSettingStore = defineStore('setting', {
   getters: {
     settingTree(): SettingTreeNode {
       const root = buildTree(
-        Object.values(this.settings),
+        Object.values(this.settings).filter(
+          (setting: SettingParams) => setting.type !== 'hidden'
+        ),
         (setting: SettingParams) => setting.category || setting.id.split('.')
       )
 

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -31,6 +31,7 @@ export const useSettingStore = defineStore('setting', {
     settings: {}
   }),
   getters: {
+    // Setting tree structure used for the settings dialog display.
     settingTree(): SettingTreeNode {
       const root = buildTree(
         Object.values(this.settings).filter(


### PR DESCRIPTION
If the setting type is marked as 'hidden', don't include it in the settingTree for display.