### PR TITLE
[Style] Reduce opacity on workflow tabs scrollbar

### DIFF
--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -6,6 +6,7 @@
         class: 'p-0 w-full',
         onwheel: handleWheel
       }"
+      pt:barX="opacity-50"
     >
       <SelectButton
         class="workflow-tabs bg-transparent"

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -6,7 +6,7 @@
         class: 'p-0 w-full',
         onwheel: handleWheel
       }"
-      pt:barX="opacity-50"
+      pt:barX="h-1"
     >
       <SelectButton
         class="workflow-tabs bg-transparent"
@@ -198,5 +198,11 @@ const handleWheel = (event: WheelEvent) => {
 
 :deep(.p-togglebutton) .close-button {
   @apply invisible;
+}
+
+/* Scrollbar half opacity to avoid blocking the active tab bottom border */
+:deep(.p-scrollpanel:hover .p-scrollpanel-bar),
+:deep(.p-scrollpanel:active .p-scrollpanel-bar) {
+  opacity: 0.5;
 }
 </style>


### PR DESCRIPTION
Reduce the opacity so the primary color border of the tab is more blocked by the scrollbar. Also reduce the scrollbar height.

Before:

https://github.com/user-attachments/assets/8ce4757f-0af6-46e0-b577-f5fc9d232bb9


After:

https://github.com/user-attachments/assets/d93dc5b1-f15e-4cb3-8d7a-67c112693e99

