### PR TITLE
[keybinding-panel] Include label in filter fields for multilingual search

### DIFF
--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -10,7 +10,7 @@
     <DataTable
       :value="commandsData"
       v-model:selection="selectedCommandData"
-      :global-filter-fields="['id']"
+      :global-filter-fields="['id', 'label']"
       :filters="filters"
       selectionMode="single"
       stripedRows


### PR DESCRIPTION
I've updated the keybinding-panel code to include the label field in the DataTable's global filter fields. Previously, only id was being searched, which prevented searches from matching translated text (e.g., in Japanese).

Thank you in advance for your review.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2549-keybinding-panel-Include-label-in-filter-fields-for-multilingual-search-1996d73d36508160b98fe457d2536762) by [Unito](https://www.unito.io)
