### PR TITLE
Add DeleteSelectedItems command

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -566,6 +566,16 @@ export function useCoreCommands(): ComfyCommand[] {
       function: () => {
         window.open('https://forum.comfy.org/', '_blank')
       }
+    },
+    {
+      id: 'Comfy.Canvas.DeleteSelectedItems',
+      icon: 'pi pi-trash',
+      label: 'Delete Selected Items',
+      versionAdded: '1.10.5',
+      function: () => {
+        app.canvas.deleteSelected()
+        app.canvas.setDirty(true, true)
+      }
     }
   ]
 }


### PR DESCRIPTION
The litegraph hardcoded binding will be moved to the frontend once the context aware keybinding support is implemented.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2606-Add-DeleteSelectedItems-command-19d6d73d365081cba604f09e0c02b590) by [Unito](https://www.unito.io)
