### PR TITLE
[Manager] Show node pack's dependencies in info panel

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/tabs/DescriptionTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/DescriptionTabPanel.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="mt-4 overflow-hidden">
     <InfoTextSection
-      v-if="descriptionSections.length > 0"
+      v-if="nodePack?.description"
       :sections="descriptionSections"
     />
     <p v-else class="text-muted italic text-sm">
       {{ $t('manager.noDescription') }}
     </p>
-    <div v-if="nodePack.latest_version?.dependencies?.length">
+    <div v-if="nodePack?.latest_version?.dependencies?.length">
       <p class="mb-1">
         {{ $t('manager.dependencies') }}
       </p>

--- a/src/components/dialog/content/manager/infoPanel/tabs/DescriptionTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/DescriptionTabPanel.vue
@@ -1,12 +1,24 @@
 <template>
   <div class="mt-4 overflow-hidden">
     <InfoTextSection
-      v-if="nodePack.description"
+      v-if="descriptionSections.length > 0"
       :sections="descriptionSections"
     />
     <p v-else class="text-muted italic text-sm">
       {{ $t('manager.noDescription') }}
     </p>
+    <div v-if="nodePack.latest_version?.dependencies?.length">
+      <p class="mb-1">
+        {{ $t('manager.dependencies') }}
+      </p>
+      <div
+        v-for="(dep, index) in nodePack.latest_version.dependencies"
+        :key="index"
+        class="text-muted break-words"
+      >
+        {{ dep }}
+      </div>
+    </div>
   </div>
 </template>
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -99,6 +99,7 @@
   },
   "manager": {
     "title": "Custom Nodes Manager",
+    "dependencies": "Dependencies",
     "infoPanelEmpty": "Click an item to see the info",
     "restartToApplyChanges": "To apply changes, please restart ComfyUI",
     "loadingVersions": "Loading versions...",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -381,6 +381,7 @@
   },
   "manager": {
     "createdBy": "Créé par",
+    "dependencies": "Dépendances",
     "discoverCommunityContent": "Découvrez les packs de nœuds, extensions et plus encore créés par la communauté...",
     "downloads": "Téléchargements",
     "errorConnecting": "Erreur de connexion au registre de nœuds Comfy.",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -381,6 +381,7 @@
   },
   "manager": {
     "createdBy": "作成者",
+    "dependencies": "依存関係",
     "discoverCommunityContent": "コミュニティが作成したノードパック、拡張機能などを探す...",
     "downloads": "ダウンロード",
     "errorConnecting": "Comfy Node Registryへの接続エラー。",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -381,6 +381,7 @@
   },
   "manager": {
     "createdBy": "작성자",
+    "dependencies": "의존성",
     "discoverCommunityContent": "커뮤니티에서 만든 노드 팩, 확장 프로그램 등을 찾아보세요...",
     "downloads": "다운로드",
     "errorConnecting": "Comfy Node Registry에 연결하는 중 오류가 발생했습니다.",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -381,6 +381,7 @@
   },
   "manager": {
     "createdBy": "Создано",
+    "dependencies": "Зависимости",
     "discoverCommunityContent": "Откройте для себя пакеты узлов, расширения и многое другое, созданные сообществом...",
     "downloads": "Загрузки",
     "errorConnecting": "Ошибка подключения к реестру Comfy Node.",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -381,6 +381,7 @@
   },
   "manager": {
     "createdBy": "创建者",
+    "dependencies": "依赖关系",
     "discoverCommunityContent": "发现社区制作的节点包，扩展等等...",
     "downloads": "下载",
     "errorConnecting": "连接到Comfy节点注册表时出错。",


### PR DESCRIPTION
Add section to info panel for the pack's dependencies, if it has any. In the future there will be a UX-oriented way to manage conflicts.


https://github.com/user-attachments/assets/4afd0bfc-177f-4e6b-aeb5-e65834a997c6

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3130-Manager-Show-node-pack-s-dependencies-in-info-panel-1ba6d73d365081e28100f649c48877dc) by [Unito](https://www.unito.io)
