### PR TITLE
Change title of pose ControlNet template workflow

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -382,7 +382,7 @@
       },
       "ControlNet": {
         "controlnet_example": "ControlNet",
-        "2_pass_pose_worship": "2 Pass Pose Worship",
+        "2_pass_pose_worship": "Pose ControlNet 2 Pass",
         "depth_controlnet": "Depth ControlNet",
         "depth_t2i_adapter": "Depth T2I Adapter",
         "mixing_controlnets": "Mixing ControlNets"


### PR DESCRIPTION
Change the displayed title of template workflow from "2 Pass Pose Worship" to "Pose ControlNet 2 Pass". The "Worship" refererred to the particular pose being used in the example. Since the template doesn't provide that pose file, it no longer makes sense to use in the title and is confusing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2573-Change-title-of-pose-ControlNet-template-workflow-19c6d73d365081babf6fe40a6bdd631e) by [Unito](https://www.unito.io)
