### PR TITLE
Translate template categories

### DIFF
--- a/.i18nrc.cjs
+++ b/.i18nrc.cjs
@@ -10,7 +10,7 @@ module.exports = defineConfig({
   entryLocale: 'en',
   output: 'src/locales',
   outputLocales: ['zh', 'ru', 'ja', 'ko', 'fr'],
-  reference: `Special names to keep untranslated: flux, photomaker, clip, vae, cfg, stable audio, stable cascade.
+  reference: `Special names to keep untranslated: flux, photomaker, clip, vae, cfg, stable audio, stable cascade, controlnet, lora.
   'latent' is the short form of 'latent space'.
   'mask' is in the context of image processing.
   `

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -417,6 +417,20 @@
   },
   "templateWorkflows": {
     "title": "Get Started with a Template",
+    "category": {
+      "ComfyUI Examples": "ComfyUI Examples",
+      "Custom Nodes": "Custom Nodes",
+      "Basics": "Basics",
+      "Flux": "Flux",
+      "ControlNet": "ControlNet",
+      "Upscaling": "Upscaling",
+      "Video": "Video",
+      "SD3_5": "SD3.5",
+      "SDXL": "SDXL",
+      "Area Composition": "Area Composition",
+      "3D": "3D",
+      "Audio": "Audio"
+    },
     "template": {
       "Flux": {
         "flux_dev_checkpoint_example": "Flux Dev",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -825,6 +825,20 @@
     "removeFromBookmarks": "Retirer des Favoris"
   },
   "templateWorkflows": {
+    "category": {
+      "3D": "3D",
+      "Area Composition": "Composition de zone",
+      "Audio": "Audio",
+      "Basics": "Basiques",
+      "ComfyUI Examples": "Exemples ComfyUI",
+      "ControlNet": "ControlNet",
+      "Custom Nodes": "Nœuds personnalisés",
+      "Flux": "Flux",
+      "SD3_5": "SD3.5",
+      "SDXL": "SDXL",
+      "Upscaling": "Mise à l'échelle",
+      "Video": "Vidéo"
+    },
     "template": {
       "3D": {
         "stable_zero123_example": "Stable Zero123"

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -825,6 +825,20 @@
     "removeFromBookmarks": "ブックマークから削除"
   },
   "templateWorkflows": {
+    "category": {
+      "3D": "3D",
+      "Area Composition": "エリア構成",
+      "Audio": "オーディオ",
+      "Basics": "基本",
+      "ComfyUI Examples": "ComfyUIの例",
+      "ControlNet": "ControlNet",
+      "Custom Nodes": "カスタムノード",
+      "Flux": "Flux",
+      "SD3_5": "SD3.5",
+      "SDXL": "SDXL",
+      "Upscaling": "アップスケーリング",
+      "Video": "ビデオ"
+    },
     "template": {
       "3D": {
         "stable_zero123_example": "Stable Zero123"

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -825,6 +825,20 @@
     "removeFromBookmarks": "북마크에서 제거"
   },
   "templateWorkflows": {
+    "category": {
+      "3D": "3D",
+      "Area Composition": "영역 구성",
+      "Audio": "오디오",
+      "Basics": "기본",
+      "ComfyUI Examples": "ComfyUI 예시",
+      "ControlNet": "ControlNet",
+      "Custom Nodes": "사용자 정의 노드",
+      "Flux": "Flux",
+      "SD3_5": "SD3.5",
+      "SDXL": "SDXL",
+      "Upscaling": "업스케일링",
+      "Video": "비디오"
+    },
     "template": {
       "3D": {
         "stable_zero123_example": "스테이블 제로123"

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -825,6 +825,20 @@
     "removeFromBookmarks": "Удалить из закладок"
   },
   "templateWorkflows": {
+    "category": {
+      "3D": "3D",
+      "Area Composition": "Композиция области",
+      "Audio": "Аудио",
+      "Basics": "Основы",
+      "ComfyUI Examples": "Примеры ComfyUI",
+      "ControlNet": "ControlNet",
+      "Custom Nodes": "Пользовательские узлы",
+      "Flux": "Flux",
+      "SD3_5": "SD3.5",
+      "SDXL": "SDXL",
+      "Upscaling": "Увеличение разрешения",
+      "Video": "Видео"
+    },
     "template": {
       "3D": {
         "stable_zero123_example": "Stable Zero123"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -825,6 +825,20 @@
     "removeFromBookmarks": "从书签中移除"
   },
   "templateWorkflows": {
+    "category": {
+      "3D": "3D",
+      "Area Composition": "区域组成",
+      "Audio": "音频",
+      "Basics": "基础",
+      "ComfyUI Examples": "ComfyUI示例",
+      "ControlNet": "ControlNet",
+      "Custom Nodes": "自定义节点",
+      "Flux": "Flux",
+      "SD3_5": "SD3.5",
+      "SDXL": "SDXL",
+      "Upscaling": "放大",
+      "Video": "视频"
+    },
     "template": {
       "3D": {
         "stable_zero123_example": "稳定Zero123"


### PR DESCRIPTION
Add translation for categories in left nav to fix issue:

![Selection_1023](https://github.com/user-attachments/assets/0a0f6333-919f-4fd0-b65f-9b33a23626ce)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2937-Translate-template-categories-1b16d73d365081449dbbcdfe784803cb) by [Unito](https://www.unito.io)
