### PR TITLE
[Revert] Restrict applyToGraph to PrimitiveNode

### DIFF
--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -84,6 +84,14 @@ declare module '@comfyorg/litegraph' {
     refreshComboInNode?(defs: Record<string, ComfyNodeDef>)
     /** @deprecated groupNode */
     updateLink?(link: LLink): LLink | null
+    /**
+     * @deprecated primitive node.
+     * Used by virtual nodes (primitives) to insert their values into the graph prior to queueing.
+     * Externally used by
+     * - https://github.com/pythongosssss/ComfyUI-Custom-Scripts/blob/bbda5e52ad580c13ceaa53136d9c2bed9137bd2e/web/js/presetText.js#L160-L182
+     * - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/blob/4c7858ddd5126f7293dc3c9f6e0fc4c263cde079/web/js/VHS.core.js#L1889-L1889
+     */
+    applyToGraph?(extraLinks?: LLink[]): void
     onExecutionStart?(): unknown
     /**
      * Callback invoked when the node is dragged over from an external source, i.e.

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -2,7 +2,6 @@ import type { LGraph } from '@comfyorg/litegraph'
 import { LGraphEventMode } from '@comfyorg/litegraph'
 
 import type { ComfyApiWorkflow, ComfyWorkflowJSON } from '@/types/comfyWorkflow'
-import { isPrimitiveNode } from '@/utils/typeGuardUtil'
 
 /**
  * Converts the current graph workflow for sending to the API.
@@ -18,7 +17,7 @@ export const graphToPrompt = async (
   for (const node of graph.computeExecutionOrder(false)) {
     const innerNodes = node.getInnerNodes ? node.getInnerNodes() : [node]
     for (const innerNode of innerNodes) {
-      if (isPrimitiveNode(innerNode)) {
+      if (innerNode.isVirtualNode) {
         innerNode.applyToGraph?.()
       }
     }


### PR DESCRIPTION
Ref: https://github.com/Comfy-Org/ComfyUI_frontend/pull/2724#issuecomment-2682528986

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2746-Revert-Restrict-applyToGraph-to-PrimitiveNode-1a76d73d36508139903bff7f8e122aa4) by [Unito](https://www.unito.io)
