### PR TITLE
Fix type error in BaseViewTemplate

### DIFF
--- a/src/views/templates/BaseViewTemplate.vue
+++ b/src/views/templates/BaseViewTemplate.vue
@@ -28,7 +28,7 @@ import { electronAPI, isElectron } from '@/utils/envUtil'
 
 const props = withDefaults(
   defineProps<{
-    dark: boolean
+    dark?: boolean
   }>(),
   {
     dark: false


### PR DESCRIPTION
This `dark` prop is optional.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2245-Fix-type-error-in-BaseViewTemplate-17b6d73d365081f9b0f1d51827e65268) by [Unito](https://www.unito.io)
