### PR TITLE
Handle potential undefined node data in NodeBookmarkTreeExplorer

### DIFF
--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
@@ -144,7 +144,7 @@ const renderedBookmarkedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(
             return 'pi pi-circle-fill'
           }
           const customization =
-            nodeBookmarkStore.bookmarksCustomization[node.data.nodePath]
+            nodeBookmarkStore.bookmarksCustomization[node.data?.nodePath]
           return customization?.icon
             ? 'pi ' + customization.icon
             : 'pi pi-bookmark-fill'


### PR DESCRIPTION
Related issue: https://github.com/Comfy-Org/ComfyUI_frontend/issues/1299

This is not a fix to the fundamental problem. In theory node.data should never be undefined.