### PR TITLE
Add graceful correction when widgets undef.

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -751,6 +751,7 @@ app.registerExtension({
 
     nodeType.prototype.onGraphConfigured = function () {
       if (!this.inputs) return
+      this.widgets ??= []
 
       for (const input of this.inputs) {
         if (input.widget) {


### PR DESCRIPTION
Fixes crash on load of workflow where `node.widgets` has no `.find()`