### PR TITLE
Support batch image upload

### DIFF
--- a/src/composables/useNodeFileInput.ts
+++ b/src/composables/useNodeFileInput.ts
@@ -1,0 +1,45 @@
+interface FileInputOptions {
+  accept?: string
+  allow_batch?: boolean
+  fileFilter?: (file: File) => boolean
+  onSelect: (files: File[]) => void
+}
+
+/**
+ * Creates a file input for a node.
+ */
+export function useNodeFileInput(options: FileInputOptions) {
+  const {
+    accept,
+    allow_batch = false,
+    fileFilter = () => true,
+    onSelect
+  } = options
+
+  const fileInput = document.createElement('input')
+  fileInput.type = 'file'
+  fileInput.accept = accept ?? '*'
+  fileInput.multiple = allow_batch
+  fileInput.style.visibility = 'hidden'
+
+  fileInput.onchange = () => {
+    if (fileInput.files?.length) {
+      const files = Array.from(fileInput.files).filter(fileFilter)
+      if (files.length) onSelect(files)
+    }
+  }
+
+  document.body.append(fileInput)
+
+  /**
+   * Shows the system file picker dialog for selecting files.
+   */
+  function openFileSelection() {
+    fileInput.click()
+  }
+
+  return {
+    fileInput,
+    openFileSelection
+  }
+}

--- a/src/composables/useNodeImage.ts
+++ b/src/composables/useNodeImage.ts
@@ -2,25 +2,16 @@ import type { LGraphNode } from '@comfyorg/litegraph'
 
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 
-interface NodeImageOptions {
-  allowBatch?: boolean
-}
-
 /**
  * Attaches a preview image to a node.
  */
-export const useNodeImage = (node: LGraphNode, options: NodeImageOptions) => {
-  const { allowBatch = false } = options
+export const useNodeImage = (node: LGraphNode) => {
   const nodeOutputStore = useNodeOutputStore()
 
   /** Displays output image(s) on the node. */
   function showImage(output: string | string[]) {
     if (!output) return
-    if (allowBatch || typeof output === 'string') {
-      nodeOutputStore.setNodeOutputs(node, output)
-    } else {
-      nodeOutputStore.setNodeOutputs(node, output[0])
-    }
+    nodeOutputStore.setNodeOutputs(node, output)
     node.setSizeForImage?.()
     node.graph?.setDirtyCanvas(true)
   }

--- a/src/composables/useNodeImageUpload.ts
+++ b/src/composables/useNodeImageUpload.ts
@@ -1,20 +1,13 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
 
+import { useNodeDragAndDrop } from '@/composables/useNodeDragAndDrop'
+import { useNodeFileInput } from '@/composables/useNodeFileInput'
+import { useNodePaste } from '@/composables/useNodePaste'
 import { api } from '@/scripts/api'
 import { useToastStore } from '@/stores/toastStore'
 
-import { useNodeDragAndDrop } from './useNodeDragAndDrop'
-import { useNodePaste } from './useNodePaste'
-
 const ACCEPTED_IMAGE_TYPES = 'image/jpeg,image/png,image/webp'
 const PASTED_IMAGE_EXPIRY_MS = 2000
-
-const createFileInput = () => {
-  const fileInput = document.createElement('input')
-  fileInput.type = 'file'
-  fileInput.accept = ACCEPTED_IMAGE_TYPES
-  return fileInput
-}
 
 const uploadFile = async (file: File, isPasted: boolean) => {
   const body = new FormData()
@@ -38,13 +31,17 @@ const uploadFile = async (file: File, isPasted: boolean) => {
 interface ImageUploadOptions {
   fileFilter?: (file: File) => boolean
   onUploadComplete: (paths: string[]) => void
+  allow_batch?: boolean
 }
 
+/**
+ * Adds image upload to a node via drag & drop, paste, and file input.
+ */
 export const useNodeImageUpload = (
   node: LGraphNode,
   options: ImageUploadOptions
 ) => {
-  const { fileFilter = () => true, onUploadComplete } = options
+  const { fileFilter, onUploadComplete, allow_batch } = options
 
   const isPastedFile = (file: File): boolean =>
     file.name === 'image.png' &&
@@ -60,48 +57,33 @@ export const useNodeImageUpload = (
     }
   }
 
+  const handleUploadBatch = async (files: File[]) => {
+    const paths = await Promise.all(files.map(handleUpload))
+    const validPaths = paths.filter((p): p is string => !!p)
+    if (validPaths.length) onUploadComplete(validPaths)
+    return validPaths
+  }
+
   // Handle drag & drop
   useNodeDragAndDrop(node, {
     fileFilter,
-    onDrop: async (files) => {
-      const paths = await Promise.all(files.map(handleUpload))
-      const validPaths = paths.filter((p): p is string => !!p)
-      if (validPaths.length) {
-        onUploadComplete(validPaths)
-      }
-      return validPaths
-    }
+    onDrop: handleUploadBatch
   })
 
   // Handle paste
   useNodePaste(node, {
     fileFilter,
-    onPaste: async (file) => {
-      const path = await handleUpload(file)
-      if (path) {
-        onUploadComplete([path])
-      }
-      return path
-    }
+    allow_batch,
+    onPaste: handleUploadBatch
   })
 
   // Handle file input
-  const fileInput = createFileInput()
-  fileInput.onchange = async () => {
-    if (fileInput.files?.length) {
-      const paths = await Promise.all(
-        Array.from(fileInput.files).filter(fileFilter).map(handleUpload)
-      )
-      const validPaths = paths.filter((p): p is string => !!p)
-      if (validPaths.length) {
-        onUploadComplete(validPaths)
-      }
-    }
-  }
-  document.body.append(fileInput)
+  const { openFileSelection } = useNodeFileInput({
+    fileFilter,
+    allow_batch,
+    accept: ACCEPTED_IMAGE_TYPES,
+    onSelect: handleUploadBatch
+  })
 
-  return {
-    fileInput,
-    handleUpload
-  }
+  return { openFileSelection, handleUpload }
 }

--- a/src/composables/useNodePaste.ts
+++ b/src/composables/useNodePaste.ts
@@ -1,10 +1,11 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
 
-type PasteHandler<T> = (file: File) => Promise<T>
+type PasteHandler<T> = (files: File[]) => Promise<T>
 
 interface NodePasteOptions<T> {
   onPaste: PasteHandler<T>
   fileFilter?: (file: File) => boolean
+  allow_batch?: boolean
 }
 
 /**
@@ -14,12 +15,15 @@ export const useNodePaste = <T>(
   node: LGraphNode,
   options: NodePasteOptions<T>
 ) => {
-  const { onPaste, fileFilter = () => true } = options
+  const { onPaste, fileFilter = () => true, allow_batch = false } = options
 
-  node.pasteFile = function (file: File) {
-    if (!fileFilter(file)) return false
+  node.pasteFiles = function (files: File[]) {
+    const filteredFiles = Array.from(files).filter(fileFilter)
+    if (!filteredFiles.length) return false
 
-    onPaste(file).then((result) => {
+    const paste = allow_batch ? filteredFiles : filteredFiles.slice(0, 1)
+
+    onPaste(paste).then((result) => {
       if (!result) return
     })
     return true

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -28,7 +28,7 @@ export const usePaste = () => {
     // Did you mean 'Clipboard'?ts(2551)
     // TODO: Not sure what the code wants to do.
     let data = e.clipboardData || window.clipboardData
-    const items = data.items
+    const items: DataTransferItemList = data.items
 
     // Look for image paste data
     for (const item of items) {
@@ -54,7 +54,13 @@ export const usePaste = () => {
           graph.change()
         }
         const blob = item.getAsFile()
-        imageNode?.pasteFile?.(blob)
+        if (blob) imageNode?.pasteFile?.(blob)
+
+        imageNode?.pasteFiles?.(
+          Array.from(items)
+            .map((i) => i.getAsFile())
+            .filter((f) => f !== null)
+        )
         return
       }
     }

--- a/src/composables/useValueTransform.ts
+++ b/src/composables/useValueTransform.ts
@@ -1,5 +1,6 @@
 /**
  * Creates a getter/setter pair that transforms values on access if they have changed.
+ * Does not observe deep changes.
  *
  * @example
  * const { get, set } = useValueTransform<ResultItem[], string[]>(
@@ -12,7 +13,7 @@ export function useValueTransform<Internal, External>(
   transform: (value: Internal) => External,
   initialValue: Internal
 ) {
-  let internalValue = initialValue
+  let internalValue: Internal = initialValue
   let cachedValue: External = transform(initialValue)
   let isChanged = false
 

--- a/src/composables/useValueTransform.ts
+++ b/src/composables/useValueTransform.ts
@@ -1,0 +1,30 @@
+/**
+ * Creates a getter/setter pair that transforms values on access if they have changed.
+ *
+ * @example
+ * const { get, set } = useValueTransform<ResultItem[], string[]>(
+ *   items => items.map(formatPath)
+ * )
+ *
+ * Object.defineProperty(obj, 'value', { get, set })
+ */
+export function useValueTransform<Internal, External>(
+  transform: (value: Internal) => External,
+  initialValue: Internal
+) {
+  let internalValue = initialValue
+  let cachedValue: External = transform(initialValue)
+  let isChanged = false
+
+  return {
+    get: () => {
+      if (!isChanged) return cachedValue
+      cachedValue = transform(internalValue)
+      return cachedValue
+    },
+    set: (value: Internal) => {
+      isChanged = true
+      internalValue = value
+    }
+  }
+}

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -349,6 +349,7 @@ const zComboInputProps = zBaseInputSpecValue.extend({
   control_after_generate: z.boolean().optional(),
   image_upload: z.boolean().optional(),
   image_folder: z.enum(['input', 'output', 'temp']).optional(),
+  allow_batch: z.boolean().optional(),
   remote: zRemoteWidgetConfig.optional()
 })
 

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -122,6 +122,8 @@ declare module '@comfyorg/litegraph' {
     imageOffset?: number
     /** Callback for pasting an image file into the node */
     pasteFile?(file: File): void
+    /** Callback for pasting multiple files into the node */
+    pasteFiles?(files: File[]): void
   }
 }
 

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -1,4 +1,5 @@
 import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
+import type { IComboWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 export function isImageNode(node: LGraphNode) {
   return (
@@ -7,4 +8,12 @@ export function isImageNode(node: LGraphNode) {
       node.widgets &&
       node.widgets.findIndex((obj: IWidget) => obj.name === 'image') >= 0)
   )
+}
+
+export function addToComboValues(widget: IComboWidget, value: string) {
+  if (!widget.options) widget.options = { values: [] }
+  if (!widget.options.values) widget.options.values = []
+  if (!widget.options.values.includes(value)) {
+    widget.options.values.push(value)
+  }
 }


### PR DESCRIPTION
Followup on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2580: Adds support for batch image upload, which may be used while training. Accepts batches via drag-and-drop, copy-paste, or file input (upload button).


https://github.com/user-attachments/assets/902bfd06-f0e7-4149-b481-1b0c166abdbf

Node:

```python
class LoadImageBatch(LoadImage):
    @classmethod
    def INPUT_TYPES(s):
        return {
            "required": {
                "image": ([f for f in os.listdir(folder_paths.get_input_directory())], 
                          {"image_upload": True, "allow_batch": True}) # add allow_batch flag
            },
        }

    FUNCTION = "load_images"
    INPUT_IS_LIST = True

    def load_images(self, image):
        filenames = image[0] if isinstance(image[0], list) else image # also accept a single image
        image_mask_pairs = [self.load_image(i) for i in filenames]
        return tuple(torch.stack([i[n] for i in image_mask_pairs]) for n in (0,1))

    @classmethod
    def VALIDATE_INPUTS(s, image):
        filenames = image[0] if isinstance(image[0], list) else image
        return all(LoadImage.VALIDATE_INPUTS(i) for i in filenames)
```

Since there is not yet support for multi-select combo dropdowns in litegraph, drag-and-drop/paste/upload is preferred for selecting batches. Otherwise, the node author should populate the list with sublists (e.g., each item in the combo list is the contents of a folder).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2597-Support-batch-image-upload-19d6d73d365081babd90cfc97b503591) by [Unito](https://www.unito.io)
