### PR TITLE
Enforce `ComfyExtension` types

### DIFF
--- a/src/extensions/core/dynamicPrompts.ts
+++ b/src/extensions/core/dynamicPrompts.ts
@@ -17,7 +17,8 @@ app.registerExtension({
     if (node.widgets) {
       // Locate dynamic prompt text widgets
       // Include any widgets with dynamicPrompts set to true, and customtext
-      const widgets = node.widgets.filter((n) => 'dynamicPrompts' in n)
+      // @ts-expect-error dynamicPrompts is not typed
+      const widgets = node.widgets.filter((n) => n.dynamicPrompts)
       for (const widget of widgets) {
         // Override the serialization of the value to resolve dynamic prompts for all widgets supporting it in this node
         // @ts-expect-error hacky override

--- a/src/extensions/core/dynamicPrompts.ts
+++ b/src/extensions/core/dynamicPrompts.ts
@@ -17,9 +17,10 @@ app.registerExtension({
     if (node.widgets) {
       // Locate dynamic prompt text widgets
       // Include any widgets with dynamicPrompts set to true, and customtext
-      const widgets = node.widgets.filter((n) => n.dynamicPrompts)
+      const widgets = node.widgets.filter((n) => 'dynamicPrompts' in n)
       for (const widget of widgets) {
         // Override the serialization of the value to resolve dynamic prompts for all widgets supporting it in this node
+        // @ts-expect-error hacky override
         widget.serializeValue = (workflowNode, widgetIndex) => {
           let prompt = stripComments(widget.value)
           while (

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { app } from '@/scripts/app'
 import { api } from '@/scripts/api'
 import { useToastStore } from '@/stores/toastStore'
@@ -1308,6 +1309,7 @@ app.registerExtension({
     const w = node.widgets.find((w: IWidget) => w.name === 'width')
     const h = node.widgets.find((w: IWidget) => w.name === 'height')
 
+    // @ts-expect-error hacky override
     sceneWidget.serializeValue = async () => {
       node.properties['Camera Info'] = JSON.stringify(load3d.getCameraState())
 
@@ -1595,6 +1597,7 @@ app.registerExtension({
     const w = node.widgets.find((w: IWidget) => w.name === 'width')
     const h = node.widgets.find((w: IWidget) => w.name === 'height')
 
+    // @ts-expect-error hacky override
     sceneWidget.serializeValue = async () => {
       node.properties['Camera Info'] = JSON.stringify(load3d.getCameraState())
 

--- a/src/extensions/core/slotDefaults.ts
+++ b/src/extensions/core/slotDefaults.ts
@@ -54,6 +54,7 @@ app.registerExtension({
         LiteGraph.registered_slot_in_types[lowerType] = { nodes: [] }
       }
       LiteGraph.registered_slot_in_types[lowerType].nodes.push(
+        // @ts-expect-error ComfyNode
         nodeType.comfyClass
       )
     }
@@ -71,6 +72,7 @@ app.registerExtension({
       if (!(type in LiteGraph.registered_slot_out_types)) {
         LiteGraph.registered_slot_out_types[type] = { nodes: [] }
       }
+      // @ts-expect-error ComfyNode
       LiteGraph.registered_slot_out_types[type].nodes.push(nodeType.comfyClass)
 
       if (!LiteGraph.slot_types_out.includes(type)) {

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -81,6 +81,7 @@ app.registerExtension({
   name: 'Comfy.AudioWidget',
   async beforeRegisterNodeDef(nodeType, nodeData) {
     if (
+      // @ts-expect-error ComfyNode
       ['LoadAudio', 'SaveAudio', 'PreviewAudio'].includes(nodeType.comfyClass)
     ) {
       nodeData.input.required.audioUI = ['AUDIO_UI']

--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -73,17 +73,22 @@ app.registerExtension({
     const canvas = document.createElement('canvas')
 
     const capture = () => {
+      // @ts-expect-error widget value type narrow down
       canvas.width = w.value
+      // @ts-expect-error widget value type narrow down
       canvas.height = h.value
       const ctx = canvas.getContext('2d')
+      // @ts-expect-error widget value type narrow down
       ctx.drawImage(video, 0, 0, w.value, h.value)
       const data = canvas.toDataURL('image/png')
 
       const img = new Image()
       img.onload = () => {
+        // @ts-expect-error adding extra property
         node.imgs = [img]
         app.graph.setDirtyCanvas(true)
         requestAnimationFrame(() => {
+          // @ts-expect-error accessing extra property
           node.setSizeForImage?.()
         })
       }
@@ -97,11 +102,14 @@ app.registerExtension({
       capture
     )
     btn.disabled = true
+    // @ts-expect-error hacky override
     btn.serializeValue = () => undefined
 
+    // @ts-expect-error hacky override
     camera.serializeValue = async () => {
       if (captureOnQueue.value) {
         capture()
+        // @ts-expect-error accessing extra property
       } else if (!node.imgs?.length) {
         const err = `No webcam image captured`
         useToastStore().addAlert(err)

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -724,6 +724,7 @@ app.registerExtension({
   async beforeRegisterNodeDef(nodeType, nodeData, app) {
     // Add menu options to convert to/from widgets
     const origGetExtraMenuOptions = nodeType.prototype.getExtraMenuOptions
+    // @ts-expect-error adding extra property
     nodeType.prototype.convertWidgetToInput = function (widget) {
       const config = getConfig.call(this, widget.name) ?? [
         widget.type,
@@ -746,8 +747,10 @@ app.registerExtension({
           if (w.options?.forceInput) {
             continue
           }
+          // @ts-expect-error custom widget type
           if (w.type === CONVERTED_TYPE) {
             toWidget.push({
+              // @ts-expect-error never
               content: `Convert ${w.name} to widget`,
               callback: () => convertToWidget(this, w)
             })
@@ -860,7 +863,9 @@ app.registerExtension({
         for (const input of this.inputs) {
           if (input.widget && !input.widget[GET_CONFIG]) {
             input.widget[GET_CONFIG] = () =>
+              // @ts-expect-error input.widget has unknown type
               getConfig.call(this, input.widget.name)
+            // @ts-expect-error input.widget has unknown type
             const w = this.widgets.find((w) => w.name === input.widget.name)
             if (w) {
               hideWidget(this, w)
@@ -935,6 +940,7 @@ app.registerExtension({
       originNode,
       originSlot
     ) {
+      // @ts-expect-error onConnectInput has 5 arguments
       const v = onConnectInput?.(this, arguments)
       // Not a combo, ignore
       if (type !== 'COMBO') return v

--- a/src/types/comfy.ts
+++ b/src/types/comfy.ts
@@ -1,11 +1,12 @@
-import type { LGraphNode } from './litegraph'
-import type { ComfyApp } from '../scripts/app'
+import type { LGraphNode } from '@comfyorg/litegraph'
+import type { ComfyApp } from '@/scripts/app'
 import type { ComfyNodeDef } from '@/types/apiTypes'
 import type { Keybinding } from '@/types/keyBindingTypes'
 import type { ComfyCommand } from '@/stores/commandStore'
-import type { SettingParams } from './settingTypes'
-import type { BottomPanelExtension } from './extensionTypes'
+import type { SettingParams } from '@/types/settingTypes'
+import type { BottomPanelExtension } from '@/types/extensionTypes'
 import type { ComfyWidgetConstructor } from '@/scripts/widgets'
+import type { ComfyWorkflowJSON } from '@/types/comfyWorkflow'
 
 export type Widgets = Record<string, ComfyWidgetConstructor>
 


### PR DESCRIPTION
Rename `comfy.d.ts` to `comfy.ts` to enforce `ComfyExtension` types defined. This PR does not alter any existing logic defined in existing extensions. Currently we just mark them with `@ts-expect-error`.