### PR TITLE
Disable slow jest tests

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -20,7 +20,7 @@ jobs:
       run: |
         npm run test:generate
         npm run test:generate:examples
-        npm test:jest:fast -- --verbose
+        npm run test:jest:fast -- --verbose
       working-directory: ComfyUI_frontend
 
   playwright-tests-chromium:

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -20,7 +20,7 @@ jobs:
       run: |
         npm run test:generate
         npm run test:generate:examples
-        npm test -- --verbose
+        npm test:jest:fast -- --verbose
       working-directory: ComfyUI_frontend
 
   playwright-tests-chromium:


### PR DESCRIPTION
Legacy `slow` tests are very heavily coupled with app.ts logic, and thus becoming very hard to maintain. Since https://github.com/Comfy-Org/ComfyUI_frontend/pull/1563 landed, legacy tests trend to fail because the new load3d extension imports threejs imperatively, and this causes jest runner sometimes running out of resources.

This PR disables slow group of tests until we potentially migrate to vitest, and remove features we no longer want to support, such as group node.