### PR TITLE
Fix widget label extraction

### DIFF
--- a/playwright.i18n.config.ts
+++ b/playwright.i18n.config.ts
@@ -7,7 +7,7 @@ const config: PlaywrightTestConfig = {
     headless: true
   },
   reporter: 'list',
-  timeout: 10000,
+  timeout: 60000,
   testMatch: /collect-i18n-.*\.ts/
 }
 

--- a/scripts/collect-i18n-node-defs.ts
+++ b/scripts/collect-i18n-node-defs.ts
@@ -9,6 +9,13 @@ const localePath = './src/locales/en/main.json'
 const nodeDefsPath = './src/locales/en/nodeDefs.json'
 
 test('collect-i18n-node-defs', async ({ comfyPage }) => {
+  // Mock view route
+  comfyPage.page.route('**/view**', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({})
+    })
+  })
+
   const nodeDefs: ComfyNodeDefImpl[] = Object.values(
     await comfyPage.page.evaluate(async () => {
       const api = window['app'].api as ComfyApi


### PR DESCRIPTION
Increases robustness of widget label extraction added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/2688 in order to address [test failures](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/13546969493):

- Move `page.evaluate` to inside of `try`/`catch`, which seemed to be the principal issue
- Increase timeout 10s -> 60s
- Remove adding/removing of node to graph, as all that's necessary is node object instantiation
- Mock the `/view` route

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2737-Fix-widget-label-extraction-1a66d73d365081d8ab9adf5bcb0fdf3f) by [Unito](https://www.unito.io)
