### PR TITLE
Add work dir to i18n-node-defs.yaml

### DIFF
--- a/.github/workflows/i18n-node-defs.yaml
+++ b/.github/workflows/i18n-node-defs.yaml
@@ -45,3 +45,4 @@ jobs:
         branch: update-locales-node-defs-{{ github.event.inputs.trigger_type }}-{{ github.run_id }}
         base: main
         labels: dependencies
+        path: ComfyUI_frontend

--- a/.github/workflows/i18n-node-defs.yaml
+++ b/.github/workflows/i18n-node-defs.yaml
@@ -42,7 +42,7 @@ jobs:
           Automated PR to update locales for node definitions
 
           This PR was created automatically by the frontend update workflow.
-        branch: update-locales-node-defs-{{ github.event.inputs.trigger_type }}-{{ github.run_id }}
+        branch: update-locales-node-defs-${{ github.event.inputs.trigger_type }}-${{ github.run_id }}
         base: main
         labels: dependencies
         path: ComfyUI_frontend


### PR DESCRIPTION
Fixes the node def i18n sync GH workflow. See generated PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/2256

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2255-Add-work-dir-to-i18n-node-defs-yaml-17c6d73d365081c3a336d1598162a069) by [Unito](https://www.unito.io)
