### PR TITLE
Add frontend extension management panel

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -106,12 +106,18 @@ const extensionPanelNode: SettingTreeNode = {
   children: []
 }
 
+const extensionPanelNodeList = computed<SettingTreeNode[]>(() => {
+  const settingStore = useSettingStore()
+  const showExtensionPanel = settingStore.get('Comfy.Settings.ExtensionPanel')
+  return showExtensionPanel ? [extensionPanelNode] : []
+})
+
 const settingStore = useSettingStore()
 const settingRoot = computed<SettingTreeNode>(() => settingStore.settingTree)
 const categories = computed<SettingTreeNode[]>(() => [
   ...(settingRoot.value.children || []),
   keybindingPanelNode,
-  extensionPanelNode,
+  ...extensionPanelNodeList.value,
   aboutPanelNode
 ])
 const activeCategory = ref<SettingTreeNode | null>(null)

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -57,6 +57,9 @@
           <TabPanel key="keybinding" value="Keybinding">
             <KeybindingPanel />
           </TabPanel>
+          <TabPanel key="extension" value="Extension">
+            <ExtensionPanel />
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </div>
@@ -78,6 +81,7 @@ import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import { flattenTree } from '@/utils/treeUtil'
 import AboutPanel from './setting/AboutPanel.vue'
 import KeybindingPanel from './setting/KeybindingPanel.vue'
+import ExtensionPanel from './setting/ExtensionPanel.vue'
 
 interface ISettingGroup {
   label: string
@@ -96,11 +100,18 @@ const keybindingPanelNode: SettingTreeNode = {
   children: []
 }
 
+const extensionPanelNode: SettingTreeNode = {
+  key: 'extension',
+  label: 'Extension',
+  children: []
+}
+
 const settingStore = useSettingStore()
 const settingRoot = computed<SettingTreeNode>(() => settingStore.settingTree)
 const categories = computed<SettingTreeNode[]>(() => [
   ...(settingRoot.value.children || []),
   keybindingPanelNode,
+  extensionPanelNode,
   aboutPanelNode
 ])
 const activeCategory = ref<SettingTreeNode | null>(null)

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -226,4 +226,15 @@ const tabValue = computed(() =>
     width: 100%;
   }
 }
+
+/* Show a separator line above the Keybinding tab */
+/* This indicates the start of custom setting panels */
+.settings-sidebar :deep(.p-listbox-option[aria-label='Keybinding']) {
+  position: relative;
+}
+
+.settings-sidebar :deep(.p-listbox-option[aria-label='Keybinding'])::before {
+  @apply content-[''] top-0 left-0 absolute w-full;
+  border-top: 1px solid var(--p-divider-border-color);
+}
 </style>

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -16,7 +16,7 @@
         <template #body="slotProps">
           <ToggleSwitch
             v-model="editingEnabledExtensions[slotProps.data.name]"
-            @change="updateExtensionStatus(slotProps.data.name)"
+            @change="updateExtensionStatus"
           />
         </template>
       </Column>
@@ -68,13 +68,17 @@ const hasChanges = computed(() => {
   )
 })
 
-const updateExtensionStatus = (name: string) => {
-  settingStore.set(
-    'Comfy.Extension.Disabled',
-    Object.entries(editingEnabledExtensions.value)
-      .filter(([_, enabled]) => !enabled)
-      .map(([name]) => name)
+const updateExtensionStatus = () => {
+  const editingDisabledExtensionNames = Object.entries(
+    editingEnabledExtensions.value
   )
+    .filter(([_, enabled]) => !enabled)
+    .map(([name]) => name)
+
+  settingStore.set('Comfy.Extension.Disabled', [
+    ...extensionStore.inactiveDisabledExtensionNames,
+    ...editingDisabledExtensionNames
+  ])
 }
 
 const applyChanges = () => {

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -1,8 +1,18 @@
 <template>
   <div class="extension-panel">
-    <DataTable :value="extensions" stripedRows size="small">
+    <DataTable
+      :value="extensions"
+      stripedRows
+      size="small"
+      scrollable
+      scrollHeight="800px"
+    >
       <Column field="name" :header="$t('extensionName')" sortable></Column>
-      <Column>
+      <Column
+        :pt="{
+          bodyCell: 'flex items-center justify-end'
+        }"
+      >
         <template #body="slotProps">
           <ToggleSwitch
             v-model="enabledExtensions[slotProps.data.name]"

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -23,7 +23,14 @@
     </DataTable>
     <div class="mt-4">
       <Message v-if="hasChanges" severity="info">
-        {{ $t('extensionChangesDetected') }}
+        <ul>
+          <li v-for="ext in changedExtensions" :key="ext.name">
+            <span>
+              {{ extensionStore.isExtensionEnabled(ext.name) ? '[-]' : '[+]' }}
+            </span>
+            {{ ext.name }}
+          </li>
+        </ul>
       </Message>
       <Button
         :label="$t('reloadToApplyChanges')"
@@ -60,12 +67,16 @@ onMounted(() => {
   })
 })
 
-const hasChanges = computed(() => {
-  return extensionStore.enabledExtensions.some(
+const changedExtensions = computed(() => {
+  return extensionStore.extensions.filter(
     (ext) =>
       editingEnabledExtensions.value[ext.name] !==
       extensionStore.isExtensionEnabled(ext.name)
   )
+})
+
+const hasChanges = computed(() => {
+  return changedExtensions.value.length > 0
 })
 
 const updateExtensionStatus = () => {

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -1,12 +1,6 @@
 <template>
   <div class="extension-panel">
-    <DataTable
-      :value="extensionStore.extensions"
-      stripedRows
-      size="small"
-      scrollable
-      scrollHeight="800px"
-    >
+    <DataTable :value="extensionStore.extensions" stripedRows size="small">
       <Column field="name" :header="$t('extensionName')" sortable></Column>
       <Column
         :pt="{

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="extension-panel">
+    <DataTable :value="extensions" stripedRows size="small">
+      <Column field="name" :header="$t('extensionName')" sortable></Column>
+      <Column>
+        <template #body="slotProps">
+          <ToggleSwitch
+            v-model="enabledExtensions[slotProps.data.name]"
+            @change="updateExtensionStatus(slotProps.data.name)"
+          />
+        </template>
+      </Column>
+    </DataTable>
+    <div class="mt-4">
+      <Message v-if="hasChanges" severity="info">
+        {{ $t('extensionChangesDetected') }}
+      </Message>
+      <Button
+        :label="$t('applyChanges')"
+        icon="pi pi-refresh"
+        @click="applyChanges"
+        :disabled="!hasChanges"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useExtensionStore } from '@/stores/extensionStore'
+import { useSettingStore } from '@/stores/settingStore'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import ToggleSwitch from 'primevue/toggleswitch'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+
+const extensionStore = useExtensionStore()
+const settingStore = useSettingStore()
+
+const extensions = computed(() => extensionStore.extensions)
+const enabledExtensions = ref<Record<string, boolean>>({})
+const originalEnabledExtensions = ref<Record<string, boolean>>({})
+
+onMounted(() => {
+  const disabledExtensions = new Set(
+    settingStore.get('Comfy.Extension.Disabled')
+  )
+  extensions.value.forEach((ext) => {
+    enabledExtensions.value[ext.name] = !disabledExtensions.has(ext.name)
+    originalEnabledExtensions.value[ext.name] = !disabledExtensions.has(
+      ext.name
+    )
+  })
+})
+
+const hasChanges = computed(() => {
+  return Object.keys(enabledExtensions.value).some(
+    (name) =>
+      enabledExtensions.value[name] !== originalEnabledExtensions.value[name]
+  )
+})
+
+const updateExtensionStatus = (name: string) => {
+  // This function is called when a ToggleButton is changed
+  // No need to do anything here as the v-model will update enabledExtensions
+}
+
+const applyChanges = () => {
+  const disabledExtensions = Object.keys(enabledExtensions.value).filter(
+    (name) => !enabledExtensions.value[name]
+  )
+
+  settingStore.set('Comfy.Extension.Disabled', disabledExtensions)
+
+  // Refresh the page to apply changes
+  window.location.reload()
+}
+</script>

--- a/src/extensions/core/nodeBadge.ts
+++ b/src/extensions/core/nodeBadge.ts
@@ -9,7 +9,6 @@ import _ from 'lodash'
 import { getColorPalette, defaultColorPalette } from './colorPalette'
 import { BadgePosition } from '@comfyorg/litegraph'
 import type { Palette } from '@/types/colorPalette'
-import type { ComfyNodeDef } from '@/types/apiTypes'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 function getNodeSource(node: LGraphNode): NodeSource | null {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,6 +3,7 @@ import { createI18n } from 'vue-i18n'
 const messages = {
   en: {
     extensionName: 'Extension Name',
+    reloadToApplyChanges: 'Reload to apply changes',
     insert: 'Insert',
     systemInfo: 'System Info',
     devices: 'Devices',
@@ -110,6 +111,7 @@ const messages = {
   },
   zh: {
     extensionName: '扩展名称',
+    reloadToApplyChanges: '重新加载以应用更改',
     insert: '插入',
     systemInfo: '系统信息',
     devices: '设备',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,6 +2,7 @@ import { createI18n } from 'vue-i18n'
 
 const messages = {
   en: {
+    extensionName: 'Extension Name',
     insert: 'Insert',
     systemInfo: 'System Info',
     devices: 'Devices',
@@ -108,6 +109,7 @@ const messages = {
     }
   },
   zh: {
+    extensionName: '扩展名称',
     insert: '插入',
     systemInfo: '系统信息',
     devices: '设备',

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -52,8 +52,7 @@ import type { ToastMessageOptions } from 'primevue/toast'
 import { useWorkspaceStore } from '@/stores/workspaceStateStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { IWidget } from '@comfyorg/litegraph'
-import { useKeybindingStore } from '@/stores/keybindingStore'
-import { useCommandStore } from '@/stores/commandStore'
+import { useExtensionStore } from '@/stores/extensionStore'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
@@ -2943,22 +2942,12 @@ export class ComfyApp {
    * @param {ComfyExtension} extension
    */
   registerExtension(extension: ComfyExtension) {
-    if (!extension.name) {
-      throw new Error("Extensions must have a 'name' property.")
-    }
-    // https://github.com/Comfy-Org/litegraph.js/pull/117
-    if (extension.name === 'pysssss.Locking') {
-      console.log('pysssss.Locking is replaced by pin/unpin in ComfyUI core.')
-      return
-    }
-    if (this.extensions.find((ext) => ext.name === extension.name)) {
-      throw new Error(`Extension named '${extension.name}' already registered.`)
-    }
     if (this.vueAppReady) {
-      useKeybindingStore().loadExtensionKeybindings(extension)
-      useCommandStore().loadExtensionCommands(extension)
+      useExtensionStore().registerExtension(extension)
+    } else {
+      // For jest testing.
+      this.extensions.push(extension)
     }
-    this.extensions.push(extension)
   }
 
   /**

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -356,6 +356,13 @@ export class ComfyApp {
     }
   }
 
+  get enabledExtensions() {
+    if (!this.vueAppReady) {
+      return this.extensions
+    }
+    return useExtensionStore().enabledExtensions
+  }
+
   /**
    * Invoke an extension callback
    * @param {keyof ComfyExtension} method The extension callback to execute
@@ -364,7 +371,7 @@ export class ComfyApp {
    */
   #invokeExtensions(method, ...args) {
     let results = []
-    for (const ext of this.extensions) {
+    for (const ext of this.enabledExtensions) {
       if (method in ext) {
         try {
           results.push(ext[method](...args, this))
@@ -390,7 +397,7 @@ export class ComfyApp {
    */
   async #invokeExtensionsAsync(method, ...args) {
     return await Promise.all(
-      this.extensions.map(async (ext) => {
+      this.enabledExtensions.map(async (ext) => {
         if (method in ext) {
           try {
             return await ext[method](...args, this)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1772,6 +1772,8 @@ export class ComfyApp {
    * Loads all extensions from the API into the window in parallel
    */
   async #loadExtensions() {
+    useExtensionStore().loadDisabledExtensionNames()
+
     const extensions = await api.getExtensions()
     this.logging.addEntry('Comfy.App', 'debug', { Extensions: extensions })
 

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -425,11 +425,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Extension.Disabled',
     name: 'Disabled extension names',
     type: 'hidden',
-    defaultValue: [
-      // pysssss.Locking is replaced by pin/unpin in ComfyUI core.
-      // https://github.com/Comfy-Org/litegraph.js/pull/117
-      'pysssss.Locking'
-    ],
+    defaultValue: [] as string[],
     versionAdded: '1.3.11'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -427,5 +427,13 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'hidden',
     defaultValue: [] as string[],
     versionAdded: '1.3.11'
+  },
+  {
+    id: 'Comfy.Settings.ExtensionPanel',
+    name: 'Show extension panel in settings dialog',
+    type: 'boolean',
+    defaultValue: false,
+    experimental: true,
+    versionAdded: '1.3.11'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -425,7 +425,11 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Extension.Disabled',
     name: 'Disabled extension names',
     type: 'hidden',
-    defaultValue: [] as string[],
+    defaultValue: [
+      // pysssss.Locking is replaced by pin/unpin in ComfyUI core.
+      // https://github.com/Comfy-Org/litegraph.js/pull/117
+      'pysssss.Locking'
+    ],
     versionAdded: '1.3.11'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -420,5 +420,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'hidden',
     defaultValue: [] as Keybinding[],
     versionAdded: '1.3.7'
+  },
+  {
+    id: 'Comfy.Extension.Disabled',
+    name: 'Disabled extension names',
+    type: 'hidden',
+    defaultValue: [] as string[],
+    versionAdded: '1.3.11'
   }
 ]

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -13,6 +13,11 @@ export const useExtensionStore = defineStore('extension', () => {
   // Not using computed because disable extension requires reloading of the page.
   // Dynamically update this list won't affect extensions that are already loaded.
   const disabledExtensionNames = ref<Set<string>>(new Set())
+  const isExtensionEnabled = (name: string) =>
+    !disabledExtensionNames.value.has(name)
+  const enabledExtensions = computed(() => {
+    return extensions.value.filter((ext) => isExtensionEnabled(ext.name))
+  })
 
   function registerExtension(extension: ComfyExtension) {
     if (!extension.name) {
@@ -47,6 +52,8 @@ export const useExtensionStore = defineStore('extension', () => {
 
   return {
     extensions,
+    enabledExtensions,
+    isExtensionEnabled,
     registerExtension,
     loadDisabledExtensionNames
   }

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -13,6 +13,16 @@ export const useExtensionStore = defineStore('extension', () => {
   // Not using computed because disable extension requires reloading of the page.
   // Dynamically update this list won't affect extensions that are already loaded.
   const disabledExtensionNames = ref<Set<string>>(new Set())
+
+  // Disabled extension names that are currently not in the extension list.
+  // If a node pack is disabled in the backend, we shouldn't remove the configuration
+  // of the frontend extension disable list, in case the node pack is re-enabled.
+  const inactiveDisabledExtensionNames = computed(() => {
+    return Array.from(disabledExtensionNames.value).filter(
+      (name) => !(name in extensionByName.value)
+    )
+  })
+
   const isExtensionEnabled = (name: string) =>
     !disabledExtensionNames.value.has(name)
   const enabledExtensions = computed(() => {
@@ -60,6 +70,7 @@ export const useExtensionStore = defineStore('extension', () => {
   return {
     extensions,
     enabledExtensions,
+    inactiveDisabledExtensionNames,
     isExtensionEnabled,
     registerExtension,
     loadDisabledExtensionNames

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -57,6 +57,9 @@ export const useExtensionStore = defineStore('extension', () => {
     disabledExtensionNames.value = new Set(
       useSettingStore().get('Comfy.Extension.Disabled')
     )
+    // pysssss.Locking is replaced by pin/unpin in ComfyUI core.
+    // https://github.com/Comfy-Org/litegraph.js/pull/117
+    disabledExtensionNames.value.add('pysssss.Locking')
   }
 
   // Some core extensions are registered before the store is initialized, e.g.

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -3,12 +3,16 @@ import { defineStore } from 'pinia'
 import type { ComfyExtension } from '@/types/comfy'
 import { useKeybindingStore } from './keybindingStore'
 import { useCommandStore } from './commandStore'
+import { useSettingStore } from './settingStore'
 import { app } from '@/scripts/app'
 
 export const useExtensionStore = defineStore('extension', () => {
   // For legacy reasons, the name uniquely identifies an extension
   const extensionByName = ref<Record<string, ComfyExtension>>({})
   const extensions = computed(() => Object.values(extensionByName.value))
+  // Not using computed because disable extension requires reloading of the page.
+  // Dynamically update this list won't affect extensions that are already loaded.
+  const disabledExtensionNames = ref<string[]>([])
 
   function registerExtension(extension: ComfyExtension) {
     if (!extension.name) {
@@ -37,8 +41,15 @@ export const useExtensionStore = defineStore('extension', () => {
     app.extensions.push(extension)
   }
 
+  function loadDisabledExtensionNames() {
+    disabledExtensionNames.value = useSettingStore().get(
+      'Comfy.Extension.Disabled'
+    )
+  }
+
   return {
     extensions,
-    registerExtension
+    registerExtension,
+    loadDisabledExtensionNames
   }
 })

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -1,0 +1,44 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import type { ComfyExtension } from '@/types/comfy'
+import { useKeybindingStore } from './keybindingStore'
+import { useCommandStore } from './commandStore'
+import { app } from '@/scripts/app'
+
+export const useExtensionStore = defineStore('extension', () => {
+  // For legacy reasons, the name uniquely identifies an extension
+  const extensionByName = ref<Record<string, ComfyExtension>>({})
+  const extensions = computed(() => Object.values(extensionByName.value))
+
+  function registerExtension(extension: ComfyExtension) {
+    if (!extension.name) {
+      throw new Error("Extensions must have a 'name' property.")
+    }
+
+    // https://github.com/Comfy-Org/litegraph.js/pull/117
+    if (extension.name === 'pysssss.Locking') {
+      console.log('pysssss.Locking is replaced by pin/unpin in ComfyUI core.')
+      return
+    }
+
+    if (extensionByName.value[extension.name]) {
+      throw new Error(`Extension named '${extension.name}' already registered.`)
+    }
+
+    extensionByName.value[extension.name] = extension
+
+    useKeybindingStore().loadExtensionKeybindings(extension)
+    useCommandStore().loadExtensionCommands(extension)
+
+    /*
+     * Extensions are currently stored in both extensionStore and app.extensions.
+     * Legacy jest tests still depend on app.extensions being populated.
+     */
+    app.extensions.push(extension)
+  }
+
+  return {
+    extensions,
+    registerExtension
+  }
+})

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -19,12 +19,6 @@ export const useExtensionStore = defineStore('extension', () => {
       throw new Error("Extensions must have a 'name' property.")
     }
 
-    // https://github.com/Comfy-Org/litegraph.js/pull/117
-    if (extension.name === 'pysssss.Locking') {
-      console.log('pysssss.Locking is replaced by pin/unpin in ComfyUI core.')
-      return
-    }
-
     if (extensionByName.value[extension.name]) {
       throw new Error(`Extension named '${extension.name}' already registered.`)
     }

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -12,7 +12,7 @@ export const useExtensionStore = defineStore('extension', () => {
   const extensions = computed(() => Object.values(extensionByName.value))
   // Not using computed because disable extension requires reloading of the page.
   // Dynamically update this list won't affect extensions that are already loaded.
-  const disabledExtensionNames = ref<string[]>([])
+  const disabledExtensionNames = ref<Set<string>>(new Set())
 
   function registerExtension(extension: ComfyExtension) {
     if (!extension.name) {
@@ -23,8 +23,12 @@ export const useExtensionStore = defineStore('extension', () => {
       throw new Error(`Extension named '${extension.name}' already registered.`)
     }
 
-    extensionByName.value[extension.name] = extension
+    if (disabledExtensionNames.value.has(extension.name)) {
+      console.log(`Extension ${extension.name} is disabled.`)
+      return
+    }
 
+    extensionByName.value[extension.name] = extension
     useKeybindingStore().loadExtensionKeybindings(extension)
     useCommandStore().loadExtensionCommands(extension)
 
@@ -36,8 +40,8 @@ export const useExtensionStore = defineStore('extension', () => {
   }
 
   function loadDisabledExtensionNames() {
-    disabledExtensionNames.value = useSettingStore().get(
-      'Comfy.Extension.Disabled'
+    disabledExtensionNames.value = new Set(
+      useSettingStore().get('Comfy.Extension.Disabled')
     )
   }
 

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -507,7 +507,8 @@ const zSettings = z.record(z.any()).and(
       'Comfy.NodeBadge.NodeLifeCycleBadgeMode': zNodeBadgeMode,
       'Comfy.QueueButton.BatchCountLimit': z.number(),
       'Comfy.Keybinding.UnsetBindings': z.array(zKeybinding),
-      'Comfy.Keybinding.NewBindings': z.array(zKeybinding)
+      'Comfy.Keybinding.NewBindings': z.array(zKeybinding),
+      'Comfy.Extension.Disabled': z.array(z.string())
     })
     .optional()
 )

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -508,7 +508,8 @@ const zSettings = z.record(z.any()).and(
       'Comfy.QueueButton.BatchCountLimit': z.number(),
       'Comfy.Keybinding.UnsetBindings': z.array(zKeybinding),
       'Comfy.Keybinding.NewBindings': z.array(zKeybinding),
-      'Comfy.Extension.Disabled': z.array(z.string())
+      'Comfy.Extension.Disabled': z.array(z.string()),
+      'Comfy.Settings.ExtensionPanel': z.boolean()
     })
     .optional()
 )

--- a/tests-ui/globalSetup.ts
+++ b/tests-ui/globalSetup.ts
@@ -36,6 +36,15 @@ module.exports = async function () {
     }
   })
 
+  jest.mock('@/stores/extensionStore', () => {
+    return {
+      useExtensionStore: () => ({
+        registerExtension: jest.fn(),
+        loadDisabledExtensionNames: jest.fn()
+      })
+    }
+  })
+
   jest.mock('vue-i18n', () => {
     return {
       useI18n: jest.fn()


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/1122

![image](https://github.com/user-attachments/assets/958531e1-6c6b-4702-b611-023a29adddda)
![image](https://github.com/user-attachments/assets/82fa9892-d598-43aa-b1c3-c9c90aa8e19b)

## Note
The feature is now marked as experimental and guarded behind a setting (Default disabled). I think we should distinguish extension source as many extension has confusing names, e.g. using 'Comfy.' prefix while not being a core extension. And disabling a core extension might indeed cause breakage. We need to think these through before rolling the feature to the general user base.

![image](https://github.com/user-attachments/assets/22beb2d1-4bd1-4540-8de9-a79dfc38394c)
