### PR TITLE
Support custom SaveImage nodes when registering SaveImageExtraOutput

### DIFF
--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -16,8 +16,10 @@ app.registerExtension({
           : undefined
 
         const widget = this.widgets.find((w) => w.name === 'filename_prefix')
-        widget.serializeValue = () => {
-          return applyTextReplacements(app, widget.value)
+        if (widget) {
+          widget.serializeValue = () => {
+            return applyTextReplacements(app, widget.value)
+          }
         }
 
         return r

--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -7,7 +7,7 @@ import { applyTextReplacements } from '../../scripts/utils'
 app.registerExtension({
   name: 'Comfy.SaveImageExtraOutput',
   async beforeRegisterNodeDef(nodeType, nodeData, app) {
-    if (nodeData.name === 'SaveImage' || nodeData.name === 'SaveAnimatedWEBP') {
+    if (nodeData.name.includes('SaveImage') || nodeData.name === 'SaveAnimatedWEBP') {
       const onNodeCreated = nodeType.prototype.onNodeCreated
       // When the SaveImage node is created we want to override the serialization of the output name widget to run our S&R
       nodeType.prototype.onNodeCreated = function () {


### PR DESCRIPTION
Updated the conditional logic to use `includes` for matching `SaveImage` node variants. This ensures broader compatibility with nodes sharing similar naming conventions while maintaining functionality for `SaveAnimatedWEBP`.

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2218

---

This PR seeks to extend some support for custom `SaveImage` nodes so that they may also make use of the rather bespoke functionality surrounding the native `SaveImage` and `SaveAnimatedWEBP` nodes.

I've chosen to suggest an extremely lite implementation here, as I suspect we may be expecting some more broadly encompassing work later down the track.

The additional guard included is to make sure that we don't throw a tantrum if we find a match but that match doesn't yet have a `filename_prefix` associated with it.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2219-Support-custom-SaveImage-nodes-when-registering-SaveImageExtraOutput-1776d73d365081ada3efcc8a1862e639) by [Unito](https://www.unito.io)
