### PR TITLE
Fix animated webp output preview

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -394,7 +394,12 @@ export const useLitegraphService = () => {
       if (isNewOutput || isNewPreview) {
         this.animatedImages = output?.animated?.find(Boolean)
 
-        if (this.animatedImages || isVideoNode(this)) {
+        const isAnimatedWebp =
+          this.animatedImages &&
+          output.images.some((img) => img.filename?.includes('webp'))
+        const isVideo =
+          (this.animatedImages && !isAnimatedWebp) || isVideoNode(this)
+        if (isVideo) {
           useNodeVideo(this).showPreview()
         } else {
           useNodeImage(this).showPreview()


### PR DESCRIPTION
Result Item's `animatedImages` denotes that an output's images are animated and is used for both webp and webm output nodes. `animatedImages` is currently being used in draw loop as a flag for video outputs. However this results in webp sequences being treated as videos which is wrong.

This is a fairly major regression resulting from https://github.com/Comfy-Org/ComfyUI_frontend/pull/2635 (on v1.11.0).

After change, jpg latent preview, png output, animated webp output, and webm output all work in unison:

https://github.com/user-attachments/assets/2a1001bc-e2ec-4e00-b61a-c469875b3381


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2897-Fix-animated-webp-output-preview-1ae6d73d365081bb964ee5c74a585811) by [Unito](https://www.unito.io)
