### PR TITLE
Fix missing model dialog test

### DIFF
--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -70,6 +70,9 @@ test.describe('Execution error', () => {
 
 test.describe('Missing models warning', () => {
   test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.page.evaluate((url: string) => {
+      return fetch(`${url}/api/devtools/cleanup_fake_model`)
+    }, comfyPage.url)
     await comfyPage.setSetting('Comfy.Workflow.ModelDownload.AllowedSources', [
       'http://localhost:8188'
     ])


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI_frontend/pull/779 introduced a regression as we are now running the missing model dialog test twice without cleaning up. This PR fixes the test by cleaning up downloaded assets.