### PR TITLE
Exclude litegraph from being cached

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -167,5 +167,9 @@ export default defineConfig({
     alias: {
       '@': '/src'
     }
+  },
+
+  optimizeDeps: {
+    exclude: ['@comfyorg/litegraph']
   }
 }) as UserConfigExport


### PR DESCRIPTION
When developing the litegraph package via npm link, vite caches this dependency and so the changes may not be detected, this should improve that.