### PR TITLE
[3d] move change background color button

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -254,14 +254,6 @@ app.registerExtension({
           if (modelWidget) {
             modelWidget.value = ''
           }
-
-          const speedSelect = node.widgets?.find(
-            (w: IWidget) => w.name === 'animation_speed'
-          )
-
-          if (speedSelect) {
-            speedSelect.value = '1'
-          }
         })
 
         return {
@@ -301,17 +293,6 @@ app.registerExtension({
     const upDirection = node.widgets.find(
       (w: IWidget) => w.name === 'up_direction'
     )
-
-    const speedSelect = node.widgets.find(
-      (w: IWidget) => w.name === 'animation_speed'
-    )
-
-    speedSelect.callback = (value: string) => {
-      const load3d = containerToLoad3D.get(container.id) as Load3dAnimation
-      if (load3d) {
-        load3d.setAnimationSpeed(parseFloat(value))
-      }
-    }
 
     const fov = node.widgets.find((w: IWidget) => w.name === 'fov')
 
@@ -564,17 +545,6 @@ app.registerExtension({
     const upDirection = node.widgets.find(
       (w: IWidget) => w.name === 'up_direction'
     )
-
-    const speedSelect = node.widgets.find(
-      (w: IWidget) => w.name === 'animation_speed'
-    )
-
-    speedSelect.callback = (value: string) => {
-      const load3d = containerToLoad3D.get(container.id) as Load3dAnimation
-      if (load3d) {
-        load3d.setAnimationSpeed(parseFloat(value))
-      }
-    }
 
     const fov = node.widgets.find((w: IWidget) => w.name === 'fov')
 

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -123,8 +123,6 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const bgColor = node.widgets.find((w: IWidget) => w.name === 'bg_color')
-
     const lightIntensity = node.widgets.find(
       (w: IWidget) => w.name === 'light_intensity'
     )
@@ -143,7 +141,6 @@ app.registerExtension({
       'input',
       modelWidget,
       material,
-      bgColor,
       lightIntensity,
       upDirection,
       fov,
@@ -297,8 +294,6 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const bgColor = node.widgets.find((w: IWidget) => w.name === 'bg_color')
-
     const lightIntensity = node.widgets.find(
       (w: IWidget) => w.name === 'light_intensity'
     )
@@ -328,7 +323,6 @@ app.registerExtension({
       'input',
       modelWidget,
       material,
-      bgColor,
       lightIntensity,
       upDirection,
       fov,
@@ -439,8 +433,6 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const bgColor = node.widgets.find((w: IWidget) => w.name === 'bg_color')
-
     const lightIntensity = node.widgets.find(
       (w: IWidget) => w.name === 'light_intensity'
     )
@@ -474,7 +466,6 @@ app.registerExtension({
         'output',
         modelWidget,
         material,
-        bgColor,
         lightIntensity,
         upDirection,
         fov
@@ -566,8 +557,6 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const bgColor = node.widgets.find((w: IWidget) => w.name === 'bg_color')
-
     const lightIntensity = node.widgets.find(
       (w: IWidget) => w.name === 'light_intensity'
     )
@@ -612,7 +601,6 @@ app.registerExtension({
         'output',
         modelWidget,
         material,
-        bgColor,
         lightIntensity,
         upDirection,
         fov

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -11,7 +11,6 @@ class Load3DConfiguration {
     loadFolder: 'input' | 'output',
     modelWidget: IWidget,
     material: IWidget,
-    bgColor: IWidget,
     lightIntensity: IWidget,
     upDirection: IWidget,
     fov: IWidget,
@@ -25,7 +24,6 @@ class Load3DConfiguration {
       postModelUpdateFunc
     )
     this.setupMaterial(material)
-    this.setupBackground(bgColor)
     this.setupLighting(lightIntensity)
     this.setupDirection(upDirection)
     this.setupCamera(fov)
@@ -56,13 +54,6 @@ class Load3DConfiguration {
     this.load3d.setMaterialMode(
       material.value as 'original' | 'normal' | 'wireframe'
     )
-  }
-
-  private setupBackground(bgColor: IWidget) {
-    bgColor.callback = (value: string) => {
-      this.load3d.setBackgroundColor(value)
-    }
-    this.load3d.setBackgroundColor(bgColor.value as string)
   }
 
   private setupLighting(lightIntensity: IWidget) {
@@ -99,6 +90,10 @@ class Load3DConfiguration {
 
     const showGrid = this.load3d.loadNodeProperty('Show Grid', true)
     this.load3d.toggleGrid(showGrid)
+
+    const bgColor = this.load3d.loadNodeProperty('Background Color', '#282828')
+
+    this.load3d.setBackgroundColor(bgColor)
   }
 
   private createModelUpdateHandler(

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -44,6 +44,7 @@ class Load3d {
   cameraSwitcherContainer: HTMLDivElement = {} as HTMLDivElement
   gridSwitcherContainer: HTMLDivElement = {} as HTMLDivElement
   node: LGraphNode = {} as LGraphNode
+  bgColorInput: HTMLInputElement = {} as HTMLInputElement
 
   constructor(container: Element | HTMLElement) {
     this.scene = new THREE.Scene()
@@ -127,6 +128,8 @@ class Load3d {
 
     this.createCameraSwitcher(container)
 
+    this.createColorPicker(container)
+
     this.handleResize()
 
     this.startAnimation()
@@ -143,7 +146,11 @@ class Load3d {
   }
 
   loadNodeProperty(name: string, defaultValue: any) {
-    if (!this.node || !(name in this.node.properties)) {
+    if (
+      !this.node ||
+      !this.node.properties ||
+      !(name in this.node.properties)
+    ) {
       return defaultValue
     }
     return this.node.properties[name]
@@ -273,6 +280,47 @@ class Load3d {
     this.cameraSwitcherContainer.appendChild(cameraIcon)
 
     container.appendChild(this.cameraSwitcherContainer)
+  }
+
+  createColorPicker(container: Element | HTMLElement) {
+    const colorPickerContainer = document.createElement('div')
+    colorPickerContainer.style.position = 'absolute'
+    colorPickerContainer.style.top = '53px'
+    colorPickerContainer.style.left = '3px'
+    colorPickerContainer.style.width = '20px'
+    colorPickerContainer.style.height = '20px'
+    colorPickerContainer.style.cursor = 'pointer'
+    colorPickerContainer.style.alignItems = 'center'
+    colorPickerContainer.style.justifyContent = 'center'
+    colorPickerContainer.title = 'Background Color'
+
+    const colorInput = document.createElement('input')
+    colorInput.type = 'color'
+    colorInput.style.opacity = '0'
+    colorInput.style.position = 'absolute'
+    colorInput.style.width = '100%'
+    colorInput.style.height = '100%'
+    colorInput.style.cursor = 'pointer'
+
+    const colorIcon = document.createElement('div')
+    colorIcon.innerHTML = `
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2">
+        <rect x="3" y="3" width="18" height="18" rx="2"/>
+        <path d="M12 3v18"/>
+        <path d="M3 12h18"/>
+      </svg>
+    `
+
+    colorInput.addEventListener('input', (event) => {
+      const color = (event.target as HTMLInputElement).value
+      this.setBackgroundColor(color)
+      this.storeNodeProperty('Background Color', color)
+    })
+
+    this.bgColorInput = colorInput
+    colorPickerContainer.appendChild(colorInput)
+    colorPickerContainer.appendChild(colorIcon)
+    container.appendChild(colorPickerContainer)
   }
 
   setFOV(fov: number) {
@@ -939,6 +987,10 @@ class Load3d {
   setBackgroundColor(color: string) {
     this.renderer.setClearColor(new THREE.Color(color))
     this.renderer.render(this.scene, this.activeCamera)
+
+    if (this.bgColorInput) {
+      this.bgColorInput.value = color
+    }
   }
 }
 

--- a/src/extensions/core/load3d/Load3dAnimation.ts
+++ b/src/extensions/core/load3d/Load3dAnimation.ts
@@ -12,11 +12,13 @@ class Load3dAnimation extends Load3d {
   animationSpeed: number = 1.0
   playPauseContainer: HTMLDivElement = {} as HTMLDivElement
   animationSelect: HTMLSelectElement = {} as HTMLSelectElement
+  speedSelect: HTMLSelectElement = {} as HTMLSelectElement
 
   constructor(container: Element | HTMLElement) {
     super(container)
     this.createPlayPauseButton(container)
     this.createAnimationList(container)
+    this.createSpeedSelect(container)
   }
 
   createAnimationList(container: Element | HTMLElement) {
@@ -122,6 +124,52 @@ class Load3dAnimation extends Load3d {
     this.playPauseContainer.style.display = 'none'
   }
 
+  createSpeedSelect(container: Element | HTMLElement) {
+    this.speedSelect = document.createElement('select')
+    Object.assign(this.speedSelect.style, {
+      position: 'absolute',
+      top: '3px',
+      left: '50%',
+      transform: 'translateX(-75px)',
+      width: '60px',
+      height: '20px',
+      backgroundColor: 'rgba(0, 0, 0, 0.3)',
+      color: 'white',
+      border: 'none',
+      borderRadius: '4px',
+      fontSize: '12px',
+      padding: '0 8px',
+      cursor: 'pointer',
+      display: 'none',
+      outline: 'none'
+    })
+
+    const speeds = [0.1, 0.5, 1, 1.5, 2]
+    speeds.forEach((speed) => {
+      const option = document.createElement('option')
+      option.value = speed.toString()
+      option.text = `${speed}x`
+      option.selected = speed === 1
+      this.speedSelect.appendChild(option)
+    })
+
+    this.speedSelect.addEventListener('mouseenter', () => {
+      this.speedSelect.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
+    })
+
+    this.speedSelect.addEventListener('mouseleave', () => {
+      this.speedSelect.style.backgroundColor = 'rgba(0, 0, 0, 0.3)'
+    })
+
+    this.speedSelect.addEventListener('change', (event) => {
+      const select = event.target as HTMLSelectElement
+      const newSpeed = parseFloat(select.value)
+      this.setAnimationSpeed(newSpeed)
+    })
+
+    container.appendChild(this.speedSelect)
+  }
+
   protected async setupModel(model: THREE.Object3D) {
     await super.setupModel(model)
 
@@ -161,10 +209,12 @@ class Load3dAnimation extends Load3d {
     if (this.animationClips.length > 0) {
       this.playPauseContainer.style.display = 'block'
       this.animationSelect.style.display = 'block'
+      this.speedSelect.style.display = 'block'
       this.updateAnimationList()
     } else {
       this.playPauseContainer.style.display = 'none'
       this.animationSelect.style.display = 'none'
+      this.speedSelect.style.display = 'none'
     }
   }
 
@@ -232,6 +282,11 @@ class Load3dAnimation extends Load3d {
     if (this.animationSelect) {
       this.animationSelect.style.display = 'none'
       this.animationSelect.innerHTML = ''
+    }
+
+    if (this.speedSelect) {
+      this.speedSelect.style.display = 'none'
+      this.speedSelect.value = '1'
     }
   }
 


### PR DESCRIPTION
UI change for background color picker and animation speed change, remove bg_color and animation_speed from input list and switch to html5 native color picker for better user experience.
The demo is 

https://github.com/user-attachments/assets/9e14f8f7-4187-4662-a2ba-f593150c63ff

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2365-3d-move-change-background-color-button-1886d73d36508114977bec5d7712a04b) by [Unito](https://www.unito.io)
