### PR TITLE
Bind Ctrl+s to Comfy.SaveWorkflow

### DIFF
--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -59,7 +59,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       key: 's',
       ctrl: true
     },
-    commandId: 'Comfy.ExportWorkflow'
+    commandId: 'Comfy.SaveWorkflow'
   },
   {
     combo: {


### PR DESCRIPTION
As new UI is default in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1515. `Ctrl + s` makes more sense to be bound to save workflow instead of export workflow.