### PR TITLE
[ExtensionPanel] Distinguish core and 3rd party extensions

### DIFF
--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -38,9 +38,10 @@
       <Column :header="$t('g.extensionName')" sortable>
         <template #body="slotProps">
           {{ slotProps.data.name }}
-          <Tag v-if="extensionStore.isCoreExtension(slotProps.data.name)"
-            >Core</Tag
-          >
+          <Tag
+            v-if="extensionStore.isCoreExtension(slotProps.data.name)"
+            value="Core"
+          />
         </template>
       </Column>
       <Column

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -5,7 +5,12 @@
         v-model="filters['global'].value"
         :placeholder="$t('g.searchExtensions') + '...'"
       />
-      <Message v-if="hasChanges" severity="info" pt:text="w-full">
+      <Message
+        v-if="hasChanges"
+        severity="info"
+        pt:text="w-full"
+        class="max-h-96 overflow-y-auto"
+      >
         <ul>
           <li v-for="ext in changedExtensions" :key="ext.name">
             <span>
@@ -48,9 +53,7 @@
         </template>
         <template #body="slotProps">
           <ToggleSwitch
-            :disabled="
-              extensionStore.isExtensionAlwaysEnabled(slotProps.data.name)
-            "
+            :disabled="extensionStore.isExtensionReadOnly(slotProps.data.name)"
             v-model="editingEnabledExtensions[slotProps.data.name]"
             @change="updateExtensionStatus"
           />
@@ -117,6 +120,8 @@ const updateExtensionStatus = () => {
 
 const enableAllExtensions = () => {
   extensionStore.extensions.forEach((ext) => {
+    if (extensionStore.isExtensionReadOnly(ext.name)) return
+
     editingEnabledExtensions.value[ext.name] = true
   })
   updateExtensionStatus()
@@ -124,7 +129,16 @@ const enableAllExtensions = () => {
 
 const disableAllExtensions = () => {
   extensionStore.extensions.forEach((ext) => {
-    if (extensionStore.isExtensionAlwaysEnabled(ext.name)) return
+    if (extensionStore.isExtensionReadOnly(ext.name)) return
+
+    editingEnabledExtensions.value[ext.name] = false
+  })
+  updateExtensionStatus()
+}
+
+const disableThirdPartyExtensions = () => {
+  extensionStore.extensions.forEach((ext) => {
+    if (extensionStore.isCoreExtension(ext.name)) return
 
     editingEnabledExtensions.value[ext.name] = false
   })
@@ -147,6 +161,12 @@ const contextMenuItems = [
     label: 'Disable All',
     icon: 'pi pi-times',
     command: disableAllExtensions
+  },
+  {
+    label: 'Disable 3rd Party',
+    icon: 'pi pi-times',
+    command: disableThirdPartyExtensions,
+    disabled: !extensionStore.hasThirdPartyExtensions
   }
 ]
 </script>

--- a/src/components/dialog/content/setting/ExtensionPanel.vue
+++ b/src/components/dialog/content/setting/ExtensionPanel.vue
@@ -35,7 +35,14 @@
       size="small"
       :filters="filters"
     >
-      <Column field="name" :header="$t('g.extensionName')" sortable></Column>
+      <Column :header="$t('g.extensionName')" sortable>
+        <template #body="slotProps">
+          {{ slotProps.data.name }}
+          <Tag v-if="extensionStore.isCoreExtension(slotProps.data.name)"
+            >Core</Tag
+          >
+        </template>
+      </Column>
       <Column
         :pt="{
           headerCell: 'flex items-center justify-end',
@@ -70,6 +77,7 @@ import { useSettingStore } from '@/stores/settingStore'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import ToggleSwitch from 'primevue/toggleswitch'
+import Tag from 'primevue/tag'
 import Button from 'primevue/button'
 import ContextMenu from 'primevue/contextmenu'
 import Message from 'primevue/message'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1640,13 +1640,15 @@ export class ComfyApp {
    * Loads all extensions from the API into the window in parallel
    */
   async #loadExtensions() {
-    useExtensionStore().loadDisabledExtensionNames()
+    const extensionStore = useExtensionStore()
+    extensionStore.loadDisabledExtensionNames()
 
     const extensions = await api.getExtensions()
 
     // Need to load core extensions first as some custom extensions
     // may depend on them.
     await import('../extensions/core/index')
+    extensionStore.captureCoreExtensions()
     await Promise.all(
       extensions
         .filter((extension) => !extension.includes('extensions/core'))


### PR DESCRIPTION
This PR distinguishes core and 3rd party extensions by `Core` tag.

![image](https://github.com/user-attachments/assets/fd646388-0477-47ea-ace9-b4275211a688)

An action to disable all 3rd party extension is also added.

![image](https://github.com/user-attachments/assets/e6f04ca0-c0ab-4cd1-97c1-39e7f69c3426)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2020-ExtensionPanel-Distinguish-core-and-3rd-party-extensions-1656d73d3650818f8f63f7b63b53e0ff) by [Unito](https://www.unito.io)
