### PR TITLE
[DevExperience] Tailwind rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist-ssr
 *.code-workspace
 !.vscode/extensions.json
 !.vscode/tailwind.json
+!.vscode/settings.json.default
 .idea
 .DS_Store
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 .vscode/*
 *.code-workspace
 !.vscode/extensions.json
+!.vscode/tailwind.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json.default
+++ b/.vscode/settings.json.default
@@ -1,0 +1,5 @@
+{
+  "css.customData": [
+    ".vscode/tailwind.json"
+  ]
+}

--- a/.vscode/tailwind.json
+++ b/.vscode/tailwind.json
@@ -1,0 +1,55 @@
+{
+  "version": 1.1,
+  "atDirectives": [
+    {
+      "name": "@tailwind",
+      "description": "Use the `@tailwind` directive to insert Tailwind's `base`, `components`, `utilities` and `screens` styles into your CSS.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#tailwind"
+        }
+      ]
+    },
+    {
+      "name": "@apply",
+      "description": "Use the `@apply` directive to inline any existing utility classes into your own custom CSS. This is useful when you find a common utility pattern in your HTML that you’d like to extract to a new component.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#apply"
+        }
+      ]
+    },
+    {
+      "name": "@responsive",
+      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the `@responsive` directive:\n```css\n@responsive {\n  .alert {\n    background-color: #E53E3E;\n  }\n}\n```\n",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#responsive"
+        }
+      ]
+    },
+    {
+      "name": "@screen",
+      "description": "The `@screen` directive allows you to create media queries that reference your breakpoints by **name** instead of duplicating their values in your own CSS:\n```css\n@screen sm {\n  /* ... */\n}\n```\n…gets transformed into this:\n```css\n@media (min-width: 640px) {\n  /* ... */\n}\n```\n",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#screen"
+        }
+      ]
+    },
+    {
+      "name": "@variants",
+      "description": "Generate `hover`, `focus`, `active` and other **variants** of your own utilities by wrapping their definitions in the `@variants` directive:\n```css\n@variants hover, focus {\n   .btn-brand {\n    background-color: #3182CE;\n  }\n}\n```\n",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#variants"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### Current

IDE warnings for unknown at rules.

![image](https://github.com/user-attachments/assets/7ee394db-854f-4847-bbac-0fe77f52ae4a)

#### Proposed

Developers can opt to rename `settings.json.default` -> `settings.json`, or copy the rule.  This includes tailwind rules in the CSS language for this directory (repo).

![image](https://github.com/user-attachments/assets/983352d1-386b-418c-a3c4-9423463e4213)

Source / credit:
https://github.com/tailwindlabs/tailwindcss/discussions/5258#discussioncomment-1979394

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2292-DevExperience-Tailwind-rules-1806d73d36508190abc3cf07e19b0256) by [Unito](https://www.unito.io)
