### PR TITLE
Fix keybinds invalidated by capslock state

### DIFF
--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -37,26 +37,26 @@ app.registerExtension({
         return
       }
 
-      // Finished Handling all modifier keybinds, now handle the rest
+      // Only clear dialogs if not using modifiers
       if (event.ctrlKey || event.altKey || event.metaKey) {
         return
       }
 
-      // Close out of modals using escape
+      // Escape key: close the first open modal found, and all dialogs
       if (event.key === 'Escape') {
         const modals = document.querySelectorAll<HTMLElement>('.comfy-modal')
-        const modal = Array.from(modals).find(
-          (modal) =>
-            window.getComputedStyle(modal).getPropertyValue('display') !==
-            'none'
-        )
-        if (modal) {
-          modal.style.display = 'none'
+        for (const modal of modals) {
+          const modalDisplay = window
+            .getComputedStyle(modal)
+            .getPropertyValue('display')
+
+          if (modalDisplay !== 'none') {
+            modal.style.display = 'none'
+            break
+          }
         }
 
-        ;[...document.querySelectorAll('dialog')].forEach((d) => {
-          d.close()
-        })
+        for (const d of document.querySelectorAll('dialog')) d.close()
       }
     }
 

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -163,11 +163,13 @@ export class ChangeTracker {
   }
 
   async undoRedo(e: KeyboardEvent) {
-    if (e.ctrlKey || e.metaKey) {
-      if (e.key === 'y' || e.key == 'Z') {
+    if ((e.ctrlKey || e.metaKey) && !e.altKey) {
+      const key = e.key.toUpperCase()
+      // Redo: Ctrl + Y, or Ctrl + Shift + Z
+      if ((key === 'Y' && !e.shiftKey) || (key == 'Z' && e.shiftKey)) {
         await this.redo()
         return true
-      } else if (e.key === 'z') {
+      } else if (key === 'Z' && !e.shiftKey) {
         await this.undo()
         return true
       }

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -62,7 +62,7 @@ export class KeyComboImpl implements KeyCombo {
   }
 
   serialize(): string {
-    return `${this.key}:${this.ctrl}:${this.alt}:${this.shift}`
+    return `${this.key.toUpperCase()}:${this.ctrl}:${this.alt}:${this.shift}`
   }
 
   deserialize(serialized: string): KeyComboImpl {

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -65,17 +65,6 @@ export class KeyComboImpl implements KeyCombo {
     return `${this.key.toUpperCase()}:${this.ctrl}:${this.alt}:${this.shift}`
   }
 
-  /** @deprecated Should be not used as keys are mutated when serialized to resolve capslock issue. */
-  deserialize(serialized: string): KeyComboImpl {
-    const [key, ctrl, alt, shift] = serialized.split(':')
-    return new KeyComboImpl({
-      key,
-      ctrl: ctrl === 'true',
-      alt: alt === 'true',
-      shift: shift === 'true'
-    })
-  }
-
   toString(): string {
     return this.getKeySequences().join(' + ')
   }

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -16,15 +16,14 @@ export class KeybindingImpl implements Keybinding {
     this.targetSelector = obj.targetSelector
   }
 
-  equals(other: any): boolean {
-    if (toRaw(other) instanceof KeybindingImpl) {
-      return (
-        this.commandId === other.commandId &&
-        this.combo.equals(other.combo) &&
-        this.targetSelector === other.targetSelector
-      )
-    }
-    return false
+  equals(other: unknown): boolean {
+    const raw = toRaw(other)
+
+    return raw instanceof KeybindingImpl
+      ? this.commandId === raw.commandId &&
+          this.combo.equals(raw.combo) &&
+          this.targetSelector === raw.targetSelector
+      : false
   }
 }
 

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -51,16 +51,15 @@ export class KeyComboImpl implements KeyCombo {
     })
   }
 
-  equals(other: any): boolean {
-    if (toRaw(other) instanceof KeyComboImpl) {
-      return (
-        this.key === other.key &&
-        this.ctrl === other.ctrl &&
-        this.alt === other.alt &&
-        this.shift === other.shift
-      )
-    }
-    return false
+  equals(other: unknown): boolean {
+    const raw = toRaw(other)
+
+    return raw instanceof KeyComboImpl
+      ? this.key.toUpperCase() === raw.key.toUpperCase() &&
+          this.ctrl === raw.ctrl &&
+          this.alt === raw.alt &&
+          this.shift === raw.shift
+      : false
   }
 
   serialize(): string {

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -65,6 +65,7 @@ export class KeyComboImpl implements KeyCombo {
     return `${this.key.toUpperCase()}:${this.ctrl}:${this.alt}:${this.shift}`
   }
 
+  /** @deprecated Should be not used as keys are mutated when serialized to resolve capslock issue. */
   deserialize(serialized: string): KeyComboImpl {
     const [key, ctrl, alt, shift] = serialized.split(':')
     return new KeyComboImpl({


### PR DESCRIPTION
### User changes

- Keybinds now always serialise in upper case
- Fixes `changeTracker` behaviour inverted by capslock (ctrl / ctrl + shift + z)
- If two keybinds for the same key exist (e.g. `Ctrl` + `e`, and `Ctrl` + `E`), one will need to be rebound - it will not show up in GUI
  - This can probably be fixed, but would require larger changes
  - A script to detect and delete duplicate binds, then notify the user would be easier

#### Notes

- Removes `KeyComboImpl.deserialize` method (unused?)
- Adds compile-time type safety to some explicit-any methods
- Individual commits should be easy to revert if desired
- Resolves #1315