### PR TITLE
Fix husky pre-commit for winnt clients II

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,7 @@
 if [[ "$OS" == "Windows_NT" ]]; then
   npx.cmd lint-staged
+  npm.cmd run typecheck
 else
   npx lint-staged
+  npm run typecheck
 fi
-npm run typecheck


### PR DESCRIPTION
- Fixes line missed in #1551 due to husky bypass
- Allows pre-commit to run in GitHub Desktop on winnt
- Tested `git` CLI & API, hook now rejects and accepts commits as expected