### PR TITLE
Fix video preview widget computed min height

### DIFF
--- a/src/composables/node/useNodeImage.ts
+++ b/src/composables/node/useNodeImage.ts
@@ -7,7 +7,7 @@ const VIDEO_DEFAULT_OPTIONS = {
   playsInline: true,
   controls: true,
   loop: true
-}
+} as const
 const MEDIA_LOAD_TIMEOUT = 8192
 const MAX_RETRIES = 1
 const DEFAULT_VIDEO_SIZE = 256

--- a/src/composables/node/useNodeImage.ts
+++ b/src/composables/node/useNodeImage.ts
@@ -2,15 +2,15 @@ import type { LGraphNode } from '@comfyorg/litegraph'
 
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 
-const VIDEO_WIDGET_NAME = 'video-preview' as const
+const VIDEO_WIDGET_NAME = 'video-preview'
 const VIDEO_DEFAULT_OPTIONS = {
   playsInline: true,
   controls: true,
   loop: true
-} as const
-const MEDIA_LOAD_TIMEOUT = 8192 as const
-const MAX_RETRIES = 1 as const
-const VIDEO_PIXEL_OFFSET = 64 as const
+}
+const MEDIA_LOAD_TIMEOUT = 8192
+const MAX_RETRIES = 1
+const DEFAULT_VIDEO_SIZE = 256
 
 type MediaElement = HTMLImageElement | HTMLVideoElement
 
@@ -127,12 +127,26 @@ export const useNodeImage = (node: LGraphNode) => {
  */
 export const useNodeVideo = (node: LGraphNode) => {
   node.previewMediaType = 'video'
+  let minHeight = DEFAULT_VIDEO_SIZE
+  let minWidth = DEFAULT_VIDEO_SIZE
+
+  const setMinDimensions = (video: HTMLVideoElement) => {
+    const intrinsicAspectRatio = video.videoWidth / video.videoHeight
+    if (!intrinsicAspectRatio || isNaN(intrinsicAspectRatio)) return
+
+    // Set min. height s.t. video spans node's x-axis while maintaining aspect ratio
+    minWidth = node.size?.[0] || DEFAULT_VIDEO_SIZE
+    minHeight = Math.max(minWidth / intrinsicAspectRatio, DEFAULT_VIDEO_SIZE)
+  }
 
   const loadElement = (url: string): Promise<HTMLVideoElement | null> =>
     new Promise((resolve) => {
       const video = document.createElement('video')
       Object.assign(video, VIDEO_DEFAULT_OPTIONS)
-      video.onloadeddata = () => resolve(video)
+      video.onloadeddata = () => {
+        setMinDimensions(video)
+        resolve(video)
+      }
       video.onerror = () => resolve(null)
       video.src = url
     })
@@ -140,9 +154,13 @@ export const useNodeVideo = (node: LGraphNode) => {
   const addVideoDomWidget = (container: HTMLElement) => {
     const hasWidget = node.widgets?.some((w) => w.name === VIDEO_WIDGET_NAME)
     if (!hasWidget) {
-      node.addDOMWidget(VIDEO_WIDGET_NAME, 'video', container, {
+      const widget = node.addDOMWidget(VIDEO_WIDGET_NAME, 'video', container, {
         hideOnZoom: false,
         serialize: false
+      })
+      widget.computeLayoutSize = () => ({
+        minHeight,
+        minWidth
       })
     }
   }
@@ -157,7 +175,6 @@ export const useNodeVideo = (node: LGraphNode) => {
     }
 
     node.videoContainer.replaceChildren(videoElement)
-    node.imageOffset = VIDEO_PIXEL_OFFSET
   }
 
   return useNodePreview(node, {

--- a/src/composables/node/useNodeImage.ts
+++ b/src/composables/node/useNodeImage.ts
@@ -136,7 +136,7 @@ export const useNodeVideo = (node: LGraphNode) => {
 
     // Set min. height s.t. video spans node's x-axis while maintaining aspect ratio
     minWidth = node.size?.[0] || DEFAULT_VIDEO_SIZE
-    minHeight = Math.max(minWidth / intrinsicAspectRatio, DEFAULT_VIDEO_SIZE)
+    minHeight = Math.max(minWidth / intrinsicAspectRatio, 64)
   }
 
   const loadElement = (url: string): Promise<HTMLVideoElement | null> =>


### PR DESCRIPTION
Updates video widget to align with recent changes to widget layout system. The widget was not computing height in a good way to begin with and stopped working after https://github.com/Comfy-Org/ComfyUI_frontend/pull/2952 (v1.13.1). Currently it is always getting default value for computed size.

Before:


![Selection_1097](https://github.com/user-attachments/assets/4959eb7e-bc97-4d6e-b23c-b9eef51466e4)


After:

![Selection_1098](https://github.com/user-attachments/assets/1dc377e9-2b00-4fbb-a17a-923c7b64363e)


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3043-Fix-video-preview-widget-computed-min-height-1b66d73d365081f1a9a6e1c6be0d61c0) by [Unito](https://www.unito.io)
