### PR TITLE
Make \n correctly displayed on error message

### DIFF
--- a/src/components/common/NoResultsPlaceholder.vue
+++ b/src/components/common/NoResultsPlaceholder.vue
@@ -5,7 +5,7 @@
         <div class="flex flex-col items-center">
           <i :class="icon" style="font-size: 3rem; margin-bottom: 1rem"></i>
           <h3>{{ title }}</h3>
-          <p>{{ message }}</p>
+          <p class="whitespace-pre-line text-center">{{ message }}</p>
           <Button
             v-if="buttonLabel"
             :label="buttonLabel"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/49f81d26-8a0b-4f41-a08b-d7c6a156a1bc)
