### PR TITLE
Fix vue warning on unnecessary defineEmits import

### DIFF
--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineEmits, Ref } from 'vue'
+import { ref, Ref } from 'vue'
 import { useTerminal } from '@/hooks/bottomPanelTabs/useTerminal'
 
 const emit = defineEmits<{


### PR DESCRIPTION
Resolves following warning:

```
[@vue/compiler-sfc] `defineEmits` is a compiler macro and no longer needs to be imported.
```