### PR TITLE
[Style] Fix registry search filter dropdown style

### DIFF
--- a/src/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue
@@ -6,10 +6,9 @@
       :options="options"
       optionLabel="label"
       optionValue="id"
-      class="min-w-[6rem]"
+      class="min-w-[6rem] border-none bg-transparent shadow-none"
       @change="handleChange"
       :pt="{
-        root: { class: 'border-none' },
         input: { class: 'py-0 px-1 border-none' },
         trigger: { class: 'hidden' },
         panel: { class: 'shadow-md' },


### PR DESCRIPTION
Removes bg-color and box shadow on search filter dropdown which is not supposed to be there.

Before (dark):

![Selection_1045](https://github.com/user-attachments/assets/b883598a-0d2d-42d5-b11d-2c301c7bf210)

After (dark):

![Selection_1043](https://github.com/user-attachments/assets/4bb957b5-a2f5-4c75-8714-7709d5c9f2d4)

Before (white):

![Selection_1046](https://github.com/user-attachments/assets/b6475a7d-894a-494e-9f5c-b9a5b98aa8e9)

After (white):

![Selection_1042](https://github.com/user-attachments/assets/82c24f21-d59c-4e1a-ae41-bc1860c64d17)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2974-Style-Fix-registry-search-filter-dropdown-style-1b36d73d36508178aa1cdb8bd123597c) by [Unito](https://www.unito.io)
