### PR TITLE
Add Comfy_Locale options

### DIFF
--- a/scripts/collect-i18n.ts
+++ b/scripts/collect-i18n.ts
@@ -63,18 +63,15 @@ test('collect-i18n', async ({ comfyPage }) => {
       {
         name: setting.name,
         tooltip: setting.tooltip,
-        // Don't translate the locale options as each option is in its own language.
-        // e.g. "English", "中文", "Русский", "日本語", "한국어"
-        options:
-          setting.options && setting.id !== 'Comfy.Locale'
-            ? Object.fromEntries(
-                setting.options.map((option) => {
-                  const optionLabel =
-                    typeof option === 'string' ? option : option.text
-                  return [normalizeI18nKey(optionLabel), optionLabel]
-                })
-              )
-            : undefined
+        options: setting.options
+          ? Object.fromEntries(
+              setting.options.map((option) => {
+                const optionLabel =
+                  typeof option === 'string' ? option : option.text
+                return [normalizeI18nKey(optionLabel), optionLabel]
+              })
+            )
+          : undefined
       }
     ])
   )

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -262,13 +262,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Locale',
     name: 'Language',
     type: 'combo',
-    options: [
-      { value: 'en', text: 'English' },
-      { value: 'zh', text: '中文' },
-      { value: 'ru', text: 'Русский' },
-      { value: 'ja', text: '日本語' },
-      { value: 'ko', text: '한국어' }
-    ],
+    options: ['en', 'zh', 'ru', 'ja', 'ko'],
     defaultValue: () => navigator.language.split('-')[0] || 'en'
   },
   {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -271,7 +271,14 @@
       }
     },
     "Comfy_Locale": {
-      "name": "Language"
+      "name": "Language",
+      "options": {
+        "en": "English",
+        "zh": "中文",
+        "ru": "Русский",
+        "ja": "日本語",
+        "ko": "한국어"
+      }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {
       "name": "Brush adjustment speed multiplier",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1419,10 +1419,10 @@
       "name": "言語",
       "options": {
         "en": "English",
-        "zh": "中文",
-        "ru": "Русский",
         "ja": "日本語",
-        "ko": "한국어"
+        "ko": "한국어",
+        "ru": "Русский",
+        "zh": "中文"
       }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1416,7 +1416,14 @@
       }
     },
     "Comfy_Locale": {
-      "name": "言語"
+      "name": "言語",
+      "options": {
+        "en": "English",
+        "zh": "中文",
+        "ru": "Русский",
+        "ja": "日本語",
+        "ko": "한국어"
+      }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {
       "name": "ブラシ調整速度の倍率",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1399,7 +1399,14 @@
       }
     },
     "Comfy_Locale": {
-      "name": "언어"
+      "name": "언어",
+      "options": {
+        "en": "English",
+        "zh": "中文",
+        "ru": "Русский",
+        "ja": "日本語",
+        "ko": "한국어"
+      }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {
       "name": "브러시 조정 속도 배수",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1402,10 +1402,10 @@
       "name": "언어",
       "options": {
         "en": "English",
-        "zh": "中文",
-        "ru": "Русский",
         "ja": "日本語",
-        "ko": "한국어"
+        "ko": "한국어",
+        "ru": "Русский",
+        "zh": "中文"
       }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1416,7 +1416,14 @@
       }
     },
     "Comfy_Locale": {
-      "name": "Язык"
+      "name": "Язык",
+      "options": {
+        "en": "English",
+        "zh": "中文",
+        "ru": "Русский",
+        "ja": "日本語",
+        "ko": "한국어"
+      }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {
       "name": "Множитель скорости регулировки кисти",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1419,10 +1419,10 @@
       "name": "Язык",
       "options": {
         "en": "English",
-        "zh": "中文",
-        "ru": "Русский",
         "ja": "日本語",
-        "ko": "한국어"
+        "ko": "한국어",
+        "ru": "Русский",
+        "zh": "中文"
       }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1416,7 +1416,14 @@
       }
     },
     "Comfy_Locale": {
-      "name": "语言"
+      "name": "语言",
+      "options": {
+        "en": "English",
+        "zh": "中文",
+        "ru": "Русский",
+        "ja": "日本語",
+        "ko": "한국어"
+      }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {
       "name": "画笔调整速度倍增器",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1419,10 +1419,10 @@
       "name": "语言",
       "options": {
         "en": "English",
-        "zh": "中文",
-        "ru": "Русский",
         "ja": "日本語",
-        "ko": "한국어"
+        "ko": "한국어",
+        "ru": "Русский",
+        "zh": "中文"
       }
     },
     "Comfy_MaskEditor_BrushAdjustmentSpeed": {


### PR DESCRIPTION
I addressed a warning related to `Comfy_Locale.options`.
![add-comfy-locale-options](https://github.com/user-attachments/assets/5600e574-593e-4579-bffa-97753e893749)

As a suggestion, what do you think about explicitly defining keys for each language within that language block?

```json
    "Comfy_Locale": {
      "name": "Language",
      "options": {
        "en": "English",
        "zh": "中文",
        "ru": "Русский",
        "ja": "日本語",
        "ko": "한국어"
      }
    },
```

By doing this, it’s clear at a glance which settings are configured, and it simplifies the corresponding entries in `coreSettings.ts`.

I’ve also removed the related conditional logic and comments, assuming they’re no longer necessary.
https://github.com/Comfy-Org/ComfyUI_frontend/commit/481aef304f6c7c1f9e0d87f3e7f448671c7aaa30
If my understanding is incorrect, please let me know and I’ll `revert` the changes.