### PR TITLE
Add Clear Functionality in the SearchBox

### DIFF
--- a/src/components/common/SearchBox.vue
+++ b/src/components/common/SearchBox.vue
@@ -1,17 +1,6 @@
 <template>
   <div :class="props.class">
-    <IconField
-      class="iconfield-relative"
-      :class="{ 'with-text': props.modelValue }"
-    >
-      <InputIcon :class="props.icon" />
-      <InputText
-        class="search-box-input"
-        :class="{ ['with-filter']: props.filterIcon }"
-        @input="handleInput"
-        :modelValue="props.modelValue"
-        :placeholder="props.placeholder"
-      />
+    <IconField>
       <Button
         v-if="props.filterIcon"
         class="p-inputicon filter-button"
@@ -20,6 +9,13 @@
         severity="contrast"
         @click="$emit('showFilter', $event)"
       />
+      <InputText
+        class="search-box-input w-full"
+        @input="handleInput"
+        :modelValue="props.modelValue"
+        :placeholder="props.placeholder"
+      />
+      <InputIcon v-if="!props.modelValue" :class="props.icon" />
       <Button
         v-if="props.modelValue"
         class="p-inputicon clear-button"
@@ -98,40 +94,11 @@ const clearSearch = () => {
 </script>
 
 <style scoped>
-.iconfield-relative {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.search-box-input {
-  width: 100%;
-  padding-left: 36px;
-  padding-right: 36px;
-}
-
-.search-box-input.with-filter {
-  padding-right: 72px;
+:deep(.p-inputtext) {
+  --p-form-field-padding-x: 0.625rem;
 }
 
 .p-button.p-inputicon {
-  padding: 0;
-  width: auto;
-  border: none !important;
-}
-
-/* When modelValue is empty (no 'with-text' class), the filter button stays at the far right */
-.iconfield-relative:not(.with-text) .filter-button {
-  right: 8px;
-}
-
-/* When modelValue is not empty ('with-text' class is present), move the filter button to the left */
-.iconfield-relative.with-text .filter-button {
-  right: 36px;
-}
-
-/* When modelValue is not empty (and the clear button is displayed), place the clear button at the far right */
-.iconfield-relative.with-text .clear-button {
-  right: 8px;
+  @apply p-0 w-auto border-none;
 }
 </style>

--- a/src/components/common/SearchBox.vue
+++ b/src/components/common/SearchBox.vue
@@ -1,6 +1,9 @@
 <template>
   <div :class="props.class">
-    <IconField>
+    <IconField
+      class="iconfield-relative"
+      :class="{ 'with-text': props.modelValue }"
+    >
       <InputIcon :class="props.icon" />
       <InputText
         class="search-box-input"
@@ -11,11 +14,19 @@
       />
       <Button
         v-if="props.filterIcon"
-        class="p-inputicon"
+        class="p-inputicon filter-button"
         :icon="props.filterIcon"
         text
         severity="contrast"
         @click="$emit('showFilter', $event)"
+      />
+      <Button
+        v-if="props.modelValue"
+        class="p-inputicon clear-button"
+        icon="pi pi-times"
+        text
+        severity="contrast"
+        @click="clearSearch"
       />
     </IconField>
     <div
@@ -79,21 +90,48 @@ const handleInput = (event: Event) => {
   emit('update:modelValue', target.value)
   emitSearch(target.value)
 }
+
+const clearSearch = () => {
+  emit('update:modelValue', '')
+  emitSearch('')
+}
 </script>
 
 <style scoped>
+.iconfield-relative {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .search-box-input {
   width: 100%;
   padding-left: 36px;
+  padding-right: 36px;
 }
 
 .search-box-input.with-filter {
-  padding-right: 36px;
+  padding-right: 72px;
 }
 
 .p-button.p-inputicon {
   padding: 0;
   width: auto;
   border: none !important;
+}
+
+/* When modelValue is empty (no 'with-text' class), the filter button stays at the far right */
+.iconfield-relative:not(.with-text) .filter-button {
+  right: 8px;
+}
+
+/* When modelValue is not empty ('with-text' class is present), move the filter button to the left */
+.iconfield-relative.with-text .filter-button {
+  right: 36px;
+}
+
+/* When modelValue is not empty (and the clear button is displayed), place the clear button at the far right */
+.iconfield-relative.with-text .clear-button {
+  right: 8px;
 }
 </style>

--- a/src/locales/en/nodeDefs.json
+++ b/src/locales/en/nodeDefs.json
@@ -5352,6 +5352,9 @@
       },
       "tile_size": {
         "name": "tile_size"
+      },
+      "overlap": {
+        "name": "overlap"
       }
     }
   },

--- a/src/locales/ja/nodeDefs.json
+++ b/src/locales/ja/nodeDefs.json
@@ -5319,6 +5319,9 @@
   "VAEEncodeTiled": {
     "display_name": "VAEエンコード（タイル）",
     "inputs": {
+      "overlap": {
+        "name": "オーバーラップ"
+      },
       "pixels": {
         "name": "ピクセル"
       },

--- a/src/locales/ko/nodeDefs.json
+++ b/src/locales/ko/nodeDefs.json
@@ -5319,6 +5319,9 @@
   "VAEEncodeTiled": {
     "display_name": "VAE 인코드 (타일)",
     "inputs": {
+      "overlap": {
+        "name": "중첩"
+      },
       "pixels": {
         "name": "픽셀"
       },

--- a/src/locales/ru/nodeDefs.json
+++ b/src/locales/ru/nodeDefs.json
@@ -5319,6 +5319,9 @@
   "VAEEncodeTiled": {
     "display_name": "Кодировать VAE (плитками)",
     "inputs": {
+      "overlap": {
+        "name": "перекрытие"
+      },
       "pixels": {
         "name": "пиксели"
       },

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -5319,6 +5319,9 @@
   "VAEEncodeTiled": {
     "display_name": "VAE编码（平铺）",
     "inputs": {
+      "overlap": {
+        "name": "重叠"
+      },
       "pixels": {
         "name": "像素"
       },


### PR DESCRIPTION
## Description

This pull request introduces two key improvements to the search form component:

1. **Clear Functionality:**  
   A clear button is now displayed whenever the user enters text into the search field. Clicking this button resets the input field, allowing for quick and easy clearing of the current search query.
<img width="268" alt="add-clear-search-button_1" src="https://github.com/user-attachments/assets/d8015373-aba1-4833-ac76-f46056a9cfc0" />


2. **Dynamic Layout Adjustments Based on Input State:**  
   When filters are present, the filter and clear buttons are dynamically repositioned depending on whether the user has entered text. Without input, the filter button remains at the far right. Once the user begins typing, the clear button appears on the right, and the filter button is smoothly shifted to maintain a clean and intuitive layout.
<img width="287" alt="add-clear-search-button_2" src="https://github.com/user-attachments/assets/ad25f0e0-7a92-4206-ad02-1cd1e1ea5e52" />


These enhancements improve the overall user experience by providing more direct control over the search state and ensuring that the interface remains clear and well-structured under varying conditions.

Your review would be greatly appreciated when you have time!

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1989-Add-Clear-Functionality-in-the-SearchBox-1616d73d36508103adf0da6a8ca599e9) by [Unito](https://www.unito.io)
