### PR TITLE
Allow footer component and position props in dialogs

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -25,6 +25,10 @@
       v-bind="item.contentProps"
       :maximized="item.dialogComponentProps.maximized"
     />
+
+    <template #footer v-if="item.footerComponent">
+      <component :is="item.footerComponent" />
+    </template>
   </Dialog>
 </template>
 

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -7,11 +7,24 @@ import { type Component, markRaw, ref } from 'vue'
 
 import type GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 
+type DialogPosition =
+  | 'center'
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'topleft'
+  | 'topright'
+  | 'bottomleft'
+  | 'bottomright'
+
 interface CustomDialogComponentProps {
   maximizable?: boolean
   maximized?: boolean
   onClose?: () => void
   closable?: boolean
+  modal?: boolean
+  position?: DialogPosition
   pt?: DialogPassThroughOptions
 }
 
@@ -25,6 +38,7 @@ interface DialogInstance {
   headerComponent?: Component
   component: Component
   contentProps: Record<string, any>
+  footerComponent?: Component
   dialogComponentProps: DialogComponentProps
 }
 
@@ -32,6 +46,7 @@ export interface ShowDialogOptions {
   key?: string
   title?: string
   headerComponent?: Component
+  footerComponent?: Component
   component: Component
   props?: Record<string, any>
   dialogComponentProps?: DialogComponentProps
@@ -66,6 +81,7 @@ export const useDialogStore = defineStore('dialog', () => {
     key: string
     title?: string
     headerComponent?: Component
+    footerComponent?: Component
     component: Component
     props?: Record<string, any>
     dialogComponentProps?: DialogComponentProps
@@ -80,6 +96,9 @@ export const useDialogStore = defineStore('dialog', () => {
       title: options.title,
       headerComponent: options.headerComponent
         ? markRaw(options.headerComponent)
+        : undefined,
+      footerComponent: options.footerComponent
+        ? markRaw(options.footerComponent)
         : undefined,
       component: markRaw(options.component),
       contentProps: { ...options.props },


### PR DESCRIPTION
Adds option types from PrimeVue Dialog prop and adds `footerComponent` prop which gets passed to footer slot if it was included in `showDialog` args.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3090-Allow-footer-component-and-position-props-in-dialogs-1b96d73d365081f9b6ede5ce30e81491) by [Unito](https://www.unito.io)
