### PR TITLE
Fix search result category text on light theme

### DIFF
--- a/src/components/searchbox/NodeSearchItem.vue
+++ b/src/components/searchbox/NodeSearchItem.vue
@@ -17,7 +17,7 @@
       </div>
       <div
         v-if="showCategory"
-        class="option-category font-light text-sm text-gray-400 overflow-hidden text-ellipsis whitespace-nowrap"
+        class="option-category font-light text-sm text-muted overflow-hidden text-ellipsis whitespace-nowrap"
       >
         {{ nodeDef.category.replaceAll('/', ' > ') }}
       </div>


### PR DESCRIPTION
Changes relatively static gray text class to `text-muted` utility class in category text of node search result. `text-muted` adheres to the theme and is visible in light mode. Before (left) and after (right):

![text-muted](https://github.com/user-attachments/assets/3e0bf149-7976-42d6-9a97-7feb4c842719)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2198-Fix-search-result-category-text-on-light-theme-1756d73d365081a99ad1c337d35079b6) by [Unito](https://www.unito.io)
