### PR TITLE
Auto-focus node filter search

### DIFF
--- a/src/components/searchbox/NodeSearchFilter.vue
+++ b/src/components/searchbox/NodeSearchFilter.vue
@@ -13,6 +13,7 @@
       v-model="selectedFilterValue"
       :options="filterValues"
       filter
+      autoFilterFocus
     />
   </div>
   <div class="_footer">


### PR DESCRIPTION
Auto-focus the node filter input by enabling the [`autoFilterFocus`](https://primevue.org/select/#api.select.props.autoFilterFocus) prop on the Select component.


https://github.com/user-attachments/assets/64921d72-0eeb-4157-b30c-2b8d0e712ea3



Requested in:

- #1993

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2024-Auto-focus-node-filter-search-1656d73d365081458667ee2cd3a084b2) by [Unito](https://www.unito.io)
