### PR TITLE
Increase width of actionbar drag handle

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -239,4 +239,8 @@ watch([isDragging, isOverlappingWithTopMenu], ([dragging, overlapping]) => {
 :deep(.p-panel-header) {
   display: none;
 }
+
+.drag-handle {
+  @apply w-3 h-max;
+}
 </style>


### PR DESCRIPTION
Currently, the action bar's drag handle can be hard to click. This PR Changes the width from `10px` to `0.75rem` (`w-3`) and increases height by 1 pixel. Style props cannot be inlined because of the psuedo element.

Before / After (Large browser font size):

![drag-handle](https://github.com/user-attachments/assets/e45308ac-5263-49de-9349-4e7bd6f18c46)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2511-Increase-width-of-actionbar-drag-handle-1976d73d365081efbc21dde715d37331) by [Unito](https://www.unito.io)
