### PR TITLE
[Manager] Use iI8n for date strings

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
@@ -49,7 +49,7 @@ interface InfoItem {
   value: string | number | undefined
 }
 
-const { t } = useI18n()
+const { t, d } = useI18n()
 
 const { nodePack } = defineProps<{
   nodePack: components['schemas']['Node']
@@ -70,7 +70,9 @@ const infoItems = computed<InfoItem[]>(() => [
     key: 'lastUpdated',
     label: t('manager.lastUpdated'),
     value: nodePack.latest_version?.createdAt
-      ? new Date(nodePack.latest_version.createdAt).toLocaleDateString()
+      ? d(nodePack.latest_version.createdAt, {
+          dateStyle: 'medium'
+        })
       : undefined
   }
 ])

--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -71,9 +71,16 @@
             {{ nodePack.latest_version.version }}
           </span>
         </div>
-        <div v-if="nodePack.latest_version" class="flex items-center gap-2">
+        <div
+          v-if="nodePack.latest_version"
+          class="flex items-center gap-2 truncate"
+        >
           {{ $t('g.updated') }}
-          {{ new Date(nodePack.latest_version.createdAt).toLocaleDateString() }}
+          {{
+            $d(new Date(nodePack.latest_version.createdAt), {
+              dateStyle: 'medium'
+            })
+          }}
         </div>
       </div>
     </template>


### PR DESCRIPTION
Use iI8n for date strings.

Before:

![Selection_1026](https://github.com/user-attachments/assets/74243230-e187-44c9-8c87-fa7674da779e)

After:

![Selection_1025](https://github.com/user-attachments/assets/85ecb61e-0567-4fee-8ff1-b4bb389868c6)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2938-Manager-Use-iI8n-for-date-strings-1b16d73d3650811da4cffba80c857594) by [Unito](https://www.unito.io)
