### PR TITLE
[Electron] Show version number in error state

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -62,7 +62,7 @@ export default {
       'python-setup': 'Setting up Python Environment...',
       'starting-server': 'Starting ComfyUI server...',
       ready: 'Finishing...',
-      error: 'Unable to start ComfyUI'
+      error: 'Unable to start ComfyUI Desktop'
     }
   },
   serverConfig: {

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -2,9 +2,14 @@
   <div
     class="font-sans flex flex-col justify-center items-center h-screen m-0 text-neutral-300 bg-neutral-900 dark-theme pointer-events-auto"
   >
-    <h2 class="text-2xl font-bold">{{ t(`serverStart.process.${status}`) }}</h2>
+    <h2 class="text-2xl font-bold">
+      {{ t(`serverStart.process.${status}`) }}
+      <span v-if="status === ProgressStatus.ERROR">
+        v{{ electronVersion }}
+      </span>
+    </h2>
     <div
-      v-if="status == ProgressStatus.ERROR"
+      v-if="status === ProgressStatus.ERROR"
       class="flex items-center my-4 gap-2"
     >
       <Button
@@ -43,6 +48,7 @@ const electron = electronAPI()
 const { t } = useI18n()
 
 const status = ref<ProgressStatus>(ProgressStatus.INITIAL_STATE)
+const electronVersion = ref<string>('')
 let xterm: Terminal | undefined
 
 const updateProgress = ({ status: newStatus }: { status: ProgressStatus }) => {
@@ -72,9 +78,10 @@ const reportIssue = () => {
 }
 const openLogs = () => electron.openLogsFolder()
 
-onMounted(() => {
+onMounted(async () => {
   electron.sendReady()
   electron.onProgressUpdate(updateProgress)
+  electronVersion.value = await electron.getElectronVersion()
 })
 </script>
 


### PR DESCRIPTION
When user enters error state on server-start page, displays the electron app version.

![image](https://github.com/user-attachments/assets/98e96a0f-8bfb-4d4c-baf8-da5dd3a0c189)
