### PR TITLE
[Style] Only show sidebar tool buttons when sidebar hovered

### DIFF
--- a/src/components/sidebar/tabs/SidebarTabTemplate.vue
+++ b/src/components/sidebar/tabs/SidebarTabTemplate.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="comfy-vue-side-bar-container flex flex-col h-full"
+    class="comfy-vue-side-bar-container flex flex-col h-full group"
     :class="props.class"
   >
     <div class="comfy-vue-side-bar-header">
@@ -11,7 +11,11 @@
           </span>
         </template>
         <template #end>
-          <slot name="tool-buttons"></slot>
+          <div
+            class="flex flex-row w-0 opacity-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200"
+          >
+            <slot name="tool-buttons"></slot>
+          </div>
         </template>
       </Toolbar>
       <slot name="header"></slot>


### PR DESCRIPTION

https://github.com/user-attachments/assets/c061103e-6930-499b-bdab-c8e8b6448752

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2378-Style-Only-show-sidebar-tool-buttons-when-sidebar-hovered-18b6d73d3650812d8a77d272c095b9df) by [Unito](https://www.unito.io)
