### PR TITLE
[CodeHealth] Convert useAutoSize to kwargs

### DIFF
--- a/src/components/bottomPanel/tabs/terminal/CommandTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/CommandTerminal.vue
@@ -20,11 +20,16 @@ const terminalCreated = (
   let offData: IDisposable
   let offOutput: () => void
 
-  useAutoSize(root, true, true, () => {
-    // If we aren't visible, don't resize
-    if (!terminal.element?.offsetParent) return
+  useAutoSize({
+    root,
+    autoRows: true,
+    autoCols: true,
+    onResize: () => {
+      // If we aren't visible, don't resize
+      if (!terminal.element?.offsetParent) return
 
-    terminalApi.resize(terminal.cols, terminal.rows)
+      terminalApi.resize(terminal.cols, terminal.rows)
+    }
   })
 
   onMounted(async () => {

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
@@ -29,7 +29,7 @@ const terminalCreated = (
   { terminal, useAutoSize }: ReturnType<typeof useTerminal>,
   root: Ref<HTMLElement>
 ) => {
-  useAutoSize(root, true, false)
+  useAutoSize({ root, autoRows: true, autoCols: false })
 
   const update = (entries: Array<LogEntry>, size?: TerminalSize) => {
     if (size) {

--- a/src/hooks/bottomPanelTabs/useTerminal.ts
+++ b/src/hooks/bottomPanelTabs/useTerminal.ts
@@ -36,12 +36,17 @@ export function useTerminal(element: Ref<HTMLElement>) {
 
   return {
     terminal,
-    useAutoSize(
-      root: Ref<HTMLElement>,
-      autoRows: boolean = true,
-      autoCols: boolean = true,
+    useAutoSize({
+      root,
+      autoRows = true,
+      autoCols = true,
+      onResize
+    }: {
+      root: Ref<HTMLElement>
+      autoRows?: boolean
+      autoCols?: boolean
       onResize?: () => void
-    ) {
+    }) {
       const ensureValidRows = (rows: number | undefined) => {
         if (rows == null || isNaN(rows)) {
           return root.value?.clientHeight / 20

--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -78,7 +78,7 @@ const terminalCreated = (
 ) => {
   xterm = terminal
 
-  useAutoSize(root, true, true)
+  useAutoSize({ root, autoRows: true, autoCols: true })
   electron.onLogMessage((message: string) => {
     terminal.write(message)
   })


### PR DESCRIPTION
The unnamed boolean params are very hard to read. This PR changes them to named kwargs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2259-CodeHealth-Convert-useAutoSize-to-kwargs-17c6d73d365081288b5fca3163214e00) by [Unito](https://www.unito.io)
