### PR TITLE
Move floating menu to a Vue component

### DIFF
--- a/src/components/appMenu/floating/FloatingMenu.vue
+++ b/src/components/appMenu/floating/FloatingMenu.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="floating-menu" ref="container"></div>
+</template>
+
+<script setup lang="ts">
+import { app } from '@/scripts/app'
+import { onMounted, ref } from 'vue'
+
+const container = ref<HTMLDivElement | null>(null)
+
+onMounted(() => {
+  app.ui.setup(container.value)
+})
+</script>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -6,6 +6,7 @@
       </template>
     </LiteGraphCanvasSplitterOverlay>
     <TitleEditor />
+    <FloatingMenu />
     <canvas ref="canvasRef" id="graph-canvas" tabindex="1" />
   </teleport>
   <NodeSearchboxPopover />
@@ -18,6 +19,7 @@ import SideToolbar from '@/components/sidebar/SideToolbar.vue'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import NodeSearchboxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
 import NodeTooltip from '@/components/graph/NodeTooltip.vue'
+import FloatingMenu from '@/components/appMenu/floating/FloatingMenu.vue'
 import { ref, computed, onUnmounted, onMounted, watchEffect } from 'vue'
 import { app as comfyApp } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -732,6 +732,7 @@ export class ComfyUI {
       $el('button', {
         id: 'comfy-clipspace-button',
         textContent: 'Clipspace',
+        // @ts-expect-error Move to ComfyApp
         onclick: () => app.openClipspace()
       }),
       $el('button', {

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -371,6 +371,11 @@ export class ComfyUI {
       this.queue.update()
       this.history.update()
     })
+
+    // For testing. Legacy ui tests don't have vue app initialized.
+    if (!app.vueAppReady) {
+      this.setup(document.body)
+    }
   }
 
   setup(containerElement: HTMLElement) {

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -371,7 +371,9 @@ export class ComfyUI {
       this.queue.update()
       this.history.update()
     })
+  }
 
+  setup(containerElement: HTMLElement) {
     const confirmClear = this.settings.addSetting({
       id: 'Comfy.ConfirmClear',
       category: ['Comfy', 'Workflow', 'ConfirmClear'],
@@ -497,7 +499,7 @@ export class ComfyUI {
     this.menuHamburger = $el(
       'div.comfy-menu-hamburger',
       {
-        parent: document.body,
+        parent: containerElement,
         onclick: () => {
           this.menuContainer.style.display = 'block'
           this.menuHamburger.style.display = 'none'
@@ -506,7 +508,7 @@ export class ComfyUI {
       [$el('div'), $el('div'), $el('div')]
     ) as HTMLDivElement
 
-    this.menuContainer = $el('div.comfy-menu', { parent: document.body }, [
+    this.menuContainer = $el('div.comfy-menu', { parent: containerElement }, [
       $el(
         'div.drag-handle.comfy-menu-header',
         {


### PR DESCRIPTION
This PR moves the legacy floating menu from `document.body` to a vue container.