### PR TITLE
Restore backend state when Playwright test finishes

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -12,6 +12,10 @@ DEV_SERVER_COMFYUI_URL=http://127.0.0.1:8188
 # to ComfyUI launch script to serve the custom web version.
 DEPLOY_COMFYUI_DIR=/home/ComfyUI/web
 
+# The directory containing the ComfyUI installation used to run Playwright tests.
+# If you aren't using a separate install for testing, point this to your regular install.
+TEST_COMFYUI_DIR=/home/ComfyUI
+
 # The directory containing the ComfyUI_examples repo used to extract test workflows.
 EXAMPLE_REPO_PATH=tests-ui/ComfyUI_examples
 

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -5,7 +5,7 @@ This document outlines the setup and usage of Playwright for testing the ComfyUI
 ## WARNING
 
 The browser tests will change the ComfyUI backend state, such as user settings and saved workflows.
-If `DEPLOY_COMFYUI_DIR` in `.env` isn't set to your `(Comfy Path)/ComfyUI/web` directory, these changes won't be automatically restored.
+If `TEST_COMFYUI_DIR` in `.env` isn't set to your `(Comfy Path)/ComfyUI/web` directory, these changes won't be automatically restored.
 
 ## Setup
 

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -5,7 +5,7 @@ This document outlines the setup and usage of Playwright for testing the ComfyUI
 ## WARNING
 
 The browser tests will change the ComfyUI backend state, such as user settings and saved workflows.
-Please backup your ComfyUI data before running the tests locally.
+If `DEPLOY_COMFYUI_DIR` in `.env` isn't set to your `(Comfy Path)/ComfyUI/web` directory, these changes won't be automatically restored.
 
 ## Setup
 

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -5,7 +5,7 @@ This document outlines the setup and usage of Playwright for testing the ComfyUI
 ## WARNING
 
 The browser tests will change the ComfyUI backend state, such as user settings and saved workflows.
-If `TEST_COMFYUI_DIR` in `.env` isn't set to your `(Comfy Path)/ComfyUI/web` directory, these changes won't be automatically restored.
+If `TEST_COMFYUI_DIR` in `.env` isn't set to your `(Comfy Path)/ComfyUI` directory, these changes won't be automatically restored.
 
 ## Setup
 

--- a/browser_tests/globalSetup.ts
+++ b/browser_tests/globalSetup.ts
@@ -6,14 +6,14 @@ dotenv.config()
 
 export default function globalSetup(config: FullConfig) {
   if (!process.env.CI) {
-    if (process.env.DEPLOY_COMFYUI_DIR) {
-      backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
-      backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'models'], {
+    if (process.env.TEST_COMFYUI_DIR) {
+      backupPath([process.env.TEST_COMFYUI_DIR, '..', 'user'])
+      backupPath([process.env.TEST_COMFYUI_DIR, '..', 'models'], {
         renameAndReplaceWithScaffolding: true
       })
     } else {
       console.warn(
-        'Set DEPLOY_COMFYUI_DIR in .env to prevent user data (settings, workflows, etc.) from being overwritten'
+        'Set TEST_COMFYUI_DIR in .env to prevent user data (settings, workflows, etc.) from being overwritten'
       )
     }
   }

--- a/browser_tests/globalSetup.ts
+++ b/browser_tests/globalSetup.ts
@@ -7,8 +7,8 @@ dotenv.config()
 export default function globalSetup(config: FullConfig) {
   if (!process.env.CI) {
     if (process.env.TEST_COMFYUI_DIR) {
-      backupPath([process.env.TEST_COMFYUI_DIR, '..', 'user'])
-      backupPath([process.env.TEST_COMFYUI_DIR, '..', 'models'], {
+      backupPath([process.env.TEST_COMFYUI_DIR, 'user'])
+      backupPath([process.env.TEST_COMFYUI_DIR, 'models'], {
         renameAndReplaceWithScaffolding: true
       })
     } else {

--- a/browser_tests/globalSetup.ts
+++ b/browser_tests/globalSetup.ts
@@ -5,7 +5,13 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 export default function globalSetup(config: FullConfig) {
-  if (!process.env.CI && process.env.DEPLOY_COMFYUI_DIR) {
-    backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
+  if (!process.env.CI) {
+    if (process.env.DEPLOY_COMFYUI_DIR) {
+      backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
+    } else {
+      console.warn(
+        'Set DEPLOY_COMFYUI_DIR in .env to prevent user data (settings, workflows, etc.) from being overwritten'
+      )
+    }
   }
 }

--- a/browser_tests/globalSetup.ts
+++ b/browser_tests/globalSetup.ts
@@ -8,6 +8,9 @@ export default function globalSetup(config: FullConfig) {
   if (!process.env.CI) {
     if (process.env.DEPLOY_COMFYUI_DIR) {
       backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
+      backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'models'], {
+        renameAndReplaceWithScaffolding: true
+      })
     } else {
       console.warn(
         'Set DEPLOY_COMFYUI_DIR in .env to prevent user data (settings, workflows, etc.) from being overwritten'

--- a/browser_tests/globalSetup.ts
+++ b/browser_tests/globalSetup.ts
@@ -1,0 +1,11 @@
+import { FullConfig } from '@playwright/test'
+import { backupPath } from './utils/backupUtils'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+export default function globalSetup(config: FullConfig) {
+  if (!process.env.CI && process.env.DEPLOY_COMFYUI_DIR) {
+    backupPath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
+  }
+}

--- a/browser_tests/globalTeardown.ts
+++ b/browser_tests/globalTeardown.ts
@@ -1,0 +1,11 @@
+import { FullConfig } from '@playwright/test'
+import { restorePath } from './utils/backupUtils'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+export default function globalTeardown(config: FullConfig) {
+  if (!process.env.CI && process.env.DEPLOY_COMFYUI_DIR) {
+    restorePath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
+  }
+}

--- a/browser_tests/globalTeardown.ts
+++ b/browser_tests/globalTeardown.ts
@@ -5,8 +5,8 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 export default function globalTeardown(config: FullConfig) {
-  if (!process.env.CI && process.env.DEPLOY_COMFYUI_DIR) {
-    restorePath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
-    restorePath([process.env.DEPLOY_COMFYUI_DIR, '..', 'models'])
+  if (!process.env.CI && process.env.TEST_COMFYUI_DIR) {
+    restorePath([process.env.TEST_COMFYUI_DIR, '..', 'user'])
+    restorePath([process.env.TEST_COMFYUI_DIR, '..', 'models'])
   }
 }

--- a/browser_tests/globalTeardown.ts
+++ b/browser_tests/globalTeardown.ts
@@ -6,7 +6,7 @@ dotenv.config()
 
 export default function globalTeardown(config: FullConfig) {
   if (!process.env.CI && process.env.TEST_COMFYUI_DIR) {
-    restorePath([process.env.TEST_COMFYUI_DIR, '..', 'user'])
-    restorePath([process.env.TEST_COMFYUI_DIR, '..', 'models'])
+    restorePath([process.env.TEST_COMFYUI_DIR, 'user'])
+    restorePath([process.env.TEST_COMFYUI_DIR, 'models'])
   }
 }

--- a/browser_tests/globalTeardown.ts
+++ b/browser_tests/globalTeardown.ts
@@ -7,5 +7,6 @@ dotenv.config()
 export default function globalTeardown(config: FullConfig) {
   if (!process.env.CI && process.env.DEPLOY_COMFYUI_DIR) {
     restorePath([process.env.DEPLOY_COMFYUI_DIR, '..', 'user'])
+    restorePath([process.env.DEPLOY_COMFYUI_DIR, '..', 'models'])
   }
 }

--- a/browser_tests/utils/backupUtils.ts
+++ b/browser_tests/utils/backupUtils.ts
@@ -1,0 +1,42 @@
+import path from 'path'
+import fs from 'fs-extra'
+
+const getBackupPath = (originalPath: string): string => `${originalPath}.bak`
+
+const getPathIfExists = (pathParts: [string, ...string[]]): string | null => {
+  const resolvedPath = path.resolve(...pathParts)
+  if (!fs.pathExistsSync(resolvedPath)) {
+    console.warn(`Path not found: ${resolvedPath}`)
+    return null
+  }
+  return resolvedPath
+}
+
+export function backupPath(pathParts: [string, ...string[]]) {
+  const resolvedPath = getPathIfExists(pathParts)
+  if (!resolvedPath) return
+
+  const backupPath = getBackupPath(resolvedPath)
+  try {
+    fs.copySync(resolvedPath, backupPath)
+  } catch (error) {
+    console.error(`Failed to backup ${resolvedPath} to ${backupPath}`, error)
+  }
+}
+
+export function restorePath(pathParts: [string, ...string[]]) {
+  const resolvedPath = getPathIfExists(pathParts)
+  if (!resolvedPath) return
+
+  const backupPath = getBackupPath(resolvedPath)
+  if (!fs.pathExistsSync(backupPath)) {
+    console.warn(`Backup not found for: ${resolvedPath}, skipping restore.`)
+    return
+  }
+
+  try {
+    fs.moveSync(backupPath, resolvedPath, { overwrite: true })
+  } catch (error) {
+    console.error(`Failed to restore ${resolvedPath} from ${backupPath}`, error)
+  }
+}

--- a/browser_tests/utils/backupUtils.ts
+++ b/browser_tests/utils/backupUtils.ts
@@ -12,13 +12,41 @@ const getPathIfExists = (pathParts: [string, ...string[]]): string | null => {
   return resolvedPath
 }
 
-export function backupPath(pathParts: [string, ...string[]]) {
+const createScaffoldingCopy = (srcDir: string, destDir: string) => {
+  // Get all items (files and directories) in the source directory
+  const items = fs.readdirSync(srcDir, { withFileTypes: true })
+
+  for (const item of items) {
+    const srcPath = path.join(srcDir, item.name)
+    const destPath = path.join(destDir, item.name)
+
+    if (item.isDirectory()) {
+      // Create the corresponding directory in the destination
+      fs.ensureDirSync(destPath)
+
+      // Recursively copy the directory structure
+      createScaffoldingCopy(srcPath, destPath)
+    }
+  }
+}
+
+export function backupPath(
+  pathParts: [string, ...string[]],
+  { renameAndReplaceWithScaffolding = false } = {}
+) {
   const resolvedPath = getPathIfExists(pathParts)
   if (!resolvedPath) return
 
   const backupPath = getBackupPath(resolvedPath)
   try {
-    fs.copySync(resolvedPath, backupPath)
+    if (renameAndReplaceWithScaffolding) {
+      // Rename the original path and create scaffolding in its place
+      fs.moveSync(resolvedPath, backupPath)
+      createScaffoldingCopy(backupPath, resolvedPath)
+    } else {
+      // Create a copy of the original path
+      fs.copySync(resolvedPath, backupPath)
+    }
   } catch (error) {
     console.error(`Failed to backup ${resolvedPath} to ${backupPath}`, error)
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry'
   },
+  /* Path to global setup file. Exported function runs once before all the tests */
+  globalSetup: './browser_tests/globalSetup.ts',
+  /* Path to global teardown file. Exported function runs once after all the tests */
+  globalTeardown: './browser_tests/globalTeardown.ts',
 
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/1094

Backup and restore `user` and `models` folders in global setup/teardown of local Playwright tests. 

Backup `user` by making a copy. Backup `models` by renaming and replacing with scaffolding copy (folders only).

Get base ComfyUI path from `DEPLOY_COMFYUI_DIR` var.