### PR TITLE
Add previewMediaType flag for simpler node preview rendering

### DIFF
--- a/src/composables/useNodeImage.ts
+++ b/src/composables/useNodeImage.ts
@@ -10,6 +10,7 @@ const VIDEO_DEFAULT_OPTIONS = {
 } as const
 const MEDIA_LOAD_TIMEOUT = 8192 as const
 const MAX_RETRIES = 1 as const
+const VIDEO_PIXEL_OFFSET = 64 as const
 
 type MediaElement = HTMLImageElement | HTMLVideoElement
 
@@ -54,11 +55,6 @@ export const useNodePreview = <T extends MediaElement>(
   const loadElements = async (urls: string[]) =>
     Promise.all(urls.map((url) => loadElementWithTimeout(url)))
 
-  const render = () => {
-    node.setSizeForImage?.()
-    node.graph?.setDirtyCanvas(true)
-  }
-
   /**
    * Displays media element(s) on the node.
    */
@@ -77,7 +73,7 @@ export const useNodePreview = <T extends MediaElement>(
         )
         if (validElements.length) {
           onLoaded?.(validElements)
-          render()
+          node.graph?.setDirtyCanvas(true)
         }
       })
       .catch(() => {
@@ -110,6 +106,7 @@ export const useNodeImage = (node: LGraphNode) => {
   const onLoaded = (elements: HTMLImageElement[]) => {
     node.imageIndex = null
     node.imgs = elements
+    node.setSizeForImage?.()
   }
 
   return useNodePreview(node, {
@@ -156,7 +153,8 @@ export const useNodeVideo = (node: LGraphNode) => {
     }
 
     node.videoContainer.replaceChildren(videoElement)
-    node.imageOffset = 64
+    node.imageOffset = VIDEO_PIXEL_OFFSET
+    node.setSizeForImage?.(true)
   }
 
   return useNodePreview(node, {

--- a/src/composables/useNodeImage.ts
+++ b/src/composables/useNodeImage.ts
@@ -76,6 +76,7 @@ export const useNodePreview = <T extends MediaElement>(
           (el): el is NonNullable<Awaited<T>> => el !== null
         )
         if (validElements.length) {
+          console.count('render count:')
           onLoaded?.(validElements)
           render()
         }
@@ -108,6 +109,7 @@ export const useNodeImage = (node: LGraphNode) => {
   const onLoaded = (elements: HTMLImageElement[]) => {
     node.imageIndex = null
     node.imgs = elements
+    node.previewMediaType = 'image'
   }
 
   return useNodePreview(node, {
@@ -145,6 +147,8 @@ export const useNodeVideo = (node: LGraphNode) => {
   const onLoaded = (videoElements: HTMLVideoElement[]) => {
     const videoElement = videoElements[0]
     if (!videoElement) return
+
+    node.previewMediaType = 'video'
 
     if (!node.videoContainer) {
       node.videoContainer = createContainer()

--- a/src/composables/useNodeImage.ts
+++ b/src/composables/useNodeImage.ts
@@ -76,7 +76,6 @@ export const useNodePreview = <T extends MediaElement>(
           (el): el is NonNullable<Awaited<T>> => el !== null
         )
         if (validElements.length) {
-          console.count('render count:')
           onLoaded?.(validElements)
           render()
         }
@@ -98,6 +97,8 @@ export const useNodePreview = <T extends MediaElement>(
  * Attaches a preview image to a node.
  */
 export const useNodeImage = (node: LGraphNode) => {
+  node.previewMediaType = 'image'
+
   const loadElement = (url: string): Promise<HTMLImageElement | null> =>
     new Promise((resolve) => {
       const img = new Image()
@@ -109,7 +110,6 @@ export const useNodeImage = (node: LGraphNode) => {
   const onLoaded = (elements: HTMLImageElement[]) => {
     node.imageIndex = null
     node.imgs = elements
-    node.previewMediaType = 'image'
   }
 
   return useNodePreview(node, {
@@ -125,6 +125,8 @@ export const useNodeImage = (node: LGraphNode) => {
  * Attaches a preview video to a node.
  */
 export const useNodeVideo = (node: LGraphNode) => {
+  node.previewMediaType = 'video'
+
   const loadElement = (url: string): Promise<HTMLVideoElement | null> =>
     new Promise((resolve) => {
       const video = document.createElement('video')
@@ -147,8 +149,6 @@ export const useNodeVideo = (node: LGraphNode) => {
   const onLoaded = (videoElements: HTMLVideoElement[]) => {
     const videoElement = videoElements[0]
     if (!videoElement) return
-
-    node.previewMediaType = 'video'
 
     if (!node.videoContainer) {
       node.videoContainer = createContainer()

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -200,6 +200,8 @@ app.registerExtension({
         )
         uploadWidget.label = 'choose file to upload'
 
+        node.previewMediaType = 'audio'
+
         return { widget: uploadWidget }
       }
     }

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -115,6 +115,8 @@ declare module '@comfyorg/litegraph' {
     videoContainer?: HTMLElement
     /** Whether the node's preview media is loading */
     isLoading?: boolean
+    /** The content type of the node's preview media */
+    previewMediaType?: 'image' | 'video' | 'audio' | 'model'
 
     preview: string[]
     /** Index of the currently selected image on a multi-image node such as Preview Image */

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -129,7 +129,7 @@ declare module '@comfyorg/litegraph' {
     /** @deprecated Unused */
     inputHeight?: unknown
 
-    /** @deprecated Unused */
+    /** The y offset of the image preview to the top of the node body. */
     imageOffset?: number
     /** Callback for pasting an image file into the node */
     pasteFile?(file: File): void

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -8,67 +8,23 @@ import {
 import type { IComboWidget } from '@comfyorg/litegraph/dist/types/widgets'
 import _ from 'lodash'
 
-import { ComfyInputsSpec, ComfyNodeDef, InputSpec } from '@/types/apiTypes'
-
-const IMAGE_NODE_PROPERTY = 'image_upload'
-const VIDEO_NODE_PROPERTY = 'video_upload'
-
-const getNodeData = (node: LGraphNode): ComfyNodeDef | undefined =>
-  node.constructor?.nodeData as ComfyNodeDef | undefined
-
-const getInputSpecsFromData = (
-  inputData: ComfyInputsSpec | undefined
-): InputSpec[] => {
-  if (!inputData) return []
-
-  const { required, optional } = inputData
-  const inputSpecs: InputSpec[] = []
-  if (required) {
-    for (const value of Object.values(required)) {
-      inputSpecs.push(value)
-    }
-  }
-  if (optional) {
-    for (const value of Object.values(optional)) {
-      inputSpecs.push(value)
-    }
-  }
-  return inputSpecs
+type ImageNode = LGraphNode & { imgs: HTMLImageElement[] | undefined }
+type VideoNode = LGraphNode & {
+  videoContainer: HTMLElement | undefined
+  imgs: HTMLVideoElement[] | undefined
 }
-
-const hasImageElements = (imgs: unknown[]): boolean =>
-  Array.isArray(imgs) &&
-  imgs.some((img): img is HTMLImageElement => img instanceof HTMLImageElement)
-
-const hasInputProperty = (
-  node: LGraphNode | undefined,
-  property: string
-): boolean => {
-  if (!node) return false
-  const nodeData = getNodeData(node)
-  if (!nodeData?.input) return false
-
-  const inputs = getInputSpecsFromData(nodeData.input)
-  return inputs.some((input) => input?.[1]?.[property])
-}
-
-type ImageNode = LGraphNode & { imgs: HTMLImageElement[] }
-type VideoNode = LGraphNode & { videoContainer: HTMLElement }
 
 export function isImageNode(node: LGraphNode | undefined): node is ImageNode {
   if (!node) return false
-  if (node.imgs?.length && hasImageElements(node.imgs)) return true
-  if (!node.widgets) return false
-
-  return hasInputProperty(node, IMAGE_NODE_PROPERTY)
+  return (
+    node.previewMediaType === 'image' ||
+    (node.previewMediaType !== 'video' && !!node.imgs?.length)
+  )
 }
 
 export function isVideoNode(node: LGraphNode | undefined): node is VideoNode {
   if (!node) return false
-  if (node.videoContainer) return true
-  if (!node.widgets) return false
-
-  return hasInputProperty(node, VIDEO_NODE_PROPERTY)
+  return node.previewMediaType === 'video' || !!node.videoContainer
 }
 
 export function addToComboValues(widget: IComboWidget, value: string) {


### PR DESCRIPTION
This PR simplifies node preview rendering by setting a `previewMediaType` property on the node, rather than traversing the entire node in search of widgets with specific options (`image_upload`, `video_upload`, etc.) within every frame cycle. The responsibility for setting the media type falls to:

- For media uploaded from the client: The preview constuctor (`useNodeImage`, `useNodeVideo`, `AUDIOUPLOAD`, etc.)
- For media created on the backend: The server via fields in the result items of the response 

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2694-Add-previewMediaType-flag-for-simpler-node-preview-rendering-1a36d73d3650815ebe51ef2b3ecd0adb) by [Unito](https://www.unito.io)
