### PR TITLE
[Desktop] Update uv cache clear task to show terminal

### DIFF
--- a/src/constants/desktopMaintenanceTasks.ts
+++ b/src/constants/desktopMaintenanceTasks.ts
@@ -119,6 +119,7 @@ export const DESKTOP_MAINTENANCE_TASKS: Readonly<MaintenanceTask>[] = [
     description:
       'This will remove the uv cache directory and its contents. All downloaded python packages will need to be downloaded again.',
     confirmText: 'Delete uv cache of python packages?',
+    usesTerminal: true,
     isInstallationFix: true,
     button: {
       icon: PrimeIcons.TRASH,


### PR DESCRIPTION
- Clearing the uv cache is now done with uv itself
- Shows terminal output automatically
- Requires https://github.com/Comfy-Org/desktop/pull/930

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2598-Desktop-Update-uv-cache-clear-to-show-terminal-19d6d73d365081409c67d613ab3799a2) by [Unito](https://www.unito.io)
