### PR TITLE
Fix Workflow Validation error when node pack  'unknown' version

### DIFF
--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -155,9 +155,10 @@ const zAuxId = z
   )
   .transform(([username, repo]) => `${username}/${repo}`)
 
-const zSemVer = z
-  .string()
-  .regex(semverPattern, 'Invalid semantic version (x.y.z)')
+const zSemVer = z.union([
+  z.string().regex(semverPattern, 'Invalid semantic version (x.y.z)'),
+  z.literal('unknown')
+])
 const zGitHash = z.string().regex(gitHashPattern, 'Invalid Git commit hash')
 const zVersion = z.union([zSemVer, zGitHash])
 

--- a/tests-ui/tests/comfyWorkflow.test.ts
+++ b/tests-ui/tests/comfyWorkflow.test.ts
@@ -176,7 +176,9 @@ describe('parseComfyWorkflow', () => {
       '0.1.0-alpha.1',
       '1.3.321',
       // Git hash
-      '080e6d4af809a46852d1c4b7ed85f06e8a3a72be'
+      '080e6d4af809a46852d1c4b7ed85f06e8a3a72be',
+      // Special case
+      'unknown'
     ]
     it.each(validVersionStrings)('valid version: %s', async (ver) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))


### PR DESCRIPTION
The manager adds pack version metadata to nodes [here](https://github.com/ltdrdata/ComfyUI-Manager/blob/9e66da174e6dc3e9678ba8be9b909a4af7b82418/js/workflow-metadata.js#L63-L68). If it wasn't possible to parse the version, the `ver` value in `installedNodes` wil be `unknown` rather than an undefined/null value. The schema must be updated to prevent errrors in this case.

Resolves https://github.com/comfyanonymous/ComfyUI/issues/7309

Example workflow provided by issue reportee:  [Text2Image.Styles.json](https://github.com/user-attachments/files/19383366/Text2Image.Styles.json)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3179-Fix-Workflow-Validation-error-when-node-pack-unknown-version-1bd6d73d365081369560fe16c9b8bcce) by [Unito](https://www.unito.io)
