### PR TITLE
Remove zod transformation on validation

### DIFF
--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -229,20 +229,11 @@ export function validateTaskItem(taskItem: unknown) {
 }
 
 function inputSpec<TType extends ZodType, TSpec extends ZodType>(
-  spec: [TType, TSpec],
-  allowUpcast: boolean = true
+  spec: [TType, TSpec]
 ) {
   const [inputType, inputSpec] = spec
-  // e.g. "INT" => ["INT", {}]
-  const upcastTypes = allowUpcast
-    ? [inputType.transform((type) => [type, {}])]
-    : []
 
-  return z.union([
-    z.tuple([inputType, inputSpec]),
-    z.tuple([inputType]).transform(([type]) => [type, {}]),
-    ...upcastTypes
-  ])
+  return z.union([z.tuple([inputType, inputSpec]), z.tuple([inputType])])
 }
 
 const zBaseInputSpecValue = z
@@ -304,16 +295,13 @@ const zStringInputSpec = inputSpec([
 ])
 
 // Dropdown Selection.
-const zComboInputSpec = inputSpec(
-  [
-    z.array(z.any()),
-    zBaseInputSpecValue.extend({
-      control_after_generate: z.boolean().optional(),
-      image_upload: z.boolean().optional()
-    })
-  ],
-  /* allowUpcast=*/ false
-)
+const zComboInputSpec = inputSpec([
+  z.array(z.any()),
+  zBaseInputSpecValue.extend({
+    control_after_generate: z.boolean().optional(),
+    image_upload: z.boolean().optional()
+  })
+])
 
 const excludedLiterals = new Set(['INT', 'FLOAT', 'BOOLEAN', 'STRING', 'COMBO'])
 

--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -8,6 +8,8 @@ export const zNodeId = z.union([z.number().int(), z.string()])
 export type NodeId = z.infer<typeof zNodeId>
 export const zSlotIndex = z.union([
   z.number().int(),
+  // Convert string slot index to number.
+  // This conversion should not affect the overall validness of the data.
   z
     .string()
     .transform((val) => parseInt(val))
@@ -74,6 +76,8 @@ const zProperties = z
   .passthrough()
 
 const zVector2 = z.union([
+  // Convert object to array, and strip out extra fields.
+  // This conversion should not affect the overall validness of the data.
   z
     .object({ 0: z.number(), 1: z.number() })
     .passthrough()


### PR DESCRIPTION
Previously on https://github.com/Comfy-Org/ComfyUI_frontend/issues/1188, we disabled node def validation, while the validation process actually impact the datastructure from transformation action.

This PR removes transformation actions that might cause different behaviors with validation on/off.

The following syntax is no longer supported
```python
{"required": {"foo": "INT"}} # Bad; Undefined behavior

{"required": {"foo": ["INT"]} # Good
{"required": {"foo": ["INT", {"min": 0}]} # Good
```