### PR TITLE
Add bypass action to selection toolbox

### DIFF
--- a/browser_tests/selectionToolbox.spec.ts
+++ b/browser_tests/selectionToolbox.spec.ts
@@ -9,9 +9,7 @@ test.describe('Selection Toolbox', () => {
     await comfyPage.setSetting('Comfy.Canvas.SelectionToolbox', true)
   })
 
-  test('shows/hides selection toolbox based on setting', async ({
-    comfyPage
-  }) => {
+  test('shows selection toolbox', async ({ comfyPage }) => {
     // By default, selection toolbox should be enabled
     expect(
       await comfyPage.page.locator('.selection-overlay-container').isVisible()
@@ -68,5 +66,29 @@ test.describe('Selection Toolbox', () => {
     await expect(
       comfyPage.page.locator('.selection-toolbox .pi-refresh')
     ).toBeVisible()
+  })
+
+  test('displays bypass button in toolbox when nodes are selected', async ({
+    comfyPage
+  }) => {
+    // A group + a KSampler node
+    await comfyPage.loadWorkflow('single_group')
+
+    // Select group + node should show bypass button
+    await comfyPage.page.focus('canvas')
+    await comfyPage.page.keyboard.press('Control+A')
+    await expect(
+      comfyPage.page.locator(
+        '.selection-toolbox *[data-testid="bypass-button"]'
+      )
+    ).toBeVisible()
+
+    // Deselect node (Only group is selected) should hide bypass button
+    await comfyPage.selectNodes(['KSampler'])
+    await expect(
+      comfyPage.page.locator(
+        '.selection-toolbox *[data-testid="bypass-button"]'
+      )
+    ).not.toBeVisible()
   })
 })

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -7,6 +7,18 @@
     }"
   >
     <Button
+      v-if="nodeSelected"
+      severity="secondary"
+      text
+      @click="
+        () => commandStore.execute('Comfy.Canvas.ToggleSelectedNodes.Bypass')
+      "
+    >
+      <template #icon>
+        <i-game-icons:detour />
+      </template>
+    </Button>
+    <Button
       severity="secondary"
       text
       icon="pi pi-thumbtack"
@@ -31,12 +43,19 @@
 <script setup lang="ts">
 import Button from 'primevue/button'
 import Panel from 'primevue/panel'
+import { computed } from 'vue'
 
 import { useRefreshableSelection } from '@/composables/useRefreshableSelection'
 import { useCommandStore } from '@/stores/commandStore'
+import { useCanvasStore } from '@/stores/graphStore'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 const commandStore = useCommandStore()
+const canvasStore = useCanvasStore()
 const { isRefreshable, refreshSelected } = useRefreshableSelection()
+const nodeSelected = computed(() =>
+  canvasStore.selectedItems.some(isLGraphNode)
+)
 </script>
 
 <style scoped>

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -13,6 +13,7 @@
       @click="
         () => commandStore.execute('Comfy.Canvas.ToggleSelectedNodes.Bypass')
       "
+      data-testid="bypass-button"
     >
       <template #icon>
         <i-game-icons:detour />

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -366,6 +366,7 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.3.11',
       function: () => {
         toggleSelectedNodesMode(LGraphEventMode.NEVER)
+        app.canvas.setDirty(true, true)
       }
     },
     {
@@ -375,6 +376,7 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.3.11',
       function: () => {
         toggleSelectedNodesMode(LGraphEventMode.BYPASS)
+        app.canvas.setDirty(true, true)
       }
     },
     {
@@ -386,6 +388,7 @@ export function useCoreCommands(): ComfyCommand[] {
         getSelectedNodes().forEach((node) => {
           node.pin(!node.pinned)
         })
+        app.canvas.setDirty(true, true)
       }
     },
     {
@@ -411,6 +414,7 @@ export function useCoreCommands(): ComfyCommand[] {
         getSelectedNodes().forEach((node) => {
           node.collapse()
         })
+        app.canvas.setDirty(true, true)
       }
     },
     {

--- a/src/composables/useRefreshableSelection.ts
+++ b/src/composables/useRefreshableSelection.ts
@@ -4,17 +4,13 @@ import { computed, ref, watchEffect } from 'vue'
 
 import { useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 interface RefreshableItem {
   refresh: () => Promise<void> | void
 }
 
 type RefreshableWidget = IWidget & RefreshableItem
-
-const isLGraphNode = (item: unknown): item is LGraphNode => {
-  const name = item?.constructor?.name
-  return name === 'ComfyNode' || name === 'LGraphNode'
-}
 
 const isRefreshableWidget = (widget: IWidget): widget is RefreshableWidget =>
   'refresh' in widget && typeof widget.refresh === 'function'

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -17,3 +17,8 @@ export function addToComboValues(widget: IComboWidget, value: string) {
     widget.options.values.push(value)
   }
 }
+
+export const isLGraphNode = (item: unknown): item is LGraphNode => {
+  const name = item?.constructor?.name
+  return name === 'ComfyNode' || name === 'LGraphNode'
+}


### PR DESCRIPTION
Resolve https://github.com/Comfy-Org/ComfyUI_frontend/issues/2613

![image](https://github.com/user-attachments/assets/fa405fa8-4db2-4224-9b5a-e244e7de3481)

Notes:
- Icon can probably be better but the detour one is probably the best I found so far
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/2612#discussion_r1959718696 We probably want to offer better dev experience working on selected items on the canvas

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2616-Add-bypass-action-to-selection-toolbox-19e6d73d3650810bb029f88608e07abc) by [Unito](https://www.unito.io)
