### PR TITLE
Show image size (W x H) on image nodes

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -469,8 +469,9 @@ export const useLitegraphService = () => {
 
       const shiftY = getImageTop(this)
 
+      const IMAGE_TEXT_SIZE_TEXT_HEIGHT = 15
       const dw = this.size[0]
-      const dh = this.size[1] - shiftY
+      const dh = this.size[1] - shiftY - IMAGE_TEXT_SIZE_TEXT_HEIGHT
 
       if (imageIndex == null) {
         // No image selected; draw thumbnails of all
@@ -581,8 +582,9 @@ export const useLitegraphService = () => {
         return
       }
       // Draw individual
-      let w = this.imgs[imageIndex].naturalWidth
-      let h = this.imgs[imageIndex].naturalHeight
+      const img = this.imgs[imageIndex]
+      let w = img.naturalWidth
+      let h = img.naturalHeight
 
       const scaleX = dw / w
       const scaleY = dh / h
@@ -593,7 +595,14 @@ export const useLitegraphService = () => {
 
       const x = (dw - w) / 2
       const y = (dh - h) / 2 + shiftY
-      ctx.drawImage(this.imgs[imageIndex], x, y, w, h)
+      ctx.drawImage(img, x, y, w, h)
+
+      // Draw image size text below the image
+      ctx.fillStyle = LiteGraph.NODE_TEXT_COLOR
+      ctx.textAlign = 'center'
+      const sizeText = `${Math.round(img.naturalWidth)} ×  ${Math.round(img.naturalHeight)}`
+      const textY = y + h + 10
+      ctx.fillText(sizeText, x + w / 2, textY)
 
       const drawButton = (
         x: number,

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -600,7 +600,7 @@ export const useLitegraphService = () => {
       // Draw image size text below the image
       ctx.fillStyle = LiteGraph.NODE_TEXT_COLOR
       ctx.textAlign = 'center'
-      const sizeText = `${Math.round(img.naturalWidth)} ×  ${Math.round(img.naturalHeight)}`
+      const sizeText = `${Math.round(img.naturalWidth)} × ${Math.round(img.naturalHeight)}`
       const textY = y + h + 10
       ctx.fillText(sizeText, x + w / 2, textY)
 


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2691

![image](https://github.com/user-attachments/assets/2366499c-9f01-4e33-bdce-17f1d04a025b)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2699-Show-image-size-W-x-H-on-image-nodes-1a46d73d365081ab8ef0d0c819004d50) by [Unito](https://www.unito.io)
