### PR TITLE
Use command label as header text in change keybinding dialog

### DIFF
--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -253,7 +253,7 @@ test.describe('Settings', () => {
 
     // Save keybinding
     const saveButton = comfyPage.page
-      .getByLabel('Comfy.NewBlankWorkflow')
+      .getByLabel('New Blank Workflow')
       .getByLabel('Save')
     await saveButton.click()
 

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -68,7 +68,7 @@
       class="min-w-96"
       v-model:visible="editDialogVisible"
       modal
-      :header="currentEditingCommand?.id"
+      :header="currentEditingCommand?.label"
       @hide="cancelEdit"
     >
       <div>
@@ -151,6 +151,7 @@ const { t } = useI18n()
 interface ICommandData {
   id: string
   keybinding: KeybindingImpl | null
+  label: string
 }
 
 const commandsData = computed<ICommandData[]>(() => {


### PR DESCRIPTION
Updates the dialog that appears when changing keybindings to use the command label instead of the id, which is less readable and doesn't correspond with what is in the parent dialog. The label will also be translated while the ID will not.

When this component was made (https://github.com/Comfy-Org/ComfyUI_frontend/pull/1081), the `label` field was not being set in the computed `commandsData`. In https://github.com/Comfy-Org/ComfyUI_frontend/pull/1890, the label field was added but the local interface (`ICommandData`) and dialog header were not updated to reflect the change.

Before / After:


![keybind-title](https://github.com/user-attachments/assets/b8578981-5f03-4460-9ae3-dff52b3f695b)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2404-Use-command-label-as-header-text-in-change-keybinding-dialog-18e6d73d3650813891b8e594fcb4352a) by [Unito](https://www.unito.io)
