### PR TITLE
[i18n] Fix node output label translation

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1979,9 +1979,14 @@ export class ComfyApp {
           const typeKey = `dataTypes.${normalizeI18nKey(output)}`
           const outputOptions = {
             ...shapeOptions,
-            label: nodeData['output_name'][o]
-              ? st(nameKey, outputName)
-              : st(typeKey, outputName)
+            // If the output name is different from the output type, use the output name.
+            // e.g.
+            // - type ("INT"); name ("Positive") => translate name
+            // - type ("FLOAT"); name ("FLOAT") => translate type
+            label:
+              output !== outputName
+                ? st(nameKey, outputName)
+                : st(typeKey, outputName)
           }
           this.addOutput(outputName, output, outputOptions)
         }


### PR DESCRIPTION
`nodeData['output_name'][o]` seems to be always set, so we always falls to the translate name branch.

![Screenshot 2024-12-11 at 9 23 14 AM](https://github.com/user-attachments/assets/987d6650-f3f6-4970-bfa6-ba4caf543dc4)
