### PR TITLE
[CSS] Use brighter secondary menu color in light mode

### DIFF
--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -134,7 +134,7 @@ const colorPalettes: ColorPalettes = {
         'fg-color': '#222',
         'bg-color': '#DDD',
         'comfy-menu-bg': '#F5F5F5',
-        'comfy-menu-secondary-bg': '#D9D9D9',
+        'comfy-menu-secondary-bg': '#EEE',
         'comfy-input-bg': '#C9C9C9',
         'input-text': '#222',
         'descrip-text': '#444',


### PR DESCRIPTION
Before:

![Screenshot 2024-12-11 at 4 10 52 PM](https://github.com/user-attachments/assets/c5d1082e-71ff-4baa-80aa-3d82d9c34c61)


After:

![Screenshot 2024-12-11 at 4 08 58 PM](https://github.com/user-attachments/assets/29fc2120-729b-4d75-8987-03317e7ac6fb)
