### PR TITLE
Fix node title editor's width when node is collapsed

### DIFF
--- a/src/components/graph/NodeTitleEditor.vue
+++ b/src/components/graph/NodeTitleEditor.vue
@@ -54,9 +54,12 @@ const extension: ComfyExtension = {
       editedTitle.value = this.title
       showInput.value = true
 
+      const isCollapsed = node.flags?.collapsed
       const [x1, y1, x2, y2] = this.getBounding()
       const [nodeWidth, nodeHeight] = this.size
-      const canvasWidth = nodeWidth
+      // @ts-expect-error Remove after collapsed_width is exposed in LiteGraph
+      const canvasWidth =
+        isCollapsed && node._collapsed_width ? node._collapsed_width : nodeWidth
       const canvasHeight = LiteGraph.NODE_TITLE_HEIGHT
 
       const [left, top] = app.canvasPosToClientPos([x1, y1])

--- a/src/components/graph/NodeTitleEditor.vue
+++ b/src/components/graph/NodeTitleEditor.vue
@@ -57,8 +57,8 @@ const extension: ComfyExtension = {
       const isCollapsed = node.flags?.collapsed
       const [x1, y1, x2, y2] = this.getBounding()
       const [nodeWidth, nodeHeight] = this.size
-      // @ts-expect-error Remove after collapsed_width is exposed in LiteGraph
       const canvasWidth =
+        // @ts-expect-error Remove after collapsed_width is exposed in LiteGraph
         isCollapsed && node._collapsed_width ? node._collapsed_width : nodeWidth
       const canvasHeight = LiteGraph.NODE_TITLE_HEIGHT
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/a17cbd3c-b144-4ec8-b596-ac5f6cc1ec3e

