### PR TITLE
Fix console error on adding node via searchbox

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -60,8 +60,9 @@
       <!-- FilterAndValue -->
       <template v-slot:chip="{ value }">
         <SearchFilterChip
+          v-if="Array.isArray(value) && value.length === 2"
           :key="`${value[0].id}-${value[1]}`"
-          @remove="onRemoveFilter($event, value)"
+          @remove="onRemoveFilter($event, value as FilterAndValue)"
           :text="value[1]"
           :badge="value[0].invokeSequence.toUpperCase()"
           :badge-class="value[0].invokeSequence + '-badge'"


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2313

The issue is that the default behavior of PrimeVue's AutoComplete is that selection will be added to the v-model, which is used for filter and value display right now. This PR prevents the incorrectly rendering of passing the node def as filter and value.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2317-Fix-console-error-on-adding-node-via-searchbox-1836d73d3650811db718ee2827cfd638) by [Unito](https://www.unito.io)
