### PR TITLE
[chore] Update electron-types to 0.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-        "@comfyorg/comfyui-electron-types": "^0.4.10",
+        "@comfyorg/comfyui-electron-types": "^0.4.11",
         "@comfyorg/litegraph": "^0.8.60",
         "@primevue/themes": "^4.0.5",
         "@sentry/vue": "^8.48.0",
@@ -1936,9 +1936,10 @@
       "dev": true
     },
     "node_modules/@comfyorg/comfyui-electron-types": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.4.10.tgz",
-      "integrity": "sha512-UWBgyuWeV7vussYZVUYhCe0jj+XbIq2nglrCUy6IgFgXp9pbE8Ktg5D36WxE0RWj6SvVXErlCL9wWnMktaRbCA=="
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.4.11.tgz",
+      "integrity": "sha512-RGJeWwXjyv0Ojj7xkZKgcRxC1nFv1nh7qEWpNBiofxVgFiap9Ei79b/KJYxNE0no4BoYqRMaRg+sFtCE6yEukA==",
+      "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
       "version": "0.8.60",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/comfyui-electron-types": "^0.4.10",
+    "@comfyorg/comfyui-electron-types": "^0.4.11",
     "@comfyorg/litegraph": "^0.8.60",
     "@primevue/themes": "^4.0.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of desktop API types to version 0.4.11.

Adds app quit IPC.

- Frontend: #2286
- Desktop: Comfy-Org/desktop/pull/667