### PR TITLE
Add test guard for #1477 state corruption when using undo

### DIFF
--- a/browser_tests/changeTracker.spec.ts
+++ b/browser_tests/changeTracker.spec.ts
@@ -54,34 +54,34 @@ test.describe('Change Tracker', () => {
   })
 
   test('Can undo & redo user changes', async ({ comfyPage }) => {
-    comfyPage.clickEmptySpace()
+    await comfyPage.clickEmptySpace()
     await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
 
-    comfyPage.dragAndDrop(
+    await comfyPage.dragAndDrop(
       comfyPage.clipTextEncodeNode2OutputSlot,
       comfyPage.kSamplerTitlebar
     )
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step1.png')
 
-    comfyPage.ctrlZ()
+    await comfyPage.ctrlZ()
     await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
 
-    comfyPage.dragAndDrop(
+    await comfyPage.dragAndDrop(
       comfyPage.clipTextEncodeNode1OutputSlot,
       comfyPage.kSamplerTitlebar
     )
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
 
     // Test what a real person does
-    comfyPage.ctrlZ()
-    comfyPage.ctrlZ()
-    comfyPage.ctrlZ()
-    comfyPage.ctrlZ()
+    await comfyPage.ctrlZ()
+    await comfyPage.ctrlZ()
+    await comfyPage.ctrlZ()
+    await comfyPage.ctrlZ()
     await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
 
     // Test past the bounds of the buffer
-    comfyPage.ctrlY()
-    comfyPage.ctrlY()
+    await comfyPage.ctrlY()
+    await comfyPage.ctrlY()
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
   })
 

--- a/browser_tests/changeTracker.spec.ts
+++ b/browser_tests/changeTracker.spec.ts
@@ -64,7 +64,7 @@ test.describe('Change Tracker', () => {
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step1.png')
 
     comfyPage.ctrlZ()
-    await expect(comfyPage.canvas).toHaveScreenshot('undo-step2.png')
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
 
     comfyPage.dragAndDrop(
       comfyPage.clipTextEncodeNode1OutputSlot,
@@ -73,7 +73,10 @@ test.describe('Change Tracker', () => {
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
 
     comfyPage.ctrlZ()
-    await expect(comfyPage.canvas).toHaveScreenshot('undo-step4.png')
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
+
+    comfyPage.ctrlY()
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
   })
 
   test('Can group multiple change actions into a single transaction', async ({

--- a/browser_tests/changeTracker.spec.ts
+++ b/browser_tests/changeTracker.spec.ts
@@ -72,9 +72,15 @@ test.describe('Change Tracker', () => {
     )
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
 
+    // Test what a real person does
+    comfyPage.ctrlZ()
+    comfyPage.ctrlZ()
+    comfyPage.ctrlZ()
     comfyPage.ctrlZ()
     await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
 
+    // Test past the bounds of the buffer
+    comfyPage.ctrlY()
     comfyPage.ctrlY()
     await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
   })

--- a/browser_tests/changeTracker.spec.ts
+++ b/browser_tests/changeTracker.spec.ts
@@ -53,6 +53,29 @@ test.describe('Change Tracker', () => {
     })
   })
 
+  test('Can undo & redo user changes', async ({ comfyPage }) => {
+    comfyPage.clickEmptySpace()
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-initial-state.png')
+
+    comfyPage.dragAndDrop(
+      comfyPage.clipTextEncodeNode2OutputSlot,
+      comfyPage.kSamplerTitlebar
+    )
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-step1.png')
+
+    comfyPage.ctrlZ()
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-step2.png')
+
+    comfyPage.dragAndDrop(
+      comfyPage.clipTextEncodeNode1OutputSlot,
+      comfyPage.kSamplerTitlebar
+    )
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-step3.png')
+
+    comfyPage.ctrlZ()
+    await expect(comfyPage.canvas).toHaveScreenshot('undo-step4.png')
+  })
+
   test('Can group multiple change actions into a single transaction', async ({
     comfyPage
   }) => {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -458,9 +458,19 @@ export class ComfyPage {
   get clipTextEncodeNode1InputSlot(): Position {
     return { x: 427, y: 198 }
   }
+  get clipTextEncodeNode1OutputSlot(): Position {
+    return { x: 828, y: 197 }
+  }
 
   get clipTextEncodeNode2InputSlot(): Position {
     return { x: 422, y: 402 }
+  }
+  get clipTextEncodeNode2OutputSlot(): Position {
+    return { x: 828, y: 400 }
+  }
+
+  get kSamplerTitlebar(): Position {
+    return { x: 1058, y: 175 }
   }
 
   // A point on input edge.


### PR DESCRIPTION
Added test - screenshot verification per step for undo / redo (6 checks against 3 screenshots).