### PR TITLE
Avoid calling settingStore.set when there is no legacy node bookmark

### DIFF
--- a/src/stores/nodeBookmarkStore.ts
+++ b/src/stores/nodeBookmarkStore.ts
@@ -15,21 +15,24 @@ export const useNodeBookmarkStore = defineStore('nodeBookmark', () => {
   const nodeDefStore = useNodeDefStore()
 
   const migrateLegacyBookmarks = () => {
-    settingStore
-      .get('Comfy.NodeLibrary.Bookmarks')
-      .forEach((bookmark: string) => {
-        // If the bookmark is a folder, add it as a bookmark
-        if (bookmark.endsWith('/')) {
-          addBookmark(bookmark)
-          return
-        }
-        const category = bookmark.split('/').slice(0, -1).join('/')
-        const displayName = bookmark.split('/').pop()
-        const nodeDef = nodeDefStore.nodeDefsByDisplayName[displayName]
+    const legacyBookmarks = settingStore.get('Comfy.NodeLibrary.Bookmarks')
+    if (!legacyBookmarks) {
+      return
+    }
 
-        if (!nodeDef) return
-        addBookmark(`${category === '' ? '' : category + '/'}${nodeDef.name}`)
-      })
+    legacyBookmarks.forEach((bookmark: string) => {
+      // If the bookmark is a folder, add it as a bookmark
+      if (bookmark.endsWith('/')) {
+        addBookmark(bookmark)
+        return
+      }
+      const category = bookmark.split('/').slice(0, -1).join('/')
+      const displayName = bookmark.split('/').pop()
+      const nodeDef = nodeDefStore.nodeDefsByDisplayName[displayName]
+
+      if (!nodeDef) return
+      addBookmark(`${category === '' ? '' : category + '/'}${nodeDef.name}`)
+    })
     settingStore.set('Comfy.NodeLibrary.Bookmarks', [])
   }
 

--- a/src/stores/nodeBookmarkStore.ts
+++ b/src/stores/nodeBookmarkStore.ts
@@ -16,7 +16,7 @@ export const useNodeBookmarkStore = defineStore('nodeBookmark', () => {
 
   const migrateLegacyBookmarks = () => {
     const legacyBookmarks = settingStore.get('Comfy.NodeLibrary.Bookmarks')
-    if (!legacyBookmarks) {
+    if (!legacyBookmarks.length) {
       return
     }
 


### PR DESCRIPTION
Calling `settingStore.set('Comfy.NodeLibrary.Bookmarks', [])` sends out a request to update JSON file at backend. This PR avoids this request if there is no legacy bookmarks detected.