### PR TITLE
Fix searchbox popover on touch devices

### DIFF
--- a/browser_tests/nodeSearchBox.spec.ts
+++ b/browser_tests/nodeSearchBox.spec.ts
@@ -86,6 +86,23 @@ test.describe('Node search box', () => {
       .first()
     await expect(firstResult).toHaveAttribute('aria-label', node)
   })
+
+  test('@mobile Can trigger on empty canvas tap', async ({ comfyPage }) => {
+    await comfyPage.closeMenu()
+    await comfyPage.loadWorkflow('single_ksampler')
+    const screenCenter = {
+      x: 200,
+      y: 400
+    }
+    await comfyPage.canvas.tap({
+      position: screenCenter
+    })
+    await comfyPage.canvas.tap({
+      position: screenCenter
+    })
+    await comfyPage.page.waitForTimeout(256)
+    await expect(comfyPage.searchBox.input).not.toHaveCount(0)
+  })
 })
 
 test.describe('Release context menu', () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,8 +36,9 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      timeout: 15000
-    }
+      timeout: 15000,
+      grepInvert: /@mobile/ // Run all tests except those tagged with @mobile
+    },
 
     // {
     //   name: 'firefox',
@@ -50,10 +51,11 @@ export default defineConfig({
     // },
 
     /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'], hasTouch: true },
+      grep: /@mobile/ // Run only tests tagged with @mobile
+    }
     // {
     //   name: 'Mobile Safari',
     //   use: { ...devices['iPhone 12'] },

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -98,7 +98,13 @@ const newSearchBoxEnabled = computed(
 )
 const showSearchBox = (e: LiteGraphCanvasEvent) => {
   if (newSearchBoxEnabled.value) {
-    showNewSearchBox(e)
+    if (e.detail.originalEvent?.pointerType === 'touch') {
+      setTimeout(() => {
+        showNewSearchBox(e)
+      }, 128)
+    } else {
+      showNewSearchBox(e)
+    }
   } else {
     canvasStore.canvas.showSearchBox(e.detail.originalEvent as MouseEvent)
   }


### PR DESCRIPTION
Issue: Opening search on touch device immediately selects search item if initiating event is same location as searchbox.

https://github.com/user-attachments/assets/037e94e5-fda2-4acd-af06-4883fe0dceab

Alternative solutions:

- Capture clicks on `AutoComplete` component/children (but cannot prevent primevue click handlers that are registered first - fails when click is on component root and not a child that can capture)
- Add delay to `option-select` handler (but doesn't prevent UI side effects from other click handlers)