### PR TITLE
Don't prompt unsaved when there is no unsaved workflow on window close

### DIFF
--- a/src/components/dialog/UnloadWindowConfirmDialog.vue
+++ b/src/components/dialog/UnloadWindowConfirmDialog.vue
@@ -10,14 +10,22 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted } from 'vue'
+import { computed, onBeforeUnmount, onMounted } from 'vue'
 
 import { useSettingStore } from '@/stores/settingStore'
+import { useWorkflowStore } from '@/stores/workflowStore'
 
 const settingStore = useSettingStore()
+const workflowStore = useWorkflowStore()
+const hasUnsavedWorkflows = computed(
+  () => workflowStore.modifiedWorkflows.length > 0
+)
 
 const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-  if (settingStore.get('Comfy.Window.UnloadConfirmation')) {
+  if (
+    settingStore.get('Comfy.Window.UnloadConfirmation') &&
+    hasUnsavedWorkflows.value
+  ) {
     event.preventDefault()
     return true
   }

--- a/src/components/dialog/UnloadWindowConfirmDialog.vue
+++ b/src/components/dialog/UnloadWindowConfirmDialog.vue
@@ -10,21 +10,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { onBeforeUnmount, onMounted } from 'vue'
 
 import { useSettingStore } from '@/stores/settingStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 
 const settingStore = useSettingStore()
 const workflowStore = useWorkflowStore()
-const hasUnsavedWorkflows = computed(
-  () => workflowStore.modifiedWorkflows.length > 0
-)
 
 const handleBeforeUnload = (event: BeforeUnloadEvent) => {
   if (
     settingStore.get('Comfy.Window.UnloadConfirmation') &&
-    hasUnsavedWorkflows.value
+    workflowStore.modifiedWorkflows.length > 0
   ) {
     event.preventDefault()
     return true


### PR DESCRIPTION
Resolve https://github.com/Comfy-Org/ComfyUI_frontend/issues/2254

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2257-Don-t-prompt-unsaved-when-there-is-no-unsaved-workflow-on-window-close-17c6d73d3650815ca06bcf666e68a926) by [Unito](https://www.unito.io)
