### PR TITLE
Allow passthrough to root component when creating dialog

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -7,6 +7,7 @@
     class="global-dialog"
     v-bind="item.dialogComponentProps"
     :auto-z-index="false"
+    :pt="item.dialogComponentProps.pt"
     :pt:mask:style="{ zIndex: baseZIndex + index + 1 }"
     :aria-labelledby="item.key"
   >

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -1,12 +1,21 @@
 // We should consider moving to https://primevue.org/dynamicdialog/ once everything is in Vue.
 // Currently we need to bridge between legacy app code and Vue app with a Pinia store.
+import { merge } from 'lodash'
 import { defineStore } from 'pinia'
+import type { DialogPassThroughOptions } from 'primevue/dialog'
 import { type Component, markRaw, ref } from 'vue'
 
-interface DialogComponentProps {
+import type GlobalDialog from '@/components/dialog/GlobalDialog.vue'
+
+interface CustomDialogComponentProps {
   maximizable?: boolean
+  maximized?: boolean
   onClose?: () => void
+  pt?: DialogPassThroughOptions
 }
+
+type DialogComponentProps = InstanceType<typeof GlobalDialog>['$props'] &
+  CustomDialogComponentProps
 
 interface DialogInstance {
   key: string
@@ -15,7 +24,7 @@ interface DialogInstance {
   headerComponent?: Component
   component: Component
   contentProps: Record<string, any>
-  dialogComponentProps: Record<string, any>
+  dialogComponentProps: DialogComponentProps
 }
 
 export interface ShowDialogOptions {
@@ -90,13 +99,13 @@ export const useDialogStore = defineStore('dialog', () => {
         onAfterHide: () => {
           closeDialog(dialog)
         },
-        pt: {
+        pt: merge(options.dialogComponentProps?.pt || {}, {
           root: {
             onMousedown: () => {
               riseDialog(dialog)
             }
           }
-        }
+        })
       }
     }
     dialogStack.value.push(dialog)


### PR DESCRIPTION
Allows sending passthrough prop to global diaog. For example:

```typescript
    dialogStore.showDialog({
      component: ExampleDialogComponent,
      dialogComponentProps: {
        pt: {
          content: { class: '!px-0' },
          header: { class: 'font-bold', onClick: () => {} }
        }
      },
    })
```

About passthrough:

- https://primevue.org/passthrough/
- https://primevue.org/dialog/#pt.doc.dialog

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2787-Allow-passthrough-to-root-component-when-creating-dialog-1a96d73d3650818ca227d694a689a880) by [Unito](https://www.unito.io)
