### PR TITLE
[Style] Remove unused classes

### DIFF
--- a/src/components/common/FileDownload.vue
+++ b/src/components/common/FileDownload.vue
@@ -1,9 +1,9 @@
 <!-- A file download button with a label and a size hint -->
 <template>
   <div class="flex flex-row items-center gap-2">
-    <div class="file-info">
-      <div class="file-details">
-        <span class="file-type" :title="hint">{{ label }}</span>
+    <div>
+      <div>
+        <span :title="hint">{{ label }}</span>
       </div>
       <Message
         v-if="props.error"
@@ -20,9 +20,8 @@
         {{ props.error }}
       </Message>
     </div>
-    <div class="file-action">
+    <div>
       <Button
-        class="file-action-button"
         :label="$t('g.download') + ' (' + fileSize + ')'"
         size="small"
         outlined


### PR DESCRIPTION
In https://github.com/Comfy-Org/ComfyUI_frontend/pull/1362, `FileDownload` component is extracted out from the missing models dialog. These CSS classes were removed in that PR and no longer exist in the codebase.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3005-Style-Remove-unused-classes-1b46d73d3650819a8e8cefe59884003a) by [Unito](https://www.unito.io)
