### PR TITLE
[TS] Use Litegraph strict narrowed type

### DIFF
--- a/src/composables/useContextMenuTranslation.ts
+++ b/src/composables/useContextMenuTranslation.ts
@@ -30,7 +30,7 @@ export const useContextMenuTranslation = () => {
   LGraphCanvas.prototype.getCanvasMenuOptions = getCanvasCenterMenuOptions
 
   function translateMenus(
-    values: (IContextMenuValue | string | null)[] | undefined,
+    values: readonly (IContextMenuValue | string | null)[] | undefined,
     options: IContextMenuOptions
   ) {
     if (!values) return


### PR DESCRIPTION
No runtime change; minor TS narrowing to `readonly` type.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2781-TS-Use-Litegraph-strict-narrowed-type-1a96d73d36508155b78edd3f550431b7) by [Unito](https://www.unito.io)
