### PR TITLE
Trim whitespace in URL form items

### DIFF
--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -76,8 +76,18 @@ const handleInput = (value: string) => {
 }
 
 const handleBlur = async () => {
+  const input = cleanInput(internalValue.value)
+
+  let normalizedUrl = input
+  try {
+    const url = new URL(input)
+    normalizedUrl = url.toString()
+  } catch {
+    // If URL parsing fails, just use the cleaned input
+  }
+
   // Emit the update only on blur
-  emit('update:modelValue', internalValue.value)
+  emit('update:modelValue', normalizedUrl)
 }
 
 // Default validation implementation

--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -44,14 +44,16 @@ const emit = defineEmits<{
 
 const validationState = ref<ValidationState>(ValidationState.IDLE)
 
+const cleanInput = (value: string): string => value?.trim() ?? ''
+
 // Add internal value state
-const internalValue = ref(props.modelValue)
+const internalValue = ref(cleanInput(props.modelValue))
 
 // Watch for external modelValue changes
 watch(
   () => props.modelValue,
   async (newValue: string) => {
-    internalValue.value = newValue
+    internalValue.value = cleanInput(newValue)
     await validateUrl(newValue)
   }
 )
@@ -67,7 +69,7 @@ onMounted(async () => {
 
 const handleInput = (value: string) => {
   // Update internal value without emitting
-  internalValue.value = value
+  internalValue.value = cleanInput(value)
   // Reset validation state when user types
   validationState.value = ValidationState.IDLE
 }
@@ -90,7 +92,7 @@ const defaultValidateUrl = async (url: string): Promise<boolean> => {
 const validateUrl = async (value: string) => {
   if (validationState.value === ValidationState.LOADING) return
 
-  const url = value.trim()
+  const url = cleanInput(value)
 
   // Reset state
   validationState.value = ValidationState.IDLE

--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -44,7 +44,8 @@ const emit = defineEmits<{
 
 const validationState = ref<ValidationState>(ValidationState.IDLE)
 
-const cleanInput = (value: string): string => value?.trim() ?? ''
+const cleanInput = (value: string): string =>
+  value ? value.replace(/\s+/g, '') : ''
 
 // Add internal value state
 const internalValue = ref(cleanInput(props.modelValue))

--- a/src/components/common/__tests__/UrlInput.test.ts
+++ b/src/components/common/__tests__/UrlInput.test.ts
@@ -42,11 +42,11 @@ describe('UrlInput', () => {
     })
 
     const input = wrapper.find('input')
-    await input.setValue('https://test.com')
+    await input.setValue('https://test.com/')
     await input.trigger('blur')
 
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([
-      'https://test.com'
+      'https://test.com/'
     ])
   })
 

--- a/src/components/common/__tests__/UrlInput.test.ts
+++ b/src/components/common/__tests__/UrlInput.test.ts
@@ -182,6 +182,12 @@ describe('UrlInput', () => {
       await input.trigger('input')
       await nextTick()
       expect(wrapper.vm.internalValue).toBe('https://both-spaces.com')
+
+      // Test whitespace in the middle of the URL
+      await input.setValue('https:// middle-space.com')
+      await input.trigger('input')
+      await nextTick()
+      expect(wrapper.vm.internalValue).toBe('https://middle-space.com')
     })
 
     it('trims whitespace when value set externally', async () => {

--- a/src/components/common/__tests__/UrlInput.test.ts
+++ b/src/components/common/__tests__/UrlInput.test.ts
@@ -155,4 +155,50 @@ describe('UrlInput', () => {
 
     expect(validationCount).toBe(1) // Only the initial validation should occur
   })
+
+  describe('input cleaning functionality', () => {
+    it('trims whitespace when user types', async () => {
+      const wrapper = mountComponent({
+        modelValue: '',
+        placeholder: 'Enter URL'
+      })
+
+      const input = wrapper.find('input')
+
+      // Test leading whitespace
+      await input.setValue('  https://leading-space.com')
+      await input.trigger('input')
+      await nextTick()
+      expect(wrapper.vm.internalValue).toBe('https://leading-space.com')
+
+      // Test trailing whitespace
+      await input.setValue('https://trailing-space.com  ')
+      await input.trigger('input')
+      await nextTick()
+      expect(wrapper.vm.internalValue).toBe('https://trailing-space.com')
+
+      // Test both leading and trailing whitespace
+      await input.setValue('  https://both-spaces.com  ')
+      await input.trigger('input')
+      await nextTick()
+      expect(wrapper.vm.internalValue).toBe('https://both-spaces.com')
+    })
+
+    it('trims whitespace when value set externally', async () => {
+      const wrapper = mountComponent({
+        modelValue: '  https://initial-value.com  ',
+        placeholder: 'Enter URL'
+      })
+
+      // Check initial value is trimmed
+      expect(wrapper.vm.internalValue).toBe('https://initial-value.com')
+
+      // Update props with whitespace
+      await wrapper.setProps({ modelValue: '  https://updated-value.com  ' })
+      await nextTick()
+
+      // Check updated value is trimmed
+      expect(wrapper.vm.internalValue).toBe('https://updated-value.com')
+    })
+  })
 })


### PR DESCRIPTION
Adds automatic trimming of whitespace for URL input form item values. Url inputs are used for setting mirror urls during desktop installation and can also be used by extensions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2884-Trim-whitespace-in-URL-form-items-1ae6d73d36508156a781e2eeb2793370) by [Unito](https://www.unito.io)
