### PR TITLE
[Manager] Re-evaluate search results in installed tab when node packs change

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -240,6 +240,7 @@ const onResultsChange = () => {
 
 whenever(selectedTab, onTabChange)
 watch(searchResults, onResultsChange, { flush: 'pre' })
+watch(() => comfyManagerStore.installedPacksIds, onResultsChange)
 
 const isLoading = computed(() => {
   if (isSearchLoading.value)


### PR DESCRIPTION
If in the 'Installed' tab, the search filters should be re-applied if the state of installed packs change. Otherwise if you click "uninstall" while in the installed view, the node pack won't be removed until the next re-render. After:


https://github.com/user-attachments/assets/490b3d6c-e002-4d04-9aa3-66cc2930a97c

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3144-Manager-Re-evaluate-search-results-in-installed-tab-when-node-packs-change-1bb6d73d3650810f9b24eda73a87772e) by [Unito](https://www.unito.io)
