### PR TITLE
Always include node title metadata for API export

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2410,16 +2410,14 @@ export class ComfyApp {
           }
         }
 
-        let node_data = {
+        const node_data = {
           inputs,
           class_type: node.comfyClass
         }
 
-        if (this.ui.settings.getSettingValue('Comfy.DevMode')) {
-          // Ignored by the backend.
-          node_data['_meta'] = {
-            title: node.title
-          }
+        // Ignored by the backend.
+        node_data['_meta'] = {
+          title: node.title
         }
 
         output[String(node.id)] = node_data


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1752

Currently in the new menu, the API export action is always available without user toggle the dev mode setting, we should always include the meta field in the API export format outputs.