### PR TITLE
add filename in model preview popup

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -147,7 +147,7 @@ onMounted(async () => {
               (widget) => widget.name === provider.key
             )
             if (widget) {
-              widget.value = model.name
+              widget.value = model.file_name
             }
           }
         }

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -84,11 +84,14 @@ const root: ComputedRef<TreeNode> = computed(() => {
   if (searchQuery.value) {
     const search = searchQuery.value.toLocaleLowerCase()
     modelList = modelList.filter((model: ComfyModelDef) => {
-      return model.name.toLocaleLowerCase().includes(search)
+      return model.file_name.toLocaleLowerCase().includes(search)
     })
   }
   const tree: TreeNode = buildTree(modelList, (model: ComfyModelDef) => {
-    return [model.directory, ...model.name.replaceAll('\\', '/').split('/')]
+    return [
+      model.directory,
+      ...model.file_name.replaceAll('\\', '/').split('/')
+    ]
   })
   return tree
 })
@@ -100,7 +103,7 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
     const model: ComfyModelDef | null =
       node.leaf && node.data ? node.data : null
     if (model?.is_fake_object) {
-      if (model.name === '(No Content)') {
+      if (model.file_name === '(No Content)') {
         return {
           key: node.key,
           label: t('noContent'),
@@ -130,7 +133,7 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
       label: model
         ? nameFormat === 'title'
           ? model.title
-          : model.simplified_name
+          : model.simplified_file_name
         : node.label,
       leaf: node.leaf,
       data: node.data,
@@ -149,9 +152,9 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
         if (node.children?.length === 1) {
           const onlyChild = node.children[0]
           if (onlyChild.data?.is_fake_object) {
-            if (onlyChild.data.name === '(No Content)') {
+            if (onlyChild.data.file_name === '(No Content)') {
               return '0'
-            } else if (onlyChild.data.name === 'Loading') {
+            } else if (onlyChild.data.file_name === 'Loading') {
               return '?'
             }
           }
@@ -174,7 +177,7 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
               (widget) => widget.name === provider.key
             )
             if (widget) {
-              widget.value = model.name
+              widget.value = model.file_name
             }
           }
         }

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -94,6 +94,7 @@ const root: ComputedRef<TreeNode> = computed(() => {
 })
 
 const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
+  const nameFormat = settingStore.get('Comfy.ModelLibrary.NameFormat')
   const fillNodeInfo = (node: TreeNode): TreeExplorerNode<ComfyModelDef> => {
     const children = node.children?.map(fillNodeInfo)
     const model: ComfyModelDef | null =
@@ -126,7 +127,11 @@ const renderedRoot = computed<TreeExplorerNode<ComfyModelDef>>(() => {
 
     return {
       key: node.key,
-      label: model ? model.title : node.label,
+      label: model
+        ? nameFormat === 'title'
+          ? model.title
+          : model.simplified_name
+        : node.label,
       leaf: node.leaf,
       data: node.data,
       getIcon: (node: TreeExplorerNode<ComfyModelDef>) => {

--- a/src/components/sidebar/tabs/modelLibrary/ModelPreview.vue
+++ b/src/components/sidebar/tabs/modelLibrary/ModelPreview.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="model_preview_top_container">
       <div class="model_preview_filename">
-        {{ modelDef.name }}
+        {{ modelDef.file_name }}
       </div>
       <div class="model_preview_architecture" v-if="modelDef.architecture_id">
         <span class="model_preview_prefix">Architecture: </span>

--- a/src/components/sidebar/tabs/modelLibrary/ModelPreview.vue
+++ b/src/components/sidebar/tabs/modelLibrary/ModelPreview.vue
@@ -4,6 +4,9 @@
       {{ modelDef.title }}
     </div>
     <div class="model_preview_top_container">
+      <div class="model_preview_filename">
+        {{ modelDef.name }}
+      </div>
       <div class="model_preview_architecture" v-if="modelDef.architecture_id">
         <span class="model_preview_prefix">Architecture: </span>
         {{ modelDef.architecture_id }}
@@ -75,7 +78,9 @@ const modelDef = props.modelDef
 }
 .model_preview_top_container {
   text-align: center;
+  line-height: 0.5;
 }
+.model_preview_filename,
 .model_preview_author,
 .model_preview_architecture {
   display: inline-block;

--- a/src/components/sidebar/tabs/modelLibrary/ModelTreeLeaf.vue
+++ b/src/components/sidebar/tabs/modelLibrary/ModelTreeLeaf.vue
@@ -90,6 +90,7 @@ const showPreview = computed(() => {
     !modelDef.value.is_fake_object &&
     modelDef.value.has_loaded_metadata &&
     (modelDef.value.author ||
+      modelDef.value.simplified_name != modelDef.value.title ||
       modelDef.value.description ||
       modelDef.value.usage_hint ||
       modelDef.value.trigger_phrase ||

--- a/src/components/sidebar/tabs/modelLibrary/ModelTreeLeaf.vue
+++ b/src/components/sidebar/tabs/modelLibrary/ModelTreeLeaf.vue
@@ -90,7 +90,7 @@ const showPreview = computed(() => {
     !modelDef.value.is_fake_object &&
     modelDef.value.has_loaded_metadata &&
     (modelDef.value.author ||
-      modelDef.value.simplified_name != modelDef.value.title ||
+      modelDef.value.simplified_file_name != modelDef.value.title ||
       modelDef.value.description ||
       modelDef.value.usage_hint ||
       modelDef.value.trigger_phrase ||

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -254,7 +254,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.ModelLibrary.NameFormat',
     name: 'What name to display in the model library tree view',
     tooltip:
-      'Select "filename" to render a simplified view of the raw filename in the model list. Select "title" to display the configurable model metadata title.',
+      'Select "filename" to render a simplified view of the raw filename (without directory or ".safetensors" extension) in the model list. Select "title" to display the configurable model metadata title.',
     type: 'combo',
     options: ['filename', 'title'],
     defaultValue: 'title'

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -251,6 +251,13 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: false
   },
   {
+    id: 'Comfy.ModelLibrary.NameFormat',
+    name: 'What name to display in the model library tree view',
+    type: 'combo',
+    options: ['filename', 'title'],
+    defaultValue: 'title'
+  },
+  {
     id: 'Comfy.Locale',
     name: 'Locale',
     type: 'combo',

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -253,6 +253,8 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.ModelLibrary.NameFormat',
     name: 'What name to display in the model library tree view',
+    tooltip:
+      'Select "filename" to render a simplified view of the raw filename in the model list. Select "title" to display the configurable model metadata title.',
     type: 'combo',
     options: ['filename', 'title'],
     defaultValue: 'title'

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -19,11 +19,11 @@ function _findInMetadata(metadata: any, ...keys: string[]): string | null {
 /** Defines and holds metadata for a model */
 export class ComfyModelDef {
   /** Proper filename of the model */
-  name: string = ''
+  file_name: string = ''
   /** Directory containing the model, eg 'checkpoints' */
   directory: string = ''
-  /** Simplified copy of name, used as a default title */
-  simplified_name: string = ''
+  /** Simplified copy of name, used as a default title. Excludes the directory and the '.safetensors' file extension */
+  simplified_file_name: string = ''
   /** Title / display name of the model, sometimes same as the name but not always */
   title: string = ''
   /** Metadata: architecture ID for the model, such as 'stable-diffusion-xl-v1-base' */
@@ -50,15 +50,15 @@ export class ComfyModelDef {
   is_fake_object: boolean = false
 
   constructor(name: string, directory: string) {
-    this.name = name
-    this.simplified_name = name.replaceAll('\\', '/').split('/').pop()
-    if (this.simplified_name.endsWith('.safetensors')) {
-      this.simplified_name = this.simplified_name.slice(
+    this.file_name = name
+    this.simplified_file_name = name.replaceAll('\\', '/').split('/').pop()
+    if (this.simplified_file_name.endsWith('.safetensors')) {
+      this.simplified_file_name = this.simplified_file_name.slice(
         0,
         -'.safetensors'.length
       )
     }
-    this.title = this.simplified_name
+    this.title = this.simplified_file_name
     this.directory = directory
   }
 
@@ -69,7 +69,7 @@ export class ComfyModelDef {
     }
     this.is_load_requested = true
     try {
-      const metadata = await api.viewMetadata(this.directory, this.name)
+      const metadata = await api.viewMetadata(this.directory, this.file_name)
       if (!metadata) {
         return
       }
@@ -111,7 +111,7 @@ export class ComfyModelDef {
       this.tags = tagsCommaSeparated.split(',').map((tag) => tag.trim())
       this.has_loaded_metadata = true
     } catch (error) {
-      console.error('Error loading model metadata', this.name, this, error)
+      console.error('Error loading model metadata', this.file_name, this, error)
     }
   }
 }

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -22,6 +22,8 @@ export class ComfyModelDef {
   name: string = ''
   /** Directory containing the model, eg 'checkpoints' */
   directory: string = ''
+  /** Simplified copy of name, used as a default title */
+  simplified_name: string = ''
   /** Title / display name of the model, sometimes same as the name but not always */
   title: string = ''
   /** Metadata: architecture ID for the model, such as 'stable-diffusion-xl-v1-base' */
@@ -49,10 +51,14 @@ export class ComfyModelDef {
 
   constructor(name: string, directory: string) {
     this.name = name
-    this.title = name.replaceAll('\\', '/').split('/').pop()
-    if (this.title.endsWith('.safetensors')) {
-      this.title = this.title.slice(0, -'.safetensors'.length)
+    this.simplified_name = name.replaceAll('\\', '/').split('/').pop()
+    if (this.simplified_name.endsWith('.safetensors')) {
+      this.simplified_name = this.simplified_name.slice(
+        0,
+        -'.safetensors'.length
+      )
     }
+    this.title = this.simplified_name
     this.directory = directory
   }
 

--- a/tests-ui/tests/store/modelStore.test.ts
+++ b/tests-ui/tests/store/modelStore.test.ts
@@ -69,7 +69,7 @@ describe('useModelStore', () => {
     const folderStore = await store.getModelsInFolderCached('checkpoints')
     const model = folderStore.models['noinfo.safetensors']
     await model.load()
-    expect(model.name).toBe('noinfo.safetensors')
+    expect(model.file_name).toBe('noinfo.safetensors')
     expect(model.title).toBe('noinfo')
     expect(model.architecture_id).toBe('')
     expect(model.author).toBe('')


### PR DESCRIPTION
for #1003

Adds raw filename in the preview popup, amongst the other small text bits at the top
![image](https://github.com/user-attachments/assets/57560d53-858a-4c53-90b7-1bf31607f6aa)

See linked issue for reasons this can be useful to know

Also adds a user setting for whether the name in the tree should be the filename or the title, defaulting to the clean title but allowing users to switch to raw filename if they have bad titles (this is basically a temporarily workaround pending adding features for customizing model metadata in-UI)