### PR TITLE
Add confirm dialog on window close

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
   <BlockUI full-screen :blocked="isLoading" />
   <GlobalDialog />
   <GlobalToast />
+  <UnloadWindowConfirmDialog />
   <GraphCanvas />
 </template>
 
@@ -26,6 +27,7 @@ import { useWorkspaceStore } from './stores/workspaceStateStore'
 import NodeLibrarySidebarTab from './components/sidebar/tabs/NodeLibrarySidebarTab.vue'
 import GlobalDialog from './components/dialog/GlobalDialog.vue'
 import GlobalToast from './components/toast/GlobalToast.vue'
+import UnloadWindowConfirmDialog from './components/dialog/UnloadWindowConfirmDialog.vue'
 import { api } from './scripts/api'
 import { StatusWsMessageStatus } from './types/apiTypes'
 import { useQueuePendingTaskCountStore } from './stores/queueStore'

--- a/src/components/dialog/UnloadWindowConfirmDialog.vue
+++ b/src/components/dialog/UnloadWindowConfirmDialog.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { useSettingStore } from '@/stores/settingStore'
+import { onMounted, onUnmounted } from 'vue'
+
+const settingStore = useSettingStore()
+const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+  if (settingStore.get('Comfy.Window.UnloadConfirmation')) {
+    event.preventDefault()
+    return true
+  }
+  return undefined
+}
+
+onMounted(() => {
+  window.addEventListener('beforeunload', handleBeforeUnload)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('beforeunload', handleBeforeUnload)
+})
+</script>

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -260,6 +260,13 @@ export const useSettingStore = defineStore('setting', {
         type: 'boolean',
         defaultValue: true
       })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.Window.UnloadConfirmation',
+        name: 'Show confirmation when closing window',
+        type: 'boolean',
+        defaultValue: false
+      })
     },
 
     set<K extends keyof Settings>(key: K, value: Settings[K]) {

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -469,7 +469,8 @@ const zSettings = z.record(z.any()).and(
       'Comfy.Queue.ImageFit': z.enum(['contain', 'cover']),
       'Comfy.Workflow.ModelDownload.AllowedSources': z.array(z.string()),
       'Comfy.Workflow.ModelDownload.AllowedSuffixes': z.array(z.string()),
-      'Comfy.Node.DoubleClickTitleToEdit': z.boolean()
+      'Comfy.Node.DoubleClickTitleToEdit': z.boolean(),
+      'Comfy.Window.UnloadConfirmation': z.boolean()
     })
     .optional()
 )


### PR DESCRIPTION
On window close, a browser level dialog will be poped up to remind user unsaved changes. The browser message cannot be customized due to security reasons enforced by browser vendors.

The default setting value is false. Later after the workflow manager redesign, we should have the dialog popup based whether there is unsaved content. Currently the dialog just always trigger on close based on the setting value.

![image](https://github.com/user-attachments/assets/590d980e-cef8-4ce3-96ee-ad8877c6459d)


![image](https://github.com/user-attachments/assets/60bb95b6-f1da-4efc-b9fd-283ab76c5bc6)
