### PR TITLE
feat: Stop hardcoding the default graph in the UI

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import type { Rect, Vector2 } from '@comfyorg/litegraph'
 import {
   LGraph,
   LGraphCanvas,
@@ -7,7 +8,6 @@ import {
   LiteGraph,
   strokeShape
 } from '@comfyorg/litegraph'
-import type { Rect, Vector2 } from '@comfyorg/litegraph'
 import _ from 'lodash'
 import type { ToastMessageOptions } from 'primevue/toast'
 import { shallowReactive } from 'vue'
@@ -41,7 +41,7 @@ import { isImageNode } from '@/utils/litegraphUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, api } from './api'
-import { defaultGraph } from './defaultGraph'
+import { fetchDefaultGraph } from './defaultGraph'
 import {
   getFlacMetadata,
   getLatentMetadata,
@@ -1012,7 +1012,7 @@ export class ComfyApp {
 
     let reset_invalid_values = false
     if (!graphData) {
-      graphData = defaultGraph
+      graphData = await fetchDefaultGraph()
       reset_invalid_values = true
     }
 

--- a/src/scripts/defaultGraph.ts
+++ b/src/scripts/defaultGraph.ts
@@ -1,143 +1,5 @@
 import type { ComfyWorkflowJSON } from '@/types/comfyWorkflow'
 
-export const defaultGraph: ComfyWorkflowJSON = {
-  last_node_id: 9,
-  last_link_id: 9,
-  nodes: [
-    {
-      id: 7,
-      type: 'CLIPTextEncode',
-      pos: [413, 389],
-      size: [425.27801513671875, 180.6060791015625],
-      flags: {},
-      order: 3,
-      mode: 0,
-      inputs: [{ name: 'clip', type: 'CLIP', link: 5 }],
-      outputs: [
-        {
-          name: 'CONDITIONING',
-          type: 'CONDITIONING',
-          links: [6],
-          slot_index: 0
-        }
-      ],
-      properties: {},
-      widgets_values: ['text, watermark']
-    },
-    {
-      id: 6,
-      type: 'CLIPTextEncode',
-      pos: [415, 186],
-      size: [422.84503173828125, 164.31304931640625],
-      flags: {},
-      order: 2,
-      mode: 0,
-      inputs: [{ name: 'clip', type: 'CLIP', link: 3 }],
-      outputs: [
-        {
-          name: 'CONDITIONING',
-          type: 'CONDITIONING',
-          links: [4],
-          slot_index: 0
-        }
-      ],
-      properties: {},
-      widgets_values: [
-        'beautiful scenery nature glass bottle landscape, , purple galaxy bottle,'
-      ]
-    },
-    {
-      id: 5,
-      type: 'EmptyLatentImage',
-      pos: [473, 609],
-      size: [315, 106],
-      flags: {},
-      order: 1,
-      mode: 0,
-      outputs: [{ name: 'LATENT', type: 'LATENT', links: [2], slot_index: 0 }],
-      properties: {},
-      widgets_values: [512, 512, 1]
-    },
-    {
-      id: 3,
-      type: 'KSampler',
-      pos: [863, 186],
-      size: [315, 262],
-      flags: {},
-      order: 4,
-      mode: 0,
-      inputs: [
-        { name: 'model', type: 'MODEL', link: 1 },
-        { name: 'positive', type: 'CONDITIONING', link: 4 },
-        { name: 'negative', type: 'CONDITIONING', link: 6 },
-        { name: 'latent_image', type: 'LATENT', link: 2 }
-      ],
-      outputs: [{ name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 }],
-      properties: {},
-      widgets_values: [156680208700286, true, 20, 8, 'euler', 'normal', 1]
-    },
-    {
-      id: 8,
-      type: 'VAEDecode',
-      pos: [1209, 188],
-      size: [210, 46],
-      flags: {},
-      order: 5,
-      mode: 0,
-      inputs: [
-        { name: 'samples', type: 'LATENT', link: 7 },
-        { name: 'vae', type: 'VAE', link: 8 }
-      ],
-      outputs: [{ name: 'IMAGE', type: 'IMAGE', links: [9], slot_index: 0 }],
-      properties: {}
-    },
-    {
-      id: 9,
-      type: 'SaveImage',
-      pos: [1451, 189],
-      size: [210, 26],
-      flags: {},
-      order: 6,
-      mode: 0,
-      inputs: [{ name: 'images', type: 'IMAGE', link: 9 }],
-      properties: {}
-    },
-    {
-      id: 4,
-      type: 'CheckpointLoaderSimple',
-      pos: [26, 474],
-      size: [315, 98],
-      flags: {},
-      order: 0,
-      mode: 0,
-      outputs: [
-        { name: 'MODEL', type: 'MODEL', links: [1], slot_index: 0 },
-        { name: 'CLIP', type: 'CLIP', links: [3, 5], slot_index: 1 },
-        { name: 'VAE', type: 'VAE', links: [8], slot_index: 2 }
-      ],
-      properties: {},
-      widgets_values: ['v1-5-pruned-emaonly-fp16.safetensors']
-    }
-  ],
-  links: [
-    [1, 4, 0, 3, 0, 'MODEL'],
-    [2, 5, 0, 3, 3, 'LATENT'],
-    [3, 4, 1, 6, 0, 'CLIP'],
-    [4, 6, 0, 3, 1, 'CONDITIONING'],
-    [5, 4, 1, 7, 0, 'CLIP'],
-    [6, 7, 0, 3, 2, 'CONDITIONING'],
-    [7, 3, 0, 8, 0, 'LATENT'],
-    [8, 4, 2, 8, 1, 'VAE'],
-    [9, 8, 0, 9, 0, 'IMAGE']
-  ],
-  groups: [],
-  config: {},
-  extra: {},
-  version: 0.4
-}
-
-export const defaultGraphJSON = JSON.stringify(defaultGraph)
-
 export const blankGraph: ComfyWorkflowJSON = {
   last_node_id: 0,
   last_link_id: 0,
@@ -147,4 +9,18 @@ export const blankGraph: ComfyWorkflowJSON = {
   config: {},
   extra: {},
   version: 0.4
+}
+
+export const fetchDefaultGraph = async () => {
+  try {
+    const response = await fetch('/templates/default.json')
+    if (!response.ok) {
+      throw new Error(`Response status: ${response.status}`)
+    }
+    const graph = await response.json()
+    return graph as ComfyWorkflowJSON
+  } catch (_error) {
+    console.warn('Failed to fetch default graph, using blank graph instead.')
+    return blankGraph
+  }
 }

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -1,11 +1,11 @@
-import { LGraphCanvas } from '@comfyorg/litegraph'
 import type { Vector2 } from '@comfyorg/litegraph'
+import { LGraphCanvas } from '@comfyorg/litegraph'
 import { toRaw } from 'vue'
 
 import { t } from '@/i18n'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'
+import { blankGraph, fetchDefaultGraph } from '@/scripts/defaultGraph'
 import { downloadBlob } from '@/scripts/utils'
 import { useSettingStore } from '@/stores/settingStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -95,7 +95,7 @@ export const useWorkflowService = () => {
       await renameWorkflow(workflow, newPath)
       await workflowStore.saveWorkflow(workflow)
     } else {
-      const tempWorkflow = workflowStore.createTemporary(
+      const tempWorkflow = await workflowStore.createTemporary(
         newKey,
         workflow.activeState as ComfyWorkflowJSON
       )
@@ -120,6 +120,7 @@ export const useWorkflowService = () => {
    * Load the default workflow
    */
   const loadDefaultWorkflow = async () => {
+    const defaultGraph = await fetchDefaultGraph()
     await app.loadGraphData(defaultGraph)
   }
 
@@ -311,7 +312,7 @@ export const useWorkflowService = () => {
 
     if (value === null || typeof value === 'string') {
       const path = value as string | null
-      const tempWorkflow = workflowStore.createTemporary(
+      const tempWorkflow = await workflowStore.createTemporary(
         path ? appendJsonExt(path) : undefined,
         workflowData
       )

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -4,7 +4,7 @@ import { computed, markRaw, ref } from 'vue'
 
 import { api } from '@/scripts/api'
 import { ChangeTracker } from '@/scripts/changeTracker'
-import { defaultGraphJSON } from '@/scripts/defaultGraph'
+import { fetchDefaultGraph } from '@/scripts/defaultGraph'
 import { ComfyWorkflowJSON } from '@/types/comfyWorkflow'
 import { getPathDetails } from '@/utils/formatUtil'
 import { syncEntities } from '@/utils/syncUtil'
@@ -141,7 +141,7 @@ export interface WorkflowStore {
   createTemporary: (
     path?: string,
     workflowData?: ComfyWorkflowJSON
-  ) => ComfyWorkflow
+  ) => Promise<ComfyWorkflow>
   renameWorkflow: (workflow: ComfyWorkflow, newPath: string) => Promise<void>
   deleteWorkflow: (workflow: ComfyWorkflow) => Promise<void>
   saveWorkflow: (workflow: ComfyWorkflow) => Promise<void>
@@ -277,7 +277,10 @@ export const useWorkflowStore = defineStore('workflow', () => {
     return newPath
   }
 
-  const createTemporary = (path?: string, workflowData?: ComfyWorkflowJSON) => {
+  const createTemporary = async (
+    path?: string,
+    workflowData?: ComfyWorkflowJSON
+  ) => {
     const fullPath = getUnconflictedPath(
       ComfyWorkflow.basePath + (path ?? 'Unsaved Workflow.json')
     )
@@ -289,7 +292,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
 
     workflow.originalContent = workflow.content = workflowData
       ? JSON.stringify(workflowData)
-      : defaultGraphJSON
+      : JSON.stringify(await fetchDefaultGraph())
 
     workflowLookup.value[workflow.path] = workflow
     return workflow

--- a/tests-ui/tests/comfyWorkflow.test.ts
+++ b/tests-ui/tests/comfyWorkflow.test.ts
@@ -1,10 +1,35 @@
 // @ts-strict-ignore
 import fs from 'fs'
 
-import { defaultGraph } from '@/scripts/defaultGraph'
-import { validateComfyWorkflow } from '@/types/comfyWorkflow'
+import { ComfyWorkflowJSON, validateComfyWorkflow } from '@/types/comfyWorkflow'
 
 const WORKFLOW_DIR = 'tests-ui/workflows'
+
+const createGraph = (): ComfyWorkflowJSON => ({
+  config: {},
+  extra: {},
+  groups: [],
+  last_link_id: 0,
+  last_node_id: 0,
+  links: [] as any,
+  models: [],
+  nodes: [
+    {
+      flags: {},
+      id: 1,
+      inputs: [],
+      mode: 0,
+      order: 0,
+      outputs: [],
+      pos: [0, 0],
+      properties: {},
+      size: [200, 200],
+      type: 'KSampler',
+      widgets_values: []
+    }
+  ],
+  version: 0.4
+})
 
 describe('parseComfyWorkflow', () => {
   it('parses valid workflow', async () => {
@@ -17,7 +42,7 @@ describe('parseComfyWorkflow', () => {
   })
 
   it('workflow.nodes', async () => {
-    const workflow = JSON.parse(JSON.stringify(defaultGraph))
+    const workflow = createGraph()
     workflow.nodes = undefined
     expect(await validateComfyWorkflow(workflow)).toBeNull()
 
@@ -29,10 +54,11 @@ describe('parseComfyWorkflow', () => {
   })
 
   it('workflow.version', async () => {
-    const workflow = JSON.parse(JSON.stringify(defaultGraph))
+    const workflow = createGraph()
     workflow.version = undefined
     expect(await validateComfyWorkflow(workflow)).toBeNull()
 
+    // @ts-expect-error - Invalid format (string)
     workflow.version = '1.0.1' // Invalid format (string)
     expect(await validateComfyWorkflow(workflow)).toBeNull()
 
@@ -42,7 +68,7 @@ describe('parseComfyWorkflow', () => {
   })
 
   it('workflow.extra', async () => {
-    const workflow = JSON.parse(JSON.stringify(defaultGraph))
+    const workflow = createGraph()
     workflow.extra = undefined
     expect(await validateComfyWorkflow(workflow)).not.toBeNull()
 
@@ -57,7 +83,8 @@ describe('parseComfyWorkflow', () => {
   })
 
   it('workflow.nodes.pos', async () => {
-    const workflow = JSON.parse(JSON.stringify(defaultGraph))
+    const workflow = createGraph()
+
     workflow.nodes[0].pos = [1, 2, 3]
     expect(await validateComfyWorkflow(workflow)).toBeNull()
 
@@ -65,16 +92,19 @@ describe('parseComfyWorkflow', () => {
     expect(await validateComfyWorkflow(workflow)).not.toBeNull()
 
     // Should automatically transform the legacy format object to array.
+    // @ts-expect-error - Invalid format (object)
     workflow.nodes[0].pos = { '0': 3, '1': 4 }
     let validatedWorkflow = await validateComfyWorkflow(workflow)
     expect(validatedWorkflow.nodes[0].pos).toEqual([3, 4])
 
+    // @ts-expect-error - Invalid format (object)
     workflow.nodes[0].pos = { 0: 3, 1: 4 }
     validatedWorkflow = await validateComfyWorkflow(workflow)
     expect(validatedWorkflow.nodes[0].pos).toEqual([3, 4])
 
     // Should accept the legacy bugged format object.
     // https://github.com/Comfy-Org/ComfyUI_frontend/issues/710
+    // @ts-expect-error - Invalid format (object)
     workflow.nodes[0].pos = {
       '0': 600,
       '1': 340,
@@ -92,10 +122,11 @@ describe('parseComfyWorkflow', () => {
   })
 
   it('workflow.nodes.widget_values', async () => {
-    const workflow = JSON.parse(JSON.stringify(defaultGraph))
+    const workflow = createGraph()
     workflow.nodes[0].widgets_values = ['foo', 'bar']
     expect(await validateComfyWorkflow(workflow)).not.toBeNull()
 
+    // @ts-expect-error - Invalid format (string)
     workflow.nodes[0].widgets_values = 'foo'
     expect(await validateComfyWorkflow(workflow)).toBeNull()
 
@@ -110,9 +141,10 @@ describe('parseComfyWorkflow', () => {
   })
 
   it('workflow.links', async () => {
-    const workflow = JSON.parse(JSON.stringify(defaultGraph))
+    const workflow = createGraph()
 
     workflow.links = [
+      // @ts-expect-error - Invalid format
       [
         1, // Link id
         '100:1', // Node id of source node


### PR DESCRIPTION
Addresses https://github.com/Comfy-Org/ComfyUI_frontend/issues/689. 

This pull request includes several changes to improve the handling of default graphs and workflow creation in the application. The key modifications involve replacing the `defaultGraph` constant with an asynchronous function to fetch default graph data, updating related imports, and adjusting tests to accommodate these changes.

### Default Graph Handling:

* [`src/scripts/defaultGraph.ts`](diffhunk://#diff-15aea065ea9ca28df8a5223bdba6438b4d065354d278cfc3393ae6ba80bc3172L3-L140): Removed the `defaultGraph` constant and added the `fetchDefaultGraph` function to fetch the default graph data asynchronously. [[1]](diffhunk://#diff-15aea065ea9ca28df8a5223bdba6438b4d065354d278cfc3393ae6ba80bc3172L3-L140) [[2]](diffhunk://#diff-15aea065ea9ca28df8a5223bdba6438b4d065354d278cfc3393ae6ba80bc3172R13-R26)

### Workflow Service Updates:

* [`src/services/workflowService.ts`](diffhunk://#diff-a174f8644108e10561957b6af709a4863efd05b4a2b231ee1e00d787f2a923edL1-R8): Updated the `loadDefaultWorkflow` function and other relevant code to use the `fetchDefaultGraph` function instead of the `defaultGraph` constant. [[1]](diffhunk://#diff-a174f8644108e10561957b6af709a4863efd05b4a2b231ee1e00d787f2a923edL1-R8) [[2]](diffhunk://#diff-a174f8644108e10561957b6af709a4863efd05b4a2b231ee1e00d787f2a923edL98-R98) [[3]](diffhunk://#diff-a174f8644108e10561957b6af709a4863efd05b4a2b231ee1e00d787f2a923edR123) [[4]](diffhunk://#diff-a174f8644108e10561957b6af709a4863efd05b4a2b231ee1e00d787f2a923edL314-R315)

### Workflow Store Modifications:

* [`src/stores/workflowStore.ts`](diffhunk://#diff-d8a2b6c22da5cc70be93b116a8de213be0864151ef4cf42fe3ff4f4c136d56c3L7-R7): Modified the `createTemporary` function to be asynchronous and to use the `fetchDefaultGraph` function. Updated related imports and type definitions. [[1]](diffhunk://#diff-d8a2b6c22da5cc70be93b116a8de213be0864151ef4cf42fe3ff4f4c136d56c3L7-R7) [[2]](diffhunk://#diff-d8a2b6c22da5cc70be93b116a8de213be0864151ef4cf42fe3ff4f4c136d56c3L144-R144) [[3]](diffhunk://#diff-d8a2b6c22da5cc70be93b116a8de213be0864151ef4cf42fe3ff4f4c136d56c3L280-R283) [[4]](diffhunk://#diff-d8a2b6c22da5cc70be93b116a8de213be0864151ef4cf42fe3ff4f4c136d56c3L292-R295)

### Test Adjustments:

* [`tests-ui/tests/comfyWorkflow.test.ts`](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L4-R33): Replaced references to `defaultGraph` with a new `createGraph` function to generate test graph data dynamically. [[1]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L4-R33) [[2]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L20-R45) [[3]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L32-R61) [[4]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L45-R71) [[5]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L60-R107) [[6]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L95-R129) [[7]](diffhunk://#diff-aee5a4622893cd7534e9d521f53468624fb50c4fb9e80a62d0372cdbe0dc1984L113-R147)
* [`tests-ui/tests/store/workflowStore.test.ts`](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659L4-R4): Updated tests to handle the asynchronous nature of the `createTemporary` function and adjusted mock data accordingly. [[1]](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659L4-R4) [[2]](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659R24) [[3]](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659L59-R86) [[4]](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659L105-R106) [[5]](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659L258-R259) [[6]](diffhunk://#diff-9ac8d51a86440fd2adbbb19b9ffa07a4f5fe2fc2f1be011f571ec304f730f659L283-R284)
