### PR TITLE
[Style] Visual improvements to WorkflowTabs

### DIFF
--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -8,7 +8,6 @@
     >
       <h1 class="comfyui-logo mx-2 app-drag">ComfyUI</h1>
       <CommandMenubar />
-      <!-- <Divider layout="vertical" class="mx-2" /> -->
       <div class="flex-grow min-w-0 app-drag h-full">
         <WorkflowTabs v-if="workflowTabsPosition === 'Topbar'" />
       </div>

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -8,7 +8,7 @@
     >
       <h1 class="comfyui-logo mx-2 app-drag">ComfyUI</h1>
       <CommandMenubar />
-      <Divider layout="vertical" class="mx-2" />
+      <!-- <Divider layout="vertical" class="mx-2" /> -->
       <div class="flex-grow min-w-0 app-drag h-full">
         <WorkflowTabs v-if="workflowTabsPosition === 'Topbar'" />
       </div>
@@ -42,7 +42,6 @@
 <script setup lang="ts">
 import { useEventBus } from '@vueuse/core'
 import Button from 'primevue/button'
-import Divider from 'primevue/divider'
 import { computed, onMounted, provide, ref } from 'vue'
 
 import Actionbar from '@/components/actionbar/ComfyActionbar.vue'

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -172,14 +172,23 @@ const handleWheel = (event: WheelEvent) => {
 <style scoped>
 :deep(.p-togglebutton) {
   @apply p-0 bg-transparent rounded-none flex-shrink-0 relative;
+  border: 0px;
+  border-right: 1px solid var(--border-color);
 }
 
 :deep(.p-togglebutton::before) {
   @apply hidden;
 }
 
+:deep(.p-togglebutton:first-child) {
+  border-left: 1px solid var(--border-color);
+}
+
+:deep(.p-togglebutton:not(:first-child)) {
+  border-left: none;
+}
+
 :deep(.p-togglebutton.p-togglebutton-checked) {
-  border: 0;
   border-bottom: 1px solid var(--p-button-text-primary-color);
   height: 100%;
 }

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -170,21 +170,17 @@ const handleWheel = (event: WheelEvent) => {
 </script>
 
 <style scoped>
-:deep(.p-togglebutton::before) {
-  @apply hidden;
-}
-
 :deep(.p-togglebutton) {
   @apply p-0 bg-transparent rounded-none flex-shrink-0 relative;
+}
+
+:deep(.p-togglebutton::before) {
+  @apply hidden;
 }
 
 :deep(.p-togglebutton.p-togglebutton-checked) {
   border: 0;
   border-bottom: 1px solid var(--p-button-text-primary-color);
-  height: 100%;
-}
-
-:deep(.p-scrollpanel-content) {
   height: 100%;
 }
 
@@ -203,6 +199,10 @@ const handleWheel = (event: WheelEvent) => {
 
 :deep(.p-togglebutton) .close-button {
   @apply invisible;
+}
+
+:deep(.p-scrollpanel-content) {
+  height: 100%;
 }
 
 /* Scrollbar half opacity to avoid blocking the active tab bottom border */

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -179,8 +179,8 @@ const handleWheel = (event: WheelEvent) => {
 }
 
 :deep(.p-togglebutton.p-togglebutton-checked) {
-  border-bottom-width: 1px;
-  border-bottom-color: var(--p-button-text-primary-color);
+  border: 0;
+  border-bottom: 1px solid var(--p-button-text-primary-color);
 }
 
 :deep(.p-togglebutton:not(.p-togglebutton-checked)) {

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -205,4 +205,8 @@ const handleWheel = (event: WheelEvent) => {
 :deep(.p-scrollpanel:active .p-scrollpanel-bar) {
   opacity: 0.5;
 }
+
+:deep(.p-selectbutton) {
+  border-radius: 0;
+}
 </style>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -171,9 +171,8 @@ const handleWheel = (event: WheelEvent) => {
 
 <style scoped>
 :deep(.p-togglebutton) {
-  @apply p-0 bg-transparent rounded-none flex-shrink-0 relative;
-  border: 0px;
-  border-right: 1px solid var(--border-color);
+  @apply p-0 bg-transparent rounded-none flex-shrink-0 relative border-0 border-r border-solid;
+  border-right-color: var(--border-color);
 }
 
 :deep(.p-togglebutton::before) {
@@ -181,20 +180,21 @@ const handleWheel = (event: WheelEvent) => {
 }
 
 :deep(.p-togglebutton:first-child) {
-  border-left: 1px solid var(--border-color);
+  @apply border-l border-solid;
+  border-left-color: var(--border-color);
 }
 
 :deep(.p-togglebutton:not(:first-child)) {
-  border-left: none;
+  @apply border-l-0;
 }
 
 :deep(.p-togglebutton.p-togglebutton-checked) {
-  border-bottom: 1px solid var(--p-button-text-primary-color);
-  height: 100%;
+  @apply border-b border-solid h-full;
+  border-bottom-color: var(--p-button-text-primary-color);
 }
 
 :deep(.p-togglebutton:not(.p-togglebutton-checked)) {
-  opacity: 0.75;
+  @apply opacity-75;
 }
 
 :deep(.p-togglebutton-checked) .close-button,
@@ -211,17 +211,16 @@ const handleWheel = (event: WheelEvent) => {
 }
 
 :deep(.p-scrollpanel-content) {
-  height: 100%;
+  @apply h-full;
 }
 
 /* Scrollbar half opacity to avoid blocking the active tab bottom border */
 :deep(.p-scrollpanel:hover .p-scrollpanel-bar),
 :deep(.p-scrollpanel:active .p-scrollpanel-bar) {
-  opacity: 0.5;
+  @apply opacity-50;
 }
 
 :deep(.p-selectbutton) {
-  border-radius: 0;
-  height: 100%;
+  @apply rounded-none h-full;
 }
 </style>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="workflow-tabs-container flex flex-row max-w-full">
+  <div class="workflow-tabs-container flex flex-row max-w-full h-full">
     <ScrollPanel
       class="overflow-hidden no-drag"
       :pt:content="{
@@ -181,6 +181,11 @@ const handleWheel = (event: WheelEvent) => {
 :deep(.p-togglebutton.p-togglebutton-checked) {
   border: 0;
   border-bottom: 1px solid var(--p-button-text-primary-color);
+  height: 100%;
+}
+
+:deep(.p-scrollpanel-content) {
+  height: 100%;
 }
 
 :deep(.p-togglebutton:not(.p-togglebutton-checked)) {
@@ -208,5 +213,6 @@ const handleWheel = (event: WheelEvent) => {
 
 :deep(.p-selectbutton) {
   border-radius: 0;
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
### Changes

- Removed black border leftover from PrimeVue
- Removed border radius on tabs to make them align with their blue lines when moved under TopMenubar
- Set heights to make blue line align with the bottom of TopMenubar

### Before
![image](https://github.com/user-attachments/assets/1d424d42-9e9e-411a-9464-404d3166ce04)
![image](https://github.com/user-attachments/assets/a4e24e0a-5e20-42e9-b66c-f58c578f53e6)

### After
![image](https://github.com/user-attachments/assets/4334e5d9-9d20-4b45-a561-e1817e1fcdbc)
![image](https://github.com/user-attachments/assets/3fe98305-bbfe-413f-9eb5-fd5b9c91098f)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2232-Style-Visual-improvements-to-WorkflowTabs-1796d73d3650815fbaf3f0c7bad3d4d4) by [Unito](https://www.unito.io)
