### PR TITLE
[CI] Skip draft in github release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           files: |
             dist.zip
           tag_name: v${{ steps.current_version.outputs.version }}
-          draft: true
+          draft: false
           prerelease: false
           make_latest: "true"
           generate_release_notes: true


### PR DESCRIPTION
The draft adds an extra click when publishing a new release. Skip it as it does not add much value.