### PR TITLE
Fix node min size specified by widget constructor

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -57,13 +57,16 @@ export const useLitegraphService = () => {
             inputName
           )
           if (widgetType) {
-            const { widget, minWidth, minHeight } =
-              app.widgets[widgetType](
-                this,
-                inputName,
-                [inputType, inputSpec],
-                app
-              ) ?? {}
+            const {
+              widget,
+              minWidth = 1,
+              minHeight = 1
+            } = app.widgets[widgetType](
+              this,
+              inputName,
+              [inputType, inputSpec],
+              app
+            ) ?? {}
 
             if (widget) {
               const fallback = widget.label ?? inputName

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -8,7 +8,7 @@ import {
   RenderShape
 } from '@comfyorg/litegraph'
 import { Vector2 } from '@comfyorg/litegraph'
-import { IBaseWidget, IWidget } from '@comfyorg/litegraph/dist/types/widgets'
+import { IWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import { useNodeImage, useNodeVideo } from '@/composables/node/useNodeImage'
 import { st } from '@/i18n'
@@ -46,12 +46,7 @@ export const useLitegraphService = () => {
       constructor(title?: string) {
         super(title)
 
-        const config: {
-          minWidth: number
-          minHeight: number
-          widget?: IBaseWidget
-        } = { minWidth: 1, minHeight: 1 }
-
+        const nodeMinSize = { width: 1, height: 1 }
         // Process inputs using V2 schema
         for (const [inputName, inputSpec] of Object.entries(nodeDef.inputs)) {
           const inputType = inputSpec.type
@@ -62,19 +57,38 @@ export const useLitegraphService = () => {
             inputName
           )
           if (widgetType) {
-            Object.assign(
-              config,
+            const { widget, minWidth, minHeight } =
               app.widgets[widgetType](
                 this,
                 inputName,
                 [inputType, inputSpec],
                 app
               ) ?? {}
-            )
-            if (config.widget) {
-              const fallback = config.widget.label ?? inputName
-              config.widget.label = st(nameKey, fallback)
+
+            if (widget) {
+              const fallback = widget.label ?? inputName
+              widget.label = st(nameKey, fallback)
+
+              widget.options ??= {}
+              if (inputSpec.isOptional) {
+                widget.options.inputIsOptional = true
+              }
+              if (inputSpec.forceInput) {
+                widget.options.forceInput = true
+              }
+              if (inputSpec.defaultInput) {
+                widget.options.defaultInput = true
+              }
+              if (inputSpec.advanced) {
+                widget.advanced = true
+              }
+              if (inputSpec.hidden) {
+                widget.hidden = true
+              }
             }
+
+            nodeMinSize.width = Math.max(nodeMinSize.width, minWidth)
+            nodeMinSize.height = Math.max(nodeMinSize.height, minHeight)
           } else {
             // Node connection inputs
             const shapeOptions = inputSpec.isOptional
@@ -85,25 +99,6 @@ export const useLitegraphService = () => {
               ...shapeOptions,
               localized_name: st(nameKey, inputName)
             })
-          }
-
-          if (widgetType && config?.widget) {
-            config.widget.options ??= {}
-            if (inputSpec.isOptional) {
-              config.widget.options.inputIsOptional = true
-            }
-            if (inputSpec.forceInput) {
-              config.widget.options.forceInput = true
-            }
-            if (inputSpec.defaultInput) {
-              config.widget.options.defaultInput = true
-            }
-            if (inputSpec.advanced) {
-              config.widget.advanced = true
-            }
-            if (inputSpec.hidden) {
-              config.widget.hidden = true
-            }
           }
         }
 
@@ -132,8 +127,8 @@ export const useLitegraphService = () => {
         }
 
         const s = this.computeSize()
-        s[0] = Math.max(config.minWidth, s[0] * 1.5)
-        s[1] = Math.max(config.minHeight, s[1])
+        s[0] = Math.max(nodeMinSize.width, s[0] * 1.5)
+        s[1] = Math.max(nodeMinSize.height, s[1])
         this.setSize(s)
         this.serialize_widgets = true
 


### PR DESCRIPTION
Previously the min node size specified by a widget can be overwritten by the min node size specified by another widget without comparison. This PR fixes this issue.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2876-Fix-node-min-size-specified-by-widget-constructor-1ad6d73d3650816a8188d37de9057c52) by [Unito](https://www.unito.io)
