### PR TITLE
Rework queue button

### DIFF
--- a/browser_tests/appMenu.spec.ts
+++ b/browser_tests/appMenu.spec.ts
@@ -12,10 +12,6 @@ test.describe('AppMenu', () => {
   })
 
   test.afterEach(async ({ comfyPage }) => {
-    const currentThemeId = await comfyPage.menu.getThemeId()
-    if (currentThemeId !== 'dark') {
-      await comfyPage.menu.toggleTheme()
-    }
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
   })
 
@@ -27,7 +23,7 @@ test.describe('AppMenu', () => {
     ws
   }) => {
     // Enable change auto-queue mode
-    let queueOpts = await comfyPage.appMenu.queueButton.toggleOptions()
+    const queueOpts = await comfyPage.appMenu.queueButton.toggleOptions()
     expect(await queueOpts.getMode()).toBe('disabled')
     await queueOpts.setMode('change')
     await comfyPage.nextFrame()

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -23,14 +23,22 @@
           </template>
         </SplitButton>
         <BatchCountEdit />
-        <ButtonGroup class="execution-actions" v-if="executingPrompt">
+        <ButtonGroup class="execution-actions ml-2">
           <Button
             v-tooltip.bottom="$t('menu.interrupt')"
             icon="pi pi-times"
-            severity="danger"
+            :severity="executingPrompt ? 'danger' : 'secondary'"
+            :disabled="!executingPrompt"
             @click="() => commandStore.getCommand('Comfy.Interrupt')()"
           >
           </Button>
+          <Button
+            v-tooltip.bottom="$t('sideToolbar.queueTab.clearPendingTasks')"
+            icon="pi pi-stop"
+            :severity="hasPendingTasks ? 'danger' : 'secondary'"
+            :disabled="!hasPendingTasks"
+            @click="() => commandStore.getCommand('Comfy.ClearPendingTasks')()"
+          />
         </ButtonGroup>
       </div>
       <Divider layout="vertical" class="mx-2" />
@@ -65,7 +73,8 @@ import BatchCountEdit from './BatchCountEdit.vue'
 import {
   AutoQueueMode,
   useQueuePendingTaskCountStore,
-  useQueueSettingsStore
+  useQueueSettingsStore,
+  useQueueStore
 } from '@/stores/queueStore'
 import { app } from '@/scripts/app'
 import { storeToRefs } from 'pinia'
@@ -124,6 +133,8 @@ const queueModeMenuItems = computed(() =>
 )
 
 const executingPrompt = computed(() => !!queueCountStore.count.value)
+const queueStore = useQueueStore()
+const hasPendingTasks = computed(() => queueStore.hasPendingTasks)
 
 const queuePrompt = (e: MouseEvent) => {
   app.queuePrompt(e.shiftKey ? -1 : 0, batchCount.value)

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -1,6 +1,24 @@
 <template>
   <Panel v-if="visible" class="app-menu">
     <div class="app-menu-content">
+      <ButtonGroup>
+        <Button
+          v-tooltip.bottom="$t('menu.refresh')"
+          icon="pi pi-refresh"
+          severity="secondary"
+          @click="
+            () => commandStore.getCommand('Comfy.RefreshNodeDefinitions')()
+          "
+        />
+        <Button
+          v-tooltip.bottom="$t('menu.resetView')"
+          icon="pi pi-expand"
+          severity="secondary"
+          @click="() => commandStore.getCommand('Comfy.ResetView')()"
+        />
+      </ButtonGroup>
+      <div class="separator"></div>
+
       <Popover ref="queuePopover" data-testid="queue-options">
         <div class="queue-options">
           <p class="batch-count">
@@ -45,7 +63,7 @@
         v-tooltip.bottom="$t('menu.queueWorkflow')"
         :label="$t('menu.generate')"
         :icon="`pi pi-${icon}`"
-        severity="secondary"
+        severity="primary"
         @click="queuePrompt"
         :model="[]"
         :pt="{
@@ -59,31 +77,14 @@
         data-testid="queue-button"
       >
       </SplitButton>
-      <div class="separator"></div>
       <Button
         v-tooltip.bottom="$t('menu.interrupt')"
         icon="pi pi-times"
-        severity="secondary"
+        severity="danger"
         :disabled="!executingPrompt"
         @click="() => commandStore.getCommand('Comfy.Interrupt')()"
-      ></Button>
-
-      <ButtonGroup>
-        <Button
-          v-tooltip.bottom="$t('menu.refresh')"
-          icon="pi pi-refresh"
-          severity="secondary"
-          @click="
-            () => commandStore.getCommand('Comfy.RefreshNodeDefinitions')()
-          "
-        />
-        <Button
-          v-tooltip.bottom="$t('menu.resetView')"
-          icon="pi pi-expand"
-          severity="secondary"
-          @click="() => commandStore.getCommand('Comfy.ResetView')()"
-        />
-      </ButtonGroup>
+      >
+      </Button>
     </div>
   </Panel>
 </template>

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -1,24 +1,7 @@
 <template>
   <Panel v-if="visible" class="app-menu">
     <div class="app-menu-content">
-      <ButtonGroup>
-        <Button
-          v-tooltip.bottom="$t('menu.refresh')"
-          icon="pi pi-refresh"
-          severity="secondary"
-          @click="
-            () => commandStore.getCommand('Comfy.RefreshNodeDefinitions')()
-          "
-        />
-        <Button
-          v-tooltip.bottom="$t('menu.resetView')"
-          icon="pi pi-expand"
-          severity="secondary"
-          @click="() => commandStore.getCommand('Comfy.ResetView')()"
-        />
-      </ButtonGroup>
-      <div class="separator"></div>
-      <div class="queue-button-group">
+      <div class="queue-button-group flex flex-row">
         <SplitButton
           :label="activeQueueModeMenuItem.label"
           :icon="activeQueueModeMenuItem.icon"
@@ -38,6 +21,7 @@
             />
           </template>
         </SplitButton>
+        <BatchCountEdit />
         <ButtonGroup class="execution-actions" v-if="executingPrompt">
           <Button
             v-tooltip.bottom="$t('menu.interrupt')"
@@ -48,6 +32,23 @@
           </Button>
         </ButtonGroup>
       </div>
+      <div class="separator"></div>
+      <ButtonGroup>
+        <Button
+          v-tooltip.bottom="$t('menu.refresh')"
+          icon="pi pi-refresh"
+          severity="secondary"
+          @click="
+            () => commandStore.getCommand('Comfy.RefreshNodeDefinitions')()
+          "
+        />
+        <Button
+          v-tooltip.bottom="$t('menu.resetView')"
+          icon="pi pi-expand"
+          severity="secondary"
+          @click="() => commandStore.getCommand('Comfy.ResetView')()"
+        />
+      </ButtonGroup>
     </div>
   </Panel>
 </template>
@@ -58,6 +59,7 @@ import Panel from 'primevue/panel'
 import SplitButton from 'primevue/splitbutton'
 import Button from 'primevue/button'
 import ButtonGroup from 'primevue/buttongroup'
+import BatchCountEdit from './BatchCountEdit.vue'
 import {
   AutoQueueMode,
   useQueuePendingTaskCountStore,
@@ -160,13 +162,6 @@ const queuePrompt = (e: MouseEvent) => {
 
 .queue-options {
   display: flex;
-}
-
-.batch-count {
-  padding-top: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
 }
 
 .p-slider {

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -19,7 +19,7 @@
       </ButtonGroup>
       <div class="separator"></div>
 
-      <Popover ref="queuePopover" data-testid="queue-options">
+      <!-- <Popover ref="queuePopover" data-testid="queue-options">
         <div class="queue-options">
           <p class="batch-count">
             <FloatLabel v-tooltip="$t('menu.batchCountTooltip')">
@@ -58,39 +58,44 @@
             </template>
           </p>
         </div>
-      </Popover>
-      <SplitButton
-        v-tooltip.bottom="$t('menu.queueWorkflow')"
-        :label="$t('menu.generate')"
-        :icon="`pi pi-${icon}`"
-        severity="primary"
-        @click="queuePrompt"
-        :model="[]"
-        :pt="{
-          pcDropdown: ({ instance }) => {
-            instance.onDropdownButtonClick = function (e: Event) {
-              e.preventDefault()
-              queuePopover.toggle(e)
-            }
-          }
-        }"
-        data-testid="queue-button"
-      >
-      </SplitButton>
-      <Button
-        v-tooltip.bottom="$t('menu.interrupt')"
-        icon="pi pi-times"
-        severity="danger"
-        :disabled="!executingPrompt"
-        @click="() => commandStore.getCommand('Comfy.Interrupt')()"
-      >
-      </Button>
+      </Popover> -->
+      <ButtonGroup>
+        <SplitButton
+          v-tooltip.bottom="$t('menu.queueWorkflow')"
+          :label="activeQueueModeMenuItem.label"
+          :icon="activeQueueModeMenuItem.icon"
+          severity="primary"
+          @click="queuePrompt"
+          :model="queueModeMenuItems"
+          data-testid="queue-button"
+          v-tooltip="activeQueueModeMenuItem.tooltip"
+          :pt="{}"
+        >
+          <template #item="{ item }">
+            <Button
+              :label="item.label"
+              :icon="item.icon"
+              severity="secondary"
+              text
+              v-tooltip="item.tooltip"
+            />
+          </template>
+        </SplitButton>
+        <Button
+          v-tooltip.bottom="$t('menu.interrupt')"
+          icon="pi pi-times"
+          severity="danger"
+          :disabled="!executingPrompt"
+          @click="() => commandStore.getCommand('Comfy.Interrupt')()"
+        >
+        </Button>
+      </ButtonGroup>
     </div>
   </Panel>
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import Panel from 'primevue/panel'
 import SplitButton from 'primevue/splitbutton'
 import Button from 'primevue/button'
@@ -102,6 +107,7 @@ import Slider from 'primevue/slider'
 import RadioButton from 'primevue/radiobutton'
 import ButtonGroup from 'primevue/buttongroup'
 import {
+  AutoQueueMode,
   useQueuePendingTaskCountStore,
   useQueueSettingsStore
 } from '@/stores/queueStore'
@@ -109,6 +115,8 @@ import { app } from '@/scripts/app'
 import { storeToRefs } from 'pinia'
 import { useSettingStore } from '@/stores/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
+import { MenuItem } from 'primevue/menuitem'
+import { useI18n } from 'vue-i18n'
 
 const settingsStore = useSettingStore()
 const commandStore = useCommandStore()
@@ -119,19 +127,45 @@ const visible = computed(
   () => settingsStore.get('Comfy.UseNewMenu') === 'Floating'
 )
 
-const queuePopover = ref(null)
-const queueModes = ['disabled', 'instant', 'change']
-
-const icon = computed(() => {
-  switch (queueMode.value) {
-    case 'instant':
-      return 'forward'
-    case 'change':
-      return 'step-forward-alt'
-    default:
-      return 'play'
+const { t } = useI18n()
+const queueModeMenuItemLookup: Record<AutoQueueMode, MenuItem> = {
+  disabled: {
+    key: 'disabled',
+    label: 'Queue',
+    icon: 'pi pi-play',
+    tooltip: t('menu.disabledTooltip'),
+    command: () => {
+      queueMode.value = 'disabled'
+    }
+  },
+  instant: {
+    key: 'instant',
+    label: 'Queue (Instant)',
+    icon: 'pi pi-forward',
+    tooltip: t('menu.instantTooltip'),
+    command: () => {
+      queueMode.value = 'instant'
+    }
+  },
+  change: {
+    key: 'change',
+    label: 'Queue (Change)',
+    icon: 'pi pi-step-forward-alt',
+    tooltip: t('menu.changeTooltip'),
+    command: () => {
+      queueMode.value = 'change'
+    }
   }
-})
+}
+
+const activeQueueModeMenuItem = computed(
+  () => queueModeMenuItemLookup[queueMode.value]
+)
+const queueModeMenuItems = computed(() =>
+  Object.values(queueModeMenuItemLookup).filter(
+    (item) => item.key !== queueMode.value
+  )
+)
 
 const executingPrompt = computed(() => !!queueCountStore.count.value)
 

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -1,8 +1,9 @@
 <template>
   <Panel v-if="visible" class="app-menu">
-    <div class="app-menu-content">
-      <div class="queue-button-group flex flex-row">
+    <div class="app-menu-content flex align-center">
+      <div class="queue-button-group flex">
         <SplitButton
+          class="comfyui-queue-button"
           :label="activeQueueModeMenuItem.label"
           :icon="activeQueueModeMenuItem.icon"
           severity="primary"
@@ -139,11 +140,6 @@ const queuePrompt = (e: MouseEvent) => {
   z-index: 1000;
 }
 
-.app-menu-content {
-  display: flex;
-  align-items: center;
-}
-
 :deep(.p-panel-content) {
   padding: 10px;
 }
@@ -152,7 +148,8 @@ const queuePrompt = (e: MouseEvent) => {
   display: none;
 }
 
-.queue-options {
-  display: flex;
+.comfyui-queue-button :deep(.p-splitbutton-dropdown) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
 </style>

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -32,7 +32,7 @@
           </Button>
         </ButtonGroup>
       </div>
-      <div class="separator"></div>
+      <Divider layout="vertical" class="mx-2" />
       <ButtonGroup>
         <Button
           v-tooltip.bottom="$t('menu.refresh')"
@@ -56,6 +56,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import Panel from 'primevue/panel'
+import Divider from 'primevue/divider'
 import SplitButton from 'primevue/splitbutton'
 import Button from 'primevue/button'
 import ButtonGroup from 'primevue/buttongroup'
@@ -140,7 +141,6 @@ const queuePrompt = (e: MouseEvent) => {
 
 .app-menu-content {
   display: flex;
-  gap: 10px;
   align-items: center;
 }
 
@@ -152,43 +152,7 @@ const queuePrompt = (e: MouseEvent) => {
   display: none;
 }
 
-.separator {
-  background-color: var(--p-content-border-color);
-  border-radius: 10px;
-  opacity: 0.75;
-  width: 5px;
-  height: 20px;
-}
-
 .queue-options {
   display: flex;
-}
-
-.p-slider {
-  --p-slider-border-radius: 5px;
-  margin: 5px;
-  padding: 2px;
-}
-
-.p-floatlabel label {
-  left: 2px;
-}
-
-.label {
-  font-size: 12px;
-  color: var(--p-floatlabel-focus-color);
-}
-
-.auto-queue {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-top: 6px;
-}
-
-.auto-queue-mode {
-  display: flex;
-  align-items: center;
-  gap: 5px;
 }
 </style>

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -16,7 +16,7 @@
             <Button
               :label="item.label"
               :icon="item.icon"
-              severity="secondary"
+              :severity="item.key === queueMode ? 'primary' : 'secondary'"
               text
               v-tooltip="item.tooltip"
             />
@@ -73,8 +73,7 @@ import BatchCountEdit from './BatchCountEdit.vue'
 import {
   AutoQueueMode,
   useQueuePendingTaskCountStore,
-  useQueueSettingsStore,
-  useQueueStore
+  useQueueSettingsStore
 } from '@/stores/queueStore'
 import { app } from '@/scripts/app'
 import { storeToRefs } from 'pinia'
@@ -127,9 +126,7 @@ const activeQueueModeMenuItem = computed(
   () => queueModeMenuItemLookup[queueMode.value]
 )
 const queueModeMenuItems = computed(() =>
-  Object.values(queueModeMenuItemLookup).filter(
-    (item) => item.key !== queueMode.value
-  )
+  Object.values(queueModeMenuItemLookup)
 )
 
 const executingPrompt = computed(() => !!queueCountStore.count.value)

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -133,8 +133,7 @@ const queueModeMenuItems = computed(() =>
 )
 
 const executingPrompt = computed(() => !!queueCountStore.count.value)
-const queueStore = useQueueStore()
-const hasPendingTasks = computed(() => queueStore.hasPendingTasks)
+const hasPendingTasks = computed(() => queueCountStore.count.value > 1)
 
 const queuePrompt = (e: MouseEvent) => {
   app.queuePrompt(e.shiftKey ? -1 : 0, batchCount.value)

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -18,59 +18,15 @@
         />
       </ButtonGroup>
       <div class="separator"></div>
-
-      <!-- <Popover ref="queuePopover" data-testid="queue-options">
-        <div class="queue-options">
-          <p class="batch-count">
-            <FloatLabel v-tooltip="$t('menu.batchCountTooltip')">
-              <InputNumber id="batchCount" v-model="batchCount" :min="1" />
-              <label for="batchCount">{{ $t('menu.batchCount') }}</label>
-            </FloatLabel>
-
-            <Slider
-              v-model="batchCount"
-              :min="1"
-              :max="100"
-              v-tooltip="$t('menu.batchCountTooltip')"
-            />
-          </p>
-
-          <Divider layout="vertical" />
-
-          <p class="auto-queue">
-            <span class="label">{{ $t('menu.autoQueue') }}</span>
-            <template v-for="mode in queueModes" :key="mode">
-              <div
-                v-tooltip="$t(`menu.${mode}Tooltip`)"
-                class="auto-queue-mode"
-              >
-                <RadioButton
-                  v-model="queueMode"
-                  :inputId="`autoqueue-${mode}`"
-                  name="dynamic"
-                  :value="mode"
-                  :data-testid="`autoqueue-${mode}`"
-                />
-                <label :for="`autoqueue-${mode}`">{{
-                  $t(`menu.${mode}`)
-                }}</label>
-              </div>
-            </template>
-          </p>
-        </div>
-      </Popover> -->
-
       <div class="queue-button-group">
         <SplitButton
-          v-tooltip.bottom="$t('menu.queueWorkflow')"
           :label="activeQueueModeMenuItem.label"
           :icon="activeQueueModeMenuItem.icon"
           severity="primary"
           @click="queuePrompt"
           :model="queueModeMenuItems"
           data-testid="queue-button"
-          v-tooltip="activeQueueModeMenuItem.tooltip"
-          :pt="{}"
+          v-tooltip.bottom="$t('menu.queueWorkflow')"
         >
           <template #item="{ item }">
             <Button
@@ -101,12 +57,6 @@ import { computed } from 'vue'
 import Panel from 'primevue/panel'
 import SplitButton from 'primevue/splitbutton'
 import Button from 'primevue/button'
-import FloatLabel from 'primevue/floatlabel'
-import InputNumber from 'primevue/inputnumber'
-import Popover from 'primevue/popover'
-import Divider from 'primevue/divider'
-import Slider from 'primevue/slider'
-import RadioButton from 'primevue/radiobutton'
 import ButtonGroup from 'primevue/buttongroup'
 import {
   AutoQueueMode,

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -59,7 +59,8 @@
           </p>
         </div>
       </Popover> -->
-      <ButtonGroup>
+
+      <div class="queue-button-group">
         <SplitButton
           v-tooltip.bottom="$t('menu.queueWorkflow')"
           :label="activeQueueModeMenuItem.label"
@@ -81,15 +82,16 @@
             />
           </template>
         </SplitButton>
-        <Button
-          v-tooltip.bottom="$t('menu.interrupt')"
-          icon="pi pi-times"
-          severity="danger"
-          :disabled="!executingPrompt"
-          @click="() => commandStore.getCommand('Comfy.Interrupt')()"
-        >
-        </Button>
-      </ButtonGroup>
+        <ButtonGroup class="execution-actions" v-if="executingPrompt">
+          <Button
+            v-tooltip.bottom="$t('menu.interrupt')"
+            icon="pi pi-times"
+            severity="danger"
+            @click="() => commandStore.getCommand('Comfy.Interrupt')()"
+          >
+          </Button>
+        </ButtonGroup>
+      </div>
     </div>
   </Panel>
 </template>

--- a/src/components/appMenu/BatchCountEdit.vue
+++ b/src/components/appMenu/BatchCountEdit.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="batch-count" :class="props.class">
+  <div
+    class="batch-count"
+    :class="props.class"
+    v-tooltip.bottom="$t('menu.batchCount')"
+  >
     <InputNumber
       class="w-14"
       v-model="batchCount"

--- a/src/components/appMenu/BatchCountEdit.vue
+++ b/src/components/appMenu/BatchCountEdit.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="batch-count relative">
+  <div class="batch-count" :class="props.class">
     <InputNumber
-      class="max-w-16"
+      class="w-14"
       v-model="batchCount"
       :min="minQueueCount"
       :max="maxQueueCount"
@@ -30,6 +30,14 @@ import { useQueueSettingsStore } from '@/stores/queueStore'
 import { storeToRefs } from 'pinia'
 import InputNumber from 'primevue/inputnumber'
 
+interface Props {
+  class?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  class: ''
+})
+
 const queueSettingsStore = useQueueSettingsStore()
 const { batchCount } = storeToRefs(queueSettingsStore)
 const minQueueCount = 1
@@ -48,3 +56,10 @@ const handleClick = (increment: boolean) => {
   batchCount.value = newCount
 }
 </script>
+
+<style scoped>
+:deep(.p-inputtext) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+</style>

--- a/src/components/appMenu/BatchCountEdit.vue
+++ b/src/components/appMenu/BatchCountEdit.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="batch-count relative">
+    <InputNumber
+      class="max-w-16"
+      v-model="batchCount"
+      :min="minQueueCount"
+      :max="maxQueueCount"
+      fluid
+      showButtons
+      :pt="{
+        incrementButton: {
+          class: 'w-6',
+          onmousedown: () => {
+            handleClick(true)
+          }
+        },
+        decrementButton: {
+          class: 'w-6',
+          onmousedown: () => {
+            handleClick(false)
+          }
+        }
+      }"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useQueueSettingsStore } from '@/stores/queueStore'
+import { storeToRefs } from 'pinia'
+import InputNumber from 'primevue/inputnumber'
+
+const queueSettingsStore = useQueueSettingsStore()
+const { batchCount } = storeToRefs(queueSettingsStore)
+const minQueueCount = 1
+const maxQueueCount = 100
+
+const handleClick = (increment: boolean) => {
+  let newCount: number
+  if (increment) {
+    const originalCount = batchCount.value - 1
+    newCount = originalCount * 2
+  } else {
+    const originalCount = batchCount.value + 1
+    newCount = Math.floor(originalCount / 2)
+  }
+
+  batchCount.value = newCount
+}
+</script>

--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -34,11 +34,10 @@
         <Button
           v-if="queueStore.hasPendingTasks"
           icon="pi pi-stop"
-          text
           severity="danger"
-          @click="clearPendingTasks"
-          class="clear-pending-button"
-          v-tooltip="$t('sideToolbar.queueTab.clearPendingTasks')"
+          text
+          @click="() => commandStore.getCommand('Comfy.ClearPendingTasks')()"
+          v-tooltip.bottom="$t('sideToolbar.queueTab.clearPendingTasks')"
         />
         <Button
           icon="pi pi-trash"
@@ -109,6 +108,7 @@ import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { api } from '@/scripts/api'
 import { ComfyNode } from '@/types/comfyWorkflow'
 import { useSettingStore } from '@/stores/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { app } from '@/scripts/app'
 
 const IMAGE_FIT = 'Comfy.Queue.ImageFit'
@@ -116,6 +116,7 @@ const confirm = useConfirm()
 const toast = useToast()
 const queueStore = useQueueStore()
 const settingStore = useSettingStore()
+const commandStore = useCommandStore()
 const { t } = useI18n()
 
 // Expanded view: show all outputs in a flat list.
@@ -227,16 +228,6 @@ const confirmRemoveAll = (event: Event) => {
         life: 3000
       })
     }
-  })
-}
-
-const clearPendingTasks = async () => {
-  await queueStore.clear(['queue'])
-  toast.add({
-    severity: 'info',
-    summary: 'Confirmed',
-    detail: 'Pending tasks deleted',
-    life: 3000
   })
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -79,7 +79,7 @@ const messages = {
       change: 'On Change',
       changeTooltip: 'The workflow will be queued once a change is made',
       queueWorkflow: 'Queue workflow',
-      generate: 'Generate',
+      queue: 'Queue',
       interrupt: 'Cancel current run',
       refresh: 'Refresh node definitions',
       clipspace: 'Open Clipspace',

--- a/src/scripts/ui/menu/menu.css
+++ b/src/scripts/ui/menu/menu.css
@@ -269,10 +269,6 @@
   display: none;
 }
 
-.lt-lg .comfyui-queue-button {
-  margin-right: 44px;
-}
-
 .lt-lg .comfyui-menu-button {
   position: absolute;
   top: 4px;
@@ -296,13 +292,6 @@
 }
 
 /** Extra small */
-.lt-sm .comfyui-queue-button {
-  margin-right: 0;
-  width: 100%;
-}
-.lt-sm .comfyui-queue-button .comfyui-button {
-  justify-content: center;
-}
 .lt-sm .comfyui-interrupt-button {
   margin-right: 45px;
 }

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -6,6 +6,7 @@ import { globalTracker } from '@/scripts/changeTracker'
 import { useSettingStore } from '@/stores/settingStore'
 import { useToastStore } from '@/stores/toastStore'
 import { showTemplateWorkflowsDialog } from '@/services/dialogService'
+import { useQueueStore } from './queueStore'
 
 type Command = () => void | Promise<void>
 
@@ -71,6 +72,15 @@ export const useCommandStore = defineStore('command', () => {
         summary: 'Interrupted',
         detail: 'Execution has been interrupted',
         life: 1000
+      })
+    },
+    'Comfy.ClearPendingTasks': async () => {
+      await useQueueStore().clear(['queue'])
+      useToastStore().add({
+        severity: 'info',
+        summary: 'Confirmed',
+        detail: 'Pending tasks deleted',
+        life: 3000
       })
     },
     'Comfy.BrowseTemplates': showTemplateWorkflowsDialog

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -9,7 +9,7 @@ import type {
   TaskOutput,
   ResultItem
 } from '@/types/apiTypes'
-import type { ComfyNode, NodeId } from '@/types/comfyWorkflow'
+import type { NodeId } from '@/types/comfyWorkflow'
 import { plainToClass } from 'class-transformer'
 import _ from 'lodash'
 import { defineStore } from 'pinia'

--- a/src/stores/workspaceStateStore.ts
+++ b/src/stores/workspaceStateStore.ts
@@ -1,6 +1,7 @@
-import { SidebarTabExtension, ToastManager } from '@/types/extensionTypes'
+import type { SidebarTabExtension, ToastManager } from '@/types/extensionTypes'
 import { defineStore } from 'pinia'
 import { useToastStore } from './toastStore'
+import { useQueueSettingsStore } from './queueStore'
 
 interface WorkspaceState {
   spinner: boolean
@@ -17,6 +18,9 @@ export const useWorkspaceStore = defineStore('workspace', {
   getters: {
     toast(): ToastManager {
       return useToastStore()
+    },
+    queueSettings() {
+      return useQueueSettingsStore()
     }
   },
   actions: {


### PR DESCRIPTION
Rework/Restyle queue button

- Reduces popover to a selection list of queue mode
- Surface the batch count to top level
- Added clear pending tasks button to clear all pending tasks other than the currently executing one

![image](https://github.com/user-attachments/assets/65f65469-e2bc-45b6-90b0-b8bdf18d3a19)


https://github.com/user-attachments/assets/5cbde7e3-6950-4380-a467-b42e3e5c0771

