### PR TITLE
Remove `defineProps` import

### DIFF
--- a/src/components/dialog/content/error/ReportIssueButton.vue
+++ b/src/components/dialog/content/error/ReportIssueButton.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, defineProps } from 'vue'
+import { computed, ref } from 'vue'
 import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 import { ExecutionErrorWsMessage } from '@/types/apiTypes'


### PR DESCRIPTION
Remove `defineProps` import because `<script setup>` helper types are available globally [since Vue 3.1.3](https://github.com/vuejs/core/blob/main/changelogs/CHANGELOG-3.1.md#features:~:text=sfc/types%3A%20make%20%3Cscript%20setup%3E%20helper%20types%20available%20globally%20(004bd18)). Causing complaint:


![Selection_666](https://github.com/user-attachments/assets/a42d6bce-f660-4e98-889e-c30d9421e3ac)


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2025-Remove-defineProps-import-1656d73d365081ab94bcec5f97f02786) by [Unito](https://www.unito.io)
