### PR TITLE
Fix sidebar splitter state

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -1,7 +1,10 @@
 <template>
   <teleport to=".graph-canvas-container">
+    <!-- Load splitter overlay only after comfyApp is ready. -->
+    <!-- If load immediately, the top-level splitter stateKey won't be correctly
+    synced with the stateStorage (localStorage). -->
     <LiteGraphCanvasSplitterOverlay
-      v-if="betaMenuEnabled && !workspaceStore.focusMode"
+      v-if="comfyAppReady && betaMenuEnabled && !workspaceStore.focusMode"
     >
       <template #side-bar-panel>
         <SideToolbar />
@@ -237,6 +240,7 @@ usePragmaticDroppable(() => canvasRef.value, {
   }
 })
 
+const comfyAppReady = ref(false)
 onMounted(async () => {
   // Backward compatible
   // Assign all properties of lg to window
@@ -263,6 +267,7 @@ onMounted(async () => {
   window['app'] = comfyApp
   window['graph'] = comfyApp.graph
 
+  comfyAppReady.value = true
   emit('ready')
 })
 </script>


### PR DESCRIPTION
Culprit: https://github.com/Comfy-Org/ComfyUI_frontend/pull/1515

Previously the `LiteGraphCanvasSplitterOverlay` won't load until the setting is initialized in `app.setup`, i.e. when `GraphCanvas` component mounted. Now we set the default value of `Comfy.UseNewMenu` to be `Top`, which causes the `LiteGraphCanvasSplitterOverlay` to load immediately before `GraphCanvas` fully mounted, i.e. also before `app`'s setup. This causes the toplevel splitter's state is not correctly synced with localstorage somehow. Each time the sidebar is opened, the splitter will always be in the middle instead of the previous position. I am not sure what underlying factor causes this, but delay the initialization after app.setup does seem to fix the issue.