### PR TITLE
[Manager] Allow scrolling info panel while keeping the icon pinned at top 

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <template v-if="nodePack">
     <div class="flex flex-col h-full z-40 w-80 overflow-hidden relative">
-      <div class="sticky top-0 z-10 px-6 pt-6 w-full">
+      <div class="top-0 z-10 px-6 pt-6 w-full">
         <InfoPanelHeader :node-packs="[nodePack]" />
       </div>
       <div class="p-6 pt-2 overflow-y-auto flex-1 text-sm hidden-scrollbar">

--- a/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
@@ -1,8 +1,10 @@
 <template>
   <template v-if="nodePack">
-    <div class="flex flex-col h-full z-40 hidden-scrollbar w-80">
-      <div class="p-6 flex-1 overflow-hidden text-sm">
+    <div class="flex flex-col h-full z-40 w-80 overflow-hidden relative">
+      <div class="sticky top-0 z-10 px-6 pt-6 w-full">
         <InfoPanelHeader :node-packs="[nodePack]" />
+      </div>
+      <div class="p-6 pt-2 overflow-y-auto flex-1 text-sm hidden-scrollbar">
         <div class="mb-6">
           <MetadataRow
             v-if="isPackInstalled(nodePack.id)"
@@ -104,9 +106,6 @@ const infoItems = computed<InfoItem[]>(() => [
 </script>
 <style scoped>
 .hidden-scrollbar {
-  height: 100%;
-  overflow-y: auto;
-
   /* Firefox */
   scrollbar-width: none;
 


### PR DESCRIPTION
Adjusts info panel header to match the design file's scroll behavior:


https://github.com/user-attachments/assets/c92510bb-1d1a-4d99-a97b-da01c2f86ec5

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3139-Manager-Allow-scrolling-info-panel-while-keeping-the-icon-pinned-at-top-1bb6d73d3650812faaddfd26139bffbb) by [Unito](https://www.unito.io)
