### PR TITLE
Change maskeditor undo key combo

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -4919,7 +4919,7 @@ class KeyboardManager {
   // combinations
 
   private undoCombinationPressed() {
-    const combination = ['ctrl', 'z']
+    const combination = ['alt', 'z']
     const keysDownLower = this.keysDown.map((key) => key.toLowerCase())
     const result = combination.every((key) => keysDownLower.includes(key))
     if (result) this.messageBroker.publish('undo')
@@ -4927,7 +4927,7 @@ class KeyboardManager {
   }
 
   private redoCombinationPressed() {
-    const combination = ['ctrl', 'shift', 'z']
+    const combination = ['alt', 'shift', 'z']
     const keysDownLower = this.keysDown.map((key) => key.toLowerCase())
     const result = combination.every((key) => keysDownLower.includes(key))
     if (result) this.messageBroker.publish('redo')


### PR DESCRIPTION
Previous one conflicted with the litegraph node canvas undo action and did not have any effect. Alt key when used in combination with these keypresses should not have any conflict with browser or frontend.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2915-Change-maskeditor-undo-key-combo-1af6d73d365081aeb8fed453421ebfe2) by [Unito](https://www.unito.io)
