### PR TITLE
Swap eslint/prettier trigger order in pre-commit

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -11,7 +11,7 @@ export default {
 
 function formatAndEslint(fileNames) {
   return [
-    `prettier --write ${fileNames.join(' ')}`,
-    `eslint --fix ${fileNames.join(' ')}`
+    `eslint --fix ${fileNames.join(' ')}`,
+    `prettier --write ${fileNames.join(' ')}`
   ]
 }


### PR DESCRIPTION
Swap trigger order to avoid eslint making changes that are against prettier. Example: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/13162564235/job/36734774186?pr=2427