### PR TITLE
Use relative url path for reverse proxy hosting on template thumbnails

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -103,8 +103,8 @@ const isHovered = useElementHover(cardRef)
 const getThumbnailUrl = (index = '') => {
   const basePath =
     sourceModule === 'default'
-      ? `/templates/${template.name}`
-      : `/api/workflow_templates/${sourceModule}/${template.name}`
+      ? `templates/${template.name}`
+      : `api/workflow_templates/${sourceModule}/${template.name}`
 
   // For templates from custom nodes, multiple images is not yet supported
   const indexSuffix = sourceModule === 'default' && index ? `-${index}` : ''


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2958

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2959-Use-relative-url-path-for-reverse-proxy-hosting-on-template-thumbnails-1b26d73d3650812d9f75f1728e240e4d) by [Unito](https://www.unito.io)
