### PR TITLE
keyboard shortcut rewrite + shortcut context + maskEditor shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,11 +309,20 @@ app.extensionManager.setting.set('TestSetting', 'Hello, universe!')
 
   Extensions can call the following API to register commands and keybindings. Do
   note that keybindings defined in core cannot be overwritten, and some keybindings
-  are reserved by the browser.
+  are reserved by the browser. Extensions can create custom keyBinding contexts to 
+  restrict keyboard shortcuts to specific areas of the application. If no context is 
+  specified, shortcuts are assigned to the "global" context and will work throughout 
+  ComfyUI, except in areas with their own specific context definitions.
 
 ```js
   app.registerExtension({
     name: 'TestExtension1',
+    keybindingContexts: [
+      {
+        id: 'testContext',
+        name: 'Test Context'
+      }
+    ],
     commands: [
       {
         id: 'TestCommand',
@@ -325,12 +334,20 @@ app.extensionManager.setting.set('TestSetting', 'Hello, universe!')
     keybindings: [
       {
         combo: { key: 'k' },
-        commandId: 'TestCommand'
+        commandId: 'TestCommand',
+        context: testContext //must match id in keybindingContexts
       }
     ]
   })
 ```
 
+```js
+//activate context
+app.extensionManager.setting.set('Comfy.KeybindContext', 'testContext') //must match id in keybindingContexts
+
+//deactivate context
+app.extensionManager.setting.set('Comfy.KeybindContext', 'global') //always go back to global
+```
 </details>
 
 <details>

--- a/src/components/dialog/content/setting/keybinding/KeyComboDisplay.vue
+++ b/src/components/dialog/content/setting/keybinding/KeyComboDisplay.vue
@@ -1,11 +1,14 @@
 <template>
   <span>
-    <template v-for="(sequence, index) in keySequences" :key="index">
-      <Tag :severity="isModified ? 'info' : 'secondary'">
-        {{ sequence }}
-      </Tag>
-      <span v-if="index < keySequences.length - 1" class="px-2">+</span>
+    <template v-if="keyCombo">
+      <template v-for="(sequence, index) in keySequences" :key="index">
+        <Tag :severity="isModified ? 'info' : 'secondary'">
+          {{ sequence }}
+        </Tag>
+        <span v-if="index < keySequences.length - 1" class="px-2">+</span>
+      </template>
     </template>
+    <span v-else>-</span>
   </span>
 </template>
 
@@ -16,7 +19,7 @@ import { computed } from 'vue'
 
 const props = withDefaults(
   defineProps<{
-    keyCombo: KeyComboImpl
+    keyCombo: KeyComboImpl | null
     isModified: boolean
   }>(),
   {
@@ -24,5 +27,5 @@ const props = withDefaults(
   }
 )
 
-const keySequences = computed(() => props.keyCombo.getKeySequences())
+const keySequences = computed(() => props.keyCombo?.getKeySequences() ?? [])
 </script>

--- a/src/components/dialog/content/setting/keybinding/KeyContextSelect.vue
+++ b/src/components/dialog/content/setting/keybinding/KeyContextSelect.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="context-select">
+    <button
+      v-for="context in props.contexts"
+      :key="context.id"
+      :class="{ selected: selectedContext === context.id }"
+      @click="selectContext(context.id)"
+      class="context-button"
+    >
+      {{ context.name }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { KeyBindingContextImpl } from '@/stores/keybindingStore'
+interface Props {
+  contexts: KeyBindingContextImpl[]
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  contexts: () => []
+})
+
+const emit = defineEmits<{
+  (e: 'context-changed', contextId: string): void
+}>()
+
+const selectedContext = ref(
+  props.contexts.find((c) => c.id === 'global')?.id || 'global'
+)
+
+const selectContext = (contextId: string) => {
+  selectedContext.value = contextId
+  emit('context-changed', contextId)
+}
+</script>
+
+<style scoped>
+.context-select {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.context-button {
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.context-button.selected {
+  background: var(--p-highlight-focus-background);
+}
+</style>

--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -173,5 +173,22 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       key: 'f'
     },
     commandId: 'Workspace.ToggleFocusMode'
+  },
+  {
+    combo: {
+      key: 'z',
+      ctrl: true
+    },
+    commandId: 'Comfy.Undo',
+    targetSelector: '#graph-canvas'
+  },
+  {
+    combo: {
+      key: 'z',
+      ctrl: true,
+      shift: true
+    },
+    commandId: 'Comfy.Redo',
+    targetSelector: '#graph-canvas'
   }
 ]

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -410,18 +410,11 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.3.5'
   },
   {
-    id: 'Comfy.Keybinding.UnsetBindings',
-    name: 'Keybindings unset by the user',
+    id: 'Comfy.Keybinding.ModifiedBindings',
+    name: 'Keybindings changed by the user',
     type: 'hidden',
     defaultValue: [] as Keybinding[],
-    versionAdded: '1.3.7'
-  },
-  {
-    id: 'Comfy.Keybinding.NewBindings',
-    name: 'Keybindings set by the user',
-    type: 'hidden',
-    defaultValue: [] as Keybinding[],
-    versionAdded: '1.3.7'
+    versionAdded: '1.5.7'
   },
   {
     id: 'Comfy.Extension.Disabled',

--- a/src/extensions/core/keybinds.ts
+++ b/src/extensions/core/keybinds.ts
@@ -43,7 +43,7 @@ class KeyboardManager {
 
     if (event.key === 'F12') return
 
-    this.setContext()
+    this.setContext(event)
 
     const target = event.composedPath()[0] as HTMLElement
     const excludedTags = ['TEXTAREA', 'INPUT', 'SPAN']

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1703,7 +1703,7 @@ export class ComfyApp {
     await this.#loadExtensions()
 
     this.#addProcessMouseHandler()
-    this.#addProcessKeyHandler()
+    //this.#addProcessKeyHandler()
     this.#addConfigureHandler()
     this.#addApiUpdateHandlers()
     this.#addRestoreWorkflowView()

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -162,20 +162,6 @@ export class ChangeTracker {
     )
   }
 
-  async undoRedo(e: KeyboardEvent) {
-    if ((e.ctrlKey || e.metaKey) && !e.altKey) {
-      const key = e.key.toUpperCase()
-      // Redo: Ctrl + Y, or Ctrl + Shift + Z
-      if ((key === 'Y' && !e.shiftKey) || (key == 'Z' && e.shiftKey)) {
-        await this.redo()
-        return true
-      } else if (key === 'Z' && !e.shiftKey) {
-        await this.undo()
-        return true
-      }
-    }
-  }
-
   beforeChange() {
     this.changeCount++
   }
@@ -194,6 +180,7 @@ export class ChangeTracker {
     ChangeTracker.app = app
 
     let keyIgnored = false
+    /*
     window.addEventListener(
       'keydown',
       (e: KeyboardEvent) => {
@@ -227,7 +214,6 @@ export class ChangeTracker {
           if (!changeTracker) return
 
           // Check if this is a ctrl+z ctrl+y
-          if (await changeTracker.undoRedo(e)) return
 
           // If our active element is some type of input then handle changes after they're done
           if (ChangeTracker.bindInput(app, bindInputEl)) return
@@ -237,6 +223,7 @@ export class ChangeTracker {
       },
       true
     )
+    */
 
     window.addEventListener('keyup', (e) => {
       if (keyIgnored) {

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -57,7 +57,7 @@ export class ComfyCommandImpl implements ComfyCommand {
       : this._menubarLabel
   }
 
-  get keybinding(): KeybindingImpl | null {
+  get keybinding(): KeybindingImpl | undefined {
     return useKeybindingStore().getKeybindingByCommandId(this.id)
   }
 }

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -46,6 +46,7 @@ export const useExtensionStore = defineStore('extension', () => {
     }
 
     extensionByName.value[extension.name] = markRaw(extension)
+    useKeybindingStore().loadExtensionKeybindingContexts(extension)
     useKeybindingStore().loadExtensionKeybindings(extension)
     useCommandStore().loadExtensionCommands(extension)
     useMenuItemStore().loadExtensionMenuCommands(extension)

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore - will remove in the future
 
 import { defineStore } from 'pinia'
-import { computed, Ref, ref, toRaw } from 'vue'
+import { ref, toRaw } from 'vue'
 import {
   Keybinding,
   KeyCombo,

--- a/src/types/keyBindingTypes.ts
+++ b/src/types/keyBindingTypes.ts
@@ -13,13 +13,22 @@ export const zKeyCombo = z.object({
 export const zKeybinding = z.object({
   commandId: z.string(),
   combo: zKeyCombo,
+  currentCombo: zKeyCombo.optional(),
   // Optional target element CSS selector to limit keybinding to.
   // Note: Currently only used to distinguish between global keybindings
   // and litegraph canvas keybindings.
   // Do NOT use this field in extensions as it has no effect.
-  targetSelector: z.string().optional()
+  targetSelector: z.string().optional(),
+  context: z.string().optional()
+})
+
+// KeyBindingContext schema
+export const zKeyBindingContext = z.object({
+  id: z.string(),
+  name: z.string()
 })
 
 // Infer types from schemas
 export type KeyCombo = z.infer<typeof zKeyCombo>
 export type Keybinding = z.infer<typeof zKeybinding>
+export type KeyBindingContext = z.infer<typeof zKeyBindingContext>

--- a/tests-ui/tests/slow/store/keybindingStore.test.ts
+++ b/tests-ui/tests/slow/store/keybindingStore.test.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { setActivePinia, createPinia } from 'pinia'
 import { useKeybindingStore, KeybindingImpl } from '@/stores/keybindingStore'
 
@@ -16,7 +17,7 @@ describe('useKeybindingStore', () => {
     store.addDefaultKeybinding(keybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
+    expect(store.getKeybinding(keybinding!.combo)).toEqual(keybinding)
   })
 
   it('should add and retrieve user keybindings', () => {
@@ -57,7 +58,7 @@ describe('useKeybindingStore', () => {
       combo: { key: 'C', ctrl: true }
     })
     store.addDefaultKeybinding(defaultKeybinding)
-    store.unsetKeybinding(defaultKeybinding)
+    store.unsetKeybinding(defaultKeybinding.commandId)
 
     const userKeybinding = new KeybindingImpl({
       commandId: 'test.command2',
@@ -79,8 +80,10 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(keybinding)
     expect(store.keybindings).toHaveLength(1)
 
-    store.unsetKeybinding(keybinding)
-    expect(store.keybindings).toHaveLength(0)
+    store.unsetKeybinding(keybinding.commandId)
+    expect(
+      store.getKeybindingByCommandId(keybinding.commandId).currentCombo
+    ).toBeNull()
   })
 
   it('should unset default keybindings', () => {
@@ -93,8 +96,10 @@ describe('useKeybindingStore', () => {
     store.addDefaultKeybinding(keybinding)
     expect(store.keybindings).toHaveLength(1)
 
-    store.unsetKeybinding(keybinding)
-    expect(store.keybindings).toHaveLength(0)
+    store.unsetKeybinding(keybinding.commandId)
+    expect(
+      store.getKeybindingByCommandId(keybinding.commandId).currentCombo
+    ).toBeNull()
   })
 
   it('should throw an error when adding duplicate default keybindings', () => {
@@ -133,7 +138,7 @@ describe('useKeybindingStore', () => {
       combo: { key: 'H', alt: true, shift: true }
     })
 
-    expect(() => store.unsetKeybinding(keybinding)).not.toThrow()
+    expect(() => store.unsetKeybinding(keybinding.commandId)).not.toThrow()
   })
 
   it('should remove unset keybinding when adding back a default keybinding', () => {
@@ -148,7 +153,7 @@ describe('useKeybindingStore', () => {
     expect(store.keybindings).toHaveLength(1)
 
     // Unset the default keybinding
-    store.unsetKeybinding(defaultKeybinding)
+    store.unsetKeybinding(defaultKeybinding.commandId)
     expect(store.keybindings).toHaveLength(0)
 
     // Add the same keybinding as a user keybinding
@@ -215,7 +220,7 @@ describe('useKeybindingStore', () => {
     )
 
     for (const keybinding of userUnsetKeybindings) {
-      store.unsetKeybinding(keybinding)
+      store.unsetKeybinding(keybinding.commandId)
     }
 
     expect(store.keybindings).toHaveLength(1)


### PR DESCRIPTION
- Added context system for keyboard shortcuts to limit their scope to specific UI areas
- Implemented keyboard controls for the mask editor
- Created UI for easy shortcut customization
- added setting to change stepSize of new brush increase/brush decrease shortcut
- added undo & redo to coreKeybindings

![image](https://github.com/user-attachments/assets/3f8457d0-c095-4532-b895-1e5023385b9c)

Future Work needed:
- remove bypassed typescript strict errors in 2 files
- restrict reset keyboard shortcut button to current context
- fix playwright tests