### PR TITLE
[i18n] Supress expected translation/fallback warnings

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -16,7 +16,11 @@ export const i18n = createI18n({
     ru,
     ja,
     ko
-  }
+  },
+  // Ignore warnings for locale options as each option is in its own language.
+  // e.g. "English", "中文", "Русский", "日本語", "한국어"
+  missingWarn: /^(?!settingsDialog\.Comfy_Locale\.options\.).+/,
+  fallbackWarn: /^(?!settingsDialog\.Comfy_Locale\.options\.).+/
 })
 
 /** Convenience shorthand: i18n.global */


### PR DESCRIPTION
Replaces https://github.com/Comfy-Org/ComfyUI_frontend/pull/1864

This PR supress expected translation warnings. #1864 has higher maintainance cost when adding new language support.