### PR TITLE
[BugFix] Properly trigger onClose hook in dialogService

### DIFF
--- a/browser_tests/extensionAPI.spec.ts
+++ b/browser_tests/extensionAPI.spec.ts
@@ -280,5 +280,22 @@ test.describe('Topbar commands', () => {
       await comfyPage.confirmDialog.click('confirm')
       expect(await comfyPage.page.evaluate(() => window['value'])).toBe(true)
     })
+
+    test('Should allow dismissing a dialog', async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(() => {
+        window['value'] = 'foo'
+        window['app'].extensionManager.dialog
+          .confirm({
+            title: 'Test Confirm',
+            message: 'Test Confirm Message'
+          })
+          .then((value: boolean) => {
+            window['value'] = value
+          })
+      })
+
+      await comfyPage.confirmDialog.click('reject')
+      expect(await comfyPage.page.evaluate(() => window['value'])).toBeNull()
+    })
   })
 })

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -43,18 +43,10 @@ export const useDialogStore = defineStore('dialog', () => {
   }
 
   function closeDialog(options?: { key: string }) {
-    let targetDialog: DialogInstance | undefined
-
-    if (!options) {
-      targetDialog = dialogStack.value.pop()
-    } else {
-      const dialogKey = options.key
-      targetDialog = dialogStack.value.find((d) => d.key === dialogKey)
-    }
-
-    if (!targetDialog) {
-      return
-    }
+    const targetDialog = options
+      ? dialogStack.value.find((d) => d.key === options.key)
+      : dialogStack.value[0]
+    if (!targetDialog) return
 
     targetDialog.dialogComponentProps?.onClose?.()
     dialogStack.value.splice(dialogStack.value.indexOf(targetDialog), 1)

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -43,18 +43,21 @@ export const useDialogStore = defineStore('dialog', () => {
   }
 
   function closeDialog(options?: { key: string }) {
+    let targetDialog: DialogInstance | undefined
+
     if (!options) {
-      dialogStack.value.pop()
+      targetDialog = dialogStack.value.pop()
+    } else {
+      const dialogKey = options.key
+      targetDialog = dialogStack.value.find((d) => d.key === dialogKey)
+    }
+
+    if (!targetDialog) {
       return
     }
 
-    const dialogKey = options.key
-
-    const index = dialogStack.value.findIndex((d) => d.key === dialogKey)
-    if (index === -1) {
-      return
-    }
-    dialogStack.value.splice(index, 1)
+    targetDialog.dialogComponentProps?.onClose?.()
+    dialogStack.value.splice(dialogStack.value.indexOf(targetDialog), 1)
   }
 
   function createDialog(options: {
@@ -93,7 +96,6 @@ export const useDialogStore = defineStore('dialog', () => {
           dialog.dialogComponentProps.maximized = false
         },
         onAfterHide: () => {
-          options.dialogComponentProps?.onClose?.()
           closeDialog(dialog)
         },
         pt: {


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2649

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2655-BugFix-Properly-trigger-onClose-hook-in-dialogService-1a06d73d365081d08ff6cdbd8b204583) by [Unito](https://www.unito.io)
