### PR TITLE
Refactor core sidebar tab registration

### DIFF
--- a/src/hooks/sidebarTabs/modelLibrarySidebarTab.ts
+++ b/src/hooks/sidebarTabs/modelLibrarySidebarTab.ts
@@ -1,0 +1,16 @@
+import { markRaw } from 'vue'
+import { useI18n } from 'vue-i18n'
+import ModelLibrarySidebarTab from '@/components/sidebar/tabs/ModelLibrarySidebarTab.vue'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
+
+export const useModelLibrarySidebarTab = (): SidebarTabExtension => {
+  const { t } = useI18n()
+  return {
+    id: 'model-library',
+    icon: 'pi pi-box',
+    title: t('sideToolbar.modelLibrary'),
+    tooltip: t('sideToolbar.modelLibrary'),
+    component: markRaw(ModelLibrarySidebarTab),
+    type: 'vue'
+  }
+}

--- a/src/hooks/sidebarTabs/nodeLibrarySidebarTab.ts
+++ b/src/hooks/sidebarTabs/nodeLibrarySidebarTab.ts
@@ -1,0 +1,16 @@
+import { markRaw } from 'vue'
+import { useI18n } from 'vue-i18n'
+import NodeLibrarySidebarTab from '@/components/sidebar/tabs/NodeLibrarySidebarTab.vue'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
+
+export const useNodeLibrarySidebarTab = (): SidebarTabExtension => {
+  const { t } = useI18n()
+  return {
+    id: 'node-library',
+    icon: 'pi pi-book',
+    title: t('sideToolbar.nodeLibrary'),
+    tooltip: t('sideToolbar.nodeLibrary'),
+    component: markRaw(NodeLibrarySidebarTab),
+    type: 'vue'
+  }
+}

--- a/src/hooks/sidebarTabs/queueSidebarTab.ts
+++ b/src/hooks/sidebarTabs/queueSidebarTab.ts
@@ -1,0 +1,22 @@
+import { useQueuePendingTaskCountStore } from '@/stores/queueStore'
+import { markRaw } from 'vue'
+import { useI18n } from 'vue-i18n'
+import QueueSidebarTab from '@/components/sidebar/tabs/QueueSidebarTab.vue'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
+
+export const useQueueSidebarTab = (): SidebarTabExtension => {
+  const { t } = useI18n()
+  const queuePendingTaskCountStore = useQueuePendingTaskCountStore()
+  return {
+    id: 'queue',
+    icon: 'pi pi-history',
+    iconBadge: () => {
+      const value = queuePendingTaskCountStore.count.toString()
+      return value === '0' ? null : value
+    },
+    title: t('sideToolbar.queue'),
+    tooltip: t('sideToolbar.queue'),
+    component: markRaw(QueueSidebarTab),
+    type: 'vue'
+  }
+}

--- a/src/hooks/sidebarTabs/workflowsSidebarTab.ts
+++ b/src/hooks/sidebarTabs/workflowsSidebarTab.ts
@@ -1,0 +1,30 @@
+import { markRaw } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useWorkflowStore } from '@/stores/workflowStore'
+import { useSettingStore } from '@/stores/settingStore'
+import WorkflowsSidebarTab from '@/components/sidebar/tabs/WorkflowsSidebarTab.vue'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
+
+export const useWorkflowsSidebarTab = (): SidebarTabExtension => {
+  const { t } = useI18n()
+  const settingStore = useSettingStore()
+  const workflowStore = useWorkflowStore()
+
+  return {
+    id: 'workflows',
+    icon: 'pi pi-folder-open',
+    iconBadge: () => {
+      if (
+        settingStore.get('Comfy.Workflow.WorkflowTabsPosition') !== 'Sidebar'
+      ) {
+        return null
+      }
+      const value = workflowStore.openWorkflows.length.toString()
+      return value === '0' ? null : value
+    },
+    title: t('sideToolbar.workflows'),
+    tooltip: t('sideToolbar.workflows'),
+    component: markRaw(WorkflowsSidebarTab),
+    type: 'vue'
+  }
+}

--- a/src/stores/workspace/sidebarTabStore.ts
+++ b/src/stores/workspace/sidebarTabStore.ts
@@ -1,3 +1,7 @@
+import { useModelLibrarySidebarTab } from '@/hooks/sidebarTabs/modelLibrarySidebarTab'
+import { useNodeLibrarySidebarTab } from '@/hooks/sidebarTabs/nodeLibrarySidebarTab'
+import { useQueueSidebarTab } from '@/hooks/sidebarTabs/queueSidebarTab'
+import { useWorkflowsSidebarTab } from '@/hooks/sidebarTabs/workflowsSidebarTab'
 import { SidebarTabExtension } from '@/types/extensionTypes'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
@@ -34,12 +38,23 @@ export const useSidebarTabStore = defineStore('sidebarTab', () => {
     }
   }
 
+  /**
+   * Register the core sidebar tabs.
+   */
+  const registerCoreSidebarTabs = () => {
+    registerSidebarTab(useQueueSidebarTab())
+    registerSidebarTab(useNodeLibrarySidebarTab())
+    registerSidebarTab(useModelLibrarySidebarTab())
+    registerSidebarTab(useWorkflowsSidebarTab())
+  }
+
   return {
     sidebarTabs,
     activeSidebarTabId,
     activeSidebarTab,
     toggleSidebarTab,
     registerSidebarTab,
-    unregisterSidebarTab
+    unregisterSidebarTab,
+    registerCoreSidebarTabs
   }
 })

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -33,10 +33,7 @@ import BrowserTabTitle from '@/components/BrowserTabTitle.vue'
 import TopMenubar from '@/components/topbar/TopMenubar.vue'
 import { setupAutoQueueHandler } from '@/services/autoQueueService'
 import { useKeybindingStore } from '@/stores/keybindingStore'
-import { useNodeLibrarySidebarTab } from '@/hooks/sidebarTabs/nodeLibrarySidebarTab'
-import { useQueueSidebarTab } from '@/hooks/sidebarTabs/queueSidebarTab'
-import { useModelLibrarySidebarTab } from '@/hooks/sidebarTabs/modelLibrarySidebarTab'
-import { useWorkflowsSidebarTab } from '@/hooks/sidebarTabs/workflowsSidebarTab'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 setupAutoQueueHandler()
 
@@ -97,17 +94,8 @@ watchEffect(() => {
 const init = () => {
   settingStore.addSettings(app.ui.settings)
   useKeybindingStore().loadCoreKeybindings()
-
-  const queueSidebarTab = useQueueSidebarTab()
-  const nodeLibrarySidebarTab = useNodeLibrarySidebarTab()
-  const modelLibrarySidebarTab = useModelLibrarySidebarTab()
-  const workflowsSidebarTab = useWorkflowsSidebarTab()
-
+  useSidebarTabStore().registerCoreSidebarTabs()
   app.extensionManager = useWorkspaceStore()
-  app.extensionManager.registerSidebarTab(queueSidebarTab)
-  app.extensionManager.registerSidebarTab(nodeLibrarySidebarTab)
-  app.extensionManager.registerSidebarTab(modelLibrarySidebarTab)
-  app.extensionManager.registerSidebarTab(workflowsSidebarTab)
 }
 
 const queuePendingTaskCountStore = useQueuePendingTaskCountStore()

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -11,14 +11,7 @@
 <script setup lang="ts">
 import GraphCanvas from '@/components/graph/GraphCanvas.vue'
 
-import {
-  computed,
-  markRaw,
-  onMounted,
-  onBeforeUnmount,
-  watch,
-  watchEffect
-} from 'vue'
+import { computed, onMounted, onBeforeUnmount, watch, watchEffect } from 'vue'
 import { app } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'
 import { useI18n } from 'vue-i18n'
@@ -34,16 +27,16 @@ import {
   useWorkflowStore,
   useWorkflowBookmarkStore
 } from '@/stores/workflowStore'
-import QueueSidebarTab from '@/components/sidebar/tabs/QueueSidebarTab.vue'
-import NodeLibrarySidebarTab from '@/components/sidebar/tabs/NodeLibrarySidebarTab.vue'
-import ModelLibrarySidebarTab from '@/components/sidebar/tabs/ModelLibrarySidebarTab.vue'
 import GlobalToast from '@/components/toast/GlobalToast.vue'
 import UnloadWindowConfirmDialog from '@/components/dialog/UnloadWindowConfirmDialog.vue'
 import BrowserTabTitle from '@/components/BrowserTabTitle.vue'
-import WorkflowsSidebarTab from '@/components/sidebar/tabs/WorkflowsSidebarTab.vue'
 import TopMenubar from '@/components/topbar/TopMenubar.vue'
 import { setupAutoQueueHandler } from '@/services/autoQueueService'
 import { useKeybindingStore } from '@/stores/keybindingStore'
+import { useNodeLibrarySidebarTab } from '@/hooks/sidebarTabs/nodeLibrarySidebarTab'
+import { useQueueSidebarTab } from '@/hooks/sidebarTabs/queueSidebarTab'
+import { useModelLibrarySidebarTab } from '@/hooks/sidebarTabs/modelLibrarySidebarTab'
+import { useWorkflowsSidebarTab } from '@/hooks/sidebarTabs/workflowsSidebarTab'
 
 setupAutoQueueHandler()
 
@@ -105,52 +98,16 @@ const init = () => {
   settingStore.addSettings(app.ui.settings)
   useKeybindingStore().loadCoreKeybindings()
 
+  const queueSidebarTab = useQueueSidebarTab()
+  const nodeLibrarySidebarTab = useNodeLibrarySidebarTab()
+  const modelLibrarySidebarTab = useModelLibrarySidebarTab()
+  const workflowsSidebarTab = useWorkflowsSidebarTab()
+
   app.extensionManager = useWorkspaceStore()
-  app.extensionManager.registerSidebarTab({
-    id: 'queue',
-    icon: 'pi pi-history',
-    iconBadge: () => {
-      const value = useQueuePendingTaskCountStore().count.toString()
-      return value === '0' ? null : value
-    },
-    title: t('sideToolbar.queue'),
-    tooltip: t('sideToolbar.queue'),
-    component: markRaw(QueueSidebarTab),
-    type: 'vue'
-  })
-  app.extensionManager.registerSidebarTab({
-    id: 'node-library',
-    icon: 'pi pi-book',
-    title: t('sideToolbar.nodeLibrary'),
-    tooltip: t('sideToolbar.nodeLibrary'),
-    component: markRaw(NodeLibrarySidebarTab),
-    type: 'vue'
-  })
-  app.extensionManager.registerSidebarTab({
-    id: 'model-library',
-    icon: 'pi pi-box',
-    title: t('sideToolbar.modelLibrary'),
-    tooltip: t('sideToolbar.modelLibrary'),
-    component: markRaw(ModelLibrarySidebarTab),
-    type: 'vue'
-  })
-  app.extensionManager.registerSidebarTab({
-    id: 'workflows',
-    icon: 'pi pi-folder-open',
-    iconBadge: () => {
-      if (
-        settingStore.get('Comfy.Workflow.WorkflowTabsPosition') !== 'Sidebar'
-      ) {
-        return null
-      }
-      const value = useWorkflowStore().openWorkflows.length.toString()
-      return value === '0' ? null : value
-    },
-    title: t('sideToolbar.workflows'),
-    tooltip: t('sideToolbar.workflows'),
-    component: markRaw(WorkflowsSidebarTab),
-    type: 'vue'
-  })
+  app.extensionManager.registerSidebarTab(queueSidebarTab)
+  app.extensionManager.registerSidebarTab(nodeLibrarySidebarTab)
+  app.extensionManager.registerSidebarTab(modelLibrarySidebarTab)
+  app.extensionManager.registerSidebarTab(workflowsSidebarTab)
 }
 
 const queuePendingTaskCountStore = useQueuePendingTaskCountStore()


### PR DESCRIPTION
Jamming the core sidebar tab registration at top level of init is not very maintainable. This PR refactors creation of each sidebar tab into its separate hook.

https://github.com/Comfy-Org/ComfyUI_frontend/pull/1103 will be affected by this refactor.