### PR TITLE
Improve settings dialog accessibility

### DIFF
--- a/src/components/common/FormItem.vue
+++ b/src/components/common/FormItem.vue
@@ -2,7 +2,11 @@
 <template>
   <div class="flex flex-row items-center gap-2">
     <div class="form-label flex flex-grow items-center">
-      <span class="text-muted" :class="props.labelClass">
+      <span
+        class="text-muted"
+        :class="props.labelClass"
+        :id="`${props.id}-label`"
+      >
         <slot name="name-prefix"></slot>
         {{ props.item.name }}
         <i
@@ -17,6 +21,7 @@
       <component
         :is="markRaw(getFormComponent(props.item))"
         :id="props.id"
+        :aria-labelledby="`${props.id}-label`"
         v-model:modelValue="formValue"
         v-bind="getFormAttrs(props.item)"
       />


### PR DESCRIPTION
Sets `aria-labelledby` on settings fields in order to link the settings inputs with their associated names and badges in accessibility contexts. The `FormItem` component lacks label tags which would allow this to happen automatically.

Before / After:

![Selection_881](https://github.com/user-attachments/assets/6013982a-a12e-4bb8-9aae-b216d8265c6e)


![Selection_878](https://github.com/user-attachments/assets/a9d37794-9c2c-4b4b-b8c7-524c4005ea9a)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2513-Improve-settings-dialog-accessibility-1976d73d365081df8437fcbb436f68f9) by [Unito](https://www.unito.io)
