### PR TITLE
[Electron] Add electron-specific setup page

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,31 +1,32 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
-import ServerStartView from '@/views/ServerStartView.vue'
-import { useWorkspaceStore, WorkspaceState } from '@/stores/workspaceStore'
+import { isElectron } from './utils/envUtil'
 
 const router = createRouter({
-  history: createWebHistory(window.location.pathname),
+  history: createWebHistory(),
   routes: [
-    {
-      path: '/server-start',
-      component: ServerStartView
-    },
     {
       path: '/',
       component: LayoutDefault,
       children: [
         {
           path: '',
+          name: 'GraphView',
           component: () => import('@/views/GraphView.vue')
+        },
+        {
+          path: 'server-start',
+          name: 'ServerStartView',
+          component: () => import('@/views/ServerStartView.vue'),
+          beforeEnter: async (to, from, next) => {
+            if (isElectron()) {
+              next()
+            } else {
+              next('/')
+            }
+          }
         }
-      ],
-      beforeEnter: async (to, from, next) => {
-        if (useWorkspaceStore().state !== WorkspaceState.Ready) {
-          next('/server-start')
-        } else {
-          next()
-        }
-      }
+      ]
     }
   ],
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,6 +19,7 @@ const router = createRouter({
           name: 'ServerStartView',
           component: () => import('@/views/ServerStartView.vue'),
           beforeEnter: async (to, from, next) => {
+            // Only allow access to this page in electron environment
             if (isElectron()) {
               next()
             } else {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,9 +1,15 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
+import ServerStartView from '@/views/ServerStartView.vue'
+import { useWorkspaceStore, WorkspaceState } from '@/stores/workspaceStore'
 
 const router = createRouter({
   history: createWebHistory(window.location.pathname),
   routes: [
+    {
+      path: '/server-start',
+      component: ServerStartView
+    },
     {
       path: '/',
       component: LayoutDefault,
@@ -12,7 +18,14 @@ const router = createRouter({
           path: '',
           component: () => import('@/views/GraphView.vue')
         }
-      ]
+      ],
+      beforeEnter: async (to, from, next) => {
+        if (useWorkspaceStore().state !== WorkspaceState.Ready) {
+          next('/server-start')
+        } else {
+          next()
+        }
+      }
     }
   ],
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,9 +1,15 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import {
+  createRouter,
+  createWebHashHistory,
+  createWebHistory
+} from 'vue-router'
 import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
 import { isElectron } from './utils/envUtil'
 
+const isFileProtocol = () => window.location.protocol === 'file:'
+
 const router = createRouter({
-  history: createWebHistory(),
+  history: isFileProtocol() ? createWebHashHistory() : createWebHistory(),
   routes: [
     {
       path: '/',

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -57,7 +57,6 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   }
 
   return {
-    state: workspaceState,
     spinner,
     shiftDown,
     focusMode,

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -8,7 +8,19 @@ import { useSidebarTabStore } from './workspace/sidebarTabStore'
 import { useSettingStore } from './settingStore'
 import { useWorkflowStore } from './workflowStore'
 
+export enum WorkspaceState {
+  /**
+   * ComfyUI server is starting. Loading custom nodes happens here.
+   */
+  ServerStart = 'server-start',
+  /**
+   * ComfyUI server is ready.
+   */
+  Ready = 'ready'
+}
+
 export const useWorkspaceStore = defineStore('workspace', () => {
+  const workspaceState = ref(WorkspaceState.ServerStart)
   const spinner = ref(false)
   const shiftDown = ref(false)
   /**
@@ -57,6 +69,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   }
 
   return {
+    state: workspaceState,
     spinner,
     shiftDown,
     focusMode,

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -8,19 +8,7 @@ import { useSidebarTabStore } from './workspace/sidebarTabStore'
 import { useSettingStore } from './settingStore'
 import { useWorkflowStore } from './workflowStore'
 
-export enum WorkspaceState {
-  /**
-   * ComfyUI server is starting. Loading custom nodes happens here.
-   */
-  ServerStart = 'server-start',
-  /**
-   * ComfyUI server is ready.
-   */
-  Ready = 'ready'
-}
-
 export const useWorkspaceStore = defineStore('workspace', () => {
-  const workspaceState = ref(WorkspaceState.ServerStart)
   const spinner = ref(false)
   const shiftDown = ref(false)
   /**

--- a/src/utils/envUtil.ts
+++ b/src/utils/envUtil.ts
@@ -1,0 +1,3 @@
+export function isElectron() {
+  return window['electronAPI'] !== undefined
+}

--- a/src/utils/envUtil.ts
+++ b/src/utils/envUtil.ts
@@ -1,3 +1,3 @@
 export function isElectron() {
-  return window['electronAPI'] !== undefined
+  return 'electronAPI' in window && window['electronAPI'] !== undefined
 }

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -1,0 +1,27 @@
+<template>
+  <div
+    class="absolute inset-0 flex flex-col items-center justify-center h-screen bg-surface-0"
+  >
+    <ProgressSpinner class="w-16 h-16 mb-4" />
+    <div class="text-xl">{{ $t('loading') }}{{ counter }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ProgressSpinner from 'primevue/progressspinner'
+import { useWorkspaceStore, WorkspaceState } from '@/stores/workspaceStore'
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useInterval } from '@vueuse/core'
+
+const workspaceStore = useWorkspaceStore()
+const router = useRouter()
+const counter = useInterval(1000)
+
+onMounted(() => {
+  setTimeout(() => {
+    workspaceStore.state = WorkspaceState.Ready
+    router.push('/')
+  }, 3000)
+})
+</script>

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -9,19 +9,7 @@
 
 <script setup lang="ts">
 import ProgressSpinner from 'primevue/progressspinner'
-import { useWorkspaceStore, WorkspaceState } from '@/stores/workspaceStore'
-import { onMounted } from 'vue'
-import { useRouter } from 'vue-router'
 import { useInterval } from '@vueuse/core'
 
-const workspaceStore = useWorkspaceStore()
-const router = useRouter()
 const counter = useInterval(1000)
-
-onMounted(() => {
-  setTimeout(() => {
-    workspaceStore.state = WorkspaceState.Ready
-    router.push('/')
-  }, 3000)
-})
 </script>

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -1,3 +1,5 @@
+<!-- This is a dummy page built for electron app only. -->
+<!-- Replace this page with the electron side logic on installation & log streaming. -->
 <template>
   <div
     class="absolute inset-0 flex flex-col items-center justify-center h-screen bg-surface-0"


### PR DESCRIPTION
This is initial stepping stone of moving all UI related logic from electron app repo to the frontend repo. Later the log streaming could also be used for the comfyui main repo. We can start a dummy server early streaming the backend logs before the server is ready.

The `/start-server` route is only accessible in the electron environment.