### PR TITLE
[Desktop] Fix missing git logo in troubleshooting

### DIFF
--- a/src/constants/desktopMaintenanceTasks.ts
+++ b/src/constants/desktopMaintenanceTasks.ts
@@ -27,7 +27,7 @@ export const DESKTOP_MAINTENANCE_TASKS: Readonly<MaintenanceTask>[] = [
   },
   {
     id: 'git',
-    headerImg: '/assets/images/Git-Logo-White.svg',
+    headerImg: 'assets/images/Git-Logo-White.svg',
     execute: () => openUrl('https://git-scm.com/downloads/'),
     name: 'Download git',
     shortDescription: 'Open the git download page.',


### PR DESCRIPTION
#### Current

![image](https://github.com/user-attachments/assets/7a48d43b-4b5d-4d6d-a74c-dd3b1fce7c8a)

#### Proposed

![image](https://github.com/user-attachments/assets/a954a3da-4533-49fc-a375-93200c04dfc2)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2633-Desktop-Fix-missing-git-logo-in-troubleshooting-19f6d73d365081308180c2747686436b) by [Unito](https://www.unito.io)
