### PR TITLE
Move widget link drop conversion to widgetInputs

### DIFF
--- a/src/locales/en/nodeDefs.json
+++ b/src/locales/en/nodeDefs.json
@@ -312,6 +312,24 @@
       }
     }
   },
+  "CLIPTextEncodePixArtAlpha": {
+    "display_name": "CLIPTextEncodePixArtAlpha",
+    "description": "Encodes text and sets the resolution conditioning for PixArt Alpha. Does not apply to PixArt Sigma.",
+    "inputs": {
+      "width": {
+        "name": "width"
+      },
+      "height": {
+        "name": "height"
+      },
+      "text": {
+        "name": "text"
+      },
+      "clip": {
+        "name": "clip"
+      }
+    }
+  },
   "CLIPTextEncodeSD3": {
     "display_name": "CLIPTextEncodeSD3",
     "inputs": {

--- a/src/locales/ja/nodeDefs.json
+++ b/src/locales/ja/nodeDefs.json
@@ -249,6 +249,24 @@
       }
     }
   },
+  "CLIPTextEncodePixArtAlpha": {
+    "description": "テキストをエンコードし、PixArt Alphaの解像度条件を設定します。PixArt Sigmaには適用されません。",
+    "display_name": "CLIPTextEncodePixArtAlpha",
+    "inputs": {
+      "clip": {
+        "name": "clip"
+      },
+      "height": {
+        "name": "高さ"
+      },
+      "text": {
+        "name": "テキスト"
+      },
+      "width": {
+        "name": "幅"
+      }
+    }
+  },
   "CLIPTextEncodeSD3": {
     "display_name": "CLIPテキストエンコードSD3",
     "inputs": {

--- a/src/locales/ko/nodeDefs.json
+++ b/src/locales/ko/nodeDefs.json
@@ -249,6 +249,24 @@
       }
     }
   },
+  "CLIPTextEncodePixArtAlpha": {
+    "description": "텍스트를 인코딩하고 PixArt Alpha의 해상도 조건을 설정합니다. PixArt Sigma에는 적용되지 않습니다.",
+    "display_name": "CLIPTextEncodePixArtAlpha",
+    "inputs": {
+      "clip": {
+        "name": "클립"
+      },
+      "height": {
+        "name": "높이"
+      },
+      "text": {
+        "name": "텍스트"
+      },
+      "width": {
+        "name": "너비"
+      }
+    }
+  },
   "CLIPTextEncodeSD3": {
     "display_name": "CLIP 텍스트 인코딩 (SD3)",
     "inputs": {

--- a/src/locales/ru/nodeDefs.json
+++ b/src/locales/ru/nodeDefs.json
@@ -249,6 +249,24 @@
       }
     }
   },
+  "CLIPTextEncodePixArtAlpha": {
+    "description": "Кодирует текст и устанавливает условие разрешения для PixArt Alpha. Не применяется к PixArt Sigma.",
+    "display_name": "CLIPTextEncodePixArtAlpha",
+    "inputs": {
+      "clip": {
+        "name": "clip"
+      },
+      "height": {
+        "name": "высота"
+      },
+      "text": {
+        "name": "текст"
+      },
+      "width": {
+        "name": "ширина"
+      }
+    }
+  },
   "CLIPTextEncodeSD3": {
     "display_name": "Кодирование текста CLIP SD3",
     "inputs": {

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -249,6 +249,24 @@
       }
     }
   },
+  "CLIPTextEncodePixArtAlpha": {
+    "description": "对文本进行编码并为PixArt Alpha设置分辨率条件。不适用于PixArt Sigma。",
+    "display_name": "CLIPTextEncodePixArtAlpha",
+    "inputs": {
+      "clip": {
+        "name": "clip"
+      },
+      "height": {
+        "name": "高度"
+      },
+      "text": {
+        "name": "文本"
+      },
+      "width": {
+        "name": "宽度"
+      }
+    }
+  },
   "CLIPTextEncodeSD3": {
     "display_name": "CLIP文本编码SD3",
     "inputs": {


### PR DESCRIPTION
Allows the widget conversion to be disabled. Previously app.ts directly imports from the extension, which causes the extension is always registered.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2001-Move-widget-link-drop-conversion-to-widgetInputs-1626d73d3650811f9c63ec962abf5126) by [Unito](https://www.unito.io)
