### PR TITLE
Add support for extra system stats in error report

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -70,11 +70,21 @@ const toast = useToast()
 const { copy, isSupported } = useClipboard()
 
 onMounted(async () => {
-  const [systemStats, logs] = await Promise.all([
-    api.getSystemStats(),
-    api.getLogs()
-  ])
-  generateReport(systemStats, logs)
+  try {
+    const [systemStats, logs] = await Promise.all([
+      api.getSystemStats(),
+      api.getLogs()
+    ])
+    generateReport(systemStats, logs)
+  } catch (error) {
+    console.error('Error fetching system stats or logs:', error)
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: 'Failed to fetch system information',
+      life: 5000
+    })
+  }
 })
 
 const generateReport = (systemStats: SystemStats, logs: string) => {

--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -70,10 +70,14 @@ const toast = useToast()
 const { copy, isSupported } = useClipboard()
 
 onMounted(async () => {
-  generateReport(await api.getSystemStats())
+  const [systemStats, logs] = await Promise.all([
+    api.getSystemStats(),
+    api.getLogs()
+  ])
+  generateReport(systemStats, logs)
 })
 
-const generateReport = (systemStats: SystemStats) => {
+const generateReport = (systemStats: SystemStats, logs: string) => {
   // The default JSON workflow has about 3000 characters.
   const MAX_JSON_LENGTH = 20000
   const workflowJSONString = JSON.stringify(app.graph.serialize())
@@ -93,9 +97,12 @@ const generateReport = (systemStats: SystemStats) => {
 ${props.error.traceback.join('\n')}
 \`\`\`
 ## System Information
+- **ComfyUI Version:** ${systemStats.system.comfyui_version}
+- **Arguments:** ${systemStats.system.argv.join(' ')}
 - **OS:** ${systemStats.system.os}
 - **Python Version:** ${systemStats.system.python_version}
 - **Embedded Python:** ${systemStats.system.embedded_python}
+- **PyTorch Version:** ${systemStats.system.pytorch_version}
 ## Devices
 ${systemStats.devices
   .map(
@@ -109,7 +116,10 @@ ${systemStats.devices
 `
   )
   .join('\n')}
-
+## Logs
+\`\`\`
+${logs}
+\`\`\`
 ## Attached Workflow
 Please make sure that workflow does not contain any sensitive information such as API keys or passwords.
 \`\`\`

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -13,6 +13,7 @@ import {
   User,
   Settings
 } from '@/types/apiTypes'
+import axios from 'axios'
 
 interface QueuePromptRequestBody {
   client_id: string
@@ -44,6 +45,10 @@ class ComfyApi extends EventTarget {
     this.api_host = location.host
     this.api_base = location.pathname.split('/').slice(0, -1).join('/')
     this.initialClientId = sessionStorage.getItem('clientId')
+  }
+
+  internalURL(route: string): string {
+    return this.api_base + '/internal' + route
   }
 
   apiURL(route: string): string {
@@ -651,6 +656,10 @@ class ComfyApi extends EventTarget {
       )
     }
     return resp.json()
+  }
+
+  async getLogs(): Promise<string> {
+    return (await axios.get(this.internalURL('/logs'))).data
   }
 }
 

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -389,7 +389,10 @@ export const zSystemStats = z.object({
   system: z.object({
     os: z.string(),
     python_version: z.string(),
-    embedded_python: z.boolean()
+    embedded_python: z.boolean(),
+    comfyui_version: z.string(),
+    pytorch_version: z.string(),
+    argv: z.array(z.string())
   }),
   devices: z.array(
     z.object({

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -91,6 +91,9 @@ export default defineConfig({
   base: '',
   server: {
     proxy: {
+      '/internal': {
+        target: DEV_SERVER_COMFYUI_URL,
+      },
       '/api': {
         target: DEV_SERVER_COMFYUI_URL,
         // Return empty array for extensions API as these modules


### PR DESCRIPTION
Related issue:
https://github.com/comfyanonymous/ComfyUI/pull/4664

Sample report:

# ComfyUI Error Report
## Error Details
- **Node Type:** DevToolsErrorRaiseNode
- **Exception Type:** Exception
- **Exception Message:** Error node was called!
## Stack Trace
```
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 317, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)

  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 192, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)

  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 165, in _map_node_over_list
    process_inputs({})

  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))

  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_devtools\dev_nodes.py", line 12, in raise_error
    raise Exception("Error node was called!")

```
## System Information
- **ComfyUI Version:** unknown
- **Arguments:** main.py --windows-standalone-build --enable-cors-header --front-end-root web_custom_versions/main/dev
- **OS:** nt
- **Python Version:** 3.10.6 (tags/v3.10.6:9c7b4bd, Aug  1 2022, 21:53:49) [MSC v.1932 64 bit (AMD64)]
- **Embedded Python:** false
- **PyTorch Version:** 2.1.2+cu121
## Devices

- **Name:** cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync
  - **Type:** cuda
  - **VRAM Total:** 25756696576
  - **VRAM Free:** 24125636608
  - **Torch VRAM Total:** 0
  - **Torch VRAM Free:** 0

## Logs
```
2024-08-29 19:09:27,055 - root - INFO - Total VRAM 24564 MB, total RAM 32694 MB
2024-08-29 19:09:27,056 - root - INFO - pytorch version: 2.1.2+cu121
2024-08-29 19:09:28,820 - root - INFO - xformers version: 0.0.23.post1
2024-08-29 19:09:28,821 - root - INFO - Set vram state to: NORMAL_VRAM
2024-08-29 19:09:28,821 - root - INFO - Device: cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync
2024-08-29 19:09:32,935 - root - INFO - Using xformers cross attention
2024-08-29 19:09:34,404 - root - INFO - [Prompt Server] web root: web_custom_versions/main/dev
2024-08-29 19:09:34,413 - root - INFO - Adding extra search path checkpoints D:/stable-diffusion-webui/models/Stable-diffusion
2024-08-29 19:09:34,413 - root - INFO - Adding extra search path configs D:/stable-diffusion-webui/models/Stable-diffusion
2024-08-29 19:09:34,414 - root - INFO - Adding extra search path vae D:/stable-diffusion-webui/models/VAE
2024-08-29 19:09:34,414 - root - INFO - Adding extra search path loras D:/stable-diffusion-webui/models/Lora
2024-08-29 19:09:34,415 - root - INFO - Adding extra search path loras D:/stable-diffusion-webui/models/LyCORIS
2024-08-29 19:09:34,415 - root - INFO - Adding extra search path upscale_models D:/stable-diffusion-webui/models/ESRGAN
2024-08-29 19:09:34,415 - root - INFO - Adding extra search path upscale_models D:/stable-diffusion-webui/models/RealESRGAN
2024-08-29 19:09:34,416 - root - INFO - Adding extra search path upscale_models D:/stable-diffusion-webui/models/SwinIR
2024-08-29 19:09:34,416 - root - INFO - Adding extra search path embeddings D:/stable-diffusion-webui/embeddings
2024-08-29 19:09:34,416 - root - INFO - Adding extra search path hypernetworks D:/stable-diffusion-webui/models/hypernetworks
2024-08-29 19:09:34,417 - root - INFO - Adding extra search path controlnet D:/stable-diffusion-webui/models/ControlNet
2024-08-29 19:09:34,719 - root - INFO - Successfully imported spandrel_extra_arches: support for non commercial upscale models.
2024-08-29 19:09:57,290 - root - INFO - Total VRAM 24564 MB, total RAM 32694 MB
2024-08-29 19:09:57,291 - root - INFO - pytorch version: 2.1.2+cu121
2024-08-29 19:09:57,291 - root - INFO - xformers version: 0.0.23.post1
2024-08-29 19:09:57,292 - root - INFO - Set vram state to: NORMAL_VRAM
2024-08-29 19:09:57,292 - root - INFO - Device: cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync
2024-08-29 19:10:03,797 - root - WARNING - Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable\ComfyUI\nodes.py", line 1993, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1016, in get_code
  File "<frozen importlib._bootstrap_external>", line 1073, in get_data
FileNotFoundError: [Errno 2] No such file or directory: 'D:\\ComfyUI_windows_portable\\ComfyUI\\custom_nodes\\comfyui-native-instant-id\\__init__.py'

2024-08-29 19:10:03,801 - root - WARNING - Cannot import D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui-native-instant-id module for custom nodes: [Errno 2] No such file or directory: 'D:\\ComfyUI_windows_portable\\ComfyUI\\custom_nodes\\comfyui-native-instant-id\\__init__.py'
2024-08-29 19:10:07,848 - root - WARNING - Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable\ComfyUI\nodes.py", line 1993, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\testing-pack\__init__.py", line 1, in <module>
    from .specific_tests import TEST_NODE_CLASS_MAPPINGS, TEST_NODE_DISPLAY_NAME_MAPPINGS
  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\testing-pack\specific_tests.py", line 3, in <module>
    from comfy.graph_utils import GraphBuilder
ModuleNotFoundError: No module named 'comfy.graph_utils'

2024-08-29 19:10:07,849 - root - WARNING - Cannot import D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\testing-pack module for custom nodes: No module named 'comfy.graph_utils'
2024-08-29 19:10:15,101 - root - INFO - 
Import times for custom nodes:
2024-08-29 19:10:15,102 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Crystools-save
2024-08-29 19:10:15,102 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-NodePresets
2024-08-29 19:10:15,102 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\websocket_image_save.py
2024-08-29 19:10:15,103 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-IC-Light
2024-08-29 19:10:15,103 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\cg-use-everywhere
2024-08-29 19:10:15,103 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_ADV_CLIP_emb
2024-08-29 19:10:15,104 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\stability-ComfyUI-nodes
2024-08-29 19:10:15,104 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Lora-Auto-Trigger-Words
2024-08-29 19:10:15,104 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-OpenPose-Editor
2024-08-29 19:10:15,105 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_densediffusion
2024-08-29 19:10:15,105 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui-tooling-nodes
2024-08-29 19:10:15,105 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-post-processing-nodes
2024-08-29 19:10:15,106 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui_jankhidiffusion
2024-08-29 19:10:15,106 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_IPAdapter_plus
2024-08-29 19:10:15,106 - root - INFO -    0.0 seconds (IMPORT FAILED): D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\testing-pack
2024-08-29 19:10:15,107 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_devtools
2024-08-29 19:10:15,107 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-WD14-Tagger
2024-08-29 19:10:15,107 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_UltimateSDUpscale
2024-08-29 19:10:15,108 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui-browser
2024-08-29 19:10:15,108 - root - INFO -    0.0 seconds (IMPORT FAILED): D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui-native-instant-id
2024-08-29 19:10:15,109 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Custom-Scripts
2024-08-29 19:10:15,109 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-KJNodes
2024-08-29 19:10:15,109 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-layereddiffusion
2024-08-29 19:10:15,109 - root - INFO -    0.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Advanced-ControlNet
2024-08-29 19:10:15,110 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-IC-Light-kijai
2024-08-29 19:10:15,110 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\rgthree-comfy
2024-08-29 19:10:15,110 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-AnimateDiff-Evolved
2024-08-29 19:10:15,111 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_essentials
2024-08-29 19:10:15,111 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui_controlnet_aux
2024-08-29 19:10:15,111 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui-workspace-manager
2024-08-29 19:10:15,111 - root - INFO -    0.1 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-TiledDiffusion
2024-08-29 19:10:15,112 - root - INFO -    0.2 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Crystools
2024-08-29 19:10:15,112 - root - INFO -    0.2 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_DanTagGen
2024-08-29 19:10:15,112 - root - INFO -    0.3 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Inspire-Pack
2024-08-29 19:10:15,113 - root - INFO -    0.4 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfy_mtb
2024-08-29 19:10:15,113 - root - INFO -    0.6 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-BiRefNet-ZHO
2024-08-29 19:10:15,113 - root - INFO -    0.8 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_omost
2024-08-29 19:10:15,114 - root - INFO -    0.9 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Manager
2024-08-29 19:10:15,114 - root - INFO -    2.0 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-VideoHelperSuite
2024-08-29 19:10:15,114 - root - INFO -    2.6 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-InstantID
2024-08-29 19:10:15,115 - root - INFO -    2.6 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Impact-Pack
2024-08-29 19:10:15,115 - root - INFO -    2.7 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Easy-Use
2024-08-29 19:10:15,115 - root - INFO -    3.8 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Allor
2024-08-29 19:10:15,116 - root - INFO -    7.2 seconds: D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\was-node-suite-comfyui
2024-08-29 19:10:15,116 - root - INFO - 
2024-08-29 19:10:15,206 - root - INFO - Starting server

2024-08-29 19:10:15,206 - root - INFO - To see the GUI go to: http://127.0.0.1:8188
2024-08-29 19:10:33,168 - root - INFO - got prompt
2024-08-29 19:10:33,174 - root - ERROR - !!! Exception during processing !!! Error node was called!
2024-08-29 19:10:33,179 - root - ERROR - Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 317, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 192, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 165, in _map_node_over_list
    process_inputs({})
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_devtools\dev_nodes.py", line 12, in raise_error
    raise Exception("Error node was called!")
Exception: Error node was called!

2024-08-29 19:10:33,182 - root - INFO - Prompt executed in 0.01 seconds
2024-08-29 19:10:51,499 - root - INFO - got prompt
2024-08-29 19:10:51,503 - root - ERROR - !!! Exception during processing !!! Error node was called!
2024-08-29 19:10:51,505 - root - ERROR - Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 317, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 192, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 165, in _map_node_over_list
    process_inputs({})
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_devtools\dev_nodes.py", line 12, in raise_error
    raise Exception("Error node was called!")
Exception: Error node was called!

2024-08-29 19:10:51,508 - root - INFO - Prompt executed in 0.01 seconds
2024-08-29 19:20:11,641 - root - INFO - got prompt
2024-08-29 19:20:11,645 - root - ERROR - !!! Exception during processing !!! Error node was called!
2024-08-29 19:20:11,647 - root - ERROR - Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 317, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 192, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 165, in _map_node_over_list
    process_inputs({})
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_devtools\dev_nodes.py", line 12, in raise_error
    raise Exception("Error node was called!")
Exception: Error node was called!

2024-08-29 19:20:11,650 - root - INFO - Prompt executed in 0.01 seconds
2024-08-29 19:21:12,035 - root - INFO - got prompt
2024-08-29 19:21:12,038 - root - ERROR - !!! Exception during processing !!! Error node was called!
2024-08-29 19:21:12,039 - root - ERROR - Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 317, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 192, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 165, in _map_node_over_list
    process_inputs({})
  File "D:\ComfyUI_windows_portable\ComfyUI\execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "D:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI_devtools\dev_nodes.py", line 12, in raise_error
    raise Exception("Error node was called!")
Exception: Error node was called!

2024-08-29 19:21:12,043 - root - INFO - Prompt executed in 0.01 seconds
```
## Attached Workflow
Please make sure that workflow does not contain any sensitive information such as API keys or passwords.
```
{"last_node_id":14,"last_link_id":11,"nodes":[{"id":13,"type":"DevToolsErrorRaiseNode","pos":{"0":644,"1":-18,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0},"size":{"0":210,"1":26},"flags":{},"order":0,"mode":0,"inputs":[{"name":"input","type":"IMAGE","link":null}],"outputs":[{"name":"IMAGE","type":"IMAGE","links":[11],"slot_index":0,"shape":3}],"properties":{"Node name for S&R":"DevToolsErrorRaiseNode"}},{"id":14,"type":"PreviewImage","pos":{"0":956,"1":-14,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0},"size":{"0":210,"1":26},"flags":{},"order":1,"mode":0,"inputs":[{"name":"images","type":"IMAGE","link":11}],"outputs":[],"properties":{"Node name for S&R":"PreviewImage"}}],"links":[[11,13,0,14,0,"IMAGE"]],"groups":[],"config":{},"extra":{"ds":{"scale":1,"offset":[75,329]}},"version":0.4}
```

## Additional Context
(Please add any additional context or steps to reproduce the error here)