### PR TITLE
Whitelist RealESRGAN_x4Plus model

### DIFF
--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -52,7 +52,8 @@ const allowedSuffixes = ['.safetensors', '.sft']
 // Models that fail above conditions but are still allowed
 const whiteListedUrls = new Set([
   'https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt',
-  'https://huggingface.co/TencentARC/T2I-Adapter/resolve/main/models/t2iadapter_depth_sd14v1.pth?download=true'
+  'https://huggingface.co/TencentARC/T2I-Adapter/resolve/main/models/t2iadapter_depth_sd14v1.pth?download=true',
+  'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth'
 ])
 
 interface ModelInfo {


### PR DESCRIPTION
Whitelists the download link to RealESRGAN_x4Plus release from original authors, so that it can be downloaded via the missing models dialog.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2995-Whitelist-RealESRGAN_x4Plus-model-1b46d73d365081e0b2bad364d73e0dc9) by [Unito](https://www.unito.io)
