### PR TITLE
[Manager] Show progress spinner on initial load

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -36,8 +36,14 @@
             @update:filterBy="handleFilterChange"
           />
           <div class="flex-1 overflow-auto">
+            <div
+              v-if="isLoading || isInitialLoad"
+              class="flex justify-center items-center h-full"
+            >
+              <ProgressSpinner />
+            </div>
             <NoResultsPlaceholder
-              v-if="error || searchResults.length === 0"
+              v-else-if="error || searchResults.length === 0"
               :title="
                 error
                   ? $t('manager.errorConnecting')
@@ -49,12 +55,6 @@
                   : $t('manager.tryDifferentSearch')
               "
             />
-            <div
-              v-else-if="isLoading"
-              class="flex justify-center items-center h-full"
-            >
-              <ProgressSpinner />
-            </div>
             <div v-else class="h-full" @click="handleGridContainerClick">
               <VirtualGrid
                 :items="resultsWithKeys"
@@ -144,6 +144,11 @@ const handleTabSelection = (tab: TabItem) => {
 const { searchQuery, pageNumber, sortField, isLoading, error, searchResults } =
   useRegistrySearch()
 pageNumber.value = 1
+
+const isInitialLoad = computed(
+  () => searchResults.value.length === 0 && searchQuery.value === ''
+)
+
 const resultsWithKeys = computed(() =>
   searchResults.value.map((item) => ({
     ...item,


### PR DESCRIPTION
Fixes no results placeholder displayed on initially opening custom nodes manager dialog. The initial load is a special case in which the ProgressSpinner should be shown over the NoResultsPlaceholder when the search results array is empty.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2936-Manager-Show-progress-spinner-on-initial-load-1b16d73d365081dcb896d590eae4dbf4) by [Unito](https://www.unito.io)
