### PR TITLE
Add Comfy Forum (forum.comfy.org) to Help menu

### DIFF
--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -19,7 +19,8 @@ export const CORE_MENU_COMMANDS = [
     [
       'Comfy.Help.OpenComfyUIIssues',
       'Comfy.Help.OpenComfyUIDocs',
-      'Comfy.Help.OpenComfyOrgDiscord'
+      'Comfy.Help.OpenComfyOrgDiscord',
+      'Comfy.Help.OpenComfyUIForum'
     ]
   ],
   [['Help'], ['Comfy.Help.AboutComfyUI', 'Comfy.Feedback']]

--- a/src/hooks/coreCommandHooks.ts
+++ b/src/hooks/coreCommandHooks.ts
@@ -559,8 +559,8 @@ export function useCoreCommands(): ComfyCommand[] {
     {
       id: 'Comfy.Help.OpenComfyUIForum',
       icon: 'pi pi-comments',
-      label: 'Open Comfy-Org Forum',
-      menubarLabel: 'Comfy-Org Forum',
+      label: 'Open ComfyUI Forum',
+      menubarLabel: 'ComfyUI Forum',
       versionAdded: '1.8.2',
       function: () => {
         window.open('https://forum.comfy.org/', '_blank')

--- a/src/hooks/coreCommandHooks.ts
+++ b/src/hooks/coreCommandHooks.ts
@@ -555,6 +555,16 @@ export function useCoreCommands(): ComfyCommand[] {
           }
         })
       }
+    },
+    {
+      id: 'Comfy.Help.OpenComfyUIForum',
+      icon: 'pi pi-comments',
+      label: 'Open Comfy-Org Forum',
+      menubarLabel: 'Comfy-Org Forum',
+      versionAdded: '1.8.2',
+      function: () => {
+        window.open('https://forum.comfy.org/', '_blank')
+      }
     }
   ]
 }

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -110,6 +110,9 @@
   "Comfy_Help_OpenComfyUIDocs": {
     "label": "Open ComfyUI Docs"
   },
+  "Comfy_Help_OpenComfyUIForum": {
+    "label": "Open Comfy-Org Forum"
+  },
   "Comfy_Help_OpenComfyUIIssues": {
     "label": "Open ComfyUI Issues"
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -392,6 +392,7 @@
     "About ComfyUI": "About ComfyUI",
     "Comfy-Org Discord": "Comfy-Org Discord",
     "ComfyUI Docs": "ComfyUI Docs",
+    "Comfy-Org Forum": "Comfy-Org Forum",
     "ComfyUI Issues": "ComfyUI Issues",
     "Interrupt": "Interrupt",
     "Load Default Workflow": "Load Default Workflow",

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -110,6 +110,9 @@
   "Comfy_Help_OpenComfyUIDocs": {
     "label": "Ouvrir les documents ComfyUI"
   },
+  "Comfy_Help_OpenComfyUIForum": {
+    "label": "Ouvrir le forum Comfy-Org"
+  },
   "Comfy_Help_OpenComfyUIIssues": {
     "label": "Ouvrir les problèmes ComfyUI"
   },

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -292,6 +292,7 @@
     "Close Current Workflow": "Fermer le flux de travail actuel",
     "Collapse/Expand Selected Nodes": "Réduire/Étendre les nœuds sélectionnés",
     "Comfy-Org Discord": "Discord de Comfy-Org",
+    "Comfy-Org Forum": "Forum Comfy-Org",
     "ComfyUI Docs": "Docs de ComfyUI",
     "ComfyUI Issues": "Problèmes de ComfyUI",
     "Convert selected nodes to group node": "Convertir les nœuds sélectionnés en nœud de groupe",

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -110,6 +110,9 @@
   "Comfy_Help_OpenComfyUIDocs": {
     "label": "ComfyUIのドキュメントを開く"
   },
+  "Comfy_Help_OpenComfyUIForum": {
+    "label": "Comfy-Orgフォーラムを開く"
+  },
   "Comfy_Help_OpenComfyUIIssues": {
     "label": "ComfyUIの問題を開く"
   },

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -292,6 +292,7 @@
     "Close Current Workflow": "現在のワークフローを閉じる",
     "Collapse/Expand Selected Nodes": "選択したノードの折りたたみ/展開",
     "Comfy-Org Discord": "Comfy-Org Discord",
+    "Comfy-Org Forum": "Comfy-Org フォーラム",
     "ComfyUI Docs": "ComfyUIのドキュメント",
     "ComfyUI Issues": "ComfyUIの問題",
     "Convert selected nodes to group node": "選択したノードをグループノードに変換",

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -110,6 +110,9 @@
   "Comfy_Help_OpenComfyUIDocs": {
     "label": "ComfyUI 문서 열기"
   },
+  "Comfy_Help_OpenComfyUIForum": {
+    "label": "Comfy-Org 포럼 열기"
+  },
   "Comfy_Help_OpenComfyUIIssues": {
     "label": "ComfyUI 문제 열기"
   },

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -292,6 +292,7 @@
     "Close Current Workflow": "현재 워크플로 닫기",
     "Collapse/Expand Selected Nodes": "선택한 노드 축소/확장",
     "Comfy-Org Discord": "Comfy-Org 디스코드",
+    "Comfy-Org Forum": "Comfy-Org 포럼",
     "ComfyUI Docs": "ComfyUI 문서",
     "ComfyUI Issues": "ComfyUI 이슈 페이지",
     "Convert selected nodes to group node": "선택한 노드를 그룹 노드로 변환",

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -110,6 +110,9 @@
   "Comfy_Help_OpenComfyUIDocs": {
     "label": "Открыть документацию ComfyUI"
   },
+  "Comfy_Help_OpenComfyUIForum": {
+    "label": "Открыть форум Comfy-Org"
+  },
   "Comfy_Help_OpenComfyUIIssues": {
     "label": "Открыть ComfyUI  Issues"
   },

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -292,6 +292,7 @@
     "Close Current Workflow": "Закрыть текущий рабочий процесс",
     "Collapse/Expand Selected Nodes": "Свернуть/развернуть выбранные ноды",
     "Comfy-Org Discord": "Discord Comfy-Org",
+    "Comfy-Org Forum": "Форум Comfy-Org",
     "ComfyUI Docs": "Документация ComfyUI",
     "ComfyUI Issues": "Проблемы ComfyUI",
     "Convert selected nodes to group node": "Преобразовать выбранные ноды в групповую ноду",

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -110,6 +110,9 @@
   "Comfy_Help_OpenComfyUIDocs": {
     "label": "打开ComfyUI文档"
   },
+  "Comfy_Help_OpenComfyUIForum": {
+    "label": "打开 Comfy-Org 论坛"
+  },
   "Comfy_Help_OpenComfyUIIssues": {
     "label": "打开ComfyUI问题"
   },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -292,6 +292,7 @@
     "Close Current Workflow": "关闭当前工作流",
     "Collapse/Expand Selected Nodes": "折叠/展开选定节点",
     "Comfy-Org Discord": "Comfy-Org Discord",
+    "Comfy-Org Forum": "Comfy-Org 论坛",
     "ComfyUI Docs": "ComfyUI 文档",
     "ComfyUI Issues": "ComfyUI 问题",
     "Convert selected nodes to group node": "将选中节点转换为组节点",


### PR DESCRIPTION
This PR adds a menu entry in the Help section of the Top Menu which links to the Comfy Forum.

![Selection_783](https://github.com/user-attachments/assets/2dfaac6c-b6d2-4093-ab9b-b92d0e578ce6)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2305-Add-Comfy-Forum-forum-comfy-org-to-Help-menu-1816d73d365081b08982cac77ec8ed09) by [Unito](https://www.unito.io)
