### PR TITLE
Keep log on screen after installation error

### DIFF
--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -53,7 +53,7 @@ let xterm: Terminal | undefined
 
 const updateProgress = ({ status: newStatus }: { status: ProgressStatus }) => {
   status.value = newStatus
-  xterm?.clear()
+  if (newStatus !== ProgressStatus.ERROR) xterm?.clear()
 }
 
 const terminalCreated = (


### PR DESCRIPTION
### Current:
- Failed installation
- No useful information on screen
- Must open log folder, find right log, scroll to end...

![image](https://github.com/user-attachments/assets/21770f11-5ea6-4529-820f-8f37acc245ae)

### Proposed:
- Hide terminal entirely
- Add Show Terminal button

![image](https://github.com/user-attachments/assets/73b140e7-81fb-4426-88eb-67c1cd2a8950)

- Button clicked => Show the terminal with the error message

![image](https://github.com/user-attachments/assets/50104fb0-e469-4bd2-917b-fe9a0356b85b)
