### PR TITLE
Fix translation id in folder customization dialog

### DIFF
--- a/src/components/common/CustomizationDialog.vue
+++ b/src/components/common/CustomizationDialog.vue
@@ -42,7 +42,7 @@
                 v-else
                 class="pi pi-palette"
                 :style="{ fontSize: '1.2rem' }"
-                v-tooltip="$t('g.customColor')"
+                v-tooltip="$t('color.custom')"
               ></i>
             </template>
           </SelectButton>


### PR DESCRIPTION
Fixes translation id in folder customization dialog to use the mapping used by other custom color text instances in the same component.

 
![Selection_792](https://github.com/user-attachments/assets/1d16f87a-234e-4006-a5fc-f552b9d00b5d)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2320-Fix-translation-id-in-folder-customization-dialog-1846d73d365081458a8dd2ccfe07931e) by [Unito](https://www.unito.io)
