### PR TITLE
Fix batch count limit

### DIFF
--- a/src/components/actionbar/BatchCountEdit.vue
+++ b/src/components/actionbar/BatchCountEdit.vue
@@ -57,7 +57,7 @@ const handleClick = (increment: boolean) => {
   let newCount: number
   if (increment) {
     const originalCount = batchCount.value - 1
-    newCount = originalCount * 2
+    newCount = Math.min(originalCount * 2, maxQueueCount.value)
   } else {
     const originalCount = batchCount.value + 1
     newCount = Math.floor(originalCount / 2)


### PR DESCRIPTION
Respect batch count limit set by user. Current implementation causes this interaction when reaching limit (100):


https://github.com/user-attachments/assets/1caada85-b8c9-460d-b5e1-89a189f75fc9

After:


https://github.com/user-attachments/assets/0cf19728-5463-4658-85e2-5ea74cc74919

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2039-Fix-batch-count-limit-1666d73d36508139b87ec9f8ea3e6b7e) by [Unito](https://www.unito.io)
