### PR TITLE
Replace deprecated InputSwitch with ToggleSwitch

### DIFF
--- a/src/components/install/DesktopSettingsConfiguration.vue
+++ b/src/components/install/DesktopSettingsConfiguration.vue
@@ -21,7 +21,7 @@
             {{ $t('install.settings.autoUpdateDescription') }}
           </p>
         </div>
-        <InputSwitch v-model="autoUpdate" />
+        <ToggleSwitch v-model="autoUpdate" />
       </div>
 
       <Divider />
@@ -43,7 +43,7 @@
             {{ $t('install.settings.learnMoreAboutData') }}
           </a>
         </div>
-        <InputSwitch v-model="allowMetrics" />
+        <ToggleSwitch v-model="allowMetrics" />
       </div>
     </div>
 
@@ -98,7 +98,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import InputSwitch from 'primevue/inputswitch'
+import ToggleSwitch from 'primevue/toggleswitch'
 import Dialog from 'primevue/dialog'
 import Divider from 'primevue/divider'
 


### PR DESCRIPTION
Fix following warning.

![Screenshot 2024-12-10 at 4 59 16 PM](https://github.com/user-attachments/assets/d0f8426e-eee4-4608-8e1e-ba31c97c4dac)
