### PR TITLE
Show confirm dialog on workflow path conflict (Save As)

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -738,15 +738,17 @@ export class ComfyPage {
   }
 
   async confirmDialog(text: string = 'Yes') {
-    await this.page.locator('.comfy-modal-content').waitFor({
-      state: 'visible'
-    })
+    // Wait for any modal content to be visible
+    await expect(this.page.locator('.comfy-modal-content')).toBeVisible()
+
     await this.page
-      .locator('.comfy-modal-content .comfyui-button', { hasText: text })
+      .locator('.comfy-modal-content:visible .comfyui-button', {
+        hasText: text
+      })
       .click()
-    await this.page.locator('.comfy-modal-content').waitFor({
-      state: 'hidden'
-    })
+
+    // Wait for all modal content to be hidden
+    await expect(this.page.locator('.comfy-modal-content')).toBeHidden()
   }
 
   async convertAllNodesToGroupNode(groupNodeName: string) {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -737,6 +737,18 @@ export class ComfyPage {
     )
   }
 
+  async confirmDialog(text: string = 'Yes') {
+    await this.page.locator('.comfy-modal-content').waitFor({
+      state: 'visible'
+    })
+    await this.page
+      .locator('.comfy-modal-content .comfyui-button', { hasText: text })
+      .click()
+    await this.page.locator('.comfy-modal-content').waitFor({
+      state: 'hidden'
+    })
+  }
+
   async convertAllNodesToGroupNode(groupNodeName: string) {
     this.page.on('dialog', async (dialog) => {
       await dialog.accept(groupNodeName)

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -737,18 +737,17 @@ export class ComfyPage {
     )
   }
 
-  async confirmDialog(text: string = 'Yes') {
-    // Wait for any modal content to be visible
-    await expect(this.page.locator('.comfy-modal-content')).toBeVisible()
-
-    await this.page
-      .locator('.comfy-modal-content:visible .comfyui-button', {
+  async confirmDialog(prompt: string, text: string = 'Yes') {
+    const modal = this.page.locator(
+      `.comfy-modal-content:has-text("${prompt}")`
+    )
+    await expect(modal).toBeVisible()
+    await modal
+      .locator('.comfyui-button', {
         hasText: text
       })
       .click()
-
-    // Wait for all modal content to be hidden
-    await expect(this.page.locator('.comfy-modal-content')).toBeHidden()
+    await expect(modal).toBeHidden()
   }
 
   async convertAllNodesToGroupNode(groupNodeName: string) {

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -103,6 +103,12 @@ export class WorkflowsSidebarTab extends SidebarTab {
       .allInnerTexts()
   }
 
+  async getActiveWorkflowName() {
+    return await this.page
+      .locator('.comfyui-workflows-open .p-tree-node-selected .node-label')
+      .innerText()
+  }
+
   async getTopLevelSavedWorkflowNames() {
     return await this.page
       .locator('.comfyui-workflows-browse .node-label')

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -475,7 +475,7 @@ test.describe('Menu', () => {
         `tempWorkflow-${test.info().title}`
       )
       const closeButton = comfyPage.page.locator(
-        '.comfyui-workflows-open .p-button-icon.pi-times'
+        '.comfyui-workflows-open .close-workflow-button'
       )
       await closeButton.click()
       expect(

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -457,7 +457,7 @@ test.describe('Menu', () => {
       ).toEqual(['workflow5.json'])
 
       await comfyPage.menu.topbar.saveWorkflowAs('workflow5.json')
-      await comfyPage.confirmDialog('Yes')
+      await comfyPage.confirmDialog('Overwrite existing file?', 'Yes')
       expect(
         await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
       ).toEqual(['workflow5.json'])
@@ -477,7 +477,7 @@ test.describe('Menu', () => {
       )
 
       await topbar.saveWorkflowAs('workflow1.json')
-      await comfyPage.confirmDialog('Yes')
+      await comfyPage.confirmDialog('Overwrite existing file?', 'Yes')
       // The old workflow1.json should be deleted and the new one should be saved.
       expect(
         await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -450,6 +450,43 @@ test.describe('Menu', () => {
       ).toEqual(['*Unsaved Workflow.json', 'workflow3.json', 'workflow4.json'])
     })
 
+    test('Can save workflow as with same name', async ({ comfyPage }) => {
+      await comfyPage.menu.topbar.saveWorkflow('workflow5.json')
+      expect(
+        await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
+      ).toEqual(['workflow5.json'])
+
+      await comfyPage.menu.topbar.saveWorkflowAs('workflow5.json')
+      await comfyPage.confirmDialog('Yes')
+      expect(
+        await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
+      ).toEqual(['workflow5.json'])
+    })
+
+    test('Can overwrite other workflows with save as', async ({
+      comfyPage
+    }) => {
+      const topbar = comfyPage.menu.topbar
+      await topbar.saveWorkflow('workflow1.json')
+      await topbar.saveWorkflowAs('workflow2.json')
+      expect(
+        await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
+      ).toEqual(['workflow1.json', 'workflow2.json'])
+      expect(await comfyPage.menu.workflowsTab.getActiveWorkflowName()).toEqual(
+        'workflow2.json'
+      )
+
+      await topbar.saveWorkflowAs('workflow1.json')
+      await comfyPage.confirmDialog('Yes')
+      // The old workflow1.json should be deleted and the new one should be saved.
+      expect(
+        await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
+      ).toEqual(['workflow2.json', 'workflow1.json'])
+      expect(await comfyPage.menu.workflowsTab.getActiveWorkflowName()).toEqual(
+        'workflow1.json'
+      )
+    })
+
     test('Does not report warning when switching between opened workflows', async ({
       comfyPage
     }) => {

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -379,7 +379,9 @@ test.describe('Menu', () => {
       // Open the sidebar
       const tab = comfyPage.menu.workflowsTab
       await tab.open()
+    })
 
+    test.afterEach(async ({ comfyPage }) => {
       await comfyPage.setupWorkflowsDirectory({})
     })
 

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -54,6 +54,7 @@
                 </template>
                 <template #actions="{ node }">
                   <Button
+                    class="close-workflow-button"
                     icon="pi pi-times"
                     text
                     :severity="


### PR DESCRIPTION
Resolve https://github.com/Comfy-Org/ComfyUI_frontend/issues/1505

When use "Save As" command with a workflow name that already exists, instead of creating a non-conflicting name automatically, now a confirmation will pop up ask whether to overwrite the existing workflow.

![image](https://github.com/user-attachments/assets/6d740236-04cd-4c55-ae1d-f779d326516b)
