### PR TITLE
Remove lora dependency from flux canny template

### DIFF
--- a/public/templates/flux_canny_model_example.json
+++ b/public/templates/flux_canny_model_example.json
@@ -456,11 +456,6 @@
       "directory": "text_encoders"
     },
     {
-      "name": "flux1-canny-dev-lora.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Canny-dev-lora/resolve/main/flux1-canny-dev-lora.safetensors?download=true",
-      "directory": "loras"
-    },
-    {
       "name": "flux1-dev-fp8.safetensors",
       "url": "https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev-fp8.safetensors?download=true",
       "directory": "checkpoints"


### PR DESCRIPTION
Removes the flux canny lora dependency from the flux canny template. The lora is a suggestion, while the actual template uses the full model. https://comfyanonymous.github.io/ComfyUI_examples/flux/#canny-and-depth

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2603-Remove-lora-dependency-from-flux-canny-template-19d6d73d365081b2afeec6f419eccf09) by [Unito](https://www.unito.io)
