### PR TITLE
Update litegraph 0.8.98

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
-        "@comfyorg/litegraph": "^0.8.97",
+        "@comfyorg/litegraph": "^0.8.98",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -1944,9 +1944,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.97",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.97.tgz",
-      "integrity": "sha512-eTr44lZYVzg1IChSmYi5xYT/S42wYaFxpTbBU4XT5CrceGKbJ8kptweYuROvXuvS1/fMO23VpY3ZzxZnZ6yRnQ==",
+      "version": "0.8.98",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.98.tgz",
+      "integrity": "sha512-AXw4Sn6EZ7esik8KLm7nybnaHxyjtV0WDKEhTXn8ubC5RNaT40psolWWAckAyYTB05o0xa5YKlCCH35QxK7D2A==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
-    "@comfyorg/litegraph": "^0.8.97",
+    "@comfyorg/litegraph": "^0.8.98",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.98. Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.8.98

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2742-Update-litegraph-0-8-98-1a76d73d36508129be62caac8d156fe0) by [Unito](https://www.unito.io)
