### PR TITLE
Type INodeOutputSlot widget hack on PrimitiveNode

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -1,12 +1,12 @@
 // @ts-strict-ignore
 import { LGraphNode, LiteGraph } from '@comfyorg/litegraph'
 import type {
+  IFoundSlot,
   INodeInputSlot,
+  INodeOutputSlot,
   IWidget,
   LiteGraphCanvasEvent
 } from '@comfyorg/litegraph'
-import type { IFoundSlot } from '@comfyorg/litegraph'
-import { INodeSlot } from '@comfyorg/litegraph'
 
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSettingStore } from '@/stores/settingStore'
@@ -422,7 +422,7 @@ export class PrimitiveNode extends LGraphNode {
   }
 }
 
-export function getWidgetConfig(slot: INodeSlot) {
+export function getWidgetConfig(slot: INodeInputSlot | INodeOutputSlot) {
   return slot.widget[CONFIG] ?? slot.widget[GET_CONFIG]?.() ?? ['*', {}]
 }
 

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -148,6 +148,14 @@ declare module '@comfyorg/litegraph' {
     /** Callback for pasting multiple files into the node */
     pasteFiles?(files: File[]): void
   }
+  /**
+   * Only used by the Primitive node. Primitive node is using the widget property
+   * to store/access the widget config.
+   * We should remove this hacky solution once we have a proper solution.
+   */
+  interface INodeOutputSlot {
+    widget?: IWidget
+  }
 }
 
 /**


### PR DESCRIPTION
Primitive node is adding `widget` prop to node output slot, which is a type hack. This PR documents this type hack.