### PR TITLE
Align desktop version badge format with other badges

### DIFF
--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -146,7 +146,7 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
 
     aboutPageBadges: [
       {
-        label: 'ComfyUI_Desktop ' + desktopAppVersion,
+        label: 'ComfyUI_desktop v' + desktopAppVersion,
         url: 'https://github.com/Comfy-Org/electron',
         icon: 'pi pi-github'
       }


### PR DESCRIPTION
Add `v` prefix and make `Desktop` lowercase.

![image](https://github.com/user-attachments/assets/ffa5f33d-c4e6-4b04-a9a2-e97bccf7cf6f)
