### PR TITLE
Add About to Help menu

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -82,6 +82,10 @@ import { isElectron } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 import { useI18n } from 'vue-i18n'
 
+const props = defineProps<{
+  defaultPanel?: 'about' | 'keybinding' | 'extension' | 'server-config'
+}>()
+
 const KeybindingPanel = defineAsyncComponent(
   () => import('./setting/KeybindingPanel.vue')
 )
@@ -156,7 +160,10 @@ watch(activeCategory, (newCategory, oldCategory) => {
 })
 
 onMounted(() => {
-  activeCategory.value = categories.value[0]
+  activeCategory.value = props.defaultPanel
+    ? categories.value.find((x) => x.key === props.defaultPanel) ??
+      categories.value[0]
+    : categories.value[0]
 })
 
 const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {

--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -21,5 +21,6 @@ export const CORE_MENU_COMMANDS = [
       'Comfy.Help.OpenComfyUIDocs',
       'Comfy.Help.OpenComfyOrgDiscord'
     ]
-  ]
+  ],
+  [['Help'], ['Comfy.Help.AboutComfyUI']]
 ]

--- a/src/hooks/coreCommandHooks.ts
+++ b/src/hooks/coreCommandHooks.ts
@@ -500,6 +500,16 @@ export function useCoreCommands(): ComfyCommand[] {
       function: () => {
         useSearchBoxStore().toggleVisible()
       }
+    },
+    {
+      id: 'Comfy.Help.AboutComfyUI',
+      icon: 'pi pi-info-circle',
+      label: 'Open About ComfyUI',
+      menubarLabel: 'About ComfyUI',
+      versionAdded: '1.6.4',
+      function: () => {
+        showSettingsDialog('about')
+      }
     }
   ]
 }

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -95,6 +95,9 @@
   "Comfy_GroupNode_UngroupSelectedGroupNodes": {
     "label": "Ungroup selected group nodes"
   },
+  "Comfy_Help_AboutComfyUI": {
+    "label": "Open About ComfyUI"
+  },
   "Comfy_Help_OpenComfyOrgDiscord": {
     "label": "Open Comfy-Org Discord"
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -341,6 +341,7 @@
     "Convert selected nodes to group node": "Convert selected nodes to group node",
     "Manage group nodes": "Manage group nodes",
     "Ungroup selected group nodes": "Ungroup selected group nodes",
+    "About ComfyUI": "About ComfyUI",
     "Comfy-Org Discord": "Comfy-Org Discord",
     "ComfyUI Docs": "ComfyUI Docs",
     "ComfyUI Issues": "ComfyUI Issues",

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -95,6 +95,9 @@
   "Comfy_GroupNode_UngroupSelectedGroupNodes": {
     "label": "選択したグループノードのグループ解除"
   },
+  "Comfy_Help_AboutComfyUI": {
+    "label": "ComfyUIについてを開く"
+  },
   "Comfy_Help_OpenComfyOrgDiscord": {
     "label": "Comfy-OrgのDiscordを開く"
   },

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -235,6 +235,7 @@
     "toggleBottomPanel": "下部パネルを切り替え"
   },
   "menuLabels": {
+    "About ComfyUI": "ComfyUIについて",
     "Browse Templates": "テンプレートを参照",
     "Bypass/Unbypass Selected Nodes": "選択したノードのバイパス/バイパス解除",
     "Canvas Toggle Link Visibility": "キャンバスのリンク表示を切り替え",

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -95,6 +95,9 @@
   "Comfy_GroupNode_UngroupSelectedGroupNodes": {
     "label": "선택한 그룹 노드 분리"
   },
+  "Comfy_Help_AboutComfyUI": {
+    "label": "ComfyUI 정보 열기"
+  },
   "Comfy_Help_OpenComfyOrgDiscord": {
     "label": "Comfy-Org 디스코드 열기"
   },

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -235,6 +235,7 @@
     "toggleBottomPanel": "하단 패널 전환"
   },
   "menuLabels": {
+    "About ComfyUI": "ComfyUI에 대하여",
     "Browse Templates": "템플릿 탐색",
     "Bypass/Unbypass Selected Nodes": "선택한 노드 우회/우회 해제",
     "Canvas Toggle Link Visibility": "캔버스 토글 링크 가시성",

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -95,6 +95,9 @@
   "Comfy_GroupNode_UngroupSelectedGroupNodes": {
     "label": "Разгруппировать выбранные групповые узлы"
   },
+  "Comfy_Help_AboutComfyUI": {
+    "label": "Открыть о ComfyUI"
+  },
   "Comfy_Help_OpenComfyOrgDiscord": {
     "label": "Открыть Comfy-Org Discord"
   },

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -235,6 +235,7 @@
     "toggleBottomPanel": "Переключить нижнюю панель"
   },
   "menuLabels": {
+    "About ComfyUI": "О ComfyUI",
     "Browse Templates": "Просмотреть шаблоны",
     "Bypass/Unbypass Selected Nodes": "Обойти/восстановить выбранные узлы",
     "Canvas Toggle Link Visibility": "Переключение видимости ссылки на холст",

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -95,6 +95,9 @@
   "Comfy_GroupNode_UngroupSelectedGroupNodes": {
     "label": "取消选定组节点的分组"
   },
+  "Comfy_Help_AboutComfyUI": {
+    "label": "打开关于ComfyUI"
+  },
   "Comfy_Help_OpenComfyOrgDiscord": {
     "label": "打开Comfy-Org Discord"
   },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -235,6 +235,7 @@
     "toggleBottomPanel": "底部面板"
   },
   "menuLabels": {
+    "About ComfyUI": "关于ComfyUI",
     "Browse Templates": "浏览模板",
     "Bypass/Unbypass Selected Nodes": "旁路/取消旁路选定节点",
     "Canvas Toggle Link Visibility": "切换链接可见性",

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -39,11 +39,27 @@ export function showMissingModelsWarning(props: {
   })
 }
 
-export function showSettingsDialog() {
+export function showSettingsDialog(
+  panel?: 'about' | 'keybinding' | 'extension' | 'server-config'
+) {
+  const props = panel ? { props: { defaultPanel: panel } } : undefined
+
   useDialogStore().showDialog({
     key: 'global-settings',
     headerComponent: SettingDialogHeader,
-    component: SettingDialogContent
+    component: SettingDialogContent,
+    ...props
+  })
+}
+
+export function showAboutDialog() {
+  useDialogStore().showDialog({
+    key: 'global-settings',
+    headerComponent: SettingDialogHeader,
+    component: SettingDialogContent,
+    props: {
+      defaultPanel: 'about'
+    }
   })
 }
 


### PR DESCRIPTION
Adds About ComfyUI entry to Help menu.  Opens settings panel on the about tab.

![image](https://github.com/user-attachments/assets/45bf90d1-321e-486a-aefa-42462e2a8c93)
