### PR TITLE
Fix handling of templates index.json not found

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -420,7 +420,8 @@ export class ComfyApi extends EventTarget {
    */
   async getCoreWorkflowTemplates(): Promise<WorkflowTemplates[]> {
     const res = await axios.get('/templates/index.json')
-    return res.status === 200 ? res.data : []
+    const contentType = res.headers['content-type']
+    return contentType?.includes('application/json') ? res.data : []
   }
 
   /**


### PR DESCRIPTION
When `/templates/index.json` doesn't exist, response is just the homepage with 200 status.  handler therefore needs to validate that the content type is json, instead of just checking for 200. Otherwise the index.html contents are sent to the templates store as templates.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2842-Fix-handling-of-templates-index-json-not-found-1ab6d73d365081d5ab57d60fa995f356) by [Unito](https://www.unito.io)
