### PR TITLE
[Refactor] useAbsolutePosition composable

### DIFF
--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -1,0 +1,45 @@
+import type { Size, Vector2 } from '@comfyorg/litegraph'
+import { CSSProperties, ref } from 'vue'
+
+import { app } from '@/scripts/app'
+import { useCanvasStore } from '@/stores/graphStore'
+
+export interface PositionConfig {
+  pos: Vector2
+  size: Size
+  scale?: number
+}
+
+export function useAbsolutePosition() {
+  const canvasStore = useCanvasStore()
+  const style = ref<CSSProperties>({
+    position: 'fixed',
+    left: '0px',
+    top: '0px',
+    width: '0px',
+    height: '0px'
+  })
+
+  const updatePosition = (
+    config: PositionConfig,
+    extraStyle?: CSSProperties
+  ) => {
+    const { pos, size, scale = canvasStore.canvas?.ds?.scale ?? 1 } = config
+    const [left, top] = app.canvasPosToClientPos(pos)
+    const [width, height] = size
+
+    style.value = {
+      ...style.value,
+      left: `${left}px`,
+      top: `${top}px`,
+      width: `${width * scale}px`,
+      height: `${height * scale}px`,
+      ...extraStyle
+    }
+  }
+
+  return {
+    style,
+    updatePosition
+  }
+}

--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -5,8 +5,11 @@ import { app } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 
 export interface PositionConfig {
+  /* The position of the element on litegraph canvas */
   pos: Vector2
+  /* The size of the element on litegraph canvas */
   size: Size
+  /* The scale factor of the canvas */
   scale?: number
 }
 


### PR DESCRIPTION
This PR introduces a new composable `useAbsolutePosition` to handle absolute positioning calculations for elements on the LiteGraph canvas. The main changes involve extracting the positioning logic from `TitleEditor.vue` into a reusable composable that manages the conversion of canvas coordinates to client coordinates, handling scaling, and maintaining the position state. The `TitleEditor` component has been simplified by leveraging this new composable, replacing the manual style object initialization and coordinate calculations with cleaner, more maintainable code. The composable accepts a `PositionConfig` interface for position and size, along with optional scale and extra style properties, making it more flexible for reuse across different components that need canvas-to-screen coordinate conversion.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2589-Refactor-useAbsolutePosition-composable-19c6d73d365081cea155d3bc48c249f1) by [Unito](https://www.unito.io)
