### PR TITLE
Type widget.options.serialize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
-        "@comfyorg/litegraph": "^0.8.92",
+        "@comfyorg/litegraph": "^0.8.93",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.92",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.92.tgz",
-      "integrity": "sha512-vDOYEYqFVboVPg7lzUGKgtVJUsy2LObajw1ghKETM0DTYx5NP2Dw76RjjdD+lGUSAw8AjaBC6tbWH7HP0XXHaw==",
+      "version": "0.8.93",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.93.tgz",
+      "integrity": "sha512-Cc2S5okfn0WeTpyr7vyKnYQHN+VaEuekUUnP+IXjDQoYMIOv6/nFAglWdS2tYEjEDkUfkdyMJER8Hj/USgezow==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
-    "@comfyorg/litegraph": "^0.8.92",
+    "@comfyorg/litegraph": "^0.8.93",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -11,6 +11,12 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
   interface IWidgetOptions {
     /** Currently used by DOM widgets only.  Declaring here reduces complexity. */
     onHide?: (widget: DOMWidget) => void
+    /**
+     * Controls whether the widget's value is included in the API workflow/prompt.
+     * - If false, the value will be excluded from the API workflow but still serialized as part of the graph state
+     * - If true or undefined, the value will be included in both the API workflow and graph state
+     */
+    serialize?: boolean
   }
 
   interface IBaseWidget {


### PR DESCRIPTION
The `serialize` option is used by ComfyUI_Frontend in these places:

- [image upload widget](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/composables/widgets/useImageUploadWidget.ts#L84)
- [value control widget](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/scripts/widgets.ts#L124)

It is in need of documentation, since its behavior can be misleading. Relies on https://github.com/Comfy-Org/litegraph.js/pull/562 (typing `options` parameter of `addWidget` to `IWidgetOptions`)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2692-Type-widget-options-serialize-1a36d73d3650819ca435da555501e76a) by [Unito](https://www.unito.io)
