### PR TITLE
Reset FileInput value after load

### DIFF
--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -390,3 +390,23 @@ test.describe('Load workflow', () => {
     await expect(comfyPage.canvas).toHaveScreenshot('string_node_id.png')
   })
 })
+
+test.describe('Load duplicate workflow', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Floating')
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
+  })
+
+  test('A workflow can be loaded multiple times in a row', async ({
+    comfyPage
+  }) => {
+    await comfyPage.loadWorkflow('single_ksampler')
+    await comfyPage.menu.workflowsTab.open()
+    await comfyPage.menu.workflowsTab.newBlankWorkflowButton.click()
+    await comfyPage.loadWorkflow('single_ksampler')
+    expect(await comfyPage.getGraphNodesCount()).toBe(1)
+  })
+})

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -382,8 +382,9 @@ export class ComfyUI {
       accept: '.json,image/png,.latent,.safetensors,image/webp,audio/flac',
       style: { display: 'none' },
       parent: document.body,
-      onchange: () => {
-        app.handleFile(fileInput.files[0])
+      onchange: async () => {
+        await app.handleFile(fileInput.files[0])
+        fileInput.value = ''
       }
     })
 


### PR DESCRIPTION
When a file is browsed for, the fileInput remains associated with the chosen file even after the associated workflow is loaded. If a user attempts to load the same file again, the onchange event does not fire and loading fails silently. This is fixed by clearing the fileInput after the workflow has been loaded.

Out of an abundance of caution, the onchange is made async to ensure the fileInput isn't cleared until after the workflow has loaded.

This is a long standing issue which had befuddled me for many months.