### PR TITLE
Fix sorting on type filter + empty query

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -106,15 +106,15 @@ const placeholder = computed(() => {
 const nodeDefStore = useNodeDefStore()
 const nodeFrequencyStore = useNodeFrequencyStore()
 const search = (query: string) => {
+  const queryIsEmpty = query === '' && props.filters.length === 0
   currentQuery.value = query
-  suggestions.value =
-    query === ''
-      ? nodeFrequencyStore.topNodeDefs
-      : [
-          ...nodeDefStore.nodeSearchService.searchNode(query, props.filters, {
-            limit: props.searchLimit
-          })
-        ]
+  suggestions.value = queryIsEmpty
+    ? nodeFrequencyStore.topNodeDefs
+    : [
+        ...nodeDefStore.nodeSearchService.searchNode(query, props.filters, {
+          limit: props.searchLimit
+        })
+      ]
 }
 
 const emit = defineEmits(['addFilter', 'removeFilter', 'addNode'])

--- a/src/services/nodeSearchService.ts
+++ b/src/services/nodeSearchService.ts
@@ -32,11 +32,10 @@ export class FuseSearch<T> {
   }
 
   public search(query: string, options?: FuseSearchOptions): T[] {
-    if (!query || query === '') {
-      return [...this.data]
-    }
+    const fuseResult = !query
+      ? this.data.map((x) => ({ item: x, score: 0 }))
+      : this.fuse.search(query, options)
 
-    const fuseResult = this.fuse.search(query, options)
     if (!this.advancedScoring) {
       return fuseResult.map((x) => x.item)
     }

--- a/tests-ui/tests/nodeSearchService.test.ts
+++ b/tests-ui/tests/nodeSearchService.test.ts
@@ -1,7 +1,6 @@
 import { NodeSearchService } from '@/services/nodeSearchService'
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { plainToClass } from 'class-transformer'
-import { mockNodeDefStore } from '../utils/setup'
 
 const EXAMPLE_NODE_DEFS: ComfyNodeDefImpl[] = [
   {
@@ -52,11 +51,14 @@ const EXAMPLE_NODE_DEFS: ComfyNodeDefImpl[] = [
     category: 'latent/batch',
     output_node: false
   }
-].map((nodeDef) => plainToClass(ComfyNodeDefImpl, nodeDef))
+].map((nodeDef) => {
+  const def = plainToClass(ComfyNodeDefImpl, nodeDef)
+  def['postProcessSearchScores'] = (s) => s
+  return def
+})
 
 describe('nodeSearchService', () => {
   it('searches with input filter', () => {
-    mockNodeDefStore()
     const service = new NodeSearchService(EXAMPLE_NODE_DEFS)
     const inputFilter = service.getFilterById('input')
     expect(service.searchNode('L', [[inputFilter, 'LATENT']])).toHaveLength(1)

--- a/tests-ui/tests/nodeSearchService.test.ts
+++ b/tests-ui/tests/nodeSearchService.test.ts
@@ -1,6 +1,7 @@
 import { NodeSearchService } from '@/services/nodeSearchService'
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { plainToClass } from 'class-transformer'
+import { mockNodeDefStore } from '../utils/setup'
 
 const EXAMPLE_NODE_DEFS: ComfyNodeDefImpl[] = [
   {
@@ -55,6 +56,7 @@ const EXAMPLE_NODE_DEFS: ComfyNodeDefImpl[] = [
 
 describe('nodeSearchService', () => {
   it('searches with input filter', () => {
+    mockNodeDefStore()
     const service = new NodeSearchService(EXAMPLE_NODE_DEFS)
     const inputFilter = service.getFilterById('input')
     expect(service.searchNode('L', [[inputFilter, 'LATENT']])).toHaveLength(1)


### PR DESCRIPTION
When the query is empty but there is type filter, the results are now also sorted by node frequency.

![image](https://github.com/user-attachments/assets/ffd7b284-8987-4f56-b96e-e5e747d77f92)
