### PR TITLE
[BugFix] Fire resize callback for all dom widgets under the same node

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -68,6 +68,8 @@ export interface DOMWidgetOptions<
    * @deprecated Use `afterResize` instead. This callback is a legacy API
    * that fires before resize happens, but it is no longer supported. Now it
    * fires after resize happens.
+   * The resize logic has been upstreamed to litegraph in
+   * https://github.com/Comfy-Org/ComfyUI_frontend/pull/2557
    */
   beforeResize?: (this: DOMWidget<T, V>, node: LGraphNode) => void
   afterResize?: (this: DOMWidget<T, V>, node: LGraphNode) => void


### PR DESCRIPTION
Previously resize callback is only fired for the first added DOM widget, because of the `SIZE` symbol check. This PR fixes this issue so that all DOM widgets should receive the callback.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2882-BugFix-Fire-resize-callback-for-all-dom-widgets-under-the-same-node-1ad6d73d365081e68f2cc6f4c8785aff) by [Unito](https://www.unito.io)
