### PR TITLE
Fix terminal resizes incorrectly in flex parent

### DIFF
--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative h-full w-full bg-black" ref="rootEl">
+  <div class="relative overflow-hidden h-full w-full bg-black" ref="rootEl">
     <div class="p-terminal rounded-none h-full w-full p-2">
       <div class="h-full terminal-host" ref="terminalEl"></div>
     </div>


### PR DESCRIPTION
Short: The terminal resizes to the visible area on screen.

Longer: Resolves issue where `@xterm/addon-fit` resize cannot correctly calculate the bounds, as flex children have unlimited growth on one plane.

Containing both axes with overflow: hidden ensures max width/height are available when calculating space.