### PR TITLE
[CI] Refactor test-ui gh action

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -36,18 +36,6 @@ jobs:
         with:
           node-version: lts/*
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Install requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements.txt
-          pip install wait-for-it
-        working-directory: ComfyUI
-
       - name: Build & Install ComfyUI_frontend
         run: |
           npm ci
@@ -80,6 +68,18 @@ jobs:
             ComfyUI_frontend
           key: comfyui-setup-${{ needs.setup.outputs.cache-key }}
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt
+          pip install wait-for-it
+        working-directory: ComfyUI
+
       - name: Start ComfyUI server
         run: |
           python main.py --cpu --multi-user &
@@ -107,6 +107,18 @@ jobs:
             ComfyUI
             ComfyUI_frontend
           key: comfyui-setup-${{ needs.setup.outputs.cache-key }}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt
+          pip install wait-for-it
+        working-directory: ComfyUI
 
       - name: Start ComfyUI server
         run: |

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -2,76 +2,129 @@ name: Tests CI
 
 on:
   push:
-    branches: [ main, master, core/*, desktop/* ]
+    branches: [main, master, core/*, desktop/*]
   pull_request:
-    branches: [ main, master, dev*, core/*, desktop/* ]
+    branches: [main, master, dev*, core/*, desktop/*]
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      cache-key: ${{ steps.cache-key.outputs.key }}
+    steps:
+      - name: Checkout ComfyUI
+        uses: actions/checkout@v4
+        with:
+          repository: 'comfyanonymous/ComfyUI'
+          path: 'ComfyUI'
+          ref: master
+
+      - name: Checkout ComfyUI_frontend
+        uses: actions/checkout@v4
+        with:
+          repository: 'Comfy-Org/ComfyUI_frontend'
+          path: 'ComfyUI_frontend'
+
+      - name: Checkout ComfyUI_devtools
+        uses: actions/checkout@v4
+        with:
+          repository: 'Comfy-Org/ComfyUI_devtools'
+          path: 'ComfyUI/custom_nodes/ComfyUI_devtools'
+          ref: '080e6d4af809a46852d1c4b7ed85f06e8a3a72be'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt
+          pip install wait-for-it
+        working-directory: ComfyUI
+
+      - name: Build & Install ComfyUI_frontend
+        run: |
+          npm ci
+          npm run build
+          rm -rf ../ComfyUI/web/*
+          mv dist/* ../ComfyUI/web/
+        working-directory: ComfyUI_frontend
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=$(date +%s)" >> $GITHUB_OUTPUT
+
+      - name: Cache setup
+        uses: actions/cache@v3
+        with:
+          path: |
+            ComfyUI
+            ComfyUI_frontend
+          key: comfyui-setup-${{ steps.cache-key.outputs.key }}
+
   jest-tests:
+    needs: setup
     runs-on: ubuntu-latest
     steps:
-    - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
-      with:
-        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
-    - name: Run Jest tests
-      run: |
-        npm run test:generate
-        npm run test:jest -- --verbose
-      working-directory: ComfyUI_frontend
+      - name: Restore cached setup
+        uses: actions/cache@v3
+        with:
+          path: |
+            ComfyUI
+            ComfyUI_frontend
+          key: comfyui-setup-${{ needs.setup.outputs.cache-key }}
 
-  playwright-tests-chromium:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
-      with:
-        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
-    - name: Install Playwright Browsers
-      run: npx playwright install chromium --with-deps
-      working-directory: ComfyUI_frontend
-    - name: Run Playwright tests (Chromium)
-      run: npx playwright test --project=chromium
-      working-directory: ComfyUI_frontend
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report-chromium
-        path: ComfyUI_frontend/playwright-report/
-        retention-days: 30
+      - name: Start ComfyUI server
+        run: |
+          python main.py --cpu --multi-user &
+          wait-for-it --service 127.0.0.1:8188 -t 600
+        working-directory: ComfyUI
 
-  playwright-tests-chromium-2x:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
-      with:
-        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
-    - name: Install Playwright Browsers
-      run: npx playwright install chromium --with-deps
-      working-directory: ComfyUI_frontend
-    - name: Run Playwright tests (Chromium 2x)
-      run: npx playwright test --project=chromium-2x
-      working-directory: ComfyUI_frontend
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report-chromium-2x
-        path: ComfyUI_frontend/playwright-report/
-        retention-days: 30
+      - name: Run Jest tests
+        run: |
+          npm run test:generate
+          npm run test:jest -- --verbose
+        working-directory: ComfyUI_frontend
 
-  playwright-tests-mobile-chrome:
+  playwright-tests:
+    needs: setup
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, chromium-2x, mobile-chrome]
     steps:
-    - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.2
-      with:
-        devtools_ref: 080e6d4af809a46852d1c4b7ed85f06e8a3a72be
-    - name: Install Playwright Browsers
-      run: npx playwright install chromium --with-deps
-      working-directory: ComfyUI_frontend
-    - name: Run Playwright tests (Mobile Chrome)
-      run: npx playwright test --project=mobile-chrome
-      working-directory: ComfyUI_frontend
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report-mobile-chrome
-        path: ComfyUI_frontend/playwright-report/
-        retention-days: 30
+      - name: Restore cached setup
+        uses: actions/cache@v3
+        with:
+          path: |
+            ComfyUI
+            ComfyUI_frontend
+          key: comfyui-setup-${{ needs.setup.outputs.cache-key }}
+
+      - name: Start ComfyUI server
+        run: |
+          python main.py --cpu --multi-user &
+          wait-for-it --service 127.0.0.1:8188 -t 600
+        working-directory: ComfyUI
+
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: ComfyUI_frontend
+
+      - name: Run Playwright tests (${{ matrix.browser }})
+        run: npx playwright test --project=${{ matrix.browser }}
+        working-directory: ComfyUI_frontend
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: ComfyUI_frontend/playwright-report/
+          retention-days: 30


### PR DESCRIPTION
Refactors test-ui.yaml.

Removes the dependency on `Comfy-Org/ComfyUI_frontend_setup_action`. The setup action result now is shared between downstream actions.

![image](https://github.com/user-attachments/assets/cc250ca1-62ae-4ad6-a803-be5be4f392db)


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2776-CI-Refactor-test-ui-gh-action-1a96d73d365081d1bf01f7b33316f71a) by [Unito](https://www.unito.io)
