### PR TITLE
Bypass selected nodes

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -591,27 +591,13 @@ export class ComfyApp {
       options.push({
         content: 'Bypass',
         callback: (obj) => {
-          const selectedNodes = app.canvas.selectedItems
-          const nodes: LGraphNode[] = []
-          if (selectedNodes) {
-            for (const n of selectedNodes) {
-              const node = this.graph.getNodeById(n.id)
-              nodes.push(node)
-            }
+          const mode =
+            this.mode === LGraphEventMode.BYPASS
+              ? LGraphEventMode.ALWAYS
+              : LGraphEventMode.BYPASS
+          for (const item of app.canvas.selectedItems) {
+            if (item instanceof LGraphNode) item.mode = mode
           }
-
-          let toggle = false
-          for (const n of nodes) {
-            if (n.mode === LGraphEventMode.ALWAYS) {
-              toggle = true
-              break
-            }
-          }
-
-          for (const n of nodes) {
-            n.mode = toggle ? LGraphEventMode.BYPASS : LGraphEventMode.ALWAYS
-          }
-
           this.graph.change()
         }
       })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -591,9 +591,27 @@ export class ComfyApp {
       options.push({
         content: 'Bypass',
         callback: (obj) => {
-          if (this.mode === LGraphEventMode.BYPASS)
-            this.mode = LGraphEventMode.ALWAYS
-          else this.mode = LGraphEventMode.BYPASS
+          const selectedNodes = app.canvas.selectedItems
+          const nodes: LGraphNode[] = []
+          if (selectedNodes) {
+            for (const n of selectedNodes) {
+              const node = this.graph.getNodeById(n.id)
+              nodes.push(node)
+            }
+          }
+
+          let toggle = false
+          for (const n of nodes) {
+            if (n.mode === LGraphEventMode.ALWAYS) {
+              toggle = true
+              break
+            }
+          }
+
+          for (const n of nodes) {
+            n.mode = toggle ? LGraphEventMode.BYPASS : LGraphEventMode.ALWAYS
+          }
+
           this.graph.change()
         }
       })


### PR DESCRIPTION
Change bypass target in the context menu option from single node to selected nodes.

![Screenshot 2024-12-23 020503](https://github.com/user-attachments/assets/7945bf76-a2d9-406c-ab55-46cc328e2c44)
![Screenshot 2024-12-23 020508](https://github.com/user-attachments/assets/076b9bf0-820a-45a5-9719-b42368342134)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2013-Bypass-selected-nodes-1646d73d365081afbb9ded8fd8d9f6e0) by [Unito](https://www.unito.io)
