### PR TITLE
[Theme] Loosen color palette schema

### DIFF
--- a/browser_tests/colorPalette.spec.ts
+++ b/browser_tests/colorPalette.spec.ts
@@ -131,11 +131,8 @@ const customColorPalettes = {
 }
 
 test.describe('Color Palette', () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.CustomColorPalettes', customColorPalettes)
-  })
-
   test('Can show custom color palette', async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.CustomColorPalettes', customColorPalettes)
     await comfyPage.setSetting('Comfy.ColorPalette', 'custom_obsidian_dark')
     await comfyPage.nextFrame()
     await expect(comfyPage.canvas).toHaveScreenshot(
@@ -144,6 +141,19 @@ test.describe('Color Palette', () => {
     await comfyPage.setSetting('Comfy.ColorPalette', 'dark')
     await comfyPage.nextFrame()
     await expect(comfyPage.canvas).toHaveScreenshot('default-color-palette.png')
+  })
+
+  test('Can add custom color palette', async ({ comfyPage }) => {
+    await comfyPage.page.evaluate((p) => {
+      window['app'].extensionManager.colorPalette.addCustomPalette(p)
+    }, customColorPalettes.obsidian_dark)
+    expect(await comfyPage.getToastErrorCount()).toBe(0)
+
+    await comfyPage.setSetting('Comfy.ColorPalette', 'custom_obsidian_dark')
+    await comfyPage.nextFrame()
+    await expect(comfyPage.canvas).toHaveScreenshot(
+      'custom-color-palette-obsidian-dark.png'
+    )
   })
 })
 

--- a/browser_tests/colorPalette.spec.ts
+++ b/browser_tests/colorPalette.spec.ts
@@ -145,7 +145,7 @@ test.describe('Color Palette', () => {
 
   test('Can add custom color palette', async ({ comfyPage }) => {
     await comfyPage.page.evaluate((p) => {
-      window['app'].extensionManager.colorPalette.addCustomPalette(p)
+      window['app'].extensionManager.colorPalette.addCustomColorPalette(p)
     }, customColorPalettes.obsidian_dark)
     expect(await comfyPage.getToastErrorCount()).toBe(0)
 

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -31,7 +31,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     set: useSettingStore().set
   }))
   const workflow = computed(() => useWorkflowStore())
-  const colorPalette = computed(() => useColorPaletteService())
+  const colorPalette = useColorPaletteService()
 
   /**
    * Registers a sidebar tab.

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -7,6 +7,7 @@ import { useCommandStore } from './commandStore'
 import { useSidebarTabStore } from './workspace/sidebarTabStore'
 import { useSettingStore } from './settingStore'
 import { useWorkflowStore } from './workflowStore'
+import { useColorPaletteService } from '@/services/colorPaletteService'
 
 export const useWorkspaceStore = defineStore('workspace', () => {
   const spinner = ref(false)
@@ -30,6 +31,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     set: useSettingStore().set
   }))
   const workflow = computed(() => useWorkflowStore())
+  const colorPalette = computed(() => useColorPaletteService())
 
   /**
    * Registers a sidebar tab.
@@ -71,6 +73,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     sidebarTab,
     setting,
     workflow,
+    colorPalette,
 
     registerSidebarTab,
     unregisterSidebarTab,

--- a/src/types/colorPaletteTypes.ts
+++ b/src/types/colorPaletteTypes.ts
@@ -34,7 +34,9 @@ const litegraphBaseSchema = z.object({
   NODE_DEFAULT_SHAPE: z.union([
     z.literal(LiteGraph.BOX_SHAPE),
     z.literal(LiteGraph.ROUND_SHAPE),
-    z.literal(LiteGraph.CARD_SHAPE)
+    z.literal(LiteGraph.CARD_SHAPE),
+    // Legacy palettes have string field for NODE_DEFAULT_SHAPE.
+    z.string()
   ]),
   NODE_BOX_OUTLINE_COLOR: z.string(),
   NODE_BYPASS_BGCOLOR: z.string(),
@@ -85,17 +87,22 @@ const partialColorsSchema = z.object({
   comfy_base: comfyBaseSchema.partial()
 })
 
-export const paletteSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  colors: partialColorsSchema
-})
+// Palette in the wild can have custom metadata fields such as 'version'.
+export const paletteSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    colors: partialColorsSchema
+  })
+  .passthrough()
 
-export const completedPaletteSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  colors: colorsSchema
-})
+export const completedPaletteSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    colors: colorsSchema
+  })
+  .passthrough()
 
 export const colorPalettesSchema = z.record(paletteSchema)
 


### PR DESCRIPTION
Loosen the schema to handle legacy palettes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2053-Theme-Loosen-color-palette-schema-1686d73d3650819db447d15cb7f8ea94) by [Unito](https://www.unito.io)
