### PR TITLE
Allow quitting instant queue mode with the stop button

### DIFF
--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -50,7 +50,12 @@
         :disabled="!hasPendingTasks"
         text
         :aria-label="$t('sideToolbar.queueTab.clearPendingTasks')"
-        @click="() => commandStore.execute('Comfy.ClearPendingTasks')"
+        @click="
+          () => {
+            commandStore.execute('Comfy.ClearPendingTasks')
+            queueMode = 'disabled'
+          }
+        "
       />
     </ButtonGroup>
   </div>
@@ -113,7 +118,9 @@ const queueModeMenuItems = computed(() =>
 )
 
 const executingPrompt = computed(() => !!queueCountStore.count.value)
-const hasPendingTasks = computed(() => queueCountStore.count.value > 1)
+const hasPendingTasks = computed(
+  () => queueCountStore.count.value > 1 || queueMode.value !== 'disabled'
+)
 
 const commandStore = useCommandStore()
 const queuePrompt = (e: MouseEvent) => {

--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -52,7 +52,9 @@
         :aria-label="$t('sideToolbar.queueTab.clearPendingTasks')"
         @click="
           () => {
-            commandStore.execute('Comfy.ClearPendingTasks')
+            if (queueCountStore.count.value > 1) {
+              commandStore.execute('Comfy.ClearPendingTasks')
+            }
             queueMode = 'disabled'
           }
         "


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2707

![image](https://github.com/user-attachments/assets/7adbc464-58c3-4004-81f1-14766f3c5239)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2708-Allow-quitting-instant-queue-mode-with-the-stop-button-1a46d73d3650819598d4dbaff4d014d1) by [Unito](https://www.unito.io)
