### PR TITLE
Fix text wrapping in dropdown menu

### DIFF
--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -19,7 +19,7 @@
         <span class="p-menubar-item-label">{{ item.label }}</span>
         <span
           v-if="item?.comfyCommand?.keybinding"
-          class="ml-auto border border-surface rounded text-muted text-xs p-1 keybinding-tag"
+          class="ml-auto border border-surface rounded text-muted text-xs text-nowrap p-1 keybinding-tag"
         >
           {{ item.comfyCommand.keybinding.combo.toString() }}
         </span>


### PR DESCRIPTION
Prevents keybinding tags in dropdown menu from wrapping to next line. Requested [here](https://github.com/Comfy-Org/ComfyUI_frontend/pull/1127#issuecomment-2402099036) (comment). Before / After:

![wrap](https://github.com/user-attachments/assets/66210c66-fc78-418c-81f7-077b4a678e0c)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2162-Fix-text-wrapping-in-dropdown-menu-1726d73d3650816b9fcbfb4b00f26fce) by [Unito](https://www.unito.io)
