### PR TITLE
Caching brush settings in mask editor

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2867,7 +2867,6 @@ class UIManager {
     const circle_shape = document.createElement('div')
     circle_shape.id = 'maskEditor_sidePanelBrushShapeCircle'
     circle_shape.classList.add(shapeColor)
-    circle_shape.style.background = 'var(--p-button-text-primary-color)'
     circle_shape.addEventListener('click', () => {
       this.messageBroker.publish('setBrushShape', BrushShape.Arc)
       this.setBrushBorderRadius()
@@ -2878,13 +2877,20 @@ class UIManager {
     const square_shape = document.createElement('div')
     square_shape.id = 'maskEditor_sidePanelBrushShapeSquare'
     square_shape.classList.add(shapeColor)
-    square_shape.style.background = ''
     square_shape.addEventListener('click', () => {
       this.messageBroker.publish('setBrushShape', BrushShape.Rect)
       this.setBrushBorderRadius()
       square_shape.style.background = 'var(--p-button-text-primary-color)'
       circle_shape.style.background = ''
     })
+
+    if ((await this.messageBroker.pull('brushSettings')).type === BrushShape.Arc) {
+      circle_shape.style.background = 'var(--p-button-text-primary-color)'
+      square_shape.style.background = ''
+    } else {
+      circle_shape.style.background = ''
+      square_shape.style.background = 'var(--p-button-text-primary-color)'
+    }
 
     brush_shape_container.appendChild(circle_shape)
     brush_shape_container.appendChild(square_shape)

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2961,7 +2961,7 @@ class UIManager {
     resetBrushSettingsButton.addEventListener('click', () => {
       this.messageBroker.publish('setBrushShape', BrushShape.Arc)
       this.messageBroker.publish('setBrushSize', 10)
-      this.messageBroker.publish('setBrushOpacity', 100)
+      this.messageBroker.publish('setBrushOpacity', 0.7)
       this.messageBroker.publish('setBrushHardness', 1)
       this.messageBroker.publish('setBrushSmoothingPrecision', 10)
 
@@ -2969,7 +2969,7 @@ class UIManager {
       square_shape.style.background = ''
 
       thicknesSliderObj.slider.value = '10'
-      opacitySliderObj.slider.value = '100'
+      opacitySliderObj.slider.value = '0.7'
       hardnessSliderObj.slider.value = '1'
       brushSmoothingPrecisionSliderObj.slider.value = '10'
 

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -782,6 +782,33 @@ export interface Brush {
   type: BrushShape
 }
 
+function saveBrushToCache(key: string, brush: Brush): void {
+  try {
+    const brushString = JSON.stringify(brush);
+    localStorage.setItem(key, brushString);
+  } catch (error) {
+    console.error("Failed to save brush to cache:", error);
+  }
+}
+
+function loadBrushFromCache(key: string): Brush | null {
+  try {
+    const brushString = localStorage.getItem(key);
+    if (brushString) {
+      const brush = JSON.parse(brushString) as Brush;
+      console.log("Loaded brush from cache:", brush);
+      return brush; // Return the parsed brush object
+    } else {
+      console.log("No brush found in cache.");
+      return null; // Return null if no brush is found
+    }
+  } catch (error) {
+    console.error("Failed to load brush from cache:", error);
+    return null; // Return null in case of an error
+  }
+}
+
+
 type Callback = (data?: any) => void
 
 class MaskEditorDialog extends ComfyDialog {
@@ -1952,12 +1979,17 @@ class BrushTool {
       'Comfy.MaskEditor.BrushAdjustmentSpeed'
     )
 
-    this.brushSettings = {
-      size: 10,
-      opacity: 100,
-      hardness: 1,
-      type: BrushShape.Arc
+    if (loadBrushFromCache("maskeditor_brush_settings")) {
+      this.brushSettings = loadBrushFromCache("maskeditor_brush_settings")
+    } else {
+      this.brushSettings = {
+        size: 10,
+        opacity: 100,
+        hardness: 1,
+        type: BrushShape.Arc
+      }
     }
+
     this.maskBlendMode = MaskBlendMode.Black
   }
 
@@ -2545,18 +2577,22 @@ class BrushTool {
 
   private setBrushSize(size: number) {
     this.brushSettings.size = size
+    saveBrushToCache('maskeditor_brush_settings', this.brushSettings)
   }
 
   private setBrushOpacity(opacity: number) {
     this.brushSettings.opacity = opacity
+    saveBrushToCache('maskeditor_brush_settings', this.brushSettings)
   }
 
   private setBrushHardness(hardness: number) {
     this.brushSettings.hardness = hardness
+    saveBrushToCache('maskeditor_brush_settings', this.brushSettings)
   }
 
   private setBrushType(type: BrushShape) {
     this.brushSettings.type = type
+    saveBrushToCache('maskeditor_brush_settings', this.brushSettings)
   }
 
   private setBrushSmoothingPrecision(precision: number) {

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1,5 +1,4 @@
-import _ from 'lodash'
-
+import { debounce } from 'lodash'
 import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
 import { ComfyApp } from '../../scripts/app'
@@ -786,7 +785,7 @@ export interface Brush {
   smoothingPrecision: number
 }
 
-const saveBrushToCache = _.debounce(function (key: string, brush: Brush): void {
+const saveBrushToCache = debounce(function (key: string, brush: Brush): void {
   try {
     const brushString = JSON.stringify(brush)
     setStorageValue(key, brushString)

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2,6 +2,7 @@ import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
 import { ComfyApp } from '../../scripts/app'
 import { $el, ComfyDialog } from '../../scripts/ui'
+import { getStorageValue, setStorageValue } from '../../scripts/utils'
 import { ClipspaceDialog } from './clipspace'
 import { MaskEditorDialogOld } from './maskEditorOld'
 
@@ -786,7 +787,7 @@ export interface Brush {
 function saveBrushToCache(key: string, brush: Brush): void {
   try {
     const brushString = JSON.stringify(brush)
-    localStorage.setItem(key, brushString)
+    setStorageValue(key, brushString)
   } catch (error) {
     console.error('Failed to save brush to cache:', error)
   }
@@ -794,18 +795,18 @@ function saveBrushToCache(key: string, brush: Brush): void {
 
 function loadBrushFromCache(key: string): Brush | null {
   try {
-    const brushString = localStorage.getItem(key)
+    const brushString = getStorageValue(key)
     if (brushString) {
       const brush = JSON.parse(brushString) as Brush
       console.log('Loaded brush from cache:', brush)
-      return brush // Return the parsed brush object
+      return brush
     } else {
       console.log('No brush found in cache.')
-      return null // Return null if no brush is found
+      return null
     }
   } catch (error) {
     console.error('Failed to load brush from cache:', error)
-    return null // Return null in case of an error
+    return null
   }
 }
 

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1979,9 +1979,9 @@ class BrushTool {
       'Comfy.MaskEditor.BrushAdjustmentSpeed'
     )
 
-    const cachedBrushSettings = loadBrushFromCache('maskeditor_brush_settings');
+    const cachedBrushSettings = loadBrushFromCache('maskeditor_brush_settings')
     if (cachedBrushSettings) {
-      this.brushSettings = cachedBrushSettings;
+      this.brushSettings = cachedBrushSettings
     } else {
       this.brushSettings = {
         type: BrushShape.Arc,

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -785,30 +785,29 @@ export interface Brush {
 
 function saveBrushToCache(key: string, brush: Brush): void {
   try {
-    const brushString = JSON.stringify(brush);
-    localStorage.setItem(key, brushString);
+    const brushString = JSON.stringify(brush)
+    localStorage.setItem(key, brushString)
   } catch (error) {
-    console.error("Failed to save brush to cache:", error);
+    console.error('Failed to save brush to cache:', error)
   }
 }
 
 function loadBrushFromCache(key: string): Brush | null {
   try {
-    const brushString = localStorage.getItem(key);
+    const brushString = localStorage.getItem(key)
     if (brushString) {
-      const brush = JSON.parse(brushString) as Brush;
-      console.log("Loaded brush from cache:", brush);
-      return brush; // Return the parsed brush object
+      const brush = JSON.parse(brushString) as Brush
+      console.log('Loaded brush from cache:', brush)
+      return brush // Return the parsed brush object
     } else {
-      console.log("No brush found in cache.");
-      return null; // Return null if no brush is found
+      console.log('No brush found in cache.')
+      return null // Return null if no brush is found
     }
   } catch (error) {
-    console.error("Failed to load brush from cache:", error);
-    return null; // Return null in case of an error
+    console.error('Failed to load brush from cache:', error)
+    return null // Return null in case of an error
   }
 }
-
 
 type Callback = (data?: any) => void
 
@@ -1980,8 +1979,8 @@ class BrushTool {
       'Comfy.MaskEditor.BrushAdjustmentSpeed'
     )
 
-    if (loadBrushFromCache("maskeditor_brush_settings")) {
-      this.brushSettings = loadBrushFromCache("maskeditor_brush_settings")
+    if (loadBrushFromCache('maskeditor_brush_settings')) {
+      this.brushSettings = loadBrushFromCache('maskeditor_brush_settings')
     } else {
       this.brushSettings = {
         type: BrushShape.Arc,

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2884,7 +2884,9 @@ class UIManager {
       circle_shape.style.background = ''
     })
 
-    if ((await this.messageBroker.pull('brushSettings')).type === BrushShape.Arc) {
+    if (
+      (await this.messageBroker.pull('brushSettings')).type === BrushShape.Arc
+    ) {
       circle_shape.style.background = 'var(--p-button-text-primary-color)'
       square_shape.style.background = ''
     } else {
@@ -2950,32 +2952,29 @@ class UIManager {
         )
       }
     )
-    
-    const resetBrushSettingsButton = document.createElement('button');
-    resetBrushSettingsButton.id = 'resetBrushSettingsButton';
-    resetBrushSettingsButton.innerText = 'Reset to Default';
+
+    const resetBrushSettingsButton = document.createElement('button')
+    resetBrushSettingsButton.id = 'resetBrushSettingsButton'
+    resetBrushSettingsButton.innerText = 'Reset to Default'
 
     resetBrushSettingsButton.addEventListener('click', () => {
       this.messageBroker.publish('setBrushShape', BrushShape.Arc)
       this.messageBroker.publish('setBrushSize', 10)
       this.messageBroker.publish('setBrushOpacity', 100)
       this.messageBroker.publish('setBrushHardness', 1)
-      this.messageBroker.publish(
-        'setBrushSmoothingPrecision',
-        10
-      )
+      this.messageBroker.publish('setBrushSmoothingPrecision', 10)
 
       circle_shape.style.background = 'var(--p-button-text-primary-color)'
       square_shape.style.background = ''
 
-      thicknesSliderObj.slider.value = '10';
-      opacitySliderObj.slider.value = '100';
-      hardnessSliderObj.slider.value = '1';
-      brushSmoothingPrecisionSliderObj.slider.value = '10';
+      thicknesSliderObj.slider.value = '10'
+      opacitySliderObj.slider.value = '100'
+      hardnessSliderObj.slider.value = '1'
+      brushSmoothingPrecisionSliderObj.slider.value = '10'
 
       this.setBrushBorderRadius()
       this.updateBrushPreview()
-    });
+    })
 
     brush_settings_container.appendChild(brush_settings_title)
     brush_settings_container.appendChild(resetBrushSettingsButton)

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2891,7 +2891,7 @@ class UIManager {
       1,
       100,
       1,
-      10,
+      (await this.messageBroker.pull('brushSettings')).size,
       (event, value) => {
         this.messageBroker.publish('setBrushSize', parseInt(value))
         this.updateBrushPreview()
@@ -2904,7 +2904,7 @@ class UIManager {
       0,
       1,
       0.01,
-      0.7,
+      (await this.messageBroker.pull('brushSettings')).opacity,
       (event, value) => {
         this.messageBroker.publish('setBrushOpacity', parseFloat(value))
         this.updateBrushPreview()
@@ -2917,7 +2917,7 @@ class UIManager {
       0,
       1,
       0.01,
-      1,
+      (await this.messageBroker.pull('brushSettings')).hardness,
       (event, value) => {
         this.messageBroker.publish('setBrushHardness', parseFloat(value))
         this.updateBrushPreview()

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2944,8 +2944,35 @@ class UIManager {
         )
       }
     )
+    
+    const resetBrushSettingsButton = document.createElement('button');
+    resetBrushSettingsButton.id = 'resetBrushSettingsButton';
+    resetBrushSettingsButton.innerText = 'Reset to Default';
+
+    resetBrushSettingsButton.addEventListener('click', () => {
+      this.messageBroker.publish('setBrushShape', BrushShape.Arc)
+      this.messageBroker.publish('setBrushSize', 10)
+      this.messageBroker.publish('setBrushOpacity', 100)
+      this.messageBroker.publish('setBrushHardness', 1)
+      this.messageBroker.publish(
+        'setBrushSmoothingPrecision',
+        10
+      )
+
+      circle_shape.style.background = 'var(--p-button-text-primary-color)'
+      square_shape.style.background = ''
+
+      thicknesSliderObj.slider.value = '10';
+      opacitySliderObj.slider.value = '100';
+      hardnessSliderObj.slider.value = '1';
+      brushSmoothingPrecisionSliderObj.slider.value = '10';
+
+      this.setBrushBorderRadius()
+      this.updateBrushPreview()
+    });
 
     brush_settings_container.appendChild(brush_settings_title)
+    brush_settings_container.appendChild(resetBrushSettingsButton)
     brush_settings_container.appendChild(brush_shape_outer_container)
     brush_settings_container.appendChild(thicknesSliderObj.container)
     brush_settings_container.appendChild(opacitySliderObj.container)

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1979,8 +1979,9 @@ class BrushTool {
       'Comfy.MaskEditor.BrushAdjustmentSpeed'
     )
 
-    if (loadBrushFromCache('maskeditor_brush_settings')) {
-      this.brushSettings = loadBrushFromCache('maskeditor_brush_settings')
+    const cachedBrushSettings = loadBrushFromCache('maskeditor_brush_settings');
+    if (cachedBrushSettings) {
+      this.brushSettings = cachedBrushSettings;
     } else {
       this.brushSettings = {
         type: BrushShape.Arc,

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1987,7 +1987,7 @@ class BrushTool {
       this.brushSettings = {
         type: BrushShape.Arc,
         size: 10,
-        opacity: 100,
+        opacity: 0.7,
         hardness: 1,
         smoothingPrecision: 10
       }
@@ -2961,7 +2961,7 @@ class UIManager {
     resetBrushSettingsButton.addEventListener('click', () => {
       this.messageBroker.publish('setBrushShape', BrushShape.Arc)
       this.messageBroker.publish('setBrushSize', 10)
-      this.messageBroker.publish('setBrushOpacity', 100)
+      this.messageBroker.publish('setBrushOpacity', 0.7)
       this.messageBroker.publish('setBrushHardness', 1)
       this.messageBroker.publish('setBrushSmoothingPrecision', 10)
 
@@ -2969,7 +2969,7 @@ class UIManager {
       square_shape.style.background = ''
 
       thicknesSliderObj.slider.value = '10'
-      opacitySliderObj.slider.value = '100'
+      opacitySliderObj.slider.value = '0.7'
       hardnessSliderObj.slider.value = '1'
       brushSmoothingPrecisionSliderObj.slider.value = '10'
 

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
 import { ComfyApp } from '../../scripts/app'
@@ -784,14 +786,14 @@ export interface Brush {
   smoothingPrecision: number
 }
 
-function saveBrushToCache(key: string, brush: Brush): void {
+const saveBrushToCache = _.debounce(function (key: string, brush: Brush): void {
   try {
     const brushString = JSON.stringify(brush)
     setStorageValue(key, brushString)
   } catch (error) {
     console.error('Failed to save brush to cache:', error)
   }
-}
+}, 300)
 
 function loadBrushFromCache(key: string): Brush | null {
   try {

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1,4 +1,5 @@
 import { debounce } from 'lodash'
+
 import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
 import { ComfyApp } from '../../scripts/app'


### PR DESCRIPTION
For #2190 and https://github.com/comfyanonymous/ComfyUI/issues/6458

I think the mask editor needs a lot of refactoring, fixes, and features. I couldn't even navigate the file without resorting to ctrl + f and vscode's minimap.

I tested my changes and they work on my machine, but it might break on desktop? Not too sure how `localStorage.setItem` works with Electron.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2271-Caching-brush-settings-in-mask-editor-17e6d73d365081b9aef2fd63eeea3543) by [Unito](https://www.unito.io)
