### PR TITLE
Keep shim of several legacy components

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -15,14 +15,12 @@ import {
   getLatentMetadata
 } from './pnginfo'
 import { createImageHost, calculateImageGrid } from './ui/imagePreview'
-import { DraggableList } from './ui/draggableList'
-import { applyTextReplacements, addStylesheet } from './utils'
 import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 import {
   type ComfyWorkflowJSON,
   type NodeId,
   validateComfyWorkflow
-} from '../types/comfyWorkflow'
+} from '@/types/comfyWorkflow'
 import type { ComfyNodeDef } from '@/types/apiTypes'
 import { adjustColor, ColorAdjustOptions } from '@/utils/colorUtil'
 import { ComfyAppMenu } from './ui/menu/index'
@@ -113,14 +111,6 @@ export class ComfyApp {
   static clipspace_invalidate_handler: (() => void) | null = null
   static open_maskeditor = null
   static clipspace_return_node = null
-
-  // Force vite to import utils.ts as part of index.
-  // Force import of DraggableList.
-  static utils = {
-    applyTextReplacements,
-    addStylesheet,
-    DraggableList
-  }
 
   vueAppReady: boolean
   ui: ComfyUI

--- a/src/scripts/ui/menu/index.ts
+++ b/src/scripts/ui/menu/index.ts
@@ -7,6 +7,9 @@ import './menu.css'
 export { ComfyButton } from '../components/button'
 export { ComfySplitButton } from '../components/splitButton'
 export { ComfyPopup } from '../components/popup'
+export { ComfyAsyncDialog } from '@/scripts/ui/components/asyncDialog'
+export { DraggableList } from '@/scripts/ui/draggableList'
+export { applyTextReplacements, addStylesheet } from '@/scripts/utils'
 
 export class ComfyAppMenu {
   app: ComfyApp


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI_frontend/pull/1772 removes the reference to `ComfyAsyncDialog` so that it is no longer in vite's build tree, which causes the shim module not being generated. Any extension that tries to import `ComfyAsyncDialog` will be broken.

This PR adds back a dunny reference to `ComfyAsyncDialog` so that the shim module is kept there.