### PR TITLE
Fix the litegraph context menu missing prototype after adding translation

### DIFF
--- a/src/composables/useContextMenuTranslation.ts
+++ b/src/composables/useContextMenuTranslation.ts
@@ -101,4 +101,5 @@ export const useContextMenuTranslation = () => {
   }
 
   LiteGraph.ContextMenu = ContextMenu as unknown as typeof LiteGraph.ContextMenu
+  LiteGraph.ContextMenu.prototype = OriginalContextMenu.prototype
 }


### PR DESCRIPTION
The custom nodes from Easy-Use, ComfyUI-Custom-Scripts and RGthree have integrated the preview of images on context menu.
But since v1.9.3, it not working. Everyone loved this feature and didn’t want it to be removed.
I checked the code today and guessed that this might be an omission.

Before:
<img width="397" alt="截屏2025-03-16 18 13 19" src="https://github.com/user-attachments/assets/1b9db760-cac4-4741-ac6c-93e95f2e49de" />
After:
<img width="485" alt="截屏2025-03-16 18 13 39" src="https://github.com/user-attachments/assets/8a8e91ae-ca1b-466e-ac56-07b004204e15" />
Example of this function working correctly:
<img width="628" alt="截屏2025-03-16 18 35 51" src="https://github.com/user-attachments/assets/be4b26a5-7e66-4452-9916-ef67a21fd498" />

Some Issues about this:
https://github.com/Comfy-Org/ComfyUI_frontend/issues/2618
https://github.com/yolain/ComfyUI-Easy-Use/issues/669
https://github.com/pythongosssss/ComfyUI-Custom-Scripts/issues/440

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3080-Fix-the-litegraph-context-menu-missing-prototype-after-adding-translation-1b86d73d3650815b95e6c7b9661b3819) by [Unito](https://www.unito.io)
