### PR TITLE
Lazy load setting dialog tabs

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -18,7 +18,7 @@
     </ScrollPanel>
     <Divider layout="vertical" class="mx-1 2xl:mx-4" />
     <ScrollPanel class="settings-content flex-grow">
-      <Tabs :value="tabValue">
+      <Tabs :value="tabValue" :lazy="true">
         <FirstTimeUIMessage v-if="tabValue === 'Comfy'" />
         <TabPanels class="settings-tab-panels">
           <TabPanel key="search-results" value="Search Results">


### PR DESCRIPTION
Before: ~600ms x 3 + extra post work to open settings dialog
![image](https://github.com/user-attachments/assets/9de93d02-4171-4e13-82d3-94eb2abbefcd)

After: 358ms x 3 to open settings dialog

![image](https://github.com/user-attachments/assets/19329576-00d0-4b08-96d3-76561c0688e0)
