### PR TITLE
Prevent interface crash from dialog abuse

### DIFF
--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -57,6 +57,10 @@ export const useDialogStore = defineStore('dialog', () => {
     props?: Record<string, any>
     dialogComponentProps?: DialogComponentProps
   }) {
+    if (dialogStack.value.length >= 10) {
+      dialogStack.value.shift()
+    }
+
     const dialog = {
       key: options.key,
       visible: true,


### PR DESCRIPTION
- Adds hard-coded limit of 10 open dialogs
- Discards the oldest item on the dialog stack to maintain size