### PR TITLE
Use LGraphNode.setSize

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -833,10 +833,10 @@ export class GroupNodeHandler {
       groupNode.setInnerNodes(nodes)
       groupNode[GROUP].populateWidgets()
       app.graph.add(groupNode)
-      groupNode.size = [
+      groupNode.setSize([
         Math.max(groupNode.size[0], sz[0]),
         Math.max(groupNode.size[1], sz[1])
-      ]
+      ])
 
       // Remove all converted nodes and relink them
       const builder = new GroupNodeBuilder(nodes)

--- a/src/extensions/core/rerouteNode.ts
+++ b/src/extensions/core/rerouteNode.ts
@@ -155,7 +155,7 @@ app.registerExtension({
             node.outputs[0].name = node.properties.showOutputText
               ? displayType
               : ''
-            node.size = node.computeSize()
+            node.setSize(node.computeSize())
 
             for (const l of node.outputs[0].links || []) {
               const link = app.graph.links[l]
@@ -214,7 +214,7 @@ app.registerExtension({
           const cloned = RerouteNode.prototype.clone.apply(this)
           cloned.removeOutput(0)
           cloned.addOutput(this.properties.showOutputText ? '*' : '', '*')
-          cloned.size = cloned.computeSize()
+          cloned.setSize(cloned.computeSize())
           return cloned
         }
 
@@ -235,7 +235,7 @@ app.registerExtension({
               } else {
                 this.outputs[0].name = ''
               }
-              this.size = this.computeSize()
+              this.setSize(this.computeSize())
               app.graph.setDirtyCanvas(true, true)
             }
           },

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -285,10 +285,10 @@ class PrimitiveNode extends LGraphNode {
     }
 
     // Use the biggest dimensions in case the widgets caused the node to grow
-    this.size = [
+    this.setSize([
       Math.max(this.size[0], oldWidth),
       Math.max(this.size[1], oldHeight)
-    ]
+    ])
 
     if (!recreating) {
       // Grow our node more if required

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1147,7 +1147,7 @@ export class ComfyApp {
       const size = node.computeSize()
       size[0] = Math.max(node.size[0], size[0])
       size[1] = Math.max(node.size[1], size[1])
-      node.size = size
+      node.setSize(size)
       if (node.widgets) {
         // If you break something in the backend and want to patch workflows in the frontend
         // This is the place to do this

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -142,7 +142,7 @@ export const useLitegraphService = () => {
         const s = this.computeSize()
         s[0] = Math.max(config.minWidth, s[0] * 1.5)
         s[1] = Math.max(config.minHeight, s[1])
-        this.size = s
+        this.setSize(s)
         this.serialize_widgets = true
 
         extensionService.invokeExtensionsAsync('nodeCreated', this)


### PR DESCRIPTION
Properly trigger `onResize` hook by calling `LGraphNode.setSize` instead of doing direct assignment to `LGraphNode.size`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2555-Use-LGraphNode-setSize-19a6d73d365081f4b45bdecd6bc131d1) by [Unito](https://www.unito.io)
