### PR TITLE
Add color picker and image upload form items

### DIFF
--- a/src/components/common/FormColorPicker.vue
+++ b/src/components/common/FormColorPicker.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="color-picker-wrapper flex items-center gap-2">
+    <ColorPicker v-model="modelValue">
+      <template #header>
+        <div class="flex items-center justify-between p-2">
+          <span>{{ props.label }}</span>
+          <Button
+            v-if="props.defaultValue"
+            icon="pi pi-refresh"
+            text
+            size="small"
+            @click="resetColor"
+          />
+        </div>
+      </template>
+    </ColorPicker>
+    <InputText v-model="modelValue" class="w-28" :placeholder="label" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import ColorPicker from 'primevue/colorpicker'
+import InputText from 'primevue/inputtext'
+
+const modelValue = defineModel<string>('modelValue')
+const props = defineProps<{
+  defaultValue?: string
+  label?: string
+}>()
+
+const resetColor = () => {
+  modelValue.value = props.defaultValue || '#000000'
+}
+</script>

--- a/src/components/common/FormImageUpload.vue
+++ b/src/components/common/FormImageUpload.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="image-upload-wrapper">
+    <div class="flex gap-2 items-center">
+      <div
+        class="preview-box border rounded p-2 w-16 h-16 flex items-center justify-center"
+        :class="{ 'bg-gray-100 dark:bg-gray-800': !modelValue }"
+      >
+        <img
+          v-if="modelValue"
+          :src="modelValue"
+          class="max-w-full max-h-full object-contain"
+        />
+        <i v-else class="pi pi-image text-gray-400 text-xl"></i>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <Button
+          icon="pi pi-upload"
+          :label="$t('g.upload')"
+          size="small"
+          @click="triggerFileInput"
+        />
+        <Button
+          v-if="modelValue"
+          class="w-full"
+          outlined
+          icon="pi pi-trash"
+          severity="danger"
+          size="small"
+          @click="clearImage"
+        />
+      </div>
+    </div>
+    <input
+      ref="fileInput"
+      type="file"
+      class="hidden"
+      accept="image/*"
+      @change="handleFileUpload"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import Button from 'primevue/button'
+
+const props = defineProps<{
+  modelValue: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+const triggerFileInput = () => {
+  fileInput.value?.click()
+}
+
+const handleFileUpload = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  if (target.files && target.files[0]) {
+    const file = target.files[0]
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      emit('update:modelValue', e.target?.result as string)
+    }
+    reader.readAsDataURL(file)
+  }
+}
+
+const clearImage = () => {
+  emit('update:modelValue', '')
+  if (fileInput.value) {
+    fileInput.value.value = ''
+  }
+}
+</script>

--- a/src/components/common/FormItem.vue
+++ b/src/components/common/FormItem.vue
@@ -31,6 +31,8 @@ import Select from 'primevue/select'
 import ToggleSwitch from 'primevue/toggleswitch'
 import CustomFormValue from '@/components/common/CustomFormValue.vue'
 import InputSlider from '@/components/common/InputSlider.vue'
+import FormImageUpload from '@/components/common/FormImageUpload.vue'
+import FormColorPicker from '@/components/common/FormColorPicker.vue'
 
 const formValue = defineModel<any>('formValue')
 const props = defineProps<{
@@ -82,6 +84,10 @@ function getFormComponent(item: FormItem): Component {
       return InputSlider
     case 'combo':
       return Select
+    case 'image':
+      return FormImageUpload
+    case 'color':
+      return FormColorPicker
     default:
       return InputText
   }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -63,7 +63,8 @@
     "enableAll": "Enable All",
     "disableAll": "Disable All",
     "command": "Command",
-    "keybinding": "Keybinding"
+    "keybinding": "Keybinding",
+    "upload": "Upload"
   },
   "color": {
     "default": "Default",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -126,6 +126,7 @@
     "showReport": "レポートを表示",
     "systemInfo": "システム情報",
     "terminal": "ターミナル",
+    "upload": "アップロード",
     "videoFailedToLoad": "ビデオの読み込みに失敗しました"
   },
   "graphCanvasMenu": {

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -126,6 +126,7 @@
     "showReport": "보고서 보기",
     "systemInfo": "시스템 정보",
     "terminal": "터미널",
+    "upload": "업로드",
     "videoFailedToLoad": "비디오를 로드하지 못했습니다."
   },
   "graphCanvasMenu": {

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -126,6 +126,7 @@
     "showReport": "Показать отчет",
     "systemInfo": "Информация о системе",
     "terminal": "Терминал",
+    "upload": "Загрузить",
     "videoFailedToLoad": "Не удалось загрузить видео"
   },
   "graphCanvasMenu": {

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -126,6 +126,7 @@
     "showReport": "显示报告",
     "systemInfo": "系统信息",
     "terminal": "终端",
+    "upload": "上传",
     "videoFailedToLoad": "视频加载失败"
   },
   "graphCanvasMenu": {

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -6,6 +6,8 @@ export type SettingInputType =
   | 'slider'
   | 'combo'
   | 'text'
+  | 'image'
+  | 'color'
   | 'hidden'
 
 export type SettingCustomRenderer = (


### PR DESCRIPTION
This PR adds support for `image` and `color` form item type.

```ts
[
  {
    id: 'Comfy.DummyColor',
    name: 'Dummy color',
    type: 'color',
    defaultValue: '#000000',
    versionAdded: '1.5.6',
  },
  {
    id: 'Comfy.DummyImage',
    name: 'Dummy image',
    type: 'image',
    defaultValue: 'https://placehold.co/600x400',
    versionAdded: '1.5.6'
  }
]
```

![image](https://github.com/user-attachments/assets/06f1eb74-f4d5-4729-86c3-3c1936dbe7ad)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2031-Add-color-picker-and-image-upload-form-items-1656d73d365081d79e21e2b2ab222a36) by [Unito](https://www.unito.io)
