### PR TITLE
Move extension related functions from app to extensionService

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -224,7 +224,8 @@ export class ComfyApp {
 
   set nodeOutputs(value) {
     this._nodeOutputs = value
-    useExtensionService().invokeExtensions('onNodeOutputsUpdated', value)
+    if (this.vueAppReady)
+      useExtensionService().invokeExtensions('onNodeOutputsUpdated', value)
   }
 
   getPreviewFormatParam() {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1580,34 +1580,6 @@ export class ComfyApp {
   }
 
   /**
-   * Loads all extensions from the API into the window in parallel
-   */
-  async #loadExtensions() {
-    const extensionStore = useExtensionStore()
-    extensionStore.loadDisabledExtensionNames(
-      useSettingStore().get('Comfy.Extension.Disabled')
-    )
-
-    const extensions = await api.getExtensions()
-
-    // Need to load core extensions first as some custom extensions
-    // may depend on them.
-    await import('../extensions/core/index')
-    extensionStore.captureCoreExtensions()
-    await Promise.all(
-      extensions
-        .filter((extension) => !extension.includes('extensions/core'))
-        .map(async (ext) => {
-          try {
-            await import(/* @vite-ignore */ api.fileURL(ext))
-          } catch (error) {
-            console.error('Error loading extension', ext, error)
-          }
-        })
-    )
-  }
-
-  /**
    * Set up the app on the page
    */
   async setup(canvasEl: HTMLCanvasElement) {
@@ -1621,7 +1593,7 @@ export class ComfyApp {
       useWorkspaceStore().workflow.syncWorkflows(),
       this.ui.settings.load()
     ])
-    await this.#loadExtensions()
+    await useExtensionService().loadExtensions()
 
     this.#addProcessMouseHandler()
     this.#addProcessKeyHandler()
@@ -2734,6 +2706,7 @@ export class ComfyApp {
   /**
    * Registers a Comfy web extension with the app
    * @param {ComfyExtension} extension
+   * @deprecated Use useExtensionService().registerExtension instead
    */
   registerExtension(extension: ComfyExtension) {
     useExtensionService().registerExtension(extension)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -63,6 +63,7 @@ import { useWidgetStore } from '@/stores/widgetStore'
 import { deserialiseAndCreate } from '@/extensions/core/vintageClipboard'
 import { st } from '@/i18n'
 import { normalizeI18nKey } from '@/utils/formatUtil'
+import { useExtensionService } from '@/services/extensionService'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
@@ -1641,7 +1642,9 @@ export class ComfyApp {
    */
   async #loadExtensions() {
     const extensionStore = useExtensionStore()
-    extensionStore.loadDisabledExtensionNames()
+    extensionStore.loadDisabledExtensionNames(
+      useSettingStore().get('Comfy.Extension.Disabled')
+    )
 
     const extensions = await api.getExtensions()
 
@@ -2780,12 +2783,7 @@ export class ComfyApp {
    * @param {ComfyExtension} extension
    */
   registerExtension(extension: ComfyExtension) {
-    if (this.vueAppReady) {
-      useExtensionStore().registerExtension(extension)
-    } else {
-      // For jest testing.
-      this.extensions.push(extension)
-    }
+    useExtensionService().registerExtension(extension)
   }
 
   /**

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -119,7 +119,6 @@ export class ComfyApp {
   vueAppReady: boolean
   api: ComfyApi
   ui: ComfyUI
-  extensions: ComfyExtension[]
   extensionManager: ExtensionManager
   _nodeOutputs: Record<string, any>
   nodePreviewImages: Record<string, string[]>
@@ -185,6 +184,13 @@ export class ComfyApp {
     return false
   }
 
+  /**
+   * @deprecated Use useExtensionStore().extensions instead
+   */
+  get extensions(): ComfyExtension[] {
+    return useExtensionStore().extensions
+  }
+
   constructor() {
     this.vueAppReady = false
     this.ui = new ComfyUI(this)
@@ -198,12 +204,6 @@ export class ComfyApp {
     })
     this.menu = new ComfyAppMenu(this)
     this.bypassBgColor = '#FF00FF'
-
-    /**
-     * List of extensions that are registered with the app
-     * @type {ComfyExtension[]}
-     */
-    this.extensions = []
 
     /**
      * Stores the execution output data for each node

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -1,3 +1,4 @@
+import { app } from '@/scripts/app'
 import { api } from '@/scripts/api'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExtensionStore } from '@/stores/extensionStore'
@@ -74,7 +75,7 @@ export const useExtensionService = () => {
     for (const ext of extensionStore.enabledExtensions) {
       if (method in ext) {
         try {
-          results.push(ext[method](...args, this))
+          results.push(ext[method](...args, app))
         } catch (error) {
           console.error(
             `Error calling extension '${ext.name}' method '${method}'`,
@@ -103,7 +104,7 @@ export const useExtensionService = () => {
       extensionStore.enabledExtensions.map(async (ext) => {
         if (method in ext) {
           try {
-            return await ext[method](...args, this)
+            return await ext[method](...args, app)
           } catch (error) {
             console.error(
               `Error calling extension '${ext.name}' method '${method}'`,

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -1,0 +1,35 @@
+import { useCommandStore } from '@/stores/commandStore'
+import { useExtensionStore } from '@/stores/extensionStore'
+import { useKeybindingStore } from '@/stores/keybindingStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useSettingStore } from '@/stores/settingStore'
+import { useWidgetStore } from '@/stores/widgetStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import type { ComfyExtension } from '@/types/comfy'
+
+export const useExtensionService = () => {
+  const extensionStore = useExtensionStore()
+
+  const registerExtension = (extension: ComfyExtension) => {
+    extensionStore.registerExtension(extension)
+
+    useKeybindingStore().loadExtensionKeybindings(extension)
+    useCommandStore().loadExtensionCommands(extension)
+    useMenuItemStore().loadExtensionMenuCommands(extension)
+    useSettingStore().loadExtensionSettings(extension)
+    useBottomPanelStore().registerExtensionBottomPanelTabs(extension)
+    if (extension.getCustomWidgets) {
+      // TODO(huchenlei): We should deprecate the async return value of
+      // getCustomWidgets.
+      ;(async () => {
+        if (extension.getCustomWidgets) {
+          const widgets = await extension.getCustomWidgets(app)
+          useWidgetStore().registerCustomWidgets(widgets)
+        }
+      })()
+    }
+  }
+  return {
+    registerExtension
+  }
+}

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -81,7 +81,7 @@ export const useExtensionStore = defineStore('extension', () => {
    */
   const coreExtensionNames = ref<string[]>([])
   function captureCoreExtensions() {
-    coreExtensionNames.value = app.extensions.map((ext) => ext.name)
+    coreExtensionNames.value = extensions.value.map((ext) => ext.name)
   }
 
   function isCoreExtension(name: string) {

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -1,7 +1,6 @@
 import { ref, computed, markRaw } from 'vue'
 import { defineStore } from 'pinia'
 import type { ComfyExtension } from '@/types/comfy'
-import { app } from '@/scripts/app'
 
 /**
  * These extensions are always active, even if they are disabled in the setting.

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -1,13 +1,7 @@
 import { ref, computed, markRaw } from 'vue'
 import { defineStore } from 'pinia'
 import type { ComfyExtension } from '@/types/comfy'
-import { useKeybindingStore } from './keybindingStore'
-import { useCommandStore } from './commandStore'
-import { useSettingStore } from './settingStore'
 import { app } from '@/scripts/app'
-import { useMenuItemStore } from './menuItemStore'
-import { useBottomPanelStore } from './workspace/bottomPanelStore'
-import { useWidgetStore } from './widgetStore'
 
 /**
  * These extensions are always active, even if they are disabled in the setting.
@@ -69,32 +63,10 @@ export const useExtensionStore = defineStore('extension', () => {
     }
 
     extensionByName.value[extension.name] = markRaw(extension)
-    useKeybindingStore().loadExtensionKeybindings(extension)
-    useCommandStore().loadExtensionCommands(extension)
-    useMenuItemStore().loadExtensionMenuCommands(extension)
-    useSettingStore().loadExtensionSettings(extension)
-    useBottomPanelStore().registerExtensionBottomPanelTabs(extension)
-    if (extension.getCustomWidgets) {
-      // TODO(huchenlei): We should deprecate the async return value of
-      // getCustomWidgets.
-      ;(async () => {
-        if (extension.getCustomWidgets) {
-          const widgets = await extension.getCustomWidgets(app)
-          useWidgetStore().registerCustomWidgets(widgets)
-        }
-      })()
-    }
-    /*
-     * Extensions are currently stored in both extensionStore and app.extensions.
-     * Legacy jest tests still depend on app.extensions being populated.
-     */
-    app.extensions.push(extension)
   }
 
-  function loadDisabledExtensionNames() {
-    disabledExtensionNames.value = new Set(
-      useSettingStore().get('Comfy.Extension.Disabled')
-    )
+  function loadDisabledExtensionNames(names: string[]) {
+    disabledExtensionNames.value = new Set(names)
     for (const name of ALWAYS_DISABLED_EXTENSIONS) {
       disabledExtensionNames.value.add(name)
     }
@@ -119,14 +91,6 @@ export const useExtensionStore = defineStore('extension', () => {
   const hasThirdPartyExtensions = computed(() => {
     return extensions.value.some((ext) => !isCoreExtension(ext.name))
   })
-
-  // Some core extensions are registered before the store is initialized, e.g.
-  // colorPalette.
-  // Register them manually here so the state of app.extensions and
-  // extensionByName are in sync.
-  for (const ext of app.extensions) {
-    extensionByName.value[ext.name] = markRaw(ext)
-  }
 
   return {
     extensions,


### PR DESCRIPTION
This PR moves extension related operations from ComfyApp to ExtensionService.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2055-Move-extension-related-functions-from-app-to-extensionService-1686d73d36508172ae49ec868a7de0e4) by [Unito](https://www.unito.io)
