### PR TITLE
Fix husky pre-commit & type check only staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,5 @@
 if [[ "$OS" == "Windows_NT" ]]; then
   npx.cmd lint-staged
-  npm.cmd run typecheck
 else
   npx lint-staged
-  npm run typecheck
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,7 @@
-npx lint-staged
-npm run typecheck
+if [[ "$OS" == "Windows_NT" ]]; then
+  npx.cmd lint-staged
+  npm.cmd run typecheck
+else
+  npx lint-staged
+  npm run typecheck
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "tailwindcss": "^3.4.4",
         "ts-jest": "^29.1.4",
         "ts-node": "^10.9.2",
+        "tsc-files": "^1.1.4",
         "tsx": "^4.15.6",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.0.0",
@@ -12103,6 +12104,19 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsc-files": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/tsc-files/-/tsc-files-1.1.4.tgz",
+      "integrity": "sha512-RePsRsOLru3BPpnf237y1Xe1oCGta8rmSYzM76kYo5tLGsv5R2r3s64yapYorGTPuuLyfS9NVbh9ydzmvNie2w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsc-files": "cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=3"
       }
     },
     "node_modules/tsconfig": {

--- a/package.json
+++ b/package.json
@@ -84,10 +84,7 @@
     "zod-validation-error": "^3.3.0"
   },
   "lint-staged": {
-    "./**/*.{js,ts,tsx,vue}": [
-      "prettier --write",
-      "git add"
-    ],
+    "./**/*.{js,ts,tsx,vue}": "prettier --write",
     "**/*.ts": "tsc-files --noEmit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "tailwindcss": "^3.4.4",
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
+    "tsc-files": "^1.1.4",
     "tsx": "^4.15.6",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.0.0",
@@ -86,6 +87,7 @@
     "./**/*.{js,ts,tsx,vue}": [
       "prettier --write",
       "git add"
-    ]
+    ],
+    "**/*.ts": "tsc-files --noEmit"
   }
 }


### PR DESCRIPTION
Does what it says on the commits.
- Fix husky pre-commit on some Windows clients
- Limit commit type check to staged files
- Remove deprecated `git add` from `lint-staged`