### PR TITLE
Rearrange workflow tabs

### DIFF
--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="flex p-2 gap-2 workflow-tab" ref="workflowTabRef" v-bind="$attrs">
+    <span
+      class="workflow-label text-sm max-w-[150px] truncate inline-block"
+      v-tooltip.bottom="workflowOption.workflow.key"
+    >
+      {{ workflowOption.workflow.filename }}
+    </span>
+    <div class="relative">
+      <span
+        class="status-indicator"
+        v-if="
+          !workspaceStore.shiftDown &&
+          (workflowOption.workflow.isModified ||
+            !workflowOption.workflow.isPersisted)
+        "
+        >•</span
+      >
+      <Button
+        class="close-button p-0 w-auto"
+        icon="pi pi-times"
+        text
+        severity="secondary"
+        size="small"
+        @click.stop="onCloseWorkflow(workflowOption)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ComfyWorkflow } from '@/stores/workflowStore'
+import { useWorkflowStore } from '@/stores/workflowStore'
+import Button from 'primevue/button'
+import { ref } from 'vue'
+import { workflowService } from '@/services/workflowService'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { usePragmaticDraggable, usePragmaticDroppable } from '@/hooks/dndHooks'
+
+interface WorkflowOption {
+  value: string
+  workflow: ComfyWorkflow
+}
+
+const props = defineProps<{
+  class?: string
+  workflowOption: WorkflowOption
+}>()
+
+const workspaceStore = useWorkspaceStore()
+const workflowStore = useWorkflowStore()
+const workflowTabRef = ref<HTMLElement | null>(null)
+
+const closeWorkflows = async (options: WorkflowOption[]) => {
+  for (const opt of options) {
+    if (
+      !(await workflowService.closeWorkflow(opt.workflow, {
+        warnIfUnsaved: !workspaceStore.shiftDown
+      }))
+    ) {
+      // User clicked cancel
+      break
+    }
+  }
+}
+
+const onCloseWorkflow = (option: WorkflowOption) => {
+  closeWorkflows([option])
+}
+const tabGetter = () => workflowTabRef.value as HTMLElement
+
+usePragmaticDraggable(tabGetter, {
+  getInitialData: () => {
+    return {
+      workflowKey: props.workflowOption.workflow.key
+    }
+  }
+})
+
+usePragmaticDroppable(tabGetter, {
+  getData: () => {
+    return {
+      workflowKey: props.workflowOption.workflow.key
+    }
+  },
+  onDrop: (e) => {
+    const fromIndex = workflowStore.openWorkflows.findIndex(
+      (wf) => wf.key === e.source.data.workflowKey
+    )
+    const toIndex = workflowStore.openWorkflows.findIndex(
+      (wf) => wf.key === e.location.current.dropTargets[0]?.data.workflowKey
+    )
+    if (fromIndex !== toIndex) {
+      workflowStore.reorderWorkflows(fromIndex, toIndex)
+    }
+  }
+})
+</script>
+
+<style scoped>
+.status-indicator {
+  @apply absolute font-bold;
+  font-size: 1.5rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -8,11 +8,22 @@
     optionLabel="label"
     dataKey="value"
   >
-    <template #option="{ option }">
+    <template #option="{ option, index }">
       <div
-        class="flex p-2 gap-2"
+        :class="[
+          'flex p-2 gap-2 workflow-tab',
+          { 'border border-dashed': index === draggingTabIndex },
+          {
+            'border-r-4 border-0 border-solid':
+              targetTabIndex === index && draggingTabIndex < index
+          },
+          {
+            'border-l-4 border-0 border-solid':
+              targetTabIndex === index && draggingTabIndex > index
+          }
+        ]"
         @contextmenu="showContextMenu($event, option)"
-        @click.middle="onCloseWorkflow(option)"
+        @click.middle="onCloseWorkflow(option, index)"
       >
         <span
           class="workflow-label text-sm max-w-[150px] truncate inline-block"
@@ -35,7 +46,7 @@
             text
             severity="secondary"
             size="small"
-            @click.stop="onCloseWorkflow(option)"
+            @click.stop="onCloseWorkflow(option, index)"
           />
         </div>
       </div>
@@ -57,11 +68,15 @@ import { useWorkflowStore } from '@/stores/workflowStore'
 import { useCommandStore } from '@/stores/commandStore'
 import SelectButton from 'primevue/selectbutton'
 import Button from 'primevue/button'
-import { computed, ref } from 'vue'
+import { computed, ref, watch, nextTick, onUnmounted } from 'vue'
 import { workflowService } from '@/services/workflowService'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import ContextMenu from 'primevue/contextmenu'
 import { useI18n } from 'vue-i18n'
+import {
+  draggable,
+  dropTargetForElements
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
 
 interface WorkflowOption {
   value: string
@@ -122,8 +137,10 @@ const closeWorkflows = async (options: WorkflowOption[]) => {
   }
 }
 
-const onCloseWorkflow = (option: WorkflowOption) => {
+const onCloseWorkflow = (option: WorkflowOption, index: number) => {
   closeWorkflows([option])
+  runCleanups(cleanups)
+  cleanups.splice(index, 1)
 }
 
 const contextMenuItems = computed(() => {
@@ -143,7 +160,7 @@ const contextMenuItems = computed(() => {
     },
     {
       label: t('tabMenu.closeTab'),
-      command: () => onCloseWorkflow(tab)
+      command: () => onCloseWorkflow(tab, index)
     },
     {
       label: t('tabMenu.closeTabsToLeft'),
@@ -166,8 +183,70 @@ const contextMenuItems = computed(() => {
     }
   ]
 })
-
 const commandStore = useCommandStore()
+
+const draggingTabIndex = ref<number | null>(null)
+const targetTabIndex = ref<number | null>(null)
+let cleanups = []
+const runCleanups = (cleanups: (() => void)[]) => {
+  cleanups.forEach((cb) => {
+    cb()
+  })
+}
+watch(options, () => {
+  nextTick(() => {
+    const tabs = document.querySelectorAll('.workflow-tab')
+    cleanups = []
+    tabs.forEach((tab, index) => {
+      const cleanupDraggable = draggable({
+        element: tab as HTMLElement,
+        getInitialData: (e) => {
+          console.log('get initial data', e)
+          return {
+            tabIndex: index
+          }
+        },
+        onDrag: () => {
+          draggingTabIndex.value = index
+        },
+        onDrop: () => {
+          draggingTabIndex.value = null
+        }
+      })
+
+      const cleanupDropTarget = dropTargetForElements({
+        element: tab as HTMLElement,
+        getData: () => {
+          return {
+            tabIndex: index
+          }
+        },
+        onDrop: (e) => {
+          const fromIndex = e.source.data.tabIndex as number
+          const toIndex = e.location.current.dropTargets[0].data
+            .tabIndex as number
+          if (fromIndex !== toIndex) {
+            workflowStore.reorderWorkflows(fromIndex, toIndex)
+          }
+          targetTabIndex.value = null
+        },
+        onDropTargetChange: (e) => {
+          console.log(
+            'target changed',
+            e.location.current.dropTargets[0].data.tabIndex
+          )
+          targetTabIndex.value = e.location.current.dropTargets[0].data
+            .tabIndex as number
+        }
+      })
+
+      cleanups.push([cleanupDraggable, cleanupDropTarget])
+    })
+  })
+})
+onUnmounted(() => {
+  runCleanups(cleanups)
+})
 </script>
 
 <style scoped>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -203,7 +203,6 @@ watch(options, () => {
       const cleanupDraggable = draggable({
         element: tab as HTMLElement,
         getInitialData: (e) => {
-          console.log('get initial data', e)
           return {
             tabIndex: index
           }
@@ -233,10 +232,6 @@ watch(options, () => {
           targetTabIndex.value = null
         },
         onDropTargetChange: (e) => {
-          console.log(
-            'target changed',
-            e.location.current.dropTargets[0].data.tabIndex
-          )
           targetTabIndex.value = e.location.current.dropTargets[0].data
             .tabIndex as number
         }

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -139,7 +139,9 @@ const closeWorkflows = async (options: WorkflowOption[]) => {
 
 const onCloseWorkflow = (option: WorkflowOption, index: number) => {
   closeWorkflows([option])
-  runCleanups(cleanups)
+  cleanups[index].forEach((cb) => {
+    cb()
+  })
   cleanups.splice(index, 1)
 }
 

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -145,6 +145,7 @@ export interface WorkflowStore {
   modifiedWorkflows: ComfyWorkflow[]
   getWorkflowByPath: (path: string) => ComfyWorkflow | null
   syncWorkflows: (dir?: string) => Promise<void>
+  reorderWorkflows: (from: number, to: number) => void
 }
 
 export const useWorkflowStore = defineStore('workflow', () => {
@@ -202,6 +203,11 @@ export const useWorkflowStore = defineStore('workflow', () => {
   const openWorkflows = computed(() =>
     openWorkflowPaths.value.map((path) => workflowLookup.value[path])
   )
+  const reorderWorkflows = (from: number, to: number) => {
+    const movedTab = openWorkflowPaths.value[from]
+    openWorkflowPaths.value.splice(from, 1)
+    openWorkflowPaths.value.splice(to, 0, movedTab)
+  }
   const isOpen = (workflow: ComfyWorkflow) =>
     openWorkflowPathSet.value.has(workflow.path)
 
@@ -388,6 +394,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     renameWorkflow,
     deleteWorkflow,
     saveWorkflow,
+    reorderWorkflows,
 
     workflows,
     bookmarkedWorkflows,


### PR DESCRIPTION
Closes: [2006](https://github.com/Comfy-Org/ComfyUI_frontend/issues/2006)

- Workflow Tab is now separated to its own component to easily use the dnd Hooks.

https://github.com/user-attachments/assets/78465149-3e89-4306-b02e-29afa94f7bd4

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2026-Rearrange-workflow-tabs-1656d73d36508102a9dfec6dc90bba70) by [Unito](https://www.unito.io)
