### PR TITLE
Fix collapsed node textarea causes UI inconsistency

### DIFF
--- a/browser_tests/assets/collapsed_multiline.json
+++ b/browser_tests/assets/collapsed_multiline.json
@@ -1,0 +1,37 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CLIPTextEncode",
+      "pos": [20, 50],
+      "size": [400, 200],
+      "flags": { "collapsed": true },
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null,
+          "localized_name": "clip"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": null,
+          "localized_name": "CONDITIONING"
+        }
+      ],
+      "properties": {},
+      "widgets_values": ["Should not be displayed."]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "version": 0.4
+}

--- a/browser_tests/domWidget.spec.ts
+++ b/browser_tests/domWidget.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from './fixtures/ComfyPage'
+
+test.describe('DOM Widget', () => {
+  test('Collapsed multiline textarea is not visible', async ({ comfyPage }) => {
+    await comfyPage.loadWorkflow('collapsed_multiline')
+
+    expect(comfyPage.page.locator('.comfy-multiline-input')).not.toBeVisible()
+  })
+
+  test('Multiline textarea correctly collapses', async ({ comfyPage }) => {
+    const multilineTextAreas = comfyPage.page.locator('.comfy-multiline-input')
+    const firstMultiline = multilineTextAreas.first()
+    const lastMultiline = multilineTextAreas.last()
+
+    await expect(firstMultiline).toBeVisible()
+    await expect(lastMultiline).toBeVisible()
+
+    const nodes = await comfyPage.getNodeRefsByType('CLIPTextEncode')
+    for (const node of nodes) {
+      await node.click('collapse')
+    }
+    await expect(firstMultiline).not.toBeVisible()
+    await expect(lastMultiline).not.toBeVisible()
+  })
+})

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -417,6 +417,12 @@ LGraphNode.prototype.addDOMWidget = function <
     element.dataset.collapsed = this.flags?.collapsed ? 'true' : 'false'
   }
 
+  const { onConfigure } = this
+  this.onConfigure = function () {
+    onConfigure?.apply(this, arguments)
+    element.dataset.collapsed = this.flags?.collapsed ? 'true' : 'false'
+  }
+
   const onRemoved = this.onRemoved
   this.onRemoved = function () {
     element.remove()


### PR DESCRIPTION
Fixes a long-standing issue (appears to be from #475), which may have had more impact in previous versions - I recall giant dark grey blocks taking over half the screen when tabbing.

### Reproduction

1. Collapse a multiline input node
1. Reload the workflow
1. (Optional) To avoid tabbing through everything, click the eyeball in the bottom-right corner to focus the last element
1. Press tab until you see the below
![image](https://github.com/user-attachments/assets/3f680852-534d-45a8-b103-44d8855e1a64)

### Solution

Add an `onConfigure` monkey patch to set the correct dataset value (used to show/hide the node elsewhere).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2267-Fix-collapsed-node-textarea-causes-UI-inconsistency-17d6d73d365081a5adb4cd65b11d4546) by [Unito](https://www.unito.io)
