### PR TITLE
Fix element style override CSS in #2499

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -292,7 +292,7 @@ LGraphCanvas.prototype.computeVisibleNodes = function (
           const wasHidden = w.element.hidden
           const actualHidden = hidden || shouldOtherwiseHide || isCollapsed
           w.element.hidden = actualHidden
-          w.element.style.display = actualHidden ? 'none' : 'block'
+          w.element.style.display = actualHidden ? 'none' : ''
           if (actualHidden && !wasHidden) {
             w.options.onHide?.(w as DOMWidget<HTMLElement, object>)
           }
@@ -371,7 +371,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
     const actualHidden = hidden || !isInVisibleNodes || isCollapsed
     const wasHidden = this.element.hidden
     this.element.hidden = actualHidden
-    this.element.style.display = actualHidden ? 'none' : 'block'
+    this.element.style.display = actualHidden ? 'none' : ''
 
     if (actualHidden && !wasHidden) {
       this.options.onHide?.(this)


### PR DESCRIPTION
Prefer empty string to forcing CSS style.  Can be used in place of `null`/`undefined` to resolve TypeScript lib no longer allowing null value.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2501-Fix-element-style-override-CSS-in-2499-1966d73d3650815e82b3f073018f723d) by [Unito](https://www.unito.io)
