### PR TITLE
[Manager] Refactor node pack card footer to separate component

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -66,28 +66,7 @@
     </template>
     <template #footer>
       <ContentDivider :width="0.1" />
-      <div class="flex justify-between p-5 text-xs text-muted">
-        <div class="flex items-center gap-2 cursor-pointer">
-          <span v-if="nodePack.publisher?.name">
-            {{ nodePack.publisher.name }}
-          </span>
-          <PackVersionBadge v-if="isPackInstalled" :node-pack="nodePack" />
-          <span v-else-if="nodePack.latest_version">
-            {{ nodePack.latest_version.version }}
-          </span>
-        </div>
-        <div
-          v-if="nodePack.latest_version?.createdAt"
-          class="flex items-center gap-2 truncate"
-        >
-          {{ $t('g.updated') }}
-          {{
-            $d(new Date(nodePack.latest_version.createdAt), {
-              dateStyle: 'medium'
-            })
-          }}
-        </div>
-      </div>
+      <PackCardFooter :node-pack="nodePack" />
     </template>
   </Card>
 </template>
@@ -97,9 +76,9 @@ import Card from 'primevue/card'
 import { computed } from 'vue'
 
 import ContentDivider from '@/components/common/ContentDivider.vue'
-import PackVersionBadge from '@/components/dialog/content/manager/PackVersionBadge.vue'
 import PackEnableToggle from '@/components/dialog/content/manager/button/PackEnableToggle.vue'
 import PackInstallButton from '@/components/dialog/content/manager/button/PackInstallButton.vue'
+import PackCardFooter from '@/components/dialog/content/manager/packCard/PackCardFooter.vue'
 import PackIcon from '@/components/dialog/content/manager/packIcon/PackIcon.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import type { components } from '@/types/comfyRegistryTypes'

--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="flex justify-between p-5 text-xs text-muted">
+    <div class="flex items-center gap-2 cursor-pointer">
+      <span v-if="nodePack.publisher?.name">
+        {{ nodePack.publisher.name }}
+      </span>
+      <PackVersionBadge v-if="isPackInstalled" :node-pack="nodePack" />
+      <span v-else-if="nodePack.latest_version">
+        {{ nodePack.latest_version.version }}
+      </span>
+    </div>
+    <div
+      v-if="nodePack.latest_version?.createdAt"
+      class="flex items-center gap-2 truncate"
+    >
+      {{ $t('g.updated') }}
+      {{
+        $d(new Date(nodePack.latest_version.createdAt), {
+          dateStyle: 'medium'
+        })
+      }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import PackVersionBadge from '@/components/dialog/content/manager/PackVersionBadge.vue'
+import { useComfyManagerStore } from '@/stores/comfyManagerStore'
+import type { components } from '@/types/comfyRegistryTypes'
+
+const { nodePack } = defineProps<{
+  nodePack: components['schemas']['Node']
+}>()
+
+const managerStore = useComfyManagerStore()
+
+const isPackInstalled = computed(() =>
+  managerStore.isPackInstalled(nodePack?.id)
+)
+</script>

--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -4,7 +4,7 @@
       <span v-if="nodePack.publisher?.name">
         {{ nodePack.publisher.name }}
       </span>
-      <PackVersionBadge v-if="isPackInstalled" :node-pack="nodePack" />
+      <PackVersionBadge v-if="isInstalled" :node-pack="nodePack" />
       <span v-else-if="nodePack.latest_version">
         {{ nodePack.latest_version.version }}
       </span>
@@ -34,9 +34,6 @@ const { nodePack } = defineProps<{
   nodePack: components['schemas']['Node']
 }>()
 
-const managerStore = useComfyManagerStore()
-
-const isPackInstalled = computed(() =>
-  managerStore.isPackInstalled(nodePack?.id)
-)
+const { isPackInstalled } = useComfyManagerStore()
+const isInstalled = computed(() => isPackInstalled(nodePack?.id))
 </script>


### PR DESCRIPTION
Moves node pack card footer to its own component, as the card component is becoming large and the footer wants to be re-used elswhere.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3028-Manager-Refactor-node-pack-card-footer-to-separate-component-1b56d73d365081f1a26fe70166b76c7a) by [Unito](https://www.unito.io)
