### PR TITLE
Show templates to first time user

### DIFF
--- a/browser_tests/dialog.spec.ts
+++ b/browser_tests/dialog.spec.ts
@@ -133,14 +133,6 @@ test.describe('Missing models warning', () => {
     await expect(missingModelsWarning).not.toBeVisible()
   })
 
-  test('should show on tutorial workflow', async ({ comfyPage }) => {
-    await comfyPage.setSetting('Comfy.TutorialCompleted', false)
-    await comfyPage.setup({ clearStorage: true })
-    const missingModelsWarning = comfyPage.page.locator('.comfy-missing-models')
-    await expect(missingModelsWarning).toBeVisible()
-    expect(await comfyPage.getSetting('Comfy.TutorialCompleted')).toBe(true)
-  })
-
   // Flaky test after parallelization
   // https://github.com/Comfy-Org/ComfyUI_frontend/pull/1400
   test.skip('Should download missing model when clicking download button', async ({

--- a/browser_tests/templates.spec.ts
+++ b/browser_tests/templates.spec.ts
@@ -73,4 +73,17 @@ test.describe('Templates', () => {
       expect(await comfyPage.getGraphNodesCount()).toBeGreaterThan(0)
     }).toPass({ timeout: 250 })
   })
+
+  test('dialog should be automatically shown to first-time users', async ({
+    comfyPage
+  }) => {
+    // Set the tutorial as not completed to mark the user as a first-time user
+    await comfyPage.setSetting('Comfy.TutorialCompleted', false)
+
+    // Load the page
+    await comfyPage.setup({ clearStorage: true })
+
+    // Expect the templates dialog to be shown
+    expect(await comfyPage.templates.content.isVisible()).toBe(true)
+  })
 })

--- a/src/composables/useWorkflowPersistence.ts
+++ b/src/composables/useWorkflowPersistence.ts
@@ -4,6 +4,7 @@ import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { getStorageValue, setStorageValue } from '@/scripts/utils'
 import { useWorkflowService } from '@/services/workflowService'
+import { useCommandStore } from '@/stores/commandStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
@@ -50,8 +51,11 @@ export function useWorkflowPersistence() {
   const loadDefaultWorkflow = async () => {
     if (!settingStore.get('Comfy.TutorialCompleted')) {
       await settingStore.set('Comfy.TutorialCompleted', true)
+      // Ensure model folders are loaded so missing models dialog can be shown to new users
       await useModelStore().loadModelFolders()
-      await useWorkflowService().loadTutorialWorkflow()
+
+      await useWorkflowService().loadBlankWorkflow()
+      await useCommandStore().execute('Comfy.BrowseTemplates')
     } else {
       await comfyApp.loadGraphData()
     }

--- a/src/composables/useWorkflowPersistence.ts
+++ b/src/composables/useWorkflowPersistence.ts
@@ -5,7 +5,6 @@ import { app as comfyApp } from '@/scripts/app'
 import { getStorageValue, setStorageValue } from '@/scripts/utils'
 import { useWorkflowService } from '@/services/workflowService'
 import { useCommandStore } from '@/stores/commandStore'
-import { useModelStore } from '@/stores/modelStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 
@@ -51,9 +50,6 @@ export function useWorkflowPersistence() {
   const loadDefaultWorkflow = async () => {
     if (!settingStore.get('Comfy.TutorialCompleted')) {
       await settingStore.set('Comfy.TutorialCompleted', true)
-      // Ensure model folders are loaded so missing models dialog can be shown to new users
-      await useModelStore().loadModelFolders()
-
       await useWorkflowService().loadBlankWorkflow()
       await useCommandStore().execute('Comfy.BrowseTemplates')
     } else {

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -4,7 +4,6 @@ import { toRaw } from 'vue'
 
 import { t } from '@/i18n'
 import { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
-import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'
 import { downloadBlob } from '@/scripts/utils'
@@ -121,18 +120,6 @@ export const useWorkflowService = () => {
    */
   const loadDefaultWorkflow = async () => {
     await app.loadGraphData(defaultGraph)
-  }
-
-  /**
-   * Load the tutorial workflow
-   */
-  const loadTutorialWorkflow = async () => {
-    const tutorialWorkflow = await fetch(
-      api.fileURL('/templates/default.json')
-    ).then((r) => r.json())
-    await app.loadGraphData(tutorialWorkflow, false, false, 'tutorial', {
-      showMissingModelsDialog: true
-    })
   }
 
   /**
@@ -386,7 +373,6 @@ export const useWorkflowService = () => {
     saveWorkflow,
     loadDefaultWorkflow,
     loadBlankWorkflow,
-    loadTutorialWorkflow,
     reloadCurrentWorkflow,
     openWorkflow,
     closeWorkflow,


### PR DESCRIPTION
Removes `showTutorialWorkflow` in favor of showing templates dialog to first-time users (on top of empty graph).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2841-Show-templates-to-first-time-user-1ab6d73d36508163a7b7fa7859afb4cf) by [Unito](https://www.unito.io)
