### PR TITLE
Rename EditAttention to EditTokenWeight

### DIFF
--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -7,6 +7,7 @@ app.registerExtension({
   init() {
     const editAttentionDelta = app.ui.settings.addSetting({
       id: 'Comfy.EditAttention.Delta',
+      category: ['Comfy', 'Edit Token Weight', 'Delta'],
       name: 'Ctrl+up/down precision',
       type: 'slider',
       attrs: {

--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -7,7 +7,7 @@ app.registerExtension({
   init() {
     const editAttentionDelta = app.ui.settings.addSetting({
       id: 'Comfy.EditAttention.Delta',
-      category: ['Comfy', 'Edit Token Weight', 'Delta'],
+      category: ['Comfy', 'EditTokenWeight', 'Delta'],
       name: 'Ctrl+up/down precision',
       type: 'slider',
       attrs: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -666,7 +666,8 @@
     "Validation": "Validation",
     "Window": "Window",
     "Server-Config": "Server-Config",
-    "About": "About"
+    "About": "About",
+    "Edit Token Weight": "Edit Token Weight"
   },
   "serverConfigItems": {
     "tls-keyfile": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -666,7 +666,7 @@
     "Window": "Window",
     "Server-Config": "Server-Config",
     "About": "About",
-    "Edit Token Weight": "Edit Token Weight"
+    "EditTokenWeight": "Edit Token Weight"
   },
   "serverConfigItems": {
     "tls-keyfile": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -638,7 +638,6 @@
     "LiteGraph": "Lite Graph",
     "Node Widget": "Node Widget",
     "Node": "Node",
-    "EditAttention": "Edit Attention",
     "Extension": "Extension",
     "Canvas": "Canvas",
     "Link": "Link",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1250,7 +1250,6 @@
     "Comfy-Desktop": "Comfyデスクトップ",
     "DevMode": "開発モード",
     "Edit Token Weight": "トークンの重みを編集",
-    "EditAttention": "編集Attention",
     "Extension": "拡張",
     "General": "一般",
     "Graph": "グラフ",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1249,6 +1249,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfyデスクトップ",
     "DevMode": "開発モード",
+    "Edit Token Weight": "トークンの重みを編集",
     "EditAttention": "編集Attention",
     "Extension": "拡張",
     "General": "一般",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1249,7 +1249,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfyデスクトップ",
     "DevMode": "開発モード",
-    "Edit Token Weight": "トークンの重みを編集",
+    "EditTokenWeight": "トークンの重みを編集",
     "Extension": "拡張",
     "General": "一般",
     "Graph": "グラフ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1233,7 +1233,6 @@
     "Comfy-Desktop": "Comfy-Desktop",
     "DevMode": "개발자 모드",
     "Edit Token Weight": "토큰 가중치 편집",
-    "EditAttention": "토큰 가중치 편집",
     "Extension": "확장",
     "General": "일반",
     "Graph": "그래프",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1232,6 +1232,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy-Desktop",
     "DevMode": "개발자 모드",
+    "Edit Token Weight": "토큰 가중치 편집",
     "EditAttention": "토큰 가중치 편집",
     "Extension": "확장",
     "General": "일반",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1232,7 +1232,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy-Desktop",
     "DevMode": "개발자 모드",
-    "Edit Token Weight": "토큰 가중치 편집",
+    "EditTokenWeight": "토큰 가중치 편집",
     "Extension": "확장",
     "General": "일반",
     "Graph": "그래프",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1249,7 +1249,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy рабочий стол",
     "DevMode": "Режим разработчика",
-    "Edit Token Weight": "Редактировать вес токена",
+    "EditTokenWeight": "Редактировать вес токена",
     "Extension": "Расширение",
     "General": "Общие",
     "Graph": "Граф",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1250,7 +1250,6 @@
     "Comfy-Desktop": "Comfy рабочий стол",
     "DevMode": "Режим разработчика",
     "Edit Token Weight": "Редактировать вес токена",
-    "EditAttention": "Редактировать внимание",
     "Extension": "Расширение",
     "General": "Общие",
     "Graph": "Граф",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1249,6 +1249,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy рабочий стол",
     "DevMode": "Режим разработчика",
+    "Edit Token Weight": "Редактировать вес токена",
     "EditAttention": "Редактировать внимание",
     "Extension": "Расширение",
     "General": "Общие",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1249,6 +1249,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy桌面版",
     "DevMode": "开发模式",
+    "Edit Token Weight": "编辑令牌权重",
     "EditAttention": "编辑Attention",
     "Extension": "扩展",
     "General": "常规",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1250,7 +1250,6 @@
     "Comfy-Desktop": "Comfy桌面版",
     "DevMode": "开发模式",
     "Edit Token Weight": "编辑令牌权重",
-    "EditAttention": "编辑Attention",
     "Extension": "扩展",
     "General": "常规",
     "Graph": "图",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1249,7 +1249,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy桌面版",
     "DevMode": "开发模式",
-    "Edit Token Weight": "编辑令牌权重",
+    "EditTokenWeight": "编辑令牌权重",
     "Extension": "扩展",
     "General": "常规",
     "Graph": "图",


### PR DESCRIPTION
According to @ltdrdata, `EditAttention` name can be misleading, and `EditTokenWeight` would be a better name describing the feature.

![image](https://github.com/user-attachments/assets/b93fc1d8-7e77-42cd-8ab4-cd1e299b3c8c)
