### PR TITLE
Fix topbar submenu width on mobile/tablet 

### DIFF
--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -231,7 +231,7 @@ class Topbar {
   }
 
   async openSubmenuMobile() {
-    await this.page.locator('.p-menubar-mobile').click()
+    await this.page.locator('.p-menubar-mobile .p-menubar-button').click()
   }
 
   async triggerTopbarCommand(path: string[]) {

--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -230,6 +230,10 @@ class Topbar {
       .allInnerTexts()
   }
 
+  async openSubmenuMobile() {
+    await this.page.locator('.p-menubar-mobile').click()
+  }
+
   async triggerTopbarCommand(path: string[]) {
     if (path.length < 2) {
       throw new Error('Path is too short')

--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -230,7 +230,6 @@ class Topbar {
       .allInnerTexts()
   }
 
-
   async openSubmenuMobile() {
     await this.page.locator('.p-menubar-mobile .p-menubar-button').click()
   }

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -454,6 +454,21 @@ test.describe('Menu', () => {
     })
   })
 
+  test.describe('Topbar submmenus', () => {
+    test('@mobile Items fully visible on mobile screen width', async ({
+      comfyPage
+    }) => {
+      await comfyPage.menu.topbar.openSubmenuMobile()
+      const topLevelMenuItem = comfyPage.page
+        .locator('a.p-menubar-item-link')
+        .first()
+      const isTextCutoff = await topLevelMenuItem.evaluate((el) => {
+        return el.scrollWidth > el.clientWidth
+      })
+      expect(isTextCutoff).toBe(false)
+    })
+  })
+
   // Only test 'Top' to reduce test time.
   // ['Bottom', 'Top']
   ;['Top'].forEach(async (position) => {

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -6,7 +6,7 @@
         :model="items"
         class="top-menubar border-none p-0 bg-transparent"
         :pt="{
-          rootList: 'gap-0 flex-nowrap'
+          rootList: 'gap-0 flex-nowrap w-auto'
         }"
       />
       <Divider layout="vertical" class="mx-2" />


### PR DESCRIPTION
Primevue menubar is narrower than expected due to right menu. The submenus have `width: 100%` by default, which is not enough past large breakpoint.

Before / After:

![sbs](https://github.com/user-attachments/assets/ef39ab8a-b177-438a-afe0-1af04fad7a68)
