### PR TITLE
Add option to disable ctrl + shift + zoom

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1227,7 +1227,8 @@ export class ComfyApp {
     const origProcessMouseDown = LGraphCanvas.prototype.processMouseDown
     LGraphCanvas.prototype.processMouseDown = function (e) {
       // prepare for ctrl+shift drag: zoom start
-      if (e.ctrlKey && e.shiftKey && e.buttons) {
+      const useFastZoom = useSettingStore().get('Comfy.Graph.CtrlShiftZoom')
+      if (useFastZoom && e.ctrlKey && e.shiftKey && !e.altKey && e.buttons) {
         self.zoom_drag_start = [e.x, e.y, this.ds.scale]
         return
       }

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -527,6 +527,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Enable fast-zoom shortcut (Ctrl + Shift + Drag)',
     type: 'boolean',
     defaultValue: true,
-    versionAdded: '1.3.45'
+    versionAdded: '1.4.0'
   }
 ]

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -521,5 +521,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Enable DOM element clipping (enabling may reduce performance)',
     type: 'boolean',
     defaultValue: true
+  },
+  {
+    id: 'Comfy.Graph.CtrlShiftZoom',
+    name: 'Enable fast-zoom shortcut (Ctrl + Shift + Drag)',
+    type: 'boolean',
+    defaultValue: true,
+    versionAdded: '1.3.45'
   }
 ]


### PR DESCRIPTION
Minor change to default behaviour: zoom no longer triggers if alt key is also down.