### PR TITLE
[Test] Update expectation - graph ID

### DIFF
--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -573,6 +573,8 @@ test.describe('Menu', () => {
       })
 
       // Compare the exported workflow with the original
+      delete downloadedContent.id
+      delete downloadedContentZh.id
       expect(downloadedContent).toBeDefined()
       expect(downloadedContent).toEqual(downloadedContentZh)
     })


### PR DESCRIPTION
Update test expectation to ignore auto-generated graph IDs.

- Ref: https://github.com/Comfy-Org/litegraph.js/pull/790

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3083-Test-Update-expectation-graph-ID-1b86d73d36508155b289eee3450a3a62) by [Unito](https://www.unito.io)
