### PR TITLE
Fix pasting image from browser on Windows

### DIFF
--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -22,8 +22,8 @@ export const usePaste = () => {
   ) => {
     if (!node) return
 
-    const filteredItems = Array.from(items).filter(
-      (item) => item.type === contentType
+    const filteredItems = Array.from(items).filter((item) =>
+      item.type.startsWith(contentType)
     )
 
     const blob = filteredItems[0]?.getAsFile()

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -15,18 +15,23 @@ export const usePaste = () => {
   const workspaceStore = useWorkspaceStore()
   const canvasStore = useCanvasStore()
 
-  const pasteItemOnNode = (
+  const pasteItemsOnNode = (
     items: DataTransferItemList,
-    node: LGraphNode | null
+    node: LGraphNode | null,
+    contentType: string
   ) => {
     if (!node) return
 
-    const blob = items[0]?.getAsFile()
+    const filteredItems = Array.from(items).filter(
+      (item) => item.type === contentType
+    )
+
+    const blob = filteredItems[0]?.getAsFile()
     if (!blob) return
 
     node.pasteFile?.(blob)
     node.pasteFiles?.(
-      Array.from(items)
+      Array.from(filteredItems)
         .map((i) => i.getAsFile())
         .filter((f) => f !== null)
     )
@@ -71,14 +76,14 @@ export const usePaste = () => {
           }
           graph?.change()
         }
-        pasteItemOnNode(items, imageNode)
+        pasteItemsOnNode(items, imageNode, 'image')
         return
       } else if (item.type.startsWith('video/')) {
         if (!videoNode) {
           // No video node selected: add a new one
           // TODO: when video node exists
         } else {
-          pasteItemOnNode(items, videoNode)
+          pasteItemsOnNode(items, videoNode, 'video')
           return
         }
       } else if (item.type.startsWith('audio/')) {
@@ -91,7 +96,7 @@ export const usePaste = () => {
           }
           graph?.change()
         }
-        pasteItemOnNode(items, audioNode)
+        pasteItemsOnNode(items, audioNode, 'audio')
         return
       }
     }


### PR DESCRIPTION
Fixes #2629 (second bug detailed in comments) introduced by https://github.com/Comfy-Org/ComfyUI_frontend/pull/2635. `pasteItemOnNode` made assumption that the first item in the data transfer list was the media item, which is not the case on Windows where the text representation comes first in the clipboard making `items[0]?.getAsFile()` resolve to `undefined`. Fix by filtering rather than passing an index.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2797-Fix-pasting-image-from-browser-on-Windows-1aa6d73d365081bcae98e96f322af2d7) by [Unito](https://www.unito.io)
