### PR TITLE
Track previous workflow name on Vue side

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -53,6 +53,8 @@ import {
 } from '@/stores/modelToNodeStore'
 import GraphCanvasMenu from '@/components/graph/GraphCanvasMenu.vue'
 import { usePragmaticDroppable } from '@/hooks/dndHooks'
+import { useWorkflowStore } from '@/stores/workflowStore'
+import { setStorageValue } from '@/scripts/utils'
 
 const emit = defineEmits(['ready'])
 const canvasRef = ref<HTMLCanvasElement | null>(null)
@@ -139,6 +141,14 @@ watchEffect(() => {
   }
 
   canvasStore.canvas.canvas.style.cursor = 'default'
+})
+
+const workflowStore = useWorkflowStore()
+watchEffect(() => {
+  if (workflowStore.activeWorkflow) {
+    const workflow = workflowStore.activeWorkflow
+    setStorageValue('Comfy.PreviousWorkflow', workflow.path ?? workflow.name)
+  }
 })
 
 usePragmaticDroppable(() => canvasRef.value, {

--- a/src/scripts/workflows.ts
+++ b/src/scripts/workflows.ts
@@ -3,7 +3,6 @@ import type { ComfyApp } from './app'
 import { api } from './api'
 import { ChangeTracker } from './changeTracker'
 import { ComfyAsyncDialog } from './ui/components/asyncDialog'
-import { setStorageValue } from './utils'
 import { LGraphCanvas, LGraph } from '@comfyorg/litegraph'
 import { appendJsonExt, trimJsonExt } from '@/utils/formatUtil'
 import {
@@ -120,7 +119,6 @@ export class ComfyWorkflowManager extends EventTarget {
 
     this._activeWorkflow = workflow
 
-    setStorageValue('Comfy.PreviousWorkflow', this.activeWorkflow.path ?? '')
     this.dispatchEvent(new CustomEvent('changeWorkflow'))
   }
 
@@ -317,7 +315,6 @@ export class ComfyWorkflow {
       await this.favorite(true)
     }
     this.manager.dispatchEvent(new CustomEvent('rename', { detail: this }))
-    setStorageValue('Comfy.PreviousWorkflow', this.path ?? '')
   }
 
   async insert() {
@@ -417,7 +414,6 @@ export class ComfyWorkflow {
       await this.manager.loadWorkflows()
       this.unsaved = false
       this.manager.dispatchEvent(new CustomEvent('rename', { detail: this }))
-      setStorageValue('Comfy.PreviousWorkflow', this.path ?? '')
     } else if (path !== this.path) {
       // Saved as, open the new copy
       await this.manager.loadWorkflows()


### PR DESCRIPTION
Previously temporary workflow name is always empty string, which is not user friendly. This PR makes temporary workflow name is restored after reload.