### PR TITLE
Fix litegraph copy in Chrome 133

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -572,7 +572,8 @@ export class ComfyApp {
       }
       const isTargetInGraph =
         e.target.classList.contains('litegraph') ||
-        e.target.classList.contains('graph-canvas-container')
+        e.target.classList.contains('graph-canvas-container') ||
+        e.target.id === 'graph-canvas'
 
       // copy nodes and clear clipboard
       if (isTargetInGraph && this.canvas.selected_nodes) {


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2445

In Chrome 133, the copy event target changes to the HTML canvas element.