### PR TITLE
Replace "clip" with "text_encoders" in template workflows

### DIFF
--- a/browser_tests/assets/missing_models.json
+++ b/browser_tests/assets/missing_models.json
@@ -18,7 +18,7 @@
     {
       "name": "fake_model.safetensors",
       "url": "http://localhost:8188/api/devtools/fake_model.safetensors",
-      "directory": "clip"
+      "directory": "text_encoders"
     }
   ],
   "version": 0.4

--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -85,8 +85,8 @@ test.describe('Missing models warning', () => {
       status: 200,
       body: JSON.stringify([
         {
-          name: 'clip',
-          folders: ['ComfyUI/models/clip']
+          name: 'text_encoders',
+          folders: ['ComfyUI/models/text_encoders']
         }
       ])
     }
@@ -109,7 +109,7 @@ test.describe('Missing models warning', () => {
       ])
     }
     comfyPage.page.route(
-      '**/api/experiment/models/clip',
+      '**/api/experiment/models/text_encoders',
       (route) => route.fulfill(clipModelsRes),
       { times: 1 }
     )

--- a/public/templates/flux_canny_model_example.json
+++ b/public/templates/flux_canny_model_example.json
@@ -453,7 +453,7 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "flux1-canny-dev-lora.safetensors",
@@ -478,7 +478,7 @@
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     }
   ]
 }

--- a/public/templates/flux_depth_lora_example.json
+++ b/public/templates/flux_depth_lora_example.json
@@ -428,7 +428,7 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "flux1-dev-fp8.safetensors",
@@ -448,7 +448,7 @@
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "flux1-depth-dev-lora.safetensors",

--- a/public/templates/flux_dev_example.json
+++ b/public/templates/flux_dev_example.json
@@ -750,12 +750,12 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "ae.safetensors",

--- a/public/templates/flux_fill_inpaint_example.json
+++ b/public/templates/flux_fill_inpaint_example.json
@@ -437,12 +437,12 @@
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "flux1-fill-dev.safetensors",

--- a/public/templates/flux_fill_outpaint_example.json
+++ b/public/templates/flux_fill_outpaint_example.json
@@ -470,12 +470,12 @@
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "flux1-fill-dev.safetensors",

--- a/public/templates/flux_redux_model_example.json
+++ b/public/templates/flux_redux_model_example.json
@@ -920,7 +920,7 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "flux1-dev-fp8.safetensors",
@@ -950,7 +950,7 @@
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     }
   ]
 }

--- a/public/templates/hunyuan_video_text_to_video.json
+++ b/public/templates/hunyuan_video_text_to_video.json
@@ -542,7 +542,7 @@
     {
       "name": "clip_l.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "hunyuan_video_t2v_720p_bf16.safetensors",

--- a/public/templates/ltxv_image_to_video.json
+++ b/public/templates/ltxv_image_to_video.json
@@ -471,7 +471,7 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "ltx-video-2b-v0.9.safetensors",

--- a/public/templates/ltxv_text_to_video.json
+++ b/public/templates/ltxv_text_to_video.json
@@ -408,7 +408,7 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "ltx-video-2b-v0.9.safetensors",

--- a/public/templates/mochi_text_to_video_example.json
+++ b/public/templates/mochi_text_to_video_example.json
@@ -297,7 +297,7 @@
     {
       "name": "t5xxl_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "mochi_preview_bf16.safetensors",

--- a/public/templates/stable_audio_example.json
+++ b/public/templates/stable_audio_example.json
@@ -291,7 +291,7 @@
     {
       "name": "t5_base.safetensors",
       "url": "https://huggingface.co/google-t5/t5-base/resolve/main/model.safetensors",
-      "directory": "clip"
+      "directory": "text_encoders"
     },
     {
       "name": "stable_audio_open_1.0.safetensors",


### PR DESCRIPTION
Per comfyanonymous/ComfyUI@ee8abf0:

> Update folder paths: "clip" -> "text_encoders"
> You can still use models/clip but the folder might get removed eventually
> on new installs of ComfyUI.

Although there is [automatic conversion on backend](https://github.com/comfyanonymous/ComfyUI/blob/93c8607d5157d2e30c4d598b01b32d71e07e9e6a/folder_paths.py#L90-L93), using "clip" in `models` field of workflow data will fail validaton at route handler and result in screen:

![Selection_930](https://github.com/user-attachments/assets/9e2e010c-a0fe-4dee-a0cc-a73fc65f1b5c)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2572-Replace-clip-with-text_encoders-in-template-workflows-19c6d73d3650818495d9d0c9d7414451) by [Unito](https://www.unito.io)
