### PR TITLE
[Manager] Fix registry search results flashing screen

### DIFF
--- a/src/composables/useRegistrySearch.ts
+++ b/src/composables/useRegistrySearch.ts
@@ -10,7 +10,7 @@ import {
 import type { NodesIndexSuggestion } from '@/services/algoliaSearchService'
 import { PackField } from '@/types/comfyManagerTypes'
 
-const SEARCH_DEBOUNCE_TIME = 16
+const SEARCH_DEBOUNCE_TIME = 256
 const DEFAULT_PAGE_SIZE = 64
 
 /**


### PR DESCRIPTION
Increases debounce on registry search. Algolia returns search results in <1ms so if the input is not debounced, results re-render too many times per second and create painful screen flash effect. Resolves https://github.com/Comfy-Org/ComfyUI_frontend/pull/3041#pullrequestreview-2685954660

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3092-Manager-Fix-registry-search-results-flashing-screen-1b96d73d3650813ca643dc9a557b8b3f) by [Unito](https://www.unito.io)
