### PR TITLE
[Cleanup] Remove unused hooks on DOMWidget

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -67,8 +67,6 @@ export interface DOMWidgetOptions<
   getMaxHeight?: () => number
   getHeight?: () => string | number
   onDraw?: (widget: DOMWidget<T, V>) => void
-  beforeResize?: (this: DOMWidget<T, V>, node: LGraphNode) => void
-  afterResize?: (this: DOMWidget<T, V>, node: LGraphNode) => void
 }
 
 function intersect(a: Rect, b: Rect): Vector4 | null {
@@ -490,10 +488,8 @@ LGraphNode.prototype.addDOMWidget = function <
     this[SIZE] = true
     const onResize = this.onResize
     this.onResize = function (size: Size) {
-      options.beforeResize?.call(widget, this)
       computeSize.call(this, size)
       onResize?.call(this, size)
-      options.afterResize?.call(widget, this)
     }
   }
 


### PR DESCRIPTION
`beforeResize` and `afterResize` are unused by custom nodes verified by code search.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2540-Cleanup-Remove-unused-hooks-on-DOMWidget-1996d73d3650814a8c07ff0df339dbeb) by [Unito](https://www.unito.io)
