### PR TITLE
Fix save temporary workflow loop on overwrite

### DIFF
--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -465,6 +465,20 @@ test.describe('Menu', () => {
       ).toEqual(['workflow5.json'])
     })
 
+    test('Can save temporary workflow with unmodified name', async ({
+      comfyPage
+    }) => {
+      expect(await comfyPage.isCurrentWorkflowModified()).toBe(false)
+
+      await comfyPage.menu.topbar.saveWorkflow('Unsaved Workflow')
+      // Should not trigger the overwrite dialog
+      expect(
+        await comfyPage.page.locator('.comfy-modal-content:visible').count()
+      ).toBe(0)
+
+      expect(await comfyPage.isCurrentWorkflowModified()).toBe(false)
+    })
+
     test('Can overwrite other workflows with save as', async ({
       comfyPage
     }) => {

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -66,7 +66,7 @@ export const workflowService = {
     const workflowStore = useWorkflowStore()
     const existingWorkflow = workflowStore.getWorkflowByPath(newPath)
 
-    if (existingWorkflow) {
+    if (existingWorkflow && !existingWorkflow.isTemporary) {
       const res = (await ComfyAsyncDialog.prompt({
         title: 'Overwrite existing file?',
         message: `"${newPath}" already exists. Do you want to overwrite it?`,


### PR DESCRIPTION
Fixes the loop of dialogs when trying to save temporary workflow with the same name.

Bug detail:

https://github.com/user-attachments/assets/755f6021-f1e7-4399-868a-c2f295f5533c

