### PR TITLE
Add translated setting names to the search index for improved localization support

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -183,14 +183,14 @@ const handleSearch = (query: string) => {
     return
   }
 
-  const queryLower = query.toLowerCase()
+  const queryLower = query.toLocaleLowerCase()
   const allSettings = flattenTree<SettingParams>(settingRoot.value)
   const filteredSettings = allSettings.filter((setting) => {
     const idLower = setting.id.toLowerCase()
     const nameLower = setting.name.toLowerCase()
     const translatedName = t(
       `settingsDialog.${normalizeI18nKey(setting.id)}.name`
-    ).toLowerCase()
+    ).toLocaleLowerCase()
 
     return (
       idLower.includes(queryLower) ||

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -183,12 +183,21 @@ const handleSearch = (query: string) => {
     return
   }
 
+  const queryLower = query.toLowerCase()
   const allSettings = flattenTree<SettingParams>(settingRoot.value)
-  const filteredSettings = allSettings.filter(
-    (setting) =>
-      setting.id.toLowerCase().includes(query.toLowerCase()) ||
-      setting.name.toLowerCase().includes(query.toLowerCase())
-  )
+  const filteredSettings = allSettings.filter((setting) => {
+    const idLower = setting.id.toLowerCase()
+    const nameLower = setting.name.toLowerCase()
+    const translatedName = t(
+      `settingsDialog.${normalizeI18nKey(setting.id)}.name`
+    ).toLowerCase()
+
+    return (
+      idLower.includes(queryLower) ||
+      nameLower.includes(queryLower) ||
+      translatedName.includes(queryLower)
+    )
+  })
 
   const groupedSettings: { [key: string]: SettingParams[] } = {}
   filteredSettings.forEach((setting) => {


### PR DESCRIPTION
This PR updates the search logic to include translated setting names in addition to their original identifiers and names.

By incorporating the translated text, users who view the interface in different locales can now search and find relevant settings more easily.

This change enhances the user experience in multilingual environments and provides better support for localized UIs.

## Screenshots

before
<img width="973" alt="search-localization-support_before" src="https://github.com/user-attachments/assets/a247ce18-e144-4dba-823e-f9cb72a3469e">

after
<img width="959" alt="search-localization-support_after" src="https://github.com/user-attachments/assets/7ccff93c-dcb9-4f7f-be76-61c10c08999f">


