### PR TITLE
Support create folder in workflow sidebar tab

### DIFF
--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -218,10 +218,7 @@ const renderTreeNode = (
   node: TreeNode,
   type: WorkflowTreeType
 ): TreeExplorerNode<ComfyWorkflow> => {
-  const children = node.children
-    ?.filter((child) => !child.data?.isFolderPlaceholder)
-    ?.map((child) => renderTreeNode(child, type))
-
+  const children = node.children?.map((child) => renderTreeNode(child, type))
   const workflow: ComfyWorkflow = node.data
 
   function handleClick(this: TreeExplorerNode<ComfyWorkflow>, e: MouseEvent) {
@@ -232,7 +229,7 @@ const renderTreeNode = (
     }
   }
 
-  const actions = node.leaf
+  const actions: Partial<TreeExplorerNode<ComfyWorkflow>> = node.leaf
     ? {
         handleClick,
         async handleRename(newName: string) {
@@ -262,7 +259,14 @@ const renderTreeNode = (
         },
         draggable: true
       }
-    : { handleClick }
+    : {
+        handleClick,
+        async handleAddFolder(folderName: string) {
+          const parentPath = this.key.replace(/^root\//, '')
+          const folderPath = parentPath + '/' + folderName
+          await workflowStore.createFolder(folderPath)
+        }
+      }
 
   return {
     key: node.key,

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -220,7 +220,9 @@ const renderTreeNode = (
   node: TreeNode,
   type: WorkflowTreeType
 ): TreeExplorerNode<ComfyWorkflow> => {
-  const children = node.children?.map((child) => renderTreeNode(child, type))
+  const children = node.children
+    ?.filter((child) => !child.data?.isFolderPlaceholder)
+    ?.map((child) => renderTreeNode(child, type))
 
   const workflow: ComfyWorkflow = node.data
 

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -5,6 +5,13 @@
   >
     <template #tool-buttons>
       <Button
+        icon="pi pi-folder-plus"
+        @click="addNewFolder"
+        severity="secondary"
+        text
+        v-tooltip.bottom="$t('g.newFolder')"
+      />
+      <Button
         icon="pi pi-refresh"
         @click="workflowStore.syncWorkflows()"
         severity="secondary"
@@ -91,6 +98,7 @@
             :root="renderTreeNode(workflowsTree, WorkflowTreeType.Browse)"
             v-model:expandedKeys="expandedKeys"
             :selectionKeys="selectionKeys"
+            ref="persistedWorkflowsTreeExplorerRef"
             v-if="workflowStore.persistedWorkflows.length > 0"
           >
             <template #node="{ node }">
@@ -262,7 +270,9 @@ const renderTreeNode = (
     : {
         handleClick,
         async handleAddFolder(folderName: string) {
-          const parentPath = this.key.replace(/^root\//, '')
+          if (folderName === '') return
+
+          const parentPath = this.key.replace(/^root\/?/, '')
           const folderPath = parentPath + '/' + folderName
           await workflowStore.createFolder(folderPath)
         }
@@ -286,4 +296,11 @@ const workflowBookmarkStore = useWorkflowBookmarkStore()
 onMounted(async () => {
   await workflowBookmarkStore.loadBookmarks()
 })
+
+const persistedWorkflowsTreeExplorerRef = ref<InstanceType<
+  typeof TreeExplorer
+> | null>(null)
+const addNewFolder = () => {
+  persistedWorkflowsTreeExplorerRef.value?.addFolderCommand?.('root')
+}
 </script>

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -136,7 +136,6 @@ import SidebarTabTemplate from '@/components/sidebar/tabs/SidebarTabTemplate.vue
 import WorkflowTreeLeaf from '@/components/sidebar/tabs/workflows/WorkflowTreeLeaf.vue'
 import { useTreeExpansion } from '@/composables/useTreeExpansion'
 import { useWorkflowService } from '@/services/workflowService'
-import { useCommandStore } from '@/stores/commandStore'
 import { useSettingStore } from '@/stores/settingStore'
 import {
   useWorkflowBookmarkStore,
@@ -174,7 +173,6 @@ const handleSearch = (query: string) => {
   })
 }
 
-const commandStore = useCommandStore()
 const workflowStore = useWorkflowStore()
 const workflowService = useWorkflowService()
 const workspaceStore = useWorkspaceStore()

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -13,6 +13,7 @@ import { UserFile } from './userFileStore'
 
 export class ComfyWorkflow extends UserFile {
   static readonly basePath = 'workflows/'
+  static readonly folderPlaceholderFilename = 'folder.index'
 
   /**
    * The change tracker for the workflow. Non-reactive raw object.
@@ -32,7 +33,9 @@ export class ComfyWorkflow extends UserFile {
   }
 
   get key() {
-    return this.path.substring(ComfyWorkflow.basePath.length)
+    const key = this.isFolderPlaceholder ? this.directory + '/' : this.path
+
+    return key.substring(ComfyWorkflow.basePath.length)
   }
 
   get activeState(): ComfyWorkflowJSON | null {
@@ -59,7 +62,7 @@ export class ComfyWorkflow extends UserFile {
    * Whether the workflow is a folder placeholder.
    */
   get isFolderPlaceholder(): boolean {
-    return this.filename === '.index'
+    return this.fullFilename === ComfyWorkflow.folderPlaceholderFilename
   }
 
   /**
@@ -441,7 +444,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
         : folderPath
 
       // Create the full path including the reserved index file
-      const indexFilePath = `${ComfyWorkflow.basePath}${normalizedPath}/.index`
+      const indexFilePath = `${ComfyWorkflow.basePath}${normalizedPath}/${ComfyWorkflow.folderPlaceholderFilename}`
 
       // Create an empty file to represent the folder
       const resp = await api.storeUserData(indexFilePath, '', {


### PR DESCRIPTION

https://github.com/user-attachments/assets/14c74b91-cad9-4d92-a2d2-4940004f5b01

A few other TODOs:
- Delete folder
- Rename folder
- Drag workflow to move to folder

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3104-Support-create-folder-in-workflow-sidebar-tab-1b96d73d365081e18c95e00014b353f4) by [Unito](https://www.unito.io)
