### PR TITLE
Fix #1769 - Keep log on screen after installation error

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -155,6 +155,7 @@
     "reinstall": "Reinstall",
     "reportIssue": "Report Issue",
     "openLogs": "Open Logs",
+    "showTerminal": "Show Terminal",
     "process": {
       "initial-state": "Loading...",
       "python-setup": "Setting up Python Environment...",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -488,7 +488,8 @@
       "starting-server": "ComfyUIサーバーを起動中..."
     },
     "reinstall": "再インストール",
-    "reportIssue": "問題を報告"
+    "reportIssue": "問題を報告",
+    "showTerminal": "ターミナルを表示"
   },
   "settingsCategories": {
     "About": "情報",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -488,7 +488,8 @@
       "starting-server": "ComfyUI 서버 시작 중..."
     },
     "reinstall": "재설치",
-    "reportIssue": "문제 보고"
+    "reportIssue": "문제 보고",
+    "showTerminal": "터미널 보기"
   },
   "settingsCategories": {
     "About": "정보",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -488,7 +488,8 @@
       "starting-server": "Запуск сервера ComfyUI..."
     },
     "reinstall": "Переустановить",
-    "reportIssue": "Сообщить о проблеме"
+    "reportIssue": "Сообщить о проблеме",
+    "showTerminal": "Показать терминал"
   },
   "settingsCategories": {
     "About": "О программе",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -488,7 +488,8 @@
       "starting-server": "正在启动 ComfyUI 服务器..."
     },
     "reinstall": "重新安装",
-    "reportIssue": "报告问题"
+    "reportIssue": "报告问题",
+    "showTerminal": "显示终端"
   },
   "settingsCategories": {
     "About": "关于",

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -64,6 +64,8 @@ const terminalVisible = ref(true)
 
 const updateProgress = ({ status: newStatus }: { status: ProgressStatus }) => {
   status.value = newStatus
+
+  // Make critical error screen more obvious.
   if (newStatus === ProgressStatus.ERROR) terminalVisible.value = false
   else xterm?.clear()
 }

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -10,27 +10,36 @@
     </h2>
     <div
       v-if="status === ProgressStatus.ERROR"
-      class="flex items-center my-4 gap-2"
+      class="flex flex-col items-center gap-4"
     >
+      <div class="flex items-center my-4 gap-2">
+        <Button
+          icon="pi pi-flag"
+          severity="secondary"
+          :label="t('serverStart.reportIssue')"
+          @click="reportIssue"
+        />
+        <Button
+          icon="pi pi-file"
+          severity="secondary"
+          :label="t('serverStart.openLogs')"
+          @click="openLogs"
+        />
+        <Button
+          icon="pi pi-refresh"
+          :label="t('serverStart.reinstall')"
+          @click="reinstall"
+        />
+      </div>
       <Button
-        icon="pi pi-flag"
+        v-if="!terminalVisible"
+        icon="pi pi-search"
         severity="secondary"
-        :label="t('serverStart.reportIssue')"
-        @click="reportIssue"
-      />
-      <Button
-        icon="pi pi-file"
-        severity="secondary"
-        :label="t('serverStart.openLogs')"
-        @click="openLogs"
-      />
-      <Button
-        icon="pi pi-refresh"
-        :label="t('serverStart.reinstall')"
-        @click="reinstall"
+        :label="t('serverStart.showTerminal')"
+        @click="terminalVisible = true"
       />
     </div>
-    <BaseTerminal @created="terminalCreated" />
+    <BaseTerminal v-show="terminalVisible" @created="terminalCreated" />
   </div>
 </template>
 
@@ -51,9 +60,12 @@ const status = ref<ProgressStatus>(ProgressStatus.INITIAL_STATE)
 const electronVersion = ref<string>('')
 let xterm: Terminal | undefined
 
+const terminalVisible = ref(true)
+
 const updateProgress = ({ status: newStatus }: { status: ProgressStatus }) => {
   status.value = newStatus
-  if (newStatus !== ProgressStatus.ERROR) xterm?.clear()
+  if (newStatus === ProgressStatus.ERROR) terminalVisible.value = false
+  else xterm?.clear()
 }
 
 const terminalCreated = (


### PR DESCRIPTION
Issue:
- PR does not do as described https://github.com/Comfy-Org/ComfyUI_frontend/pull/1769
- _Does_ keep terminal content on error
- _Does not_ hide the terminal

Solution:
- Hide terminal on error, with button to show

Must have lost a commit somewhere.