### PR TITLE
Add fuzzy search in context menu (search for Model, LoRA, ...)

### DIFF
--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -352,5 +352,40 @@ export const CORE_SETTINGS: SettingParams[] = [
         element.style.display = value ? 'flex' : 'none'
       }
     }
+  },
+  {
+    id: 'Comfy.FuzzySearch.ContextMenuFilterEnabled',
+    category: ['Comfy', 'Fuzzy Search', 'FuzzySearchContextMenuFilterEnabled'],
+    name: 'Enable fuzzy search in context menu',
+    tooltip: 'Fuzzy search allows for spelling mistakes and partial matches',
+    type: 'boolean',
+    defaultValue: true
+  },
+  {
+    id: 'Comfy.FuzzySearch.IncludeThreshold',
+    category: ['Comfy', 'Fuzzy Search', 'FuzzySearchIncludeThreshold'],
+    name: 'Fuzzy search include threshold',
+    tooltip: 'Lower values include less results (1.0 = match anything)',
+    type: 'slider',
+    defaultValue: 0.5,
+    attrs: {
+      min: 0.0,
+      max: 1.0,
+      step: 0.01
+    }
+  },
+  {
+    id: 'Comfy.FuzzySearch.MatchDistance',
+    category: ['Comfy', 'Fuzzy Search', 'FuzzySearchMatchDistance'],
+    name: 'Fuzzy search match distance',
+    tooltip:
+      'Determines how close the match must be to the fuzzy location (0 = exact match, larger values = more lenient)',
+    type: 'slider',
+    defaultValue: 200,
+    attrs: {
+      min: 0,
+      max: 1200,
+      step: 1
+    }
   }
 ]

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -501,7 +501,10 @@ const zSettings = z.record(z.any()).and(
       'Comfy.Window.UnloadConfirmation': z.boolean(),
       'Comfy.NodeBadge.NodeSourceBadgeMode': zNodeBadgeMode,
       'Comfy.NodeBadge.NodeIdBadgeMode': zNodeBadgeMode,
-      'Comfy.NodeBadge.NodeLifeCycleBadgeMode': zNodeBadgeMode
+      'Comfy.NodeBadge.NodeLifeCycleBadgeMode': zNodeBadgeMode,
+      'Comfy.FuzzySearch.ContextMenuFilterEnabled': z.boolean(),
+      'Comfy.FuzzySearch.IncludeThreshold': z.number(),
+      'Comfy.FuzzySearch.MatchDistance': z.number()
     })
     .optional()
 )


### PR DESCRIPTION
This PR adds fuzzy search support to the drop down menu when searching for LoRA's, checkpoints or similar. 

![image](https://github.com/user-attachments/assets/e5af47be-3ac7-4521-94f2-d587c6c640f3)

It also adds some entries in the setting menu to configure this fuzzy search:

![image](https://github.com/user-attachments/assets/16f01ba6-c628-4b81-ab79-74cd64d10908)

Running the tests for me fails, however in no code I have touched, but instead in `workflowStore` (`src/scripts/workflows.ts:14:3 - error TS2502: 'workflowStore' is referenced directly or indirectly in its own type annotation.`)


<details>
  <summary>Additional Note about alternative implementation (Click to expand)</summary>

This is a second branch on my fork using Fuse.js, as I realized you are already have this library as a dependency.

I first however did [another implementation](https://github.com/Comfy-Org/ComfyUI_frontend/commit/d83acec76aa5030e19a24ecb722181c53a997690) with [FuzzySearch.js](https://www.npmjs.com/package/fz-search/v/1.0.0) which in my opinion has superior matching, speed, and available configuration. 

But as I made the assumption you do not want to add another library for fuzzy matching if you have already included one, this PR uses Fuse.js. 

I also did a preliminary check of your `nodeSearchService`, it would however be too much work for me to rewrite this to the other library to have only one fuzzy library.
</details>



