### PR TITLE
[i18n] Fix ko translation schema

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -5,18 +5,20 @@ import ru from './locales/ru/main.json'
 import ja from './locales/ja/main.json'
 import ko from './locales/ko/main.json'
 
+const messages: Record<string, typeof en> = {
+  en,
+  zh,
+  ru,
+  ja,
+  ko
+}
+
 export const i18n = createI18n({
   // Must set `false`, as Vue I18n Legacy API is for Vue 2
   legacy: false,
   locale: navigator.language.split('-')[0] || 'en',
   fallbackLocale: 'en',
-  messages: {
-    en,
-    zh,
-    ru,
-    ja,
-    ko
-  },
+  messages,
   // Ignore warnings for locale options as each option is in its own language.
   // e.g. "English", "中文", "Русский", "日本語", "한국어"
   missingWarn: /^(?!settingsDialog\.Comfy_Locale\.options\.).+/,

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1,5 +1,13 @@
 {
-  "color": "색상",
+  "color": {
+    "blue": "파란색",
+    "custom": "사용자 정의",
+    "default": "기본값",
+    "green": "초록색",
+    "pink": "분홍색",
+    "red": "빨간색",
+    "yellow": "노란색"
+  },
   "dataTypes": {
     "AUDIO": "오디오",
     "BOOLEAN": "부울",
@@ -127,7 +135,16 @@
     "create": "그룹 노드 만들기",
     "enterName": "이름 입력"
   },
-  "icon": "아이콘",
+  "icon": {
+    "bookmark": "북마크",
+    "box": "상자",
+    "briefcase": "서류가방",
+    "file": "파일",
+    "folder": "폴더",
+    "heart": "하트",
+    "inbox": "받은 편지함",
+    "star": "별"
+  },
   "install": {
     "appDataLocationTooltip": "ComfyUI의 앱 데이터 디렉토리. 저장소:\n- 로그\n- 서버 구성",
     "appPathLocationTooltip": "ComfyUI의 앱 에셋 디렉토리. ComfyUI 코드 및 에셋을 저장합니다.",


### PR DESCRIPTION
This PR fixes ko translation json that is out of sync, and adds typecheck to ensure that all translation files share the same en.json schema.