### PR TITLE
Enable ts-strict for scripts/domWidgets

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -1,5 +1,6 @@
 import { LGraphCanvas, LGraphNode, LiteGraph } from '@comfyorg/litegraph'
 import type { Vector4 } from '@comfyorg/litegraph'
+import { Size } from '@comfyorg/litegraph'
 import type {
   ICustomWidget,
   IWidget,
@@ -133,7 +134,7 @@ function isDomWidget(
   return !!widget.element
 }
 
-function computeSize(this: LGraphNode, size: [number, number]): void {
+function computeSize(this: LGraphNode, size: Size): void {
   if (!this.widgets?.[0]?.last_y) return
 
   let y = this.widgets[0].last_y
@@ -353,7 +354,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
     y: number
   ): void {
     if (this.computedHeight == null) {
-      computeSize.call(node, [node.size[0], node.size[1]])
+      computeSize.call(node, node.size)
     }
 
     const { offset, scale } = app.canvas.ds
@@ -484,7 +485,7 @@ LGraphNode.prototype.addDOMWidget = function <
     const onResize = this.onResize
     this.onResize = function (size: [number, number]) {
       options.beforeResize?.call(widget, this)
-      computeSize.call(this, [size[0], size[1]])
+      computeSize.call(this, size)
       onResize?.call(this, size)
       options.afterResize?.call(widget, this)
     }

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -218,12 +218,7 @@ function computeSize(this: LGraphNode, size: [number, number]): void {
     }
   }
 
-  // Ensure this.imgs exists before accessing
-  if (
-    this.imgs &&
-    this.widgets &&
-    !this.widgets.find((w) => w.name === ANIM_PREVIEW_WIDGET)
-  ) {
+  if (this.imgs && !this.widgets?.find((w) => w.name === ANIM_PREVIEW_WIDGET)) {
     freeSpace -= 220
   }
 

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -475,12 +475,10 @@ LGraphNode.prototype.addDOMWidget = function <
     onRemoved?.call(this)
   }
 
-  // Add type for SIZE symbol
-  const sizeSymbol = SIZE
   // @ts-ignore index with symbol
-  if (!this[sizeSymbol]) {
+  if (!this[SIZE]) {
     // @ts-ignore index with symbol
-    this[sizeSymbol] = true
+    this[SIZE] = true
     const onResize = this.onResize
     this.onResize = function (size: Size) {
       options.beforeResize?.call(widget, this)

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -1,6 +1,5 @@
 import { LGraphCanvas, LGraphNode, LiteGraph } from '@comfyorg/litegraph'
-import type { Vector4 } from '@comfyorg/litegraph'
-import { Size } from '@comfyorg/litegraph'
+import type { Size, Vector4 } from '@comfyorg/litegraph'
 import type {
   ICustomWidget,
   IWidget,

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -482,7 +482,7 @@ LGraphNode.prototype.addDOMWidget = function <
     // @ts-ignore index with symbol
     this[sizeSymbol] = true
     const onResize = this.onResize
-    this.onResize = function (size: [number, number]) {
+    this.onResize = function (size: Size) {
       options.beforeResize?.call(widget, this)
       computeSize.call(this, size)
       onResize?.call(this, size)


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2499-Enable-ts-strict-for-scripts-domWidgets-1966d73d365081398393dc8f4e6316df) by [Unito](https://www.unito.io)
