### PR TITLE
Fix logging setting's display name

### DIFF
--- a/src/scripts/logging.ts
+++ b/src/scripts/logging.ts
@@ -276,11 +276,11 @@ export class ComfyLogging {
   }
 
   addSetting() {
-    const settingId: string = 'Comfy.Logging.Enabled'
+    const settingId = 'Comfy.Logging.Enabled'
     const htmlSettingId = settingId.replaceAll('.', '-')
     const setting = this.app.ui.settings.addSetting({
       id: settingId,
-      name: settingId,
+      name: 'Enable logging',
       defaultValue: true,
       onChange: (value) => {
         this.enabled = value


### PR DESCRIPTION
This setting field was using its ID as its display name:

![Selection_317](https://github.com/user-attachments/assets/9474a0e1-4c0e-4777-98cc-d243e3f95a5d)

After:

![Selection_318](https://github.com/user-attachments/assets/24cedc74-3b54-45cf-9208-7a8e65ddcbf3)


The `settingID` was also being explicitly set as `string` type, which makes it not an element of `keyof Settings`