### PR TITLE
don't merge, test for PrimeVue Select

### DIFF
--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -76,12 +76,16 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
     >
       {{ nodeDef.description }}
     </div>
+    <div>
+      <Select v-model="selectedAnimation" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import _ from 'lodash'
-import { computed } from 'vue'
+import Select from 'primevue/select'
+import { computed, ref } from 'vue'
 
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useWidgetStore } from '@/stores/widgetStore'
@@ -93,6 +97,8 @@ const props = defineProps({
     required: true
   }
 })
+
+const selectedAnimation = ref(0)
 
 const colorPaletteStore = useColorPaletteStore()
 const litegraphColors = computed(


### PR DESCRIPTION
@huchenlei still need your help about vue.
while using vnode=h() and render(vnode), if I import Select from 'primevue/select', the page will throw some error such as 
```
Property "$primevue" was accessed during render but is not defined on instance. 
onMounted is called when there is no active component instance to be associated with.
```
![image](https://github.com/user-attachments/assets/c49710ea-b064-427a-87a1-7bab605ce326)
Previously, if I create a sepreate vue app, the solution is app.use(PrimeVue), however if I switch to vnode approach, this plugin is already added in main.ts, and I have no idea to inject it.
I keep using NodePreview for your example in this PR, just drop a node from node liberay, you will see the error in console

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2582-don-t-merge-test-for-PrimeVue-Select-19c6d73d365081e3ab07c7ebc11ce6a0) by [Unito](https://www.unito.io)
