### PR TITLE
Fix settings content not visible on large font sizes

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -289,7 +289,7 @@ watch(activeCategory, (_, oldValue) => {
   display: flex;
   height: 70vh;
   width: 60vw;
-  max-width: 1024px;
+  max-width: 64rem;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Use rem for settingss dialog max width to ensure all content is visible on all browser font sizes. 64rem is equal to 1024px on default browser font size (16px).

Before (large font):

![Selection_1034](https://github.com/user-attachments/assets/a8aa3be6-7086-4df8-874b-53c5fd57d23b)

After (large font):

![Selection_1033](https://github.com/user-attachments/assets/29f252ae-e082-4ec3-ab11-f9525ac1d730)

Before (small font):

![Selection_1029](https://github.com/user-attachments/assets/5abf3703-0f87-4042-8c3c-ef1b782cc426)


After (small font):

![Selection_1030](https://github.com/user-attachments/assets/164f82a5-920f-472c-bc07-1a9695720dc6)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2940-Fix-settings-content-not-visible-on-large-font-sizes-1b16d73d365081d5876fd69dd51a28e1) by [Unito](https://www.unito.io)
