### PR TITLE
[Manager] Fallback text on info panel

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/InfoPanelMultiItem.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanelMultiItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="nodePacks?.length" class="flex flex-col h-full">
     <div class="p-6 flex-1 overflow-auto">
-      <InfoPanelHeader :node-packs="nodePacks">
+      <InfoPanelHeader :node-packs>
         <template #thumbnail>
           <PackIconStacked :node-packs="nodePacks" />
         </template>

--- a/src/components/dialog/content/manager/infoPanel/InfoPanelMultiItem.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanelMultiItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-full">
+  <div v-if="nodePacks?.length" class="flex flex-col h-full">
     <div class="p-6 flex-1 overflow-auto">
       <InfoPanelHeader :node-packs="nodePacks">
         <template #thumbnail>
@@ -23,6 +23,9 @@
         />
       </div>
     </div>
+  </div>
+  <div v-else class="mt-4 mx-8 flex-1 overflow-hidden text-sm">
+    {{ $t('manager.infoPanelEmpty') }}
   </div>
 </template>
 


### PR DESCRIPTION
Use fallback text on info panel when no node pack selected, instead of showing the component that is only meant to be shown on error.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3138-Manager-Fallback-text-on-info-panel-1bb6d73d365081c7a578fcfb6be5287f) by [Unito](https://www.unito.io)
