### PR TITLE
Update mobile settings visibility test

### DIFF
--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -34,6 +34,8 @@ There are two ways to run the tests:
    ```
    This opens a user interface where you can select specific tests to run and inspect the test execution timeline.
 
+   To run the same test multiple times in the UI, you must launch the main ComfyUI process with the `--multi-user`.
+
    ![Playwright UI Mode](https://github.com/user-attachments/assets/6a1ebef0-90eb-4157-8694-f5ee94d03755)
 
 ## Screenshot Expectations

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -34,7 +34,7 @@ There are two ways to run the tests:
    ```
    This opens a user interface where you can select specific tests to run and inspect the test execution timeline.
 
-   To run the same test multiple times in the UI, you must launch the main ComfyUI process with the `--multi-user`.
+   To run the same test multiple times in Playwright's UI mode, you must launch the main ComfyUI process with the `--multi-user` flag.
 
    ![Playwright UI Mode](https://github.com/user-attachments/assets/6a1ebef0-90eb-4157-8694-f5ee94d03755)
 

--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -77,8 +77,12 @@ test.describe('Missing models warning', () => {
 test.describe('Settings', () => {
   test('@mobile Should be visible on mobile', async ({ comfyPage }) => {
     await comfyPage.page.keyboard.press('Control+,')
-    const searchBox = comfyPage.page.locator('.settings-content')
-    await expect(searchBox).toBeVisible()
+    const settingsContent = comfyPage.page.locator('.settings-content')
+    await expect(settingsContent).toBeVisible()
+    const isUsableHeight = await settingsContent.evaluate(
+      (el) => el.clientHeight > 30
+    )
+    expect(isUsableHeight).toBeTruthy()
   })
 
   test('Can open settings with hotkey', async ({ comfyPage }) => {
@@ -94,7 +98,7 @@ test.describe('Settings', () => {
   test('Can change canvas zoom speed setting', async ({ comfyPage }) => {
     const maxSpeed = 2.5
     await comfyPage.setSetting('Comfy.Graph.ZoomSpeed', maxSpeed)
-    test.step('Setting should persist', async () => {
+    await test.step('Setting should persist', async () => {
       expect(await comfyPage.getSetting('Comfy.Graph.ZoomSpeed')).toBe(maxSpeed)
     })
   })


### PR DESCRIPTION
Update the mobile settings visbility test to properly cover case from issue:

- #1895

The settings content should be considered hidden if it's visible but too small to interact with.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2009-Update-mobile-settings-visibility-test-1646d73d3650817395a2e0c05c480bd5) by [Unito](https://www.unito.io)
