### PR TITLE
Allow Ctrl + C to send interrupt in terminal

### DIFF
--- a/src/hooks/bottomPanelTabs/useTerminal.ts
+++ b/src/hooks/bottomPanelTabs/useTerminal.ts
@@ -14,11 +14,14 @@ export function useTerminal(element: Ref<HTMLElement>) {
   terminal.loadAddon(fitAddon)
 
   terminal.attachCustomKeyEventHandler((event) => {
-    if (event.type === 'keydown' && (event.ctrlKey || event.metaKey)) {
-      if (event.key === 'c' || event.key === 'v') {
-        // Allow default browser copy/paste handling
-        return false
-      }
+    // Allow default browser copy/paste handling
+    if (
+      event.type === 'keydown' &&
+      (event.ctrlKey || event.metaKey) &&
+      ((event.key === 'c' && terminal.hasSelection()) || event.key === 'v')
+    ) {
+      // TODO: Deselect text after copy/paste; use IPC.
+      return false
     }
     return true
   })


### PR DESCRIPTION
Interrupt is sent to terminal when entering `Ctrl` + `C` with no text selected.

Adds TODO for additional logic:
- Deselect all text immediately after copying to clipboard via `Ctrl` + `C`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2221-Allow-Ctrl-C-to-send-interrupt-in-terminal-1776d73d3650811f87f4ccf688f2c52d) by [Unito](https://www.unito.io)
