### PR TITLE
Consistently use -1 for temporary file size

### DIFF
--- a/src/stores/userFileStore.ts
+++ b/src/stores/userFileStore.ts
@@ -65,7 +65,7 @@ export class UserFile {
   }
 
   get isTemporary() {
-    return this.size === 0
+    return this.size === -1
   }
 
   get isPersisted() {

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -215,7 +215,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     const workflow = new ComfyWorkflow({
       path: fullPath,
       modified: Date.now(),
-      size: 0
+      size: -1
     })
 
     workflow.originalContent = workflow.content = workflowData

--- a/tests-ui/tests/fast/store/userFileStore.test.ts
+++ b/tests-ui/tests/fast/store/userFileStore.test.ts
@@ -191,7 +191,9 @@ describe('useUserFileStore', () => {
         expect(api.storeUserData).toHaveBeenCalledWith(
           'newfile.txt',
           'file content',
-          { throwOnError: true, full_info: true, overwrite: true }
+          // SaveAs should create a new temporary file, which will mean
+          // overwrite is false
+          { throwOnError: true, full_info: true, overwrite: false }
         )
         expect(newFile).toBeInstanceOf(UserFile)
         expect(newFile.path).toBe('newfile.txt')

--- a/tests-ui/tests/fast/store/workflowStore.test.ts
+++ b/tests-ui/tests/fast/store/workflowStore.test.ts
@@ -25,7 +25,7 @@ describe('useWorkflowStore', () => {
       filenames.map((filename) => ({
         path: filename,
         modified: new Date().toISOString(),
-        size: 1 // size !== 0 for remote workflows
+        size: 1 // size !== -1 for remote workflows
       }))
     )
     return await store.syncWorkflows()


### PR DESCRIPTION
According to documentation of size field, -1 is used for temporary file. This PR fixes the size usage in the codebase to match the documentation. A remote empty file can have size 0 so we cannot use 0.