### PR TITLE
Fix metrics setting update persistence

### DIFF
--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -31,7 +31,9 @@ function onChange(setting: SettingParams, newValue: any, oldValue: any) {
   }
   // Backward compatibility with old settings dialog.
   // Some extensions still listens event emitted by the old settings dialog.
-  app.ui.settings.dispatchChange(setting.id, newValue, oldValue)
+  if (setting?.id) {
+    app.ui.settings.dispatchChange(setting.id, newValue, oldValue)
+  }
 }
 
 export const useSettingStore = defineStore('setting', () => {

--- a/src/views/MetricsConsentView.vue
+++ b/src/views/MetricsConsentView.vue
@@ -53,19 +53,22 @@ import ToggleSwitch from 'primevue/toggleswitch'
 import { useToast } from 'primevue/usetoast'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
 
+import { useSettingStore } from '@/stores/settingStore'
 import { electronAPI } from '@/utils/envUtil'
 
 const toast = useToast()
 const { t } = useI18n()
 
 const allowMetrics = ref(true)
-const router = useRouter()
 const isUpdating = ref(false)
 
 const updateConsent = async () => {
   isUpdating.value = true
+  await useSettingStore().set(
+    'Comfy-Desktop.SendStatistics',
+    allowMetrics.value
+  )
   try {
     await electronAPI().setMetricsConsent(allowMetrics.value)
   } catch (error) {
@@ -78,6 +81,5 @@ const updateConsent = async () => {
   } finally {
     isUpdating.value = false
   }
-  router.push('/')
 }
 </script>

--- a/src/views/MetricsConsentView.vue
+++ b/src/views/MetricsConsentView.vue
@@ -65,18 +65,19 @@ const isUpdating = ref(false)
 
 const updateConsent = async () => {
   isUpdating.value = true
-  await useSettingStore().set(
-    'Comfy-Desktop.SendStatistics',
-    allowMetrics.value
-  )
   try {
+    await useSettingStore().set(
+      'Comfy-Desktop.SendStatistics',
+      allowMetrics.value
+    )
     await electronAPI().setMetricsConsent(allowMetrics.value)
   } catch (error) {
+    console.error('Failed to update metrics consent:', error)
     toast.add({
       severity: 'error',
       summary: t('install.errorUpdatingConsent'),
       detail: t('install.errorUpdatingConsentDetail'),
-      life: 3000
+      life: 5000
     })
   } finally {
     isUpdating.value = false


### PR DESCRIPTION
Fixes issue with metrics setting persistence that occurs when updating desktop.

To reproduce:

1. Download previous version of desktop
2. Optin to crash reports in onboarding
3. Close the application
4. Update to >0.4.7 Desktop
5. Start desktop app
6. During update metrics consent process, change preference to disabled
7. Close the app
8. Open the app
9. Check `Comfy-Desktop.SendStatistics` setting

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2288-Fix-metrics-setting-update-persistence-1806d73d365081bdbd86c89240f3e1d3) by [Unito](https://www.unito.io)
