### PR TITLE
Add pointer events back on video preview widget

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -533,6 +533,7 @@ dialog::backdrop {
 }
 
 .comfy-img-preview video {
+  pointer-events: auto;
   object-fit: contain;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
Adds pointer events back to video widgets so the video controls can be interactable again. 

Cause of bug:

- Image previews are put into container with class `.comfy-img-preview` which has `pointer-events: none` set in `style.css`
- `DOMWidgets.ts` sets pointer events back to auto during every draw: 
    ```ts
        Object.assign(this.element.style, {
          transformOrigin: '0 0',
          // ...
          pointerEvents: app.canvas.read_only ? 'none' : 'auto'
        })
    ```
- After https://github.com/Comfy-Org/ComfyUI_frontend/pull/2946 (v1.13.1), still setting `pointerEvents = 'auto'` in same way:
    https://github.com/Comfy-Org/ComfyUI_frontend/blob/9f0abac57ba0d5752c51198bf8a075b8336fdda1/src/components/graph/widgets/DomWidget.vue#L53 
- But now it gets set on a wrapper instead of the `div.comfy-img-preview`
- As a result, `div.comfy-img-preview`'s pointer events is no longer being overriden and the original `none` value persists, making element unclickable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3044-Add-pointer-events-back-on-video-preview-widget-1b66d73d3650817e931bea4ce2baf369) by [Unito](https://www.unito.io)
