### PR TITLE
[Test] Add ComfyMouse fixture for Playwright tests

### DIFF
--- a/browser_tests/fixtures/ComfyMouse.ts
+++ b/browser_tests/fixtures/ComfyMouse.ts
@@ -1,0 +1,97 @@
+import type { Mouse } from '@playwright/test'
+
+import type { ComfyPage } from './ComfyPage'
+import type { Position } from './types'
+
+/**
+ * Used for drag and drop ops
+ * @see
+ * - {@link Mouse.down}
+ * - {@link Mouse.move}
+ * - {@link Mouse.up}
+ */
+export interface DragOptions {
+  button?: 'left' | 'right' | 'middle'
+  clickCount?: number
+  steps?: number
+}
+
+/**
+ * Wraps mouse drag and drop to work with a canvas-based app.
+ *
+ * Requires the next frame animated before and after all steps, giving the
+ * canvas time to render the changes before screenshots are taken.
+ */
+export class ComfyMouse implements Omit<Mouse, 'move'> {
+  static defaultSteps = 5
+  static defaultOptions: DragOptions = { steps: ComfyMouse.defaultSteps }
+
+  constructor(readonly comfyPage: ComfyPage) {}
+
+  /** The normal Playwright {@link Mouse} property from {@link ComfyPage.page}. */
+  get mouse() {
+    return this.comfyPage.page.mouse
+  }
+
+  async nextFrame() {
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Drags from current location to a new location and hovers there (no pointerup event) */
+  async drag(to: Position, options = ComfyMouse.defaultOptions) {
+    const { steps, ...downOptions } = options
+
+    await this.mouse.down(downOptions)
+    await this.nextFrame()
+
+    await this.move(to, { steps })
+    await this.nextFrame()
+  }
+
+  async drop(options = ComfyMouse.defaultOptions) {
+    await this.mouse.up(options)
+    await this.nextFrame()
+  }
+
+  async dragAndDrop(
+    from: Position,
+    to: Position,
+    options = ComfyMouse.defaultOptions
+  ) {
+    const { steps } = options
+
+    await this.nextFrame()
+    
+    await this.move(from, { steps })
+    await this.drag(to, options)
+    await this.drop(options)
+  }
+
+  /** @see {@link Mouse.move} */
+  async move(to: Position, options = ComfyMouse.defaultOptions) {
+    await this.mouse.move(to.x, to.y, options);
+    await this.nextFrame()
+  }
+
+  //#region Pass-through
+  async click(...args: Parameters<Mouse['click']>) {
+    return await this.mouse.click(...args)
+  }
+
+  async dblclick(...args: Parameters<Mouse['dblclick']>) {
+    return await this.mouse.dblclick(...args)
+  }
+
+  async down(...args: Parameters<Mouse['down']>) {
+    return await this.mouse.down(...args)
+  }
+
+  async up(...args: Parameters<Mouse['up']>) {
+    return await this.mouse.up(...args)
+  }
+
+  async wheel(...args: Parameters<Mouse['wheel']>) {
+    return await this.mouse.wheel(...args)
+  }
+  //#endregion Pass-through
+}

--- a/browser_tests/fixtures/ComfyMouse.ts
+++ b/browser_tests/fixtures/ComfyMouse.ts
@@ -61,7 +61,7 @@ export class ComfyMouse implements Omit<Mouse, 'move'> {
     const { steps } = options
 
     await this.nextFrame()
-    
+
     await this.move(from, { steps })
     await this.drag(to, options)
     await this.drop(options)
@@ -69,7 +69,7 @@ export class ComfyMouse implements Omit<Mouse, 'move'> {
 
   /** @see {@link Mouse.move} */
   async move(to: Position, options = ComfyMouse.defaultOptions) {
-    await this.mouse.move(to.x, to.y, options);
+    await this.mouse.move(to.x, to.y, options)
     await this.nextFrame()
   }
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -22,6 +22,7 @@ import { Topbar } from './components/Topbar'
 import type { Position, Size } from './types'
 import { NodeReference } from './utils/litegraphUtils'
 import TaskHistory from './utils/taskHistory'
+import { ComfyMouse } from './ComfyMouse'
 
 dotenv.config()
 
@@ -910,7 +911,10 @@ export class ComfyPage {
   }
 }
 
-export const comfyPageFixture = base.extend<{ comfyPage: ComfyPage }>({
+export const comfyPageFixture = base.extend<{
+  comfyPage: ComfyPage
+  comfyMouse: ComfyMouse
+}>({
   comfyPage: async ({ page, request }, use, testInfo) => {
     const comfyPage = new ComfyPage(page, request)
 
@@ -941,6 +945,10 @@ export const comfyPageFixture = base.extend<{ comfyPage: ComfyPage }>({
 
     await comfyPage.setup()
     await use(comfyPage)
+  },
+  comfyMouse: async ({ comfyPage }, use) => {
+    const comfyMouse = new ComfyMouse(comfyPage)
+    use(comfyMouse)
   }
 })
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -11,6 +11,7 @@ import type { useWorkspaceStore } from '../../src/stores/workspaceStore'
 import { NodeBadgeMode } from '../../src/types/nodeSource'
 import { ComfyActionbar } from '../helpers/actionbar'
 import { ComfyTemplates } from '../helpers/templates'
+import { ComfyMouse } from './ComfyMouse'
 import { ComfyNodeSearchBox } from './components/ComfyNodeSearchBox'
 import { SettingDialog } from './components/SettingDialog'
 import {
@@ -22,7 +23,6 @@ import { Topbar } from './components/Topbar'
 import type { Position, Size } from './types'
 import { NodeReference } from './utils/litegraphUtils'
 import TaskHistory from './utils/taskHistory'
-import { ComfyMouse } from './ComfyMouse'
 
 dotenv.config()
 

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -140,20 +140,14 @@ test.describe('Node Interaction', () => {
     })
 
     test('Auto snap&highlight when dragging link over node', async ({
-      comfyPage
+      comfyPage,
+      comfyMouse
     }) => {
       await comfyPage.setSetting('Comfy.Node.AutoSnapLinkToSlot', true)
       await comfyPage.setSetting('Comfy.Node.SnapHighlightsNode', true)
 
-      await comfyPage.page.mouse.move(
-        comfyPage.clipTextEncodeNode1InputSlot.x,
-        comfyPage.clipTextEncodeNode1InputSlot.y
-      )
-      await comfyPage.page.mouse.down()
-      await comfyPage.page.mouse.move(
-        comfyPage.clipTextEncodeNode2InputSlot.x,
-        comfyPage.clipTextEncodeNode2InputSlot.y
-      )
+      await comfyMouse.move(comfyPage.clipTextEncodeNode1InputSlot)
+      await comfyMouse.drag(comfyPage.clipTextEncodeNode2InputSlot)
       await expect(comfyPage.canvas).toHaveScreenshot('snapped-highlighted.png')
     })
   })
@@ -506,24 +500,24 @@ test.describe('Canvas Interaction', () => {
     expect(await getCursorStyle()).toBe('default')
   })
 
-  test('Can pan when dragging a link', async ({ comfyPage }) => {
+  test('Can pan when dragging a link', async ({ comfyPage, comfyMouse }) => {
     const posSlot1 = comfyPage.clipTextEncodeNode1InputSlot
-    await comfyPage.page.mouse.move(posSlot1.x, posSlot1.y)
-    await comfyPage.page.mouse.down()
+    await comfyMouse.move(posSlot1)
     const posEmpty = comfyPage.emptySpace
-    await comfyPage.page.mouse.move(posEmpty.x, posEmpty.y)
+    await comfyMouse.drag(posEmpty)
     await expect(comfyPage.canvas).toHaveScreenshot('dragging-link1.png')
+
     await comfyPage.page.keyboard.down('Space')
-    await comfyPage.page.mouse.move(posEmpty.x + 100, posEmpty.y + 100)
+    await comfyMouse.mouse.move(posEmpty.x + 100, posEmpty.y + 100)
     // Canvas should be panned.
     await expect(comfyPage.canvas).toHaveScreenshot(
       'panning-when-dragging-link.png'
     )
     await comfyPage.page.keyboard.up('Space')
-    await comfyPage.page.mouse.move(posEmpty.x, posEmpty.y)
+    await comfyMouse.move(posEmpty)
     // Should be back to dragging link mode when space is released.
     await expect(comfyPage.canvas).toHaveScreenshot('dragging-link2.png')
-    await comfyPage.page.mouse.up()
+    await comfyMouse.drop()
   })
 
   test('Can pan very far and back', async ({ comfyPage }) => {


### PR DESCRIPTION
Playwright is written for a DOM app.  There are sometimes-subtle differences with our canvas app, which can cause issues in tests, especially when comparing screenshots.  Flakiness and race conditions can occur.

- Adds `comfyMouse` fixture / class to wrap pointer interaction
- Adds slightly more realism to simulated mouse input
- Allows canvas time to process between events, firing any logic that is bound to the animation frame
- Friendly, less verbose API
- Extremely low impact on test execution time