### PR TITLE
[Manager] Set max size on custom node pack icons

### DIFF
--- a/src/components/dialog/content/manager/packIcon/PackIcon.vue
+++ b/src/components/dialog/content/manager/packIcon/PackIcon.vue
@@ -2,7 +2,7 @@
   <img
     :src="isImageError ? DEFAULT_ICON : imgSrc"
     :alt="nodePack.name + ' icon'"
-    class="object-contain rounded-lg"
+    class="object-contain rounded-lg max-h-72 max-w-72"
     :style="{ width: cssWidth, height: cssHeight }"
     @error="isImageError = true"
   />


### PR DESCRIPTION
Resolves issue that occurs when the custom node pack's icon has relatively large natural dimensions. Example with before and after:


![size](https://github.com/user-attachments/assets/d7c555ea-8a73-439d-a875-487ea71c4af2)
