### PR TITLE
[Manager] Keep node previews inside info panel bounds

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
@@ -45,11 +45,11 @@ const placeholderNodeDef: ComfyNodeDef = {
 
 <style scoped>
 :deep(._sb_node_preview) {
-  min-width: unset !important;
+  min-width: unset;
   width: 100%;
 }
 
 :deep(._sb_col) {
-  font-size: 10px !important;
+  font-size: 10px;
 }
 </style>

--- a/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
@@ -42,3 +42,14 @@ const placeholderNodeDef: ComfyNodeDef = {
   python_module: 'nodes'
 }
 </script>
+
+<style scoped>
+:deep(._sb_node_preview) {
+  min-width: unset !important;
+  width: 100%;
+}
+
+:deep(._sb_col) {
+  font-size: 10px !important;
+}
+</style>

--- a/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
@@ -9,7 +9,10 @@
       :key="i"
       class="border border-surface-border rounded-lg p-4"
     >
-      <NodePreview :node-def="placeholderNodeDef" />
+      <NodePreview
+        :node-def="placeholderNodeDef"
+        class="!text-[.625rem] !min-w-full"
+      />
     </div>
   </div>
 </template>
@@ -42,14 +45,3 @@ const placeholderNodeDef: ComfyNodeDef = {
   python_module: 'nodes'
 }
 </script>
-
-<style scoped>
-:deep(._sb_node_preview) {
-  min-width: unset;
-  width: 100%;
-}
-
-:deep(._sb_col) {
-  font-size: 10px;
-}
-</style>


### PR DESCRIPTION
Adjusts stlye. Before:

![Selection_1135](https://github.com/user-attachments/assets/7a75a514-fac9-4ce6-88b5-5ba1cf7b3125)


After:

![Selection_1133](https://github.com/user-attachments/assets/cd288b16-1769-4a4f-852b-6550f366de2f)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3140-Manager-Keep-node-previews-inside-info-panel-bounds-1bb6d73d365081ac923ef8534f4f1536) by [Unito](https://www.unito.io)
