### PR TITLE
Remove 'clean' param from graphToPrompt

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1227,9 +1227,8 @@ export class ComfyApp {
     return graph.serialize({ sortNodes })
   }
 
-  async graphToPrompt(graph = this.graph, clean = true) {
+  async graphToPrompt(graph = this.graph) {
     return graphToPrompt(graph, {
-      clean,
       sortNodes: useSettingStore().get('Comfy.Workflow.SortNodeIdOnSave')
     })
   }

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -10,9 +10,9 @@ import type { ComfyApiWorkflow, ComfyWorkflowJSON } from '@/types/comfyWorkflow'
  */
 export const graphToPrompt = async (
   graph: LGraph,
-  options: { clean?: boolean; sortNodes?: boolean } = {}
+  options: { sortNodes?: boolean } = {}
 ): Promise<{ workflow: ComfyWorkflowJSON; output: ComfyApiWorkflow }> => {
-  const { clean = true, sortNodes = false } = options
+  const { sortNodes = false } = options
 
   for (const outerNode of graph.computeExecutionOrder(false)) {
     if (outerNode.widgets) {
@@ -165,16 +165,14 @@ export const graphToPrompt = async (
   }
 
   // Remove inputs connected to removed nodes
-  if (clean) {
-    for (const o in output) {
-      for (const i in output[o].inputs) {
-        if (
-          Array.isArray(output[o].inputs[i]) &&
-          output[o].inputs[i].length === 2 &&
-          !output[output[o].inputs[i][0]]
-        ) {
-          delete output[o].inputs[i]
-        }
+  for (const o in output) {
+    for (const i in output[o].inputs) {
+      if (
+        Array.isArray(output[o].inputs[i]) &&
+        output[o].inputs[i].length === 2 &&
+        !output[output[o].inputs[i][0]]
+      ) {
+        delete output[o].inputs[i]
       }
     }
   }


### PR DESCRIPTION
According to codesearch, the param is unused (Never set to false).

https://cs.comfy.org/search?q=context:global+graphToPrompt%28&patternType=keyword&sm=0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2665-Remove-clean-param-from-graphToPrompt-1a16d73d3650810f80edf71b53279184) by [Unito](https://www.unito.io)
