### PR TITLE
Fix regression when configuring graph with missing converted input

### DIFF
--- a/browser_tests/assets/renamed_converted_widget.json
+++ b/browser_tests/assets/renamed_converted_widget.json
@@ -1,0 +1,101 @@
+{
+  "last_node_id": 4,
+  "last_link_id": 2,
+  "nodes": [
+    {
+      "id": 3,
+      "type": "EmptyLatentImage",
+      "pos": [
+        380.51641845703125,
+        191.39659118652344
+      ],
+      "size": [
+        315,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "breadth",
+          "type": "INT",
+          "widget": {
+            "name": "breadth"
+          },
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        512,
+        512,
+        1
+      ]
+    },
+    {
+      "id": 4,
+      "type": "PrimitiveNode",
+      "pos": [
+        73.6164321899414,
+        197.9966278076172
+      ],
+      "size": [
+        210,
+        82
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "widget": {
+            "name": "bredth"
+          },
+          "links": [
+            2
+          ]
+        }
+      ],
+      "title": "breadth",
+      "properties": {
+        "Run widget replace on values": false
+      },
+      "widgets_values": [
+        512,
+        "fixed"
+      ]
+    }
+  ],
+  "links": [
+    [
+      2,
+      4,
+      0,
+      3,
+      0,
+      "INT"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "VHS_latentpreview": true,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": false,
+    "VHS_KeepIntermediate": false
+  },
+  "version": 0.4
+}

--- a/browser_tests/nodeDisplay.spec.ts
+++ b/browser_tests/nodeDisplay.spec.ts
@@ -49,6 +49,13 @@ test.describe('Optional input', () => {
     expect(vaeInput.link).toBeNull()
     expect(convertedInput.link).not.toBeNull()
   })
+  test('Renamed converted input', async ({ comfyPage }) => {
+    await comfyPage.loadWorkflow('renamed_converted_widget')
+    const node = await comfyPage.getNodeRefById('3')
+    const inputs = await node.getProperty('inputs')
+    const renamedInput = inputs.find((w) => w.name === 'breadth')
+    expect(renamedInput).toBeNull()
+  })
   test('slider', async ({ comfyPage }) => {
     await comfyPage.loadWorkflow('simple_slider')
     await expect(comfyPage.canvas).toHaveScreenshot('simple_slider.png')

--- a/browser_tests/nodeDisplay.spec.ts
+++ b/browser_tests/nodeDisplay.spec.ts
@@ -54,7 +54,7 @@ test.describe('Optional input', () => {
     const node = await comfyPage.getNodeRefById('3')
     const inputs = await node.getProperty('inputs')
     const renamedInput = inputs.find((w) => w.name === 'breadth')
-    expect(renamedInput).toBeNull()
+    expect(renamedInput).toBeUndefined()
   })
   test('slider', async ({ comfyPage }) => {
     await comfyPage.loadWorkflow('simple_slider')

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -805,7 +805,7 @@ app.registerExtension({
           if (w) {
             hideWidget(this, w)
           } else {
-            convertToWidget(this, w)
+            this.removeInput(this.inputs.findIndex((i) => i === input))
           }
         }
       }


### PR DESCRIPTION
#2793 changes a convertToWidget call to take a widget which was just established as undefined instead of input. As this widget is null, the subsequent showWidget call raises an error. Prior to this change, when convertToWidget is called with a nodeInputSlot instead of an widget, showWidget is a no-op, the passed input is removed (as it matches its own name),  and widgets are shifted up to account for the removed input (which seemingly has no affect as heights are recalculated on the next draw call).

This null check and call to convertToWidget originates in ComfyUI commit 44b6eaad6. As this was committed soon after the introduction of widget inputs, I am not aware of a non-artificial core only reproduction workflow

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3066-Fix-regression-when-configuring-graph-with-missing-converted-input-1b76d73d365081b4bf80e59ca8c6474d) by [Unito](https://www.unito.io)
