### PR TITLE
Add nullcheck to snap-to-grid's grid size default value

### DIFF
--- a/src/extensions/core/snapToGrid.ts
+++ b/src/extensions/core/snapToGrid.ts
@@ -34,7 +34,7 @@ app.registerExtension({
         'When dragging and resizing nodes while holding shift they will be aligned to the grid, this controls the size of that grid.',
       defaultValue: LiteGraph.CANVAS_GRID_SIZE,
       onChange(value) {
-        LiteGraph.CANVAS_GRID_SIZE = +value
+        LiteGraph.CANVAS_GRID_SIZE = +value || 10
       }
     })
 


### PR DESCRIPTION
Ensure the Snap to Grid setting does not set `LiteGraph.CANVAS_GRID_SIZE` to `0` when `defaultValue` is implicitly false.

Closes #856