### PR TITLE
[Electron] Add fp32 and fp64 to unet inference precision options

### DIFF
--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -163,6 +163,8 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     type: 'combo',
     options: [
       FloatingPointPrecision.AUTO,
+      FloatingPointPrecision.FP64,
+      FloatingPointPrecision.FP32,
       FloatingPointPrecision.FP16,
       FloatingPointPrecision.BF16,
       FloatingPointPrecision.FP8E4M3FN,

--- a/src/types/serverArgs.ts
+++ b/src/types/serverArgs.ts
@@ -40,6 +40,7 @@ export enum CudaMalloc {
 
 export enum FloatingPointPrecision {
   AUTO = 'auto',
+  FP64 = 'fp64',
   FP32 = 'fp32',
   FP16 = 'fp16',
   BF16 = 'bf16',


### PR DESCRIPTION
Sync with https://github.com/comfyanonymous/ComfyUI/commit/61196d88576c95c1cd8535e881af48172d5af525