### PR TITLE
[Style] Set topbar height to 2.5rem (40px)

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -10,7 +10,7 @@
   --bg-color: #fff;
   --comfy-menu-bg: #353535;
   --comfy-menu-secondary-bg: #292929;
-  --comfy-topbar-height: 2.421875rem;
+  --comfy-topbar-height: 2.5rem;
   --comfy-input-bg: #222;
   --input-text: #ddd;
   --descrip-text: #999;


### PR DESCRIPTION
Ref: https://github.com/Comfy-Org/ComfyUI_frontend/pull/2209#issuecomment-2584300926

Previous height was calculated from the content, which resulted in a `38.5px` fractional number.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2224-Style-Set-topbar-height-to-2-5rem-40px-1776d73d365081a3b9a1f952fb40d392) by [Unito](https://www.unito.io)
