### PR TITLE
[Electron] Allow users to submit error reports

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -20,6 +20,7 @@
     </template>
 
     <div class="action-container">
+      <ReportIssueButton v-if="showSendError" :error="props.error" />
       <FindIssueButton
         :errorMessage="props.error.exception_message"
         :repoOwner="repoOwner"
@@ -44,9 +45,11 @@ import Divider from 'primevue/divider'
 import ScrollPanel from 'primevue/scrollpanel'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import FindIssueButton from '@/components/dialog/content/error/FindIssueButton.vue'
+import ReportIssueButton from '@/components/dialog/content/error/ReportIssueButton.vue'
 import type { ExecutionErrorWsMessage, SystemStats } from '@/types/apiTypes'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import { isElectron } from '@/utils/envUtil'
 
 const props = defineProps<{
   error: ExecutionErrorWsMessage
@@ -59,6 +62,7 @@ const reportOpen = ref(false)
 const showReport = () => {
   reportOpen.value = true
 }
+const showSendError = isElectron()
 
 const toast = useToast()
 const { copy, isSupported } = useClipboard()

--- a/src/components/dialog/content/error/ReportIssueButton.vue
+++ b/src/components/dialog/content/error/ReportIssueButton.vue
@@ -1,0 +1,53 @@
+<template>
+  <Button
+    @click="reportIssue"
+    :label="$t('reportIssue')"
+    severity="secondary"
+    :icon="icon"
+    :disabled="submitted"
+  >
+  </Button>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, defineProps } from 'vue'
+import Button from 'primevue/button'
+import { useToast } from 'primevue/usetoast'
+import { ExecutionErrorWsMessage } from '@/types/apiTypes'
+import { useI18n } from 'vue-i18n'
+import { electronAPI } from '@/utils/envUtil'
+
+const { error } = defineProps<{
+  error: ExecutionErrorWsMessage
+}>()
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { t } = useI18n()
+const toast = useToast()
+const submitting = ref(false)
+const submitted = ref(false)
+const icon = computed(
+  () => `pi ${submitting.value ? 'pi-spin pi-spinner' : 'pi-send'}`
+)
+
+const reportIssue = async () => {
+  if (submitting.value) return
+  submitting.value = true
+  try {
+    await electronAPI().sendErrorToSentry(error.exception_message, {
+      stackTrace: error.traceback?.join('\n'),
+      nodeType: error.node_type
+    })
+    submitted.value = true
+    toast.add({
+      severity: 'success',
+      summary: t('reportSent'),
+      life: 3000
+    })
+  } finally {
+    submitting.value = false
+  }
+}
+</script>

--- a/src/components/dialog/content/error/ReportIssueButton.vue
+++ b/src/components/dialog/content/error/ReportIssueButton.vue
@@ -2,9 +2,10 @@
   <Button
     @click="reportIssue"
     :label="$t('reportIssue')"
-    severity="secondary"
+    :severity="submitted ? 'success' : 'secondary'"
     :icon="icon"
     :disabled="submitted"
+    v-tooltip="$t('reportIssueTooltip')"
   >
   </Button>
 </template>
@@ -19,9 +20,6 @@ import { electronAPI } from '@/utils/envUtil'
 
 const { error } = defineProps<{
   error: ExecutionErrorWsMessage
-}>()
-const emit = defineEmits<{
-  close: []
 }>()
 
 const { t } = useI18n()

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -97,6 +97,8 @@ const messages = {
     error: 'Error',
     loading: 'Loading',
     findIssues: 'Find Issues',
+    reportIssue: 'Report Issue',
+    reportSent: 'Report Submitted',
     copyToClipboard: 'Copy to Clipboard',
     openNewIssue: 'Open New Issue',
     showReport: 'Show Report',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -98,6 +98,7 @@ const messages = {
     loading: 'Loading',
     findIssues: 'Find Issues',
     reportIssue: 'Send Report',
+    reportIssueTooltip: 'Submit the error report to Comfy Org',
     reportSent: 'Report Submitted',
     copyToClipboard: 'Copy to Clipboard',
     openNewIssue: 'Open New Issue',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -97,7 +97,7 @@ const messages = {
     error: 'Error',
     loading: 'Loading',
     findIssues: 'Find Issues',
-    reportIssue: 'Report Issue',
+    reportIssue: 'Send Report',
     reportSent: 'Report Submitted',
     copyToClipboard: 'Copy to Clipboard',
     openNewIssue: 'Open New Issue',


### PR DESCRIPTION
Adds a Send Report button to the execution error dialog to allow users to report errors.  
![image](https://github.com/user-attachments/assets/54e1f968-c304-4b99-a6d6-836944fb8c82)


This submits the error message, stacktrace and node type.
We can extend this in future to allow opting in to include more details if they are found to be useful for diagnosing issues (e.g. logs, installed nodes, version, etc)