### PR TITLE
Add "Don't show this again" checkbox to missing models dialog

### DIFF
--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -156,7 +156,7 @@ test.describe('Missing models warning', () => {
       closeButton = comfyPage.page.getByLabel('Close')
     })
 
-    test('Checking box should disable missing models dialog setting', async ({
+    test('Should disable warning dialog when checkbox is checked', async ({
       comfyPage
     }) => {
       await checkbox.click()
@@ -172,7 +172,7 @@ test.describe('Missing models warning', () => {
       expect(settingValue).toBe(false)
     })
 
-    test('Not checking box should not disable missing models dialog setting', async ({
+    test('Should keep warning dialog enabled when checkbox is unchecked', async ({
       comfyPage
     }) => {
       await closeButton.click()

--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -69,6 +69,8 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
+const doNotAskAgain = ref(false)
+
 const modelDownloads = ref<Record<string, ModelInfo>>({})
 const missingModels = computed(() => {
   return props.missingModels.map((model) => {
@@ -118,8 +120,6 @@ const missingModels = computed(() => {
     }
   })
 })
-
-const doNotAskAgain = ref(false)
 
 onBeforeUnmount(() => {
   if (doNotAskAgain.value) {

--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -2,9 +2,15 @@
   <NoResultsPlaceholder
     class="pb-0"
     icon="pi pi-exclamation-circle"
-    title="Missing Models"
-    message="When loading the graph, the following models were not found"
+    :title="t('missingModelsDialog.missingModels')"
+    :message="t('missingModelsDialog.missingModelsMessage')"
   />
+  <div class="flex gap-1 mb-4">
+    <Checkbox v-model="doNotAskAgain" binary input-id="doNotAskAgain" />
+    <label for="doNotAskAgain">{{
+      t('missingModelsDialog.doNotAskAgain')
+    }}</label>
+  </div>
   <ListBox :options="missingModels" class="comfy-missing-models">
     <template #option="{ option }">
       <Suspense v-if="isElectron()">
@@ -25,11 +31,14 @@
 </template>
 
 <script setup lang="ts">
+import Checkbox from 'primevue/checkbox'
 import ListBox from 'primevue/listbox'
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import FileDownload from '@/components/common/FileDownload.vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
+import { useSettingStore } from '@/stores/settingStore'
 import { isElectron } from '@/utils/envUtil'
 
 // TODO: Read this from server internal API rather than hardcoding here
@@ -57,6 +66,8 @@ const props = defineProps<{
   missingModels: ModelInfo[]
   paths: Record<string, string[]>
 }>()
+
+const { t } = useI18n()
 
 const modelDownloads = ref<Record<string, ModelInfo>>({})
 const missingModels = computed(() => {
@@ -106,6 +117,14 @@ const missingModels = computed(() => {
       folderPath: downloadInfo.folder_path
     }
   })
+})
+
+const doNotAskAgain = ref(false)
+
+onBeforeUnmount(() => {
+  if (doNotAskAgain.value) {
+    useSettingStore().set('Comfy.Workflow.ShowMissingModelsWarning', false)
+  }
 })
 </script>
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -708,5 +708,10 @@
       "taskFailed": "Task failed to run.",
       "defaultDescription": "An error occurred while running a maintenance task."
     }
+  },
+  "missingModelsDialog": {
+    "doNotAskAgain": "Don't show this again",
+    "missingModels": "Missing Models",
+    "missingModelsMessage": "When loading the graph, the following models were not found"
   }
 }

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -370,6 +370,11 @@
     "Zoom In": "Zoom avant",
     "Zoom Out": "Zoom arrière"
   },
+  "missingModelsDialog": {
+    "doNotAskAgain": "Ne plus afficher ce message",
+    "missingModels": "Modèles manquants",
+    "missingModelsMessage": "Lors du chargement du graphique, les modèles suivants n'ont pas été trouvés"
+  },
   "nodeCategories": {
     "3d": "3d",
     "3d_models": "modèles_3d",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -370,6 +370,11 @@
     "Zoom In": "ズームイン",
     "Zoom Out": "ズームアウト"
   },
+  "missingModelsDialog": {
+    "doNotAskAgain": "再度表示しない",
+    "missingModels": "モデルが見つかりません",
+    "missingModelsMessage": "グラフを読み込む際に、次のモデルが見つかりませんでした"
+  },
   "nodeCategories": {
     "3d": "3d",
     "3d_models": "3Dモデル",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -370,6 +370,11 @@
     "Zoom In": "확대",
     "Zoom Out": "축소"
   },
+  "missingModelsDialog": {
+    "doNotAskAgain": "다시 보지 않기",
+    "missingModels": "모델이 없습니다",
+    "missingModelsMessage": "그래프를 로드할 때 다음 모델을 찾을 수 없었습니다"
+  },
   "nodeCategories": {
     "3d": "3d",
     "3d_models": "3D 모델",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -370,6 +370,11 @@
     "Zoom In": "Увеличить",
     "Zoom Out": "Уменьшить"
   },
+  "missingModelsDialog": {
+    "doNotAskAgain": "Больше не показывать это",
+    "missingModels": "Отсутствующие модели",
+    "missingModelsMessage": "При загрузке графа следующие модели не были найдены"
+  },
   "nodeCategories": {
     "3d": "3d",
     "3d_models": "3d_модели",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -370,6 +370,11 @@
     "Zoom In": "放大画面",
     "Zoom Out": "缩小画面"
   },
+  "missingModelsDialog": {
+    "doNotAskAgain": "不再显示此消息",
+    "missingModels": "缺少模型",
+    "missingModelsMessage": "加载图表时，未找到以下模型"
+  },
   "nodeCategories": {
     "3d": "3d",
     "3d_models": "3D模型",


### PR DESCRIPTION
This PR adds a "Don't show this again" checkbox to the missing models dialog that disables the `"Comfy.Workflow.ShowMissingModelsWarning"` setting.

![Selection_812](https://github.com/user-attachments/assets/f8382b64-5dac-4acd-abb4-562004d94eaa)

Additionally, the title and subtitle field are now rendered with I18n.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2344-Add-Don-t-show-this-again-checkbox-to-missing-models-dialog-1866d73d365081f78bb6e92d54e6f8e7) by [Unito](https://www.unito.io)
