### PR TITLE
Remove migration logic (settings & templates storage location)

### DIFF
--- a/src/extensions/core/nodeTemplates.ts
+++ b/src/extensions/core/nodeTemplates.ts
@@ -85,22 +85,13 @@ class ManageTemplates extends ComfyDialog {
 
   async load() {
     let templates = []
-    if (app.isNewUserSession) {
-      // New user so migrate existing templates
-      const json = localStorage.getItem(id)
-      if (json) {
-        templates = JSON.parse(json)
-      }
-      await api.storeUserData(file, json, { stringify: false })
-    } else {
-      const res = await api.getUserData(file)
-      if (res.status === 200) {
-        try {
-          templates = await res.json()
-        } catch (error) {}
-      } else if (res.status !== 404) {
-        console.error(res.status + ' ' + res.statusText)
-      }
+    const res = await api.getUserData(file)
+    if (res.status === 200) {
+      try {
+        templates = await res.json()
+      } catch (error) {}
+    } else if (res.status !== 404) {
+      console.error(res.status + ' ' + res.statusText)
     }
     return templates ?? []
   }

--- a/src/extensions/core/nodeTemplates.ts
+++ b/src/extensions/core/nodeTemplates.ts
@@ -98,7 +98,6 @@ class ManageTemplates extends ComfyDialog {
 
   async store() {
     const templates = JSON.stringify(this.templates, undefined, 4)
-    localStorage.setItem(id, templates) // Backwards compatibility
     try {
       await api.storeUserData(file, templates, { stringify: false })
     } catch (error) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -142,7 +142,6 @@ export class ComfyApp {
   lastExecutionError: { node_id: number } | null
   progress: { value: number; max: number } | null
   configuringGraph: boolean
-  isNewUserSession: boolean
   ctx: CanvasRenderingContext2D
   bodyTop: HTMLElement
   bodyLeft: HTMLElement
@@ -184,6 +183,13 @@ export class ComfyApp {
    */
   get storageLocation() {
     return 'server'
+  }
+
+  /**
+   * @deprecated storage migration is no longer needed.
+   */
+  get isNewUserSession() {
+    return false
   }
 
   constructor() {
@@ -1707,11 +1713,8 @@ export class ComfyApp {
 
   async #setUser() {
     const userConfig = await api.getUserConfig()
-    if (typeof userConfig.migrated == 'boolean') {
-      // Single user mode migrated true/false for if the default user is created
-      if (!userConfig.migrated) {
-        this.isNewUserSession = true
-      }
+    // Return in single user mode.
+    if (userConfig.users === undefined) {
       return
     }
 
@@ -1725,18 +1728,15 @@ export class ComfyApp {
       const { UserSelectionScreen } = await import('./ui/userSelection')
 
       this.ui.menuContainer.style.display = 'none'
-      const { userId, username, created } =
-        await new UserSelectionScreen().show(users, user)
+      const { userId, username } = await new UserSelectionScreen().show(
+        users,
+        user
+      )
       this.ui.menuContainer.style.display = ''
 
       user = userId
       localStorage['Comfy.userName'] = username
       localStorage['Comfy.userId'] = user
-
-      if (created) {
-        api.user = user
-        this.isNewUserSession = true
-      }
     }
 
     api.user = user

--- a/src/scripts/ui/settings.ts
+++ b/src/scripts/ui/settings.ts
@@ -89,9 +89,6 @@ export class ComfySettingsDialog extends ComfyDialog<HTMLDialogElement> {
   ) {
     value = this.tryMigrateDeprecatedValue(id, value)
 
-    const json = JSON.stringify(value)
-    localStorage['Comfy.Settings.' + id] = json // backwards compatibility for extensions keep setting in storage
-
     let oldValue = this.getSettingValue(id, undefined)
     this.settingsValues[id] = value
 

--- a/src/scripts/ui/settings.ts
+++ b/src/scripts/ui/settings.ts
@@ -142,20 +142,7 @@ export class ComfySettingsDialog extends ComfyDialog<HTMLDialogElement> {
       throw new Error(`Setting ${id} of type ${type} must have a unique ID.`)
     }
 
-    let value = this.getSettingValue(id)
-    if (value == null) {
-      if (this.app.isNewUserSession) {
-        // Check if we have a localStorage value but not a setting value and we are a new user
-        const localValue = localStorage['Comfy.Settings.' + id]
-        if (localValue) {
-          value = JSON.parse(localValue)
-          this.setSettingValue(id, value) // Store on the server
-        }
-      }
-      if (value == null) {
-        value = defaultValue
-      }
-    }
+    const value = this.getSettingValue(id) ?? defaultValue
 
     // Trigger initial setting of value
     onChange?.(value, undefined)

--- a/tests-ui/tests/slow/users.test.ts
+++ b/tests-ui/tests/slow/users.test.ts
@@ -101,11 +101,7 @@ describe('users', () => {
           null,
           { stringify: false }
         )
-        expect(s.app.isNewUserSession).toBeTruthy()
-      } else {
-        expect(s.app.isNewUserSession).toBeFalsy()
       }
-
       return { users, selection, ...s }
     }
 
@@ -242,7 +238,6 @@ describe('users', () => {
         null,
         { stringify: false }
       )
-      expect(app.isNewUserSession).toBeTruthy()
     })
     it('doesnt show user creation if default user', async () => {
       const { app } = await start({
@@ -255,7 +250,6 @@ describe('users', () => {
       const { api } = await import('../../../src/scripts/api')
       expect(api.storeSettings).toHaveBeenCalledTimes(0)
       expect(api.storeUserData).toHaveBeenCalledTimes(0)
-      expect(app.isNewUserSession).toBeFalsy()
     })
     it('doesnt allow user switching', async () => {
       const { app } = await start({
@@ -279,7 +273,6 @@ describe('users', () => {
       const { api } = await import('../../../src/scripts/api')
       expect(api.storeSettings).toHaveBeenCalledTimes(0)
       expect(api.storeUserData).toHaveBeenCalledTimes(0)
-      expect(app.isNewUserSession).toBeFalsy()
     })
     it('doesnt show user creation if default user', async () => {
       const { app } = await start({
@@ -292,7 +285,6 @@ describe('users', () => {
       const { api } = await import('../../../src/scripts/api')
       expect(api.storeSettings).toHaveBeenCalledTimes(0)
       expect(api.storeUserData).toHaveBeenCalledTimes(0)
-      expect(app.isNewUserSession).toBeFalsy()
     })
     it('doesnt allow user switching', async () => {
       const { app } = await start({


### PR DESCRIPTION
Follow up of https://github.com/Comfy-Org/ComfyUI_frontend/pull/1731
Part of https://github.com/Comfy-Org/ComfyUI_frontend/issues/1730

This PR removes the attempt to migrate existing values of settings and templates in local storage to server storage.