### PR TITLE
Synchronize queue settings with app.ui

### DIFF
--- a/src/components/actionbar/BatchCountEdit.vue
+++ b/src/components/actionbar/BatchCountEdit.vue
@@ -35,6 +35,7 @@ import { useSettingStore } from '@/stores/settingStore'
 import { storeToRefs } from 'pinia'
 import InputNumber from 'primevue/inputnumber'
 import { computed } from 'vue'
+import { app } from '@/scripts/app'
 
 interface Props {
   class?: string
@@ -63,7 +64,8 @@ const handleClick = (increment: boolean) => {
     newCount = Math.floor(originalCount / 2)
   }
 
-  batchCount.value = newCount
+  // batchCount.value = newCount
+  app.ui.setBatchCount(newCount)
 }
 </script>
 

--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -68,6 +68,7 @@ import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import { useCommandStore } from '@/stores/commandStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { app } from '@/scripts/app'
 
 const workspaceStore = useWorkspaceStore()
 const queueCountStore = storeToRefs(useQueuePendingTaskCountStore())
@@ -80,7 +81,8 @@ const queueModeMenuItemLookup = computed(() => ({
     label: t('menu.queue'),
     tooltip: t('menu.disabledTooltip'),
     command: () => {
-      queueMode.value = 'disabled'
+      // queueMode.value = 'disabled'
+      app.ui.setAutoQueueMode('disabled')
     }
   },
   instant: {
@@ -88,7 +90,8 @@ const queueModeMenuItemLookup = computed(() => ({
     label: `${t('menu.queue')} (${t('menu.instant')})`,
     tooltip: t('menu.instantTooltip'),
     command: () => {
-      queueMode.value = 'instant'
+      // queueMode.value = 'instant'
+      app.ui.setAutoQueueMode('instant')
     }
   },
   change: {
@@ -96,7 +99,8 @@ const queueModeMenuItemLookup = computed(() => ({
     label: `${t('menu.queue')} (${t('menu.onChange')})`,
     tooltip: t('menu.onChangeTooltip'),
     command: () => {
-      queueMode.value = 'change'
+      // queueMode.value = 'change'
+      app.ui.setAutoQueueMode('change')
     }
   }
 }))

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -9,6 +9,7 @@ import { showSettingsDialog } from '@/services/dialogService'
 import { useSettingStore } from '@/stores/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { useQueueSettingsStore } from '@/stores/queueStore'
 
 export const ComfyDialog = _ComfyDialog
 
@@ -493,7 +494,9 @@ export class ComfyUI {
               min: '1',
               style: { width: '35%', marginLeft: '0.4em' },
               oninput: (i) => {
-                this.batchCount = i.target.value
+                // this.batchCount = i.target.value
+                this.setBatchCount(parseInt(i.target.value))
+
                 /* Even though an <input> element with a type of range logically represents a number (since
               it's used for numeric input), the value it holds is still treated as a string in HTML and
               JavaScript. This behavior is consistent across all <input> elements regardless of their type
@@ -512,7 +515,9 @@ export class ComfyUI {
               max: '100',
               value: this.batchCount,
               oninput: (i) => {
-                this.batchCount = i.srcElement.value
+                // this.batchCount = i.srcElement.value
+                this.setBatchCount(parseInt(i.srcElement.value))
+
                 // Note
                 ;(
                   document.getElementById(
@@ -662,5 +667,15 @@ export class ComfyUI {
       }
       this.lastQueueSize = status.exec_info.queue_remaining
     }
+  }
+
+  setBatchCount(value: number) {
+    this.batchCount = value
+    useQueueSettingsStore().batchCount = value
+  }
+
+  setAutoQueueMode(value: 'disabled' | 'instant' | 'change') {
+    this.autoQueueMode = value
+    useQueueSettingsStore().mode = value
   }
 }


### PR DESCRIPTION
I need to methods for control queue settings.

* Create methods setBatchCount and setAutoQueueMode.
* Synchronize app.ui.batchCount and app.ui.autoQueueMode with the new Actionbar.

┆Issue is synchronized with this [Notion page](https://www.notion.so/Synchronize-queue-settings-with-app-ui-15c6d73d3650813e9203c9fa3b8fce09) by [Unito](https://www.unito.io)
