### PR TITLE
Allow parent component to pass tags to issue report panel

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -30,6 +30,7 @@
       v-if="sendReportOpen"
       error-type="graphExecutionError"
       :extra-fields="[stackTraceField]"
+      :tags="{ exceptionMessage: props.error.exception_message }"
     />
     <div class="action-container">
       <FindIssueButton

--- a/src/components/dialog/content/error/ReportIssuePanel.vue
+++ b/src/components/dialog/content/error/ReportIssuePanel.vue
@@ -75,9 +75,12 @@ const props = defineProps<{
   errorType: string
   defaultFields?: DefaultField[]
   extraFields?: ReportField[]
+  tags?: Record<string, string>
 }>()
-const { defaultFields = ['Workflow', 'Logs', 'SystemStats', 'Settings'] } =
-  props
+const {
+  defaultFields = ['Workflow', 'Logs', 'SystemStats', 'Settings'],
+  tags = {}
+} = props
 
 const { t } = useI18n()
 const toast = useToast()
@@ -168,7 +171,8 @@ const createCaptureContext = async (): Promise<CaptureContext> => {
     user: getUserInfo(),
     level: 'error',
     tags: {
-      errorType: props.errorType
+      errorType: props.errorType,
+      ...tags
     },
     extra: {
       ...createFeedback(),


### PR DESCRIPTION
Enables the parent component to pass an optional tags object to allow for additional context to be included in the error reporting process.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2247-Allow-parent-component-to-pass-tags-to-issue-report-panel-17c6d73d365081249930e2937dc388d2) by [Unito](https://www.unito.io)
