### PR TITLE
Add setting to control tree explorer item padding

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,6 +60,14 @@ watchEffect(() => {
   )
 })
 
+watchEffect(() => {
+  const padding = useSettingStore().get('Comfy.TreeExplorer.ItemPadding')
+  document.documentElement.style.setProperty(
+    '--comfy-tree-explorer-item-padding',
+    `${padding}px`
+  )
+})
+
 const { t } = useI18n()
 const init = () => {
   useSettingStore().addSettings(app.ui.settings)
@@ -125,6 +133,12 @@ onUnmounted(() => {
   api.removeEventListener('reconnected', onReconnected)
 })
 </script>
+
+<style>
+.p-tree-node-content {
+  padding: var(--comfy-tree-explorer-item-padding) !important;
+}
+</style>
 
 <style scoped>
 .spinner {

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -267,6 +267,18 @@ export const useSettingStore = defineStore('setting', {
         type: 'boolean',
         defaultValue: false
       })
+
+      app.ui.settings.addSetting({
+        id: 'Comfy.TreeExplorer.ItemPadding',
+        name: 'Tree explorer item padding',
+        type: 'slider',
+        defaultValue: 2,
+        attrs: {
+          min: 0,
+          max: 8,
+          step: 1
+        }
+      })
     },
 
     set<K extends keyof Settings>(key: K, value: Settings[K]) {


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/528

![image](https://github.com/user-attachments/assets/cb84d36e-f2e3-497d-a5f4-2c628c60e7ca)

## Note
If you still feel the tree is not compact enough, you can adjust CSS in `user.css` to change the font size of various tree components.
