### PR TITLE
[Feature] Adds the litegraph knob widget support

### DIFF
--- a/src/composables/widgets/useFloatWidget.ts
+++ b/src/composables/widgets/useFloatWidget.ts
@@ -38,11 +38,13 @@ export const useFloatWidget = () => {
     const sliderEnabled = !settingStore.get('Comfy.DisableSliders')
     const inputOptions = inputData[1] ?? {}
 
-    const widgetType = sliderEnabled
-      ? inputOptions.display === 'slider'
+    const display_type = inputOptions?.display
+    const widgetType =
+      sliderEnabled && display_type == 'slider'
         ? 'slider'
-        : 'number'
-      : 'number'
+        : display_type == 'knob'
+          ? 'knob'
+          : 'number'
 
     const step = inputOptions.step ?? 0.5
     const precision =

--- a/src/composables/widgets/useIntWidget.ts
+++ b/src/composables/widgets/useIntWidget.ts
@@ -47,11 +47,13 @@ export const useIntWidget = () => {
     const settingStore = useSettingStore()
     const sliderEnabled = !settingStore.get('Comfy.DisableSliders')
     const inputOptions = inputData[1] ?? {}
-    const widgetType = sliderEnabled
-      ? inputOptions?.display === 'slider'
+    const display_type = inputOptions?.display
+    const widgetType =
+      sliderEnabled && display_type == 'slider'
         ? 'slider'
-        : 'number'
-      : 'number'
+        : display_type == 'knob'
+          ? 'knob'
+          : 'number'
 
     const step = inputOptions.step ?? 1
     const defaultValue = inputOptions.default ?? 0

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -32,7 +32,7 @@ const zNumericInputOptions = zBaseInputOptions.extend({
   step: z.number().optional(),
   // Note: Many node authors are using INT/FLOAT to pass list of INT/FLOAT.
   default: z.union([z.number(), z.array(z.number())]).optional(),
-  display: z.enum(['slider', 'number']).optional()
+  display: z.enum(['slider', 'number', 'knob']).optional()
 })
 
 const zIntInputOptions = zNumericInputOptions.extend({


### PR DESCRIPTION
Split from #2701
Adds support for the LiteGraph Knob Widget, https://github.com/Comfy-Org/litegraph.js/pull/600
![image](https://github.com/user-attachments/assets/554a3227-edbb-4113-a824-ec73c874b0a3)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2822-Feature-Adds-the-litegraph-knob-widget-support-1ab6d73d36508146a39bf1a67a1aa8fb) by [Unito](https://www.unito.io)
