### PR TITLE
[Desktop] Add electron types update script

### DIFF
--- a/scripts/update-electron-types.js
+++ b/scripts/update-electron-types.js
@@ -1,0 +1,43 @@
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+
+const packageName = '@comfyorg/comfyui-electron-types'
+const description = 'desktop API types'
+
+try {
+  // Create a new branch
+  console.log('Creating new branch...')
+  const date = new Date()
+  const isoDate = date.toISOString().split('T')[0]
+  const timestamp = date.getTime()
+  const branchName = `update-electron-types-${isoDate}-${timestamp}`
+  execSync(`git checkout -b ${branchName} -t origin/main`, { stdio: 'inherit' })
+
+  // Update npm package to latest version
+  console.log(`Updating ${description}...`)
+  execSync(`npm install ${packageName}@latest`, {
+    stdio: 'inherit'
+  })
+
+  // Get the new version from package.json
+  const packageLock = JSON.parse(readFileSync('./package-lock.json', 'utf8'))
+  const newVersion = packageLock.packages[`node_modules/${packageName}`].version
+
+  // Stage changes
+  const message = `[chore] Update electron-types to ${newVersion}`
+  execSync('git add package.json package-lock.json', { stdio: 'inherit' })
+  execSync(`git commit -m "${message}"`, { stdio: 'inherit' })
+
+  // Create the PR
+  console.log('Creating PR...')
+  execSync(
+    `gh pr create --title "${message}" --label "dependencies" --body "Automated update of ${description} to version ${newVersion}."`,
+    { stdio: 'inherit' }
+  )
+
+  console.log(
+    `✅ Successfully created PR for ${description} update to ${newVersion}`
+  )
+} catch (error) {
+  console.error('❌ Error during update process:', error.message)
+}


### PR DESCRIPTION
- Duplicated `update-litegraph.js`
- Updated commit messages to match latest electron chore commit
- Extracted name & description to `const` to allow easy duplication, or refactor to shared func / generic
- Updated package & description
- nit: Refactor date gen to use same instant

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2290-Desktop-Add-electron-types-update-script-1806d73d365081a3947dc09fb66b6f61) by [Unito](https://www.unito.io)
