### PR TITLE
[Desktop] Loading screen

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -92,6 +92,12 @@ const router = createRouter({
           name: 'ManualConfigurationView',
           component: () => import('@/views/ManualConfigurationView.vue'),
           beforeEnter: guardElectronAccess
+        },
+        {
+          path: 'desktop-start',
+          name: 'DesktopStartView',
+          component: () => import('@/views/DesktopStartView.vue'),
+          beforeEnter: guardElectronAccess
         }
       ]
     }

--- a/src/views/DesktopStartView.vue
+++ b/src/views/DesktopStartView.vue
@@ -1,0 +1,13 @@
+<template>
+  <div
+    class="w-screen h-screen grid items-center justify-around text-neutral-300 bg-neutral-900 dark-theme pointer-events-auto overflow-y-auto"
+  >
+    <div class="max-w-screen-sm w-screen p-8">
+      <ProgressBar mode="indeterminate" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ProgressBar from 'primevue/progressbar'
+</script>

--- a/src/views/DesktopStartView.vue
+++ b/src/views/DesktopStartView.vue
@@ -1,13 +1,13 @@
 <template>
-  <div
-    class="w-screen h-screen grid items-center justify-around text-neutral-300 bg-neutral-900 dark-theme pointer-events-auto overflow-y-auto"
-  >
+  <BaseViewTemplate dark>
     <div class="max-w-screen-sm w-screen p-8">
       <ProgressBar mode="indeterminate" />
     </div>
-  </div>
+  </BaseViewTemplate>
 </template>
 
 <script setup lang="ts">
 import ProgressBar from 'primevue/progressbar'
+
+import BaseViewTemplate from './templates/BaseViewTemplate.vue'
 </script>


### PR DESCRIPTION
### Desktop loading screen

- Adds a basic loading spinner that is displayed until desktop requests another route.
- This is a pre-requisite for https://github.com/Comfy-Org/desktop/pull/660

![image](https://github.com/user-attachments/assets/d7273f29-0d8a-413b-85c4-051da5e74fb4)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2274-Desktop-Loading-screen-17e6d73d3650812c9ba0f1187005e1b8) by [Unito](https://www.unito.io)
