### PR TITLE
Update Python fallback mirror in uvMirrors.ts

### DIFF
--- a/src/constants/uvMirrors.ts
+++ b/src/constants/uvMirrors.ts
@@ -22,7 +22,7 @@ export const PYTHON_MIRROR: UVMirror = {
   mirror:
     'https://github.com/astral-sh/python-build-standalone/releases/download',
   fallbackMirror:
-    'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download',
+    'https://bgithub.xyz/astral-sh/python-build-standalone/releases/download',
   validationPathSuffix:
     '/20250115/cpython-3.10.16+20250115-aarch64-apple-darwin-debug-full.tar.zst.sha256'
 }


### PR DESCRIPTION
Changed the Python fallback mirror link from 'https://ghfast.top/https://github.com/astral-sh/python-build-standalone/releases/download' to 'https://bgithub.xyz/astral-sh/python-build-standalone/releases/download', which is relatively more stable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2382-Update-Python-fallback-mirror-in-uvMirrors-ts-18b6d73d365081e98d23d9a33efdd271) by [Unito](https://www.unito.io)
