### PR TITLE
Call api.storeSetting only when setting value changes

### DIFF
--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -24,13 +24,13 @@ function tryMigrateDeprecatedValue(setting: SettingParams, value: any) {
   return setting?.migrateDeprecatedValue?.(value) ?? value
 }
 
-function onChange(setting: SettingParams, value: any, oldValue: any) {
-  if (setting?.onChange && value !== oldValue) {
-    setting.onChange(value)
-    // Backward compatibility with old settings dialog.
-    // Some extensions still listens event emitted by the old settings dialog.
-    app.ui.settings.dispatchChange(setting.id, value, oldValue)
+function onChange(setting: SettingParams, newValue: any, oldValue: any) {
+  if (setting?.onChange) {
+    setting.onChange(newValue, oldValue)
   }
+  // Backward compatibility with old settings dialog.
+  // Some extensions still listens event emitted by the old settings dialog.
+  app.ui.settings.dispatchChange(setting.id, newValue, oldValue)
 }
 
 export const useSettingStore = defineStore('setting', () => {
@@ -75,9 +75,10 @@ export const useSettingStore = defineStore('setting', () => {
    */
   async function set<K extends keyof Settings>(key: K, value: Settings[K]) {
     const newValue = tryMigrateDeprecatedValue(settingsById.value[key], value)
-    const oldValue = settingValues.value[key]
-    onChange(settingsById.value[key], newValue, oldValue)
+    const oldValue = get(key)
+    if (newValue === oldValue) return
 
+    onChange(settingsById.value[key], newValue, oldValue)
     settingValues.value[key] = newValue
     await api.storeSetting(key, newValue)
   }


### PR DESCRIPTION
Previously api.storeSetting is called even the setting value is not changed. This PR fixes this issue.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2119-Call-api-storeSetting-only-when-setting-value-changes-16e6d73d3650816b8106c41214ad3f53) by [Unito](https://www.unito.io)
