### PR TITLE
Fix combo values from optional inputs not changed when refreshing

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: 7b81139e904519db8e5481899ef36bbb4393cb6b
+        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
     - name: Run Jest tests
       run: |
         npm run test:generate
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: 7b81139e904519db8e5481899ef36bbb4393cb6b
+        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: 7b81139e904519db8e5481899ef36bbb4393cb6b
+        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend
@@ -62,7 +62,7 @@ jobs:
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
       with:
-        devtools_ref: 7b81139e904519db8e5481899ef36bbb4393cb6b
+        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend

--- a/browser_tests/assets/optional_combo_input.json
+++ b/browser_tests/assets/optional_combo_input.json
@@ -1,0 +1,37 @@
+{
+  "last_node_id": 16,
+  "last_link_id": 17,
+  "nodes": [
+    {
+      "id": 16,
+      "type": "DevToolsNodeWithOptionalComboInput",
+      "pos": [1605, 480],
+      "size": [378, 58],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DevToolsNodeWithOptionalComboInput"
+      },
+      "widgets_values": ["Random Unique Option 1740551583.3507228"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 2.0875710456451313,
+      "offset": [-1311.5753953400676, -176.7620403697558]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/widget.spec.ts
+++ b/browser_tests/widget.spec.ts
@@ -26,6 +26,30 @@ test.describe('Combo text widget', () => {
     await comfyPage.resizeLoadCheckpointNode(0.8, 1, true)
     await expect(comfyPage.canvas).toHaveScreenshot('resized-to-original.png')
   })
+
+  test('should refresh combo values of optional inputs', async ({
+    comfyPage
+  }) => {
+    const getComboValues = async () =>
+      comfyPage.page.evaluate(() => {
+        return window['app'].graph.nodes
+          .find((node) => node.title === 'Node With Optional Combo Input')
+          .widgets.find((widget) => widget.name === 'optional_combo_input')
+          .options.values
+      })
+
+    await comfyPage.loadWorkflow('optional_combo_input')
+    const initialComboValues = await getComboValues()
+
+    // Focus canvas
+    await comfyPage.page.mouse.click(400, 300)
+
+    // Press R to trigger refresh
+    await comfyPage.page.keyboard.press('r')
+
+    const refreshedComboValues = await getComboValues()
+    expect(refreshedComboValues).not.toEqual(initialComboValues)
+  })
 })
 
 test.describe('Boolean widget', () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1571,15 +1571,16 @@ export class ComfyApp {
       // Allow primitive nodes to handle refresh
       node.refreshComboInNode?.(defs)
 
-      if (!def) continue
+      if (!def?.input) continue
 
       for (const widgetNum in node.widgets) {
         const widget = node.widgets[widgetNum]
-        if (
-          widget.type == 'combo' &&
-          def['input']['required'][widget.name] !== undefined
-        ) {
-          widget.options.values = def['input']['required'][widget.name][0]
+        if (widget.type === 'combo') {
+          if (def['input'].required?.[widget.name] !== undefined) {
+            widget.options.values = def['input'].required[widget.name][0]
+          } else if (def['input'].optional?.[widget.name] !== undefined) {
+            widget.options.values = def['input'].optional[widget.name][0]
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes issue in which refreshing node definitions does not refresh optional combo inputs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2733-Fix-combo-values-from-optional-inputs-not-changed-when-refreshing-1a66d73d365081189d65ff306c9b0d9c) by [Unito](https://www.unito.io)
