### PR TITLE
Update litegraph 0.8.92

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
-        "@comfyorg/litegraph": "^0.8.91",
+        "@comfyorg/litegraph": "^0.8.92",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.91",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.91.tgz",
-      "integrity": "sha512-ui6DILHoMhSxzQOJErW/mc7VCxkyIWiVWRcAFAf8iwUTLkrlmWIFrZnl7/g+H8Bv+8mW6pwJuZtu2XXHvxQybg==",
+      "version": "0.8.92",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.92.tgz",
+      "integrity": "sha512-vDOYEYqFVboVPg7lzUGKgtVJUsy2LObajw1ghKETM0DTYx5NP2Dw76RjjdD+lGUSAw8AjaBC6tbWH7HP0XXHaw==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
-    "@comfyorg/litegraph": "^0.8.91",
+    "@comfyorg/litegraph": "^0.8.92",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.92. Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.8.92