### PR TITLE
Fix form validation message appearing unnecessarily 

### DIFF
--- a/src/components/dialog/content/error/ReportIssuePanel.vue
+++ b/src/components/dialog/content/error/ReportIssuePanel.vue
@@ -50,7 +50,7 @@
             :aria-label="$t('issueReport.provideAdditionalDetails')"
           />
           <Message
-            v-if="$field?.error && $field.touched"
+            v-if="$field?.error && $field.touched && $field.value"
             severity="error"
             size="small"
             variant="simple"


### PR DESCRIPTION
Prevents a validation error message from appearing when the user types in the textarea, deletes the input without modifying other fields, and the entire form status becomes invalid with the textarea marked as touched.

Before:

![Selection_798](https://github.com/user-attachments/assets/2b731ac8-b8b4-40c1-a681-28c7ea2a6767)

After:

![Selection_799](https://github.com/user-attachments/assets/f3bfcc61-2f52-44c1-b433-a30288827688)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2324-Fix-form-validation-message-appearing-unnecessarily-1846d73d3650810f8ff9c663158c1f72) by [Unito](https://www.unito.io)
