### PR TITLE
Move node field to tags in error report

### DIFF
--- a/src/components/dialog/content/ExecutionErrorDialogContent.vue
+++ b/src/components/dialog/content/ExecutionErrorDialogContent.vue
@@ -31,7 +31,10 @@
       :title="$t('issueReport.submitErrorReport')"
       error-type="graphExecutionError"
       :extra-fields="[stackTraceField]"
-      :tags="{ exceptionMessage: props.error.exception_message }"
+      :tags="{
+        exceptionMessage: props.error.exception_message,
+        nodeType: props.error.node_type
+      }"
     />
     <div class="action-container">
       <FindIssueButton
@@ -90,10 +93,7 @@ const stackTraceField = computed<ReportField>(() => {
     label: t('issueReport.stackTrace'),
     value: 'StackTrace',
     optIn: true,
-    getData: () => ({
-      nodeType: props.error.node_type,
-      stackTrace: props.error.traceback?.join('\n')
-    })
+    getData: () => props.error.traceback?.join('\n')
   }
 })
 

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -788,7 +788,7 @@
       "Flux": {
         "flux_canny_model_example": "Flux Canny Model",
         "flux_depth_lora_example": "Flux Depth Lora",
-        "flux_dev_example": "Flux Dev",
+        "flux_dev_checkpoint_example": "Flux Dev",
         "flux_fill_inpaint_example": "Flux Inpaint",
         "flux_fill_outpaint_example": "Flux Outpaint",
         "flux_redux_model_example": "Flux Redux Model",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -788,7 +788,7 @@
       "Flux": {
         "flux_canny_model_example": "Flux Cannyモデル",
         "flux_depth_lora_example": "Flux Depth Lora",
-        "flux_dev_example": "Flux Dev",
+        "flux_dev_checkpoint_example": "Flux Dev",
         "flux_fill_inpaint_example": "Flux Inpaint",
         "flux_fill_outpaint_example": "Flux Outpaint",
         "flux_redux_model_example": "Flux Reduxモデル",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -788,7 +788,7 @@
       "Flux": {
         "flux_canny_model_example": "Flux Canny 모델",
         "flux_depth_lora_example": "Flux Depth Lora",
-        "flux_dev_example": "Flux 개발",
+        "flux_dev_checkpoint_example": "Flux Dev",
         "flux_fill_inpaint_example": "Flux Inpaint",
         "flux_fill_outpaint_example": "Flux Outpaint",
         "flux_redux_model_example": "Flux Redux 모델",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -788,7 +788,7 @@
       "Flux": {
         "flux_canny_model_example": "Flux Canny Model",
         "flux_depth_lora_example": "Flux Depth Lora",
-        "flux_dev_example": "Flux Dev",
+        "flux_dev_checkpoint_example": "Flux Dev",
         "flux_fill_inpaint_example": "Flux Inpaint",
         "flux_fill_outpaint_example": "Flux Outpaint",
         "flux_redux_model_example": "Flux Redux Model",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -788,7 +788,7 @@
       "Flux": {
         "flux_canny_model_example": "Flux Canny Model",
         "flux_depth_lora_example": "Flux Depth Lora",
-        "flux_dev_example": "Flux Dev",
+        "flux_dev_checkpoint_example": "Flux Dev的检查点示例",
         "flux_fill_inpaint_example": "Flux Inpaint",
         "flux_fill_outpaint_example": "Flux Outpaint",
         "flux_redux_model_example": "Flux Redux Model",


### PR DESCRIPTION
Moves the `nodeType` field (node that triggered the erorr) to tags section of report (from extra data section). Tags can be searched more easily, allowing analysis of which custom node issues are correlated with which environment features.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2570-Move-node-field-to-tags-in-error-report-19c6d73d36508136839ee1f4b548954c) by [Unito](https://www.unito.io)
