### PR TITLE
Fix race when creating loader node to handle pasted media

### DIFF
--- a/src/composables/node/useNodeImage.ts
+++ b/src/composables/node/useNodeImage.ts
@@ -20,6 +20,11 @@ interface NodePreviewOptions<T extends MediaElement> {
   onFailedLoading?: () => void
 }
 
+interface ShowPreviewOptions {
+  /** If true, blocks new loading operations until the current operation is complete. */
+  block?: boolean
+}
+
 const createContainer = () => {
   const container = document.createElement('div')
   container.classList.add('comfy-img-preview')
@@ -58,13 +63,13 @@ export const useNodePreview = <T extends MediaElement>(
   /**
    * Displays media element(s) on the node.
    */
-  function showPreview() {
+  function showPreview(options: ShowPreviewOptions = {}) {
     if (node.isLoading) return
 
     const outputUrls = nodeOutputStore.getNodeImageUrls(node)
     if (!outputUrls?.length) return
 
-    node.isLoading = true
+    if (options?.block) node.isLoading = true
 
     loadElements(outputUrls)
       .then((elements) => {

--- a/src/composables/widgets/useImageUploadWidget.ts
+++ b/src/composables/widgets/useImageUploadWidget.ts
@@ -106,7 +106,7 @@ export const useImageUploadWidget = () => {
     // No change callbacks seem to be fired on initial setting of the value
     requestAnimationFrame(() => {
       nodeOutputStore.setNodeOutputs(node, fileComboWidget.value)
-      showPreview()
+      showPreview({ block: false })
     })
 
     return { widget: uploadWidget }


### PR DESCRIPTION
Fixes bug when pasting media onto empty canvas to create a loader node.

In https://github.com/Comfy-Org/ComfyUI_frontend/pull/2635, to support video nodes, node previews are changed to block overlapping calls to load media. However, to allow setting the value immediately after adding node to graph (as with empty canvas paste handler), the initial load should not block. In other cases, the load will be queued properly as the node's outputs are checked for changes during every render.

This bug would only be reproducible on low-end machine or with very large media, and it only affected previews not the node's values.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2799-Fix-race-when-creating-loader-node-to-handle-pasted-media-1aa6d73d36508185ba3af581ee5791cb) by [Unito](https://www.unito.io)
