### PR TITLE
Add workspace autosave functionality

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -755,5 +755,21 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'boolean',
     defaultValue: true,
     versionAdded: '1.10.5'
+  },
+  {
+    id: 'Comfy.Workflow.Autosave',
+    name: 'Autosave mode',
+    tooltip: 'Automatically save the workflow after a change is detected',
+    type: 'combo',
+    options: ['Disabled', 'After delay'], // Other modes may include onFocusChange and onWindowChange
+    defaultValue: 'Disabled'
+  },
+  {
+    id: 'Comfy.Workflow.AutosaveDelay',
+    name: 'Autosave delay (ms)',
+    tooltip:
+      'Delay in miliseconds after a change to autosave. Only applies if autosave mode is set to "After delay"',
+    type: 'number',
+    defaultValue: 1000
   }
 ]


### PR DESCRIPTION
hammering away...

is this already a feature? hard to imagine it not having being implemented already... i really want it at least.

also open to ideas on other autosaving modes. something like on tab change/window change/focus (?)?

would solve #1584

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3022-Add-workspace-autosave-functionality-1b56d73d3650812e941bfcd7fecefb5a) by [Unito](https://www.unito.io)
