### PR TITLE
Reduce debounce delay in settings search

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -15,7 +15,7 @@
         scrollHeight="100%"
         :optionDisabled="
           (option: SettingTreeNode) =>
-            inSearch && !searchResultsCategories.has(option.label)
+            !queryIsEmpty && !searchResultsCategories.has(option.label)
         "
         class="border-none w-full"
       />
@@ -264,9 +264,8 @@ const handleSearch = (query: string) => {
   activeCategory.value = null
 }
 
-const inSearch = computed(
-  () => searchQuery.value.length > 0 && !searchInProgress.value
-)
+const queryIsEmpty = computed(() => searchQuery.value.length === 0)
+const inSearch = computed(() => !queryIsEmpty.value && !searchInProgress.value)
 const tabValue = computed(() =>
   inSearch.value ? 'Search Results' : activeCategory.value?.label
 )

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -6,6 +6,7 @@
         v-model:modelValue="searchQuery"
         @search="handleSearch"
         :placeholder="$t('g.searchSettings') + '...'"
+        :debounce-time="128"
       />
       <Listbox
         v-model="activeCategory"


### PR DESCRIPTION
Similar to:

> - #559
> 
> The default debounce delay is 300ms which is too long in the node search context. Our current fuse search generally takes ~30ms to search among ~8k nodes.
> 
> This PR reduces the delay to 100ms to make the search more responsive.

The settings search takes ~20ms (on i7-14700). Lowering the debounce delay increases responsiveness noticeably.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2126-Reduce-debounce-delay-in-settings-search-16f6d73d36508189b539ed37368cb8c5) by [Unito](https://www.unito.io)
