### PR TITLE
Add tooltip show-delay in action bar

### DIFF
--- a/src/components/actionbar/BatchCountEdit.vue
+++ b/src/components/actionbar/BatchCountEdit.vue
@@ -2,7 +2,10 @@
   <div
     class="batch-count"
     :class="props.class"
-    v-tooltip.bottom="$t('menu.batchCount')"
+    v-tooltip.bottom="{
+      value: $t('menu.batchCount'),
+      showDelay: 600
+    }"
     :aria-label="$t('menu.batchCount')"
   >
     <InputNumber

--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -8,11 +8,12 @@
       @click="queuePrompt"
       :model="queueModeMenuItems"
       data-testid="queue-button"
-      v-tooltip.bottom="
-        workspaceStore.shiftDown
+      v-tooltip.bottom="{
+        value: workspaceStore.shiftDown
           ? $t('menu.queueWorkflowFront')
-          : $t('menu.queueWorkflow')
-      "
+          : $t('menu.queueWorkflow'),
+        showDelay: 600
+      }"
     >
       <template #icon>
         <i-lucide:list-start v-if="workspaceStore.shiftDown" />
@@ -27,14 +28,20 @@
           :severity="item.key === queueMode ? 'primary' : 'secondary'"
           size="small"
           text
-          v-tooltip="item.tooltip"
+          v-tooltip="{
+            value: item.tooltip,
+            showDelay: 600
+          }"
         />
       </template>
     </SplitButton>
     <BatchCountEdit />
     <ButtonGroup class="execution-actions flex flex-nowrap">
       <Button
-        v-tooltip.bottom="$t('menu.interrupt')"
+        v-tooltip.bottom="{
+          value: $t('menu.interrupt'),
+          showDelay: 600
+        }"
         icon="pi pi-times"
         :severity="executingPrompt ? 'danger' : 'secondary'"
         :disabled="!executingPrompt"
@@ -44,7 +51,10 @@
       >
       </Button>
       <Button
-        v-tooltip.bottom="$t('sideToolbar.queueTab.clearPendingTasks')"
+        v-tooltip.bottom="{
+          value: $t('sideToolbar.queueTab.clearPendingTasks'),
+          showDelay: 600
+        }"
         icon="pi pi-stop"
         :severity="hasPendingTasks ? 'danger' : 'secondary'"
         :disabled="!hasPendingTasks"


### PR DESCRIPTION
The fast tooltip can be annoying if the user already knows what each button is for.