### PR TITLE
Remove deprecated setting Comfy.NodeSearchBoxImpl.LinkReleaseTrigger

### DIFF
--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -25,15 +25,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: 'default'
   },
   {
-    id: 'Comfy.NodeSearchBoxImpl.LinkReleaseTrigger',
-    category: ['Comfy', 'Node Search Box', 'LinkReleaseTrigger'],
-    name: 'Trigger on link release',
-    type: 'hidden',
-    options: Object.values(LinkReleaseTriggerMode),
-    defaultValue: LinkReleaseTriggerMode.ALWAYS,
-    deprecated: true
-  },
-  {
     id: 'Comfy.LinkRelease.Action',
     category: ['LiteGraph', 'LinkRelease', 'Action'],
     name: 'Action on link release (No modifier)',

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -484,11 +484,6 @@ const zSettings = z.record(z.any()).and(
         zBookmarkCustomization
       ),
       'Comfy.NodeInputConversionSubmenus': z.boolean(),
-      'Comfy.NodeSearchBoxImpl.LinkReleaseTrigger': z.enum([
-        'always',
-        'hold shift',
-        'NOT hold shift'
-      ]),
       'Comfy.LinkRelease.Action': zLinkReleaseTriggerAction,
       'Comfy.LinkRelease.ActionShift': zLinkReleaseTriggerAction,
       'Comfy.NodeSearchBoxImpl.NodePreview': z.boolean(),


### PR DESCRIPTION
The setting was replaced by `Comfy.LinkRelease.Action` and `Comfy.LinkRelease.ActionShift`.