### PR TITLE
Add ToastMessageOptions docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,11 @@ We will support custom icons later.
   app.extensionManager.toast.add({
     severity: 'info',
     summary: 'Loaded!',
-    detail: 'Extension loaded!'
+    detail: 'Extension loaded!',
+    life: 3000
   })
 ```
+Documentation of all supported options can be found here: <https://primevue.org/toast/#api.toast.interfaces.ToastMessageOptions>
 
 ![image](https://github.com/user-attachments/assets/de02cd7e-cd81-43d1-a0b0-bccef92ff487)
 </details>


### PR DESCRIPTION
The type hints from the `ToastMessageOptions` interface may not be accessible in custom node development environment, making it hard to know that other option fields exist.

Updated readme to link to the interface in Primevue docs and to include `life` field in the snippet—since it's commonly used.