### PR TITLE
Fix frontend node tooltip error

### DIFF
--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -109,7 +109,7 @@ const onIdle = () => {
     [0, 0]
   )
   if (outputSlot !== -1) {
-    return showTooltip(nodeDef.output.all?.[outputSlot].tooltip)
+    return showTooltip(nodeDef.output.all?.[outputSlot]?.tooltip)
   }
 
   const widget = getHoveredWidget()


### PR DESCRIPTION
When hovering over a slot on a frontend-only node (e.g., rgthree Fast Bypasser, pysssss Preset Text), uncaught error trying to access slot's tooltip:


![Selection_404](https://github.com/user-attachments/assets/556558df-63c9-4717-9213-40cf74449c70)

Litegraph indicates that the node has an output but the output is never added to the nodeDef. Added a nullcheck to fix.