### PR TITLE
[Manager] Allow cancelling registry requests by route

### DIFF
--- a/src/composables/nodePack/useNodePacks.ts
+++ b/src/composables/nodePack/useNodePacks.ts
@@ -31,8 +31,8 @@ export const useNodePacks = (
     remainingIds.value?.length ? chunk(remainingIds.value, maxConcurrent) : []
   )
 
-  const fetchPack = (ids: Parameters<typeof getPackById>[0]) =>
-    ids ? getPackById(ids) : null
+  const fetchPack = (ids: Parameters<typeof getPackById.call>[0]) =>
+    ids ? getPackById.call(ids) : null
 
   const toRequestBatch = async (ids: string[]) =>
     Promise.all(ids.map(fetchPack))

--- a/src/composables/nodePack/useNodePacks.ts
+++ b/src/composables/nodePack/useNodePacks.ts
@@ -31,8 +31,8 @@ export const useNodePacks = (
     remainingIds.value?.length ? chunk(remainingIds.value, maxConcurrent) : []
   )
 
-  const fetchPack = (ids: Parameters<typeof getPackById.call>[0]) =>
-    ids ? getPackById.call(ids) : null
+  const fetchPack = (id: Parameters<typeof getPackById.call>[0]) =>
+    id ? getPackById.call(id) : null
 
   const toRequestBatch = async (ids: string[]) =>
     Promise.all(ids.map(fetchPack))

--- a/src/composables/nodePack/useNodePacks.ts
+++ b/src/composables/nodePack/useNodePacks.ts
@@ -18,7 +18,7 @@ export const useNodePacks = (
   options: UseNodePacksOptions = {}
 ) => {
   const { immediate = false, maxConcurrent = DEFAULT_MAX_CONCURRENT } = options
-  const { getPackById, cancelRequests } = useComfyRegistryStore()
+  const { getPackById } = useComfyRegistryStore()
 
   const nodePacks = ref<NodePack[]>([])
   const processedIds = ref<Set<string>>(new Set())
@@ -63,7 +63,7 @@ export const useNodePacks = (
   }
 
   const cleanup = () => {
-    cancelRequests()
+    getPackById.cancel()
     clear()
   }
 


### PR DESCRIPTION
Change comfy registry store to allow cancelling requests and clearing caches per route. The manager store is already implemented this way.

For example, consider scenario:

- Component 1 is fetching node defs
- Component 2 is fetching translations for a recently installed pack
- Component 1 closes
- Component 1 should be able to cancel the request without cancelling in-flight requests made by Component 2

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3158-Manager-Allow-cancelling-registry-requests-by-route-1bc6d73d36508181be24e54a158b0433) by [Unito](https://www.unito.io)
