### PR TITLE
Restrict applyToGraph to PrimitiveNode

### DIFF
--- a/src/nodes/PrimitiveNode.ts
+++ b/src/nodes/PrimitiveNode.ts
@@ -569,7 +569,7 @@ export function isValidCombo(combo: string[], obj: unknown) {
   return true
 }
 
-function isPrimitiveNode(node: LGraphNode): node is PrimitiveNode {
+export function isPrimitiveNode(node: LGraphNode): node is PrimitiveNode {
   return node.type === 'PrimitiveNode'
 }
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -13,7 +13,6 @@ import type { ToastMessageOptions } from 'primevue/toast'
 import { reactive } from 'vue'
 
 import { st } from '@/i18n'
-import { isPrimitiveNode } from '@/nodes/PrimitiveNode'
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -1280,17 +1279,6 @@ export class ComfyApp {
           // Allow widgets to run callbacks before a prompt has been queued
           // e.g. random seed before every gen
           executeWidgetsCallback(this.graph.nodes, 'beforeQueued')
-
-          for (const outerNode of this.graph.computeExecutionOrder(false)) {
-            const innerNodes = outerNode.getInnerNodes
-              ? outerNode.getInnerNodes()
-              : [outerNode]
-            for (const node of innerNodes) {
-              if (isPrimitiveNode(node)) {
-                node.applyToGraph()
-              }
-            }
-          }
 
           const p = await this.graphToPrompt()
           try {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -13,6 +13,7 @@ import type { ToastMessageOptions } from 'primevue/toast'
 import { reactive } from 'vue'
 
 import { st } from '@/i18n'
+import { isPrimitiveNode } from '@/nodes/PrimitiveNode'
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -1279,6 +1280,17 @@ export class ComfyApp {
           // Allow widgets to run callbacks before a prompt has been queued
           // e.g. random seed before every gen
           executeWidgetsCallback(this.graph.nodes, 'beforeQueued')
+
+          for (const outerNode of this.graph.computeExecutionOrder(false)) {
+            const innerNodes = outerNode.getInnerNodes
+              ? outerNode.getInnerNodes()
+              : [outerNode]
+            for (const node of innerNodes) {
+              if (isPrimitiveNode(node)) {
+                node.applyToGraph()
+              }
+            }
+          }
 
           const p = await this.graphToPrompt()
           try {

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -73,7 +73,6 @@ declare module '@comfyorg/litegraph' {
     convertToNodes?(): LGraphNode[]
     recreate?(): Promise<LGraphNode>
     refreshComboInNode?(defs: Record<string, ComfyNodeDef>)
-    applyToGraph?(extraLinks?: LLink[]): void
     updateLink?(link: LLink): LLink | null
     onExecutionStart?(): unknown
     /**

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -1,6 +1,7 @@
 import type { LGraph } from '@comfyorg/litegraph'
 import { LGraphEventMode } from '@comfyorg/litegraph'
 
+import { isPrimitiveNode } from '@/nodes/PrimitiveNode'
 import type { ComfyApiWorkflow, ComfyWorkflowJSON } from '@/types/comfyWorkflow'
 
 /**
@@ -13,6 +14,18 @@ export const graphToPrompt = async (
   options: { sortNodes?: boolean } = {}
 ): Promise<{ workflow: ComfyWorkflowJSON; output: ComfyApiWorkflow }> => {
   const { sortNodes = false } = options
+
+  for (const outerNode of graph.computeExecutionOrder(false)) {
+    const innerNodes = outerNode.getInnerNodes
+      ? outerNode.getInnerNodes()
+      : [outerNode]
+    for (const node of innerNodes) {
+      if (isPrimitiveNode(node)) {
+        node.applyToGraph()
+      }
+    }
+  }
+
   const workflow = graph.serialize({ sortNodes })
 
   // Remove localized_name from the workflow

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -13,21 +13,6 @@ export const graphToPrompt = async (
   options: { sortNodes?: boolean } = {}
 ): Promise<{ workflow: ComfyWorkflowJSON; output: ComfyApiWorkflow }> => {
   const { sortNodes = false } = options
-
-  for (const outerNode of graph.computeExecutionOrder(false)) {
-    const innerNodes = outerNode.getInnerNodes
-      ? outerNode.getInnerNodes()
-      : [outerNode]
-    for (const node of innerNodes) {
-      if (node.isVirtualNode) {
-        // Don't serialize frontend only nodes but let them make changes
-        if (node.applyToGraph) {
-          node.applyToGraph()
-        }
-      }
-    }
-  }
-
   const workflow = graph.serialize({ sortNodes })
 
   // Remove localized_name from the workflow


### PR DESCRIPTION
Removes `applyToGraph` in general `LGraphNode` interface, as code search shows there is no other usage other than the usage in `PrimitiveNode`. https://cs.comfy.org/search?q=context:global+applyToGraph&patternType=keyword&sm=0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2669-Restrict-applyToGraph-to-PrimitiveNode-1a16d73d36508155b72be6ebc67dedcc) by [Unito](https://www.unito.io)
