### PR TITLE
Show keybinding on topbar dropdown menus

### DIFF
--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -501,12 +501,13 @@ test.describe('Menu', () => {
     })
 
     test('Displays keybinding next to item', async ({ comfyPage }) => {
-      const workflowMenuItem = await comfyPage.menu.topbar.getMenuItem('Edit')
+      const workflowMenuItem =
+        await comfyPage.menu.topbar.getMenuItem('Workflow')
       await workflowMenuItem.click()
-      const undoTag = comfyPage.page.locator('.keybinding-tag', {
-        hasText: 'Ctrl + z'
+      const exportTag = comfyPage.page.locator('.keybinding-tag', {
+        hasText: 'Ctrl + s'
       })
-      expect(await undoTag.count()).toBe(1)
+      expect(await exportTag.count()).toBe(1)
     })
   })
 

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -499,6 +499,15 @@ test.describe('Menu', () => {
       })
       expect(isTextCutoff).toBe(false)
     })
+
+    test('Displays keybinding next to item', async ({ comfyPage }) => {
+      const workflowMenuItem = await comfyPage.menu.topbar.getMenuItem('Edit')
+      await workflowMenuItem.click()
+      const undoTag = comfyPage.page.locator('.keybinding-tag', {
+        hasText: 'Ctrl + z'
+      })
+      expect(await undoTag.count()).toBe(1)
+    })
   })
 
   // Only test 'Top' to reduce test time.

--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -47,6 +47,7 @@
 import SplitButton from 'primevue/splitbutton'
 import Button from 'primevue/button'
 import BatchCountEdit from './BatchCountEdit.vue'
+import ButtonGroup from 'primevue/buttongroup'
 import { useI18n } from 'vue-i18n'
 import {
   AutoQueueMode,

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -8,22 +8,14 @@
       item: 'relative'
     }"
   >
-    <template #item="{ item, props, root }">
-      <a class="p-menubar-item-link" v-bind="props.action">
-        <span v-if="item.icon" class="p-menubar-item-icon" :class="item.icon" />
-        <span class="p-menubar-item-label">{{ item.label }}</span>
-        <Badge
-          v-if="item.badge"
-          :class="{ 'ml-auto': !root, 'ml-2': root }"
-          :value="item.badge"
-        />
-        <span
-          v-if="!root && keybindings[item.id]"
-          class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
-        >
-          {{ keybindings[item.id] }}
-        </span>
-      </a>
+    <template #itemLabel="{ item }">
+      <span class="p-menubar-item-label">{{ item.label }}</span>
+      <span
+        v-if="keybindings[item.id]"
+        class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
+      >
+        {{ keybindings[item.id] }}
+      </span>
     </template>
   </Menubar>
 </template>
@@ -33,7 +25,6 @@ import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useKeybindingStore } from '@/stores/keybindingStore'
 import { useSettingStore } from '@/stores/settingStore'
 import Menubar from 'primevue/menubar'
-import Badge from 'primevue/badge'
 import { computed } from 'vue'
 import type { MenuItem } from 'primevue/menuitem'
 

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -1,0 +1,84 @@
+<template>
+  <Menubar
+    :model="items"
+    class="top-menubar border-none p-0 bg-transparent"
+    :pt="{
+      rootList: 'gap-0 flex-nowrap w-auto',
+      submenu: `dropdown-direction-${dropdownDirection}`,
+      item: 'relative'
+    }"
+  >
+    <template #item="{ item, props, root }">
+      <a class="p-menubar-item-link" v-bind="props.action">
+        <span v-if="item.icon" class="p-menubar-item-icon" :class="item.icon" />
+        <span class="p-menubar-item-label">{{ item.label }}</span>
+        <Badge
+          v-if="item.badge"
+          :class="{ 'ml-auto': !root, 'ml-2': root }"
+          :value="item.badge"
+        />
+        <span
+          v-if="!root && keybindings[item.id]"
+          class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
+        >
+          {{ keybindings[item.id] }}
+        </span>
+      </a>
+    </template>
+  </Menubar>
+</template>
+
+<script setup lang="ts">
+import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useKeybindingStore } from '@/stores/keybindingStore'
+import { useSettingStore } from '@/stores/settingStore'
+import Menubar from 'primevue/menubar'
+import Badge from 'primevue/badge'
+import { computed } from 'vue'
+import type { MenuItem } from 'primevue/menuitem'
+
+const settingStore = useSettingStore()
+const dropdownDirection = computed(() =>
+  settingStore.get('Comfy.UseNewMenu') === 'Top' ? 'down' : 'up'
+)
+
+const menuItemsStore = useMenuItemStore()
+const items = menuItemsStore.menuItems
+
+const keybindingStore = useKeybindingStore()
+const keybindings = computed(() => {
+  const bindings: Record<string, string> = {}
+  const stack: MenuItem[] = [...items]
+
+  while (stack.length) {
+    const item = stack.pop()!
+    if (item.id) {
+      // Is ComfyMenuItem with commandId
+      const keybinding = keybindingStore.getKeybindingByCommandId(item.id)
+      if (keybinding) {
+        bindings[item.id] = keybinding.combo.toString()
+      }
+    }
+    if (item.items) {
+      stack.push(...item.items)
+    }
+  }
+  return bindings
+})
+</script>
+
+<style scoped>
+.top-menubar :deep(.p-menubar-item-link) svg {
+  display: none;
+}
+
+:deep(.p-menubar-submenu.dropdown-direction-up) {
+  @apply top-auto bottom-full flex-col-reverse;
+}
+
+.keybinding-tag {
+  background: var(--p-content-hover-background);
+  border-color: var(--p-content-border-color);
+  border-style: solid;
+}
+</style>

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -8,25 +8,26 @@
       item: 'relative'
     }"
   >
-    <template #itemLabel="{ item }">
-      <span class="p-menubar-item-label">{{ item.label }}</span>
-      <span
-        v-if="keybindings[item.id]"
-        class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
-      >
-        {{ keybindings[item.id] }}
-      </span>
+    <template #item="{ item, props }">
+      <a class="p-menubar-item-link" v-bind="props.action">
+        <span v-if="item.icon" class="p-menubar-item-icon" :class="item.icon" />
+        <span class="p-menubar-item-label">{{ item.label }}</span>
+        <span
+          v-if="item?.comfyCommand?.keybinding"
+          class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
+        >
+          {{ item.comfyCommand.keybinding.combo.toString() }}
+        </span>
+      </a>
     </template>
   </Menubar>
 </template>
 
 <script setup lang="ts">
 import { useMenuItemStore } from '@/stores/menuItemStore'
-import { useKeybindingStore } from '@/stores/keybindingStore'
 import { useSettingStore } from '@/stores/settingStore'
 import Menubar from 'primevue/menubar'
 import { computed } from 'vue'
-import type { MenuItem } from 'primevue/menuitem'
 
 const settingStore = useSettingStore()
 const dropdownDirection = computed(() =>
@@ -35,27 +36,6 @@ const dropdownDirection = computed(() =>
 
 const menuItemsStore = useMenuItemStore()
 const items = menuItemsStore.menuItems
-
-const keybindingStore = useKeybindingStore()
-const keybindings = computed(() => {
-  const bindings: Record<string, string> = {}
-  const stack: MenuItem[] = [...items]
-
-  while (stack.length) {
-    const item = stack.pop()!
-    if (item.id) {
-      // Is ComfyMenuItem with commandId
-      const keybinding = keybindingStore.getKeybindingByCommandId(item.id)
-      if (keybinding) {
-        bindings[item.id] = keybinding.combo.toString()
-      }
-    }
-    if (item.items) {
-      stack.push(...item.items)
-    }
-  }
-  return bindings
-})
 </script>
 
 <style scoped>

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -7,37 +7,7 @@
       :class="{ dropzone: isDropZone, 'dropzone-active': isDroppable }"
     >
       <h1 class="comfyui-logo mx-2">ComfyUI</h1>
-      <Menubar
-        :model="items"
-        class="top-menubar border-none p-0 bg-transparent"
-        :pt="{
-          rootList: 'gap-0 flex-nowrap w-auto',
-          submenu: `dropdown-direction-${dropdownDirection}`,
-          item: 'relative'
-        }"
-      >
-        <template #item="{ item, props, root }">
-          <a v-ripple class="p-menubar-item-link" v-bind="props.action">
-            <span
-              v-if="item.icon"
-              class="p-menubar-item-icon"
-              :class="item.icon"
-            />
-            <span class="p-menubar-item-label">{{ item.label }}</span>
-            <Badge
-              v-if="item.badge"
-              :class="{ 'ml-auto': !root, 'ml-2': root }"
-              :value="item.badge"
-            />
-            <span
-              v-if="!root && keybindings[item.id]"
-              class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
-            >
-              {{ keybindings[item.id] }}
-            </span>
-          </a>
-        </template>
-      </Menubar>
+      <CommandMenubar />
       <Divider layout="vertical" class="mx-2" />
       <div class="flex-grow">
         <WorkflowTabs v-if="workflowTabsPosition === 'Topbar'" />
@@ -49,16 +19,14 @@
 </template>
 
 <script setup lang="ts">
-import Menubar from 'primevue/menubar'
 import Divider from 'primevue/divider'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
+import CommandMenubar from '@/components/topbar/CommandMenubar.vue'
 import Actionbar from '@/components/actionbar/ComfyActionbar.vue'
-import { ComfyMenuItem, useMenuItemStore } from '@/stores/menuItemStore'
 import { computed, onMounted, provide, ref } from 'vue'
 import { useSettingStore } from '@/stores/settingStore'
 import { app } from '@/scripts/app'
 import { useEventBus } from '@vueuse/core'
-import { useKeybindingStore } from '@/stores/keybindingStore'
 
 const settingStore = useSettingStore()
 const workflowTabsPosition = computed(() =>
@@ -72,32 +40,6 @@ const teleportTarget = computed(() =>
     ? '.comfyui-body-top'
     : '.comfyui-body-bottom'
 )
-const dropdownDirection = computed(() =>
-  settingStore.get('Comfy.UseNewMenu') === 'Top' ? 'down' : 'up'
-)
-
-const menuItemsStore = useMenuItemStore()
-const items = menuItemsStore.menuItems
-
-const keybindingStore = useKeybindingStore()
-const keybindings = computed(() => {
-  const bindings: Record<string, string> = {}
-  const stack: ComfyMenuItem[] = [...items]
-
-  while (stack.length) {
-    const item = stack.pop()!
-    if (item.id) {
-      const keybinding = keybindingStore.getKeybindingByCommandId(item.id)
-      if (keybinding) {
-        bindings[item.id] = keybinding.combo.toString()
-      }
-    }
-    if (item.items) {
-      stack.push(...item.items)
-    }
-  }
-  return bindings
-})
 
 const menuRight = ref<HTMLDivElement | null>(null)
 // Menu-right holds legacy topbar elements attached by custom scripts
@@ -146,21 +88,5 @@ eventBus.on((event: string, payload: any) => {
   font-size: 1.2em;
   user-select: none;
   cursor: default;
-}
-
-.keybinding-tag {
-  background: var(--p-content-hover-background);
-  border-color: var(--p-content-border-color);
-  border-style: solid;
-}
-</style>
-
-<style>
-.top-menubar .p-menubar-item-link svg {
-  display: none;
-}
-
-.p-menubar-submenu.dropdown-direction-up {
-  @apply top-auto bottom-full flex-col-reverse;
 }
 </style>

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -53,13 +53,12 @@ import Menubar from 'primevue/menubar'
 import Divider from 'primevue/divider'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import Actionbar from '@/components/actionbar/ComfyActionbar.vue'
-import { useMenuItemStore } from '@/stores/menuItemStore'
+import { ComfyMenuItem, useMenuItemStore } from '@/stores/menuItemStore'
 import { computed, onMounted, provide, ref } from 'vue'
 import { useSettingStore } from '@/stores/settingStore'
 import { app } from '@/scripts/app'
 import { useEventBus } from '@vueuse/core'
 import { useKeybindingStore } from '@/stores/keybindingStore'
-import { MenuItem } from 'primevue/menuitem'
 
 const settingStore = useSettingStore()
 const workflowTabsPosition = computed(() =>
@@ -83,7 +82,7 @@ const items = menuItemsStore.menuItems
 const keybindingStore = useKeybindingStore()
 const keybindings = computed(() => {
   const bindings: Record<string, string> = {}
-  const stack: MenuItem[] = [...items]
+  const stack: ComfyMenuItem[] = [...items]
 
   while (stack.length) {
     const item = stack.pop()!

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -17,8 +17,18 @@
         }"
       >
         <template #item="{ item, props, root }">
-          <a v-bind="props" class="p-menubar-item-link flex items-center">
-            <span class="p-menuitem-text">{{ item.label }}</span>
+          <a v-ripple class="p-menubar-item-link" v-bind="props.action">
+            <span
+              v-if="item.icon"
+              class="p-menubar-item-icon"
+              :class="item.icon"
+            />
+            <span class="p-menubar-item-label">{{ item.label }}</span>
+            <Badge
+              v-if="item.badge"
+              :class="{ 'ml-auto': !root, 'ml-2': root }"
+              :value="item.badge"
+            />
             <span
               v-if="!root && keybindings[item.id]"
               class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -16,6 +16,7 @@ import { LGraphGroup } from '@comfyorg/litegraph'
 import { useTitleEditorStore } from './graphStore'
 import { useErrorHandling } from '@/hooks/errorHooks'
 import { useWorkflowStore } from './workflowStore'
+import { type KeybindingImpl, useKeybindingStore } from './keybindingStore'
 
 export interface ComfyCommand {
   id: string
@@ -64,6 +65,10 @@ export class ComfyCommandImpl implements ComfyCommand {
     return typeof this._menubarLabel === 'function'
       ? this._menubarLabel()
       : this._menubarLabel
+  }
+
+  get keybinding(): KeybindingImpl | null {
+    return useKeybindingStore().getKeybindingByCommandId(this.id)
   }
 }
 

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -94,19 +94,5 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true
     },
     commandId: 'Comfy.ShowSettingsDialog'
-  },
-  {
-    combo: {
-      key: 'z',
-      ctrl: true
-    },
-    commandId: 'Comfy.Undo'
-  },
-  {
-    combo: {
-      key: 'y',
-      ctrl: true
-    },
-    commandId: 'Comfy.Redo'
   }
 ]

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -94,5 +94,19 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true
     },
     commandId: 'Comfy.ShowSettingsDialog'
+  },
+  {
+    combo: {
+      key: 'z',
+      ctrl: true
+    },
+    commandId: 'Comfy.Undo'
+  },
+  {
+    combo: {
+      key: 'y',
+      ctrl: true
+    },
+    commandId: 'Comfy.Redo'
   }
 ]

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -65,7 +65,8 @@ export const useMenuItemStore = defineStore('menuItem', () => {
     {
       label: 'New',
       icon: 'pi pi-plus',
-      command: () => commandStore.execute('Comfy.NewBlankWorkflow')
+      command: () => commandStore.execute('Comfy.NewBlankWorkflow'),
+      id: 'Comfy.NewBlankWorkflow'
     },
     {
       separator: true
@@ -73,12 +74,14 @@ export const useMenuItemStore = defineStore('menuItem', () => {
     {
       label: 'Open',
       icon: 'pi pi-folder-open',
-      command: () => commandStore.execute('Comfy.OpenWorkflow')
+      command: () => commandStore.execute('Comfy.OpenWorkflow'),
+      id: 'Comfy.OpenWorkflow'
     },
     {
       label: 'Browse Templates',
       icon: 'pi pi-th-large',
-      command: () => commandStore.execute('Comfy.BrowseTemplates')
+      command: () => commandStore.execute('Comfy.BrowseTemplates'),
+      id: 'Comfy.BrowseTemplates'
     },
     {
       separator: true
@@ -86,22 +89,26 @@ export const useMenuItemStore = defineStore('menuItem', () => {
     {
       label: 'Save',
       icon: 'pi pi-save',
-      command: () => commandStore.execute('Comfy.SaveWorkflow')
+      command: () => commandStore.execute('Comfy.SaveWorkflow'),
+      id: 'Comfy.SaveWorkflow'
     },
     {
       label: 'Save As',
       icon: 'pi pi-save',
-      command: () => commandStore.execute('Comfy.SaveWorkflowAs')
+      command: () => commandStore.execute('Comfy.SaveWorkflowAs'),
+      id: 'Comfy.SaveWorkflowAs'
     },
     {
       label: 'Export',
       icon: 'pi pi-download',
-      command: () => commandStore.execute('Comfy.ExportWorkflow')
+      command: () => commandStore.execute('Comfy.ExportWorkflow'),
+      id: 'Comfy.ExportWorkflow'
     },
     {
       label: 'Export (API Format)',
       icon: 'pi pi-download',
-      command: () => commandStore.execute('Comfy.ExportWorkflowAPI')
+      command: () => commandStore.execute('Comfy.ExportWorkflowAPI'),
+      id: 'Comfy.ExportWorkflowAPI'
     }
   ]
 

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -51,16 +51,19 @@ export const useMenuItemStore = defineStore('menuItem', () => {
       commandStore.registerCommand(command)
     }
 
-    const items = commands.map(
-      (command) =>
-        ({
-          command: command.function,
-          label: command.menubarLabel,
-          icon: command.icon,
-          tooltip: command.tooltip,
-          comfyCommand: command
-        }) as MenuItem
-    )
+    const items = commands
+      // Convert command to commandImpl
+      .map((command) => commandStore.getCommand(command.id))
+      .map(
+        (command) =>
+          ({
+            command: command.function,
+            label: command.menubarLabel,
+            icon: command.icon,
+            tooltip: command.tooltip,
+            comfyCommand: command
+          }) as MenuItem
+      )
     registerMenuGroup(path, items)
   }
 

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -3,13 +3,11 @@ import type { MenuItem } from 'primevue/menuitem'
 import { ref } from 'vue'
 import { type ComfyCommand, useCommandStore } from './commandStore'
 
-export interface ComfyMenuItem extends MenuItem {
-  id?: string
-}
+export type ComfyMenuItem = MenuItem & ComfyCommand
 
 export const useMenuItemStore = defineStore('menuItem', () => {
   const commandStore = useCommandStore()
-  const menuItems = ref<ComfyMenuItem[]>([])
+  const menuItems = ref<MenuItem[]>([])
 
   const registerMenuGroup = (path: string[], items: ComfyMenuItem[]) => {
     let currentLevel = menuItems.value
@@ -65,58 +63,28 @@ export const useMenuItemStore = defineStore('menuItem', () => {
     registerMenuGroup(path, items)
   }
 
-  const workflowMenuGroup: ComfyMenuItem[] = [
-    {
-      label: 'New',
-      icon: 'pi pi-plus',
-      command: () => commandStore.execute('Comfy.NewBlankWorkflow'),
-      id: 'Comfy.NewBlankWorkflow'
-    },
-    {
-      separator: true
-    },
-    {
-      label: 'Open',
-      icon: 'pi pi-folder-open',
-      command: () => commandStore.execute('Comfy.OpenWorkflow'),
-      id: 'Comfy.OpenWorkflow'
-    },
-    {
-      label: 'Browse Templates',
-      icon: 'pi pi-th-large',
-      command: () => commandStore.execute('Comfy.BrowseTemplates'),
-      id: 'Comfy.BrowseTemplates'
-    },
-    {
-      separator: true
-    },
-    {
-      label: 'Save',
-      icon: 'pi pi-save',
-      command: () => commandStore.execute('Comfy.SaveWorkflow'),
-      id: 'Comfy.SaveWorkflow'
-    },
-    {
-      label: 'Save As',
-      icon: 'pi pi-save',
-      command: () => commandStore.execute('Comfy.SaveWorkflowAs'),
-      id: 'Comfy.SaveWorkflowAs'
-    },
-    {
-      label: 'Export',
-      icon: 'pi pi-download',
-      command: () => commandStore.execute('Comfy.ExportWorkflow'),
-      id: 'Comfy.ExportWorkflow'
-    },
-    {
-      label: 'Export (API Format)',
-      icon: 'pi pi-download',
-      command: () => commandStore.execute('Comfy.ExportWorkflowAPI'),
-      id: 'Comfy.ExportWorkflowAPI'
-    }
-  ]
+  registerCommands(
+    ['Workflow'],
+    [commandStore.getCommand('Comfy.NewBlankWorkflow')]
+  )
 
-  registerMenuGroup(['Workflow'], workflowMenuGroup)
+  registerCommands(
+    ['Workflow'],
+    [
+      commandStore.getCommand('Comfy.OpenWorkflow'),
+      commandStore.getCommand('Comfy.BrowseTemplates')
+    ]
+  )
+  registerCommands(
+    ['Workflow'],
+    [
+      commandStore.getCommand('Comfy.SaveWorkflow'),
+      commandStore.getCommand('Comfy.SaveWorkflowAs'),
+      commandStore.getCommand('Comfy.ExportWorkflow'),
+      commandStore.getCommand('Comfy.ExportWorkflowAPI')
+    ]
+  )
+
   registerCommands(
     ['Edit'],
     [

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -3,13 +3,11 @@ import type { MenuItem } from 'primevue/menuitem'
 import { ref } from 'vue'
 import { type ComfyCommand, useCommandStore } from './commandStore'
 
-export type ComfyMenuItem = MenuItem & ComfyCommand
-
 export const useMenuItemStore = defineStore('menuItem', () => {
   const commandStore = useCommandStore()
   const menuItems = ref<MenuItem[]>([])
 
-  const registerMenuGroup = (path: string[], items: ComfyMenuItem[]) => {
+  const registerMenuGroup = (path: string[], items: MenuItem[]) => {
     let currentLevel = menuItems.value
 
     // Traverse the path, creating nodes if necessary
@@ -56,9 +54,12 @@ export const useMenuItemStore = defineStore('menuItem', () => {
     const items = commands.map(
       (command) =>
         ({
-          ...command,
-          command: command.function
-        }) as ComfyMenuItem
+          command: command.function,
+          label: command.menubarLabel,
+          icon: command.icon,
+          tooltip: command.tooltip,
+          comfyCommand: command
+        }) as MenuItem
     )
     registerMenuGroup(path, items)
   }

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -3,11 +3,15 @@ import type { MenuItem } from 'primevue/menuitem'
 import { ref } from 'vue'
 import { type ComfyCommand, useCommandStore } from './commandStore'
 
+export interface ComfyMenuItem extends MenuItem {
+  id?: string
+}
+
 export const useMenuItemStore = defineStore('menuItem', () => {
   const commandStore = useCommandStore()
-  const menuItems = ref<MenuItem[]>([])
+  const menuItems = ref<ComfyMenuItem[]>([])
 
-  const registerMenuGroup = (path: string[], items: MenuItem[]) => {
+  const registerMenuGroup = (path: string[], items: ComfyMenuItem[]) => {
     let currentLevel = menuItems.value
 
     // Traverse the path, creating nodes if necessary
@@ -56,12 +60,12 @@ export const useMenuItemStore = defineStore('menuItem', () => {
         ({
           ...command,
           command: command.function
-        }) as MenuItem
+        }) as ComfyMenuItem
     )
     registerMenuGroup(path, items)
   }
 
-  const workflowMenuGroup: MenuItem[] = [
+  const workflowMenuGroup: ComfyMenuItem[] = [
     {
       label: 'New',
       icon: 'pi pi-plus',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -174,6 +174,10 @@ export default {
           900: '#7b341e',
           950: '#431407'
         }
+      },
+
+      textColor: {
+        muted: 'var(--p-text-muted-color)'
       }
     }
   },


### PR DESCRIPTION
![Select](https://github.com/user-attachments/assets/85b19367-a024-48bb-ba80-dc7384016280)

- `TopMenuBar` use `id` of menu items to lookup keybindings 
- Menu items registered with `menuItemStore.ts#registerCommands` already inherit the command id 
- For `menuItemStore.ts#registerMenuGroup`, extend param type to include `id` field then add ids to the current menu items
