### PR TITLE
Remove support of Top/Bottom in menu positions

### DIFF
--- a/browser_tests/browserTabTitle.spec.ts
+++ b/browser_tests/browserTabTitle.spec.ts
@@ -4,7 +4,7 @@ import { comfyPageFixture as test } from './ComfyPage'
 test.describe('Browser tab title', () => {
   test.describe('Beta Menu', () => {
     test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+      await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
     })
 
     test.afterEach(async ({ comfyPage }) => {

--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -8,7 +8,7 @@ test.describe('Group Node', () => {
 
   test.describe('Node library sidebar', () => {
     test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+      await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
     })
 
     test('Is added to node library sidebar', async ({ comfyPage }) => {

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -3,7 +3,7 @@ import { comfyPageFixture as test } from './ComfyPage'
 
 test.describe('Menu', () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
   })
 
   test.afterEach(async ({ comfyPage }) => {

--- a/browser_tests/propertiesPanel.spec.ts
+++ b/browser_tests/propertiesPanel.spec.ts
@@ -3,7 +3,7 @@ import { comfyPageFixture as test } from './ComfyPage'
 
 test.describe('Properties Panel', () => {
   test('Can change property value', async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
     await comfyPage.rightClickEmptyLatentNode()
     await comfyPage.page.getByText('Properties Panel').click()
     await comfyPage.nextFrame()

--- a/browser_tests/propertiesPanel.spec.ts
+++ b/browser_tests/propertiesPanel.spec.ts
@@ -2,8 +2,16 @@ import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from './ComfyPage'
 
 test.describe('Properties Panel', () => {
-  test('Can change property value', async ({ comfyPage }) => {
+  test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
+  })
+
+  // TODO: Update expectation after new menu dropdown is added.
+  test.skip('Can change property value', async ({ comfyPage }) => {
     await comfyPage.rightClickEmptyLatentNode()
     await comfyPage.page.getByText('Properties Panel').click()
     await comfyPage.nextFrame()
@@ -19,6 +27,5 @@ test.describe('Properties Panel', () => {
     )
 
     await propertyInput.fill('Empty Latent Image')
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
   })
 })

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -75,9 +75,4 @@ const gutterClass = computed(() => {
   z-index: 999;
   border: none;
 }
-
-.comfyui-floating-menu .splitter-overlay {
-  top: var(--comfy-floating-menu-height);
-  height: calc(100% - var(--comfy-floating-menu-height));
-}
 </style>

--- a/src/scripts/ui/menu/menu.css
+++ b/src/scripts/ui/menu/menu.css
@@ -1,7 +1,3 @@
-:root {
-  --comfy-floating-menu-height: 45px;
-}
-
 .mdi.rotate270::before {
   transform: rotate(270deg);
 }
@@ -142,23 +138,6 @@
   grid-column: 1/-1;
   overflow: auto;
   max-height: 90vh;
-}
-
-.comfyui-menu.floating {
-  width: max-content;
-  padding: 8px 0 8px 12px;
-  overflow: hidden;
-  border-bottom-right-radius: 12px;
-  height: var(--comfy-floating-menu-height);
-  position: absolute;
-}
-
-.comfyui-menu.floating .comfyui-logo {
-  padding-right: 8px;
-}
-
-.comfyui-floating-menu .comfyui-body-left {
-  margin-top: var(--comfy-floating-menu-height);
 }
 
 .comfyui-menu>* {

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -363,5 +363,14 @@ export const CORE_SETTINGS: SettingParams[] = [
         element.style.display = value ? 'flex' : 'none'
       }
     }
+  },
+  {
+    id: 'Comfy.UseNewMenu',
+    category: ['Comfy', 'Menu', 'UseNewMenu'],
+    defaultValue: 'Disabled',
+    name: 'Use new menu and workflow management.',
+    experimental: true,
+    type: 'combo',
+    options: ['Disabled', 'Floating']
   }
 ]

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -493,7 +493,7 @@ const zSettings = z.record(z.any()).and(
       'Comfy.SnapToGrid.GridSize': z.number(),
       'Comfy.TextareaWidget.FontSize': z.number(),
       'Comfy.TextareaWidget.Spellcheck': z.boolean(),
-      'Comfy.UseNewMenu': z.enum(['Disabled', 'Floating', 'Top', 'Bottom']),
+      'Comfy.UseNewMenu': z.enum(['Disabled', 'Floating']),
       'Comfy.TreeExplorer.ItemPadding': z.number(),
       'Comfy.Validation.Workflows': z.boolean(),
       'Comfy.Workflow.SortNodeIdOnSave': z.boolean(),

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -87,6 +87,22 @@ watchEffect(() => {
   }
 })
 
+watchEffect(() => {
+  const useNewMenu = settingStore.get('Comfy.UseNewMenu')
+  if (useNewMenu === 'Disabled') {
+    app.ui.restoreMenuPosition()
+    document.body.style.removeProperty('display')
+    if (app.ui.menuContainer) {
+      app.ui.menuContainer.style.removeProperty('display')
+    }
+  } else {
+    document.body.style.setProperty('display', 'grid')
+    if (app.ui.menuContainer) {
+      app.ui.menuContainer.style.setProperty('display', 'none')
+    }
+  }
+})
+
 const init = () => {
   settingStore.addSettings(app.ui.settings)
   app.extensionManager = useWorkspaceStore()


### PR DESCRIPTION
This PR removes the option of Top/Bottom menu position options. Some TODOs for subsequent PRs:

- Migrate Top/Bottom setting values to Floating setting value automatically
- Add top menu bar
- Add opened workflow tabs