### PR TITLE
Disallow node library bookmark folder name with /

### DIFF
--- a/src/stores/nodeBookmarkStore.ts
+++ b/src/stores/nodeBookmarkStore.ts
@@ -115,6 +115,10 @@ export const useNodeBookmarkStore = defineStore('nodeBookmark', () => {
       throw new Error('Cannot rename non-folder node')
     }
 
+    if (newName.includes('/')) {
+      throw new Error('Folder name cannot contain "/"')
+    }
+
     const newNodePath =
       folderNode.category.split('/').slice(0, -1).concat(newName).join('/') +
       '/'


### PR DESCRIPTION
Related issue: https://github.com/Comfy-Org/ComfyUI_frontend/issues/1272

As a temporary measurement, this PR disallows renaming folder to name with '/' in it.

![image](https://github.com/user-attachments/assets/f2a3da0a-7881-4d6f-9680-773bc8c7aafb)

The more fundamental fix should be a more robust system to build folder tree.