### PR TITLE
Vue component multi-select widget

### DIFF
--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -16,7 +16,7 @@ import { computed, watch } from 'vue'
 
 import DomWidget from '@/components/graph/widgets/DomWidget.vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import { DOMWidget } from '@/scripts/domWidget'
+import { BaseDOMWidget } from '@/scripts/domWidget'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useCanvasStore } from '@/stores/graphStore'
 
@@ -24,7 +24,7 @@ const domWidgetStore = useDomWidgetStore()
 const widgets = computed(() =>
   Array.from(
     domWidgetStore.widgetInstances.values() as Iterable<
-      DOMWidget<HTMLElement, object | string>
+      BaseDOMWidget<string | object>
     >
   )
 )

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -6,6 +6,7 @@
       :key="widget.id"
       :widget="widget"
       :widget-state="domWidgetStore.widgetStates.get(widget.id)"
+      @update:widget-value="widget.value = $event"
     />
   </div>
 </template>

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -5,7 +5,15 @@
     ref="widgetElement"
     :style="style"
     v-show="widgetState.visible"
-  />
+  >
+    <component
+      v-if="isComponentWidget(widget)"
+      :is="widget.component"
+      :modelValue="widget.value"
+      @update:modelValue="emit('update:widgetValue', $event)"
+      :widget="widget"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -15,7 +23,11 @@ import { CSSProperties, computed, onMounted, ref, watch } from 'vue'
 
 import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
 import { useDomClipping } from '@/composables/element/useDomClipping'
-import { type BaseDOMWidget, isDOMWidget } from '@/scripts/domWidget'
+import {
+  type BaseDOMWidget,
+  isComponentWidget,
+  isDOMWidget
+} from '@/scripts/domWidget'
 import { DomWidgetState } from '@/stores/domWidgetStore'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
@@ -23,6 +35,10 @@ import { useSettingStore } from '@/stores/settingStore'
 const { widget, widgetState } = defineProps<{
   widget: BaseDOMWidget<string | object>
   widgetState: DomWidgetState
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:widgetValue', value: string | object): void
 }>()
 
 const widgetElement = ref<HTMLElement>()

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -15,13 +15,13 @@ import { CSSProperties, computed, onMounted, ref, watch } from 'vue'
 
 import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
 import { useDomClipping } from '@/composables/element/useDomClipping'
-import type { DOMWidget } from '@/scripts/domWidget'
+import { type BaseDOMWidget, isDOMWidget } from '@/scripts/domWidget'
 import { DomWidgetState } from '@/stores/domWidgetStore'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
 
 const { widget, widgetState } = defineProps<{
-  widget: DOMWidget<HTMLElement, any>
+  widget: BaseDOMWidget<string | object>
   widgetState: DomWidgetState
 }>()
 
@@ -92,27 +92,31 @@ watch(
   }
 )
 
-if (widget.element.blur) {
-  useEventListener(document, 'mousedown', (event) => {
-    if (!widget.element.contains(event.target as HTMLElement)) {
-      widget.element.blur()
-    }
-  })
-}
+if (isDOMWidget(widget)) {
+  if (widget.element.blur) {
+    useEventListener(document, 'mousedown', (event) => {
+      if (!widget.element.contains(event.target as HTMLElement)) {
+        widget.element.blur()
+      }
+    })
+  }
 
-for (const evt of widget.options.selectOn ?? ['focus', 'click']) {
-  useEventListener(widget.element, evt, () => {
-    const lgCanvas = canvasStore.canvas
-    lgCanvas?.selectNode(widget.node)
-    lgCanvas?.bringToFront(widget.node)
-  })
+  for (const evt of widget.options.selectOn ?? ['focus', 'click']) {
+    useEventListener(widget.element, evt, () => {
+      const lgCanvas = canvasStore.canvas
+      lgCanvas?.selectNode(widget.node)
+      lgCanvas?.bringToFront(widget.node)
+    })
+  }
 }
 
 const inputSpec = widget.node.constructor.nodeData
 const tooltip = inputSpec?.inputs?.[widget.name]?.tooltip
 
 onMounted(() => {
-  widgetElement.value.appendChild(widget.element)
+  if (isDOMWidget(widget)) {
+    widgetElement.value.appendChild(widget.element)
+  }
 })
 </script>
 

--- a/src/components/graph/widgets/MultiSelectWidget.vue
+++ b/src/components/graph/widgets/MultiSelectWidget.vue
@@ -6,6 +6,7 @@
       filter
       :placeholder="placeholder"
       :maxSelectedLabels="3"
+      :display="display"
       class="w-full"
     />
   </div>
@@ -13,7 +14,6 @@
 
 <script setup lang="ts">
 import MultiSelect from 'primevue/multiselect'
-import { computed, defineModel } from 'vue'
 
 import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { ComponentWidget } from '@/scripts/domWidget'
@@ -22,10 +22,9 @@ const selectedItems = defineModel<string[]>({ required: true })
 const { widget } = defineProps<{
   widget: ComponentWidget<string[]>
 }>()
-const options = computed(
-  () => (widget.inputSpec as ComboInputSpec).options ?? []
-)
-const placeholder = computed(
-  () => (widget.inputSpec as ComboInputSpec).placeholder ?? 'Select items'
-)
+
+const inputSpec = widget.inputSpec as ComboInputSpec
+const options = inputSpec.options ?? []
+const placeholder = inputSpec.multi_select?.placeholder ?? 'Select items'
+const display = inputSpec.multi_select?.chip ? 'chip' : 'comma'
 </script>

--- a/src/components/graph/widgets/MultiSelectWidget.vue
+++ b/src/components/graph/widgets/MultiSelectWidget.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <MultiSelect
+      v-model="selectedItems"
+      :options="options"
+      filter
+      :placeholder="placeholder"
+      :maxSelectedLabels="3"
+      class="w-full"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import MultiSelect from 'primevue/multiselect'
+import { computed, defineModel } from 'vue'
+
+import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+const selectedItems = defineModel<string[]>({ required: true })
+const { widget } = defineProps<{
+  widget: ComponentWidget<string[]>
+}>()
+const options = computed(
+  () => (widget.inputSpec as ComboInputSpec).options ?? []
+)
+const placeholder = computed(
+  () => (widget.inputSpec as ComboInputSpec).placeholder ?? 'Select items'
+)
+</script>

--- a/src/composables/widgets/useComboWidget.ts
+++ b/src/composables/widgets/useComboWidget.ts
@@ -1,6 +1,8 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
 import type { IComboWidget } from '@comfyorg/litegraph/dist/types/widgets'
+import { ref } from 'vue'
 
+import MultiSelectWidget from '@/components/graph/widgets/MultiSelectWidget.vue'
 import { transformInputSpecV2ToV1 } from '@/schemas/nodeDef/migration'
 import {
   ComboInputSpec,
@@ -8,9 +10,15 @@ import {
   isComboInputSpec
 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import {
+  type BaseDOMWidget,
+  ComponentWidgetImpl,
+  addWidget
+} from '@/scripts/domWidget'
+import {
   type ComfyWidgetConstructorV2,
   addValueControlWidgets
 } from '@/scripts/widgets'
+import { generateUUID } from '@/utils/formatUtil'
 
 import { useRemoteWidget } from './useRemoteWidget'
 
@@ -21,6 +29,70 @@ const getDefaultValue = (inputSpec: ComboInputSpec) => {
   return undefined
 }
 
+const addMultiSelectWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
+  const widgetValue = ref<string[]>([])
+  const widget = new ComponentWidgetImpl({
+    id: generateUUID(),
+    node,
+    name: inputSpec.name,
+    component: MultiSelectWidget,
+    inputSpec,
+    options: {
+      getValue: () => widgetValue.value,
+      setValue: (value: string[]) => {
+        widgetValue.value = value
+      }
+    }
+  })
+  addWidget(node, widget as BaseDOMWidget<object | string>)
+  // TODO: Add remote support to multi-select widget
+  return widget
+}
+
+const addComboWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
+  const defaultValue = getDefaultValue(inputSpec)
+  const comboOptions = inputSpec.options ?? []
+  const widget = node.addWidget(
+    'combo',
+    inputSpec.name,
+    defaultValue,
+    () => {},
+    {
+      values: comboOptions
+    }
+  ) as IComboWidget
+
+  if (inputSpec.remote) {
+    const remoteWidget = useRemoteWidget({
+      remoteConfig: inputSpec.remote,
+      defaultValue,
+      node,
+      widget
+    })
+    if (inputSpec.remote.refresh_button) remoteWidget.addRefreshButton()
+
+    const origOptions = widget.options
+    widget.options = new Proxy(origOptions as Record<string | symbol, any>, {
+      get(target, prop: string | symbol) {
+        if (prop !== 'values') return target[prop]
+        return remoteWidget.getValue()
+      }
+    })
+  }
+
+  if (inputSpec.control_after_generate) {
+    widget.linkedWidgets = addValueControlWidgets(
+      node,
+      widget,
+      undefined,
+      undefined,
+      transformInputSpecV2ToV1(inputSpec)
+    )
+  }
+
+  return widget
+}
+
 export const useComboWidget = () => {
   const widgetConstructor: ComfyWidgetConstructorV2 = (
     node: LGraphNode,
@@ -29,48 +101,9 @@ export const useComboWidget = () => {
     if (!isComboInputSpec(inputSpec)) {
       throw new Error(`Invalid input data: ${inputSpec}`)
     }
-
-    const comboOptions = inputSpec.options ?? []
-    const defaultValue = getDefaultValue(inputSpec)
-
-    const widget = node.addWidget(
-      'combo',
-      inputSpec.name,
-      defaultValue,
-      () => {},
-      {
-        values: comboOptions
-      }
-    ) as IComboWidget
-
-    if (inputSpec.remote) {
-      const remoteWidget = useRemoteWidget({
-        remoteConfig: inputSpec.remote,
-        defaultValue,
-        node,
-        widget
-      })
-      if (inputSpec.remote.refresh_button) remoteWidget.addRefreshButton()
-
-      const origOptions = widget.options
-      widget.options = new Proxy(origOptions as Record<string | symbol, any>, {
-        get(target, prop: string | symbol) {
-          if (prop !== 'values') return target[prop]
-          return remoteWidget.getValue()
-        }
-      })
-    }
-
-    if (inputSpec.control_after_generate) {
-      widget.linkedWidgets = addValueControlWidgets(
-        node,
-        widget,
-        undefined,
-        undefined,
-        transformInputSpecV2ToV1(inputSpec)
-      )
-    }
-    return widget
+    return inputSpec.multi_select
+      ? addMultiSelectWidget(node, inputSpec)
+      : addComboWidget(node, inputSpec)
   }
 
   return widgetConstructor

--- a/src/composables/widgets/useComboWidget.ts
+++ b/src/composables/widgets/useComboWidget.ts
@@ -46,6 +46,7 @@ const addMultiSelectWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
   })
   addWidget(node, widget as BaseDOMWidget<object | string>)
   // TODO: Add remote support to multi-select widget
+  // https://github.com/Comfy-Org/ComfyUI_frontend/issues/3003
   return widget
 }
 

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -12,6 +12,10 @@ const zRemoteWidgetConfig = z.object({
   timeout: z.number().gte(0).optional(),
   max_retries: z.number().gte(0).optional()
 })
+const zMultiSelectOption = z.object({
+  placeholder: z.string().optional(),
+  chip: z.boolean().optional()
+})
 
 export const zBaseInputOptions = z
   .object({
@@ -74,9 +78,7 @@ export const zComboInputOptions = zBaseInputOptions.extend({
   options: z.array(zComboOption).optional(),
   remote: zRemoteWidgetConfig.optional(),
   /** Whether the widget is a multi-select widget. */
-  multi_select: z.boolean().optional(),
-  /** Placeholder when no item is selected in multi-select widget. */
-  placeholder: z.string().optional()
+  multi_select: zMultiSelectOption.optional()
 })
 
 const zIntInputSpec = z.tuple([z.literal('INT'), zIntInputOptions.optional()])

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -72,7 +72,11 @@ export const zComboInputOptions = zBaseInputOptions.extend({
   allow_batch: z.boolean().optional(),
   video_upload: z.boolean().optional(),
   options: z.array(zComboOption).optional(),
-  remote: zRemoteWidgetConfig.optional()
+  remote: zRemoteWidgetConfig.optional(),
+  /** Whether the widget is a multi-select widget. */
+  multi_select: z.boolean().optional(),
+  /** Placeholder when no item is selected in multi-select widget. */
+  placeholder: z.string().optional()
 })
 
 const zIntInputSpec = z.tuple([z.literal('INT'), zIntInputOptions.optional()])

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -5,6 +5,7 @@ import type {
   IWidgetOptions
 } from '@comfyorg/litegraph/dist/types/widgets'
 import _ from 'lodash'
+import type { Component } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
@@ -12,7 +13,7 @@ import { generateUUID } from '@/utils/formatUtil'
 
 export interface BaseDOMWidget<
   V extends object | string,
-  W extends BaseDOMWidget<V, W>
+  W extends BaseDOMWidget<V, W> = any
 > extends ICustomWidget {
   // ICustomWidget properties
   type: 'custom'
@@ -43,6 +44,14 @@ export interface DOMWidget<T extends HTMLElement, V extends object | string>
   inputEl?: T
 }
 
+/**
+ * A DOM widget that wraps a Vue component as a litegraph widget.
+ */
+export interface ComponentWidget<V extends object | string>
+  extends BaseDOMWidget<V, ComponentWidget<V>> {
+  component: Component
+}
+
 export interface DOMWidgetOptions<
   V extends object | string,
   W extends BaseDOMWidget<V, W>
@@ -70,6 +79,10 @@ export interface DOMWidgetOptions<
 export const isDOMWidget = <T extends HTMLElement, V extends object | string>(
   widget: IWidget
 ): widget is DOMWidget<T, V> => 'element' in widget && !!widget.element
+
+export const isComponentWidget = <V extends object | string>(
+  widget: IWidget
+): widget is ComponentWidget<V> => 'component' in widget && !!widget.component
 
 export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
   implements DOMWidget<T, V>

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -5,7 +5,7 @@ import type {
   IWidgetOptions
 } from '@comfyorg/litegraph/dist/types/widgets'
 import _ from 'lodash'
-import type { Component } from 'vue'
+import { type Component, toRaw } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -231,6 +231,10 @@ export class ComponentWidgetImpl<V extends object | string>
       maxHeight,
       minWidth: 0
     }
+  }
+
+  serializeValue(): V {
+    return toRaw(this.value)
   }
 }
 

--- a/src/stores/domWidgetStore.ts
+++ b/src/stores/domWidgetStore.ts
@@ -5,7 +5,7 @@ import { defineStore } from 'pinia'
 import { markRaw, ref } from 'vue'
 
 import type { PositionConfig } from '@/composables/element/useAbsolutePosition'
-import type { DOMWidget } from '@/scripts/domWidget'
+import type { BaseDOMWidget } from '@/scripts/domWidget'
 
 export interface DomWidgetState extends PositionConfig {
   visible: boolean
@@ -18,17 +18,15 @@ export const useDomWidgetStore = defineStore('domWidget', () => {
 
   // Map to reference actual widget instances
   // Widgets are stored as raw values to avoid reactivity issues
-  const widgetInstances = ref(
-    new Map<string, DOMWidget<HTMLElement, object | string>>()
-  )
+  const widgetInstances = ref(new Map<string, BaseDOMWidget<object | string>>())
 
   // Register a widget with the store
-  const registerWidget = <T extends HTMLElement, V extends object | string>(
-    widget: DOMWidget<T, V>
+  const registerWidget = <V extends object | string>(
+    widget: BaseDOMWidget<V>
   ) => {
     widgetInstances.value.set(
       widget.id,
-      markRaw(widget as unknown as DOMWidget<HTMLElement, object | string>)
+      markRaw(widget) as unknown as BaseDOMWidget<object | string>
     )
     widgetStates.value.set(widget.id, {
       visible: true,

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -134,7 +134,7 @@ declare module '@comfyorg/litegraph' {
       name: string,
       type: string,
       element: T,
-      options?: DOMWidgetOptions<T, V>
+      options?: DOMWidgetOptions<V, DOMWidget<T, V>>
     ): DOMWidget<T, V>
 
     animatedImages?: boolean

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -134,7 +134,7 @@ declare module '@comfyorg/litegraph' {
       name: string,
       type: string,
       element: T,
-      options?: DOMWidgetOptions<V, DOMWidget<T, V>>
+      options?: DOMWidgetOptions<V>
     ): DOMWidget<T, V>
 
     animatedImages?: boolean


### PR DESCRIPTION
```python
class MultiSelectNode:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "foo": ("COMBO", {"options": ["A", "B", "C"], "multi_select": True})
            }
        }

    RETURN_TYPES = ("STRING",)
    OUTPUT_IS_LIST = [True]
    FUNCTION = "multi_select_node"
    CATEGORY = "DevTools"
    DESCRIPTION = "A node that outputs a multi select type"

    def multi_select_node(self, foo: list[str]) -> list[str]:
        print(f"foo: {foo}")
        return (foo,)
```

![image](https://github.com/user-attachments/assets/9acfece6-b891-432c-8c62-4cf89ee56e11)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2987-Vue-component-multi-select-widget-1b36d73d365081ff8c93f7b81a4be52c) by [Unito](https://www.unito.io)
