### PR TITLE
Fix manager info panel metadata text 

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/MetadataRow.vue
+++ b/src/components/dialog/content/manager/infoPanel/MetadataRow.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="flex py-1.5 text-xs">
-    <div class="w-1/3 text-color-secondary truncate pr-2 text-muted">
-      {{ label }}:
-    </div>
+    <div class="w-1/3 truncate pr-2 text-muted">{{ label }}:</div>
     <div class="w-2/3">
       <slot>{{ value }}</slot>
     </div>

--- a/src/components/dialog/content/manager/infoPanel/MetadataRow.vue
+++ b/src/components/dialog/content/manager/infoPanel/MetadataRow.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-const { value = 'N/A' } = defineProps<{
+const { value = 'N/A', label = 'N/A' } = defineProps<{
   label: string
   value?: string | number
 }>()


### PR DESCRIPTION
Removes non-existent `text-color-secondary` class and adds a fallback string for labels in info panel metadata rows.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2971-Fix-manager-info-panel-metadata-text-1b36d73d36508174a08be17591193c5f) by [Unito](https://www.unito.io)
