### PR TITLE
Fix playwright test on settings API

### DIFF
--- a/browser_tests/extensionAPI.spec.ts
+++ b/browser_tests/extensionAPI.spec.ts
@@ -98,7 +98,6 @@ test.describe('Topbar commands', () => {
         ]
       })
     })
-    expect(await comfyPage.getSetting('TestSetting')).toBe('Hello, world!')
     await comfyPage.setSetting('TestSetting', 'Hello, universe!')
     expect(await comfyPage.getSetting('TestSetting')).toBe('Hello, universe!')
   })


### PR DESCRIPTION
The test itself is leaving side-effect on the server side. If running on multiple times, the check against the default value will fail.

The long term solution is probably always start from a standard setting JSON state. https://github.com/Comfy-Org/ComfyUI_frontend/issues/1302