### PR TITLE
Add url setting type

### DIFF
--- a/src/components/common/FormItem.vue
+++ b/src/components/common/FormItem.vue
@@ -35,6 +35,7 @@ import CustomFormValue from '@/components/common/CustomFormValue.vue'
 import FormColorPicker from '@/components/common/FormColorPicker.vue'
 import FormImageUpload from '@/components/common/FormImageUpload.vue'
 import InputSlider from '@/components/common/InputSlider.vue'
+import UrlInput from '@/components/common/UrlInput.vue'
 import { FormItem } from '@/types/settingTypes'
 
 const formValue = defineModel<any>('formValue')
@@ -91,6 +92,8 @@ function getFormComponent(item: FormItem): Component {
       return FormImageUpload
     case 'color':
       return FormColorPicker
+    case 'url':
+      return UrlInput
     default:
       return InputText
   }

--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -46,7 +46,6 @@ enum UrlValidationState {
   INVALID = 'INVALID'
 }
 
-// Replace the three refs with a single state ref
 const validationState = ref<UrlValidationState>(UrlValidationState.IDLE)
 
 const handleInput = (value: string) => {

--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -1,0 +1,84 @@
+<template>
+  <IconField class="w-full">
+    <InputText
+      :model-value="modelValue"
+      class="w-full"
+      :placeholder="placeholder"
+      :invalid="validationState === UrlValidationState.INVALID"
+      @update:model-value="handleInput"
+      @blur="validateUrl"
+    />
+    <InputIcon
+      :class="{
+        'pi pi-spin pi-spinner text-neutral-400':
+          validationState === UrlValidationState.LOADING,
+        'pi pi-check text-green-500':
+          validationState === UrlValidationState.VALID,
+        'pi pi-times text-red-500':
+          validationState === UrlValidationState.INVALID
+      }"
+    />
+  </IconField>
+</template>
+
+<script setup lang="ts">
+import IconField from 'primevue/iconfield'
+import InputIcon from 'primevue/inputicon'
+import InputText from 'primevue/inputtext'
+import { ref } from 'vue'
+
+import { isValidUrl } from '@/utils/formatUtil'
+import { checkUrlReachable } from '@/utils/networkUtil'
+
+const props = defineProps<{
+  modelValue: string
+  placeholder?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+enum UrlValidationState {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  VALID = 'VALID',
+  INVALID = 'INVALID'
+}
+
+// Replace the three refs with a single state ref
+const validationState = ref<UrlValidationState>(UrlValidationState.IDLE)
+
+const handleInput = (value: string) => {
+  emit('update:modelValue', value)
+  // Reset validation state when user types
+  validationState.value = UrlValidationState.IDLE
+}
+
+const validateUrl = async () => {
+  const url = props.modelValue.trim()
+
+  // Reset state
+  validationState.value = UrlValidationState.IDLE
+
+  // Skip validation if empty
+  if (!url) return
+
+  // First check if it's a valid URL format
+  if (!isValidUrl(url)) {
+    validationState.value = UrlValidationState.INVALID
+    return
+  }
+
+  // Then check if URL is reachable
+  validationState.value = UrlValidationState.LOADING
+  try {
+    const reachable = await checkUrlReachable(url)
+    validationState.value = reachable
+      ? UrlValidationState.VALID
+      : UrlValidationState.INVALID
+  } catch {
+    validationState.value = UrlValidationState.INVALID
+  }
+}
+</script>

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -8,6 +8,7 @@ export type SettingInputType =
   | 'text'
   | 'image'
   | 'color'
+  | 'url'
   | 'hidden'
 
 export type SettingCustomRenderer = (

--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -204,3 +204,12 @@ export function processDynamicPrompt(input: string): string {
 
   return result.replace(/\\([{}|])/g, '$1')
 }
+
+export function isValidUrl(url: string): boolean {
+  try {
+    new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/utils/networkUtil.ts
+++ b/src/utils/networkUtil.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+const VALID_STATUS_CODES = [200, 201, 301, 302, 307, 308]
+export const checkUrlReachable = async (url: string): Promise<boolean> => {
+  try {
+    const response = await axios.head(url)
+    // Additional check for successful response
+    return VALID_STATUS_CODES.includes(response.status)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
# Add URL Input Component

## Changes
- Added new `UrlInput` component with validation
- Supports real-time URL format checking and reachability testing
- Visual feedback for loading, valid, and invalid states
- Integrated with existing form system

![image](https://github.com/user-attachments/assets/d8c1feac-c6bf-483c-bced-b8ee4e0d6798)

```ts
  {
    id: 'Comfy.Server.ServerUrl',
    name: 'Server URL',
    type: 'url',
    defaultValue: 'http://localhost:8188'
  }
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2327-Add-url-setting-type-1846d73d36508171abeafbcd610c9477) by [Unito](https://www.unito.io)
