### PR TITLE
[Manager] Allow searching while in 'Missing' node packs tab

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -206,7 +206,22 @@ const getInWorkflowResults = () => {
 const filterMissingPacks = (packs: components['schemas']['Node'][]) =>
   packs.filter((pack) => !comfyManagerStore.isPackInstalled(pack.id))
 
-const getMissingPacks = () => filterMissingPacks(getInWorkflowResults())
+const setMissingPacks = () => {
+  displayPacks.value = filterMissingPacks(workflowPacks.value)
+}
+
+const getMissingPacks = () => {
+  if (isEmptySearch.value) {
+    startFetchWorkflowPacks()
+    whenever(() => workflowPacks.value.length, setMissingPacks, {
+      immediate: true,
+      once: true
+    })
+    return filterMissingPacks(workflowPacks.value)
+  } else {
+    return filterMissingPacks(filterWorkflowPack(searchResults.value))
+  }
+}
 
 const onTabChange = () => {
   switch (selectedTab.value?.id) {
@@ -233,7 +248,9 @@ const onResultsChange = () => {
       displayPacks.value = filterWorkflowPack(searchResults.value)
       break
     case ManagerTab.Missing:
-      displayPacks.value = filterMissingPacks(searchResults.value)
+      displayPacks.value = filterMissingPacks(
+        filterWorkflowPack(searchResults.value)
+      )
       break
     default:
       displayPacks.value = searchResults.value


### PR DESCRIPTION
Changes the search while in the 'Missing' tab to also filter by installed.

Currently, search while in 'Missing' tab searches the domain:

`all registry packs` - `installed packs`

This PR changes it to:

(`packs in registry` ∩ `packs in workflow`) - `installed packs`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3153-Manager-Allow-searching-while-in-Missing-node-packs-tab-1bc6d73d365081e6812fc52ecc54ec8b) by [Unito](https://www.unito.io)
