### PR TITLE
Make useTreeExpansion hook accept expandedKeys as param

### DIFF
--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -92,7 +92,8 @@ import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 
 const nodeDefStore = useNodeDefStore()
 const nodeBookmarkStore = useNodeBookmarkStore()
-const { expandedKeys, expandNode, toggleNodeOnEvent } = useTreeExpansion()
+const expandedKeys = ref<Record<string, boolean>>({})
+const { expandNode, toggleNodeOnEvent } = useTreeExpansion(expandedKeys)
 
 const nodeBookmarkTreeExplorerRef = ref<InstanceType<
   typeof NodeBookmarkTreeExplorer

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
@@ -47,7 +47,8 @@ const props = defineProps<{
   filteredNodeDefs: ComfyNodeDefImpl[]
 }>()
 
-const { expandedKeys, expandNode, toggleNodeOnEvent } = useTreeExpansion()
+const expandedKeys = ref<Record<string, boolean>>({})
+const { expandNode, toggleNodeOnEvent } = useTreeExpansion(expandedKeys)
 
 const handleNodeClick = (
   node: RenderedTreeExplorerNode<ComfyNodeDefImpl>,

--- a/src/hooks/treeHooks.ts
+++ b/src/hooks/treeHooks.ts
@@ -1,9 +1,7 @@
-import { ref } from 'vue'
+import { Ref } from 'vue'
 import type { TreeNode } from 'primevue/treenode'
 
-export function useTreeExpansion() {
-  const expandedKeys = ref<Record<string, boolean>>({})
-
+export function useTreeExpansion(expandedKeys: Ref<Record<string, boolean>>) {
   const toggleNode = (node: TreeNode) => {
     if (node.key && typeof node.key === 'string') {
       if (node.key in expandedKeys.value) {
@@ -63,7 +61,6 @@ export function useTreeExpansion() {
   }
 
   return {
-    expandedKeys,
     toggleNode,
     toggleNodeRecursive,
     expandNode,


### PR DESCRIPTION
This makes `useTreeExpansion` hook more flexible. The component no longer need to own the ref to use the hook. Now all components that has access to the expandedKeys ref can use `useTreeExpansion` hook.