### PR TITLE
Enable missing models dialog by default

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -157,7 +157,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Workflow.ShowMissingModelsWarning',
     name: 'Show missing models warning',
     type: 'boolean',
-    defaultValue: false,
+    defaultValue: true,
     experimental: true
   },
   {


### PR DESCRIPTION
This PR sets the default value of `"Comfy.Workflow.ShowMissingModelsWarning"` to `true`. This setting enables the below dialog when loading workflows that have a `models` field (assuming the user doesn't have the model):

![Selection_814](https://github.com/user-attachments/assets/ba86363a-7d44-45f9-9a6a-7b76a6f49eda)

Examples of workflows with model fields can be found in the [templates](https://github.com/Comfy-Org/ComfyUI_frontend/tree/main/public/templates) folder of the frontend repo (added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1076). The format is like this:

```json
    "models": [
      {
        "name": "flux1-schnell-fp8.safetensors",
        "url": "https://huggingface.co/Comfy-Org/flux1-schnell/resolve/main/flux1-schnell-fp8.safetensors?download=true",
        "directory": "checkpoints"
      }
    ],
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2345-Enable-missing-models-dialog-by-default-1866d73d365081b4be7bde8f0ad82296) by [Unito](https://www.unito.io)
