### PR TITLE
[Desktop] Fix mirror validation in settings dialog

### DIFF
--- a/src/components/install/mirror/MirrorItem.vue
+++ b/src/components/install/mirror/MirrorItem.vue
@@ -10,7 +10,10 @@
     </div>
     <UrlInput
       v-model="modelValue"
-      :validate-url-fn="checkMirrorReachable"
+      :validate-url-fn="
+        (mirror: string) =>
+          checkMirrorReachable(mirror + (item.validationPathSuffix ?? ''))
+      "
       @state-change="validationState = $event"
     />
   </div>
@@ -20,8 +23,8 @@
 import { computed, onMounted, ref, watch } from 'vue'
 
 import { UVMirror } from '@/constants/uvMirrors'
-import { electronAPI } from '@/utils/envUtil'
-import { isValidUrl, normalizeI18nKey } from '@/utils/formatUtil'
+import { normalizeI18nKey } from '@/utils/formatUtil'
+import { checkMirrorReachable } from '@/utils/networkUtil'
 import { ValidationState } from '@/utils/validationUtil'
 
 const { item } = defineProps<{
@@ -38,15 +41,6 @@ const validationState = ref<ValidationState>(ValidationState.IDLE)
 const normalizedSettingId = computed(() => {
   return normalizeI18nKey(item.settingId)
 })
-
-const checkMirrorReachable = async (mirror: string) => {
-  return (
-    isValidUrl(mirror) &&
-    (await electronAPI().NetWork.canAccessUrl(
-      mirror + (item.validationPathSuffix ?? '')
-    ))
-  )
-}
 
 onMounted(() => {
   modelValue.value = item.mirror

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -1,8 +1,10 @@
+import { PYTHON_MIRROR } from '@/constants/uvMirrors'
 import { t } from '@/i18n'
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
+import { checkMirrorReachable } from '@/utils/networkUtil'
 
 ;(async () => {
   if (!isElectron()) return
@@ -60,21 +62,34 @@ import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
         name: 'Python Install Mirror',
         tooltip: `Managed Python installations are downloaded from the Astral python-build-standalone project. This variable can be set to a mirror URL to use a different source for Python installations. The provided URL will replace https://github.com/astral-sh/python-build-standalone/releases/download in, e.g., https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz. Distributions can be read from a local directory by using the file:// URL scheme.`,
         type: 'url',
-        defaultValue: ''
+        defaultValue: '',
+        attrs: {
+          validateUrlFn(mirror: string) {
+            return checkMirrorReachable(
+              mirror + PYTHON_MIRROR.validationPathSuffix
+            )
+          }
+        }
       },
       {
         id: 'Comfy-Desktop.UV.PypiInstallMirror',
         name: 'Pypi Install Mirror',
         tooltip: `Default pip install mirror`,
         type: 'url',
-        defaultValue: ''
+        defaultValue: '',
+        attrs: {
+          validateUrlFn: checkMirrorReachable
+        }
       },
       {
         id: 'Comfy-Desktop.UV.TorchInstallMirror',
         name: 'Torch Install Mirror',
         tooltip: `Pip install mirror for pytorch`,
         type: 'url',
-        defaultValue: ''
+        defaultValue: '',
+        attrs: {
+          validateUrlFn: checkMirrorReachable
+        }
       }
     ],
 

--- a/src/utils/networkUtil.ts
+++ b/src/utils/networkUtil.ts
@@ -1,5 +1,8 @@
 import axios from 'axios'
 
+import { electronAPI } from './envUtil'
+import { isValidUrl } from './formatUtil'
+
 const VALID_STATUS_CODES = [200, 201, 301, 302, 307, 308]
 export const checkUrlReachable = async (url: string): Promise<boolean> => {
   try {
@@ -9,4 +12,15 @@ export const checkUrlReachable = async (url: string): Promise<boolean> => {
   } catch {
     return false
   }
+}
+
+/**
+ * Check if a mirror is reachable from the electron App.
+ * @param mirror - The mirror to check.
+ * @returns True if the mirror is reachable, false otherwise.
+ */
+export const checkMirrorReachable = async (mirror: string) => {
+  return (
+    isValidUrl(mirror) && (await electronAPI().NetWork.canAccessUrl(mirror))
+  )
 }


### PR DESCRIPTION
Previously the setting items in the settings dialog was checking whether the browser can access URL, which causes inconsistency from CoRS policy. This PR overrides the check to use electronAPI for url validation.

Before:
![Screenshot 2025-01-29 at 2 43 59 PM](https://github.com/user-attachments/assets/ab694ae0-4a9b-483c-8544-5864c11782c3)
![Screenshot 2025-01-29 at 2 44 04 PM](https://github.com/user-attachments/assets/9d019e71-8472-4534-9147-5c2b5990257d)

After:
![Screenshot 2025-01-29 at 2 44 49 PM](https://github.com/user-attachments/assets/894e0477-7acd-4b46-b0f8-de46d8f713ec)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2375-Fix-mirror-validation-in-settings-dialog-18a6d73d36508121bb4eec2054f2281f) by [Unito](https://www.unito.io)
