### PR TITLE
Add bottom panel support

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -1,7 +1,7 @@
 <template>
   <Splitter
     class="splitter-overlay-root splitter-overlay"
-    :pt:gutter="gutterClass"
+    :pt:gutter="sidebarPanelVisible ? '' : 'hidden'"
   >
     <SplitterPanel
       class="side-bar-panel"
@@ -14,14 +14,16 @@
     </SplitterPanel>
 
     <SplitterPanel :size="100">
-      <Splitter class="splitter-overlay" layout="vertical">
+      <Splitter
+        class="splitter-overlay"
+        layout="vertical"
+        :pt:gutter="bottomPanelVisible ? '' : 'hidden'"
+      >
         <SplitterPanel class="graph-canvas-panel relative">
           <slot name="graph-canvas-panel"></slot>
         </SplitterPanel>
-        <SplitterPanel class="bottom-panel">
-          <div class="bottom-panel-content">
-            <slot name="bottom-panel"></slot>
-          </div>
+        <SplitterPanel class="bottom-panel" v-show="bottomPanelVisible">
+          <slot name="bottom-panel"></slot>
         </SplitterPanel>
       </Splitter>
     </SplitterPanel>
@@ -40,7 +42,8 @@
 
 <script setup lang="ts">
 import { useSettingStore } from '@/stores/settingStore'
-import { useWorkspaceStore } from '@/stores/workspaceStateStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import Splitter from 'primevue/splitter'
 import SplitterPanel from 'primevue/splitterpanel'
 import { computed } from 'vue'
@@ -51,20 +54,16 @@ const sidebarLocation = computed<'left' | 'right'>(() =>
 )
 
 const sidebarPanelVisible = computed(
-  () => useWorkspaceStore().sidebarTab.activeSidebarTab !== null
+  () => useSidebarTabStore().activeSidebarTab !== null
 )
-const gutterClass = computed(() => {
-  return sidebarPanelVisible.value ? '' : 'gutter-hidden'
-})
+const bottomPanelVisible = computed(
+  () => useBottomPanelStore().bottomPanelVisible
+)
 </script>
 
 <style scoped>
 :deep(.p-splitter-gutter) {
   pointer-events: auto;
-}
-
-:deep(.gutter-hidden) {
-  display: none !important;
 }
 
 .side-bar-panel {

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -1,5 +1,8 @@
 <template>
-  <Splitter class="splitter-overlay" :pt:gutter="gutterClass">
+  <Splitter
+    class="splitter-overlay-root splitter-overlay"
+    :pt:gutter="gutterClass"
+  >
     <SplitterPanel
       class="side-bar-panel"
       :minSize="10"
@@ -9,9 +12,20 @@
     >
       <slot name="side-bar-panel"></slot>
     </SplitterPanel>
-    <SplitterPanel class="graph-canvas-panel relative" :size="100">
-      <slot name="graph-canvas-panel"></slot>
+
+    <SplitterPanel :size="100">
+      <Splitter class="splitter-overlay" layout="vertical">
+        <SplitterPanel class="graph-canvas-panel relative">
+          <slot name="graph-canvas-panel"></slot>
+        </SplitterPanel>
+        <SplitterPanel class="bottom-panel">
+          <div class="bottom-panel-content">
+            <slot name="bottom-panel"></slot>
+          </div>
+        </SplitterPanel>
+      </Splitter>
     </SplitterPanel>
+
     <SplitterPanel
       class="side-bar-panel"
       :minSize="10"
@@ -44,35 +58,36 @@ const gutterClass = computed(() => {
 })
 </script>
 
-<style>
-.p-splitter-gutter {
+<style scoped>
+:deep(.p-splitter-gutter) {
   pointer-events: auto;
 }
 
-.gutter-hidden {
+:deep(.gutter-hidden) {
   display: none !important;
 }
-</style>
 
-<style scoped>
 .side-bar-panel {
   background-color: var(--bg-color);
   pointer-events: auto;
 }
 
+.bottom-panel {
+  background-color: var(--bg-color);
+  pointer-events: auto;
+}
+
 .splitter-overlay {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  background-color: transparent;
-  pointer-events: none;
+  @apply bg-transparent pointer-events-none border-none;
+}
+
+.splitter-overlay-root {
+  @apply w-full h-full absolute top-0 left-0;
+
   /* Set it the same as the ComfyUI menu */
   /* Note: Lite-graph DOM widgets have the same z-index as the node id, so
   999 should be sufficient to make sure splitter overlays on node's DOM
   widgets */
   z-index: 999;
-  border: none;
 }
 </style>

--- a/src/components/bottomPanel/BottomPanel.vue
+++ b/src/components/bottomPanel/BottomPanel.vue
@@ -25,7 +25,10 @@
       </div>
     </TabList>
   </Tabs>
-  <ExtensionSlot :extension="bottomPanelStore.activeBottomPanelTab" />
+  <ExtensionSlot
+    v-if="bottomPanelStore.activeBottomPanelTab"
+    :extension="bottomPanelStore.activeBottomPanelTab"
+  />
 </template>
 
 <script setup lang="ts">

--- a/src/components/bottomPanel/BottomPanel.vue
+++ b/src/components/bottomPanel/BottomPanel.vue
@@ -1,0 +1,40 @@
+<template>
+  <Tabs v-model:value="bottomPanelStore.activeBottomPanelTabId">
+    <TabList pt:tabList="border-none">
+      <div class="w-full flex justify-between">
+        <div class="tabs-container">
+          <Tab
+            v-for="tab in bottomPanelStore.bottomPanelTabs"
+            :key="tab.id"
+            :value="tab.id"
+            class="p-3 border-none"
+          >
+            <span class="font-bold">
+              {{ tab.title.toUpperCase() }}
+            </span>
+          </Tab>
+        </div>
+        <Button
+          class="justify-self-end"
+          icon="pi pi-times"
+          severity="secondary"
+          size="small"
+          text
+          @click="bottomPanelStore.bottomPanelVisible = false"
+        />
+      </div>
+    </TabList>
+  </Tabs>
+  <ExtensionSlot :extension="bottomPanelStore.activeBottomPanelTab" />
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import Tabs from 'primevue/tabs'
+import TabList from 'primevue/tablist'
+import Tab from 'primevue/tab'
+import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+
+const bottomPanelStore = useBottomPanelStore()
+</script>

--- a/src/components/common/ExtensionSlot.vue
+++ b/src/components/common/ExtensionSlot.vue
@@ -1,0 +1,34 @@
+<template>
+  <component v-if="extension.type === 'vue'" :is="extension.component" />
+  <div
+    v-else
+    :ref="
+      (el) => {
+        if (el)
+          mountCustomExtension(
+            props.extension as CustomExtension,
+            el as HTMLElement
+          )
+      }
+    "
+  ></div>
+</template>
+
+<script setup lang="ts">
+import { CustomExtension, VueExtension } from '@/types/extensionTypes'
+import { onBeforeUnmount } from 'vue'
+
+const props = defineProps<{
+  extension: VueExtension | CustomExtension
+}>()
+
+const mountCustomExtension = (extension: CustomExtension, el: HTMLElement) => {
+  extension.render(el)
+}
+
+onBeforeUnmount(() => {
+  if (props.extension.type === 'custom' && props.extension.destroy) {
+    props.extension.destroy()
+  }
+})
+</script>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -4,6 +4,9 @@
       <template #side-bar-panel>
         <SideToolbar />
       </template>
+      <template #bottom-panel>
+        <BottomPanel />
+      </template>
       <template #graph-canvas-panel>
         <GraphCanvasMenu v-if="canvasMenuEnabled" />
       </template>
@@ -19,6 +22,7 @@
 <script setup lang="ts">
 import TitleEditor from '@/components/graph/TitleEditor.vue'
 import SideToolbar from '@/components/sidebar/SideToolbar.vue'
+import BottomPanel from '@/components/bottomPanel/BottomPanel.vue'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import NodeSearchboxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
 import NodeTooltip from '@/components/graph/NodeTooltip.vue'

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -21,19 +21,7 @@
     v-if="selectedTab"
     class="sidebar-content-container h-full overflow-y-auto overflow-x-hidden"
   >
-    <component v-if="selectedTab.type === 'vue'" :is="selectedTab.component" />
-    <div
-      v-else
-      :ref="
-        (el) => {
-          if (el)
-            mountCustomTab(
-              selectedTab as CustomSidebarTabExtension,
-              el as HTMLElement
-            )
-        }
-      "
-    ></div>
+    <ExtensionSlot :extension="selectedTab" />
   </div>
 </template>
 
@@ -41,13 +29,11 @@
 import SidebarIcon from './SidebarIcon.vue'
 import SidebarThemeToggleIcon from './SidebarThemeToggleIcon.vue'
 import SidebarSettingsToggleIcon from './SidebarSettingsToggleIcon.vue'
-import { computed, onBeforeUnmount } from 'vue'
+import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
+import { computed } from 'vue'
 import { useWorkspaceStore } from '@/stores/workspaceStateStore'
 import { useSettingStore } from '@/stores/settingStore'
-import {
-  CustomSidebarTabExtension,
-  SidebarTabExtension
-} from '@/types/extensionTypes'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
 import { useKeybindingStore } from '@/stores/keybindingStore'
 
 const workspaceStore = useWorkspaceStore()
@@ -65,20 +51,9 @@ const isSmall = computed(
 
 const tabs = computed(() => workspaceStore.getSidebarTabs())
 const selectedTab = computed(() => workspaceStore.sidebarTab.activeSidebarTab)
-const mountCustomTab = (tab: CustomSidebarTabExtension, el: HTMLElement) => {
-  tab.render(el)
-}
 const onTabClick = (item: SidebarTabExtension) => {
   workspaceStore.sidebarTab.toggleSidebarTab(item.id)
 }
-onBeforeUnmount(() => {
-  tabs.value.forEach((tab) => {
-    if (tab.type === 'custom' && tab.destroy) {
-      tab.destroy()
-    }
-  })
-})
-
 const keybindingStore = useKeybindingStore()
 const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
   const keybinding = keybindingStore.getKeybindingByCommandId(

--- a/src/components/topbar/BottomPanelToggleButton.vue
+++ b/src/components/topbar/BottomPanelToggleButton.vue
@@ -1,5 +1,10 @@
 <template>
-  <Button severity="secondary" text @click="bottomPanelStore.toggleBottomPanel">
+  <Button
+    v-show="bottomPanelStore.bottomPanelTabs.length > 0"
+    severity="secondary"
+    text
+    @click="bottomPanelStore.toggleBottomPanel"
+  >
     <template #icon>
       <i-material-symbols:dock-to-bottom
         v-if="bottomPanelStore.bottomPanelVisible"

--- a/src/components/topbar/BottomPanelToggleButton.vue
+++ b/src/components/topbar/BottomPanelToggleButton.vue
@@ -4,6 +4,7 @@
     severity="secondary"
     text
     @click="bottomPanelStore.toggleBottomPanel"
+    v-tooltip="{ value: $t('menu.toggleBottomPanel'), showDelay: 300 }"
   >
     <template #icon>
       <i-material-symbols:dock-to-bottom

--- a/src/components/topbar/BottomPanelToggleButton.vue
+++ b/src/components/topbar/BottomPanelToggleButton.vue
@@ -1,0 +1,17 @@
+<template>
+  <Button severity="secondary" text @click="bottomPanelStore.toggleBottomPanel">
+    <template #icon>
+      <i-material-symbols:dock-to-bottom
+        v-if="bottomPanelStore.bottomPanelVisible"
+      />
+      <i-material-symbols:dock-to-bottom-outline v-else />
+    </template>
+  </Button>
+</template>
+
+<script setup lang="ts">
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import Button from 'primevue/button'
+
+const bottomPanelStore = useBottomPanelStore()
+</script>

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -14,6 +14,7 @@
       </div>
       <div class="comfyui-menu-right" ref="menuRight"></div>
       <Actionbar />
+      <BottomPanelToggleButton />
     </div>
   </teleport>
 </template>
@@ -23,6 +24,7 @@ import Divider from 'primevue/divider'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import CommandMenubar from '@/components/topbar/CommandMenubar.vue'
 import Actionbar from '@/components/actionbar/ComfyActionbar.vue'
+import BottomPanelToggleButton from '@/components/topbar/BottomPanelToggleButton.vue'
 import { computed, onMounted, provide, ref } from 'vue'
 import { useSettingStore } from '@/stores/settingStore'
 import { app } from '@/scripts/app'

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -91,7 +91,8 @@ const messages = {
       refresh: 'Refresh node definitions',
       clipspace: 'Open Clipspace',
       resetView: 'Reset canvas view',
-      clear: 'Clear workflow'
+      clear: 'Clear workflow',
+      toggleBottomPanel: 'Toggle Bottom Panel'
     },
     templateWorkflows: {
       title: 'Get Started with a Template',
@@ -200,7 +201,8 @@ const messages = {
       refresh: '刷新节点',
       clipspace: '打开剪贴板',
       resetView: '重置画布视图',
-      clear: '清空工作流'
+      clear: '清空工作流',
+      toggleBottomPanel: '底部面板'
     },
     templateWorkflows: {
       title: '从模板开始',

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -18,6 +18,7 @@ import { useTitleEditorStore } from './graphStore'
 import { useErrorHandling } from '@/hooks/errorHooks'
 import { useWorkflowStore } from './workflowStore'
 import { type KeybindingImpl, useKeybindingStore } from './keybindingStore'
+import { useBottomPanelStore } from './workspace/bottomPanelStore'
 import { LGraphNode } from '@comfyorg/litegraph'
 
 export interface ComfyCommand {
@@ -458,6 +459,15 @@ export const useCommandStore = defineStore('command', () => {
           }
         }
       })()
+    },
+    {
+      id: 'Workspace.ToggleBottomPanel',
+      icon: 'pi pi-list',
+      label: 'Toggle Bottom Panel',
+      versionAdded: '1.3.22',
+      function: () => {
+        useBottomPanelStore().toggleBottomPanel()
+      }
     }
   ]
 

--- a/src/stores/workspace/bottomPanelStore.ts
+++ b/src/stores/workspace/bottomPanelStore.ts
@@ -4,7 +4,7 @@ import { computed, ref } from 'vue'
 import { useCommandStore } from '@/stores/commandStore'
 
 export const useBottomPanelStore = defineStore('bottomPanel', () => {
-  const bottomPanelVisible = ref(true)
+  const bottomPanelVisible = ref(false)
   const toggleBottomPanel = () => {
     // If there are no tabs, don't show the bottom panel
     if (bottomPanelTabs.value.length === 0) {

--- a/src/stores/workspace/bottomPanelStore.ts
+++ b/src/stores/workspace/bottomPanelStore.ts
@@ -4,7 +4,7 @@ import { computed, ref } from 'vue'
 import { useCommandStore } from '@/stores/commandStore'
 
 export const useBottomPanelStore = defineStore('bottomPanel', () => {
-  const bottomPanelVisible = ref(false)
+  const bottomPanelVisible = ref(true)
   const toggleBottomPanel = () => {
     // If there are no tabs, don't show the bottom panel
     if (bottomPanelTabs.value.length === 0) {
@@ -22,6 +22,9 @@ export const useBottomPanelStore = defineStore('bottomPanel', () => {
       ) ?? null
     )
   })
+  const setActiveTab = (tabId: string) => {
+    activeBottomPanelTabId.value = tabId
+  }
   const toggleBottomPanelTab = (tabId: string) => {
     if (activeBottomPanelTabId.value === tabId) {
       bottomPanelVisible.value = false
@@ -48,6 +51,8 @@ export const useBottomPanelStore = defineStore('bottomPanel', () => {
     toggleBottomPanel,
     bottomPanelTabs,
     activeBottomPanelTab,
+    activeBottomPanelTabId,
+    setActiveTab,
     toggleBottomPanelTab,
     registerBottomPanelTab
   }

--- a/src/stores/workspace/bottomPanelStore.ts
+++ b/src/stores/workspace/bottomPanelStore.ts
@@ -1,0 +1,54 @@
+import type { BottomPanelExtension } from '@/types/extensionTypes'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { useCommandStore } from '@/stores/commandStore'
+
+export const useBottomPanelStore = defineStore('bottomPanel', () => {
+  const bottomPanelVisible = ref(false)
+  const toggleBottomPanel = () => {
+    // If there are no tabs, don't show the bottom panel
+    if (bottomPanelTabs.value.length === 0) {
+      return
+    }
+    bottomPanelVisible.value = !bottomPanelVisible.value
+  }
+
+  const bottomPanelTabs = ref<BottomPanelExtension[]>([])
+  const activeBottomPanelTabId = ref<string | null>(null)
+  const activeBottomPanelTab = computed<BottomPanelExtension | null>(() => {
+    return (
+      bottomPanelTabs.value.find(
+        (tab) => tab.id === activeBottomPanelTabId.value
+      ) ?? null
+    )
+  })
+  const toggleBottomPanelTab = (tabId: string) => {
+    if (activeBottomPanelTabId.value === tabId) {
+      bottomPanelVisible.value = false
+    } else {
+      activeBottomPanelTabId.value = tabId
+      bottomPanelVisible.value = true
+    }
+  }
+  const registerBottomPanelTab = (tab: BottomPanelExtension) => {
+    bottomPanelTabs.value = [...bottomPanelTabs.value, tab]
+    if (bottomPanelTabs.value.length === 1) {
+      activeBottomPanelTabId.value = tab.id
+    }
+    useCommandStore().registerCommand({
+      id: `Workspace.ToggleBottomPanelTab.${tab.id}`,
+      icon: 'pi pi-list',
+      label: tab.title,
+      function: () => toggleBottomPanelTab(tab.id)
+    })
+  }
+
+  return {
+    bottomPanelVisible,
+    toggleBottomPanel,
+    bottomPanelTabs,
+    activeBottomPanelTab,
+    toggleBottomPanelTab,
+    registerBottomPanelTab
+  }
+})

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -15,11 +15,13 @@ export interface BaseBottomPanelExtension {
 }
 
 export interface VueExtension {
+  id: string
   type: 'vue'
   component: Component
 }
 
 export interface CustomExtension {
+  id: string
   type: 'custom'
   render: (container: HTMLElement) => void
   destroy?: () => void

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -6,24 +6,38 @@ export interface BaseSidebarTabExtension {
   title: string
   icon?: string
   iconBadge?: string | (() => string | null)
-  order?: number
   tooltip?: string
 }
 
-export interface VueSidebarTabExtension extends BaseSidebarTabExtension {
+export interface BaseBottomPanelExtension {
+  id: string
+  title: string
+}
+
+export interface VueExtension {
   type: 'vue'
   component: Component
 }
 
-export interface CustomSidebarTabExtension extends BaseSidebarTabExtension {
+export interface CustomExtension {
   type: 'custom'
   render: (container: HTMLElement) => void
   destroy?: () => void
 }
 
+export type VueSidebarTabExtension = BaseSidebarTabExtension & VueExtension
+export type CustomSidebarTabExtension = BaseSidebarTabExtension &
+  CustomExtension
 export type SidebarTabExtension =
   | VueSidebarTabExtension
   | CustomSidebarTabExtension
+
+export type VueBottomPanelExtension = BaseBottomPanelExtension & VueExtension
+export type CustomBottomPanelExtension = BaseBottomPanelExtension &
+  CustomExtension
+export type BottomPanelExtension =
+  | VueBottomPanelExtension
+  | CustomBottomPanelExtension
 
 export type ToastManager = {
   add(message: ToastMessageOptions): void


### PR DESCRIPTION
This PR is the pre-work for the integrated terminal. The bottom panel can be toggled by clicking the icon on the top right corner of the top menu bar.

![image](https://github.com/user-attachments/assets/ba9789f0-8820-4942-a3f0-10ce7c292112)
