### PR TITLE
Improve sidebar accessibility

### DIFF
--- a/src/components/sidebar/SidebarIcon.vue
+++ b/src/components/sidebar/SidebarIcon.vue
@@ -3,11 +3,14 @@
     :class="props.class"
     text
     :pt="{
-      root: `side-bar-button ${
-        props.selected
-          ? 'p-button-primary side-bar-button-selected'
-          : 'p-button-secondary'
-      }`
+      root: {
+        class: `side-bar-button ${
+          props.selected
+            ? 'p-button-primary side-bar-button-selected'
+            : 'p-button-secondary'
+        }`,
+        'aria-label': props.tooltip
+      }
     }"
     @click="emit('click', $event)"
     v-tooltip="{ value: props.tooltip, showDelay: 300, hideDelay: 300 }"

--- a/src/components/sidebar/__tests__/SidebarIcon.spec.ts
+++ b/src/components/sidebar/__tests__/SidebarIcon.spec.ts
@@ -32,20 +32,39 @@ describe('SidebarIcon', () => {
     })
   }
 
+  it('renders label', () => {
+    const wrapper = mountSidebarIcon({})
+    expect(wrapper.find('.p-button.p-component').exists()).toBe(true)
+    expect(wrapper.find('.p-button-label').exists()).toBe(true)
+  })
+
+  it('renders icon', () => {
+    const wrapper = mountSidebarIcon({})
+    expect(wrapper.find('.p-button-icon-only').exists()).toBe(true)
+  })
+
+  it('creates badge when iconBadge prop is set', () => {
+    const badge = '2'
+    const wrapper = mountSidebarIcon({ iconBadge: badge })
+    const badgeEl = wrapper.findComponent(OverlayBadge)
+    expect(badgeEl.exists()).toBe(true)
+    expect(badgeEl.find('.p-badge').text()).toEqual(badge)
+  })
+
   it('shows tooltip on hover', async () => {
     const tooltipShowDelay = 300
     const tooltipText = 'Settings'
     const wrapper = mountSidebarIcon({ tooltip: tooltipText })
 
-    const tooltip = document.querySelector('[role="tooltip"]')
-    expect(tooltip).toBeNull()
+    const tooltipElBeforeHover = document.querySelector('[role="tooltip"]')
+    expect(tooltipElBeforeHover).toBeNull()
 
     // Hover over the icon
     await wrapper.trigger('mouseenter')
     await new Promise((resolve) => setTimeout(resolve, tooltipShowDelay + 16))
 
-    const tooltipAfterHover = document.querySelector('[role="tooltip"]')
-    expect(tooltipAfterHover).not.toBeNull()
+    const tooltipElAfterHover = document.querySelector('[role="tooltip"]')
+    expect(tooltipElAfterHover).not.toBeNull()
   })
 
   it('sets aria-label attribute when tooltip is provided', () => {

--- a/src/components/sidebar/__tests__/SidebarIcon.spec.ts
+++ b/src/components/sidebar/__tests__/SidebarIcon.spec.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils'
+import { expect, describe, it } from 'vitest'
+import SidebarIcon from '../SidebarIcon.vue'
+import OverlayBadge from 'primevue/overlaybadge'
+import Button from 'primevue/button'
+import Tooltip from 'primevue/tooltip'
+import PrimeVue from 'primevue/config'
+
+type SidebarIconProps = {
+  icon: string
+  selected: boolean
+  tooltip?: string
+  class?: string
+  iconBadge?: string | (() => string | null)
+}
+
+describe('SidebarIcon', () => {
+  const exampleProps: SidebarIconProps = {
+    icon: 'pi pi-cog',
+    selected: false
+  }
+
+  const mountSidebarIcon = (props: Partial<SidebarIconProps>, options = {}) => {
+    return mount(SidebarIcon, {
+      global: {
+        plugins: [PrimeVue],
+        directives: { tooltip: Tooltip },
+        components: { OverlayBadge, Button }
+      },
+      props: { ...exampleProps, ...props },
+      ...options
+    })
+  }
+
+  it('shows tooltip on hover', async () => {
+    const tooltipShowDelay = 300
+    const tooltipText = 'Settings'
+    const wrapper = mountSidebarIcon({ tooltip: tooltipText })
+
+    const tooltip = document.querySelector('[role="tooltip"]')
+    expect(tooltip).toBeNull()
+
+    // Hover over the icon
+    await wrapper.trigger('mouseenter')
+    await new Promise((resolve) => setTimeout(resolve, tooltipShowDelay + 16))
+
+    const tooltipAfterHover = document.querySelector('[role="tooltip"]')
+    expect(tooltipAfterHover).not.toBeNull()
+  })
+
+  it('sets aria-label attribute when tooltip is provided', () => {
+    const tooltipText = 'Settings'
+    const wrapper = mountSidebarIcon({ tooltip: tooltipText })
+    expect(wrapper.attributes('aria-label')).toEqual(tooltipText)
+  })
+})


### PR DESCRIPTION
There's no text or ARIA attrs for the sidebar buttons ([primevue bug](https://github.com/primefaces/primevue/issues/5971)). Accessibility tree:

![Selection_330](https://github.com/user-attachments/assets/86897d74-be52-49f9-9417-37ee2eec9f8a)

Resolve by setting buttons' `aria-label` to their tooltip values.