### PR TITLE
[nit] add refresh button to workflow sidebar tab

### DIFF
--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -5,6 +5,13 @@
   >
     <template #tool-buttons>
       <Button
+        icon="pi pi-refresh"
+        @click="workflowStore.syncWorkflows()"
+        severity="secondary"
+        text
+        v-tooltip.bottom="$t('g.refresh')"
+      />
+      <Button
         class="browse-templates-button"
         icon="pi pi-th-large"
         severity="secondary"


### PR DESCRIPTION
A refresh button just like the model tab.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3062-nit-add-refresh-button-to-workflow-sidebar-tab-1b76d73d3650813a990ef41cd572fcb5) by [Unito](https://www.unito.io)
