### PR TITLE
[Electron] ComfyUI server config (Launch args config)

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -101,6 +101,7 @@ import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import { flattenTree } from '@/utils/treeUtil'
 import AboutPanel from './setting/AboutPanel.vue'
 import FirstTimeUIMessage from './setting/FirstTimeUIMessage.vue'
+import { isElectron } from '@/utils/envUtil'
 
 const KeybindingPanel = defineAsyncComponent(
   () => import('./setting/KeybindingPanel.vue')
@@ -147,13 +148,21 @@ const extensionPanelNodeList = computed<SettingTreeNode[]>(() => {
   return showExtensionPanel ? [extensionPanelNode] : []
 })
 
+/**
+ * Server config panel is only available in Electron. We might want to support
+ * it in the web version in the future.
+ */
+const serverConfigPanelNodeList = computed<SettingTreeNode[]>(() => {
+  return isElectron() ? [serverConfigPanelNode] : []
+})
+
 const settingStore = useSettingStore()
 const settingRoot = computed<SettingTreeNode>(() => settingStore.settingTree)
 const categories = computed<SettingTreeNode[]>(() => [
   ...(settingRoot.value.children || []),
   keybindingPanelNode,
   ...extensionPanelNodeList.value,
-  serverConfigPanelNode,
+  ...serverConfigPanelNodeList.value,
   aboutPanelNode
 ])
 const activeCategory = ref<SettingTreeNode | null>(null)

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -71,6 +71,14 @@
               </template>
             </Suspense>
           </TabPanel>
+          <TabPanel key="server-config" value="Server-Config">
+            <Suspense>
+              <ServerConfigPanel />
+              <template #fallback>
+                <div>Loading server config panel...</div>
+              </template>
+            </Suspense>
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </ScrollPanel>
@@ -100,6 +108,9 @@ const KeybindingPanel = defineAsyncComponent(
 const ExtensionPanel = defineAsyncComponent(
   () => import('./setting/ExtensionPanel.vue')
 )
+const ServerConfigPanel = defineAsyncComponent(
+  () => import('./setting/ServerConfigPanel.vue')
+)
 
 interface ISettingGroup {
   label: string
@@ -124,6 +135,12 @@ const extensionPanelNode: SettingTreeNode = {
   children: []
 }
 
+const serverConfigPanelNode: SettingTreeNode = {
+  key: 'server-config',
+  label: 'Server-Config',
+  children: []
+}
+
 const extensionPanelNodeList = computed<SettingTreeNode[]>(() => {
   const settingStore = useSettingStore()
   const showExtensionPanel = settingStore.get('Comfy.Settings.ExtensionPanel')
@@ -136,6 +153,7 @@ const categories = computed<SettingTreeNode[]>(() => [
   ...(settingRoot.value.children || []),
   keybindingPanelNode,
   ...extensionPanelNodeList.value,
+  serverConfigPanelNode,
   aboutPanelNode
 ])
 const activeCategory = ref<SettingTreeNode | null>(null)

--- a/src/components/dialog/content/setting/ServerConfigPanel.vue
+++ b/src/components/dialog/content/setting/ServerConfigPanel.vue
@@ -1,0 +1,27 @@
+<template>
+  <div
+    v-for="([label, items], i) in Object.entries(serverConfigGroup)"
+    :key="label"
+  >
+    <Divider v-if="i > 0" />
+    <h3>{{ formatCamelCase(label) }}</h3>
+    <div v-for="item in items" :key="item.name" class="flex items-center mb-4">
+      <FormItem :item="item" :form-value="item.defaultValue" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Divider from 'primevue/divider'
+import FormItem from '@/components/common/FormItem.vue'
+import { formatCamelCase } from '@/utils/formatUtil'
+import { SERVER_CONFIG_ITEMS, ServerConfig } from '@/constants/serverConfig'
+
+const serverConfigGroup: Record<string, ServerConfig<any>[]> =
+  SERVER_CONFIG_ITEMS.reduce((acc, item) => {
+    const category = item.category?.[0] ?? 'General'
+    acc[category] = acc[category] || []
+    acc[category].push(item)
+    return acc
+  }, {})
+</script>

--- a/src/components/dialog/content/setting/ServerConfigPanel.vue
+++ b/src/components/dialog/content/setting/ServerConfigPanel.vue
@@ -1,12 +1,12 @@
 <template>
   <div
-    v-for="([label, items], i) in Object.entries(serverConfigGroup)"
+    v-for="([label, items], i) in Object.entries(serverConfigsByCategory)"
     :key="label"
   >
     <Divider v-if="i > 0" />
     <h3>{{ formatCamelCase(label) }}</h3>
     <div v-for="item in items" :key="item.name" class="flex items-center mb-4">
-      <FormItem :item="item" :form-value="item.defaultValue" />
+      <FormItem :item="item" v-model:formValue="item.value" />
     </div>
   </div>
 </template>
@@ -15,13 +15,29 @@
 import Divider from 'primevue/divider'
 import FormItem from '@/components/common/FormItem.vue'
 import { formatCamelCase } from '@/utils/formatUtil'
-import { SERVER_CONFIG_ITEMS, ServerConfig } from '@/constants/serverConfig'
+import { useSettingStore } from '@/stores/settingStore'
+import { useServerConfigStore } from '@/stores/serverConfigStore'
+import { storeToRefs } from 'pinia'
+import { onMounted, watch } from 'vue'
+import { SERVER_CONFIG_ITEMS } from '@/constants/serverConfig'
 
-const serverConfigGroup: Record<string, ServerConfig<any>[]> =
-  SERVER_CONFIG_ITEMS.reduce((acc, item) => {
-    const category = item.category?.[0] ?? 'General'
-    acc[category] = acc[category] || []
-    acc[category].push(item)
-    return acc
-  }, {})
+const settingStore = useSettingStore()
+const serverConfigStore = useServerConfigStore()
+const { serverConfigsByCategory, launchArgs, serverConfigValues } =
+  storeToRefs(serverConfigStore)
+
+onMounted(() => {
+  serverConfigStore.loadServerConfig(
+    SERVER_CONFIG_ITEMS,
+    settingStore.get('Comfy.Server.ServerConfigValues')
+  )
+})
+
+watch(launchArgs, (newVal) => {
+  settingStore.set('Comfy.Server.LaunchArgs', newVal)
+})
+
+watch(serverConfigValues, (newVal) => {
+  settingStore.set('Comfy.Server.ServerConfigValues', newVal)
+})
 </script>

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -1,0 +1,487 @@
+import { FormItem } from '@/types/settingTypes'
+import {
+  LatentPreviewMethod,
+  LogLevel,
+  HashFunction,
+  AutoLaunch,
+  CudaMalloc,
+  FloatingPointPrecision,
+  CrossAttentionMethod,
+  VramManagement
+} from '@/types/serverArgs'
+
+export interface ServerConfig<T> extends FormItem {
+  defaultValue: T
+  category?: string[]
+  // Override the default value getter with a custom function.
+  getValue?: (value: T) => Record<string, any>
+}
+
+export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
+  // Network settings
+  {
+    name: 'listen',
+    category: ['network'],
+    type: 'text',
+    defaultValue: '127.0.0.1',
+    tooltip: 'The IP address to listen on'
+  },
+  {
+    name: 'port',
+    category: ['network'],
+    type: 'number',
+    defaultValue: 8188,
+    tooltip: 'The port to listen on'
+  },
+  {
+    name: 'tls-keyfile',
+    category: ['network'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Path to TLS key file for HTTPS'
+  },
+  {
+    name: 'tls-certfile',
+    category: ['network'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Path to TLS certificate file for HTTPS'
+  },
+  {
+    name: 'enable-cors-header',
+    category: ['network'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Enable CORS header. Use "*" for all origins or specify domain'
+  },
+  {
+    name: 'max-upload-size',
+    category: ['network'],
+    type: 'number',
+    defaultValue: 100,
+    tooltip: 'Maximum upload size in MB'
+  },
+
+  // Directory settings
+  {
+    name: 'extra-model-paths-config',
+    category: ['directory'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Additional paths to search for models'
+  },
+  {
+    name: 'output-directory',
+    category: ['directory'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Directory for output files'
+  },
+  {
+    name: 'temp-directory',
+    category: ['directory'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Directory for temporary files'
+  },
+  {
+    name: 'input-directory',
+    category: ['directory'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Directory for input files'
+  },
+  {
+    name: 'user-directory',
+    category: ['directory'],
+    type: 'text',
+    defaultValue: undefined,
+    tooltip: 'Directory for user files'
+  },
+
+  // Launch behavior
+  {
+    name: 'auto-launch',
+    category: ['launch'],
+    type: 'combo',
+    options: Object.values(AutoLaunch),
+    defaultValue: AutoLaunch.Auto,
+    tooltip: 'Automatically launch the server',
+    getValue: (value: AutoLaunch) => {
+      switch (value) {
+        case AutoLaunch.Auto:
+          return {}
+        case AutoLaunch.Enable:
+          return {
+            ['auto-launch']: true
+          }
+        case AutoLaunch.Disable:
+          return {
+            ['disable-auto-launch']: true
+          }
+      }
+    }
+  },
+
+  // CUDA settings
+  {
+    name: 'cuda-device',
+    category: ['CUDA'],
+    type: 'number',
+    defaultValue: undefined,
+    tooltip: 'CUDA device index to use'
+  },
+  {
+    name: 'cuda-malloc',
+    category: ['CUDA'],
+    type: 'combo',
+    options: Object.values(CudaMalloc),
+    defaultValue: CudaMalloc.Auto,
+    tooltip: 'Use CUDA malloc for memory allocation',
+    getValue: (value: CudaMalloc) => {
+      switch (value) {
+        case CudaMalloc.Auto:
+          return {}
+        case CudaMalloc.Enable:
+          return {
+            ['cuda-malloc']: true
+          }
+        case CudaMalloc.Disable:
+          return {
+            ['disable-cuda-malloc']: true
+          }
+      }
+    }
+  },
+
+  // Precision settings
+  {
+    name: 'global-precision',
+    category: ['inference'],
+    type: 'combo',
+    options: [
+      FloatingPointPrecision.AUTO,
+      FloatingPointPrecision.FP32,
+      FloatingPointPrecision.FP16
+    ],
+    defaultValue: FloatingPointPrecision.AUTO,
+    tooltip: 'Global floating point precision',
+    getValue: (value: FloatingPointPrecision) => {
+      switch (value) {
+        case FloatingPointPrecision.AUTO:
+          return {}
+        case FloatingPointPrecision.FP32:
+          return {
+            ['force-fp32']: true
+          }
+        case FloatingPointPrecision.FP16:
+          return {
+            ['force-fp16']: true
+          }
+        default:
+          return {}
+      }
+    }
+  },
+
+  // UNET precision
+  {
+    name: 'unet-precision',
+    category: ['inference'],
+    type: 'combo',
+    options: [
+      FloatingPointPrecision.AUTO,
+      FloatingPointPrecision.FP16,
+      FloatingPointPrecision.BF16,
+      FloatingPointPrecision.FP8E4M3FN,
+      FloatingPointPrecision.FP8E5M2
+    ],
+    defaultValue: FloatingPointPrecision.AUTO,
+    tooltip: 'UNET precision',
+    getValue: (value: FloatingPointPrecision) => {
+      switch (value) {
+        case FloatingPointPrecision.AUTO:
+          return {}
+        default:
+          return {
+            [`${value.toLowerCase()}-unet`]: true
+          }
+      }
+    }
+  },
+
+  // VAE settings
+  {
+    name: 'vae-precision',
+    category: ['inference'],
+    type: 'combo',
+    options: [
+      FloatingPointPrecision.AUTO,
+      FloatingPointPrecision.FP16,
+      FloatingPointPrecision.FP32,
+      FloatingPointPrecision.BF16
+    ],
+    defaultValue: FloatingPointPrecision.AUTO,
+    tooltip: 'VAE precision',
+    getValue: (value: FloatingPointPrecision) => {
+      switch (value) {
+        case FloatingPointPrecision.AUTO:
+          return {}
+        default:
+          return {
+            [`${value.toLowerCase()}-vae`]: true
+          }
+      }
+    }
+  },
+  {
+    name: 'cpu-vae',
+    category: ['inference'],
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Run VAE on CPU'
+  },
+
+  // Text Encoder settings
+  {
+    name: 'text-encoder-precision',
+    category: ['inference'],
+    type: 'combo',
+    options: [
+      FloatingPointPrecision.AUTO,
+      FloatingPointPrecision.FP8E4M3FN,
+      FloatingPointPrecision.FP8E5M2,
+      FloatingPointPrecision.FP16,
+      FloatingPointPrecision.FP32
+    ],
+    defaultValue: FloatingPointPrecision.AUTO,
+    tooltip: 'Text Encoder precision',
+    getValue: (value: FloatingPointPrecision) => {
+      switch (value) {
+        case FloatingPointPrecision.AUTO:
+          return {}
+        default:
+          return {
+            [`${value.toLowerCase()}-text-enc`]: true
+          }
+      }
+    }
+  },
+
+  // Memory and performance settings
+  {
+    name: 'force-channels-last',
+    category: ['memory'],
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Force channels-last memory format'
+  },
+  {
+    name: 'directml',
+    category: ['memory'],
+    type: 'number',
+    defaultValue: undefined,
+    tooltip: 'DirectML device index'
+  },
+  {
+    name: 'disable-ipex-optimize',
+    category: ['memory'],
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Disable IPEX optimization'
+  },
+
+  // Preview settings
+  {
+    name: 'preview-method',
+    category: ['preview'],
+    type: 'combo',
+    options: Object.values(LatentPreviewMethod),
+    defaultValue: LatentPreviewMethod.NoPreviews,
+    tooltip: 'Method used for latent previews'
+  },
+  {
+    name: 'preview-size',
+    category: ['preview'],
+    type: 'number',
+    defaultValue: 512,
+    tooltip: 'Size of preview images'
+  },
+
+  // Cache settings
+  {
+    name: 'cache-classic',
+    category: ['Cache'],
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Use classic cache system'
+  },
+  {
+    name: 'cache-lru',
+    category: ['Cache'],
+    type: 'number',
+    defaultValue: 0,
+    tooltip:
+      'Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM (0 to disable).'
+  },
+
+  // Attention settings
+  {
+    name: 'cross-attention-method',
+    category: ['attention'],
+    type: 'combo',
+    options: Object.values(CrossAttentionMethod),
+    defaultValue: CrossAttentionMethod.Auto,
+    tooltip: 'Cross attention method',
+    getValue: (value: CrossAttentionMethod) => {
+      switch (value) {
+        case CrossAttentionMethod.Auto:
+          return {}
+        default:
+          return {
+            [`use-${value.toLowerCase()}-cross-attention`]: true
+          }
+      }
+    }
+  },
+  {
+    name: 'disable-xformers',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Disable xFormers optimization'
+  },
+  {
+    name: 'force-upcast-attention',
+    category: ['attention'],
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Force attention upcast'
+  },
+  {
+    name: 'dont-upcast-attention',
+    category: ['attention'],
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Prevent attention upcast'
+  },
+
+  // VRAM management
+  {
+    name: 'vram-management',
+    category: ['memory'],
+    type: 'combo',
+    options: Object.values(VramManagement),
+    defaultValue: VramManagement.Auto,
+    tooltip: 'VRAM management mode',
+    getValue: (value: VramManagement) => {
+      switch (value) {
+        case VramManagement.Auto:
+          return {}
+        default:
+          return {
+            [value]: true
+          }
+      }
+    }
+  },
+  {
+    name: 'reserve-vram',
+    category: ['memory'],
+    type: 'number',
+    defaultValue: undefined,
+    tooltip:
+      'Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reverved depending on your OS.'
+  },
+
+  // Misc settings
+  {
+    name: 'default-hashing-function',
+    type: 'combo',
+    options: Object.values(HashFunction),
+    defaultValue: HashFunction.SHA256,
+    tooltip: 'Default hashing function for model files'
+  },
+  {
+    name: 'disable-smart-memory',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip:
+      'Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.'
+  },
+  {
+    name: 'deterministic',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip:
+      'Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.'
+  },
+  {
+    name: 'fast',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip:
+      'Enable some untested and potentially quality deteriorating optimizations.'
+  },
+  {
+    name: 'dont-print-server',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: "Don't print server output to console."
+  },
+  {
+    name: 'quick-test-for-ci',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Quick test mode for CI'
+  },
+  {
+    name: 'windows-standalone-build',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip:
+      'Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup)'
+  },
+  {
+    name: 'disable-metadata',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Disable saving prompt metadata in files.'
+  },
+  {
+    name: 'disable-all-custom-nodes',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Disable loading all custom nodes.'
+  },
+  {
+    name: 'multi-user',
+    type: 'boolean',
+    defaultValue: false,
+    tooltip: 'Enable multi-user mode'
+  },
+  {
+    name: 'log-level',
+    type: 'combo',
+    options: Object.values(LogLevel),
+    defaultValue: LogLevel.INFO,
+    tooltip: 'Logging verbosity level',
+    getValue: (value: LogLevel) => {
+      return {
+        verbose: value
+      }
+    }
+  },
+
+  // Frontend settings
+  {
+    name: 'front-end-version',
+    type: 'text',
+    defaultValue: 'comfyanonymous/ComfyUI@latest',
+    tooltip: `Specifies the version of the frontend to be used. This command needs internet connectivity to query and
+    download available frontend implementations from GitHub releases.
+
+    The version string should be in the format of:
+    [repoOwner]/[repoName]@[version]
+    where version is one of: "latest" or a valid version number (e.g. "1.0.0")`
+  }
+]

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -272,8 +272,13 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     id: 'preview-size',
     name: 'Size of preview images',
     category: ['Preview'],
-    type: 'number',
-    defaultValue: 512
+    type: 'slider',
+    defaultValue: 512,
+    attrs: {
+      min: 128,
+      max: 2048,
+      step: 128
+    }
   },
 
   // Cache settings

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -23,42 +23,42 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'listen',
     name: 'Host: The IP address to listen on',
-    category: ['network'],
+    category: ['Network'],
     type: 'text',
     defaultValue: '127.0.0.1'
   },
   {
     id: 'port',
     name: 'Port: The port to listen on',
-    category: ['network'],
+    category: ['Network'],
     type: 'number',
     defaultValue: 8188
   },
   {
     id: 'tls-keyfile',
     name: 'TLS Key File: Path to TLS key file for HTTPS',
-    category: ['network'],
+    category: ['Network'],
     type: 'text',
     defaultValue: undefined
   },
   {
     id: 'tls-certfile',
     name: 'TLS Certificate File: Path to TLS certificate file for HTTPS',
-    category: ['network'],
+    category: ['Network'],
     type: 'text',
     defaultValue: undefined
   },
   {
     id: 'enable-cors-header',
     name: 'Enable CORS header: Use "*" for all origins or specify domain',
-    category: ['network'],
+    category: ['Network'],
     type: 'text',
     defaultValue: undefined
   },
   {
     id: 'max-upload-size',
     name: 'Maximum upload size (MB)',
-    category: ['network'],
+    category: ['Network'],
     type: 'number',
     defaultValue: 100
   },
@@ -67,7 +67,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'auto-launch',
     name: 'Automatically opens in the browser on startup',
-    category: ['launch'],
+    category: ['Launch'],
     type: 'combo',
     options: Object.values(AutoLaunch),
     defaultValue: AutoLaunch.Auto,
@@ -122,7 +122,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'global-precision',
     name: 'Global floating point precision',
-    category: ['inference'],
+    category: ['Inference'],
     type: 'combo',
     options: [
       FloatingPointPrecision.AUTO,
@@ -153,7 +153,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'unet-precision',
     name: 'UNET precision',
-    category: ['inference'],
+    category: ['Inference'],
     type: 'combo',
     options: [
       FloatingPointPrecision.AUTO,
@@ -180,7 +180,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'vae-precision',
     name: 'VAE precision',
-    category: ['inference'],
+    category: ['Inference'],
     type: 'combo',
     options: [
       FloatingPointPrecision.AUTO,
@@ -204,7 +204,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'cpu-vae',
     name: 'Run VAE on CPU',
-    category: ['inference'],
+    category: ['Inference'],
     type: 'boolean',
     defaultValue: false
   },
@@ -213,7 +213,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'text-encoder-precision',
     name: 'Text Encoder precision',
-    category: ['inference'],
+    category: ['Inference'],
     type: 'combo',
     options: [
       FloatingPointPrecision.AUTO,
@@ -240,21 +240,21 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'force-channels-last',
     name: 'Force channels-last memory format',
-    category: ['memory'],
+    category: ['Memory'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'directml',
     name: 'DirectML device index',
-    category: ['memory'],
+    category: ['Memory'],
     type: 'number',
     defaultValue: undefined
   },
   {
     id: 'disable-ipex-optimize',
     name: 'Disable IPEX optimization',
-    category: ['memory'],
+    category: ['Memory'],
     type: 'boolean',
     defaultValue: false
   },
@@ -263,7 +263,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'preview-method',
     name: 'Method used for latent previews',
-    category: ['preview'],
+    category: ['Preview'],
     type: 'combo',
     options: Object.values(LatentPreviewMethod),
     defaultValue: LatentPreviewMethod.NoPreviews
@@ -271,7 +271,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'preview-size',
     name: 'Size of preview images',
-    category: ['preview'],
+    category: ['Preview'],
     type: 'number',
     defaultValue: 512
   },
@@ -286,17 +286,18 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   },
   {
     id: 'cache-lru',
-    name: 'Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM (0 to disable).',
+    name: 'Use LRU caching with a maximum of N node results cached. (0 to disable).',
     category: ['Cache'],
     type: 'number',
-    defaultValue: 0
+    defaultValue: 0,
+    tooltip: 'May use more RAM/VRAM.'
   },
 
   // Attention settings
   {
     id: 'cross-attention-method',
     name: 'Cross attention method',
-    category: ['attention'],
+    category: ['Attention'],
     type: 'combo',
     options: Object.values(CrossAttentionMethod),
     defaultValue: CrossAttentionMethod.Auto,
@@ -320,14 +321,14 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'force-upcast-attention',
     name: 'Force attention upcast',
-    category: ['attention'],
+    category: ['Attention'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'dont-upcast-attention',
     name: 'Prevent attention upcast',
-    category: ['attention'],
+    category: ['Attention'],
     type: 'boolean',
     defaultValue: false
   },
@@ -336,7 +337,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'vram-management',
     name: 'VRAM management mode',
-    category: ['memory'],
+    category: ['Memory'],
     type: 'combo',
     options: Object.values(VramManagement),
     defaultValue: VramManagement.Auto,
@@ -354,7 +355,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'reserve-vram',
     name: 'Reserved VRAM (GB)',
-    category: ['memory'],
+    category: ['Memory'],
     type: 'number',
     defaultValue: undefined,
     tooltip:
@@ -365,7 +366,6 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'default-hashing-function',
     name: 'Default hashing function for model files',
-    category: ['misc'],
     type: 'combo',
     options: Object.values(HashFunction),
     defaultValue: HashFunction.SHA256
@@ -373,14 +373,13 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'disable-smart-memory',
     name: 'Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.',
-    category: ['memory'],
+    category: ['Memory'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'deterministic',
     name: 'Make pytorch use slower deterministic algorithms when it can.',
-    category: ['misc'],
     type: 'boolean',
     defaultValue: false,
     tooltip: 'Note that this might not make images deterministic in all cases.'
@@ -388,35 +387,30 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'fast',
     name: 'Enable some untested and potentially quality deteriorating optimizations.',
-    category: ['misc'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'dont-print-server',
     name: "Don't print server output to console.",
-    category: ['misc'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'disable-metadata',
     name: 'Disable saving prompt metadata in files.',
-    category: ['misc'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'disable-all-custom-nodes',
     name: 'Disable loading all custom nodes.',
-    category: ['misc'],
     type: 'boolean',
     defaultValue: false
   },
   {
     id: 'log-level',
     name: 'Logging verbosity level',
-    category: ['misc'],
     type: 'combo',
     options: Object.values(LogLevel),
     defaultValue: LogLevel.INFO,
@@ -425,20 +419,5 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
         verbose: value
       }
     }
-  },
-
-  // Frontend settings
-  {
-    id: 'front-end-version',
-    name: 'Frontend implementation',
-    category: ['frontend'],
-    type: 'text',
-    defaultValue: 'comfyanonymous/ComfyUI@latest',
-    tooltip: `Specifies the version of the frontend to be used. This command needs internet connectivity to query and
-    download available frontend implementations from GitHub releases.
-
-    The version string should be in the format of:
-    [repoOwner]/[repoName]@[version]
-    where version is one of: "latest" or a valid version number (e.g. "1.0.0")`
   }
 ]

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -11,6 +11,7 @@ import {
 } from '@/types/serverArgs'
 
 export interface ServerConfig<T> extends FormItem {
+  id: string
   defaultValue: T
   category?: string[]
   // Override the default value getter with a custom function.
@@ -20,93 +21,56 @@ export interface ServerConfig<T> extends FormItem {
 export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   // Network settings
   {
-    name: 'listen',
+    id: 'listen',
+    name: 'Host: The IP address to listen on',
     category: ['network'],
     type: 'text',
-    defaultValue: '127.0.0.1',
-    tooltip: 'The IP address to listen on'
+    defaultValue: '127.0.0.1'
   },
   {
-    name: 'port',
-    category: ['network'],
-    type: 'number',
-    defaultValue: 8188,
-    tooltip: 'The port to listen on'
-  },
-  {
-    name: 'tls-keyfile',
-    category: ['network'],
-    type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Path to TLS key file for HTTPS'
-  },
-  {
-    name: 'tls-certfile',
-    category: ['network'],
-    type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Path to TLS certificate file for HTTPS'
-  },
-  {
-    name: 'enable-cors-header',
-    category: ['network'],
-    type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Enable CORS header. Use "*" for all origins or specify domain'
-  },
-  {
-    name: 'max-upload-size',
+    id: 'port',
+    name: 'Port: The port to listen on',
     category: ['network'],
     type: 'number',
-    defaultValue: 100,
-    tooltip: 'Maximum upload size in MB'
-  },
-
-  // Directory settings
-  {
-    name: 'extra-model-paths-config',
-    category: ['directory'],
-    type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Additional paths to search for models'
+    defaultValue: 8188
   },
   {
-    name: 'output-directory',
-    category: ['directory'],
+    id: 'tls-keyfile',
+    name: 'TLS Key File: Path to TLS key file for HTTPS',
+    category: ['network'],
     type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Directory for output files'
+    defaultValue: undefined
   },
   {
-    name: 'temp-directory',
-    category: ['directory'],
+    id: 'tls-certfile',
+    name: 'TLS Certificate File: Path to TLS certificate file for HTTPS',
+    category: ['network'],
     type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Directory for temporary files'
+    defaultValue: undefined
   },
   {
-    name: 'input-directory',
-    category: ['directory'],
+    id: 'enable-cors-header',
+    name: 'Enable CORS header: Use "*" for all origins or specify domain',
+    category: ['network'],
     type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Directory for input files'
+    defaultValue: undefined
   },
   {
-    name: 'user-directory',
-    category: ['directory'],
-    type: 'text',
-    defaultValue: undefined,
-    tooltip: 'Directory for user files'
+    id: 'max-upload-size',
+    name: 'Maximum upload size (MB)',
+    category: ['network'],
+    type: 'number',
+    defaultValue: 100
   },
 
   // Launch behavior
   {
-    name: 'auto-launch',
+    id: 'auto-launch',
+    name: 'Automatically opens in the browser on startup',
     category: ['launch'],
     type: 'combo',
     options: Object.values(AutoLaunch),
     defaultValue: AutoLaunch.Auto,
-    tooltip: 'Automatically launch the server',
     getValue: (value: AutoLaunch) => {
       switch (value) {
         case AutoLaunch.Auto:
@@ -125,19 +89,19 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // CUDA settings
   {
-    name: 'cuda-device',
+    id: 'cuda-device',
+    name: 'CUDA device index to use',
     category: ['CUDA'],
     type: 'number',
-    defaultValue: undefined,
-    tooltip: 'CUDA device index to use'
+    defaultValue: undefined
   },
   {
-    name: 'cuda-malloc',
+    id: 'cuda-malloc',
+    name: 'Use CUDA malloc for memory allocation',
     category: ['CUDA'],
     type: 'combo',
     options: Object.values(CudaMalloc),
     defaultValue: CudaMalloc.Auto,
-    tooltip: 'Use CUDA malloc for memory allocation',
     getValue: (value: CudaMalloc) => {
       switch (value) {
         case CudaMalloc.Auto:
@@ -156,7 +120,8 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // Precision settings
   {
-    name: 'global-precision',
+    id: 'global-precision',
+    name: 'Global floating point precision',
     category: ['inference'],
     type: 'combo',
     options: [
@@ -186,7 +151,8 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // UNET precision
   {
-    name: 'unet-precision',
+    id: 'unet-precision',
+    name: 'UNET precision',
     category: ['inference'],
     type: 'combo',
     options: [
@@ -212,7 +178,8 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // VAE settings
   {
-    name: 'vae-precision',
+    id: 'vae-precision',
+    name: 'VAE precision',
     category: ['inference'],
     type: 'combo',
     options: [
@@ -235,16 +202,17 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     }
   },
   {
-    name: 'cpu-vae',
+    id: 'cpu-vae',
+    name: 'Run VAE on CPU',
     category: ['inference'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Run VAE on CPU'
+    defaultValue: false
   },
 
   // Text Encoder settings
   {
-    name: 'text-encoder-precision',
+    id: 'text-encoder-precision',
+    name: 'Text Encoder precision',
     category: ['inference'],
     type: 'combo',
     options: [
@@ -270,69 +238,68 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // Memory and performance settings
   {
-    name: 'force-channels-last',
+    id: 'force-channels-last',
+    name: 'Force channels-last memory format',
     category: ['memory'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Force channels-last memory format'
+    defaultValue: false
   },
   {
-    name: 'directml',
+    id: 'directml',
+    name: 'DirectML device index',
     category: ['memory'],
     type: 'number',
-    defaultValue: undefined,
-    tooltip: 'DirectML device index'
+    defaultValue: undefined
   },
   {
-    name: 'disable-ipex-optimize',
+    id: 'disable-ipex-optimize',
+    name: 'Disable IPEX optimization',
     category: ['memory'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Disable IPEX optimization'
+    defaultValue: false
   },
 
   // Preview settings
   {
-    name: 'preview-method',
+    id: 'preview-method',
+    name: 'Method used for latent previews',
     category: ['preview'],
     type: 'combo',
     options: Object.values(LatentPreviewMethod),
-    defaultValue: LatentPreviewMethod.NoPreviews,
-    tooltip: 'Method used for latent previews'
+    defaultValue: LatentPreviewMethod.NoPreviews
   },
   {
-    name: 'preview-size',
+    id: 'preview-size',
+    name: 'Size of preview images',
     category: ['preview'],
     type: 'number',
-    defaultValue: 512,
-    tooltip: 'Size of preview images'
+    defaultValue: 512
   },
 
   // Cache settings
   {
-    name: 'cache-classic',
+    id: 'cache-classic',
+    name: 'Use classic cache system',
     category: ['Cache'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Use classic cache system'
+    defaultValue: false
   },
   {
-    name: 'cache-lru',
+    id: 'cache-lru',
+    name: 'Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM (0 to disable).',
     category: ['Cache'],
     type: 'number',
-    defaultValue: 0,
-    tooltip:
-      'Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM (0 to disable).'
+    defaultValue: 0
   },
 
   // Attention settings
   {
-    name: 'cross-attention-method',
+    id: 'cross-attention-method',
+    name: 'Cross attention method',
     category: ['attention'],
     type: 'combo',
     options: Object.values(CrossAttentionMethod),
     defaultValue: CrossAttentionMethod.Auto,
-    tooltip: 'Cross attention method',
     getValue: (value: CrossAttentionMethod) => {
       switch (value) {
         case CrossAttentionMethod.Auto:
@@ -345,34 +312,34 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     }
   },
   {
-    name: 'disable-xformers',
+    id: 'disable-xformers',
+    name: 'Disable xFormers optimization',
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Disable xFormers optimization'
+    defaultValue: false
   },
   {
-    name: 'force-upcast-attention',
+    id: 'force-upcast-attention',
+    name: 'Force attention upcast',
     category: ['attention'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Force attention upcast'
+    defaultValue: false
   },
   {
-    name: 'dont-upcast-attention',
+    id: 'dont-upcast-attention',
+    name: 'Prevent attention upcast',
     category: ['attention'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Prevent attention upcast'
+    defaultValue: false
   },
 
   // VRAM management
   {
-    name: 'vram-management',
+    id: 'vram-management',
+    name: 'VRAM management mode',
     category: ['memory'],
     type: 'combo',
     options: Object.values(VramManagement),
     defaultValue: VramManagement.Auto,
-    tooltip: 'VRAM management mode',
     getValue: (value: VramManagement) => {
       switch (value) {
         case VramManagement.Auto:
@@ -385,7 +352,8 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     }
   },
   {
-    name: 'reserve-vram',
+    id: 'reserve-vram',
+    name: 'Reserved VRAM (GB)',
     category: ['memory'],
     type: 'number',
     defaultValue: undefined,
@@ -395,76 +363,63 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // Misc settings
   {
-    name: 'default-hashing-function',
+    id: 'default-hashing-function',
+    name: 'Default hashing function for model files',
+    category: ['misc'],
     type: 'combo',
     options: Object.values(HashFunction),
-    defaultValue: HashFunction.SHA256,
-    tooltip: 'Default hashing function for model files'
+    defaultValue: HashFunction.SHA256
   },
   {
-    name: 'disable-smart-memory',
+    id: 'disable-smart-memory',
+    name: 'Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.',
+    category: ['memory'],
+    type: 'boolean',
+    defaultValue: false
+  },
+  {
+    id: 'deterministic',
+    name: 'Make pytorch use slower deterministic algorithms when it can.',
+    category: ['misc'],
     type: 'boolean',
     defaultValue: false,
-    tooltip:
-      'Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.'
+    tooltip: 'Note that this might not make images deterministic in all cases.'
   },
   {
-    name: 'deterministic',
+    id: 'fast',
+    name: 'Enable some untested and potentially quality deteriorating optimizations.',
+    category: ['misc'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip:
-      'Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.'
+    defaultValue: false
   },
   {
-    name: 'fast',
+    id: 'dont-print-server',
+    name: "Don't print server output to console.",
+    category: ['misc'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip:
-      'Enable some untested and potentially quality deteriorating optimizations.'
+    defaultValue: false
   },
   {
-    name: 'dont-print-server',
+    id: 'disable-metadata',
+    name: 'Disable saving prompt metadata in files.',
+    category: ['misc'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: "Don't print server output to console."
+    defaultValue: false
   },
   {
-    name: 'quick-test-for-ci',
+    id: 'disable-all-custom-nodes',
+    name: 'Disable loading all custom nodes.',
+    category: ['misc'],
     type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Quick test mode for CI'
+    defaultValue: false
   },
   {
-    name: 'windows-standalone-build',
-    type: 'boolean',
-    defaultValue: false,
-    tooltip:
-      'Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup)'
-  },
-  {
-    name: 'disable-metadata',
-    type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Disable saving prompt metadata in files.'
-  },
-  {
-    name: 'disable-all-custom-nodes',
-    type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Disable loading all custom nodes.'
-  },
-  {
-    name: 'multi-user',
-    type: 'boolean',
-    defaultValue: false,
-    tooltip: 'Enable multi-user mode'
-  },
-  {
-    name: 'log-level',
+    id: 'log-level',
+    name: 'Logging verbosity level',
+    category: ['misc'],
     type: 'combo',
     options: Object.values(LogLevel),
     defaultValue: LogLevel.INFO,
-    tooltip: 'Logging verbosity level',
     getValue: (value: LogLevel) => {
       return {
         verbose: value
@@ -474,7 +429,9 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
 
   // Frontend settings
   {
-    name: 'front-end-version',
+    id: 'front-end-version',
+    name: 'Frontend implementation',
+    category: ['frontend'],
     type: 'text',
     defaultValue: 'comfyanonymous/ComfyUI@latest',
     tooltip: `Specifies the version of the frontend to be used. This command needs internet connectivity to query and

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -31,14 +31,6 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
         type: 'boolean',
         defaultValue: true,
         onChange: onChangeRestartApp
-      },
-      {
-        id: 'Comfy-Desktop.ComfyServer.ExtraLaunchArgs',
-        category: ['Comfy-Desktop', 'ComfyUI Server'],
-        name: 'Extra launch arguments passed to the ComfyUI main.py script',
-        type: 'text',
-        defaultValue: '',
-        onChange: onChangeRestartApp
       }
     ],
 

--- a/src/stores/coreSettings.ts
+++ b/src/stores/coreSettings.ts
@@ -624,5 +624,23 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'boolean',
     defaultValue: false,
     versionAdded: '1.3.13'
+  },
+  {
+    id: 'Comfy.Server.ServerConfigValues',
+    name: 'Server config values for frontend display',
+    tooltip: 'Server config values used for frontend display only',
+    type: 'hidden',
+    // Mapping from server config id to value.
+    defaultValue: {} as Record<string, any>,
+    versionAdded: '1.4.8'
+  },
+  {
+    id: 'Comfy.Server.LaunchArgs',
+    name: 'Server launch arguments',
+    tooltip:
+      'These are the actual arguments that are passed to the server when it is launched.',
+    type: 'hidden',
+    defaultValue: {} as Record<string, string>,
+    versionAdded: '1.4.8'
   }
 ]

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -29,7 +29,9 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
       serverConfigs.value.map((config) => {
         return [
           config.id,
-          config.value === config.defaultValue ? undefined : config.value
+          config.value === config.defaultValue || !config.value
+            ? undefined
+            : config.value
         ]
       })
     )
@@ -38,7 +40,7 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
     return Object.assign(
       {},
       ...serverConfigs.value.map((config) => {
-        if (config.value === config.defaultValue) {
+        if (config.value === config.defaultValue || !config.value) {
           return {}
         }
         return config.getValue

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -38,6 +38,9 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
     return Object.assign(
       {},
       ...serverConfigs.value.map((config) => {
+        if (config.value === config.defaultValue) {
+          return {}
+        }
         return config.getValue
           ? config.getValue(config.value)
           : { [config.id]: config.value }

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -1,0 +1,68 @@
+import { ServerConfig } from '@/constants/serverConfig'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export type ServerConfigWithValue<T> = ServerConfig<T> & {
+  value: T
+}
+
+export const useServerConfigStore = defineStore('serverConfig', () => {
+  const serverConfigById = ref<Record<string, ServerConfigWithValue<any>>>({})
+  const serverConfigs = computed(() => {
+    return Object.values(serverConfigById.value)
+  })
+  const serverConfigsByCategory = computed<
+    Record<string, ServerConfigWithValue<any>[]>
+  >(() => {
+    return serverConfigs.value.reduce(
+      (acc, config) => {
+        const category = config.category?.[0] ?? 'General'
+        acc[category] = acc[category] || []
+        acc[category].push(config)
+        return acc
+      },
+      {} as Record<string, ServerConfigWithValue<any>[]>
+    )
+  })
+  const serverConfigValues = computed<Record<string, any>>(() => {
+    return Object.fromEntries(
+      serverConfigs.value.map((config) => {
+        return [
+          config.id,
+          config.value === config.defaultValue ? undefined : config.value
+        ]
+      })
+    )
+  })
+  const launchArgs = computed<Record<string, string>>(() => {
+    return Object.assign(
+      {},
+      ...serverConfigs.value.map((config) => {
+        return config.getValue
+          ? config.getValue(config.value)
+          : { [config.id]: config.value }
+      })
+    )
+  })
+
+  function loadServerConfig(
+    configs: ServerConfig<any>[],
+    values: Record<string, any>
+  ) {
+    for (const config of configs) {
+      serverConfigById.value[config.id] = {
+        ...config,
+        value: values[config.id] ?? config.defaultValue
+      }
+    }
+  }
+
+  return {
+    serverConfigById,
+    serverConfigs,
+    serverConfigsByCategory,
+    serverConfigValues,
+    launchArgs,
+    loadServerConfig
+  }
+})

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -526,7 +526,9 @@ const zSettings = z.record(z.any()).and(
       'Comfy.Settings.ExtensionPanel': z.boolean(),
       'Comfy.LinkRenderMode': z.number(),
       'Comfy.Node.AutoSnapLinkToSlot': z.boolean(),
-      'Comfy.Node.SnapHighlightsNode': z.boolean()
+      'Comfy.Node.SnapHighlightsNode': z.boolean(),
+      'Comfy.Server.ServerConfigValues': z.record(z.string(), z.any()),
+      'Comfy.Server.LaunchArgs': z.record(z.string(), z.string())
     })
     .optional()
 )

--- a/src/types/serverArgs.ts
+++ b/src/types/serverArgs.ts
@@ -1,0 +1,207 @@
+export enum LatentPreviewMethod {
+  NoPreviews = 'none',
+  Auto = 'auto',
+  Latent2RGB = 'latent2rgb',
+  TAESD = 'taesd'
+}
+
+export enum LogLevel {
+  DEBUG = 'DEBUG',
+  INFO = 'INFO',
+  WARNING = 'WARNING',
+  ERROR = 'ERROR',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum HashFunction {
+  MD5 = 'md5',
+  SHA1 = 'sha1',
+  SHA256 = 'sha256',
+  SHA512 = 'sha512'
+}
+
+export interface ComfyUIServerConfig {
+  // Network settings
+  listen?: string // default: "127.0.0.1"
+  port: number // default: 8188
+  tlsKeyfile?: string
+  tlsCertfile?: string
+  enableCorsHeader?: string // default: undefined, when enabled without value: "*"
+  maxUploadSize: number // default: 100 (MB)
+
+  // Directory settings
+  extraModelPathsConfig?: string[]
+  outputDirectory?: string
+  tempDirectory?: string
+  inputDirectory?: string
+  userDirectory?: string
+
+  // Launch behavior
+  autoLaunch: boolean
+  disableAutoLaunch: boolean
+
+  // CUDA settings
+  cudaDevice?: number
+  cudaMalloc: boolean
+  disableCudaMalloc: boolean
+
+  // Precision settings
+  forceFp32: boolean
+  forceFp16: boolean
+
+  // UNET precision
+  bf16Unet: boolean
+  fp16Unet: boolean
+  fp8E4m3fnUnet: boolean
+  fp8E5m2Unet: boolean
+
+  // VAE settings
+  fp16Vae: boolean
+  fp32Vae: boolean
+  bf16Vae: boolean
+  cpuVae: boolean
+
+  // Text Encoder settings
+  fp8E4m3fnTextEnc: boolean
+  fp8E5m2TextEnc: boolean
+  fp16TextEnc: boolean
+  fp32TextEnc: boolean
+
+  // Memory and performance settings
+  forceChannelsLast: boolean
+  directml?: number
+  disableIpexOptimize: boolean
+  previewMethod: LatentPreviewMethod
+  previewSize: number
+
+  // Cache settings
+  cacheClassic: boolean
+  cacheLru: number // default: 0
+
+  // Attention settings
+  useSplitCrossAttention: boolean
+  useQuadCrossAttention: boolean
+  usePytorchCrossAttention: boolean
+  disableXformers: boolean
+  forceUpcastAttention: boolean
+  dontUpcastAttention: boolean
+
+  // VRAM management
+  gpuOnly: boolean
+  highvram: boolean
+  normalvram: boolean
+  lowvram: boolean
+  novram: boolean
+  cpu: boolean
+  reserveVram?: number
+
+  // Misc settings
+  defaultHashingFunction: HashFunction
+  disableSmartMemory: boolean
+  deterministic: boolean
+  fast: boolean
+  dontPrintServer: boolean
+  quickTestForCi: boolean
+  windowsStandaloneBuild: boolean
+  disableMetadata: boolean
+  disableAllCustomNodes: boolean
+  multiUser: boolean
+  verbose: LogLevel
+
+  // Frontend settings
+  frontEndVersion: string // default: "comfyanonymous/ComfyUI@latest"
+  frontEndRoot?: string
+}
+
+export const DEFAULT_SERVER_CONFIG: ComfyUIServerConfig = {
+  // Network settings
+  listen: '127.0.0.1',
+  port: 8188,
+  tlsKeyfile: undefined,
+  tlsCertfile: undefined,
+  enableCorsHeader: undefined,
+  maxUploadSize: 100,
+
+  // Directory settings
+  extraModelPathsConfig: undefined,
+  outputDirectory: undefined,
+  tempDirectory: undefined,
+  inputDirectory: undefined,
+  userDirectory: undefined,
+
+  // Launch behavior
+  autoLaunch: false,
+  disableAutoLaunch: false,
+
+  // CUDA settings
+  cudaDevice: undefined,
+  cudaMalloc: false,
+  disableCudaMalloc: false,
+
+  // Precision settings
+  forceFp32: false,
+  forceFp16: false,
+
+  // UNET precision
+  bf16Unet: false,
+  fp16Unet: false,
+  fp8E4m3fnUnet: false,
+  fp8E5m2Unet: false,
+
+  // VAE settings
+  fp16Vae: false,
+  fp32Vae: false,
+  bf16Vae: false,
+  cpuVae: false,
+
+  // Text Encoder settings
+  fp8E4m3fnTextEnc: false,
+  fp8E5m2TextEnc: false,
+  fp16TextEnc: false,
+  fp32TextEnc: false,
+
+  // Memory and performance settings
+  forceChannelsLast: false,
+  directml: undefined,
+  disableIpexOptimize: false,
+  previewMethod: LatentPreviewMethod.NoPreviews,
+  previewSize: 512,
+
+  // Cache settings
+  cacheClassic: false,
+  cacheLru: 0,
+
+  // Attention settings
+  useSplitCrossAttention: false,
+  useQuadCrossAttention: false,
+  usePytorchCrossAttention: false,
+  disableXformers: false,
+  forceUpcastAttention: false,
+  dontUpcastAttention: false,
+
+  // VRAM management
+  gpuOnly: false,
+  highvram: false,
+  normalvram: false,
+  lowvram: false,
+  novram: false,
+  cpu: false,
+  reserveVram: undefined,
+
+  // Misc settings
+  defaultHashingFunction: HashFunction.SHA256,
+  disableSmartMemory: false,
+  deterministic: false,
+  fast: false,
+  dontPrintServer: false,
+  quickTestForCi: false,
+  windowsStandaloneBuild: false,
+  disableMetadata: false,
+  disableAllCustomNodes: false,
+  multiUser: false,
+  verbose: LogLevel.INFO,
+
+  // Frontend settings
+  frontEndVersion: 'comfyanonymous/ComfyUI@latest',
+  frontEndRoot: undefined
+} as const

--- a/src/types/serverArgs.ts
+++ b/src/types/serverArgs.ts
@@ -20,188 +20,46 @@ export enum HashFunction {
   SHA512 = 'sha512'
 }
 
-export interface ComfyUIServerConfig {
-  // Network settings
-  listen?: string // default: "127.0.0.1"
-  port: number // default: 8188
-  tlsKeyfile?: string
-  tlsCertfile?: string
-  enableCorsHeader?: string // default: undefined, when enabled without value: "*"
-  maxUploadSize: number // default: 100 (MB)
-
-  // Directory settings
-  extraModelPathsConfig?: string[]
-  outputDirectory?: string
-  tempDirectory?: string
-  inputDirectory?: string
-  userDirectory?: string
-
-  // Launch behavior
-  autoLaunch: boolean
-  disableAutoLaunch: boolean
-
-  // CUDA settings
-  cudaDevice?: number
-  cudaMalloc: boolean
-  disableCudaMalloc: boolean
-
-  // Precision settings
-  forceFp32: boolean
-  forceFp16: boolean
-
-  // UNET precision
-  bf16Unet: boolean
-  fp16Unet: boolean
-  fp8E4m3fnUnet: boolean
-  fp8E5m2Unet: boolean
-
-  // VAE settings
-  fp16Vae: boolean
-  fp32Vae: boolean
-  bf16Vae: boolean
-  cpuVae: boolean
-
-  // Text Encoder settings
-  fp8E4m3fnTextEnc: boolean
-  fp8E5m2TextEnc: boolean
-  fp16TextEnc: boolean
-  fp32TextEnc: boolean
-
-  // Memory and performance settings
-  forceChannelsLast: boolean
-  directml?: number
-  disableIpexOptimize: boolean
-  previewMethod: LatentPreviewMethod
-  previewSize: number
-
-  // Cache settings
-  cacheClassic: boolean
-  cacheLru: number // default: 0
-
-  // Attention settings
-  useSplitCrossAttention: boolean
-  useQuadCrossAttention: boolean
-  usePytorchCrossAttention: boolean
-  disableXformers: boolean
-  forceUpcastAttention: boolean
-  dontUpcastAttention: boolean
-
-  // VRAM management
-  gpuOnly: boolean
-  highvram: boolean
-  normalvram: boolean
-  lowvram: boolean
-  novram: boolean
-  cpu: boolean
-  reserveVram?: number
-
-  // Misc settings
-  defaultHashingFunction: HashFunction
-  disableSmartMemory: boolean
-  deterministic: boolean
-  fast: boolean
-  dontPrintServer: boolean
-  quickTestForCi: boolean
-  windowsStandaloneBuild: boolean
-  disableMetadata: boolean
-  disableAllCustomNodes: boolean
-  multiUser: boolean
-  verbose: LogLevel
-
-  // Frontend settings
-  frontEndVersion: string // default: "comfyanonymous/ComfyUI@latest"
-  frontEndRoot?: string
+export enum AutoLaunch {
+  // Let server decide whether to auto launch based on the current environment
+  Auto = 'auto',
+  // Disable auto launch
+  Disable = 'disable',
+  // Enable auto launch
+  Enable = 'enable'
 }
 
-export const DEFAULT_SERVER_CONFIG: ComfyUIServerConfig = {
-  // Network settings
-  listen: '127.0.0.1',
-  port: 8188,
-  tlsKeyfile: undefined,
-  tlsCertfile: undefined,
-  enableCorsHeader: undefined,
-  maxUploadSize: 100,
+export enum CudaMalloc {
+  // Let server decide whether to use CUDA malloc based on the current environment
+  Auto = 'auto',
+  // Disable CUDA malloc
+  Disable = 'disable',
+  // Enable CUDA malloc
+  Enable = 'enable'
+}
 
-  // Directory settings
-  extraModelPathsConfig: undefined,
-  outputDirectory: undefined,
-  tempDirectory: undefined,
-  inputDirectory: undefined,
-  userDirectory: undefined,
+export enum FloatingPointPrecision {
+  AUTO = 'auto',
+  FP32 = 'fp32',
+  FP16 = 'fp16',
+  BF16 = 'bf16',
+  FP8E4M3FN = 'fp8_e4m3fn',
+  FP8E5M2 = 'fp8_e5m2'
+}
 
-  // Launch behavior
-  autoLaunch: false,
-  disableAutoLaunch: false,
+export enum CrossAttentionMethod {
+  Auto = 'auto',
+  Split = 'split',
+  Quad = 'quad',
+  Pytorch = 'pytorch'
+}
 
-  // CUDA settings
-  cudaDevice: undefined,
-  cudaMalloc: false,
-  disableCudaMalloc: false,
-
-  // Precision settings
-  forceFp32: false,
-  forceFp16: false,
-
-  // UNET precision
-  bf16Unet: false,
-  fp16Unet: false,
-  fp8E4m3fnUnet: false,
-  fp8E5m2Unet: false,
-
-  // VAE settings
-  fp16Vae: false,
-  fp32Vae: false,
-  bf16Vae: false,
-  cpuVae: false,
-
-  // Text Encoder settings
-  fp8E4m3fnTextEnc: false,
-  fp8E5m2TextEnc: false,
-  fp16TextEnc: false,
-  fp32TextEnc: false,
-
-  // Memory and performance settings
-  forceChannelsLast: false,
-  directml: undefined,
-  disableIpexOptimize: false,
-  previewMethod: LatentPreviewMethod.NoPreviews,
-  previewSize: 512,
-
-  // Cache settings
-  cacheClassic: false,
-  cacheLru: 0,
-
-  // Attention settings
-  useSplitCrossAttention: false,
-  useQuadCrossAttention: false,
-  usePytorchCrossAttention: false,
-  disableXformers: false,
-  forceUpcastAttention: false,
-  dontUpcastAttention: false,
-
-  // VRAM management
-  gpuOnly: false,
-  highvram: false,
-  normalvram: false,
-  lowvram: false,
-  novram: false,
-  cpu: false,
-  reserveVram: undefined,
-
-  // Misc settings
-  defaultHashingFunction: HashFunction.SHA256,
-  disableSmartMemory: false,
-  deterministic: false,
-  fast: false,
-  dontPrintServer: false,
-  quickTestForCi: false,
-  windowsStandaloneBuild: false,
-  disableMetadata: false,
-  disableAllCustomNodes: false,
-  multiUser: false,
-  verbose: LogLevel.INFO,
-
-  // Frontend settings
-  frontEndVersion: 'comfyanonymous/ComfyUI@latest',
-  frontEndRoot: undefined
-} as const
+export enum VramManagement {
+  Auto = 'auto',
+  GPUOnly = 'gpu-only',
+  HighVram = 'highvram',
+  NormalVram = 'normalvram',
+  LowVram = 'lowvram',
+  NoVram = 'novram',
+  CPU = 'cpu'
+}

--- a/tests-ui/tests/fast/store/serverConfigStore.test.ts
+++ b/tests-ui/tests/fast/store/serverConfigStore.test.ts
@@ -165,4 +165,25 @@ describe('useServerConfigStore', () => {
     expect(store.launchArgs['test.config1']).toBe('custom1')
     expect(store.launchArgs['test.config2']).toBeUndefined()
   })
+
+  it('should not include nullish values in launch arguments', () => {
+    const configs: ServerConfig<any>[] = [
+      { ...dummyFormItem, id: 'test.config1', defaultValue: 'default1' },
+      { ...dummyFormItem, id: 'test.config2', defaultValue: 'default2' },
+      { ...dummyFormItem, id: 'test.config3', defaultValue: 'default3' }
+    ]
+
+    store.loadServerConfig(configs, {
+      'test.config1': undefined,
+      'test.config2': null,
+      'test.config3': ''
+    })
+
+    expect(Object.keys(store.launchArgs)).toHaveLength(0)
+    expect(Object.keys(store.serverConfigValues)).toEqual([
+      'test.config1',
+      'test.config2',
+      'test.config3'
+    ])
+  })
 })

--- a/tests-ui/tests/fast/store/serverConfigStore.test.ts
+++ b/tests-ui/tests/fast/store/serverConfigStore.test.ts
@@ -1,0 +1,168 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { useServerConfigStore } from '@/stores/serverConfigStore'
+import { ServerConfig } from '@/constants/serverConfig'
+import type { FormItem } from '@/types/settingTypes'
+
+const dummyFormItem: FormItem = {
+  name: '',
+  type: 'text'
+}
+
+describe('useServerConfigStore', () => {
+  let store: ReturnType<typeof useServerConfigStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useServerConfigStore()
+  })
+
+  it('should initialize with empty configs', () => {
+    expect(store.serverConfigs).toHaveLength(0)
+    expect(Object.keys(store.serverConfigById)).toHaveLength(0)
+    expect(Object.keys(store.serverConfigsByCategory)).toHaveLength(0)
+    expect(Object.keys(store.serverConfigValues)).toHaveLength(0)
+    expect(Object.keys(store.launchArgs)).toHaveLength(0)
+  })
+
+  it('should load server configs with default values', () => {
+    const configs: ServerConfig<any>[] = [
+      {
+        ...dummyFormItem,
+        id: 'test.config1',
+        defaultValue: 'default1',
+        category: ['Test']
+      },
+      {
+        ...dummyFormItem,
+        id: 'test.config2',
+        defaultValue: 'default2'
+      }
+    ]
+
+    store.loadServerConfig(configs, {})
+
+    expect(store.serverConfigs).toHaveLength(2)
+    expect(store.serverConfigById['test.config1'].value).toBe('default1')
+    expect(store.serverConfigById['test.config2'].value).toBe('default2')
+  })
+
+  it('should load server configs with provided values', () => {
+    const configs: ServerConfig<any>[] = [
+      {
+        ...dummyFormItem,
+        id: 'test.config1',
+        defaultValue: 'default1',
+        category: ['Test']
+      }
+    ]
+
+    store.loadServerConfig(configs, {
+      'test.config1': 'custom1'
+    })
+
+    expect(store.serverConfigs).toHaveLength(1)
+    expect(store.serverConfigById['test.config1'].value).toBe('custom1')
+  })
+
+  it('should organize configs by category', () => {
+    const configs: ServerConfig<any>[] = [
+      {
+        ...dummyFormItem,
+        id: 'test.config1',
+        defaultValue: 'default1',
+        category: ['Test']
+      },
+      {
+        ...dummyFormItem,
+        id: 'test.config2',
+        defaultValue: 'default2',
+        category: ['Other']
+      },
+      {
+        ...dummyFormItem,
+        id: 'test.config3',
+        defaultValue: 'default3'
+      }
+    ]
+
+    store.loadServerConfig(configs, {})
+
+    expect(Object.keys(store.serverConfigsByCategory)).toHaveLength(3)
+    expect(store.serverConfigsByCategory['Test']).toHaveLength(1)
+    expect(store.serverConfigsByCategory['Other']).toHaveLength(1)
+    expect(store.serverConfigsByCategory['General']).toHaveLength(1)
+  })
+
+  it('should generate server config values excluding defaults', () => {
+    const configs: ServerConfig<any>[] = [
+      {
+        ...dummyFormItem,
+        id: 'test.config1',
+        defaultValue: 'default1'
+      },
+      {
+        ...dummyFormItem,
+        id: 'test.config2',
+        defaultValue: 'default2'
+      }
+    ]
+
+    store.loadServerConfig(configs, {
+      'test.config1': 'custom1',
+      'test.config2': 'default2'
+    })
+
+    expect(Object.keys(store.serverConfigValues)).toHaveLength(2)
+    expect(store.serverConfigValues['test.config1']).toBe('custom1')
+    expect(store.serverConfigValues['test.config2']).toBeUndefined()
+  })
+
+  it('should generate launch arguments with custom getValue function', () => {
+    const configs: ServerConfig<any>[] = [
+      {
+        ...dummyFormItem,
+        id: 'test.config1',
+        defaultValue: 'default1',
+        getValue: (value: string) => ({ customArg: value })
+      },
+      {
+        ...dummyFormItem,
+        id: 'test.config2',
+        defaultValue: 'default2'
+      }
+    ]
+
+    store.loadServerConfig(configs, {
+      'test.config1': 'custom1',
+      'test.config2': 'custom2'
+    })
+
+    expect(Object.keys(store.launchArgs)).toHaveLength(2)
+    expect(store.launchArgs['customArg']).toBe('custom1')
+    expect(store.launchArgs['test.config2']).toBe('custom2')
+  })
+
+  it('should not include default values in launch arguments', () => {
+    const configs: ServerConfig<any>[] = [
+      {
+        ...dummyFormItem,
+        id: 'test.config1',
+        defaultValue: 'default1'
+      },
+      {
+        ...dummyFormItem,
+        id: 'test.config2',
+        defaultValue: 'default2'
+      }
+    ]
+
+    store.loadServerConfig(configs, {
+      'test.config1': 'custom1',
+      'test.config2': 'default2'
+    })
+
+    expect(Object.keys(store.launchArgs)).toHaveLength(1)
+    expect(store.launchArgs['test.config1']).toBe('custom1')
+    expect(store.launchArgs['test.config2']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds setting panel for configuring ComfyUI's main.py arguments. Note this feature is currently for electron only and some arguments such as directory arguments and frontend version argument are not included because they are either used by the electron app directly or will cause issue if not properly controlled.

![image](https://github.com/user-attachments/assets/ad831fd8-8a9e-469d-b53e-31ae84e340bc)

## New settings

`Comfy.Server.LaunchArgs` stores the command format to be read by the electron app, while `Comfy.Server.ServerConfigValues` stores the value used for frontend display.

![image](https://github.com/user-attachments/assets/ece3c2e7-973f-48f7-a575-ebc02e3679f2)

## Follow-up

Add an extra panel to show the launch args used on the UI.

