### PR TITLE
[BrowserTest] Replace ComfyPage.reload with ComfyPage.setup

### DIFF
--- a/browser_tests/colorPalette.spec.ts
+++ b/browser_tests/colorPalette.spec.ts
@@ -150,7 +150,7 @@ test.describe('Color Palette', () => {
     await comfyPage.setSetting('Comfy.CustomColorPalettes', customColorPalettes)
     // Reload to apply the new setting. Setting Comfy.CustomColorPalettes directly
     // doesn't update the store immediately.
-    await comfyPage.reload()
+    await comfyPage.setup()
 
     await comfyPage.setSetting('Comfy.ColorPalette', 'obsidian_dark')
     await expect(comfyPage.canvas).toHaveScreenshot(

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -369,11 +369,6 @@ export class ComfyPage {
     }, settingId)
   }
 
-  async reload({ clearStorage = true }: { clearStorage?: boolean } = {}) {
-    await this.page.reload({ timeout: 15000 })
-    await this.setup({ clearStorage })
-  }
-
   async goto() {
     await this.page.goto(this.url)
   }

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -593,7 +593,7 @@ test.describe('Load workflow', () => {
   }) => {
     await comfyPage.loadWorkflow('single_ksampler')
     await expect(comfyPage.canvas).toHaveScreenshot('single_ksampler.png')
-    await comfyPage.reload({ clearStorage: false })
+    await comfyPage.setup({ clearStorage: false })
     await expect(comfyPage.canvas).toHaveScreenshot('single_ksampler.png')
   })
 
@@ -610,7 +610,7 @@ test.describe('Load workflow', () => {
     await expect(comfyPage.canvas).toHaveScreenshot(
       'single_ksampler_modified.png'
     )
-    await comfyPage.reload({ clearStorage: false })
+    await comfyPage.setup({ clearStorage: false })
     await expect(comfyPage.canvas).toHaveScreenshot(
       'single_ksampler_modified.png'
     )

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -21,7 +21,7 @@ test.describe('Menu', () => {
     expect(await comfyPage.menu.getThemeId()).toBe('light')
 
     // Theme id should persist after reload.
-    await comfyPage.reload()
+    await comfyPage.setup()
     expect(await comfyPage.menu.getThemeId()).toBe('light')
 
     await comfyPage.menu.toggleTheme()
@@ -569,7 +569,7 @@ test.describe('Menu', () => {
       })
 
       await comfyPage.setSetting('Comfy.Locale', 'zh')
-      await comfyPage.reload()
+      await comfyPage.setup()
 
       const downloadedContentZh = await comfyPage.getExportedWorkflow({
         api: false


### PR DESCRIPTION
`ComfyPage.setup` contains a navigation, which is essentially reload. `ComfyPage.reload` is doing extra unnecessary `reload` navigation call.

This PR should fix flaky test `Can export same workflow with different locales`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2208-BrowserTest-Replace-ComfyPage-reload-with-ComfyPage-setup-1766d73d36508146bf86d6567915f003) by [Unito](https://www.unito.io)
