### PR TITLE
Update litegraph 0.8.59

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.3",
-        "@comfyorg/litegraph": "^0.8.58",
+        "@comfyorg/litegraph": "^0.8.59",
         "@primevue/themes": "^4.0.5",
         "@tiptap/core": "^2.10.4",
         "@tiptap/extension-link": "^2.10.4",
@@ -1940,9 +1940,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.58",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.58.tgz",
-      "integrity": "sha512-V/4yC8i5QOpDV20ZiEMiZP6KnmYD5d15El3V4tmH/MkhjOxjc6owAFMyAVgpxphYdcBF2qj1QTNTrZLgC6x2VQ==",
+      "version": "0.8.59",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.59.tgz",
+      "integrity": "sha512-/qyTsI+NIiMU7Ie8kJMvX+TL/axkX7wCurxjxODSdrmh9mb8eq4DfOLqRVbnCsLYEYmRlc5eBhTqp/q8zQRF5Q==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.3",
-    "@comfyorg/litegraph": "^0.8.58",
+    "@comfyorg/litegraph": "^0.8.59",
     "@primevue/themes": "^4.0.5",
     "@tiptap/core": "^2.10.4",
     "@tiptap/extension-link": "^2.10.4",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.59

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2140-Update-litegraph-0-8-59-1706d73d365081e7a57de34692ac8833) by [Unito](https://www.unito.io)
