### PR TITLE
[Manager] Wrap manager requests with log wrapper

### DIFF
--- a/src/composables/useManagerQueue.ts
+++ b/src/composables/useManagerQueue.ts
@@ -20,6 +20,9 @@ export const useManagerQueue = () => {
   const clientQueueLength = computed(() => clientQueueItems.value.length)
   const onCompletedQueue = ref<((() => void) | undefined)[]>([])
   const onCompleteWaitingCount = ref(0)
+  const uncompletedCount = computed(
+    () => clientQueueLength.value + onCompleteWaitingCount.value
+  )
 
   const serverQueueStatus = ref<ManagerWsQueueStatus>(ManagerWsQueueStatus.DONE)
   const isServerIdle = computed(
@@ -93,6 +96,7 @@ export const useManagerQueue = () => {
     allTasksDone,
     statusMessage: readonly(serverQueueStatus),
     queueLength: clientQueueLength,
+    uncompletedCount,
 
     enqueueTask,
     clearQueue,

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -137,7 +137,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
         const installedPack = installedPacks.value[params.id]
 
         if (installedPack && installedPack.ver !== params.selected_version) {
-          actionDescription = `Updating from ${installedPack.ver} to ${params.selected_version}`
+          actionDescription = `Changing version from ${installedPack.ver} to ${params.selected_version}:`
         } else {
           actionDescription = 'Enabling'
         }

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -4,7 +4,9 @@ import { ref, watch } from 'vue'
 
 import { useCachedRequest } from '@/composables/useCachedRequest'
 import { useManagerQueue } from '@/composables/useManagerQueue'
+import { useServerLogs } from '@/composables/useServerLogs'
 import { useComfyManagerService } from '@/services/comfyManagerService'
+import { TaskLog } from '@/types/comfyManagerTypes'
 import {
   InstallPackParams,
   InstalledPacksResponse,
@@ -23,8 +25,10 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
   const disabledPacksIds = ref<Set<string>>(new Set())
   const installedPacksIds = ref<Set<string>>(new Set())
   const isStale = ref(true)
+  const taskLogs = ref<TaskLog[]>([])
 
-  const { statusMessage, allTasksDone, enqueueTask } = useManagerQueue()
+  const { statusMessage, allTasksDone, enqueueTask, uncompletedCount } =
+    useManagerQueue()
 
   const setStale = () => {
     isStale.value = true
@@ -107,12 +111,29 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
 
   whenever(isStale, refreshInstalledList, { immediate: true })
 
+  const withLogs = (task: () => Promise<null>, taskName: string) => {
+    const { startListening, stopListening, logs } = useServerLogs({
+      immediate: true
+    })
+
+    const loggedTask = async () => {
+      taskLogs.value.push({ taskName, logs: logs.value })
+      startListening()
+      return task()
+    }
+
+    const onComplete = () => {
+      stopListening()
+      setStale()
+    }
+
+    return { task: loggedTask, onComplete }
+  }
+
   const installPack = useCachedRequest<InstallPackParams, void>(
     async (params: InstallPackParams, signal?: AbortSignal) => {
-      enqueueTask({
-        task: () => managerService.installPack(params, signal),
-        onComplete: setStale
-      })
+      const task = () => managerService.installPack(params, signal)
+      enqueueTask(withLogs(task, 'Installing pack'))
     },
     { maxSize: 1 }
   )
@@ -120,41 +141,34 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
   const uninstallPack = (params: ManagerPackInfo, signal?: AbortSignal) => {
     installPack.clear()
     installPack.cancel()
-
-    enqueueTask({
-      task: () => managerService.uninstallPack(params, signal),
-      onComplete: setStale
-    })
+    const task = () => managerService.uninstallPack(params, signal)
+    enqueueTask(withLogs(task, 'Uninstalling pack'))
   }
 
   const updatePack = useCachedRequest<ManagerPackInfo, void>(
     async (params: ManagerPackInfo, signal?: AbortSignal) => {
-      updateAllPacks.clear()
       updateAllPacks.cancel()
-
-      enqueueTask({
-        task: () => managerService.updatePack(params, signal),
-        onComplete: setStale
-      })
+      const task = () => managerService.updatePack(params, signal)
+      enqueueTask(withLogs(task, 'Updating pack'))
     },
     { maxSize: 1 }
   )
 
   const updateAllPacks = useCachedRequest<UpdateAllPacksParams, void>(
     async (params: UpdateAllPacksParams, signal?: AbortSignal) => {
-      enqueueTask({
-        task: () => managerService.updateAllPacks(params, signal),
-        onComplete: setStale
-      })
+      const task = () => managerService.updateAllPacks(params, signal)
+      enqueueTask(withLogs(task, 'Updating all packs'))
     },
     { maxSize: 1 }
   )
 
   const disablePack = (params: ManagerPackInfo, signal?: AbortSignal) => {
-    enqueueTask({
-      task: () => managerService.disablePack(params, signal),
-      onComplete: setStale
-    })
+    const task = () => managerService.disablePack(params, signal)
+    enqueueTask(withLogs(task, 'Disabling pack'))
+  }
+
+  const clearLogs = () => {
+    taskLogs.value = []
   }
 
   return {
@@ -163,6 +177,9 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     error: managerService.error,
     statusMessage,
     allTasksDone,
+    uncompletedCount,
+    taskLogs,
+    clearLogs,
 
     // Installed packs state
     installedPacks,

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -16,6 +16,11 @@ export interface SearchOption<T> {
   label: string
 }
 
+export type TaskLog = {
+  taskName: string
+  logs: string[]
+}
+
 enum ManagerPackState {
   /** Pack is installed and enabled */
   INSTALLED = 'installed',


### PR DESCRIPTION
Uses server log listener added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/3074 to wrap manager request functions with log listener. Example of the `taskLogs` after using the Manager to do some thing:

```typescript
[
  {
    "taskName": "Uninstalling comfyui-custom-scripts",
    "logs": [
      "\n[ComfyUI-Manager] Queued works are completed.\n{'uninstall': 1}\n",
      "\nAfter restarting ComfyUI, please refresh the browser.\n"
    ]
  },
  {
    "taskName": "Disabling comfyui-easy-use",
    "logs": [
      "\n[ComfyUI-Manager] Queued works are completed.\n{'disable': 1}\n",
      "\nAfter restarting ComfyUI, please refresh the browser.\n"
    ]
  },
  {
    "taskName": "Installing comfyui-custom-scripts",
    "logs": [
      "\n\n\nAttempting cnr install: comfyui-custom-scripts@1.1.1 => unknown => return\n",
      "Downloading https://storage.googleapis.com/comfy-registry/pythongosssss/comfyui-custom-scripts/1.1.1/node.zip to /home/c_byrne/projects/comfy-testing-environment/ComfyUI/custom_nodes/CNR_temp_8fe00324-7a0f-419d-ae73-460069c830a1.zip",
      "\r  0%|                                                                                | 0.00/159k [00:00<?, ?B/s]",
      "\r100%|████████████████████████████████████████████████████████████████████████| 159k/159k [00:00<00:00, 1.61MB/s]",
      "Extracted zip file to /home/c_byrne/projects/comfy-testing-environment/ComfyUI/custom_nodes/comfyui-custom-scripts\n",
      "cnr install successful: comfyui-custom-scripts@1.1.1 => \n/home/c_byrne/projects/comfy-testing-environment/ComfyUI/custom_nodes/comfyui-custom-scripts => return\n",
      "\n[ComfyUI-Manager] Queued works are completed.\n{'install': 1}\n",
      "\nAfter restarting ComfyUI, please refresh the browser.\n"
    ]
  },
  {
    "taskName": "Installing cg-use-everywhere",
    "logs": [
      "\n\n\nAttempting cnr install: cg-use-everywhere@5.0.8 => unknown => return\n",
      "Downloading https://storage.googleapis.com/comfy-registry/chrisgoringe/cg-use-everywhere/5.0.8/node.zip to /home/c_byrne/projects/comfy-testing-environment/ComfyUI/custom_nodes/CNR_temp_4f93686f-f22c-447c-9ffc-884c264e2e23.zip",
      "\r  0%|                                                                               | 0.00/6.57M [00:00<?, ?B/s]",
      "\r  2%|█▊                                                                     | 164k/6.57M [00:00<00:04, 1.57MB/s]",
      "\r 21%|███████████████                                                       | 1.41M/6.57M [00:00<00:00, 7.85MB/s]",
      "\r 89%|██████████████████████████████████████████████████████████████▍       | 5.87M/6.57M [00:00<00:00, 24.4MB/s]",
      "\r100%|██████████████████████████████████████████████████████████████████████| 6.57M/6.57M [00:00<00:00, 20.5MB/s]",
      "Extracted zip file to /home/c_byrne/projects/comfy-testing-environment/ComfyUI/custom_nodes/cg-use-everywhere\n",
      "cnr install successful: cg-use-everywhere@5.0.8 => \n/home/c_byrne/projects/comfy-testing-environment/ComfyUI/custom_nodes/cg-use-everywhere => return\n",
      "\n[ComfyUI-Manager] Queued works are completed.\n{'install': 1}\n",
      "\nAfter restarting ComfyUI, please refresh the browser.\n"
    ]
  },
  {
    "taskName": "Uninstalling comfyui-custom-scripts",
    "logs": [
      "\n[ComfyUI-Manager] Queued works are completed.\n{'uninstall': 1}\n",
      "\nAfter restarting ComfyUI, please refresh the browser.\n"
    ]
  }
]
```

This can be used to render progress feedback UI components.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3081-Manager-Wrap-manager-requests-with-log-wrapper-1b86d73d365081b6a1b7ca70f471ed5c) by [Unito](https://www.unito.io)
