### PR TITLE
[i18n] Safe fallback to original string

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -17,5 +17,15 @@ export const i18n = createI18n({
   }
 })
 
-/** Convenience shorthand: i18n.global should be . */
-export const { t } = i18n.global
+/** Convenience shorthand: i18n.global */
+export const { t, te } = i18n.global
+
+/**
+ * Safe translation function that returns the fallback message if the key is not found.
+ *
+ * @param key - The key to translate.
+ * @param fallbackMessage - The fallback message to use if the key is not found.
+ */
+export function st(key: string, fallbackMessage: string) {
+  return i18n.global.te(key) ? t(key) : fallbackMessage
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -27,5 +27,5 @@ export const { t, te } = i18n.global
  * @param fallbackMessage - The fallback message to use if the key is not found.
  */
 export function st(key: string, fallbackMessage: string) {
-  return i18n.global.te(key) ? t(key) : fallbackMessage
+  return te(key) ? t(key) : fallbackMessage
 }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -61,7 +61,7 @@ import { type IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
 import { workflowService } from '@/services/workflowService'
 import { useWidgetStore } from '@/stores/widgetStore'
 import { deserialiseAndCreate } from '@/extensions/core/vintageClipboard'
-import { t } from '@/i18n'
+import { st } from '@/i18n'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
@@ -1827,12 +1827,12 @@ export class ComfyApp {
         name,
         {
           ...def,
-          display_name: t(
+          display_name: st(
             `nodeDefs.${name}.display_name`,
             def.display_name ?? def.name
           ),
           description: def.description
-            ? t(`nodeDefs.${name}.description`, def.description)
+            ? st(`nodeDefs.${name}.description`, def.description)
             : undefined
         }
       ])


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1834

The root cause of the issue is that in node name / description, some custom nodes are using reserved chars for i18n messages in vue-i18n. This PR adds a extra safe translate method `st` to check for existense of the key first then fallback to the extact original message instead of trying to interpret the message.

Ref: https://vue-i18n.intlify.dev/guide/essentials/syntax#special-characters