### PR TITLE
Fix Vue console warning flood on settings open

### DIFF
--- a/src/components/common/InputSlider.vue
+++ b/src/components/common/InputSlider.vue
@@ -13,7 +13,7 @@
       :modelValue="modelValue"
       @update:modelValue="updateValue"
       class="input-part"
-      max-fraction-digits="3"
+      :max-fraction-digits="3"
       :class="inputClass"
       :min="min"
       :max="max"


### PR DESCRIPTION
Resolves issue introduced in #1566

> [Vue warn]: Invalid prop: type check failed for prop "maxFractionDigits". Expected Number with value 3, got String with value "3".
