### PR TITLE
[CI] Auto-generate release notes in GH action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
           draft: true
           prerelease: false
           make_latest: "true"
+          generate_release_notes: true
   publish_types:
     runs-on: ubuntu-latest
     if: >


### PR DESCRIPTION
Adds option to automatically generate release notes to the release process:

https://github.com/softprops/action-gh-release/blob/master/LICENSE#-customizing

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2364-CI-Auto-generate-release-notes-in-GH-action-1886d73d365081c686dec26e48d31dd3) by [Unito](https://www.unito.io)
