### PR TITLE
Update litegraph 0.8.77

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.16",
-        "@comfyorg/litegraph": "^0.8.76",
+        "@comfyorg/litegraph": "^0.8.77",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.76",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.76.tgz",
-      "integrity": "sha512-trYJ9mw7rTjS2Aq/cqUgbIiNC3urx4aELpfFTbuS/NuTKP4SMeReGabSTTyTUOctwdz7uEPuFmkTTBqf5pBT3g==",
+      "version": "0.8.77",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.77.tgz",
+      "integrity": "sha512-PMMJBishdaB/Nz3wYV/iC0qO8lqzoG5r+Zky/hCFt2LLCrRhktn+HciT4Kimk6ekldWiridNY165sazQLKQWGQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.16",
-    "@comfyorg/litegraph": "^0.8.76",
+    "@comfyorg/litegraph": "^0.8.77",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/scripts/update-litegraph.js
+++ b/scripts/update-litegraph.js
@@ -26,8 +26,7 @@ try {
 
   // Create the PR
   console.log('Creating PR...')
-  const prBody = `Automated update of litegraph to version ${newVersion}.
-Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v${newVersion}`
+  const prBody = `Automated update of litegraph to version ${newVersion}. Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v${newVersion}`
   execSync(
     `gh pr create --title "Update litegraph ${newVersion}" --label "dependencies" --body "${prBody}"`,
     { stdio: 'inherit' }


### PR DESCRIPTION
Automated update of litegraph to version 0.8.77.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2530-Update-litegraph-0-8-77-1986d73d365081d3bb10e333aa3528fb) by [Unito](https://www.unito.io)
