### PR TITLE
Fix saved keybinding persistence

### DIFF
--- a/src/services/keybindingService.ts
+++ b/src/services/keybindingService.ts
@@ -84,11 +84,11 @@ export const useKeybindingService = () => {
     // Allow setting multiple values at once in settingStore
     await settingStore.set(
       'Comfy.Keybinding.NewBindings',
-      Object.values(keybindingStore.userKeybindings.value)
+      Object.values(keybindingStore.getUserKeybindings())
     )
     await settingStore.set(
       'Comfy.Keybinding.UnsetBindings',
-      Object.values(keybindingStore.userUnsetKeybindings.value)
+      Object.values(keybindingStore.getUserUnsetKeybindings())
     )
   }
 

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -105,6 +105,20 @@ export const useKeybindingStore = defineStore('keybinding', () => {
    */
   const userUnsetKeybindings = ref<Record<string, KeybindingImpl>>({})
 
+  /**
+   * Get user-defined keybindings.
+   */
+  function getUserKeybindings() {
+    return userKeybindings.value
+  }
+
+  /**
+   * Get user-defined keybindings that unset default keybindings.
+   */
+  function getUserUnsetKeybindings() {
+    return userUnsetKeybindings.value
+  }
+
   const keybindingByKeyCombo = computed<Record<string, KeybindingImpl>>(() => {
     const result: Record<string, KeybindingImpl> = {
       ...defaultKeybindings.value
@@ -262,8 +276,8 @@ export const useKeybindingStore = defineStore('keybinding', () => {
 
   return {
     keybindings,
-    userKeybindings,
-    userUnsetKeybindings,
+    getUserKeybindings,
+    getUserUnsetKeybindings,
     getKeybinding,
     getKeybindingsByCommandId,
     getKeybindingByCommandId,


### PR DESCRIPTION
This PR fixes an issue in which keybindings set in the settings dialog are not saved. `userKeybindings` raw value evaluated to undefined when accessed in `Object.values(keybindingStore.userKeybindings.value)`, interfering with the saving process.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2176-Fix-saved-keybinding-persistence-1736d73d365081168872d428332e566b) by [Unito](https://www.unito.io)
