### PR TITLE
[Manager] Remove shadows on version selector list

### DIFF
--- a/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
+++ b/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
@@ -25,7 +25,7 @@
       option-value="value"
       :options="allVersionOptions"
       :highlight-on-select="false"
-      class="my-3 w-full max-h-[50vh] border-none"
+      class="my-3 w-full max-h-[50vh] border-none shadow-none"
     >
       <template #option="slotProps">
         <div class="flex justify-between items-center w-full p-1">


### PR DESCRIPTION
Removes out-of-place shadow

Before:

![Selection_1120](https://github.com/user-attachments/assets/a8c1f986-644d-4b0d-b740-629a1d11e4dc)

After:


![Selection_1119](https://github.com/user-attachments/assets/d5de36e0-6044-4d7e-a632-938ffc596c24)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3094-Manager-Remove-shadows-on-version-selector-list-1b96d73d36508195b619c0da67613c89) by [Unito](https://www.unito.io)
