### PR TITLE
Fix render issue when removing search filter chips

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -54,6 +54,7 @@
       <!-- FilterAndValue -->
       <template v-slot:chip="{ value }">
         <SearchFilterChip
+          :key="`${value[0].id}-${value[1]}`"
           @remove="onRemoveFilter($event, value)"
           :text="value[1]"
           :badge="value[0].invokeSequence.toUpperCase()"


### PR DESCRIPTION
Adds unique keys to search filter chips to fix render issues (#2028) when removing sibling chips.

Before / After

![Selection_669](https://github.com/user-attachments/assets/78977f97-0bca-405b-8f09-1aa57735cc22)


![Selection_671](https://github.com/user-attachments/assets/13f01267-8fa0-45c4-bca7-315a6d5f473d)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2038-Fix-render-issue-when-removing-search-filter-chips-1666d73d365081cea41ed4b7fe0fba19) by [Unito](https://www.unito.io)
