### PR TITLE
Fix mirror item key not being unique

### DIFF
--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -5,7 +5,10 @@
     :collapsed="!showMirrorInputs"
     pt:root="bg-neutral-800 border-none w-[600px]"
   >
-    <template v-for="([item, modelValue], index) in mirrors" :key="item.mirror">
+    <template
+      v-for="([item, modelValue], index) in mirrors"
+      :key="item.settingId + item.mirror"
+    >
       <Divider v-if="index > 0" />
 
       <MirrorItem


### PR DESCRIPTION
`item.mirror` might not be unique. Using `settingId` + `mirror` to guarantee uniqueness.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2371-Fix-mirror-item-key-not-being-unique-18a6d73d365081d5a8d2ff68ccff4285) by [Unito](https://www.unito.io)
