### PR TITLE
Move queueStore update to GraphView

### DIFF
--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -284,11 +284,6 @@ const confirmRemoveAll = (event: Event) => {
   })
 }
 
-const onStatus = async () => {
-  await queueStore.update()
-  updateVisibleTasks()
-}
-
 const menu = ref(null)
 const menuTargetTask = ref<TaskItemImpl | null>(null)
 const menuTargetNode = ref<ComfyNode | null>(null)
@@ -351,12 +346,11 @@ const toggleImageFit = () => {
 }
 
 onMounted(() => {
-  api.addEventListener('status', onStatus)
-  queueStore.update()
+  api.addEventListener('status', updateVisibleTasks)
 })
 
 onUnmounted(() => {
-  api.removeEventListener('status', onStatus)
+  api.removeEventListener('status', updateVisibleTasks)
 })
 
 // Watch for changes in allTasks and reset visibleTasks if necessary

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -19,7 +19,10 @@ import { useI18n } from 'vue-i18n'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { api } from '@/scripts/api'
 import { StatusWsMessageStatus } from '@/types/apiTypes'
-import { useQueuePendingTaskCountStore } from '@/stores/queueStore'
+import {
+  useQueuePendingTaskCountStore,
+  useQueueStore
+} from '@/stores/queueStore'
 import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { i18n } from '@/i18n'
@@ -103,8 +106,10 @@ const init = () => {
 }
 
 const queuePendingTaskCountStore = useQueuePendingTaskCountStore()
-const onStatus = (e: CustomEvent<StatusWsMessageStatus>) => {
+const queueStore = useQueueStore()
+const onStatus = async (e: CustomEvent<StatusWsMessageStatus>) => {
   queuePendingTaskCountStore.update(e)
+  await queueStore.update()
 }
 
 const reconnectingMessage: ToastMessageOptions = {


### PR DESCRIPTION
This PR moves the update of queueStore to `GraphView`. Previously queueStore only updates when the queue sidebar tab is opened, which can cause queueStore out of sync if queue sidebar tab is toggled while queue is being updated by the backend.