### PR TITLE
Set Node ID badges to hidden by default

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -290,7 +290,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Node ID badge mode',
     type: 'combo',
     options: [NodeBadgeMode.None, NodeBadgeMode.ShowAll],
-    defaultValue: NodeBadgeMode.ShowAll
+    defaultValue: NodeBadgeMode.None
   },
   {
     id: 'Comfy.NodeBadge.NodeLifeCycleBadgeMode',


### PR DESCRIPTION
Sets `'Comfy.NodeBadge.NodeIdBadgeMode'` setting to `'None'` by default.

Reasons:

- Most users do not have a use for node ID badges
- Confusing for new users, as it gives false impression they are important or relate to logical flow of the graph
- They are clipped by other nodes, which is awkward visually
- They clutter the graph

![Selection_821](https://github.com/user-attachments/assets/a32023b4-0841-45c4-8b68-1e8430be9ed4)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2356-Set-Node-ID-badges-to-hidden-by-default-1876d73d365081ecbfb0c1b63a97024c) by [Unito](https://www.unito.io)
