### PR TITLE
Document registerCustomNodes to reflect LGraphNode ES6 class conversion

### DIFF
--- a/src/types/comfy.d.ts
+++ b/src/types/comfy.d.ts
@@ -66,7 +66,9 @@ export interface ComfyExtension {
   beforeRegisterVueAppNodeDefs?(defs: ComfyNodeDef[], app: ComfyApp): void
 
   /**
-   * Allows the extension to register additional nodes with LGraph after standard nodes are added
+   * Allows the extension to register additional nodes with LGraph after standard nodes are added.
+   * Custom node classes should extend **LGraphNode**.
+   *
    * @param app The ComfyUI app instance
    */
   registerCustomNodes?(app: ComfyApp): Promise<void>


### PR DESCRIPTION
Updated doc comment to indicate that custom node classes need to subclass `LGraphNode` (since Comfy-Org/litegraph.js#98). The litegraph type for `registerNodeType` is already correct.

Related Issues:
- pythongosssss/ComfyUI-Custom-Scripts#343
- ltdrdata/ComfyUI-Manager#1042