### PR TITLE
Hotfix scoped --sidebar-width uasges in maskeditor.ts

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -262,15 +262,15 @@ var styles = `
   }
   #maskEditor_toolPanel {
     height: 100%;
-    width: var(--sidebar-width);
+    width: 4rem;
     z-index: 8888;
     background: var(--comfy-menu-bg);
     display: flex;
     flex-direction: column;
   }
   .maskEditor_toolPanelContainer {
-    width: var(--sidebar-width);
-    height: var(--sidebar-width);
+    width: 4rem;
+    height: 4rem;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -331,7 +331,7 @@ var styles = `
     margin-bottom: 5px;
   }
   #maskEditor_pointerZone {
-    width: calc(100% - var(--sidebar-width) - 220px);
+    width: calc(100% - 4rem - 220px);
     height: 100%;
   }
   #maskEditor_uiContainer {
@@ -703,8 +703,8 @@ var styles = `
   }
 
   .maskEditor_toolPanelZoomIndicator {
-    width: var(--sidebar-width);
-    height: var(--sidebar-width);
+    width: 4rem;
+    height: 4rem;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
maskeditor.ts had `--sidebar-width` usages from `:root` defined in 237fca0bf1e4f14218bd313c13162f47d0c41007 that was changed.

![image](https://github.com/user-attachments/assets/7af232f4-97e1-48f6-9ccd-abb52010e734)

I just hardcoded the same `4rem` value in for now, but I think it could possibly be replaced by a global `--comfy-sidebar-width` for components to standardize their sidebar sizes with comfy.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2269-Hotfix-scoped-sidebar-width-uasges-in-maskeditor-ts-17d6d73d365081a9a472c0d523451707) by [Unito](https://www.unito.io)
