### PR TITLE
[Manager] Remove version from footer

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -6,9 +6,6 @@
       <span v-if="publisherName" class="max-w-40 truncate">
         {{ publisherName }}
       </span>
-      <span v-else-if="nodePack.latest_version">
-        {{ nodePack.latest_version.version }}
-      </span>
     </div>
     <div
       v-if="nodePack.latest_version?.createdAt"


### PR DESCRIPTION
Remove version details from node pack card footer, as it was moved to the card body in https://github.com/Comfy-Org/ComfyUI_frontend/pull/3089, which aligns with current design.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3111-Manager-Remove-version-from-footer-1b96d73d36508126ae5de04f1f0321d7) by [Unito](https://www.unito.io)
