### PR TITLE
Remove outdated dialog dismiss workaround

### DIFF
--- a/browser_tests/nodeSearchBox.spec.ts
+++ b/browser_tests/nodeSearchBox.spec.ts
@@ -104,6 +104,25 @@ test.describe('Node search box', () => {
     await expect(comfyPage.searchBox.input).not.toHaveCount(0)
   })
 
+  test('@mobile Does not trigger dismissable mask on opening double-tap', async ({
+    comfyPage
+  }) => {
+    await comfyPage.closeMenu()
+    await comfyPage.loadWorkflow('single_ksampler')
+    const screenBottom = {
+      x: 200,
+      y: 720
+    }
+    await comfyPage.canvas.tap({
+      position: screenBottom
+    })
+    await comfyPage.canvas.tap({
+      position: screenBottom
+    })
+    await comfyPage.page.waitForTimeout(256)
+    await expect(comfyPage.searchBox.input).not.toHaveCount(0)
+  })
+
   test.describe('Filtering', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.doubleClickCanvas()

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -3,7 +3,7 @@
     <Dialog
       v-model:visible="visible"
       modal
-      :dismissable-mask="dismissable"
+      dismissable-mask
       @hide="clearFilters"
       :pt="{
         root: {
@@ -50,7 +50,6 @@ import { LiteGraph } from '@comfyorg/litegraph'
 const settingStore = useSettingStore()
 
 const visible = ref(false)
-const dismissable = ref(true)
 const triggerEvent = ref<LiteGraphCanvasEvent | null>(null)
 const getNewNodeLocation = (): [number, number] => {
   if (triggerEvent.value === null) {
@@ -130,12 +129,6 @@ const showNewSearchBox = (e: LiteGraphCanvasEvent) => {
 
   visible.value = true
   triggerEvent.value = e
-
-  // Prevent the dialog from being dismissed immediately
-  dismissable.value = false
-  setTimeout(() => {
-    dismissable.value = true
-  }, 300)
 }
 
 const showContextMenu = (e: LiteGraphCanvasEvent) => {


### PR DESCRIPTION
Remove workaround added in PR #171, as the dialog dismissal issue is resolved in PrimeVue v4.0.4. Added a test to verify.