### PR TITLE
Remove unnecessary localization calls for System Info and Devices headers

### DIFF
--- a/src/components/common/DeviceInfo.vue
+++ b/src/components/common/DeviceInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grid grid-cols-2 gap-2">
     <template v-for="col in deviceColumns" :key="col.field">
-      <div class="font-medium">{{ $t(col.header) }}</div>
+      <div class="font-medium">{{ col.header }}</div>
       <div>{{ formatValue(props.device[col.field], col.field) }}</div>
     </template>
   </div>

--- a/src/components/common/SystemStatsPanel.vue
+++ b/src/components/common/SystemStatsPanel.vue
@@ -4,7 +4,7 @@
       <h2 class="text-2xl font-semibold mb-4">{{ $t('systemInfo') }}</h2>
       <div class="grid grid-cols-2 gap-2">
         <template v-for="col in systemColumns" :key="col.field">
-          <div class="font-medium">{{ $t(col.header) }}</div>
+          <div class="font-medium">{{ col.header }}</div>
           <div>{{ formatValue(systemInfo[col.field], col.field) }}</div>
         </template>
       </div>


### PR DESCRIPTION
I noticed a warning in the `Settings > About` panel stating that a locale message key (e.g., "Python Version") could not be found, and confirmed that these keys do not exist in the locale files.

 
![fix-warning-not-found-locale-message-key](https://github.com/user-attachments/assets/0d2c53db-b8ad-4a41-8de2-d7bf551ad306)


Given the nature of these texts (e.g., Python Version, OS), I decided they don’t require localization and removed the $t calls accordingly.

If the intention is to localize these texts, please let me know.

I would appreciate it if you could review this PR at your convenience!