### PR TITLE
Fix rename open/bookmark workflow

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { Locator, Page } from '@playwright/test'
 
 class SidebarTab {
   constructor(
@@ -110,11 +110,30 @@ export class WorkflowsSidebarTab extends SidebarTab {
   }
 
   async switchToWorkflow(workflowName: string) {
-    const workflowLocator = this.page.locator(
-      '.comfyui-workflows-open .node-label',
-      { hasText: workflowName }
-    )
+    const workflowLocator = this.getOpenedItem(workflowName)
     await workflowLocator.click()
+    await this.page.waitForTimeout(300)
+  }
+
+  getOpenedItem(name: string) {
+    return this.page.locator('.comfyui-workflows-open .node-label', {
+      hasText: name
+    })
+  }
+
+  getPersistedItem(name: string) {
+    return this.page.locator('.comfyui-workflows-browse .node-label', {
+      hasText: name
+    })
+  }
+
+  async renameWorkflow(locator: Locator, newName: string) {
+    await locator.click({ button: 'right' })
+    await this.page
+      .locator('.p-contextmenu-item-content', { hasText: 'Rename' })
+      .click()
+    await this.page.keyboard.type(newName)
+    await this.page.keyboard.press('Enter')
     await this.page.waitForTimeout(300)
   }
 }

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -401,7 +401,6 @@ test.describe('Menu', () => {
         'workflow1.json': 'default.json',
         'workflow2.json': 'default.json'
       })
-      // Avoid reset view as the button is not visible in BetaMenu UI.
       await comfyPage.setup()
 
       const tab = comfyPage.menu.workflowsTab
@@ -409,6 +408,33 @@ test.describe('Menu', () => {
       expect(await tab.getTopLevelSavedWorkflowNames()).toEqual(
         expect.arrayContaining(['workflow1.json', 'workflow2.json'])
       )
+    })
+
+    test('Can rename nested workflow from opened workflow item', async ({
+      comfyPage
+    }) => {
+      await comfyPage.setupWorkflowsDirectory({
+        foo: {
+          'bar.json': 'default.json'
+        }
+      })
+      await comfyPage.setup()
+
+      const tab = comfyPage.menu.workflowsTab
+      await tab.open()
+      // Switch to the parent folder
+      await tab.getPersistedItem('foo').click()
+      await comfyPage.page.waitForTimeout(300)
+      // Switch to the nested workflow
+      await tab.getPersistedItem('bar').click()
+      await comfyPage.page.waitForTimeout(300)
+
+      const openedWorkflow = tab.getOpenedItem('foo/bar')
+      await tab.renameWorkflow(openedWorkflow, 'foo/baz')
+      expect(await tab.getOpenedWorkflowNames()).toEqual([
+        '*Unsaved Workflow.json',
+        'foo/baz.json'
+      ])
     })
 
     test('Can save workflow as', async ({ comfyPage }) => {

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -61,14 +61,15 @@ export const workflowService = {
     })
     if (!newFilename) return
 
+    const newPath = workflow.directory + '/' + appendJsonExt(newFilename)
+    const newKey = newPath.substring(ComfyWorkflow.basePath.length)
+
     if (workflow.isTemporary) {
-      await this.renameWorkflow(workflow, newFilename)
+      await this.renameWorkflow(workflow, newPath)
       await useWorkflowStore().saveWorkflow(workflow)
     } else {
       const tempWorkflow = useWorkflowStore().createTemporary(
-        (workflow.directory + '/' + appendJsonExt(newFilename)).substring(
-          ComfyWorkflow.basePath.length
-        ),
+        newKey,
         workflow.activeState as ComfyWorkflowJSON
       )
       await this.openWorkflow(tempWorkflow)

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -67,7 +67,7 @@ export const workflowService = {
     } else {
       const tempWorkflow = useWorkflowStore().createTemporary(
         (workflow.directory + '/' + appendJsonExt(newFilename)).substring(
-          'workflows/'.length
+          ComfyWorkflow.basePath.length
         ),
         workflow.activeState as ComfyWorkflowJSON
       )
@@ -162,8 +162,8 @@ export const workflowService = {
     await workflowStore.closeWorkflow(workflow)
   },
 
-  async renameWorkflow(workflow: ComfyWorkflow, newName: string) {
-    await useWorkflowStore().renameWorkflow(workflow, newName)
+  async renameWorkflow(workflow: ComfyWorkflow, newPath: string) {
+    await useWorkflowStore().renameWorkflow(workflow, newPath)
   },
 
   async deleteWorkflow(workflow: ComfyWorkflow) {
@@ -212,7 +212,7 @@ export const workflowService = {
     const workflowStore = useWorkspaceStore().workflow
     if (typeof value === 'string') {
       const workflow = workflowStore.getWorkflowByPath(
-        'workflows/' + appendJsonExt(value)
+        ComfyWorkflow.basePath + appendJsonExt(value)
       )
       if (workflow?.isPersisted) {
         const loadedWorkflow = await workflowStore.openWorkflow(workflow)

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -5,11 +5,13 @@ import { api } from '@/scripts/api'
 import { UserFile } from './userFileStore'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import { ComfyWorkflowJSON } from '@/types/comfyWorkflow'
-import { appendJsonExt, getPathDetails } from '@/utils/formatUtil'
+import { getPathDetails } from '@/utils/formatUtil'
 import { defaultGraphJSON } from '@/scripts/defaultGraph'
 import { syncEntities } from '@/utils/syncUtil'
 
 export class ComfyWorkflow extends UserFile {
+  static readonly basePath = 'workflows/'
+
   /**
    * The change tracker for the workflow. Non-reactive raw object.
    */
@@ -28,7 +30,7 @@ export class ComfyWorkflow extends UserFile {
   }
 
   get key() {
-    return this.path.substring('workflows/'.length)
+    return this.path.substring(ComfyWorkflow.basePath.length)
   }
 
   get activeState(): ComfyWorkflowJSON | null {
@@ -103,12 +105,6 @@ export class ComfyWorkflow extends UserFile {
   async saveAs(path: string) {
     this.content = JSON.stringify(this.activeState)
     return await super.saveAs(path)
-  }
-
-  async rename(newName: string) {
-    const newPath = this.directory + '/' + appendJsonExt(newName)
-    await super.rename(newPath)
-    return this
   }
 }
 
@@ -210,7 +206,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
 
   const createTemporary = (path?: string, workflowData?: ComfyWorkflowJSON) => {
     const fullPath = getUnconflictedPath(
-      'workflows/' + (path ?? 'Unsaved Workflow.json')
+      ComfyWorkflow.basePath + (path ?? 'Unsaved Workflow.json')
     )
     const workflow = new ComfyWorkflow({
       path: fullPath,
@@ -289,33 +285,15 @@ export const useWorkflowStore = defineStore('workflow', () => {
     workflows.value.filter((workflow) => workflow.isModified)
   )
 
-  const buildWorkflowTree = (workflows: ComfyWorkflow[]) => {
-    return buildTree(workflows, (workflow: ComfyWorkflow) =>
-      workflow.key.split('/')
-    )
-  }
-  const workflowsTree = computed(() =>
-    sortedTree(buildWorkflowTree(persistedWorkflows.value), { groupLeaf: true })
-  )
-  // Bookmarked workflows tree is flat.
-  const bookmarkedWorkflowsTree = computed(() =>
-    buildTree(bookmarkedWorkflows.value, (workflow) => [workflow.key])
-  )
-  // Open workflows tree is flat.
-  const openWorkflowsTree = computed(() =>
-    buildTree(openWorkflows.value, (workflow) => [workflow.key])
-  )
-
-  const renameWorkflow = async (workflow: ComfyWorkflow, newName: string) => {
+  const renameWorkflow = async (workflow: ComfyWorkflow, newPath: string) => {
     // Capture all needed values upfront
     const oldPath = workflow.path
-    const newPath = workflow.directory + '/' + appendJsonExt(newName)
     const wasBookmarked = bookmarkStore.isBookmarked(oldPath)
 
     const openIndex = detachWorkflow(workflow)
     // Perform the actual rename operation first
     try {
-      await workflow.rename(newName)
+      await workflow.rename(newPath)
     } finally {
       attachWorkflow(workflow, openIndex)
     }
@@ -353,7 +331,6 @@ export const useWorkflowStore = defineStore('workflow', () => {
     activeWorkflow,
     isActive,
     openWorkflows,
-    openWorkflowsTree,
     openedWorkflowIndexShift,
     openWorkflow,
     isOpen,
@@ -365,11 +342,9 @@ export const useWorkflowStore = defineStore('workflow', () => {
 
     workflows,
     bookmarkedWorkflows,
+    persistedWorkflows,
     modifiedWorkflows,
     getWorkflowByPath,
-    workflowsTree,
-    bookmarkedWorkflowsTree,
-    buildWorkflowTree,
     syncWorkflows
   }
 })

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { computed, markRaw, ref } from 'vue'
-import { buildTree, sortedTree } from '@/utils/treeUtil'
 import { api } from '@/scripts/api'
 import { UserFile } from './userFileStore'
 import { ChangeTracker } from '@/scripts/changeTracker'

--- a/tests-ui/tests/fast/store/workflowStore.test.ts
+++ b/tests-ui/tests/fast/store/workflowStore.test.ts
@@ -178,9 +178,8 @@ describe('useWorkflowStore', () => {
         } as any)
 
       // Perform rename
-      const newName = 'renamed.json'
       const newPath = 'workflows/dir/renamed.json'
-      await store.renameWorkflow(workflow, newName)
+      await store.renameWorkflow(workflow, newPath)
 
       // Check that bookmark was transferred
       expect(bookmarkStore.isBookmarked(newPath)).toBe(true)


### PR DESCRIPTION
Previously rename the workflows in nested folders from the open or bookmark item does not work as expected. The folder prefix is added multiple times. This PR fixes this issue.