### PR TITLE
Run pre-commit type check only for TypeScript

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,5 @@
 if [[ "$OS" == "Windows_NT" ]]; then
   npx.cmd lint-staged
-  npm.cmd run typecheck
 else
   npx lint-staged
-  npm run typecheck
 fi

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,6 +1,4 @@
 export default {
-  // '*.css': stagedFiles => `prettier --write ${stagedFiles.join(' ')}`,
-
   './**/*.js': (stagedFiles) => formatFiles(stagedFiles),
 
   './**/*.{ts,tsx,vue}': (stagedFiles) => [
@@ -11,8 +9,5 @@ export default {
 }
 
 function formatFiles(fileNames) {
-  return [
-    `prettier --write ${fileNames.join(' ')}`
-    // `eslint --fix ${fileNames.join(' ')}`,
-  ]
+  return [`prettier --write ${fileNames.join(' ')}`]
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,18 @@
+export default {
+  // '*.css': stagedFiles => `prettier --write ${stagedFiles.join(' ')}`,
+
+  './**/*.js': (stagedFiles) => formatFiles(stagedFiles),
+
+  './**/*.{ts,tsx,vue}': (stagedFiles) => [
+    ...formatFiles(stagedFiles),
+    'tsc --noEmit',
+    'tsc-strict'
+  ]
+}
+
+function formatFiles(fileNames) {
+  return [
+    `prettier --write ${fileNames.join(' ')}`
+    // `eslint --fix ${fileNames.join(' ')}`,
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -93,10 +93,4 @@
     "vue-router": "^4.4.3",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.3.0"
-  },
-  "lint-staged": {
-    "./**/*.{js,ts,tsx,vue}": [
-      "prettier --write"
-    ]
-  }
-}
+  }}


### PR DESCRIPTION
Pros:
- Only runs type check if there is a `.ts`, `.tsx` or `.vue` file staged
- Is otherwise the same as current `npm typecheck` (inc. `tsc-strict`)

Cons:
- Changing other files, e.g. `tsconfig.json` without any .ts files staged, type checking will not run
