### PR TITLE
Update litegraph 0.8.73

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.16",
-        "@comfyorg/litegraph": "^0.8.72",
+        "@comfyorg/litegraph": "^0.8.73",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.72",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.72.tgz",
-      "integrity": "sha512-/DCbV+zYjICC0uQWPqcj0KioAJ3j89y6eEnbpGgDSpH6SmbSks+Hpko7HWokWFMOKqriRa/NT5xMcHAiRts2cA==",
+      "version": "0.8.73",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.73.tgz",
+      "integrity": "sha512-KL9oZ0QqDsM6ahr9jfDx/XTgN9PfhYNYX6WKT4sFZS5cjZ4q4TpL4zukz60fv33EeuPjZW5s16VfGrnrhC1KqQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.16",
-    "@comfyorg/litegraph": "^0.8.72",
+    "@comfyorg/litegraph": "^0.8.73",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.73

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2468

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2472-Update-litegraph-0-8-73-1946d73d365081bcae83f341d192576d) by [Unito](https://www.unito.io)
