### PR TITLE
[Docs] Extract comfy workflow zod schema as json schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ browser_tests/*/*-win32.png
 dist.zip
 
 /temp/
+
+# Generated JSON Schemas
+/schemas/

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "locale": "lobe-i18n locale",
-    "collect-i18n": "playwright test --config=playwright.i18n.config.ts"
+    "collect-i18n": "playwright test --config=playwright.i18n.config.ts",
+    "json-schema": "tsx scripts/generate-json-schema.ts"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -1,0 +1,35 @@
+import fs from 'fs'
+import path from 'path'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+
+import { zComfyWorkflow, zComfyWorkflow1 } from '../src/types/comfyWorkflow'
+
+// Convert both workflow schemas to JSON Schema
+const workflow04Schema = zodToJsonSchema(zComfyWorkflow, {
+  name: 'ComfyWorkflow0_4',
+  $refStrategy: 'none'
+})
+
+const workflow1Schema = zodToJsonSchema(zComfyWorkflow1, {
+  name: 'ComfyWorkflow1_0',
+  $refStrategy: 'none'
+})
+
+// Create output directory if it doesn't exist
+const outputDir = './schemas'
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true })
+}
+
+// Write schemas to files
+fs.writeFileSync(
+  path.join(outputDir, 'workflow-0_4.json'),
+  JSON.stringify(workflow04Schema, null, 2)
+)
+
+fs.writeFileSync(
+  path.join(outputDir, 'workflow-1_0.json'),
+  JSON.stringify(workflow1Schema, null, 2)
+)
+
+console.log('JSON Schemas generated successfully!')

--- a/src/types/comfyWorkflow.ts
+++ b/src/types/comfyWorkflow.ts
@@ -200,7 +200,7 @@ export const zComfyWorkflow = z
   .passthrough()
 
 /** Schema version 1 */
-const zComfyWorkflow1 = z
+export const zComfyWorkflow1 = z
   .object({
     version: z.literal(1),
     config: zConfig.optional().nullable(),


### PR DESCRIPTION
Adds a script that extracts comfy workflow format schema from zod to json schema. JSON schema is language independent which is more suitable for documentation / rfc purpose.

Sample json schema extracted: 
[workflow-1_0.json](https://github.com/user-attachments/files/18364270/workflow-1_0.json)


Follow-up:
- Host the json schema on https://github.com/Comfy-Org/docs

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2206-Docs-Extract-comfy-workflow-zod-schema-as-json-schema-1766d73d365081a8ab6fdf9f9a7e51e0) by [Unito](https://www.unito.io)
