### PR TITLE
forward mouse events from textareas to canvas

### DIFF
--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -343,13 +343,12 @@ function addMultilineWidget(node, name: string, opts, app: ComfyApp) {
 
   inputEl.addEventListener('pointerdown', (event: PointerEvent) => {
     if (event.button === 1) {
-      event.preventDefault()
       app.canvas.processMouseDown(event)
     }
   })
 
   inputEl.addEventListener('pointermove', (event: PointerEvent) => {
-    if (event.buttons === 4) {
+    if ((event.buttons & 4) === 4) {
       app.canvas.processMouseMove(event)
     }
   })

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -341,21 +341,20 @@ function addMultilineWidget(node, name: string, opts, app: ComfyApp) {
     widget.callback?.(widget.value)
   })
 
-  inputEl.addEventListener('mousedown', (event: PointerEvent) => {
+  inputEl.addEventListener('pointerdown', (event: PointerEvent) => {
     if (event.button === 1) {
       event.preventDefault()
       app.canvas.processMouseDown(event)
     }
   })
 
-  inputEl.addEventListener('mousemove', (event: PointerEvent) => {
+  inputEl.addEventListener('pointermove', (event: PointerEvent) => {
     if (event.buttons === 4) {
-      app.canvas.pointer.onDragStart(app.canvas.pointer)
       app.canvas.processMouseMove(event)
     }
   })
 
-  inputEl.addEventListener('mouseup', (event: PointerEvent) => {
+  inputEl.addEventListener('pointerup', (event: PointerEvent) => {
     if (event.button === 1) {
       app.canvas.processMouseUp(event)
     }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -341,21 +341,21 @@ function addMultilineWidget(node, name: string, opts, app: ComfyApp) {
     widget.callback?.(widget.value)
   })
 
-  inputEl.addEventListener('mousedown', function (event: PointerEvent) {
+  inputEl.addEventListener('mousedown', (event: PointerEvent) => {
     if (event.button === 1) {
       event.preventDefault()
       app.canvas.processMouseDown(event)
     }
   })
 
-  inputEl.addEventListener('mousemove', function (event: PointerEvent) {
+  inputEl.addEventListener('mousemove', (event: PointerEvent) => {
     if (event.buttons === 4) {
       app.canvas.pointer.onDragStart(app.canvas.pointer)
+      app.canvas.processMouseMove(event)
     }
-    app.canvas.processMouseMove(event)
   })
 
-  inputEl.addEventListener('mouseup', function (event: PointerEvent) {
+  inputEl.addEventListener('mouseup', (event: PointerEvent) => {
     if (event.button === 1) {
       app.canvas.processMouseUp(event)
     }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -341,6 +341,26 @@ function addMultilineWidget(node, name: string, opts, app: ComfyApp) {
     widget.callback?.(widget.value)
   })
 
+  inputEl.addEventListener('mousedown', function (event: PointerEvent) {
+    if (event.button === 1) {
+      event.preventDefault()
+      app.canvas.processMouseDown(event)
+    }
+  })
+
+  inputEl.addEventListener('mousemove', function (event: PointerEvent) {
+    if (event.buttons === 4) {
+      app.canvas.pointer.onDragStart(app.canvas.pointer)
+    }
+    app.canvas.processMouseMove(event)
+  })
+
+  inputEl.addEventListener('mouseup', function (event: PointerEvent) {
+    if (event.button === 1) {
+      app.canvas.processMouseUp(event)
+    }
+  })
+
   return { minWidth: 400, minHeight: 200, widget }
 }
 


### PR DESCRIPTION
This should fix [1773](https://github.com/Comfy-Org/ComfyUI_frontend/issues/1773).
I'm not sure though if there are more DOM elements to handle. This currently only handles textareas




https://github.com/user-attachments/assets/3811eddd-9d01-4c8c-a918-a801e6d0db01

┆Issue is synchronized with this [Notion page](https://www.notion.so/1911-forward-mouse-events-from-textareas-to-canvas-15c6d73d3650810f8c4cdc68d026c862) by [Unito](https://www.unito.io)
