### PR TITLE
Clean tags in issue reports

### DIFF
--- a/src/components/dialog/content/error/ReportIssuePanel.vue
+++ b/src/components/dialog/content/error/ReportIssuePanel.vue
@@ -105,6 +105,7 @@ import { Form, FormField, type FormSubmitEvent } from '@primevue/forms'
 import { zodResolver } from '@primevue/forms/resolvers/zod'
 import type { CaptureContext, User } from '@sentry/core'
 import { captureMessage } from '@sentry/core'
+import _ from 'lodash'
 import cloneDeep from 'lodash/cloneDeep'
 import Button from 'primevue/button'
 import Checkbox from 'primevue/checkbox'
@@ -218,7 +219,7 @@ const createCaptureContext = async (
         ? formData.notifyOnResolution
         : false,
       isElectron: isElectron(),
-      ...props.tags
+      ..._.mapValues(props.tags, (tag) => _.trim(tag).replace(/[\n\r\t]/g, ' '))
     },
     extra: {
       details: formData.details,


### PR DESCRIPTION
If a tag value in an issue report has a newline or tab character, the value is not searchable and it causes Sentry to complain. This PR adds cleaning of tag values.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2323-Clean-tags-in-issue-reports-1846d73d365081458457ddfc45ec74f1) by [Unito](https://www.unito.io)
