### PR TITLE
Move install directory selection tooltip to not block buttons

### DIFF
--- a/src/components/install/InstallLocationPicker.vue
+++ b/src/components/install/InstallLocationPicker.vue
@@ -20,7 +20,7 @@
           />
           <InputIcon
             class="pi pi-info-circle"
-            v-tooltip="$t('install.installLocationTooltip')"
+            v-tooltip.top="$t('install.installLocationTooltip')"
           />
         </IconField>
         <Button icon="pi pi-folder" @click="browsePath" class="w-12" />


### PR DESCRIPTION
Moves the tooltip on the installation location to top, as the auto direction places it on the right which blocks interactable buttons.

![Selection_885](https://github.com/user-attachments/assets/fa5aea3a-a272-4a69-8624-36235f52b03b)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2527-Move-install-directory-selection-tooltip-to-not-block-buttons-1986d73d365081f28f82c16170a37832) by [Unito](https://www.unito.io)
