### PR TITLE
Update public API syntax of remote (lazy) widgets

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: a9c49e4c57464da41ec346deb4a9eeeb00a52c9a
+        devtools_ref: 8ff192366066cd44bfc2a25713c9957ccf665938
     - name: Run Jest tests
       run: |
         npm run test:generate
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: a9c49e4c57464da41ec346deb4a9eeeb00a52c9a
+        devtools_ref: 8ff192366066cd44bfc2a25713c9957ccf665938
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend
@@ -48,7 +48,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: a9c49e4c57464da41ec346deb4a9eeeb00a52c9a
+        devtools_ref: 8ff192366066cd44bfc2a25713c9957ccf665938
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: a9c49e4c57464da41ec346deb4a9eeeb00a52c9a
+        devtools_ref: 8ff192366066cd44bfc2a25713c9957ccf665938
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -565,8 +565,7 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
   },
   COMBO(node, inputName, inputData: InputSpec) {
     const widgetStore = useWidgetStore()
-
-    const { type, options } = inputData[1]
+    const { remote, options } = inputData[1]
     const defaultValue = widgetStore.getDefaultValue(inputData)
 
     const res = {
@@ -575,7 +574,7 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
       }) as IComboWidget
     }
 
-    if (type === 'remote') {
+    if (remote) {
       const remoteWidget = useRemoteWidget(inputData)
 
       const origOptions = res.widget.options

--- a/src/stores/widgetStore.ts
+++ b/src/stores/widgetStore.ts
@@ -53,7 +53,7 @@ export const useWidgetStore = defineStore('widget', () => {
     if (props.default) return props.default
 
     if (widgetType === 'COMBO' && props.options?.length) return props.options[0]
-    if (props.type === 'remote') return 'Loading...'
+    if (props.remote) return 'Loading...'
     return undefined
   }
 

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -269,6 +269,13 @@ function inputSpec<TType extends ZodType, TSpec extends ZodType>(
   ])
 }
 
+const zRemoteWidgetConfig = z.object({
+  route: z.string().url().or(z.string().startsWith('/')),
+  refresh: z.number().gte(128).safe().or(z.number().lte(0).safe()).optional(),
+  response_key: z.string().optional(),
+  query_params: z.record(z.string(), z.string()).optional()
+})
+
 const zBaseInputSpecValue = z
   .object({
     default: z.any().optional(),
@@ -332,11 +339,7 @@ const zStringInputSpec = inputSpec([
 const zComboInputProps = zBaseInputSpecValue.extend({
   control_after_generate: z.boolean().optional(),
   image_upload: z.boolean().optional(),
-  type: z.enum(['remote']).optional(),
-  route: z.string().url().or(z.string().startsWith('/')).optional(),
-  refresh: z.number().gte(128).safe().or(z.number().lte(0).safe()).optional(),
-  response_key: z.string().optional(),
-  query_params: z.record(z.string(), z.string()).optional()
+  remote: zRemoteWidgetConfig.optional()
 })
 
 // Dropdown Selection.
@@ -594,3 +597,4 @@ export type UserDataFullInfo = z.infer<typeof zUserDataFullInfo>
 export type TerminalSize = z.infer<typeof zTerminalSize>
 export type LogEntry = z.infer<typeof zLogEntry>
 export type LogsRawResponse = z.infer<typeof zLogRawResponse>
+export type RemoteWidgetConfig = z.infer<typeof zRemoteWidgetConfig>

--- a/tests-ui/tests/remoteWidgetHook.test.ts
+++ b/tests-ui/tests/remoteWidgetHook.test.ts
@@ -35,10 +35,11 @@ function createMockInputData(overrides = {}): ComboInputSpecV2 {
     'COMBO',
     {
       name: 'test_widget',
-      type: 'remote',
-      route: `/api/test/${Date.now()}${Math.random().toString(36).substring(2, 15)}`,
-      refresh: 0,
-      ...overrides
+      remote: {
+        route: `/api/test/${Date.now()}${Math.random().toString(36).substring(2, 15)}`,
+        refresh: 0,
+        ...overrides
+      }
     }
   ]
 }


### PR DESCRIPTION
Updates the public API syntax of nodes with remote inputs. The `type` property already exists on [`BaseInputSpec`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/3d59d478b6ddab42251eba51af39e171d7b1e22a/src/stores/nodeDefStore.ts#L24-L31), causing remote widget's `type` to be shadowed when transformed to `ComfyNodeDefImpl`, potentially causing issues in the future.

No custom nodes use this feature yet ([code source query](https://cs.comfy.org/search?q=context%3Aglobal+route%3A+&patternType=keyword&sm=0&filters=%5B%5B%22lang%22%2C%22Python%22%2C%22lang%3Apython%22%5D%5D)).

```diff
class RemoteWidgetNode:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "remote_widget_value": (
                    "COMBO",
                    {
-                        "type": "remote",
-                        "route": "/api/models/checkpoints",
-                        "refresh": 1000,
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                            "refresh": 1000,
+                        },
                    },
                ),
            },
        }
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2477-Update-public-API-syntax-of-remote-lazy-widgets-1956d73d365081628dd4e1877e52fd3a) by [Unito](https://www.unito.io)
