### PR TITLE
[BugFix] Remove outputs.animated in queueStore

### DIFF
--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -144,6 +144,16 @@ export class TaskItemImpl {
     this.status = status
     this.outputs = outputs ?? {}
     this.flatOutputs = flatOutputs ?? this.calculateFlatOutputs()
+
+    // Remove animated outputs from the outputs object
+    // outputs.animated is an array of boolean values that indicates if the images
+    // array in the result are animated or not.
+    // The queueStore does not use this information.
+    // It is part of the legacy API response. We should redesign the backend API.
+    // https://github.com/Comfy-Org/ComfyUI_frontend/issues/2739
+    if ('animated' in this.outputs) {
+      delete this.outputs.animated
+    }
   }
 
   calculateFlatOutputs(): ReadonlyArray<ResultItemImpl> {

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -142,18 +142,16 @@ export class TaskItemImpl {
     this.taskType = taskType
     this.prompt = prompt
     this.status = status
-    this.outputs = outputs ?? {}
-    this.flatOutputs = flatOutputs ?? this.calculateFlatOutputs()
-
     // Remove animated outputs from the outputs object
     // outputs.animated is an array of boolean values that indicates if the images
     // array in the result are animated or not.
     // The queueStore does not use this information.
     // It is part of the legacy API response. We should redesign the backend API.
     // https://github.com/Comfy-Org/ComfyUI_frontend/issues/2739
-    if ('animated' in this.outputs) {
-      delete this.outputs.animated
-    }
+    this.outputs = _.mapValues(outputs ?? {}, (nodeOutputs) =>
+      _.omit(nodeOutputs, 'animated')
+    )
+    this.flatOutputs = flatOutputs ?? this.calculateFlatOutputs()
   }
 
   calculateFlatOutputs(): ReadonlyArray<ResultItemImpl> {

--- a/tests-ui/tests/store/queueStore.test.ts
+++ b/tests-ui/tests/store/queueStore.test.ts
@@ -1,0 +1,42 @@
+// @ts-strict-ignore
+import { TaskItemImpl } from '@/stores/queueStore'
+
+describe('TaskItemImpl', () => {
+  it('should remove animated property from outputs during construction', () => {
+    const taskItem = new TaskItemImpl(
+      'History',
+      [0, 'prompt-id', {}, {}, []],
+      { status_str: 'success', messages: [] },
+      {
+        'node-1': {
+          images: [{ filename: 'test.png', type: 'output', subfolder: '' }],
+          animated: [false]
+        }
+      }
+    )
+
+    // Check that animated property was removed
+    expect('animated' in taskItem.outputs['node-1']).toBe(false)
+
+    // Verify other output properties remain intact
+    expect(taskItem.outputs['node-1'].images).toBeDefined()
+    expect(taskItem.outputs['node-1'].images[0].filename).toBe('test.png')
+  })
+
+  it('should handle outputs without animated property', () => {
+    const taskItem = new TaskItemImpl(
+      'History',
+      [0, 'prompt-id', {}, {}, []],
+      { status_str: 'success', messages: [] },
+      {
+        'node-1': {
+          images: [{ filename: 'test.png', type: 'output', subfolder: '' }]
+        }
+      }
+    )
+
+    // Verify outputs are preserved when no animated property exists
+    expect(taskItem.outputs['node-1'].images).toBeDefined()
+    expect(taskItem.outputs['node-1'].images[0].filename).toBe('test.png')
+  })
+})


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2739

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2740-BugFix-Remove-outputs-animated-in-queueStore-1a66d73d36508146ad51ec7c5faefd4a) by [Unito](https://www.unito.io)
