### PR TITLE
Fix loading of old workflows with converted input

### DIFF
--- a/browser_tests/assets/old_workflow_converted_input.json
+++ b/browser_tests/assets/old_workflow_converted_input.json
@@ -1,0 +1,128 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "ControlNetApplyAdvanced",
+      "pos": {
+        "0": 449,
+        "1": 204
+      },
+      "size": [
+        340.20001220703125,
+        166
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "control_net",
+          "type": "CONTROL_NET",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "strength",
+          "type": "FLOAT",
+          "link": 1,
+          "widget": {
+            "name": "strength"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ControlNetApplyAdvanced"
+      },
+      "widgets_values": [
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "id": 2,
+      "type": "PrimitiveNode",
+      "pos": {
+        "0": 177,
+        "1": 265
+      },
+      "size": [
+        210,
+        82
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1
+          ],
+          "widget": {
+            "name": "strength"
+          }
+        }
+      ],
+      "properties": {
+        "Run widget replace on values": false
+      },
+      "widgets_values": [
+        1,
+        "fixed"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      2,
+      0,
+      1,
+      4,
+      "FLOAT"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": {
+        "0": 47.541666666666515,
+        "1": 186.9375
+      }
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/nodeDisplay.spec.ts
+++ b/browser_tests/nodeDisplay.spec.ts
@@ -32,4 +32,16 @@ test.describe('Optional input', () => {
     // If the node's multiline text widget is visible, then it was loaded successfully
     expect(comfyPage.page.locator('.comfy-multiline-input')).toHaveCount(1)
   })
+  test('Old workflow with converted input', async ({ comfyPage }) => {
+    await comfyPage.loadWorkflow('old_workflow_converted_input')
+    const node = await comfyPage.getNodeRefById('1')
+    const inputs = await node.getProperty('inputs')
+    const vaeInput = inputs.find((w) => w.name === 'vae')
+    const convertedInput = inputs.find((w) => w.name === 'strength')
+
+    expect(vaeInput).toBeDefined()
+    expect(convertedInput).toBeDefined()
+    expect(vaeInput.link).toBeNull()
+    expect(convertedInput.link).not.toBeNull()
+  })
 })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -38,7 +38,7 @@ import {
   SYSTEM_NODE_DEFS,
   useNodeDefStore
 } from '@/stores/nodeDefStore'
-import { Vector2 } from '@comfyorg/litegraph'
+import { INodeInputSlot, Vector2 } from '@comfyorg/litegraph'
 import _ from 'lodash'
 import {
   showExecutionErrorDialog,
@@ -2093,6 +2093,11 @@ export class ComfyApp {
           incoming: Record<string, any>
         ) => {
           const result = { ...incoming }
+          if (current.widget === undefined && incoming.widget !== undefined) {
+            // Field must be input as only inputs can be converted
+            this.inputs.push(current as INodeInputSlot)
+            return incoming
+          }
           for (const key of ['name', 'type', 'shape']) {
             if (current[key] !== undefined) {
               result[key] = current[key]


### PR DESCRIPTION
I've traced down a failed test in VHS to a regression introduced in f74973(#912)

If a node adds a new input, an old saved workflow with converted input fails to load properly. Prior to f74973, The newly added input does not display on the node, but the workflow will still properly execute if the added input is optional. After f74973, the connection is incorrectly made to the new input and the converted input does not exist on the node.

I can account for this in the VHS code, but I figure it's worth fixing here as it's reproducable with only core nodes.
A workflow of a ControlNetApplyAdvanced with a converted input created prior to ComfyUI@7a415f4 (front end version does not matter when saving) will instead have a connection to vae and have the converted input missing.

This fix keeps the converted widget (to ensure other link references like primitive nodes don't break) and adds the new input to the end of the input list. Inputs are out of order, but are correctly handled at execution time.
