### PR TITLE
Move color palettes to constants/coreColorPalettes.ts

### DIFF
--- a/src/assets/palettes/dark.json
+++ b/src/assets/palettes/dark.json
@@ -4,7 +4,7 @@
   "colors": {
     "node_slot": {
       "CLIP": "#FFD500",
-      "clip_vision": "#A8DADC",
+      "CLIP_VISION": "#A8DADC",
       "CLIP_VISION_OUTPUT": "#ad7452",
       "CONDITIONING": "#FFA931",
       "CONTROL_NET": "#6EE7B7",

--- a/src/constants/coreColorPalettes.ts
+++ b/src/constants/coreColorPalettes.ts
@@ -1,0 +1,16 @@
+import dark from '@/assets/palettes/dark.json'
+import light from '@/assets/palettes/light.json'
+import solarized from '@/assets/palettes/solarized.json'
+import arc from '@/assets/palettes/arc.json'
+import nord from '@/assets/palettes/nord.json'
+import github from '@/assets/palettes/github.json'
+import type { ColorPalettes } from '@/types/colorPaletteTypes'
+
+export const CORE_COLOR_PALETTES: ColorPalettes = {
+  dark,
+  light,
+  solarized,
+  arc,
+  nord,
+  github
+} as const

--- a/src/extensions/core/colorPalette.ts
+++ b/src/extensions/core/colorPalette.ts
@@ -4,24 +4,10 @@ import { app } from '../../scripts/app'
 import { $el } from '../../scripts/ui'
 import type { ColorPalettes, Palette } from '@/types/colorPaletteTypes'
 import { LGraphCanvas, LiteGraph } from '@comfyorg/litegraph'
-import dark from '@/assets/palettes/dark.json'
-import light from '@/assets/palettes/light.json'
-import solarized from '@/assets/palettes/solarized.json'
-import arc from '@/assets/palettes/arc.json'
-import nord from '@/assets/palettes/nord.json'
-import github from '@/assets/palettes/github.json'
-
+import { CORE_COLOR_PALETTES } from '@/constants/coreColorPalettes'
 // Manage color palettes
 
-const colorPalettes: ColorPalettes = {
-  dark,
-  light,
-  solarized,
-  arc,
-  nord,
-  github
-} as const
-
+const colorPalettes = CORE_COLOR_PALETTES
 const id = 'Comfy.ColorPalette'
 const idCustomColorPalettes = 'Comfy.CustomColorPalettes'
 const defaultColorPaletteId = 'dark'

--- a/src/types/colorPaletteTypes.ts
+++ b/src/types/colorPaletteTypes.ts
@@ -1,69 +1,67 @@
 import { LiteGraph } from '@comfyorg/litegraph'
 import { z } from 'zod'
 
-const nodeSlotSchema = z
-  .object({
-    BOOLEAN: z.string().optional(),
-    CLIP: z.string(),
-    CLIP_VISION: z.string(),
-    CLIP_VISION_OUTPUT: z.string(),
-    CONDITIONING: z.string(),
-    CONTROL_NET: z.string(),
-    CONTROL_NET_WEIGHTS: z.string().optional(),
-    FLOAT: z.string().optional(),
-    GLIGEN: z.string().optional(),
-    IMAGE: z.string(),
-    IMAGEUPLOAD: z.string().optional(),
-    INT: z.string().optional(),
-    LATENT: z.string(),
-    LATENT_KEYFRAME: z.string().optional(),
-    MASK: z.string(),
-    MODEL: z.string(),
-    SAMPLER: z.string().optional(),
-    SIGMAS: z.string().optional(),
-    STRING: z.string().optional(),
-    STYLE_MODEL: z.string(),
-    T2I_ADAPTER_WEIGHTS: z.string().optional(),
-    TAESD: z.string(),
-    TIMESTEP_KEYFRAME: z.string().optional(),
-    UPSCALE_MODEL: z.string().optional(),
-    VAE: z.string()
-  })
-  .passthrough()
+const nodeSlotSchema = z.object({
+  BOOLEAN: z.string().optional(),
+  CLIP: z.string().optional(),
+  CLIP_VISION: z.string().optional(),
+  CLIP_VISION_OUTPUT: z.string().optional(),
+  CONDITIONING: z.string().optional(),
+  CONTROL_NET: z.string().optional(),
+  CONTROL_NET_WEIGHTS: z.string().optional(),
+  FLOAT: z.string().optional(),
+  GLIGEN: z.string().optional(),
+  IMAGE: z.string().optional(),
+  IMAGEUPLOAD: z.string().optional(),
+  INT: z.string().optional(),
+  LATENT: z.string().optional(),
+  LATENT_KEYFRAME: z.string().optional(),
+  MASK: z.string().optional(),
+  MODEL: z.string().optional(),
+  SAMPLER: z.string().optional(),
+  SIGMAS: z.string().optional(),
+  STRING: z.string().optional(),
+  STYLE_MODEL: z.string().optional(),
+  T2I_ADAPTER_WEIGHTS: z.string().optional(),
+  TAESD: z.string().optional(),
+  TIMESTEP_KEYFRAME: z.string().optional(),
+  UPSCALE_MODEL: z.string().optional(),
+  VAE: z.string().optional()
+})
 
-const litegraphBaseSchema = z
-  .object({
-    BACKGROUND_IMAGE: z.string(),
-    CLEAR_BACKGROUND_COLOR: z.string(),
-    NODE_TITLE_COLOR: z.string(),
-    NODE_SELECTED_TITLE_COLOR: z.string(),
-    NODE_TEXT_SIZE: z.number(),
-    NODE_TEXT_COLOR: z.string(),
-    NODE_SUBTEXT_SIZE: z.number(),
-    NODE_DEFAULT_COLOR: z.string(),
-    NODE_DEFAULT_BGCOLOR: z.string(),
-    NODE_DEFAULT_BOXCOLOR: z.string(),
-    NODE_DEFAULT_SHAPE: z.union([
+const litegraphBaseSchema = z.object({
+  BACKGROUND_IMAGE: z.string().optional(),
+  CLEAR_BACKGROUND_COLOR: z.string().optional(),
+  NODE_TITLE_COLOR: z.string().optional(),
+  NODE_SELECTED_TITLE_COLOR: z.string().optional(),
+  NODE_TEXT_SIZE: z.number().optional(),
+  NODE_TEXT_COLOR: z.string().optional(),
+  NODE_SUBTEXT_SIZE: z.number().optional(),
+  NODE_DEFAULT_COLOR: z.string().optional(),
+  NODE_DEFAULT_BGCOLOR: z.string().optional(),
+  NODE_DEFAULT_BOXCOLOR: z.string().optional(),
+  NODE_DEFAULT_SHAPE: z
+    .union([
       z.literal(LiteGraph.BOX_SHAPE),
       z.literal(LiteGraph.ROUND_SHAPE),
       z.literal(LiteGraph.CARD_SHAPE)
-    ]),
-    NODE_BOX_OUTLINE_COLOR: z.string(),
-    NODE_BYPASS_BGCOLOR: z.string(),
-    NODE_ERROR_COLOUR: z.string(),
-    DEFAULT_SHADOW_COLOR: z.string(),
-    DEFAULT_GROUP_FONT: z.number(),
-    WIDGET_BGCOLOR: z.string(),
-    WIDGET_OUTLINE_COLOR: z.string(),
-    WIDGET_TEXT_COLOR: z.string(),
-    WIDGET_SECONDARY_TEXT_COLOR: z.string(),
-    LINK_COLOR: z.string(),
-    EVENT_LINK_COLOR: z.string(),
-    CONNECTING_LINK_COLOR: z.string(),
-    BADGE_FG_COLOR: z.string().optional(),
-    BADGE_BG_COLOR: z.string().optional()
-  })
-  .passthrough()
+    ])
+    .optional(),
+  NODE_BOX_OUTLINE_COLOR: z.string().optional(),
+  NODE_BYPASS_BGCOLOR: z.string().optional(),
+  NODE_ERROR_COLOUR: z.string().optional(),
+  DEFAULT_SHADOW_COLOR: z.string().optional(),
+  DEFAULT_GROUP_FONT: z.number().optional(),
+  WIDGET_BGCOLOR: z.string().optional(),
+  WIDGET_OUTLINE_COLOR: z.string().optional(),
+  WIDGET_TEXT_COLOR: z.string().optional(),
+  WIDGET_SECONDARY_TEXT_COLOR: z.string().optional(),
+  LINK_COLOR: z.string().optional(),
+  EVENT_LINK_COLOR: z.string().optional(),
+  CONNECTING_LINK_COLOR: z.string().optional(),
+  BADGE_FG_COLOR: z.string().optional(),
+  BADGE_BG_COLOR: z.string().optional()
+})
 
 const comfyBaseSchema = z.object({
   ['fg-color']: z.string(),


### PR DESCRIPTION
Moves and enforce ts-strict.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2035-Move-color-palettes-to-constants-coreColorPalettes-ts-1666d73d365081c0a603d3361695fa6c) by [Unito](https://www.unito.io)
