### PR TITLE
Model Library sidebar: allow searching metadata

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -42,7 +42,7 @@ import type {
   RenderedTreeExplorerNode,
   TreeExplorerNode
 } from '@/types/treeExplorerTypes'
-import { computed, ref, type ComputedRef, watch, toRef } from 'vue'
+import { computed, ref, type ComputedRef, watch, toRef, toRaw } from 'vue'
 import type { TreeNode } from 'primevue/treenode'
 import { app } from '@/scripts/app'
 import { buildTree } from '@/utils/treeUtil'
@@ -83,7 +83,10 @@ const root: ComputedRef<TreeNode> = computed(() => {
   if (searchQuery.value) {
     const search = searchQuery.value.toLocaleLowerCase()
     modelList = modelList.filter((model: ComfyModelDef) => {
-      return model.file_name.toLocaleLowerCase().includes(search)
+      // Note: the backing pinia store creates a proxy that breaks 'computed' values,
+      // so use toRaw to fix that
+      const rawModel = toRaw(model)
+      return rawModel.searchable.value.includes(search)
     })
   }
   const tree: TreeNode = buildTree(modelList, (model: ComfyModelDef) => {

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -83,10 +83,7 @@ const root: ComputedRef<TreeNode> = computed(() => {
   if (searchQuery.value) {
     const search = searchQuery.value.toLocaleLowerCase()
     modelList = modelList.filter((model: ComfyModelDef) => {
-      // Note: the backing pinia store creates a proxy that breaks 'computed' values,
-      // so use toRaw to fix that
-      const rawModel = toRaw(model)
-      return rawModel.searchable.value.includes(search)
+      return model.searchable.includes(search)
     })
   }
   const tree: TreeNode = buildTree(modelList, (model: ComfyModelDef) => {

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -42,7 +42,7 @@ import type {
   RenderedTreeExplorerNode,
   TreeExplorerNode
 } from '@/types/treeExplorerTypes'
-import { computed, ref, type ComputedRef, watch, toRef, toRaw } from 'vue'
+import { computed, ref, type ComputedRef, watch, toRef } from 'vue'
 import type { TreeNode } from 'primevue/treenode'
 import { app } from '@/scripts/app'
 import { buildTree } from '@/utils/treeUtil'

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -1,6 +1,5 @@
 import { api } from '@/scripts/api'
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
 
 /** (Internal helper) finds a value in a metadata object from any of a list of keys. */
 function _findInMetadata(metadata: any, ...keys: string[]): string | null {

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -50,18 +50,7 @@ export class ComfyModelDef {
   /** If true, this is a fake model object used as a placeholder for something (eg a loading icon) */
   is_fake_object: boolean = false
   /** A string full of auto-computed lowercase-only searchable text for this model */
-  searchable = computed<string>(() => {
-    return [
-      this.file_name,
-      this.title,
-      this.author,
-      this.description,
-      this.trigger_phrase,
-      this.tags.join(', ')
-    ]
-      .join('\n')
-      .toLowerCase()
-  })
+  searchable: string = ''
 
   constructor(name: string, directory: string) {
     this.file_name = name
@@ -74,6 +63,20 @@ export class ComfyModelDef {
     }
     this.title = this.simplified_file_name
     this.directory = directory
+    this.updateSearchable()
+  }
+
+  updateSearchable() {
+    this.searchable = [
+      this.file_name,
+      this.title,
+      this.author,
+      this.description,
+      this.trigger_phrase,
+      this.tags.join(', ')
+    ]
+      .join('\n')
+      .toLowerCase()
   }
 
   /** Loads the model metadata from the server, filling in this object if data is available */
@@ -124,6 +127,7 @@ export class ComfyModelDef {
         _findInMetadata(metadata, 'modelspec.tags', 'tags') || ''
       this.tags = tagsCommaSeparated.split(',').map((tag) => tag.trim())
       this.has_loaded_metadata = true
+      this.updateSearchable()
     } catch (error) {
       console.error('Error loading model metadata', this.file_name, this, error)
     }

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -1,5 +1,6 @@
 import { api } from '@/scripts/api'
 import { defineStore } from 'pinia'
+import { computed } from 'vue'
 
 /** (Internal helper) finds a value in a metadata object from any of a list of keys. */
 function _findInMetadata(metadata: any, ...keys: string[]): string | null {
@@ -48,6 +49,19 @@ export class ComfyModelDef {
   is_load_requested: boolean = false
   /** If true, this is a fake model object used as a placeholder for something (eg a loading icon) */
   is_fake_object: boolean = false
+  /** A string full of auto-computed lowercase-only searchable text for this model */
+  searchable = computed<string>(() => {
+    return [
+      this.file_name,
+      this.title,
+      this.author,
+      this.description,
+      this.trigger_phrase,
+      this.tags.join(', ')
+    ]
+      .join('\n')
+      .toLowerCase()
+  })
 
   constructor(name: string, directory: string) {
     this.file_name = name


### PR DESCRIPTION
You can now title in the metadata title, author, description, etc. into the search box and find relevant results

Future upgrade: add a 'filter menu' like the node sidebar has, to allow selecting which metadata values are included in search

Note: `toRaw` is hacky but needed, as the pinia store does weird things to models in the list. The `Proxy` object it creates successfully calls and runs the `computed` searchable val, but then breaks down and errors out with an `undefined` error.
I'm not sure what's up with that and my recommended solution of "stop using a complex framework for what could just be a map" isn't likely to happen, so...
Note the reason for `computed` here is mainly just the caching benefit - it'd be messy to recompute the combined and lowercased search string everytime, so computed very nicely caches it for us and only recomputes if the underlying values change.