### PR TITLE
Remove duplicated toolbuttons for workflow sidebar

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -95,18 +95,6 @@ export class WorkflowsSidebarTab extends SidebarTab {
     return this.page.locator('.workflows-sidebar-tab')
   }
 
-  get browseGalleryButton() {
-    return this.root.locator('.browse-templates-button')
-  }
-
-  get newBlankWorkflowButton() {
-    return this.root.locator('.new-blank-workflow-button')
-  }
-
-  get openWorkflowButton() {
-    return this.root.locator('.open-workflow-button')
-  }
-
   async getOpenedWorkflowNames() {
     return await this.root
       .locator('.comfyui-workflows-open .node-label')

--- a/browser_tests/interaction.spec.ts
+++ b/browser_tests/interaction.spec.ts
@@ -673,7 +673,7 @@ test.describe('Load duplicate workflow', () => {
   }) => {
     await comfyPage.loadWorkflow('single_ksampler')
     await comfyPage.menu.workflowsTab.open()
-    await comfyPage.menu.workflowsTab.newBlankWorkflowButton.click()
+    await comfyPage.executeCommand('Comfy.NewBlankWorkflow')
     await comfyPage.loadWorkflow('single_ksampler')
     expect(await comfyPage.getGraphNodesCount()).toBe(1)
   })

--- a/browser_tests/menu.spec.ts
+++ b/browser_tests/menu.spec.ts
@@ -397,7 +397,7 @@ test.describe('Menu', () => {
         '*Unsaved Workflow.json'
       ])
 
-      await tab.newBlankWorkflowButton.click()
+      await comfyPage.executeCommand('Comfy.NewBlankWorkflow')
       expect(await tab.getOpenedWorkflowNames()).toEqual([
         '*Unsaved Workflow.json',
         '*Unsaved Workflow (2).json'
@@ -496,7 +496,7 @@ test.describe('Menu', () => {
     })
 
     test('Can save workflow as', async ({ comfyPage }) => {
-      await comfyPage.menu.workflowsTab.newBlankWorkflowButton.click()
+      await comfyPage.executeCommand('Comfy.NewBlankWorkflow')
       await comfyPage.menu.topbar.saveWorkflowAs('workflow3.json')
       expect(
         await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()
@@ -620,7 +620,7 @@ test.describe('Menu', () => {
 
       // Load blank workflow
       await comfyPage.menu.workflowsTab.open()
-      await comfyPage.menu.workflowsTab.newBlankWorkflowButton.click()
+      await comfyPage.executeCommand('Comfy.NewBlankWorkflow')
 
       // Switch back to the missing_nodes workflow
       await comfyPage.menu.workflowsTab.switchToWorkflow('missing_nodes')

--- a/browser_tests/templates.spec.ts
+++ b/browser_tests/templates.spec.ts
@@ -57,13 +57,13 @@ test.describe('Templates', () => {
   test('Can load template workflows', async ({ comfyPage }) => {
     // Clear the workflow
     await comfyPage.menu.workflowsTab.open()
-    await comfyPage.menu.workflowsTab.newBlankWorkflowButton.click()
+    await comfyPage.executeCommand('Comfy.NewBlankWorkflow')
     await expect(async () => {
       expect(await comfyPage.getGraphNodesCount()).toBe(0)
     }).toPass({ timeout: 250 })
 
     // Load a template
-    await comfyPage.menu.workflowsTab.browseGalleryButton.click()
+    await comfyPage.executeCommand('Comfy.BrowseTemplates')
     await expect(comfyPage.templates.content).toBeVisible()
     await comfyPage.templates.loadTemplate('default')
     await expect(comfyPage.templates.content).toBeHidden()

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -11,30 +11,6 @@
         text
         v-tooltip.bottom="$t('g.refresh')"
       />
-      <Button
-        class="browse-templates-button"
-        icon="pi pi-th-large"
-        severity="secondary"
-        v-tooltip.bottom="$t('sideToolbar.browseTemplates')"
-        text
-        @click="() => commandStore.execute('Comfy.BrowseTemplates')"
-      />
-      <Button
-        class="open-workflow-button"
-        icon="pi pi-folder-open"
-        severity="secondary"
-        v-tooltip.bottom="$t('sideToolbar.openWorkflow')"
-        text
-        @click="() => commandStore.execute('Comfy.OpenWorkflow')"
-      />
-      <Button
-        class="new-blank-workflow-button"
-        icon="pi pi-plus"
-        severity="secondary"
-        v-tooltip.bottom="$t('sideToolbar.newBlankWorkflow')"
-        @click="() => commandStore.execute('Comfy.NewBlankWorkflow')"
-        text
-      />
     </template>
     <template #header>
       <SearchBox


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/3062

All actions can be accessed via the workflows topbar menu dropdown now. Removing these tool buttons to leave space for the up-coming new folder button.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3087-Remove-duplicated-toolbuttons-for-workflow-sidebar-1b86d73d3650812a9a45e6e47b358e93) by [Unito](https://www.unito.io)
