### PR TITLE
dont merge, test for tooltip

### DIFF
--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -53,6 +53,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
           :style="{
             color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR
           }"
+          v-tooltip="'test for tooltip'"
         >
           {{ widgetInput.name }}
         </div>

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -82,6 +82,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 
 <script setup lang="ts">
 import _ from 'lodash'
+import { Tooltip } from 'primevue'
 import { computed } from 'vue'
 
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -126,6 +127,8 @@ const truncateDefaultValue = (value: any, charLimit: number = 32): string => {
 
   return _.truncate(stringValue, { length: charLimit })
 }
+
+const vTooltip = Tooltip
 </script>
 
 <style scoped>


### PR DESCRIPTION
@huchenlei I created this PR for testing, while I try to refactor code by your suggestion to use vnode = h() and render(vnode, container),
As my test, using this way, in the vue component it could not use v-tooltip even though we already define it in main.ts
I tried several solutions (Withdirectives, resolveDirectives ) , but none could work it out, I migh be wrong. So may you help this issue?
in this testing code, I just added one v-tooltip="'test for tooltip'", and on UI, calling it, then then in the broswer console, got [Vue warn]: Failed to resolve directive: tooltip 
![image](https://github.com/user-attachments/assets/b514c67b-6022-405d-9f34-32e94834f876)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2544-dont-merge-test-for-tooltip-1996d73d36508174b876d489f3b1db52) by [Unito](https://www.unito.io)
