### PR TITLE
Fix ComfyUI class setup procedure

### DIFF
--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -373,7 +373,7 @@ export class ComfyUI {
     })
 
     // For testing. Legacy ui tests don't have vue app initialized.
-    if (!app.vueAppReady) {
+    if (window['IS_TEST']) {
       this.setup(document.body)
     }
   }

--- a/src/scripts/ui/menu/index.ts
+++ b/src/scripts/ui/menu/index.ts
@@ -181,7 +181,9 @@ export class ComfyAppMenu {
             resizeHandler = null
           }
           document.body.style.removeProperty('display')
-          app.ui.menuContainer.style.removeProperty('display')
+          if (app.ui.menuContainer) {
+            app.ui.menuContainer.style.removeProperty('display')
+          }
           this.element.style.display = 'none'
           app.ui.restoreMenuPosition()
         }
@@ -192,7 +194,9 @@ export class ComfyAppMenu {
 
   updatePosition(v: MenuPosition) {
     document.body.style.display = 'grid'
-    this.app.ui.menuContainer.style.display = 'none'
+    if (this.app.ui.menuContainer) {
+      this.app.ui.menuContainer.style.display = 'none'
+    }
     this.element.style.removeProperty('display')
     this.position = v
     if (v === 'Bottom') {

--- a/tests-ui/utils/index.ts
+++ b/tests-ui/utils/index.ts
@@ -38,6 +38,7 @@ export async function start(config: StartConfig = {}): Promise<StartResult> {
 
   Object.assign(localStorage, config.localStorage ?? {})
   document.body.innerHTML = html.toString()
+  window['IS_TEST'] = true
 
   mockApi(config)
   mockSettingStore()


### PR DESCRIPTION
`ComfyUI` constructor is called immediately when `app.ts` is imported. At that time, the vue app is not available in both production and test.

This PR adds a `IS_TEST` flag on window to help distinguish test run and production run.