### PR TITLE
Fix color and slider settings types to inherit attrs

### DIFF
--- a/browser_tests/extensionAPI.spec.ts
+++ b/browser_tests/extensionAPI.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 
+import { SettingParams } from '../src/types/settingTypes'
 import { comfyPageFixture as test } from './fixtures/ComfyPage'
 
 test.describe('Topbar commands', () => {
@@ -133,6 +134,90 @@ test.describe('Topbar commands', () => {
       await comfyPage.settingDialog.toggleBooleanSetting('Comfy.TestSetting')
       expect(await comfyPage.getSetting('Comfy.TestSetting')).toBe(true)
       expect(await comfyPage.page.evaluate(() => window['changeCount'])).toBe(2)
+    })
+
+    test.describe('Passing through attrs to setting components', () => {
+      const testCases: Array<{
+        config: Partial<SettingParams>
+        selector: string
+      }> = [
+        {
+          config: {
+            type: 'boolean',
+            defaultValue: true
+          },
+          selector: '.p-toggleswitch.p-component'
+        },
+        {
+          config: {
+            type: 'number',
+            defaultValue: 10
+          },
+          selector: '.p-inputnumber input'
+        },
+        {
+          config: {
+            type: 'slider',
+            defaultValue: 10
+          },
+          selector: '.p-slider.p-component'
+        },
+        {
+          config: {
+            type: 'combo',
+            defaultValue: 'foo',
+            options: ['foo', 'bar', 'baz']
+          },
+          selector: '.p-select.p-component'
+        },
+        {
+          config: {
+            type: 'text',
+            defaultValue: 'Hello'
+          },
+          selector: '.p-inputtext'
+        },
+        {
+          config: {
+            type: 'color',
+            defaultValue: '#000000'
+          },
+          selector: '.p-colorpicker-preview'
+        }
+      ] as const
+
+      for (const { config, selector } of testCases) {
+        test(`${config.type} component should respect disabled attr`, async ({
+          comfyPage
+        }) => {
+          await comfyPage.page.evaluate((config) => {
+            window['app'].registerExtension({
+              name: 'TestExtension1',
+              settings: [
+                {
+                  id: 'Comfy.TestSetting',
+                  name: 'Test',
+                  // The `disabled` attr is common to all settings components
+                  attrs: { disabled: true },
+                  ...config
+                }
+              ]
+            })
+          }, config)
+
+          await comfyPage.settingDialog.open()
+          const component = comfyPage.settingDialog.root
+            .getByText('TestSetting Test')
+            .locator(selector)
+
+          const isDisabled = await component.evaluate((el) =>
+            el.tagName === 'INPUT'
+              ? (el as HTMLInputElement).disabled
+              : el.classList.contains('p-disabled')
+          )
+          expect(isDisabled).toBe(true)
+        })
+      }
     })
   })
 

--- a/browser_tests/fixtures/components/SettingDialog.ts
+++ b/browser_tests/fixtures/components/SettingDialog.ts
@@ -3,6 +3,10 @@ import { Page } from '@playwright/test'
 export class SettingDialog {
   constructor(public readonly page: Page) {}
 
+  get root() {
+    return this.page.locator('div.settings-container')
+  }
+
   async open() {
     const button = this.page.locator('button.comfy-settings-btn:visible')
     await button.click()

--- a/src/components/common/FormColorPicker.vue
+++ b/src/components/common/FormColorPicker.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="color-picker-wrapper flex items-center gap-2">
-    <ColorPicker v-model="modelValue" />
+    <ColorPicker v-model="modelValue" v-bind="$attrs" />
     <InputText v-model="modelValue" class="w-28" :placeholder="label" />
   </div>
 </template>
@@ -14,4 +14,8 @@ defineProps<{
   defaultValue?: string
   label?: string
 }>()
+
+defineOptions({
+  inheritAttrs: false
+})
 </script>

--- a/src/components/common/InputSlider.vue
+++ b/src/components/common/InputSlider.vue
@@ -8,6 +8,7 @@
       :min="min"
       :max="max"
       :step="step"
+      v-bind="$attrs"
     />
     <InputNumber
       :modelValue="modelValue"
@@ -70,4 +71,8 @@ const updateValue = (newValue: number | null) => {
   localValue.value = newValue
   emit('update:modelValue', newValue)
 }
+
+defineOptions({
+  inheritAttrs: false
+})
 </script>


### PR DESCRIPTION
This PR changes the `color` and `slider` settings components to inherit attrs passed in `attrs` field of `SettingParams` when registering settings. 

The [docs on adding settings as an extension author](setting) currently indicate that all setting components allow for this, but the `color` and `slider` do not implement it properly as they have wrapper divs which trap the `attrs` inheritance.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2483-Fix-color-and-slider-settings-types-to-inherit-attrs-1966d73d365081859ef3cba932592d04) by [Unito](https://www.unito.io)
