### PR TITLE
Add menu tabs

### DIFF
--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="queue-button-group flex">
+  <div v-if="!isMenuPaneActive" class="queue-button-group flex">
     <SplitButton
       class="comfyui-queue-button"
       :label="activeQueueModeMenuItem.label"
@@ -82,6 +82,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useCommandStore } from '@/stores/commandStore'
+import { useMenuPaneStore } from '@/stores/menuPaneStore'
 import {
   useQueuePendingTaskCountStore,
   useQueueSettingsStore
@@ -93,6 +94,9 @@ import BatchCountEdit from './BatchCountEdit.vue'
 const workspaceStore = useWorkspaceStore()
 const queueCountStore = storeToRefs(useQueuePendingTaskCountStore())
 const { mode: queueMode } = storeToRefs(useQueueSettingsStore())
+
+const menuPaneStore = useMenuPaneStore()
+const isMenuPaneActive = computed(() => menuPaneStore.activeMenuPaneId !== null)
 
 const { t } = useI18n()
 const queueModeMenuItemLookup = computed(() => ({

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -1,5 +1,6 @@
 <template>
   <ButtonGroup
+    v-if="!isMenuPaneActive"
     class="p-buttongroup-vertical absolute bottom-[10px] right-[10px] z-[1000]"
   >
     <Button
@@ -68,12 +69,16 @@ import { useI18n } from 'vue-i18n'
 
 import { useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
+import { useMenuPaneStore } from '@/stores/menuPaneStore'
 import { useSettingStore } from '@/stores/settingStore'
 
 const { t } = useI18n()
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
 const settingStore = useSettingStore()
+const menuPaneStore = useMenuPaneStore()
+
+const isMenuPaneActive = computed(() => menuPaneStore.activeMenuPaneId !== null)
 
 const linkHidden = computed(
   () => settingStore.get('Comfy.LinkRenderMode') === LiteGraph.HIDDEN_LINK

--- a/src/components/menupane/MenuPane.vue
+++ b/src/components/menupane/MenuPane.vue
@@ -1,0 +1,17 @@
+<template>
+  <div v-if="activeMenuPane" class="w-full h-full relative z-20">
+    <component
+      :is="activeMenuPane.component"
+      v-bind="activeMenuPane.props || {}"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useMenuPaneStore } from '@/stores/menuPaneStore'
+
+const menuPaneStore = useMenuPaneStore()
+const activeMenuPane = computed(() => menuPaneStore.activeMenuPane)
+</script>

--- a/src/components/topbar/MenuPaneTab.vue
+++ b/src/components/topbar/MenuPaneTab.vue
@@ -1,0 +1,50 @@
+<template>
+  <div
+    class="flex p-2 gap-2 cursor-pointer group"
+    ref="menuPaneTabRef"
+    v-bind="$attrs"
+    @contextmenu="onContextMenu"
+  >
+    <i v-if="tab.icon" :class="[tab.icon, 'mr-2']"></i>
+    <span class="text-sm max-w-[150px] truncate inline-block">
+      {{ tab.label }}
+    </span>
+
+    <div class="relative">
+      <Button
+        class="p-0 w-auto invisible group-hover:visible hover:visible"
+        icon="pi pi-times"
+        text
+        severity="secondary"
+        size="small"
+        @click.stop="onClose"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { ref } from 'vue'
+
+import { MenuPaneTabItem } from '@/types/tabTypes'
+
+const { tab } = defineProps<{
+  tab: MenuPaneTabItem
+}>()
+
+const emit = defineEmits<{
+  (e: 'close', tab: MenuPaneTabItem): void
+  (e: 'contextmenu', event: MouseEvent, tab: MenuPaneTabItem): void
+}>()
+
+const menuPaneTabRef = ref<HTMLElement | null>(null)
+
+const onClose = () => {
+  emit('close', tab)
+}
+
+const onContextMenu = (event: MouseEvent) => {
+  emit('contextmenu', event, tab)
+}
+</script>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -11,17 +11,26 @@
       <SelectButton
         class="workflow-tabs bg-transparent"
         :class="props.class"
-        :modelValue="selectedWorkflow"
-        @update:modelValue="onWorkflowChange"
-        :options="options"
+        :modelValue="selectedTab"
+        @update:modelValue="onTabChange"
+        :options="tabs"
         optionLabel="label"
-        dataKey="value"
+        dataKey="id"
       >
         <template #option="{ option }">
           <WorkflowTab
+            v-if="isWorkflowTab(option)"
+            :tab="option"
+            @close="closeTab(option)"
             @contextmenu="showContextMenu($event, option)"
-            @click.middle="onCloseWorkflow(option)"
-            :workflow-option="option"
+            @middle-click="closeTab(option)"
+            @reorder="handleReorder"
+          />
+          <MenuPaneTab
+            v-else
+            :tab="option"
+            @close="closeTab(option)"
+            @contextmenu="showContextMenu($event, option)"
           />
         </template>
       </SelectButton>
@@ -42,22 +51,27 @@
 <script setup lang="ts">
 import Button from 'primevue/button'
 import ContextMenu from 'primevue/contextmenu'
+import type { MenuItem } from 'primevue/menuitem'
 import ScrollPanel from 'primevue/scrollpanel'
 import SelectButton from 'primevue/selectbutton'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import MenuPaneTab from '@/components/topbar/MenuPaneTab.vue'
 import WorkflowTab from '@/components/topbar/WorkflowTab.vue'
 import { useWorkflowService } from '@/services/workflowService'
 import { useCommandStore } from '@/stores/commandStore'
-import { ComfyWorkflow, useWorkflowBookmarkStore } from '@/stores/workflowStore'
+import { useMenuPaneStore } from '@/stores/menuPaneStore'
+import { useWorkflowBookmarkStore } from '@/stores/workflowStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-
-interface WorkflowOption {
-  value: string
-  workflow: ComfyWorkflow
-}
+import {
+  BaseTabItem,
+  MenuPaneTabItem,
+  WorkflowTabItem,
+  isMenuPaneTab,
+  isWorkflowTab
+} from '@/types/tabTypes'
 
 const props = defineProps<{
   class?: string
@@ -68,102 +82,156 @@ const workspaceStore = useWorkspaceStore()
 const workflowStore = useWorkflowStore()
 const workflowService = useWorkflowService()
 const workflowBookmarkStore = useWorkflowBookmarkStore()
-const rightClickedTab = ref<WorkflowOption>(null)
+const menuPaneStore = useMenuPaneStore()
+const rightClickedTab = ref<BaseTabItem | null>(null)
 const menu = ref()
 
-const workflowToOption = (workflow: ComfyWorkflow): WorkflowOption => ({
-  value: workflow.path,
-  workflow
+const tabs = computed<BaseTabItem[]>(() => {
+  const workflowTabs: WorkflowTabItem[] = workflowStore.openWorkflows.map(
+    (workflow) => ({
+      id: workflow.path,
+      label: workflow.key,
+      type: 'workflow',
+      workflow
+    })
+  )
+
+  const menuPaneTabs: MenuPaneTabItem[] = menuPaneStore.visiblePanes.map(
+    (pane) => ({
+      id: pane.path,
+      label: pane.title,
+      icon: pane.icon,
+      type: 'menuPane',
+      menuPaneId: pane.id
+    })
+  )
+
+  return [...workflowTabs, ...menuPaneTabs]
 })
 
-const options = computed<WorkflowOption[]>(() =>
-  workflowStore.openWorkflows.map(workflowToOption)
-)
-const selectedWorkflow = computed<WorkflowOption | null>(() =>
-  workflowStore.activeWorkflow
-    ? workflowToOption(workflowStore.activeWorkflow as ComfyWorkflow)
-    : null
-)
-const onWorkflowChange = (option: WorkflowOption) => {
-  // Prevent unselecting the current workflow
-  if (!option) {
-    return
+const selectedTab = computed<BaseTabItem | null>(() => {
+  if (menuPaneStore.activeMenuPane) {
+    const pane = menuPaneStore.activeMenuPane
+    return {
+      id: pane.path,
+      label: pane.title,
+      icon: pane.icon,
+      type: 'menuPane',
+      menuPaneId: pane.id
+    }
   }
-  // Prevent reloading the current workflow
-  if (selectedWorkflow.value?.value === option.value) {
+
+  if (workflowStore.activeWorkflow) {
+    const workflow = workflowStore.activeWorkflow
+    return {
+      id: workflow.path,
+      label: workflow.key,
+      type: 'workflow',
+      workflow
+    }
+  }
+
+  return null
+})
+
+const onTabChange = (tab: BaseTabItem) => {
+  if (!tab) return
+  if (selectedTab.value?.id === tab.id) return
+
+  if (isMenuPaneTab(tab)) {
+    menuPaneStore.setActiveMenuPane(tab.menuPaneId)
+    if (workflowStore.activeWorkflow) workflowStore.activeWorkflow = null
     return
   }
 
-  workflowService.openWorkflow(option.workflow)
+  if (isWorkflowTab(tab)) {
+    if (menuPaneStore.activeMenuPaneId) menuPaneStore.activeMenuPaneId = null
+    workflowService.openWorkflow(tab.workflow)
+  }
 }
 
-const closeWorkflows = async (options: WorkflowOption[]) => {
-  for (const opt of options) {
-    if (
-      !(await workflowService.closeWorkflow(opt.workflow, {
-        warnIfUnsaved: !workspaceStore.shiftDown
-      }))
-    ) {
-      // User clicked cancel
-      break
+const closeTab = (tab: BaseTabItem) => {
+  if (isMenuPaneTab(tab)) {
+    menuPaneStore.hideMenuPane(tab.menuPaneId)
+  } else if (isWorkflowTab(tab)) {
+    closeTabs([tab])
+  }
+}
+
+const closeTabs = async (tabsToClose: BaseTabItem[]) => {
+  for (const tab of tabsToClose) {
+    if (isMenuPaneTab(tab)) {
+      menuPaneStore.hideMenuPane(tab.menuPaneId)
+    } else if (isWorkflowTab(tab)) {
+      if (
+        !(await workflowService.closeWorkflow(tab.workflow, {
+          warnIfUnsaved: !workspaceStore.shiftDown
+        }))
+      ) {
+        // User clicked cancel
+        break
+      }
     }
   }
 }
 
-const onCloseWorkflow = (option: WorkflowOption) => {
-  closeWorkflows([option])
-}
-
-const showContextMenu = (event, option) => {
-  rightClickedTab.value = option
+const showContextMenu = (event, tab: BaseTabItem) => {
+  rightClickedTab.value = tab
   menu.value.show(event)
 }
-const contextMenuItems = computed(() => {
-  const tab = rightClickedTab.value as WorkflowOption
-  if (!tab) return []
-  const index = options.value.findIndex((v) => v.workflow === tab.workflow)
 
-  return [
-    {
-      label: t('tabMenu.duplicateTab'),
-      command: () => {
-        workflowService.duplicateWorkflow(tab.workflow)
-      }
-    },
-    {
-      separator: true
-    },
+const contextMenuItems = computed<MenuItem[]>(() => {
+  const tab = rightClickedTab.value
+  if (!tab) return []
+
+  const index = tabs.value.findIndex((t) => t.id === tab.id)
+
+  // Base items for all tabs
+  const menuItems: MenuItem[] = [
     {
       label: t('tabMenu.closeTab'),
-      command: () => onCloseWorkflow(tab)
+      command: () => closeTab(tab)
     },
     {
       label: t('tabMenu.closeTabsToLeft'),
-      command: () => closeWorkflows(options.value.slice(0, index)),
+      command: () => closeTabs(tabs.value.slice(0, index)),
       disabled: index <= 0
     },
     {
       label: t('tabMenu.closeTabsToRight'),
-      command: () => closeWorkflows(options.value.slice(index + 1)),
-      disabled: index === options.value.length - 1
+      command: () => closeTabs(tabs.value.slice(index + 1)),
+      disabled: index === tabs.value.length - 1
     },
     {
       label: t('tabMenu.closeOtherTabs'),
       command: () =>
-        closeWorkflows([
-          ...options.value.slice(index + 1),
-          ...options.value.slice(0, index)
+        closeTabs([
+          ...tabs.value.slice(0, index),
+          ...tabs.value.slice(index + 1)
         ]),
-      disabled: options.value.length <= 1
-    },
-    {
+      disabled: tabs.value.length <= 1
+    }
+  ]
+
+  // Add workflow-specific options
+  if (isWorkflowTab(tab)) {
+    menuItems.unshift(
+      {
+        label: t('tabMenu.duplicateTab'),
+        command: () => workflowService.duplicateWorkflow(tab.workflow)
+      },
+      { separator: true }
+    )
+    menuItems.push({
       label: workflowBookmarkStore.isBookmarked(tab.workflow.path)
         ? t('tabMenu.removeFromBookmarks')
         : t('tabMenu.addToBookmarks'),
       command: () => workflowBookmarkStore.toggleBookmarked(tab.workflow.path),
       disabled: tab.workflow.isTemporary
-    }
-  ]
+    })
+  }
+
+  return menuItems
 })
 const commandStore = useCommandStore()
 
@@ -174,6 +242,29 @@ const handleWheel = (event: WheelEvent) => {
   scrollElement.scroll({
     left: scrollElement.scrollLeft + scrollAmount
   })
+}
+
+const handleReorder = (fromTabId: string, toTabId: string) => {
+  const fromIndex = tabs.value.findIndex((tab) => tab.id === fromTabId)
+  const toIndex = tabs.value.findIndex((tab) => tab.id === toTabId)
+
+  if (fromIndex !== -1 && toIndex !== -1) {
+    if (
+      isWorkflowTab(tabs.value[fromIndex]) &&
+      isWorkflowTab(tabs.value[toIndex])
+    ) {
+      const fromWorkflowIndex = workflowStore.openWorkflows.findIndex(
+        (wf) => wf.path === tabs.value[fromIndex].id
+      )
+      const toWorkflowIndex = workflowStore.openWorkflows.findIndex(
+        (wf) => wf.path === tabs.value[toIndex].id
+      )
+
+      if (fromWorkflowIndex !== -1 && toWorkflowIndex !== -1) {
+        workflowStore.reorderWorkflows(fromWorkflowIndex, toWorkflowIndex)
+      }
+    }
+  }
 }
 </script>
 
@@ -206,7 +297,8 @@ const handleWheel = (event: WheelEvent) => {
 }
 
 :deep(.p-togglebutton-checked) .close-button,
-:deep(.p-togglebutton:hover) .close-button {
+:deep(.p-togglebutton:hover) .close-button,
+.menu-pane-tab:hover .close-button {
   @apply visible;
 }
 
@@ -214,7 +306,8 @@ const handleWheel = (event: WheelEvent) => {
   @apply hidden;
 }
 
-:deep(.p-togglebutton) .close-button {
+:deep(.p-togglebutton) .close-button,
+.close-button {
   @apply invisible;
 }
 

--- a/src/stores/menuPaneStore.ts
+++ b/src/stores/menuPaneStore.ts
@@ -1,0 +1,160 @@
+import { defineStore } from 'pinia'
+import { computed, markRaw, ref } from 'vue'
+
+import { MenuPaneDefinition, RegisteredMenuPane } from '@/types/menuPaneTypes'
+
+const createId = (id: string): string => `menu-pane://${id}`
+
+const isMenuPanePath = (path: string): boolean =>
+  path.startsWith('menu-pane://')
+
+const getIdFromPath = (path: string): string | null => {
+  if (!isMenuPanePath(path)) return null
+  return path.substring('menu-pane://'.length)
+}
+
+export const useMenuPaneStore = defineStore('menuPane', () => {
+  const registeredPanes = ref<Record<string, RegisteredMenuPane>>({})
+  const activeMenuPaneId = ref<string | null>(null)
+
+  const activeMenuPane = computed(() =>
+    activeMenuPaneId.value
+      ? registeredPanes.value[activeMenuPaneId.value]
+      : null
+  )
+  const visiblePanes = computed(() =>
+    Object.values(registeredPanes.value).filter((pane) => pane.visible)
+  )
+
+  /**
+   * Register a new menu pane
+   * @param pane The menu pane definition
+   * @returns The ID of the registered pane
+   */
+  const registerMenuPane = (pane: MenuPaneDefinition) => {
+    if (registeredPanes.value[pane.id]) {
+      console.warn(`Menu pane with ID ${pane.id} already exists. Overwriting.`)
+    }
+
+    registeredPanes.value[pane.id] = {
+      ...pane,
+      component: markRaw(pane.component),
+      visible: false,
+      path: createId(pane.id)
+    }
+
+    return pane.id
+  }
+
+  /**
+   * Unregister a menu pane
+   * @param id The ID of the pane to unregister
+   */
+  const unregisterMenuPane = (id: string) => {
+    if (activeMenuPaneId.value === id) {
+      activeMenuPaneId.value = null
+    }
+
+    if (registeredPanes.value[id]?.visible) {
+      hideMenuPane(id)
+    }
+
+    delete registeredPanes.value[id]
+  }
+
+  /**
+   * Show a menu pane and make it active
+   * @param id The ID of the pane to show
+   * @param props Optional props to pass to the pane component
+   */
+  const showMenuPane = (id: string, props?: Record<string, any>) => {
+    const pane = registeredPanes.value[id]
+    if (!pane) return
+
+    if (props) {
+      pane.props = { ...pane.props, ...props }
+    }
+
+    pane.visible = true
+    activeMenuPaneId.value = id
+  }
+
+  /**
+   * Hide a menu pane
+   * @param id The ID of the pane to hide
+   */
+  const hideMenuPane = (id: string) => {
+    const pane = registeredPanes.value[id]
+    if (!pane) {
+      return
+    }
+
+    pane.visible = false
+    if (activeMenuPaneId.value === id) {
+      activeMenuPaneId.value = null
+    }
+  }
+
+  /**
+   * Set the active menu pane
+   * @param id The ID of the pane to make active, or null to clear
+   */
+  const setActiveMenuPane = (id: string | null) => {
+    if (id === null) {
+      activeMenuPaneId.value = null
+      return
+    }
+
+    const pane = registeredPanes.value[id]
+    if (!pane) return
+    if (!pane.visible) pane.visible = true
+    activeMenuPaneId.value = id
+  }
+
+  /**
+   * Toggle a menu pane's visibility
+   * @param id The ID of the pane to toggle
+   */
+  const toggleMenuPane = (id: string) => {
+    const pane = registeredPanes.value[id]
+    if (!pane) {
+      console.error(`Menu pane with ID ${id} not found`)
+      return
+    }
+
+    if (pane.visible) {
+      hideMenuPane(id)
+    } else {
+      showMenuPane(id)
+    }
+  }
+
+  /**
+   * Get a menu pane by path
+   * @param path The path to look up
+   * @returns The menu pane or null if not found
+   */
+  const getMenuPaneByPath = (path: string) => {
+    if (!isMenuPanePath(path)) return null
+
+    const id = getIdFromPath(path)
+    if (!id) return null
+
+    return registeredPanes.value[id] || null
+  }
+
+  return {
+    registeredPanes,
+    activeMenuPaneId,
+    activeMenuPane,
+    visiblePanes,
+
+    registerMenuPane,
+    unregisterMenuPane,
+    showMenuPane,
+    hideMenuPane,
+    setActiveMenuPane,
+    toggleMenuPane,
+    getMenuPaneByPath
+  }
+})

--- a/src/types/menuPaneTypes.ts
+++ b/src/types/menuPaneTypes.ts
@@ -1,0 +1,36 @@
+import { Component } from 'vue'
+
+export interface MenuPaneDefinition {
+  /**
+   * Unique identifier for the menu pane
+   */
+  id: string
+  /**
+   * Display name shown in the tab
+   */
+  title: string
+  /**
+   * Icon to display in the tab
+   */
+  icon?: string
+  /**
+   * The Vue component to render as the pane content
+   */
+  component: Component
+  /**
+   * Optional props to pass to the component
+   */
+  props?: Record<string, any>
+}
+
+export interface RegisteredMenuPane extends MenuPaneDefinition {
+  /**
+   * Whether this pane is currently visible in the UI
+   */
+  visible: boolean
+  /**
+   * Path used for tab identification (similar to workflow paths)
+   * @example "menu-pane://{id}"
+   */
+  path: string
+}

--- a/src/types/tabTypes.ts
+++ b/src/types/tabTypes.ts
@@ -1,0 +1,32 @@
+import { ComfyWorkflow } from '@/stores/workflowStore'
+
+export interface BaseTabItem {
+  /** Unique identifier for the tab */
+  id: string
+  /** Display label for the tab */
+  label: string
+  /** Icon to display (for menu panes) */
+  icon?: string
+  /** Type of tab */
+  type: 'workflow' | 'menuPane'
+}
+
+export interface WorkflowTabItem extends BaseTabItem {
+  type: 'workflow'
+  /** Reference to the workflow object */
+  workflow: ComfyWorkflow
+}
+
+export interface MenuPaneTabItem extends BaseTabItem {
+  type: 'menuPane'
+  /** Reference to the menu pane ID */
+  menuPaneId: string
+}
+
+export function isWorkflowTab(tab: BaseTabItem): tab is WorkflowTabItem {
+  return tab.type === 'workflow'
+}
+
+export function isMenuPaneTab(tab: BaseTabItem): tab is MenuPaneTabItem {
+  return tab.type === 'menuPane'
+}

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -9,6 +9,7 @@
     <div class="comfyui-body-left" id="comfyui-body-left" />
     <div class="comfyui-body-right" id="comfyui-body-right" />
     <div class="graph-canvas-container" id="graph-canvas-container">
+      <MenuPane v-if="isMenuPaneActive" class="absolute inset-0 z-20" />
       <GraphCanvas @ready="onGraphReady" />
     </div>
   </div>
@@ -30,6 +31,7 @@ import BrowserTabTitle from '@/components/BrowserTabTitle.vue'
 import MenuHamburger from '@/components/MenuHamburger.vue'
 import UnloadWindowConfirmDialog from '@/components/dialog/UnloadWindowConfirmDialog.vue'
 import GraphCanvas from '@/components/graph/GraphCanvas.vue'
+import MenuPane from '@/components/menupane/MenuPane.vue'
 import GlobalToast from '@/components/toast/GlobalToast.vue'
 import TopMenubar from '@/components/topbar/TopMenubar.vue'
 import { useCoreCommands } from '@/composables/useCoreCommands'
@@ -44,6 +46,7 @@ import { useKeybindingService } from '@/services/keybindingService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useMenuPaneStore } from '@/stores/menuPaneStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useNodeDefStore, useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import {
@@ -66,6 +69,9 @@ const settingStore = useSettingStore()
 const executionStore = useExecutionStore()
 const colorPaletteStore = useColorPaletteStore()
 const queueStore = useQueueStore()
+const menuPaneStore = useMenuPaneStore()
+
+const isMenuPaneActive = computed(() => menuPaneStore.activeMenuPaneId !== null)
 
 watch(
   () => colorPaletteStore.completedActivePalette,


### PR DESCRIPTION
Adds store to register and control menu pane tabs. Refactors topbar tabs to handle workflow and menu tabs, similar to VS code.

 

https://github.com/user-attachments/assets/87a24307-82cb-4f5d-a7df-54bad4370545

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2864-Add-menu-tabs-1ad6d73d365081708147c28aaf3fc747) by [Unito](https://www.unito.io)
