### PR TITLE
Bugfix workflow saving with control_before_generate

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1910,8 +1910,7 @@ export class ComfyApp {
 
     // Save current workflow automatically
     setInterval(() => {
-      const sortNodes = useSettingStore().get('Comfy.Workflow.SortNodeIdOnSave')
-      const workflow = JSON.stringify(this.graph.serialize({ sortNodes }))
+      const workflow = JSON.stringify(this.serializeGraph())
       localStorage.setItem('workflow', workflow)
       if (api.clientId) {
         sessionStorage.setItem(`workflow:${api.clientId}`, workflow)
@@ -2445,7 +2444,18 @@ export class ComfyApp {
   }
 
   /**
-   * Converts the current graph workflow for sending to the API
+   * Serializes a graph using preferred user settings.
+   * @param graph The litegraph to serialize.
+   * @returns A serialized graph (aka workflow) with preferred user settings.
+   */
+  serializeGraph(graph: LGraph = this.graph) {
+    const sortNodes = useSettingStore().get('Comfy.Workflow.SortNodeIdOnSave')
+    return graph.serialize({ sortNodes })
+  }
+
+  /**
+   * Converts the current graph workflow for sending to the API.
+   * Note: Node widgets are updated before serialization to prepare queueing.
    * @returns The workflow and node links
    */
   async graphToPrompt(graph = this.graph, clean = true) {
@@ -2471,9 +2481,7 @@ export class ComfyApp {
       }
     }
 
-    const sortNodes = useSettingStore().get('Comfy.Workflow.SortNodeIdOnSave')
-
-    const workflow = graph.serialize({ sortNodes })
+    const workflow = this.serializeGraph(graph)
     const output = {}
     // Process nodes in order of execution
     for (const outerNode of graph.computeExecutionOrder(false)) {

--- a/src/scripts/workflows.ts
+++ b/src/scripts/workflows.ts
@@ -380,8 +380,8 @@ export class ComfyWorkflow {
 
     path = appendJsonExt(path)
 
-    const p = await this.manager.app.graphToPrompt()
-    const json = JSON.stringify(p.workflow, null, 2)
+    const workflow = this.manager.app.serializeGraph()
+    const json = JSON.stringify(workflow, null, 2)
     let resp = await api.storeUserData('workflows/' + path, json, {
       stringify: false,
       throwOnError: false,


### PR DESCRIPTION
Fixes #1203 

The bug was that `graphToPrompt()` was called to get the serialized workflow. But that also invokes `beforeQueued()` which should not happen when saving the workflow.
My solution is to separate the graph serialization logic from `graphToPrompt()` which seems to be intended to be called only before enqueueing the prompt.

To test:
- Set control mode to `before` in settings.
- Change something in the workflow that has a random seed widget, note the seed number.
- Save the workflow
- Check that the seed does not change.