### PR TITLE
Support models metadata in node properties

### DIFF
--- a/browser_tests/assets/missing_models_from_node_properties.json
+++ b/browser_tests/assets/missing_models_from_node_properties.json
@@ -1,0 +1,49 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [256, 256],
+      "size": [315, 98],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": null
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": null
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "fake_model.safetensors",
+            "url": "http://localhost:8188/api/devtools/fake_model.safetensors",
+            "directory": "text_encoders"
+          }
+        ]
+      },
+      "widgets_values": ["fake_model.safetensors"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -78,6 +78,19 @@ test.describe('Missing models warning', () => {
     await expect(downloadButton).toBeVisible()
   })
 
+  test('Should display a warning when missing models are found in node properties', async ({
+    comfyPage
+  }) => {
+    // Load workflow that has a node with models metadata at the node level
+    await comfyPage.loadWorkflow('missing_models_from_node_properties')
+
+    const missingModelsWarning = comfyPage.page.locator('.comfy-missing-models')
+    await expect(missingModelsWarning).toBeVisible()
+
+    const downloadButton = missingModelsWarning.getByLabel('Download')
+    await expect(downloadButton).toBeVisible()
+  })
+
   test('Should not display a warning when no missing models are found', async ({
     comfyPage
   }) => {

--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -166,7 +166,8 @@ const zProperties = z
     ['Node name for S&R']: z.string().optional(),
     cnr_id: zCnrId.optional(),
     aux_id: zAuxId.optional(),
-    ver: zVersion.optional()
+    ver: zVersion.optional(),
+    models: z.array(zModelFile).optional()
   })
   .passthrough()
 
@@ -265,6 +266,7 @@ export const zComfyWorkflow1 = z
   })
   .passthrough()
 
+export type ModelFile = z.infer<typeof zModelFile>
 export type NodeInput = z.infer<typeof zNodeInput>
 export type NodeOutput = z.infer<typeof zNodeOutput>
 export type ComfyLink = z.infer<typeof zComfyLink>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1067,7 +1067,8 @@ export class ComfyApp {
       }
 
       // Collect models metadata from node
-      if (n.properties?.models) embeddedModels.push(...n.properties.models)
+      if (n.properties?.models?.length)
+        embeddedModels.push(...n.properties.models)
     }
 
     // Merge models from the workflow's root-level 'models' field

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -16,8 +16,8 @@ import { st } from '@/i18n'
 import type { ComfyNodeDef } from '@/schemas/apiSchema'
 import {
   type ComfyWorkflowJSON,
-  type NodeId,
   type ModelFile,
+  type NodeId,
   validateComfyWorkflow
 } from '@/schemas/comfyWorkflowSchema'
 import { useDialogService } from '@/services/dialogService'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -17,6 +17,7 @@ import type { ComfyNodeDef } from '@/schemas/apiSchema'
 import {
   type ComfyWorkflowJSON,
   type NodeId,
+  type ModelFile,
   validateComfyWorkflow
 } from '@/schemas/comfyWorkflowSchema'
 import { useDialogService } from '@/services/dialogService'
@@ -1042,13 +1043,16 @@ export class ComfyApp {
     useWorkflowService().beforeLoadNewGraph()
 
     const missingNodeTypes: MissingNodeType[] = []
-    const missingModels = []
+    const missingModels: ModelFile[] = []
     await useExtensionService().invokeExtensionsAsync(
       'beforeConfigureGraph',
       graphData,
       missingNodeTypes
       // TODO: missingModels
     )
+
+    const embeddedModels: ModelFile[] = []
+
     for (let n of graphData.nodes) {
       // Patch T2IAdapterLoader to ControlNetLoader since they are the same node now
       if (n.type == 'T2IAdapterLoader') n.type = 'ControlNetLoader'
@@ -1061,13 +1065,27 @@ export class ComfyApp {
         missingNodeTypes.push(n.type)
         n.type = sanitizeNodeName(n.type)
       }
+
+      // Collect models metadata from node
+      if (n.properties?.models) embeddedModels.push(...n.properties.models)
     }
+
+    // Merge models from the workflow's root-level 'models' field
+    const workflowSchemaV1Models = graphData.models
+    if (workflowSchemaV1Models?.length)
+      embeddedModels.push(...workflowSchemaV1Models)
+
+    const getModelKey = (model: ModelFile) => model.url || model.hash
+    const validModels = embeddedModels.filter(getModelKey)
+    const uniqueModels = _.uniqBy(validModels, getModelKey)
+
     if (
-      graphData.models &&
+      uniqueModels.length &&
       useSettingStore().get('Comfy.Workflow.ShowMissingModelsWarning')
     ) {
       const modelStore = useModelStore()
-      for (const m of graphData.models) {
+      await modelStore.loadModelFolders()
+      for (const m of uniqueModels) {
         const modelFolder = await modelStore.getLoadedModelFolder(m.directory)
         // @ts-expect-error
         if (!modelFolder) m.directory_invalid = true


### PR DESCRIPTION
Currently, models are stored in the root level of the workflow. The issues with this are: 

1. Custom node authors cannot specify models metadata in node python class
2. Workflow creators cannot embed models in workflows they export and share
3. The metadata is not persisted at runtime (lost once workflow is saved)
4. It's difficult to map models to the associated widget value consistently, making it hard to know when the metadata should be removed or is otherwise invalid

This PR enables models to be embedded in node properties, which solves 3 and 4 and sets groundwork for 1 and 2 to be implemented in upcoming PRs.

Models embedded using the old schema will still be parsed as before.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2754-Support-models-metadata-in-node-properties-1a76d73d365081dbbacde1d51dcdd219) by [Unito](https://www.unito.io)
