### PR TITLE
Enable category-based narrowing and reset to default on search clear

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -6,6 +6,7 @@
         v-model:modelValue="searchQuery"
         @search="handleSearch"
         :placeholder="$t('g.searchSettings') + '...'"
+        :debounceTime="100"
       />
       <Listbox
         v-model="activeCategory"
@@ -67,7 +68,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, defineAsyncComponent } from 'vue'
+import {
+  ref,
+  computed,
+  onMounted,
+  watch,
+  defineAsyncComponent
+} from 'vue'
 import Listbox from 'primevue/listbox'
 import Tabs from 'primevue/tabs'
 import TabPanels from 'primevue/tabpanels'
@@ -160,17 +167,14 @@ const categories = computed<SettingTreeNode[]>(() =>
 )
 
 const activeCategory = ref<SettingTreeNode | null>(null)
-watch(activeCategory, (newCategory, oldCategory) => {
-  if (newCategory === null) {
-    activeCategory.value = oldCategory
-  }
-})
-
-onMounted(() => {
-  activeCategory.value = props.defaultPanel
+const getDefaultCategory = () => {
+  return props.defaultPanel
     ? categories.value.find((x) => x.key === props.defaultPanel) ??
-      categories.value[0]
+        categories.value[0]
     : categories.value[0]
+}
+onMounted(() => {
+  activeCategory.value = getDefaultCategory()
 })
 
 const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {
@@ -219,6 +223,7 @@ const searchResultsCategories = computed<Set<string>>(() => {
 const handleSearch = (query: string) => {
   if (!query) {
     filteredSettingIds.value = []
+    activeCategory.value = getDefaultCategory()
     return
   }
 
@@ -240,6 +245,7 @@ const handleSearch = (query: string) => {
 
   filteredSettingIds.value = filteredSettings.map((x) => x.id)
   searchInProgress.value = false
+  activeCategory.value = null
 }
 
 const inSearch = computed(

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -18,6 +18,15 @@ import type { ComfyExtension } from '@/types/comfy'
 import { buildTree } from '@/utils/treeUtil'
 import { CORE_SETTINGS } from '@/constants/coreSettings'
 
+export const getSettingInfo = (setting: SettingParams) => {
+  const parts = setting.category || setting.id.split('.')
+  return {
+    category: parts[0],
+    subCategory: parts[1],
+    name: parts.slice(2).join('.')
+  }
+}
+
 export interface SettingTreeNode extends TreeNode {
   data?: SettingParams
 }


### PR DESCRIPTION
This PR modifies the search behavior in the settings dialog to allow category-based narrowing of results. When a user initiates a search, the `activeCategory` is set to `null`, displaying all matching results across categories. Users can then click an enabled category to further refine those matches.

### Additional Fix: Text Changes During Search
Previously, certain labels would change unexpectedly when search results were displayed (e.g., "Edit Token Weight" became "EditAttention," as shown in the attached images). This PR resolves that issue, ensuring text remains consistent regardless of whether a search is active.

**before:**
![searched-display-categories_before](https://github.com/user-attachments/assets/d2c86845-3250-482a-98be-17583ff83ba4)

**after:**
![searched-display-categories_after](https://github.com/user-attachments/assets/3c20b6ab-ba6b-4cd0-a66b-af63999bcd6a)

Please review these changes at your convenience, and feel free to share any questions or feedback.
Thank you for your time and support!


Demo video:

https://github.com/user-attachments/assets/cf63ab2a-c64c-4645-ad4c-f77700524136

