### PR TITLE
[3d] support output normal and lineart at once

### DIFF
--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="relative w-full h-full">
+  <div
+    class="relative w-full h-full"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
     <Load3DScene
+      ref="load3DSceneRef"
       :node="node"
       :type="type"
       :backgroundColor="backgroundColor"
@@ -90,10 +95,23 @@ const backgroundImage = ref('')
 const upDirection = ref<UpDirection>('original')
 const materialMode = ref<MaterialMode>('original')
 const edgeThreshold = ref(85)
+const load3DSceneRef = ref(null)
 
 const showPreviewButton = computed(() => {
   return !type.includes('Preview')
 })
+
+const handleMouseEnter = () => {
+  if (load3DSceneRef.value?.load3d) {
+    load3DSceneRef.value.load3d.updateStatusMouseOnScene(true)
+  }
+}
+
+const handleMouseLeave = () => {
+  if (load3DSceneRef.value?.load3d) {
+    load3DSceneRef.value.load3d.updateStatusMouseOnScene(false)
+  }
+}
 
 const switchCamera = () => {
   cameraType.value =

--- a/src/components/load3d/Load3DAnimation.vue
+++ b/src/components/load3d/Load3DAnimation.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="relative w-full h-full">
+  <div
+    class="relative w-full h-full"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
     <Load3DAnimationScene
+      ref="load3DAnimationSceneRef"
       :node="node"
       :type="type"
       :backgroundColor="backgroundColor"
@@ -109,6 +114,22 @@ const backgroundImage = ref('')
 const showPreviewButton = computed(() => {
   return !type.includes('Preview')
 })
+
+const load3DAnimationSceneRef = ref(null)
+
+const handleMouseEnter = () => {
+  const sceneRef = load3DAnimationSceneRef.value?.load3DSceneRef
+  if (sceneRef?.load3d) {
+    sceneRef.load3d.updateStatusMouseOnScene(true)
+  }
+}
+
+const handleMouseLeave = () => {
+  const sceneRef = load3DAnimationSceneRef.value?.load3DSceneRef
+  if (sceneRef?.load3d) {
+    sceneRef.load3d.updateStatusMouseOnScene(false)
+  }
+}
 
 const switchCamera = () => {
   cameraType.value =

--- a/src/components/load3d/Load3DAnimationScene.vue
+++ b/src/components/load3d/Load3DAnimationScene.vue
@@ -183,4 +183,8 @@ const animationListeners = {
     emit('animationListChange', newValue)
   }
 }
+
+defineExpose({
+  load3DSceneRef
+})
 </script>

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -124,21 +124,30 @@ app.registerExtension({
     sceneWidget.serializeValue = async () => {
       node.properties['Camera Info'] = load3d.getCameraState()
 
-      const { scene: imageData, mask: maskData } = await load3d.captureScene(
+      const {
+        scene: imageData,
+        mask: maskData,
+        normal: normalData,
+        lineart: lineartData
+      } = await load3d.captureScene(
         width.value as number,
         height.value as number
       )
 
-      const [data, dataMask] = await Promise.all([
+      const [data, dataMask, dataNormal, dataLineart] = await Promise.all([
         Load3dUtils.uploadTempImage(imageData, 'scene'),
-        Load3dUtils.uploadTempImage(maskData, 'scene_mask')
+        Load3dUtils.uploadTempImage(maskData, 'scene_mask'),
+        Load3dUtils.uploadTempImage(normalData, 'scene_normal'),
+        Load3dUtils.uploadTempImage(lineartData, 'scene_lineart')
       ])
 
       load3d.handleResize()
 
       return {
         image: `threed/${data.name} [temp]`,
-        mask: `threed/${dataMask.name} [temp]`
+        mask: `threed/${dataMask.name} [temp]`,
+        normal: `threed/${dataNormal.name} [temp]`,
+        lineart: `threed/${dataLineart.name} [temp]`
       }
     }
   }
@@ -252,21 +261,27 @@ app.registerExtension({
 
       load3d.toggleAnimation(false)
 
-      const { scene: imageData, mask: maskData } = await load3d.captureScene(
+      const {
+        scene: imageData,
+        mask: maskData,
+        normal: normalData
+      } = await load3d.captureScene(
         width.value as number,
         height.value as number
       )
 
-      const [data, dataMask] = await Promise.all([
+      const [data, dataMask, dataNormal] = await Promise.all([
         Load3dUtils.uploadTempImage(imageData, 'scene'),
-        Load3dUtils.uploadTempImage(maskData, 'scene_mask')
+        Load3dUtils.uploadTempImage(maskData, 'scene_mask'),
+        Load3dUtils.uploadTempImage(normalData, 'scene_normal')
       ])
 
       load3d.handleResize()
 
       return {
         image: `threed/${data.name} [temp]`,
-        mask: `threed/${dataMask.name} [temp]`
+        mask: `threed/${dataMask.name} [temp]`,
+        normal: `threed/${dataNormal.name} [temp]`
       }
     }
   }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -36,6 +36,9 @@ class Load3d {
   protected loaderManager: LoaderManager
   protected modelManager: ModelManager
 
+  STATUS_MOUSE_ON_NODE: boolean
+  STATUS_MOUSE_ON_SCENE: boolean
+
   constructor(
     container: Element | HTMLElement,
     options: Load3DOptions = {
@@ -124,6 +127,9 @@ class Load3d {
       this.previewManager.init()
     }
 
+    this.STATUS_MOUSE_ON_NODE = false
+    this.STATUS_MOUSE_ON_SCENE = false
+
     this.handleResize()
     this.startAnimation()
   }
@@ -165,6 +171,18 @@ class Load3d {
     }
 
     animate()
+  }
+
+  updateStatusMouseOnNode(onNode: boolean): void {
+    this.STATUS_MOUSE_ON_NODE = onNode
+  }
+
+  updateStatusMouseOnScene(onScene: boolean): void {
+    this.STATUS_MOUSE_ON_SCENE = onScene
+  }
+
+  isActive(): boolean {
+    return this.STATUS_MOUSE_ON_NODE || this.STATUS_MOUSE_ON_SCENE
   }
 
   setBackgroundColor(color: string): void {

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -40,6 +40,8 @@ export interface Load3DOptions {
 export interface CaptureResult {
   scene: string
   mask: string
+  normal: string
+  lineart: string
 }
 
 export interface BaseManager {

--- a/src/services/load3dService.ts
+++ b/src/services/load3dService.ts
@@ -41,6 +41,12 @@ export class Load3dService {
 
     rawNode.onMouseEnter = function () {
       instance.refreshViewport()
+
+      instance.updateStatusMouseOnNode(true)
+    }
+
+    rawNode.onMouseLeave = function () {
+      instance.updateStatusMouseOnNode(false)
     }
 
     rawNode.onResize = function () {


### PR DESCRIPTION
add support that output multi layers, such as normal and lineart at once, the demo is

https://github.com/user-attachments/assets/251e1916-ee90-42ca-9593-57f82c5b8b39

need https://github.com/comfyanonymous/ComfyUI/pull/7290 as BE changes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3122-3d-support-output-normal-and-lineart-at-once-1ba6d73d3650811aa38fd259757dd76c) by [Unito](https://www.unito.io)
