### PR TITLE
Lower floor on max history items setting

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -657,9 +657,9 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip: 'The maximum number of tasks that show in the queue history.',
     type: 'slider',
     attrs: {
-      min: 16,
+      min: 2,
       max: 256,
-      step: 16
+      step: 2
     },
     defaultValue: 64,
     versionAdded: '1.4.12'


### PR DESCRIPTION
Lowers the max history items setting floor, allowing users on low end machines or who are using streaming or webcam setups to improve performance via elevated control over configuration. This change has been requested multiple times. The [related server code](https://github.com/comfyanonymous/ComfyUI/blob/b07f116dea4e00b42df3fbbe045f4c8c76c9d97b/execution.py#L955) works fine with lower minimum, and the experience on FE with max=2 is also fine:

https://github.com/user-attachments/assets/d3e923d2-2417-41bb-973f-0de0e782945b

Resolves #2725.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2748-Lower-floor-on-max-history-items-setting-1a76d73d3650814d9b70e94ba6fe2abe) by [Unito](https://www.unito.io)
