### PR TITLE
Add back/forwards compatibility to schema validation

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -395,8 +395,11 @@ export class ChangeTracker {
         return false
       }
 
+      // Reroutes (schema 0.4)
+      if (!_.isEqual(a.extra?.reroutes, b.extra?.reroutes)) return false
+
       // Compare other properties normally
-      for (const key of ['links', 'groups']) {
+      for (const key of ['links', 'reroutes', 'groups']) {
         if (!_.isEqual(a[key], b[key])) {
           return false
         }

--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -174,6 +174,7 @@ const zExtra = z
   })
   .passthrough()
 
+/** Schema version 0.4 */
 export const zComfyWorkflow = z
   .object({
     last_node_id: zNodeId,
@@ -188,9 +189,10 @@ export const zComfyWorkflow = z
   })
   .passthrough()
 
+/** Schema version 1 */
 const zComfyWorkflow1 = z
   .object({
-    version: z.number(),
+    version: z.literal(1),
     config: zConfig.optional().nullable(),
     state: zGraphState,
     groups: z.array(zGroup).optional(),

--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -38,12 +38,14 @@ const zModelFile = z.object({
   directory: z.string()
 })
 
-const zGraphState = z.object({
-  lastGroupid: z.number().optional(),
-  lastNodeId: z.number().optional(),
-  lastLinkId: z.number().optional(),
-  lastRerouteId: z.number().optional()
-})
+const zGraphState = z
+  .object({
+    lastGroupid: z.number().optional(),
+    lastNodeId: z.number().optional(),
+    lastLinkId: z.number().optional(),
+    lastRerouteId: z.number().optional()
+  })
+  .passthrough()
 
 const zComfyLink = z.tuple([
   z.number(), // Link id
@@ -54,22 +56,26 @@ const zComfyLink = z.tuple([
   zDataType // Data type
 ])
 
-const zComfyLinkObject = z.object({
-  id: z.number(),
-  origin_id: zNodeId,
-  origin_slot: zSlotIndex,
-  target_id: zNodeId,
-  target_slot: zSlotIndex,
-  type: zDataType,
-  parentId: z.number().optional()
-})
+const zComfyLinkObject = z
+  .object({
+    id: z.number(),
+    origin_id: zNodeId,
+    origin_slot: zSlotIndex,
+    target_id: zNodeId,
+    target_slot: zSlotIndex,
+    type: zDataType,
+    parentId: z.number().optional()
+  })
+  .passthrough()
 
-const zReroute = z.object({
-  id: z.number(),
-  parentId: z.number().optional(),
-  pos: zVector2,
-  linkIds: z.array(z.number()).nullish()
-})
+const zReroute = z
+  .object({
+    id: z.number(),
+    parentId: z.number().optional(),
+    pos: zVector2,
+    linkIds: z.array(z.number()).nullish()
+  })
+  .passthrough()
 
 const zNodeOutput = z
   .object({

--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -56,6 +56,14 @@ const zComfyLink = z.tuple([
   zDataType // Data type
 ])
 
+/** Extension to 0.4 schema (links as arrays): parent reroute ID */
+const zComfyLinkExtension = z
+  .object({
+    id: z.number(),
+    parentId: z.number()
+  })
+  .passthrough()
+
 const zComfyLinkObject = z
   .object({
     id: z.number(),
@@ -170,7 +178,9 @@ const zConfig = z
 const zExtra = z
   .object({
     ds: zDS.optional(),
-    info: zInfo.optional()
+    info: zInfo.optional(),
+    linkExtensions: z.array(zComfyLinkExtension).optional(),
+    reroutes: z.array(zReroute).optional()
   })
   .passthrough()
 


### PR DESCRIPTION
### Issue
The v1 schema change is non-trivial.  Anything (apps, services, etc) that need to parse links from workflows will require an update.

Until that can happen, features that require serialisation cannot be added.

### Proposed
- Use 0.4-compatible `extra` fields to include reroutes and the additional link property
- Allow future additions to schema v1 objects (`passthrough`)
- Minor adjustment to `changeTracker` to match above
  - if no reroutes, only change is two `undefined` equality checks

#### Example workflow (snipped):
```jsonc
{
  "links": [
    // No changes
    [3, 4, 1, 6, 0, "CLIP"],
    [4, 6, 0, 3, 1, "CONDITIONING"]
  ],
  "extra": {
    "linkExtensions": [
      {
        // LLink.id
        "id": 3,
        "parentId": 7
      }
    ],
    "reroutes": [
      {
        "id": 7,
        "parentId": 6,
        "pos": [100, 75],
        "linkIds": [3]
      }
    ]
  },
  "version": 0.4
}
```