### PR TITLE
Type addDOMWidget

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -28,6 +28,12 @@ export interface DOMWidget<T extends HTMLElement, V extends object | string>
   options: DOMWidgetOptions<T, V>
   value: V
   y?: number
+  /**
+   * @deprecated Legacy property used by some extensions for customtext
+   * (textarea) widgets. Use `element` instead as it provides the same
+   * functionality and works for all DOMWidget types.
+   */
+  inputEl?: T
   callback?: (value: V) => void
   /**
    * Draw the widget on the canvas.

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -432,11 +432,14 @@ export const useLitegraphService = () => {
             host.el,
             {
               host,
+              // @ts-expect-error `getHeight` of image host returns void instead of number.
               getHeight: host.getHeight,
               onDraw: host.onDraw,
               hideOnZoom: false
             }
-          )
+          ) as IWidget & {
+            options: { host: ReturnType<typeof createImageHost> }
+          }
           widget.serializeValue = () => undefined
           widget.options.host.updateImages(this.imgs)
         }

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -1,7 +1,7 @@
 import '@comfyorg/litegraph'
 import type { LLink, Size } from '@comfyorg/litegraph'
 
-import type { DOMWidget } from '@/scripts/domWidget'
+import type { DOMWidget, DOMWidgetOptions } from '@/scripts/domWidget'
 import type { ComfyNodeDef } from '@/types/apiTypes'
 
 import type { NodeId } from './comfyWorkflow'
@@ -112,12 +112,15 @@ declare module '@comfyorg/litegraph' {
      */
     isVirtualNode?: boolean
 
-    addDOMWidget(
+    addDOMWidget<
+      T extends HTMLElement = HTMLElement,
+      V extends object | string = string
+    >(
       name: string,
       type: string,
-      element: HTMLElement,
-      options?: Record<string, any>
-    ): DOMWidget
+      element: T,
+      options?: DOMWidgetOptions<T, V>
+    ): DOMWidget<T, V>
 
     animatedImages?: boolean
     imgs?: HTMLImageElement[]


### PR DESCRIPTION
Adds type to `options` parameter in `addDOMWidget`. `widget.inputEl` is not used in Comfy-Org repos since at least the beginning of ComfyUI_Frontend, but is used frequently in extensions per codesearch.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2705-Type-addDOMWidget-1a46d73d3650818aaf1ecf09b25175e8) by [Unito](https://www.unito.io)
