### PR TITLE
[Style] Fix root CSS selector

### DIFF
--- a/src/components/install/GpuPicker.vue
+++ b/src/components/install/GpuPicker.vue
@@ -160,7 +160,7 @@ const pickGpu = (value: typeof selected.value) => {
 </script>
 
 <style scoped>
-:root {
+.p-tag {
   --p-tag-gap: 0.5rem;
 }
 

--- a/src/views/ManualConfigurationView.vue
+++ b/src/views/ManualConfigurationView.vue
@@ -76,7 +76,7 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-:root {
+.p-tag {
   --p-tag-gap: 0.5rem;
 }
 


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2262.

`:root` selector does not work under `scoped` annotation.