### PR TITLE
Use v2 input spec in string widgets

### DIFF
--- a/src/composables/widgets/useMarkdownWidget.ts
+++ b/src/composables/widgets/useMarkdownWidget.ts
@@ -8,15 +8,14 @@ import TiptapTableRow from '@tiptap/extension-table-row'
 import TiptapStarterKit from '@tiptap/starter-kit'
 import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
 
-import type { InputSpec } from '@/schemas/nodeDefSchema'
-import type { ComfyWidgetConstructor } from '@/scripts/widgets'
-import type { ComfyApp } from '@/types'
+import { type InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { app } from '@/scripts/app'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
 
 function addMarkdownWidget(
   node: LGraphNode,
   name: string,
-  opts: { defaultVal: string },
-  app: ComfyApp
+  opts: { defaultVal: string }
 ) {
   TiptapMarkdown.configure({
     html: false,
@@ -52,6 +51,7 @@ function addMarkdownWidget(
     }
   })
   widget.inputEl = inputEl
+  widget.options.minNodeSize = [400, 200]
 
   inputEl.addEventListener('pointerdown', (event: PointerEvent) => {
     if (event.button !== 0) {
@@ -98,23 +98,17 @@ function addMarkdownWidget(
     }
   })
 
-  return { minWidth: 400, minHeight: 200, widget }
+  return widget
 }
 
 export const useMarkdownWidget = () => {
-  const widgetConstructor: ComfyWidgetConstructor = (
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
     node: LGraphNode,
-    inputName: string,
-    inputData: InputSpec,
-    app: ComfyApp
+    inputSpec: InputSpec
   ) => {
-    const defaultVal = inputData[1]?.default || ''
-    return addMarkdownWidget(
-      node,
-      inputName,
-      { defaultVal, ...inputData[1] },
-      app
-    )
+    return addMarkdownWidget(node, inputSpec.name, {
+      defaultVal: inputSpec.default ?? ''
+    })
   }
 
   return widgetConstructor

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -46,8 +46,11 @@ const transformWidgetConstructorV2ToV1 = (
     const inputSpec = transformInputSpecV1ToV2(inputData, {
       name: inputName
     })
+    const widget = widgetConstructorV2(node, inputSpec)
     return {
-      widget: widgetConstructorV2(node, inputSpec)
+      widget,
+      minWidth: widget.options.minNodeSize?.[0],
+      minHeight: widget.options.minNodeSize?.[1]
     }
   }
 }
@@ -288,8 +291,8 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
   INT: transformWidgetConstructorV2ToV1(useIntWidget()),
   FLOAT: transformWidgetConstructorV2ToV1(useFloatWidget()),
   BOOLEAN: transformWidgetConstructorV2ToV1(useBooleanWidget()),
-  STRING: useStringWidget(),
-  MARKDOWN: useMarkdownWidget(),
+  STRING: transformWidgetConstructorV2ToV1(useStringWidget()),
+  MARKDOWN: transformWidgetConstructorV2ToV1(useMarkdownWidget()),
   COMBO: useComboWidget(),
   IMAGEUPLOAD: useImageUploadWidget()
 }

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -22,6 +22,10 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
      * Rounding value for numeric float widgets.
      */
     round?: number
+    /**
+     * The minimum size of the node if the widget is present.
+     */
+    minNodeSize?: Size
   }
 
   interface IBaseWidget {


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2860

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2877-Use-v2-input-spec-in-string-widgets-1ad6d73d3650811198a9cf9658141aed) by [Unito](https://www.unito.io)
