### PR TITLE
Add Comfy Registry store and search hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.12.2",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@alloc/quick-lru": "5.2.0",
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.20",
         "@comfyorg/litegraph": "^0.9.5",
@@ -116,7 +117,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "dependencies": {
+    "@alloc/quick-lru": "^5.2.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.20",
     "@comfyorg/litegraph": "^0.9.5",

--- a/src/composables/useCachedRequest.ts
+++ b/src/composables/useCachedRequest.ts
@@ -17,7 +17,7 @@ export interface CachedRequestOptions {
 }
 
 /**
- * Composable that wraps a function with memoization and request deduplication.
+ * Composable that wraps a function with memoization, request deduplication, and abort handling.
  */
 export function useCachedRequest<TParams, TResult>(
   requestFunction: (
@@ -48,10 +48,6 @@ export function useCachedRequest<TParams, TResult>(
 
       return result
     } catch (err) {
-      const isAborted = err instanceof DOMException && err.name === 'AbortError'
-      if (!isAborted)
-        console.error(`Error in request with params ${cacheKey}:`, err)
-
       return null
     } finally {
       pendingRequests.delete(cacheKey)

--- a/src/composables/useCachedRequest.ts
+++ b/src/composables/useCachedRequest.ts
@@ -17,24 +17,30 @@ export interface CachedRequestOptions {
 }
 
 /**
- * Composable that creates a cached version of a function with LRU caching
- * and request deduplication.
+ * Composable that wraps a function with memoization and request deduplication.
  */
 export function useCachedRequest<TParams, TResult>(
-  requestFunction: (params: TParams) => Promise<TResult | null>,
+  requestFunction: (
+    params: TParams,
+    signal?: AbortSignal
+  ) => Promise<TResult | null>,
   options: CachedRequestOptions = {}
 ) {
   const { maxSize = DEFAULT_MAX_SIZE, cacheKeyFn = paramsToCacheKey } = options
 
   const cache = new QuickLRU<string, TResult>({ maxSize })
   const pendingRequests = new Map<string, Promise<TResult | null>>()
+  const abortControllers = new Map<string, AbortController>()
 
   const executeAndCacheCall = async (
     params: TParams,
     cacheKey: string
   ): Promise<TResult | null> => {
     try {
-      const responsePromise = requestFunction(params)
+      const controller = new AbortController()
+      abortControllers.set(cacheKey, controller)
+
+      const responsePromise = requestFunction(params, controller.signal)
       pendingRequests.set(cacheKey, responsePromise)
 
       const result = await responsePromise
@@ -42,10 +48,14 @@ export function useCachedRequest<TParams, TResult>(
 
       return result
     } catch (err) {
-      console.error(`Error in request with params ${cacheKey}:`, err)
+      const isAborted = err instanceof DOMException && err.name === 'AbortError'
+      if (!isAborted)
+        console.error(`Error in request with params ${cacheKey}:`, err)
+
       return null
     } finally {
       pendingRequests.delete(cacheKey)
+      abortControllers.delete(cacheKey)
     }
   }
 
@@ -60,10 +70,25 @@ export function useCachedRequest<TParams, TResult>(
     }
   }
 
+  const abortAllRequests = () => {
+    for (const controller of abortControllers.values()) {
+      controller.abort()
+    }
+  }
+
+  /**
+   * Cancel and clear any pending requests
+   */
+  const cancel = () => {
+    abortAllRequests()
+    abortControllers.clear()
+    pendingRequests.clear()
+  }
+
   /**
    * Cached version of the request function
    */
-  async function cachedCall(params: TParams): Promise<TResult | null> {
+  const call = async (params: TParams): Promise<TResult | null> => {
     const cacheKey = cacheKeyFn(params)
 
     const cachedResult = cache.get(cacheKey)
@@ -75,23 +100,9 @@ export function useCachedRequest<TParams, TResult>(
     return executeAndCacheCall(params, cacheKey)
   }
 
-  /**
-   * Clear all cached data
-   */
-  function clearCache() {
-    cache.clear()
-  }
-
-  /**
-   * Cancel any in-flight requests
-   */
-  function cancel() {
-    pendingRequests.clear()
-  }
-
   return {
-    call: cachedCall,
-    clear: clearCache,
-    cancel
+    call,
+    cancel,
+    clear: () => cache.clear()
   }
 }

--- a/src/composables/useCachedRequest.ts
+++ b/src/composables/useCachedRequest.ts
@@ -1,0 +1,102 @@
+import QuickLRU from '@alloc/quick-lru'
+
+import { paramsToCacheKey } from '@/utils/formatUtil'
+
+const DEFAULT_MAX_SIZE = 50
+
+export interface CachedRequestOptions {
+  /**
+   * Maximum number of items to store in the cache
+   * @default 50
+   */
+  maxSize?: number
+  /**
+   * Function to generate a cache key from parameters
+   */
+  cacheKeyFn?: (params: unknown) => string
+}
+
+/**
+ * Composable that creates a cached version of a function with LRU caching
+ * and request deduplication.
+ */
+export function useCachedRequest<TParams, TResult>(
+  requestFunction: (params: TParams) => Promise<TResult | null>,
+  options: CachedRequestOptions = {}
+) {
+  const { maxSize = DEFAULT_MAX_SIZE, cacheKeyFn = paramsToCacheKey } = options
+
+  const cache = new QuickLRU<string, TResult>({ maxSize })
+  const pendingRequests = new Map<string, Promise<TResult | null>>()
+
+  const getFromCache = (params: TParams): TResult | null => {
+    const cacheKey = cacheKeyFn(params)
+    return cache.get(cacheKey) || null
+  }
+
+  const executeAndCacheCall = async (
+    params: TParams,
+    cacheKey: string
+  ): Promise<TResult | null> => {
+    try {
+      const result = await requestFunction(params)
+      if (result) {
+        cache.set(cacheKey, result)
+      }
+      return result
+    } catch (err) {
+      console.error(`Error in request with params ${cacheKey}:`, err)
+      return null
+    } finally {
+      pendingRequests.delete(cacheKey)
+    }
+  }
+
+  const handlePendingRequest = async (
+    pendingRequest: Promise<TResult | null>
+  ): Promise<TResult | null> => {
+    try {
+      return await pendingRequest
+    } catch (err) {
+      console.error('Error in pending request:', err)
+      return null
+    }
+  }
+
+  /**
+   * Cached version of the request function
+   */
+  async function cachedCall(params: TParams): Promise<TResult | null> {
+    const cacheKey = cacheKeyFn(params)
+
+    const cachedResult = getFromCache(params)
+    if (cachedResult) return cachedResult
+
+    const pendingRequest = pendingRequests.get(cacheKey)
+    if (pendingRequest) return handlePendingRequest(pendingRequest)
+
+    const newRequest = executeAndCacheCall(params, cacheKey)
+    pendingRequests.set(cacheKey, newRequest)
+    return newRequest
+  }
+
+  /**
+   * Clear all cached data
+   */
+  function clearCache() {
+    cache.clear()
+  }
+
+  /**
+   * Cancel all pending requests
+   */
+  function cancel() {
+    pendingRequests.clear()
+  }
+
+  return {
+    call: cachedCall,
+    clear: clearCache,
+    cancel
+  }
+}

--- a/src/composables/useRegistrySearch.ts
+++ b/src/composables/useRegistrySearch.ts
@@ -1,0 +1,68 @@
+import { debounce } from 'lodash'
+import { onUnmounted, ref, watch } from 'vue'
+
+import { useComfyRegistryService } from '@/services/comfyRegistryService'
+import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
+import type { components } from '@/types/comfyRegistryTypes'
+
+const SEARCH_DEBOUNCE_TIME = 256
+const DEFAULT_PAGE_SIZE = 60
+
+/**
+ * Composable for managing UI state of Comfy Node Registry search.
+ */
+export function useRegistrySearch() {
+  const registryStore = useComfyRegistryStore()
+  const registryService = useComfyRegistryService()
+
+  const searchQuery = ref('')
+  const pageNumber = ref(1)
+  const pageSize = ref(DEFAULT_PAGE_SIZE)
+  const searchResults = ref<components['schemas']['Node'][]>([])
+
+  const search = async () => {
+    try {
+      const isEmptySearch = searchQuery.value === ''
+      const result = isEmptySearch
+        ? await registryStore.listAllPacks({
+            page: pageNumber.value,
+            limit: pageSize.value
+          })
+        : await registryService.search({
+            search: searchQuery.value,
+            page: pageNumber.value,
+            limit: pageSize.value
+          })
+
+      if (result) {
+        searchResults.value = result.nodes || []
+      } else {
+        searchResults.value = []
+      }
+    } catch (err) {
+      console.error('Error loading packs:', err)
+      searchResults.value = []
+    }
+  }
+
+  // Debounce search when query changes
+  const debouncedSearch = debounce(search, SEARCH_DEBOUNCE_TIME)
+  watch(() => searchQuery.value, debouncedSearch)
+
+  // Normal search when page number changes and on load
+  watch(() => pageNumber.value, search, { immediate: true })
+
+  onUnmounted(() => {
+    debouncedSearch.cancel() // Cancel pending searches
+    registryStore.clearCache() // Clear cached responses
+  })
+
+  return {
+    pageNumber,
+    pageSize,
+    searchQuery,
+    searchResults,
+    isLoading: registryService.isLoading,
+    error: registryService.error
+  }
+}

--- a/src/composables/useRegistrySearch.ts
+++ b/src/composables/useRegistrySearch.ts
@@ -53,7 +53,8 @@ export function useRegistrySearch() {
   watch(() => pageNumber.value, search, { immediate: true })
 
   onUnmounted(() => {
-    debouncedSearch.cancel() // Cancel pending searches
+    debouncedSearch.cancel() // Cancel debounced searches
+    registryStore.cancelRequests() // Cancel in-flight requests
     registryStore.clearCache() // Clear cached responses
   })
 

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -1,0 +1,82 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import { useCachedRequest } from '@/composables/useCachedRequest'
+import { useComfyRegistryService } from '@/services/comfyRegistryService'
+import type { components, operations } from '@/types/comfyRegistryTypes'
+
+const PACK_LIST_CACHE_SIZE = 20
+const PACK_BY_ID_CACHE_SIZE = 50
+
+type NodePack = components['schemas']['Node']
+type ListPacksParams = operations['listAllNodes']['parameters']['query']
+type ListPacksResult =
+  operations['listAllNodes']['responses'][200]['content']['application/json']
+
+/**
+ * Store for managing remote custom nodes
+ */
+export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
+  const registryService = useComfyRegistryService()
+
+  let listAllPacksHandler: ReturnType<
+    typeof useCachedRequest<ListPacksParams, ListPacksResult>
+  >
+  let getPackByIdHandler: ReturnType<typeof useCachedRequest<string, NodePack>>
+
+  const recentListResult = ref<NodePack[]>([])
+  const hasPacks = computed(() => recentListResult.value.length > 0)
+
+  /**
+   * Get a list of all node packs from the registry
+   */
+  const listAllPacks = async (params: ListPacksParams) => {
+    listAllPacksHandler ??= useCachedRequest<ListPacksParams, ListPacksResult>(
+      registryService.listAllPacks,
+      { maxSize: PACK_LIST_CACHE_SIZE }
+    )
+
+    const response = await listAllPacksHandler.call(params)
+    if (response) recentListResult.value = response.nodes || []
+
+    return response
+  }
+
+  /**
+   * Get a pack by its ID from the registry
+   */
+  const getPackById = async (
+    packId: NodePack['id']
+  ): Promise<NodePack | null> => {
+    if (!packId) return null
+
+    getPackByIdHandler ??= useCachedRequest<string, NodePack>(
+      registryService.getPackById,
+      { maxSize: PACK_BY_ID_CACHE_SIZE }
+    )
+
+    return getPackByIdHandler.call(packId)
+  }
+
+  /**
+   * Clear all cached data
+   */
+  const clearCache = () => {
+    listAllPacksHandler?.cancel()
+    getPackByIdHandler?.cancel()
+    listAllPacksHandler?.clear()
+    getPackByIdHandler?.clear()
+  }
+
+  return {
+    recentListResult,
+    hasPacks,
+
+    listAllPacks,
+    getPackById,
+    clearCache,
+
+    isLoading: registryService.isLoading,
+    error: registryService.error
+  }
+})

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -62,10 +62,16 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
    * Clear all cached data
    */
   const clearCache = () => {
-    listAllPacksHandler?.cancel()
-    getPackByIdHandler?.cancel()
     listAllPacksHandler?.clear()
     getPackByIdHandler?.clear()
+  }
+
+  /**
+   * Cancel all pending requests
+   */
+  const cancelRequests = () => {
+    listAllPacksHandler?.cancel()
+    getPackByIdHandler?.cancel()
   }
 
   return {
@@ -75,6 +81,7 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     listAllPacks,
     getPackById,
     clearCache,
+    cancelRequests,
 
     isLoading: registryService.isLoading,
     error: registryService.error

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -67,7 +67,7 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
   }
 
   /**
-   * Cancel all pending requests
+   * Cancel any in-flight requests
    */
   const cancelRequests = () => {
     listAllPacksHandler?.cancel()

--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -297,3 +297,18 @@ export function formatDate(text: string, date: Date) {
     return text
   })
 }
+
+/**
+ * Generate a cache key from parameters
+ * Sorts the parameters to ensure consistent keys regardless of parameter order
+ */
+export const paramsToCacheKey = (params: unknown): string => {
+  if (typeof params === 'string') return params
+  if (typeof params === 'object' && params !== null)
+    return Object.keys(params)
+      .sort((a, b) => a.localeCompare(b))
+      .map((key) => `${key}:${params[key as keyof typeof params]}`)
+      .join('&')
+
+  return String(params)
+}

--- a/src/utils/typeGuardUtil.ts
+++ b/src/utils/typeGuardUtil.ts
@@ -7,3 +7,12 @@ export function isPrimitiveNode(
 ): node is PrimitiveNode & LGraphNode {
   return node.type === 'PrimitiveNode'
 }
+
+/**
+ * Check if an error is an AbortError triggered by `AbortController#abort`
+ * when cancelling a request.
+ */
+export const isAbortError = (
+  err: unknown
+): err is DOMException & { name: 'AbortError' } =>
+  err instanceof DOMException && err.name === 'AbortError'

--- a/tests-ui/tests/composables/useCachedRequest.test.ts
+++ b/tests-ui/tests/composables/useCachedRequest.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCachedRequest } from '@/composables/useCachedRequest'
+
+describe('useCachedRequest', () => {
+  let mockRequestFn: ReturnType<typeof vi.fn>
+  let abortSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Create a spy for the AbortController.abort method
+    abortSpy = vi.fn()
+
+    // Mock AbortController
+    vi.stubGlobal(
+      'AbortController',
+      class MockAbortController {
+        signal = { aborted: false }
+        abort = abortSpy
+      }
+    )
+
+    // Create a mock request function that returns different results based on params
+    mockRequestFn = vi.fn(async (params: any, signal?: AbortSignal) => {
+      // Simulate a request that takes some time
+      await new Promise((resolve) => setTimeout(resolve, 8))
+
+      if (params === null) return null
+
+      // Return a result based on the params
+      return { data: `Result for ${JSON.stringify(params)}` }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('should cache results and not repeat calls with the same params', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // First call should make the request
+    const result1 = await cachedRequest.call({ id: 1 })
+    expect(result1).toEqual({ data: 'Result for {"id":1}' })
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Second call with the same params should use the cache
+    const result2 = await cachedRequest.call({ id: 1 })
+    expect(result2).toEqual({ data: 'Result for {"id":1}' })
+    expect(mockRequestFn).toHaveBeenCalledTimes(1) // Still only called once
+
+    // Call with different params should make a new request
+    const result3 = await cachedRequest.call({ id: 2 })
+    expect(result3).toEqual({ data: 'Result for {"id":2}' })
+    expect(mockRequestFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should deduplicate in-flight requests with the same params', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // Start two requests with the same params simultaneously
+    const promise1 = cachedRequest.call({ id: 1 })
+    const promise2 = cachedRequest.call({ id: 1 })
+
+    // Wait for both to complete
+    const [result1, result2] = await Promise.all([promise1, promise2])
+
+    // Both should have the same result
+    expect(result1).toEqual({ data: 'Result for {"id":1}' })
+    expect(result2).toEqual({ data: 'Result for {"id":1}' })
+
+    // But the request function should only be called once
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not repeat requests that throw errors', async () => {
+    // Create a mock function that throws an error
+    const errorMockFn = vi.fn(async () => {
+      throw new Error('Test error')
+    })
+
+    const cachedRequest = useCachedRequest(errorMockFn)
+
+    // Make a request that will throw
+    const result = await cachedRequest.call({ id: 1 })
+
+    // The result should be null
+    expect(result).toBeNull()
+    expect(errorMockFn).toHaveBeenCalledTimes(1)
+
+    // Make the same request again
+    const result2 = await cachedRequest.call({ id: 1 })
+    expect(result2).toBeNull()
+
+    // Verify error result is cached and not called again
+    expect(errorMockFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should evict least recently used entries when cache exceeds maxSize', async () => {
+    // Create a cached request with a small max size
+    const cachedRequest = useCachedRequest(mockRequestFn, { maxSize: 2 })
+
+    // Make 3 different requests to exceed the cache size
+    await cachedRequest.call({ id: 1 })
+    await cachedRequest.call({ id: 2 })
+    await cachedRequest.call({ id: 3 })
+    await cachedRequest.call({ id: 4 })
+
+    expect(mockRequestFn).toHaveBeenCalledTimes(4)
+
+    // Request id:1 again - it should have been evicted
+    await cachedRequest.call({ id: 1 })
+    expect(mockRequestFn).toHaveBeenCalledTimes(5)
+
+    // Request least recently used entries
+    await cachedRequest.call({ id: 1 })
+    await cachedRequest.call({ id: 4 })
+    expect(mockRequestFn).toHaveBeenCalledTimes(5) // No new calls
+  })
+
+  it('should not repeat calls with same params in different order', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // First call with params in one order
+    await cachedRequest.call({ a: 1, b: 2 })
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Params in different order should still share cache key
+    await cachedRequest.call({ b: 2, a: 1 })
+
+    // Verify request function not called again (cache hit)
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should use custom cache key function if provided', async () => {
+    // Create a cache key function that sorts object keys
+    const cacheKeyFn = (params: any) => {
+      if (typeof params !== 'object' || params === null) return String(params)
+      return JSON.stringify(
+        Object.keys(params)
+          .sort()
+          .reduce((acc, key) => ({ ...acc, [key]: params[key] }), {})
+      )
+    }
+
+    const cachedRequest = useCachedRequest(mockRequestFn, { cacheKeyFn })
+
+    // First call with params in one order
+    const result1 = await cachedRequest.call({ a: 1, b: 2 })
+    expect(result1).toEqual({ data: 'Result for {"a":1,"b":2}' })
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Second call with same params in different order should use cache
+    const result2 = await cachedRequest.call({ b: 2, a: 1 })
+    expect(result2).toEqual({ data: 'Result for {"a":1,"b":2}' })
+    expect(mockRequestFn).toHaveBeenCalledTimes(1) // Still only called once
+  })
+
+  it('should abort requests when cancel is called', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // Start a request but don't await it
+    const promise = cachedRequest.call({ id: 1 })
+
+    // Cancel all requests
+    cachedRequest.cancel()
+
+    // The abort method should have been called
+    expect(abortSpy).toHaveBeenCalled()
+
+    // The promise should still resolve (our mock doesn't actually abort)
+    const result = await promise
+    expect(result).toEqual({ data: 'Result for {"id":1}' })
+  })
+
+  it('should clear the cache when clear is called', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // Make a request to populate the cache
+    await cachedRequest.call({ id: 1 })
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Clear the cache
+    cachedRequest.clear()
+
+    // Make the same request again
+    await cachedRequest.call({ id: 1 })
+
+    // The request function should be called again
+    expect(mockRequestFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle null results correctly', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // Make a request that returns null
+    const result = await cachedRequest.call(null)
+    expect(result).toBeNull()
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Make the same request again
+    const result2 = await cachedRequest.call(null)
+    expect(result2).toBeNull()
+
+    // Verify null result is treated as any other result (doesn't cause infinite cache miss)
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle string params correctly', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // Make requests with string params
+    await cachedRequest.call('string-param')
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Verify cache hit
+    await cachedRequest.call('string-param')
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle number params correctly', async () => {
+    const cachedRequest = useCachedRequest(mockRequestFn)
+
+    // Make request with number param
+    await cachedRequest.call(123)
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+
+    // Verify cache hit
+    await cachedRequest.call(123)
+    expect(mockRequestFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests-ui/tests/store/comfyRegistryStore.test.ts
+++ b/tests-ui/tests/store/comfyRegistryStore.test.ts
@@ -1,0 +1,129 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useComfyRegistryService } from '@/services/comfyRegistryService'
+import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
+import type { components, operations } from '@/types/comfyRegistryTypes'
+
+vi.mock('@/services/comfyRegistryService', () => ({
+  useComfyRegistryService: vi.fn()
+}))
+
+const mockNodePack: components['schemas']['Node'] = {
+  id: 'test-pack-id',
+  name: 'Test Pack',
+  description: 'A test node pack',
+  downloads: 1000,
+  publisher: {
+    id: 'test-publisher',
+    name: 'Test Publisher'
+  },
+  latest_version: {
+    id: 'test-version',
+    version: '1.0.0',
+    createdAt: '2023-01-01T00:00:00Z'
+  }
+}
+
+const mockListResult: operations['listAllNodes']['responses'][200]['content']['application/json'] =
+  {
+    nodes: [mockNodePack],
+    total: 1,
+    page: 1,
+    limit: 10
+  }
+
+describe('useComfyRegistryStore', () => {
+  let mockRegistryService: {
+    isLoading: ReturnType<typeof ref<boolean>>
+    error: ReturnType<typeof ref<string | null>>
+    listAllPacks: ReturnType<typeof vi.fn>
+    getPackById: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockRegistryService = {
+      isLoading: ref(false),
+      error: ref(null),
+      listAllPacks: vi.fn().mockResolvedValue(mockListResult),
+      getPackById: vi.fn().mockResolvedValue(mockNodePack)
+    }
+
+    vi.mocked(useComfyRegistryService).mockReturnValue(
+      mockRegistryService as any
+    )
+  })
+
+  it('should initialize with empty state', () => {
+    const store = useComfyRegistryStore()
+
+    expect(store.recentListResult).toEqual([])
+    expect(store.hasPacks).toBe(false)
+  })
+
+  it('should fetch and store packs', async () => {
+    const store = useComfyRegistryStore()
+    const params = { page: 1, limit: 10 }
+
+    const result = await store.listAllPacks(params)
+
+    expect(result).toEqual(mockListResult)
+    expect(store.recentListResult).toEqual(mockListResult.nodes)
+    expect(store.hasPacks).toBe(true)
+    expect(mockRegistryService.listAllPacks).toHaveBeenCalledWith(
+      params,
+      expect.any(Object) // abort signal
+    )
+  })
+
+  it('should handle empty nodes array in response', async () => {
+    const emptyResult = {
+      nodes: undefined,
+      total: 0,
+      page: 1,
+      limit: 10
+    }
+    mockRegistryService.listAllPacks.mockResolvedValueOnce(emptyResult)
+
+    const store = useComfyRegistryStore()
+    await store.listAllPacks({ page: 1, limit: 10 })
+
+    expect(store.recentListResult).toEqual([])
+    expect(store.hasPacks).toBe(false)
+  })
+
+  it('should fetch a pack by ID', async () => {
+    const store = useComfyRegistryStore()
+    const packId = 'test-pack-id'
+
+    const result = await store.getPackById(packId)
+
+    expect(result).toEqual(mockNodePack)
+    expect(mockRegistryService.getPackById).toHaveBeenCalledWith(
+      packId,
+      expect.any(Object) // abort signal
+    )
+  })
+
+  it('should return null when fetching a pack with null ID', async () => {
+    const store = useComfyRegistryStore()
+
+    const result = await store.getPackById(null as any)
+
+    expect(result).toBeNull()
+    expect(mockRegistryService.getPackById).not.toHaveBeenCalled()
+  })
+
+  it('should handle service errors gracefully', async () => {
+    mockRegistryService.listAllPacks.mockResolvedValueOnce(null)
+
+    const store = useComfyRegistryStore()
+    const result = await store.listAllPacks({ page: 1, limit: 10 })
+
+    expect(result).toBeNull()
+    expect(store.recentListResult).toEqual([])
+  })
+})


### PR DESCRIPTION
Followup from https://github.com/Comfy-Org/ComfyUI_frontend/pull/2836: Adds store to centralize data from Comfy Registry service and hook to use Comfy Registry search in a UI component. 

The store handles caching, deduplicating, retrying of requests and exposes functions to clear caches and cancel requests.

The component hook handles debouncing and calling all cleanup (cache clear, map clear, abort requests, cancel debounced functions) in unmount hook.

Afterwards, a component can simply use:

```vue
<template>
  <InputText
    v-model="searchQuery"
    placeholder="Search nodes"
    class="w-5/12 rounded-xl"
  />
  <div v-if="!isLoading && !error"> {{ searchResults }} </div>
</template>
<script>

const { searchQuery, pageNumber, pageSize, isLoading, error, searchResults } =
  useRegistrySearch()

// Handle pagination or infinite scroll here
pageNumber.value = 1
pageSize.value = 20
</script>
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2848-Add-Comfy-Registry-store-and-search-hook-1ac6d73d365081e29d76ccff5ab53af7) by [Unito](https://www.unito.io)
