### PR TITLE
template workflows fails to load behind a url rewritting proxy

### DIFF
--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -15,7 +15,7 @@
             @click="loadWorkflow(template)"
           >
             <img
-              :src="`/templates/${template}.jpg`"
+              :src="`templates/${template}.jpg`"
               class="w-64 h-64 rounded-lg object-cover"
             />
             <a>


### PR DESCRIPTION
Behind a personal proxy that prefix the comfy url by host:443/comfy, the workflow templates are not displayed correclty
cf  Opened Bug https://github.com/Comfy-Org/ComfyUI_frontend/issues/1923 and previous occurrence: https://github.com/Comfy-Org/ComfyUI_frontend/issues/1256