### PR TITLE
Add default setting for node error colour

### DIFF
--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -45,6 +45,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#FFF',
         NODE_BYPASS_BGCOLOR: '#FF00FF',
+        NODE_ERROR_COLOUR: '#E00',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
 
@@ -111,6 +112,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#000',
         NODE_BYPASS_BGCOLOR: '#FF00FF',
+        NODE_ERROR_COLOUR: '#E00',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.1)',
         DEFAULT_GROUP_FONT: 24,
 
@@ -175,6 +177,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#fdf6e3', // Base3
         NODE_BYPASS_BGCOLOR: '#FF00FF',
+        NODE_ERROR_COLOUR: '#E00',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
 
@@ -252,6 +255,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#FFF',
         NODE_BYPASS_BGCOLOR: '#FF00FF',
+        NODE_ERROR_COLOUR: '#E00',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 22,
         WIDGET_BGCOLOR: '#2b2f38',
@@ -327,6 +331,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#e5eaf0',
         NODE_BYPASS_BGCOLOR: '#FF00FF',
+        NODE_ERROR_COLOUR: '#E00',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
         WIDGET_BGCOLOR: '#2e3440',
@@ -402,6 +407,7 @@ const colorPalettes: ColorPalettes = {
         NODE_DEFAULT_SHAPE: 'box',
         NODE_BOX_OUTLINE_COLOR: '#e5eaf0',
         NODE_BYPASS_BGCOLOR: '#FF00FF',
+        NODE_ERROR_COLOUR: '#E00',
         DEFAULT_SHADOW_COLOR: 'rgba(0,0,0,0.5)',
         DEFAULT_GROUP_FONT: 24,
         WIDGET_BGCOLOR: '#161b22',

--- a/src/types/colorPalette.ts
+++ b/src/types/colorPalette.ts
@@ -45,6 +45,7 @@ const litegraphBaseSchema = z
     NODE_DEFAULT_SHAPE: z.string(),
     NODE_BOX_OUTLINE_COLOR: z.string(),
     NODE_BYPASS_BGCOLOR: z.string(),
+    NODE_ERROR_COLOUR: z.string(),
     DEFAULT_SHADOW_COLOR: z.string(),
     DEFAULT_GROUP_FONT: z.number(),
     WIDGET_BGCOLOR: z.string(),


### PR DESCRIPTION
### Invalid node redesign

- Requires https://github.com/Comfy-Org/litegraph.js/pull/358
- Uses node "type" as a fallback title
- Fixes scaling of padding when drawing borders of rounded shapes
- Replaces default behaviour on the left:

![image](https://github.com/user-attachments/assets/18074d36-0492-4612-957f-05383c6c8beb)

### Configuration

#### Colour

`NODE_ERROR_COLOUR` can be set in a ComfyUI theme file, the same way as other litegraph colours.

```ts
// Or direct via script / console
LiteGraph.NODE_ERROR_COLOUR = "#d61"
```

![image](https://github.com/user-attachments/assets/101561e2-a870-4568-adcf-5288504532e9)

#### Old indicator + title

```ts
LiteGraph.use_legacy_node_error_indicator = true
```

![image](https://github.com/user-attachments/assets/3a57ac7b-3ff4-4489-b8e3-3494bf177676)
