### PR TITLE
Disable node def validation by default

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -273,9 +273,15 @@ class ComfyApi extends EventTarget {
    * Loads node object definitions for the graph
    * @returns The node definitions
    */
-  async getNodeDefs(): Promise<Record<string, ComfyNodeDef>> {
+  async getNodeDefs({ validate = false }: { validate?: boolean } = {}): Promise<
+    Record<string, ComfyNodeDef>
+  > {
     const resp = await this.fetchApi('/object_info', { cache: 'no-store' })
     const objectInfoUnsafe = await resp.json()
+    if (!validate) {
+      return objectInfoUnsafe
+    }
+    // Validate node definitions against zod schema. (slow)
     const objectInfo: Record<string, ComfyNodeDef> = {}
     for (const key in objectInfoUnsafe) {
       const validatedDef = validateComfyNodeDef(

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1968,7 +1968,9 @@ export class ComfyApp {
    */
   async registerNodes() {
     // Load node definitions from the backend
-    const defs = await api.getNodeDefs()
+    const defs = await api.getNodeDefs({
+      validate: useSettingStore().get('Comfy.Validation.NodeDefs')
+    })
     await this.registerNodesFromDefs(defs)
     await this.#invokeExtensionsAsync('registerCustomNodes')
     if (this.vueAppReady) {
@@ -2911,7 +2913,9 @@ export class ComfyApp {
       useModelStore().clearCache()
     }
 
-    const defs = await api.getNodeDefs()
+    const defs = await api.getNodeDefs({
+      validate: useSettingStore().get('Comfy.Validation.NodeDefs')
+    })
 
     for (const nodeId in defs) {
       this.registerNodeDef(nodeId, defs[nodeId])

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -435,5 +435,14 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: false,
     experimental: true,
     versionAdded: '1.3.11'
+  },
+  {
+    id: 'Comfy.Validation.NodeDefs',
+    name: 'Validate node definitions (slow)',
+    type: 'boolean',
+    tooltip:
+      'Recommended for node developers. This will validate all node definitions on startup.',
+    defaultValue: false,
+    versionAdded: '1.3.14'
   }
 ]


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/1188

I think eventually the validation should happen at backend once at startup of the server, not in the frontend where it is done on every new page load.