### PR TITLE
Fix group node manage opening to wrong node type

### DIFF
--- a/browser_tests/groupNode.spec.ts
+++ b/browser_tests/groupNode.spec.ts
@@ -103,6 +103,36 @@ test.describe('Group Node', () => {
     await expect(comfyPage.page.locator('.node-tooltip')).toBeVisible()
   })
 
+  test('Manage group opens with the correct group selected', async ({
+    comfyPage
+  }) => {
+    const makeGroup = async (name, type1, type2) => {
+      const node1 = (await comfyPage.getNodeRefsByType(type1))[0]
+      const node2 = (await comfyPage.getNodeRefsByType(type2))[0]
+      await node1.click('title')
+      await node2.click('title', {
+        modifiers: ['Shift']
+      })
+      return await node2.convertToGroupNode(name)
+    }
+
+    const group1 = await makeGroup(
+      'g1',
+      'CLIPTextEncode',
+      'CheckpointLoaderSimple'
+    )
+    const group2 = await makeGroup('g2', 'EmptyLatentImage', 'KSampler')
+
+    const manage1 = await group1.manageGroupNode()
+    await comfyPage.nextFrame()
+    expect(await manage1.getSelectedNodeType()).toBe('g1')
+    await manage1.close()
+    await expect(manage1.root).not.toBeVisible()
+
+    const manage2 = await group2.manageGroupNode()
+    expect(await manage2.getSelectedNodeType()).toBe('g2')
+  })
+
   test('Reconnects inputs after configuration changed via manage dialog save', async ({
     comfyPage
   }) => {

--- a/browser_tests/helpers/manageGroupNode.ts
+++ b/browser_tests/helpers/manageGroupNode.ts
@@ -1,12 +1,14 @@
 import { Locator, Page } from '@playwright/test'
 export class ManageGroupNode {
   footer: Locator
+  header: Locator
 
   constructor(
     readonly page: Page,
     readonly root: Locator
   ) {
     this.footer = root.locator('footer')
+    this.header = root.locator('header')
   }
 
   async setLabel(name: string, label: string) {
@@ -21,6 +23,11 @@ export class ManageGroupNode {
 
   async close() {
     await this.footer.getByText('Close').click()
+  }
+
+  async getSelectedNodeType() {
+    const select = this.header.locator('select').first()
+    return await select.inputValue()
   }
 
   async selectNode(name: string) {

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -1001,7 +1001,7 @@ export class GroupNodeHandler {
         },
         {
           content: 'Manage Group Node',
-          callback: manageGroupNodes
+          callback: () => manageGroupNodes(this.type)
         }
       )
     }
@@ -1488,8 +1488,8 @@ function ungroupSelectedGroupNodes() {
   }
 }
 
-function manageGroupNodes() {
-  new ManageGroupDialog(app).show()
+function manageGroupNodes(type?: string) {
+  new ManageGroupDialog(app).show(type)
 }
 
 const id = 'Comfy.GroupNode'

--- a/src/extensions/core/groupNodeManage.ts
+++ b/src/extensions/core/groupNodeManage.ts
@@ -519,6 +519,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
 
     this.element.addEventListener('close', () => {
       this.draggable?.dispose()
+      this.element.remove()
     })
   }
 }


### PR DESCRIPTION
Resolves #1713, looks to have broken as part of the command/keybind update

Also, now removes dialog from DOM when closed which was found when writing the test