### PR TITLE
[Accessibility] Use keybindings to add keybindings

### DIFF
--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -77,7 +77,7 @@
           ref="keybindingInput"
           :modelValue="newBindingKeyCombo?.toString() ?? ''"
           placeholder="Press keys for new binding"
-          @keydown.stop.prevent="captureKeybinding"
+          @keydown="captureKeybinding"
           autocomplete="off"
           fluid
           :invalid="!!existingKeybindingOnCombo"
@@ -213,6 +213,13 @@ function removeKeybinding(commandData: ICommandData) {
 }
 
 function captureKeybinding(event: KeyboardEvent) {
+  // Accessibility: Tab and shift-tab are standard keyboard navigation shortcuts
+  const pressingAltOrCtrl = event.altKey || event.ctrlKey || event.metaKey
+  if (!pressingAltOrCtrl && event.key === 'Tab') return
+
+  event.stopPropagation()
+  event.preventDefault()
+
   const keyCombo = KeyComboImpl.fromEvent(event)
   newBindingKeyCombo.value = keyCombo
 }

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -220,6 +220,17 @@ function captureKeybinding(event: KeyboardEvent) {
   event.stopPropagation()
   event.preventDefault()
 
+  // Allow the use of keyboard shortcuts when adding keyboard shortcuts
+  if (!event.shiftKey && !pressingAltOrCtrl) {
+    switch (event.key) {
+      case 'Escape':
+        cancelEdit()
+        return
+      case 'Enter':
+        saveKeybinding()
+        return
+    }
+  }
   const keyCombo = KeyComboImpl.fromEvent(event)
   newBindingKeyCombo.value = keyCombo
 }

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -77,7 +77,7 @@
           ref="keybindingInput"
           :modelValue="newBindingKeyCombo?.toString() ?? ''"
           placeholder="Press keys for new binding"
-          @keydown="captureKeybinding"
+          @keydown.stop.prevent="captureKeybinding"
           autocomplete="off"
           fluid
           :invalid="!!existingKeybindingOnCombo"
@@ -213,15 +213,8 @@ function removeKeybinding(commandData: ICommandData) {
 }
 
 function captureKeybinding(event: KeyboardEvent) {
-  // Accessibility: Tab and shift-tab are standard keyboard navigation shortcuts
-  const pressingAltOrCtrl = event.altKey || event.ctrlKey || event.metaKey
-  if (!pressingAltOrCtrl && event.key === 'Tab') return
-
-  event.stopPropagation()
-  event.preventDefault()
-
   // Allow the use of keyboard shortcuts when adding keyboard shortcuts
-  if (!event.shiftKey && !pressingAltOrCtrl) {
+  if (!event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
     switch (event.key) {
       case 'Escape':
         cancelEdit()


### PR DESCRIPTION
Adds standard keyboard navigation to the keyboard shortcut editor.

- Enter saves the shortcut
- Escape cancels the edit

Edit: Tab removed.

These keys have intuitive contextual expectations for all users.  They are rarely offered as options for key binding in apps, as it is extremely likely to add unnecessary complexity.  This will be the case for us, and it will worsen as the app matures and other accessibility concerns are addressed.

N.B. Use of these keys with modifiers is not affected.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2384-Accessibility-Use-keybindings-to-add-keybindings-18b6d73d36508155bab8d23e6a49ea5e) by [Unito](https://www.unito.io)
