### PR TITLE
don't remove invalid dropdown values

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2939,15 +2939,6 @@ export class ComfyApp {
           def['input']['required'][widget.name] !== undefined
         ) {
           widget.options.values = def['input']['required'][widget.name][0]
-
-          if (
-            widget.name != 'image' &&
-            !widget.options.values.includes(widget.value)
-          ) {
-            widget.value = widget.options.values[0]
-            // @ts-expect-error
-            widget.callback(widget.value)
-          }
         }
       }
     }


### PR DESCRIPTION
for #963

The behavior of resetting dropdowns to the first entry like that is explicitly programmed in, so the most direct solution is just remove that behavior code.

Though there's open questions:
- should this apply to all dropdowns, or should it be changed to a per-widget setting, so that eg model lists don't reset but something more static like a sampler would (ie, is it wanted that values silently reset? imo no this is rarely or never wanted behavior)
- Should there be some form of better solution to this case, eg immediately highlight the node/widget as errored until the user adjusts it? (imo yes this would be very helpful)
- Should whatever final solution we go with here, be synchronized to also happen on workflow first load? (imo yes. Currently if you merge this PR they will be in sync, as first workflow load doesn't reset values or do anything else, but if the error highlight is added, that should be applied to load as well)