### PR TITLE
[BugFix] Migrate deprecated Comfy.Keybinding.UnsetBindings values

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -423,7 +423,16 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Keybindings unset by the user',
     type: 'hidden',
     defaultValue: [] as Keybinding[],
-    versionAdded: '1.3.7'
+    versionAdded: '1.3.7',
+    versionModified: '1.7.3',
+    migrateDeprecatedValue: (value: any[]) => {
+      return value.map((keybinding) => {
+        if (keybinding['targetSelector'] === '#graph-canvas') {
+          keybinding['targetElementId'] = 'graph-canvas'
+        }
+        return keybinding
+      })
+    }
   },
   {
     id: 'Comfy.Keybinding.NewBindings',


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2183

Follow-up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2169. Although new binding cannot have `targetSelector` field, the unset bindings can have. Migrate these existing deprecated values.