### PR TITLE
[Cleanup] Remove duplicated group header drawing logic

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -582,48 +582,6 @@ export class ComfyApp {
   }
 
   /**
-   * Draws group header bar
-   */
-  #addDrawGroupsHandler() {
-    const self = this
-    const origDrawGroups = LGraphCanvas.prototype.drawGroups
-    LGraphCanvas.prototype.drawGroups = function (canvas, ctx) {
-      if (!this.graph) {
-        return
-      }
-
-      var groups = this.graph.groups
-
-      ctx.save()
-      ctx.globalAlpha = 0.7 * this.editor_alpha
-
-      for (var i = 0; i < groups.length; ++i) {
-        var group = groups[i]
-
-        if (!LiteGraph.overlapBounding(this.visible_area, group._bounding)) {
-          continue
-        } //out of the visible area
-
-        ctx.fillStyle = group.color || '#335'
-        ctx.strokeStyle = group.color || '#335'
-        var pos = group._pos
-        var size = group._size
-        ctx.globalAlpha = 0.25 * this.editor_alpha
-        ctx.beginPath()
-        var font_size = group.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE
-        ctx.rect(pos[0] + 0.5, pos[1] + 0.5, size[0], font_size * 1.4)
-        ctx.fill()
-        ctx.globalAlpha = this.editor_alpha
-      }
-
-      ctx.restore()
-
-      const res = origDrawGroups.apply(this, arguments)
-      return res
-    }
-  }
-
-  /**
    * Draws node highlights (executing, drag drop) and progress bar
    */
   #addDrawNodeHandler() {
@@ -899,7 +857,6 @@ export class ComfyApp {
     await this.registerNodes()
 
     this.#addDrawNodeHandler()
-    this.#addDrawGroupsHandler()
     this.#addDropHandler()
 
     await useExtensionService().invokeExtensionsAsync('setup')


### PR DESCRIPTION
Group titlebar drawing has already been implemented in litegraph here: https://github.com/Comfy-Org/litegraph.js/blob/9d5e94859ed7b5668ae31f3d772848ded6e8f9de/src/LGraphGroup.ts#L158-L163

This PR removes the duplicated drawing logic.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2453-Cleanup-Remove-duplicated-group-header-drawing-logic-1926d73d3650818ca66dc4aa178749e5) by [Unito](https://www.unito.io)
