### PR TITLE
Update litegraph 0.8.71

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.16",
-        "@comfyorg/litegraph": "^0.8.70",
+        "@comfyorg/litegraph": "^0.8.71",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.70",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.70.tgz",
-      "integrity": "sha512-YZSMVzr/gUn7Xoe4orFjypq58faDy1kMvF1/kGTzmukF6w7WZ3tPjkng1ZBAWIztjcGDSmeTLYRayj5hfaDavA==",
+      "version": "0.8.71",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.71.tgz",
+      "integrity": "sha512-BHe8BbrEC8hvLqRRv9vT7kkfn5CGY+w13DEhJOwXPj72PBtISa4ESfeOIZAMAASpjPWyagwWeSr4BzJTspSl6w==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.16",
-    "@comfyorg/litegraph": "^0.8.70",
+    "@comfyorg/litegraph": "^0.8.71",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.71
Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.8.71

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2465-Update-litegraph-0-8-71-1946d73d365081e9b474f019aa2211b3) by [Unito](https://www.unito.io)
