### PR TITLE
[3d] add output preview screen for load3d node

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -25,7 +25,7 @@ app.registerExtension({
         container.id = `comfy-load-3d-${load3dNode.length}`
         container.classList.add('comfy-load-3d')
 
-        const load3d = new Load3d(container)
+        const load3d = new Load3d(container, true)
 
         containerToLoad3D.set(container.id, load3d)
 
@@ -129,17 +129,14 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const lightIntensity = node.widgets.find(
-      (w: IWidget) => w.name === 'light_intensity'
-    )
-
     const upDirection = node.widgets.find(
       (w: IWidget) => w.name === 'up_direction'
     )
 
-    const fov = node.widgets.find((w: IWidget) => w.name === 'fov')
-
     let cameraState = node.properties['Camera Info']
+
+    const width = node.widgets.find((w: IWidget) => w.name === 'width')
+    const height = node.widgets.find((w: IWidget) => w.name === 'height')
 
     const config = new Load3DConfiguration(load3d)
 
@@ -147,22 +144,19 @@ app.registerExtension({
       'input',
       modelWidget,
       material,
-      lightIntensity,
       upDirection,
-      fov,
-      cameraState
+      cameraState,
+      width,
+      height
     )
-
-    const w = node.widgets.find((w: IWidget) => w.name === 'width')
-    const h = node.widgets.find((w: IWidget) => w.name === 'height')
 
     // @ts-expect-error hacky override
     sceneWidget.serializeValue = async () => {
       node.properties['Camera Info'] = load3d.getCameraState()
 
       const { scene: imageData, mask: maskData } = await load3d.captureScene(
-        w.value,
-        h.value
+        width.value,
+        height.value
       )
 
       const [data, dataMask] = await Promise.all([
@@ -194,7 +188,7 @@ app.registerExtension({
         container.id = `comfy-load-3d-animation-${load3dNode.length}`
         container.classList.add('comfy-load-3d-animation')
 
-        const load3d = new Load3dAnimation(container)
+        const load3d = new Load3dAnimation(container, true)
 
         containerToLoad3D.set(container.id, load3d)
 
@@ -298,17 +292,14 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const lightIntensity = node.widgets.find(
-      (w: IWidget) => w.name === 'light_intensity'
-    )
-
     const upDirection = node.widgets.find(
       (w: IWidget) => w.name === 'up_direction'
     )
 
-    const fov = node.widgets.find((w: IWidget) => w.name === 'fov')
-
     let cameraState = node.properties['Camera Info']
+
+    const width = node.widgets.find((w: IWidget) => w.name === 'width')
+    const height = node.widgets.find((w: IWidget) => w.name === 'height')
 
     const config = new Load3DConfiguration(load3d)
 
@@ -316,14 +307,11 @@ app.registerExtension({
       'input',
       modelWidget,
       material,
-      lightIntensity,
       upDirection,
-      fov,
-      cameraState
+      cameraState,
+      width,
+      height
     )
-
-    const w = node.widgets.find((w: IWidget) => w.name === 'width')
-    const h = node.widgets.find((w: IWidget) => w.name === 'height')
 
     // @ts-expect-error hacky override
     sceneWidget.serializeValue = async () => {
@@ -332,8 +320,8 @@ app.registerExtension({
       load3d.toggleAnimation(false)
 
       const { scene: imageData, mask: maskData } = await load3d.captureScene(
-        w.value,
-        h.value
+        width.value,
+        height.value
       )
 
       const [data, dataMask] = await Promise.all([
@@ -432,15 +420,9 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const lightIntensity = node.widgets.find(
-      (w: IWidget) => w.name === 'light_intensity'
-    )
-
     const upDirection = node.widgets.find(
       (w: IWidget) => w.name === 'up_direction'
     )
-
-    const fov = node.widgets.find((w: IWidget) => w.name === 'fov')
 
     const onExecuted = node.onExecuted
 
@@ -461,14 +443,7 @@ app.registerExtension({
 
       const config = new Load3DConfiguration(load3d)
 
-      config.configure(
-        'output',
-        modelWidget,
-        material,
-        lightIntensity,
-        upDirection,
-        fov
-      )
+      config.configure('output', modelWidget, material, upDirection)
     }
   }
 })
@@ -562,15 +537,9 @@ app.registerExtension({
 
     const material = node.widgets.find((w: IWidget) => w.name === 'material')
 
-    const lightIntensity = node.widgets.find(
-      (w: IWidget) => w.name === 'light_intensity'
-    )
-
     const upDirection = node.widgets.find(
       (w: IWidget) => w.name === 'up_direction'
     )
-
-    const fov = node.widgets.find((w: IWidget) => w.name === 'fov')
 
     const onExecuted = node.onExecuted
 
@@ -591,14 +560,7 @@ app.registerExtension({
 
       const config = new Load3DConfiguration(load3d)
 
-      config.configure(
-        'output',
-        modelWidget,
-        material,
-        lightIntensity,
-        upDirection,
-        fov
-      )
+      config.configure('output', modelWidget, material, upDirection)
     }
   }
 })

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -11,10 +11,10 @@ class Load3DConfiguration {
     loadFolder: 'input' | 'output',
     modelWidget: IWidget,
     material: IWidget,
-    lightIntensity: IWidget,
     upDirection: IWidget,
-    fov: IWidget,
     cameraState?: any,
+    width: IWidget | null = null,
+    height: IWidget | null = null,
     postModelUpdateFunc?: (load3d: Load3d) => void
   ) {
     this.setupModelHandling(
@@ -24,9 +24,8 @@ class Load3DConfiguration {
       postModelUpdateFunc
     )
     this.setupMaterial(material)
-    this.setupLighting(lightIntensity)
     this.setupDirection(upDirection)
-    this.setupCamera(fov)
+    this.setupTargetSize(width, height)
     this.setupDefaultProperties()
   }
 
@@ -56,13 +55,6 @@ class Load3DConfiguration {
     )
   }
 
-  private setupLighting(lightIntensity: IWidget) {
-    lightIntensity.callback = (value: number) => {
-      this.load3d.setLightIntensity(value)
-    }
-    this.load3d.setLightIntensity(lightIntensity.value as number)
-  }
-
   private setupDirection(upDirection: IWidget) {
     upDirection.callback = (
       value: 'original' | '-x' | '+x' | '-y' | '+y' | '-z' | '+z'
@@ -74,11 +66,18 @@ class Load3DConfiguration {
     )
   }
 
-  private setupCamera(fov: IWidget) {
-    fov.callback = (value: number) => {
-      this.load3d.setFOV(value)
+  private setupTargetSize(width: IWidget | null, height: IWidget | null) {
+    if (width && height) {
+      this.load3d.setTargetSize(width.value as number, height.value as number)
+
+      width.callback = (value: number) => {
+        this.load3d.setTargetSize(value, height.value as number)
+      }
+
+      height.callback = (value: number) => {
+        this.load3d.setTargetSize(width.value as number, value)
+      }
     }
-    this.load3d.setFOV(fov.value as number)
   }
 
   private setupDefaultProperties() {
@@ -94,6 +93,21 @@ class Load3DConfiguration {
     const bgColor = this.load3d.loadNodeProperty('Background Color', '#282828')
 
     this.load3d.setBackgroundColor(bgColor)
+
+    const fov = this.load3d.loadNodeProperty('FOV', '75')
+
+    this.load3d.setFOV(fov)
+
+    const lightIntensity = this.load3d.loadNodeProperty('Light Intensity', '5')
+
+    this.load3d.setLightIntensity(lightIntensity)
+
+    const previewVisible = this.load3d.loadNodeProperty(
+      'Preview Visible',
+      false
+    )
+
+    this.load3d.setPreviewVisible(previewVisible)
   }
 
   private createModelUpdateHandler(

--- a/src/extensions/core/load3d/Load3dAnimation.ts
+++ b/src/extensions/core/load3d/Load3dAnimation.ts
@@ -14,8 +14,11 @@ class Load3dAnimation extends Load3d {
   animationSelect: HTMLSelectElement = {} as HTMLSelectElement
   speedSelect: HTMLSelectElement = {} as HTMLSelectElement
 
-  constructor(container: Element | HTMLElement) {
-    super(container)
+  constructor(
+    container: Element | HTMLElement,
+    createPreview: boolean = false
+  ) {
+    super(container, createPreview)
     this.createPlayPauseButton(container)
     this.createAnimationList(container)
     this.createSpeedSelect(container)
@@ -202,12 +205,6 @@ class Load3dAnimation extends Load3d {
 
     if (this.animationClips.length > 0) {
       this.playPauseContainer.style.display = 'block'
-    } else {
-      this.playPauseContainer.style.display = 'none'
-    }
-
-    if (this.animationClips.length > 0) {
-      this.playPauseContainer.style.display = 'block'
       this.animationSelect.style.display = 'block'
       this.speedSelect.style.display = 'block'
       this.updateAnimationList()
@@ -330,6 +327,11 @@ class Load3dAnimation extends Load3d {
   startAnimation() {
     const animate = () => {
       this.animationFrameId = requestAnimationFrame(animate)
+
+      if (this.isPreviewVisible) {
+        this.updatePreviewRender()
+      }
+
       const delta = this.clock.getDelta()
 
       if (this.currentAnimation && this.isAnimationPlaying) {


### PR DESCRIPTION
add a output preview screen for load3d, because at before, it is hard to know the output exactly.
also moved two params (fov and light intensity) from node panel to the scene.
here is the demo:
https://github.com/user-attachments/assets/401f7773-a219-47de-b529-864c83ba7370
need https://github.com/comfyanonymous/ComfyUI/pull/6742 as BE change

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2464-3d-add-output-preview-screen-for-load3d-node-1946d73d365081bfb7aff392c167ab43) by [Unito](https://www.unito.io)
