### PR TITLE
Update litegraph 0.8.85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.16",
-        "@comfyorg/litegraph": "^0.8.84",
+        "@comfyorg/litegraph": "^0.8.85",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.84",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.84.tgz",
-      "integrity": "sha512-NjyWpBsccgFsNn81pMz8MA2n6Y6FS5Aw8sOWO7btHh/BvO+wFykLc9sal4bISyUFmVq2KDkoGDQUPsM46zad/g==",
+      "version": "0.8.85",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.85.tgz",
+      "integrity": "sha512-lNI/iZ624lnfdXcTwvDGnhks34oT9S28bpcyZopPaYSgz3DCKzWHwNiFVttbfpfZIvQch1JFWulzX+pNHKHr7A==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.16",
-    "@comfyorg/litegraph": "^0.8.84",
+    "@comfyorg/litegraph": "^0.8.85",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.85. Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.8.85