### PR TITLE
[Style] Update toolbox style

### DIFF
--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -1,7 +1,7 @@
 <!-- This component is used to bound the selected items on the canvas. -->
 <template>
   <div
-    class="selection-overlay-container pointer-events-none"
+    class="selection-overlay-container pointer-events-none z-40"
     :class="{
       'show-border': showBorder
     }"

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -1,6 +1,6 @@
 <template>
   <Panel
-    class="selection-toolbox absolute left-1/2"
+    class="selection-toolbox absolute left-1/2 rounded-lg"
     :pt="{
       header: 'hidden',
       content: 'p-0 flex flex-row'


### PR DESCRIPTION
Sets z-index of overlay to prevent clipping by DOM widgets. Sets border radius to match design spec.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2614-Style-Update-toolbox-style-19e6d73d3650811e82b4efceb096c923) by [Unito](https://www.unito.io)
