### PR TITLE
Add current user message in settings dialog

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -29,6 +29,7 @@
           :value="category.label"
         >
           <template #header>
+            <CurrentUserMessage v-if="tabValue === 'Comfy'" />
             <FirstTimeUIMessage v-if="tabValue === 'Comfy'" />
           </template>
           <SettingsPanel :settingGroups="sortedGroups(category)" />
@@ -74,6 +75,7 @@ import SettingsPanel from './setting/SettingsPanel.vue'
 import PanelTemplate from './setting/PanelTemplate.vue'
 import AboutPanel from './setting/AboutPanel.vue'
 import FirstTimeUIMessage from './setting/FirstTimeUIMessage.vue'
+import CurrentUserMessage from './setting/CurrentUserMessage.vue'
 import { flattenTree } from '@/utils/treeUtil'
 import { isElectron } from '@/utils/envUtil'
 

--- a/src/components/dialog/content/setting/CurrentUserMessage.vue
+++ b/src/components/dialog/content/setting/CurrentUserMessage.vue
@@ -1,0 +1,26 @@
+<!-- A message that displays the current user -->
+<template>
+  <Message
+    v-if="userStore.isMultiUserServer"
+    severity="info"
+    icon="pi pi-user"
+    pt:text="w-full"
+  >
+    <div class="flex items-center justify-between">
+      <div>{{ $t('currentUser') }}: {{ userStore.currentUser?.username }}</div>
+      <Button icon="pi pi-sign-out" @click="logout" text />
+    </div>
+  </Message>
+</template>
+
+<script setup lang="ts">
+import Message from 'primevue/message'
+import Button from 'primevue/button'
+import { useUserStore } from '@/stores/userStore'
+
+const userStore = useUserStore()
+const logout = () => {
+  userStore.logout()
+  window.location.reload()
+}
+</script>

--- a/src/components/dialog/content/setting/FirstTimeUIMessage.vue
+++ b/src/components/dialog/content/setting/FirstTimeUIMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <Message
     v-if="show"
-    class="first-time-ui-message m-2"
+    class="first-time-ui-message"
     severity="info"
     :closable="true"
     @close="handleClose"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -88,6 +88,7 @@ export default {
     revertChanges: 'Revert Changes',
     restart: 'Restart'
   },
+  currentUser: 'Current user',
   empty: 'Empty',
   noWorkflowsFound: 'No workflows found.',
   comingSoon: 'Coming Soon',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -81,6 +81,7 @@ export default {
     revertChanges: '変更を元に戻す',
     restart: '再起動'
   },
+  currentUser: '現在のユーザー',
   empty: '表示する項目がありません',
   noWorkflowsFound: 'ワークフローが見つかりませんでした。',
   comingSoon: '近日公開',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1,4 +1,5 @@
 export default {
+  currentUser: 'Текущий пользователь',
   empty: 'Пусто',
   noWorkflowsFound: 'Рабочие процессы не найдены.',
   download: 'Скачать',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1,4 +1,5 @@
 export default {
+  currentUser: '当前用户',
   empty: '空',
   noWorkflowsFound: '未找到工作流',
   firstTimeUIMessage:


### PR DESCRIPTION
Adds a current user message in settings dialog so users in legacy UI can still switch user via settings dialog the same way as before.

![image](https://github.com/user-attachments/assets/c25fe598-e1ea-4ef9-b677-783fedc184c1)
