### PR TITLE
Fix missing models dialog

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1313,17 +1313,19 @@ export class ComfyApp {
       graphData.models &&
       useSettingStore().get('Comfy.Workflow.ShowMissingModelsWarning')
     ) {
+      const modelStore = useModelStore()
       for (const m of graphData.models) {
-        const models_available = await useModelStore().getLoadedModelFolder(
-          m.directory
-        )
-        if (models_available === null) {
-          // @ts-expect-error
-          m.directory_invalid = true
-          missingModels.push(m)
-        } else if (!(m.name in models_available.models)) {
-          missingModels.push(m)
-        }
+        const modelFolder = await modelStore.getLoadedModelFolder(m.directory)
+        // @ts-expect-error
+        if (!modelFolder) m.directory_invalid = true
+
+        const modelsAvailable = modelFolder?.models
+        const modelExists =
+          modelsAvailable &&
+          Object.values(modelsAvailable).some(
+            (model) => model.file_name === m.name
+          )
+        if (!modelExists) missingModels.push(m)
       }
     }
 


### PR DESCRIPTION
In https://github.com/Comfy-Org/ComfyUI_frontend/pull/1739, `api.getModels` and `api.getModelFolders` are changed to use `/api/experiment/models` routes, and the model store's `models` object is changed to prepend the "pathIndex" to each each key. This PR updates the missing models check in `loadGraphData` to account for the change.

Additionally, the disabled missing models dialog test is split into 3 parts: show dialog test, don't show dialog test, download model test. Only the download test is left disabled.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2336-Fix-missing-models-dialog-1856d73d3650813cab3cf8a9be4379a0) by [Unito](https://www.unito.io)
