### PR TITLE
Add back type guard on string widget

### DIFF
--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -1,6 +1,6 @@
 import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
 
-import { type InputSpec } from '@/schemas/nodeDefSchema'
+import { type InputSpec, isStringInputSpec } from '@/schemas/nodeDefSchema'
 import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import { useSettingStore } from '@/stores/settingStore'
 import type { ComfyApp } from '@/types'
@@ -64,6 +64,10 @@ export const useStringWidget = () => {
     inputData: InputSpec,
     app: ComfyApp
   ) => {
+    if (!isStringInputSpec(inputData)) {
+      throw new Error(`Invalid input data: ${inputData}`)
+    }
+
     const inputOptions = inputData[1] ?? {}
     const defaultVal = inputOptions.default ?? ''
     const multiline = inputOptions.multiline

--- a/src/extensions/core/noteNode.ts
+++ b/src/extensions/core/noteNode.ts
@@ -26,10 +26,9 @@ app.registerExtension({
           this.properties = { text: '' }
         }
         ComfyWidgets.STRING(
-          // Should we extends LGraphNode?  Yesss
           this,
-          '',
-          ['', { default: this.properties.text, multiline: true }],
+          'text',
+          ['STRING', { default: this.properties.text, multiline: true }],
           app
         )
 
@@ -66,8 +65,8 @@ app.registerExtension({
         }
         ComfyWidgets.MARKDOWN(
           this,
-          '',
-          ['', { default: this.properties.text }],
+          'text',
+          ['STRING', { default: this.properties.text }],
           app
         )
 


### PR DESCRIPTION
Partially revert #2850.

Adds back string widget type guard and make sure note nodes correctly pass the input spec to widget constructor.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2859-Add-back-type-guard-on-string-widget-1ac6d73d365081a2970dfb278ba23d1b) by [Unito](https://www.unito.io)
