### PR TITLE
Deprecate widgetType:widgetName key in widgets map

### DIFF
--- a/src/composables/widgets/useIntWidget.ts
+++ b/src/composables/widgets/useIntWidget.ts
@@ -71,7 +71,15 @@ export const useIntWidget = () => {
       }
     )
 
-    if (inputSpec.control_after_generate) {
+    const controlAfterGenerate =
+      inputSpec.control_after_generate ??
+      /**
+       * Compatibility with legacy node convention. Int input with name
+       * 'seed' or 'noise_seed' get automatically added a control widget.
+       */
+      ['seed', 'noise_seed'].includes(inputSpec.name)
+
+    if (controlAfterGenerate) {
       const seedControl = addValueControlWidget(
         node,
         widget,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -934,8 +934,6 @@ export class ComfyApp {
 
     if (Array.isArray(type)) {
       return 'COMBO'
-    } else if (`${type}:${inputName}` in this.widgets) {
-      return `${type}:${inputName}`
     } else if (type in this.widgets) {
       return type
     } else {

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -278,16 +278,7 @@ export function addValueControlWidgets(
   return widgets
 }
 
-const seedWidget = transformWidgetConstructorV2ToV1((node, inputSpec) => {
-  return useIntWidget()(node, {
-    ...inputSpec,
-    control_after_generate: true
-  })
-})
-
 export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
-  'INT:seed': seedWidget,
-  'INT:noise_seed': seedWidget,
   INT: transformWidgetConstructorV2ToV1(useIntWidget()),
   FLOAT: transformWidgetConstructorV2ToV1(useFloatWidget()),
   BOOLEAN: transformWidgetConstructorV2ToV1(useBooleanWidget()),

--- a/src/stores/widgetStore.ts
+++ b/src/stores/widgetStore.ts
@@ -12,23 +12,8 @@ export const useWidgetStore = defineStore('widget', () => {
     ...coreWidgets
   }))
 
-  function getWidgetType(type: string, inputName: string) {
-    if (type === 'COMBO') {
-      return 'COMBO'
-      /**
-       * @deprecated Group node logic. Remove once group node feature is removed.
-       */
-    } else if (`${type}:${inputName}` in widgets.value) {
-      return `${type}:${inputName}`
-    } else if (type in widgets.value) {
-      return type
-    } else {
-      return null
-    }
-  }
-
   function inputIsWidget(spec: InputSpecV2) {
-    return getWidgetType(spec.type, spec.name) !== null
+    return spec.type in widgets.value
   }
 
   function registerCustomWidgets(
@@ -42,7 +27,6 @@ export const useWidgetStore = defineStore('widget', () => {
 
   return {
     widgets,
-    getWidgetType,
     inputIsWidget,
     registerCustomWidgets
   }


### PR DESCRIPTION
Ref: https://github.com/comfyanonymous/ComfyUI/pull/7059

The syntax is very confusing. Deprecate the usage and hardcode the 'seed' & 'noise_seed' logic in `useIntWidget` directly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2879-Deprecate-widgetType-widgetName-key-in-widgets-map-1ad6d73d3650816fa7b9f92998235b3f) by [Unito](https://www.unito.io)
