### PR TITLE
Rename Keybinding.targetSelector to targetElementId

### DIFF
--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -95,7 +95,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
@@ -104,7 +104,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       shift: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   // For number pad '+'
   {
@@ -113,7 +113,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
@@ -121,21 +121,21 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomOut',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
       key: '.'
     },
     commandId: 'Comfy.Canvas.FitView',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
       key: 'p'
     },
     commandId: 'Comfy.Canvas.ToggleSelected.Pin',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
@@ -143,7 +143,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Collapse',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
@@ -151,7 +151,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Bypass',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {
@@ -159,7 +159,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Mute',
-    targetElementId: '#graph-canvas'
+    targetElementId: 'graph-canvas'
   },
   {
     combo: {

--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -95,7 +95,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
@@ -104,7 +104,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       shift: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   // For number pad '+'
   {
@@ -113,7 +113,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
@@ -121,21 +121,21 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomOut',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
       key: '.'
     },
     commandId: 'Comfy.Canvas.FitView',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
       key: 'p'
     },
     commandId: 'Comfy.Canvas.ToggleSelected.Pin',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
@@ -143,7 +143,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Collapse',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
@@ -151,7 +151,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Bypass',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {
@@ -159,7 +159,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       ctrl: true
     },
     commandId: 'Comfy.Canvas.ToggleSelectedNodes.Mute',
-    targetSelector: '#graph-canvas'
+    targetElementId: '#graph-canvas'
   },
   {
     combo: {

--- a/src/locales/en/nodeDefs.json
+++ b/src/locales/en/nodeDefs.json
@@ -184,6 +184,9 @@
       },
       "type": {
         "name": "type"
+      },
+      "device": {
+        "name": "device"
       }
     }
   },
@@ -1221,6 +1224,9 @@
       },
       "type": {
         "name": "type"
+      },
+      "device": {
+        "name": "device"
       }
     }
   },

--- a/src/locales/fr/nodeDefs.json
+++ b/src/locales/fr/nodeDefs.json
@@ -119,6 +119,9 @@
       "clip_name": {
         "name": "clip_name"
       },
+      "device": {
+        "name": "appareil"
+      },
       "type": {
         "name": "type"
       }
@@ -1218,6 +1221,9 @@
       },
       "clip_name2": {
         "name": "nom_clip2"
+      },
+      "device": {
+        "name": "appareil"
       },
       "type": {
         "name": "type"

--- a/src/locales/ja/nodeDefs.json
+++ b/src/locales/ja/nodeDefs.json
@@ -119,6 +119,9 @@
       "clip_name": {
         "name": "clip名"
       },
+      "device": {
+        "name": "デバイス"
+      },
       "type": {
         "name": "タイプ"
       }
@@ -1218,6 +1221,9 @@
       },
       "clip_name2": {
         "name": "clip_name2"
+      },
+      "device": {
+        "name": "デバイス"
       },
       "type": {
         "name": "タイプ"

--- a/src/locales/ko/nodeDefs.json
+++ b/src/locales/ko/nodeDefs.json
@@ -119,6 +119,9 @@
       "clip_name": {
         "name": "CLIP 파일명"
       },
+      "device": {
+        "name": "장치"
+      },
       "type": {
         "name": "유형"
       }
@@ -1218,6 +1221,9 @@
       },
       "clip_name2": {
         "name": "CLIP 파일명2"
+      },
+      "device": {
+        "name": "장치"
       },
       "type": {
         "name": "유형"

--- a/src/locales/ru/nodeDefs.json
+++ b/src/locales/ru/nodeDefs.json
@@ -119,6 +119,9 @@
       "clip_name": {
         "name": "имя_clip"
       },
+      "device": {
+        "name": "устройство"
+      },
       "type": {
         "name": "тип"
       }
@@ -1218,6 +1221,9 @@
       },
       "clip_name2": {
         "name": "clip_name2"
+      },
+      "device": {
+        "name": "устройство"
       },
       "type": {
         "name": "тип"

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -119,6 +119,9 @@
       "clip_name": {
         "name": "CLIP名称"
       },
+      "device": {
+        "name": "设备"
+      },
       "type": {
         "name": "类型"
       }
@@ -1218,6 +1221,9 @@
       },
       "clip_name2": {
         "name": "CLIP名称2"
+      },
+      "device": {
+        "name": "设备"
       },
       "type": {
         "name": "类型"

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -655,7 +655,7 @@ export class ComfyApp {
         const keyCombo = KeyComboImpl.fromEvent(e)
         const keybindingStore = useKeybindingStore()
         const keybinding = keybindingStore.getKeybinding(keyCombo)
-        if (keybinding && keybinding.targetElementId === '#graph-canvas') {
+        if (keybinding && keybinding.targetElementId === 'graph-canvas') {
           useCommandStore().execute(keybinding.commandId)
           block_default = true
         }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -655,7 +655,7 @@ export class ComfyApp {
         const keyCombo = KeyComboImpl.fromEvent(e)
         const keybindingStore = useKeybindingStore()
         const keybinding = keybindingStore.getKeybinding(keyCombo)
-        if (keybinding && keybinding.targetSelector === '#graph-canvas') {
+        if (keybinding && keybinding.targetElementId === '#graph-canvas') {
           useCommandStore().execute(keybinding.commandId)
           block_default = true
         }

--- a/src/services/keybindingService.ts
+++ b/src/services/keybindingService.ts
@@ -31,7 +31,7 @@ export const useKeybindingService = () => {
     }
 
     const keybinding = keybindingStore.getKeybinding(keyCombo)
-    if (keybinding && keybinding.targetElementId !== '#graph-canvas') {
+    if (keybinding && keybinding.targetElementId !== 'graph-canvas') {
       // Prevent default browser behavior first, then execute the command
       event.preventDefault()
       await commandStore.execute(keybinding.commandId)

--- a/src/services/keybindingService.ts
+++ b/src/services/keybindingService.ts
@@ -31,7 +31,7 @@ export const useKeybindingService = () => {
     }
 
     const keybinding = keybindingStore.getKeybinding(keyCombo)
-    if (keybinding && keybinding.targetSelector !== '#graph-canvas') {
+    if (keybinding && keybinding.targetElementId !== '#graph-canvas') {
       // Prevent default browser behavior first, then execute the command
       event.preventDefault()
       await commandStore.execute(keybinding.commandId)

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -6,12 +6,12 @@ import { KeyCombo, Keybinding } from '@/types/keyBindingTypes'
 export class KeybindingImpl implements Keybinding {
   commandId: string
   combo: KeyComboImpl
-  targetSelector?: string
+  targetElementId?: string
 
   constructor(obj: Keybinding) {
     this.commandId = obj.commandId
     this.combo = new KeyComboImpl(obj.combo)
-    this.targetSelector = obj.targetSelector
+    this.targetElementId = obj.targetElementId
   }
 
   equals(other: unknown): boolean {
@@ -20,7 +20,7 @@ export class KeybindingImpl implements Keybinding {
     return raw instanceof KeybindingImpl
       ? this.commandId === raw.commandId &&
           this.combo.equals(raw.combo) &&
-          this.targetSelector === raw.targetSelector
+          this.targetElementId === raw.targetElementId
       : false
   }
 }

--- a/src/types/keyBindingTypes.ts
+++ b/src/types/keyBindingTypes.ts
@@ -13,11 +13,11 @@ export const zKeyCombo = z.object({
 export const zKeybinding = z.object({
   commandId: z.string(),
   combo: zKeyCombo,
-  // Optional target element CSS selector to limit keybinding to.
+  // Optional target element ID to limit keybinding to.
   // Note: Currently only used to distinguish between global keybindings
   // and litegraph canvas keybindings.
   // Do NOT use this field in extensions as it has no effect.
-  targetSelector: z.string().optional()
+  targetElementId: z.string().optional()
 })
 
 // Infer types from schemas


### PR DESCRIPTION
Currently there is no way to set `targetSelector` field in `Keybinding` in the UI, so it should be safe to just rename it. Change to id matching would reduce the risk of matching multiple elements which helps prepare for keybinding context implementation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2169-Rename-Keybinding-targetSelector-to-targetElementId-1726d73d365081af86b1c6ac26eee8d1) by [Unito](https://www.unito.io)
