### PR TITLE
Some custom_nodes does not provide the second option of 'STRING'

### DIFF
--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -434,6 +434,7 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
     }
   },
   STRING(node, inputName, inputData: InputSpec, app) {
+    inputData[1] = inputData[1] || {}
     const defaultVal = inputData[1].default || ''
     const multiline = !!inputData[1].multiline
 


### PR DESCRIPTION
Seems like it is legal for ComfyUI backend.