### PR TITLE
[Desktop] Allow dragging window on empty titlebar

### DIFF
--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -9,7 +9,7 @@
       <h1 class="comfyui-logo mx-2 app-drag">ComfyUI</h1>
       <CommandMenubar />
       <Divider layout="vertical" class="mx-2" />
-      <div class="flex-grow min-w-0">
+      <div class="flex-grow min-w-0 app-drag h-full">
         <WorkflowTabs v-if="workflowTabsPosition === 'Topbar'" />
       </div>
       <div class="comfyui-menu-right" ref="menuRight"></div>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="workflow-tabs-container flex flex-row w-full">
+  <div class="workflow-tabs-container flex flex-row max-w-full">
     <ScrollPanel
-      class="overflow-hidden"
+      class="overflow-hidden no-drag"
       :pt:content="{
         class: 'p-0 w-full',
         onwheel: handleWheel
@@ -28,7 +28,7 @@
     </ScrollPanel>
     <Button
       v-tooltip="{ value: $t('sideToolbar.newBlankWorkflow'), showDelay: 300 }"
-      class="new-blank-workflow-button flex-shrink-0"
+      class="new-blank-workflow-button flex-shrink-0 no-drag"
       icon="pi pi-plus"
       text
       severity="secondary"


### PR DESCRIPTION
Red area are drag handle of the native window:

![image](https://github.com/user-attachments/assets/f1df4e99-2499-47c5-ad3d-bd6b431dd976)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2222-Desktop-Allow-dragging-window-on-empty-titlebar-1776d73d3650810cacd1c9f95f973955) by [Unito](https://www.unito.io)
