### PR TITLE
Add toggle command for each sidebar tab registered

### DIFF
--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -262,19 +262,6 @@ export const useCommandStore = defineStore('command', () => {
       }
     },
     {
-      id: 'Comfy.ToggleQueueSidebarTab',
-      icon: 'pi pi-history',
-      label: 'Queue',
-      versionAdded: '1.3.7',
-      function: () => {
-        const tabId = 'queue'
-        const workspaceStore = useWorkspaceStore()
-        workspaceStore.updateActiveSidebarTab(
-          workspaceStore.activeSidebarTab === tabId ? null : tabId
-        )
-      }
-    },
-    {
       id: 'Comfy.ShowSettingsDialog',
       icon: 'pi pi-cog',
       label: 'Settings',

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -34,13 +34,31 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
     combo: {
       key: 'q'
     },
-    commandId: 'Comfy.ToggleQueueSidebarTab'
+    commandId: 'Workspace.ToggleSidebarTab.queue'
   },
   {
     combo: {
       key: 'h'
     },
-    commandId: 'Comfy.ToggleQueueSidebarTab'
+    commandId: 'Workspace.ToggleSidebarTab.queue'
+  },
+  {
+    combo: {
+      key: 'w'
+    },
+    commandId: 'Workspace.ToggleSidebarTab.workflows'
+  },
+  {
+    combo: {
+      key: 'n'
+    },
+    commandId: 'Workspace.ToggleSidebarTab.node-library'
+  },
+  {
+    combo: {
+      key: 'm'
+    },
+    commandId: 'Workspace.ToggleSidebarTab.model-library'
   },
   {
     combo: {

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -38,12 +38,6 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
-      key: 'h'
-    },
-    commandId: 'Workspace.ToggleSidebarTab.queue'
-  },
-  {
-    combo: {
       key: 'w'
     },
     commandId: 'Workspace.ToggleSidebarTab.workflows'

--- a/src/stores/workspaceStateStore.ts
+++ b/src/stores/workspaceStateStore.ts
@@ -39,8 +39,20 @@ export const useWorkspaceStore = defineStore('workspace', {
     updateActiveSidebarTab(tabId: string) {
       this.activeSidebarTab = tabId
     },
+    toggleSidebarTab(tabId: string) {
+      this.activeSidebarTab = this.activeSidebarTab === tabId ? null : tabId
+    },
     registerSidebarTab(tab: SidebarTabExtension) {
       this.sidebarTabs = [...this.sidebarTabs, tab]
+      useCommandStore().registerCommand({
+        id: `Workspace.ToggleSidebarTab.${tab.id}`,
+        icon: tab.icon,
+        label: tab.tooltip,
+        tooltip: tab.tooltip,
+        function: () => {
+          this.toggleSidebarTab(tab.id)
+        }
+      })
     },
     unregisterSidebarTab(id: string) {
       const index = this.sidebarTabs.findIndex((tab) => tab.id === id)


### PR DESCRIPTION
Related issue: https://github.com/Comfy-Org/ComfyUI_frontend/issues/1097

- `Comfy.ToggleQueueSidebarTab` is directly removed without mapping as it has only been out for 2 versions (2days) without major reference. We definitely need a mechanism to deprecate command, but it will be designed later.
- Removed binding of `h` on queue tab
- Added new bindings of workflows and nodes and models tabs.

![image](https://github.com/user-attachments/assets/126ae18c-9136-4062-bf87-95d23f8eb64b)
