### PR TITLE
[CNR] Support module sytax of <node name>@<version>

### DIFF
--- a/src/types/nodeSource.ts
+++ b/src/types/nodeSource.ts
@@ -37,7 +37,11 @@ export const getNodeSource = (python_module?: string): NodeSource => {
       badgeText: '🦊'
     }
   } else if (modules[0] === 'custom_nodes') {
-    const displayName = shortenNodeName(modules[1])
+    const moduleName = modules[1]
+    // Custom nodes installed via ComfyNodeRegistry will be in the format of
+    // custom_nodes.<custom node name>@<version>
+    const customNodeName = moduleName.split('@')[0]
+    const displayName = shortenNodeName(customNodeName)
     return {
       type: NodeSourceType.CustomNodes,
       className: 'comfy-custom-nodes',

--- a/tests-ui/tests/fast/nodeSource.test.ts
+++ b/tests-ui/tests/fast/nodeSource.test.ts
@@ -1,0 +1,63 @@
+import { getNodeSource, NodeSourceType } from '@/types/nodeSource'
+
+describe('getNodeSource', () => {
+  it('should return UNKNOWN_NODE_SOURCE when python_module is undefined', () => {
+    const result = getNodeSource(undefined)
+    expect(result).toEqual({
+      type: NodeSourceType.Unknown,
+      className: 'comfy-unknown',
+      displayText: 'Unknown',
+      badgeText: '?'
+    })
+  })
+
+  it('should identify core nodes from nodes module', () => {
+    const result = getNodeSource('nodes.some_module')
+    expect(result).toEqual({
+      type: NodeSourceType.Core,
+      className: 'comfy-core',
+      displayText: 'Comfy Core',
+      badgeText: '🦊'
+    })
+  })
+
+  it('should identify core nodes from comfy_extras module', () => {
+    const result = getNodeSource('comfy_extras.some_module')
+    expect(result).toEqual({
+      type: NodeSourceType.Core,
+      className: 'comfy-core',
+      displayText: 'Comfy Core',
+      badgeText: '🦊'
+    })
+  })
+
+  it('should identify custom nodes and format their names', () => {
+    const result = getNodeSource('custom_nodes.ComfyUI-Example')
+    expect(result).toEqual({
+      type: NodeSourceType.CustomNodes,
+      className: 'comfy-custom-nodes',
+      displayText: 'Example',
+      badgeText: 'Example'
+    })
+  })
+
+  it('should identify custom nodes with version and format their names', () => {
+    const result = getNodeSource('custom_nodes.ComfyUI-Example@1.0.0')
+    expect(result).toEqual({
+      type: NodeSourceType.CustomNodes,
+      className: 'comfy-custom-nodes',
+      displayText: 'Example',
+      badgeText: 'Example'
+    })
+  })
+
+  it('should return UNKNOWN_NODE_SOURCE for unrecognized modules', () => {
+    const result = getNodeSource('unknown_module.something')
+    expect(result).toEqual({
+      type: NodeSourceType.Unknown,
+      className: 'comfy-unknown',
+      displayText: 'Unknown',
+      badgeText: '?'
+    })
+  })
+})


### PR DESCRIPTION
ComfyUI manager will check out custom node from Comfy Node Registry to module in format of `<node name>@<version`. This PR makes the frontend properly support the format.

Ref: https://github.com/ltdrdata/ComfyUI-Manager/compare/feat/cnr

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1994-CNR-Support-module-sytax-of-node-name-version-1616d73d365081e384a6d8a7cd1b955f) by [Unito](https://www.unito.io)
