### PR TITLE
ChangeTracker: emit after editing a widget value by typing

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -200,6 +200,16 @@ export class ChangeTracker {
       return v
     }
 
+    // Handle litegraph dialog popup for number/string widgets
+    const prompt = LGraphCanvas.prototype.prompt
+    LGraphCanvas.prototype.prompt = function (title, value, callback, event) {
+      const extendedCallback = (v) => {
+        callback(v)
+        changeTracker().checkState()
+      }
+      return prompt.apply(this, [title, value, extendedCallback, event])
+    }
+
     // Handle litegraph context menu for COMBO widgets
     const close = LiteGraph.ContextMenu.prototype.close
     LiteGraph.ContextMenu.prototype.close = function (e) {


### PR DESCRIPTION
Currently clicking on a node widget and entering a new value via keyboard does not emit a `graphChanged` event. Changing an input that way doesn't trigger (auto-)queue or create an undo checkpoint.

This PR fixes the issue: after typing in a new value and accepting (pressing "Enter" or clicking "Ok"), the change tracker is notified.