### PR TITLE
Add UV mirrors settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,8 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-<<<<<<< HEAD
-        "@comfyorg/comfyui-electron-types": "^0.4.11",
+        "@comfyorg/comfyui-electron-types": "^0.4.16",
         "@comfyorg/litegraph": "^0.8.62",
-=======
-        "@comfyorg/comfyui-electron-types": "^0.4.15",
-        "@comfyorg/litegraph": "^0.8.61",
->>>>>>> d8f515ab (Update electron-types)
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1942,9 +1937,9 @@
       "dev": true
     },
     "node_modules/@comfyorg/comfyui-electron-types": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.4.15.tgz",
-      "integrity": "sha512-qyytIfA52AmTtFSfKhWft8omYJ+bdwpwdCZ3yG7bUcar7NgawbAP8+pSU3Xv19NrPwSTB3cY9WkWpgCjqHRFCw==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.4.16.tgz",
+      "integrity": "sha512-AKy4WLVAuDka/Xjv8zrKwfU/wfRSQpFVE5DgxoLfvroCI0sw+rV1JqdL6xFVrYIoeprzbfKhQiyqlAWU+QgHyg==",
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,13 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
+<<<<<<< HEAD
         "@comfyorg/comfyui-electron-types": "^0.4.11",
         "@comfyorg/litegraph": "^0.8.62",
+=======
+        "@comfyorg/comfyui-electron-types": "^0.4.15",
+        "@comfyorg/litegraph": "^0.8.61",
+>>>>>>> d8f515ab (Update electron-types)
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1937,9 +1942,9 @@
       "dev": true
     },
     "node_modules/@comfyorg/comfyui-electron-types": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.4.11.tgz",
-      "integrity": "sha512-RGJeWwXjyv0Ojj7xkZKgcRxC1nFv1nh7qEWpNBiofxVgFiap9Ei79b/KJYxNE0no4BoYqRMaRg+sFtCE6yEukA==",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/@comfyorg/comfyui-electron-types/-/comfyui-electron-types-0.4.15.tgz",
+      "integrity": "sha512-qyytIfA52AmTtFSfKhWft8omYJ+bdwpwdCZ3yG7bUcar7NgawbAP8+pSU3Xv19NrPwSTB3cY9WkWpgCjqHRFCw==",
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/comfyui-electron-types": "^0.4.11",
+    "@comfyorg/comfyui-electron-types": "^0.4.16",
     "@comfyorg/litegraph": "^0.8.62",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -83,13 +83,8 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-<<<<<<< HEAD
     "@comfyorg/comfyui-electron-types": "^0.4.11",
     "@comfyorg/litegraph": "^0.8.62",
-=======
-    "@comfyorg/comfyui-electron-types": "^0.4.15",
-    "@comfyorg/litegraph": "^0.8.61",
->>>>>>> d8f515ab (Update electron-types)
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,13 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
+<<<<<<< HEAD
     "@comfyorg/comfyui-electron-types": "^0.4.11",
     "@comfyorg/litegraph": "^0.8.62",
+=======
+    "@comfyorg/comfyui-electron-types": "^0.4.15",
+    "@comfyorg/litegraph": "^0.8.61",
+>>>>>>> d8f515ab (Update electron-types)
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -4,18 +4,18 @@
       v-bind="$attrs"
       :model-value="internalValue"
       class="w-full"
-      :invalid="validationState === UrlValidationState.INVALID"
+      :invalid="validationState === ValidationState.INVALID"
       @update:model-value="handleInput"
       @blur="handleBlur"
     />
     <InputIcon
       :class="{
         'pi pi-spin pi-spinner text-neutral-400':
-          validationState === UrlValidationState.LOADING,
+          validationState === ValidationState.LOADING,
         'pi pi-check text-green-500 cursor-pointer':
-          validationState === UrlValidationState.VALID,
+          validationState === ValidationState.VALID,
         'pi pi-times text-red-500 cursor-pointer':
-          validationState === UrlValidationState.INVALID
+          validationState === ValidationState.INVALID
       }"
       @click="validateUrl(props.modelValue)"
     />
@@ -30,6 +30,7 @@ import { onMounted, ref, watch } from 'vue'
 
 import { isValidUrl } from '@/utils/formatUtil'
 import { checkUrlReachable } from '@/utils/networkUtil'
+import { ValidationState } from '@/utils/validationUtil'
 
 const props = defineProps<{
   modelValue: string
@@ -40,14 +41,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
 }>()
 
-enum UrlValidationState {
-  IDLE = 'IDLE',
-  LOADING = 'LOADING',
-  VALID = 'VALID',
-  INVALID = 'INVALID'
-}
-
-const validationState = ref<UrlValidationState>(UrlValidationState.IDLE)
+const validationState = ref<ValidationState>(ValidationState.IDLE)
 
 // Add internal value state
 const internalValue = ref(props.modelValue)
@@ -69,7 +63,7 @@ const handleInput = (value: string) => {
   // Update internal value without emitting
   internalValue.value = value
   // Reset validation state when user types
-  validationState.value = UrlValidationState.IDLE
+  validationState.value = ValidationState.IDLE
 }
 
 const handleBlur = async () => {
@@ -88,24 +82,24 @@ const defaultValidateUrl = async (url: string): Promise<boolean> => {
 }
 
 const validateUrl = async (value: string) => {
-  if (validationState.value === UrlValidationState.LOADING) return
+  if (validationState.value === ValidationState.LOADING) return
 
   const url = value.trim()
 
   // Reset state
-  validationState.value = UrlValidationState.IDLE
+  validationState.value = ValidationState.IDLE
 
   // Skip validation if empty
   if (!url) return
 
-  validationState.value = UrlValidationState.LOADING
+  validationState.value = ValidationState.LOADING
   try {
     const isValid = await (props.validateUrlFn ?? defaultValidateUrl)(url)
     validationState.value = isValid
-      ? UrlValidationState.VALID
-      : UrlValidationState.INVALID
+      ? ValidationState.VALID
+      : ValidationState.INVALID
   } catch {
-    validationState.value = UrlValidationState.INVALID
+    validationState.value = ValidationState.INVALID
   }
 }
 

--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -39,6 +39,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:modelValue': [value: string]
+  'state-change': [state: ValidationState]
 }>()
 
 const validationState = ref<ValidationState>(ValidationState.IDLE)
@@ -54,6 +55,11 @@ watch(
     await validateUrl(newValue)
   }
 )
+
+watch(validationState, (newState) => {
+  emit('state-change', newState)
+})
+
 // Validate on mount
 onMounted(async () => {
   await validateUrl(props.modelValue)

--- a/src/components/install/DesktopSettingsConfiguration.vue
+++ b/src/components/install/DesktopSettingsConfiguration.vue
@@ -45,66 +45,6 @@
         </div>
         <ToggleSwitch v-model="allowMetrics" />
       </div>
-
-      <Divider />
-      <Message
-        v-if="checkingMirrors"
-        severity="info"
-        :closable="false"
-        icon="pi pi-spin pi-spinner"
-        class="w-full"
-      >
-        {{ $t('install.settings.checkingMirrors') }}
-      </Message>
-
-      <Message
-        v-if="!checkingMirrors && !showMirrorInputs"
-        severity="success"
-        :closable="false"
-        icon="pi pi-check"
-        class="w-full"
-      >
-        {{ $t('install.settings.mirrorsReachable') }}
-      </Message>
-
-      <!-- Mirror Settings (Conditional) -->
-      <template v-if="showMirrorInputs">
-        <!-- Python Mirror Setting -->
-        <div class="flex flex-col items-center gap-4">
-          <div class="w-full">
-            <h3 class="text-lg font-medium text-neutral-100">
-              {{ $t('settings.Comfy-Desktop_UV_PythonInstallMirror.name') }}
-            </h3>
-            <p class="text-sm text-neutral-400 mt-1">
-              {{ $t('settings.Comfy-Desktop_UV_PythonInstallMirror.tooltip') }}
-            </p>
-          </div>
-          <UrlInput
-            v-model="pythonMirror"
-            :placeholder="$t('install.settings.pythonMirrorPlaceholder')"
-            :validate-url-fn="checkPythonMirrorReachable"
-          />
-        </div>
-
-        <Divider />
-
-        <!-- Pypi Mirror Setting -->
-        <div class="flex flex-col items-center gap-4">
-          <div class="w-full">
-            <h3 class="text-lg font-medium text-neutral-100">
-              {{ $t('settings.Comfy-Desktop_UV_PypiInstallMirror.name') }}
-            </h3>
-            <p class="text-sm text-neutral-400 mt-1">
-              {{ $t('settings.Comfy-Desktop_UV_PypiInstallMirror.tooltip') }}
-            </p>
-          </div>
-          <UrlInput
-            v-model="pypiMirror"
-            :placeholder="$t('install.settings.pypiMirrorPlaceholder')"
-            :validate-url-fn="checkPypiMirrorReachable"
-          />
-        </div>
-      </template>
     </div>
 
     <!-- Info Dialog -->
@@ -186,60 +126,12 @@
 <script setup lang="ts">
 import Dialog from 'primevue/dialog'
 import Divider from 'primevue/divider'
-import Message from 'primevue/message'
 import ToggleSwitch from 'primevue/toggleswitch'
-import { onMounted, ref } from 'vue'
-
-import UrlInput from '@/components/common/UrlInput.vue'
-import {
-  DEFAULT_UV_PYPY_INSTALL_MIRROR,
-  DEFAULT_UV_PYTHON_INSTALL_MIRROR,
-  FALLBACK_UV_PYPY_INSTALL_MIRROR,
-  FALLBACK_UV_PYTHON_INSTALL_MIRROR
-} from '@/constants/uvMirrors'
-import { electronAPI } from '@/utils/envUtil'
-import { isValidUrl } from '@/utils/formatUtil'
+import { ref } from 'vue'
 
 const showDialog = ref(false)
-const checkingMirrors = ref(true)
-const showMirrorInputs = ref(false)
 const autoUpdate = defineModel<boolean>('autoUpdate', { required: true })
 const allowMetrics = defineModel<boolean>('allowMetrics', { required: true })
-const pythonMirror = defineModel<string>('pythonMirror', { required: true })
-const pypiMirror = defineModel<string>('pypiMirror', { required: true })
-
-const checkPythonMirrorReachable = async (mirror: string) => {
-  return (
-    isValidUrl(mirror) &&
-    (await electronAPI().NetWork.canAccessUrl(
-      `${mirror}/cpython-3.10.16+20250115-aarch64-apple-darwin-debug-full.tar.zst`
-    ))
-  )
-}
-
-const checkPypiMirrorReachable = async (mirror: string) => {
-  return (
-    isValidUrl(mirror) &&
-    (await electronAPI().NetWork.canAccessUrl(
-      `${mirror}/pypy3.8-v7.3.7-osx64.tar.bz2`
-    ))
-  )
-}
-
-onMounted(async () => {
-  const [isPythonMirrorReachable, isPypiMirrorReachable] = await Promise.all([
-    checkPythonMirrorReachable(DEFAULT_UV_PYTHON_INSTALL_MIRROR),
-    checkPypiMirrorReachable(DEFAULT_UV_PYPY_INSTALL_MIRROR)
-  ])
-  checkingMirrors.value = false
-
-  showMirrorInputs.value = !isPythonMirrorReachable || !isPypiMirrorReachable
-
-  if (showMirrorInputs.value) {
-    pythonMirror.value = FALLBACK_UV_PYTHON_INSTALL_MIRROR
-    pypiMirror.value = FALLBACK_UV_PYPY_INSTALL_MIRROR
-  }
-})
 
 const showMetricsInfo = () => {
   showDialog.value = true

--- a/src/components/install/DesktopSettingsConfiguration.vue
+++ b/src/components/install/DesktopSettingsConfiguration.vue
@@ -54,10 +54,10 @@
         <div class="flex flex-col items-center gap-4">
           <div class="w-full">
             <h3 class="text-lg font-medium text-neutral-100">
-              {{ $t('settings.Comfy-Desktop_PythonInstallMirror.name') }}
+              {{ $t('settings.Comfy-Desktop_UV_PythonInstallMirror.name') }}
             </h3>
             <p class="text-sm text-neutral-400 mt-1">
-              {{ $t('settings.Comfy-Desktop_PythonInstallMirror.tooltip') }}
+              {{ $t('settings.Comfy-Desktop_UV_PythonInstallMirror.tooltip') }}
             </p>
           </div>
           <UrlInput
@@ -73,10 +73,10 @@
         <div class="flex flex-col items-center gap-4">
           <div class="w-full">
             <h3 class="text-lg font-medium text-neutral-100">
-              {{ $t('settings.Comfy-Desktop_PypiMirror.name') }}
+              {{ $t('settings.Comfy-Desktop_UV_PypiInstallMirror.name') }}
             </h3>
             <p class="text-sm text-neutral-400 mt-1">
-              {{ $t('settings.Comfy-Desktop_PypiMirror.tooltip') }}
+              {{ $t('settings.Comfy-Desktop_UV_PypiInstallMirror.tooltip') }}
             </p>
           </div>
           <UrlInput

--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -1,0 +1,118 @@
+<template>
+  <Panel
+    :header="$t('install.settings.mirrorSettings')"
+    toggleable
+    :collapsed="!showMirrorInputs"
+    pt:root="bg-neutral-800 border-none w-[600px]"
+  >
+    <template v-for="(item, index) in mirrorItems" :key="item.settingId">
+      <Divider v-if="index > 0" />
+
+      <div class="flex flex-col items-center gap-4">
+        <div class="w-full">
+          <h3 class="text-lg font-medium text-neutral-100">
+            {{ $t(`settings.${item.settingId}.name`) }}
+          </h3>
+          <p class="text-sm text-neutral-400 mt-1">
+            {{ $t(`settings.${item.settingId}.tooltip`) }}
+          </p>
+        </div>
+        <UrlInput
+          v-model="item.modelValue.value"
+          :validate-url-fn="item.checkMirrorReachable"
+        />
+      </div>
+    </template>
+  </Panel>
+</template>
+
+<script setup lang="ts">
+import {
+  CUDA_TORCH_URL,
+  NIGHTLY_CPU_TORCH_URL
+} from '@comfyorg/comfyui-electron-types'
+import Divider from 'primevue/divider'
+import Panel from 'primevue/panel'
+import { ModelRef, onMounted, ref } from 'vue'
+
+import UrlInput from '@/components/common/UrlInput.vue'
+import {
+  DEFAULT_UV_PYPI_INSTALL_MIRROR,
+  DEFAULT_UV_PYTHON_INSTALL_MIRROR,
+  FALLBACK_UV_PYPI_INSTALL_MIRROR,
+  FALLBACK_UV_PYTHON_INSTALL_MIRROR
+} from '@/constants/uvMirrors'
+import { electronAPI } from '@/utils/envUtil'
+import { isValidUrl } from '@/utils/formatUtil'
+
+const checkingMirrors = ref(false)
+const showMirrorInputs = ref(false)
+const pythonMirror = defineModel<string>('pythonMirror', { required: true })
+const pypiMirror = defineModel<string>('pypiMirror', { required: true })
+const torchMirror = defineModel<string>('torchMirror', { required: true })
+
+const checkMirrorReachable = async (mirror: string) => {
+  return (
+    isValidUrl(mirror) && (await electronAPI().NetWork.canAccessUrl(mirror))
+  )
+}
+
+interface MirrorItem {
+  settingId: string
+  mirror: string
+  fallbackMirror: string
+  checkMirrorReachable: (mirror: string) => Promise<boolean>
+  modelValue: ModelRef<string>
+}
+
+const DEFAULT_TORCH_MIRROR =
+  electronAPI().getPlatform() === 'darwin'
+    ? NIGHTLY_CPU_TORCH_URL
+    : CUDA_TORCH_URL
+
+const mirrorItems: MirrorItem[] = [
+  {
+    settingId: 'Comfy-Desktop_UV_PythonInstallMirror',
+    mirror: DEFAULT_UV_PYTHON_INSTALL_MIRROR,
+    fallbackMirror: FALLBACK_UV_PYTHON_INSTALL_MIRROR,
+    checkMirrorReachable: (mirror: string) =>
+      checkMirrorReachable(
+        mirror +
+          '/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz'
+      ),
+    modelValue: pythonMirror
+  },
+  {
+    settingId: 'Comfy-Desktop_UV_PypiInstallMirror',
+    mirror: DEFAULT_UV_PYPI_INSTALL_MIRROR,
+    fallbackMirror: FALLBACK_UV_PYPI_INSTALL_MIRROR,
+    checkMirrorReachable,
+    modelValue: pypiMirror
+  },
+  {
+    settingId: 'Comfy-Desktop_UV_TorchInstallMirror',
+    mirror: DEFAULT_TORCH_MIRROR,
+    fallbackMirror: DEFAULT_TORCH_MIRROR,
+    checkMirrorReachable,
+    modelValue: torchMirror
+  }
+]
+
+onMounted(async () => {
+  checkingMirrors.value = true
+  const mirrorsReachable = await Promise.all(
+    mirrorItems.map((item) => item.checkMirrorReachable(item.mirror))
+  )
+  checkingMirrors.value = false
+
+  showMirrorInputs.value = mirrorsReachable.some((reachable) => !reachable)
+
+  if (showMirrorInputs.value) {
+    mirrorItems.forEach((item) => {
+      if (!mirrorsReachable[item.settingId]) {
+        item.modelValue.value = item.fallbackMirror
+      }
+    })
+  }
+})
+</script>

--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -27,6 +27,7 @@
           'pi pi-times text-red-500':
             validationState === ValidationState.INVALID
         }"
+        v-tooltip="validationStateTooltip"
       />
     </template>
   </Panel>
@@ -40,6 +41,7 @@ import { computed, ref } from 'vue'
 
 import MirrorItem from '@/components/install/mirror/MirrorItem.vue'
 import { UV_MIRRORS } from '@/constants/uvMirrors'
+import { t } from '@/i18n'
 import { ValidationState, mergeValidationStates } from '@/utils/validationUtil'
 
 const showMirrorInputs = ref(false)
@@ -54,5 +56,15 @@ const validationStates = ref<ValidationState[]>(
 )
 const validationState = computed(() => {
   return mergeValidationStates(validationStates.value)
+})
+const validationStateTooltip = computed(() => {
+  switch (validationState.value) {
+    case ValidationState.INVALID:
+      return t('install.settings.mirrorsUnreachable')
+    case ValidationState.VALID:
+      return t('install.settings.mirrorsReachable')
+    default:
+      return t('install.settings.checkingMirrors')
+  }
 })
 </script>

--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -5,114 +5,45 @@
     :collapsed="!showMirrorInputs"
     pt:root="bg-neutral-800 border-none w-[600px]"
   >
-    <template v-for="(item, index) in mirrorItems" :key="item.settingId">
+    <template
+      v-for="([item, modelValue], index) in mirrors"
+      :key="item.settingId"
+    >
       <Divider v-if="index > 0" />
 
-      <div class="flex flex-col items-center gap-4">
-        <div class="w-full">
-          <h3 class="text-lg font-medium text-neutral-100">
-            {{ $t(`settings.${item.settingId}.name`) }}
-          </h3>
-          <p class="text-sm text-neutral-400 mt-1">
-            {{ $t(`settings.${item.settingId}.tooltip`) }}
-          </p>
-        </div>
-        <UrlInput
-          v-model="item.modelValue.value"
-          :validate-url-fn="item.checkMirrorReachable"
-        />
-      </div>
+      <MirrorItem :item="item" v-model="modelValue.value" />
+    </template>
+    <template #icons>
+      <i
+        :class="{
+          'pi pi-spin pi-spinner text-neutral-400':
+            validationState === ValidationState.LOADING,
+          'pi pi-check text-green-500':
+            validationState === ValidationState.VALID,
+          'pi pi-times text-red-500':
+            validationState === ValidationState.INVALID
+        }"
+      />
     </template>
   </Panel>
 </template>
 
 <script setup lang="ts">
-import {
-  CUDA_TORCH_URL,
-  NIGHTLY_CPU_TORCH_URL
-} from '@comfyorg/comfyui-electron-types'
+import _ from 'lodash'
 import Divider from 'primevue/divider'
 import Panel from 'primevue/panel'
-import { ModelRef, onMounted, ref } from 'vue'
+import { ref } from 'vue'
 
-import UrlInput from '@/components/common/UrlInput.vue'
-import {
-  DEFAULT_UV_PYPI_INSTALL_MIRROR,
-  DEFAULT_UV_PYTHON_INSTALL_MIRROR,
-  FALLBACK_UV_PYPI_INSTALL_MIRROR,
-  FALLBACK_UV_PYTHON_INSTALL_MIRROR
-} from '@/constants/uvMirrors'
-import { electronAPI } from '@/utils/envUtil'
-import { isValidUrl } from '@/utils/formatUtil'
+import MirrorItem from '@/components/install/mirror/MirrorItem.vue'
+import { UV_MIRRORS } from '@/constants/uvMirrors'
+import { ValidationState } from '@/utils/validationUtil'
 
-const checkingMirrors = ref(false)
 const showMirrorInputs = ref(false)
 const pythonMirror = defineModel<string>('pythonMirror', { required: true })
 const pypiMirror = defineModel<string>('pypiMirror', { required: true })
 const torchMirror = defineModel<string>('torchMirror', { required: true })
 
-const checkMirrorReachable = async (mirror: string) => {
-  return (
-    isValidUrl(mirror) && (await electronAPI().NetWork.canAccessUrl(mirror))
-  )
-}
+const mirrors = _.zip(UV_MIRRORS, [pythonMirror, pypiMirror, torchMirror])
 
-interface MirrorItem {
-  settingId: string
-  mirror: string
-  fallbackMirror: string
-  checkMirrorReachable: (mirror: string) => Promise<boolean>
-  modelValue: ModelRef<string>
-}
-
-const DEFAULT_TORCH_MIRROR =
-  electronAPI().getPlatform() === 'darwin'
-    ? NIGHTLY_CPU_TORCH_URL
-    : CUDA_TORCH_URL
-
-const mirrorItems: MirrorItem[] = [
-  {
-    settingId: 'Comfy-Desktop_UV_PythonInstallMirror',
-    mirror: DEFAULT_UV_PYTHON_INSTALL_MIRROR,
-    fallbackMirror: FALLBACK_UV_PYTHON_INSTALL_MIRROR,
-    checkMirrorReachable: (mirror: string) =>
-      checkMirrorReachable(
-        mirror +
-          '/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz'
-      ),
-    modelValue: pythonMirror
-  },
-  {
-    settingId: 'Comfy-Desktop_UV_PypiInstallMirror',
-    mirror: DEFAULT_UV_PYPI_INSTALL_MIRROR,
-    fallbackMirror: FALLBACK_UV_PYPI_INSTALL_MIRROR,
-    checkMirrorReachable,
-    modelValue: pypiMirror
-  },
-  {
-    settingId: 'Comfy-Desktop_UV_TorchInstallMirror',
-    mirror: DEFAULT_TORCH_MIRROR,
-    fallbackMirror: DEFAULT_TORCH_MIRROR,
-    checkMirrorReachable,
-    modelValue: torchMirror
-  }
-]
-
-onMounted(async () => {
-  checkingMirrors.value = true
-  const mirrorsReachable = await Promise.all(
-    mirrorItems.map((item) => item.checkMirrorReachable(item.mirror))
-  )
-  checkingMirrors.value = false
-
-  showMirrorInputs.value = mirrorsReachable.some((reachable) => !reachable)
-
-  if (showMirrorInputs.value) {
-    mirrorItems.forEach((item) => {
-      if (!mirrorsReachable[item.settingId]) {
-        item.modelValue.value = item.fallbackMirror
-      }
-    })
-  }
-})
+const validationState = ref<ValidationState>(ValidationState.IDLE)
 </script>

--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -11,7 +11,11 @@
     >
       <Divider v-if="index > 0" />
 
-      <MirrorItem :item="item" v-model="modelValue.value" />
+      <MirrorItem
+        :item="item"
+        v-model="modelValue.value"
+        @state-change="validationStates[index] = $event"
+      />
     </template>
     <template #icons>
       <i
@@ -32,11 +36,11 @@
 import _ from 'lodash'
 import Divider from 'primevue/divider'
 import Panel from 'primevue/panel'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import MirrorItem from '@/components/install/mirror/MirrorItem.vue'
 import { UV_MIRRORS } from '@/constants/uvMirrors'
-import { ValidationState } from '@/utils/validationUtil'
+import { ValidationState, mergeValidationStates } from '@/utils/validationUtil'
 
 const showMirrorInputs = ref(false)
 const pythonMirror = defineModel<string>('pythonMirror', { required: true })
@@ -45,5 +49,10 @@ const torchMirror = defineModel<string>('torchMirror', { required: true })
 
 const mirrors = _.zip(UV_MIRRORS, [pythonMirror, pypiMirror, torchMirror])
 
-const validationState = ref<ValidationState>(ValidationState.IDLE)
+const validationStates = ref<ValidationState[]>(
+  mirrors.map(() => ValidationState.IDLE)
+)
+const validationState = computed(() => {
+  return mergeValidationStates(validationStates.value)
+})
 </script>

--- a/src/components/install/mirror/MirrorItem.vue
+++ b/src/components/install/mirror/MirrorItem.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="flex flex-col items-center gap-4">
+    <div class="w-full">
+      <h3 class="text-lg font-medium text-neutral-100">
+        {{ $t(`settings.${normalizedSettingId}.name`) }}
+      </h3>
+      <p class="text-sm text-neutral-400 mt-1">
+        {{ $t(`settings.${normalizedSettingId}.tooltip`) }}
+      </p>
+    </div>
+    <UrlInput
+      v-model="modelValue"
+      :validate-url-fn="checkMirrorReachable"
+      @state-change="validationState = $event"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+
+import { UVMirror } from '@/constants/uvMirrors'
+import { electronAPI } from '@/utils/envUtil'
+import { isValidUrl, normalizeI18nKey } from '@/utils/formatUtil'
+import { ValidationState } from '@/utils/validationUtil'
+
+const { item } = defineProps<{
+  item: UVMirror
+}>()
+
+const emit = defineEmits<{
+  'state-change': [state: ValidationState]
+}>()
+
+const modelValue = defineModel<string>('modelValue', { required: true })
+const validationState = ref<ValidationState>(ValidationState.IDLE)
+
+const normalizedSettingId = computed(() => {
+  return normalizeI18nKey(item.settingId)
+})
+
+const checkMirrorReachable = async (mirror: string) => {
+  return (
+    isValidUrl(mirror) &&
+    (await electronAPI().NetWork.canAccessUrl(
+      mirror + (item.validationPathSuffix ?? '')
+    ))
+  )
+}
+
+onMounted(() => {
+  modelValue.value = item.mirror
+})
+
+watch(validationState, (newState) => {
+  emit('state-change', newState)
+
+  // Set fallback mirror if default mirror is invalid
+  if (
+    newState === ValidationState.INVALID &&
+    modelValue.value === item.mirror
+  ) {
+    modelValue.value = item.fallbackMirror
+  }
+})
+</script>

--- a/src/constants/uvMirrors.ts
+++ b/src/constants/uvMirrors.ts
@@ -1,10 +1,51 @@
-export const DEFAULT_UV_PYPI_INSTALL_MIRROR = 'https://pypi.org/simple/'
+import { CUDA_TORCH_URL } from '@comfyorg/comfyui-electron-types'
+import { NIGHTLY_CPU_TORCH_URL } from '@comfyorg/comfyui-electron-types'
 
-export const DEFAULT_UV_PYTHON_INSTALL_MIRROR =
-  'https://github.com/astral-sh/python-build-standalone/releases/download'
+import { electronAPI, isElectron } from '@/utils/envUtil'
 
-export const FALLBACK_UV_PYPI_INSTALL_MIRROR =
-  'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple'
+export interface UVMirror {
+  /**
+   * The setting id defined for the mirror.
+   */
+  settingId: string
+  /**
+   * The default mirror to use.
+   */
+  mirror: string
+  /**
+   * The fallback mirror to use.
+   */
+  fallbackMirror: string
+  /**
+   * The path suffix to validate the mirror is reachable.
+   */
+  validationPathSuffix?: string
+}
 
-export const FALLBACK_UV_PYTHON_INSTALL_MIRROR =
-  'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download'
+const DEFAULT_TORCH_MIRROR = isElectron()
+  ? electronAPI().getPlatform() === 'darwin'
+    ? NIGHTLY_CPU_TORCH_URL
+    : CUDA_TORCH_URL
+  : ''
+
+export const UV_MIRRORS: UVMirror[] = [
+  {
+    settingId: 'Comfy-Desktop.UV.PythonInstallMirror',
+    mirror:
+      'https://github.com/astral-sh/python-build-standalone/releases/download',
+    fallbackMirror:
+      'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download',
+    validationPathSuffix:
+      '/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz'
+  },
+  {
+    settingId: 'Comfy-Desktop.UV.PypiInstallMirror',
+    mirror: 'https://pypi.org/simple/',
+    fallbackMirror: 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple'
+  },
+  {
+    settingId: 'Comfy-Desktop.UV.TorchInstallMirror',
+    mirror: DEFAULT_TORCH_MIRROR,
+    fallbackMirror: DEFAULT_TORCH_MIRROR
+  }
+]

--- a/src/constants/uvMirrors.ts
+++ b/src/constants/uvMirrors.ts
@@ -1,10 +1,9 @@
-export const DEFAULT_UV_PYPY_INSTALL_MIRROR =
-  'https://downloads.python.org/pypy'
+export const DEFAULT_UV_PYPI_INSTALL_MIRROR = 'https://pypi.org/simple/'
 
 export const DEFAULT_UV_PYTHON_INSTALL_MIRROR =
   'https://github.com/astral-sh/python-build-standalone/releases/download'
 
-export const FALLBACK_UV_PYPY_INSTALL_MIRROR =
+export const FALLBACK_UV_PYPI_INSTALL_MIRROR =
   'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple'
 
 export const FALLBACK_UV_PYTHON_INSTALL_MIRROR =

--- a/src/constants/uvMirrors.ts
+++ b/src/constants/uvMirrors.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_UV_PYPY_INSTALL_MIRROR =
+  'https://downloads.python.org/pypy'
+
+export const DEFAULT_UV_PYTHON_INSTALL_MIRROR =
+  'https://github.com/astral-sh/python-build-standalone/releases/download'
+
+export const FALLBACK_UV_PYPY_INSTALL_MIRROR =
+  'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple'
+
+export const FALLBACK_UV_PYTHON_INSTALL_MIRROR =
+  'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download'

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -65,7 +65,14 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
       {
         id: 'Comfy-Desktop.UV.PypiInstallMirror',
         name: 'Pypi Install Mirror',
-        tooltip: `Managed PyPy installations are downloaded from python.org. This variable can be set to a mirror URL to use a different source for PyPy installations. The provided URL will replace https://downloads.python.org/pypy in, e.g., https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Distributions can be read from a local directory by using the file:// URL scheme`,
+        tooltip: `Default pip install mirror`,
+        type: 'url',
+        defaultValue: ''
+      },
+      {
+        id: 'Comfy-Desktop.UV.TorchInstallMirror',
+        name: 'Torch Install Mirror',
+        tooltip: `Pip install mirror for pytorch`,
         type: 'url',
         defaultValue: ''
       }

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -1,7 +1,6 @@
 import { t } from '@/i18n'
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
-import { useSettingStore } from '@/stores/settingStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
 
@@ -55,6 +54,20 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
 
           electronAPI.Config.setWindowStyle(newValue)
         }
+      },
+      {
+        id: 'Comfy-Desktop.UV.PythonInstallMirror',
+        name: 'Python Install Mirror',
+        tooltip: `Managed Python installations are downloaded from the Astral python-build-standalone project. This variable can be set to a mirror URL to use a different source for Python installations. The provided URL will replace https://github.com/astral-sh/python-build-standalone/releases/download in, e.g., https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Distributions can be read from a local directory by using the file:// URL scheme.`,
+        type: 'url',
+        defaultValue: ''
+      },
+      {
+        id: 'Comfy-Desktop.UV.PypiInstallMirror',
+        name: 'Pypi Install Mirror',
+        tooltip: `Managed PyPy installations are downloaded from python.org. This variable can be set to a mirror URL to use a different source for PyPy installations. The provided URL will replace https://downloads.python.org/pypy in, e.g., https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Distributions can be read from a local directory by using the file:// URL scheme`,
+        type: 'url',
+        defaultValue: ''
       }
     ],
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -212,7 +212,9 @@
           "customNodeConfigurations": "Custom node configurations"
         },
         "viewFullPolicy": "View full policy"
-      }
+      },
+      "pythonMirrorPlaceholder": "Enter Python mirror URL",
+      "pypiMirrorPlaceholder": "Enter PyPI mirror URL"
     },
     "customNodes": "Custom Nodes",
     "customNodesDescription": "Reinstall custom nodes from existing ComfyUI installations.",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -216,7 +216,8 @@
       "pythonMirrorPlaceholder": "Enter Python mirror URL",
       "pypiMirrorPlaceholder": "Enter PyPI mirror URL",
       "checkingMirrors": "Checking network access to python mirrors...",
-      "mirrorsReachable": "Network access to python mirrors is good"
+      "mirrorsReachable": "Network access to python mirrors is good",
+      "mirrorSettings": "Mirror Settings"
     },
     "customNodes": "Custom Nodes",
     "customNodesDescription": "Reinstall custom nodes from existing ComfyUI installations.",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -214,7 +214,9 @@
         "viewFullPolicy": "View full policy"
       },
       "pythonMirrorPlaceholder": "Enter Python mirror URL",
-      "pypiMirrorPlaceholder": "Enter PyPI mirror URL"
+      "pypiMirrorPlaceholder": "Enter PyPI mirror URL",
+      "checkingMirrors": "Checking network access to python mirrors...",
+      "mirrorsReachable": "Network access to python mirrors is good"
     },
     "customNodes": "Custom Nodes",
     "customNodesDescription": "Reinstall custom nodes from existing ComfyUI installations.",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -217,6 +217,7 @@
       "pypiMirrorPlaceholder": "Enter PyPI mirror URL",
       "checkingMirrors": "Checking network access to python mirrors...",
       "mirrorsReachable": "Network access to python mirrors is good",
+      "mirrorsUnreachable": "Network access to some python mirrors is bad",
       "mirrorSettings": "Mirror Settings"
     },
     "customNodes": "Custom Nodes",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -474,6 +474,7 @@
     "About": "About",
     "EditTokenWeight": "Edit Token Weight",
     "CustomColorPalettes": "Custom Color Palettes",
+    "UV": "UV",
     "ContextMenu": "Context Menu"
   },
   "serverConfigItems": {

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -7,11 +7,15 @@
   },
   "Comfy-Desktop_UV_PypiInstallMirror": {
     "name": "Pypi Install Mirror",
-    "tooltip": "Managed PyPy installations are downloaded from python.org. This variable can be set to a mirror URL to use a different source for PyPy installations. The provided URL will replace https://downloads.python.org/pypy in, e.g., https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Distributions can be read from a local directory by using the file:// URL scheme"
+    "tooltip": "Default pip install mirror"
   },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python Install Mirror",
     "tooltip": "Managed Python installations are downloaded from the Astral python-build-standalone project. This variable can be set to a mirror URL to use a different source for Python installations. The provided URL will replace https://github.com/astral-sh/python-build-standalone/releases/download in, e.g., https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Distributions can be read from a local directory by using the file:// URL scheme."
+  },
+  "Comfy-Desktop_UV_TorchInstallMirror": {
+    "name": "Torch Install Mirror",
+    "tooltip": "Pip install mirror for pytorch"
   },
   "Comfy-Desktop_WindowStyle": {
     "name": "Window Style",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -5,6 +5,14 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Send anonymous usage metrics"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi Install Mirror",
+    "tooltip": "Managed PyPy installations are downloaded from python.org. This variable can be set to a mirror URL to use a different source for PyPy installations. The provided URL will replace https://downloads.python.org/pypy in, e.g., https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Distributions can be read from a local directory by using the file:// URL scheme"
+  },
+  "Comfy-Desktop_UV_PythonInstallMirror": {
+    "name": "Python Install Mirror",
+    "tooltip": "Managed Python installations are downloaded from the Astral python-build-standalone project. This variable can be set to a mirror URL to use a different source for Python installations. The provided URL will replace https://github.com/astral-sh/python-build-standalone/releases/download in, e.g., https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Distributions can be read from a local directory by using the file:// URL scheme."
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "Window Style",
     "tooltip": "Custom: Replace the system title bar with ComfyUI's Top menu",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -220,6 +220,7 @@
       "allowMetricsDescription": "Aidez à améliorer ComfyUI en envoyant des métriques d'utilisation anonymes. Aucune information personnelle ou contenu de flux de travail ne sera collecté.",
       "autoUpdate": "Mises à jour automatiques",
       "autoUpdateDescription": "Téléchargez et installez automatiquement les mises à jour lorsqu'elles deviennent disponibles. Vous serez toujours informé avant l'installation des mises à jour.",
+      "checkingMirrors": "Vérification de l'accès réseau aux miroirs python...",
       "dataCollectionDialog": {
         "collect": {
           "errorReports": "Message d'erreur et trace de la pile",
@@ -240,6 +241,7 @@
       "errorUpdatingConsent": "Erreur de mise à jour du consentement",
       "errorUpdatingConsentDetail": "Échec de la mise à jour des paramètres de consentement aux métriques",
       "learnMoreAboutData": "En savoir plus sur la collecte de données",
+      "mirrorsReachable": "L'accès réseau aux miroirs python est bon",
       "pypiMirrorPlaceholder": "Entrez l'URL du miroir PyPI",
       "pythonMirrorPlaceholder": "Entrez l'URL du miroir Python"
     },

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -239,7 +239,9 @@
       },
       "errorUpdatingConsent": "Erreur de mise à jour du consentement",
       "errorUpdatingConsentDetail": "Échec de la mise à jour des paramètres de consentement aux métriques",
-      "learnMoreAboutData": "En savoir plus sur la collecte de données"
+      "learnMoreAboutData": "En savoir plus sur la collecte de données",
+      "pypiMirrorPlaceholder": "Entrez l'URL du miroir PyPI",
+      "pythonMirrorPlaceholder": "Entrez l'URL du miroir Python"
     },
     "systemLocations": "Emplacements système",
     "unhandledError": "Erreur inconnue",
@@ -634,6 +636,7 @@
     "Settings": "Paramètres",
     "Sidebar": "Barre Latérale",
     "Tree Explorer": "Explorateur d'Arbre",
+    "UV": "UV",
     "Validation": "Validation",
     "Window": "Fenêtre",
     "Workflow": "Flux de Travail"

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -243,6 +243,7 @@
       "learnMoreAboutData": "En savoir plus sur la collecte de données",
       "mirrorSettings": "Paramètres du Miroir",
       "mirrorsReachable": "L'accès réseau aux miroirs python est bon",
+      "mirrorsUnreachable": "L'accès au réseau à certains miroirs python est mauvais",
       "pypiMirrorPlaceholder": "Entrez l'URL du miroir PyPI",
       "pythonMirrorPlaceholder": "Entrez l'URL du miroir Python"
     },

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -241,6 +241,7 @@
       "errorUpdatingConsent": "Erreur de mise à jour du consentement",
       "errorUpdatingConsentDetail": "Échec de la mise à jour des paramètres de consentement aux métriques",
       "learnMoreAboutData": "En savoir plus sur la collecte de données",
+      "mirrorSettings": "Paramètres du Miroir",
       "mirrorsReachable": "L'accès réseau aux miroirs python est bon",
       "pypiMirrorPlaceholder": "Entrez l'URL du miroir PyPI",
       "pythonMirrorPlaceholder": "Entrez l'URL du miroir Python"

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -13,6 +13,10 @@
     "name": "Miroir d'installation Python",
     "tooltip": "Les installations Python gérées sont téléchargées depuis le projet Astral python-build-standalone. Cette variable peut être définie sur une URL de miroir pour utiliser une source différente pour les installations Python. L'URL fournie remplacera https://github.com/astral-sh/python-build-standalone/releases/download dans, par exemple, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Les distributions peuvent être lues à partir d'un répertoire local en utilisant le schéma d'URL file://."
   },
+  "Comfy-Desktop_UV_TorchInstallMirror": {
+    "name": "Miroir d'installation Torch",
+    "tooltip": "Miroir d'installation Pip pour pytorch"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "Style de fenêtre",
     "options": {

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -5,6 +5,10 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Envoyer des métriques d'utilisation anonymes"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Miroir d'installation Pypi",
+    "tooltip": "Miroir d'installation pip par défaut"
+  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Miroir d'installation Python",
     "tooltip": "Les installations Python gérées sont téléchargées depuis le projet Astral python-build-standalone. Cette variable peut être définie sur une URL de miroir pour utiliser une source différente pour les installations Python. L'URL fournie remplacera https://github.com/astral-sh/python-build-standalone/releases/download dans, par exemple, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Les distributions peuvent être lues à partir d'un répertoire local en utilisant le schéma d'URL file://."

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -5,6 +5,14 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Envoyer des métriques d'utilisation anonymes"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Miroir d'installation Pypi",
+    "tooltip": "Les installations PyPy gérées sont téléchargées depuis python.org. Cette variable peut être définie sur une URL de miroir pour utiliser une source différente pour les installations PyPy. L'URL fournie remplacera https://downloads.python.org/pypy dans, par exemple, https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Les distributions peuvent être lues à partir d'un répertoire local en utilisant le schéma d'URL file://"
+  },
+  "Comfy-Desktop_UV_PythonInstallMirror": {
+    "name": "Miroir d'installation Python",
+    "tooltip": "Les installations Python gérées sont téléchargées depuis le projet Astral python-build-standalone. Cette variable peut être définie sur une URL de miroir pour utiliser une source différente pour les installations Python. L'URL fournie remplacera https://github.com/astral-sh/python-build-standalone/releases/download dans, par exemple, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Les distributions peuvent être lues à partir d'un répertoire local en utilisant le schéma d'URL file://."
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "Style de fenêtre",
     "options": {

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -5,10 +5,6 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Envoyer des métriques d'utilisation anonymes"
   },
-  "Comfy-Desktop_UV_PypiInstallMirror": {
-    "name": "Miroir d'installation Pypi",
-    "tooltip": "Les installations PyPy gérées sont téléchargées depuis python.org. Cette variable peut être définie sur une URL de miroir pour utiliser une source différente pour les installations PyPy. L'URL fournie remplacera https://downloads.python.org/pypy dans, par exemple, https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Les distributions peuvent être lues à partir d'un répertoire local en utilisant le schéma d'URL file://"
-  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Miroir d'installation Python",
     "tooltip": "Les installations Python gérées sont téléchargées depuis le projet Astral python-build-standalone. Cette variable peut être définie sur une URL de miroir pour utiliser une source différente pour les installations Python. L'URL fournie remplacera https://github.com/astral-sh/python-build-standalone/releases/download dans, par exemple, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Les distributions peuvent être lues à partir d'un répertoire local en utilisant le schéma d'URL file://."

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -239,7 +239,9 @@
       },
       "errorUpdatingConsent": "同意の更新エラー",
       "errorUpdatingConsentDetail": "メトリクスの同意設定の更新に失敗しました",
-      "learnMoreAboutData": "データ収集の詳細を見る"
+      "learnMoreAboutData": "データ収集の詳細を見る",
+      "pypiMirrorPlaceholder": "PyPIミラーURLを入力してください",
+      "pythonMirrorPlaceholder": "PythonミラーURLを入力してください"
     },
     "systemLocations": "システムの場所",
     "unhandledError": "未知のエラー",
@@ -634,6 +636,7 @@
     "Settings": "設定",
     "Sidebar": "サイドバー",
     "Tree Explorer": "ツリーエクスプローラー",
+    "UV": "UV",
     "Validation": "検証",
     "Window": "ウィンドウ",
     "Workflow": "ワークフロー"

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -243,6 +243,7 @@
       "learnMoreAboutData": "データ収集の詳細を見る",
       "mirrorSettings": "ミラー設定",
       "mirrorsReachable": "Pythonミラーへのネットワークアクセスは良好です",
+      "mirrorsUnreachable": "一部のpythonミラーへのネットワークアクセスが悪い",
       "pypiMirrorPlaceholder": "PyPIミラーURLを入力してください",
       "pythonMirrorPlaceholder": "PythonミラーURLを入力してください"
     },

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -241,6 +241,7 @@
       "errorUpdatingConsent": "同意の更新エラー",
       "errorUpdatingConsentDetail": "メトリクスの同意設定の更新に失敗しました",
       "learnMoreAboutData": "データ収集の詳細を見る",
+      "mirrorSettings": "ミラー設定",
       "mirrorsReachable": "Pythonミラーへのネットワークアクセスは良好です",
       "pypiMirrorPlaceholder": "PyPIミラーURLを入力してください",
       "pythonMirrorPlaceholder": "PythonミラーURLを入力してください"

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -220,6 +220,7 @@
       "allowMetricsDescription": "匿名の使用状況メトリクスを送信してComfyUIを改善します。個人情報やワークフローの内容は収集されません。",
       "autoUpdate": "自動更新",
       "autoUpdateDescription": "更新が利用可能になると、自動的にダウンロードおよびインストールを行います。インストール前に通知が表示されます。",
+      "checkingMirrors": "Pythonミラーへのネットワークアクセスを確認中...",
       "dataCollectionDialog": {
         "collect": {
           "errorReports": "エラーメッセージとスタックトレース",
@@ -240,6 +241,7 @@
       "errorUpdatingConsent": "同意の更新エラー",
       "errorUpdatingConsentDetail": "メトリクスの同意設定の更新に失敗しました",
       "learnMoreAboutData": "データ収集の詳細を見る",
+      "mirrorsReachable": "Pythonミラーへのネットワークアクセスは良好です",
       "pypiMirrorPlaceholder": "PyPIミラーURLを入力してください",
       "pythonMirrorPlaceholder": "PythonミラーURLを入力してください"
     },

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -5,6 +5,10 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "匿名の使用統計を送信する"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi インストールミラー",
+    "tooltip": "デフォルトの pip インストールミラー"
+  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python Install Mirror",
     "tooltip": "管理されたPythonのインストールは、Astral python-build-standaloneプロジェクトからダウンロードされます。この変数は、Pythonのインストールのための異なるソースを使用するためのミラーURLに設定することができます。提供されたURLは、例えば、https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gzの中でhttps://github.com/astral-sh/python-build-standalone/releases/downloadを置き換えます。ディストリビューションは、file:// URLスキームを使用してローカルディレクトリから読み取ることができます。"

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -5,6 +5,14 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "匿名の使用統計を送信する"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi Install Mirror",
+    "tooltip": "管理されたPyPyのインストールはpython.orgからダウンロードされます。この変数は、PyPyのインストールのための異なるソースを使用するためのミラーURLに設定することができます。提供されたURLは、例えば、https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2の中でhttps://downloads.python.org/pypyを置き換えます。ディストリビューションは、file:// URLスキームを使用してローカルディレクトリから読み取ることができます。"
+  },
+  "Comfy-Desktop_UV_PythonInstallMirror": {
+    "name": "Python Install Mirror",
+    "tooltip": "管理されたPythonのインストールは、Astral python-build-standaloneプロジェクトからダウンロードされます。この変数は、Pythonのインストールのための異なるソースを使用するためのミラーURLに設定することができます。提供されたURLは、例えば、https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gzの中でhttps://github.com/astral-sh/python-build-standalone/releases/downloadを置き換えます。ディストリビューションは、file:// URLスキームを使用してローカルディレクトリから読み取ることができます。"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "ウィンドウスタイル",
     "options": {

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -13,6 +13,10 @@
     "name": "Python Install Mirror",
     "tooltip": "管理されたPythonのインストールは、Astral python-build-standaloneプロジェクトからダウンロードされます。この変数は、Pythonのインストールのための異なるソースを使用するためのミラーURLに設定することができます。提供されたURLは、例えば、https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gzの中でhttps://github.com/astral-sh/python-build-standalone/releases/downloadを置き換えます。ディストリビューションは、file:// URLスキームを使用してローカルディレクトリから読み取ることができます。"
   },
+  "Comfy-Desktop_UV_TorchInstallMirror": {
+    "name": "Torch Install Mirror",
+    "tooltip": "pytorchのpipインストールミラー"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "ウィンドウスタイル",
     "options": {

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -5,10 +5,6 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "匿名の使用統計を送信する"
   },
-  "Comfy-Desktop_UV_PypiInstallMirror": {
-    "name": "Pypi Install Mirror",
-    "tooltip": "管理されたPyPyのインストールはpython.orgからダウンロードされます。この変数は、PyPyのインストールのための異なるソースを使用するためのミラーURLに設定することができます。提供されたURLは、例えば、https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2の中でhttps://downloads.python.org/pypyを置き換えます。ディストリビューションは、file:// URLスキームを使用してローカルディレクトリから読み取ることができます。"
-  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python Install Mirror",
     "tooltip": "管理されたPythonのインストールは、Astral python-build-standaloneプロジェクトからダウンロードされます。この変数は、Pythonのインストールのための異なるソースを使用するためのミラーURLに設定することができます。提供されたURLは、例えば、https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gzの中でhttps://github.com/astral-sh/python-build-standalone/releases/downloadを置き換えます。ディストリビューションは、file:// URLスキームを使用してローカルディレクトリから読み取ることができます。"

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -239,7 +239,9 @@
       },
       "errorUpdatingConsent": "데이터 수집 동의 설정 업데이트 오류",
       "errorUpdatingConsentDetail": "데이터 수집 동의 설정 업데이트에 실패했습니다",
-      "learnMoreAboutData": "데이터 수집에 대해 더 알아보기"
+      "learnMoreAboutData": "데이터 수집에 대해 더 알아보기",
+      "pypiMirrorPlaceholder": "PyPI 미러 URL 입력",
+      "pythonMirrorPlaceholder": "Python 미러 URL 입력"
     },
     "systemLocations": "시스템 위치",
     "unhandledError": "알 수 없는 오류",
@@ -634,6 +636,7 @@
     "Settings": "설정",
     "Sidebar": "사이드바",
     "Tree Explorer": "트리 탐색기",
+    "UV": "UV",
     "Validation": "검증",
     "Window": "창",
     "Workflow": "워크플로"

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -243,6 +243,7 @@
       "learnMoreAboutData": "데이터 수집에 대해 더 알아보기",
       "mirrorSettings": "미러 설정",
       "mirrorsReachable": "파이썬 미러에 대한 네트워크 액세스가 좋습니다",
+      "mirrorsUnreachable": "일부 파이썬 미러에 대한 네트워크 접근이 나쁩니다",
       "pypiMirrorPlaceholder": "PyPI 미러 URL 입력",
       "pythonMirrorPlaceholder": "Python 미러 URL 입력"
     },

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -241,6 +241,7 @@
       "errorUpdatingConsent": "데이터 수집 동의 설정 업데이트 오류",
       "errorUpdatingConsentDetail": "데이터 수집 동의 설정 업데이트에 실패했습니다",
       "learnMoreAboutData": "데이터 수집에 대해 더 알아보기",
+      "mirrorSettings": "미러 설정",
       "mirrorsReachable": "파이썬 미러에 대한 네트워크 액세스가 좋습니다",
       "pypiMirrorPlaceholder": "PyPI 미러 URL 입력",
       "pythonMirrorPlaceholder": "Python 미러 URL 입력"

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -220,6 +220,7 @@
       "allowMetricsDescription": "익명의 사용 통계를 보내 ComfyUI를 개선하는 데 도움을 줍니다. 개인 정보나 워크플로 내용은 수집되지 않습니다.",
       "autoUpdate": "자동 업데이트",
       "autoUpdateDescription": "업데이트가 가능해지면 자동으로 다운로드하고 설치합니다. 업데이트가 설치되기 전에 항상 알림을 받습니다.",
+      "checkingMirrors": "파이썬 미러에 대한 네트워크 액세스 확인 중...",
       "dataCollectionDialog": {
         "collect": {
           "errorReports": "오류 메시지 및 스택 추적",
@@ -240,6 +241,7 @@
       "errorUpdatingConsent": "데이터 수집 동의 설정 업데이트 오류",
       "errorUpdatingConsentDetail": "데이터 수집 동의 설정 업데이트에 실패했습니다",
       "learnMoreAboutData": "데이터 수집에 대해 더 알아보기",
+      "mirrorsReachable": "파이썬 미러에 대한 네트워크 액세스가 좋습니다",
       "pypiMirrorPlaceholder": "PyPI 미러 URL 입력",
       "pythonMirrorPlaceholder": "Python 미러 URL 입력"
     },

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -5,6 +5,10 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "익명 사용 통계 보내기"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi 설치 미러",
+    "tooltip": "기본 pip 설치 미러"
+  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python 설치 미러",
     "tooltip": "관리되는 Python 설치파일은 Astral python-build-standalone 프로젝트에서 다운로드됩니다. 이 변수는 Python 설치파일의 다른 출처를 사용하기 위해 미러 URL로 설정할 수 있습니다. 제공된 URL은 예를 들어, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz에서 https://github.com/astral-sh/python-build-standalone/releases/download를 대체합니다. 배포판은 file:// URL 스키마를 사용하여 로컬 디렉토리에서 읽을 수 있습니다."

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -13,6 +13,10 @@
     "name": "Python 설치 미러",
     "tooltip": "관리되는 Python 설치파일은 Astral python-build-standalone 프로젝트에서 다운로드됩니다. 이 변수는 Python 설치파일의 다른 출처를 사용하기 위해 미러 URL로 설정할 수 있습니다. 제공된 URL은 예를 들어, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz에서 https://github.com/astral-sh/python-build-standalone/releases/download를 대체합니다. 배포판은 file:// URL 스키마를 사용하여 로컬 디렉토리에서 읽을 수 있습니다."
   },
+  "Comfy-Desktop_UV_TorchInstallMirror": {
+    "name": "토치 설치 미러",
+    "tooltip": "pytorch를 위한 Pip 설치 미러"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "창 스타일",
     "options": {

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -5,10 +5,6 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "익명 사용 통계 보내기"
   },
-  "Comfy-Desktop_UV_PypiInstallMirror": {
-    "name": "Pypi 설치 미러",
-    "tooltip": "관리되는 PyPy 설치파일은 python.org에서 다운로드됩니다. 이 변수는 PyPy 설치파일의 다른 출처를 사용하기 위해 미러 URL로 설정할 수 있습니다. 제공된 URL은 예를 들어, https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2에서 https://downloads.python.org/pypy를 대체합니다. 배포판은 file:// URL 스키마를 사용하여 로컬 디렉토리에서 읽을 수 있습니다."
-  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python 설치 미러",
     "tooltip": "관리되는 Python 설치파일은 Astral python-build-standalone 프로젝트에서 다운로드됩니다. 이 변수는 Python 설치파일의 다른 출처를 사용하기 위해 미러 URL로 설정할 수 있습니다. 제공된 URL은 예를 들어, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz에서 https://github.com/astral-sh/python-build-standalone/releases/download를 대체합니다. 배포판은 file:// URL 스키마를 사용하여 로컬 디렉토리에서 읽을 수 있습니다."

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -5,6 +5,14 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "익명 사용 통계 보내기"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi 설치 미러",
+    "tooltip": "관리되는 PyPy 설치파일은 python.org에서 다운로드됩니다. 이 변수는 PyPy 설치파일의 다른 출처를 사용하기 위해 미러 URL로 설정할 수 있습니다. 제공된 URL은 예를 들어, https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2에서 https://downloads.python.org/pypy를 대체합니다. 배포판은 file:// URL 스키마를 사용하여 로컬 디렉토리에서 읽을 수 있습니다."
+  },
+  "Comfy-Desktop_UV_PythonInstallMirror": {
+    "name": "Python 설치 미러",
+    "tooltip": "관리되는 Python 설치파일은 Astral python-build-standalone 프로젝트에서 다운로드됩니다. 이 변수는 Python 설치파일의 다른 출처를 사용하기 위해 미러 URL로 설정할 수 있습니다. 제공된 URL은 예를 들어, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz에서 https://github.com/astral-sh/python-build-standalone/releases/download를 대체합니다. 배포판은 file:// URL 스키마를 사용하여 로컬 디렉토리에서 읽을 수 있습니다."
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "창 스타일",
     "options": {

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -220,6 +220,7 @@
       "allowMetricsDescription": "Помогите улучшить ComfyUI, отправляя анонимные метрики использования. Личная информация или содержание рабочего процесса не будут собираться.",
       "autoUpdate": "Автоматические обновления",
       "autoUpdateDescription": "Автоматически загружать и устанавливать обновления, когда они становятся доступными. Вы всегда будете уведомлены перед установкой обновлений.",
+      "checkingMirrors": "Проверка доступа к зеркалам python по сети...",
       "dataCollectionDialog": {
         "collect": {
           "errorReports": "Сообщение об ошибке и трассировка стека",
@@ -240,6 +241,7 @@
       "errorUpdatingConsent": "Ошибка обновления согласия",
       "errorUpdatingConsentDetail": "Не удалось обновить настройки согласия на метрики",
       "learnMoreAboutData": "Узнать больше о сборе данных",
+      "mirrorsReachable": "Сетевой доступ к зеркалам python хороший",
       "pypiMirrorPlaceholder": "Введите URL-зеркало PyPI",
       "pythonMirrorPlaceholder": "Введите URL-зеркало Python"
     },

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -241,6 +241,7 @@
       "errorUpdatingConsent": "Ошибка обновления согласия",
       "errorUpdatingConsentDetail": "Не удалось обновить настройки согласия на метрики",
       "learnMoreAboutData": "Узнать больше о сборе данных",
+      "mirrorSettings": "Настройки зеркала",
       "mirrorsReachable": "Сетевой доступ к зеркалам python хороший",
       "pypiMirrorPlaceholder": "Введите URL-зеркало PyPI",
       "pythonMirrorPlaceholder": "Введите URL-зеркало Python"

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -239,7 +239,9 @@
       },
       "errorUpdatingConsent": "Ошибка обновления согласия",
       "errorUpdatingConsentDetail": "Не удалось обновить настройки согласия на метрики",
-      "learnMoreAboutData": "Узнать больше о сборе данных"
+      "learnMoreAboutData": "Узнать больше о сборе данных",
+      "pypiMirrorPlaceholder": "Введите URL-зеркало PyPI",
+      "pythonMirrorPlaceholder": "Введите URL-зеркало Python"
     },
     "systemLocations": "Системные места",
     "unhandledError": "Неизвестная ошибка",
@@ -634,6 +636,7 @@
     "Settings": "Настройки",
     "Sidebar": "Боковая панель",
     "Tree Explorer": "Дерево проводника",
+    "UV": "UV",
     "Validation": "Валидация",
     "Window": "Окно",
     "Workflow": "Рабочий процесс"

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -243,6 +243,7 @@
       "learnMoreAboutData": "Узнать больше о сборе данных",
       "mirrorSettings": "Настройки зеркала",
       "mirrorsReachable": "Сетевой доступ к зеркалам python хороший",
+      "mirrorsUnreachable": "Сетевой доступ к некоторым зеркалам python плохой",
       "pypiMirrorPlaceholder": "Введите URL-зеркало PyPI",
       "pythonMirrorPlaceholder": "Введите URL-зеркало Python"
     },

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -5,10 +5,6 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Отправлять анонимную статистику использования"
   },
-  "Comfy-Desktop_UV_PypiInstallMirror": {
-    "name": "Зеркало для установки Pypi",
-    "tooltip": "Управляемые установки PyPy загружаются с python.org. Эта переменная может быть установлена на URL-адрес зеркала для использования другого источника для установок PyPy. Предоставленный URL заменит https://downloads.python.org/pypy в, например, https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Дистрибутивы могут быть прочитаны из локального каталога, используя схему URL file://"
-  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Зеркало для установки Python",
     "tooltip": "Управляемые установки Python загружаются из проекта Astral python-build-standalone. Эта переменная может быть установлена на URL-адрес зеркала для использования другого источника для установок Python. Предоставленный URL заменит https://github.com/astral-sh/python-build-standalone/releases/download в, например, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Дистрибутивы могут быть прочитаны из локального каталога, используя схему URL file://."

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -5,6 +5,14 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Отправлять анонимную статистику использования"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Зеркало для установки Pypi",
+    "tooltip": "Управляемые установки PyPy загружаются с python.org. Эта переменная может быть установлена на URL-адрес зеркала для использования другого источника для установок PyPy. Предоставленный URL заменит https://downloads.python.org/pypy в, например, https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2. Дистрибутивы могут быть прочитаны из локального каталога, используя схему URL file://"
+  },
+  "Comfy-Desktop_UV_PythonInstallMirror": {
+    "name": "Зеркало для установки Python",
+    "tooltip": "Управляемые установки Python загружаются из проекта Astral python-build-standalone. Эта переменная может быть установлена на URL-адрес зеркала для использования другого источника для установок Python. Предоставленный URL заменит https://github.com/astral-sh/python-build-standalone/releases/download в, например, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Дистрибутивы могут быть прочитаны из локального каталога, используя схему URL file://."
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "Стиль окна",
     "options": {

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -5,6 +5,10 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "Отправлять анонимную статистику использования"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi Установить Зеркало",
+    "tooltip": "Зеркало установки pip по умолчанию"
+  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Зеркало для установки Python",
     "tooltip": "Управляемые установки Python загружаются из проекта Astral python-build-standalone. Эта переменная может быть установлена на URL-адрес зеркала для использования другого источника для установок Python. Предоставленный URL заменит https://github.com/astral-sh/python-build-standalone/releases/download в, например, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Дистрибутивы могут быть прочитаны из локального каталога, используя схему URL file://."

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -13,6 +13,10 @@
     "name": "Зеркало для установки Python",
     "tooltip": "Управляемые установки Python загружаются из проекта Astral python-build-standalone. Эта переменная может быть установлена на URL-адрес зеркала для использования другого источника для установок Python. Предоставленный URL заменит https://github.com/astral-sh/python-build-standalone/releases/download в, например, https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Дистрибутивы могут быть прочитаны из локального каталога, используя схему URL file://."
   },
+  "Comfy-Desktop_UV_TorchInstallMirror": {
+    "name": "Установочное Зеркало Torch",
+    "tooltip": "Зеркало для установки pip для pytorch"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "Стиль окна",
     "options": {

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -241,6 +241,7 @@
       "errorUpdatingConsent": "更新同意错误",
       "errorUpdatingConsentDetail": "无法更新度量同意设置",
       "learnMoreAboutData": "了解更多关于数据收集的信息",
+      "mirrorSettings": "镜像设置",
       "mirrorsReachable": "到Python镜像的网络访问良好",
       "pypiMirrorPlaceholder": "输入PyPI镜像URL",
       "pythonMirrorPlaceholder": "输入Python镜像URL"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -239,7 +239,9 @@
       },
       "errorUpdatingConsent": "更新同意错误",
       "errorUpdatingConsentDetail": "无法更新度量同意设置",
-      "learnMoreAboutData": "了解更多关于数据收集的信息"
+      "learnMoreAboutData": "了解更多关于数据收集的信息",
+      "pypiMirrorPlaceholder": "输入PyPI镜像URL",
+      "pythonMirrorPlaceholder": "输入Python镜像URL"
     },
     "systemLocations": "系统位置",
     "unhandledError": "未知错误",
@@ -634,6 +636,7 @@
     "Settings": "设置",
     "Sidebar": "侧边栏",
     "Tree Explorer": "树形浏览器",
+    "UV": "UV",
     "Validation": "验证",
     "Window": "窗口",
     "Workflow": "工作流"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -220,6 +220,7 @@
       "allowMetricsDescription": "通过发送匿名使用情况指标来帮助改进ComfyUI。不会收集任何个人信息或工作流内容。",
       "autoUpdate": "自动更新",
       "autoUpdateDescription": "更新可用时自动更新。您将在安装更新之前收到通知。",
+      "checkingMirrors": "正在检查到Python镜像的网络访问...",
       "dataCollectionDialog": {
         "collect": {
           "errorReports": "错误报告和堆栈跟踪",
@@ -240,6 +241,7 @@
       "errorUpdatingConsent": "更新同意错误",
       "errorUpdatingConsentDetail": "无法更新度量同意设置",
       "learnMoreAboutData": "了解更多关于数据收集的信息",
+      "mirrorsReachable": "到Python镜像的网络访问良好",
       "pypiMirrorPlaceholder": "输入PyPI镜像URL",
       "pythonMirrorPlaceholder": "输入Python镜像URL"
     },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -243,6 +243,7 @@
       "learnMoreAboutData": "了解更多关于数据收集的信息",
       "mirrorSettings": "镜像设置",
       "mirrorsReachable": "到Python镜像的网络访问良好",
+      "mirrorsUnreachable": "对某些python镜像的网络访问不佳",
       "pypiMirrorPlaceholder": "输入PyPI镜像URL",
       "pythonMirrorPlaceholder": "输入Python镜像URL"
     },

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -5,6 +5,10 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "发送匿名使用情况统计"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi 安装镜像",
+    "tooltip": "默认 pip 安装镜像"
+  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python安装镜像",
     "tooltip": "管理的Python安装包从Astral python-build-standalone项目下载。此变量可以设置为镜像URL，以使用不同的Python安装源。提供的URL将替换https://github.com/astral-sh/python-build-standalone/releases/download，例如，在https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz中。可以通过使用file:// URL方案从本地目录读取分发包。"

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -5,6 +5,14 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "发送匿名使用情况统计"
   },
+  "Comfy-Desktop_UV_PypiInstallMirror": {
+    "name": "Pypi安装镜像",
+    "tooltip": "管理的PyPy安装包从python.org下载。此变量可以设置为镜像URL，以使用不同的PyPy安装源。提供的URL将替换https://downloads.python.org/pypy，例如，在https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2中。可以通过使用file:// URL方案从本地目录读取分发包。"
+  },
+  "Comfy-Desktop_UV_PythonInstallMirror": {
+    "name": "Python安装镜像",
+    "tooltip": "管理的Python安装包从Astral python-build-standalone项目下载。此变量可以设置为镜像URL，以使用不同的Python安装源。提供的URL将替换https://github.com/astral-sh/python-build-standalone/releases/download，例如，在https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz中。可以通过使用file:// URL方案从本地目录读取分发包。"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "窗口样式",
     "options": {

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -13,6 +13,10 @@
     "name": "Python安装镜像",
     "tooltip": "管理的Python安装包从Astral python-build-standalone项目下载。此变量可以设置为镜像URL，以使用不同的Python安装源。提供的URL将替换https://github.com/astral-sh/python-build-standalone/releases/download，例如，在https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz中。可以通过使用file:// URL方案从本地目录读取分发包。"
   },
+  "Comfy-Desktop_UV_TorchInstallMirror": {
+    "name": "Torch安装镜像",
+    "tooltip": "用于pytorch的Pip安装镜像"
+  },
   "Comfy-Desktop_WindowStyle": {
     "name": "窗口样式",
     "options": {

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -5,10 +5,6 @@
   "Comfy-Desktop_SendStatistics": {
     "name": "发送匿名使用情况统计"
   },
-  "Comfy-Desktop_UV_PypiInstallMirror": {
-    "name": "Pypi安装镜像",
-    "tooltip": "管理的PyPy安装包从python.org下载。此变量可以设置为镜像URL，以使用不同的PyPy安装源。提供的URL将替换https://downloads.python.org/pypy，例如，在https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2中。可以通过使用file:// URL方案从本地目录读取分发包。"
-  },
   "Comfy-Desktop_UV_PythonInstallMirror": {
     "name": "Python安装镜像",
     "tooltip": "管理的Python安装包从Astral python-build-standalone项目下载。此变量可以设置为镜像URL，以使用不同的Python安装源。提供的URL将替换https://github.com/astral-sh/python-build-standalone/releases/download，例如，在https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz中。可以通过使用file:// URL方案从本地目录读取分发包。"

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -1,0 +1,19 @@
+export enum ValidationState {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  VALID = 'VALID',
+  INVALID = 'INVALID'
+}
+
+export const mergeValidationStates = (states: ValidationState[]) => {
+  if (states.some((state) => state === ValidationState.INVALID)) {
+    return ValidationState.INVALID
+  }
+  if (states.some((state) => state === ValidationState.LOADING)) {
+    return ValidationState.LOADING
+  }
+  if (states.every((state) => state === ValidationState.VALID)) {
+    return ValidationState.VALID
+  }
+  return ValidationState.IDLE
+}

--- a/src/views/InstallView.vue
+++ b/src/views/InstallView.vue
@@ -80,10 +80,14 @@
           <DesktopSettingsConfiguration
             v-model:autoUpdate="autoUpdate"
             v-model:allowMetrics="allowMetrics"
+          />
+          <MirrorsConfiguration
             v-model:pythonMirror="pythonMirror"
             v-model:pypiMirror="pypiMirror"
+            v-model:torchMirror="torchMirror"
+            class="mt-6"
           />
-          <div class="flex pt-6 justify-between">
+          <div class="flex mt-6 justify-between">
             <Button
               :label="$t('g.back')"
               severity="secondary"
@@ -122,6 +126,7 @@ import DesktopSettingsConfiguration from '@/components/install/DesktopSettingsCo
 import GpuPicker from '@/components/install/GpuPicker.vue'
 import InstallLocationPicker from '@/components/install/InstallLocationPicker.vue'
 import MigrationPicker from '@/components/install/MigrationPicker.vue'
+import MirrorsConfiguration from '@/components/install/MirrorsConfiguration.vue'
 import { electronAPI } from '@/utils/envUtil'
 import BaseViewTemplate from '@/views/templates/BaseViewTemplate.vue'
 
@@ -137,6 +142,7 @@ const autoUpdate = ref(true)
 const allowMetrics = ref(true)
 const pythonMirror = ref('')
 const pypiMirror = ref('')
+const torchMirror = ref('')
 
 /** Forces each install step to be visited at least once. */
 const highestStep = ref(0)
@@ -168,6 +174,7 @@ const install = () => {
     migrationItemIds: toRaw(migrationItemIds.value),
     pythonMirror: pythonMirror.value,
     pypiMirror: pypiMirror.value,
+    torchMirror: torchMirror.value,
     device: device.value
   }
   electron.installComfyUI(options)

--- a/src/views/InstallView.vue
+++ b/src/views/InstallView.vue
@@ -80,6 +80,8 @@
           <DesktopSettingsConfiguration
             v-model:autoUpdate="autoUpdate"
             v-model:allowMetrics="allowMetrics"
+            v-model:pythonMirror="pythonMirror"
+            v-model:pypiMirror="pypiMirror"
           />
           <div class="flex pt-6 justify-between">
             <Button
@@ -133,6 +135,8 @@ const migrationItemIds = ref<string[]>([])
 
 const autoUpdate = ref(true)
 const allowMetrics = ref(true)
+const pythonMirror = ref('')
+const pypiMirror = ref('')
 
 /** Forces each install step to be visited at least once. */
 const highestStep = ref(0)
@@ -162,6 +166,8 @@ const install = () => {
     allowMetrics: allowMetrics.value,
     migrationSourcePath: migrationSourcePath.value,
     migrationItemIds: toRaw(migrationItemIds.value),
+    pythonMirror: pythonMirror.value,
+    pypiMirror: pypiMirror.value,
     device: device.value
   }
   electron.installComfyUI(options)

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -68,6 +68,13 @@ const mockElectronAPI: Plugin = {
               console.log('incrementUserProperty', property, value)
             }
           },
+          NetWork: {
+            canAccessUrl: (url) => {
+              const canAccess = url.includes('good')
+              console.log('canAccessUrl', url, canAccess)
+              return new Promise((resolve) => setTimeout(() => resolve(canAccess), 3000))
+            }
+          },
           setMetricsConsent: (consent) => {}
         };`
       }

--- a/vite.electron.config.mts
+++ b/vite.electron.config.mts
@@ -72,7 +72,7 @@ const mockElectronAPI: Plugin = {
             canAccessUrl: (url) => {
               const canAccess = url.includes('good')
               console.log('canAccessUrl', url, canAccess)
-              return new Promise((resolve) => setTimeout(() => resolve(canAccess), 3000))
+              return new Promise((resolve) => setTimeout(() => resolve(canAccess), 10000))
             }
           },
           setMetricsConsent: (consent) => {}


### PR DESCRIPTION
Requires:
- https://github.com/Comfy-Org/desktop/pull/711
- https://github.com/Comfy-Org/desktop/pull/713

This PR adds python/pypi mirrors configuration to the install wizard. Users will be prompted to configure mirrors if they don't have access to the default python mirrors.

## Good connection
![image](https://github.com/user-attachments/assets/49566b9f-cbba-4d9f-8042-0902d62cacff)

## Bad connection
![image](https://github.com/user-attachments/assets/c034d49e-080c-47df-910f-3dd6ab4ee01b)

## Loading state
![image](https://github.com/user-attachments/assets/ca167513-1adb-49f1-88b5-34f50a79ecdc)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2333-Add-UV-mirrors-settings-1846d73d365081c99f82f219da84cbe1) by [Unito](https://www.unito.io)
