### PR TITLE
Fix search box props type

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -119,7 +119,7 @@ const showIdName = computed(() =>
 const props = withDefaults(
   defineProps<{
     filters: FilterAndValue[]
-    searchLimit: number
+    searchLimit?: number
   }>(),
   {
     searchLimit: 64


### PR DESCRIPTION
The `searchLimit` prop on `NodeSearchBox` should be optional, since it is set with `withDefaults`. Currently it causes warning:

![Selection_323](https://github.com/user-attachments/assets/97ac0fc7-3531-489b-866e-9f54f1eaae6d)
