### PR TITLE
[Style] Improve error message in missing models dialog

### DIFF
--- a/src/components/common/FileDownload.vue
+++ b/src/components/common/FileDownload.vue
@@ -5,9 +5,20 @@
       <div class="file-details">
         <span class="file-type" :title="hint">{{ label }}</span>
       </div>
-      <div v-if="props.error" class="file-error">
+      <Message
+        v-if="props.error"
+        severity="error"
+        icon="pi pi-exclamation-triangle"
+        size="small"
+        variant="outlined"
+        class="h-min my-2 px-1 max-w-xs"
+        :title="props.error"
+        :pt="{
+          text: { class: 'overflow-hidden text-ellipsis' }
+        }"
+      >
         {{ props.error }}
-      </div>
+      </Message>
     </div>
     <div class="file-action">
       <Button
@@ -25,6 +36,7 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button'
+import Message from 'primevue/message'
 import { computed } from 'vue'
 
 import { useDownload } from '@/composables/useDownload'


### PR DESCRIPTION
Use the `Message` component which is used in other places for inline error messages (e.g., forms).

Before:

![Selection_1055](https://github.com/user-attachments/assets/8c7e434b-5166-4050-ad6b-953ac7e39480)

After:

![Selection_1056](https://github.com/user-attachments/assets/bebb70b5-f880-4401-8324-87e3755f4f1e)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-2997-Style-Improve-error-message-in-missing-models-dialog-1b46d73d365081e68aefd17473b0fe3c) by [Unito](https://www.unito.io)
