### PR TITLE
Add settings option: Keep links on delete

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -99,6 +99,12 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
+  LGraphNode.keepAllLinksOnBypass = settingStore.get(
+    'Comfy.Node.BypassAllLinksOnDelete'
+  )
+})
+
+watchEffect(() => {
   nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')
 })
 

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -476,5 +476,14 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'boolean',
     defaultValue: true,
     versionAdded: '1.3.29'
+  },
+  {
+    id: 'Comfy.Node.BypassAllLinksOnDelete',
+    name: 'Keep all links when deleting nodes',
+    tooltip:
+      'When deleting a node, attempt to reconnect all of its input and output links (bypassing the deleted node)',
+    type: 'boolean',
+    defaultValue: true,
+    versionAdded: '1.3.40'
   }
 ]


### PR DESCRIPTION
### Optional match-any mode
- Adds an option for: https://github.com/Comfy-Org/litegraph.js/pull/288
![image](https://github.com/user-attachments/assets/f5b173be-cedc-4362-b638-c5658d7cf8e1)
- This mode will first try the default behaviour, then try to bypass each input to the first matching output

https://github.com/user-attachments/assets/397d7bcc-ffa7-4fa2-bec0-213d8c108704

### Default behaviour change
- Currently, when deleting a node, a bypass link is created only for the first input <-> first output
- New default is that this same behaviour is now applied to every input & output pair (e.g. input 3 <-> output 3)

https://github.com/user-attachments/assets/0e5c3c3b-bbc4-499b-8cfa-28eba4a98072
