### PR TITLE
Fix name of SaveWEBM node for applying output filename text replacements

### DIFF
--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -11,7 +11,7 @@ app.registerExtension({
     if (
       nodeData.name === 'SaveImage' ||
       nodeData.name === 'SaveAnimatedWEBP' ||
-      nodeData.name === 'SaveAnimatedWEBM'
+      nodeData.name === 'SaveWEBM'
     ) {
       const onNodeCreated = nodeType.prototype.onNodeCreated
       // When the SaveImage node is created we want to override the serialization of the output name widget to run our S&R


### PR DESCRIPTION
The name of the core webm save node is actually SaveWEBM, not SaveAnimatedWEBM

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3021-Fix-name-of-SaveWEBM-node-for-applying-output-filename-text-replacements-1b56d73d3650819db21bc6698bd6f1e6) by [Unito](https://www.unito.io)
