### PR TITLE
[3d] temp fix preview camera not sync up

### DIFF
--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -92,6 +92,12 @@ export class CameraManager implements CameraManagerInterface {
       : 'orthographic'
   }
 
+  refreshCamera() {
+    // TODO need to improve the logic here
+    this.toggleCamera()
+    this.toggleCamera()
+  }
+
   toggleCamera(cameraType?: CameraType): void {
     const oldCamera = this.activeCamera
 

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -18,6 +18,7 @@ class Load3DConfiguration {
     this.setupModelHandling(modelWidget, loadFolder, cameraState)
     this.setupTargetSize(width, height)
     this.setupDefaultProperties()
+    this.load3d.refreshCamera()
   }
 
   private setupTargetSize(width: IWidget | null, height: IWidget | null) {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -269,6 +269,10 @@ class Load3d {
     this.previewManager.togglePreview(showPreview)
   }
 
+  refreshCamera(): void {
+    this.cameraManager.refreshCamera()
+  }
+
   setTargetSize(width: number, height: number): void {
     this.previewManager.setTargetSize(width, height)
   }

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -60,6 +60,7 @@ export interface CameraManagerInterface extends BaseManager {
   perspectiveCamera: THREE.PerspectiveCamera
   orthographicCamera: THREE.OrthographicCamera
   getCurrentCameraType(): CameraType
+  refreshCamera(): void
   toggleCamera(cameraType?: CameraType): void
   setFOV(fov: number): void
   setCameraState(state: CameraState): void


### PR DESCRIPTION
sometimes, for example, load new model, the preview camera will not be sync up with main camera.
due to we will merge into main repo soon, I would like to use this temp solution (toggle twice) to fix this issue for now and will provide better solution later

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2743-3d-temp-fix-preview-camera-not-sync-up-1a76d73d365081fc8f1edcb763ca23ef) by [Unito](https://www.unito.io)
