### PR TITLE
(fix): added missing slash to "loadWorkflow" templates endpoint

### DIFF
--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -112,7 +112,7 @@ const loadWorkflow = async (id: string) => {
   let json
   if (selectedTab.value.moduleName === 'default') {
     // Default templates provided by frontend are served on this separate endpoint
-    json = await fetch(api.fileURL(`templates/${id}.json`)).then((r) =>
+    json = await fetch(api.fileURL(`/templates/${id}.json`)).then((r) =>
       r.json()
     )
   } else {


### PR DESCRIPTION
I think it's just a typo in the source code, but I can make a lot of wrong assumptions in the frontend development, because it's not my area of ​​expertise.

Without this, if ComfyUI is deployed to the `/comfy` subpath, the frontend sends requests like this:

`GET /comfytemplates/image2image.json HTTP/1.1" 404`

If you run the frontend with this slash, then the normal URLs are as they should be, namely:

`GET /comfy/templates/image2image.json HTTP/1.1" 200`

I repeat, I can be wrong and perhaps this needs to be fixed elsewhere, not here.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2174-fix-added-missing-slash-to-loadWorkflow-templates-endpoint-1736d73d36508132bffdca4806f88108) by [Unito](https://www.unito.io)
