### PR TITLE
Reduce SearchBox margins for lower resolutions.

### DIFF
--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -226,12 +226,18 @@ onUnmounted(() => {
 
 <style>
 .invisible-dialog-root {
-  width: 30%;
+  width: 60%;
   min-width: 24rem;
   max-width: 48rem;
   border: 0 !important;
   background-color: transparent !important;
   margin-top: 25vh;
+  margin-left: 400px;
+}
+@media all and (max-width: 768px) {
+  .invisible-dialog-root {
+    margin-left: 0px;
+  }
 }
 
 .node-search-box-dialog-mask {


### PR DESCRIPTION
On lower screen widths, the SearchBox would scale itself down instead of reducing the fairly wide margins. This wastes space and reduces the usability of the search box itself by cutting off information (such as the experimental badge) on nodes with medium or longer titles

This is not without side effects, so further adjustments may be needed. Currently, the searchbox is slightly offset to the right even for normal screen width. Additionally, the adjustment is disabled for very small screen widths (<=768) such that the preview is offscreen, but the entirety of the searchbox is properly displayed down to 512.

![image](https://github.com/user-attachments/assets/71e9c1f3-6372-4b03-868e-c8e3f2e9f17e)
