### PR TITLE
Add case-insensitive matches to workflow search results

### DIFF
--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -127,8 +127,9 @@ const handleSearch = (query: string) => {
     expandedKeys.value = {}
     return
   }
+  const lowerQuery = query.toLocaleLowerCase()
   filteredWorkflows.value = workflowStore.workflows.filter((workflow) => {
-    return workflow.name.includes(query)
+    return workflow.name.toLocaleLowerCase().includes(lowerQuery)
   })
   nextTick(() => {
     expandNode(filteredRoot.value)


### PR DESCRIPTION
Instead of fixing a bug in the search logic (#905), this just makes the new search case-insensitive.

Can't find `u`:
![image](https://github.com/user-attachments/assets/3bf95e40-bf60-4e20-8bd9-cccad2a2f114)

Found `U`!
![image](https://github.com/user-attachments/assets/7aea62ab-4f91-44bc-85c9-ec3ed1405194)
