### PR TITLE
Fix memory leak in preview code

### DIFF
--- a/src/components/sidebar/tabs/queue/TaskItem.vue
+++ b/src/components/sidebar/tabs/queue/TaskItem.vue
@@ -110,7 +110,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  if (progressPreviewBlobUrl) {
+  if (progressPreviewBlobUrl.value) {
     URL.revokeObjectURL(progressPreviewBlobUrl.value)
   }
   api.removeEventListener('b_preview', onProgressPreviewReceived)
@@ -167,7 +167,7 @@ const formatTime = (time?: number) => {
 
 const onProgressPreviewReceived = async ({ detail }: CustomEvent) => {
   if (props.task.displayStatus === TaskItemDisplayStatus.Running) {
-    if (progressPreviewBlobUrl) {
+    if (progressPreviewBlobUrl.value) {
       URL.revokeObjectURL(progressPreviewBlobUrl.value)
     }
     progressPreviewBlobUrl.value = URL.createObjectURL(detail)

--- a/src/components/sidebar/tabs/queue/TaskItem.vue
+++ b/src/components/sidebar/tabs/queue/TaskItem.vue
@@ -110,6 +110,9 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  if (progressPreviewBlobUrl) {
+    URL.revokeObjectURL(progressPreviewBlobUrl.value)
+  }
   api.removeEventListener('b_preview', onProgressPreviewReceived)
 })
 
@@ -164,6 +167,9 @@ const formatTime = (time?: number) => {
 
 const onProgressPreviewReceived = async ({ detail }: CustomEvent) => {
   if (props.task.displayStatus === TaskItemDisplayStatus.Running) {
+    if (progressPreviewBlobUrl) {
+      URL.revokeObjectURL(progressPreviewBlobUrl.value)
+    }
     progressPreviewBlobUrl.value = URL.createObjectURL(detail)
   }
 }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1547,6 +1547,7 @@ export class ComfyApp {
     api.addEventListener('executing', ({ detail }) => {
       this.progress = null
       this.graph.setDirtyCanvas(true, false)
+      this.revokePreviews(this.runningNodeId)
       delete this.nodePreviewImages[this.runningNodeId]
     })
 
@@ -1589,6 +1590,7 @@ export class ComfyApp {
 
       const blob = detail
       const blobUrl = URL.createObjectURL(blob)
+      this.revokePreviews(id)
       this.nodePreviewImages[id] = [blobUrl]
     })
 
@@ -2835,11 +2837,21 @@ export class ComfyApp {
     app.graph.setDirtyCanvas(true, true)
   }
 
+  revokePreviews(nodeId: NodeId) {
+    if (this.nodePreviewImages[nodeId]) {
+      for (let blob of this.nodePreviewImages[nodeId]) {
+        URL.revokeObjectURL(blob)
+      }
+    }
+  }
   /**
    * Clean current state
    */
   clean() {
     this.nodeOutputs = {}
+    for (let k in this.nodePreviewImages) {
+      this.revokePreviews(k)
+    }
     this.nodePreviewImages = {}
     this.lastNodeErrors = null
     this.lastExecutionError = null


### PR DESCRIPTION
Both TaskItem and the in node preview create object URL to display previews, but fail to ever revoke. This causes a memory leak.

This is resolved by adding a revoke calls whenever these previews are discarded.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2012-Fix-memory-leak-in-preview-code-1646d73d365081089cdad39d05cdd08f) by [Unito](https://www.unito.io)
