### PR TITLE
[CI] Publish comfyui-frontend-package to pypi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,13 @@ on:
       - 'package.json'
 
 jobs:
-  draft_release:
+  build:
     runs-on: ubuntu-latest
     if: >
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'Release')
+    outputs:
+      version: ${{ steps.current_version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,7 +23,7 @@ jobs:
           node-version: 'lts/*'
       - name: Get current version
         id: current_version
-        run: echo ::set-output name=version::$(node -p "require('./package.json').version")
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Build project
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -29,6 +31,24 @@ jobs:
           npm ci
           npm run build
           npm run zipdist
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-files
+          path: |
+            dist/
+            dist.zip
+
+  draft_release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -37,17 +57,47 @@ jobs:
         with:
           files: |
             dist.zip
-          tag_name: v${{ steps.current_version.outputs.version }}
+          tag_name: v${{ needs.build.outputs.version }}
           target_commitish: ${{ github.event.pull_request.base.ref }}
           make_latest: ${{ github.event.pull_request.base.ref == 'main' }}
           draft: true
           prerelease: false
           generate_release_notes: true
-  publish_types:
+
+  publish_pypi:
+    needs: build
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'Release')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        run: python -m pip install build
+      - name: Setup pypi package
+        run: |
+          mkdir -p comfyui_frontend_package/comfyui_frontend_package/static/
+          cp -r dist/* comfyui_frontend_package/comfyui_frontend_package/static/
+      - name: Build pypi package
+        run: python -m build
+        working-directory: comfyui_frontend_package
+        env:
+          COMFYUI_FRONTEND_VERSION: ${{ needs.build.outputs.version }}
+      - name: Publish pypi package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: comfyui_frontend_package/dist
+
+  publish_types:
+    needs: build
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/comfyui_frontend_package/.gitignore
+++ b/comfyui_frontend_package/.gitignore
@@ -1,0 +1,4 @@
+comfyui_frontend_package/static/*
+comfyui_frontend_package.egg-info/*
+
+__pycache__/

--- a/comfyui_frontend_package/MANIFEST.in
+++ b/comfyui_frontend_package/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include comfyui_frontend_package/static *

--- a/comfyui_frontend_package/README.md
+++ b/comfyui_frontend_package/README.md
@@ -1,0 +1,13 @@
+# comfyui_frontend pypi package
+
+This is the pypi package structure for the comfyui frontend.
+
+During build process, the compiled assets are copied into the `${PROJECT_ROOT}/comfyui_frontend_package/comfyui_frontend_package/static` directory.
+
+The package can be installed with the following command:
+
+```bash
+pip install comfyui-frontend-package
+```
+
+Ref: <https://pypi.org/project/comfyui-frontend-package/>

--- a/comfyui_frontend_package/setup.py
+++ b/comfyui_frontend_package/setup.py
@@ -1,0 +1,11 @@
+import os
+from setuptools import setup, find_packages
+
+setup(
+    name="comfyui_frontend_package",
+    version=os.getenv("COMFYUI_FRONTEND_VERSION") or "0.1.0",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[],
+    python_requires=">=3.9",
+)


### PR DESCRIPTION
Originally landed in core/1.10 branch in https://github.com/Comfy-Org/ComfyUI_frontend/pull/2765

This PR ported the final version to main branch with all patches applied.

Ref: https://github.com/comfyanonymous/ComfyUI/pull/7021

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2774-CI-Publish-comfyui-frontend-package-to-pypi-1a86d73d365081519296e98d7c2295b6) by [Unito](https://www.unito.io)
