### PR TITLE
Fix pasting image that was copied from browser

### DIFF
--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -3,15 +3,14 @@ import { defineStore } from 'pinia'
 
 import { api } from '@/scripts/api'
 import { ExecutedWsMessage, ResultItem } from '@/types/apiTypes'
+import { parseFilePath } from '@/utils/formatUtil'
 
 const toOutputs = (
   filenames: string[],
   type: string
 ): ExecutedWsMessage['output'] => {
   return {
-    images: filenames.map((image) => {
-      return { filename: image, subfolder: '', type }
-    })
+    images: filenames.map((image) => ({ type, ...parseFilePath(image) }))
   }
 }
 

--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -232,3 +232,41 @@ export function createAnnotatedPath(
     return `${createPath(item, subfolder)}${createAnnotation(rootFolder)}`
   return `${createPath(item.filename ?? '', item.subfolder)}${createAnnotation(item.type)}`
 }
+
+/**
+ * Parses a filepath into its filename and subfolder components.
+ *
+ * @example
+ * parseFilePath('folder/file.txt')    // → { filename: 'file.txt', subfolder: 'folder' }
+ * parseFilePath('/folder/file.txt')   // → { filename: 'file.txt', subfolder: 'folder' }
+ * parseFilePath('file.txt')           // → { filename: 'file.txt', subfolder: '' }
+ * parseFilePath('folder//file.txt')   // → { filename: 'file.txt', subfolder: 'folder' }
+ *
+ * @param filepath The filepath to parse
+ * @returns Object containing filename and subfolder
+ */
+export function parseFilePath(filepath: string): {
+  filename: string
+  subfolder: string
+} {
+  if (!filepath?.trim()) return { filename: '', subfolder: '' }
+
+  const normalizedPath = filepath
+    .replace(/[\\/]+/g, '/') // Normalize path separators
+    .replace(/^\//, '') // Remove leading slash
+    .replace(/\/$/, '') // Remove trailing slash
+
+  const lastSlashIndex = normalizedPath.lastIndexOf('/')
+
+  if (lastSlashIndex === -1) {
+    return {
+      filename: normalizedPath,
+      subfolder: ''
+    }
+  }
+
+  return {
+    filename: normalizedPath.slice(lastSlashIndex + 1),
+    subfolder: normalizedPath.slice(0, lastSlashIndex)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/2629. In [PR #2580](https://github.com/Comfy-Org/ComfyUI_frontend/pull/2580), all node images are centralized in a store, represented using the `ResultItem` type:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/e4444d407462fa3ac9779e824cc3950978dee1a4/src/types/apiTypes.ts#L14-L18

To maintain consistency, file paths are sometimes transformed into `ResultItem` objects. This PR fixes an issue where the transformation was incorrect when the initial image path was a string and contained a subfolder—occurs during intra-browser copy-pasting.


Previous Behavior (Incorrect Transformation)

```
'pasted/file.png'
↓
{ filename: 'pasted/file.png', subfolder: '', type: 'input' }
↓
/api/view?filename=pasted%2Ffile+%288%29.png&subfolder=&type=input
```

after:

```
'pasted/file.png'
↓
{ filename: 'file.png', subfolder: 'pasted', type: 'input' }
↓
/api/view?filename=file+%288%29.png&subfolder=pasted&type=input
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2630-Fix-pasting-image-that-was-copied-from-browser-19f6d73d365081d1ba23ccafa62b72df) by [Unito](https://www.unito.io)
