### PR TITLE
[chore] Update litegraph accessor: isNodeOverInput

### DIFF
--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -10,7 +10,11 @@
 </template>
 
 <script setup lang="ts">
-import { LiteGraph } from '@comfyorg/litegraph'
+import {
+  LiteGraph,
+  isOverNodeInput,
+  isOverNodeOutput
+} from '@comfyorg/litegraph'
 import { useEventListener } from '@vueuse/core'
 import { nextTick, ref } from 'vue'
 
@@ -66,7 +70,7 @@ const onIdle = () => {
 
   if (node.flags?.collapsed) return
 
-  const inputSlot = canvas.isOverNodeInput(
+  const inputSlot = isOverNodeInput(
     node,
     canvas.graph_mouse[0],
     canvas.graph_mouse[1],
@@ -81,7 +85,7 @@ const onIdle = () => {
     return showTooltip(translatedTooltip)
   }
 
-  const outputSlot = canvas.isOverNodeOutput(
+  const outputSlot = isOverNodeOutput(
     node,
     canvas.graph_mouse[0],
     canvas.graph_mouse[1],


### PR DESCRIPTION
Removes single instance of legacy accessor, which may be removed from the LiteGraph public API.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2909-chore-Update-litegraph-accessor-isNodeOverInput-1af6d73d3650810e9586f57c1068c7c5) by [Unito](https://www.unito.io)
