### PR TITLE
Remove github button in error dialog

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -20,6 +20,11 @@
     </template>
 
     <div class="action-container">
+      <FindIssueButton
+        :errorMessage="props.error.exception_message"
+        :repoOwner="repoOwner"
+        :repoName="repoName"
+      />
       <Button
         v-if="reportOpen"
         :label="$t('copyToClipboard')"
@@ -38,6 +43,7 @@ import Button from 'primevue/button'
 import Divider from 'primevue/divider'
 import ScrollPanel from 'primevue/scrollpanel'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
+import FindIssueButton from '@/components/dialog/content/error/FindIssueButton.vue'
 import type { ExecutionErrorWsMessage, SystemStats } from '@/types/apiTypes'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'

--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -20,17 +20,6 @@
     </template>
 
     <div class="action-container">
-      <FindIssueButton
-        :errorMessage="props.error.exception_message"
-        :repoOwner="repoOwner"
-        :repoName="repoName"
-      />
-      <Button
-        :label="$t('openNewIssue')"
-        icon="pi pi-github"
-        @click="openNewGithubIssue"
-        class="p-button-secondary"
-      />
       <Button
         v-if="reportOpen"
         :label="$t('copyToClipboard')"
@@ -48,7 +37,6 @@ import { useToast } from 'primevue/usetoast'
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
 import ScrollPanel from 'primevue/scrollpanel'
-import FindIssueButton from '@/components/dialog/content/error/FindIssueButton.vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import type { ExecutionErrorWsMessage, SystemStats } from '@/types/apiTypes'
 import { api } from '@/scripts/api'

--- a/src/components/dialog/content/error/FindIssueButton.vue
+++ b/src/components/dialog/content/error/FindIssueButton.vue
@@ -1,20 +1,16 @@
 <template>
   <Button
     @click="openGitHubIssues"
-    :label="buttonLabel"
+    :label="$t('findIssues')"
     severity="secondary"
     icon="pi pi-github"
-    :badge="issueCount.toString()"
   >
   </Button>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useAsyncState } from '@vueuse/core'
-import axios from 'axios'
 import Button from 'primevue/button'
-import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
   errorMessage: string
@@ -22,30 +18,7 @@ const props = defineProps<{
   repoName: string
 }>()
 
-const GITHUB_API_URL = 'https://api.github.com/search/issues'
-
 const queryString = computed(() => props.errorMessage + ' is:issue')
-const getIssueCount = async () => {
-  const query = `${queryString.value} repo:${props.repoOwner}/${props.repoName}`
-  const response = await axios.get(GITHUB_API_URL, {
-    params: {
-      q: query,
-      per_page: 1
-    }
-  })
-  return response.data.total_count
-}
-
-const {
-  state: issueCount,
-  isLoading,
-  execute
-} = useAsyncState(getIssueCount, 0)
-
-const { t } = useI18n()
-const buttonLabel = computed(() => {
-  return isLoading.value ? 'Loading...' : t('findIssues')
-})
 
 const openGitHubIssues = () => {
   const query = encodeURIComponent(queryString.value)


### PR DESCRIPTION
Github file issue button is removed because we are getting too many unrelated error reports in the main repo. Until we find a way to direct error report to extension repo, we should not offer a direct one-click way to file github issue

Github issue count badge is removed because there are user complaints on eager web requests without user action.