### PR TITLE
Fix audio widget serialize option

### DIFF
--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -95,11 +95,9 @@ app.registerExtension({
         const audioUIWidget: DOMWidget<HTMLAudioElement> = node.addDOMWidget(
           inputName,
           /* name=*/ 'audioUI',
-          audio
+          audio,
+          { serialize: false }
         )
-        // @ts-expect-error
-        // TODO: Sort out the DOMWidget type.
-        audioUIWidget.serialize = false
 
         const isOutputNode = node.constructor.nodeData.output_node
         if (isOutputNode) {
@@ -193,10 +191,10 @@ app.registerExtension({
           /* value=*/ '',
           () => {
             fileInput.click()
-          }
+          },
+          { serialize: false }
         )
         uploadWidget.label = 'choose file to upload'
-        uploadWidget.serialize = false
 
         return { widget: uploadWidget }
       }


### PR DESCRIPTION
Closes #866.


`serialize` should be on `options` property of widget.

https://github.com/Comfy-Org/ComfyUI_frontend/blob/4052fc55f331469607c5e5275a7423c8a6c4f419/src/types/litegraph-augmentation.d.ts#L45

https://github.com/Comfy-Org/ComfyUI_frontend/blob/4052fc55f331469607c5e5275a7423c8a6c4f419/src/scripts/domWidget.ts#L14

https://github.com/Comfy-Org/ComfyUI_frontend/blob/4052fc55f331469607c5e5275a7423c8a6c4f419/src/scripts/app.ts#L2429-L2439

API Workflow before:

```json
{
  "15": {
    "inputs": {
      "audio": "song.mp3",
      "upload": ""
    },
    "class_type": "LoadAudio",
    "_meta": {
      "title": "LoadAudio"
    }
  }
}
```

API Workflow after:

```json
{
  "15": {
    "inputs": {
      "audio": "song.mp3"
    },
    "class_type": "LoadAudio",
    "_meta": {
      "title": "LoadAudio"
    }
  }
}
```
