### PR TITLE
Disable debug logic in changeTracker

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -99,7 +99,7 @@ export class ChangeTracker {
         this.initialState,
         this.activeState
       )
-      if (workflow.isModified) {
+      if (logger.getLevel() <= logger.levels.DEBUG && workflow.isModified) {
         const diff = ChangeTracker.graphDiff(
           this.initialState,
           this.activeState


### PR DESCRIPTION
Disables expensive graphDiff calculation when logger level is higher than debug. (Prod)