### PR TITLE
Add AIGODLIKE team to translation codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,11 +7,8 @@
 /browser_tests/ @Comfy-Org/comfy_maintainer
 /.env_example @Comfy-Org/comfy_maintainer
 
-# Translations (AIGODLIKE team)
-/src/locales/ @Yorha4D @KarryCharon @Comfy-Org/comfy_maintainer
-
-# Japanese translation
-/src/locales/ja.json @shinshin86 @Comfy-Org/comfy_maintainer
+# Translations (AIGODLIKE team + shinshin86)
+/src/locales/ @Yorha4D @KarryCharon @shinshin86 @Comfy-Org/comfy_maintainer
 
 # Load 3D extension
 /src/extensions/core/load3d.ts @jtydhr88 @Comfy-Org/comfy_frontend_devs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,9 @@
 /tests-ui/ @Comfy-Org/comfy_maintainer
 /browser_tests/ @Comfy-Org/comfy_maintainer
 /.env_example @Comfy-Org/comfy_maintainer
-/src/locales/ @Comfy-Org/comfy_maintainer
+
+# Translations (AIGODLIKE team)
+/src/locales/ @Yorha4D @KarryCharon @Comfy-Org/comfy_maintainer
 
 # Japanese translation
 /src/locales/ja.json @shinshin86 @Comfy-Org/comfy_maintainer


### PR DESCRIPTION
Note:
Merge when collaborator invitations are accepted.

┆Issue is synchronized with this [Notion page](https://www.notion.so/1983-Add-AIGODLIKE-team-to-translation-codeowner-1606d73d3650813b9e1bc4dcde8e242e) by [Unito](https://www.unito.io)
