### PR TITLE
[Develop] Remove duplicated run of tsc typecheck

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,8 +3,7 @@ export default {
 
   './**/*.{ts,tsx,vue,mts}': (stagedFiles) => [
     ...formatAndEslint(stagedFiles),
-    'vue-tsc --noEmit',
-    'tsc --noEmit'
+    'vue-tsc --noEmit'
   ]
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run typecheck && vite build",
     "build:types": "vite build --config vite.types.config.mts && node scripts/prepare-types.js",
     "zipdist": "node scripts/zipdist.js",
-    "typecheck": "vue-tsc --noEmit && tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit",
     "format": "prettier --write './**/*.{js,ts,tsx,vue,mts}'",
     "format:check": "prettier --check './**/*.{js,ts,tsx,vue,mts}'",
     "test:browser": "npx playwright test",


### PR DESCRIPTION
`vue-tsc` overlaps with `tsc`. Keeping `vue-tsc` run is sufficient for typecheck.