### PR TITLE
Remove Ctrl+D keybinding

### DIFF
--- a/src/stores/coreKeybindings.ts
+++ b/src/stores/coreKeybindings.ts
@@ -76,13 +76,6 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
-      key: 'd',
-      ctrl: true
-    },
-    commandId: 'Comfy.LoadDefaultWorkflow'
-  },
-  {
-    combo: {
       key: 'g',
       ctrl: true
     },


### PR DESCRIPTION
Resolves https://github.com/comfyanonymous/ComfyUI/issues/5728

Maybe we should bind `Comfy.BrowseTemplates` to a key instead.