### PR TITLE
[BrowserTest] Add test on groupnode with duplicate hidden inputs

### DIFF
--- a/browser_tests/assets/group_node_identical_nodes_hidden_inputs.json
+++ b/browser_tests/assets/group_node_identical_nodes_hidden_inputs.json
@@ -1,0 +1,163 @@
+{
+  "last_node_id": 19,
+  "last_link_id": 14,
+  "nodes": [
+    {
+      "id": 19,
+      "type": "workflow>two_VAE_decode",
+      "pos": [
+        1368.800048828125,
+        768.7999877929688
+      ],
+      "size": [
+        418.1999816894531,
+        86
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "VAEDecode IMAGE",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {}
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [
+        0,
+        0
+      ]
+    },
+    "node_versions": {},
+    "ue_links": [],
+    "groupNodes": {
+      "two_VAE_decode": {
+        "nodes": [
+          {
+            "id": -1,
+            "type": "VAEDecode",
+            "pos": [
+              1368.800048828125,
+              768.7999877929688
+            ],
+            "size": [
+              210,
+              46
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "samples",
+                "type": "LATENT",
+                "link": null,
+                "localized_name": "samples"
+              },
+              {
+                "name": "vae",
+                "type": "VAE",
+                "link": null,
+                "localized_name": "vae"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": null,
+                "localized_name": "IMAGE"
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode"
+            },
+            "index": 0
+          },
+          {
+            "id": -1,
+            "type": "VAEDecode",
+            "pos": [
+              1368.800048828125,
+              873.7999877929688
+            ],
+            "size": [
+              210,
+              46
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "samples",
+                "type": "LATENT",
+                "link": null,
+                "localized_name": "samples"
+              },
+              {
+                "name": "vae",
+                "type": "VAE",
+                "link": null,
+                "localized_name": "vae"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": null,
+                "localized_name": "IMAGE"
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode"
+            },
+            "index": 1
+          }
+        ],
+        "links": [],
+        "external": [],
+        "config": {
+          "1": {
+            "input": {
+              "samples": {
+                "visible": false
+              },
+              "vae": {
+                "visible": false
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Adds test on groupnode with duplicated hidden inputs.

The issue being tested against can be reproduced on v1.8.9-1.8.13 following these steps:

1. Open a new blank workflow
2. Add 2 of the same node to the workflow
3. Create a group node containing those 2 identical nodes
4. Right click group node to open node right-click context menu
5. Click `Manage Group Node` in the node right-click context menu
6. In the Manage Group Node dialog, uncheck the `Visible` checkbox for one of the inputs belonging to one of the 2 identical nodes
7. Export/save the workflow
8. Reload the page or open a new workflow tab
9. Load the saved workflow
10. Observe that the hidden inputs are no longer hidden, despite the Manage Group Node dialog indicating that they are. On ComfyUI_frontend@=<1.8.8, the hidden status persists as expected.

Steps 1-7 are already completed in the form of the saved workflow asset (`group_node_identical_nodes_hidden_inputs.json`).

Ref:

- https://github.com/Comfy-Org/ComfyUI_frontend/issues/2397
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/2399

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2403-BrowserTest-Add-test-on-groupnode-with-duplicate-hidden-inputs-18e6d73d365081af8cb3feded1caae93) by [Unito](https://www.unito.io)
