### PR TITLE
[Refactor] Move isImageNode to litegraphUtil

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -37,6 +37,7 @@ import {
 } from '@/types/comfyWorkflow'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
+import { isImageNode } from '@/utils/litegraphUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, api } from './api'
@@ -185,6 +186,13 @@ export class ComfyApp {
     return useExecutionStore()._executingNodeProgress
   }
 
+  /**
+   * @deprecated Use {@link isImageNode} from @/utils/litegraphUtil instead
+   */
+  static isImageNode(node: LGraphNode) {
+    return isImageNode(node)
+  }
+
   constructor() {
     this.vueAppReady = false
     this.ui = new ComfyUI(this)
@@ -230,15 +238,6 @@ export class ComfyApp {
 
   getRandParam() {
     return '&rand=' + Math.random()
-  }
-
-  static isImageNode(node) {
-    return (
-      node.imgs ||
-      (node &&
-        node.widgets &&
-        node.widgets.findIndex((obj) => obj.name === 'image') >= 0)
-    )
   }
 
   static onClipspaceEditorSave() {
@@ -502,7 +501,7 @@ export class ComfyApp {
           if (
             this.canvas.current_node &&
             this.canvas.current_node.is_selected &&
-            ComfyApp.isImageNode(this.canvas.current_node)
+            isImageNode(this.canvas.current_node)
           ) {
             imageNode = this.canvas.current_node
           }

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -18,6 +18,7 @@ import { useToastStore } from '@/stores/toastStore'
 import { ComfyNodeDef, ExecutedWsMessage } from '@/types/apiTypes'
 import type { NodeId } from '@/types/comfyWorkflow'
 import { normalizeI18nKey } from '@/utils/formatUtil'
+import { isImageNode } from '@/utils/litegraphUtil'
 
 import { useExtensionService } from './extensionService'
 
@@ -337,7 +338,7 @@ export const useLitegraphService = () => {
           })
         }
 
-        if (ComfyApp.isImageNode(this)) {
+        if (isImageNode(this)) {
           options.push({
             content: 'Open in MaskEditor',
             callback: (obj) => {

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -1,0 +1,10 @@
+import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
+
+export function isImageNode(node: LGraphNode) {
+  return (
+    node.imgs ||
+    (node &&
+      node.widgets &&
+      node.widgets.findIndex((obj: IWidget) => obj.name === 'image') >= 0)
+  )
+}


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2450-Refactor-Move-isImageNode-to-litegraphUtil-1926d73d365081908414cc26fb99f063) by [Unito](https://www.unito.io)
