### PR TITLE
[Refactor] Deprecate ComfyApp.progress

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -127,8 +127,6 @@ export class ComfyApp {
   lastNodeErrors: any[] | null
   /** @type {ExecutionErrorWsMessage} */
   lastExecutionError: { node_id?: NodeId } | null
-  /** @type {ProgressWsMessage} */
-  progress: { value?: number; max?: number } | null
   configuringGraph: boolean
   ctx: CanvasRenderingContext2D
   bodyTop: HTMLElement
@@ -185,6 +183,14 @@ export class ComfyApp {
    */
   get extensions(): ComfyExtension[] {
     return useExtensionStore().extensions
+  }
+
+  /**
+   * The progress on the current executing node, if the node reports any.
+   * @deprecated Use useExecutionStore().executingNodeProgress instead
+   */
+  get progress() {
+    return useExecutionStore()._executingNodeProgress
   }
 
   constructor() {
@@ -1484,12 +1490,10 @@ export class ComfyApp {
     })
 
     api.addEventListener('progress', ({ detail }) => {
-      this.progress = detail
       this.graph.setDirtyCanvas(true, false)
     })
 
     api.addEventListener('executing', ({ detail }) => {
-      this.progress = null
       this.graph.setDirtyCanvas(true, false)
       this.revokePreviews(this.runningNodeId)
       delete this.nodePreviewImages[this.runningNodeId]

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -192,6 +192,8 @@ export const useExecutionStore = defineStore('execution', () => {
     executingNodeProgress,
     bindExecutionEvents,
     unbindExecutionEvents,
-    storePrompt
+    storePrompt,
+    // Raw executing progress data for backward compatibility in ComfyApp.
+    _executingNodeProgress
   }
 })


### PR DESCRIPTION
Remove the copy of `ComfyApp.progress`. The state is now exclusively managed in `executionStore`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2065-Refactor-Deprecate-ComfyApp-progress-1686d73d365081f1aeeecf5f29d2ace0) by [Unito](https://www.unito.io)
