### PR TITLE
[Desktop] Remove beforeunload handler - unusable in electron

### DIFF
--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -4,7 +4,7 @@
   <TopMenubar />
   <GraphCanvas @ready="onGraphReady" />
   <GlobalToast />
-  <UnloadWindowConfirmDialog />
+  <UnloadWindowConfirmDialog v-if="!isElectron()" />
   <BrowserTabTitle />
   <MenuHamburger />
 </template>


### PR DESCRIPTION
- Resolves https://github.com/Comfy-Org/desktop/issues/688
- Introduced in #2258
- Removes the beforeunload component when using the desktop app - this API is non-functional in Electron and has never worked there
- This feature will be added for the desktop app separately

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2318-Desktop-Remove-beforeunload-handler-unusable-in-electron-1836d73d3650813188f9d6d91944f3f9) by [Unito](https://www.unito.io)
