### PR TITLE
Remove broken/unused widget[TARGET]

### DIFF
--- a/src/extensions/core/rerouteNode.ts
+++ b/src/extensions/core/rerouteNode.ts
@@ -144,7 +144,6 @@ app.registerExtension({
           const color = LGraphCanvas.link_type_colors[displayType]
 
           let widgetConfig
-          let targetWidget
           let widgetType
           // Update the types of each node
           for (const node of updateNodes) {
@@ -171,11 +170,6 @@ app.registerExtension({
                     widgetConfig = config[1] ?? {}
                     widgetType = config[0]
                   }
-                  if (!targetWidget) {
-                    targetWidget = targetNode.widgets?.find(
-                      (w) => w.name === (targetInput.widget as any).name
-                    )
-                  }
 
                   const merged = mergeIfValid(targetInput, [
                     config[0],
@@ -192,11 +186,10 @@ app.registerExtension({
           for (const node of updateNodes) {
             if (widgetConfig && outputType) {
               node.inputs[0].widget = { name: 'value' }
-              setWidgetConfig(
-                node.inputs[0],
-                [widgetType ?? displayType, widgetConfig],
-                targetWidget
-              )
+              setWidgetConfig(node.inputs[0], [
+                widgetType ?? displayType,
+                widgetConfig
+              ])
             } else {
               setWidgetConfig(node.inputs[0], null)
             }


### PR DESCRIPTION
Primitive node cannot be connected to legacy reroute node currently. Removing the supporting logic.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2795-Remove-broken-unused-widget-TARGET-1aa6d73d36508121b230cbbf0afa743a) by [Unito](https://www.unito.io)
