### PR TITLE
[BugFix] Fix open workflow after insert

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -821,6 +821,11 @@ export class ComfyPage {
   async getNodeRefById(id: NodeId) {
     return new NodeReference(id, this)
   }
+  async getNodes() {
+    return await this.page.evaluate(() => {
+      return window['app'].graph.nodes
+    })
+  }
   async getNodeRefsByType(type: string): Promise<NodeReference[]> {
     return Promise.all(
       (

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -152,6 +152,13 @@ export class WorkflowsSidebarTab extends SidebarTab {
     await this.page.keyboard.press('Enter')
     await this.page.waitForTimeout(300)
   }
+
+  async insertWorkflow(locator: Locator) {
+    await locator.click({ button: 'right' })
+    await this.page
+      .locator('.p-contextmenu-item-content', { hasText: 'Insert' })
+      .click()
+  }
 }
 
 export class QueueSidebarTab extends SidebarTab {

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -429,6 +429,26 @@ test.describe('Menu', () => {
       ])
     })
 
+    test('Can open workflow after insert', async ({ comfyPage }) => {
+      await comfyPage.setupWorkflowsDirectory({
+        'workflow1.json': 'single_ksampler.json'
+      })
+      await comfyPage.setup()
+
+      const tab = comfyPage.menu.workflowsTab
+      await tab.open()
+      await comfyPage.executeCommand('Comfy.LoadDefaultWorkflow')
+      const originalNodeCount = (await comfyPage.getNodes()).length
+
+      await tab.insertWorkflow(tab.getPersistedItem('workflow1.json'))
+      await comfyPage.nextFrame()
+      expect((await comfyPage.getNodes()).length).toEqual(originalNodeCount + 1)
+
+      await tab.getPersistedItem('workflow1.json').click()
+      await comfyPage.nextFrame()
+      expect((await comfyPage.getNodes()).length).toEqual(1)
+    })
+
     test('Can rename nested workflow from opened workflow item', async ({
       comfyPage
     }) => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -49,7 +49,7 @@ import {
 } from './pnginfo'
 import { $el, ComfyUI } from './ui'
 import { ComfyAppMenu } from './ui/menu/index'
-import { getStorageValue } from './utils'
+import { clone, getStorageValue } from './utils'
 import { type ComfyWidgetConstructor, ComfyWidgets } from './widgets'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
@@ -1271,11 +1271,7 @@ export class ComfyApp {
       reset_invalid_values = true
     }
 
-    if (typeof structuredClone === 'undefined') {
-      graphData = JSON.parse(JSON.stringify(graphData))
-    } else {
-      graphData = structuredClone(graphData)
-    }
+    graphData = clone(graphData)
 
     if (useSettingStore().get('Comfy.Validation.Workflows')) {
       // TODO: Show validation error in a dialog.


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2135

Previously the structuredClone failed to handle graphData. This PR replaces the logic with `utils.clone` which fallback to `JSON.parse(JSON.serialize())` method when `structuredClone` failed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2138-BugFix-Fix-open-workflow-after-insert-1706d73d3650819eb104fccf5f9ae3a1) by [Unito](https://www.unito.io)
