### PR TITLE
Add tutorial workflow function for new desktop users

### DIFF
--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -125,6 +125,7 @@ test.describe('Missing models warning', () => {
     await comfyPage.setup({ clearStorage: true })
     const missingModelsWarning = comfyPage.page.locator('.comfy-missing-models')
     await expect(missingModelsWarning).toBeVisible()
+    expect(await comfyPage.getSetting('Comfy.TutorialCompleted')).toBe(true)
   })
 
   // Flaky test after parallelization

--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -120,6 +120,13 @@ test.describe('Missing models warning', () => {
     await expect(missingModelsWarning).not.toBeVisible()
   })
 
+  test('should show on tutorial workflow', async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.TutorialCompleted', false)
+    await comfyPage.setup({ clearStorage: true })
+    const missingModelsWarning = comfyPage.page.locator('.comfy-missing-models')
+    await expect(missingModelsWarning).toBeVisible()
+  })
+
   // Flaky test after parallelization
   // https://github.com/Comfy-Org/ComfyUI_frontend/pull/1400
   test.skip('Should download missing model when clicking download button', async ({

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -904,7 +904,9 @@ export const comfyPageFixture = base.extend<{ comfyPage: ComfyPage }>({
         'Comfy.NodeBadge.NodeSourceBadgeMode': NodeBadgeMode.None,
         // Disable tooltips by default to avoid flakiness.
         'Comfy.EnableTooltips': false,
-        'Comfy.userId': userId
+        'Comfy.userId': userId,
+        // Set tutorial completed to true to avoid loading the tutorial workflow.
+        'Comfy.TutorialCompleted': true
       })
     } catch (e) {
       console.error(e)

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -714,6 +714,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Tutorial completed',
     type: 'hidden',
     defaultValue: true,
-    versionAdded: '1.8.5'
+    versionAdded: '1.8.6'
   }
 ]

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -713,7 +713,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.TutorialCompleted',
     name: 'Tutorial completed',
     type: 'hidden',
-    defaultValue: true,
-    versionAdded: '1.8.5'
+    defaultValue: false,
+    versionAdded: '1.8.7'
   }
 ]

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -708,5 +708,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: 'after',
     options: ['before', 'after'],
     versionModified: '1.6.10'
+  },
+  {
+    id: 'Comfy.TutorialCompleted',
+    name: 'Tutorial completed',
+    type: 'hidden',
+    defaultValue: true,
+    versionAdded: '1.8.5'
   }
 ]

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -714,6 +714,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Tutorial completed',
     type: 'hidden',
     defaultValue: true,
-    versionAdded: '1.8.6'
+    versionAdded: '1.8.5'
   }
 ]

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1062,8 +1062,13 @@ export class ComfyApp {
     // We failed to restore a workflow so load the default
     if (!restored) {
       const settingStore = useSettingStore()
-      if (settingStore.get('Comfy.TutorialCompleted') === false) {
+
+      // If tutorial is not completed, load the tutorial workflow
+      if (!settingStore.get('Comfy.TutorialCompleted')) {
         await settingStore.set('Comfy.TutorialCompleted', true)
+        // Load model folders to ensure the missing models' corresponding folders
+        // can be correctly identified.
+        await useModelStore().loadModelFolders()
         await useWorkflowService().loadTutorialWorkflow()
       } else {
         await this.loadGraphData()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -36,7 +36,6 @@ import {
 } from '@/types/comfyWorkflow'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
-import { isElectron } from '@/utils/envUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, api } from './api'
@@ -1063,9 +1062,13 @@ export class ComfyApp {
     // We failed to restore a workflow so load the default
     if (!restored) {
       const isNewDesktopUser =
-        isElectron() && !useSettingStore().exists('Comfy.UseNewMenu')
-      if (isNewDesktopUser) await useWorkflowService().loadTutorialWorkflow()
-      else await this.loadGraphData()
+        useSettingStore().get('Comfy.TutorialCompleted') === false
+      if (isNewDesktopUser) {
+        await useSettingStore().set('Comfy.TutorialCompleted', true)
+        await useWorkflowService().loadTutorialWorkflow()
+      } else {
+        await this.loadGraphData()
+      }
     }
 
     this.#addDrawNodeHandler()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -36,6 +36,7 @@ import {
 } from '@/types/comfyWorkflow'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
+import { isElectron } from '@/utils/envUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, api } from './api'
@@ -1061,7 +1062,10 @@ export class ComfyApp {
 
     // We failed to restore a workflow so load the default
     if (!restored) {
-      await this.loadGraphData()
+      const isNewDesktopUser =
+        isElectron() && !useSettingStore().exists('Comfy.UseNewMenu')
+      if (isNewDesktopUser) await useWorkflowService().loadTutorialWorkflow()
+      else await this.loadGraphData()
     }
 
     this.#addDrawNodeHandler()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1061,10 +1061,9 @@ export class ComfyApp {
 
     // We failed to restore a workflow so load the default
     if (!restored) {
-      const isNewDesktopUser =
-        useSettingStore().get('Comfy.TutorialCompleted') === false
-      if (isNewDesktopUser) {
-        await useSettingStore().set('Comfy.TutorialCompleted', true)
+      const settingStore = useSettingStore()
+      if (settingStore.get('Comfy.TutorialCompleted') === false) {
+        await settingStore.set('Comfy.TutorialCompleted', true)
         await useWorkflowService().loadTutorialWorkflow()
       } else {
         await this.loadGraphData()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -36,7 +36,6 @@ import {
 } from '@/types/comfyWorkflow'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
-import { electronAPI, isElectron } from '@/utils/envUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, api } from './api'
@@ -1063,10 +1062,7 @@ export class ComfyApp {
     // We failed to restore a workflow so load the default
     if (!restored) {
       const settingStore = useSettingStore()
-
-      const isNewDesktopUser =
-        isElectron() && (await electronAPI().isFirstTimeSetup())
-      if (isNewDesktopUser && !settingStore.get('Comfy.TutorialCompleted')) {
+      if (settingStore.get('Comfy.TutorialCompleted') === false) {
         await settingStore.set('Comfy.TutorialCompleted', true)
         await useWorkflowService().loadTutorialWorkflow()
       } else {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -36,6 +36,7 @@ import {
 } from '@/types/comfyWorkflow'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
+import { electronAPI, isElectron } from '@/utils/envUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, api } from './api'
@@ -1062,7 +1063,10 @@ export class ComfyApp {
     // We failed to restore a workflow so load the default
     if (!restored) {
       const settingStore = useSettingStore()
-      if (settingStore.get('Comfy.TutorialCompleted') === false) {
+
+      const isNewDesktopUser =
+        isElectron() && (await electronAPI().isFirstTimeSetup())
+      if (isNewDesktopUser && !settingStore.get('Comfy.TutorialCompleted')) {
         await settingStore.set('Comfy.TutorialCompleted', true)
         await useWorkflowService().loadTutorialWorkflow()
       } else {

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -2,6 +2,7 @@ import { LGraphCanvas } from '@comfyorg/litegraph'
 import { toRaw } from 'vue'
 
 import { t } from '@/i18n'
+import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'
 import { downloadBlob } from '@/scripts/utils'
@@ -125,16 +126,9 @@ export const useWorkflowService = () => {
    * Load the tutorial workflow
    */
   const loadTutorialWorkflow = async () => {
-    const tutorialWorkflow = {
-      ...defaultGraph,
-      models: [
-        {
-          name: 'v1-5-pruned-emaonly.safetensors',
-          url: 'https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly.safetensors?download=true',
-          directory: 'checkpoints'
-        }
-      ]
-    }
+    const tutorialWorkflow = await fetch(
+      api.fileURL('/templates/default.json')
+    ).then((r) => r.json())
     await app.loadGraphData(tutorialWorkflow, false, false, 'tutorial', {
       showMissingModelsDialog: true
     })

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -122,6 +122,25 @@ export const useWorkflowService = () => {
   }
 
   /**
+   * Load the tutorial workflow
+   */
+  const loadTutorialWorkflow = async () => {
+    const tutorialWorkflow = {
+      ...defaultGraph,
+      models: [
+        {
+          name: 'v1-5-pruned-emaonly.safetensors',
+          url: 'https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly.safetensors?download=true',
+          directory: 'checkpoints'
+        }
+      ]
+    }
+    await app.loadGraphData(tutorialWorkflow, false, false, 'tutorial', {
+      showMissingModelsDialog: true
+    })
+  }
+
+  /**
    * Load a blank workflow
    */
   const loadBlankWorkflow = async () => {
@@ -366,6 +385,7 @@ export const useWorkflowService = () => {
     saveWorkflow,
     loadDefaultWorkflow,
     loadBlankWorkflow,
+    loadTutorialWorkflow,
     reloadCurrentWorkflow,
     openWorkflow,
     closeWorkflow,

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -192,7 +192,6 @@ export const useModelStore = defineStore('models', () => {
   const models = computed<ComfyModelDef[]>(() =>
     modelFolders.value.flatMap((folder) => Object.values(folder.models))
   )
-  const isLoaded = ref(false)
 
   /**
    * Loads the model folders from the server
@@ -204,13 +203,11 @@ export const useModelStore = defineStore('models', () => {
     for (const folderName of modelFolderNames.value) {
       modelFolderByName.value[folderName] = new ModelFolder(folderName)
     }
-    isLoaded.value = true
   }
 
   async function getLoadedModelFolder(
     folderName: string
   ): Promise<ModelFolder | null> {
-    if (!isLoaded.value) await loadModelFolders()
     const folder = modelFolderByName.value[folderName]
     return folder ? await folder.load() : null
   }

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -192,6 +192,7 @@ export const useModelStore = defineStore('models', () => {
   const models = computed<ComfyModelDef[]>(() =>
     modelFolders.value.flatMap((folder) => Object.values(folder.models))
   )
+  const isLoaded = ref(false)
 
   /**
    * Loads the model folders from the server
@@ -203,11 +204,13 @@ export const useModelStore = defineStore('models', () => {
     for (const folderName of modelFolderNames.value) {
       modelFolderByName.value[folderName] = new ModelFolder(folderName)
     }
+    isLoaded.value = true
   }
 
   async function getLoadedModelFolder(
     folderName: string
   ): Promise<ModelFolder | null> {
+    if (!isLoaded.value) await loadModelFolders()
     const folder = modelFolderByName.value[folderName]
     return folder ? await folder.load() : null
   }


### PR DESCRIPTION
This PR adds a function in workflow service that loads a tutorial workflow for first time users on the desktop app. 

Currently it just loads the default workflow with model information. The option to show missing models dialog is set to true to help download the missing model.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2315-Add-tutorial-workflow-function-for-new-desktop-users-1836d73d36508182b16ac2c7b12e635b) by [Unito](https://www.unito.io)
