### PR TITLE
Fix image not shown on PreviewImage

### DIFF
--- a/src/composables/node/useNodeCanvasImagePreview.ts
+++ b/src/composables/node/useNodeCanvasImagePreview.ts
@@ -15,9 +15,8 @@ export function useNodeCanvasImagePreview() {
    */
   function showCanvasImagePreview(node: LGraphNode) {
     if (!node.imgs?.length) return
-    if (!node.widgets) return
 
-    if (!node.widgets.find((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET)) {
+    if (!node.widgets?.find((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET)) {
       imagePreviewWidget(node, {
         type: 'IMAGE_PREVIEW',
         name: CANVAS_IMAGE_PREVIEW_WIDGET


### PR DESCRIPTION
When node is present on graph configure, its `widgets` won't be `undefined` because of `onGraphConfigured` patch:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/29df14f477cf9505ec7929598a7282df33e4ff7f/src/extensions/core/widgetInputs.ts#L778

If the node is not part of the workflow being configured on graph load, that patch doesn't execute. Then if there's no other widget inputs, `widgets` is `undefined`.

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/2985

I did not fix by puting `node.widgets ??= []` in node constuctor, since the property is optional so `undefined` is expected.