### PR TITLE
Add bottom panel to extension manager

### DIFF
--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -10,6 +10,7 @@ import { useQueueSettingsStore } from './queueStore'
 import { useSettingStore } from './settingStore'
 import { useToastStore } from './toastStore'
 import { useWorkflowStore } from './workflowStore'
+import { useBottomPanelStore } from './workspace/bottomPanelStore'
 import { useSidebarTabStore } from './workspace/sidebarTabStore'
 
 export const useWorkspaceStore = defineStore('workspace', () => {
@@ -36,6 +37,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   const workflow = computed(() => useWorkflowStore())
   const colorPalette = useColorPaletteService()
   const dialog = useDialogService()
+  const bottomPanel = useBottomPanelStore()
 
   /**
    * Registers a sidebar tab.
@@ -79,6 +81,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     workflow,
     colorPalette,
     dialog,
+    bottomPanel,
 
     registerSidebarTab,
     unregisterSidebarTab,


### PR DESCRIPTION
Allows extensions to manage the bottom panel. For instance, if an extension wants to show the terminal:

```typescript
  const panel = app.extensionManager.bottomPanel
  const isTerminalVisible =
    panel.bottomPanelVisible &&
    panel.activeBottomPanelTab.id === 'logs-terminal'
  if (!isTerminalVisible) panel.toggleBottomPanelTab('logs-terminal')
```

The bottom panel support was added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1294. Adding custom bottom panel tabs is possible through `regsterExtension`, but managing the panel is not easy for extensions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2393-Add-bottom-panel-to-extension-manager-18e6d73d365081989c38ce0127fa0dc5) by [Unito](https://www.unito.io)
