### PR TITLE
Prevent converted widget being duplicated

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -715,6 +715,7 @@ app.registerExtension({
         widget.options || {}
       ]
       if (!isConvertibleWidget(widget, config)) return false
+      if (widget.type?.startsWith(CONVERTED_TYPE)) return false
       convertToInput(this, widget, config)
       return true
     }


### PR DESCRIPTION
If multiple calls are made to `LGraphNode.convertWidgetToInput`, multiple inputs will be created, corrupting the node.

Multiple calls are not made when this function is called by _frontend's context menus, but it does impact any other callers / extensions.  A popular example is Fix node (recreate) from ComfyUI Manager.

Reproduction:
- Convert a widget to input
- Right click node, then click `Fix node (recreate)`
- New node has duplicate converted inputs