### PR TITLE
[Manager] Reset Manager state on reboot

### DIFF
--- a/src/components/dialog/footer/ManagerProgressFooter.vue
+++ b/src/components/dialog/footer/ManagerProgressFooter.vue
@@ -101,6 +101,8 @@ const handleRestart = async () => {
 
   const onReconnect = () => {
     useCommandStore().execute('Comfy.RefreshNodeDefinitions')
+    comfyManagerStore.clearLogs()
+    comfyManagerStore.setStale()
   }
   useEventListener(api, 'reconnected', onReconnect, { once: true })
 }

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -200,6 +200,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     uncompletedCount,
     taskLogs,
     clearLogs,
+    setStale,
 
     // Installed packs state
     installedPacks,


### PR DESCRIPTION
It's no longer necessary to refresh the browser when doing post-install reboot. However, some state updates are required since this is a hot reload:

- Logs should be cleared
- The manager defers some file system actions until after `execv`, so we need to manually set the manager store as stale to trigger a re-fetch of server state. This would normally happen on store intialization but the store is kept alive if browser not refreshed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3129-Manager-Reset-Manager-state-on-reboot-1ba6d73d365081a68ccad44401c46552) by [Unito](https://www.unito.io)
