### PR TITLE
[Theme] Fallback secondary menu bg to menu bg if not set

### DIFF
--- a/src/stores/workspace/colorPaletteStore.ts
+++ b/src/stores/workspace/colorPaletteStore.ts
@@ -53,6 +53,15 @@ export const useColorPaletteStore = defineStore('colorPalette', () => {
    * @returns The completed palette.
    */
   const completePalette = (palette: Palette): CompletedPalette => {
+    // Set comfy-menu-secondary-bg to comfy-menu-bg if not set
+    if (
+      palette.colors.comfy_base['comfy-menu-bg'] &&
+      !palette.colors.comfy_base['comfy-menu-secondary-bg']
+    ) {
+      palette.colors.comfy_base['comfy-menu-secondary-bg'] =
+        palette.colors.comfy_base['comfy-menu-bg']
+    }
+
     return {
       ...palette,
       colors: {


### PR DESCRIPTION
`comfy-menu-secondary-bg` was introduced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1853, which means to change color of the sidebar only. However, existing color paletees don't have this field, which makes the sidebar color always fallback to default dark color. This PR fixes the issue by make secondary menu bg fallback to menu bg if menu bg is present but secondary menu bg is not.

Before:
![image](https://github.com/user-attachments/assets/b7cb1fe4-b76c-417d-8495-a0db29ee6323)

After:
![image](https://github.com/user-attachments/assets/80fdc26b-7bce-4eda-8b33-8bd2c13d5288)

Custom theme used:
[obsidian_dark.json](https://github.com/user-attachments/files/18249087/obsidian_dark.json)
