### PR TITLE
Add refresh button to selecton toolbox

### DIFF
--- a/browser_tests/remoteWidgets.spec.ts
+++ b/browser_tests/remoteWidgets.spec.ts
@@ -176,6 +176,23 @@ test.describe('Remote COMBO Widget', () => {
   })
 
   test.describe('Refresh Behavior', () => {
+    test('refresh button is visible in selection toolbar when node is selected', async ({
+      comfyPage
+    }) => {
+      await comfyPage.setSetting('Comfy.Canvas.SelectionToolbox', true)
+
+      const nodeName = 'Remote Widget Node'
+      await addRemoteWidgetNode(comfyPage, nodeName)
+      await waitForWidgetUpdate(comfyPage)
+
+      // Select remote widget node
+      await comfyPage.page.keyboard.press('Control+A')
+
+      await expect(
+        comfyPage.page.locator('.selection-toolbox .pi-refresh')
+      ).toBeVisible()
+    })
+
     test('refreshes options when TTL expires', async ({ comfyPage }) => {
       // Fulfill each request with a unique timestamp
       await comfyPage.page.route(

--- a/browser_tests/selectionToolbox.spec.ts
+++ b/browser_tests/selectionToolbox.spec.ts
@@ -57,4 +57,16 @@ test.describe('Selection Toolbox', () => {
       comfyPage.page.locator('.selection-overlay-container.show-border')
     ).not.toBeVisible()
   })
+
+  test('displays refresh button in toolbox when all nodes are selected', async ({
+    comfyPage
+  }) => {
+    // Select all nodes
+    await comfyPage.page.focus('canvas')
+    await comfyPage.page.keyboard.press('Control+A')
+
+    await expect(
+      comfyPage.page.locator('.selection-toolbox .pi-refresh')
+    ).toBeVisible()
+  })
 })

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -18,6 +18,13 @@
       icon="pi pi-trash"
       @click="() => commandStore.execute('Comfy.Canvas.DeleteSelectedItems')"
     />
+    <Button
+      v-if="isRefreshable"
+      severity="info"
+      text
+      icon="pi pi-refresh"
+      @click="refreshSelected"
+    />
   </Panel>
 </template>
 
@@ -25,9 +32,11 @@
 import Button from 'primevue/button'
 import Panel from 'primevue/panel'
 
+import { useRefreshableSelection } from '@/composables/useRefreshableSelection'
 import { useCommandStore } from '@/stores/commandStore'
 
 const commandStore = useCommandStore()
+const { isRefreshable, refreshSelected } = useRefreshableSelection()
 </script>
 
 <style scoped>

--- a/src/composables/useRefreshableSelection.ts
+++ b/src/composables/useRefreshableSelection.ts
@@ -1,0 +1,61 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import type { IWidget } from '@comfyorg/litegraph'
+import { computed, ref, watchEffect } from 'vue'
+
+import { useCommandStore } from '@/stores/commandStore'
+import { useCanvasStore } from '@/stores/graphStore'
+
+interface RefreshableItem {
+  refresh: () => Promise<void> | void
+}
+
+type RefreshableWidget = IWidget & RefreshableItem
+
+const isLGraphNode = (item: unknown): item is LGraphNode => {
+  const name = item?.constructor?.name
+  return name === 'ComfyNode' || name === 'LGraphNode'
+}
+
+const isRefreshableWidget = (widget: IWidget): widget is RefreshableWidget =>
+  'refresh' in widget && typeof widget.refresh === 'function'
+
+/**
+ * Tracks selected nodes and their refreshable widgets
+ */
+export const useRefreshableSelection = () => {
+  const graphStore = useCanvasStore()
+  const commandStore = useCommandStore()
+  const selectedNodes = ref<LGraphNode[]>([])
+  const isAllNodesSelected = ref(false)
+
+  watchEffect(() => {
+    selectedNodes.value = graphStore.selectedItems.filter(isLGraphNode)
+    isAllNodesSelected.value =
+      graphStore.canvas?.graph?.nodes?.every((node) => !!node.selected) ?? false
+  })
+
+  const refreshableWidgets = computed(() =>
+    selectedNodes.value.flatMap(
+      (node) => node.widgets?.filter(isRefreshableWidget) ?? []
+    )
+  )
+
+  const isRefreshable = computed(
+    () => refreshableWidgets.value.length > 0 || isAllNodesSelected.value
+  )
+
+  async function refreshSelected() {
+    if (!isRefreshable.value) return
+
+    if (isAllNodesSelected.value) {
+      commandStore.execute('Comfy.RefreshNodeDefinitions')
+    } else {
+      await Promise.all(refreshableWidgets.value.map((item) => item.refresh()))
+    }
+  }
+
+  return {
+    isRefreshable,
+    refreshSelected
+  }
+}

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -23,6 +23,11 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
     ) => Promise<unknown> | unknown
 
     /**
+     * Refreshes the widget's value or options from its remote source.
+     */
+    refresh?: () => unknown
+
+    /**
      * If the widget supports dynamic prompts, this will be set to true.
      * See extensions/core/dynamicPrompts.ts
      */


### PR DESCRIPTION
Adds refresh button to selection toolbox. If nodes with remote/lazy widgets are selected, the refresh button is visible, allowing refreshing the selected widgets. If all nodes on the graph are selected, the refresh button triggers the refresh node defs command.

- [Design Specification for this component](https://www.figma.com/design/L0besWUa1yq96DNVaSfdRt/Refresh-Icon?node-id=0-1&p=f&t=xWMuCdGzVuwQvRes-0)

https://github.com/user-attachments/assets/dbe165ee-abaf-4d56-b556-f5f2072ef18b

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2612-Add-refresh-button-to-selecton-toolbox-19e6d73d3650815dae93fa1e82b2adef) by [Unito](https://www.unito.io)
