### PR TITLE
[Desktop] Fix invalid type assertion in API

### DIFF
--- a/src/components/MenuHamburger.vue
+++ b/src/components/MenuHamburger.vue
@@ -13,7 +13,7 @@
       :aria-label="$t('menu.showMenu')"
       aria-live="assertive"
       @click="exitFocusMode"
-      @contextmenu="showNativeMenu"
+      @contextmenu="showNativeSystemMenu"
     />
     <div v-show="menuSetting !== 'Bottom'" class="window-actions-spacer" />
   </div>
@@ -26,7 +26,7 @@ import { CSSProperties, computed, watchEffect } from 'vue'
 import { app } from '@/scripts/app'
 import { useSettingStore } from '@/stores/settingStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { showNativeMenu } from '@/utils/envUtil'
+import { showNativeSystemMenu } from '@/utils/envUtil'
 
 const workspaceState = useWorkspaceStore()
 const settingStore = useSettingStore()

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -21,7 +21,7 @@
       v-tooltip="{ value: $t('menu.hideMenu'), showDelay: 300 }"
       :aria-label="$t('menu.hideMenu')"
       @click="workspaceState.focusMode = true"
-      @contextmenu="showNativeMenu"
+      @contextmenu="showNativeSystemMenu"
     />
     <div
       v-show="menuSetting !== 'Bottom'"
@@ -52,7 +52,7 @@ import {
   electronAPI,
   isElectron,
   isNativeWindow,
-  showNativeMenu
+  showNativeSystemMenu
 } from '@/utils/envUtil'
 
 const workspaceState = useWorkspaceStore()

--- a/src/utils/envUtil.ts
+++ b/src/utils/envUtil.ts
@@ -1,7 +1,4 @@
-import {
-  ElectronAPI,
-  ElectronContextMenuOptions
-} from '@comfyorg/comfyui-electron-types'
+import { ElectronAPI } from '@comfyorg/comfyui-electron-types'
 
 export function isElectron() {
   return 'electronAPI' in window && window.electronAPI !== undefined
@@ -11,8 +8,8 @@ export function electronAPI() {
   return (window as any).electronAPI as ElectronAPI
 }
 
-export function showNativeMenu(event: MouseEvent) {
-  electronAPI()?.showContextMenu(event as ElectronContextMenuOptions)
+export function showNativeSystemMenu() {
+  electronAPI()?.showContextMenu()
 }
 
 export function isNativeWindow() {


### PR DESCRIPTION
- Removes API call using invalid object; passing MouseEvent across IPC boundary.
- Restricts function to single task - showNativeSystemMenu
- Renames function - showNativeSystemMenu

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2631-Desktop-Fix-invalid-type-assertion-in-API-19f6d73d365081cf878deca7cc1fc461) by [Unito](https://www.unito.io)
