### PR TITLE
[Refactor] Simplify keybindingStore with _.groupBy

### DIFF
--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { defineStore } from 'pinia'
 import { Ref, computed, ref, toRaw } from 'vue'
 
@@ -145,20 +146,9 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     return keybindingByKeyCombo.value[combo.serialize()]
   }
 
-  function createKeybindingsByCommandId(keybindings: KeybindingImpl[]) {
-    const result: Record<string, KeybindingImpl[]> = {}
-    for (const keybinding of keybindings) {
-      if (!(keybinding.commandId in result)) {
-        result[keybinding.commandId] = []
-      }
-      result[keybinding.commandId].push(keybinding)
-    }
-    return result
-  }
-
   const keybindingsByCommandId = computed<Record<string, KeybindingImpl[]>>(
     () => {
-      return createKeybindingsByCommandId(keybindings.value)
+      return _.groupBy(keybindings.value, 'commandId')
     }
   )
 
@@ -169,7 +159,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
   const defaultKeybindingsByCommandId = computed<
     Record<string, KeybindingImpl[]>
   >(() => {
-    return createKeybindingsByCommandId(Object.values(defaultKeybindings.value))
+    return _.groupBy(Object.values(defaultKeybindings.value), 'commandId')
   })
 
   function getKeybindingByCommandId(commandId: string) {

--- a/tests-ui/tests/store/keybindingStore.test.ts
+++ b/tests-ui/tests/store/keybindingStore.test.ts
@@ -33,6 +33,18 @@ describe('useKeybindingStore', () => {
     expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
   })
 
+  it('should get keybindings by command id', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'C', ctrl: true }
+    })
+    store.addDefaultKeybinding(keybinding)
+    expect(store.getKeybindingsByCommandId('test.command')).toEqual([
+      keybinding
+    ])
+  })
+
   it('should override default keybindings with user keybindings', () => {
     const store = useKeybindingStore()
     const defaultKeybinding = new KeybindingImpl({


### PR DESCRIPTION
Replace manual grouping with `_.groupBy`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2180-Refactor-Simplify-keybindingStore-with-_-groupBy-1746d73d3650815ebe6bd2a9094841da) by [Unito](https://www.unito.io)
