### PR TITLE
Revert "Fix setting list nav separator"

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -241,11 +241,11 @@ const tabValue = computed(() =>
 
 /* Show a separator line above the Keybinding tab */
 /* This indicates the start of custom setting panels */
-.settings-sidebar :deep(.p-listbox-option:nth-last-child(4)) {
+.settings-sidebar :deep(.p-listbox-option[aria-label='Keybinding']) {
   position: relative;
 }
 
-.settings-sidebar :deep(.p-listbox-option:nth-last-child(4))::before {
+.settings-sidebar :deep(.p-listbox-option[aria-label='Keybinding'])::before {
   @apply content-[''] top-0 left-0 absolute w-full;
   border-top: 1px solid var(--p-divider-border-color);
 }


### PR DESCRIPTION
Reverts Comfy-Org/ComfyUI_frontend#1799

Reason: The PR fails to account for dynamic panels like "Extension" and "Server-Config". We need to find a better way to add that separator.