### PR TITLE
[Style] Update workflow template cards style

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -3,7 +3,7 @@
     <template #header>
       <div class="flex items-center justify-center">
         <div
-          class="relative overflow-hidden rounded-lg cursor-pointer w-64 h-64"
+          class="relative overflow-hidden rounded-t-lg cursor-pointer w-64 h-64"
         >
           <img
             v-if="!imageError"
@@ -13,7 +13,7 @@
                 : `api/workflow_templates/${props.moduleName}/${props.workflowName}.jpg`
             "
             @error="imageError = true"
-            class="w-64 h-64 rounded-lg object-cover thumbnail"
+            class="w-64 h-64 rounded-t-lg object-cover thumbnail"
           />
           <div v-else class="w-64 h-64 content-center text-center">
             <i class="pi pi-file" style="font-size: 4rem"></i>

--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -13,7 +13,6 @@
         scroll-height="auto"
         class="overflow-y-auto w-64 h-full"
         listStyle="max-height:unset"
-        :disabled="!workflowTemplatesStore.isLoaded"
       />
     </div>
     <Carousel

--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -13,6 +13,7 @@
         scroll-height="auto"
         class="overflow-y-auto w-64 h-full"
         listStyle="max-height:unset"
+        :disabled="!workflowTemplatesStore.isLoaded"
       />
     </div>
     <Carousel
@@ -24,7 +25,7 @@
       :key="selectedTab.moduleName"
     >
       <template #item="slotProps">
-        <div @click="loadWorkflow(slotProps.data)">
+        <div @click="loadWorkflow(slotProps.data)" class="p-2">
           <TemplateWorkflowCard
             :moduleName="selectedTab.moduleName"
             :workflowName="slotProps.data"


### PR DESCRIPTION
This PR:

- adds padding to template workflow cards,
- removes border rounding on bottom of card images,
- and sets template list as disabled while templates are loading

Before:

![Selection_744](https://github.com/user-attachments/assets/91a7669b-9eb4-489b-8780-c6182e07c1e7)

After:

![Selection_743](https://github.com/user-attachments/assets/1830c45d-a7f4-4a80-b4d5-1afbc3f39877)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2239-Style-Update-workflow-template-cards-style-17a6d73d365081d9b713cda495c60c02) by [Unito](https://www.unito.io)
