### PR TITLE
Translate runtime-generated widget labels

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -82,7 +82,8 @@ export const useLitegraphService = () => {
               )
             }
             if (config.widget) {
-              config.widget.label = st(nameKey, inputName)
+              const fallback = config.widget.label ?? inputName
+              config.widget.label = st(nameKey, fallback)
             }
           } else {
             // Node connection inputs


### PR DESCRIPTION
In https://github.com/Comfy-Org/ComfyUI_frontend/pull/1883, widget labels are translated by seting them to the associated input name and collecting input names from node defs in translation script. This PR preserves the widget's existing label and compensates by changing `collect-il8n-node-defs` script to collect runtime-generate widget labels. The result is:

- Widgets added at runtime (e.g., LoadImage's upload button) are translated
- Widget labels can be configured again (e.g., LoadImage's upload button has its original label from last year restored)

Before after english:

![ba-eng](https://github.com/user-attachments/assets/9709c19e-983d-4394-9928-a05dd607dc8d)

Kr:

![ba-kr](https://github.com/user-attachments/assets/8bbb790b-f94c-4a9e-8f89-19cfd56891e4)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2688-Translate-runtime-generated-widget-labels-1a36d73d36508196874ecbcf60c50724) by [Unito](https://www.unito.io)
