### PR TITLE
Fix widget/input conversion on text widgets

### DIFF
--- a/browser_tests/ComfyPage.ts
+++ b/browser_tests/ComfyPage.ts
@@ -1198,6 +1198,11 @@ export class NodeReference {
     )
     return originSlot
   }
+  async getContextMenuOptionNames() {
+    await this.click('title', { button: 'right' })
+    const ctx = this.comfyPage.page.locator('.litecontextmenu')
+    return await ctx.locator('.litemenu-entry').allInnerTexts()
+  }
   async clickContextMenuOption(optionText: string) {
     await this.click('title', { button: 'right' })
     const ctx = this.comfyPage.page.locator('.litecontextmenu')

--- a/browser_tests/rightClickMenu.spec.ts
+++ b/browser_tests/rightClickMenu.spec.ts
@@ -125,6 +125,7 @@ test.describe('Node Right Click Menu', () => {
           },
           [nodeType, widgetType]
         )
+        await comfyPage.nextFrame()
 
         // Verify the context menu contains the option to convert the widget to input
         const menuOptions = await node?.getContextMenuOptionNames()

--- a/browser_tests/rightClickMenu.spec.ts
+++ b/browser_tests/rightClickMenu.spec.ts
@@ -128,7 +128,9 @@ test.describe('Node Right Click Menu', () => {
 
         // Verify the context menu contains the option to convert the widget to input
         const menuOptions = await node?.getContextMenuOptionNames()
-        expect(menuOptions).toContain(`Convert ${widgetType} to input`)
+        expect(menuOptions.includes(`Convert ${widgetType} to input`)).toBe(
+          true
+        )
       })
     })
   })

--- a/browser_tests/rightClickMenu.spec.ts
+++ b/browser_tests/rightClickMenu.spec.ts
@@ -125,7 +125,8 @@ test.describe('Node Right Click Menu', () => {
           },
           [nodeType, widgetType]
         )
-        await comfyPage.nextFrame()
+        await comfyPage.page.waitForTimeout(256)
+        await comfyPage.page.mouse.move(64, 64)
 
         // Verify the context menu contains the option to convert the widget to input
         const menuOptions = await node?.getContextMenuOptionNames()

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -6,7 +6,15 @@ import type { INodeInputSlot, IWidget } from '@comfyorg/litegraph'
 import type { InputSpec } from '@/types/apiTypes'
 
 const CONVERTED_TYPE = 'converted-widget'
-const VALID_TYPES = ['STRING', 'combo', 'number', 'toggle', 'BOOLEAN']
+const VALID_TYPES = [
+  'STRING',
+  'combo',
+  'number',
+  'toggle',
+  'BOOLEAN',
+  'text',
+  'string'
+]
 const CONFIG = Symbol()
 const GET_CONFIG = Symbol()
 const TARGET = Symbol() // Used for reroutes to specify the real target widget


### PR DESCRIPTION
Check when converting widget to input:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/b97331cbab432a5716c04a5ff5112a2cc5675ec5/src/extensions/core/widgetInputs.ts#L409-L420

If using `node.addWidget` to add a text widget:

1. First condition false because `string` and `text` not in `VALID_TYPES` despite being valid [LiteGraph widget types](https://github.com/Comfy-Org/litegraph.js/blob/36a8b1fea0ac7ba077406f01d706bcc272ac4bc9/public/litegraph.d.ts#L9-L15)
2. Second condition false because the widget is instance-bound so `config[0]` is undefined
 
So the widget won't be convertible. Fix by adding `string` and `text` to `VALID_TYPES`. Fixes #1114