### PR TITLE
[Docs] Add id to details tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ We will support custom icons later.
 ![image](https://github.com/user-attachments/assets/7bff028a-bf91-4cab-bf97-55c243b3f5e0)
 </details>
 
-<details>
+<details id='extension-api-selection-toolbox'>
   <summary>v1.10.9: Selection Toolbox API</summary>
 
 Extensions can register commands that appear in the selection toolbox when specific items are selected on the canvas.


### PR DESCRIPTION
Adds id to tag to allow for anchor URL and improve SEO.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2676-Docs-Add-id-to-details-tag-in-README-md-1a26d73d365081b6af96c29b4182e9f0) by [Unito](https://www.unito.io)
