### PR TITLE
[Refactor] Extract top menu bar command definitions

### DIFF
--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -1,0 +1,25 @@
+export const CORE_MENU_COMMANDS = [
+  [['Workflow'], ['Comfy.NewBlankWorkflow']],
+  [['Workflow'], ['Comfy.OpenWorkflow', 'Comfy.BrowseTemplates']],
+  [
+    ['Workflow'],
+    [
+      'Comfy.SaveWorkflow',
+      'Comfy.SaveWorkflowAs',
+      'Comfy.ExportWorkflow',
+      'Comfy.ExportWorkflowAPI'
+    ]
+  ],
+  [['Edit'], ['Comfy.Undo', 'Comfy.Redo']],
+  [['Edit'], ['Comfy.RefreshNodeDefinitions']],
+  [['Edit'], ['Comfy.ClearWorkflow']],
+  [['Edit'], ['Comfy.OpenClipspace']],
+  [
+    ['Help'],
+    [
+      'Comfy.Help.OpenComfyUIIssues',
+      'Comfy.Help.OpenComfyUIDocs',
+      'Comfy.Help.OpenComfyOrgDiscord'
+    ]
+  ]
+]

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -511,6 +511,36 @@ export const useCommandStore = defineStore('command', () => {
           }
         }
       }
+    },
+    {
+      id: 'Comfy.Help.OpenComfyUIIssues',
+      icon: 'pi pi-github',
+      label: 'ComfyUI Issues',
+      versionAdded: '1.5.5',
+      function: () => {
+        window.open(
+          'https://github.com/comfyanonymous/ComfyUI/issues',
+          '_blank'
+        )
+      }
+    },
+    {
+      id: 'Comfy.Help.OpenComfyUIDocs',
+      icon: 'pi pi-info-circle',
+      label: 'ComfyUI Docs',
+      versionAdded: '1.5.5',
+      function: () => {
+        window.open('https://docs.comfy.org/', '_blank')
+      }
+    },
+    {
+      id: 'Comfy.Help.OpenComfyOrgDiscord',
+      icon: 'pi pi-discord',
+      label: 'Comfy-Org Discord',
+      versionAdded: '1.5.5',
+      function: () => {
+        window.open('https://www.comfy.org/discord', '_blank')
+      }
     }
   ]
 

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -3,6 +3,7 @@ import type { MenuItem } from 'primevue/menuitem'
 import { ref } from 'vue'
 import { useCommandStore } from './commandStore'
 import { ComfyExtension } from '@/types/comfy'
+import { CORE_MENU_COMMANDS } from '@/constants/coreMenuCommands'
 
 export const useMenuItemStore = defineStore('menuItem', () => {
   const commandStore = useCommandStore()
@@ -77,53 +78,17 @@ export const useMenuItemStore = defineStore('menuItem', () => {
     })
   }
 
-  // Core menu commands
-  registerCommands(['Workflow'], ['Comfy.NewBlankWorkflow'])
-
-  registerCommands(
-    ['Workflow'],
-    ['Comfy.OpenWorkflow', 'Comfy.BrowseTemplates']
-  )
-  registerCommands(
-    ['Workflow'],
-    [
-      'Comfy.SaveWorkflow',
-      'Comfy.SaveWorkflowAs',
-      'Comfy.ExportWorkflow',
-      'Comfy.ExportWorkflowAPI'
-    ]
-  )
-
-  registerCommands(['Edit'], ['Comfy.Undo', 'Comfy.Redo'])
-  registerCommands(['Edit'], ['Comfy.RefreshNodeDefinitions'])
-  registerCommands(['Edit'], ['Comfy.ClearWorkflow'])
-  registerCommands(['Edit'], ['Comfy.OpenClipspace'])
-
-  registerMenuGroup(
-    ['Help'],
-    [
-      {
-        icon: 'pi pi-github',
-        label: 'ComfyUI Issues',
-        url: 'https://github.com/comfyanonymous/ComfyUI/issues'
-      },
-      {
-        icon: 'pi pi-info-circle',
-        label: 'ComfyUI Docs',
-        url: 'https://docs.comfy.org/'
-      },
-      {
-        icon: 'pi pi-discord',
-        label: 'Comfy-Org',
-        url: 'https://www.comfy.org/discord'
-      }
-    ]
-  )
+  const registerCoreMenuCommands = () => {
+    for (const [path, commands] of CORE_MENU_COMMANDS) {
+      registerCommands(path, commands)
+    }
+  }
 
   return {
     menuItems,
     registerMenuGroup,
     registerCommands,
-    loadExtensionMenuCommands
+    loadExtensionMenuCommands,
+    registerCoreMenuCommands
   }
 })

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -39,6 +39,7 @@ import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useServerConfigStore } from '@/stores/serverConfigStore'
 import { SERVER_CONFIG_ITEMS } from '@/constants/serverConfig'
+import { useMenuItemStore } from '@/stores/menuItemStore'
 
 setupAutoQueueHandler()
 
@@ -104,6 +105,7 @@ watchEffect(() => {
 
 const init = () => {
   settingStore.addSettings(app.ui.settings)
+  useMenuItemStore().registerCoreMenuCommands()
   useKeybindingStore().loadCoreKeybindings()
   useSidebarTabStore().registerCoreSidebarTabs()
   useBottomPanelStore().registerCoreBottomPanelTabs()


### PR DESCRIPTION
This PR splits the top menu bar command definitions to a separate constant file so that we can perform i18n on paths later.