### PR TITLE
[Refactor] Use V2 node def in ComfyApp

### DIFF
--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -91,3 +91,33 @@ export type CustomInputSpec = z.infer<typeof zCustomInputSpec>
 export type InputSpec = z.infer<typeof zInputSpec>
 export type OutputSpec = z.infer<typeof zOutputSpec>
 export type ComfyNodeDef = z.infer<typeof zNodeDef>
+
+export const isIntInputSpec = (
+  inputSpec: InputSpec
+): inputSpec is IntInputSpec => {
+  return inputSpec.type === 'INT'
+}
+
+export const isFloatInputSpec = (
+  inputSpec: InputSpec
+): inputSpec is FloatInputSpec => {
+  return inputSpec.type === 'FLOAT'
+}
+
+export const isBooleanInputSpec = (
+  inputSpec: InputSpec
+): inputSpec is BooleanInputSpec => {
+  return inputSpec.type === 'BOOLEAN'
+}
+
+export const isStringInputSpec = (
+  inputSpec: InputSpec
+): inputSpec is StringInputSpec => {
+  return inputSpec.type === 'STRING'
+}
+
+export const isComboInputSpec = (
+  inputSpec: InputSpec
+): inputSpec is ComboInputSpec => {
+  return inputSpec.type === 'COMBO'
+}

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -225,7 +225,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   )
   const nodeTree = computed(() => buildNodeDefTree(visibleNodeDefs.value))
 
-  function updateNodeDefs(nodeDefs: ComfyNodeDefV1 & ComfyNodeDefV2[]) {
+  function updateNodeDefs(nodeDefs: ComfyNodeDefV1[]) {
     const newNodeDefsByName: Record<string, ComfyNodeDefImpl> = {}
     const newNodeDefsByDisplayName: Record<string, ComfyNodeDefImpl> = {}
 

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -225,20 +225,20 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   )
   const nodeTree = computed(() => buildNodeDefTree(visibleNodeDefs.value))
 
-  function updateNodeDefs(nodeDefs: ComfyNodeDefV1[]) {
+  function updateNodeDefs(nodeDefs: ComfyNodeDefV1 & ComfyNodeDefV2[]) {
     const newNodeDefsByName: Record<string, ComfyNodeDefImpl> = {}
     const newNodeDefsByDisplayName: Record<string, ComfyNodeDefImpl> = {}
+
     for (const nodeDef of nodeDefs) {
-      try {
-        const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
-        newNodeDefsByName[nodeDef.name] = nodeDefImpl
-        newNodeDefsByDisplayName[nodeDef.display_name] = nodeDefImpl
-      } catch (e) {
-        // Avoid breaking the app for invalid nodeDefs
-        // NodeDef validation is now optional for performance reasons
-        console.error('Error adding nodeDef:', e)
-      }
+      const nodeDefImpl =
+        nodeDef instanceof ComfyNodeDefImpl
+          ? nodeDef
+          : new ComfyNodeDefImpl(nodeDef)
+
+      newNodeDefsByName[nodeDef.name] = nodeDefImpl
+      newNodeDefsByDisplayName[nodeDef.display_name] = nodeDefImpl
     }
+
     nodeDefsByName.value = newNodeDefsByName
     nodeDefsByDisplayName.value = newNodeDefsByDisplayName
   }


### PR DESCRIPTION
This PR makes significant changes to how node definitions are handled in the application:

1. Adds type guard functions in `nodeDefSchemaV2.ts` to check input specification types (INT, FLOAT, BOOLEAN, STRING, COMBO)

2. Improves the node definition handling in `app.ts`:
   - Updates type imports and adds proper type annotations
   - Refactors the translation of node definitions
   - Creates `ComfyNodeDefImpl` instances directly in `#getNodeDefs()`
   - Improves combo widget options handling using the new type guards

3. Simplifies the `updateNodeDefs` function in `nodeDefStore.ts`:
   - Removes try-catch error handling
   - Adds a check to reuse existing `ComfyNodeDefImpl` instances
   - Streamlines the node definition registration process

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2854-Refactor-Use-V2-node-def-in-ComfyApp-1ac6d73d36508194ac04cbd199fcc12f) by [Unito](https://www.unito.io)
