### PR TITLE
[3d] performance improve

### DIFF
--- a/src/extensions/core/load3d/Load3dAnimation.ts
+++ b/src/extensions/core/load3d/Load3dAnimation.ts
@@ -38,6 +38,10 @@ class Load3dAnimation extends Load3d {
     const animate = () => {
       this.animationFrameId = requestAnimationFrame(animate)
 
+      if (!this.isActive()) {
+        return
+      }
+
       if (this.previewManager.showPreview) {
         this.previewManager.updatePreviewRender()
       }


### PR DESCRIPTION
Improved threejs performance with only render scene on isActive. 
There is no significant functional impact. The only effect is that for certain animations playing in the center, when the mouse moves out of the node, these animations will be "paused," and when the mouse moves back, they will "resume." I think this impact is acceptable because it will greatly improve the performance of the behavior, as there will only be one WebGL requestAnimationFrame request at a time, whereas previously there were as many simultaneous requests as there were nodes.

https://github.com/user-attachments/assets/0b812ae9-3977-4ffd-979c-b96cd11d6316

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3131-3d-performance-improve-1ba6d73d3650818bbc89cce17d47e780) by [Unito](https://www.unito.io)
