### PR TITLE
[Extension API] Custom commands and keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,35 @@ https://github.com/user-attachments/assets/c142c43f-2fe9-4030-8196-b3bfd4c6977d
 ### Node developers API
 
 <details>
+  <summary>v1.3.7: Register commands and keybindings</summary>
+
+  Extensions can call the following API to register commands and keybindings. Do
+  note that keybindings defined in core cannot be overwritten, and some keybindings
+  are reserved by the browser.
+
+```js
+  app.registerExtension({
+    name: 'TestExtension1',
+    commands: [
+      {
+        id: 'TestCommand',
+        function: () => {
+          alert('TestCommand')
+        }
+      }
+    ],
+    keybindings: [
+      {
+        combo: { key: 'k' },
+        commandId: 'TestCommand'
+      }
+    ]
+  })
+```
+
+</details>
+
+<details>
   <summary>v1.3.1: Extension API to register custom topbar menu items</summary>
 
   Extensions can call the following API to register custom topbar menu items.

--- a/browser_tests/extensionAPI.spec.ts
+++ b/browser_tests/extensionAPI.spec.ts
@@ -29,4 +29,32 @@ test.describe('Topbar commands', () => {
     await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo'])
     expect(await comfyPage.page.evaluate(() => window['foo'])).toBe(true)
   })
+
+  test('Should allow registering keybindings', async ({ comfyPage }) => {
+    await comfyPage.page.evaluate(() => {
+      const app = window['app']
+      app.registerExtension({
+        name: 'TestExtension1',
+        commands: [
+          {
+            id: 'TestCommand',
+            function: () => {
+              window['TestCommand'] = true
+            }
+          }
+        ],
+        keybindings: [
+          {
+            combo: { key: 'k' },
+            commandId: 'TestCommand'
+          }
+        ]
+      })
+    })
+
+    await comfyPage.page.keyboard.press('k')
+    expect(await comfyPage.page.evaluate(() => window['TestCommand'])).toBe(
+      true
+    )
+  })
 })

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -8,6 +8,10 @@ app.registerExtension({
   name: 'Comfy.Keybinds',
   init() {
     const keybindListener = async function (event: KeyboardEvent) {
+      // Ignore keybindings for legacy jest tests as jest tests don't have
+      // a Vue app instance or pinia stores.
+      if (!app.vueAppReady) return
+
       const keyCombo = KeyComboImpl.fromEvent(event)
       const keybindingStore = useKeybindingStore()
       const commandStore = useCommandStore()

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -1,11 +1,22 @@
 import { app } from '../../scripts/app'
 import { api } from '../../scripts/api'
 import { useToastStore } from '@/stores/toastStore'
+import { KeyComboImpl, useKeybindingStore } from '@/stores/keybindingStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 app.registerExtension({
   name: 'Comfy.Keybinds',
   init() {
-    const keybindListener = async function (event) {
+    const keybindListener = async function (event: KeyboardEvent) {
+      const keyCombo = KeyComboImpl.fromEvent(event)
+      const keybindingStore = useKeybindingStore()
+      const commandStore = useCommandStore()
+      const keybinding = keybindingStore.getKeybinding(keyCombo)
+      if (keybinding) {
+        await commandStore.getCommandFunction(keybinding.commandId)()
+        return
+      }
+
       const modifierPressed = event.ctrlKey || event.metaKey
 
       // Queue prompt using (ctrl or command) + enter
@@ -26,7 +37,7 @@ app.registerExtension({
         return
       }
 
-      const target = event.composedPath()[0]
+      const target = event.composedPath()[0] as HTMLElement
       if (
         target.tagName === 'TEXTAREA' ||
         target.tagName === 'INPUT' ||

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -53,6 +53,7 @@ import type { ToastMessageOptions } from 'primevue/toast'
 import { useWorkspaceStore } from '@/stores/workspaceStateStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { IWidget } from '@comfyorg/litegraph'
+import { useKeybindingStore } from '@/stores/keybindingStore'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
@@ -2950,6 +2951,9 @@ export class ComfyApp {
     }
     if (this.extensions.find((ext) => ext.name === extension.name)) {
       throw new Error(`Extension named '${extension.name}' already registered.`)
+    }
+    if (this.vueAppReady) {
+      useKeybindingStore().loadExtensionKeybindings(extension)
     }
     this.extensions.push(extension)
   }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -54,6 +54,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStateStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { IWidget } from '@comfyorg/litegraph'
 import { useKeybindingStore } from '@/stores/keybindingStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
@@ -2954,6 +2955,7 @@ export class ComfyApp {
     }
     if (this.vueAppReady) {
       useKeybindingStore().loadExtensionKeybindings(extension)
+      useCommandStore().loadExtensionCommands(extension)
     }
     this.extensions.push(extension)
   }

--- a/src/scripts/logging.ts
+++ b/src/scripts/logging.ts
@@ -377,7 +377,5 @@ export class ComfyLogging {
     if (!this.enabled) return
     const source = 'ComfyUI.Logging'
     this.addEntry(source, 'debug', { UserAgent: navigator.userAgent })
-    const systemStats = await api.getSystemStats()
-    this.addEntry(source, 'debug', systemStats)
   }
 }

--- a/src/scripts/ui/menu/index.ts
+++ b/src/scripts/ui/menu/index.ts
@@ -4,13 +4,10 @@ import { downloadBlob } from '../../utils'
 import { ComfyButtonGroup } from '../components/buttonGroup'
 import './menu.css'
 
-// Import ComfyButton to make sure it's shimmed and exported by vite
-import { ComfyButton } from '../components/button'
-import { ComfySplitButton } from '../components/splitButton'
-import { ComfyPopup } from '../components/popup'
-console.debug(
-  `Keep following definitions ${ComfyButton} ${ComfySplitButton} ${ComfyPopup}`
-)
+// Export to make sure following components are shimmed and exported by vite
+export { ComfyButton } from '../components/button'
+export { ComfySplitButton } from '../components/splitButton'
+export { ComfyPopup } from '../components/popup'
 
 export class ComfyAppMenu {
   app: ComfyApp

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -8,6 +8,7 @@ import { useToastStore } from '@/stores/toastStore'
 import { showTemplateWorkflowsDialog } from '@/services/dialogService'
 import { useQueueStore } from './queueStore'
 import { LiteGraph } from '@comfyorg/litegraph'
+import { ComfyExtension } from '@/types/comfy'
 
 export interface ComfyCommand {
   id: string
@@ -251,10 +252,19 @@ export const useCommandStore = defineStore('command', () => {
     return !!commands.value[command]
   }
 
+  const loadExtensionCommands = (extension: ComfyExtension) => {
+    if (extension.commands) {
+      for (const command of extension.commands) {
+        registerCommand(command)
+      }
+    }
+  }
+
   return {
     getCommand,
     getCommandFunction,
     registerCommand,
-    isRegistered
+    isRegistered,
+    loadExtensionCommands
   }
 })

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -13,6 +13,11 @@ export interface ComfyCommand {
   id: string
   function: () => void | Promise<void>
 
+  /**
+   * The condition that must be met for the command to be enabled
+   */
+  condition?: () => boolean
+
   label?: string | (() => string)
   icon?: string | (() => string)
   tooltip?: string | (() => string)

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -14,11 +14,6 @@ export interface ComfyCommand {
   id: string
   function: () => void | Promise<void>
 
-  /**
-   * The condition that must be met for the command to be enabled
-   */
-  condition?: () => boolean
-
   label?: string | (() => string)
   icon?: string | (() => string)
   tooltip?: string | (() => string)

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -1,0 +1,3 @@
+import type { Keybinding } from '@/types/keyBindingTypes'
+
+export const CORE_KEYBINDINGS: Keybinding[] = []

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -1,3 +1,4 @@
+import type { Keybinding } from '@/types/keyBindingTypes'
 import { NodeBadgeMode } from '@/types/nodeSource'
 import {
   LinkReleaseTriggerAction,
@@ -404,5 +405,19 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'number',
     defaultValue: 100,
     versionAdded: '1.3.5'
+  },
+  {
+    id: 'Comfy.Keybinding.UnsetBindings',
+    name: 'Keybindings unset by the user',
+    type: 'hidden',
+    defaultValue: [] as Keybinding[],
+    versionAdded: '1.3.6'
+  },
+  {
+    id: 'Comfy.Keybinding.NewBindings',
+    name: 'Keybindings set by the user',
+    type: 'hidden',
+    defaultValue: [] as Keybinding[],
+    versionAdded: '1.3.6'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -411,13 +411,13 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Keybindings unset by the user',
     type: 'hidden',
     defaultValue: [] as Keybinding[],
-    versionAdded: '1.3.6'
+    versionAdded: '1.3.7'
   },
   {
     id: 'Comfy.Keybinding.NewBindings',
     name: 'Keybindings set by the user',
     type: 'hidden',
     defaultValue: [] as Keybinding[],
-    versionAdded: '1.3.6'
+    versionAdded: '1.3.7'
   }
 ]

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -184,7 +184,14 @@ export const useKeybindingStore = defineStore('keybinding', () => {
   function loadExtensionKeybindings(extension: ComfyExtension) {
     if (extension.keybindings) {
       for (const keybinding of extension.keybindings) {
-        addDefaultKeybinding(new KeybindingImpl(keybinding))
+        try {
+          addDefaultKeybinding(new KeybindingImpl(keybinding))
+        } catch (error) {
+          console.warn(
+            `Failed to load keybinding for extension ${extension.name}`,
+            error
+          )
+        }
       }
     }
   }

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -18,21 +18,20 @@ export function deserializeKeyCombo(serialized: string): KeyCombo {
 }
 
 export const useKeybindingStore = defineStore('keybinding', () => {
-  const keybindingsByCommandId = ref<Map<string, Keybinding[]>>(new Map())
   const keybindingByKeyCombo = ref<Map<string, Keybinding>>(new Map())
   const keybindings = computed<Keybinding[]>(() =>
     Array.from(keybindingByKeyCombo.value.values())
   )
 
-  const getCommandKeybindings = (command: string) =>
-    keybindingsByCommandId.value.get(command) ?? []
-
   function getKeybinding(combo: KeyCombo) {
     return keybindingByKeyCombo.value.get(serializeKeyCombo(combo))
   }
 
-  function addKeybinding(keybinding: Keybinding) {
-    if (getKeybinding(keybinding.combo)) {
+  function addKeybinding(
+    keybinding: Keybinding,
+    { existOk = false }: { existOk: boolean }
+  ) {
+    if (!existOk && getKeybinding(keybinding.combo)) {
       throw new Error(
         `Keybinding on ${keybinding.combo} already exists on ${getKeybinding(
           keybinding.combo
@@ -44,29 +43,14 @@ export const useKeybindingStore = defineStore('keybinding', () => {
       serializeKeyCombo(keybinding.combo),
       keybinding
     )
-
-    const command = keybinding.commandId
-    if (!keybindingsByCommandId.value.has(command)) {
-      keybindingsByCommandId.value.set(command, [])
-    }
-    keybindingsByCommandId.value.get(command)?.push(keybinding)
   }
 
   function removeKeybinding(keybinding: Keybinding) {
     keybindingByKeyCombo.value.delete(serializeKeyCombo(keybinding.combo))
-    const command = keybinding.commandId
-    const commandKeybindings = keybindingsByCommandId.value.get(command)
-    if (commandKeybindings) {
-      keybindingsByCommandId.value.set(
-        command,
-        commandKeybindings.filter((kb) => kb.commandId !== keybinding.commandId)
-      )
-    }
   }
 
   return {
     keybindings,
-    getCommandKeybindings,
     getKeybinding,
     addKeybinding,
     removeKeybinding

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -38,6 +38,15 @@ export class KeyComboImpl implements KeyCombo {
     this.shift = obj.shift ?? false
   }
 
+  static fromEvent(event: KeyboardEvent) {
+    return new KeyComboImpl({
+      key: event.key,
+      ctrl: event.ctrlKey,
+      alt: event.altKey,
+      shift: event.shiftKey
+    })
+  }
+
   equals(other: any): boolean {
     if (toRaw(other) instanceof KeyComboImpl) {
       return (

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -1,0 +1,74 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { Keybinding, KeyCombo } from '@/types/keyBindingTypes'
+
+export function serializeKeyCombo(combo: KeyCombo): string {
+  return `${combo.key}:${combo.ctrl ?? false}:${combo.alt ?? false}:${combo.shift ?? false}:${combo.meta ?? false}`
+}
+
+export function deserializeKeyCombo(serialized: string): KeyCombo {
+  const [key, ctrl, alt, shift, meta] = serialized.split(':')
+  return {
+    key,
+    ctrl: ctrl === 'true',
+    alt: alt === 'true',
+    shift: shift === 'true',
+    meta: meta === 'true'
+  }
+}
+
+export const useKeybindingStore = defineStore('keybinding', () => {
+  const keybindingsByCommandId = ref<Map<string, Keybinding[]>>(new Map())
+  const keybindingByKeyCombo = ref<Map<string, Keybinding>>(new Map())
+  const keybindings = computed<Keybinding[]>(() =>
+    Array.from(keybindingByKeyCombo.value.values())
+  )
+
+  const getCommandKeybindings = (command: string) =>
+    keybindingsByCommandId.value.get(command) ?? []
+
+  function getKeybinding(combo: KeyCombo) {
+    return keybindingByKeyCombo.value.get(serializeKeyCombo(combo))
+  }
+
+  function addKeybinding(keybinding: Keybinding) {
+    if (getKeybinding(keybinding.combo)) {
+      throw new Error(
+        `Keybinding on ${keybinding.combo} already exists on ${getKeybinding(
+          keybinding.combo
+        )}`
+      )
+    }
+
+    keybindingByKeyCombo.value.set(
+      serializeKeyCombo(keybinding.combo),
+      keybinding
+    )
+
+    const command = keybinding.commandId
+    if (!keybindingsByCommandId.value.has(command)) {
+      keybindingsByCommandId.value.set(command, [])
+    }
+    keybindingsByCommandId.value.get(command)?.push(keybinding)
+  }
+
+  function removeKeybinding(keybinding: Keybinding) {
+    keybindingByKeyCombo.value.delete(serializeKeyCombo(keybinding.combo))
+    const command = keybinding.commandId
+    const commandKeybindings = keybindingsByCommandId.value.get(command)
+    if (commandKeybindings) {
+      keybindingsByCommandId.value.set(
+        command,
+        commandKeybindings.filter((kb) => kb.commandId !== keybinding.commandId)
+      )
+    }
+  }
+
+  return {
+    keybindings,
+    getCommandKeybindings,
+    getKeybinding,
+    addKeybinding,
+    removeKeybinding
+  }
+})

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -4,6 +4,7 @@ import { fromZodError } from 'zod-validation-error'
 import { colorPalettesSchema } from './colorPalette'
 import { LinkReleaseTriggerAction } from './searchBoxTypes'
 import { NodeBadgeMode } from './nodeSource'
+import { zKeybinding } from './keyBindingTypes'
 
 const zNodeType = z.string()
 const zQueueIndex = z.number()
@@ -504,7 +505,9 @@ const zSettings = z.record(z.any()).and(
       'Comfy.NodeBadge.NodeSourceBadgeMode': zNodeBadgeMode,
       'Comfy.NodeBadge.NodeIdBadgeMode': zNodeBadgeMode,
       'Comfy.NodeBadge.NodeLifeCycleBadgeMode': zNodeBadgeMode,
-      'Comfy.QueueButton.BatchCountLimit': z.number()
+      'Comfy.QueueButton.BatchCountLimit': z.number(),
+      'Comfy.Keybinding.UnsetBindings': z.array(zKeybinding),
+      'Comfy.Keybinding.NewBindings': z.array(zKeybinding)
     })
     .optional()
 )

--- a/src/types/comfy.d.ts
+++ b/src/types/comfy.d.ts
@@ -1,6 +1,7 @@
 import { LGraphNode, IWidget } from './litegraph'
 import { ComfyApp } from '../scripts/app'
 import type { ComfyNodeDef } from '@/types/apiTypes'
+import type { Keybinding } from '@/types/keyBindingTypes'
 
 export type Widgets = Record<
   string,
@@ -17,6 +18,10 @@ export interface ComfyExtension {
    * The name of the extension
    */
   name: string
+  /**
+   * The keybindings for the extension
+   */
+  keybindings: Keybinding[]
   /**
    * Allows any initialisation, e.g. loading resources. Called after the canvas is created but before nodes are added
    * @param app The ComfyUI app instance

--- a/src/types/comfy.d.ts
+++ b/src/types/comfy.d.ts
@@ -2,6 +2,7 @@ import { LGraphNode, IWidget } from './litegraph'
 import { ComfyApp } from '../scripts/app'
 import type { ComfyNodeDef } from '@/types/apiTypes'
 import type { Keybinding } from '@/types/keyBindingTypes'
+import type { ComfyCommand } from '@/stores/commandStore'
 
 export type Widgets = Record<
   string,
@@ -19,7 +20,11 @@ export interface ComfyExtension {
    */
   name: string
   /**
-   * The keybindings for the extension
+   * The commands defined by the extension
+   */
+  commands?: ComfyCommand[]
+  /**
+   * The keybindings defined by the extension
    */
   keybindings?: Keybinding[]
   /**

--- a/src/types/comfy.d.ts
+++ b/src/types/comfy.d.ts
@@ -21,7 +21,7 @@ export interface ComfyExtension {
   /**
    * The keybindings for the extension
    */
-  keybindings: Keybinding[]
+  keybindings?: Keybinding[]
   /**
    * Allows any initialisation, e.g. loading resources. Called after the canvas is created but before nodes are added
    * @param app The ComfyUI app instance

--- a/src/types/keyBindingTypes.ts
+++ b/src/types/keyBindingTypes.ts
@@ -9,17 +9,12 @@ export const zKeyCombo = z.object({
   meta: z.boolean().optional()
 })
 
-// TriggerCondition schema
-export const zTriggerCondition = z.function().returns(z.boolean())
-
 // Keybinding schema
 export const zKeybinding = z.object({
   commandId: z.string(),
-  combo: zKeyCombo,
-  triggerCondition: zTriggerCondition
+  combo: zKeyCombo
 })
 
 // Infer types from schemas
 export type KeyCombo = z.infer<typeof zKeyCombo>
-export type TriggerCondition = z.infer<typeof zTriggerCondition>
 export type Keybinding = z.infer<typeof zKeybinding>

--- a/src/types/keyBindingTypes.ts
+++ b/src/types/keyBindingTypes.ts
@@ -14,9 +14,8 @@ export const zTriggerCondition = z.function().returns(z.boolean())
 
 // Keybinding schema
 export const zKeybinding = z.object({
-  id: z.string(),
+  commandId: z.string(),
   combo: zKeyCombo,
-  command: z.string(),
   triggerCondition: zTriggerCondition,
   source: z.string()
 })

--- a/src/types/keyBindingTypes.ts
+++ b/src/types/keyBindingTypes.ts
@@ -16,8 +16,7 @@ export const zTriggerCondition = z.function().returns(z.boolean())
 export const zKeybinding = z.object({
   commandId: z.string(),
   combo: zKeyCombo,
-  triggerCondition: zTriggerCondition,
-  source: z.string()
+  triggerCondition: zTriggerCondition
 })
 
 // Infer types from schemas

--- a/src/types/keyBindingTypes.ts
+++ b/src/types/keyBindingTypes.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+// KeyCombo schema
+export const zKeyCombo = z.object({
+  key: z.string(),
+  ctrl: z.boolean().optional(),
+  alt: z.boolean().optional(),
+  shift: z.boolean().optional(),
+  meta: z.boolean().optional()
+})
+
+// TriggerCondition schema
+export const zTriggerCondition = z.function().returns(z.boolean())
+
+// Keybinding schema
+export const zKeybinding = z.object({
+  id: z.string(),
+  combo: zKeyCombo,
+  command: z.string(),
+  triggerCondition: zTriggerCondition,
+  source: z.string()
+})
+
+// Infer types from schemas
+export type KeyCombo = z.infer<typeof zKeyCombo>
+export type TriggerCondition = z.infer<typeof zTriggerCondition>
+export type Keybinding = z.infer<typeof zKeybinding>

--- a/tests-ui/tests/store/keybindingStore.test.ts
+++ b/tests-ui/tests/store/keybindingStore.test.ts
@@ -1,0 +1,122 @@
+import { setActivePinia, createPinia } from 'pinia'
+import {
+  useKeybindingStore,
+  KeybindingImpl
+} from '../../../src/stores/keybindingStore'
+
+describe('useKeybindingStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('should add and retrieve default keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'A', ctrl: true }
+    })
+
+    store.addDefaultKeybinding(keybinding)
+
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
+  })
+
+  it('should add and retrieve user keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'B', alt: true }
+    })
+
+    store.addUserKeybinding(keybinding)
+
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
+  })
+
+  it('should override default keybindings with user keybindings', () => {
+    const store = useKeybindingStore()
+    const defaultKeybinding = new KeybindingImpl({
+      commandId: 'test.command1',
+      combo: { key: 'C', ctrl: true }
+    })
+    const userKeybinding = new KeybindingImpl({
+      commandId: 'test.command2',
+      combo: { key: 'C', ctrl: true }
+    })
+
+    store.addDefaultKeybinding(defaultKeybinding)
+    store.addUserKeybinding(userKeybinding)
+
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybinding(userKeybinding.combo)).toEqual(userKeybinding)
+  })
+
+  it('should unset user keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'D', meta: true }
+    })
+
+    store.addUserKeybinding(keybinding)
+    expect(store.keybindings).toHaveLength(1)
+
+    store.unsetKeybinding(keybinding)
+    expect(store.keybindings).toHaveLength(0)
+  })
+
+  it('should unset default keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'E', ctrl: true, alt: true }
+    })
+
+    store.addDefaultKeybinding(keybinding)
+    expect(store.keybindings).toHaveLength(1)
+
+    store.unsetKeybinding(keybinding)
+    expect(store.keybindings).toHaveLength(0)
+  })
+
+  it('should throw an error when adding duplicate default keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'F', shift: true }
+    })
+
+    store.addDefaultKeybinding(keybinding)
+    expect(() => store.addDefaultKeybinding(keybinding)).toThrow()
+  })
+
+  it('should allow adding duplicate user keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding1 = new KeybindingImpl({
+      commandId: 'test.command1',
+      combo: { key: 'G', ctrl: true }
+    })
+    const keybinding2 = new KeybindingImpl({
+      commandId: 'test.command2',
+      combo: { key: 'G', ctrl: true }
+    })
+
+    store.addUserKeybinding(keybinding1)
+    store.addUserKeybinding(keybinding2)
+
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybinding(keybinding2.combo)).toEqual(keybinding2)
+  })
+
+  it('should throw an error when unsetting non-existent keybindings', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'H', alt: true, shift: true }
+    })
+
+    expect(() => store.unsetKeybinding(keybinding)).toThrow()
+  })
+})


### PR DESCRIPTION
Extensions can now use following API to register custom keybindings:

```js
  app.registerExtension({
    name: 'TestExtension1',
    commands: [
      {
        id: 'TestCommand',
        function: () => {
          alert('TestCommand')
        }
      }
    ],
    keybindings: [
      {
        combo: { key: 'k' },
        commandId: 'TestCommand'
      }
    ]
  })
```

Proper support for user keybinding customizations coming soon.