### PR TITLE
Fix group node naming compatibility

### DIFF
--- a/browser_tests/assets/legacy_group_node.json
+++ b/browser_tests/assets/legacy_group_node.json
@@ -1,0 +1,252 @@
+{
+  "last_node_id": 15,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 15,
+      "type": "workflow/hello",
+      "pos": {
+        "0": 566,
+        "1": 316
+      },
+      "size": {
+        "0": 468.5999755859375,
+        "1": 582
+      },
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": null,
+          "label": "model"
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null,
+          "label": "positive"
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null,
+          "label": "negative"
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": null,
+          "label": "latent_image"
+        },
+        {
+          "name": "KSampler model",
+          "type": "MODEL",
+          "link": null,
+          "label": "KSampler model"
+        },
+        {
+          "name": "KSampler positive",
+          "type": "CONDITIONING",
+          "link": null,
+          "label": "KSampler positive"
+        },
+        {
+          "name": "KSampler negative",
+          "type": "CONDITIONING",
+          "link": null,
+          "label": "KSampler negative"
+        },
+        {
+          "name": "KSampler latent_image",
+          "type": "LATENT",
+          "link": null,
+          "label": "KSampler latent_image"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": null,
+          "shape": 3,
+          "label": "LATENT"
+        },
+        {
+          "name": "KSampler LATENT",
+          "type": "LATENT",
+          "links": null,
+          "shape": 3,
+          "label": "KSampler LATENT"
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "workflow/hello"
+      },
+      "widgets_values": [
+        "enable",
+        0,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "normal",
+        0,
+        10000,
+        "disable",
+        0,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "normal",
+        1
+      ]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "groupNodes": {
+      "hello": {
+        "nodes": [
+          {
+            "id": -1,
+            "type": "KSamplerAdvanced",
+            "pos": {
+              "0": 351.3332824707031,
+              "1": 577.3333129882812
+            },
+            "size": {
+              "0": 315,
+              "1": 334
+            },
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "model",
+                "type": "MODEL",
+                "link": null,
+                "label": "model"
+              },
+              {
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": null,
+                "label": "positive"
+              },
+              {
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": null,
+                "label": "negative"
+              },
+              {
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": null,
+                "label": "latent_image"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": null,
+                "shape": 3,
+                "label": "LATENT"
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSamplerAdvanced"
+            },
+            "widgets_values": [
+              "enable",
+              0,
+              "randomize",
+              20,
+              8,
+              "euler",
+              "normal",
+              0,
+              10000,
+              "disable"
+            ],
+            "index": 0
+          },
+          {
+            "id": -1,
+            "type": "KSampler",
+            "pos": {
+              "0": 636,
+              "1": 427
+            },
+            "size": {
+              "0": 315,
+              "1": 262
+            },
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "model",
+                "type": "MODEL",
+                "link": null,
+                "label": "model"
+              },
+              {
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": null,
+                "label": "positive"
+              },
+              {
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": null,
+                "label": "negative"
+              },
+              {
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": null,
+                "label": "latent_image"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": null,
+                "shape": 3,
+                "label": "LATENT"
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler"
+            },
+            "widgets_values": [
+              0,
+              "randomize",
+              20,
+              8,
+              "euler",
+              "normal",
+              1
+            ],
+            "index": 1
+          }
+        ],
+        "links": [],
+        "external": []
+      }
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -140,4 +140,12 @@ test.describe('Group Node', () => {
     // Ensure the link is still present
     expect(await input.getLinkCount()).toBe(1)
   })
+
+  test('Loads from a workflow using the legacy path separator ("/")', async ({
+    comfyPage
+  }) => {
+    await comfyPage.loadWorkflow('legacy_group_node')
+    expect(await comfyPage.getGraphNodesCount()).toBe(1)
+    expect(comfyPage.page.locator('.comfy-missing-nodes')).not.toBeVisible()
+  })
 })

--- a/src/extensions/core/groupNodeManage.ts
+++ b/src/extensions/core/groupNodeManage.ts
@@ -10,6 +10,7 @@ import {
 } from '@comfyorg/litegraph'
 
 const ORDER: symbol = Symbol()
+const PREFIX = 'workflow'
 const SEPARATOR = '>'
 
 function merge(target, source) {
@@ -104,7 +105,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
   getGroupData() {
     this.groupNodeType =
       LiteGraph.registered_node_types[
-        `workflow${SEPARATOR}` + this.selectedGroup
+        `${PREFIX}${SEPARATOR}` + this.selectedGroup
       ]
     this.groupNodeDef = this.groupNodeType.nodeData
     this.groupData = GroupNodeHandler.getGroupData(this.groupNodeType)
@@ -370,7 +371,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
           groupNodes.map((g) =>
             $el('option', {
               textContent: g,
-              selected: `workflow${SEPARATOR}` + g === type,
+              selected: `${PREFIX}${SEPARATOR}` + g === type,
               value: g
             })
           )
@@ -392,7 +393,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
           {
             onclick: (e) => {
               const node = app.graph.nodes.find(
-                (n) => n.type === `workflow${SEPARATOR}` + this.selectedGroup
+                (n) => n.type === `${PREFIX}${SEPARATOR}` + this.selectedGroup
               )
               if (node) {
                 alert(
@@ -407,7 +408,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
               ) {
                 delete app.graph.extra.groupNodes[this.selectedGroup]
                 LiteGraph.unregisterNodeType(
-                  `workflow${SEPARATOR}` + this.selectedGroup
+                  `${PREFIX}${SEPARATOR}` + this.selectedGroup
                 )
               }
               this.show()
@@ -481,7 +482,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
                   }, {})
                 }
 
-                const nodes = nodesByType[`workflow${SEPARATOR}` + g]
+                const nodes = nodesByType[`${PREFIX}${SEPARATOR}` + g]
                 if (nodes) recreateNodes.push(...nodes)
               }
 
@@ -509,7 +510,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
     this.element.replaceChildren(outer)
     this.changeGroup(
       type
-        ? groupNodes.find((g) => `workflow${SEPARATOR}` + g === type)
+        ? groupNodes.find((g) => `${PREFIX}${SEPARATOR}` + g === type)
         : groupNodes[0]
     )
     this.element.showModal()

--- a/src/extensions/core/groupNodeManage.ts
+++ b/src/extensions/core/groupNodeManage.ts
@@ -10,6 +10,7 @@ import {
 } from '@comfyorg/litegraph'
 
 const ORDER: symbol = Symbol()
+const SEPARATOR = '>'
 
 function merge(target, source) {
   if (typeof target === 'object' && typeof source === 'object') {
@@ -102,7 +103,9 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
 
   getGroupData() {
     this.groupNodeType =
-      LiteGraph.registered_node_types['workflow>' + this.selectedGroup]
+      LiteGraph.registered_node_types[
+        `workflow${SEPARATOR}` + this.selectedGroup
+      ]
     this.groupNodeDef = this.groupNodeType.nodeData
     this.groupData = GroupNodeHandler.getGroupData(this.groupNodeType)
   }
@@ -367,7 +370,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
           groupNodes.map((g) =>
             $el('option', {
               textContent: g,
-              selected: 'workflow>' + g === type,
+              selected: `workflow${SEPARATOR}` + g === type,
               value: g
             })
           )
@@ -389,7 +392,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
           {
             onclick: (e) => {
               const node = app.graph.nodes.find(
-                (n) => n.type === 'workflow>' + this.selectedGroup
+                (n) => n.type === `workflow${SEPARATOR}` + this.selectedGroup
               )
               if (node) {
                 alert(
@@ -403,7 +406,9 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
                 )
               ) {
                 delete app.graph.extra.groupNodes[this.selectedGroup]
-                LiteGraph.unregisterNodeType('workflow>' + this.selectedGroup)
+                LiteGraph.unregisterNodeType(
+                  `workflow${SEPARATOR}` + this.selectedGroup
+                )
               }
               this.show()
             }
@@ -476,7 +481,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
                   }, {})
                 }
 
-                const nodes = nodesByType['workflow>' + g]
+                const nodes = nodesByType[`workflow${SEPARATOR}` + g]
                 if (nodes) recreateNodes.push(...nodes)
               }
 
@@ -503,7 +508,9 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
 
     this.element.replaceChildren(outer)
     this.changeGroup(
-      type ? groupNodes.find((g) => 'workflow>' + g === type) : groupNodes[0]
+      type
+        ? groupNodes.find((g) => `workflow${SEPARATOR}` + g === type)
+        : groupNodes[0]
     )
     this.element.showModal()
 


### PR DESCRIPTION
#950 changed group node names' prefix from `workflow/` to `workflow>`. To be compatible with older workflows, change `workflow/` to `workflow>` in graph data when configuring.

Issue:

- https://github.com/comfyanonymous/ComfyUI/issues/5052