### PR TITLE
Update litegraph 0.8.100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
-        "@comfyorg/litegraph": "^0.8.99",
+        "@comfyorg/litegraph": "^0.8.100",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -297,9 +297,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.8.99",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.99.tgz",
-      "integrity": "sha512-XpIEX9DB0hhcMer/nwP/Fz7QuV8dBaOKXitJosTilozcDuIOBCiprbrqBXKYkPLUQUZ99MBqO68kokv74w3U9w==",
+      "version": "0.8.100",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.8.100.tgz",
+      "integrity": "sha512-S+xRcd6jwcNCN+ZXLCyE9QozVCPuTq2AH0/q460ypUyBPKKCdORVE84U1xQ+jY+RYAniCNct6CBYonWJu3W8yQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
-    "@comfyorg/litegraph": "^0.8.99",
+    "@comfyorg/litegraph": "^0.8.100",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.8.100. Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.8.100

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2786-Update-litegraph-0-8-100-1a96d73d365081ce9b5ae41b31d63a4d) by [Unito](https://www.unito.io)
