### PR TITLE
Hide Comfy.Workflow.WorkflowTabsPosition

### DIFF
--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -378,7 +378,7 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Workflow.WorkflowTabsPosition',
     name: 'Opened workflows position',
-    type: 'combo',
+    type: 'hidden',
     options: ['Sidebar', 'Topbar'],
     defaultValue: 'Sidebar'
   }


### PR DESCRIPTION
Hide `Comfy.Workflow.WorkflowTabsPosition`. Users can still change this setting by editing `default/settings.json`.