### PR TITLE
Litegraph Reroute Beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.2.10",
-        "@comfyorg/litegraph": "^0.8.25",
+        "@comfyorg/litegraph": "^0.8.26",
         "@primevue/themes": "^4.0.5",
         "@vueuse/core": "^11.0.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -1922,9 +1922,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.25",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.25.tgz",
-      "integrity": "sha512-VYMpxNLAwLgmT1mFX77RNA3O5KavhWBmYJpb3+BLW6BwmnDCd0QHX9gy5IFsGSpQP28k2lWgANIcGZF2Ev2eqg==",
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.26.tgz",
+      "integrity": "sha512-q0Vcd5usphR5nghfyFksVx+VM+eSB1MyX8Ne304KFDnr214KQMA6DAjrEQJlGBUUCybLiOtPCvd3dxPecEQiSQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.2.10",
-    "@comfyorg/litegraph": "^0.8.25",
+    "@comfyorg/litegraph": "^0.8.26",
     "@primevue/themes": "^4.0.5",
     "@vueuse/core": "^11.0.0",
     "@xterm/addon-fit": "^0.10.0",

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -141,6 +141,15 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
+  const linkMarkerShape = settingStore.get('Comfy.Graph.LinkMarkers')
+  const { canvas } = canvasStore
+  if (canvas) {
+    canvas.linkMarkerShape = linkMarkerShape
+    canvas.setDirty(false, true)
+  }
+})
+
+watchEffect(() => {
   const reroutesEnabled = settingStore.get('Comfy.RerouteBeta')
   const { canvas } = canvasStore
   if (canvas) {

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -105,6 +105,12 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
+  LiteGraph.middle_click_slot_add_default_node = settingStore.get(
+    'Comfy.Node.MiddleClickRerouteNode'
+  )
+})
+
+watchEffect(() => {
   nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')
 })
 

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -135,6 +135,15 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
+  const reroutesEnabled = settingStore.get('Comfy.RerouteBeta')
+  const { canvas } = canvasStore
+  if (canvas) {
+    canvas.reroutesEnabled = reroutesEnabled
+    canvas.setDirty(false, true)
+  }
+})
+
+watchEffect(() => {
   if (!canvasStore.canvas) return
 
   if (canvasStore.canvas.state.draggingCanvas) {

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -58,7 +58,6 @@ const getNewNodeLocation = (): [number, number] => {
   }
 
   const originalEvent = triggerEvent.value.detail.originalEvent
-  // @ts-expect-error LiteGraph types are not typed
   return [originalEvent.canvasX, originalEvent.canvasY]
 }
 const nodeFilters = ref<FilterAndValue[]>([])
@@ -186,7 +185,6 @@ const canvasEventHandler = (e: LiteGraphCanvasEvent) => {
   } else if (e.detail.subType === 'group-double-click') {
     const group = e.detail.group
     const [x, y] = group.pos
-    // @ts-expect-error LiteGraphCanvasEvent is not typed
     const relativeY = e.detail.originalEvent.canvasY - y
     // Show search box if the click is NOT on the title bar
     if (relativeY > group.titleHeight) {

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -153,8 +153,16 @@ const showContextMenu = (e: LiteGraphCanvasEvent) => {
     showSearchBox: () => showSearchBox(e)
   }
   const connectionOptions = firstLink.output
-    ? { nodeFrom: firstLink.node, slotFrom: firstLink.output }
-    : { nodeTo: firstLink.node, slotTo: firstLink.input }
+    ? {
+        nodeFrom: firstLink.node,
+        slotFrom: firstLink.output,
+        afterRerouteId: firstLink.afterRerouteId
+      }
+    : {
+        nodeTo: firstLink.node,
+        slotTo: firstLink.input,
+        afterRerouteId: firstLink.afterRerouteId
+      }
   canvasStore.canvas.showConnectionMenu({
     ...connectionOptions,
     ...commonOptions

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -495,5 +495,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'boolean',
     defaultValue: true,
     versionAdded: '1.3.40'
+  },
+  {
+    id: 'Comfy.Node.MiddleClickRerouteNode',
+    name: 'Middle-click creates a new Reroute node',
+    type: 'boolean',
+    defaultValue: true,
+    versionAdded: '1.3.40'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -388,16 +388,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     }
   },
   {
-    id: 'Comfy.RerouteBeta',
-    name: 'Opt-in to the reroute beta test',
-    tooltip:
-      'Enables the new native reroutes.\n\nReroutes can be added by holding alt and dragging from a link line, or on the link menu.\n\nDisabling this option is non-destructive - reroutes are hidden.',
-    experimental: true,
-    type: 'boolean',
-    defaultValue: false,
-    versionAdded: '1.3.41'
-  },
-  {
     id: 'Comfy.Workflow.WorkflowTabsPosition',
     name: 'Opened workflows position',
     type: 'combo',
@@ -471,18 +461,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     ]
   },
   {
-    id: 'Comfy.Graph.LinkMarkers',
-    name: 'Link midpoint markers',
-    defaultValue: LinkMarkerShape.Circle,
-    type: 'combo',
-    options: [
-      { value: LinkMarkerShape.None, text: 'None' },
-      { value: LinkMarkerShape.Circle, text: 'Circle' },
-      { value: LinkMarkerShape.Arrow, text: 'Arrow' }
-    ],
-    versionAdded: '1.3.41'
-  },
-  {
     id: 'Comfy.Node.AutoSnapLinkToSlot',
     name: 'Auto snap link to node slot',
     tooltip:
@@ -514,6 +492,28 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Middle-click creates a new Reroute node',
     type: 'boolean',
     defaultValue: true,
-    versionAdded: '1.3.40'
+    versionAdded: '1.3.42'
+  },
+  {
+    id: 'Comfy.RerouteBeta',
+    name: 'Opt-in to the reroute beta test',
+    tooltip:
+      'Enables the new native reroutes.\n\nReroutes can be added by holding alt and dragging from a link line, or on the link menu.\n\nDisabling this option is non-destructive - reroutes are hidden.',
+    experimental: true,
+    type: 'boolean',
+    defaultValue: false,
+    versionAdded: '1.3.42'
+  },
+  {
+    id: 'Comfy.Graph.LinkMarkers',
+    name: 'Link midpoint markers',
+    defaultValue: LinkMarkerShape.Circle,
+    type: 'combo',
+    options: [
+      { value: LinkMarkerShape.None, text: 'None' },
+      { value: LinkMarkerShape.Circle, text: 'Circle' },
+      { value: LinkMarkerShape.Arrow, text: 'Arrow' }
+    ],
+    versionAdded: '1.3.42'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -387,6 +387,16 @@ export const CORE_SETTINGS: SettingParams[] = [
     }
   },
   {
+    id: 'Comfy.RerouteBeta',
+    name: 'Opt-in to the reroute beta test',
+    tooltip:
+      'Enables the new native reroutes.\n\nReroutes can be added by holding alt and dragging from a link line, or on the link menu.\n\nDisabling this option is non-destructive - reroutes are hidden.',
+    experimental: true,
+    type: 'boolean',
+    defaultValue: false,
+    versionAdded: '1.3.41'
+  },
+  {
     id: 'Comfy.Workflow.WorkflowTabsPosition',
     name: 'Opened workflows position',
     type: 'combo',

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -5,6 +5,7 @@ import {
   LinkReleaseTriggerMode
 } from '@/types/searchBoxTypes'
 import type { SettingParams } from '@/types/settingTypes'
+import { LinkMarkerShape } from '@comfyorg/litegraph'
 import { LiteGraph } from '@comfyorg/litegraph'
 
 export const CORE_SETTINGS: SettingParams[] = [
@@ -468,6 +469,18 @@ export const CORE_SETTINGS: SettingParams[] = [
       { value: LiteGraph.SPLINE_LINK, text: 'Spline' },
       { value: LiteGraph.HIDDEN_LINK, text: 'Hidden' }
     ]
+  },
+  {
+    id: 'Comfy.Graph.LinkMarkers',
+    name: 'Link midpoint markers',
+    defaultValue: LinkMarkerShape.Circle,
+    type: 'combo',
+    options: [
+      { value: LinkMarkerShape.None, text: 'None' },
+      { value: LinkMarkerShape.Circle, text: 'Circle' },
+      { value: LinkMarkerShape.Arrow, text: 'Arrow' }
+    ],
+    versionAdded: '1.3.41'
   },
   {
     id: 'Comfy.Node.AutoSnapLinkToSlot',

--- a/src/types/litegraphTypes.ts
+++ b/src/types/litegraphTypes.ts
@@ -1,35 +1,24 @@
-// @ts-strict-ignore
 import type {
   ConnectingLink,
   LGraphNode,
   Vector2,
   INodeInputSlot,
   INodeOutputSlot,
-  INodeSlot
+  INodeSlot,
+  ISlotType
 } from '@comfyorg/litegraph'
-import type { ISlotType } from '@comfyorg/litegraph'
 import { LiteGraph } from '@comfyorg/litegraph'
+import { RerouteId } from '@comfyorg/litegraph/dist/Reroute'
 
 export class ConnectingLinkImpl implements ConnectingLink {
-  node: LGraphNode
-  slot: number
-  input: INodeInputSlot | null
-  output: INodeOutputSlot | null
-  pos: Vector2
-
   constructor(
-    node: LGraphNode,
-    slot: number,
-    input: INodeInputSlot | null,
-    output: INodeOutputSlot | null,
-    pos: Vector2
-  ) {
-    this.node = node
-    this.slot = slot
-    this.input = input
-    this.output = output
-    this.pos = pos
-  }
+    public node: LGraphNode,
+    public slot: number,
+    public input: INodeInputSlot | undefined,
+    public output: INodeOutputSlot | undefined,
+    public pos: Vector2,
+    public afterRerouteId?: RerouteId
+  ) {}
 
   static createFromPlainObject(obj: ConnectingLink) {
     return new ConnectingLinkImpl(
@@ -37,12 +26,13 @@ export class ConnectingLinkImpl implements ConnectingLink {
       obj.slot,
       obj.input,
       obj.output,
-      obj.pos
+      obj.pos,
+      obj.afterRerouteId
     )
   }
 
   get type(): ISlotType | null {
-    const result = this.input ? this.input.type : this.output.type
+    const result = this.input ? this.input.type : this.output?.type ?? null
     return result === -1 ? null : result
   }
 
@@ -71,9 +61,9 @@ export class ConnectingLinkImpl implements ConnectingLink {
     }
 
     if (this.releaseSlotType === 'input') {
-      this.node.connect(this.slot, newNode, newNodeSlot)
+      this.node.connect(this.slot, newNode, newNodeSlot, this.afterRerouteId)
     } else {
-      newNode.connect(newNodeSlot, this.node, this.slot)
+      newNode.connect(newNodeSlot, this.node, this.slot, this.afterRerouteId)
     }
   }
 }


### PR DESCRIPTION
### Native Reroutes
- Allows users to start using the new Litegraph reroutes
- All reroute features are disabled by default
- Reroute features are not yet complete; more ways to create and manage reroutes are planned

#### Settings
<details open>
<summary>Litegraph native reroute opt-in</summary>

![image](https://github.com/user-attachments/assets/aedab6d3-4f1a-425c-b3ea-37cd0f9af5c8)

</details>

<details>
<summary>Middle click slot -> Original ComfyUI Reroute node</summary>

![image](https://github.com/user-attachments/assets/e4580188-5e92-4a5f-bfa8-08344cd0db92)

</details>

<details>
<summary>Link midpoint markers</summary>

![image](https://github.com/user-attachments/assets/6b328292-74f5-4910-b0a0-61edd2e8f28a)

</details>

#### Alt drag from a link to create a reroute

https://github.com/user-attachments/assets/78403e3e-a79f-474f-bb70-cb5097d59664

#### Shift drag from a reroute to create another link

https://github.com/user-attachments/assets/97520b7d-8756-4aa4-9e2e-e6c939eaa6a4

### Link midpoint markers
- No marker
![link-marker-none](https://github.com/user-attachments/assets/bd03e8ba-0005-4849-a1d3-7e11af76b6a1)
- Default circles
![link-marker-circle](https://github.com/user-attachments/assets/859d19b6-2479-4f21-95aa-fe28643f6017)
- New directional Arrow
![link-marker-arrow](https://github.com/user-attachments/assets/de038043-908f-4b86-b885-171139b99853)

#### Frontend code changes
- `afterRerouteId` to the frontend `ConnectingLinks` wrapper (which discards the original object)
- `afterRerouteId` to `showConnectionMenu` options wrapper

#### Requires
* https://github.com/Comfy-Org/litegraph.js/pull/301