### PR TITLE
[BugFix] Copy LGraphCanvas.ds on serialization

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -405,7 +405,7 @@ export class ComfyApp {
         }
         workflow.extra.ds = {
           scale: self.canvas.ds.scale,
-          offset: self.canvas.ds.offset
+          offset: [...self.canvas.ds.offset]
         }
       } else if (workflow.extra?.ds) {
         // Clear any old view data


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI_frontend/pull/2608 marks litegraph `DragAndScale` state reactive, which results the serialization result to be proxied. This PR copies the array content to a new array to avoid the original array reference being passed to the serialization result.

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2650, https://github.com/chrisgoringe/cg-use-everywhere/issues/257

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2653-BugFix-Copy-LGraphCanvas-ds-on-serialization-1a06d73d36508177bf13d79fb9a39762) by [Unito](https://www.unito.io)
