### PR TITLE
Update default value for 'Opened workflows position' setting from 'Sidebar' to 'Topbar' in coreSettings.ts

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -397,7 +397,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Opened workflows position',
     type: 'combo',
     options: ['Sidebar', 'Topbar'],
-    defaultValue: 'Sidebar'
+    defaultValue: 'Topbar'
   },
   {
     id: 'Comfy.Graph.CanvasMenu',


### PR DESCRIPTION
This switches the default option of workflow position to topbar.

┆Issue is synchronized with this [Notion page](https://www.notion.so/Update-default-value-for-Opened-workflows-position-setting-from-Sidebar-to-Topbar-in-coreSetti-15b6d73d365081ffaf78d167b1e9b872) by [Unito](https://www.unito.io)
