### PR TITLE
Add ComfyUI-Manager API types

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -119,7 +119,7 @@ import PackCard from '@/components/dialog/content/manager/packCard/PackCard.vue'
 import RegistrySearchBar from '@/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue'
 import { useResponsiveCollapse } from '@/composables/element/useResponsiveCollapse'
 import { useRegistrySearch } from '@/composables/useRegistrySearch'
-import type { NodeField, TabItem } from '@/types/comfyManagerTypes'
+import type { PackField, TabItem } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
 
 const DEFAULT_CARD_SIZE = 512
@@ -198,10 +198,10 @@ const showInfoPanel = computed(() => selectedNodePacks.value.length > 0)
 const hasMultipleSelections = computed(() => selectedNodePacks.value.length > 1)
 
 const currentFilterBy = ref('all')
-const handleSortChange = (sortBy: NodeField) => {
+const handleSortChange = (sortBy: PackField) => {
   sortField.value = sortBy
 }
-const handleFilterChange = (filterBy: NodeField) => {
+const handleFilterChange = (filterBy: PackField) => {
   currentFilterBy.value = filterBy
 }
 </script>

--- a/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
@@ -44,10 +44,10 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SearchFilterDropdown from '@/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue'
-import type { NodeField, SearchOption } from '@/types/comfyManagerTypes'
+import type { PackField, SearchOption } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
 
-const DEFAULT_SORT: NodeField = 'downloads'
+const DEFAULT_SORT: PackField = 'downloads'
 const DEFAULT_FILTER = 'nodePack'
 
 const props = defineProps<{
@@ -57,12 +57,12 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const currentSort = ref<NodeField>(DEFAULT_SORT)
+const currentSort = ref<PackField>(DEFAULT_SORT)
 const currentFilter = ref<string>(DEFAULT_FILTER)
 
 const emit = defineEmits<{
   'update:searchQuery': [value: string]
-  'update:sortBy': [value: NodeField]
+  'update:sortBy': [value: PackField]
   'update:filterBy': [value: string]
 }>()
 
@@ -70,7 +70,7 @@ const hasResults = computed(
   () => props.searchQuery.trim() && props.searchResults?.length
 )
 
-const sortOptions: SearchOption<NodeField>[] = [
+const sortOptions: SearchOption<PackField>[] = [
   { id: 'downloads', label: t('manager.sort.downloads') },
   { id: 'name', label: t('g.name') },
   { id: 'rating', label: t('manager.sort.rating') },

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -123,8 +123,8 @@ export type InstalledPacksResponse = Record<
  * Returned by `/customnode/getlist`
  */
 export interface ManagerPack extends ManagerPackInfo {
-  /** The github username of the pack author */
-  author: string
+  /** Pack author name or 'Unclaimed' if the pack was added automatically via GitHub crawl. */
+  author: components['schemas']['Node']['author']
   /** Files included in the pack */
   files: string[]
   /** The type of installation that was used to install the pack */

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -65,15 +65,13 @@ export enum ManagerChannel {
   TUTORIAL = 'tutorial'
 }
 
-export enum ManagerSourceMode {
+export enum ManagerDatabaseSource {
   /** Get pack info from the Comfy Registry */
   REMOTE = 'remote',
-  /** Get pack info from the custom-node-list.json file in the ComfyUI-Manager directory */
+  /** If set to `local`, the channel is ignored */
   LOCAL = 'local',
-  /** Get pack info from the cached response from the Comfy Registry */
-  CACHE = 'cache',
-  /** Get pack info from imported data */
-  IMPORTED = 'imported'
+  /** Get pack info from the cached response from the Comfy Registry (1 day TTL) */
+  CACHE = 'cache'
 }
 
 export interface ManagerQueueStatus {
@@ -163,9 +161,9 @@ export interface InstallPackParams extends ManagerPackInfo {
    */
   selected_version: WorkflowNodeProperties['ver'] | SelectedVersion
   /**
-   * The mode to install the node in.
+   * If set to `imported`, returns only the packs that were imported at app startup.
    */
-  mode: ManagerSourceMode
+  mode: 'imported' | null
   /**
    * The GitHub link to the repository of the node to install.
    * Required if `selected_version` is `nightly`.

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -3,7 +3,7 @@ import type { components } from '@/types/comfyRegistryTypes'
 
 type RegistryPack = components['schemas']['Node']
 type WorkflowNodeProperties = ComfyWorkflowJSON['nodes'][0]['properties']
-export type NodeField = keyof RegistryPack | null
+export type PackField = keyof RegistryPack | null
 
 export type PackWithSelectedVersion = {
   nodePack: RegistryPack
@@ -39,7 +39,7 @@ enum ManagerPackInstallType {
   GIT = 'git-clone',
   /** Installed via file copy */
   COPY = 'copy',
-  /** Installed from the Comfy Node Registry */
+  /** Installed from the Comfy Registry */
   REGISTRY = 'cnr'
 }
 

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -1,4 +1,14 @@
+import type { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import type { components } from '@/types/comfyRegistryTypes'
+
+type RegistryPack = components['schemas']['Node']
+type WorkflowNodeProperties = ComfyWorkflowJSON['nodes'][0]['properties']
+export type NodeField = keyof RegistryPack | null
+
+export type PackWithSelectedVersion = {
+  nodePack: RegistryPack
+  selectedVersion?: InstallPackParams['selected_version']
+}
 
 export interface TabItem {
   id: string
@@ -6,9 +16,167 @@ export interface TabItem {
   icon: string
 }
 
-export type NodeField = keyof components['schemas']['Node'] | null
-
 export interface SearchOption<T> {
   id: T
   label: string
+}
+
+enum ManagerPackState {
+  /** Pack is installed and enabled */
+  INSTALLED = 'installed',
+  /** Pack is installed but disabled */
+  DISABLED = 'disabled',
+  /** Pack is not installed */
+  NOT_INSTALLED = 'not_installed',
+  /** Pack failed to import */
+  IMPORT_FAILED = 'import_failed',
+  /** Pack has an update available */
+  NEEDS_UPDATE = 'needs_update'
+}
+
+enum ManagerPackInstallType {
+  /** Installed via git clone */
+  GIT = 'git-clone',
+  /** Installed via file copy */
+  COPY = 'copy',
+  /** Installed from the Comfy Node Registry */
+  REGISTRY = 'cnr'
+}
+
+export enum SelectedVersion {
+  /** Latest version of the pack from the registry */
+  LATEST = 'latest',
+  /** Latest commit of the pack from its GitHub repository */
+  NIGHTLY = 'nightly'
+}
+
+export enum ManagerChannel {
+  /** All packs except those with instability or security issues */
+  DEFAULT = 'default',
+  /** Packs that were recently updated */
+  RECENT = 'recent',
+  /** Packs that were superseded by distinct replacements of some type */
+  LEGACY = 'legacy',
+  /** Packs that were forked as a result of the original pack going unmaintained */
+  FORKED = 'forked',
+  /** Packs with instability or security issues suitable only for developers */
+  DEV = 'dev',
+  /** Packs suitable for beginners */
+  TUTORIAL = 'tutorial'
+}
+
+export enum ManagerSourceMode {
+  /** Get pack info from the Comfy Registry */
+  REMOTE = 'remote',
+  /** Get pack info from the custom-node-list.json file in the ComfyUI-Manager directory */
+  LOCAL = 'local',
+  /** Get pack info from the cached response from the Comfy Registry */
+  CACHE = 'cache',
+  /** Get pack info from imported data */
+  IMPORTED = 'imported'
+}
+
+export interface ManagerQueueStatus {
+  /** `done_count` + `in_progress_count` + number of items queued */
+  total_count: number
+  /** Task worker thread is alive, a queued operation is running */
+  is_processing: boolean
+  /** Number of items in the queue that have been completed */
+  done_count: number
+  /** Number of items in the queue that are currently running */
+  in_progress_count: number
+}
+
+export interface ManagerPackInfo {
+  /** Either github-author/github-repo or name of pack from the registry (not id) */
+  id: WorkflowNodeProperties['aux_id'] | WorkflowNodeProperties['cnr_id']
+  /** Semantic version or Git commit hash */
+  version: WorkflowNodeProperties['ver']
+}
+
+export interface ManagerPackInstalled {
+  /**
+   * The version of the pack that is installed.
+   * Git commit hash or semantic version.
+   */
+  ver: WorkflowNodeProperties['ver']
+  /**
+   * The name of the pack if the pack is installed from the registry.
+   * Corresponds to `Node#name` in comfy-api.
+   */
+  cnr_id: WorkflowNodeProperties['cnr_id']
+  /**
+   * The name of the pack if the pack is installed from github.
+   * In the format author/repo-name. If the pack is installed from the registry, this is `null`.
+   */
+  aux_id: WorkflowNodeProperties['aux_id'] | null
+  enabled: boolean
+}
+
+/**
+ * Returned by `/customnode/installed`
+ */
+export type InstalledPacksResponse = Record<
+  NonNullable<RegistryPack['name']>,
+  ManagerPackInstalled
+>
+
+/**
+ * Returned by `/customnode/getlist`
+ */
+export interface ManagerPack extends ManagerPackInfo {
+  /** The github username of the pack author */
+  author: string
+  /** Files included in the pack */
+  files: string[]
+  /** The type of installation that was used to install the pack */
+  reference: string
+  /** The display name of the pack */
+  title: string
+  /** The latest version of the pack */
+  cnr_latest: SelectedVersion
+  /** The github link to the repository of the pack */
+  repository: string
+  /** The state of the pack */
+  state: ManagerPackState
+  /** The state of the pack update */
+  'update-state': 'false' | 'true' | null
+  /** The number of stars the pack has on GitHub. Distinct from registry stars */
+  stars: number
+  /**
+   * The last time the pack was updated. In ISO 8601 format.
+   * @example '2024-05-22 20:00:00'
+   */
+  last_update: string
+  health: string
+  description: string
+  trust: boolean
+  install_type: ManagerPackInstallType
+}
+
+/**
+ * Payload for posting to `/manager/queue/install`
+ */
+export interface InstallPackParams extends ManagerPackInfo {
+  /**
+   * Semantic version, Git commit hash, `latest`, or `nightly`.
+   */
+  selected_version: WorkflowNodeProperties['ver'] | SelectedVersion
+  /**
+   * The mode to install the node in.
+   */
+  mode: ManagerSourceMode
+  /**
+   * The GitHub link to the repository of the node to install.
+   * Required if `selected_version` is `nightly`.
+   */
+  repository: string
+  /**
+   * List of PyPi dependencies associated with the node.
+   * Used to determine whether the node should be installed based on
+   * user's security level configuration and package whitelist/locks.
+   */
+  pip?: string[]
+  channel: ManagerChannel
+  skip_post_install?: boolean
 }

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -153,7 +153,22 @@ export interface ManagerPack extends ManagerPackInfo {
 }
 
 /**
- * Payload for posting to `/manager/queue/install`
+ * Returned by `/customnode/getmappings`.
+ */
+export type ManagerMappings = Record<
+  NonNullable<components['schemas']['Node']['name']>,
+  [
+    /** List of ComfyNode names included in the pack */
+    Array<components['schemas']['ComfyNode']['comfy_node_name']>,
+    {
+      /** The display name of the pack */
+      title_aux: string
+    }
+  ]
+>
+
+/**
+ * Payload for `/manager/queue/install`
  */
 export interface InstallPackParams extends ManagerPackInfo {
   /**
@@ -163,16 +178,15 @@ export interface InstallPackParams extends ManagerPackInfo {
   /**
    * If set to `imported`, returns only the packs that were imported at app startup.
    */
-  mode: 'imported' | null
+  mode?: 'imported' | 'default'
   /**
-   * The GitHub link to the repository of the node to install.
+   * The GitHub link to the repository of the pack to install.
    * Required if `selected_version` is `nightly`.
    */
   repository: string
   /**
-   * List of PyPi dependencies associated with the node.
-   * Used to determine whether the node should be installed based on
-   * user's security level configuration and package whitelist/locks.
+   * List of PyPi dependency names associated with the pack.
+   * Used in coordination with pip package whitelist and version lock features.
    */
   pip?: string[]
   channel: ManagerChannel

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -192,3 +192,10 @@ export interface InstallPackParams extends ManagerPackInfo {
   channel: ManagerChannel
   skip_post_install?: boolean
 }
+
+/**
+ * Params for `/manager/queue/update_all`
+ */
+export interface UpdateAllPacksParams {
+  mode?: ManagerDatabaseSource
+}


### PR DESCRIPTION
Adds some of the types and structures specified by the ComfyUI-Manager API. In particular, the types used for node pack mangament endpoints:

- manager/queue/start
- manager/queue/reset
- manager/queue/status
- manager/queue/install
- manager/queue/update
- manager/queue/update_all
- manager/queue/uninstall
- manager/queue/disable
- customnode/installed
- customnode/getlist
- customnode/getmappings

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2967-Add-ComfyUI-Manager-API-types-1b36d73d365081e88e0ce68fcd9d2937) by [Unito](https://www.unito.io)
