### PR TITLE
Update litegraph 0.8.95

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
-        "@comfyorg/litegraph": "^0.8.95",
+        "@comfyorg/litegraph": "^0.8.96",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.95",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.95.tgz",
-      "integrity": "sha512-CS/EhJyczMOjAEDiwLcnMy6eIPMr4NYOdPzc9YDZjjgpfjNd6hWEil1QrZ1leslERT1scc3jV0iY9D+gC/gBpg==",
+      "version": "0.8.96",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.96.tgz",
+      "integrity": "sha512-t9vlj8zVXwVhgjdZlOioNXY+AJADknEYhsWwbMmmRU4oQVskhWzrK3G/OqNOMilDRla+/oinqoFmVg4ujE9MVA==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
-        "@comfyorg/litegraph": "^0.8.94",
+        "@comfyorg/litegraph": "^0.8.95",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.94",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.94.tgz",
-      "integrity": "sha512-/eKe4sufoZ2Non3tfdyA89DgxpMJ55U+uHP82Hj4AoGH1O3ZhGV9KG6B0XIdiAfqSzqkMIMVazYCYwlWSHA/cg==",
+      "version": "0.8.95",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.95.tgz",
+      "integrity": "sha512-CS/EhJyczMOjAEDiwLcnMy6eIPMr4NYOdPzc9YDZjjgpfjNd6hWEil1QrZ1leslERT1scc3jV0iY9D+gC/gBpg==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
-    "@comfyorg/litegraph": "^0.8.94",
+    "@comfyorg/litegraph": "^0.8.95",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
-    "@comfyorg/litegraph": "^0.8.95",
+    "@comfyorg/litegraph": "^0.8.96",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -515,6 +515,7 @@ export function convertToInput(
   const [oldWidth, oldHeight] = node.size
   const inputIsOptional = !!widget.options?.inputIsOptional
   const input = node.addInput(widget.name, type, {
+    // @ts-expect-error [GET_CONFIG] is not a valid property of IWidget
     widget: { name: widget.name, [GET_CONFIG]: () => config },
     ...(inputIsOptional ? { shape: LiteGraph.SlotShape.HollowCircle } : {})
   })

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -4,10 +4,10 @@ import {
   type INodeInputSlot,
   LGraphEventMode,
   LGraphNode,
-  LiteGraph
+  LiteGraph,
+  RenderShape
 } from '@comfyorg/litegraph'
 import { Vector2 } from '@comfyorg/litegraph'
-import { RenderShape } from '@comfyorg/litegraph/dist/types/globalEnums'
 import { IBaseWidget, IWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import { useNodeImage, useNodeVideo } from '@/composables/node/useNodeImage'

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -7,6 +7,7 @@ import {
   LiteGraph
 } from '@comfyorg/litegraph'
 import { Vector2 } from '@comfyorg/litegraph'
+import { RenderShape } from '@comfyorg/litegraph/dist/types/globalEnums'
 import { IBaseWidget, IWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import { useNodeImage, useNodeVideo } from '@/composables/node/useNodeImage'
@@ -89,7 +90,7 @@ export const useLitegraphService = () => {
             // Node connection inputs
             const shapeOptions = inputIsRequired
               ? {}
-              : { shape: LiteGraph.SlotShape.HollowCircle }
+              : { shape: RenderShape.HollowCircle }
             const inputOptions = {
               ...shapeOptions,
               localized_name: st(nameKey, inputName)


### PR DESCRIPTION
Automated update of litegraph to version 0.8.95. Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.8.95

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2718-Update-litegraph-0-8-95-1a56d73d365081b387c4fce43a54f6bf) by [Unito](https://www.unito.io)
