### PR TITLE
[Desktop] Re-run path validation when re-focusing installation location input

### DIFF
--- a/src/components/install/InstallLocationPicker.vue
+++ b/src/components/install/InstallLocationPicker.vue
@@ -17,6 +17,7 @@
             class="w-full"
             :class="{ 'p-invalid': pathError }"
             @update:modelValue="validatePath"
+            @focus="onFocus"
           />
           <InputIcon
             class="pi pi-info-circle"
@@ -81,6 +82,7 @@ const pathError = defineModel<string>('pathError', { required: true })
 const pathExists = ref(false)
 const appData = ref('')
 const appPath = ref('')
+const inputTouched = ref(false)
 
 const electron = electronAPI()
 
@@ -131,5 +133,14 @@ const browsePath = async () => {
   } catch (error) {
     pathError.value = t('install.failedToSelectDirectory')
   }
+}
+
+const onFocus = () => {
+  if (!inputTouched.value) {
+    inputTouched.value = true
+    return
+  }
+  // Refresh validation on re-focus
+  validatePath(installPath.value)
 }
 </script>


### PR DESCRIPTION
Adds focus handler to installation location input that re-runs validator, ignoring the first focus. This creates a smoother experience if user has to alt-tab to change something in directory explorer to fix validation issue:


https://github.com/user-attachments/assets/9977202f-6aae-4ab6-a548-e021664d2743

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2528-Desktop-Re-run-path-validation-when-re-focusing-installation-location-input-1986d73d365081a7b0aac5800c6790da) by [Unito](https://www.unito.io)
