### PR TITLE
[Refactor] Generalize dom widget layout as Widget.computeLayoutSize hook

### DIFF
--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -30,6 +30,19 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
      * See scripts/domWidget.ts for more details.
      */
     computedHeight?: number
+
+    /**
+     * Compute the layout size of the widget. Overrides {@link IBaseWidget.computeSize}.
+     */
+    computeLayoutSize?: (
+      this: IBaseWidget,
+      node: LGraphNode
+    ) => {
+      minHeight: number
+      maxHeight?: number
+      minWidth: number
+      maxWidth?: number
+    }
   }
 }
 


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2547-Refactor-Generalize-dom-widget-layout-as-Widget-computeLayoutSize-hook-1996d73d3650814692c8fc8ff61e8049) by [Unito](https://www.unito.io)
