### PR TITLE
Fix actionbar has drag preview

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -4,7 +4,7 @@
     :style="style"
     :class="{ 'is-dragging': isDragging, 'is-docked': isDocked }"
   >
-    <div class="actionbar-content flex items-center" ref="panelRef">
+    <div class="actionbar-content flex items-center select-none" ref="panelRef">
       <span class="drag-handle cursor-move mr-2 p-0!" ref="dragHandleRef">
       </span>
       <ComfyQueueButton />


### PR DESCRIPTION
Fixes #2484. `select-none` prevent text selection interfering with drag operations. The text in the batch count input can still be selected.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2512-Fix-actionbar-has-drag-preview-1976d73d365081d9b712cbd5699d71d6) by [Unito](https://www.unito.io)
