### PR TITLE
Update history task item schema

### DIFF
--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -198,11 +198,21 @@ const zPendingTaskItem = z.object({
 
 const zTaskOutput = z.record(zNodeId, zOutputs)
 
+const zNodeOutputsMeta = z.object({
+  node_id: zNodeId,
+  display_node: zNodeId,
+  prompt_id: zPromptId.optional(),
+  read_node_id: zNodeId.optional()
+})
+
+const zTaskMeta = z.record(zNodeId, zNodeOutputsMeta)
+
 const zHistoryTaskItem = z.object({
   taskType: z.literal('History'),
   prompt: zTaskPrompt,
   status: zStatus.optional(),
-  outputs: zTaskOutput
+  outputs: zTaskOutput,
+  meta: zTaskMeta.optional()
 })
 
 const zTaskItem = z.union([


### PR DESCRIPTION
This PR updates the history task item schema to include the `meta` field which is set [here](https://github.com/comfyanonymous/ComfyUI/blob/a90aafafc119b1bc5dc18b86dd419546d5643fb5/execution.py#L329-L337) and possibly other places.

It seems that the backend code was updated to include the `meta` field 4 days after this schema was initially made.

