### PR TITLE
Fix always snap to grid

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -182,9 +182,9 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
+  const alwaysSnapToGrid = settingStore.get('pysssss.SnapToGrid')
   if (comfyApp.graph?.config) {
-    comfyApp.graph.config.alwaysSnapToGrid =
-      settingStore.get('pysssss.SnapToGrid')
+    comfyApp.graph.config.alwaysSnapToGrid = alwaysSnapToGrid
   }
 })
 


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1601

Here are some context on `watchEffect` in Vue:

## How It Works:
- When the callback first runs, Vue creates an internal "effect scope"
- During execution, Vue records all reactive properties that are read
- Any time one of these tracked dependencies changes:
- The callback is automatically re-run
- Dependencies are re-tracked (they can change between executions)\

## Important Notes:
- Only reactive property reads are tracked, not writes
- The tracking is automatic - you don't need to specify dependencies like in watch
- Tracking only works for synchronous access within the callback
- Nested function calls are also tracked as long as they're synchronous

Previously the issue was that on the first execution, the graph does not exist and the setting reactive state is not accessed. `comfyApp.graph` is also not reactive, so when it becomes available later, the effect is also not triggered.