### PR TITLE
Fix `execution_interrupted`

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -7,6 +7,7 @@ import type {
   ExecutingWsMessage,
   ExecutionCachedWsMessage,
   ExecutionErrorWsMessage,
+  ExecutionInterruptedWsMessage,
   ExecutionStartWsMessage,
   ExecutionSuccessWsMessage,
   ExtensionsResponse,
@@ -59,6 +60,7 @@ interface BackendApiCalls {
   execution_start: ExecutionStartWsMessage
   execution_success: ExecutionSuccessWsMessage
   execution_error: ExecutionErrorWsMessage
+  execution_interrupted: ExecutionInterruptedWsMessage
   execution_cached: ExecutionCachedWsMessage
   logs: LogsWsMessage
   /** Mr Blob Preview, I presume? */
@@ -355,6 +357,7 @@ export class ComfyApi extends EventTarget {
               break
             case 'execution_start':
             case 'execution_error':
+            case 'execution_interrupted':
             case 'execution_cached':
             case 'execution_success':
             case 'progress':


### PR DESCRIPTION
This was being delivered to the front-end but logging a warning because it was unrecognized.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2244-Fix-execution_interrupted-17b6d73d365081c89e55c28f72ae79a7) by [Unito](https://www.unito.io)
