### PR TITLE
Add always snap to grid setting

### DIFF
--- a/src/extensions/core/snapToGrid.ts
+++ b/src/extensions/core/snapToGrid.ts
@@ -1,3 +1,4 @@
+import type { SettingParams } from '@/types/settingTypes'
 import { app } from '../../scripts/app'
 import {
   LGraphCanvas,
@@ -37,12 +38,16 @@ app.registerExtension({
         LiteGraph.CANVAS_GRID_SIZE = +value || 10
       }
     })
+    // Keep the 'pysssss.SnapToGrid' setting id so we don't need to migrate setting values.
+    // Using a new setting id can cause existing users to lose their existing settings.
     const alwaysSnapToGrid = app.ui.settings.addSetting({
-      id: 'Comfy.Graph.AlwaysSnapToGrid',
+      id: 'pysssss.SnapToGrid',
+      category: ['Comfy', 'Graph', 'AlwaysSnapToGrid'],
       name: 'Always snap to grid',
       type: 'boolean',
-      defaultValue: false
-    })
+      defaultValue: false,
+      versionAdded: '1.3.13'
+    } as SettingParams)
 
     const shouldSnapToGrid = () => app.shiftDown || alwaysSnapToGrid.value
 

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -62,6 +62,11 @@ export const useExtensionStore = defineStore('extension', () => {
     // pysssss.Locking is replaced by pin/unpin in ComfyUI core.
     // https://github.com/Comfy-Org/litegraph.js/pull/117
     disabledExtensionNames.value.add('pysssss.Locking')
+    // pysssss.SnapToGrid is replaced by Comfy.Graph.AlwaysSnapToGrid in ComfyUI core.
+    // pysssss.SnapToGrid tries to write global app.shiftDown state, which is no longer
+    // allowed since v1.3.12.
+    // https://github.com/Comfy-Org/ComfyUI_frontend/issues/1176
+    disabledExtensionNames.value.add('pysssss.SnapToGrid')
   }
 
   // Some core extensions are registered before the store is initialized, e.g.


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1176

Moves always snap to grid setting to core. `pysssss.SnapToGrid` tries to write a global state `app.shiftDown` directly in a very dangerous way as other code can also depend on that state.

The setting id `pysssss.SnapToGrid` is reused here to avoid confusion on existing users who already have always snap to grid option on.

![image](https://github.com/user-attachments/assets/f9789dec-9ae5-4349-bffe-ce194b7bf749)
