### PR TITLE
Decouple group node from Litegraph copy & paste

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -851,7 +851,7 @@ export class GroupNodeHandler {
           }
           c.nodes[i] = { ...c.nodes[i], id }
         }
-        deserialise(JSON.stringify(c), app.canvas)
+        deserialiseAndCreate(JSON.stringify(c), app.canvas)
 
         const [x, y] = this.node.pos
         let top
@@ -1542,7 +1542,7 @@ function serialise(nodes: LGraphNode[], graph: LGraph): string {
  * @param data The serialised nodes and links to create
  * @param canvas The canvas to create the serialised items in
  */
-function deserialise(data: string, canvas: LGraphCanvas): void {
+function deserialiseAndCreate(data: string, canvas: LGraphCanvas): void {
   if (!data) return
 
   const { graph, graph_mouse } = canvas

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -923,10 +923,8 @@ export class GroupNodeHandler {
 
         // Shift each node
         for (const newNode of newNodes) {
-          newNode.pos = [
-            newNode.pos[0] - (left - x),
-            newNode.pos[1] - (top - y)
-          ]
+          newNode.pos[0] -= left - x
+          newNode.pos[1] -= top - y
         }
 
         return { newNodes, selectedIds }


### PR DESCRIPTION
Decouples groupNode from Litegraph's copy & paste function by copying the bits it needs and refactoring out a lot of now-redundant code.

Not going to win any beauty prizes, but it gets the job done.

Resolves test block on https://github.com/Comfy-Org/litegraph.js/pull/302