### PR TITLE
Standardise widgets - always initialize y to 0

### DIFF
--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -235,6 +235,7 @@ class ImagePreviewWidget implements ICustomWidget {
   readonly options: IWidgetOptions<unknown>
   // Dummy value to satisfy type requirements
   value: string
+  y: number = 0
 
   constructor(name: string, options: IWidgetOptions<unknown>) {
     this.type = 'custom'

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -69,6 +69,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
   readonly element: T
   readonly options: DOMWidgetOptions<T, V>
   computedHeight?: number
+  y: number = 0
   callback?: (value: V) => void
 
   readonly id: string


### PR DESCRIPTION
Widget `y` is no longer optional.  All widgets will initialize `y` to `0` instead of `undefined`.

- Ref: https://github.com/Comfy-Org/litegraph.js/pull/752

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2982-Standardise-widgets-always-initialize-y-to-0-1b36d73d365081ba9cccd701d2d8d780) by [Unito](https://www.unito.io)
