### PR TITLE
Add null checks to widget constructor options

### DIFF
--- a/src/composables/widgets/useFloatWidget.ts
+++ b/src/composables/widgets/useFloatWidget.ts
@@ -20,7 +20,7 @@ export const useFloatWidget = () => {
     const inputOptions = inputData[1]
 
     const widgetType = sliderEnabled
-      ? inputOptions.display === 'slider'
+      ? inputOptions?.display === 'slider'
         ? 'slider'
         : 'number'
       : 'number'

--- a/src/composables/widgets/useIntWidget.ts
+++ b/src/composables/widgets/useIntWidget.ts
@@ -22,7 +22,7 @@ export const useIntWidget = () => {
     const sliderEnabled = !settingStore.get('Comfy.DisableSliders')
     const inputOptions = inputData[1]
     const widgetType = sliderEnabled
-      ? inputOptions.display === 'slider'
+      ? inputOptions?.display === 'slider'
         ? 'slider'
         : 'number'
       : 'number'

--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -81,7 +81,7 @@ export const useStringWidget = () => {
       }
     }
 
-    if (inputData[1].dynamicPrompts != undefined)
+    if (inputData[1]?.dynamicPrompts != undefined)
       res.widget.dynamicPrompts = inputData[1].dynamicPrompts
 
     return res


### PR DESCRIPTION
Extension of #2551 nullcheck to other widget constructors. The input options objects can be undefined, as the constructors are called by custom nodes. These additional instances were found by changing the type and using strict mode.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2552-Add-null-checks-to-widget-constructor-options-19a6d73d365081768040cd8c08dd0864) by [Unito](https://www.unito.io)
