### PR TITLE
Remove life on default error handler toast

### DIFF
--- a/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
+++ b/src/components/common/__tests__/TreeExplorerTreeNode.spec.ts
@@ -129,8 +129,7 @@ describe('TreeExplorerTreeNode', () => {
     expect(addToastSpy).toHaveBeenCalledWith({
       severity: 'error',
       summary: 'Error',
-      detail: 'Rename failed',
-      life: 3000
+      detail: 'Rename failed'
     })
   })
 })

--- a/src/hooks/errorHooks.ts
+++ b/src/hooks/errorHooks.ts
@@ -8,8 +8,7 @@ export function useErrorHandling() {
     toast.add({
       severity: 'error',
       summary: t('g.error'),
-      detail: error.message,
-      life: 3000
+      detail: error.message
     })
   }
 


### PR DESCRIPTION
Error toast is not supposed to disappear until user dismiss them manually as we may want user to report error based on the error message in the toast, and some error messages can be long.