### PR TITLE
Fix save workflow binding on Ctrl + S

### DIFF
--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -31,8 +31,8 @@ app.registerExtension({
       const commandStore = useCommandStore()
       const keybinding = keybindingStore.getKeybinding(keyCombo)
       if (keybinding && keybinding.targetSelector !== '#graph-canvas') {
-        await commandStore.execute(keybinding.commandId)
         event.preventDefault()
+        await commandStore.execute(keybinding.commandId)
         return
       }
 

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -31,6 +31,7 @@ app.registerExtension({
       const commandStore = useCommandStore()
       const keybinding = keybindingStore.getKeybinding(keyCombo)
       if (keybinding && keybinding.targetSelector !== '#graph-canvas') {
+        // Prevent default browser behavior first, then execute the command
         event.preventDefault()
         await commandStore.execute(keybinding.commandId)
         return


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1441

Prevents default first. I think it might be due to async function exeucting too long that event reaches the browser level handler. 