### PR TITLE
Use v1-5-pruned-emaonly-fp16 model in default template workflow

### DIFF
--- a/public/templates/default.json
+++ b/public/templates/default.json
@@ -350,7 +350,7 @@
   "version": 0.4,
   "models": [{
     "name": "v1-5-pruned-emaonly.safetensors",
-    "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly.safetensors?download=true",
+    "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly-fp16.safetensors?download=true",
     "directory": "checkpoints"
   }]
 }

--- a/public/templates/default.json
+++ b/public/templates/default.json
@@ -266,7 +266,7 @@
       ],
       "properties": {},
       "widgets_values": [
-        "v1-5-pruned-emaonly.safetensors"
+        "v1-5-pruned-emaonly-fp16.safetensors"
       ]
     }
   ],
@@ -349,7 +349,7 @@
   "extra": {},
   "version": 0.4,
   "models": [{
-    "name": "v1-5-pruned-emaonly.safetensors",
+    "name": "v1-5-pruned-emaonly-fp16.safetensors",
     "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly-fp16.safetensors?download=true",
     "directory": "checkpoints"
   }]


### PR DESCRIPTION
This PR changes the default template workflow to use `v1-5-pruned-emaonly-fp16` instead of `v1-5-pruned-emaonly`. This workflow and model is suggested to first-time users during onboarding. 

In terms of UI, this is the before and after:

![ba](https://github.com/user-attachments/assets/f7dd677a-2d51-4fa7-a71e-7773ba126a01)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2346-Use-v1-5-pruned-emaonly-fp16-model-in-default-template-workflow-1866d73d365081839d2ee77dc6aaa121) by [Unito](https://www.unito.io)
