### PR TITLE
Update litegraph API - add @ts-expect-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.29",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-        "@comfyorg/litegraph": "^0.8.12",
+        "@comfyorg/litegraph": "^0.8.13",
         "@primevue/themes": "^4.0.5",
         "@vueuse/core": "^11.0.0",
         "axios": "^1.7.4",
@@ -1911,9 +1911,9 @@
       "dev": true
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.12.tgz",
-      "integrity": "sha512-5cAzn4QEoFFD74zBQH4LlKCyxGYYK15N9dQ7O/GtjD+xo3aGsjVR5D4SG0CZ8O4++ycI7l1YzcEBSkNh07JMzQ==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.13.tgz",
+      "integrity": "sha512-WT0wlouwGQhjcvd+kQfAXooKTPWMu3CUb2bw702Hs3ctFnVEm8+Z9kaK6z1KRg45GkjhajCdlEuQ9XFQ5A0nVA==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/litegraph": "^0.8.12",
+    "@comfyorg/litegraph": "^0.8.13",
     "@primevue/themes": "^4.0.5",
     "@vueuse/core": "^11.0.0",
     "axios": "^1.7.4",

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2299,6 +2299,7 @@ export class ComfyApp {
     }
 
     try {
+      // @ts-expect-error Discrepancies between zod and litegraph - in progress
       this.graph.configure(graphData)
       if (
         restore_view &&
@@ -2636,6 +2637,7 @@ export class ComfyApp {
           const p = await this.graphToPrompt()
 
           try {
+            // @ts-expect-error Discrepancies between zod and litegraph - in progress
             const res = await api.queuePrompt(number, p)
             this.lastNodeErrors = res.node_errors
             if (this.lastNodeErrors.length > 0) {


### PR DESCRIPTION
Litegraph update resolves some implicit `any`, exposing existing type errors.  Pull the rug over them until time permits.

Fixes build errors introduced upstream by https://github.com/Comfy-Org/litegraph.js/pull/215