### PR TITLE
[3d] disable depth mode

### DIFF
--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -349,8 +349,8 @@ const showMaterialMode = ref(false)
 const materialModes: MaterialMode[] = [
   'original',
   'normal',
-  'wireframe',
-  'depth'
+  'wireframe'
+  //'depth' disable for now
 ]
 
 const switchCamera = () => {


### PR DESCRIPTION
I disabled depth mode for now,  because it doesn't perform well.
I will redesign it and add it back later

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2720-3d-disable-depth-mode-1a56d73d365081e08b57de927d3b874d) by [Unito](https://www.unito.io)
