### PR TITLE
[Style] Replace px with rem in sidebar width

### DIFF
--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -71,11 +71,11 @@ const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
 
 <style>
 :root {
-  --sidebar-width: 64px;
+  --sidebar-width: 4rem;
   --sidebar-icon-size: 1.5rem;
 }
 :root .small-sidebar {
-  --sidebar-width: 40px;
+  --sidebar-width: 2.5rem;
   --sidebar-icon-size: 1rem;
 }
 </style>


### PR DESCRIPTION
Before (Setting browser font to `Small`):

![image](https://github.com/user-attachments/assets/fe321dca-0d31-46bb-b269-605fa19f5e72)

After:

![image](https://github.com/user-attachments/assets/b58e3126-4464-4196-9bd9-8b2b976d5f78)

Context: 1rem = 16px when user set the browser font to `Medium`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2210-Style-Replace-px-with-rem-in-sidebar-width-1766d73d3650813cb815ca03134e1573) by [Unito](https://www.unito.io)
