### PR TITLE
[Cleanup] Remove redundant reroute opt-in setting

### DIFF
--- a/src/composables/useLitegraphSettings.ts
+++ b/src/composables/useLitegraphSettings.ts
@@ -78,15 +78,6 @@ export const useLitegraphSettings = () => {
   })
 
   watchEffect(() => {
-    const reroutesEnabled = settingStore.get('Comfy.RerouteBeta')
-    const { canvas } = canvasStore
-    if (canvas) {
-      canvas.reroutesEnabled = reroutesEnabled
-      canvas.setDirty(false, true)
-    }
-  })
-
-  watchEffect(() => {
     const maximumFps = settingStore.get('LiteGraph.Canvas.MaximumFps')
     const { canvas } = canvasStore
     if (canvas) canvas.maximumFps = maximumFps

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -528,12 +528,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.RerouteBeta',
     category: ['LiteGraph', 'RerouteBeta'],
     name: 'Opt-in to the reroute beta test',
-    tooltip:
-      'Enables the new native reroutes.\n\nReroutes can be added by holding alt and dragging from a link line, or on the link menu.\n\nDisabling this option is non-destructive - reroutes are hidden.',
-    experimental: true,
+    tooltip: 'No longer has any effect; reroutes are always enabled.',
+    deprecated: true,
     type: 'boolean',
     defaultValue: false,
-    versionAdded: '1.3.42'
+    versionAdded: '1.3.42',
+    versionModified: '1.13.3'
   },
   {
     id: 'Comfy.Graph.LinkMarkers',

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -245,7 +245,7 @@
   },
   "Comfy_RerouteBeta": {
     "name": "Opt-in to the reroute beta test",
-    "tooltip": "Enables the new native reroutes.\n\nReroutes can be added by holding alt and dragging from a link line, or on the link menu.\n\nDisabling this option is non-destructive - reroutes are hidden."
+    "tooltip": "No longer has any effect; reroutes are always enabled."
   },
   "Comfy_Sidebar_Location": {
     "name": "Sidebar location",

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -332,6 +332,9 @@ export const useWorkflowService = () => {
       skip_events: true,
       skip_render: true
     })
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Temporary fix for Litegraph issue.
+    canvas.reroutesEnabled = true
     canvas.selectItems()
     canvas.copyToClipboard()
     app.canvas.pasteFromClipboard(options)

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -332,7 +332,6 @@ export const useWorkflowService = () => {
       skip_events: true,
       skip_render: true
     })
-    canvas.reroutesEnabled = app.canvas.reroutesEnabled
     canvas.selectItems()
     canvas.copyToClipboard()
     app.canvas.pasteFromClipboard(options)


### PR DESCRIPTION
Also removes supporting code for the now-removed reroute beta opt-in setting.

- Requires: https://github.com/Comfy-Org/litegraph.js/pull/747

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2972-Cleanup-Remove-redundant-reroute-opt-in-setting-1b36d73d36508123b27cef4c4c741bf2) by [Unito](https://www.unito.io)
