### PR TITLE
Mark show missing models warning as experimental

### DIFF
--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -39,6 +39,8 @@ test.describe('Missing models warning', () => {
   test('Should display a warning when missing models are found', async ({
     comfyPage
   }) => {
+    await comfyPage.setSetting('Comfy.Workflow.ShowMissingModelsWarning', true)
+
     // The fake_model.safetensors is served by
     // https://github.com/Comfy-Org/ComfyUI_devtools/blob/main/__init__.py
     await comfyPage.loadWorkflow('missing_models')

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -188,7 +188,8 @@ export const useSettingStore = defineStore('setting', {
         id: 'Comfy.Workflow.ShowMissingModelsWarning',
         name: 'Show missing models warning',
         type: 'boolean',
-        defaultValue: true
+        defaultValue: false,
+        experimental: true
       })
 
       app.ui.settings.addSetting({


### PR DESCRIPTION
Disable by default as the mechanism of saving workflow with model info is not there yet. Enable by default might create confusion to our users.