### PR TITLE
S&R improved filename sanitizing

### DIFF
--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -81,7 +81,7 @@ export function applyTextReplacements(app: ComfyApp, value: string): string {
       return match
     }
 
-    return ((widget.value ?? '') + '').replaceAll(/\/|\\/g, '_')
+    return ((widget.value ?? '') + '').replaceAll(/[\/\?<>\\:\*\|"\x00-\x1F\x7F]/g, '_')
   })
 }
 


### PR DESCRIPTION
Currently, special characters result in unexpected behaviour. For example, a colon injected into a SaveImage node truncates the filename.

![image](https://github.com/user-attachments/assets/12c7afd5-6792-4d4e-8ca5-04a6f7fc1dda)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2750-S-R-improved-filename-sanitizing-1a76d73d365081178559f90468afb37d) by [Unito](https://www.unito.io)
