### PR TITLE
Add bookmark option in workflow tab context menu

### DIFF
--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -50,7 +50,7 @@ import { useI18n } from 'vue-i18n'
 import WorkflowTab from '@/components/topbar/WorkflowTab.vue'
 import { useWorkflowService } from '@/services/workflowService'
 import { useCommandStore } from '@/stores/commandStore'
-import { ComfyWorkflow } from '@/stores/workflowStore'
+import { ComfyWorkflow, useWorkflowBookmarkStore } from '@/stores/workflowStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
@@ -67,6 +67,7 @@ const { t } = useI18n()
 const workspaceStore = useWorkspaceStore()
 const workflowStore = useWorkflowStore()
 const workflowService = useWorkflowService()
+const workflowBookmarkStore = useWorkflowBookmarkStore()
 const rightClickedTab = ref<WorkflowOption>(null)
 const menu = ref()
 
@@ -154,6 +155,13 @@ const contextMenuItems = computed(() => {
           ...options.value.slice(0, index)
         ]),
       disabled: options.value.length <= 1
+    },
+    {
+      label: workflowBookmarkStore.isBookmarked(tab.workflow.path)
+        ? t('tabMenu.removeFromBookmarks')
+        : t('tabMenu.addToBookmarks'),
+      command: () => workflowBookmarkStore.toggleBookmarked(tab.workflow.path),
+      disabled: tab.workflow.isTemporary
     }
   ]
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -279,7 +279,9 @@
     "closeTab": "Close Tab",
     "closeTabsToLeft": "Close Tabs to Left",
     "closeTabsToRight": "Close Tabs to Right",
-    "closeOtherTabs": "Close Other Tabs"
+    "closeOtherTabs": "Close Other Tabs",
+    "addToBookmarks": "Add to Bookmarks",
+    "removeFromBookmarks": "Remove from Bookmarks"
   },
   "templateWorkflows": {
     "title": "Get Started with a Template",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -623,11 +623,13 @@
     "workflows": "Flux de travail"
   },
   "tabMenu": {
+    "addToBookmarks": "Ajouter aux Favoris",
     "closeOtherTabs": "Fermer les autres onglets",
     "closeTab": "Fermer l'onglet",
     "closeTabsToLeft": "Fermer les onglets à gauche",
     "closeTabsToRight": "Fermer les onglets à droite",
-    "duplicateTab": "Dupliquer l'onglet"
+    "duplicateTab": "Dupliquer l'onglet",
+    "removeFromBookmarks": "Retirer des Favoris"
   },
   "templateWorkflows": {
     "template": {

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -623,11 +623,13 @@
     "workflows": "ワークフロー"
   },
   "tabMenu": {
+    "addToBookmarks": "ブックマークに追加",
     "closeOtherTabs": "他のタブを閉じる",
     "closeTab": "タブを閉じる",
     "closeTabsToLeft": "左のタブを閉じる",
     "closeTabsToRight": "右のタブを閉じる",
-    "duplicateTab": "タブを複製"
+    "duplicateTab": "タブを複製",
+    "removeFromBookmarks": "ブックマークから削除"
   },
   "templateWorkflows": {
     "template": {

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -623,11 +623,13 @@
     "workflows": "워크플로"
   },
   "tabMenu": {
+    "addToBookmarks": "북마크에 추가",
     "closeOtherTabs": "다른 탭 닫기",
     "closeTab": "탭 닫기",
     "closeTabsToLeft": "왼쪽 탭 닫기",
     "closeTabsToRight": "오른쪽 탭 닫기",
-    "duplicateTab": "탭 복제"
+    "duplicateTab": "탭 복제",
+    "removeFromBookmarks": "북마크에서 제거"
   },
   "templateWorkflows": {
     "template": {

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -623,11 +623,13 @@
     "workflows": "Рабочие процессы"
   },
   "tabMenu": {
+    "addToBookmarks": "Добавить в закладки",
     "closeOtherTabs": "Закрыть другие вкладки",
     "closeTab": "Закрыть вкладку",
     "closeTabsToLeft": "Закрыть вкладки слева",
     "closeTabsToRight": "Закрыть вкладки справа",
-    "duplicateTab": "Дублировать вкладку"
+    "duplicateTab": "Дублировать вкладку",
+    "removeFromBookmarks": "Удалить из закладок"
   },
   "templateWorkflows": {
     "template": {

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -623,11 +623,13 @@
     "workflows": "工作流"
   },
   "tabMenu": {
+    "addToBookmarks": "添加到书签",
     "closeOtherTabs": "关闭其他标签",
     "closeTab": "关闭标签",
     "closeTabsToLeft": "关闭左侧标签",
     "closeTabsToRight": "关闭右侧标签",
-    "duplicateTab": "复制标签"
+    "duplicateTab": "复制标签",
+    "removeFromBookmarks": "从书签中移除"
   },
   "templateWorkflows": {
     "template": {


### PR DESCRIPTION
Introduces an option in the workflow tabs context menu to (un)bookmark the workflow. The option is disabled if the workflow is temporary.

https://github.com/user-attachments/assets/ac62288f-29e1-42ef-96cb-d56bc36df899

Requested in Discord by hicho.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2231-Add-bookmark-option-in-workflow-tab-context-menu-1796d73d36508116bee2f541ba2ee566) by [Unito](https://www.unito.io)
