### PR TITLE
Updated About label translation to a more appropriate Japanese term

### DIFF
--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1155,7 +1155,7 @@
   },
   "settings": "設定",
   "settingsCategories": {
-    "About": "について",
+    "About": "情報",
     "Appearance": "外観",
     "BrushAdjustment": "ブラシ調整",
     "Canvas": "キャンバス",


### PR DESCRIPTION
Updated the translation for the 'About' label in Japanese from "について" to a more appropriate and natural term.
This change improves clarity and aligns better with user expectations.

I would appreciate it if you could review this at your convenience.