### PR TITLE
Update issue report image

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -25,7 +25,7 @@ body:
 
         Open the setting by clicking the cog icon in the bottom-left of the screen, then click `About`.
 
-        ![Desktop version](https://github.com/user-attachments/assets/eb741720-00c1-4d45-b0a2-341a45d089c5)
+        ![Frontend version](https://github.com/user-attachments/assets/561fb7c3-3012-457c-a494-9bdc1ff035c0)
 
         </details>
     validations:


### PR DESCRIPTION
- Follow-up on #2645
- Changes highlight in image from desktop version to frontend version

![Frontend version](https://github.com/user-attachments/assets/561fb7c3-3012-457c-a494-9bdc1ff035c0)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2647-Update-issue-report-image-1a06d73d36508103b65bd4b14fd910e0) by [Unito](https://www.unito.io)
