### PR TITLE
[3d] fix file path issue for preview 3d node

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -1748,7 +1748,17 @@ app.registerExtension({
     node.onExecuted = function (message: any) {
       onExecuted?.apply(this, arguments)
 
-      modelWidget.value = message.model_file[0]
+      let filePath = message.model_file[0]
+
+      if (!filePath) {
+        const msg = 'unable to get model file path.'
+
+        console.error(msg)
+
+        useToastStore().addAlert(msg)
+      }
+
+      modelWidget.value = filePath.replaceAll('\\', '/')
 
       configureLoad3D(
         load3d,


### PR DESCRIPTION
a tiny fix about file path for preview 3d, also using https://github.com/if-ai/ComfyUI-IF_Trellis as example

https://github.com/user-attachments/assets/202e6f8b-05a6-42ac-a96f-3612570748e7

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2005-3d-fix-file-path-issue-for-preview-3d-node-1646d73d3650818f8d18eedebd3e7e0e) by [Unito](https://www.unito.io)
