### PR TITLE
Rename 'ControlNet' template to 'Scribble ControlNet'

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -457,7 +457,7 @@
         "inpain_model_outpainting": "Outpaint"
       },
       "ControlNet": {
-        "controlnet_example": "ControlNet",
+        "controlnet_example": "Scribble ControlNet",
         "2_pass_pose_worship": "Pose ControlNet 2 Pass",
         "depth_controlnet": "Depth ControlNet",
         "depth_t2i_adapter": "Depth T2I Adapter",


### PR DESCRIPTION
Rename controlnet template to include "Scribble." It doesn't make sense for all controlnet templates to be named based on the controlnet model except the scribble example.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3000-Rename-ControlNet-template-to-Scribble-ControlNet-1b46d73d36508108b563ef69761f8375) by [Unito](https://www.unito.io)
