### PR TITLE
Fix slot middle click for Reroute

### DIFF
--- a/src/extensions/core/slotDefaults.ts
+++ b/src/extensions/core/slotDefaults.ts
@@ -41,11 +41,11 @@ app.registerExtension({
         if (!customProperties?.forceInput) continue //ignore widgets that don't force input
       }
 
-      if (!(type in this.slot_types_default_out)) {
-        this.slot_types_default_out[type] = ['Reroute']
+      if (!(type in this.slot_types_default_in)) {
+        this.slot_types_default_in[type] = ['Reroute']
       }
-      if (this.slot_types_default_out[type].includes(nodeId)) continue
-      this.slot_types_default_out[type].push(nodeId)
+      if (this.slot_types_default_in[type].includes(nodeId)) continue
+      this.slot_types_default_in[type].push(nodeId)
 
       // Input types have to be stored as lower case
       // Store each node that can handle this input type
@@ -61,11 +61,11 @@ app.registerExtension({
     var outputs = nodeData['output'] ?? []
     for (const el of outputs) {
       const type = el as string
-      if (!(type in this.slot_types_default_in)) {
-        this.slot_types_default_in[type] = ['Reroute'] // ["Reroute", "Primitive"];  primitive doesn't always work :'()
+      if (!(type in this.slot_types_default_out)) {
+        this.slot_types_default_out[type] = ['Reroute'] // ["Reroute", "Primitive"];  primitive doesn't always work :'()
       }
 
-      this.slot_types_default_in[type].push(nodeId)
+      this.slot_types_default_out[type].push(nodeId)
 
       // Store each node that can handle this output type
       if (!(type in LiteGraph.registered_slot_out_types)) {

--- a/src/extensions/core/slotDefaults.ts
+++ b/src/extensions/core/slotDefaults.ts
@@ -36,14 +36,15 @@ app.registerExtension({
       if (typeof input[0] !== 'string') continue
 
       var type = input[0]
+      if (!(type in this.slot_types_default_in)) {
+        this.slot_types_default_in[type] = ['Reroute']
+      }
+
       if (type in ComfyWidgets) {
         var customProperties = input[1]
         if (!customProperties?.forceInput) continue //ignore widgets that don't force input
       }
 
-      if (!(type in this.slot_types_default_in)) {
-        this.slot_types_default_in[type] = ['Reroute']
-      }
       if (this.slot_types_default_in[type].includes(nodeId)) continue
       this.slot_types_default_in[type].push(nodeId)
 

--- a/src/extensions/core/slotDefaults.ts
+++ b/src/extensions/core/slotDefaults.ts
@@ -59,6 +59,13 @@ app.registerExtension({
       )
     }
 
+    for (const input of Object.values(nodeData.input?.optional ?? {})) {
+      const type = input[0]
+      if (!(type in this.slot_types_default_in)) {
+        this.slot_types_default_in[type] = ['Reroute']
+      }
+    }
+
     var outputs = nodeData['output'] ?? []
     for (const el of outputs) {
       const type = el as string


### PR DESCRIPTION
Makes middle click for reroute work on all slot types.

Currently doesn't work depending on what extensions you have installed - e.g. base install + ComfyUI Essentials, and you can't middle click on INT outputs for a reroute.

`LGraphCanvas.createDefaultNodeForSlot` is used for this and elsewhere, so behaviour sometimes feels brittle in the UI.

Changes:
- Input types now registered as inputs (prev. outputs)
- Vice versa outputs
- Registers types of inputs that aren't `forceInput`
- Registers types of `optional` inputs (prev. only `required`)