### PR TITLE
Normalize translation keys in template card component

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -67,6 +67,11 @@ const { t } = useI18n()
 
 const imageError = ref(false)
 
+const normalizeName = (name: string) => {
+  // Convert dots to dashes as dots are reserved as path separators (e.g. 'category.key')
+  return name.replace(/\./g, '-')
+}
+
 const thumbnailSrc = computed(() =>
   sourceModule === 'default'
     ? `/templates/${template.name}.${template.mediaSubtype}`
@@ -75,8 +80,7 @@ const thumbnailSrc = computed(() =>
 const title = computed(() => {
   return sourceModule === 'default'
     ? t(
-        `templateWorkflows.template.${categoryTitle}.${template.name}`,
-        template.name
+        `templateWorkflows.template.${normalizeName(categoryTitle)}.${normalizeName(template.name)}`
       )
     : template.name ?? `${sourceModule} Template`
 })

--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -55,6 +55,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { TemplateInfo } from '@/types/workflowTemplateTypes'
+import { normalizeI18nKey } from '@/utils/formatUtil'
 
 const { sourceModule, categoryTitle, loading, template } = defineProps<{
   sourceModule: string
@@ -67,11 +68,6 @@ const { t } = useI18n()
 
 const imageError = ref(false)
 
-const normalizeName = (name: string) => {
-  // Convert dots to dashes as dots are reserved as path separators (e.g. 'category.key')
-  return name.replace(/\./g, '-')
-}
-
 const thumbnailSrc = computed(() =>
   sourceModule === 'default'
     ? `/templates/${template.name}.${template.mediaSubtype}`
@@ -80,7 +76,7 @@ const thumbnailSrc = computed(() =>
 const title = computed(() => {
   return sourceModule === 'default'
     ? t(
-        `templateWorkflows.template.${normalizeName(categoryTitle)}.${normalizeName(template.name)}`
+        `templateWorkflows.template.${normalizeI18nKey(categoryTitle)}.${normalizeI18nKey(template.name)}`
       )
     : template.name ?? `${sourceModule} Template`
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -402,11 +402,11 @@
         "mochi_text_to_video_example": "Mochi Text to Video",
         "hunyuan_video_text_to_video": "Hunyuan Video Text to Video"
       },
-      "SD3.5": {
-        "sd3.5_simple_example": "SD3.5 Simple",
-        "sd3.5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",
-        "sd3.5_large_depth": "SD3.5 Large Depth",
-        "sd3.5_large_blur": "SD3.5 Large Blur"
+      "SD3-5": {
+        "sd3-5_simple_example": "SD3.5 Simple",
+        "sd3-5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",
+        "sd3-5_large_depth": "SD3.5 Large Depth",
+        "sd3-5_large_blur": "SD3.5 Large Blur"
       },
       "SDXL": {
         "sdxl_simple_example": "SDXL Simple",
@@ -415,7 +415,7 @@
         "sdxl_revision_zero_positive": "SDXL Revision Zero Positive",
         "sdxlturbo_example": "SDXL Turbo"
       },
-      "Comfy - Area Composition": {
+      "Area Composition": {
         "area_composition": "Area Composition",
         "area_composition_reversed": "Area Composition Reversed",
         "area_composition_square_area_for_subject": "Area Composition Square Area for Subject"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -402,11 +402,11 @@
         "mochi_text_to_video_example": "Mochi Text to Video",
         "hunyuan_video_text_to_video": "Hunyuan Video Text to Video"
       },
-      "SD3-5": {
-        "sd3-5_simple_example": "SD3.5 Simple",
-        "sd3-5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",
-        "sd3-5_large_depth": "SD3.5 Large Depth",
-        "sd3-5_large_blur": "SD3.5 Large Blur"
+      "SD3_5": {
+        "sd3_5_simple_example": "SD3.5 Simple",
+        "sd3_5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",
+        "sd3_5_large_depth": "SD3.5 Large Depth",
+        "sd3_5_large_blur": "SD3.5 Large Blur"
       },
       "SDXL": {
         "sdxl_simple_example": "SDXL Simple",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux Model",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3-5": {
-        "sd3-5_large_blur": "SD3.5 Grand Flou",
-        "sd3-5_large_canny_controlnet_example": "SD3.5 Grand Canny ControlNet",
-        "sd3-5_large_depth": "SD3.5 Grande Profondeur",
-        "sd3-5_simple_example": "SD3.5 Simple"
+      "SD3_5": {
+        "sd3_5_large_blur": "SD3.5 Grand Flou",
+        "sd3_5_large_canny_controlnet_example": "SD3.5 Grand Canny ControlNet",
+        "sd3_5_large_depth": "SD3.5 Grande Profondeur",
+        "sd3_5_simple_example": "SD3.5 Simple"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner Prompt",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -759,6 +759,11 @@
       "3D": {
         "stable_zero123_example": "Stable Zero123"
       },
+      "Area Composition": {
+        "area_composition": "Composition de Zone",
+        "area_composition_reversed": "Composition de Zone Inversée",
+        "area_composition_square_area_for_subject": "Composition de Zone Carrée pour le Sujet"
+      },
       "Audio": {
         "stable_audio_example": "Stable Audio"
       },
@@ -772,11 +777,6 @@
         "lora": "Lora",
         "lora_multiple": "Lora Multiple",
         "yosemite_outpaint_example": "Yosemite Outpaint"
-      },
-      "Comfy - Area Composition": {
-        "area_composition": "Composition de Zone",
-        "area_composition_reversed": "Composition de Zone Inversée",
-        "area_composition_square_area_for_subject": "Composition de Zone Carrée pour le Sujet"
       },
       "ControlNet": {
         "2_pass_pose_worship": "2 Passes Pose Worship",
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux Model",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3.5": {
-        "sd3.5_large_blur": "SD3.5 Grand Flou",
-        "sd3.5_large_canny_controlnet_example": "SD3.5 Grand Canny ControlNet",
-        "sd3.5_large_depth": "SD3.5 Grande Profondeur",
-        "sd3.5_simple_example": "SD3.5 Simple"
+      "SD3-5": {
+        "sd3-5_large_blur": "SD3.5 Grand Flou",
+        "sd3-5_large_canny_controlnet_example": "SD3.5 Grand Canny ControlNet",
+        "sd3-5_large_depth": "SD3.5 Grande Profondeur",
+        "sd3-5_simple_example": "SD3.5 Simple"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner Prompt",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Reduxモデル",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3-5": {
-        "sd3-5_large_blur": "SD3.5 ラージブラー",
-        "sd3-5_large_canny_controlnet_example": "SD3.5 ラージキャニーコントロールネット",
-        "sd3-5_large_depth": "SD3.5 ラージデプス",
-        "sd3-5_simple_example": "SD3.5 シンプル"
+      "SD3_5": {
+        "sd3_5_large_blur": "SD3.5 ラージブラー",
+        "sd3_5_large_canny_controlnet_example": "SD3.5 ラージキャニーコントロールネット",
+        "sd3_5_large_depth": "SD3.5 ラージデプス",
+        "sd3_5_simple_example": "SD3.5 シンプル"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refinerプロンプト",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -759,6 +759,11 @@
       "3D": {
         "stable_zero123_example": "Stable Zero123"
       },
+      "Area Composition": {
+        "area_composition": "エリア構成",
+        "area_composition_reversed": "エリア構成反転",
+        "area_composition_square_area_for_subject": "主題のためのエリア構成スクエア"
+      },
       "Audio": {
         "stable_audio_example": "Stable Audio"
       },
@@ -772,11 +777,6 @@
         "lora": "Lora",
         "lora_multiple": "Lora複数",
         "yosemite_outpaint_example": "Yosemite Outpaint"
-      },
-      "Comfy - Area Composition": {
-        "area_composition": "エリア構成",
-        "area_composition_reversed": "エリア構成反転",
-        "area_composition_square_area_for_subject": "主題のためのエリア構成スクエアエリア"
       },
       "ControlNet": {
         "2_pass_pose_worship": "2 Pass Pose Worship",
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Reduxモデル",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3.5": {
-        "sd3.5_large_blur": "SD3.5 Large Blur",
-        "sd3.5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",
-        "sd3.5_large_depth": "SD3.5 Large Depth",
-        "sd3.5_simple_example": "SD3.5シンプル"
+      "SD3-5": {
+        "sd3-5_large_blur": "SD3.5 ラージブラー",
+        "sd3-5_large_canny_controlnet_example": "SD3.5 ラージキャニーコントロールネット",
+        "sd3-5_large_depth": "SD3.5 ラージデプス",
+        "sd3-5_simple_example": "SD3.5 シンプル"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refinerプロンプト",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -759,6 +759,11 @@
       "3D": {
         "stable_zero123_example": "Stable Zero123"
       },
+      "Area Composition": {
+        "area_composition": "영역 구성",
+        "area_composition_reversed": "역 영역 구성",
+        "area_composition_square_area_for_subject": "주제를 위한 사각형 영역 구성"
+      },
       "Audio": {
         "stable_audio_example": "Stable Audio"
       },
@@ -772,11 +777,6 @@
         "lora": "Lora",
         "lora_multiple": "Lora 다중",
         "yosemite_outpaint_example": "Yosemite Outpaint"
-      },
-      "Comfy - Area Composition": {
-        "area_composition": "영역 구성",
-        "area_composition_reversed": "영역 구성 반전",
-        "area_composition_square_area_for_subject": "주제에 대한 영역 구성 사각형"
       },
       "ControlNet": {
         "2_pass_pose_worship": "2 패스 포즈 워십",
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux 모델",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3.5": {
-        "sd3.5_large_blur": "SD3.5 큰 Blur",
-        "sd3.5_large_canny_controlnet_example": "SD3.5 큰 Canny ControlNet",
-        "sd3.5_large_depth": "SD3.5 큰 Depth",
-        "sd3.5_simple_example": "SD3.5 간단한 예"
+      "SD3-5": {
+        "sd3-5_large_blur": "SD3.5 큰 흐림",
+        "sd3-5_large_canny_controlnet_example": "SD3.5 큰 캐니 컨트롤넷",
+        "sd3-5_large_depth": "SD3.5 큰 깊이",
+        "sd3-5_simple_example": "SD3.5 간단한 예시"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner 프롬프트",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux 모델",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3-5": {
-        "sd3-5_large_blur": "SD3.5 큰 흐림",
-        "sd3-5_large_canny_controlnet_example": "SD3.5 큰 캐니 컨트롤넷",
-        "sd3-5_large_depth": "SD3.5 큰 깊이",
-        "sd3-5_simple_example": "SD3.5 간단한 예시"
+      "SD3_5": {
+        "sd3_5_large_blur": "SD3.5 큰 흐림",
+        "sd3_5_large_canny_controlnet_example": "SD3.5 큰 캐니 컨트롤넷",
+        "sd3_5_large_depth": "SD3.5 큰 깊이",
+        "sd3_5_simple_example": "SD3.5 간단한 예시"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner 프롬프트",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux Model",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3-5": {
-        "sd3-5_large_blur": "SD3.5 Большое размытие",
-        "sd3-5_large_canny_controlnet_example": "SD3.5 Большой Canny ControlNet",
-        "sd3-5_large_depth": "SD3.5 Большая глубина",
-        "sd3-5_simple_example": "SD3.5 Простой"
+      "SD3_5": {
+        "sd3_5_large_blur": "SD3.5 Большое размытие",
+        "sd3_5_large_canny_controlnet_example": "SD3.5 Большой Canny ControlNet",
+        "sd3_5_large_depth": "SD3.5 Большая глубина",
+        "sd3_5_simple_example": "SD3.5 Простой"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner Prompt",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -759,6 +759,11 @@
       "3D": {
         "stable_zero123_example": "Stable Zero123"
       },
+      "Area Composition": {
+        "area_composition": "Композиция области",
+        "area_composition_reversed": "Обратная композиция области",
+        "area_composition_square_area_for_subject": "Композиция области квадратной области для субъекта"
+      },
       "Audio": {
         "stable_audio_example": "Stable Audio"
       },
@@ -772,11 +777,6 @@
         "lora": "Lora",
         "lora_multiple": "Lora Multiple",
         "yosemite_outpaint_example": "Yosemite Outpaint"
-      },
-      "Comfy - Area Composition": {
-        "area_composition": "Композиция области",
-        "area_composition_reversed": "Обратная композиция области",
-        "area_composition_square_area_for_subject": "Композиция области квадратной области для субъекта"
       },
       "ControlNet": {
         "2_pass_pose_worship": "2 Pass Pose Worship",
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux Model",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3.5": {
-        "sd3.5_large_blur": "SD3.5 Large Blur",
-        "sd3.5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",
-        "sd3.5_large_depth": "SD3.5 Large Depth",
-        "sd3.5_simple_example": "SD3.5 Simple"
+      "SD3-5": {
+        "sd3-5_large_blur": "SD3.5 Большое размытие",
+        "sd3-5_large_canny_controlnet_example": "SD3.5 Большой Canny ControlNet",
+        "sd3-5_large_depth": "SD3.5 Большая глубина",
+        "sd3-5_simple_example": "SD3.5 Простой"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner Prompt",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -759,6 +759,11 @@
       "3D": {
         "stable_zero123_example": "稳定Zero123"
       },
+      "Area Composition": {
+        "area_composition": "区域构成",
+        "area_composition_reversed": "反向区域构成",
+        "area_composition_square_area_for_subject": "主题的方形区域构成"
+      },
       "Audio": {
         "stable_audio_example": "稳定音频"
       },
@@ -772,11 +777,6 @@
         "lora": "Lora",
         "lora_multiple": "Lora多个",
         "yosemite_outpaint_example": "优胜美地Outpaint"
-      },
-      "Comfy - Area Composition": {
-        "area_composition": "区域构成",
-        "area_composition_reversed": "区域构成反转",
-        "area_composition_square_area_for_subject": "主题的区域构成方形区域"
       },
       "ControlNet": {
         "2_pass_pose_worship": "2通道姿势崇拜",
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux Model",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3.5": {
-        "sd3.5_large_blur": "SD3.5大模糊",
-        "sd3.5_large_canny_controlnet_example": "SD3.5大型Canny ControlNet",
-        "sd3.5_large_depth": "SD3.5大深度",
-        "sd3.5_simple_example": "SD3.5简单"
+      "SD3-5": {
+        "sd3-5_large_blur": "SD3.5 大型模糊",
+        "sd3-5_large_canny_controlnet_example": "SD3.5 大型 Canny 控制网",
+        "sd3-5_large_depth": "SD3.5 大型深度",
+        "sd3-5_simple_example": "SD3.5 简单"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner提示",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -794,11 +794,11 @@
         "flux_redux_model_example": "Flux Redux Model",
         "flux_schnell": "Flux Schnell"
       },
-      "SD3-5": {
-        "sd3-5_large_blur": "SD3.5 大型模糊",
-        "sd3-5_large_canny_controlnet_example": "SD3.5 大型 Canny 控制网",
-        "sd3-5_large_depth": "SD3.5 大型深度",
-        "sd3-5_simple_example": "SD3.5 简单"
+      "SD3_5": {
+        "sd3_5_large_blur": "SD3.5 Large 模糊",
+        "sd3_5_large_canny_controlnet_example": "SD3.5 Large Canny 控制网",
+        "sd3_5_large_depth": "SD3.5 Large 深度",
+        "sd3_5_simple_example": "SD3.5 简易示例"
       },
       "SDXL": {
         "sdxl_refiner_prompt_example": "SDXL Refiner提示",


### PR DESCRIPTION
Converts dots to dashes in template card component translation keys. Dots are reserved as path separators (e.g. 'category.key'). 

Also fixes misnamed key in area composition category.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2574-Normalize-translation-keys-in-template-card-component-19c6d73d3650810d9048d2fd3062efa7) by [Unito](https://www.unito.io)
