### PR TITLE
[Refactor] Remove app.getWidgetType

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -12,6 +12,7 @@ import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { useDialogService } from '@/services/dialogService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useToastStore } from '@/stores/toastStore'
+import { useWidgetStore } from '@/stores/widgetStore'
 import { ComfyExtension } from '@/types/comfy'
 import { deserialiseAndCreate, serialise } from '@/utils/vintageClipboard'
 
@@ -442,8 +443,7 @@ export class GroupNodeConfig {
     const converted = new Map()
     const widgetMap = (this.oldToNewWidgetMap[node.index] = {})
     for (const inputName of inputNames) {
-      let widgetType = app.getWidgetType(inputs[inputName], inputName)
-      if (widgetType) {
+      if (useWidgetStore().inputIsWidget(inputs[inputName])) {
         const convertedIndex = node.inputs?.findIndex(
           (inp) => inp.name === inputName && inp.widget?.name === inputName
         )

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import type { IWidget } from '@comfyorg/litegraph'
+import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
 import type { IStringWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import { useNodeDragAndDrop } from '@/composables/node/useNodeDragAndDrop'
@@ -97,7 +97,7 @@ app.registerExtension({
   },
   getCustomWidgets() {
     return {
-      AUDIO_UI(node, inputName: string) {
+      AUDIO_UI(node: LGraphNode, inputName: string) {
         const audio = document.createElement('audio')
         audio.controls = true
         audio.classList.add('comfy-audio')

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -19,11 +19,7 @@ import {
   type NodeId,
   validateComfyWorkflow
 } from '@/schemas/comfyWorkflowSchema'
-import {
-  type ComfyNodeDef as ComfyNodeDefV2,
-  isComboInputSpec,
-  isComfyNodeDef as isComfyNodeDefV2
-} from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { type ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { getFromWebmFile } from '@/scripts/metadata/ebml'
 import { useDialogService } from '@/services/dialogService'
@@ -35,11 +31,7 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { useExtensionStore } from '@/stores/extensionStore'
 import { KeyComboImpl, useKeybindingStore } from '@/stores/keybindingStore'
 import { useModelStore } from '@/stores/modelStore'
-import {
-  ComfyNodeDefImpl,
-  SYSTEM_NODE_DEFS,
-  useNodeDefStore
-} from '@/stores/nodeDefStore'
+import { SYSTEM_NODE_DEFS, useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useToastStore } from '@/stores/toastStore'
 import { useWidgetStore } from '@/stores/widgetStore'
@@ -64,7 +56,7 @@ import {
 } from './pnginfo'
 import { $el, ComfyUI } from './ui'
 import { ComfyAppMenu } from './ui/menu/index'
-import { clone, getStorageValue } from './utils'
+import { clone } from './utils'
 import { type ComfyWidgetConstructor, ComfyWidgets } from './widgets'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
@@ -92,10 +84,6 @@ type Clipspace = {
   selectedIndex: number
   img_paste_mode: string
 }
-
-/**
- * @typedef {import("types/comfy").ComfyExtension} ComfyExtension
- */
 
 export class ComfyApp {
   /**
@@ -922,22 +910,6 @@ export class ComfyApp {
     await useExtensionService().invokeExtensionsAsync('registerCustomNodes')
     if (this.vueAppReady) {
       this.updateVueAppNodeDefs(defs)
-    }
-  }
-
-  /**
-   * Remove the impl after groupNode unit tests are removed.
-   * @deprecated Use useWidgetStore().getWidgetType instead
-   */
-  getWidgetType(inputData, inputName: string) {
-    const type = inputData[0]
-
-    if (Array.isArray(type)) {
-      return 'COMBO'
-    } else if (type in this.widgets) {
-      return type
-    } else {
-      return null
     }
   }
 

--- a/src/stores/widgetStore.ts
+++ b/src/stores/widgetStore.ts
@@ -2,6 +2,10 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
 import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import {
+  type InputSpec as InputSpecV1,
+  getInputSpecType
+} from '@/schemas/nodeDefSchema'
 import { ComfyWidgetConstructor, ComfyWidgets } from '@/scripts/widgets'
 
 export const useWidgetStore = defineStore('widget', () => {
@@ -12,8 +16,9 @@ export const useWidgetStore = defineStore('widget', () => {
     ...coreWidgets
   }))
 
-  function inputIsWidget(spec: InputSpecV2) {
-    return spec.type in widgets.value
+  function inputIsWidget(spec: InputSpecV2 | InputSpecV1) {
+    const type = Array.isArray(spec) ? getInputSpecType(spec) : spec.type
+    return type in widgets.value
   }
 
   function registerCustomWidgets(


### PR DESCRIPTION
Code search: https://cs.comfy.org/search?q=context:global+.getWidgetType&patternType=keyword&sm=0

Only a single hacky patch is affected in a non-popular node pack.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2880-Refactor-Remove-app-getWidgetType-1ad6d73d365081eea385d99c5c540b5a) by [Unito](https://www.unito.io)
