### PR TITLE
[Bug] Fix widget remove when node is deleted

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -360,7 +360,7 @@ LGraphNode.prototype.addDOMWidget = function <
 
   const onRemoved = this.onRemoved
   this.onRemoved = function (this: LGraphNode) {
-    element.remove()
+    widget.onRemove()
     elementWidgets.delete(this)
     onRemoved?.call(this)
   }


### PR DESCRIPTION
Call widget.onRemove to properly sync the store state and unregister listener.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2918-Bug-Fix-widget-remove-when-node-is-deleted-1af6d73d3650815c8ebcde14c6b9623c) by [Unito](https://www.unito.io)
