### PR TITLE
allow custom bypass color

### DIFF
--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -42,6 +42,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_BOXCOLOR: '#666',
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#FFF',
+        NODE_BYPASS_BGCOLOR: '#FF00FF',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
 
@@ -73,9 +74,6 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#fff',
         'content-hover-bg': '#222',
         'content-hover-fg': '#fff'
-      },
-      other: {
-        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -110,6 +108,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_BOXCOLOR: '#CCC',
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#000',
+        NODE_BYPASS_BGCOLOR: '#FF00FF',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.1)',
         DEFAULT_GROUP_FONT: 24,
 
@@ -141,9 +140,6 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#222',
         'content-hover-bg': '#adadad',
         'content-hover-fg': '#222'
-      },
-      other: {
-        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -176,6 +172,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_BOXCOLOR: '#839496', // Base0
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#fdf6e3', // Base3
+        NODE_BYPASS_BGCOLOR: '#FF00FF',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
 
@@ -204,9 +201,6 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#fdf6e3',
         'content-hover-bg': '#002b36',
         'content-hover-fg': '#fdf6e3'
-      },
-      other: {
-        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -255,6 +249,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_BOXCOLOR: '#6e7581',
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#FFF',
+        NODE_BYPASS_BGCOLOR: '#FF00FF',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 22,
         WIDGET_BGCOLOR: '#2b2f38',
@@ -281,9 +276,6 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#fff',
         'content-hover-bg': '#2b2f38',
         'content-hover-fg': '#fff'
-      },
-      other: {
-        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -332,6 +324,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_BOXCOLOR: '#545d70',
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#e5eaf0',
+        NODE_BYPASS_BGCOLOR: '#FF00FF',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
         WIDGET_BGCOLOR: '#2e3440',
@@ -358,9 +351,6 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#e5eaf0',
         'content-hover-bg': '#2e3440',
         'content-hover-fg': '#e5eaf0'
-      },
-      other: {
-        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -409,6 +399,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_BOXCOLOR: '#30363d',
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#e5eaf0',
+        NODE_BYPASS_BGCOLOR: '#FF00FF',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
         WIDGET_BGCOLOR: '#161b22',
@@ -435,9 +426,6 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#e5eaf0',
         'content-hover-bg': '#161b22',
         'content-hover-fg': '#e5eaf0'
-      },
-      other: {
-        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   }
@@ -714,12 +702,11 @@ app.registerExtension({
             )
           }
         }
-        // Sets the other colors
+        // Sets special case colors
         if (
-          colorPalette.colors.other &&
-          colorPalette.colors.other.NODE_BYPASS_BGCOLOR
+          colorPalette.colors.litegraph_base.NODE_BYPASS_BGCOLOR
         ) {
-          app.bypassBgColor = colorPalette.colors.other.NODE_BYPASS_BGCOLOR
+          app.bypassBgColor = colorPalette.colors.litegraph_base.NODE_BYPASS_BGCOLOR
         }
         app.canvas.draw(true, true)
       }

--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -703,10 +703,9 @@ app.registerExtension({
           }
         }
         // Sets special case colors
-        if (
-          colorPalette.colors.litegraph_base.NODE_BYPASS_BGCOLOR
-        ) {
-          app.bypassBgColor = colorPalette.colors.litegraph_base.NODE_BYPASS_BGCOLOR
+        if (colorPalette.colors.litegraph_base.NODE_BYPASS_BGCOLOR) {
+          app.bypassBgColor =
+            colorPalette.colors.litegraph_base.NODE_BYPASS_BGCOLOR
         }
         app.canvas.draw(true, true)
       }

--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -73,6 +73,9 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#fff',
         'content-hover-bg': '#222',
         'content-hover-fg': '#fff'
+      },
+      other: {
+        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -138,6 +141,9 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#222',
         'content-hover-bg': '#adadad',
         'content-hover-fg': '#222'
+      },
+      other: {
+        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -198,6 +204,9 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#fdf6e3',
         'content-hover-bg': '#002b36',
         'content-hover-fg': '#fdf6e3'
+      },
+      other: {
+        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -272,6 +281,9 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#fff',
         'content-hover-bg': '#2b2f38',
         'content-hover-fg': '#fff'
+      },
+      other: {
+        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -346,6 +358,9 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#e5eaf0',
         'content-hover-bg': '#2e3440',
         'content-hover-fg': '#e5eaf0'
+      },
+      other: {
+        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   },
@@ -420,6 +435,9 @@ const colorPalettes: ColorPalettes = {
         'content-fg': '#e5eaf0',
         'content-hover-bg': '#161b22',
         'content-hover-fg': '#e5eaf0'
+      },
+      other: {
+        NODE_BYPASS_BGCOLOR: '#FF00FF'
       }
     }
   }
@@ -695,6 +713,13 @@ app.registerExtension({
               colorPalette.colors.comfy_base[key]
             )
           }
+        }
+        // Sets the other colors
+        if (
+          colorPalette.colors.other &&
+          colorPalette.colors.other.NODE_BYPASS_BGCOLOR
+        ) {
+          app.bypassBgColor = colorPalette.colors.other.NODE_BYPASS_BGCOLOR
         }
         app.canvas.draw(true, true)
       }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -134,6 +134,7 @@ export class ComfyApp {
   bodyBottom: HTMLElement
   canvasContainer: HTMLElement
   menu: ComfyAppMenu
+  bypassBgColor: string
 
   // @deprecated
   // Use useExecutionStore().executingNodeId instead
@@ -154,6 +155,7 @@ export class ComfyApp {
       parent: document.body
     })
     this.menu = new ComfyAppMenu(this)
+    this.bypassBgColor = '#FF00FF'
 
     /**
      * List of extensions that are registered with the app
@@ -1565,7 +1567,7 @@ export class ComfyApp {
       // @ts-expect-error
       if (node.mode === 4) {
         // never
-        bgColor = '#FF00FF'
+        bgColor = app.bypassBgColor
         this.editor_alpha = 0.2
       } else {
         bgColor = old_bgcolor || LiteGraph.NODE_DEFAULT_BGCOLOR

--- a/src/types/colorPalette.ts
+++ b/src/types/colorPalette.ts
@@ -44,6 +44,7 @@ const litegraphBaseSchema = z
     NODE_DEFAULT_BOXCOLOR: z.string(),
     NODE_DEFAULT_SHAPE: z.string(),
     NODE_BOX_OUTLINE_COLOR: z.string(),
+    NODE_BYPASS_BGCOLOR: z.string(),
     DEFAULT_SHADOW_COLOR: z.string(),
     DEFAULT_GROUP_FONT: z.number(),
     WIDGET_BGCOLOR: z.string(),
@@ -77,16 +78,11 @@ const comfyBaseSchema = z.object({
   ['content-hover-fg']: z.string()
 })
 
-const otherColorsSchema = z.object({
-  NODE_BYPASS_BGCOLOR: z.string()
-})
-
 const colorsSchema = z
   .object({
     node_slot: nodeSlotSchema,
     litegraph_base: litegraphBaseSchema,
-    comfy_base: comfyBaseSchema,
-    other: otherColorsSchema
+    comfy_base: comfyBaseSchema
   })
   .passthrough()
 

--- a/src/types/colorPalette.ts
+++ b/src/types/colorPalette.ts
@@ -77,11 +77,16 @@ const comfyBaseSchema = z.object({
   ['content-hover-fg']: z.string()
 })
 
+const otherColorsSchema = z.object({
+  NODE_BYPASS_BGCOLOR: z.string()
+})
+
 const colorsSchema = z
   .object({
     node_slot: nodeSlotSchema,
     litegraph_base: litegraphBaseSchema,
-    comfy_base: comfyBaseSchema
+    comfy_base: comfyBaseSchema,
+    other: otherColorsSchema
   })
   .passthrough()
 


### PR DESCRIPTION
NOTE: see my comment here https://github.com/Comfy-Org/ComfyUI_frontend/issues/964 regardless the design of the theme/color palette system (the current impl feels very hacky, and it's made worse by trying to add a color that isn't explicitly an upstreamed value in litegraph or css, as is the case here).

Regardless, this PR does let you change the color of node bypass if you want, for example here I made it green (`#00FF00`)
![image](https://github.com/user-attachments/assets/09416755-e0fc-4205-b5b9-fd304a4eff17)
