### PR TITLE
Replace window.prompt with custom prompt impl

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -14,6 +14,8 @@ import {
   serialise
 } from '@/extensions/core/vintageClipboard'
 import type { ComfyNodeDef } from '@/types/apiTypes'
+import { showPromptDialog } from '@/services/dialogService'
+import { t } from '@/i18n'
 
 type GroupNodeWorkflowData = {
   external: ComfyLink[]
@@ -63,8 +65,8 @@ class GroupNodeBuilder {
     this.nodes = nodes
   }
 
-  build() {
-    const name = this.getName()
+  async build() {
+    const name = await this.getName()
     if (!name) return
 
     // Sort the nodes so they are in execution order
@@ -77,8 +79,12 @@ class GroupNodeBuilder {
     return { name, nodeData: this.nodeData }
   }
 
-  getName() {
-    const name = prompt('Enter group name')
+  async getName() {
+    const name = await showPromptDialog({
+      title: t('groupNode.create'),
+      message: t('groupNode.enterName'),
+      defaultValue: ''
+    })
     if (!name) return
     const used = Workflow.isInUseGroupNode(name)
     switch (used) {
@@ -1379,7 +1385,7 @@ export class GroupNodeHandler {
   static async fromNodes(nodes: LGraphNode[]) {
     // Process the nodes into the stored workflow group node data
     const builder = new GroupNodeBuilder(nodes)
-    const res = builder.build()
+    const res = await builder.build()
     if (!res) return
 
     const { name, nodeData } = res

--- a/src/extensions/core/nodeTemplates.ts
+++ b/src/extensions/core/nodeTemplates.ts
@@ -6,6 +6,8 @@ import { GroupNodeConfig, GroupNodeHandler } from './groupNode'
 import { LGraphCanvas } from '@comfyorg/litegraph'
 import { useToastStore } from '@/stores/toastStore'
 import { deserialiseAndCreate } from '@/extensions/core/vintageClipboard'
+import { showPromptDialog } from '@/services/dialogService'
+import { t } from '@/i18n'
 
 // Adds the ability to save and add multiple nodes as a template
 // To save:
@@ -348,8 +350,12 @@ app.registerExtension({
       options.push({
         content: `Save Selected as Template`,
         disabled: !Object.keys(app.canvas.selected_nodes || {}).length,
-        callback: () => {
-          const name = prompt('Enter name')
+        callback: async () => {
+          const name = await showPromptDialog({
+            title: t('nodeTemplates.saveAsTemplate'),
+            message: t('nodeTemplates.enterName'),
+            defaultValue: ''
+          })
           if (!name?.trim()) return
 
           clipboardAction(() => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -543,6 +543,14 @@
     "panMode": "Pan Mode",
     "toggleLinkVisibility": "Toggle Link Visibility"
   },
+  "groupNode": {
+    "create": "Create group node",
+    "enterName": "Enter name"
+  },
+  "nodeTemplates": {
+    "saveAsTemplate": "Save as template",
+    "enterName": "Enter name"
+  },
   "electronFileDownload": {
     "inProgress": "In Progress",
     "pause": "Pause Download",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -99,6 +99,10 @@
     "zoomIn": "拡大",
     "zoomOut": "縮小"
   },
+  "groupNode": {
+    "create": "グループノードを作成",
+    "enterName": "名前を入力"
+  },
   "icon": {
     "bookmark": "ブックマーク",
     "box": "ボックス",
@@ -1086,6 +1090,10 @@
     "unCLIPConditioning": {
       "display_name": "unCLIP条件付け"
     }
+  },
+  "nodeTemplates": {
+    "enterName": "名前を入力",
+    "saveAsTemplate": "テンプレートとして保存"
   },
   "notSupported": {
     "continue": "続ける",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -91,6 +91,10 @@
     "zoomIn": "확대",
     "zoomOut": "축소"
   },
+  "groupNode": {
+    "create": "그룹 노드 만들기",
+    "enterName": "이름 입력"
+  },
   "icon": "아이콘",
   "install": {
     "appDataLocationTooltip": "ComfyUI의 앱 데이터 디렉토리. 저장소:\n- 로그\n- 서버 구성",
@@ -1069,6 +1073,10 @@
     "unCLIPConditioning": {
       "display_name": "unCLIP 조건 설정"
     }
+  },
+  "nodeTemplates": {
+    "enterName": "이름 입력",
+    "saveAsTemplate": "템플릿으로 저장"
   },
   "notSupported": {
     "continue": "계속",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -99,6 +99,10 @@
     "zoomIn": "Увеличить",
     "zoomOut": "Уменьшить"
   },
+  "groupNode": {
+    "create": "Создать узел группы",
+    "enterName": "Введите имя"
+  },
   "icon": {
     "bookmark": "Закладка",
     "box": "Коробка",
@@ -1086,6 +1090,10 @@
     "unCLIPConditioning": {
       "display_name": "unCLIP кондиционирование"
     }
+  },
+  "nodeTemplates": {
+    "enterName": "Введите имя",
+    "saveAsTemplate": "Сохранить как шаблон"
   },
   "notSupported": {
     "continue": "Продолжить",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -99,6 +99,10 @@
     "zoomIn": "放大",
     "zoomOut": "缩小"
   },
+  "groupNode": {
+    "create": "创建组节点",
+    "enterName": "输入名称"
+  },
   "icon": {
     "bookmark": "书签",
     "box": "盒子",
@@ -1086,6 +1090,10 @@
     "unCLIPConditioning": {
       "display_name": "unCLIP条件"
     }
+  },
+  "nodeTemplates": {
+    "enterName": "输入名称",
+    "saveAsTemplate": "另存为模板"
   },
   "notSupported": {
     "continue": "继续",


### PR DESCRIPTION
This PR replaces `window.prompt` usage in node template and group node creation so that these features can be used in the context of desktop app, where `window.prompt` is not available.