### PR TITLE
Add stable zero model url to whitelist

### DIFF
--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -50,9 +50,9 @@ const allowedSources = [
 ]
 const allowedSuffixes = ['.safetensors', '.sft']
 // Models that fail above conditions but are still allowed
-const whiteListedUrls = [
+const whiteListedUrls = new Set([
   'https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt'
-]
+])
 
 interface ModelInfo {
   name: string
@@ -97,7 +97,7 @@ const missingModels = computed(() => {
       folder_path: paths[0]
     }
     modelDownloads.value[model.name] = downloadInfo
-    if (!whiteListedUrls.includes(model.url)) {
+    if (!whiteListedUrls.has(model.url)) {
       if (!allowedSources.some((source) => model.url.startsWith(source))) {
         return {
           label: `${model.directory} / ${model.name}`,

--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -49,6 +49,10 @@ const allowedSources = [
   'http://localhost:' // Included for testing usage only
 ]
 const allowedSuffixes = ['.safetensors', '.sft']
+// Models that fail above conditions but are still allowed
+const whiteListedUrls = [
+  'https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt'
+]
 
 interface ModelInfo {
   name: string
@@ -93,18 +97,20 @@ const missingModels = computed(() => {
       folder_path: paths[0]
     }
     modelDownloads.value[model.name] = downloadInfo
-    if (!allowedSources.some((source) => model.url.startsWith(source))) {
-      return {
-        label: `${model.directory} / ${model.name}`,
-        url: model.url,
-        error: `Download not allowed from source '${model.url}', only allowed from '${allowedSources.join("', '")}'`
+    if (!whiteListedUrls.includes(model.url)) {
+      if (!allowedSources.some((source) => model.url.startsWith(source))) {
+        return {
+          label: `${model.directory} / ${model.name}`,
+          url: model.url,
+          error: `Download not allowed from source '${model.url}', only allowed from '${allowedSources.join("', '")}'`
+        }
       }
-    }
-    if (!allowedSuffixes.some((suffix) => model.name.endsWith(suffix))) {
-      return {
-        label: `${model.directory} / ${model.name}`,
-        url: model.url,
-        error: `Only allowed suffixes are: '${allowedSuffixes.join("', '")}'`
+      if (!allowedSuffixes.some((suffix) => model.name.endsWith(suffix))) {
+        return {
+          label: `${model.directory} / ${model.name}`,
+          url: model.url,
+          error: `Only allowed suffixes are: '${allowedSuffixes.join("', '")}'`
+        }
       }
     }
     return {


### PR DESCRIPTION
Temporary solution that fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/2576. Model URLs in whitelist will bypass existing validation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2577-Add-stable-zero-model-url-to-whitelist-19c6d73d365081fa9938f45a829cd47e) by [Unito](https://www.unito.io)
