### PR TITLE
Fit view to bounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.37",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-        "@comfyorg/litegraph": "^0.8.23",
+        "@comfyorg/litegraph": "^0.8.24",
         "@primevue/themes": "^4.0.5",
         "@vueuse/core": "^11.0.0",
         "axios": "^1.7.4",
@@ -1919,9 +1919,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.23",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.23.tgz",
-      "integrity": "sha512-XSZxWfAlINOoh2NPVK8wTxkJbwlzb7fW7KyJy4PZQmZCYu5cI4d+UDU6MqvvcXNSFp5lckup65JHlfnvaX6AvQ==",
+      "version": "0.8.24",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.24.tgz",
+      "integrity": "sha512-jlr0oR0fwtP3r+2nQTo73xq8URyqWnhQrNfmrHsw893pVM1SXEOor8KdzGy9pZ0dxTRLS8afityBQLO0pBDKeg==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/litegraph": "^0.8.23",
+    "@comfyorg/litegraph": "^0.8.24",
     "@primevue/themes": "^4.0.5",
     "@vueuse/core": "^11.0.0",
     "axios": "^1.7.4",

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -16,11 +16,18 @@
       @mousedown="repeat('Comfy.Canvas.ZoomOut')"
       @mouseup="stopRepeat"
     />
+    <hr />
     <Button
       severity="secondary"
       icon="pi pi-expand"
       v-tooltip.left="t('graphCanvasMenu.resetView')"
       @click="() => commandStore.execute('Comfy.Canvas.ResetView')"
+    />
+    <Button
+      severity="secondary"
+      icon="pi pi-arrow-down-left-and-arrow-up-right-to-center"
+      v-tooltip.left="t('graphCanvasMenu.fitView')"
+      @click="() => commandStore.execute('Comfy.Canvas.FitView')"
     />
     <Button
       severity="secondary"
@@ -95,5 +102,10 @@ const stopRepeat = () => {
 .p-buttongroup-vertical .p-button {
   margin: 0;
   border-radius: 0;
+}
+
+.p-buttongroup-vertical hr {
+  margin: 0;
+  border-color: var(--p-panel-border-color);
 }
 </style>

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -16,16 +16,9 @@
       @mousedown="repeat('Comfy.Canvas.ZoomOut')"
       @mouseup="stopRepeat"
     />
-    <hr />
     <Button
       severity="secondary"
       icon="pi pi-expand"
-      v-tooltip.left="t('graphCanvasMenu.resetView')"
-      @click="() => commandStore.execute('Comfy.Canvas.ResetView')"
-    />
-    <Button
-      severity="secondary"
-      icon="pi pi-arrow-down-left-and-arrow-up-right-to-center"
       v-tooltip.left="t('graphCanvasMenu.fitView')"
       @click="() => commandStore.execute('Comfy.Canvas.FitView')"
     />
@@ -102,10 +95,5 @@ const stopRepeat = () => {
 .p-buttongroup-vertical .p-button {
   margin: 0;
   border-radius: 0;
-}
-
-.p-buttongroup-vertical hr {
-  margin: 0;
-  border-color: var(--p-panel-border-color);
 }
 </style>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -115,6 +115,7 @@ const messages = {
       zoomIn: 'Zoom In',
       zoomOut: 'Zoom Out',
       resetView: 'Reset View',
+      fitView: 'Fit View',
       selectMode: 'Select Mode',
       panMode: 'Pan Mode',
       toggleLinkVisibility: 'Toggle Link Visibility'
@@ -233,6 +234,7 @@ const messages = {
       zoomIn: '放大',
       zoomOut: '缩小',
       resetView: '重置视图',
+      fitView: 'Fit View',
       selectMode: '选择模式',
       panMode: '平移模式',
       toggleLinkVisibility: '切换链接可见性'
@@ -352,6 +354,7 @@ const messages = {
       zoomIn: 'Увеличить',
       zoomOut: 'Уменьшить',
       resetView: 'Сбросить вид',
+      fitView: 'Fit View',
       selectMode: 'Выбрать режим',
       panMode: 'Режим панорамирования',
       toggleLinkVisibility: 'Переключить видимость ссылок'

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -234,7 +234,7 @@ const messages = {
       zoomIn: '放大',
       zoomOut: '缩小',
       resetView: '重置视图',
-      fitView: 'Fit View',
+      fitView: '适应视图',
       selectMode: '选择模式',
       panMode: '平移模式',
       toggleLinkVisibility: '切换链接可见性'
@@ -354,7 +354,7 @@ const messages = {
       zoomIn: 'Увеличить',
       zoomOut: 'Уменьшить',
       resetView: 'Сбросить вид',
-      fitView: 'Fit View',
+      fitView: 'Подгонять под выделенные',
       selectMode: 'Выбрать режим',
       panMode: 'Режим панорамирования',
       toggleLinkVisibility: 'Переключить видимость ссылок'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2965,22 +2965,7 @@ export class ComfyApp {
   public goToNode(nodeId: NodeId) {
     const graphNode = this.graph.getNodeById(nodeId)
     if (!graphNode) return
-    this.canvas.animateToBounds(LGraphGroup.createBounds([graphNode]))
-  }
-
-  /**
-   * Fits the view to the selected nodes with animation.
-   * If nothing is selected, the view is fitted around all nodes in the graph.
-   */
-  fitView() {
-    let selection: LGraphNode[]
-    selection = Array.from(app.canvas.selectedItems.values())
-      .map((i) => this.graph.getNodeById(i.id))
-      .filter((i) => i !== null)
-    if (selection.length === 0) {
-      selection = this.graph.nodes
-    }
-    this.canvas.animateToBounds(LGraphGroup.createBounds(selection))
+    this.canvas.animateToBounds(graphNode.boundingRect)
   }
 }
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -27,6 +27,7 @@ import { ComfyAppMenu } from './ui/menu/index'
 import { getStorageValue } from './utils'
 import { ComfyWorkflow } from '@/stores/workflowStore'
 import {
+  LGraphGroup,
   LGraphCanvas,
   LGraph,
   LGraphNode,
@@ -2964,7 +2965,22 @@ export class ComfyApp {
   public goToNode(nodeId: NodeId) {
     const graphNode = this.graph.getNodeById(nodeId)
     if (!graphNode) return
-    this.canvas.animateToBounds(graphNode.boundingRect)
+    this.canvas.animateToBounds(LGraphGroup.createBounds([graphNode]))
+  }
+
+  /**
+   * Fits the view to the selected nodes with animation.
+   * If nothing is selected, the view is fitted around all nodes in the graph.
+   */
+  fitView() {
+    let selection: LGraphNode[]
+    selection = Array.from(app.canvas.selectedItems.values())
+      .map((i) => this.graph.getNodeById(i.id))
+      .filter((i) => i !== null)
+    if (selection.length === 0) {
+      selection = this.graph.nodes
+    }
+    this.canvas.animateToBounds(LGraphGroup.createBounds(selection))
   }
 }
 

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -293,6 +293,12 @@ export const useCommandStore = defineStore('command', () => {
       }
     },
     {
+      id: 'Comfy.Canvas.FitView',
+      icon: 'pi pi-arrow-down-left-and-arrow-up-right-to-center',
+      label: 'Fit view to selected nodes',
+      function: () => app.fitView()
+    },
+    {
       id: 'Comfy.Canvas.ToggleLock',
       icon: 'pi pi-lock',
       label: 'Toggle Lock',

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -294,9 +294,9 @@ export const useCommandStore = defineStore('command', () => {
     },
     {
       id: 'Comfy.Canvas.FitView',
-      icon: 'pi pi-arrow-down-left-and-arrow-up-right-to-center',
+      icon: 'pi pi-expand',
       label: 'Fit view to selected nodes',
-      function: () => app.fitView()
+      function: () => app.canvas.fitViewToSelectionAnimated()
     },
     {
       id: 'Comfy.Canvas.ToggleLock',

--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -132,6 +132,13 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
+      key: '.'
+    },
+    commandId: 'Comfy.Canvas.FitView',
+    targetSelector: '#graph-canvas'
+  },
+  {
+    combo: {
       key: 'p'
     },
     commandId: 'Comfy.Canvas.ToggleSelected.Pin',


### PR DESCRIPTION
This PR adds a new functionality to fit the canvas view to the currently selected group of nodes, or to the whole graph when nothing is selected.

- Replaces the reset view button on graph canvas menu 
![image](https://github.com/user-attachments/assets/2451d14e-f54d-40aa-ba75-a2156e248718)

- since `f` shortcut is already taken, I bound it to `.` by default which may be familiar from Blender's node editor with the same function.

This PR fixes #1402 

https://github.com/user-attachments/assets/17ecad49-9bcb-41a6-b8d7-a50a4281cb57

Waiting on this PR in litegraph repo to be merged: https://github.com/Comfy-Org/litegraph.js/pull/282