### PR TITLE
Restyle SettingGroup

### DIFF
--- a/src/components/common/InputSlider.vue
+++ b/src/components/common/InputSlider.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="input-slider">
+  <div class="input-slider flex flex-row items-center gap-2">
     <Slider
       :modelValue="modelValue"
       @update:modelValue="updateValue"
@@ -69,19 +69,3 @@ const updateValue = (newValue: number | null) => {
   emit('update:modelValue', newValue)
 }
 </script>
-
-<style scoped>
-.input-slider {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.slider-part {
-  flex-grow: 1;
-}
-
-.input-part {
-  width: 5rem !important;
-}
-</style>

--- a/src/components/common/InputSlider.vue
+++ b/src/components/common/InputSlider.vue
@@ -17,6 +17,7 @@
       :min="min"
       :max="max"
       :step="step"
+      :allowEmpty="false"
     />
   </div>
 </template>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -17,7 +17,7 @@
           {{ setting.name }}
           <i
             v-if="setting.tooltip"
-            class="pi pi-info-circle info-chip bg-transparent"
+            class="pi pi-info-circle bg-transparent"
             v-tooltip="setting.tooltip"
         /></span>
       </div>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -5,9 +5,9 @@
     <div
       v-for="setting in group.settings"
       :key="setting.id"
-      class="setting-item"
+      class="setting-item flex items-center mb-4"
     >
-      <div class="setting-label">
+      <div class="setting-label flex flex-grow items-center">
         <span>
           <Tag v-if="setting.experimental" :value="$t('experimental')" />
           <Tag
@@ -17,11 +17,11 @@
           {{ setting.name }}
           <i
             v-if="setting.tooltip"
-            class="pi pi-info-circle info-chip"
+            class="pi pi-info-circle info-chip bg-transparent"
             v-tooltip="setting.tooltip"
         /></span>
       </div>
-      <div class="setting-input">
+      <div class="setting-input flex justify-end">
         <component
           :is="markRaw(getSettingComponent(setting))"
           :id="setting.id"
@@ -110,45 +110,11 @@ function getSettingComponent(setting: SettingParams): Component {
 </script>
 
 <style scoped>
-.info-chip {
-  background: transparent;
-}
-
-.setting-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.setting-label {
-  display: flex;
-  align-items: center;
-  flex: 1;
-}
-
-.setting-input {
-  flex: 1;
-  display: flex;
-  justify-content: flex-end;
-  margin-left: 1rem;
-}
-
 /* Ensure PrimeVue components take full width of their container */
 .setting-input :deep(.p-inputtext),
 .setting-input :deep(.input-slider),
 .setting-input :deep(.p-select),
 .setting-input :deep(.p-togglebutton) {
-  width: 100%;
   max-width: 200px;
-}
-
-.setting-input :deep(.p-inputtext) {
-  max-width: unset;
-}
-
-/* Special case for ToggleSwitch to align it to the right */
-.setting-input :deep(.p-toggleswitch) {
-  margin-left: auto;
 }
 </style>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -108,13 +108,3 @@ function getSettingComponent(setting: SettingParams): Component {
   }
 }
 </script>
-
-<style scoped>
-/* Ensure PrimeVue components take full width of their container */
-.setting-input :deep(.p-inputtext),
-.setting-input :deep(.input-slider),
-.setting-input :deep(.p-select),
-.setting-input :deep(.p-togglebutton) {
-  max-width: 200px;
-}
-</style>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -108,3 +108,15 @@ function getSettingComponent(setting: SettingParams): Component {
   }
 }
 </script>
+
+<style scoped>
+.setting-input :deep(.input-slider) .p-inputnumber input,
+.setting-input :deep(.input-slider) .slider-part {
+  @apply w-20;
+}
+
+.setting-input :deep(.p-inputtext),
+.setting-input :deep(.p-select) {
+  @apply w-44;
+}
+</style>

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -8,7 +8,7 @@
       class="setting-item flex items-center mb-4"
     >
       <div class="setting-label flex flex-grow items-center">
-        <span>
+        <span class="text-[var(--p-text-muted-color)]">
           <Tag v-if="setting.experimental" :value="$t('experimental')" />
           <Tag
             v-if="setting.deprecated"


### PR DESCRIPTION
Two major change:
- label now takes as much space the input field left
- label text is dimmed to a weaker color

Before:
![image](https://github.com/user-attachments/assets/8139f441-e7c9-41f3-ba22-08a47d2ef3a5)

After:
![image](https://github.com/user-attachments/assets/1f9b3da5-5285-44ce-9065-99d1c6dc949e)
