### PR TITLE
Track floating link changes in undo/redo history

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -397,7 +397,7 @@ export class ChangeTracker {
         return false
 
       // Compare other properties normally
-      for (const key of ['links', 'reroutes', 'groups']) {
+      for (const key of ['links', 'floatingLinks', 'reroutes', 'groups']) {
         if (!_.isEqual(a[key], b[key])) {
           return false
         }


### PR DESCRIPTION
Ensures floating link changes are tracked as undo/redo steps

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3160-Track-floating-link-changes-in-undo-redo-history-1bc6d73d3650813c8e34dec97fff5b1d) by [Unito](https://www.unito.io)
