### PR TITLE
Fix incorrect link in template workflow

### DIFF
--- a/public/templates/depth_controlnet.json
+++ b/public/templates/depth_controlnet.json
@@ -324,7 +324,7 @@
       "outputs": [],
       "properties": {},
       "widgets_values": [
-        "\ud83d\udec8 [Learn more about this workflow](https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#pose-controlnet)"
+        "\ud83d\udec8 [Learn more about this workflow](https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#t2i-adapter-vs-controlnets)"
       ],
       "color": "#432",
       "bgcolor": "#653"

--- a/public/templates/lora.json
+++ b/public/templates/lora.json
@@ -268,7 +268,7 @@
       "outputs": [],
       "properties": {},
       "widgets_values": [
-        "\ud83d\udec8 [Learn more about this workflow](https://comfyanonymous.github.io/ComfyUI_examples/inpaint/#outpainting)"
+        "\ud83d\udec8 [Learn more about this workflow](https://comfyanonymous.github.io/ComfyUI_examples/lora/)"
       ],
       "color": "#432",
       "bgcolor": "#653"

--- a/src/constants/coreTemplates.ts
+++ b/src/constants/coreTemplates.ts
@@ -6,8 +6,6 @@ export const CORE_TEMPLATES = [
     templates: [
       {
         name: 'default',
-        tutorialUrl:
-          'https://github.com/comfyanonymous/ComfyUI/wiki/Basic-Tutorial',
         mediaType: 'image',
         mediaSubtype: 'png'
       },
@@ -139,14 +137,14 @@ export const CORE_TEMPLATES = [
         mediaType: 'image',
         mediaSubtype: 'png',
         tutorialUrl:
-          'https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#2-pass-pose-worship'
+          'https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#pose-controlnet'
       },
       {
         name: 'depth_controlnet',
         mediaType: 'image',
         mediaSubtype: 'png',
         tutorialUrl:
-          'https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#pose-controlnet'
+          'https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#t2i-adapter-vs-controlnets'
       },
       {
         name: 'depth_t2i_adapter',


### PR DESCRIPTION
Fixes incorrect links in 2 template workflows and coreTemplates constant (direct to wrong page in examples repo). The documentation links in the templates were added by way of script but have now all been verified by hand.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2579-Fix-incorrect-link-in-template-workflow-19c6d73d365081d69ff0e7ef9b370060) by [Unito](https://www.unito.io)
