### PR TITLE
Update litegraph 0.8.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.3",
-        "@comfyorg/litegraph": "^0.8.48",
+        "@comfyorg/litegraph": "^0.8.49",
         "@primevue/themes": "^4.0.5",
         "@vueuse/core": "^11.0.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -1957,9 +1957,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.48",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.48.tgz",
-      "integrity": "sha512-acbbo5LXPqgo5mxa+hxWKx6oUalEotkjgk6/UpYyOp+fVN3UPHCD07jgijcujDQTVUYzeNWVj0v9iZBU5DBTpg==",
+      "version": "0.8.49",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.49.tgz",
+      "integrity": "sha512-G8wuna+Zplxe/kpfk/UOn9nCNqibneCglsQvM6DsrFsxtYX1rDdeK4q+/ejdKa4EI1ZMmcau1zOmS8KNQ9MTrA==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.3",
-    "@comfyorg/litegraph": "^0.8.48",
+    "@comfyorg/litegraph": "^0.8.49",
     "@primevue/themes": "^4.0.5",
     "@vueuse/core": "^11.0.0",
     "@xterm/addon-fit": "^0.10.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.49

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2056-Update-litegraph-0-8-49-1686d73d365081e1b0f9f9a3cf55ccc5) by [Unito](https://www.unito.io)
