### PR TITLE
Improve accessibility of dialogs

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -12,13 +12,15 @@
     @maximize="onMaximize"
     @unmaximize="onUnmaximize"
     :pt="{ header: 'pb-0' }"
+    :aria-labelledby="headerId"
   >
     <template #header>
       <component
         v-if="dialogStore.headerComponent"
         :is="dialogStore.headerComponent"
+        :id="headerId"
       />
-      <h3 v-else>{{ dialogStore.title || ' ' }}</h3>
+      <h3 v-else :id="headerId">{{ dialogStore.title || ' ' }}</h3>
     </template>
 
     <component :is="dialogStore.component" v-bind="contentProps" />
@@ -48,4 +50,6 @@ const contentProps = computed(() => ({
   ...dialogStore.props,
   maximized: maximized.value
 }))
+
+const headerId = `dialog-${Math.random().toString(36).substr(2, 9)}`
 </script>


### PR DESCRIPTION
Dialogs should include `aria-label` or `aria-labelledby` ([APG](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)). PrimeVue automatically sets `aria-labelledby` to an unused header component, resulting in dialogs without proper labels even when the screen-reader could otherwise easily infer it. So it must be set manually.

Before / After

![Selection_484](https://github.com/user-attachments/assets/576d26dd-a388-4321-867f-ab56b7c542ff)

![Selection_482](https://github.com/user-attachments/assets/5b76bd41-4d9b-485d-90a7-54a96b07d851)

