### PR TITLE
[Electron] Show server launch args in server config panel

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -38,7 +38,6 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { useClipboard } from '@vueuse/core'
 import { useToast } from 'primevue/usetoast'
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
@@ -50,6 +49,7 @@ import type { ExecutionErrorWsMessage, SystemStats } from '@/types/apiTypes'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { isElectron } from '@/utils/envUtil'
+import { useCopyToClipboard } from '@/hooks/clipboardHooks'
 
 const props = defineProps<{
   error: ExecutionErrorWsMessage
@@ -65,7 +65,6 @@ const showReport = () => {
 const showSendError = isElectron()
 
 const toast = useToast()
-const { copy, isSupported } = useClipboard()
 
 onMounted(async () => {
   try {
@@ -140,30 +139,9 @@ ${workflowText}
 `
 }
 
+const { copyToClipboard } = useCopyToClipboard()
 const copyReportToClipboard = async () => {
-  if (isSupported) {
-    try {
-      await copy(reportContent.value)
-      toast.add({
-        severity: 'success',
-        summary: 'Success',
-        detail: 'Report copied to clipboard',
-        life: 3000
-      })
-    } catch (err) {
-      toast.add({
-        severity: 'error',
-        summary: 'Error',
-        detail: 'Failed to copy report'
-      })
-    }
-  } else {
-    toast.add({
-      severity: 'error',
-      summary: 'Error',
-      detail: 'Clipboard API not supported in your browser'
-    })
-  }
+  await copyToClipboard(reportContent.value)
 }
 
 const openNewGithubIssue = async () => {

--- a/src/components/dialog/content/setting/ServerConfigPanel.vue
+++ b/src/components/dialog/content/setting/ServerConfigPanel.vue
@@ -63,9 +63,7 @@ const {
 } = storeToRefs(serverConfigStore)
 
 const revertChanges = () => {
-  for (const config of modifiedConfigs.value) {
-    config.value = config.initialValue
-  }
+  serverConfigStore.revertChanges()
 }
 
 const restartApp = () => {

--- a/src/components/dialog/content/setting/ServerConfigPanel.vue
+++ b/src/components/dialog/content/setting/ServerConfigPanel.vue
@@ -1,42 +1,62 @@
 <template>
-  <Message v-if="modifiedConfigs.length > 0" severity="info" pt:text="w-full">
-    <p>
-      {{ $t('serverConfig.modifiedConfigs') }}
-    </p>
-    <ul>
-      <li v-for="config in modifiedConfigs" :key="config.id">
-        {{ config.name }}: {{ config.initialValue }} → {{ config.value }}
-      </li>
-    </ul>
-    <div class="flex justify-end gap-2">
-      <Button
-        :label="$t('serverConfig.revertChanges')"
-        @click="revertChanges"
-        outlined
-      />
-      <Button
-        :label="$t('serverConfig.restart')"
-        @click="restartApp"
-        outlined
-        severity="danger"
-      />
-    </div>
-  </Message>
-  <div
-    v-for="([label, items], i) in Object.entries(serverConfigsByCategory)"
-    :key="label"
-  >
-    <Divider v-if="i > 0" />
-    <h3>{{ formatCamelCase(label) }}</h3>
-    <div v-for="item in items" :key="item.name" class="flex items-center mb-4">
-      <FormItem
-        :item="item"
-        v-model:formValue="item.value"
-        :id="item.id"
-        :labelClass="{
-          'text-highlight': item.initialValue !== item.value
-        }"
-      />
+  <div class="flex flex-col gap-2">
+    <Message v-if="modifiedConfigs.length > 0" severity="info" pt:text="w-full">
+      <p>
+        {{ $t('serverConfig.modifiedConfigs') }}
+      </p>
+      <ul>
+        <li v-for="config in modifiedConfigs" :key="config.id">
+          {{ config.name }}: {{ config.initialValue }} → {{ config.value }}
+        </li>
+      </ul>
+      <div class="flex justify-end gap-2">
+        <Button
+          :label="$t('serverConfig.revertChanges')"
+          @click="revertChanges"
+          outlined
+        />
+        <Button
+          :label="$t('serverConfig.restart')"
+          @click="restartApp"
+          outlined
+          severity="danger"
+        />
+      </div>
+    </Message>
+    <Message v-if="commandLineArgs" severity="secondary" pt:text="w-full">
+      <template #icon>
+        <i-lucide:terminal class="text-xl font-bold" />
+      </template>
+      <div class="flex items-center justify-between">
+        <p>{{ commandLineArgs }}</p>
+        <Button
+          icon="pi pi-clipboard"
+          @click="copyCommandLineArgs"
+          severity="secondary"
+          text
+        />
+      </div>
+    </Message>
+    <div
+      v-for="([label, items], i) in Object.entries(serverConfigsByCategory)"
+      :key="label"
+    >
+      <Divider v-if="i > 0" />
+      <h3>{{ formatCamelCase(label) }}</h3>
+      <div
+        v-for="item in items"
+        :key="item.name"
+        class="flex items-center mb-4"
+      >
+        <FormItem
+          :item="item"
+          v-model:formValue="item.value"
+          :id="item.id"
+          :labelClass="{
+            'text-highlight': item.initialValue !== item.value
+          }"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -52,6 +72,7 @@ import { storeToRefs } from 'pinia'
 import { electronAPI } from '@/utils/envUtil'
 import { useSettingStore } from '@/stores/settingStore'
 import { watch } from 'vue'
+import { useCopyToClipboard } from '@/hooks/clipboardHooks'
 
 const settingStore = useSettingStore()
 const serverConfigStore = useServerConfigStore()
@@ -59,6 +80,7 @@ const {
   serverConfigsByCategory,
   serverConfigValues,
   launchArgs,
+  commandLineArgs,
   modifiedConfigs
 } = storeToRefs(serverConfigStore)
 
@@ -77,4 +99,9 @@ watch(launchArgs, (newVal) => {
 watch(serverConfigValues, (newVal) => {
   settingStore.set('Comfy.Server.ServerConfigValues', newVal)
 })
+
+const { copyToClipboard } = useCopyToClipboard()
+const copyCommandLineArgs = async () => {
+  await copyToClipboard(commandLineArgs.value)
+}
 </script>

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -10,15 +10,17 @@ import {
   VramManagement
 } from '@/types/serverArgs'
 
+export type ServerConfigValue = string | number | true | null | undefined
+
 export interface ServerConfig<T> extends FormItem {
   id: string
   defaultValue: T
   category?: string[]
   // Override the default value getter with a custom function.
-  getValue?: (value: T) => Record<string, any>
+  getValue?: (value: T) => Record<string, ServerConfigValue>
 }
 
-export const WEB_ONLY_CONFIG_ITEMS: ServerConfig<any>[] = [
+export const WEB_ONLY_CONFIG_ITEMS: ServerConfig<ServerConfigValue>[] = [
   // We only need these settings in the web version. Desktop app manages them already.
   {
     id: 'listen',
@@ -43,21 +45,21 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     name: 'TLS Key File: Path to TLS key file for HTTPS',
     category: ['Network'],
     type: 'text',
-    defaultValue: undefined
+    defaultValue: null
   },
   {
     id: 'tls-certfile',
     name: 'TLS Certificate File: Path to TLS certificate file for HTTPS',
     category: ['Network'],
     type: 'text',
-    defaultValue: undefined
+    defaultValue: null
   },
   {
     id: 'enable-cors-header',
     name: 'Enable CORS header: Use "*" for all origins or specify domain',
     category: ['Network'],
     type: 'text',
-    defaultValue: undefined
+    defaultValue: null
   },
   {
     id: 'max-upload-size',
@@ -97,7 +99,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     name: 'CUDA device index to use',
     category: ['CUDA'],
     type: 'number',
-    defaultValue: undefined
+    defaultValue: null
   },
   {
     id: 'cuda-malloc',
@@ -253,7 +255,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     name: 'DirectML device index',
     category: ['Memory'],
     type: 'number',
-    defaultValue: undefined
+    defaultValue: null
   },
   {
     id: 'disable-ipex-optimize',
@@ -366,7 +368,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     name: 'Reserved VRAM (GB)',
     category: ['Memory'],
     type: 'number',
-    defaultValue: undefined,
+    defaultValue: null,
     tooltip:
       'Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reverved depending on your OS.'
   },

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -297,10 +297,10 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   },
   {
     id: 'cache-lru',
-    name: 'Use LRU caching with a maximum of N node results cached. (0 to disable).',
+    name: 'Use LRU caching with a maximum of N node results cached.',
     category: ['Cache'],
     type: 'number',
-    defaultValue: 0,
+    defaultValue: null,
     tooltip: 'May use more RAM/VRAM.'
   },
 

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -45,21 +45,21 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     name: 'TLS Key File: Path to TLS key file for HTTPS',
     category: ['Network'],
     type: 'text',
-    defaultValue: null
+    defaultValue: ''
   },
   {
     id: 'tls-certfile',
     name: 'TLS Certificate File: Path to TLS certificate file for HTTPS',
     category: ['Network'],
     type: 'text',
-    defaultValue: null
+    defaultValue: ''
   },
   {
     id: 'enable-cors-header',
     name: 'Enable CORS header: Use "*" for all origins or specify domain',
     category: ['Network'],
     type: 'text',
-    defaultValue: null
+    defaultValue: ''
   },
   {
     id: 'max-upload-size',

--- a/src/hooks/clipboardHooks.ts
+++ b/src/hooks/clipboardHooks.ts
@@ -1,0 +1,37 @@
+import { useClipboard } from '@vueuse/core'
+import { useToast } from 'primevue/usetoast'
+
+export function useCopyToClipboard() {
+  const { copy, isSupported } = useClipboard()
+  const toast = useToast()
+
+  const copyToClipboard = async (text: string) => {
+    if (isSupported) {
+      try {
+        await copy(text)
+        toast.add({
+          severity: 'success',
+          summary: 'Success',
+          detail: 'Copied to clipboard',
+          life: 3000
+        })
+      } catch (err) {
+        toast.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to copy report'
+        })
+      }
+    } else {
+      toast.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Clipboard API not supported in your browser'
+      })
+    }
+  }
+
+  return {
+    copyToClipboard
+  }
+}

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -50,7 +50,9 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
       serverConfigs.value.map((config) => {
         return [
           config.id,
-          config.value === config.defaultValue || !config.value
+          config.value === config.defaultValue ||
+          config.value === null ||
+          config.value === undefined
             ? undefined
             : config.value
         ]
@@ -65,7 +67,11 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
       {},
       ...serverConfigs.value.map((config) => {
         // Filter out configs that have the default value or undefined | null value
-        if (config.value === config.defaultValue || !config.value) {
+        if (
+          config.value === config.defaultValue ||
+          config.value === null ||
+          config.value === undefined
+        ) {
           return {}
         }
         return config.getValue

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -66,6 +66,13 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
       })
     )
   })
+  const commandLineArgs = computed<string>(() => {
+    return Object.entries(launchArgs.value)
+      .map(([key, value]) => [`--${key}`, value])
+      .flat()
+      .filter((arg) => typeof arg === 'string' && arg.length > 0)
+      .join(' ')
+  })
 
   function loadServerConfig(
     configs: ServerConfig<any>[],
@@ -88,6 +95,7 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
     serverConfigsByCategory,
     serverConfigValues,
     launchArgs,
+    commandLineArgs,
     revertChanges,
     loadServerConfig
   }

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -23,7 +23,11 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
       return config.initialValue !== config.value
     })
   })
-
+  const revertChanges = () => {
+    for (const config of modifiedConfigs.value) {
+      config.value = config.initialValue
+    }
+  }
   const serverConfigsByCategory = computed<
     Record<string, ServerConfigWithValue<any>[]>
   >(() => {
@@ -84,6 +88,7 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
     serverConfigsByCategory,
     serverConfigValues,
     launchArgs,
+    revertChanges,
     loadServerConfig
   }
 })

--- a/tests-ui/tests/fast/store/serverConfigStore.test.ts
+++ b/tests-ui/tests/fast/store/serverConfigStore.test.ts
@@ -170,20 +170,29 @@ describe('useServerConfigStore', () => {
     const configs: ServerConfig<any>[] = [
       { ...dummyFormItem, id: 'test.config1', defaultValue: 'default1' },
       { ...dummyFormItem, id: 'test.config2', defaultValue: 'default2' },
-      { ...dummyFormItem, id: 'test.config3', defaultValue: 'default3' }
+      { ...dummyFormItem, id: 'test.config3', defaultValue: 'default3' },
+      { ...dummyFormItem, id: 'test.config4', defaultValue: null }
     ]
 
     store.loadServerConfig(configs, {
       'test.config1': undefined,
       'test.config2': null,
-      'test.config3': ''
+      'test.config3': '',
+      'test.config4': 0
     })
 
-    expect(Object.keys(store.launchArgs)).toHaveLength(0)
-    expect(Object.keys(store.serverConfigValues)).toEqual([
-      'test.config1',
-      'test.config2',
-      'test.config3'
+    expect(Object.keys(store.launchArgs)).toEqual([
+      'test.config3',
+      'test.config4'
+    ])
+    expect(Object.values(store.launchArgs)).toEqual(['', '0'])
+    expect(store.serverConfigById['test.config3'].value).toBe('')
+    expect(store.serverConfigById['test.config4'].value).toBe(0)
+    expect(Object.values(store.serverConfigValues)).toEqual([
+      undefined,
+      undefined,
+      '',
+      0
     ])
   })
 

--- a/tests-ui/tests/fast/store/serverConfigStore.test.ts
+++ b/tests-ui/tests/fast/store/serverConfigStore.test.ts
@@ -187,6 +187,56 @@ describe('useServerConfigStore', () => {
     ])
   })
 
+  it('should convert true to empty string in launch arguments', () => {
+    store.loadServerConfig(
+      [
+        {
+          ...dummyFormItem,
+          id: 'test.config1',
+          defaultValue: 0
+        }
+      ],
+      {
+        'test.config1': true
+      }
+    )
+    expect(store.launchArgs['test.config1']).toBe('')
+    expect(store.commandLineArgs).toBe('--test.config1')
+  })
+
+  it('should convert number to string in launch arguments', () => {
+    store.loadServerConfig(
+      [
+        {
+          ...dummyFormItem,
+          id: 'test.config1',
+          defaultValue: 1
+        }
+      ],
+      {
+        'test.config1': 123
+      }
+    )
+    expect(store.launchArgs['test.config1']).toBe('123')
+    expect(store.commandLineArgs).toBe('--test.config1 123')
+  })
+
+  it('should drop nullish values in launch arguments', () => {
+    store.loadServerConfig(
+      [
+        {
+          ...dummyFormItem,
+          id: 'test.config1',
+          defaultValue: 1
+        }
+      ],
+      {
+        'test.config1': null
+      }
+    )
+    expect(Object.keys(store.launchArgs)).toHaveLength(0)
+  })
+
   it('should track modified configs', () => {
     const configs = [
       {


### PR DESCRIPTION
Show server launch args according to current values configured in the server config panel.

![image](https://github.com/user-attachments/assets/9d534b41-c7a3-4dfc-8d00-9dfcbd5e3bf4)

Some other notable changes in this PR:
- Extract clipboard copy as a hook
- Changes default value for text field from `undefined` to `''`, because empty text input is treated as `''` in PrimeVue.
- Changes default value for number field from `undefined` to `null`, because empty number input is treated as `null` in PrimeVue.
- Launch args is strictly type `Record<string, string>` now.