### PR TITLE
Fix download gated HF models

### DIFF
--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -365,3 +365,30 @@ export const isCivitaiModelUrl = (url: string): boolean => {
     /^\/api\/v1\/models-versions\/(\d+)$/.test(pathname)
   )
 }
+
+/**
+ * Converts a Hugging Face download URL to a repository page URL
+ * @param url The download URL to convert
+ * @returns The repository page URL or the original URL if conversion fails
+ * @example
+ * downloadUrlToHfRepoUrl(
+ *  'https://huggingface.co/bfl/FLUX.1/resolve/main/flux1-canny-dev.safetensors?download=true'
+ * ) // https://huggingface.co/bfl/FLUX.1
+ */
+export const downloadUrlToHfRepoUrl = (url: string): string => {
+  try {
+    const urlObj = new URL(url)
+    const pathname = urlObj.pathname
+
+    // Use regex to match everything before /resolve/ or /blob/
+    const regex = /^(.*?)(?:\/resolve\/|\/blob\/|$)/
+    const repoPathMatch = regex.exec(pathname)
+
+    // Extract the repository path and remove leading slash if present
+    const repoPath = repoPathMatch?.[1]?.replace(/^\//, '') || ''
+
+    return `https://huggingface.co/${repoPath}`
+  } catch (error) {
+    return url
+  }
+}


### PR DESCRIPTION
Fixes issue in which gated HF models give 401 when clicking Download button in missing models dialog. Gated models do not allow cross-origin so the fetch always throws error regardless of token or cookie. This PR adds check if error occurred and the url is an HF repo and handles it by sending the user to the repo directly when they click Download, instead of initiating a download that will fail.

> The downside is if the user is logged into HF(has access token in browser storage from recent <30days logging in) and has accepted the terms and conditions of the model already, they lose ability to 1-click download (for gated models specifically, not all downloads), but there doesn't seem to be a perfect solution.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3004-Fix-download-gated-HF-models-1b46d73d365081b392bdf53f58055886) by [Unito](https://www.unito.io)
