### PR TITLE
add an option to auto-expand model subfolders

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -202,20 +202,22 @@ const handleNodeClick = (
   }
 }
 
+const hasExpanded = new Set<string>()
+
 watch(
   toRef(expandedKeys, 'value'),
   (newExpandedKeys) => {
     Object.entries(newExpandedKeys).forEach(([key, isExpanded]) => {
       if (isExpanded) {
         const folderPath = key.split('/').slice(1).join('/')
-        if (
-          folderPath &&
-          !folderPath.includes('/') &&
-          !modelStore.modelStoreMap[folderPath]
-        ) {
+        if (folderPath && !folderPath.includes('/')) {
           // Trigger (async) load of model data for this folder
-          modelStore.getModelsInFolderCached(folderPath).then((models) => {
-            if (settingStore.get('Comfy.ModelLibrary.AutoExpandFolders')) {
+          modelStore.getModelsInFolderCached(folderPath).then(() => {
+            if (
+              settingStore.get('Comfy.ModelLibrary.AutoExpandFolders') &&
+              !hasExpanded.has(folderPath)
+            ) {
+              hasExpanded.add(folderPath)
               const node = root.value.children.find((node) => node.key === key)
               if (node) {
                 expandNode(node)

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -251,6 +251,14 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: false
   },
   {
+    id: 'Comfy.ModelLibrary.AutoExpandFolders',
+    name: 'Automatically expand all model folders',
+    tooltip:
+      'If true, all sub-folders will expand as soon as you open the root folder the first time. If false, you will have to click on each folder to expand it.',
+    type: 'boolean',
+    defaultValue: false
+  },
+  {
     id: 'Comfy.ModelLibrary.NameFormat',
     name: 'What name to display in the model library tree view',
     tooltip:


### PR DESCRIPTION
for #1006

Very straightforward: just a setting, and if you enable it, when a model root folder is opened, once it loads, call `expandNode` on the folder, and maintain a set to avoid avoid calling expand again after it's happened once

I wouldn't want this on myself, but it's a reasonable enough request so why not