### PR TITLE
Don't serialize file upload and video preview widgets

### DIFF
--- a/src/composables/useNodeImage.ts
+++ b/src/composables/useNodeImage.ts
@@ -136,7 +136,8 @@ export const useNodeVideo = (node: LGraphNode) => {
     const hasWidget = node.widgets?.some((w) => w.name === VIDEO_WIDGET_NAME)
     if (!hasWidget) {
       node.addDOMWidget(VIDEO_WIDGET_NAME, 'video', container, {
-        hideOnZoom: false
+        hideOnZoom: false,
+        serialize: false
       })
     }
   }

--- a/src/composables/widgets/useImageUploadWidget.ts
+++ b/src/composables/widgets/useImageUploadWidget.ts
@@ -76,12 +76,16 @@ export const useImageUploadWidget = () => {
     })
 
     // Create the button widget for selecting the files
-    const uploadWidget = node.addWidget('button', inputName, 'image', () =>
-      openFileSelection()
+    const uploadWidget = node.addWidget(
+      'button',
+      inputName,
+      'image',
+      () => openFileSelection(),
+      {
+        serialize: false
+      }
     )
     uploadWidget.label = 'choose file to upload'
-    // @ts-expect-error serialize is not typed
-    uploadWidget.serialize = false
 
     // TODO: Explain this?
     // @ts-expect-error LGraphNode.callback is not typed


### PR DESCRIPTION
Sets `serialize: false` on video preview and LoadImage's upload widget. The upload widget originally was modifying the `serialize` property of the widget instance, but it should be on `widget.options` as there is no `widget.serialize`.

https://github.com/Comfy-Org/ComfyUI_frontend/blob/8dcf7eca749ac8fe339490d714691d2ab8718285/src/utils/executionUtil.ts#L72-L79

Related: 

- https://github.com/Comfy-Org/litegraph.js/pull/563

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2689-Don-t-serialize-file-upload-and-video-preview-widgets-1a36d73d365081a79978df8d8f9bc77d) by [Unito](https://www.unito.io)
