### PR TITLE
Fix cannot open groupNodes menu from canvas

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - core/1.5
     paths:
       - "package.json"
 

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -1425,7 +1425,7 @@ function addConvertToGroupOptions() {
     options.splice(index + 1, null, {
       content: `Manage Group Nodes`,
       disabled,
-      callback: manageGroupNodes
+      callback: () => manageGroupNodes()
     })
   }
 

--- a/src/extensions/core/groupNodeManage.ts
+++ b/src/extensions/core/groupNodeManage.ts
@@ -373,7 +373,7 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
           groupNodes.map((g) =>
             $el('option', {
               textContent: g,
-              selected: `${PREFIX}${SEPARATOR}` + g === type,
+              selected: `${PREFIX}${SEPARATOR}${g}` === type,
               value: g
             })
           )
@@ -512,7 +512,8 @@ export class ManageGroupDialog extends ComfyDialog<HTMLDialogElement> {
     this.element.replaceChildren(outer)
     this.changeGroup(
       type
-        ? groupNodes.find((g) => `${PREFIX}${SEPARATOR}` + g === type)
+        ? groupNodes.find((g) => `${PREFIX}${SEPARATOR}${g}` === type) ??
+            groupNodes[0]
         : groupNodes[0]
     )
     this.element.showModal()


### PR DESCRIPTION
- Backport of #1925

Original PR:
- Resolves #1924
- Adds guard against group not found
- Minor refactor for clarity