### PR TITLE
Add support for image_folder field in node image input spec

### DIFF
--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -1,4 +1,4 @@
-import { ComfyNodeDef } from '@/types/apiTypes'
+import { ComfyNodeDef, InputSpec } from '@/types/apiTypes'
 
 import { app } from '../../scripts/app'
 
@@ -7,8 +7,16 @@ import { app } from '../../scripts/app'
 app.registerExtension({
   name: 'Comfy.UploadImage',
   beforeRegisterNodeDef(nodeType, nodeData: ComfyNodeDef) {
-    if (nodeData?.input?.required?.image?.[1]?.image_upload === true) {
-      nodeData.input.required.upload = ['IMAGEUPLOAD']
+    // Check if there is a required input named 'image' in the nodeData
+    const imageInputSpec: InputSpec | undefined =
+      nodeData?.input?.required?.image
+
+    // Get the config from the image input spec if it exists
+    const config = imageInputSpec?.[1] ?? {}
+    const { image_upload = false, image_folder = 'input' } = config
+
+    if (image_upload && nodeData.input?.required) {
+      nodeData.input.required.upload = ['IMAGEUPLOAD', { image_folder }]
     }
   }
 })

--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -15,7 +15,7 @@ app.registerExtension({
     const config = imageInputSpec?.[1] ?? {}
     const { image_upload = false, image_folder = 'input' } = config
 
-    if (image_upload && nodeData.input?.required) {
+    if (image_upload && nodeData?.input?.required) {
       nodeData.input.required.upload = ['IMAGEUPLOAD', { image_folder }]
     }
   }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -522,6 +522,7 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
       (w) => w.name === (inputData[1]?.widget ?? 'image')
     ) as IStringWidget
     let uploadWidget
+    const { image_folder = 'input' } = inputData[1] ?? {}
 
     function showImage(name) {
       const img = new Image()
@@ -536,7 +537,7 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
         name = name.substring(folder_separator + 1)
       }
       img.src = api.apiURL(
-        `/view?filename=${encodeURIComponent(name)}&type=input&subfolder=${subfolder}${app.getPreviewFormatParam()}${app.getRandParam()}`
+        `/view?filename=${encodeURIComponent(name)}&type=${image_folder}&subfolder=${subfolder}${app.getPreviewFormatParam()}${app.getRandParam()}`
       )
       node.setSizeForImage?.()
     }

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -339,6 +339,7 @@ const zStringInputSpec = inputSpec([
 const zComboInputProps = zBaseInputSpecValue.extend({
   control_after_generate: z.boolean().optional(),
   image_upload: z.boolean().optional(),
+  image_folder: z.string().optional(),
   remote: zRemoteWidgetConfig.optional()
 })
 

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -339,7 +339,7 @@ const zStringInputSpec = inputSpec([
 const zComboInputProps = zBaseInputSpecValue.extend({
   control_after_generate: z.boolean().optional(),
   image_upload: z.boolean().optional(),
-  image_folder: z.string().optional(),
+  image_folder: z.enum(['input', 'output', 'temp']).optional(),
   remote: zRemoteWidgetConfig.optional()
 })
 


### PR DESCRIPTION
This PR adds support for node inputs with `image_upload` inputs to specify the folder to use when requesting the image preview in the automatically added image preview.

The field corresponds with the [`/view`](https://github.com/comfyanonymous/ComfyUI/blob/4027466c802d174d76347726d74de73c39acedb3/server.py#L401-L402) route's `type` query param (folder type). [Supported types](https://github.com/comfyanonymous/ComfyUI/blob/4027466c802d174d76347726d74de73c39acedb3/folder_paths.py#L134-L141) are 'input', 'output', and 'temp'.

When the field is not set, it will default to 'input', maintaining the current behavior.

#### Example Usage:

```python
class LoadImageOutputRefresh(LoadImage):
    @classmethod
    def INPUT_TYPES(s):
        output_dir = folder_paths.get_output_directory()
        files = [f for f in os.listdir(output_dir) if os.path.isfile(os.path.join(output_dir, f))]
        return {"required":
                    {"image": (files, {
                        "image_upload": True,
                        "image_folder": "output",
                    })},
                }

    RETURN_TYPES = ("IMAGE", "MASK")
    FUNCTION = "load_image_output"

    def load_image_output(self, image):
        return self.load_image(f"{image} [output]")
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2509-Add-support-for-image_folder-field-in-node-image-input-spec-1976d73d3650814cbaa6cc42291a4aca) by [Unito](https://www.unito.io)
