### PR TITLE
[Desktop] Fix unnecessary setting update

### DIFF
--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -41,15 +41,17 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
         id: 'Comfy-Desktop.WindowStyle',
         category: ['Comfy-Desktop', 'General', 'Window Style'],
         name: 'Window Style',
-        tooltip: 'Choose custom option to hide the system title bar',
+        tooltip: "Custom: Replace the system title bar with ComfyUI's Top menu",
         type: 'combo',
         experimental: true,
         defaultValue: 'default',
         options: ['default', 'custom'],
         onChange: (
           newValue: 'default' | 'custom',
-          oldValue: 'default' | 'custom'
+          oldValue?: 'default' | 'custom'
         ) => {
+          if (!oldValue) return
+
           electronAPI.Config.setWindowStyle(newValue)
 
           onChangeRestartApp(newValue, oldValue)

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -1,6 +1,7 @@
 import { t } from '@/i18n'
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
+import { useSettingStore } from '@/stores/settingStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
 
@@ -52,9 +53,12 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
         ) => {
           if (!oldValue) return
 
-          electronAPI.Config.setWindowStyle(newValue)
+          // Custom window mode requires the Top menu.
+          if (newValue === 'custom' && oldValue !== newValue) {
+            useSettingStore().set('Comfy.UseNewMenu', 'Top')
+          }
 
-          onChangeRestartApp(newValue, oldValue)
+          electronAPI.Config.setWindowStyle(newValue)
         }
       }
     ],

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -53,11 +53,6 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
         ) => {
           if (!oldValue) return
 
-          // Custom window mode requires the Top menu.
-          if (newValue === 'custom' && oldValue !== newValue) {
-            useSettingStore().set('Comfy.UseNewMenu', 'Top')
-          }
-
           electronAPI.Config.setWindowStyle(newValue)
         }
       }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -9,8 +9,8 @@
     "name": "Window Style",
     "tooltip": "Custom: Replace the system title bar with ComfyUI's Top menu",
     "options": {
-      "default": "Default",
-      "custom": "Custom"
+      "default": "default",
+      "custom": "custom"
     }
   },
   "Comfy_ConfirmClear": {

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -7,10 +7,10 @@
   },
   "Comfy-Desktop_WindowStyle": {
     "name": "Window Style",
-    "tooltip": "Choose custom option to hide the system title bar",
+    "tooltip": "Custom: Replace the system title bar with ComfyUI's Top menu",
     "options": {
-      "default": "default",
-      "custom": "custom"
+      "default": "Default",
+      "custom": "Custom"
     }
   },
   "Comfy_ConfirmClear": {


### PR DESCRIPTION
- Prevents setting change from being sent to desktop when nothing has changed.
- Fixes infinite setting loop in https://github.com/Comfy-Org/desktop/pull/601.
- Fixes option display capitalisation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2301-Desktop-Fix-unnecessary-setting-update-1816d73d36508126a16bcbeccda13b58) by [Unito](https://www.unito.io)
