### PR TITLE
Fix setting list nav separator

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -241,11 +241,11 @@ const tabValue = computed(() =>
 
 /* Show a separator line above the Keybinding tab */
 /* This indicates the start of custom setting panels */
-.settings-sidebar :deep(.p-listbox-option[aria-label='Keybinding']) {
+.settings-sidebar :deep(.p-listbox-option:nth-last-child(4)) {
   position: relative;
 }
 
-.settings-sidebar :deep(.p-listbox-option[aria-label='Keybinding'])::before {
+.settings-sidebar :deep(.p-listbox-option:nth-last-child(4))::before {
   @apply content-[''] top-0 left-0 absolute w-full;
   border-top: 1px solid var(--p-divider-border-color);
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/346865e0-49f3-48b5-9765-5c5db7a597cc)

Fix aria-label css selector match failure when in non-en locale.