### PR TITLE
[Refactor] improve type safety in dialog service

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -942,7 +942,7 @@ export class ComfyApp {
 
     api.addEventListener('execution_error', ({ detail }) => {
       this.lastExecutionError = detail
-      useDialogService().showExecutionErrorDialog(detail)
+      useDialogService().showExecutionErrorDialog({ error: detail })
       this.canvas.draw(true, true)
     })
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -8,8 +8,6 @@ import SettingDialogHeader from '@/components/dialog/header/SettingDialogHeader.
 import TemplateWorkflowsContent from '@/components/templates/TemplateWorkflowsContent.vue'
 import { t } from '@/i18n'
 import { type ShowDialogOptions, useDialogStore } from '@/stores/dialogStore'
-import type { ExecutionErrorWsMessage } from '@/types/apiTypes'
-import type { MissingNodeType } from '@/types/comfy'
 
 export type ConfirmationDialogType =
   | 'default'
@@ -20,10 +18,9 @@ export type ConfirmationDialogType =
 
 export const useDialogService = () => {
   const dialogStore = useDialogStore()
-  function showLoadWorkflowWarning(props: {
-    missingNodeTypes: MissingNodeType[]
-    [key: string]: any
-  }) {
+  function showLoadWorkflowWarning(
+    props: InstanceType<typeof LoadWorkflowWarning>['$props']
+  ) {
     dialogStore.showDialog({
       key: 'global-load-workflow-warning',
       component: LoadWorkflowWarning,
@@ -31,11 +28,9 @@ export const useDialogService = () => {
     })
   }
 
-  function showMissingModelsWarning(props: {
-    missingModels: any[]
-    paths: Record<string, string[]>
-    [key: string]: any
-  }) {
+  function showMissingModelsWarning(
+    props: InstanceType<typeof MissingModelsWarning>['$props']
+  ) {
     dialogStore.showDialog({
       key: 'global-missing-models-warning',
       component: MissingModelsWarning,
@@ -67,21 +62,24 @@ export const useDialogService = () => {
     })
   }
 
-  function showExecutionErrorDialog(error: ExecutionErrorWsMessage) {
+  function showExecutionErrorDialog(
+    props: InstanceType<typeof ExecutionErrorDialogContent>['$props']
+  ) {
     dialogStore.showDialog({
       key: 'global-execution-error',
       component: ExecutionErrorDialogContent,
-      props: {
-        error
-      }
+      props
     })
   }
 
-  function showTemplateWorkflowsDialog() {
+  function showTemplateWorkflowsDialog(
+    props?: InstanceType<typeof TemplateWorkflowsContent>['$props']
+  ) {
     dialogStore.showDialog({
       key: 'global-template-workflows',
       title: t('templateWorkflows.title'),
-      component: TemplateWorkflowsContent
+      component: TemplateWorkflowsContent,
+      props
     })
   }
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -73,7 +73,7 @@ export const useDialogService = () => {
   }
 
   function showTemplateWorkflowsDialog(
-    props?: InstanceType<typeof TemplateWorkflowsContent>['$props']
+    props: InstanceType<typeof TemplateWorkflowsContent>['$props'] = {}
   ) {
     dialogStore.showDialog({
       key: 'global-template-workflows',


### PR DESCRIPTION
Establishes pattern in dialog service functions of inheriting the rendered component's prop types directly instead of re-declaring manually.

[According to codesearch](https://cs.comfy.org/search?q=context:global+show%28%3F:ExecutionError%7CTemplateWorkflows%29Dialog+&patternType=regexp&sm=0), no custom nodes are using `showTemplateWorkflowsDialog` or `showExecutionErrorDialog`



https://github.com/user-attachments/assets/441f54af-4879-4141-8d84-a0d251783d58

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2283-Refactor-improve-type-safety-in-dialog-service-17f6d73d3650811692d2cad827832272) by [Unito](https://www.unito.io)
