### PR TITLE
Fix Comfy-Desktop.Reinstall command label

### DIFF
--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -103,7 +103,7 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
       },
       {
         id: 'Comfy-Desktop.Reinstall',
-        label: t('desktopMenu.reinstall'),
+        label: 'Reinstall',
         icon: 'pi pi-refresh',
         async function() {
           const proceed = await showConfirmationDialog({


### PR DESCRIPTION
It is not necessary to translate label in the command. They are automatically collected and translated.

![image](https://github.com/user-attachments/assets/1a528511-f88a-441a-9d70-65628c3410cc)
