### PR TITLE
Fix template dialog double scrollbar

### DIFF
--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col h-[83vh] w-[90vw] relative"
+    class="flex flex-col h-[83vh] w-[90vw] relative pb-6"
     data-testid="template-workflows-content"
   >
     <Button

--- a/src/components/templates/TemplateWorkflowsSideNav.vue
+++ b/src/components/templates/TemplateWorkflowsSideNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <ScrollPanel class="w-80" style="height: calc(85vh - 48px)">
+  <ScrollPanel class="w-80" style="height: calc(83vh - 48px)">
     <Listbox
       :model-value="selectedTab"
       @update:model-value="handleTabSelection"

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -84,7 +84,7 @@ export const useDialogService = () => {
       headerComponent: TemplateWorkflowsDialogHeader,
       dialogComponentProps: {
         pt: {
-          content: { class: '!px-0' }
+          content: { class: '!px-0 overflow-y-hidden' }
         }
       },
       props


### PR DESCRIPTION
Fixes double scrollbar in templates dialog.

![Selection_1012](https://github.com/user-attachments/assets/8eb1a564-bfa8-444c-90a7-20cc281844a0)

`85vh` changed to `83vh` in dialog content but scrollpanel nav was mistakenly left at `85vh`. It's also safe to disable y-axis scroll on the dialog component altogether, as both main content and nav have their own scrolling.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2896-Fix-template-dialog-double-scrollbar-1ae6d73d3650813ba1e3cdff50c27ac2) by [Unito](https://www.unito.io)
