### PR TITLE
[Manager] Remove title hover

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -42,7 +42,6 @@
           >
             <span
               class="text-sm font-bold truncate overflow-hidden text-ellipsis"
-              :title="nodePack.name"
             >
               {{ nodePack.name }}
             </span>
@@ -52,7 +51,6 @@
               <p
                 v-if="nodePack.description"
                 class="flex-1 justify-start text-muted text-sm font-medium leading-3 break-words overflow-hidden min-h-12 line-clamp-3"
-                :title="nodePack.description"
               >
                 {{ nodePack.description }}
               </p>


### PR DESCRIPTION
Remove title hover effect, as the node packs' full metadata can be accessed by simply clicking the card and checking the info panel.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3142-Manager-Remove-title-hover-1bb6d73d365081bc9a93e1ef9fc54433) by [Unito](https://www.unito.io)
