### PR TITLE
Add Comfy Manager service

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -119,7 +119,7 @@ import PackCard from '@/components/dialog/content/manager/packCard/PackCard.vue'
 import RegistrySearchBar from '@/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue'
 import { useResponsiveCollapse } from '@/composables/element/useResponsiveCollapse'
 import { useRegistrySearch } from '@/composables/useRegistrySearch'
-import type { NodeField, TabItem } from '@/types/comfyManagerTypes'
+import type { PackField, TabItem } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
 
 const DEFAULT_CARD_SIZE = 512
@@ -198,10 +198,10 @@ const showInfoPanel = computed(() => selectedNodePacks.value.length > 0)
 const hasMultipleSelections = computed(() => selectedNodePacks.value.length > 1)
 
 const currentFilterBy = ref('all')
-const handleSortChange = (sortBy: NodeField) => {
+const handleSortChange = (sortBy: PackField) => {
   sortField.value = sortBy
 }
-const handleFilterChange = (filterBy: NodeField) => {
+const handleFilterChange = (filterBy: PackField) => {
   currentFilterBy.value = filterBy
 }
 </script>

--- a/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
@@ -44,10 +44,10 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SearchFilterDropdown from '@/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue'
-import type { NodeField, SearchOption } from '@/types/comfyManagerTypes'
+import type { PackField, SearchOption } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
 
-const DEFAULT_SORT: NodeField = 'downloads'
+const DEFAULT_SORT: PackField = 'downloads'
 const DEFAULT_FILTER = 'nodePack'
 
 const props = defineProps<{
@@ -57,12 +57,12 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const currentSort = ref<NodeField>(DEFAULT_SORT)
+const currentSort = ref<PackField>(DEFAULT_SORT)
 const currentFilter = ref<string>(DEFAULT_FILTER)
 
 const emit = defineEmits<{
   'update:searchQuery': [value: string]
-  'update:sortBy': [value: NodeField]
+  'update:sortBy': [value: PackField]
   'update:filterBy': [value: string]
 }>()
 
@@ -70,7 +70,7 @@ const hasResults = computed(
   () => props.searchQuery.trim() && props.searchResults?.length
 )
 
-const sortOptions: SearchOption<NodeField>[] = [
+const sortOptions: SearchOption<PackField>[] = [
   { id: 'downloads', label: t('manager.sort.downloads') },
   { id: 'name', label: t('g.name') },
   { id: 'rating', label: t('manager.sort.rating') },

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -1,0 +1,273 @@
+import axios, { AxiosError, AxiosResponse } from 'axios'
+import { ref } from 'vue'
+
+import { api } from '@/scripts/api'
+import {
+  type InstallPackParams,
+  type InstalledPacksResponse,
+  type ManagerPackInfo,
+  type ManagerQueueStatus,
+  SelectedVersion,
+  type UpdateAllPacksParams
+} from '@/types/comfyManagerTypes'
+import { isAbortError } from '@/utils/typeGuardUtil'
+
+const GENERIC_SECURITY_ERR_MSG =
+  'Forbidden: A security error has occurred. Please check the terminal logs'
+
+/**
+ * API routes for ComfyUI Manager
+ */
+enum ManagerRoute {
+  START_QUEUE = 'manager/queue/start',
+  RESET_QUEUE = 'manager/queue/reset',
+  QUEUE_STATUS = 'manager/queue/status',
+  INSTALL = 'manager/queue/install',
+  UPDATE = 'manager/queue/update',
+  UPDATE_ALL = 'manager/queue/update_all',
+  UNINSTALL = 'manager/queue/uninstall',
+  DISABLE = 'manager/queue/disable',
+  FIX_NODE = 'manager/queue/fix',
+  LIST_INSTALLED = 'customnode/installed',
+  GET_NODES = 'customnode/getmappings',
+  GET_PACKS = 'customnode/getlist',
+  IMPORT_FAIL_INFO = 'customnode/import_fail_info',
+  REBOOT = 'manager/reboot'
+}
+
+const managerApiClient = axios.create({
+  baseURL: api.apiURL(''),
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})
+
+/**
+ * Service for interacting with the ComfyUI Manager API
+ * Provides methods for managing packs, ComfyUI-Manager queue operations, and system functions
+ */
+export const useComfyManagerService = () => {
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const didStartQueue = ref(false)
+
+  const handleRequestError = (
+    err: unknown,
+    context: string,
+    routeSpecificErrors?: Record<number, string>
+  ) => {
+    // Don't treat cancellation as an error
+    if (isAbortError(err)) return
+
+    let message: string
+    if (!axios.isAxiosError(err)) {
+      message = `${context} failed: ${err instanceof Error ? err.message : String(err)}`
+    } else {
+      const axiosError = err as AxiosError<{ message: string }>
+      const status = axiosError.response?.status
+      if (status && routeSpecificErrors?.[status]) {
+        message = routeSpecificErrors[status]
+      } else if (status === 404) {
+        message = 'Could not connect to ComfyUI-Manager'
+      } else {
+        message =
+          axiosError.response?.data?.message ??
+          `${context} failed with status ${status}`
+      }
+    }
+
+    error.value = message
+  }
+
+  const executeRequest = async <T>(
+    requestCall: () => Promise<AxiosResponse<T>>,
+    options: {
+      errorContext: string
+      routeSpecificErrors?: Record<number, string>
+      isQueueOperation?: boolean
+    }
+  ): Promise<T | null> => {
+    const { errorContext, routeSpecificErrors, isQueueOperation } = options
+
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const response = await requestCall()
+      if (isQueueOperation) await startQueue()
+      return response.data
+    } catch (err) {
+      handleRequestError(err, errorContext, routeSpecificErrors)
+      return null
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const startQueue = async (signal?: AbortSignal) => {
+    const errorContext = 'Starting ComfyUI-Manager job queue'
+    const routeSpecificErrors = {
+      201: 'Created: ComfyUI-Manager job queue is already running'
+    }
+
+    didStartQueue.value = true
+
+    return executeRequest<null>(
+      () => managerApiClient.get(ManagerRoute.START_QUEUE, { signal }),
+      { errorContext, routeSpecificErrors }
+    )
+  }
+
+  const getQueueStatus = async (signal?: AbortSignal) => {
+    const errorContext = 'Getting ComfyUI-Manager queue status'
+
+    return executeRequest<ManagerQueueStatus>(
+      () => managerApiClient.get(ManagerRoute.QUEUE_STATUS, { signal }),
+      { errorContext }
+    )
+  }
+
+  const resetQueue = async (signal?: AbortSignal) => {
+    const errorContext = 'Resetting ComfyUI-Manager queue'
+
+    return executeRequest<null>(
+      () => managerApiClient.get(ManagerRoute.RESET_QUEUE, { signal }),
+      { errorContext }
+    )
+  }
+
+  const listInstalledPacks = async (signal?: AbortSignal) => {
+    const errorContext = 'Fetching installed packs'
+
+    return executeRequest<InstalledPacksResponse>(
+      () => managerApiClient.get(ManagerRoute.LIST_INSTALLED, { signal }),
+      { errorContext }
+    )
+  }
+
+  const getImportFailInfo = async (signal?: AbortSignal) => {
+    const errorContext = 'Fetching import failure information'
+
+    return executeRequest<any>(
+      () => managerApiClient.get(ManagerRoute.IMPORT_FAIL_INFO, { signal }),
+      { errorContext }
+    )
+  }
+
+  const installPack = async (
+    params: InstallPackParams,
+    signal?: AbortSignal
+  ) => {
+    const errorContext = `Installing pack ${params.id}`
+    const routeSpecificErrors = {
+      403: GENERIC_SECURITY_ERR_MSG,
+      404:
+        params.selected_version === SelectedVersion.NIGHTLY
+          ? `Not Found: Node pack ${params.id} does not provide nightly version`
+          : GENERIC_SECURITY_ERR_MSG
+    }
+
+    return executeRequest<null>(
+      () => managerApiClient.post(ManagerRoute.INSTALL, params, { signal }),
+      { errorContext, routeSpecificErrors, isQueueOperation: true }
+    )
+  }
+
+  const uninstallPack = async (
+    params: ManagerPackInfo,
+    signal?: AbortSignal
+  ) => {
+    const errorContext = `Uninstalling pack ${params.id}`
+    const routeSpecificErrors = {
+      403: GENERIC_SECURITY_ERR_MSG
+    }
+
+    return executeRequest<null>(
+      () => managerApiClient.post(ManagerRoute.UNINSTALL, params, { signal }),
+      { errorContext, routeSpecificErrors, isQueueOperation: true }
+    )
+  }
+
+  const disablePack = async (
+    params: ManagerPackInfo,
+    signal?: AbortSignal
+  ): Promise<null> => {
+    const errorContext = `Disabling pack ${params.id}`
+    const routeSpecificErrors = {
+      404: `Pack ${params.id} not found or not installed`,
+      409: `Pack ${params.id} is already disabled`
+    }
+
+    return executeRequest<null>(
+      () => managerApiClient.post(ManagerRoute.DISABLE, params, { signal }),
+      { errorContext, routeSpecificErrors, isQueueOperation: true }
+    )
+  }
+
+  const updatePack = async (
+    params: ManagerPackInfo,
+    signal?: AbortSignal
+  ): Promise<null> => {
+    const errorContext = `Updating pack ${params.id}`
+    const routeSpecificErrors = {
+      403: GENERIC_SECURITY_ERR_MSG
+    }
+
+    return executeRequest<null>(
+      () => managerApiClient.post(ManagerRoute.UPDATE, params, { signal }),
+      { errorContext, routeSpecificErrors, isQueueOperation: true }
+    )
+  }
+
+  const updateAllPacks = async (
+    params?: UpdateAllPacksParams,
+    signal?: AbortSignal
+  ) => {
+    const errorContext = 'Updating all packs'
+    const routeSpecificErrors = {
+      403: 'Forbidden: To use this action, a security_level of `middle or below` is required',
+      401: 'Unauthorized: ComfyUI-Manager job queue is busy'
+    }
+
+    return executeRequest<null>(
+      () => managerApiClient.get(ManagerRoute.UPDATE_ALL, { params, signal }),
+      { errorContext, routeSpecificErrors, isQueueOperation: true }
+    )
+  }
+
+  const rebootComfyUI = async (signal?: AbortSignal) => {
+    const errorContext = 'Rebooting ComfyUI'
+    const routeSpecificErrors = {
+      403: 'Forbidden: Rebooting ComfyUI requires security_level of middle or below'
+    }
+
+    return executeRequest<null>(
+      () => managerApiClient.get(ManagerRoute.REBOOT, { signal }),
+      { errorContext, routeSpecificErrors }
+    )
+  }
+
+  return {
+    // State
+    isLoading,
+    error,
+
+    // Queue operations
+    startQueue,
+    resetQueue,
+    getQueueStatus,
+
+    // Pack management
+    listInstalledPacks,
+    getImportFailInfo,
+    installPack,
+    uninstallPack,
+    enablePack: installPack, // enable is done via install
+    disablePack,
+    updatePack,
+    updateAllPacks,
+
+    // System operations
+    rebootComfyUI
+  }
+}

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -123,8 +123,8 @@ export type InstalledPacksResponse = Record<
  * Returned by `/customnode/getlist`
  */
 export interface ManagerPack extends ManagerPackInfo {
-  /** The github username of the pack author */
-  author: string
+  /** Pack author name or 'Unclaimed' if the pack was added automatically via GitHub crawl. */
+  author: components['schemas']['Node']['author']
   /** Files included in the pack */
   files: string[]
   /** The type of installation that was used to install the pack */

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -65,15 +65,13 @@ export enum ManagerChannel {
   TUTORIAL = 'tutorial'
 }
 
-export enum ManagerSourceMode {
+export enum ManagerDatabaseSource {
   /** Get pack info from the Comfy Registry */
   REMOTE = 'remote',
-  /** Get pack info from the custom-node-list.json file in the ComfyUI-Manager directory */
+  /** If set to `local`, the channel is ignored */
   LOCAL = 'local',
-  /** Get pack info from the cached response from the Comfy Registry */
-  CACHE = 'cache',
-  /** Get pack info from imported data */
-  IMPORTED = 'imported'
+  /** Get pack info from the cached response from the Comfy Registry (1 day TTL) */
+  CACHE = 'cache'
 }
 
 export interface ManagerQueueStatus {
@@ -163,9 +161,9 @@ export interface InstallPackParams extends ManagerPackInfo {
    */
   selected_version: WorkflowNodeProperties['ver'] | SelectedVersion
   /**
-   * The mode to install the node in.
+   * If set to `imported`, returns only the packs that were imported at app startup.
    */
-  mode: ManagerSourceMode
+  mode: 'imported' | null
   /**
    * The GitHub link to the repository of the node to install.
    * Required if `selected_version` is `nightly`.

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -3,7 +3,7 @@ import type { components } from '@/types/comfyRegistryTypes'
 
 type RegistryPack = components['schemas']['Node']
 type WorkflowNodeProperties = ComfyWorkflowJSON['nodes'][0]['properties']
-export type NodeField = keyof RegistryPack | null
+export type PackField = keyof RegistryPack | null
 
 export type PackWithSelectedVersion = {
   nodePack: RegistryPack
@@ -39,7 +39,7 @@ enum ManagerPackInstallType {
   GIT = 'git-clone',
   /** Installed via file copy */
   COPY = 'copy',
-  /** Installed from the Comfy Node Registry */
+  /** Installed from the Comfy Registry */
   REGISTRY = 'cnr'
 }
 

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -1,4 +1,14 @@
+import type { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import type { components } from '@/types/comfyRegistryTypes'
+
+type RegistryPack = components['schemas']['Node']
+type WorkflowNodeProperties = ComfyWorkflowJSON['nodes'][0]['properties']
+export type NodeField = keyof RegistryPack | null
+
+export type PackWithSelectedVersion = {
+  nodePack: RegistryPack
+  selectedVersion?: InstallPackParams['selected_version']
+}
 
 export interface TabItem {
   id: string
@@ -6,9 +16,167 @@ export interface TabItem {
   icon: string
 }
 
-export type NodeField = keyof components['schemas']['Node'] | null
-
 export interface SearchOption<T> {
   id: T
   label: string
+}
+
+enum ManagerPackState {
+  /** Pack is installed and enabled */
+  INSTALLED = 'installed',
+  /** Pack is installed but disabled */
+  DISABLED = 'disabled',
+  /** Pack is not installed */
+  NOT_INSTALLED = 'not_installed',
+  /** Pack failed to import */
+  IMPORT_FAILED = 'import_failed',
+  /** Pack has an update available */
+  NEEDS_UPDATE = 'needs_update'
+}
+
+enum ManagerPackInstallType {
+  /** Installed via git clone */
+  GIT = 'git-clone',
+  /** Installed via file copy */
+  COPY = 'copy',
+  /** Installed from the Comfy Node Registry */
+  REGISTRY = 'cnr'
+}
+
+export enum SelectedVersion {
+  /** Latest version of the pack from the registry */
+  LATEST = 'latest',
+  /** Latest commit of the pack from its GitHub repository */
+  NIGHTLY = 'nightly'
+}
+
+export enum ManagerChannel {
+  /** All packs except those with instability or security issues */
+  DEFAULT = 'default',
+  /** Packs that were recently updated */
+  RECENT = 'recent',
+  /** Packs that were superseded by distinct replacements of some type */
+  LEGACY = 'legacy',
+  /** Packs that were forked as a result of the original pack going unmaintained */
+  FORKED = 'forked',
+  /** Packs with instability or security issues suitable only for developers */
+  DEV = 'dev',
+  /** Packs suitable for beginners */
+  TUTORIAL = 'tutorial'
+}
+
+export enum ManagerSourceMode {
+  /** Get pack info from the Comfy Registry */
+  REMOTE = 'remote',
+  /** Get pack info from the custom-node-list.json file in the ComfyUI-Manager directory */
+  LOCAL = 'local',
+  /** Get pack info from the cached response from the Comfy Registry */
+  CACHE = 'cache',
+  /** Get pack info from imported data */
+  IMPORTED = 'imported'
+}
+
+export interface ManagerQueueStatus {
+  /** `done_count` + `in_progress_count` + number of items queued */
+  total_count: number
+  /** Task worker thread is alive, a queued operation is running */
+  is_processing: boolean
+  /** Number of items in the queue that have been completed */
+  done_count: number
+  /** Number of items in the queue that are currently running */
+  in_progress_count: number
+}
+
+export interface ManagerPackInfo {
+  /** Either github-author/github-repo or name of pack from the registry (not id) */
+  id: WorkflowNodeProperties['aux_id'] | WorkflowNodeProperties['cnr_id']
+  /** Semantic version or Git commit hash */
+  version: WorkflowNodeProperties['ver']
+}
+
+export interface ManagerPackInstalled {
+  /**
+   * The version of the pack that is installed.
+   * Git commit hash or semantic version.
+   */
+  ver: WorkflowNodeProperties['ver']
+  /**
+   * The name of the pack if the pack is installed from the registry.
+   * Corresponds to `Node#name` in comfy-api.
+   */
+  cnr_id: WorkflowNodeProperties['cnr_id']
+  /**
+   * The name of the pack if the pack is installed from github.
+   * In the format author/repo-name. If the pack is installed from the registry, this is `null`.
+   */
+  aux_id: WorkflowNodeProperties['aux_id'] | null
+  enabled: boolean
+}
+
+/**
+ * Returned by `/customnode/installed`
+ */
+export type InstalledPacksResponse = Record<
+  NonNullable<RegistryPack['name']>,
+  ManagerPackInstalled
+>
+
+/**
+ * Returned by `/customnode/getlist`
+ */
+export interface ManagerPack extends ManagerPackInfo {
+  /** The github username of the pack author */
+  author: string
+  /** Files included in the pack */
+  files: string[]
+  /** The type of installation that was used to install the pack */
+  reference: string
+  /** The display name of the pack */
+  title: string
+  /** The latest version of the pack */
+  cnr_latest: SelectedVersion
+  /** The github link to the repository of the pack */
+  repository: string
+  /** The state of the pack */
+  state: ManagerPackState
+  /** The state of the pack update */
+  'update-state': 'false' | 'true' | null
+  /** The number of stars the pack has on GitHub. Distinct from registry stars */
+  stars: number
+  /**
+   * The last time the pack was updated. In ISO 8601 format.
+   * @example '2024-05-22 20:00:00'
+   */
+  last_update: string
+  health: string
+  description: string
+  trust: boolean
+  install_type: ManagerPackInstallType
+}
+
+/**
+ * Payload for posting to `/manager/queue/install`
+ */
+export interface InstallPackParams extends ManagerPackInfo {
+  /**
+   * Semantic version, Git commit hash, `latest`, or `nightly`.
+   */
+  selected_version: WorkflowNodeProperties['ver'] | SelectedVersion
+  /**
+   * The mode to install the node in.
+   */
+  mode: ManagerSourceMode
+  /**
+   * The GitHub link to the repository of the node to install.
+   * Required if `selected_version` is `nightly`.
+   */
+  repository: string
+  /**
+   * List of PyPi dependencies associated with the node.
+   * Used to determine whether the node should be installed based on
+   * user's security level configuration and package whitelist/locks.
+   */
+  pip?: string[]
+  channel: ManagerChannel
+  skip_post_install?: boolean
 }

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -153,7 +153,22 @@ export interface ManagerPack extends ManagerPackInfo {
 }
 
 /**
- * Payload for posting to `/manager/queue/install`
+ * Returned by `/customnode/getmappings`.
+ */
+export type ManagerMappings = Record<
+  NonNullable<components['schemas']['Node']['name']>,
+  [
+    /** List of ComfyNode names included in the pack */
+    Array<components['schemas']['ComfyNode']['comfy_node_name']>,
+    {
+      /** The display name of the pack */
+      title_aux: string
+    }
+  ]
+>
+
+/**
+ * Payload for `/manager/queue/install`
  */
 export interface InstallPackParams extends ManagerPackInfo {
   /**
@@ -163,16 +178,15 @@ export interface InstallPackParams extends ManagerPackInfo {
   /**
    * If set to `imported`, returns only the packs that were imported at app startup.
    */
-  mode: 'imported' | null
+  mode?: 'imported' | 'default'
   /**
-   * The GitHub link to the repository of the node to install.
+   * The GitHub link to the repository of the pack to install.
    * Required if `selected_version` is `nightly`.
    */
   repository: string
   /**
-   * List of PyPi dependencies associated with the node.
-   * Used to determine whether the node should be installed based on
-   * user's security level configuration and package whitelist/locks.
+   * List of PyPi dependency names associated with the pack.
+   * Used in coordination with pip package whitelist and version lock features.
    */
   pip?: string[]
   channel: ManagerChannel

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -192,3 +192,10 @@ export interface InstallPackParams extends ManagerPackInfo {
   channel: ManagerChannel
   skip_post_install?: boolean
 }
+
+/**
+ * Params for `/manager/queue/update_all`
+ */
+export interface UpdateAllPacksParams {
+  mode?: ManagerDatabaseSource
+}


### PR DESCRIPTION
Adds service for making requests to ComfyUI-Manager API endpoints and handling errors. The error messages are taken from the ComfyUI-Manager source code.

Based on https://github.com/Comfy-Org/ComfyUI_frontend/pull/2967

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2968-Add-Comfy-Manager-service-1b36d73d3650810ab4cff898a0059f7a) by [Unito](https://www.unito.io)
