### PR TITLE
Fix menu drag on touch device

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -316,6 +316,7 @@ span.drag-handle {
   letter-spacing: 2px;
   color: var(--drag-text);
   text-shadow: 1px 0 1px black;
+  touch-action: none;
 }
 
 span.drag-handle::after {


### PR DESCRIPTION
Set `touch-action: none` on drag handle to allow dragging floating menu on touch device.