### PR TITLE
Increase width of settings dialog on mobile

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -297,6 +297,7 @@ watch(activeCategory, (_, oldValue) => {
   .settings-container {
     flex-direction: column;
     height: auto;
+    width: 80vw;
   }
 
   .settings-sidebar {


### PR DESCRIPTION
This increases the width of the settings dialog on sm screens from 60vw to 80vw as it is currently too narrow to comfortably use. Before and after:

![o](https://github.com/user-attachments/assets/25a34471-2f5b-4ac7-9339-70b8140670c9)
