### PR TITLE
Fix error translating legacy setting options

### DIFF
--- a/scripts/collect-i18n-general.ts
+++ b/scripts/collect-i18n-general.ts
@@ -69,11 +69,11 @@ test('collect-i18n-general', async ({ comfyPage }) => {
         name: setting.name,
         tooltip: setting.tooltip,
         category: setting.category,
-        // @ts-expect-error: Audit and deprecate usage of legacy options type:
-        // (value) => [string | {text: string, value: string}]
         options:
           typeof setting.options === 'function'
-            ? setting.options()
+            ? // @ts-expect-error: Audit and deprecate usage of legacy options type:
+              // (value) => [string | {text: string, value: string}]
+              setting.options(setting.defaultValue ?? '')
             : setting.options
       }))
   })

--- a/scripts/collect-i18n-general.ts
+++ b/scripts/collect-i18n-general.ts
@@ -69,7 +69,12 @@ test('collect-i18n-general', async ({ comfyPage }) => {
         name: setting.name,
         tooltip: setting.tooltip,
         category: setting.category,
-        options: setting.options
+        // @ts-expect-error: Audit and deprecate usage of legacy options type:
+        // (value) => [string | {text: string, value: string}]
+        options:
+          typeof setting.options === 'function'
+            ? setting.options()
+            : setting.options
       }))
   })
 

--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -32,6 +32,9 @@ const props = defineProps<{
 
 const { t } = useI18n()
 function translateOptions(options: (SettingOption | string)[]) {
+  // @ts-expect-error: Audit and deprecate usage of legacy options type:
+  // (value) => [string | {text: string, value: string}]
+  if (typeof options === 'function') return translateOptions(options())
   return options.map((option) => {
     const optionLabel = typeof option === 'string' ? option : option.text
     const optionValue = typeof option === 'string' ? option : option.value

--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -32,9 +32,12 @@ const props = defineProps<{
 
 const { t } = useI18n()
 function translateOptions(options: (SettingOption | string)[]) {
-  // @ts-expect-error: Audit and deprecate usage of legacy options type:
-  // (value) => [string | {text: string, value: string}]
-  if (typeof options === 'function') return translateOptions(options())
+  if (typeof options === 'function') {
+    // @ts-expect-error: Audit and deprecate usage of legacy options type:
+    // (value) => [string | {text: string, value: string}]
+    return translateOptions([options(props.setting.value ?? '')])
+  }
+
   return options.map((option) => {
     const optionLabel = typeof option === 'string' ? option : option.text
     const optionValue = typeof option === 'string' ? option : option.value

--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -35,7 +35,7 @@ function translateOptions(options: (SettingOption | string)[]) {
   if (typeof options === 'function') {
     // @ts-expect-error: Audit and deprecate usage of legacy options type:
     // (value) => [string | {text: string, value: string}]
-    return translateOptions([options(props.setting.value ?? '')])
+    return translateOptions(options(props.setting.value ?? ''))
   }
 
   return options.map((option) => {

--- a/src/components/dialog/content/setting/__tests__/SettingItem.spec.ts
+++ b/src/components/dialog/content/setting/__tests__/SettingItem.spec.ts
@@ -34,7 +34,7 @@ describe('SettingItem', () => {
         name: 'Node Input Conversion Submenus',
         type: 'combo',
         value: 'Top',
-        options: (value: string) => 'Correctly Translated'
+        options: (value: string) => ['Correctly Translated']
       }
     })
 

--- a/src/components/dialog/content/setting/__tests__/SettingItem.spec.ts
+++ b/src/components/dialog/content/setting/__tests__/SettingItem.spec.ts
@@ -1,0 +1,47 @@
+// @ts-strict-ignore
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SettingItem from '../SettingItem.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en'
+})
+
+vi.mock('@/utils/formatUtil', () => ({
+  normalizeI18nKey: vi.fn()
+}))
+
+describe('SettingItem', () => {
+  const mountComponent = (props: any, options = {}): any => {
+    return mount(SettingItem, {
+      global: {
+        plugins: [PrimeVue, i18n, createPinia()]
+      },
+      props,
+      ...options
+    })
+  }
+
+  it('translates options that use legacy type', () => {
+    const wrapper = mountComponent({
+      setting: {
+        id: 'Comfy.NodeInputConversionSubmenus',
+        name: 'Node Input Conversion Submenus',
+        type: 'combo',
+        value: 'Top',
+        options: (value: string) => 'Correctly Translated'
+      }
+    })
+
+    // Get the options property of the FormItem
+    const options = wrapper.vm.formItem.options
+    expect(options).toEqual([
+      { text: 'Correctly Translated', value: 'Correctly Translated' }
+    ])
+  })
+})


### PR DESCRIPTION
Fixes error that occurs when an extension is using the old combo options type. It already happens here:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/9c7d86ee4903a72778ac032906dcbdca6a23425d/src/components/common/FormItem.vue#L68-L72

But the original options are retrieved again in `SettingItem`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2648-Fix-error-translating-legacy-setting-options-1a06d73d365081188317db470817117a) by [Unito](https://www.unito.io)
