### PR TITLE
Support redo with Ctrl+Shift+Z

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -90,7 +90,7 @@ export class ChangeTracker {
 
   async undoRedo(e) {
     if (e.ctrlKey || e.metaKey) {
-      if (e.key === 'y') {
+      if (e.key === 'y' || e.key == 'Z') {
         await this.redo()
         return true
       } else if (e.key === 'z') {


### PR DESCRIPTION
This adds Ctrl+Shift+Z as an alternative keybind for redo. 

As this is frequently the keybind used in other software, it provides minor quality of life to any who would default to the keybind out of muscle memory.