### PR TITLE
Use friendly language names for Comfy.Locale setting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,10 +487,10 @@ Our project supports multiple languages using `vue-i18n`. This allows users arou
 
 ### Supported Languages
 
- - en
- - zh
- - ru
- - ja
+ - en (English)
+ - zh (中文)
+ - ru (Русский)
+ - ja (日本語)
 
 ### How to Add a New Language
 
@@ -540,7 +540,13 @@ Add the newly added language to the following item in `src/constants/coreSetting
     id: 'Comfy.Locale',
     name: 'Locale',
     type: 'combo',
-    options: ['en', 'zh', 'ru', 'ja'], // Add the new language(s) here
+    // Add the new language(s) here
+    options: [
+      { value: 'en', text: 'English' },
+      { value: 'zh', text: '中文' },
+      { value: 'ru', text: 'Русский' },
+      { value: 'ja', text: '日本語' }
+    ],
     defaultValue: navigator.language.split('-')[0] || 'en'
   },
 ```

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -262,7 +262,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Locale',
     name: 'Language',
     type: 'combo',
-    options: ['en', 'zh', 'ru', 'ja'],
+    options: [
+      { value: 'en', text: 'English' },
+      { value: 'zh', text: '中文' },
+      { value: 'ru', text: 'Русский' },
+      { value: 'ja', text: '日本語' }
+    ],
     defaultValue: () => navigator.language.split('-')[0] || 'en'
   },
   {


### PR DESCRIPTION
This PR updates the `Comfy.Locale` setting options to display user-friendly language names instead of language codes. Internally, the language codes remain unchanged, ensuring that the i18n functionality and locale switching logic continue to work as before.
Users will now see labels like "English" and "日本語" in the dropdown, improving overall user experience.

Your review would be greatly appreciated when you have time!