### PR TITLE
Add node tooltip delay setting

### DIFF
--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -18,9 +18,11 @@ import { st } from '@/i18n'
 import { app as comfyApp } from '@/scripts/app'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { normalizeI18nKey } from '@/utils/formatUtil'
+import { useSettingStore } from '@/stores/settingStore'
 
 let idleTimeout: number
 const nodeDefStore = useNodeDefStore()
+const settingStore = useSettingStore()
 const tooltipRef = ref<HTMLDivElement>()
 const tooltipText = ref('')
 const left = ref<string>()
@@ -110,7 +112,7 @@ const onMouseMove = (e: MouseEvent) => {
   clearTimeout(idleTimeout)
 
   if ((e.target as Node).nodeName !== 'CANVAS') return
-  idleTimeout = window.setTimeout(onIdle, 500)
+  idleTimeout = window.setTimeout(onIdle, settingStore.get('LiteGraph.Node.TooltipDelay'))
 }
 
 useEventListener(window, 'mousemove', onMouseMove)

--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -17,8 +17,8 @@ import { nextTick, ref } from 'vue'
 import { st } from '@/i18n'
 import { app as comfyApp } from '@/scripts/app'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
-import { normalizeI18nKey } from '@/utils/formatUtil'
 import { useSettingStore } from '@/stores/settingStore'
+import { normalizeI18nKey } from '@/utils/formatUtil'
 
 let idleTimeout: number
 const nodeDefStore = useNodeDefStore()
@@ -112,7 +112,10 @@ const onMouseMove = (e: MouseEvent) => {
   clearTimeout(idleTimeout)
 
   if ((e.target as Node).nodeName !== 'CANVAS') return
-  idleTimeout = window.setTimeout(onIdle, settingStore.get('LiteGraph.Node.TooltipDelay'))
+  idleTimeout = window.setTimeout(
+    onIdle,
+    settingStore.get('LiteGraph.Node.TooltipDelay')
+  )
 }
 
 useEventListener(window, 'mousemove', onMouseMove)

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -373,7 +373,7 @@ export const CORE_SETTINGS: SettingParams[] = [
       step: 50
     },
     defaultValue: 500,
-    versionAdded: '1.8.13'
+    versionAdded: '1.9.0'
   },
   {
     id: 'Comfy.EnableTooltips',

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -364,6 +364,18 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: 0
   },
   {
+    id: 'LiteGraph.Node.TooltipDelay',
+    name: 'Tooltip Delay',
+    type: 'number',
+    attrs: {
+      min: 100,
+      max: 3000,
+      step: 50
+    },
+    defaultValue: 500,
+    versionAdded: '1.8.13'
+  },
+  {
     id: 'Comfy.EnableTooltips',
     category: ['LiteGraph', 'Node', 'EnableTooltips'],
     name: 'Enable Tooltips',


### PR DESCRIPTION
- Defaults to 500ms (no change)
- 100ms - 3000ms
- 50ms increments
- Resolves #303

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2396-Add-node-tooltip-delay-setting-18e6d73d365081dfb142cef7f7d508c0) by [Unito](https://www.unito.io)
