### PR TITLE
Remove new default workflow button in workflows sidebar

### DIFF
--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -192,12 +192,8 @@ class WorkflowsSidebarTab extends SidebarTab {
     return this.page.locator('.new-blank-workflow-button')
   }
 
-  get browseWorkflowsButton() {
-    return this.page.locator('.browse-workflows-button')
-  }
-
-  get newDefaultWorkflowButton() {
-    return this.page.locator('.new-default-workflow-button')
+  get openWorkflowButton() {
+    return this.page.locator('.open-workflow-button')
   }
 
   async getOpenedWorkflowNames() {

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -426,9 +426,9 @@ test.describe('Menu', () => {
       await comfyPage.loadWorkflow('missing_nodes')
       await comfyPage.closeDialog()
 
-      // Load default workflow
+      // Load blank workflow
       await comfyPage.menu.workflowsTab.open()
-      await comfyPage.menu.workflowsTab.newDefaultWorkflowButton.click()
+      await comfyPage.menu.workflowsTab.newBlankWorkflowButton.click()
 
       // Switch back to the missing_nodes workflow
       await comfyPage.menu.workflowsTab.switchToWorkflow('missing_nodes')

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -11,25 +11,16 @@
         "
       />
       <Button
-        class="browse-workflows-button"
+        class="open-workflow-button"
         icon="pi pi-folder-open"
-        v-tooltip="'Browse for an image or exported workflow'"
+        v-tooltip="$t('sideToolbar.openWorkflow')"
         text
         @click="() => commandStore.getCommandFunction('Comfy.OpenWorkflow')()"
       />
       <Button
-        class="new-default-workflow-button"
-        icon="pi pi-code"
-        v-tooltip="'Load default workflow'"
-        text
-        @click="
-          () => commandStore.getCommandFunction('Comfy.LoadDefaultWorkflow')()
-        "
-      />
-      <Button
         class="new-blank-workflow-button"
         icon="pi pi-plus"
-        v-tooltip="'Create a new blank workflow'"
+        v-tooltip="$t('sideToolbar.newBlankWorkflow')"
         @click="
           () => commandStore.getCommandFunction('Comfy.NewBlankWorkflow')()
         "

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -55,6 +55,8 @@ const messages = {
       nodeLibrary: 'Node Library',
       workflows: 'Workflows',
       browseTemplates: 'Browse example templates',
+      openWorkflow: 'Open workflow in local file system',
+      newBlankWorkflow: 'Create a new blank workflow',
       nodeLibraryTab: {
         sortOrder: 'Sort Order'
       },
@@ -159,6 +161,8 @@ const messages = {
       nodeLibrary: '节点库',
       workflows: '工作流',
       browseTemplates: '浏览示例模板',
+      openWorkflow: '在本地文件系统中打开工作流',
+      newBlankWorkflow: '创建一个新空白工作流',
       nodeLibraryTab: {
         sortOrder: '排序顺序'
       },


### PR DESCRIPTION
This PR removes the new default workflow button in workflows sidebar as its functionality is replaced/overlapped with the browse template button.