### PR TITLE
Fix node videos when preview format setting is set 

### DIFF
--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import { api } from '@/scripts/api'
 import { ExecutedWsMessage, ResultItem } from '@/types/apiTypes'
 import { parseFilePath } from '@/utils/formatUtil'
+import { isVideoNode } from '@/utils/litegraphUtil'
 
 const createOutputs = (
   filenames: string[],
@@ -15,7 +16,7 @@ const createOutputs = (
 }
 
 const getPreviewParam = (node: LGraphNode): string => {
-  if (node.animatedImages) return ''
+  if (node.animatedImages || isVideoNode(node)) return ''
   return app.getPreviewFormatParam()
 }
 


### PR DESCRIPTION
The `preview` param in the `/view` query indicates to the server that the requested content is a preview image of the format specificed by the `Comfy.PreviewFormat` setting. It is only added if the user specifies a format, but is blank by default.

If a node has `animatedImages` flag (videos from server), the preview param is not added. The `isVideoNode` check needs to be added to account for videos from client, otherwise the server will try to load the video as an image.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2706-Fix-node-videos-when-preview-format-setting-is-set-1a46d73d36508181a234d7a855b2a1a5) by [Unito](https://www.unito.io)
