### PR TITLE
Add Comfy Manager store

### DIFF
--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -13,7 +13,7 @@ import {
 } from '@/types/comfyManagerTypes'
 
 /**
- * Store for managing node pack operations and install state
+ * Store for state of installed node packs
  */
 export const useComfyManagerStore = defineStore('comfyManager', () => {
   const managerService = useComfyManagerService()
@@ -39,16 +39,13 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
       enqueueTask({
         task: () => managerService.installPack(params, signal),
         onComplete: () => {
-          console.log('installPack onComplete')
           appNeedsRestart.value = true
-          console.log('installedPacks before', installedPacks.value)
           installedPacks.value[id] = {
             ver: params.version,
             cnr_id: params.id,
             aux_id: null,
             enabled: true
           }
-          console.log('installedPacks after', installedPacks.value)
         }
       })
     },

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -46,6 +46,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
             aux_id: null,
             enabled: true
           }
+          isStale.value = true
         }
       })
     },
@@ -64,6 +65,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
       onComplete: () => {
         appNeedsRestart.value = true
         delete installedPacks.value[id]
+        isStale.value = true
       }
     })
   }
@@ -80,6 +82,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
         onComplete: () => {
           appNeedsRestart.value = true
           installedPacks.value[id].ver = params.version
+          isStale.value = true
         }
       })
     },
@@ -108,6 +111,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
       onComplete: () => {
         appNeedsRestart.value = true
         installedPacks.value[id].enabled = false
+        isStale.value = true
       }
     })
   }

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -1,0 +1,148 @@
+import { whenever } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+import { useCachedRequest } from '@/composables/useCachedRequest'
+import { useManagerQueue } from '@/composables/useManagerQueue'
+import { useComfyManagerService } from '@/services/comfyManagerService'
+import {
+  InstallPackParams,
+  InstalledPacksResponse,
+  ManagerPackInfo,
+  UpdateAllPacksParams
+} from '@/types/comfyManagerTypes'
+
+/**
+ * Store for managing node pack operations and install state
+ */
+export const useComfyManagerStore = defineStore('comfyManager', () => {
+  const managerService = useComfyManagerService()
+  const installedPacks = ref<InstalledPacksResponse>({})
+  const isStale = ref(true)
+  const appNeedsRestart = ref(false)
+
+  const { statusMessage, allTasksDone, enqueueTask } = useManagerQueue()
+
+  const refreshInstalledList = async () => {
+    const packs = await managerService.listInstalledPacks()
+    if (packs) installedPacks.value = packs
+    isStale.value = false
+  }
+
+  whenever(isStale, refreshInstalledList, { immediate: true })
+
+  const installPack = useCachedRequest<InstallPackParams, void>(
+    async (params: InstallPackParams, signal?: AbortSignal) => {
+      const id = params.id
+      if (!id) return
+
+      enqueueTask({
+        task: () => managerService.installPack(params, signal),
+        onComplete: () => {
+          console.log('installPack onComplete')
+          appNeedsRestart.value = true
+          console.log('installedPacks before', installedPacks.value)
+          installedPacks.value[id] = {
+            ver: params.version,
+            cnr_id: params.id,
+            aux_id: null,
+            enabled: true
+          }
+          console.log('installedPacks after', installedPacks.value)
+        }
+      })
+    },
+    { maxSize: 1 }
+  )
+
+  const uninstallPack = (params: ManagerPackInfo, signal?: AbortSignal) => {
+    const id = params.id
+    if (!id) return
+
+    installPack.clear()
+    installPack.cancel()
+
+    enqueueTask({
+      task: () => managerService.uninstallPack(params, signal),
+      onComplete: () => {
+        appNeedsRestart.value = true
+        delete installedPacks.value[id]
+      }
+    })
+  }
+
+  const updatePack = useCachedRequest<ManagerPackInfo, void>(
+    async (params: ManagerPackInfo, signal?: AbortSignal) => {
+      const id = params.id
+      if (!id) return
+
+      updateAllPacks.clear()
+
+      enqueueTask({
+        task: () => managerService.updatePack(params, signal),
+        onComplete: () => {
+          appNeedsRestart.value = true
+          installedPacks.value[id].ver = params.version
+        }
+      })
+    },
+    { maxSize: 1 }
+  )
+
+  const updateAllPacks = useCachedRequest<UpdateAllPacksParams, void>(
+    async (params: UpdateAllPacksParams, signal?: AbortSignal) => {
+      enqueueTask({
+        task: () => managerService.updateAllPacks(params, signal),
+        onComplete: () => {
+          appNeedsRestart.value = true
+          isStale.value = true
+        }
+      })
+    },
+    { maxSize: 1 }
+  )
+
+  const disablePack = (params: ManagerPackInfo, signal?: AbortSignal) => {
+    const id = params.id
+    if (!id) return
+
+    enqueueTask({
+      task: () => managerService.disablePack(params, signal),
+      onComplete: () => {
+        appNeedsRestart.value = true
+        installedPacks.value[id].enabled = false
+      }
+    })
+  }
+
+  const isPackInstalled = (packName: string | undefined): boolean => {
+    if (!packName) return false
+    return !!installedPacks.value[packName]
+  }
+
+  const isPackEnabled = (packName: string | undefined): boolean => {
+    if (!packName) return false
+    return !!installedPacks.value[packName]?.enabled
+  }
+
+  return {
+    // Manager state
+    isLoading: managerService.isLoading,
+    error: managerService.error,
+    statusMessage,
+    allTasksDone,
+
+    // Installed packs state
+    installedPacks,
+    isPackInstalled,
+    isPackEnabled,
+
+    // Pack actions
+    installPack,
+    uninstallPack,
+    updatePack,
+    updateAllPacks,
+    disablePack,
+    enablePack: installPack // Enable is done via install endpoint with a disabled pack
+  }
+})


### PR DESCRIPTION
Adds store for holding installed node packs and global state of ComfyUI-Manager task queue.

In reality, ComfyUI-Manager process completely owns and dictates state of installed node packs, and the client store only tracks status of the Manager's task queue and whether the current response from the Manager is stale, as well as handling request deduplication.

Components will be responsible for handling the loading state between Manager request and response/message, inferred from queue status.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3007-Add-Comfy-Manager-store-1b46d73d365081dcb0a0cfaebfb8a745) by [Unito](https://www.unito.io)
