### PR TITLE
Fix reroute to wildcard & multi-typed slots

### DIFF
--- a/src/extensions/core/rerouteNode.ts
+++ b/src/extensions/core/rerouteNode.ts
@@ -128,8 +128,8 @@ app.registerExtension({
                       : null
                   if (
                     inputType &&
-                    inputType !== '*' &&
-                    nodeOutType !== inputType
+                    // @ts-expect-error Will self-resolve when LiteGraph types are generated
+                    !LiteGraph.isValidConnection(inputType, nodeOutType)
                   ) {
                     // The output doesnt match our input so disconnect it
                     node.disconnectInput(link.target_slot)


### PR DESCRIPTION
### Issue
Reroutes currently will not connect to nodes that do not _exactly_ match their type.

The following result in silent auto-disconnects during `onConnectionsChange` callback:
- Type to typeless (e.g. `INT` to `*`)
- Multi-types that don't match exactly (e.g. neither `INT` nor `INT,FLOAT` will work with `FLOAT,INT`)
- `INT` to `int`

### New behaviour
Use the same type check the rest of the connection process uses.