### PR TITLE
Add video_upload to combo input schema

### DIFF
--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -85,6 +85,7 @@ const zComboInputOptions = zBaseInputOptions.extend({
   image_upload: z.boolean().optional(),
   image_folder: z.enum(['input', 'output', 'temp']).optional(),
   allow_batch: z.boolean().optional(),
+  video_upload: z.boolean().optional(),
   remote: zRemoteWidgetConfig.optional()
 })
 


### PR DESCRIPTION
Adds `video_upload` to combo input schema. `video_upload` flag is added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/2635 and is used to denote that a combo input accepts videos via file upload button, drag and drop, and copy/paste (mirroring existing `image_upload` flag).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2760-Add-video_upload-to-combo-input-schema-1a76d73d36508105ab73f110079893ae) by [Unito](https://www.unito.io)
