### PR TITLE
Revert "Bump @intlify/core-base and vue-i18n"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "primevue": "^4.0.5",
         "three": "^0.170.0",
         "vue": "^3.4.31",
-        "vue-i18n": "^9.14.2",
+        "vue-i18n": "^9.13.1",
         "vue-router": "^4.4.3",
         "zod": "^3.23.8",
         "zod-validation-error": "^3.3.0"
@@ -2609,13 +2609,12 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.2.tgz",
-      "integrity": "sha512-DZyQ4Hk22sC81MP4qiCDuU+LdaYW91A6lCjq8AWPvY3+mGMzhGDfOCzvyR6YBQxtlPjFqMoFk9ylnNYRAQwXtQ==",
-      "license": "MIT",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.13.1.tgz",
+      "integrity": "sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==",
       "dependencies": {
-        "@intlify/message-compiler": "9.14.2",
-        "@intlify/shared": "9.14.2"
+        "@intlify/message-compiler": "9.13.1",
+        "@intlify/shared": "9.13.1"
       },
       "engines": {
         "node": ">= 16"
@@ -2625,12 +2624,11 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.2.tgz",
-      "integrity": "sha512-YsKKuV4Qv4wrLNsvgWbTf0E40uRv+Qiw1BeLQ0LAxifQuhiMe+hfTIzOMdWj/ZpnTDj4RSZtkXjJM7JDiiB5LQ==",
-      "license": "MIT",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.13.1.tgz",
+      "integrity": "sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==",
       "dependencies": {
-        "@intlify/shared": "9.14.2",
+        "@intlify/shared": "9.13.1",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -2641,10 +2639,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.2.tgz",
-      "integrity": "sha512-uRAHAxYPeF+G5DBIboKpPgC/Waecd4Jz8ihtkpJQD5ycb5PwXp0k/+hBGl5dAjwF7w+l74kz/PKA8r8OK//RUw==",
-      "license": "MIT",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.13.1.tgz",
+      "integrity": "sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==",
       "engines": {
         "node": ">= 16"
       },
@@ -18057,13 +18054,12 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.2.tgz",
-      "integrity": "sha512-JK9Pm80OqssGJU2Y6F7DcM8RFHqVG4WkuCqOZTVsXkEzZME7ABejAUqUdA931zEBedc4thBgSUWxeQh4uocJAQ==",
-      "license": "MIT",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.13.1.tgz",
+      "integrity": "sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==",
       "dependencies": {
-        "@intlify/core-base": "9.14.2",
-        "@intlify/shared": "9.14.2",
+        "@intlify/core-base": "9.13.1",
+        "@intlify/shared": "9.13.1",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "primevue": "^4.0.5",
     "three": "^0.170.0",
     "vue": "^3.4.31",
-    "vue-i18n": "^9.14.2",
+    "vue-i18n": "^9.13.1",
     "vue-router": "^4.4.3",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.3.0"


### PR DESCRIPTION
Reverts Comfy-Org/ComfyUI_frontend#1762

Reason: Broke compile. It seems like `$t` syntax is no longer supported in the newer version of vue-i18n.