### PR TITLE
Fix remote widget undefined arg

### DIFF
--- a/src/composables/widgets/useComboWidget.ts
+++ b/src/composables/widgets/useComboWidget.ts
@@ -15,7 +15,7 @@ export const useComboWidget = () => {
     inputData: InputSpec
   ) => {
     const widgetStore = useWidgetStore()
-    const { remote, options } = inputData[1]
+    const { remote, options } = inputData[1] || {}
     const defaultValue = widgetStore.getDefaultValue(inputData)
 
     const res = {

--- a/src/stores/widgetStore.ts
+++ b/src/stores/widgetStore.ts
@@ -47,9 +47,11 @@ export const useWidgetStore = defineStore('widget', () => {
     if (Array.isArray(inputData[0]))
       return getDefaultValue(transformComboInput(inputData))
 
-    const widgetType = getWidgetType(inputData[0], inputData[1].name)
+    const widgetType = getWidgetType(inputData[0], inputData[1]?.name)
 
     const [_, props] = inputData
+
+    if (!props) return undefined
     if (props.default) return props.default
 
     if (widgetType === 'COMBO' && props.options?.length) return props.options[0]
@@ -63,7 +65,7 @@ export const useWidgetStore = defineStore('widget', () => {
           'COMBO',
           {
             options: inputData[0],
-            ...Object(inputData[1])
+            ...Object(inputData[1] || {})
           }
         ]
       : inputData

--- a/tests-ui/tests/composables/widgets/useComboWidget.test.ts
+++ b/tests-ui/tests/composables/widgets/useComboWidget.test.ts
@@ -1,0 +1,44 @@
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useComboWidget } from '@/composables/widgets/useComboWidget'
+import type { InputSpec } from '@/types/apiTypes'
+
+jest.mock('@/scripts/widgets', () => ({
+  addValueControlWidgets: jest.fn()
+}))
+
+describe('useComboWidget', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    jest.clearAllMocks() // Clear mock state between tests
+  })
+
+  it('should handle undefined spec', () => {
+    const constructor = useComboWidget()
+    const mockNode = {
+      addWidget: jest.fn().mockReturnValue({ options: {} } as any)
+    }
+
+    const inputSpec: InputSpec = ['INT', undefined]
+
+    const widget = constructor(
+      mockNode as any,
+      'inputName',
+      inputSpec,
+      undefined as any
+    )
+
+    expect(mockNode.addWidget).toHaveBeenCalledWith(
+      'combo',
+      'inputName',
+      undefined, // default value
+      expect.any(Function), // callback
+      expect.objectContaining({
+        values: 'INT'
+      })
+    )
+    expect(widget).toEqual({
+      widget: { options: {} }
+    })
+  })
+})

--- a/tests-ui/tests/composables/widgets/useComboWidget.test.ts
+++ b/tests-ui/tests/composables/widgets/useComboWidget.test.ts
@@ -10,7 +10,7 @@ jest.mock('@/scripts/widgets', () => ({
 describe('useComboWidget', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    jest.clearAllMocks() // Clear mock state between tests
+    jest.clearAllMocks()
   })
 
   it('should handle undefined spec', () => {
@@ -19,7 +19,7 @@ describe('useComboWidget', () => {
       addWidget: jest.fn().mockReturnValue({ options: {} } as any)
     }
 
-    const inputSpec: InputSpec = ['INT', undefined]
+    const inputSpec: InputSpec = ['COMBO', undefined]
 
     const widget = constructor(
       mockNode as any,
@@ -34,7 +34,7 @@ describe('useComboWidget', () => {
       undefined, // default value
       expect.any(Function), // callback
       expect.objectContaining({
-        values: 'INT'
+        values: 'COMBO'
       })
     )
     expect(widget).toEqual({


### PR DESCRIPTION
Adds null checking of COMBO widget constructor's `inputData` param, as it is sometimes `undefined` when called by custom nodes.

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/2550.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2551-Fix-remote-widget-undefined-arg-19a6d73d365081b2a326f0e243202f62) by [Unito](https://www.unito.io)
