### PR TITLE
Add beforeRegisterVueAppNodeDefs hook

### DIFF
--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -129,7 +129,9 @@ const filteredRoot = computed<TreeNode | null>(() => {
 const filters: Ref<Array<SearchFilter & { filter: FilterAndValue<string> }>> =
   ref([])
 const handleSearch = (query: string) => {
-  if (query.length < 3 && !filters.value.length) {
+  // Don't apply a min length filter because it does not make sense in
+  // multi-byte languages like Chinese, Japanese, Korean, etc.
+  if (query.length === 0 && !filters.value.length) {
     filteredNodeDefs.value = []
     expandedKeys.value = {}
     return

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1968,7 +1968,9 @@ export class ComfyApp {
     }
 
     const nodeDefStore = useNodeDefStore()
-    nodeDefStore.updateNodeDefs(Object.values(allNodeDefs))
+    const nodeDefArray: ComfyNodeDef[] = Object.values(allNodeDefs)
+    this.#invokeExtensions('beforeRegisterVueAppNodeDefs', nodeDefArray, this)
+    nodeDefStore.updateNodeDefs(nodeDefArray)
     nodeDefStore.updateWidgets(this.widgets)
   }
 

--- a/src/types/comfy.d.ts
+++ b/src/types/comfy.d.ts
@@ -1,5 +1,6 @@
 import { LGraphNode, IWidget } from './litegraph'
 import { ComfyApp } from '../scripts/app'
+import type { ComfyNodeDef } from '@/types/apiTypes'
 
 export interface ComfyExtension {
   /**
@@ -44,7 +45,7 @@ export interface ComfyExtension {
     >
   >
   /**
-   * Allows the extension to add additional handling to the node before it is registered with LGraph
+   * Allows the extension to add additional handling to the node before it is registered with **LGraph**
    * @param nodeType The node class (not an instance)
    * @param nodeData The original node object info config object
    * @param app The ComfyUI app instance
@@ -54,6 +55,16 @@ export interface ComfyExtension {
     nodeData: ComfyObjectInfo,
     app: ComfyApp
   ): Promise<void>
+
+  /**
+   * Allows the extension to modify the node definitions before they are used in the Vue app
+   * Modifications is expected to be made in place.
+   *
+   * @param defs The node definitions
+   * @param app The ComfyUI app instance
+   */
+  beforeRegisterVueAppNodeDefs?(defs: ComfyNodeDef[], app: ComfyApp): void
+
   /**
    * Allows the extension to register additional nodes with LGraph after standard nodes are added
    * @param app The ComfyUI app instance


### PR DESCRIPTION
Add `beforeRegisterVueAppNodeDefs` for translation custom node to overwrite display_name in node definition.