### PR TITLE
[Electron] Fix initial default install location validation

### DIFF
--- a/src/components/install/InstallLocationPicker.vue
+++ b/src/components/install/InstallLocationPicker.vue
@@ -85,6 +85,8 @@ onMounted(async () => {
   appData.value = paths.appData
   appPath.value = paths.appPath
   installPath.value = paths.defaultInstallPath
+
+  await validatePath(paths.defaultInstallPath)
 })
 
 const validatePath = async (path: string) => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,7 +8,9 @@ import {
 import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
 import { isElectron } from './utils/envUtil'
 
-const isFileProtocol = () => window.location.protocol === 'file:'
+const isFileProtocol = window.location.protocol === 'file:'
+const basePath = isElectron() ? '/' : window.location.pathname
+
 const guardElectronAccess = (
   to: RouteLocationNormalized,
   from: RouteLocationNormalized,
@@ -22,12 +24,12 @@ const guardElectronAccess = (
 }
 
 const router = createRouter({
-  history: isFileProtocol()
+  history: isFileProtocol
     ? createWebHashHistory()
     : // Base path must be specified to ensure correct relative paths
       // Example: For URL 'http://localhost:7801/ComfyBackendDirect',
       // we need this base path or assets will incorrectly resolve from 'http://localhost:7801/'
-      createWebHistory(window.location.pathname),
+      createWebHistory(basePath),
   routes: [
     {
       path: '/',

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -20,7 +20,7 @@ const mockElectronAPI: Plugin = {
             Promise.resolve({
               appData: 'C:/Users/username/AppData/Roaming',
               appPath: 'C:/Program Files/comfyui-electron/resources/app',
-              defaultInstallPath: 'C:/Users/username/comfyui-electron'
+              defaultInstallPath: 'bad'
             }),
           validateInstallPath: (path) => {
             if (path === 'bad') {
@@ -42,7 +42,12 @@ const mockElectronAPI: Plugin = {
             }
             return { isValid: true }
           },
-          showDirectoryPicker: () => Promise.resolve('C:/Users/username/comfyui-electron/1')
+          showDirectoryPicker: () => Promise.resolve('C:/Users/username/comfyui-electron/1'),
+          DownloadManager: {
+            getAllDownloads: () => Promise.resolve([]),
+            onDownloadProgress: () => {}
+          },
+          getElectronVersion: () => Promise.resolve('1.0.0')
         };`
       }
     ]


### PR DESCRIPTION
This PR fixes the issue that the default install location is not validated on initial load.

The changes to `router.ts` is necessary to make sure electron mock with dev server can function correctly with correct base path.

Extra mocks to electron API are added to make sure frontend don't raise errors when running electron mock dev server.