### PR TITLE
[Desktop] Use fallback mirrors for China users

### DIFF
--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -41,11 +41,12 @@ import {
 } from '@comfyorg/comfyui-electron-types'
 import Divider from 'primevue/divider'
 import Panel from 'primevue/panel'
-import { ModelRef, computed, ref } from 'vue'
+import { ModelRef, computed, onMounted, ref } from 'vue'
 
 import MirrorItem from '@/components/install/mirror/MirrorItem.vue'
 import { PYPI_MIRROR, PYTHON_MIRROR, UVMirror } from '@/constants/uvMirrors'
 import { t } from '@/i18n'
+import { isInChina } from '@/utils/networkUtil'
 import { ValidationState, mergeValidationStates } from '@/utils/validationUtil'
 
 const showMirrorInputs = ref(false)
@@ -99,6 +100,15 @@ const validationStateTooltip = computed(() => {
       return t('install.settings.mirrorsReachable')
     default:
       return t('install.settings.checkingMirrors')
+  }
+})
+
+onMounted(async () => {
+  // Check if user is in China and set fallback mirrors directly
+  if (await isInChina()) {
+    for (const [item, modelValue] of mirrors.value) {
+      modelValue.value = item.fallbackMirror
+    }
   }
 })
 </script>

--- a/src/components/install/mirror/MirrorItem.vue
+++ b/src/components/install/mirror/MirrorItem.vue
@@ -44,7 +44,10 @@ const normalizedSettingId = computed(() => {
 })
 
 onMounted(() => {
-  modelValue.value = item.mirror
+  // Set mirror value if not already set
+  if (!modelValue.value) {
+    modelValue.value = item.mirror
+  }
 })
 
 watch(validationState, (newState) => {

--- a/src/components/install/mirror/MirrorItem.vue
+++ b/src/components/install/mirror/MirrorItem.vue
@@ -22,6 +22,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 
+import UrlInput from '@/components/common/UrlInput.vue'
 import { UVMirror } from '@/constants/uvMirrors'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 import { checkMirrorReachable } from '@/utils/networkUtil'

--- a/src/utils/networkUtil.ts
+++ b/src/utils/networkUtil.ts
@@ -24,3 +24,47 @@ export const checkMirrorReachable = async (mirror: string) => {
     isValidUrl(mirror) && (await electronAPI().NetWork.canAccessUrl(mirror))
   )
 }
+
+/**
+ * Checks if the user is likely in mainland China by:
+ * 1. Checking navigator.language
+ * 2. Testing connectivity to commonly blocked services
+ * 3. Testing latency to China-specific domains
+ */
+export async function isInChina(): Promise<boolean> {
+  // Quick check based on language/locale
+  const isChineseLocale = navigator.language.toLowerCase().startsWith('zh-cn')
+
+  try {
+    // Test connectivity to Google - commonly blocked in China
+    const googleTest = await Promise.race([
+      fetch('https://www.google.com/generate_204'),
+      new Promise((_, reject) => setTimeout(() => reject(), 2000))
+    ])
+
+    // If Google is accessible, user is likely not in China
+    if (googleTest) {
+      return false
+    }
+  } catch {
+    // Google is not accessible - potential indicator of being in China
+    if (isChineseLocale) {
+      return true
+    }
+
+    // Additional check - test latency to a reliable Chinese domain
+    try {
+      const start = performance.now()
+      await fetch('https://www.baidu.com/generate_204')
+      const latency = performance.now() - start
+
+      // If Baidu responds quickly (<150ms), user is likely in China
+      return latency < 150
+    } catch {
+      // If both tests fail, default to locale check
+      return isChineseLocale
+    }
+  }
+
+  return false
+}

--- a/src/utils/networkUtil.ts
+++ b/src/utils/networkUtil.ts
@@ -38,7 +38,10 @@ export async function isInChina(): Promise<boolean> {
   try {
     // Test connectivity to Google - commonly blocked in China
     const googleTest = await Promise.race([
-      fetch('https://www.google.com'),
+      fetch('https://www.google.com', {
+        mode: 'no-cors',
+        cache: 'no-cache'
+      }),
       new Promise((_, reject) => setTimeout(() => reject(), 2000))
     ])
 
@@ -55,7 +58,10 @@ export async function isInChina(): Promise<boolean> {
     // Additional check - test latency to a reliable Chinese domain
     try {
       const start = performance.now()
-      await fetch('https://www.baidu.com')
+      await fetch('https://www.baidu.com', {
+        mode: 'no-cors',
+        cache: 'no-cache'
+      })
       const latency = performance.now() - start
 
       // If Baidu responds quickly (<150ms), user is likely in China

--- a/src/utils/networkUtil.ts
+++ b/src/utils/networkUtil.ts
@@ -38,7 +38,7 @@ export async function isInChina(): Promise<boolean> {
   try {
     // Test connectivity to Google - commonly blocked in China
     const googleTest = await Promise.race([
-      fetch('https://www.google.com/generate_204'),
+      fetch('https://www.google.com'),
       new Promise((_, reject) => setTimeout(() => reject(), 2000))
     ])
 
@@ -55,7 +55,7 @@ export async function isInChina(): Promise<boolean> {
     // Additional check - test latency to a reliable Chinese domain
     try {
       const start = performance.now()
-      await fetch('https://www.baidu.com/generate_204')
+      await fetch('https://www.baidu.com')
       const latency = performance.now() - start
 
       // If Baidu responds quickly (<150ms), user is likely in China


### PR DESCRIPTION
Users in China have poor access to the mirrors, but sometimes the initial accessibility check can pass so the default mirror is selected.

This PR checks whether the user in China in a very reliable way and directly set the fallback mirrors for them.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2424-Desktop-Use-fallback-mirrors-for-China-users-1916d73d36508100b227d6c082bec364) by [Unito](https://www.unito.io)
