### PR TITLE
[Electron] Use electronAPI to get ComfyUI core version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-        "@comfyorg/comfyui-electron-types": "^0.3.19",
+        "@comfyorg/comfyui-electron-types": "^0.3.25",
         "@comfyorg/litegraph": "^0.8.42",
         "@primevue/themes": "^4.0.5",
         "@vueuse/core": "^11.0.0",
@@ -1951,9 +1951,9 @@
       "dev": true
     },
     "node_modules/@comfyorg/comfyui-electron-types": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.3.19.tgz",
-      "integrity": "sha512-VNr542eaLVmaeSJIvGv/Y5OiC2vYiLy+FtjwYtP+J8M5BSy88GCikX2K9NIkLPtcw9DLolVK3XWuIvFpsOK0zg==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.3.25.tgz",
+      "integrity": "sha512-DKZJ5qXJG3dn3bmdJShm/a893cPm2OzJPxI62J/9ED8OTRmKEN3CVNX3Ire7Nj4g+GRLDZHnKVo/GYSXXOtufA==",
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/comfyui-electron-types": "^0.3.19",
+    "@comfyorg/comfyui-electron-types": "^0.3.25",
     "@comfyorg/litegraph": "^0.8.42",
     "@primevue/themes": "^4.0.5",
     "@vueuse/core": "^11.0.0",

--- a/src/stores/aboutPanelStore.ts
+++ b/src/stores/aboutPanelStore.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { computed } from 'vue'
 import { useSystemStatsStore } from './systemStatsStore'
 import { useExtensionStore } from './extensionStore'
+import { electronAPI, isElectron } from '@/utils/envUtil'
 
 export const useAboutPanelStore = defineStore('aboutPanel', () => {
   const frontendVersion = __COMFYUI_FRONTEND_VERSION__
@@ -13,8 +14,14 @@ export const useAboutPanelStore = defineStore('aboutPanel', () => {
   )
 
   const coreBadges = computed<AboutPageBadge[]>(() => [
+    // In electron, the ComfyUI is packaged without the git repo,
+    // so the python server's API doesn't have the version info.
     {
-      label: `ComfyUI ${coreVersion.value}`,
+      label: `ComfyUI ${
+        isElectron()
+          ? 'v' + electronAPI().getComfyUIVersion()
+          : coreVersion.value
+      }`,
       url: 'https://github.com/comfyanonymous/ComfyUI',
       icon: 'pi pi-github'
     },

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -50,7 +50,8 @@ const mockElectronAPI: Plugin = {
             getAllDownloads: () => Promise.resolve([]),
             onDownloadProgress: () => {}
           },
-          getElectronVersion: () => Promise.resolve('1.0.0')
+          getElectronVersion: () => Promise.resolve('1.0.0'),
+          getComfyUIVersion: () => '9.9.9'
         };`
       }
     ]


### PR DESCRIPTION
Requires https://github.com/Comfy-Org/desktop/pull/431

![image](https://github.com/user-attachments/assets/bea948b9-890b-4b77-ba05-b1375e601eac)
