### PR TITLE
Add node to default/tutorial workflow with link to getting started page of docs

### DIFF
--- a/public/templates/default.json
+++ b/public/templates/default.json
@@ -268,6 +268,23 @@
       "widgets_values": [
         "v1-5-pruned-emaonly-fp16.safetensors"
       ]
+    },
+    {
+      "id": 10,
+      "type": "MarkdownNote",
+      "pos": [30, 630],
+      "size": [315, 88],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "🛈 Need more details? Check out [docs.comfy.org/get_started](https://docs.comfy.org/get_started/gettingstarted)"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
     }
   ],
   "links": [


### PR DESCRIPTION
Adds Markdown node to the default txt2img template (also currently used as tutorial workflow for first time users) with link to getting started page of docs (https://docs.comfy.org/get_started/gettingstarted).

![Selection_977](https://github.com/user-attachments/assets/f3b477ad-2cad-4d7e-bf48-726e5b9b20f0)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2734-Add-node-to-default-tutorial-workflow-with-link-to-getting-started-page-of-docs-1a66d73d3650815592b7dc1b23f479db) by [Unito](https://www.unito.io)
