### PR TITLE
add a hotkey for settings

### DIFF
--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -425,9 +425,9 @@ test.describe('Load duplicate workflow', () => {
 
 test.describe('Menu interactions', () => {
   test('Can open settings with hotkey', async ({ comfyPage }) => {
-    await comfyPage.page.keyboard.down('Control')
+    await comfyPage.page.keyboard.down('ControlOrMeta')
     await comfyPage.page.keyboard.press(',')
-    await comfyPage.page.keyboard.up('Control')
+    await comfyPage.page.keyboard.up('ControlOrMeta')
     const settingsLocator = comfyPage.page.locator('.settings-container')
     await expect(settingsLocator).toBeVisible()
     await comfyPage.page.keyboard.press('Escape')

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -422,3 +422,15 @@ test.describe('Load duplicate workflow', () => {
     expect(await comfyPage.getGraphNodesCount()).toBe(1)
   })
 })
+
+test.describe('Menu interactions', () => {
+  test('Can open settings with hotkey', async ({ comfyPage }) => {
+    await comfyPage.page.keyboard.down('Control')
+    await comfyPage.page.keyboard.press(',')
+    await comfyPage.page.keyboard.up('Control')
+    const settingsLocator = comfyPage.page.locator('.settings-container')
+    await expect(settingsLocator).toBeVisible()
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(settingsLocator).not.toBeVisible()
+  })
+})

--- a/src/components/sidebar/SidebarSettingsToggleIcon.vue
+++ b/src/components/sidebar/SidebarSettingsToggleIcon.vue
@@ -1,6 +1,7 @@
 <template>
   <SidebarIcon
     icon="pi pi-cog"
+    class="settings-icon-button"
     @click="showSetting"
     :tooltip="$t('settings')"
   />

--- a/src/components/sidebar/SidebarSettingsToggleIcon.vue
+++ b/src/components/sidebar/SidebarSettingsToggleIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <SidebarIcon
     icon="pi pi-cog"
-    class="settings-icon-button"
+    class="comfy-settings-btn"
     @click="showSetting"
     :tooltip="$t('settings')"
   />

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -42,7 +42,7 @@ app.registerExtension({
         Backspace: '#comfy-clear-button',
         d: '#comfy-load-default-button',
         g: '#comfy-group-selected-nodes-button',
-        ',': '.settings-icon-button'
+        ',': '.comfy-settings-btn'
       }
 
       const modifierKeybindId = modifierKeyIdMap[event.key]

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -41,7 +41,8 @@ app.registerExtension({
         o: '#comfy-file-input',
         Backspace: '#comfy-clear-button',
         d: '#comfy-load-default-button',
-        g: '#comfy-group-selected-nodes-button'
+        g: '#comfy-group-selected-nodes-button',
+        ',': '.settings-icon-button'
       }
 
       const modifierKeybindId = modifierKeyIdMap[event.key]


### PR DESCRIPTION
for #942

That issue links multiple Human-Interface-Guidelines that suggest `CTRL+,` (meta key and comma) as recommended for a Settings hotkey, so I used that.

The keybinds extension uses a mix of classname and ID based button maps as its hotkey registration handling, so I matched that, using specifically a unique classname as that's easiest to apply directly (vs adding an ID requires also modifying SidebarIcon to support that). The old UI uses classname `comfy-settings-btn` so I copied that to the new UI, allowing the hotkey to work the same on both UI variants.

Worked in local testing, will add playwright test momentarily