### PR TITLE
[Refactor] Extract color selector as component

### DIFF
--- a/src/components/common/ColorCustomizationSelector.vue
+++ b/src/components/common/ColorCustomizationSelector.vue
@@ -7,6 +7,7 @@
       :options="colorOptionsWithCustom"
       optionLabel="name"
       dataKey="value"
+      :allow-empty="false"
     >
       <template #option="slotProps">
         <div

--- a/src/components/common/ColorCustomizationSelector.vue
+++ b/src/components/common/ColorCustomizationSelector.vue
@@ -1,0 +1,86 @@
+<template>
+  <div
+    class="color-customization-selector-container flex flex-row items-center gap-2"
+  >
+    <SelectButton
+      v-model="selectedColorOption"
+      :options="colorOptionsWithCustom"
+      optionLabel="name"
+      dataKey="value"
+    >
+      <template #option="slotProps">
+        <div
+          v-if="slotProps.option.name !== '_custom'"
+          :style="{
+            width: '20px',
+            height: '20px',
+            backgroundColor: slotProps.option.value,
+            borderRadius: '50%'
+          }"
+        ></div>
+        <i
+          v-else
+          class="pi pi-palette text-lg"
+          v-tooltip="$t('color.custom')"
+        ></i>
+      </template>
+    </SelectButton>
+    <ColorPicker
+      v-if="selectedColorOption.name === '_custom'"
+      v-model="customColorValue"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ColorPicker from 'primevue/colorpicker'
+import SelectButton from 'primevue/selectbutton'
+import { computed, onMounted, ref, watch } from 'vue'
+
+const { modelValue, colorOptions } = defineProps<{
+  modelValue: string | null
+  colorOptions: { name: Exclude<string, '_custom'>; value: string }[]
+}>()
+
+const customColorOption = { name: '_custom', value: '' }
+const colorOptionsWithCustom = computed(() => [
+  ...colorOptions,
+  customColorOption
+])
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | null]
+}>()
+
+const selectedColorOption = ref(customColorOption)
+const customColorValue = ref('')
+
+// Initialize the component with the provided modelValue
+onMounted(() => {
+  if (modelValue) {
+    const predefinedColor = colorOptions.find((opt) => opt.value === modelValue)
+    if (predefinedColor) {
+      selectedColorOption.value = predefinedColor
+    } else {
+      selectedColorOption.value = customColorOption
+      customColorValue.value = modelValue.replace('#', '')
+    }
+  }
+})
+
+// Watch for changes in selection and emit updates
+watch(selectedColorOption, (newOption, oldOption) => {
+  if (newOption.name === '_custom') {
+    // Inherit the color from previous selection
+    customColorValue.value = oldOption.value.replace('#', '')
+  } else {
+    emit('update:modelValue', newOption.value)
+  }
+})
+
+watch(customColorValue, (newValue) => {
+  if (selectedColorOption.value.name === '_custom') {
+    emit('update:modelValue', newValue ? `#${newValue}` : null)
+  }
+})
+</script>

--- a/src/components/common/ColorCustomizationSelector.vue
+++ b/src/components/common/ColorCustomizationSelector.vue
@@ -18,11 +18,7 @@
             borderRadius: '50%'
           }"
         ></div>
-        <i
-          v-else
-          class="pi pi-palette text-lg"
-          v-tooltip="$t('color.custom')"
-        ></i>
+        <i v-else class="pi pi-palette text-lg"></i>
       </template>
     </SelectButton>
     <ColorPicker

--- a/src/components/common/CustomizationDialog.vue
+++ b/src/components/common/CustomizationDialog.vue
@@ -20,37 +20,10 @@
       <Divider />
       <div class="field color-field">
         <label for="color">{{ $t('g.color') }}</label>
-        <div class="color-picker-container">
-          <SelectButton
-            v-model="selectedColor"
-            :options="colorOptions"
-            optionLabel="name"
-            dataKey="value"
-            :allow-empty="false"
-          >
-            <template #option="slotProps">
-              <div
-                v-if="slotProps.option.value !== 'custom'"
-                :style="{
-                  width: '20px',
-                  height: '20px',
-                  backgroundColor: slotProps.option.value,
-                  borderRadius: '50%'
-                }"
-              ></div>
-              <i
-                v-else
-                class="pi pi-palette"
-                :style="{ fontSize: '1.2rem' }"
-                v-tooltip="$t('color.custom')"
-              ></i>
-            </template>
-          </SelectButton>
-          <ColorPicker
-            v-if="selectedColor.value === 'custom'"
-            v-model="customColor"
-          />
-        </div>
+        <ColorCustomizationSelector
+          v-model="finalColor"
+          :color-options="colorOptions"
+        />
       </div>
     </div>
     <template #footer>
@@ -72,13 +45,13 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button'
-import ColorPicker from 'primevue/colorpicker'
 import Dialog from 'primevue/dialog'
 import Divider from 'primevue/divider'
 import SelectButton from 'primevue/selectbutton'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import ColorCustomizationSelector from '@/components/common/ColorCustomizationSelector.vue'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 
 const { t } = useI18n()
@@ -118,29 +91,24 @@ const colorOptions = [
   { name: t('color.green'), value: '#28a745' },
   { name: t('color.red'), value: '#dc3545' },
   { name: t('color.pink'), value: '#e83e8c' },
-  { name: t('color.yellow'), value: '#ffc107' },
-  { name: t('color.custom'), value: 'custom' }
+  { name: t('color.yellow'), value: '#ffc107' }
 ]
 
 const defaultIcon = iconOptions.find(
   (option) => option.value === nodeBookmarkStore.defaultBookmarkIcon
 )
-const defaultColor = colorOptions.find(
-  (option) => option.value === nodeBookmarkStore.defaultBookmarkColor
-)
 
 const selectedIcon = ref<{ name: string; value: string }>(defaultIcon)
-const selectedColor = ref<{ name: string; value: string }>(defaultColor)
-const finalColor = computed(() =>
-  selectedColor.value.value === 'custom'
-    ? `#${customColor.value}`
-    : selectedColor.value.value
+const finalColor = ref(
+  props.initialColor || nodeBookmarkStore.defaultBookmarkColor
 )
 
-const customColor = ref('000000')
-
-const closeDialog = () => {
-  visible.value = false
+const resetCustomization = () => {
+  selectedIcon.value =
+    iconOptions.find((option) => option.value === props.initialIcon) ||
+    defaultIcon
+  finalColor.value =
+    props.initialColor || nodeBookmarkStore.defaultBookmarkColor
 }
 
 const confirmCustomization = () => {
@@ -148,21 +116,8 @@ const confirmCustomization = () => {
   closeDialog()
 }
 
-const resetCustomization = () => {
-  selectedIcon.value =
-    iconOptions.find((option) => option.value === props.initialIcon) ||
-    defaultIcon
-  const colorOption = colorOptions.find(
-    (option) => option.value === props.initialColor
-  )
-  if (!props.initialColor) {
-    selectedColor.value = defaultColor
-  } else if (!colorOption) {
-    customColor.value = props.initialColor.replace('#', '')
-    selectedColor.value = { name: t('color.custom'), value: 'custom' }
-  } else {
-    selectedColor.value = colorOption
-  }
+const closeDialog = () => {
+  visible.value = false
 }
 
 watch(
@@ -188,12 +143,6 @@ watch(
 .field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-}
-
-.color-picker-container {
-  display: flex;
-  align-items: center;
   gap: 0.5rem;
 }
 </style>

--- a/src/components/common/__tests__/ColorCustomizationSelector.spec.ts
+++ b/src/components/common/__tests__/ColorCustomizationSelector.spec.ts
@@ -1,0 +1,129 @@
+import { mount } from '@vue/test-utils'
+import ColorPicker from 'primevue/colorpicker'
+import PrimeVue from 'primevue/config'
+import SelectButton from 'primevue/selectbutton'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import ColorCustomizationSelector from '../ColorCustomizationSelector.vue'
+
+describe('ColorCustomizationSelector', () => {
+  const colorOptions = [
+    { name: 'Blue', value: '#0d6efd' },
+    { name: 'Green', value: '#28a745' }
+  ]
+
+  beforeEach(() => {
+    // Setup PrimeVue
+    const app = createApp({})
+    app.use(PrimeVue)
+  })
+
+  const mountComponent = (props = {}) => {
+    return mount(ColorCustomizationSelector, {
+      global: {
+        plugins: [PrimeVue],
+        components: { SelectButton, ColorPicker }
+      },
+      props: {
+        modelValue: null,
+        colorOptions,
+        ...props
+      }
+    })
+  }
+
+  it('renders predefined color options and custom option', () => {
+    const wrapper = mountComponent()
+    const selectButton = wrapper.findComponent(SelectButton)
+
+    expect(selectButton.props('options')).toHaveLength(colorOptions.length + 1)
+    expect(selectButton.props('options')?.at(-1)?.name).toBe('_custom')
+  })
+
+  it('initializes with predefined color when provided', async () => {
+    const wrapper = mountComponent({
+      modelValue: '#0d6efd'
+    })
+
+    await nextTick()
+    const selectButton = wrapper.findComponent(SelectButton)
+    expect(selectButton.props('modelValue')).toEqual({
+      name: 'Blue',
+      value: '#0d6efd'
+    })
+  })
+
+  it('initializes with custom color when non-predefined color provided', async () => {
+    const wrapper = mountComponent({
+      modelValue: '#123456'
+    })
+
+    await nextTick()
+    const selectButton = wrapper.findComponent(SelectButton)
+    const colorPicker = wrapper.findComponent(ColorPicker)
+
+    expect(selectButton.props('modelValue').name).toBe('_custom')
+    expect(colorPicker.props('modelValue')).toBe('123456')
+  })
+
+  it('shows color picker when custom option is selected', async () => {
+    const wrapper = mountComponent()
+    const selectButton = wrapper.findComponent(SelectButton)
+
+    // Select custom option
+    await selectButton.setValue({ name: '_custom', value: '' })
+
+    expect(wrapper.findComponent(ColorPicker).exists()).toBe(true)
+  })
+
+  it('emits update when predefined color is selected', async () => {
+    const wrapper = mountComponent()
+    const selectButton = wrapper.findComponent(SelectButton)
+
+    await selectButton.setValue(colorOptions[0])
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['#0d6efd'])
+  })
+
+  it('emits update when custom color is changed', async () => {
+    const wrapper = mountComponent()
+    const selectButton = wrapper.findComponent(SelectButton)
+
+    // Select custom option
+    await selectButton.setValue({ name: '_custom', value: '' })
+
+    // Change custom color
+    const colorPicker = wrapper.findComponent(ColorPicker)
+    await colorPicker.setValue('ff0000')
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['#ff0000'])
+  })
+
+  it('inherits color from previous selection when switching to custom', async () => {
+    const wrapper = mountComponent()
+    const selectButton = wrapper.findComponent(SelectButton)
+
+    // First select a predefined color
+    await selectButton.setValue(colorOptions[0])
+
+    // Then switch to custom
+    await selectButton.setValue({ name: '_custom', value: '' })
+
+    const colorPicker = wrapper.findComponent(ColorPicker)
+    expect(colorPicker.props('modelValue')).toBe('0d6efd')
+  })
+
+  it('handles null modelValue correctly', async () => {
+    const wrapper = mountComponent({
+      modelValue: null
+    })
+
+    await nextTick()
+    const selectButton = wrapper.findComponent(SelectButton)
+    expect(selectButton.props('modelValue')).toEqual({
+      name: '_custom',
+      value: ''
+    })
+  })
+})


### PR DESCRIPTION
# Color Customization Component Refactor

This PR extracts the color selection functionality into a reusable `ColorCustomizationSelector` component, improving code maintainability and reusability across the application.

## Changes
- Created new `ColorCustomizationSelector.vue` component that handles both predefined and custom color selection
- Updated `CustomizationDialog.vue` to use the new component
- Simplified color state management by using a single `finalColor` ref instead of separate states for predefined/custom colors
- Improved type safety with TypeScript props definitions
- Maintained existing functionality while reducing code duplication

## Testing
- Verify that both predefined and custom color selection work as before
- Confirm that color reset and initialization work correctly
- Check that color updates are properly emitted to parent components

The refactor makes the color selection logic more maintainable and easier to reuse in other parts of the application where color customization is needed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2620-Refactor-Extract-color-selector-as-component-19e6d73d365081f18690f6296e92d8ab) by [Unito](https://www.unito.io)
