### PR TITLE
Improve searchbox accessibility

### DIFF
--- a/browser_tests/nodeSearchBox.spec.ts
+++ b/browser_tests/nodeSearchBox.spec.ts
@@ -76,6 +76,16 @@ test.describe('Node search box', () => {
       'added-node-no-connection.png'
     )
   })
+
+  test('Has correct aria-labels on search results', async ({ comfyPage }) => {
+    const node = 'Load Checkpoint'
+    await comfyPage.doubleClickCanvas()
+    await comfyPage.searchBox.fillAndSelectFirstNode(node)
+    const firstResult = comfyPage.page
+      .locator('li.p-autocomplete-option')
+      .first()
+    await expect(firstResult).toHaveAttribute('aria-label', node)
+  })
 })
 
 test.describe('Release context menu', () => {

--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -40,6 +40,7 @@
       auto-option-focus
       force-selection
       multiple
+      :optionLabel="'display_name'"
     >
       <template v-slot:option="{ option }">
         <div class="option-container">

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -6,7 +6,10 @@
       :dismissable-mask="dismissable"
       @hide="clearFilters"
       :pt="{
-        root: { class: 'invisible-dialog-root' },
+        root: {
+          class: 'invisible-dialog-root',
+          role: 'search'
+        },
         mask: { class: 'node-search-box-dialog-mask' },
         transition: {
           enterFromClass: 'opacity-0 scale-75',


### PR DESCRIPTION
Currently, ARIA labels on search results are all `[object Object]`. Accessibility tree:

![Selection_334](https://github.com/user-attachments/assets/e0f40838-6934-4afe-a20c-a4842a98871c)

Resolved by setting `optionLabel` prop in `AutoComplete` component (see [AutoComplete source](https://github.com/primefaces/primevue/blob/500181a3e23909a23de954a3897cea53f9db699e/packages/primevue/src/autocomplete/AutoComplete.vue#L149))