### PR TITLE
Add enable/disable toggle to node pack info panel

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
@@ -5,8 +5,9 @@
       <div class="mb-6">
         <MetadataRow
           v-if="isPackInstalled(nodePack.id)"
-          class="flex gap-2 w-full justify-center"
           :label="t('manager.filter.enabled')"
+          class="flex"
+          style="align-items: center"
         >
           <PackEnableToggle :node-pack="nodePack" />
         </MetadataRow>

--- a/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
@@ -4,6 +4,13 @@
       <InfoPanelHeader :node-packs="[nodePack]" />
       <div class="mb-6">
         <MetadataRow
+          v-if="isPackInstalled(nodePack.id)"
+          class="flex gap-2 w-full justify-center"
+          :label="t('manager.filter.enabled')"
+        >
+          <PackEnableToggle :node-pack="nodePack" />
+        </MetadataRow>
+        <MetadataRow
           v-for="item in infoItems"
           v-show="item.value !== undefined && item.value !== null"
           :key="item.key"
@@ -34,9 +41,11 @@ import { useI18n } from 'vue-i18n'
 
 import PackStatusMessage from '@/components/dialog/content/manager/PackStatusMessage.vue'
 import PackVersionBadge from '@/components/dialog/content/manager/PackVersionBadge.vue'
+import PackEnableToggle from '@/components/dialog/content/manager/button/PackEnableToggle.vue'
 import InfoPanelHeader from '@/components/dialog/content/manager/infoPanel/InfoPanelHeader.vue'
 import InfoTabs from '@/components/dialog/content/manager/infoPanel/InfoTabs.vue'
 import MetadataRow from '@/components/dialog/content/manager/infoPanel/MetadataRow.vue'
+import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import { components } from '@/types/comfyRegistryTypes'
 
 interface InfoItem {
@@ -48,6 +57,8 @@ interface InfoItem {
 const { nodePack } = defineProps<{
   nodePack: components['schemas']['Node']
 }>()
+
+const { isPackInstalled } = useComfyManagerStore()
 
 const { t, d, n } = useI18n()
 


### PR DESCRIPTION
Adds enable/disable toggle to info panel. The toggle enables or disables the node pack via ComfyUI-Manager API.

![Selection_1073](https://github.com/user-attachments/assets/9cd5bb6f-d7a8-4592-b204-c6bc19c09ec7)


![Selection_1075](https://github.com/user-attachments/assets/f8be19a8-ad97-418c-a1b1-0b689955542c)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3026-Add-enable-disable-toggle-to-node-pack-info-panel-1b56d73d3650817cb6b5ef5c5021db55) by [Unito](https://www.unito.io)
