### PR TITLE
[Refactor] Move type extensions out of LG (SoC)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.11",
-        "@comfyorg/litegraph": "^0.8.60",
+        "@comfyorg/litegraph": "^0.8.61",
         "@primevue/themes": "^4.0.5",
         "@sentry/vue": "^8.48.0",
         "@tiptap/core": "^2.10.4",
@@ -1942,9 +1942,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.60",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.60.tgz",
-      "integrity": "sha512-LkZalBcka1xVxkL7JnkF/1EzyvspLyrSthzyN9ZumWJw7kAaZkO9omraXv2t/UiFsqwMr5M/AV5UY915Vq8cxQ==",
+      "version": "0.8.61",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.61.tgz",
+      "integrity": "sha512-7DroJ0PLgI9TFvQR//6rf0NRXRvV60hapxVX5lmKzNn4Mn2Ni/JsB2ypNLKeSU5sacNyu8QT3W5Jdpafl7lcnA==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.11",
-    "@comfyorg/litegraph": "^0.8.60",
+    "@comfyorg/litegraph": "^0.8.61",
     "@primevue/themes": "^4.0.5",
     "@sentry/vue": "^8.48.0",
     "@tiptap/core": "^2.10.4",

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -272,7 +272,7 @@ LGraphCanvas.prototype.computeVisibleNodes = function (): LGraphNode[] {
           w.element.hidden = actualHidden
           w.element.style.display = actualHidden ? 'none' : null
           if (actualHidden && !wasHidden) {
-            w.options.onHide?.(w)
+            w.options.onHide?.(w as DOMWidget<HTMLElement, object>)
           }
         }
       }

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -367,7 +367,6 @@ export const useLitegraphService = () => {
         const w = node.widgets[node.widgets.length - 1]
         shiftY = w.last_y
         if (w.computeSize) {
-          // @ts-expect-error requires 1 param
           shiftY += w.computeSize()[1] + 4
           // @ts-expect-error computedHeight only exists for DOMWidget
         } else if (w.computedHeight) {

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -1,9 +1,23 @@
 import '@comfyorg/litegraph'
 import type { LLink } from '@comfyorg/litegraph'
 
+import type { DOMWidget } from '@/scripts/domWidget'
 import type { ComfyNodeDef } from '@/types/apiTypes'
 
 import type { NodeId } from './comfyWorkflow'
+
+/** ComfyUI extensions of litegraph */
+declare module '@comfyorg/litegraph/dist/types/widgets' {
+  interface IWidgetOptions {
+    /** Currently used by DOM widgets only.  Declaring here reduces complexity. */
+    onHide?: (widget: DOMWidget) => void
+  }
+
+  interface IBaseWidget {
+    onRemove?: () => void
+    beforeQueued?: () => unknown
+  }
+}
 
 /**
  *  ComfyUI extensions of litegraph


### PR DESCRIPTION
- Requires https://github.com/Comfy-Org/litegraph.js/pull/428
- Improves separation of concerns
- Allows frontend to add more of its own widget extension props

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2303-Refactor-Move-type-extensions-out-of-LG-SoC-1816d73d36508174938de3849aa2a48c) by [Unito](https://www.unito.io)
