### PR TITLE
Prevent Enter Key from Triggering Selection During IME Composition in AutoCompletePlus

### DIFF
--- a/src/components/primevueOverride/AutoCompletePlus.vue
+++ b/src/components/primevueOverride/AutoCompletePlus.vue
@@ -6,11 +6,27 @@ export default {
   name: 'AutoCompletePlus',
   extends: AutoComplete,
   emits: ['focused-option-changed'],
+  data() {
+    return {
+      // Flag to determine if IME is active
+      isComposing: false
+    }
+  },
   mounted() {
     if (typeof AutoComplete.mounted === 'function') {
       AutoComplete.mounted.call(this)
     }
 
+    // Retrieve the actual <input> element and attach IME events
+    const inputEl = this.$el.querySelector('input')
+    if (inputEl) {
+      inputEl.addEventListener('compositionstart', () => {
+        this.isComposing = true
+      })
+      inputEl.addEventListener('compositionend', () => {
+        this.isComposing = false
+      })
+    }
     // Add a watcher on the focusedOptionIndex property
     this.$watch(
       () => this.focusedOptionIndex,
@@ -19,6 +35,18 @@ export default {
         this.$emit('focused-option-changed', newVal)
       }
     )
+  },
+  methods: {
+    // Override onKeyDown to block Enter when IME is active
+    onKeyDown(event) {
+      if (event.key === 'Enter' && this.isComposing) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+
+      AutoComplete.methods.onKeyDown.call(this, event)
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Summary
This PR fixes an issue where pressing the Enter key during an IME composition would prematurely select a suggested option in the AutoCompletePlus component. By properly detecting and blocking the Enter key when IME is active, users can now finalize their text input without accidentally triggering an unwanted selection.

**before:**
<video src="https://github.com/user-attachments/assets/1a835fb1-f57f-4100-8533-35618956f75f.mov" />

**after:**
<video src="https://github.com/user-attachments/assets/d9332c5c-3011-43c6-aa63-3a2aecb28be4" />


## Changes
1. **IME Active Flag**  
   - Added `isComposing` to track whether IME composition is in progress.

2. **onKeyDown Override**  
   - Overrode the parent component's `onKeyDown` method to prevent the default behavior and event propagation if Enter is pressed while IME is active.

3. **Event Listeners**  
   - Attached `compositionstart` and `compositionend` event handlers to the underlying `<input>` element to update the `isComposing` flag.

## Testing
 -  Verified that pressing Enter during IME input (e.g., Japanese) no longer selects a suggestion prematurely.
 -  Ensured that normal Enter-to-select functionality remains unaffected once IME composition is finished.

Please review the changes to ensure they align with your requirements. Feedback and suggestions are welcome!

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2285-Prevent-Enter-Key-from-Triggering-Selection-During-IME-Composition-in-AutoCompletePlus-17f6d73d365081eab725de9d27ff31b5) by [Unito](https://www.unito.io)
