### PR TITLE
Wrap widget value in API format workflow

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -66,9 +66,12 @@ export const graphToPrompt = async (
         for (const [i, widget] of widgets.entries()) {
           if (!widget.name || widget.options?.serialize === false) continue
 
-          inputs[widget.name] = widget.serializeValue
+          const widgetValue = widget.serializeValue
             ? await widget.serializeValue(node, i)
             : widget.value
+          inputs[widget.name] = {
+            __value__: widgetValue
+          }
         }
       }
 

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -69,9 +69,16 @@ export const graphToPrompt = async (
           const widgetValue = widget.serializeValue
             ? await widget.serializeValue(node, i)
             : widget.value
-          inputs[widget.name] = {
-            __value__: widgetValue
-          }
+          // By default, Array values are reserved to represent node connections.
+          // We need to wrap the array as an object to avoid the misinterpretation
+          // of the array as a node connection.
+          // The backend automatically unwraps the object to an array during
+          // execution.
+          inputs[widget.name] = Array.isArray(widgetValue)
+            ? {
+                __value__: widgetValue
+              }
+            : widgetValue
         }
       }
 


### PR DESCRIPTION
Ref: https://github.com/comfyanonymous/ComfyUI/pull/7197

Wrap widget value in object to clearly distinguish between node connection. Note: the API format previously used will still be compatible after the change, but the API workflow format produced after the change won't be able to be used on previous ComfyUI versions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2989-Wrap-widget-value-in-API-format-workflow-1b36d73d365081188758c4196292e12a) by [Unito](https://www.unito.io)
