### PR TITLE
Fix NoteNode constructor fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.16",
-        "@comfyorg/litegraph": "^0.8.63",
+        "@comfyorg/litegraph": "^0.8.64",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.63",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.63.tgz",
-      "integrity": "sha512-DQ4LUWr+wPUAztDSdpYi5QuAd/cXs18/cO6nifVoSLk1YyHvnfPORIJmXLqnUBEtb2LO3igl06ToSklpL4kCyA==",
+      "version": "0.8.64",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.64.tgz",
+      "integrity": "sha512-cYMUXH91m/80n2+OjvXBQFSXDeF2eGBMrOZpqQtA4d6qiLVW6oDS5QeWFiSSJ6Jpo8mF3hgg1SunKb29qabO3w==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.16",
-    "@comfyorg/litegraph": "^0.8.63",
+    "@comfyorg/litegraph": "^0.8.64",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/src/extensions/core/noteNode.ts
+++ b/src/extensions/core/noteNode.ts
@@ -12,13 +12,13 @@ app.registerExtension({
   registerCustomNodes() {
     class NoteNode extends LGraphNode {
       static category: string
+      static collapsable: boolean
+      static title_mode: number
 
       color = LGraphCanvas.node_colors.yellow.color
       bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
       groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
       isVirtualNode: boolean
-      collapsable: boolean
-      title_mode: number
 
       constructor(title?: string) {
         super(title)


### PR DESCRIPTION
`collapsable` and `title_mode` belongs to LGraphNode constructor instead of LGraphNode instance.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2410-Fix-NoteNode-constructor-fields-18f6d73d365081078482dd555266be76) by [Unito](https://www.unito.io)
