### PR TITLE
[Desktop] Ctrl+w to close workflow tab

### DIFF
--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -181,6 +181,16 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
       }
     ],
 
+    keybindings: [
+      {
+        commandId: 'Workspace.CloseWorkflow',
+        combo: {
+          key: 'w',
+          ctrl: true
+        }
+      }
+    ],
+
     aboutPageBadges: [
       {
         label: 'ComfyUI_desktop v' + desktopAppVersion,


### PR DESCRIPTION
In browser `Ctrl + w` is binded to close the current browser tab. So set this keybinding for desktop only.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2282-Desktop-Ctrl-w-to-close-workflow-tab-17f6d73d365081898beaf9c824cfa396) by [Unito](https://www.unito.io)
