### PR TITLE
better badges for empty/loading model library folders

### DIFF
--- a/src/components/common/TreeExplorer.vue
+++ b/src/components/common/TreeExplorer.vue
@@ -91,9 +91,7 @@ const fillNodeInfo = (node: TreeExplorerNode): RenderedTreeExplorerNode => {
     children,
     type: node.leaf ? 'node' : 'folder',
     totalLeaves,
-    badgeText: node.getBadgeText
-      ? node.getBadgeText(node)
-      : totalLeaves.toString()
+    badgeText: node.getBadgeText ? node.getBadgeText(node) : null
   }
 }
 const onNodeContentClick = async (

--- a/src/components/common/TreeExplorer.vue
+++ b/src/components/common/TreeExplorer.vue
@@ -82,14 +82,18 @@ const getTreeNodeIcon = (node: TreeExplorerNode) => {
 }
 const fillNodeInfo = (node: TreeExplorerNode): RenderedTreeExplorerNode => {
   const children = node.children?.map(fillNodeInfo)
+  const totalLeaves = node.leaf
+    ? 1
+    : children.reduce((acc, child) => acc + child.totalLeaves, 0)
   return {
     ...node,
     icon: getTreeNodeIcon(node),
     children,
     type: node.leaf ? 'node' : 'folder',
-    totalLeaves: node.leaf
-      ? 1
-      : children.reduce((acc, child) => acc + child.totalLeaves, 0)
+    totalLeaves,
+    badgeText: node.getBadgeText
+      ? node.getBadgeText(node)
+      : totalLeaves.toString()
   }
 }
 const onNodeContentClick = async (

--- a/src/components/common/TreeExplorerTreeNode.vue
+++ b/src/components/common/TreeExplorerTreeNode.vue
@@ -22,7 +22,7 @@
       </span>
       <Badge
         v-if="!props.node.leaf"
-        :value="props.node.badgeText"
+        :value="props.node.badgeText ?? props.node.totalLeaves"
         severity="secondary"
         class="leaf-count-badge"
       />

--- a/src/components/common/TreeExplorerTreeNode.vue
+++ b/src/components/common/TreeExplorerTreeNode.vue
@@ -22,7 +22,7 @@
       </span>
       <Badge
         v-if="!props.node.leaf"
-        :value="props.node.totalLeaves"
+        :value="props.node.badgeText"
         severity="secondary"
         class="leaf-count-badge"
       />

--- a/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
+++ b/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
@@ -57,7 +57,7 @@ describe('TreeExplorerTreeNode', () => {
     expect(wrapper.findComponent(EditableText).props('modelValue')).toBe(
       'Test Node'
     )
-    expect(wrapper.findComponent(Badge).props()['value']).toBe(3)
+    expect(wrapper.findComponent(Badge).props()['value']).toBe('3')
   })
 
   it('makes node label editable when renamingEditingNode matches', async () => {

--- a/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
+++ b/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
@@ -26,7 +26,8 @@ describe('TreeExplorerTreeNode', () => {
     totalLeaves: 3,
     icon: 'pi pi-folder',
     type: 'folder',
-    handleRename: () => {}
+    handleRename: () => {},
+    badgeText: '3'
   } as RenderedTreeExplorerNode
 
   beforeAll(() => {

--- a/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
+++ b/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
@@ -26,8 +26,7 @@ describe('TreeExplorerTreeNode', () => {
     totalLeaves: 3,
     icon: 'pi pi-folder',
     type: 'folder',
-    handleRename: () => {},
-    badgeText: '3'
+    handleRename: () => {}
   } as RenderedTreeExplorerNode
 
   beforeAll(() => {
@@ -57,7 +56,7 @@ describe('TreeExplorerTreeNode', () => {
     expect(wrapper.findComponent(EditableText).props('modelValue')).toBe(
       'Test Node'
     )
-    expect(wrapper.findComponent(Badge).props()['value']).toBe('3')
+    expect(wrapper.findComponent(Badge).props()['value'].toString()).toBe('3')
   })
 
   it('makes node label editable when renamingEditingNode matches', async () => {

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -139,7 +139,7 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
       },
       getBadgeText: (node: TreeExplorerNode<ComfyModelDef>) => {
         if (node.leaf) {
-          return ''
+          return null
         }
         if (node.children?.length === 1) {
           const onlyChild = node.children[0]
@@ -151,16 +151,7 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
             }
           }
         }
-        const getTotalLeaves = (node: TreeExplorerNode<ComfyModelDef>) => {
-          if (node.leaf) {
-            return 1
-          }
-          return node.children.reduce(
-            (acc, child) => acc + getTotalLeaves(child),
-            0
-          )
-        }
-        return getTotalLeaves(node).toString()
+        return null
       },
       children,
       draggable: node.leaf,

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -151,7 +151,16 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
             }
           }
         }
-        return node.children?.length.toString() ?? '0'
+        const getTotalLeaves = (node: TreeExplorerNode<ComfyModelDef>) => {
+          if (node.leaf) {
+            return 1
+          }
+          return node.children.reduce(
+            (acc, child) => acc + getTotalLeaves(child),
+            0
+          )
+        }
+        return getTotalLeaves(node).toString()
       },
       children,
       draggable: node.leaf,

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -137,6 +137,22 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
           return 'pi pi-file'
         }
       },
+      getBadgeText: (node: TreeExplorerNode<ComfyModelDef>) => {
+        if (node.leaf) {
+          return ''
+        }
+        if (node.children?.length === 1) {
+          const onlyChild = node.children[0]
+          if (onlyChild.data?.is_fake_object) {
+            if (onlyChild.data.name === '(No Content)') {
+              return '0'
+            } else if (onlyChild.data.name === 'Loading') {
+              return '?'
+            }
+          }
+        }
+        return node.children?.length.toString() ?? '0'
+      },
       children,
       draggable: node.leaf,
       handleClick: (

--- a/src/types/treeExplorerTypes.ts
+++ b/src/types/treeExplorerTypes.ts
@@ -52,7 +52,7 @@ export interface RenderedTreeExplorerNode<T = any> extends TreeExplorerNode<T> {
   /** Total number of leaves in the subtree */
   totalLeaves: number
   /** Text to display on the leaf-count badge */
-  badgeText: string
+  badgeText?: string
 }
 
 export type TreeExplorerDragAndDropData<T = any> = {

--- a/src/types/treeExplorerTypes.ts
+++ b/src/types/treeExplorerTypes.ts
@@ -7,36 +7,39 @@ export interface TreeExplorerNode<T = any> {
   data?: T
   children?: TreeExplorerNode<T>[]
   icon?: string
+  /** Function to override what icon to use for the node */
   getIcon?: (node: TreeExplorerNode<T>) => string
-  // Function to handle renaming the node
+  /** Function to override what text to use for the leaf-count badge on a folder node */
+  getBadgeText?: (node: TreeExplorerNode<T>) => string
+  /** Function to handle renaming the node */
   handleRename?: (
     node: TreeExplorerNode<T>,
     newName: string
   ) => void | Promise<void>
-  // Function to handle deleting the node
+  /** Function to handle deleting the node */
   handleDelete?: (node: TreeExplorerNode<T>) => void | Promise<void>
-  // Function to handle adding a child node
+  /** Function to handle adding a child node */
   handleAddChild?: (
     node: TreeExplorerNode<T>,
     child: TreeExplorerNode<T>
   ) => void | Promise<void>
-  // Whether the node is draggable
+  /** Whether the node is draggable */
   draggable?: boolean
-  // Whether the node is droppable
+  /** Whether the node is droppable */
   droppable?: boolean
-  // Function to handle dropping a node
+  /** Function to handle dropping a node */
   handleDrop?: (
     node: TreeExplorerNode<T>,
     data: TreeExplorerDragAndDropData
   ) => void | Promise<void>
-  // Function to handle clicking a node
+  /** Function to handle clicking a node */
   handleClick?: (
     node: TreeExplorerNode<T>,
     event: MouseEvent
   ) => void | Promise<void>
-  // Function to handle errors
+  /** Function to handle errors */
   handleError?: (error: Error) => void
-  // Extra context menu items
+  /** Extra context menu items */
   contextMenuItems?:
     | MenuItem[]
     | ((targetNode: RenderedTreeExplorerNode) => MenuItem[])
@@ -46,8 +49,10 @@ export interface RenderedTreeExplorerNode<T = any> extends TreeExplorerNode<T> {
   children?: RenderedTreeExplorerNode<T>[]
   icon: string
   type: 'folder' | 'node'
-  // Total number of leaves in the subtree
+  /** Total number of leaves in the subtree */
   totalLeaves: number
+  /** Text to display on the leaf-count badge */
+  badgeText: string
 }
 
 export type TreeExplorerDragAndDropData<T = any> = {


### PR DESCRIPTION
for https://github.com/Comfy-Org/ComfyUI_frontend/issues/945

![image](https://github.com/user-attachments/assets/849d61d9-21fd-4357-8716-94846832f428)

Unloaded folders display `?`, empty folders display `0`

Adds helper functions in the tree explorer code to support altering the badge text, similar to the icon alteration code.

Minor side change, but I also changed the `// ...` comments documenting a few options to `/** ... */` doc comments so that IDEs will render them