### PR TITLE
Move queueStore update from QueueSidebarTab to GraphView

### DIFF
--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -99,7 +99,7 @@ import type { MenuItem } from 'primevue/menuitem'
 import ProgressSpinner from 'primevue/progressspinner'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
-import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
@@ -194,10 +194,6 @@ const confirmRemoveAll = (event: Event) => {
   })
 }
 
-const onStatus = async () => {
-  await queueStore.update()
-}
-
 const menu = ref(null)
 const menuTargetTask = ref<TaskItemImpl | null>(null)
 const menuTargetNode = ref<ComfyNode | null>(null)
@@ -266,14 +262,5 @@ watch(allTasks, () => {
 
   const newIndex = galleryActiveIndex.value + lengthChange
   galleryActiveIndex.value = Math.max(0, newIndex)
-})
-
-onMounted(() => {
-  api.addEventListener('status', onStatus)
-  queueStore.update()
-})
-
-onUnmounted(() => {
-  api.removeEventListener('status', onStatus)
 })
 </script>

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -55,6 +55,7 @@ const toast = useToast()
 const settingStore = useSettingStore()
 const executionStore = useExecutionStore()
 const colorPaletteStore = useColorPaletteStore()
+const queueStore = useQueueStore()
 
 watch(
   () => colorPaletteStore.completedActivePalette,
@@ -110,9 +111,7 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
-  useQueueStore().maxHistoryItems = settingStore.get(
-    'Comfy.Queue.MaxHistoryItems'
-  )
+  queueStore.maxHistoryItems = settingStore.get('Comfy.Queue.MaxHistoryItems')
 })
 
 const init = () => {
@@ -126,8 +125,9 @@ const init = () => {
 }
 
 const queuePendingTaskCountStore = useQueuePendingTaskCountStore()
-const onStatus = (e: CustomEvent<StatusWsMessageStatus>) => {
+const onStatus = async (e: CustomEvent<StatusWsMessageStatus>) => {
   queuePendingTaskCountStore.update(e)
+  await queueStore.update()
 }
 
 const reconnectingMessage: ToastMessageOptions = {


### PR DESCRIPTION
This PR moves `queueStore.update` call from QueueSidebarTab to GraphView, so even when the queue sidebar tab is collapsed, the queueStore states are still up-to-date.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2278-Move-queueStore-update-from-QueueSidebarTab-to-GraphView-17e6d73d36508129a4b0ee4f9b12bb24) by [Unito](https://www.unito.io)
