### PR TITLE
Revert markdown note node, reland as new node

### DIFF
--- a/src/extensions/core/noteNode.ts
+++ b/src/extensions/core/noteNode.ts
@@ -50,5 +50,35 @@ app.registerExtension({
     )
 
     NoteNode.category = 'utils'
+
+    /** Adds Markdown capabilities to the standard NoteNode */
+    class MarkdownNoteNode extends LGraphNode {
+      static category = 'utils'
+
+      color = LGraphCanvas.node_colors.yellow.color
+      bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
+      groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
+      isVirtualNode: boolean
+      collapsable: boolean
+      title_mode: number
+
+      constructor(title?: string) {
+        super(title)
+        if (!this.properties) {
+          this.properties = { text: '' }
+        }
+        ComfyWidgets.MARKDOWN(
+          this,
+          '',
+          ['', { default: this.properties.text }],
+          app
+        )
+
+        this.serialize_widgets = true
+        this.isVirtualNode = true
+      }
+    }
+
+    LiteGraph.registerNodeType('MarkdownNote', MarkdownNoteNode)
   }
 })

--- a/src/extensions/core/noteNode.ts
+++ b/src/extensions/core/noteNode.ts
@@ -25,11 +25,11 @@ app.registerExtension({
         if (!this.properties) {
           this.properties = { text: '' }
         }
-        ComfyWidgets.MARKDOWN(
+        ComfyWidgets.STRING(
           // Should we extends LGraphNode?  Yesss
           this,
           '',
-          ['', { default: this.properties.text }],
+          ['', { default: this.properties.text, multiline: true }],
           app
         )
 

--- a/src/extensions/core/noteNode.ts
+++ b/src/extensions/core/noteNode.ts
@@ -51,16 +51,13 @@ app.registerExtension({
 
     NoteNode.category = 'utils'
 
-    /** Adds Markdown capabilities to the standard NoteNode */
+    /** Markdown variant of NoteNode */
     class MarkdownNoteNode extends LGraphNode {
-      static category = 'utils'
+      static title = 'Markdown Note'
 
       color = LGraphCanvas.node_colors.yellow.color
       bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
       groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
-      isVirtualNode: boolean
-      collapsable: boolean
-      title_mode: number
 
       constructor(title?: string) {
         super(title)
@@ -80,5 +77,6 @@ app.registerExtension({
     }
 
     LiteGraph.registerNodeType('MarkdownNote', MarkdownNoteNode)
+    MarkdownNoteNode.category = 'utils'
   }
 })

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -291,7 +291,7 @@ export const SYSTEM_NODE_DEFS: Record<string, ComfyNodeDef> = {
     description: 'Node that add notes to your project'
   },
   MarkdownNote: {
-    name: 'Markdown Note',
+    name: 'MarkdownNote',
     display_name: 'Markdown Note',
     category: 'utils',
     input: { required: {}, optional: {} },

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -300,7 +300,8 @@ export const SYSTEM_NODE_DEFS: Record<string, ComfyNodeDef> = {
     output_is_list: [],
     output_node: false,
     python_module: 'nodes',
-    description: 'Node that add notes to your project. Reformats text as markdown.'
+    description:
+      'Node that add notes to your project. Reformats text as markdown.'
   }
 }
 

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -289,6 +289,18 @@ export const SYSTEM_NODE_DEFS: Record<string, ComfyNodeDef> = {
     output_node: false,
     python_module: 'nodes',
     description: 'Node that add notes to your project'
+  },
+  MarkdownNote: {
+    name: 'Markdown Note',
+    display_name: 'Markdown Note',
+    category: 'utils',
+    input: { required: {}, optional: {} },
+    output: [],
+    output_name: [],
+    output_is_list: [],
+    output_node: false,
+    python_module: 'nodes',
+    description: 'Node that add notes to your project. Reformats text as markdown.'
   }
 }
 


### PR DESCRIPTION
- Resolves #2146
- Adds markdown note node as a new node: `MarkdownNote`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2148-Revert-markdown-note-node-reland-as-new-node-1706d73d3650814c965ce0aa6927fbd7) by [Unito](https://www.unito.io)
