### PR TITLE
[Bug] Make Queue history compatible with WebM (<video>)

### DIFF
--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -105,7 +105,7 @@ export class ResultItemImpl {
   }
 
   get isVideo(): boolean {
-    return !this.isImage && !!this.format?.startsWith('video/')
+    return !this.isImage || !!this.format?.startsWith('video/')
   }
 
   get isGif(): boolean {
@@ -116,8 +116,14 @@ export class ResultItemImpl {
     return this.filename.endsWith('.webp')
   }
 
+  get isWebm(): boolean {
+    return this.filename.endsWith('.webm')
+  }
+
   get isImage(): boolean {
-    return this.mediaType === 'images' || this.isGif || this.isWebp
+    return (
+      !this.isWebm && (this.mediaType === 'images' || this.isGif || this.isWebp)
+    )
   }
 
   get supportsPreview(): boolean {


### PR DESCRIPTION
Using the SaveWEBM node for output currently breaks the queue history, due to trying to render with `<img>` instead of `<video>`. This fixes that.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3117-Bug-Make-Queue-history-compatible-with-WebM-video-1ba6d73d3650811aa69adafe726c61de) by [Unito](https://www.unito.io)
