### PR TITLE
Refresh Preview3D node with node.onMouseEnter

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -362,6 +362,12 @@ app.registerExtension({
 
         containerToLoad3D.set(container.id, load3d)
 
+        node.onMouseEnter = function () {
+          if (load3d) {
+            load3d.refreshViewport()
+          }
+        }
+
         node.onResize = function () {
           if (load3d) {
             load3d.handleResize()

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -29,6 +29,12 @@ app.registerExtension({
 
         containerToLoad3D.set(container.id, load3d)
 
+        node.onMouseEnter = function () {
+          if (load3d) {
+            load3d.refreshViewport()
+          }
+        }
+
         node.onResize = function () {
           if (load3d) {
             load3d.handleResize()
@@ -191,6 +197,12 @@ app.registerExtension({
         const load3d = new Load3dAnimation(container)
 
         containerToLoad3D.set(container.id, load3d)
+
+        node.onMouseEnter = function () {
+          if (load3d) {
+            load3d.refreshViewport()
+          }
+        }
 
         node.onResize = function () {
           if (load3d) {
@@ -487,6 +499,12 @@ app.registerExtension({
         const load3d = new Load3dAnimation(container)
 
         containerToLoad3D.set(container.id, load3d)
+
+        node.onMouseEnter = function () {
+          if (load3d) {
+            load3d.refreshViewport()
+          }
+        }
 
         node.onResize = function () {
           if (load3d) {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -892,6 +892,10 @@ class Load3d {
     this.handleResize()
   }
 
+  refreshViewport() {
+    this.handleResize()
+  }
+
   handleResize() {
     const parentElement = this.renderer?.domElement?.parentElement
 


### PR DESCRIPTION
The Preview3D node is frequently in an invalid state and this is just a quick change to refresh the viewport on mouse enter over the node to improve the UX without drastically affecting perf. 

Internally this calls resize because it seems like there are some initialization order issues going on, the viewport always boots up in an invalid state, so a better fix long term would be ideal.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2439-Refresh-Preview3D-node-with-node-onMouseEnter-1916d73d36508181a1a3c463fb12eec6) by [Unito](https://www.unito.io)
