### PR TITLE
Fix closing saved workflows

### DIFF
--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -230,6 +230,34 @@ class Topbar {
       .allInnerTexts()
   }
 
+  async getMenuItem(itemLabel: string): Promise<Locator> {
+    return this.page.locator(`.p-menubar-item-label:text-is("${itemLabel}")`)
+  }
+
+  async getWorkflowTab(tabName: string): Promise<Locator> {
+    return this.page
+      .locator(`.workflow-tabs .workflow-label:has-text("${tabName}")`)
+      .locator('..')
+  }
+
+  async closeWorkflowTab(tabName: string) {
+    const tab = await this.getWorkflowTab(tabName)
+    await tab.locator('.close-button').click({ force: true })
+  }
+
+  async saveWorkflow(workflowName: string) {
+    this.page.on('dialog', async (dialog) => {
+      await dialog.accept(workflowName)
+    })
+    const workflowMenuItem = await this.getMenuItem('Workflow')
+    workflowMenuItem.click()
+    await this.page.evaluate(() => {
+      return new Promise<number>(requestAnimationFrame)
+    })
+    const saveButton = await this.getMenuItem('Save')
+    await saveButton.click()
+  }
+
   async triggerTopbarCommand(path: string[]) {
     if (path.length < 2) {
       throw new Error('Path is too short')

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -437,6 +437,19 @@ test.describe('Menu', () => {
         comfyPage.page.locator('.comfy-missing-nodes')
       ).not.toBeVisible()
     })
+
+    test('Can close saved-workflows from the open workflows section', async ({
+      comfyPage
+    }) => {
+      await comfyPage.menu.topbar.saveWorkflow('deault')
+      const closeButton = comfyPage.page.locator(
+        '.comfyui-workflows-open .p-button-icon.pi-times'
+      )
+      await closeButton.click()
+      expect(
+        await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
+      ).toEqual(['*Unsaved Workflow (2).json'])
+    })
   })
 
   test.describe('Workflows topbar tabs', () => {

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -447,9 +447,28 @@ test.describe('Menu', () => {
       )
     })
 
+    test.afterEach(async ({ comfyPage }) => {
+      // Delete the saved workflow for cleanup.
+      await comfyPage.page.evaluate(async () => {
+        window['app'].workflowManager.activeWorkflow.delete()
+      })
+    })
+
     test('Can show opened workflows', async ({ comfyPage }) => {
       expect(await comfyPage.menu.topbar.getTabNames()).toEqual([
         'Unsaved Workflow'
+      ])
+    })
+
+    test('Can close saved-workflow tabs', async ({ comfyPage }) => {
+      const savedWorkflowName = 'default'
+      await comfyPage.menu.topbar.saveWorkflow(savedWorkflowName)
+      expect(await comfyPage.menu.topbar.getTabNames()).toEqual([
+        savedWorkflowName
+      ])
+      await comfyPage.menu.topbar.closeWorkflowTab('default')
+      expect(await comfyPage.menu.topbar.getTabNames()).toEqual([
+        'Unsaved Workflow (2)'
       ])
     })
   })

--- a/src/scripts/workflows.ts
+++ b/src/scripts/workflows.ts
@@ -405,7 +405,13 @@ export class ComfyWorkflow {
 
     if (!this.path) {
       // Saved new workflow, patch this instance
+      const oldKey = this.key
       this.updatePath(path, null)
+
+      // Update workflowLookup: change the key from the old unsaved path to the new saved path
+      delete this.manager.workflowStore.workflowLookup[oldKey]
+      this.manager.workflowStore.workflowLookup[this.key] = this
+
       await this.manager.loadWorkflows()
       this.unsaved = false
       this.manager.dispatchEvent(new CustomEvent('rename', { detail: this }))


### PR DESCRIPTION
During save of a new workflow:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/0117964ca56d806b8e144a8956e685f90f1f5951/src/scripts/workflows.ts#L407-L410

The `ComfyWorkflow` instance's path is updated then `loadWorkflows` is called. In `loadWorkflows`:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/0117964ca56d806b8e144a8956e685f90f1f5951/src/scripts/workflows.ts#L71-L75

This `if` block triggers, since the `ComfyWorkflow` instance has not been remapped to its new path in `workflowLookup`. So a new instance is created instead of just patching and remapping the existing one. The new instance is closed by default so trying to close it in tab or sidebar does nothing.



