### PR TITLE
Allow decimal places typed in settings

### DIFF
--- a/src/components/common/InputSlider.vue
+++ b/src/components/common/InputSlider.vue
@@ -13,6 +13,7 @@
       :modelValue="modelValue"
       @update:modelValue="updateValue"
       class="input-part"
+      max-fraction-digits="3"
       :class="inputClass"
       :min="min"
       :max="max"


### PR DESCRIPTION
- Currently you can't type e.g. `0.5` into a numeric field in the settings dialog, unless the `.` is already there (typing the decimal point is always ignored)
- Working around it is weird: if you have `0.0`, select `.0`, then type `.1`, the result is `0.01` instead of `0.1`

New behaviour:

https://github.com/user-attachments/assets/7e2cda2d-5198-4e9b-bcf6-c59be23df49a