### PR TITLE
[Desktop] Set window action buttons style

### DIFF
--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -42,7 +42,7 @@ import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import { app } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { showNativeMenu } from '@/utils/envUtil'
+import { electronAPI, isElectron, showNativeMenu } from '@/utils/envUtil'
 
 const workspaceState = useWorkspaceStore()
 const settingStore = useSettingStore()
@@ -75,6 +75,14 @@ eventBus.on((event: string, payload: any) => {
   if (event === 'updateHighlight') {
     isDropZone.value = payload.isDragging
     isDroppable.value = payload.isOverlapping && payload.isDragging
+  }
+})
+
+onMounted(() => {
+  if (isElectron()) {
+    electronAPI().changeTheme({
+      height: topMenuRef.value.getBoundingClientRect().height
+    })
   }
 })
 </script>

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -68,7 +68,7 @@ watch(
 
     if (isElectron()) {
       electronAPI().changeTheme({
-        color: newTheme.colors.comfy_base['comfy-menu-bg'],
+        color: 'rgba(0, 0, 0, 0)',
         symbolColor: newTheme.colors.comfy_base['input-text']
       })
     }

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -46,6 +46,7 @@ import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { StatusWsMessageStatus } from '@/types/apiTypes'
+import { electronAPI, isElectron } from '@/utils/envUtil'
 
 setupAutoQueueHandler()
 
@@ -63,6 +64,13 @@ watch(
       document.body.classList.remove(DARK_THEME_CLASS)
     } else {
       document.body.classList.add(DARK_THEME_CLASS)
+    }
+
+    if (isElectron()) {
+      electronAPI().changeTheme({
+        color: newTheme.colors.comfy_base['comfy-menu-bg'],
+        symbolColor: newTheme.colors.comfy_base['input-text']
+      })
     }
   },
   { immediate: true }

--- a/src/views/templates/BaseViewTemplate.vue
+++ b/src/views/templates/BaseViewTemplate.vue
@@ -26,12 +26,12 @@ const props = withDefaults(
 )
 
 const darkTheme = {
-  color: '#171717',
+  color: 'rgba(0, 0, 0, 0)',
   symbolColor: '#d4d4d4'
 }
 
 const lightTheme = {
-  color: '#d4d4d4',
+  color: 'rgba(0, 0, 0, 0)',
   symbolColor: '#171717'
 }
 

--- a/src/views/templates/BaseViewTemplate.vue
+++ b/src/views/templates/BaseViewTemplate.vue
@@ -12,6 +12,10 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+
+import { electronAPI, isElectron } from '@/utils/envUtil'
+
 const props = withDefaults(
   defineProps<{
     dark: boolean
@@ -20,4 +24,20 @@ const props = withDefaults(
     dark: false
   }
 )
+
+const darkTheme = {
+  color: '#171717',
+  symbolColor: '#d4d4d4'
+}
+
+const lightTheme = {
+  color: '#d4d4d4',
+  symbolColor: '#171717'
+}
+
+onMounted(() => {
+  if (isElectron()) {
+    electronAPI().changeTheme(props.dark ? darkTheme : lightTheme)
+  }
+})
 </script>

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -53,7 +53,8 @@ const mockElectronAPI: Plugin = {
           },
           getElectronVersion: () => Promise.resolve('1.0.0'),
           getComfyUIVersion: () => '9.9.9',
-          getPlatform: () => 'win32'
+          getPlatform: () => 'win32',
+          changeTheme: () => {}
         };`
       }
     ]


### PR DESCRIPTION
Adjust window action button's style.

![image](https://github.com/user-attachments/assets/440415eb-38a1-4ba1-977d-3e734aeb1a46)

![image](https://github.com/user-attachments/assets/4ab96099-5110-4ad7-8ac4-246f38b14b02)

The location issue will be fixed in a separate PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2214-Desktop-Set-window-action-buttons-style-1776d73d365081f5b289e1e3075636cf) by [Unito](https://www.unito.io)
