### PR TITLE
Move workflows management to pinia

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,7 @@ import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { i18n } from './i18n'
 import { useExecutionStore } from './stores/executionStore'
+import { useWorkflowStore } from './stores/workflowStore'
 
 const isLoading = computed<boolean>(() => useWorkspaceStore().spinner)
 const theme = computed<string>(() =>
@@ -131,6 +132,8 @@ app.workflowManager.executionStore = executionStore
 watchEffect(() => {
   app.menu.workflows.buttonProgress.style.width = `${executionStore.executionProgress}%`
 })
+const workflowStore = useWorkflowStore()
+app.workflowManager.workflowStore = workflowStore
 
 onMounted(() => {
   api.addEventListener('status', onStatus)

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { ComfyWorkflow } from '@/scripts/workflows'
 import { getStorageValue } from '@/scripts/utils'
 
@@ -9,8 +9,15 @@ export const useWorkflowStore = defineStore('workflow', () => {
     Boolean(getStorageValue('Comfy.PreviousWorkflowUnsaved'))
   )
 
+  const workflowLookup = ref<Record<string, ComfyWorkflow>>({})
+  const workflows = computed(() => Object.values(workflowLookup.value))
+  const openWorkflows = ref<ComfyWorkflow[]>([])
+
   return {
     activeWorkflow,
-    previousWorkflowUnsaved
+    previousWorkflowUnsaved,
+    workflows,
+    openWorkflows,
+    workflowLookup
   }
 })


### PR DESCRIPTION
This PR moves following structure from WorkflowManager to workflowStore.

```js
  workflowLookup: Record<string, ComfyWorkflow> = {}
  workflows: Array<ComfyWorkflow> = []
  openWorkflows: Array<ComfyWorkflow> = []
```