### PR TITLE
Cleanup node's file input elements on node removal

### DIFF
--- a/src/composables/useNodeFileInput.ts
+++ b/src/composables/useNodeFileInput.ts
@@ -1,5 +1,7 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
 
+import { useChainCallback } from './functional/useChainCallback'
+
 interface FileInputOptions {
   accept?: string
   allow_batch?: boolean
@@ -30,16 +32,12 @@ export function useNodeFileInput(node: LGraphNode, options: FileInputOptions) {
     }
   }
 
-  const originalOnRemoved = node.onRemoved
-  node.onRemoved = function (...args) {
+  node.onRemoved = useChainCallback(node.onRemoved, () => {
     if (fileInput) {
       fileInput.onchange = null
       fileInput = null
     }
-    if (originalOnRemoved) {
-      originalOnRemoved.apply(this, args)
-    }
-  }
+  })
 
   return {
     openFileSelection: () => fileInput?.click()

--- a/src/composables/useNodeImageUpload.ts
+++ b/src/composables/useNodeImageUpload.ts
@@ -82,7 +82,7 @@ export const useNodeImageUpload = (
   })
 
   // Handle file input
-  const { openFileSelection } = useNodeFileInput({
+  const { openFileSelection } = useNodeFileInput(node, {
     fileFilter,
     allow_batch,
     accept,

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -2,6 +2,7 @@
 import type { IWidget } from '@comfyorg/litegraph'
 import type { IStringWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
+import { useNodeFileInput } from '@/composables/useNodeFileInput'
 import type { DOMWidget } from '@/scripts/domWidget'
 import { useToastStore } from '@/stores/toastStore'
 import { ComfyNodeDef } from '@/types/apiTypes'
@@ -179,23 +180,19 @@ app.registerExtension({
           }
         }
 
-        const fileInput = document.createElement('input')
-        fileInput.type = 'file'
-        fileInput.accept = 'audio/*'
-        fileInput.style.display = 'none'
-        fileInput.onchange = () => {
-          if (fileInput.files.length) {
-            uploadFile(audioWidget, audioUIWidget, fileInput.files[0], true)
+        const { openFileSelection } = useNodeFileInput(node, {
+          accept: 'audio/*',
+          onSelect: (files) => {
+            uploadFile(audioWidget, audioUIWidget, files[0], true)
           }
-        }
+        })
+
         // The widget to pop up the upload dialog.
         const uploadWidget = node.addWidget(
           'button',
           inputName,
-          /* value=*/ '',
-          () => {
-            fileInput.click()
-          },
+          '',
+          openFileSelection,
           { serialize: false }
         )
         uploadWidget.label = 'choose file to upload'

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -183,7 +183,9 @@ app.registerExtension({
         const { openFileSelection } = useNodeFileInput(node, {
           accept: 'audio/*',
           onSelect: (files) => {
-            uploadFile(audioWidget, audioUIWidget, files[0], true)
+            if (files?.length) {
+              uploadFile(audioWidget, audioUIWidget, files[0], true)
+            }
           }
         })
 


### PR DESCRIPTION
This PR adds cleanup handling for nodes that have file upload (LoadAudio, LoadImage, LoadAnimatedWEBM, etc.). The file input elements do not need to be added to the DOM at all, and their style/visibility therefore does not need to be set. When the node is removed, all element and listener references are set to `null`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2703-Cleanup-node-s-file-input-elements-on-node-removal-1a46d73d365081538544e5c970ca20d2) by [Unito](https://www.unito.io)
