### PR TITLE
Add workflow to generate comfy registry ts types

### DIFF
--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -11,16 +11,18 @@ on:
 jobs:
   update-registry-types:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Checkout ComfyUI_frontend
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: lts/*
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -69,29 +71,23 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create PR for API type changes
+      - name: Create Pull Request
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "actions@github.com"
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PR_GH_TOKEN }}
+          commit-message: '[chore] Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}'
+          title: '[chore] Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}'
+          body: |
+            ## Automated API Type Update
 
-          # Create branch with timestamp
-          DATE=$(date '+%Y-%m-%d')
-          TIMESTAMP=$(date '+%s')
-          BRANCH="update-registry-types-${DATE}-${TIMESTAMP}"
-          git checkout -b $BRANCH
+            This PR updates the Comfy Registry API types from the latest comfy-api OpenAPI specification.
 
-          # Commit changes
-          git add src/types/comfyRegistryTypes.ts
-          git commit -m "[chore] Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}"
-          git push origin $BRANCH
+            - API commit: ${{ steps.api-info.outputs.commit }}
+            - Generated on: ${{ github.event.repository.updated_at }}
 
-          # Create PR
-          gh pr create \
-            --title "Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}" \
-            --body "Automated update of Comfy Registry API types from the latest comfy-api OpenAPI specification." \
-            --label "CNR,auto-generated" \
-            --base main \
-            --head $BRANCH
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            These types are automatically generated using openapi-typescript.
+          branch: update-registry-types-${{ steps.api-info.outputs.commit }}
+          base: main
+          labels: CNR
+          delete-branch: true

--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -1,0 +1,97 @@
+name: Update API Types
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+
+  # Triggered from comfy-api repo
+  repository_dispatch:
+    types: [comfy-api-updated]
+
+jobs:
+  update-api-types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ComfyUI_frontend
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Checkout comfy-api repository
+        uses: actions/checkout@v4
+        with:
+          repository: Comfy-Org/comfy-api
+          path: comfy-api
+          token: ${{ secrets.COMFY_API_PAT }}
+
+      - name: Get API commit information
+        id: api-info
+        run: |
+          cd comfy-api
+          API_COMMIT=$(git rev-parse --short HEAD)
+          echo "commit=${API_COMMIT}" >> $GITHUB_OUTPUT
+
+      - name: Generate API types
+        run: |
+          echo "Generating TypeScript types from comfy-api@${{ steps.api-info.outputs.commit }}..."
+          npx openapi-typescript comfy-api/openapi.yml --output src/types/comfyRegistryTypes.ts
+
+      - name: Validate generated types
+        run: |
+          if [ ! -f src/types/comfyRegistryTypes.ts ]; then
+            echo "Error: Types file was not generated."
+            exit 1
+          fi
+
+          # Check if file is not empty
+          if [ ! -s src/types/comfyRegistryTypes.ts ]; then
+            echo "Error: Generated types file is empty."
+            exit 1
+          fi
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if [[ -z $(git status --porcelain src/types/comfyRegistryTypes.ts) ]]; then
+            echo "No changes to Comfy Registry API types detected."
+            echo "changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Changes detected in Comfy Registry API types."
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR for API type changes
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "actions@github.com"
+
+          # Create branch with timestamp
+          DATE=$(date '+%Y-%m-%d')
+          TIMESTAMP=$(date '+%s')
+          BRANCH="update-registry-types-${DATE}-${TIMESTAMP}"
+          git checkout -b $BRANCH
+
+          # Commit changes
+          git add src/types/comfyRegistryTypes.ts
+          git commit -m "[chore] Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}"
+          git push origin $BRANCH
+
+          # Create PR
+          gh pr create \
+            --title "Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}" \
+            --body "Automated update of Comfy Registry API types from the latest comfy-api OpenAPI specification." \
+            --label "dependencies,auto-generated" \
+            --base main \
+            --head $BRANCH
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -1,4 +1,4 @@
-name: Update API Types
+name: Update Comfy Registry API Types
 
 on:
   # Manual trigger
@@ -9,7 +9,7 @@ on:
     types: [comfy-api-updated]
 
 jobs:
-  update-api-types:
+  update-registry-types:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ComfyUI_frontend
@@ -90,7 +90,7 @@ jobs:
           gh pr create \
             --title "Update Comfy Registry API types from comfy-api@${{ steps.api-info.outputs.commit }}" \
             --body "Automated update of Comfy Registry API types from the latest comfy-api OpenAPI specification." \
-            --label "dependencies,auto-generated" \
+            --label "CNR,auto-generated" \
             --base main \
             --head $BRANCH
         env:


### PR DESCRIPTION
Generates types from https://github.com/Comfy-Org/comfy-api/blob/main/openapi.yml using `openapi-typescript`. Types are used in future features that interact with `api.comfy.org`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2818-Add-workflow-to-generate-comfy-registry-ts-types-1ab6d73d365081478df2e8bbd8d56b3e) by [Unito](https://www.unito.io)
