### PR TITLE
Add tests on using group nodes in library sidebar

### DIFF
--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -2,10 +2,42 @@ import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from './ComfyPage'
 
 test.describe('Group Node', () => {
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
+  })
+
+  test('is added to node library sidebar', async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+    const groupNodeName = 'DefautWorkflowGroupNode'
+    await comfyPage.convertAllNodesToGroupNode(groupNodeName)
+    const tab = comfyPage.menu.nodeLibraryTab
+    await tab.open()
+    expect(await tab.getFolder('group nodes').count()).toBe(1)
+  })
+
+  test('Can be added with node library sidebar', async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+    const groupNodeName = 'DefautWorkflowGroupNode'
+    await comfyPage.convertAllNodesToGroupNode(groupNodeName)
+    const initialNodeCount = await comfyPage.getGraphNodesCount()
+
+    // Add group node from node library sidebar
+    const tab = comfyPage.menu.nodeLibraryTab
+    await tab.open()
+    await tab.getFolder('group nodes').click()
+    await tab.getFolder('workflow').click()
+    await tab.getFolder('workflow').last().click()
+    await tab.getNode(groupNodeName).click()
+
+    // Verify the node is added to the canvas
+    expect(await comfyPage.getGraphNodesCount()).toBe(initialNodeCount + 1)
+  })
+
   test('Can be added with search', async ({ comfyPage }) => {
     const groupNodeName = 'DefautWorkflowGroupNode'
     await comfyPage.convertAllNodesToGroupNode(groupNodeName)
     await comfyPage.doubleClickCanvas()
+    await comfyPage.nextFrame()
     await comfyPage.searchBox.fillAndSelectFirstNode(groupNodeName)
     await expect(comfyPage.canvas).toHaveScreenshot(
       'group-node-copy-added-from-search.png'

--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -6,7 +6,7 @@ test.describe('Group Node', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
   })
 
-  test('is added to node library sidebar', async ({ comfyPage }) => {
+  test('Is added to node library sidebar', async ({ comfyPage }) => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
     const groupNodeName = 'DefautWorkflowGroupNode'
     await comfyPage.convertAllNodesToGroupNode(groupNodeName)
@@ -15,7 +15,9 @@ test.describe('Group Node', () => {
     expect(await tab.getFolder('group nodes').count()).toBe(1)
   })
 
-  test('Can be added with node library sidebar', async ({ comfyPage }) => {
+  test('Can be added to canvas using node library sidebar', async ({
+    comfyPage
+  }) => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
     const groupNodeName = 'DefautWorkflowGroupNode'
     await comfyPage.convertAllNodesToGroupNode(groupNodeName)
@@ -33,7 +35,7 @@ test.describe('Group Node', () => {
     expect(await comfyPage.getGraphNodesCount()).toBe(initialNodeCount + 1)
   })
 
-  test('Can be added with search', async ({ comfyPage }) => {
+  test('Can be added to canvas using search', async ({ comfyPage }) => {
     const groupNodeName = 'DefautWorkflowGroupNode'
     await comfyPage.convertAllNodesToGroupNode(groupNodeName)
     await comfyPage.doubleClickCanvas()


### PR DESCRIPTION
#861 enabled adding group nodes to canvas via search and via node library sidebar, but the tests only covered adding via search. Added tests to ensure group nodes work with node library as well. 