### PR TITLE
[Refactor] Use more explicit types in usePaste

### DIFF
--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -44,7 +44,7 @@ export const usePaste = () => {
     let data: DataTransfer | string | null = e.clipboardData
     if (!data) throw new Error('No clipboard data on clipboard event')
 
-    const items: DataTransferItemList = data.items
+    const items = data.items
 
     const currentNode = canvas.current_node as LGraphNode
     const isNodeSelected = currentNode?.is_selected

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -41,7 +41,7 @@ export const usePaste = () => {
     if (!canvas) return
 
     const graph = canvas.graph
-    let data = e.clipboardData
+    let data: DataTransfer | string | null = e.clipboardData
     if (!data) throw new Error('No clipboard data on clipboard event')
 
     const items: DataTransferItemList = data.items

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -66,7 +66,7 @@ export const usePaste = () => {
           // No image node selected: add a new one
           const newNode = LiteGraph.createNode('LoadImage')
           newNode.pos = [canvas.graph_mouse[0], canvas.graph_mouse[1]]
-          imageNode = graph?.add(newNode) ?? null
+          if (newNode) imageNode = graph?.add(newNode) ?? null
           graph?.change()
         }
         pasteItemOnNode(items, imageNode)
@@ -84,7 +84,7 @@ export const usePaste = () => {
           // No audio node selected: add a new one
           const newNode = LiteGraph.createNode('LoadAudio')
           newNode.pos = [canvas.graph_mouse[0], canvas.graph_mouse[1]]
-          audioNode = graph?.add(newNode) ?? null
+          if (newNode) audioNode = graph?.add(newNode) ?? null
           graph?.change()
         }
         pasteItemOnNode(items, audioNode)

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -37,14 +37,14 @@ export const usePaste = () => {
     // this is handled by litegraph
     if (workspaceStore.shiftDown) return
 
-    const canvas = canvasStore.canvas
+    const { canvas } = canvasStore
     if (!canvas) return
 
-    const graph = canvas.graph
+    const { graph } = canvas
     let data: DataTransfer | string | null = e.clipboardData
     if (!data) throw new Error('No clipboard data on clipboard event')
 
-    const items = data.items
+    const { items } = data
 
     const currentNode = canvas.current_node as LGraphNode
     const isNodeSelected = currentNode?.is_selected

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -65,8 +65,7 @@ export const usePaste = () => {
         if (!imageNode) {
           // No image node selected: add a new one
           const newNode = LiteGraph.createNode('LoadImage')
-          // @ts-expect-error array to Float32Array
-          newNode.pos = [...canvas.graph_mouse]
+          newNode.pos = [canvas.graph_mouse[0], canvas.graph_mouse[1]]
           imageNode = graph?.add(newNode) ?? null
           graph?.change()
         }
@@ -84,8 +83,7 @@ export const usePaste = () => {
         if (!audioNode) {
           // No audio node selected: add a new one
           const newNode = LiteGraph.createNode('LoadAudio')
-          // @ts-expect-error array to Float32Array
-          newNode.pos = [...canvas.graph_mouse]
+          newNode.pos = [canvas.graph_mouse[0], canvas.graph_mouse[1]]
           audioNode = graph?.add(newNode) ?? null
           graph?.change()
         }

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -41,10 +41,9 @@ export const usePaste = () => {
     if (!canvas) return
 
     const graph = canvas.graph
-    // @ts-expect-error: Property 'clipboardData' does not exist on type 'Window & typeof globalThis'.
-    // Did you mean 'Clipboard'?ts(2551)
-    // TODO: Not sure what the code wants to do.
-    let data = e.clipboardData || window.clipboardData
+    let data = e.clipboardData
+    if (!data) throw new Error('No clipboard data on clipboard event')
+
     const items: DataTransferItemList = data.items
 
     const currentNode = canvas.current_node as LGraphNode

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -32,7 +32,7 @@ export const usePaste = () => {
     )
   }
 
-  useEventListener(document, 'paste', async (e: ClipboardEvent) => {
+  useEventListener(document, 'paste', async (e) => {
     // ctrl+shift+v is used to paste nodes with connections
     // this is handled by litegraph
     if (workspaceStore.shiftDown) return


### PR DESCRIPTION
- Required after https://github.com/Comfy-Org/litegraph.js/pull/593
- Removes `any` typing
- Removes type assertion
- Throws explicit error instead of `TypeError` for undefined props

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2721-Refactor-Use-more-explicit-types-in-usePaste-1a56d73d36508198b0d0ebf05bfcd624) by [Unito](https://www.unito.io)
