### PR TITLE
Fix dark mode card surface in workflow templates dialog

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -81,12 +81,10 @@
 
 <script setup lang="ts">
 import Card from 'primevue/card'
-import { computed } from 'vue'
 
 import ContentDivider from '@/components/common/ContentDivider.vue'
 import PackInstallButton from '@/components/dialog/content/manager/PackInstallButton.vue'
 import PackIcon from '@/components/dialog/content/manager/packIcon/PackIcon.vue'
-import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import type { components } from '@/types/comfyRegistryTypes'
 import { formatNumber } from '@/utils/formatUtil'
 
@@ -94,9 +92,4 @@ defineProps<{
   nodePack: components['schemas']['Node']
   isSelected?: boolean
 }>()
-
-const colorPaletteStore = useColorPaletteStore()
-const isLightTheme = computed(
-  () => colorPaletteStore.completedActivePalette.light_theme
-)
 </script>

--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -1,8 +1,7 @@
 <template>
   <Card
-    class="absolute inset-0 flex flex-col overflow-hidden rounded-2xl shadow-[0_0_15px_rgba(0,0,0,0.15),0_10px_15px_-3px_rgba(0,0,0,0.12),0_4px_6px_-4px_rgba(0,0,0,0.08)] transition-all duration-200"
+    class="absolute inset-0 flex flex-col overflow-hidden rounded-2xl shadow-elevation-4 dark-theme:bg-dark-elevation-1 transition-all duration-200"
     :class="{
-      'bg-[#ffffff08]': !isLightTheme,
       'outline outline-[6px] outline-[var(--p-primary-color)]': isSelected
     }"
     :pt="{

--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -3,6 +3,9 @@
     ref="cardRef"
     :data-testid="`template-workflow-${template.name}`"
     class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-[0_10px_15px_-3px_rgba(0,0,0,0.08),0_4px_6px_-4px_rgba(0,0,0,0.05)]"
+    :class="{
+      'bg-[#ffffff06]': !isLightTheme
+    }"
     :pt="{
       body: { class: 'p-0' }
     }"
@@ -82,6 +85,7 @@ import AudioThumbnail from '@/components/templates/thumbnails/AudioThumbnail.vue
 import CompareSliderThumbnail from '@/components/templates/thumbnails/CompareSliderThumbnail.vue'
 import DefaultThumbnail from '@/components/templates/thumbnails/DefaultThumbnail.vue'
 import HoverDissolveThumbnail from '@/components/templates/thumbnails/HoverDissolveThumbnail.vue'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { TemplateInfo } from '@/types/workflowTemplateTypes'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
@@ -99,6 +103,11 @@ const { t } = useI18n()
 
 const cardRef = ref<HTMLElement | null>(null)
 const isHovered = useElementHover(cardRef)
+
+const colorPaletteStore = useColorPaletteStore()
+const isLightTheme = computed(
+  () => colorPaletteStore.completedActivePalette.light_theme
+)
 
 const getThumbnailUrl = (index = '') => {
   const basePath =

--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -2,7 +2,7 @@
   <Card
     ref="cardRef"
     :data-testid="`template-workflow-${template.name}`"
-    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-1 dark-theme:bg-dark-elevation-1"
+    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-1"
     :pt="{
       body: { class: 'p-0' }
     }"

--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -2,10 +2,7 @@
   <Card
     ref="cardRef"
     :data-testid="`template-workflow-${template.name}`"
-    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-[0_10px_15px_-3px_rgba(0,0,0,0.08),0_4px_6px_-4px_rgba(0,0,0,0.05)]"
-    :class="{
-      'bg-[#ffffff06]': !isLightTheme
-    }"
+    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-1 dark-theme:bg-dark-elevation-1"
     :pt="{
       body: { class: 'p-0' }
     }"
@@ -85,7 +82,6 @@ import AudioThumbnail from '@/components/templates/thumbnails/AudioThumbnail.vue
 import CompareSliderThumbnail from '@/components/templates/thumbnails/CompareSliderThumbnail.vue'
 import DefaultThumbnail from '@/components/templates/thumbnails/DefaultThumbnail.vue'
 import HoverDissolveThumbnail from '@/components/templates/thumbnails/HoverDissolveThumbnail.vue'
-import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { TemplateInfo } from '@/types/workflowTemplateTypes'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
@@ -103,11 +99,6 @@ const { t } = useI18n()
 
 const cardRef = ref<HTMLElement | null>(null)
 const isHovered = useElementHover(cardRef)
-
-const colorPaletteStore = useColorPaletteStore()
-const isLightTheme = computed(
-  () => colorPaletteStore.completedActivePalette.light_theme
-)
 
 const getThumbnailUrl = (index = '') => {
   const basePath =

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -188,15 +188,15 @@ export default {
       boxShadow: {
         'elevation-0': 'none',
         'elevation-1':
-          '0 1px 3px -1px rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.04)',
+          '0 0 2px 0px rgb(0 0 0 / 0.01), 0 1px 2px -1px rgb(0 0 0 / 0.03), 0 1px 1px -1px rgb(0 0 0 / 0.01)',
         'elevation-2':
-          '0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.05)',
+          '0 0 10px 0px rgb(0 0 0 / 0.06), 0 6px 8px -2px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.04)',
         'elevation-3':
-          '0 15px 20px -3px rgb(0 0 0 / 0.1), 0 8px 12px -4px rgb(0 0 0 / 0.06)',
+          '0 0 15px 0px rgb(0 0 0 / 0.10), 0 8px 12px -3px rgb(0 0 0 / 0.09), 0 3px 5px -4px rgb(0 0 0 / 0.06)',
         'elevation-4':
-          '0 20px 25px -5px rgb(0 0 0 / 0.12), 0 10px 15px -5px rgb(0 0 0 / 0.07)',
+          '0 0 18px 0px rgb(0 0 0 / 0.12), 0 10px 15px -3px rgb(0 0 0 / 0.11), 0 4px 6px -4px rgb(0 0 0 / 0.08)',
         'elevation-5':
-          '0 25px 30px -5px rgb(0 0 0 / 0.14), 0 15px 20px -5px rgb(0 0 0 / 0.08)'
+          '0 0 20px 0px rgb(0 0 0 / 0.14), 0 12px 16px -4px rgb(0 0 0 / 0.13), 0 5px 7px -5px rgb(0 0 0 / 0.10)'
       },
 
       /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -179,9 +179,44 @@ export default {
       textColor: {
         muted: 'var(--p-text-muted-color)',
         highlight: 'var(--p-primary-color)'
+      },
+
+      /**
+       * Box shadows for different elevation levels
+       * https://m3.material.io/styles/elevation/overview
+       */
+      boxShadow: {
+        'elevation-0': 'none',
+        'elevation-1':
+          '0 1px 3px -1px rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.04)',
+        'elevation-2':
+          '0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.05)',
+        'elevation-3':
+          '0 15px 20px -3px rgb(0 0 0 / 0.1), 0 8px 12px -4px rgb(0 0 0 / 0.06)',
+        'elevation-4':
+          '0 20px 25px -5px rgb(0 0 0 / 0.12), 0 10px 15px -5px rgb(0 0 0 / 0.07)',
+        'elevation-5':
+          '0 25px 30px -5px rgb(0 0 0 / 0.14), 0 15px 20px -5px rgb(0 0 0 / 0.08)'
+      },
+
+      /**
+       * Background colors for different elevation levels
+       * https://m3.material.io/styles/elevation/overview
+       */
+      backgroundColor: {
+        'dark-elevation-0': 'rgba(255, 255, 255, 0)',
+        'dark-elevation-1': 'rgba(255, 255, 255, 0.01)',
+        'dark-elevation-2': 'rgba(255, 255, 255, 0.03)',
+        'dark-elevation-3': 'rgba(255, 255, 255, 0.04)',
+        'dark-elevation-4': 'rgba(255, 255, 255, 0.08)',
+        'dark-elevation-5': 'rgba(255, 255, 255, 0.12)'
       }
     }
   },
 
-  plugins: []
+  plugins: [
+    function ({ addVariant }) {
+      addVariant('dark-theme', '.dark-theme &')
+    }
+  ]
 }


### PR DESCRIPTION
Primevue is style-agnostic and does not have concept of surface elevation like other UI libraries. Card surfaces need to be added manually when drop shadow is not sufficient for establishing elevation (e.g., on dark mode). This change makes Template cards match Custom Nodes Manager card surface.

Before:

![Selection_1039](https://github.com/user-attachments/assets/3edfec7e-ee70-4cf2-b142-ec2c0b83ec30)

After:

![Selection_1038](https://github.com/user-attachments/assets/a457e0f2-cfa9-43f3-8388-95e7260c5897)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2942-Fix-dark-mode-card-surface-in-workflow-templates-dialog-1b16d73d3650813a9c21cadfa5da04f8) by [Unito](https://www.unito.io)
