### PR TITLE
Make action bar draggable

### DIFF
--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -640,9 +640,10 @@ export class ComfyPage {
         y: 645
       }
     })
-    await page.locator('input[type="text"]').click()
-    await page.locator('input[type="text"]').fill('128')
-    await page.locator('input[type="text"]').press('Enter')
+    const dialogInput = page.locator('.graphdialog input[type="text"]')
+    await dialogInput.click()
+    await dialogInput.fill('128')
+    await dialogInput.press('Enter')
     await this.nextFrame()
   }
 

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -91,8 +91,8 @@ import { useSettingStore } from '@/stores/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { MenuItem } from 'primevue/menuitem'
 import { useI18n } from 'vue-i18n'
-import { useDraggable, useLocalStorage } from '@vueuse/core'
-import { debounce } from 'lodash'
+import { useDraggable, useEventListener, useLocalStorage } from '@vueuse/core'
+import { debounce, clamp } from 'lodash'
 
 const settingsStore = useSettingStore()
 const commandStore = useCommandStore()
@@ -198,6 +198,23 @@ watch(visible, (newVisible) => {
     nextTick(setInitialPosition)
   }
 })
+
+const adjustMenuPosition = () => {
+  if (panelRef.value) {
+    const screenWidth = window.innerWidth
+    const screenHeight = window.innerHeight
+    const menuWidth = panelRef.value.offsetWidth
+    const menuHeight = panelRef.value.offsetHeight
+
+    // Adjust x position if menu is off-screen horizontally
+    x.value = clamp(x.value, 0, screenWidth - menuWidth)
+
+    // Adjust y position if menu is off-screen vertically
+    y.value = clamp(y.value, 0, screenHeight - menuHeight)
+  }
+}
+
+useEventListener(window, 'resize', adjustMenuPosition)
 </script>
 
 <style scoped>

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -212,7 +212,7 @@ watch(visible, (newVisible) => {
 }
 
 :deep(.p-panel-content) {
-  padding: 10px;
+  @apply p-2;
 }
 
 :deep(.p-panel-header) {

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -157,13 +157,18 @@ const { x, y, style, isDragging } = useDraggable(panelRef, {
 
 // Set initial position to bottom center
 const setInitialPosition = () => {
+  if (x.value !== 0 || y.value !== 0) {
+    return
+  }
   if (panelRef.value) {
     const screenWidth = window.innerWidth
     const screenHeight = window.innerHeight
     const menuWidth = panelRef.value.offsetWidth
     const menuHeight = panelRef.value.offsetHeight
 
-    console.log(menuWidth, menuHeight)
+    if (menuWidth === 0 || menuHeight === 0) {
+      return
+    }
 
     x.value = (screenWidth - menuWidth) / 2
     y.value = screenHeight - menuHeight - 10 // 10px margin from bottom

--- a/src/components/appMenu/AppMenu.vue
+++ b/src/components/appMenu/AppMenu.vue
@@ -30,7 +30,7 @@
           </template>
         </SplitButton>
         <BatchCountEdit />
-        <ButtonGroup class="execution-actions ml-2">
+        <ButtonGroup class="execution-actions ml-2 flex flex-nowrap">
           <Button
             v-tooltip.bottom="$t('menu.interrupt')"
             icon="pi pi-times"
@@ -51,7 +51,7 @@
         </ButtonGroup>
       </div>
       <Divider layout="vertical" class="mx-2" />
-      <ButtonGroup>
+      <ButtonGroup class="flex flex-nowrap">
         <Button
           v-tooltip.bottom="$t('menu.refresh')"
           icon="pi pi-refresh"

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -172,7 +172,7 @@ function dragElement(dragEl, settings): () => void {
   settings.addSetting({
     id: 'Comfy.MenuPosition',
     category: ['Comfy', 'Menu', 'MenuPosition'],
-    name: "Save legacy menu's position",
+    name: "Save menu's position",
     type: 'boolean',
     defaultValue: savePos,
     onChange(value) {

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -172,7 +172,7 @@ function dragElement(dragEl, settings): () => void {
   settings.addSetting({
     id: 'Comfy.MenuPosition',
     category: ['Comfy', 'Menu', 'MenuPosition'],
-    name: "Save menu's position",
+    name: "Save legacy menu's position",
     type: 'boolean',
     defaultValue: savePos,
     onChange(value) {


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/1026

Related issues:
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1030
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1028
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1026
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1025
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1007
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1001

What this PR implements:
- Draggable action bar
- Action bar drag boundary
- Action bar kept in sight on window resize
- Action bar position persisted in browser local storage

The default action bar position is bottom center of the window.


https://github.com/user-attachments/assets/ad6d08b1-dc7a-4e6a-a838-93cc7488f98f



