### PR TITLE
[Manager] Adjust node pack card style according to installing or disabled state

### DIFF
--- a/src/components/dialog/content/manager/button/PackInstallButton.vue
+++ b/src/components/dialog/content/manager/button/PackInstallButton.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
+import { inject, ref } from 'vue'
 
 import PackActionButton from '@/components/dialog/content/manager/button/PackActionButton.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
@@ -29,7 +29,7 @@ const { nodePacks } = defineProps<{
   nodePacks: NodePack[]
 }>()
 
-const isInstalling = inject(IsInstallingKey)
+const isInstalling = inject(IsInstallingKey, ref(false))
 
 const managerStore = useComfyManagerStore()
 

--- a/src/components/dialog/content/manager/button/PackInstallButton.vue
+++ b/src/components/dialog/content/manager/button/PackInstallButton.vue
@@ -11,11 +11,12 @@
 </template>
 
 <script setup lang="ts">
-import { type Ref, inject } from 'vue'
+import { inject } from 'vue'
 
 import PackActionButton from '@/components/dialog/content/manager/button/PackActionButton.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import {
+  IsInstallingKey,
   ManagerChannel,
   ManagerDatabaseSource,
   SelectedVersion
@@ -28,7 +29,7 @@ const { nodePacks } = defineProps<{
   nodePacks: NodePack[]
 }>()
 
-const isInstalling = inject<Ref<boolean>>('isInstalling')
+const isInstalling = inject(IsInstallingKey)
 
 const managerStore = useComfyManagerStore()
 

--- a/src/components/dialog/content/manager/button/PackInstallButton.vue
+++ b/src/components/dialog/content/manager/button/PackInstallButton.vue
@@ -11,6 +11,8 @@
 </template>
 
 <script setup lang="ts">
+import { type Ref, inject } from 'vue'
+
 import PackActionButton from '@/components/dialog/content/manager/button/PackActionButton.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import {
@@ -25,6 +27,8 @@ type NodePack = components['schemas']['Node']
 const { nodePacks } = defineProps<{
   nodePacks: NodePack[]
 }>()
+
+const isInstalling = inject<Ref<boolean>>('isInstalling')
 
 const managerStore = useComfyManagerStore()
 
@@ -49,6 +53,8 @@ const installPack = (item: NodePack) =>
 
 const installAllPacks = async () => {
   if (!nodePacks?.length) return
+
+  isInstalling.value = true
 
   const uninstalledPacks = nodePacks.filter(
     (pack) => !managerStore.isPackInstalled(pack.id)

--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -90,6 +90,7 @@
 </template>
 
 <script setup lang="ts">
+import { whenever } from '@vueuse/core'
 import Card from 'primevue/card'
 import ProgressSpinner from 'primevue/progressspinner'
 import { computed, provide, ref } from 'vue'
@@ -117,6 +118,9 @@ const isInstalled = computed(() => isPackInstalled(nodePack?.id))
 const isDisabled = computed(
   () => isInstalled.value && !isPackEnabled(nodePack?.id)
 )
+
+whenever(isInstalled, () => (isInstalling.value = false))
+
 const isUpdateAvailable = computed(() => {
   if (!isInstalled.value) return false
 

--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -100,6 +100,7 @@ import PackVersionBadge from '@/components/dialog/content/manager/PackVersionBad
 import PackCardFooter from '@/components/dialog/content/manager/packCard/PackCardFooter.vue'
 import PackIcon from '@/components/dialog/content/manager/packIcon/PackIcon.vue'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
+import { IsInstallingKey } from '@/types/comfyManagerTypes'
 import type { components } from '@/types/comfyRegistryTypes'
 import { compareVersions, isSemVer } from '@/utils/formatUtil'
 
@@ -109,7 +110,7 @@ const { nodePack, isSelected = false } = defineProps<{
 }>()
 
 const isInstalling = ref(false)
-provide('isInstalling', isInstalling)
+provide(IsInstallingKey, isInstalling)
 
 const { isPackInstalled, isPackEnabled, getInstalledPackVersion } =
   useComfyManagerStore()

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -1,9 +1,14 @@
+import type { InjectionKey, Ref } from 'vue'
+
 import type { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import type { components } from '@/types/comfyRegistryTypes'
 
 type RegistryPack = components['schemas']['Node']
 type WorkflowNodeProperties = ComfyWorkflowJSON['nodes'][0]['properties']
 export type PackField = keyof RegistryPack | null
+
+export const IsInstallingKey: InjectionKey<Ref<boolean>> =
+  Symbol('isInstalling')
 
 export interface TabItem {
   id: string


### PR DESCRIPTION
Applies appropriate styles based on whether the node pack is disabled/enabled (opacity set to 60%) or installing (card body content replaced with progress spinner).

![Selection_1118](https://github.com/user-attachments/assets/2cd822c4-eb41-4145-b457-1da29ccb4c90)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3103-Manager-Adjust-node-pack-card-style-according-to-installing-or-disabled-state-1b96d73d3650815bb19fcce826dbc7cc) by [Unito](https://www.unito.io)
