### PR TITLE
Restrict file drop target to litegraph canvas element

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -497,7 +497,7 @@ export class ComfyPage {
           writable: false
         })
 
-        document.dispatchEvent(dropEvent)
+        document.getElementById('graph-canvas')?.dispatchEvent(dropEvent)
       },
       { buffer: [...new Uint8Array(buffer)], fileName, fileType }
     )

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -414,7 +414,7 @@ export class ComfyApp {
    */
   #addDropHandler() {
     // Get prompt from dropped PNG or json
-    document.addEventListener('drop', async (event) => {
+    this.canvasEl.addEventListener('drop', async (event) => {
       event.preventDefault()
       event.stopPropagation()
 


### PR DESCRIPTION
Restrict file drop zone to litegraph canvas.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2405-Restrict-file-drop-target-to-litegraph-canvas-element-18f6d73d365081209fd5d0931af6f054) by [Unito](https://www.unito.io)
