### PR TITLE
Unify title edit handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.3.34",
-        "@comfyorg/litegraph": "^0.8.46",
+        "@comfyorg/litegraph": "^0.8.47",
         "@primevue/themes": "^4.0.5",
         "@vueuse/core": "^11.0.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -1957,9 +1957,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.46",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.46.tgz",
-      "integrity": "sha512-uI4AZJzW9p85jRmDWLhpQXnG9xqXo46oKaHRHhqYAzM7Ai0/d9gqIP//h3O4joEYw2zYOYVMGx2gCZAsyJcSmA==",
+      "version": "0.8.47",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.47.tgz",
+      "integrity": "sha512-JWKXWiqDyJjHz8oQ2kW8AVhTwYoGXHjynFuNeJrx1mtXurT6om1ywZoRptJbAwvNcSvbVWmdBdG0mf2NOqqwKQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.3.34",
-    "@comfyorg/litegraph": "^0.8.46",
+    "@comfyorg/litegraph": "^0.8.47",
     "@primevue/themes": "^4.0.5",
     "@vueuse/core": "^11.0.0",
     "@xterm/addon-fit": "^0.10.0",


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1413

This PR unifies title edit handling logic so that frontend only node's title can also be edited.

Other behaviour change:
- Double click on collapsed node to edit title.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1995-Unify-title-edit-handling-1626d73d365081988fa8cd3aae6bb8f3) by [Unito](https://www.unito.io)
