### PR TITLE
[Style] Show right arrow on nested submenu item

### DIFF
--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -8,7 +8,7 @@
       item: 'relative'
     }"
   >
-    <template #item="{ item, props }">
+    <template #item="{ item, props, root }">
       <a
         class="p-menubar-item-link"
         v-bind="props.action"
@@ -23,6 +23,7 @@
         >
           {{ item.comfyCommand.keybinding.combo.toString() }}
         </span>
+        <i v-if="!root && item.items" class="ml-auto pi pi-angle-right" />
       </a>
     </template>
   </Menubar>
@@ -64,10 +65,6 @@ const translatedItems = computed(() =>
 </script>
 
 <style scoped>
-.top-menubar :deep(.p-menubar-item-link) svg {
-  display: none;
-}
-
 :deep(.p-menubar-submenu.dropdown-direction-up) {
   @apply top-auto bottom-full flex-col-reverse;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fcade402-a537-45b7-a02b-0a2cdd6bd70e)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2564-Style-Show-right-arrow-on-nested-submenu-item-19b6d73d36508188be41f36947fbf304) by [Unito](https://www.unito.io)
