### PR TITLE
Add cursor drop effect when dragging nodes/models onto graph

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -247,7 +247,8 @@ watch(
 )
 
 usePragmaticDroppable(() => canvasRef.value, {
-  getDropEffect: (): Exclude<DataTransfer['dropEffect'], 'none'> => 'copy',
+  getDropEffect: (args): Exclude<DataTransfer['dropEffect'], 'none'> =>
+    args.source.data.type === 'tree-explorer-node' ? 'copy' : 'move',
   onDrop: (event) => {
     const loc = event.location.current.input
     const dndData = event.source.data

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -247,6 +247,7 @@ watch(
 )
 
 usePragmaticDroppable(() => canvasRef.value, {
+  getDropEffect: (): Exclude<DataTransfer['dropEffect'], 'none'> => 'copy',
   onDrop: (event) => {
     const loc = event.location.current.input
     const dndData = event.source.data


### PR DESCRIPTION
Adds cursors drag effect when dragging tree explorer nodes onto graph. Example:


https://github.com/user-attachments/assets/032aed33-d565-40c9-bcc8-97ec50cde499


Type hint:

```typescript
(property) getDropEffect?: (args: DropTargetGetFeedbackArgs<ElementDragType>) => DropTargetAllowedDropEffect
```

> Optionally provide a drop effect to be applied when this drop target is the innermost drop target being dragged over.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2354-Add-cursor-drop-effect-when-dragging-nodes-models-onto-graph-1876d73d365081cdb9afe8d88a784137) by [Unito](https://www.unito.io)
