### PR TITLE
Minor: add toggle terminal to help menu in electron

### DIFF
--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -1,4 +1,5 @@
 import { app } from '@/scripts/app'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore';
 import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
 ;(async () => {
   if (!isElectron()) return
@@ -97,6 +98,14 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
         function() {
           // TODO(huchenlei): Add a confirmation dialog.
           electronAPI.reinstall()
+        },
+      },
+      {
+        id: 'Comfy-Desktop.ToggleBottomPanel',
+        label: 'Toggle Bottom Panel',
+        icon: 'pi pi-bars',
+        function() {
+          useBottomPanelStore().toggleBottomPanel()
         }
       }
     ],
@@ -124,6 +133,10 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
       {
         path: ['Help'],
         commands: ['Comfy-Desktop.Reinstall']
+      },
+      {
+        path: ['Help'],
+        commands: ['Comfy-Desktop.ToggleBottomPanel']
       }
     ],
 

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -16,6 +16,7 @@ const mockElectronAPI: Plugin = {
           onProgressUpdate: () => {},
           onLogMessage: () => {},
           isFirstTimeSetup: () => Promise.resolve(true),
+          getElectronVersion: () => Promise.resolve('0.0.0'),
           getSystemPaths: () =>
             Promise.resolve({
               appData: 'C:/Users/username/AppData/Roaming',


### PR DESCRIPTION
<img width="437" alt="Screenshot 2024-11-15 at 12 35 52 PM" src="https://github.com/user-attachments/assets/098386c7-231e-4f19-891d-a816b80b1795">
