### PR TITLE
[Style] Remove underline hover effect in custom nodes manager

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/InfoTextSection.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoTextSection.vue
@@ -8,7 +8,7 @@
           :href="section.text"
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center gap-2 hover:underline"
+          class="flex items-center gap-2"
         >
           <i
             v-if="isGitHubLink(section.text)"

--- a/src/components/dialog/content/manager/infoPanel/MarkdownText.vue
+++ b/src/components/dialog/content/manager/infoPanel/MarkdownText.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="hover:underline">
+  <div>
     <div v-if="!hasMarkdown" v-text="text" class="break-words"></div>
     <div v-else class="break-words">
       <template v-for="(segment, index) in parsedSegments" :key="index">


### PR DESCRIPTION
Removes hover underline effect on info description hyperlinks. Hover effects should align with UI library or design spec which this effect does not.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2977-Style-Remove-underline-hover-effect-in-custom-nodes-manager-1b36d73d3650819ab5e2ed52682ea1db) by [Unito](https://www.unito.io)
