### PR TITLE
Allow dragging model library outputs onto existing nodes

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -1,7 +1,6 @@
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { defineStore } from 'pinia'
-import { toRaw } from 'vue'
 
 /** Helper class that defines how to construct a node from a model. */
 export class ModelNodeProvider {
@@ -20,7 +19,7 @@ export class ModelNodeProvider {
 /** Service for mapping model types (by folder name) to nodes. */
 export const useModelToNodeStore = defineStore('modelToNode', {
   state: () => ({
-    modelToNodeMap: {} as Record<string, ModelNodeProvider>,
+    modelToNodeMap: {} as Record<string, ModelNodeProvider[]>,
     nodeDefStore: useNodeDefStore(),
     haveDefaultsLoaded: false
   }),
@@ -32,6 +31,16 @@ export const useModelToNodeStore = defineStore('modelToNode', {
      */
     getNodeProvider(modelType: string): ModelNodeProvider {
       this.registerDefaults()
+      return this.modelToNodeMap[modelType]?.[0]
+    },
+
+    /**
+     * Get the list of all valid node providers for the given model type name.
+     * @param modelType The name of the model type to get the node providers for.
+     * @returns The list of all valid node providers for the given model type name.
+     */
+    getAllNodeProviders(modelType: string): ModelNodeProvider[] {
+      this.registerDefaults()
       return this.modelToNodeMap[modelType]
     },
 
@@ -42,7 +51,8 @@ export const useModelToNodeStore = defineStore('modelToNode', {
      */
     registerNodeProvider(modelType: string, nodeProvider: ModelNodeProvider) {
       this.registerDefaults()
-      this.modelToNodeMap[modelType] = nodeProvider
+      this.modelToNodeMap[modelType] ??= []
+      this.modelToNodeMap[modelType].push(nodeProvider)
     },
 
     registerDefaults() {

--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -77,7 +77,13 @@ export const useModelToNodeStore = defineStore('modelToNode', {
       }
       this.haveDefaultsLoaded = true
       this.quickRegister('checkpoints', 'CheckpointLoaderSimple', 'ckpt_name')
+      this.quickRegister(
+        'checkpoints',
+        'ImageOnlyCheckpointLoader',
+        'ckpt_name'
+      )
       this.quickRegister('loras', 'LoraLoader', 'lora_name')
+      this.quickRegister('loras', 'LoraLoaderModelOnly', 'lora_name')
       this.quickRegister('vae', 'VAELoader', 'vae_name')
       this.quickRegister('controlnet', 'ControlNetLoader', 'control_net_name')
     }

--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -55,6 +55,19 @@ export const useModelToNodeStore = defineStore('modelToNode', {
       this.modelToNodeMap[modelType].push(nodeProvider)
     },
 
+    /**
+     * Register a node provider for the given simple names.
+     * @param modelType The name of the model type to register the node provider for.
+     * @param nodeClass The node class name to register.
+     * @param key The key to use for the node input.
+     */
+    quickRegister(modelType: string, nodeClass: string, key: string) {
+      this.registerNodeProvider(
+        modelType,
+        new ModelNodeProvider(this.nodeDefStore.nodeDefsByName[nodeClass], key)
+      )
+    },
+
     registerDefaults() {
       if (this.haveDefaultsLoaded) {
         return
@@ -63,34 +76,10 @@ export const useModelToNodeStore = defineStore('modelToNode', {
         return
       }
       this.haveDefaultsLoaded = true
-      this.registerNodeProvider(
-        'checkpoints',
-        new ModelNodeProvider(
-          this.nodeDefStore.nodeDefsByName['CheckpointLoaderSimple'],
-          'ckpt_name'
-        )
-      )
-      this.registerNodeProvider(
-        'loras',
-        new ModelNodeProvider(
-          this.nodeDefStore.nodeDefsByName['LoraLoader'],
-          'lora_name'
-        )
-      )
-      this.registerNodeProvider(
-        'vae',
-        new ModelNodeProvider(
-          this.nodeDefStore.nodeDefsByName['VAELoader'],
-          'vae_name'
-        )
-      )
-      this.registerNodeProvider(
-        'controlnet',
-        new ModelNodeProvider(
-          this.nodeDefStore.nodeDefsByName['ControlNetLoader'],
-          'control_net_name'
-        )
-      )
+      this.quickRegister('checkpoints', 'CheckpointLoaderSimple', 'ckpt_name')
+      this.quickRegister('loras', 'LoraLoader', 'lora_name')
+      this.quickRegister('vae', 'VAELoader', 'vae_name')
+      this.quickRegister('controlnet', 'ControlNetLoader', 'control_net_name')
     }
   }
 })


### PR DESCRIPTION
for #1000 

This also changes modelToNodeStore to be backed by a list, which allows multiple node type registrations - that way many different nodes can be registered as compatible with a given model class.

(Future todo: automatic registration from object_info maybe? We can easily identify which inputs have lists that exact match a given expected model type list, and arguably that can be abused to define compatibility. Or if not, maybe a field in the custom node in python side?)

Having the list that allows multiple entries also means we can in the future display a list of what node types are valid and let the user choose / set defaults / etc.

I've registered a second core loader node for checkpoint and lora, and validated that dragging onto either works. Naturally this also providers an easy test reference for other future usages of the multiple node options list.

Also added `quickRegister` to reduce the copypasta