### PR TITLE
Save sidebar width per tab

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -2,7 +2,8 @@
   <Splitter
     class="splitter-overlay-root splitter-overlay"
     :pt:gutter="sidebarPanelVisible ? '' : 'hidden'"
-    stateKey="sidebar-splitter"
+    :key="activeSidebarTabId"
+    :stateKey="activeSidebarTabId"
     stateStorage="local"
   >
     <SplitterPanel
@@ -62,6 +63,9 @@ const sidebarPanelVisible = computed(
 )
 const bottomPanelVisible = computed(
   () => useBottomPanelStore().bottomPanelVisible
+)
+const activeSidebarTabId = computed(
+  () => useSidebarTabStore().activeSidebarTabId
 )
 </script>
 


### PR DESCRIPTION
Small PR that closes #1268 

Note: I had to provide the `:key` on the `Splitter` as well because it only considers the `stateKey` property on mount

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1985-Save-sidebar-width-per-tab-1606d73d36508146966ed3a20dd7cddf) by [Unito](https://www.unito.io)
