### PR TITLE
[Manager] Improve node pack card header style

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -124,7 +124,7 @@ import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import type { TabItem } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
 
-const DEFAULT_CARD_SIZE = 512
+const DEFAULT_CARD_SIZE = 349
 
 const { t } = useI18n()
 const comfyManagerStore = useComfyManagerStore()

--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -5,39 +5,17 @@
       'outline outline-[6px] outline-[var(--p-primary-color)]': isSelected
     }"
     :pt="{
-      body: { class: 'p-0 flex flex-col h-full rounded-2xl' },
+      body: { class: 'p-0 flex flex-col h-full rounded-2xl gap-0' },
       content: { class: 'flex-1 flex flex-col rounded-2xl' },
-      title: { class: 'p-0 m-0' },
+      title: {
+        class:
+          'self-stretch px-4 py-3 inline-flex justify-start items-center gap-6'
+      },
       footer: { class: 'p-0 m-0' }
     }"
   >
     <template #title>
-      <div class="flex justify-between p-5 pb-1 align-middle text-sm">
-        <span class="flex items-start mt-2">
-          <i
-            class="pi pi-box text-muted text-2xl ml-1 mr-5"
-            style="opacity: 0.5"
-          />
-          <span class="text-lg relative top-[.25rem]">{{
-            $t('manager.nodePack')
-          }}</span>
-        </span>
-        <div class="flex items-center gap-2.5">
-          <div
-            v-if="nodePack.downloads"
-            class="flex items-center text-sm text-muted tracking-tighter"
-          >
-            <i class="pi pi-download mr-2" />
-            {{ $n(nodePack.downloads) }}
-          </div>
-          <template v-if="isPackInstalled">
-            <PackEnableToggle :node-pack="nodePack" />
-          </template>
-          <template v-else>
-            <PackInstallButton :node-packs="[nodePack]" />
-          </template>
-        </div>
-      </div>
+      <PackCardHeader :node-pack="nodePack" />
     </template>
     <template #content>
       <ContentDivider />
@@ -102,8 +80,6 @@ import { computed } from 'vue'
 
 import ContentDivider from '@/components/common/ContentDivider.vue'
 import PackVersionBadge from '@/components/dialog/content/manager/PackVersionBadge.vue'
-import PackEnableToggle from '@/components/dialog/content/manager/button/PackEnableToggle.vue'
-import PackInstallButton from '@/components/dialog/content/manager/button/PackInstallButton.vue'
 import PackCardFooter from '@/components/dialog/content/manager/packCard/PackCardFooter.vue'
 import PackIcon from '@/components/dialog/content/manager/packIcon/PackIcon.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'

--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex justify-between p-5 text-xs text-muted font-medium leading-3"
+    class="flex justify-between px-5 py-4 text-xs text-muted font-medium leading-3"
   >
     <div class="flex items-center gap-2 cursor-pointer">
       <span v-if="publisherName" class="max-w-40 truncate">

--- a/src/components/dialog/content/manager/packCard/PackCardHeader.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardHeader.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="w-[100%] flex justify-between items-center">
+    <div class="flex justify-start items-center">
+      <div class="w-1 h-6 rounded-md" />
+      <div class="w-6 h-6 relative overflow-hidden">
+        <i class="pi pi-box text-xl text-muted" style="opacity: 0.6" />
+      </div>
+      <div class="px-3 py-2 rounded-md flex justify-start items-start gap-2.5">
+        <div class="text-right justify-start text-sm font-bold leading-none">
+          {{ $t('manager.nodePack') }}
+        </div>
+      </div>
+    </div>
+    <div class="inline-flex justify-start items-center gap-3">
+      <div
+        v-if="nodePack.downloads"
+        class="flex items-center text-sm text-muted tracking-tighter"
+      >
+        <i class="pi pi-download mr-2" />
+        {{ $n(nodePack.downloads) }}
+      </div>
+      <template v-if="isPackInstalled">
+        <PackEnableToggle :node-pack="nodePack" />
+      </template>
+      <template v-else>
+        <PackInstallButton :node-packs="[nodePack]" />
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import PackEnableToggle from '@/components/dialog/content/manager/button/PackEnableToggle.vue'
+import PackInstallButton from '@/components/dialog/content/manager/button/PackInstallButton.vue'
+import { useComfyManagerStore } from '@/stores/comfyManagerStore'
+import type { components } from '@/types/comfyRegistryTypes'
+
+const { nodePack } = defineProps<{
+  nodePack: components['schemas']['Node']
+}>()
+
+const { isPackInstalled } = useComfyManagerStore()
+</script>

--- a/src/components/dialog/content/manager/packCard/PackCardHeader.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardHeader.vue
@@ -19,7 +19,7 @@
         <i class="pi pi-download mr-2" />
         {{ $n(nodePack.downloads) }}
       </div>
-      <template v-if="isPackInstalled">
+      <template v-if="isInstalled">
         <PackEnableToggle :node-pack="nodePack" />
       </template>
       <template v-else>
@@ -30,6 +30,8 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import PackEnableToggle from '@/components/dialog/content/manager/button/PackEnableToggle.vue'
 import PackInstallButton from '@/components/dialog/content/manager/button/PackInstallButton.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
@@ -40,4 +42,5 @@ const { nodePack } = defineProps<{
 }>()
 
 const { isPackInstalled } = useComfyManagerStore()
+const isInstalled = computed(() => isPackInstalled(nodePack?.id))
 </script>


### PR DESCRIPTION
Splits node pack card header to separate file and applies exact values from design file:

![Selection_1116](https://github.com/user-attachments/assets/6f1c648f-8701-4de7-95e6-6a17238560b4)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3098-Manager-Improve-node-pack-card-header-style-1b96d73d365081b39cb9ef8b492e78ab) by [Unito](https://www.unito.io)
