### PR TITLE
Fix queue button overlaped by pysssss.ImageFeed

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -83,7 +83,10 @@ body {
   /* Position at the first row */
   grid-row: 1;
   /* Top menu bar dropdown needs to be above of graph canvas splitter overlay which is z-index: 999 */
-  z-index: 1000;
+  /* Top menu bar z-index needs to be higher than bottom menu bar z-index as by default
+  pysssss's image feed is located at body-bottom, and it can overlap with the queue button, which
+  is located in body-top. */
+  z-index: 1001;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Users new to the new menu have reported that they cannot find the queue button, which was overlapped by pysssss.ImageFeed. This PR somewhat fixes the issue in the default state. (pysssss.ImageFeed by default is at bottom of the screen).

![image](https://github.com/user-attachments/assets/6cfabb4f-653c-4a3d-8019-4fc92b4fff94)
