### PR TITLE
Update issue report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -16,7 +16,18 @@ body:
   - type: textarea
     attributes:
       label: Frontend Version
-      description: 'What is the frontend version you are using? You can check this in the settings dialog'
+      description: |
+        What is the frontend version you are using? You can check this in the settings dialog.
+
+        <details>
+
+        <summary>Click to show where to find the version</summary>
+
+        Open the setting by clicking the cog icon in the bottom-left of the screen, then click `About`.
+
+        ![Desktop version](https://github.com/user-attachments/assets/eb741720-00c1-4d45-b0a2-341a45d089c5)
+
+        </details>
     validations:
       required: true
   - type: textarea
@@ -47,13 +58,33 @@ body:
   - type: textarea
     attributes:
       label: Browser Logs
-      description: 'Please copy the output from your browser logs here. You can access this by pressing F12 to toggle the developer tools, then navigating to the Console tab.'
+      description: |
+        Please copy the output from your browser logs here. You can access this by pressing F12 to toggle the developer tools, then navigating to the Console tab. You can right click and select "Save As" then drag the file into this section.
+
+        <details>
+
+        <summary>Click to show how to open the browser console</summary>
+
+        ![OpenDevTools](https://github.com/user-attachments/assets/4505621e-34f0-4b66-b9d0-2e1a9133a635)
+
+        ![ConsoleTab](https://github.com/user-attachments/assets/cc96c0db-2880-40bb-93a2-c035360c41b2)
+
+        </details>
     validations:
       required: true
   - type: textarea
     attributes:
       label: Setting JSON
-      description: 'Please upload the setting file here. The setting file is located at `user/default/comfy.settings.json`'
+      description: |
+        Please upload the setting file here. The setting file is located at `user/default/comfy.settings.json`
+
+        <details>
+
+        <summary>Click to show how to open the models directory</summary>
+
+        ![OpenFolder](https://github.com/user-attachments/assets/254e41c7-6335-4d6a-a7dd-c93ab74a9d5e)
+
+        </details>
     validations:
       required: true
   - type: dropdown
@@ -72,7 +103,8 @@ body:
         - Other
   - type: textarea
     attributes:
-      label: Other
-      description: 'Any other additional information you think might be helpful.'
+      label: Other Information
+      description: 'Any other context, details, or screenshots that might help solve the issue.'
+      placeholder: 'Add any other relevant information here...'
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -58,33 +58,13 @@ body:
   - type: textarea
     attributes:
       label: Browser Logs
-      description: |
-        Please copy the output from your browser logs here. You can access this by pressing F12 to toggle the developer tools, then navigating to the Console tab. You can right click and select "Save As" then drag the file into this section.
-
-        <details>
-
-        <summary>Click to show how to open the browser console</summary>
-
-        ![OpenDevTools](https://github.com/user-attachments/assets/4505621e-34f0-4b66-b9d0-2e1a9133a635)
-
-        ![ConsoleTab](https://github.com/user-attachments/assets/cc96c0db-2880-40bb-93a2-c035360c41b2)
-
-        </details>
+      description: 'Please copy the output from your browser logs here. You can access this by pressing F12 to toggle the developer tools, then navigating to the Console tab.'
     validations:
       required: true
   - type: textarea
     attributes:
       label: Setting JSON
-      description: |
-        Please upload the setting file here. The setting file is located at `user/default/comfy.settings.json`
-
-        <details>
-
-        <summary>Click to show how to open the models directory</summary>
-
-        ![OpenFolder](https://github.com/user-attachments/assets/254e41c7-6335-4d6a-a7dd-c93ab74a9d5e)
-
-        </details>
+      description: 'Please upload the setting file here. The setting file is located at `user/default/comfy.settings.json`'
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
Copies over expandable help field from [desktop repo issue template](https://github.com/Comfy-Org/desktop/blob/main/.github/ISSUE_TEMPLATE/bug-report.yaml?plain=1). See formatting: https://github.com/Comfy-Org/desktop/issues/new?template=bug-report.yaml

It will be helpful if more issues started to include screenshot of About badges.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2645-Update-issue-report-template-1a06d73d365081b7b426f5f0c0457d9b) by [Unito](https://www.unito.io)
