### PR TITLE
[BugFix] Set height to 0 for hidden widgets on GroupNode

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -195,6 +195,15 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
 
   /** Extract DOM widget size info */
   computeLayoutSize(node: LGraphNode) {
+    // @ts-expect-error custom widget type
+    if (this.type === 'hidden') {
+      return {
+        minHeight: 0,
+        maxHeight: 0,
+        minWidth: 0
+      }
+    }
+
     const styles = getComputedStyle(this.element)
     let minHeight =
       this.options.getMinHeight?.() ??


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2565

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2566-BugFix-Set-height-to-0-for-hidden-widgets-on-GroupNode-19b6d73d365081c4be1ff72556013d36) by [Unito](https://www.unito.io)
