### PR TITLE
Restore all open workflows on load

### DIFF
--- a/browser_tests/fixtures/components/Topbar.ts
+++ b/browser_tests/fixtures/components/Topbar.ts
@@ -9,6 +9,12 @@ export class Topbar {
       .allInnerTexts()
   }
 
+  async getActiveTabName(): Promise<string> {
+    return this.page
+      .locator('.workflow-tabs .p-togglebutton-checked')
+      .innerText()
+  }
+
   async openSubmenuMobile() {
     await this.page.locator('.p-menubar-mobile .p-menubar-button').click()
   }

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -616,85 +616,64 @@ test.describe('Load workflow', () => {
     )
   })
 
-  test.describe('Restore inactive workflows on reload', () => {
-    const uniqueFilename = (extension?: string) =>
+  test.describe('Restore all open workflows on reload', () => {
+    let workflowA: string
+    let workflowB: string
+
+    const generateUniqueFilename = (extension = '') =>
       `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}${extension}`
 
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+
+      workflowA = generateUniqueFilename()
+      await comfyPage.menu.topbar.saveWorkflow(workflowA)
+      workflowB = generateUniqueFilename()
+      await comfyPage.menu.topbar.triggerTopbarCommand(['Workflow', 'New'])
+      await comfyPage.menu.topbar.saveWorkflow(workflowB)
+
+      // Wait for localStorage to persist the workflow paths before reloading
+      await comfyPage.page.waitForFunction(
+        () => !!window.localStorage.getItem('Comfy.OpenWorkflowsPaths')
+      )
+      await comfyPage.setup({ clearStorage: false })
     })
 
-    test('Restores opened workflow topbar tabs on reload', async ({
+    test('Restores topbar workflow tabs after reload', async ({
       comfyPage
     }) => {
       await comfyPage.setSetting(
         'Comfy.Workflow.WorkflowTabsPosition',
         'Topbar'
       )
+      const tabs = await comfyPage.menu.topbar.getTabNames()
+      const activeWorkflowName = await comfyPage.menu.topbar.getActiveTabName()
 
-      const uniqueId1 = uniqueFilename()
-      await comfyPage.menu.topbar.saveWorkflow(uniqueId1)
-
-      const uniqueId2 = uniqueFilename()
-      await comfyPage.menu.topbar.triggerTopbarCommand(['Workflow', 'New'])
-      await comfyPage.menu.topbar.saveWorkflow(uniqueId2)
-
-      await comfyPage.page.waitForFunction(
-        () => !!window.localStorage.getItem('Comfy.OpenWorkflowsPaths')
-      )
-      await comfyPage.setup({ clearStorage: false })
-      const tabNames = await comfyPage.menu.topbar.getTabNames()
-
-      // Verify restored workflows in topbar tabs
-      expect(tabNames).toEqual(expect.arrayContaining([uniqueId1, uniqueId2]))
-
-      // Verify order is restored
-      expect(tabNames.indexOf(uniqueId1)).toBeLessThan(
-        tabNames.indexOf(uniqueId2)
-      )
-
-      // Verify active tab focus is restored
-      const activeTabName = await comfyPage.menu.topbar.getActiveTabName()
-      expect(activeTabName).toEqual(uniqueId2)
+      expect(tabs).toEqual(expect.arrayContaining([workflowA, workflowB]))
+      expect(tabs.indexOf(workflowA)).toBeLessThan(tabs.indexOf(workflowB))
+      expect(activeWorkflowName).toEqual(workflowB)
     })
 
-    test('Restores opened workflows in sidebar on reload', async ({
-      comfyPage
-    }) => {
+    test('Restores sidebar workflows after reload', async ({ comfyPage }) => {
       await comfyPage.setSetting(
         'Comfy.Workflow.WorkflowTabsPosition',
         'Sidebar'
       )
-
-      const uniqueId1 = uniqueFilename('.json')
-      await comfyPage.menu.topbar.saveWorkflow(uniqueId1)
-
-      const uniqueId2 = uniqueFilename('.json')
-      await comfyPage.menu.topbar.triggerTopbarCommand(['Workflow', 'New'])
-      await comfyPage.menu.topbar.saveWorkflow(uniqueId2)
-
-      await comfyPage.page.waitForFunction(
-        () => !!window.localStorage.getItem('Comfy.OpenWorkflowsPaths')
-      )
-      await comfyPage.setup({ clearStorage: false })
       await comfyPage.menu.workflowsTab.open()
-      const openedWorkflowNames =
+      const openWorkflows =
         await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
-
-      // Verify restored workflows in sidebar
-      expect(openedWorkflowNames).toEqual(
-        expect.arrayContaining([uniqueId1, uniqueId2])
-      )
-
-      // Verify oder is restored
-      expect(openedWorkflowNames.indexOf(uniqueId1)).toBeLessThan(
-        openedWorkflowNames.indexOf(uniqueId2)
-      )
-
-      // Verify active tab focus is restored
-      const activeTabName =
+      const activeWorkflowName =
         await comfyPage.menu.workflowsTab.getActiveWorkflowName()
-      expect(activeTabName).toEqual(uniqueId2)
+      const workflowPathA = `${workflowA}.json`
+      const workflowPathB = `${workflowB}.json`
+
+      expect(openWorkflows).toEqual(
+        expect.arrayContaining([workflowPathA, workflowPathB])
+      )
+      expect(openWorkflows.indexOf(workflowPathA)).toBeLessThan(
+        openWorkflows.indexOf(workflowPathB)
+      )
+      expect(activeWorkflowName).toEqual(workflowPathB)
     })
   })
 })

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -57,7 +57,7 @@ import { usePragmaticDroppable } from '@/hooks/dndHooks'
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { ChangeTracker } from '@/scripts/changeTracker'
-import { setStorageValue } from '@/scripts/utils'
+import { getStorageValue, setStorageValue } from '@/scripts/utils'
 import { IS_CONTROL_WIDGET, updateControlWidgetLabel } from '@/scripts/widgets'
 import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -95,12 +95,12 @@ const canvasMenuEnabled = computed(() =>
 )
 const tooltipEnabled = computed(() => settingStore.get('Comfy.EnableTooltips'))
 
-const getStorageValue = (key: string) => {
-  const value = localStorage.getItem(key)
-  return value ? JSON.parse(value) : null
-}
-const storedWorkflows = getStorageValue('Comfy.OpenWorkflowsPaths')
-const storedActiveIndex = getStorageValue('Comfy.ActiveWorkflowIndex')
+const storedWorkflows = JSON.parse(
+  getStorageValue('Comfy.OpenWorkflowsPaths') || '[]'
+)
+const storedActiveIndex = JSON.parse(
+  getStorageValue('Comfy.ActiveWorkflowIndex') || '-1'
+)
 const restoreState = computed<{ paths: string[]; activeIndex: number }>(() => {
   const store = workspaceStore?.workflow
   if (!store) return { paths: [], activeIndex: -1 }
@@ -392,11 +392,8 @@ onMounted(async () => {
     })
 
   watch(restoreState, ({ paths, activeIndex }) => {
-    localStorage.setItem('Comfy.OpenWorkflowsPaths', JSON.stringify(paths))
-    localStorage.setItem(
-      'Comfy.ActiveWorkflowIndex',
-      JSON.stringify(activeIndex)
-    )
+    setStorageValue('Comfy.OpenWorkflowsPaths', JSON.stringify(paths))
+    setStorageValue('Comfy.ActiveWorkflowIndex', JSON.stringify(activeIndex))
   })
 
   // Start watching for locale change after the initial value is loaded.

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -101,15 +101,18 @@ const storedWorkflows = JSON.parse(
 const storedActiveIndex = JSON.parse(
   getStorageValue('Comfy.ActiveWorkflowIndex') || '-1'
 )
+const openWorkflows = computed(() => workspaceStore?.workflow?.openWorkflows)
+const activeWorkflow = computed(() => workspaceStore?.workflow?.activeWorkflow)
 const restoreState = computed<{ paths: string[]; activeIndex: number }>(() => {
-  const store = workspaceStore?.workflow
-  if (!store) return { paths: [], activeIndex: -1 }
+  if (!openWorkflows.value || !activeWorkflow.value) {
+    return { paths: [], activeIndex: -1 }
+  }
 
-  const paths = store.openWorkflows
+  const paths = openWorkflows.value
     .filter((workflow) => workflow?.isPersisted && !workflow.isModified)
     .map((workflow) => workflow.path)
-  const activeIndex = store.openWorkflows.findIndex(
-    (workflow) => workflow.path === store.activeWorkflow?.path
+  const activeIndex = openWorkflows.value.findIndex(
+    (workflow) => workflow.path === activeWorkflow.value?.path
   )
 
   return { paths, activeIndex }

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -176,10 +176,6 @@ export const useWorkflowService = () => {
     workflow: ComfyWorkflow,
     options: { warnIfUnsaved: boolean } = { warnIfUnsaved: true }
   ): Promise<boolean> => {
-    if (!workflow.isLoaded) {
-      return true
-    }
-
     if (workflow.isModified && options.warnIfUnsaved) {
       const confirmed = await dialogService.confirm({
         title: t('sideToolbar.workflowTab.dirtyCloseTitle'),

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -225,13 +225,27 @@ export const useWorkflowStore = defineStore('workflow', () => {
    * @param paths - The workflows to open, specified as:
    *   - `left`: Workflows to be added to the left.
    *   - `right`: Workflows to be added to the right.
+   *
+   * Invalid paths (non-strings or paths not found in `workflowLookup.value`)
+   * will be ignored. Duplicate paths are automatically removed.
    */
   const openWorkflowsInBackground = (paths: {
     left?: string[]
     right?: string[]
   }) => {
     const { left = [], right = [] } = paths
-    openWorkflowPaths.value = _.union(left, openWorkflowPaths.value, right)
+    if (!left.length && !right.length) return
+
+    const isValidPath = (
+      path: unknown
+    ): path is keyof typeof workflowLookup.value =>
+      typeof path === 'string' && path in workflowLookup.value
+
+    openWorkflowPaths.value = _.union(
+      left.filter(isValidPath),
+      openWorkflowPaths.value,
+      right.filter(isValidPath)
+    )
   }
 
   /**

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { defineStore } from 'pinia'
 import { computed, markRaw, ref } from 'vue'
 
@@ -130,6 +131,10 @@ export interface WorkflowStore {
   openWorkflows: LoadedComfyWorkflow[]
   openedWorkflowIndexShift: (shift: number) => LoadedComfyWorkflow | null
   openWorkflow: (workflow: ComfyWorkflow) => Promise<LoadedComfyWorkflow>
+  openWorkflowsInBackground: (paths: {
+    left?: string[]
+    right?: string[]
+  }) => void
   isOpen: (workflow: ComfyWorkflow) => boolean
   isBusy: boolean
   closeWorkflow: (workflow: ComfyWorkflow) => Promise<void>
@@ -212,6 +217,22 @@ export const useWorkflowStore = defineStore('workflow', () => {
   }
   const isOpen = (workflow: ComfyWorkflow) =>
     openWorkflowPathSet.value.has(workflow.path)
+
+  /**
+   * Add paths to the list of open workflow paths without loading the files
+   * or changing the active workflow.
+   *
+   * @param paths - The workflows to open, specified as:
+   *   - `left`: Workflows to be added to the left.
+   *   - `right`: Workflows to be added to the right.
+   */
+  const openWorkflowsInBackground = (paths: {
+    left?: string[]
+    right?: string[]
+  }) => {
+    const { left = [], right = [] } = paths
+    openWorkflowPaths.value = _.union(left, openWorkflowPaths.value, right)
+  }
 
   /**
    * Set the workflow as the active workflow.
@@ -389,6 +410,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     openWorkflows,
     openedWorkflowIndexShift,
     openWorkflow,
+    openWorkflowsInBackground,
     isOpen,
     isBusy,
     closeWorkflow,

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -242,10 +242,10 @@ export const useWorkflowStore = defineStore('workflow', () => {
       typeof path === 'string' && path in workflowLookup.value
 
     openWorkflowPaths.value = _.union(
-      left.filter(isValidPath),
+      left,
       openWorkflowPaths.value,
-      right.filter(isValidPath)
-    )
+      right
+    ).filter(isValidPath)
   }
 
   /**


### PR DESCRIPTION
Introduces restoring of open workflows and active tab focus on reload. The workflow files are not read until the tab is focused (lazy). The state is stored in localstorage rather than in settings.

https://github.com/user-attachments/assets/b11ece20-6cb2-45a0-9b9d-9e42a42b92f1

Closes https://github.com/Comfy-Org/ComfyUI_frontend/issues/1575

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2238-Restore-all-open-workflows-on-load-17a6d73d365081c4898cec18f5857442) by [Unito](https://www.unito.io)
