### PR TITLE
Manage style of DOM widgets in Vue

### DIFF
--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -1,5 +1,6 @@
 <template>
-  <div>
+  <!-- Create a new stacking context for widgets to avoid z-index issues -->
+  <div class="isolate">
     <DomWidget
       v-for="widget in widgets"
       :key="widget.id"

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <DomWidget v-for="widget in widgets" :key="widget.id" :widget="widget" />
+    <DomWidget
+      v-for="widget in widgets"
+      :key="widget.id"
+      :widget="widget"
+      :widget-state="domWidgetStore.widgetStates.get(widget.id)"
+    />
   </div>
 </template>
 

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -53,8 +53,8 @@ watch(
           node.pos[1] + MARGIN + widget.y
         ]
         widgetState.size = [
-          widget.width ?? node.width - MARGIN * 2,
-          widget.computedHeight ?? 50 - MARGIN * 2
+          (widget.width ?? node.width) - MARGIN * 2,
+          (widget.computedHeight ?? 50) - MARGIN * 2
         ]
         // TODO: optimize this logic as it's O(n), where n is the number of nodes
         widgetState.zIndex = lgCanvas.graph.nodes.indexOf(node)

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -10,11 +10,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { computed, watch } from 'vue'
 
 import DomWidget from '@/components/graph/widgets/DomWidget.vue'
+import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { DOMWidget } from '@/scripts/domWidget'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { useCanvasStore } from '@/stores/graphStore'
 
 const domWidgetStore = useDomWidgetStore()
 const widgets = computed(() =>
@@ -23,5 +26,41 @@ const widgets = computed(() =>
       DOMWidget<HTMLElement, object | string>
     >
   )
+)
+
+const MARGIN = 10
+const canvasStore = useCanvasStore()
+watch(
+  () => canvasStore.canvas,
+  (lgCanvas) => {
+    if (!lgCanvas) return
+
+    lgCanvas.onRender = useChainCallback(lgCanvas.onRender, () => {
+      const lowQuality = lgCanvas.low_quality
+      for (const widget of domWidgetStore.widgetInstances.values()) {
+        const node = widget.node as LGraphNode
+        const widgetState = domWidgetStore.widgetStates.get(widget.id)
+
+        if (!widgetState) continue
+
+        widgetState.visible =
+          lgCanvas.isNodeVisible(node) &&
+          !(widget.options.hideOnZoom && lowQuality) &&
+          widget.isVisible()
+
+        widgetState.pos = [
+          node.pos[0] + MARGIN,
+          node.pos[1] + MARGIN + widget.y
+        ]
+        widgetState.size = [
+          widget.width ?? node.width - MARGIN * 2,
+          widget.computedHeight ?? 50 - MARGIN * 2
+        ]
+        // TODO: optimize this logic as it's O(n), where n is the number of nodes
+        widgetState.zIndex = lgCanvas.graph.nodes.indexOf(node)
+        widgetState.readonly = lgCanvas.read_only
+      }
+    })
+  }
 )
 </script>

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -1,17 +1,56 @@
 <template>
-  <div ref="widgetElement" />
+  <div ref="widgetElement" :style="style" />
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { computed, onMounted, ref, watch } from 'vue'
 
+import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
+import { useDomClipping } from '@/composables/element/useDomClipping'
 import type { DOMWidget } from '@/scripts/domWidget'
+import { DomWidgetState } from '@/stores/domWidgetStore'
+import { useCanvasStore } from '@/stores/graphStore'
 
-const { widget } = defineProps<{
+const { widget, widgetState } = defineProps<{
   widget: DOMWidget<HTMLElement, any>
+  widgetState: DomWidgetState
 }>()
 
 const widgetElement = ref<HTMLElement>()
+
+const { style: positionStyle, updatePositionWithTransform } =
+  useAbsolutePosition()
+const { style: clippingStyle, updateClipPath } = useDomClipping()
+const style = computed(() => ({
+  ...positionStyle.value,
+  ...clippingStyle.value
+}))
+
+const canvasStore = useCanvasStore()
+watch(widgetState, (newState) => {
+  updatePositionWithTransform(newState)
+
+  const lgCanvas = canvasStore.canvas
+  const selectedNode = Object.values(
+    lgCanvas.selected_nodes ?? {}
+  )[0] as LGraphNode
+  const node = widget.node
+  const isSelected = selectedNode === node
+
+  const renderArea = node.renderArea
+  const offset = lgCanvas.ds.offset
+  const scale = lgCanvas.ds.scale
+
+  updateClipPath(widgetElement.value, lgCanvas.canvas, isSelected, {
+    x: renderArea[0],
+    y: renderArea[1],
+    width: renderArea[2],
+    height: renderArea[3],
+    scale,
+    offset: [offset[0], offset[1]]
+  })
+})
 
 onMounted(() => {
   widgetElement.value.appendChild(widget.element)

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -48,19 +48,26 @@ const updateDomClipping = () => {
   )[0] as LGraphNode
   const node = widget.node
   const isSelected = selectedNode === node
-
-  const renderArea = node.renderArea
+  const renderArea = selectedNode?.renderArea
   const offset = lgCanvas.ds.offset
   const scale = lgCanvas.ds.scale
+  const selectedAreaConfig = renderArea
+    ? {
+        x: renderArea[0],
+        y: renderArea[1],
+        width: renderArea[2],
+        height: renderArea[3],
+        scale,
+        offset: [offset[0], offset[1]] as [number, number]
+      }
+    : undefined
 
-  updateClipPath(widgetElement.value, lgCanvas.canvas, isSelected, {
-    x: renderArea[0],
-    y: renderArea[1],
-    width: renderArea[2],
-    height: renderArea[3],
-    scale,
-    offset: [offset[0], offset[1]]
-  })
+  updateClipPath(
+    widgetElement.value,
+    lgCanvas.canvas,
+    isSelected,
+    selectedAreaConfig
+  )
 }
 
 watch(

--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -66,8 +66,8 @@ export function useAbsolutePosition() {
       ...style.value,
       transformOrigin: '0 0',
       transform: `scale(${scale})`,
-      left: `${top}px`,
-      top: `${left}px`,
+      left: `${left}px`,
+      top: `${top}px`,
       width: `${width}px`,
       height: `${height}px`,
       ...extraStyle

--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -23,6 +23,12 @@ export function useAbsolutePosition() {
     height: '0px'
   })
 
+  /**
+   * Update the position of the element on the litegraph canvas.
+   *
+   * @param config
+   * @param extraStyle
+   */
   const updatePosition = (
     config: PositionConfig,
     extraStyle?: CSSProperties
@@ -41,8 +47,36 @@ export function useAbsolutePosition() {
     }
   }
 
+  /**
+   * Update the position and size of the element on the litegraph canvas,
+   * with CSS transform scaling applied.
+   *
+   * @param config
+   * @param extraStyle
+   */
+  const updatePositionWithTransform = (
+    config: PositionConfig,
+    extraStyle?: CSSProperties
+  ) => {
+    const { pos, size, scale = canvasStore.canvas?.ds?.scale ?? 1 } = config
+    const [left, top] = app.canvasPosToClientPos(pos)
+    const [width, height] = size
+
+    style.value = {
+      ...style.value,
+      transformOrigin: '0 0',
+      transform: `scale(${scale})`,
+      left: `${top}px`,
+      top: `${left}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+      ...extraStyle
+    }
+  }
+
   return {
     style,
-    updatePosition
+    updatePosition,
+    updatePositionWithTransform
   }
 }

--- a/src/composables/element/useDomClipping.ts
+++ b/src/composables/element/useDomClipping.ts
@@ -1,0 +1,123 @@
+import { CSSProperties, ref } from 'vue'
+
+interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Finds the intersection between two rectangles
+ */
+function intersect(a: Rect, b: Rect): [number, number, number, number] | null {
+  const x1 = Math.max(a.x, b.x)
+  const y1 = Math.max(a.y, b.y)
+  const x2 = Math.min(a.x + a.width, b.x + b.width)
+  const y2 = Math.min(a.y + a.height, b.y + b.height)
+
+  if (x1 >= x2 || y1 >= y2) {
+    return null
+  }
+
+  return [x1, y1, x2 - x1, y2 - y1]
+}
+
+export interface ClippingOptions {
+  margin?: number
+}
+
+export const useDomClipping = (options: ClippingOptions = {}) => {
+  const style = ref<CSSProperties>({})
+  const { margin = 4 } = options
+
+  /**
+   * Calculates a clip path for an element based on its intersection with a selected area
+   */
+  const calculateClipPath = (
+    elementRect: DOMRect,
+    canvasRect: DOMRect,
+    isSelected: boolean,
+    selectedArea?: {
+      x: number
+      y: number
+      width: number
+      height: number
+      scale: number
+      offset: [number, number]
+    }
+  ): string => {
+    if (!isSelected && selectedArea) {
+      const { scale, offset } = selectedArea
+
+      // Get intersection in browser space
+      const intersection = intersect(
+        {
+          x: elementRect.left - canvasRect.left,
+          y: elementRect.top - canvasRect.top,
+          width: elementRect.width,
+          height: elementRect.height
+        },
+        {
+          x: (selectedArea.x + offset[0] - margin) * scale,
+          y: (selectedArea.y + offset[1] - margin) * scale,
+          width: (selectedArea.width + 2 * margin) * scale,
+          height: (selectedArea.height + 2 * margin) * scale
+        }
+      )
+
+      if (!intersection) {
+        return ''
+      }
+
+      // Convert intersection to canvas scale (element has scale transform)
+      const clipX =
+        (intersection[0] - elementRect.left + canvasRect.left) / scale + 'px'
+      const clipY =
+        (intersection[1] - elementRect.top + canvasRect.top) / scale + 'px'
+      const clipWidth = intersection[2] / scale + 'px'
+      const clipHeight = intersection[3] / scale + 'px'
+
+      return `polygon(0% 0%, 0% 100%, ${clipX} 100%, ${clipX} ${clipY}, calc(${clipX} + ${clipWidth}) ${clipY}, calc(${clipX} + ${clipWidth}) calc(${clipY} + ${clipHeight}), ${clipX} calc(${clipY} + ${clipHeight}), ${clipX} 100%, 100% 100%, 100% 0%)`
+    }
+
+    return ''
+  }
+
+  /**
+   * Updates the clip-path style based on element and selection information
+   */
+  const updateClipPath = (
+    element: HTMLElement,
+    canvasElement: HTMLElement,
+    isSelected: boolean,
+    selectedArea?: {
+      x: number
+      y: number
+      width: number
+      height: number
+      scale: number
+      offset: [number, number]
+    }
+  ) => {
+    const elementRect = element.getBoundingClientRect()
+    const canvasRect = canvasElement.getBoundingClientRect()
+
+    const clipPath = calculateClipPath(
+      elementRect,
+      canvasRect,
+      isSelected,
+      selectedArea
+    )
+
+    style.value = {
+      ...style.value,
+      clipPath: clipPath || undefined
+    }
+  }
+
+  return {
+    style,
+    updateClipPath
+  }
+}

--- a/src/composables/element/useDomClipping.ts
+++ b/src/composables/element/useDomClipping.ts
@@ -89,7 +89,7 @@ export const useDomClipping = (options: ClippingOptions = {}) => {
    */
   const updateClipPath = (
     element: HTMLElement,
-    canvasElement: HTMLElement,
+    canvasElement: HTMLCanvasElement,
     isSelected: boolean,
     selectedArea?: {
       x: number

--- a/src/composables/element/useDomClipping.ts
+++ b/src/composables/element/useDomClipping.ts
@@ -111,8 +111,8 @@ export const useDomClipping = (options: ClippingOptions = {}) => {
     )
 
     style.value = {
-      ...style.value,
-      clipPath: clipPath || undefined
+      clipPath: clipPath || 'none',
+      willChange: 'clip-path'
     }
   }
 

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -1,4 +1,4 @@
-import { LGraphCanvas, LGraphNode } from '@comfyorg/litegraph'
+import { LGraphNode } from '@comfyorg/litegraph'
 import type {
   ICustomWidget,
   IWidgetOptions

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -36,6 +36,8 @@ export interface DOMWidget<T extends HTMLElement, V extends object | string>
   // DOMWidget properties
   /** The unique ID of the widget. */
   id: string
+  /** The node that the widget belongs to. */
+  node: LGraphNode
 }
 
 export interface DOMWidgetOptions<
@@ -159,10 +161,12 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
   callback?: (value: V) => void
 
   readonly id: string
+  readonly node: LGraphNode
   mouseDownHandler?: (event: MouseEvent) => void
 
   constructor(obj: {
     id: string
+    node: LGraphNode
     name: string
     type: string
     element: T
@@ -175,6 +179,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
     this.options = obj.options
 
     this.id = obj.id
+    this.node = obj.node
 
     if (this.element.blur) {
       this.mouseDownHandler = (event) => {
@@ -327,6 +332,7 @@ LGraphNode.prototype.addDOMWidget = function <
 
   const widget = new DOMWidgetImpl({
     id: `${this.id}:${name}:${generateRandomSuffix()}`,
+    node: this,
     name,
     type,
     element,

--- a/src/stores/domWidgetStore.ts
+++ b/src/stores/domWidgetStore.ts
@@ -4,9 +4,17 @@
 import { defineStore } from 'pinia'
 import { markRaw, ref } from 'vue'
 
+import type { PositionConfig } from '@/composables/element/useAbsolutePosition'
 import type { DOMWidget } from '@/scripts/domWidget'
 
+export interface DomWidgetState extends PositionConfig {
+  visible: boolean
+  zIndex: number
+}
+
 export const useDomWidgetStore = defineStore('domWidget', () => {
+  const widgetStates = ref<Map<string, DomWidgetState>>(new Map())
+
   // Map to reference actual widget instances
   // Widgets are stored as raw values to avoid reactivity issues
   const widgetInstances = ref(
@@ -21,14 +29,22 @@ export const useDomWidgetStore = defineStore('domWidget', () => {
       widget.id,
       markRaw(widget as unknown as DOMWidget<HTMLElement, object | string>)
     )
+    widgetStates.value.set(widget.id, {
+      visible: true,
+      zIndex: 0,
+      pos: [0, 0],
+      size: [0, 0]
+    })
   }
 
   // Unregister a widget from the store
   const unregisterWidget = (widgetId: string) => {
     widgetInstances.value.delete(widgetId)
+    widgetStates.value.delete(widgetId)
   }
 
   return {
+    widgetStates,
     widgetInstances,
     registerWidget,
     unregisterWidget

--- a/src/stores/domWidgetStore.ts
+++ b/src/stores/domWidgetStore.ts
@@ -9,6 +9,7 @@ import type { DOMWidget } from '@/scripts/domWidget'
 
 export interface DomWidgetState extends PositionConfig {
   visible: boolean
+  readonly: boolean
   zIndex: number
 }
 
@@ -31,6 +32,7 @@ export const useDomWidgetStore = defineStore('domWidget', () => {
     )
     widgetStates.value.set(widget.id, {
       visible: true,
+      readonly: false,
       zIndex: 0,
       pos: [0, 0],
       size: [0, 0]


### PR DESCRIPTION
This PR moves the style calculation from `domWidget.ts` to Vue side, so the logic can be reused for vue component widgets.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2946-Manage-style-of-DOM-widgets-in-Vue-1b16d73d3650813094baf2ec5782bcf1) by [Unito](https://www.unito.io)
