### PR TITLE
Revert "Fix playwright test on settings API"

### DIFF
--- a/browser_tests/extensionAPI.spec.ts
+++ b/browser_tests/extensionAPI.spec.ts
@@ -94,6 +94,7 @@ test.describe('Topbar commands', () => {
         ]
       })
     })
+    expect(await comfyPage.getSetting('TestSetting')).toBe('Hello, world!')
     await comfyPage.setSetting('TestSetting', 'Hello, universe!')
     expect(await comfyPage.getSetting('TestSetting')).toBe('Hello, universe!')
   })


### PR DESCRIPTION
Reverts Comfy-Org/ComfyUI_frontend#1303

Reason: setting side-effect handled automatically in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1309