### PR TITLE
Remove yarn packageManager claim from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,5 @@
     "vue-router": "^4.4.3",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.3.0"
-  },
-  "packageManager": "yarn@4.5.0+sha512.837566d24eec14ec0f5f1411adb544e892b3454255e61fdef8fd05f3429480102806bac7446bc9daff3896b01ae4b62d00096c7e989f1596f2af10b927532f39"
+  }
 }


### PR DESCRIPTION
- `packageManager` inadvertently added in #3059
- Ensures tools that read `packageManager` do not choose `yarn` over `npm`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3145-Remove-yarn-packageManager-claim-from-package-json-1bb6d73d365081cbbb14fed6f37136e1) by [Unito](https://www.unito.io)
