### PR TITLE
[Desktop] Fix server start view layout

### DIFF
--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -1,43 +1,45 @@
 <template>
   <BaseViewTemplate dark class="flex-col">
-    <h2 class="text-2xl font-bold">
-      {{ t(`serverStart.process.${status}`) }}
-      <span v-if="status === ProgressStatus.ERROR">
-        v{{ electronVersion }}
-      </span>
-    </h2>
-    <div
-      v-if="status === ProgressStatus.ERROR"
-      class="flex flex-col items-center gap-4"
-    >
-      <div class="flex items-center my-4 gap-2">
+    <div class="flex flex-col w-full h-full items-center">
+      <h2 class="text-2xl font-bold">
+        {{ t(`serverStart.process.${status}`) }}
+        <span v-if="status === ProgressStatus.ERROR">
+          v{{ electronVersion }}
+        </span>
+      </h2>
+      <div
+        v-if="status === ProgressStatus.ERROR"
+        class="flex flex-col items-center gap-4"
+      >
+        <div class="flex items-center my-4 gap-2">
+          <Button
+            icon="pi pi-flag"
+            severity="secondary"
+            :label="t('serverStart.reportIssue')"
+            @click="reportIssue"
+          />
+          <Button
+            icon="pi pi-file"
+            severity="secondary"
+            :label="t('serverStart.openLogs')"
+            @click="openLogs"
+          />
+          <Button
+            icon="pi pi-refresh"
+            :label="t('serverStart.reinstall')"
+            @click="reinstall"
+          />
+        </div>
         <Button
-          icon="pi pi-flag"
+          v-if="!terminalVisible"
+          icon="pi pi-search"
           severity="secondary"
-          :label="t('serverStart.reportIssue')"
-          @click="reportIssue"
-        />
-        <Button
-          icon="pi pi-file"
-          severity="secondary"
-          :label="t('serverStart.openLogs')"
-          @click="openLogs"
-        />
-        <Button
-          icon="pi pi-refresh"
-          :label="t('serverStart.reinstall')"
-          @click="reinstall"
+          :label="t('serverStart.showTerminal')"
+          @click="terminalVisible = true"
         />
       </div>
-      <Button
-        v-if="!terminalVisible"
-        icon="pi pi-search"
-        severity="secondary"
-        :label="t('serverStart.showTerminal')"
-        @click="terminalVisible = true"
-      />
+      <BaseTerminal v-show="terminalVisible" @created="terminalCreated" />
     </div>
-    <BaseTerminal v-show="terminalVisible" @created="terminalCreated" />
   </BaseViewTemplate>
 </template>
 

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -54,7 +54,11 @@ const mockElectronAPI: Plugin = {
           getElectronVersion: () => Promise.resolve('1.0.0'),
           getComfyUIVersion: () => '9.9.9',
           getPlatform: () => 'win32',
-          changeTheme: () => {}
+          changeTheme: () => {},
+          Config: {
+            setWindowStyle: () => {},
+            getWindowStyle: () => Promise.resolve('default')
+          }
         };`
       }
     ]


### PR DESCRIPTION
Previous `BaseViewTemplate` change breaks the layout in the server start view. `BaseViewTemplate` should have a single children for layout consistency.