### PR TITLE
[Style] Set fixed top menu bar height

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -10,6 +10,7 @@
   --bg-color: #fff;
   --comfy-menu-bg: #353535;
   --comfy-menu-secondary-bg: #292929;
+  --comfy-topbar-height: 38.75px;
   --comfy-input-bg: #222;
   --input-text: #ddd;
   --descrip-text: #999;

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -10,7 +10,7 @@
   --bg-color: #fff;
   --comfy-menu-bg: #353535;
   --comfy-menu-secondary-bg: #292929;
-  --comfy-topbar-height: 38.75px;
+  --comfy-topbar-height: 2.421875rem;
   --comfy-input-bg: #222;
   --input-text: #ddd;
   --descrip-text: #999;

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -82,6 +82,7 @@ eventBus.on((event: string, payload: any) => {
 <style scoped>
 .comfyui-menu {
   width: 100vw;
+  height: var(--comfy-topbar-height);
   background: var(--comfy-menu-bg);
   color: var(--fg-color);
   box-shadow: var(--bar-shadow);
@@ -91,7 +92,6 @@ eventBus.on((event: string, payload: any) => {
   z-index: 1000;
   order: 0;
   grid-column: 1/-1;
-  max-height: 90vh;
 }
 
 .comfyui-menu.dropzone {


### PR DESCRIPTION
Ref:
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1992
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/2188

Having top menu bar height vary with content is generally a bad design, as the extra height really screws up the overall styles. Considering we are also hosting extension-added widgets on the top menu bar. Using REM here to account different browser font size.