### PR TITLE
[CI] Update frontend install method

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -36,12 +36,10 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Build & Install ComfyUI_frontend
+      - name: Build ComfyUI_frontend
         run: |
           npm ci
           npm run build
-          rm -rf ../ComfyUI/web/*
-          mv dist/* ../ComfyUI/web/
         working-directory: ComfyUI_frontend
 
       - name: Generate cache key
@@ -86,7 +84,7 @@ jobs:
 
       - name: Start ComfyUI server
         run: |
-          python main.py --cpu --multi-user &
+          python main.py --cpu --multi-user --front-end-root ../ComfyUI_frontend/dist &
           wait-for-it --service 127.0.0.1:8188 -t 600
         working-directory: ComfyUI
 


### PR DESCRIPTION
https://github.com/comfyanonymous/ComfyUI/pull/7021 changes install method of the frontend, so `web/` no longer exists in the main repo. Explicitly set `--front-end-root` arg to specify web assets folder in CI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2783-CI-Update-frontend-install-method-1a96d73d3650817d8771ecfcdc53f5d1) by [Unito](https://www.unito.io)
