### PR TITLE
Setup clean setting state before every playwright test

### DIFF
--- a/browser_tests/actionbar.spec.ts
+++ b/browser_tests/actionbar.spec.ts
@@ -11,10 +11,6 @@ test.describe('Actionbar', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   /**
    * This test ensures that the autoqueue change mode can only queue one change at a time
    */

--- a/browser_tests/browserTabTitle.spec.ts
+++ b/browser_tests/browserTabTitle.spec.ts
@@ -7,10 +7,6 @@ test.describe('Browser tab title', () => {
       await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
     })
 
-    test.afterEach(async ({ comfyPage }) => {
-      await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-    })
-
     test('Can display workflow name', async ({ comfyPage }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
         return window['app'].workflowManager.activeWorkflow.name

--- a/browser_tests/colorPalette.spec.ts
+++ b/browser_tests/colorPalette.spec.ts
@@ -135,12 +135,6 @@ test.describe('Color Palette', () => {
     await comfyPage.setSetting('Comfy.CustomColorPalettes', customColorPalettes)
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.CustomColorPalettes', {})
-    await comfyPage.setSetting('Comfy.ColorPalette', 'dark')
-    await comfyPage.setSetting('Comfy.Node.Opacity', 1.0)
-  })
-
   test('Can show custom color palette', async ({ comfyPage }) => {
     await comfyPage.setSetting('Comfy.ColorPalette', 'custom_obsidian_dark')
     await comfyPage.nextFrame()
@@ -156,11 +150,6 @@ test.describe('Color Palette', () => {
 test.describe('Node Color Adjustments', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.loadWorkflow('every_node_color')
-  })
-
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.Node.Opacity', 1.0)
-    await comfyPage.setSetting('Comfy.ColorPalette', 'dark')
   })
 
   test('should adjust opacity via node opacity setting', async ({

--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -97,11 +97,6 @@ test.describe('Missing models warning', () => {
 })
 
 test.describe('Settings', () => {
-  test.afterEach(async ({ comfyPage }) => {
-    // Restore default setting value
-    await comfyPage.setSetting('Comfy.Graph.ZoomSpeed', 1.1)
-  })
-
   test('@mobile Should be visible on mobile', async ({ comfyPage }) => {
     await comfyPage.page.keyboard.press('Control+,')
     const searchBox = comfyPage.page.locator('.settings-content')

--- a/browser_tests/extensionAPI.spec.ts
+++ b/browser_tests/extensionAPI.spec.ts
@@ -6,10 +6,6 @@ test.describe('Topbar commands', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   test('Should allow registering topbar commands', async ({ comfyPage }) => {
     await comfyPage.page.evaluate(() => {
       window['app'].registerExtension({

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -191,6 +191,7 @@ export class ComfyPage {
     await this.page.waitForFunction(
       () => window['app'] !== undefined && window['app'].vueAppReady
     )
+    await this.nextFrame()
   }
 
   public assetPath(fileName: string) {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -194,6 +194,7 @@ export class ComfyPage {
         // window['app'].extensionManager => GraphView ready
         window['app'] && window['app'].extensionManager
     )
+    await this.page.waitForSelector('.p-blockui-mask', { state: 'hidden' })
     await this.nextFrame()
   }
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -164,9 +164,7 @@ export class ComfyPage {
     )
 
     if (resp.status() !== 200) {
-      throw new Error(
-        `Failed to setup workflows directory: ${await resp.text()}`
-      )
+      throw new Error(`Failed to setup settings: ${await resp.text()}`)
     }
   }
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -189,7 +189,10 @@ export class ComfyPage {
     })
     await this.page.waitForFunction(() => document.fonts.ready)
     await this.page.waitForFunction(
-      () => window['app'] !== undefined && window['app'].vueAppReady
+      () =>
+        // window['app'] => GraphCanvas ready
+        // window['app'].extensionManager => GraphView ready
+        window['app'] && window['app'].extensionManager
     )
     await this.nextFrame()
   }

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -155,7 +155,7 @@ export class ComfyPage {
     }
   }
 
-  async setup({ resetView = true } = {}) {
+  async setup() {
     await this.goto()
     await this.page.evaluate(() => {
       localStorage.clear()
@@ -180,13 +180,9 @@ export class ComfyPage {
     )
     await this.page.evaluate(() => {
       window['app']['canvas'].show_info = false
+      window['app']['canvas'].setDirty(true, true)
     })
     await this.nextFrame()
-    if (resetView) {
-      // Reset view to force re-rendering of canvas. So that info fields like fps
-      // become hidden.
-      await this.resetView()
-    }
 
     // Hide all badges by default.
     await this.setSetting('Comfy.NodeBadge.NodeIdBadgeMode', NodeBadgeMode.None)

--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -3,10 +3,6 @@ import { ComfyPage, comfyPageFixture as test } from './fixtures/ComfyPage'
 import type { NodeReference } from './fixtures/utils/litegraphUtils'
 
 test.describe('Group Node', () => {
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   test.describe('Node library sidebar', () => {
     const groupNodeName = 'DefautWorkflowGroupNode'
     const groupNodeCategory = 'group nodes>workflow'
@@ -18,11 +14,6 @@ test.describe('Group Node', () => {
       libraryTab = comfyPage.menu.nodeLibraryTab
       await comfyPage.convertAllNodesToGroupNode(groupNodeName)
       await libraryTab.open()
-    })
-
-    test.afterEach(async ({ comfyPage }) => {
-      await comfyPage.setSetting('Comfy.NodeLibrary.Bookmarks.V2', [])
-      await libraryTab.close()
     })
 
     test('Is added to node library sidebar', async ({ comfyPage }) => {
@@ -191,13 +182,6 @@ test.describe('Group Node', () => {
       if (!groupNode)
         throw new Error(`Group node not found in workflow ${WORKFLOW_NAME}`)
       await groupNode.copy()
-    })
-
-    test.afterEach(async ({ comfyPage }) => {
-      await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-      await comfyPage.page.evaluate((groupNodeName) => {
-        window['LiteGraph'].unregisterNodeType(groupNodeName)
-      }, GROUP_NODE_TYPE)
     })
 
     test('Copies and pastes group node within the same workflow', async ({

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -493,10 +493,6 @@ test.describe('Load duplicate workflow', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   test('A workflow can be loaded multiple times in a row', async ({
     comfyPage
   }) => {

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -25,8 +25,7 @@ test.describe('Menu', () => {
     expect(await comfyPage.menu.getThemeId()).toBe('light')
 
     // Theme id should persist after reload.
-    await comfyPage.page.reload()
-    await comfyPage.setup()
+    await comfyPage.reload()
     expect(await comfyPage.menu.getThemeId()).toBe('light')
 
     await comfyPage.menu.toggleTheme()
@@ -368,8 +367,7 @@ test.describe('Menu', () => {
         'KSampler'
       ])
       await comfyPage.setSetting('Comfy.NodeLibrary.Bookmarks.V2', [])
-      await comfyPage.page.reload()
-      await comfyPage.setup()
+      await comfyPage.reload()
       expect(await comfyPage.getSetting('Comfy.NodeLibrary.Bookmarks')).toEqual(
         []
       )
@@ -412,7 +410,7 @@ test.describe('Menu', () => {
         'workflow2.json': 'default.json'
       })
       // Avoid reset view as the button is not visible in BetaMenu UI.
-      await comfyPage.setup({ resetView: false })
+      await comfyPage.setup()
 
       const tab = comfyPage.menu.workflowsTab
       await tab.open()

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -6,14 +6,6 @@ test.describe('Menu', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    const currentThemeId = await comfyPage.menu.getThemeId()
-    if (currentThemeId !== 'dark') {
-      await comfyPage.menu.toggleTheme()
-    }
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   // Skip reason: Flaky.
   test.skip('Toggle theme', async ({ comfyPage }) => {
     test.setTimeout(30000)

--- a/browser_tests/propertiesPanel.spec.ts
+++ b/browser_tests/propertiesPanel.spec.ts
@@ -6,10 +6,6 @@ test.describe('Properties Panel', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   // TODO: Update expectation after new menu dropdown is added.
   test.skip('Can change property value', async ({ comfyPage }) => {
     await comfyPage.rightClickEmptyLatentNode()

--- a/browser_tests/rightClickMenu.spec.ts
+++ b/browser_tests/rightClickMenu.spec.ts
@@ -96,11 +96,6 @@ test.describe('Node Right Click Menu', () => {
   test.describe('Widget conversion', () => {
     const convertibleWidgetTypes = ['text', 'string', 'number', 'toggle']
 
-    test.afterEach(async ({ comfyPage }) => {
-      // Restore default setting value
-      await comfyPage.setSetting('Comfy.NodeInputConversionSubmenus', true)
-    })
-
     test('Can convert widget to input', async ({ comfyPage }) => {
       await comfyPage.rightClickEmptyLatentNode()
       await expect(comfyPage.canvas).toHaveScreenshot('right-click-node.png')

--- a/browser_tests/templates.spec.ts
+++ b/browser_tests/templates.spec.ts
@@ -6,10 +6,6 @@ test.describe('Templates', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
   test('Can load template workflows', async ({ comfyPage }) => {
     // This test will need expanding on once the templates are decided
 


### PR DESCRIPTION
Resolves  https://github.com/Comfy-Org/ComfyUI_frontend/issues/1302

Setup clean setting state before every playwright test. Cleanup logic like following code should no longer be necessary.

```js
  test.afterEach(async ({ comfyPage }) => {
    await comfyPage.setSetting('Comfy.CustomColorPalettes', {})
    await comfyPage.setSetting('Comfy.ColorPalette', 'dark')
    await comfyPage.setSetting('Comfy.Node.Opacity', 1.0)
  })
```