### PR TITLE
Type Widget.computedHeight

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -31,7 +31,6 @@ export interface DOMWidget<T extends HTMLElement, V extends object | string>
   // All unrecognized types will be treated the same way as 'custom' in litegraph internally.
   type: 'custom'
   name: string
-  computedHeight?: number
   element: T
   options: DOMWidgetOptions<T, V>
   value: V

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -260,9 +260,7 @@ function computeSize(this: LGraphNode, size: Size): void {
   // Position each of the widgets
   for (const w of this.widgets) {
     w.y = y
-    // @ts-expect-error custom widget type
     if (w.computedHeight) {
-      // @ts-expect-error custom widget type
       y += w.computedHeight
     } else if (w.computeSize) {
       y += w.computeSize()[1] + 4

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -371,9 +371,7 @@ export const useLitegraphService = () => {
         shiftY = w.last_y
         if (w.computeSize) {
           shiftY += w.computeSize()[1] + 4
-          // @ts-expect-error computedHeight only exists for DOMWidget
         } else if (w.computedHeight) {
-          // @ts-expect-error computedHeight only exists for DOMWidget
           shiftY += w.computedHeight
         } else {
           shiftY += LiteGraph.NODE_WIDGET_HEIGHT + 4

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -24,6 +24,12 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
      * See extensions/core/dynamicPrompts.ts
      */
     dynamicPrompts?: boolean
+
+    /**
+     * The computed height of the widget. Used by customized node resize logic.
+     * See scripts/domWidget.ts for more details.
+     */
+    computedHeight?: number
   }
 }
 


### PR DESCRIPTION
`Widget.computedHeight` is used by general widget instead of DOMWidget only. It is used in over 10 custom nodes: https://cs.comfy.org/search?q=context%3Aglobal+computedHeight&patternType=keyword&sm=0&filters=%5B%5B%22lang%22%2C%22JavaScript%22%2C%22lang%3Ajavascript%22%5D%5D

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2539-Type-Widget-computedHeight-1986d73d3650810ebd70c6698eb6a646) by [Unito](https://www.unito.io)
