### PR TITLE
[Test] Sync workflow instead of full page reload

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -214,6 +214,10 @@ export class ComfyPage {
         `Failed to setup workflows directory: ${await resp.text()}`
       )
     }
+
+    await this.page.evaluate(async () => {
+      await window['app'].extensionManager.workflow.syncWorkflows()
+    })
   }
 
   async setupUser(username: string) {

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -172,6 +172,7 @@ test.describe('Workflows sidebar', () => {
     })
 
     await comfyPage.setSetting('Comfy.Locale', 'zh')
+    await comfyPage.setup()
 
     const downloadedContentZh = await comfyPage.getExportedWorkflow({
       api: false

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -34,7 +34,6 @@ test.describe('Workflows sidebar', () => {
       'workflow1.json': 'default.json',
       'workflow2.json': 'default.json'
     })
-    await comfyPage.setup()
 
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
@@ -77,7 +76,6 @@ test.describe('Workflows sidebar', () => {
     await comfyPage.setupWorkflowsDirectory({
       'workflow1.json': 'single_ksampler.json'
     })
-    await comfyPage.setup()
 
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
@@ -101,7 +99,6 @@ test.describe('Workflows sidebar', () => {
         'bar.json': 'default.json'
       }
     })
-    await comfyPage.setup()
 
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
@@ -175,7 +172,6 @@ test.describe('Workflows sidebar', () => {
     })
 
     await comfyPage.setSetting('Comfy.Locale', 'zh')
-    await comfyPage.setup()
 
     const downloadedContentZh = await comfyPage.getExportedWorkflow({
       api: false
@@ -323,7 +319,7 @@ test.describe('Workflows sidebar', () => {
     await comfyPage.setupWorkflowsDirectory({
       'workflow1.json': 'default.json'
     })
-    await comfyPage.setup()
+
     await comfyPage.menu.workflowsTab.open()
 
     const nodeCount = await comfyPage.getGraphNodesCount()


### PR DESCRIPTION
Avoid full page refresh to speed up tests.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3168-Test-Sync-workflow-instead-of-full-page-reload-1bd6d73d365081cb8ac7c3721522d352) by [Unito](https://www.unito.io)
