### PR TITLE
[Cleanup] Remove combo connection type check

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -551,26 +551,6 @@ function getWidgetType(config: InputSpec) {
   return { type }
 }
 
-function isValidCombo(combo: string[], obj: unknown) {
-  // New input isnt a combo
-  if (!(obj instanceof Array)) {
-    console.log(`connection rejected: tried to connect combo to ${obj}`)
-    return false
-  }
-  // New input combo has a different size
-  if (combo.length !== obj.length) {
-    console.log(`connection rejected: combo lists dont match`)
-    return false
-  }
-  // New input combo has different elements
-  if (combo.find((v, i) => obj[i] !== v)) {
-    console.log(`connection rejected: combo lists dont match`)
-    return false
-  }
-
-  return true
-}
-
 export function setWidgetConfig(
   slot: INodeInputSlot | INodeOutputSlot,
   config: InputSpec
@@ -930,37 +910,6 @@ app.registerExtension({
       }, 300)
 
       return r
-    }
-
-    // Prevent connecting COMBO lists to converted inputs that dont match types
-    const onConnectInput = nodeType.prototype.onConnectInput
-    nodeType.prototype.onConnectInput = function (
-      this: LGraphNode,
-      targetSlot: number,
-      type: string,
-      output: INodeOutputSlot,
-      originNode: LGraphNode,
-      originSlot: number
-    ) {
-      // @ts-expect-error onConnectInput has 5 arguments
-      const v = onConnectInput?.(this, arguments)
-      // Not a combo, ignore
-      if (type !== 'COMBO') return v
-      // Primitive output, allow that to handle
-      if (originNode.outputs[originSlot].widget) return v
-
-      // Ensure target is also a combo
-      const targetCombo = this.inputs[targetSlot].widget?.[GET_CONFIG]?.()?.[0]
-      if (!targetCombo || !(targetCombo instanceof Array)) return v
-
-      // Check they match
-      const originConfig =
-        originNode.constructor?.nodeData?.output?.[originSlot]
-      if (!originConfig || !isValidCombo(targetCombo, originConfig)) {
-        return false
-      }
-
-      return v
     }
   },
   registerCustomNodes() {

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
+const zComboOption = z.union([z.string(), z.number()])
 const zRemoteWidgetConfig = z.object({
   route: z.string().url().or(z.string().startsWith('/')),
   refresh: z.number().gte(128).safe().or(z.number().lte(0).safe()).optional(),
@@ -71,7 +72,7 @@ const zComboInputOptions = zBaseInputOptions.extend({
   allow_batch: z.boolean().optional(),
   video_upload: z.boolean().optional(),
   remote: zRemoteWidgetConfig.optional(),
-  options: z.array(z.union([z.string(), z.number()])).optional()
+  options: z.array(zComboOption).optional()
 })
 
 const zIntInputSpec = z.tuple([z.literal('INT'), zIntInputOptions.optional()])
@@ -87,8 +88,12 @@ const zStringInputSpec = z.tuple([
   z.literal('STRING'),
   zStringInputOptions.optional()
 ])
+/**
+ * Legacy combo syntax.
+ * @deprecated Use `zComboInputSpecV2` instead.
+ */
 const zComboInputSpec = z.tuple([
-  z.array(z.union([z.string(), z.number()])),
+  z.array(zComboOption),
   zComboInputOptions.optional()
 ])
 const zComboInputSpecV2 = z.tuple([
@@ -193,7 +198,7 @@ const zComfyInputsSpec = z.object({
 })
 
 const zComfyNodeDataType = z.string()
-const zComfyComboOutput = z.array(z.any())
+const zComfyComboOutput = z.array(zComboOption)
 const zComfyOutputTypesSpec = z.array(
   z.union([zComfyNodeDataType, zComfyComboOutput])
 )


### PR DESCRIPTION
Current type checking is trying to enforce exact option match, which is restricting its usage. Lift this constraint as it is confusing for users who trys to connect combo output to a combo input, but only get error message from browser console.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2838-Cleanup-Remove-combo-connection-type-check-1ab6d73d36508153b59fe5a6b0de7ec5) by [Unito](https://www.unito.io)
