### PR TITLE
More robust group node playwright test

### DIFF
--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -1,5 +1,6 @@
 import type { Page, Locator } from '@playwright/test'
 import { test as base } from '@playwright/test'
+import { expect } from '@playwright/test'
 import dotenv from 'dotenv'
 dotenv.config()
 import * as fs from 'fs'

--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -713,8 +713,9 @@ export class ComfyPage {
       await dialog.accept(groupNodeName)
     })
     await this.canvas.press('Control+a')
-    await this.rightClickEmptyLatentNode()
-    await this.page.getByText('Convert to Group Node').click()
+    const node = await this.getFirstNodeRef()
+    expect(node).not.toBeNull()
+    await node!.clickContextMenuOption('Convert to Group Node')
     await this.nextFrame()
   }
   async convertOffsetToCanvas(pos: [number, number]) {
@@ -728,11 +729,18 @@ export class ComfyPage {
   async getNodeRefsByType(type: string): Promise<NodeReference[]> {
     return (
       await this.page.evaluate((type) => {
-        return window['app'].graph._nodes
+        return window['app'].graph.nodes
           .filter((n) => n.type === type)
           .map((n) => n.id)
       }, type)
     ).map((id: NodeId) => this.getNodeRefById(id))
+  }
+  async getFirstNodeRef(): Promise<NodeReference | null> {
+    const id = await this.page.evaluate(() => {
+      return window['app'].graph.nodes[0]?.id
+    })
+    if (!id) return null
+    return this.getNodeRefById(id)
   }
 }
 class NodeSlotReference {

--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -8,7 +8,7 @@ test.describe('Group Node', () => {
 
   test.describe('Node library sidebar', () => {
     test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
+      await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
     })
 
     test('Is added to node library sidebar', async ({ comfyPage }) => {

--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -6,33 +6,37 @@ test.describe('Group Node', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
   })
 
-  test('Is added to node library sidebar', async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
-    const groupNodeName = 'DefautWorkflowGroupNode'
-    await comfyPage.convertAllNodesToGroupNode(groupNodeName)
-    const tab = comfyPage.menu.nodeLibraryTab
-    await tab.open()
-    expect(await tab.getFolder('group nodes').count()).toBe(1)
-  })
+  test.describe('Node library sidebar', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
+    })
 
-  test('Can be added to canvas using node library sidebar', async ({
-    comfyPage
-  }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
-    const groupNodeName = 'DefautWorkflowGroupNode'
-    await comfyPage.convertAllNodesToGroupNode(groupNodeName)
-    const initialNodeCount = await comfyPage.getGraphNodesCount()
+    test('Is added to node library sidebar', async ({ comfyPage }) => {
+      const groupNodeName = 'DefautWorkflowGroupNode'
+      await comfyPage.convertAllNodesToGroupNode(groupNodeName)
+      const tab = comfyPage.menu.nodeLibraryTab
+      await tab.open()
+      expect(await tab.getFolder('group nodes').count()).toBe(1)
+    })
 
-    // Add group node from node library sidebar
-    const tab = comfyPage.menu.nodeLibraryTab
-    await tab.open()
-    await tab.getFolder('group nodes').click()
-    await tab.getFolder('workflow').click()
-    await tab.getFolder('workflow').last().click()
-    await tab.getNode(groupNodeName).click()
+    test('Can be added to canvas using node library sidebar', async ({
+      comfyPage
+    }) => {
+      const groupNodeName = 'DefautWorkflowGroupNode'
+      await comfyPage.convertAllNodesToGroupNode(groupNodeName)
+      const initialNodeCount = await comfyPage.getGraphNodesCount()
 
-    // Verify the node is added to the canvas
-    expect(await comfyPage.getGraphNodesCount()).toBe(initialNodeCount + 1)
+      // Add group node from node library sidebar
+      const tab = comfyPage.menu.nodeLibraryTab
+      await tab.open()
+      await tab.getFolder('group nodes').click()
+      await tab.getFolder('workflow').click()
+      await tab.getFolder('workflow').last().click()
+      await tab.getNode(groupNodeName).click()
+
+      // Verify the node is added to the canvas
+      expect(await comfyPage.getGraphNodesCount()).toBe(initialNodeCount + 1)
+    })
   })
 
   test('Can be added to canvas using search', async ({ comfyPage }) => {


### PR DESCRIPTION
Instead of relying on `rightClickEmptyLatentNode` on default graph, we now dynamically select the first node on the graph.

This change is blocking https://github.com/Comfy-Org/ComfyUI_frontend/pull/933