### PR TITLE
[Cleanup] Remove app.getWidgetType

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -12,6 +12,7 @@ import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { useDialogService } from '@/services/dialogService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useToastStore } from '@/stores/toastStore'
+import { useWidgetStore } from '@/stores/widgetStore'
 import { ComfyExtension } from '@/types/comfy'
 import { deserialiseAndCreate, serialise } from '@/utils/vintageClipboard'
 
@@ -442,7 +443,10 @@ export class GroupNodeConfig {
     const converted = new Map()
     const widgetMap = (this.oldToNewWidgetMap[node.index] = {})
     for (const inputName of inputNames) {
-      let widgetType = app.getWidgetType(inputs[inputName], inputName)
+      let widgetType = useWidgetStore().getWidgetType(
+        inputs[inputName][0],
+        inputName
+      )
       if (widgetType) {
         const convertedIndex = node.inputs?.findIndex(
           (inp) => inp.name === inputName && inp.widget?.name === inputName

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -920,24 +920,6 @@ export class ComfyApp {
     }
   }
 
-  /**
-   * Remove the impl after groupNode unit tests are removed.
-   * @deprecated Use useWidgetStore().getWidgetType instead
-   */
-  getWidgetType(inputData, inputName: string) {
-    const type = inputData[0]
-
-    if (Array.isArray(type)) {
-      return 'COMBO'
-    } else if (`${type}:${inputName}` in this.widgets) {
-      return `${type}:${inputName}`
-    } else if (type in this.widgets) {
-      return type
-    } else {
-      return null
-    }
-  }
-
   async registerNodeDef(nodeId: string, nodeData: ComfyNodeDef) {
     return await useLitegraphService().registerNodeDef(nodeId, nodeData)
   }


### PR DESCRIPTION
Code search shows there is only one reference of getWidgetType in a uncommonly used node pack. https://cs.comfy.org/search?q=context:global++.getWidgetType&patternType=keyword&sm=0

Removing app.getWidgetType as the legacy group node test has been removed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2845-Cleanup-Remove-app-getWidgetType-1ac6d73d365081c7abf2d48276d0b527) by [Unito](https://www.unito.io)
