### PR TITLE
[Manager] Make node pack card dynamically sized

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -57,29 +57,22 @@
             <div v-else class="h-full" @click="handleGridContainerClick">
               <VirtualGrid
                 :items="resultsWithKeys"
-                :defaultItemSize="DEFAULT_CARD_SIZE"
-                class="p-0 m-0 max-w-full"
-                :buffer-rows="2"
+                :buffer-rows="5"
                 :gridStyle="{
                   display: 'grid',
-                  gridTemplateColumns: `repeat(auto-fill, minmax(${DEFAULT_CARD_SIZE}px, 1fr))`,
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(22rem, 1fr))',
                   padding: '0.5rem',
-                  gap: '1.125rem 1.25rem',
-                  justifyContent: 'stretch'
+                  gap: '1.5rem'
                 }"
               >
                 <template #item="{ item }">
-                  <div
-                    class="relative w-full aspect-square cursor-pointer"
+                  <PackCard
                     @click.stop="(event) => selectNodePack(item, event)"
-                  >
-                    <PackCard
-                      :node-pack="item"
-                      :is-selected="
-                        selectedNodePacks.some((pack) => pack.id === item.id)
-                      "
-                    />
-                  </div>
+                    :node-pack="item"
+                    :is-selected="
+                      selectedNodePacks.some((pack) => pack.id === item.id)
+                    "
+                  />
                 </template>
               </VirtualGrid>
             </div>
@@ -123,8 +116,6 @@ import { useRegistrySearch } from '@/composables/useRegistrySearch'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import type { TabItem } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
-
-const DEFAULT_CARD_SIZE = 349
 
 const { t } = useI18n()
 const comfyManagerStore = useComfyManagerStore()

--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -1,15 +1,15 @@
 <template>
   <Card
-    class="absolute inset-0 flex flex-col overflow-hidden rounded-2xl shadow-elevation-4 dark-theme:bg-dark-elevation-1 transition-all duration-200"
+    class="w-full h-full inline-flex flex-col justify-between items-start overflow-hidden rounded-2xl shadow-elevation-4 dark-theme:bg-dark-elevation-1 transition-all duration-200"
     :class="{
       'outline outline-[6px] outline-[var(--p-primary-color)]': isSelected
     }"
     :pt="{
-      body: { class: 'p-0 flex flex-col h-full rounded-2xl gap-0' },
+      body: { class: 'p-0 flex flex-col w-full h-full rounded-2xl gap-0' },
       content: { class: 'flex-1 flex flex-col rounded-2xl' },
       title: {
         class:
-          'self-stretch px-4 py-3 inline-flex justify-start items-center gap-6'
+          'self-stretch w-full px-4 py-3 inline-flex justify-start items-center gap-6'
       },
       footer: { class: 'p-0 m-0' }
     }"


### PR DESCRIPTION
Until now, the node pack card was forced to be a square to be compatible with `VirtualGrid` component. After https://github.com/Comfy-Org/ComfyUI_frontend/pull/3093, the card can now freely use the styles outlined in the design file:

![Selection_1121](https://github.com/user-attachments/assets/99851c9b-7d03-4be4-adcc-43e7f98e1f86)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3112-Manager-Make-node-pack-card-dynamically-sized-1b96d73d365081e19696d64fea2a4ef5) by [Unito](https://www.unito.io)
