### PR TITLE
allow dragging embeddings onto text boxes

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -253,6 +253,8 @@ onMounted(() => {
       const textBeforeCursor = textarea.value.substring(0, cursorPosition)
       const textAfterCursor = textarea.value.substring(cursorPosition)
       textarea.value = textBeforeCursor + insertText + textAfterCursor
+      // This setTimeout is a workaround for browsers behaving weirdly about the drop event itself
+      // so apply the textarea focus outside of the event (with a timeout zero)
       setTimeout(() => {
         textarea.focus()
         const newCursorPosition = cursorPosition + insertText.length


### PR DESCRIPTION
requested by #1029

hardcoded to 'embeddings' model type only for now (I'm not aware of any third party model types that behave similarly, this is very embeddings-specific)

set to work with any textarea for now (would be somewhere between nontrivial and impossible to only get prompt text inputs, as, well, yknow, there could be any number of nodes used as prompt inputs - primitive, textbox, cliptextencode, any number of third party ones, ...) so if you drag an embedding onto a text box, assume you probably meant to do that.

will preserve selection area, and insert where you have selected, which is pretty neat.

side note: i don't want to talk about how long it took me to figure out the specifics of how to listen to dragging from a tree thing properly. Turned out as usual, random obscure specific framework doesn't do the job any better than the default browser functionality but is basically required regardless. `document.elementFromPoint` is a bit cursed but I don't think pdnd supplies an element anywhere I can find.

`setTimeout` usage looks a bit odd at a glance so I tacked on a comment to explain it

`dropTargetCleanup` naming and usage style copied from GraphCanvas