### PR TITLE
Remove interchangeable models from template workflows

### DIFF
--- a/public/templates/2_pass_pose_worship.json
+++ b/public/templates/2_pass_pose_worship.json
@@ -668,21 +668,6 @@
       "name": "control_v11p_sd15_openpose_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_openpose_fp16.safetensors",
       "directory": "controlnet"
-    },
-    {
-      "name": "Anything-V3.0.ckpt",
-      "url": "https://huggingface.co/xiaolxl/Stable-diffusion-models/resolve/main/Anything-V3.0.ckpt?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "AOM3A3.safetensors",
-      "url": "https://huggingface.co/WarriorMama777/OrangeMixs/resolve/eb7490173381625e0403dd52b8051cb969093dc1/Models/AbyssOrangeMix3/AOM3A3.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "kl-f8-anime2.ckpt",
-      "url": "https://huggingface.co/hakurei/waifu-diffusion-v1-4/resolve/main/vae/kl-f8-anime2.ckpt?download=true",
-      "directory": "vae"
     }
   ]
 }

--- a/public/templates/area_composition.json
+++ b/public/templates/area_composition.json
@@ -958,16 +958,6 @@
   "version": 0.4,
   "models": [
     {
-      "name": "Anything-V3.0.ckpt",
-      "url": "https://huggingface.co/xiaolxl/Stable-diffusion-models/resolve/main/Anything-V3.0.ckpt?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "AbyssOrangeMix2_hard.safetensors",
-      "url": "https://huggingface.co/WarriorMama777/OrangeMixs/resolve/main/Models/AbyssOrangeMix2/AbyssOrangeMix2_hard.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
       "name": "vae-ft-mse-840000-ema-pruned.safetensors",
       "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
       "directory": "vae"

--- a/public/templates/area_composition_reversed.json
+++ b/public/templates/area_composition_reversed.json
@@ -959,16 +959,6 @@
   "version": 0.4,
   "models": [
     {
-      "name": "Anything-V3.0.ckpt",
-      "url": "https://huggingface.co/xiaolxl/Stable-diffusion-models/resolve/main/Anything-V3.0.ckpt?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "AbyssOrangeMix2_hard.safetensors",
-      "url": "https://huggingface.co/WarriorMama777/OrangeMixs/resolve/main/Models/AbyssOrangeMix2/AbyssOrangeMix2_hard.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
       "name": "vae-ft-mse-840000-ema-pruned.safetensors",
       "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
       "directory": "vae"

--- a/public/templates/area_composition_square_area_for_subject.json
+++ b/public/templates/area_composition_square_area_for_subject.json
@@ -612,11 +612,6 @@
   "version": 0.4,
   "models": [
     {
-      "name": "Anything-V3.0.ckpt",
-      "url": "https://huggingface.co/xiaolxl/Stable-diffusion-models/resolve/main/Anything-V3.0.ckpt?download=true",
-      "directory": "checkpoints"
-    },
-    {
       "name": "vae-ft-mse-840000-ema-pruned.safetensors",
       "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
       "directory": "vae"

--- a/public/templates/controlnet_example.json
+++ b/public/templates/controlnet_example.json
@@ -372,11 +372,6 @@
   "version": 0.4,
   "models": [
     {
-      "name": "Anything-V3.0.ckpt",
-      "url": "https://huggingface.co/xiaolxl/Stable-diffusion-models/resolve/main/Anything-V3.0.ckpt?download=true",
-      "directory": "checkpoints"
-    },
-    {
       "name": "control_v11p_sd15_scribble_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_scribble_fp16.safetensors?download=true",
       "directory": "controlnet"

--- a/public/templates/latent_upscale_different_prompt_model.json
+++ b/public/templates/latent_upscale_different_prompt_model.json
@@ -524,17 +524,5 @@
       "offset": [1200.17, 444.58]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "wd-illusion-fp16.safetensors",
-      "url": "https://huggingface.co/waifu-diffusion/wd-1-5-beta3/resolve/main/wd-illusion-fp16.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "cardosAnime_v10.safetensors",
-      "url": "https://huggingface.co/jomcs/NeverEnding_Dream-Feb19-2023/resolve/07c9bc67d4ac9a85b68321d9b62f20c00171d8d5/CarDos%20Anime/cardosAnime_v10.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/public/templates/mixing_controlnets.json
+++ b/public/templates/mixing_controlnets.json
@@ -484,19 +484,9 @@
       "directory": "controlnet"
     },
     {
-      "name": "AOM3A1.safetensors",
-      "url": "https://huggingface.co/Eata/Model_V1/resolve/main/AOM3A1.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
       "name": "control_v11p_sd15_openpose_fp16.safetensors",
       "url": "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_openpose_fp16.safetensors",
       "directory": "controlnet"
-    },
-    {
-      "name": "kl-f8-anime2.ckpt",
-      "url": "https://huggingface.co/hakurei/waifu-diffusion-v1-4/resolve/main/vae/kl-f8-anime2.ckpt?download=true",
-      "directory": "vae"
     }
   ]
 }


### PR DESCRIPTION
Remove urls to models in template workflows when the model is interchangeable and not integral to the purpose of the workflow, following approach of ComfyUI_examples documentation. The user should be able to choose whatever model they have and still be able to use these workflows. All urls should now be from relatively trusted repos.

Model urls in templates can be added back or changed easily at a later time using [this script](https://gist.github.com/christian-byrne/d194149105f9a11457b0f69c5f0d19e3)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2575-Remove-interchangeable-models-from-template-workflows-19c6d73d365081429b64e3dee9cad785) by [Unito](https://www.unito.io)
