### PR TITLE
Fix type for Comfy.Sidebar.Size in apiTypes

### DIFF
--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -488,7 +488,7 @@ const zSettings = z.record(z.any()).and(
       'Comfy.PreviewFormat': z.string(),
       'Comfy.PromptFilename': z.boolean(),
       'Comfy.Sidebar.Location': z.enum(['left', 'right']),
-      'Comfy.Sidebar.Size': z.number(),
+      'Comfy.Sidebar.Size': z.enum(['small', 'normal']),
       'Comfy.SwitchUser': z.any(),
       'Comfy.SnapToGrid.GridSize': z.number(),
       'Comfy.TextareaWidget.FontSize': z.number(),


### PR DESCRIPTION
`Comfy.Sidebar.Size` is a combo type with options "small" and "normal"