### PR TITLE
Add apiTypes present in docs but missing in zod

### DIFF
--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -251,7 +251,7 @@ const zBaseInputSpecValue = z
     forceInput: z.boolean().optional(),
     lazy: z.boolean().optional(),
     rawLink: z.boolean().optional(),
-    tooltip: z.string().optional(),
+    tooltip: z.string().optional()
   })
   .passthrough()
 

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -247,7 +247,11 @@ function inputSpec(
 const zBaseInputSpecValue = z
   .object({
     default: z.any().optional(),
-    forceInput: z.boolean().optional()
+    defaultInput: z.boolean().optional(),
+    forceInput: z.boolean().optional(),
+    lazy: z.boolean().optional(),
+    rawLink: z.boolean().optional(),
+    tooltip: z.string().optional(),
   })
   .passthrough()
 


### PR DESCRIPTION
Adds types used in `INPUT_TYPES` in core:

- defaultInput
- forceInput
- lazy
- rawLink
- tooltip