### PR TITLE
[TS] Fix TreeExplorerNode types

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -136,14 +136,13 @@ const renderedRoot = computed<TreeExplorerNode<ModelOrFolder>>(() => {
         }
         return 'pi pi-folder'
       },
-      // @ts-expect-error fixme ts strict error
       getBadgeText() {
-        // Return null to apply default badge text
+        // Return undefined to apply default badge text
         // Return empty string to hide badge
         if (!folder) {
-          return null
+          return
         }
-        return folder.state === ResourceState.Loaded ? null : ''
+        return folder.state === ResourceState.Loaded ? undefined : ''
       },
       children,
       draggable: node.leaf,

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -117,7 +117,6 @@ const renderedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(() => {
       // @ts-expect-error fixme ts strict error
       leaf: node.leaf,
       data: node.data,
-      // @ts-expect-error fixme ts strict error
       getIcon() {
         if (this.leaf) {
           return 'pi pi-circle-fill'

--- a/src/types/treeExplorerTypes.ts
+++ b/src/types/treeExplorerTypes.ts
@@ -8,9 +8,16 @@ export interface TreeExplorerNode<T = any> {
   data?: T
   children?: TreeExplorerNode<T>[]
   icon?: string
-  /** Function to override what icon to use for the node */
+  /**
+   * Function to override what icon to use for the node.
+   * Return undefined to fallback to {@link icon} property.
+   */
   getIcon?: (this: TreeExplorerNode<T>) => string | undefined
-  /** Function to override what text to use for the leaf-count badge on a folder node */
+  /**
+   * Function to override what text to use for the leaf-count badge on a folder node.
+   * Return undefined to fallback to default badge text, which is the subtree's leaf count.
+   * Return empty string to hide the badge.
+   */
   getBadgeText?: (this: TreeExplorerNode<T>) => string | undefined
   /** Function to handle renaming the node */
   handleRename?: (

--- a/src/types/treeExplorerTypes.ts
+++ b/src/types/treeExplorerTypes.ts
@@ -9,9 +9,9 @@ export interface TreeExplorerNode<T = any> {
   children?: TreeExplorerNode<T>[]
   icon?: string
   /** Function to override what icon to use for the node */
-  getIcon?: (this: TreeExplorerNode<T>) => string
+  getIcon?: (this: TreeExplorerNode<T>) => string | undefined
   /** Function to override what text to use for the leaf-count badge on a folder node */
-  getBadgeText?: (this: TreeExplorerNode<T>) => string
+  getBadgeText?: (this: TreeExplorerNode<T>) => string | undefined
   /** Function to handle renaming the node */
   handleRename?: (
     this: TreeExplorerNode<T>,


### PR DESCRIPTION
Fixes signature on `getBadgeText` and `getIcon`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3163-TS-Fix-TreeExplorerNode-types-1bc6d73d3650810ca40afa5d059de2f2) by [Unito](https://www.unito.io)
