### PR TITLE
[Desktop] Apply default pypi mirror when installing CPU torch

### DIFF
--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -5,10 +5,7 @@
     :collapsed="!showMirrorInputs"
     pt:root="bg-neutral-800 border-none w-[600px]"
   >
-    <template
-      v-for="([item, modelValue], index) in mirrors"
-      :key="item.settingId"
-    >
+    <template v-for="([item, modelValue], index) in mirrors" :key="item.mirror">
       <Divider v-if="index > 0" />
 
       <MirrorItem
@@ -79,15 +76,14 @@ const getTorchMirrorItem = (device: TorchDeviceType): UVMirror => {
   }
 }
 
-const torchMirrorItem = getTorchMirrorItem(device)
-const mirrors: [UVMirror, ModelRef<string>][] = [
+const mirrors = computed<[UVMirror, ModelRef<string>][]>(() => [
   [PYTHON_MIRROR, pythonMirror],
   [PYPI_MIRROR, pypiMirror],
-  [torchMirrorItem, torchMirror]
-]
+  [getTorchMirrorItem(device), torchMirror]
+])
 
 const validationStates = ref<ValidationState[]>(
-  mirrors.map(() => ValidationState.IDLE)
+  mirrors.value.map(() => ValidationState.IDLE)
 )
 const validationState = computed(() => {
   return mergeValidationStates(validationStates.value)

--- a/src/constants/uvMirrors.ts
+++ b/src/constants/uvMirrors.ts
@@ -1,8 +1,3 @@
-import { CUDA_TORCH_URL } from '@comfyorg/comfyui-electron-types'
-import { NIGHTLY_CPU_TORCH_URL } from '@comfyorg/comfyui-electron-types'
-
-import { electronAPI, isElectron } from '@/utils/envUtil'
-
 export interface UVMirror {
   /**
    * The setting id defined for the mirror.
@@ -22,30 +17,18 @@ export interface UVMirror {
   validationPathSuffix?: string
 }
 
-const DEFAULT_TORCH_MIRROR = isElectron()
-  ? electronAPI().getPlatform() === 'darwin'
-    ? NIGHTLY_CPU_TORCH_URL
-    : CUDA_TORCH_URL
-  : ''
+export const PYTHON_MIRROR: UVMirror = {
+  settingId: 'Comfy-Desktop.UV.PythonInstallMirror',
+  mirror:
+    'https://github.com/astral-sh/python-build-standalone/releases/download',
+  fallbackMirror:
+    'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download',
+  validationPathSuffix:
+    '/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz'
+}
 
-export const UV_MIRRORS: UVMirror[] = [
-  {
-    settingId: 'Comfy-Desktop.UV.PythonInstallMirror',
-    mirror:
-      'https://github.com/astral-sh/python-build-standalone/releases/download',
-    fallbackMirror:
-      'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download',
-    validationPathSuffix:
-      '/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz'
-  },
-  {
-    settingId: 'Comfy-Desktop.UV.PypiInstallMirror',
-    mirror: 'https://pypi.org/simple/',
-    fallbackMirror: 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple'
-  },
-  {
-    settingId: 'Comfy-Desktop.UV.TorchInstallMirror',
-    mirror: DEFAULT_TORCH_MIRROR,
-    fallbackMirror: DEFAULT_TORCH_MIRROR
-  }
-]
+export const PYPI_MIRROR: UVMirror = {
+  settingId: 'Comfy-Desktop.UV.PypiInstallMirror',
+  mirror: 'https://pypi.org/simple/',
+  fallbackMirror: 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple'
+}

--- a/src/views/InstallView.vue
+++ b/src/views/InstallView.vue
@@ -82,6 +82,7 @@
             v-model:allowMetrics="allowMetrics"
           />
           <MirrorsConfiguration
+            :device="device"
             v-model:pythonMirror="pythonMirror"
             v-model:pypiMirror="pypiMirror"
             v-model:torchMirror="torchMirror"


### PR DESCRIPTION
Update torch mirror based on the device selected in the gpu selection step.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2367-Desktop-Apply-default-pypi-mirror-when-installing-CPU-torch-18a6d73d365081b596dbc79612f7baf0) by [Unito](https://www.unito.io)
