### PR TITLE
Handle invalid node def errors

### DIFF
--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -73,6 +73,8 @@ test.describe('Node Interaction', () => {
       await comfyPage.disconnectEdge()
       await expect(comfyPage.canvas).toHaveScreenshot('disconnected-edge.png')
       await comfyPage.connectEdge()
+      // Move mouse to empty area to avoid slot highlight.
+      await comfyPage.moveMouseToEmptyArea()
       // Litegraph renders edge with a slight offset.
       await expect(comfyPage.canvas).toHaveScreenshot('default.png', {
         maxDiffPixels: 50

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -311,6 +311,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
         newNodeDefsByDisplayName[nodeDef.display_name] = nodeDefImpl
       } catch (e) {
         // Avoid breaking the app for invalid nodeDefs
+        // NodeDef validation is now optional for performance reasons
         console.error('Error adding nodeDef:', e)
       }
     }

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -305,9 +305,14 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     const newNodeDefsByName: Record<string, ComfyNodeDefImpl> = {}
     const newNodeDefsByDisplayName: Record<string, ComfyNodeDefImpl> = {}
     for (const nodeDef of nodeDefs) {
-      const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
-      newNodeDefsByName[nodeDef.name] = nodeDefImpl
-      newNodeDefsByDisplayName[nodeDef.display_name] = nodeDefImpl
+      try {
+        const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
+        newNodeDefsByName[nodeDef.name] = nodeDefImpl
+        newNodeDefsByDisplayName[nodeDef.display_name] = nodeDefImpl
+      } catch (e) {
+        // Avoid breaking the app for invalid nodeDefs
+        console.error('Error adding nodeDef:', e)
+      }
     }
     nodeDefsByName.value = newNodeDefsByName
     nodeDefsByDisplayName.value = newNodeDefsByDisplayName

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -302,8 +302,8 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   const nodeTree = computed(() => buildNodeDefTree(visibleNodeDefs.value))
 
   function updateNodeDefs(nodeDefs: ComfyNodeDef[]) {
-    const newNodeDefsByName: { [key: string]: ComfyNodeDefImpl } = {}
-    const newNodeDefsByDisplayName: { [key: string]: ComfyNodeDefImpl } = {}
+    const newNodeDefsByName: Record<string, ComfyNodeDefImpl> = {}
+    const newNodeDefsByDisplayName: Record<string, ComfyNodeDefImpl> = {}
     for (const nodeDef of nodeDefs) {
       const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
       newNodeDefsByName[nodeDef.name] = nodeDefImpl


### PR DESCRIPTION
Node def validation is disabled by default in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1190 for performance reasons.

This PR adds extra exception handling so that invalid node def does not break the whole app.