### PR TITLE
[CI] Fix vite config condition

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Build project
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          CI: false
+          NODE_ENV: production
         run: |
           npm ci
           npm run build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Build project
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          NODE_ENV: production
         run: |
           npm ci
           npm run build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Build project
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          CI: false
           NODE_ENV: production
         run: |
           npm ci

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -180,11 +180,7 @@ export default defineConfig({
       process.env.npm_package_version
     ),
     __SENTRY_ENABLED__: JSON.stringify(
-      !(
-        process.env.CI === 'true' ||
-        process.env.NODE_ENV === 'development' ||
-        !process.env.SENTRY_DSN
-      )
+      !(process.env.NODE_ENV === 'development' || !process.env.SENTRY_DSN)
     ),
     __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || '')
   },


### PR DESCRIPTION
Enables sentry in release workflow. By mistake, the current condition is `false` in all actions runner envs:

```ts
!(
  process.env.CI === 'true' ||
  process.env.NODE_ENV === 'development' ||
  !process.env.SENTRY_DSN
)
```

The condition in this PR will be `false` in all actions runner envs except those that set `SENTRY_DSN`, which includes only the release workflow:

```ts
!(process.env.NODE_ENV === 'development' || !process.env.SENTRY_DSN)
```

Ref:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/2229

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2235-CI-Fix-vite-config-condition-1796d73d365081abb23ed1a239cd1250) by [Unito](https://www.unito.io)
