### PR TITLE
Manage undo/redo keybindings

### DIFF
--- a/browser_tests/changeTracker.spec.ts
+++ b/browser_tests/changeTracker.spec.ts
@@ -87,12 +87,12 @@ test.describe('Change Tracker', () => {
 
     await multipleChanges()
 
-    await comfyPage.ctrlZ()
+    await comfyPage.executeCommand('Comfy.Undo')
     await expect(node).not.toBeBypassed()
     await expect(node).not.toBePinned()
     await expect(node).not.toBeCollapsed()
 
-    await comfyPage.ctrlY()
+    await comfyPage.executeCommand('Comfy.Redo')
     await expect(node).toBeBypassed()
     await expect(node).toBePinned()
     await expect(node).toBeCollapsed()

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -499,7 +499,7 @@ test.describe('Menu', () => {
       const workflowMenuItem =
         await comfyPage.menu.topbar.getMenuItem('Workflow')
       await workflowMenuItem.click()
-      const exportTag = comfyPage.page.locator('.keybinding-tag', {
+      const exportTag = comfyPage.page.locator('.keybinding-tag:visible', {
         hasText: 'Ctrl + s'
       })
       expect(await exportTag.count()).toBe(1)

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -89,18 +89,6 @@ export class ChangeTracker {
     await this.updateState(this.redoQueue, this.undoQueue)
   }
 
-  async undoRedo(e) {
-    if (e.ctrlKey || e.metaKey) {
-      if (e.key === 'y' || e.key == 'Z') {
-        await this.redo()
-        return true
-      } else if (e.key === 'z') {
-        await this.undo()
-        return true
-      }
-    }
-  }
-
   beforeChange() {
     this.changeCount++
   }
@@ -157,9 +145,6 @@ export class ChangeTracker {
             e.key === 'Alt' ||
             e.key === 'Meta'
           if (keyIgnored) return
-
-          // Check if this is a ctrl+z ctrl+y
-          if (await changeTracker().undoRedo(e)) return
 
           // If our active element is some type of input then handle changes after they're done
           if (ChangeTracker.bindInput(app, bindInputEl)) return

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -166,7 +166,8 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       key: 'z',
       ctrl: true
     },
-    commandId: 'Comfy.Undo'
+    commandId: 'Comfy.Undo',
+    targetSelector: '#graph-canvas'
   },
   {
     combo: {
@@ -174,6 +175,15 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true,
       shift: true
     },
-    commandId: 'Comfy.Redo'
+    commandId: 'Comfy.Redo',
+    targetSelector: '#graph-canvas'
+  },
+  {
+    combo: {
+      key: 'y',
+      ctrl: true
+    },
+    commandId: 'Comfy.Redo',
+    targetSelector: '#graph-canvas'
   }
 ]

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -160,5 +160,20 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Mute',
     targetSelector: '#graph-canvas'
+  },
+  {
+    combo: {
+      key: 'z',
+      ctrl: true
+    },
+    commandId: 'Comfy.Undo'
+  },
+  {
+    combo: {
+      key: 'Z',
+      ctrl: true,
+      shift: true
+    },
+    commandId: 'Comfy.Redo'
   }
 ]


### PR DESCRIPTION
Move undo/redo commands to new keybinding management system.

![image](https://github.com/user-attachments/assets/a2185504-cc97-4414-a79e-ae9c03a4dfe2)

There is no outstanding usage of `ChangeTracker.undoRedo` according to codesearch.
