### PR TITLE
[Manager] Remove shadows on left nav list

### DIFF
--- a/src/components/dialog/content/manager/ManagerNavSidebar.vue
+++ b/src/components/dialog/content/manager/ManagerNavSidebar.vue
@@ -8,7 +8,7 @@
         :options="tabs"
         optionLabel="label"
         listStyle="max-height:unset"
-        class="w-full border-0 bg-transparent"
+        class="w-full border-0 bg-transparent shadow-none"
         :pt="{
           list: { class: 'p-5' },
           option: { class: 'px-8 py-3 text-lg rounded-xl' },


### PR DESCRIPTION
Exact same change as https://github.com/Comfy-Org/ComfyUI_frontend/pull/3094, also applied to `ListBox`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3106-Manager-Remove-shadows-on-left-nav-list-1b96d73d3650816c965be4ab4dba46ae) by [Unito](https://www.unito.io)
