### PR TITLE
[Refactor] Move Widget.beforeQueued invocation from graphToPrompt to queuePrompt

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -15,14 +15,6 @@ export const graphToPrompt = async (
   const { sortNodes = false } = options
 
   for (const outerNode of graph.computeExecutionOrder(false)) {
-    if (outerNode.widgets) {
-      for (const widget of outerNode.widgets) {
-        // Allow widgets to run callbacks before a prompt has been queued
-        // e.g. random seed before every gen
-        widget.beforeQueued?.()
-      }
-    }
-
     const innerNodes = outerNode.getInnerNodes
       ? outerNode.getInnerNodes()
       : [outerNode]

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -42,3 +42,14 @@ export const getItemsColorOption = (items: unknown[]): ColorOption | null => {
     ? _.head(colorOptions)!
     : null
 }
+
+export function executeWidgetsCallback(
+  nodes: LGraphNode[],
+  callbackName: 'onRemove' | 'beforeQueued' | 'afterQueued'
+) {
+  for (const node of nodes) {
+    for (const widget of node.widgets ?? []) {
+      widget[callbackName]?.()
+    }
+  }
+}


### PR DESCRIPTION
`graphToPrompt` should not side effect on triggering `beforeQueued` on widgets. This PR moves the invocation to queuePrompt which matches the invocation site of `afterQueued`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2667-Refactor-Move-Widget-beforeQueued-invocation-from-graphToPrompt-to-queuePrompt-1a16d73d3650810f8992d6bfcf1441d0) by [Unito](https://www.unito.io)
