### PR TITLE
Fix context menu text blurred by CSS filter

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -638,7 +638,7 @@ dialog::backdrop {
 
 .litegraph.litecontextmenu
   .litemenu-entry:hover:not(.disabled):not(.separator) {
-  background-color: var(--border-color) !important;
+  background-color: var(--comfy-menu-hover-bg, var(--border-color)) !important;
   color: var(--fg-color);
 }
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -175,7 +175,6 @@ body {
   display: none;
 }
 
-
 .comfy-markdown .tiptap :first-child {
   margin-top: 0;
 }
@@ -635,16 +634,12 @@ dialog::backdrop {
 .litegraph.litecontextmenu.dark {
   z-index: 9999 !important;
   background-color: var(--comfy-menu-bg) !important;
-  filter: brightness(95%);
-  will-change: transform;
 }
 
 .litegraph.litecontextmenu
   .litemenu-entry:hover:not(.disabled):not(.separator) {
-  background-color: var(--comfy-menu-bg) !important;
-  filter: brightness(155%);
-  will-change: transform;
-  color: var(--input-text);
+  background-color: var(--border-color) !important;
+  color: var(--fg-color);
 }
 
 .litegraph.litecontextmenu .litemenu-entry.submenu,

--- a/src/assets/palettes/light.json
+++ b/src/assets/palettes/light.json
@@ -46,6 +46,7 @@
       "fg-color": "#222",
       "bg-color": "#DDD",
       "comfy-menu-bg": "#F5F5F5",
+      "comfy-menu-hover-bg": "#ccc",
       "comfy-menu-secondary-bg": "#EEE",
       "comfy-input-bg": "#C9C9C9",
       "input-text": "#222",


### PR DESCRIPTION
#### Current

- Uses CSS filter (brightness) to handle hover on all menus
- Unavoidably blurs text

#### Proposed

- Uses border colour as background hover colour
- Uses foreground colour as text hover colour
- ~~Requires better solution for light mode~~
- Added `--comfy-menu-hover-bg` theme var for hover, which falls back to border-color

![image](https://github.com/user-attachments/assets/5dbf2029-883d-461a-ad18-f9810a106827)
![image](https://github.com/user-attachments/assets/fb5efc72-fbb1-4929-91b4-ce79b1ac88b5)
![image](https://github.com/user-attachments/assets/b4583bcd-250a-42ba-a80c-f4d8efcc2990)
![image](https://github.com/user-attachments/assets/8dc6cc1d-d00c-4213-9b3d-805d456d69ec)
![image](https://github.com/user-attachments/assets/08490c48-80a2-4121-a770-ca0b2cc48b99)

Updated light mode:
![image](https://github.com/user-attachments/assets/ba6ac303-d577-4dde-bd34-b82d4795c49a)

<details>

<summary>Original light mode</summary>

![image](https://github.com/user-attachments/assets/f0cee159-36a0-47d3-b54f-dd413536756b)

</details>
