### PR TITLE
minor css improvement with editable text

### DIFF
--- a/src/components/common/EditableText.vue
+++ b/src/components/common/EditableText.vue
@@ -73,7 +73,7 @@ const vFocus = {
 
 <style scoped>
 .editable-text {
-  display: inline-block;
+  display: inline;
 }
 .editable-text input {
   width: 100%;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/15638f0c-4224-4a3a-9579-757e3e339291)

after:
![image](https://github.com/user-attachments/assets/e2232894-f43d-42d6-b2dd-5321a8f3d9b3)

When you click Rename, they look identical before/after.