### PR TITLE
Fix fallback of unrecognized extension categories

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -144,7 +144,10 @@ const categories = computed<SettingTreeNode[]>(() =>
     aboutPanelNode
   ].map((node) => ({
     ...node,
-    translatedLabel: t(`settingsCategories.${normalizeI18nKey(node.label)}`)
+    translatedLabel: t(
+      `settingsCategories.${normalizeI18nKey(node.label)}`,
+      node.label
+    )
   }))
 )
 

--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="setting-group">
     <Divider v-if="divider" />
-    <h3>{{ $t(`settingsCategories.${normalizeI18nKey(group.label)}`) }}</h3>
+    <h3>
+      {{
+        $t(`settingsCategories.${normalizeI18nKey(group.label)}`, group.label)
+      }}
+    </h3>
     <div
       v-for="setting in group.settings"
       :key="setting.id"


### PR DESCRIPTION
Fallback to original label for extensions. 3rd party extensions don't have ability to dynamically register i18n items now.