### PR TITLE
Handle errors from top action menu commands

### DIFF
--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -494,6 +494,31 @@ test.describe('Menu', () => {
       })
       expect(await exportTag.count()).toBe(1)
     })
+
+    test('Can catch error when executing command', async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(() => {
+        window['app'].registerExtension({
+          name: 'TestExtension1',
+          commands: [
+            {
+              id: 'foo',
+              label: 'foo-command',
+              function: () => {
+                throw new Error('foo!')
+              }
+            }
+          ],
+          menuCommands: [
+            {
+              path: ['ext'],
+              commands: ['foo']
+            }
+          ]
+        })
+      })
+      await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
+      expect(await comfyPage.getVisibleToastCount()).toBe(1)
+    })
   })
 
   // Only test 'Top' to reduce test time.

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -49,7 +49,7 @@ export const useMenuItemStore = defineStore('menuItem', () => {
       .map(
         (command) =>
           ({
-            command: command.function,
+            command: () => commandStore.execute(command.id),
             label: command.menubarLabel,
             icon: command.icon,
             tooltip: command.tooltip,


### PR DESCRIPTION
Call `commandStore.execute(command.id)` to get auto error handling.