### PR TITLE
[Refactor] Simplify & document graphToPrompt

### DIFF
--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -68,12 +68,17 @@ declare module '@comfyorg/litegraph' {
     onGraphConfigured?(): void
     onExecuted?(output: any): void
     onNodeCreated?(this: LGraphNode): void
+    /** @deprecated groupNode */
     setInnerNodes?(nodes: LGraphNode[]): void
+    /** Originally a group node API. */
     getInnerNodes?(): LGraphNode[]
+    /** @deprecated groupNode */
     convertToNodes?(): LGraphNode[]
     recreate?(): Promise<LGraphNode>
     refreshComboInNode?(defs: Record<string, ComfyNodeDef>)
+    /** Used by virtual nodes (primitives) to insert their values into the graph prior to queueing. */
     applyToGraph?(extraLinks?: LLink[]): void
+    /** @deprecated groupNode */
     updateLink?(link: LLink): LLink | null
     onExecutionStart?(): unknown
     /**

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -73,7 +73,7 @@ export const graphToPrompt = async (
       }
 
       // Store all node links
-      for (let i = 0; i < node.inputs.length; i++) {
+      for (const [i, input] of node.inputs.entries()) {
         let parent = node.getInputNode(i)
         if (!parent) continue
 
@@ -94,7 +94,7 @@ export const graphToPrompt = async (
             const parentInputIndexes = Object.keys(parent.inputs).map(Number)
             const indexes = [link.origin_slot].concat(parentInputIndexes)
             for (const index of indexes) {
-              if (parent.inputs[index]?.type === node.inputs[i].type) {
+              if (parent.inputs[index]?.type === input.type) {
                 link = parent.getInputLink(index)
                 if (link) parent = parent.getInputNode(index)
 
@@ -112,7 +112,7 @@ export const graphToPrompt = async (
             link = parent.updateLink(link)
           }
           if (link) {
-            inputs[node.inputs[i].name] = [
+            inputs[input.name] = [
               String(link.origin_id),
               // @ts-expect-error link.origin_slot is already number.
               parseInt(link.origin_slot)

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -49,15 +49,12 @@ export const graphToPrompt = async (
         ? outerNode.getInnerNodes()
         : [outerNode]
     for (const node of innerNodes) {
-      if (node.isVirtualNode) {
-        continue
-      }
-
       if (
+        node.isVirtualNode ||
+        // Don't serialize muted nodes
         node.mode === LGraphEventMode.NEVER ||
         node.mode === LGraphEventMode.BYPASS
       ) {
-        // Don't serialize muted nodes
         continue
       }
 

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -89,7 +89,9 @@ export const graphToPrompt = async (
               if (parent) found = true
             }
           } else if (parent.mode === LGraphEventMode.BYPASS && parent.inputs) {
+            // Bypass nodes by finding first link with matching type
             const parentInputIndexes = Object.keys(parent.inputs).map(Number)
+            // Try the same slot number first
             const indexes = [link.origin_slot].concat(parentInputIndexes)
             for (const index of indexes) {
               if (parent.inputs[index]?.type !== input.type) continue

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -92,9 +92,8 @@ export const graphToPrompt = async (
               }
             } else if (link && parent.mode === LGraphEventMode.BYPASS) {
               if (parent.inputs) {
-                const all_inputs = [link.origin_slot].concat(
-                  Object.keys(parent.inputs).map(Number)
-                )
+                const parentInputs = Object.keys(parent.inputs).map(Number)
+                const inputs = [link.origin_slot].concat(parentInputs)
                 for (let parent_input in all_inputs) {
                   // @ts-expect-error assign string to number
                   parent_input = all_inputs[parent_input]

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -79,18 +79,16 @@ export const graphToPrompt = async (
 
         let link = node.getInputLink(i)
         while (parent.mode === LGraphEventMode.BYPASS || parent.isVirtualNode) {
+          if (!link) break
+
           let found = false
           if (parent.isVirtualNode) {
-            link = link ? parent.getInputLink(link.origin_slot) : null
+            link = parent.getInputLink(link.origin_slot)
             if (link) {
               parent = parent.getInputNode(link.target_slot)
               if (parent) found = true
             }
-          } else if (
-            link &&
-            parent.mode === LGraphEventMode.BYPASS &&
-            parent.inputs
-          ) {
+          } else if (parent.mode === LGraphEventMode.BYPASS && parent.inputs) {
             const parentInputIndexes = Object.keys(parent.inputs).map(Number)
             const indexes = [link.origin_slot].concat(parentInputIndexes)
             for (const index of indexes) {

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -92,8 +92,9 @@ export const graphToPrompt = async (
               }
             } else if (link && parent.mode === LGraphEventMode.BYPASS) {
               if (parent.inputs) {
-                // @ts-expect-error convert list of strings to list of numbers
-                const all_inputs = [link.origin_slot].concat(Object.keys(parent.inputs))
+                const all_inputs = [link.origin_slot].concat(
+                  Object.keys(parent.inputs).map(Number)
+                )
                 for (let parent_input in all_inputs) {
                   // @ts-expect-error assign string to number
                   parent_input = all_inputs[parent_input]

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -94,17 +94,13 @@ export const graphToPrompt = async (
               if (parent.inputs) {
                 const parentInputs = Object.keys(parent.inputs).map(Number)
                 const inputs = [link.origin_slot].concat(parentInputs)
-                for (let parent_input in all_inputs) {
-                  // @ts-expect-error assign string to number
-                  parent_input = all_inputs[parent_input]
+                for (const input of inputs) {
                   if (
-                    parent.inputs[parent_input]?.type === node.inputs[i].type
+                    parent.inputs[input]?.type === node.inputs[i].type
                   ) {
-                    // @ts-expect-error convert string to number
-                    link = parent.getInputLink(parent_input)
+                    link = parent.getInputLink(input)
                     if (link) {
-                      // @ts-expect-error convert string to number
-                      parent = parent.getInputNode(parent_input)
+                      parent = parent.getInputNode(input)
                     }
                     found = true
                     break

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -94,13 +94,13 @@ export const graphToPrompt = async (
             const parentInputIndexes = Object.keys(parent.inputs).map(Number)
             const indexes = [link.origin_slot].concat(parentInputIndexes)
             for (const index of indexes) {
-              if (parent.inputs[index]?.type === input.type) {
-                link = parent.getInputLink(index)
-                if (link) parent = parent.getInputNode(index)
+              if (parent.inputs[index]?.type !== input.type) continue
 
-                found = true
-                break
-              }
+              link = parent.getInputLink(index)
+              if (link) parent = parent.getInputNode(index)
+
+              found = true
+              break
             }
           }
 

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -81,18 +81,21 @@ export const graphToPrompt = async (
         while (parent.mode === LGraphEventMode.BYPASS || parent.isVirtualNode) {
           if (!link) break
 
-          let found = false
           if (parent.isVirtualNode) {
             link = parent.getInputLink(link.origin_slot)
-            if (link) {
-              parent = parent.getInputNode(link.target_slot)
-              if (parent) found = true
-            }
-          } else if (parent.mode === LGraphEventMode.BYPASS && parent.inputs) {
+            if (!link) break
+
+            parent = parent.getInputNode(link.target_slot)
+            if (!parent) break
+          } else if (!parent.inputs) {
+            break
+          } else if (parent.mode === LGraphEventMode.BYPASS) {
             // Bypass nodes by finding first link with matching type
             const parentInputIndexes = Object.keys(parent.inputs).map(Number)
             // Try the same slot number first
             const indexes = [link.origin_slot].concat(parentInputIndexes)
+
+            let found = false
             for (const index of indexes) {
               if (parent.inputs[index]?.type !== input.type) continue
 
@@ -102,9 +105,8 @@ export const graphToPrompt = async (
               found = true
               break
             }
+            if (!found) break
           }
-
-          if (!found) break
         }
 
         if (link) {

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -59,20 +59,16 @@ export const graphToPrompt = async (
       }
 
       const inputs: ComfyApiWorkflow[string]['inputs'] = {}
-      const widgets = node.widgets
+      const { widgets } = node
 
       // Store all widget values
       if (widgets) {
-        for (let i = 0; i < widgets.length; i++) {
-          const widget = widgets[i]
-          if (
-            widget.name &&
-            (!widget.options || widget.options.serialize !== false)
-          ) {
-            inputs[widget.name] = widget.serializeValue
-              ? await widget.serializeValue(node, i)
-              : widget.value
-          }
+        for (const [i, widget] of widgets.entries()) {
+          if (!widget.name || widget.options?.serialize === false) continue
+
+          inputs[widget.name] = widget.serializeValue
+            ? await widget.serializeValue(node, i)
+            : widget.value
         }
       }
 

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -91,12 +91,12 @@ export const graphToPrompt = async (
             parent.mode === LGraphEventMode.BYPASS &&
             parent.inputs
           ) {
-            const parentInputs = Object.keys(parent.inputs).map(Number)
-            const inputs = [link.origin_slot].concat(parentInputs)
-            for (const input of inputs) {
-              if (parent.inputs[input]?.type === node.inputs[i].type) {
-                link = parent.getInputLink(input)
-                if (link) parent = parent.getInputNode(input)
+            const parentInputIndexes = Object.keys(parent.inputs).map(Number)
+            const indexes = [link.origin_slot].concat(parentInputIndexes)
+            for (const index of indexes) {
+              if (parent.inputs[index]?.type === node.inputs[i].type) {
+                link = parent.getInputLink(index)
+                if (link) parent = parent.getInputNode(index)
 
                 found = true
                 break

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -90,21 +90,21 @@ export const graphToPrompt = async (
                   found = true
                 }
               }
-            } else if (link && parent.mode === LGraphEventMode.BYPASS) {
-              if (parent.inputs) {
-                const parentInputs = Object.keys(parent.inputs).map(Number)
-                const inputs = [link.origin_slot].concat(parentInputs)
-                for (const input of inputs) {
-                  if (
-                    parent.inputs[input]?.type === node.inputs[i].type
-                  ) {
-                    link = parent.getInputLink(input)
-                    if (link) {
-                      parent = parent.getInputNode(input)
-                    }
-                    found = true
-                    break
+            } else if (
+              link &&
+              parent.mode === LGraphEventMode.BYPASS &&
+              parent.inputs
+            ) {
+              const parentInputs = Object.keys(parent.inputs).map(Number)
+              const inputs = [link.origin_slot].concat(parentInputs)
+              for (const input of inputs) {
+                if (parent.inputs[input]?.type === node.inputs[i].type) {
+                  link = parent.getInputLink(input)
+                  if (link) {
+                    parent = parent.getInputNode(input)
                   }
+                  found = true
+                  break
                 }
               }
             }

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -150,11 +150,7 @@ export const graphToPrompt = async (
   // Remove inputs connected to removed nodes
   for (const { inputs } of Object.values(output)) {
     for (const [i, input] of Object.entries(inputs)) {
-      if (
-        Array.isArray(input) &&
-        input.length === 2 &&
-        !output[input[0]]
-      ) {
+      if (Array.isArray(input) && input.length === 2 && !output[input[0]]) {
         delete inputs[i]
       }
     }

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -88,6 +88,7 @@ export const graphToPrompt = async (
             parent = parent.getInputNode(link.target_slot)
             if (!parent) break
           } else if (!parent.inputs) {
+            // Maintains existing behaviour if parent.getInputLink is overriden
             break
           } else if (parent.mode === LGraphEventMode.BYPASS) {
             // Bypass nodes by finding first link with matching type

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -95,17 +95,13 @@ export const graphToPrompt = async (
             // Try the same slot number first
             const indexes = [link.origin_slot].concat(parentInputIndexes)
 
-            let found = false
-            for (const index of indexes) {
-              if (parent.inputs[index]?.type !== input.type) continue
+            const matchingIndex = indexes.find(
+              (index) => parent.inputs[index]?.type === input.type
+            )
+            if (matchingIndex === undefined) break
 
-              link = parent.getInputLink(index)
-              if (link) parent = parent.getInputNode(index)
-
-              found = true
-              break
-            }
-            if (!found) break
+            link = parent.getInputLink(matchingIndex)
+            if (link) parent = parent.getInputNode(matchingIndex)
           }
         }
 

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -89,14 +89,15 @@ export const graphToPrompt = async (
             // Maintains existing behaviour if parent.getInputLink is overriden
             break
           } else if (parent.mode === LGraphEventMode.BYPASS) {
-            // Bypass nodes by finding first link with matching type
+            // Bypass nodes by finding first input with matching type
             const parentInputIndexes = Object.keys(parent.inputs).map(Number)
-            // Try the same slot number first
+            // Prioritise exact slot index
             const indexes = [link.origin_slot].concat(parentInputIndexes)
 
             const matchingIndex = indexes.find(
               (index) => parent.inputs[index]?.type === input.type
             )
+            // No input types match
             if (matchingIndex === undefined) break
 
             link = parent.getInputLink(matchingIndex)
@@ -106,6 +107,7 @@ export const graphToPrompt = async (
 
         if (link) {
           if (parent?.updateLink) {
+            // groupNode
             link = parent.updateLink(link)
           }
           if (link) {

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -14,14 +14,12 @@ export const graphToPrompt = async (
 ): Promise<{ workflow: ComfyWorkflowJSON; output: ComfyApiWorkflow }> => {
   const { sortNodes = false } = options
 
-  for (const outerNode of graph.computeExecutionOrder(false)) {
-    const innerNodes = outerNode.getInnerNodes
-      ? outerNode.getInnerNodes()
-      : [outerNode]
-    for (const node of innerNodes) {
+  for (const node of graph.computeExecutionOrder(false)) {
+    const innerNodes = node.getInnerNodes ? node.getInnerNodes() : [node]
+    for (const innerNode of innerNodes) {
       // Don't serialize frontend only nodes but let them make changes
-      if (node.isVirtualNode) {
-        node.applyToGraph?.()
+      if (innerNode.isVirtualNode) {
+        innerNode.applyToGraph?.()
       }
     }
   }

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -19,11 +19,9 @@ export const graphToPrompt = async (
       ? outerNode.getInnerNodes()
       : [outerNode]
     for (const node of innerNodes) {
+      // Don't serialize frontend only nodes but let them make changes
       if (node.isVirtualNode) {
-        // Don't serialize frontend only nodes but let them make changes
-        if (node.applyToGraph) {
-          node.applyToGraph()
-        }
+        node.applyToGraph?.()
       }
     }
   }

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -91,10 +91,9 @@ export const graphToPrompt = async (
                 }
               }
             } else if (link && parent.mode === LGraphEventMode.BYPASS) {
-              let all_inputs = [link.origin_slot]
               if (parent.inputs) {
                 // @ts-expect-error convert list of strings to list of numbers
-                all_inputs = all_inputs.concat(Object.keys(parent.inputs))
+                const all_inputs = [link.origin_slot].concat(Object.keys(parent.inputs))
                 for (let parent_input in all_inputs) {
                   // @ts-expect-error assign string to number
                   parent_input = all_inputs[parent_input]

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -86,9 +86,7 @@ export const graphToPrompt = async (
               link = link ? parent.getInputLink(link.origin_slot) : null
               if (link) {
                 parent = parent.getInputNode(link.target_slot)
-                if (parent) {
-                  found = true
-                }
+                if (parent) found = true
               }
             } else if (
               link &&
@@ -100,18 +98,15 @@ export const graphToPrompt = async (
               for (const input of inputs) {
                 if (parent.inputs[input]?.type === node.inputs[i].type) {
                   link = parent.getInputLink(input)
-                  if (link) {
-                    parent = parent.getInputNode(input)
-                  }
+                  if (link) parent = parent.getInputNode(input)
+
                   found = true
                   break
                 }
               }
             }
 
-            if (!found) {
-              break
-            }
+            if (!found) break
           }
 
           if (link) {

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -152,14 +152,14 @@ export const graphToPrompt = async (
   }
 
   // Remove inputs connected to removed nodes
-  for (const o in output) {
-    for (const i in output[o].inputs) {
+  for (const { inputs } of Object.values(output)) {
+    for (const [i, input] of Object.entries(inputs)) {
       if (
-        Array.isArray(output[o].inputs[i]) &&
-        output[o].inputs[i].length === 2 &&
-        !output[output[o].inputs[i][0]]
+        Array.isArray(input) &&
+        input.length === 2 &&
+        !output[input[0]]
       ) {
-        delete output[o].inputs[i]
+        delete inputs[i]
       }
     }
   }


### PR DESCRIPTION
### Subgraph prep work: clean graph to prompt legacy code

- Preparation work for subgraph
- Reduces code complexity in `graphToPrompt` (`executionUtil`)
- Adds comments to the function itself, and tooltips of some callbacks

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2696-Refactor-Simplify-document-graphToPrompt-1a36d73d365081f1af31fc9a541e0785) by [Unito](https://www.unito.io)
