### PR TITLE
[Style] Use import/export icons for colour palette

### DIFF
--- a/src/components/dialog/content/setting/ColorPaletteMessage.vue
+++ b/src/components/dialog/content/setting/ColorPaletteMessage.vue
@@ -13,13 +13,13 @@
           optionValue="id"
         />
         <Button
-          icon="pi pi-upload"
+          icon="pi pi-file-export"
           text
           :title="$t('g.export')"
           @click="colorPaletteService.exportColorPalette(activePaletteId)"
         />
         <Button
-          icon="pi pi-download"
+          icon="pi pi-file-import"
           text
           :title="$t('g.import')"
           @click="importCustomPalette"


### PR DESCRIPTION
#### Current

The upload/download icons used as export/import buttons feels reversed to some users:

![image](https://github.com/user-attachments/assets/cbb90845-b7b8-4784-b9ae-e795929dc7d0)

#### Proposed

Replace with export/import icons:

![image](https://github.com/user-attachments/assets/bc13f9e4-9b3a-45fe-bf47-2ea46a8359a2)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2300-Style-Use-import-export-icons-for-colour-palette-1816d73d36508121b98dca33d858e4a5) by [Unito](https://www.unito.io)
