### PR TITLE
Use fp16 model in default img2img template workflow

### DIFF
--- a/public/templates/image2image.json
+++ b/public/templates/image2image.json
@@ -440,8 +440,8 @@
   "extra": {},
   "version": 0.4,
   "models": [{
-    "name": "v1-5-pruned-emaonly.safetensors",
-    "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly.safetensors?download=true",
+    "name": "v1-5-pruned-emaonly-fp16.safetensors",
+    "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly-fp16.safetensors?download=true",
     "directory": "checkpoints"
   }]
 }

--- a/public/templates/image2image.json
+++ b/public/templates/image2image.json
@@ -330,7 +330,7 @@
         "Node name for S&R": "CheckpointLoaderSimple"
       },
       "widgets_values": [
-        "v1-5-pruned-emaonly.safetensors"
+        "v1-5-pruned-emaonly-fp16.safetensors"
       ]
     }
   ],


### PR DESCRIPTION
Followup on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2346. Changes default image2image workflow to use `v1-5-pruned-emaonly-fp16` instead of `v1-5-pruned-emaonly`. The user will be able to try the default txt2image and image2image template workflows by only downloading one 1.9GB model.