### PR TITLE
Add alt text to images in gallery and queue

### DIFF
--- a/src/components/common/ComfyImage.vue
+++ b/src/components/common/ComfyImage.vue
@@ -12,12 +12,14 @@
       :data-test="src"
       class="comfy-image-blur"
       :style="{ 'background-image': `url(${src})` }"
+      :alt="alt"
     />
     <img
       :src="src"
       @error="handleImageError"
       class="comfy-image-main"
       :class="[...classArray]"
+      :alt="alt"
     />
   </span>
   <div v-if="imageBroken" class="broken-image-placeholder">
@@ -34,9 +36,11 @@ const props = withDefaults(
     src: string
     class?: string | string[] | object
     contain: boolean
+    alt?: string
   }>(),
   {
-    contain: false
+    contain: false,
+    alt: 'Image content'
   }
 )
 

--- a/src/components/sidebar/tabs/queue/ResultGallery.vue
+++ b/src/components/sidebar/tabs/queue/ResultGallery.vue
@@ -24,6 +24,7 @@
         :key="item.url"
         :src="item.url"
         :contain="false"
+        :alt="item.filename"
         class="galleria-image"
         v-if="item.isImage"
       />

--- a/src/components/sidebar/tabs/queue/ResultItem.vue
+++ b/src/components/sidebar/tabs/queue/ResultItem.vue
@@ -5,6 +5,7 @@
       :src="result.url"
       class="task-output-image"
       :contain="imageFit === 'contain'"
+      :alt="result.filename"
     />
     <ResultVideo v-else-if="result.isVideo" :result="result" />
     <div v-else class="task-result-preview">


### PR DESCRIPTION
Incorporate alt text for images in the gallery and queue components to improve accessibility and make testing easier. This PR will allow tests added in #2125 to be made more robust.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2136-Add-alt-text-to-images-in-gallery-and-queue-1706d73d365081679523d3fad2d232fe) by [Unito](https://www.unito.io)
