### PR TITLE
[Workaround] Fix #2849 with runtime type guard

### DIFF
--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -64,10 +64,6 @@ export const useStringWidget = () => {
     inputData: InputSpec,
     app: ComfyApp
   ) => {
-    if (!isStringInputSpec(inputData)) {
-      throw new Error(`Invalid input data: ${inputData}`)
-    }
-
     const inputOptions = inputData[1] ?? {}
     const defaultVal = inputOptions.default ?? ''
     const multiline = inputOptions.multiline
@@ -86,7 +82,7 @@ export const useStringWidget = () => {
       }
     }
 
-    if (inputOptions.dynamicPrompts != undefined) {
+    if (typeof inputOptions.dynamicPrompts === "boolean") {
       res.widget.dynamicPrompts = inputOptions.dynamicPrompts
     }
 

--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -1,6 +1,6 @@
 import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
 
-import { type InputSpec, isStringInputSpec } from '@/schemas/nodeDefSchema'
+import { type InputSpec } from '@/schemas/nodeDefSchema'
 import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import { useSettingStore } from '@/stores/settingStore'
 import type { ComfyApp } from '@/types'
@@ -82,7 +82,7 @@ export const useStringWidget = () => {
       }
     }
 
-    if (typeof inputOptions.dynamicPrompts === "boolean") {
+    if (typeof inputOptions.dynamicPrompts === 'boolean') {
       res.widget.dynamicPrompts = inputOptions.dynamicPrompts
     }
 


### PR DESCRIPTION
- Resolves #2849
- Replaces type narrowing with runtime type assertion
- Removes throwing code: `inputData[0] === ''`
- Can be reverted once the root cause is resolved

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2850-Workaround-Fix-2849-with-runtime-type-guard-1ac6d73d36508190bce8ecb2666fc410) by [Unito](https://www.unito.io)
