### PR TITLE
[Type] Mark app as required arg for ComfyWidgetConstructor

### DIFF
--- a/src/composables/widgets/useImageUploadWidget.ts
+++ b/src/composables/widgets/useImageUploadWidget.ts
@@ -2,12 +2,13 @@ import type { LGraphNode } from '@comfyorg/litegraph'
 import type { IStringWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import { api } from '@/scripts/api'
+import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import { useToastStore } from '@/stores/toastStore'
 import type { ComfyApp } from '@/types'
 import type { InputSpec } from '@/types/apiTypes'
 
 export const useImageUploadWidget = () => {
-  const widgetConstructor = (
+  const widgetConstructor: ComfyWidgetConstructor = (
     node: LGraphNode,
     inputName: string,
     inputData: InputSpec,

--- a/src/composables/widgets/useIntWidget.ts
+++ b/src/composables/widgets/useIntWidget.ts
@@ -15,7 +15,7 @@ export const useIntWidget = () => {
     node: LGraphNode,
     inputName: string,
     inputData: InputSpec,
-    app?: ComfyApp,
+    app: ComfyApp,
     widgetName?: string
   ) => {
     const settingStore = useSettingStore()

--- a/src/composables/widgets/useMarkdownWidget.ts
+++ b/src/composables/widgets/useMarkdownWidget.ts
@@ -8,6 +8,7 @@ import TiptapTableRow from '@tiptap/extension-table-row'
 import TiptapStarterKit from '@tiptap/starter-kit'
 import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
 
+import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import type { ComfyApp } from '@/types'
 import type { InputSpec } from '@/types/apiTypes'
 
@@ -101,13 +102,13 @@ function addMarkdownWidget(
 }
 
 export const useMarkdownWidget = () => {
-  const widgetConstructor = (
+  const widgetConstructor: ComfyWidgetConstructor = (
     node: LGraphNode,
     inputName: string,
     inputData: InputSpec,
     app: ComfyApp
   ) => {
-    const defaultVal = inputData[1].default || ''
+    const defaultVal = inputData[1]?.default || ''
     return addMarkdownWidget(
       node,
       inputName,

--- a/src/composables/widgets/useSeedWidget.ts
+++ b/src/composables/widgets/useSeedWidget.ts
@@ -13,7 +13,7 @@ export const useSeedWidget = () => {
     node: LGraphNode,
     inputName: string,
     inputData: InputSpec,
-    app?: ComfyApp,
+    app: ComfyApp,
     widgetName?: string
   ) => {
     inputData[1] = {

--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -1,5 +1,6 @@
 import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
 
+import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import { useSettingStore } from '@/stores/settingStore'
 import type { ComfyApp } from '@/types'
 import type { InputSpec } from '@/types/apiTypes'
@@ -57,14 +58,14 @@ function addMultilineWidget(
 }
 
 export const useStringWidget = () => {
-  const widgetConstructor = (
+  const widgetConstructor: ComfyWidgetConstructor = (
     node: LGraphNode,
     inputName: string,
     inputData: InputSpec,
     app: ComfyApp
   ) => {
-    const defaultVal = inputData[1].default || ''
-    const multiline = !!inputData[1].multiline
+    const defaultVal = inputData[1]?.default || ''
+    const multiline = !!inputData[1]?.multiline
 
     let res: { widget: IWidget }
     if (multiline) {

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -20,7 +20,7 @@ export type ComfyWidgetConstructor = (
   node: LGraphNode,
   inputName: string,
   inputData: InputSpec,
-  app?: ComfyApp,
+  app: ComfyApp,
   widgetName?: string
 ) => { widget: IWidget; minWidth?: number; minHeight?: number }
 


### PR DESCRIPTION
Based on usage, the `app` arg should be required instead of optional. Several existing widgets depends on app being present and the call sites are indeed always passing the app instance as param.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2518-Type-Mark-app-as-required-arg-for-ComfyWidgetConstructor-1976d73d3650811aaa42c9c605bb5844) by [Unito](https://www.unito.io)
