### PR TITLE
Remove magic 10% scale on numeric widget step

### DIFF
--- a/src/composables/widgets/useIntWidget.ts
+++ b/src/composables/widgets/useIntWidget.ts
@@ -40,7 +40,7 @@ export const useIntWidget = () => {
         inputName,
         val,
         function (this: INumericWidget, v: number) {
-          const s = (this.options.step ?? 1) / 10
+          const s = this.options.step2 || 1
           let sh = (this.options.min ?? 0) % s
           if (isNaN(sh)) {
             sh = 0

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -27,6 +27,6 @@ export function getNumberDefaults(
 
   return {
     val: defaultVal,
-    config: { min, max, step: 10.0 * step, round, precision }
+    config: { min, max, step, round, precision }
   }
 }

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -27,6 +27,6 @@ export function getNumberDefaults(
 
   return {
     val: defaultVal,
-    config: { min, max, step: step * 10, step2: step, round, precision }
+    config: { min, max, step: step * 10.0, step2: step, round, precision }
   }
 }

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -27,6 +27,14 @@ export function getNumberDefaults(
 
   return {
     val: defaultVal,
-    config: { min, max, step: step * 10.0, step2: step, round, precision }
+    config: {
+      min,
+      max,
+      /** @deprecated Use step2 instead. The 10x value is a legacy implementation. */
+      step: step * 10.0,
+      step2: step,
+      round,
+      precision
+    }
   }
 }

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -27,6 +27,6 @@ export function getNumberDefaults(
 
   return {
     val: defaultVal,
-    config: { min, max, step, round, precision }
+    config: { min, max, step: step * 10, step2: step, round, precision }
   }
 }


### PR DESCRIPTION
Requires https://github.com/Comfy-Org/litegraph.js/pull/643/

There are external code still dependent on the fact that `Widget.options.step` is scaled 10x, so the 10x-ed value is still kept there, while we use the new unscaled step2 within our code now.

Ref: https://cs.comfy.org/search?q=context:global+%22step+/+10%22&patternType=keyword&sm=0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2759-Remove-magic-10-scale-on-numeric-widget-step-1a76d73d365081e59854dbae1d0cb63b) by [Unito](https://www.unito.io)
