### PR TITLE
[Cleanup] Remove unnecessary pointer-event-auto

### DIFF
--- a/src/components/MenuHamburger.vue
+++ b/src/components/MenuHamburger.vue
@@ -57,6 +57,6 @@ const positionCSS = computed<CSSProperties>(() =>
 
 <style scoped>
 .comfy-menu-hamburger {
-  @apply pointer-events-auto fixed z-[9999] flex flex-row;
+  @apply fixed z-[9999] flex flex-row;
 }
 </style>

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <ButtonGroup
-    class="p-buttongroup-vertical absolute bottom-[10px] right-[10px] z-[1000] pointer-events-auto"
+    class="p-buttongroup-vertical absolute bottom-[10px] right-[10px] z-[1000]"
   >
     <Button
       severity="secondary"

--- a/src/components/load3d/Load3DAnimationControls.vue
+++ b/src/components/load3d/Load3DAnimationControls.vue
@@ -20,7 +20,7 @@
 
     <div
       v-if="animations && animations.length > 0"
-      class="absolute top-0 left-0 w-full flex justify-center pt-2 gap-2 items-center pointer-events-auto z-10"
+      class="absolute top-0 left-0 w-full flex justify-center pt-2 gap-2 items-center z-10"
     >
       <Button class="p-button-rounded p-button-text" @click="togglePlay">
         <i

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="absolute top-2 left-2 flex flex-col gap-2 pointer-events-auto z-20"
-  >
+  <div class="absolute top-2 left-2 flex flex-col gap-2 z-20">
     <Button class="p-button-rounded p-button-text" @click="toggleCamera">
       <i class="pi pi-camera text-white text-lg"></i>
     </Button>

--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="comfy-vue-node-search-container flex justify-center items-center w-full min-w-96 pointer-events-auto"
+    class="comfy-vue-node-search-container flex justify-center items-center w-full min-w-96"
   >
     <div
       class="comfy-vue-node-preview-container absolute left-[-350px] top-[50px]"

--- a/src/components/topbar/SecondRowWorkflowTabs.vue
+++ b/src/components/topbar/SecondRowWorkflowTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute top-0 left-0 w-auto max-w-full pointer-events-auto">
+  <div class="absolute top-0 left-0 w-auto max-w-full">
     <WorkflowTabs />
   </div>
 </template>

--- a/src/views/MaintenanceView.vue
+++ b/src/views/MaintenanceView.vue
@@ -1,7 +1,7 @@
 <template>
   <BaseViewTemplate dark>
     <div
-      class="min-w-full min-h-full font-sans w-screen h-screen grid justify-around text-neutral-300 bg-neutral-900 dark-theme pointer-events-auto overflow-y-auto"
+      class="min-w-full min-h-full font-sans w-screen h-screen grid justify-around text-neutral-300 bg-neutral-900 dark-theme overflow-y-auto"
     >
       <div class="max-w-screen-sm w-screen m-8 relative">
         <!-- Header -->

--- a/src/views/templates/BaseViewTemplate.vue
+++ b/src/views/templates/BaseViewTemplate.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="font-sans w-screen h-screen flex flex-col pointer-events-auto"
+    class="font-sans w-screen h-screen flex flex-col"
     :class="[
       props.dark
         ? 'text-neutral-300 bg-neutral-900 dark-theme'


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2522

Now since the pointer-events for the whole vue app by default auto, all explicit pointer-event-auto can be removed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2523-Cleanup-Remove-unnecessary-pointer-event-auto-1986d73d365081e39892f4db84caf124) by [Unito](https://www.unito.io)
