### PR TITLE
Remove unused plugin vite-plugin-static-copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
         "unplugin-vue-components": "^0.27.4",
         "vite": "^5.4.14",
         "vite-plugin-dts": "^4.3.0",
-        "vite-plugin-static-copy": "^1.0.5",
         "vitest": "^2.0.0",
         "vue-tsc": "^2.1.10",
         "zip-dir": "^2.0.0",
@@ -12721,24 +12720,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/vite-plugin-static-copy": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-1.0.6.tgz",
-      "integrity": "sha512-3uSvsMwDVFZRitqoWHj0t4137Kz7UynnJeq1EZlRW7e25h2068fyIZX4ORCCOAkfp1FklGxJNVJBkBOD+PZIew==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^5.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "unplugin-vue-components": "^0.27.4",
     "vite": "^5.4.14",
     "vite-plugin-dts": "^4.3.0",
-    "vite-plugin-static-copy": "^1.0.5",
     "vitest": "^2.0.0",
     "vue-tsc": "^2.1.10",
     "zip-dir": "^2.0.0",


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3182-Remove-unused-plugin-vite-plugin-static-copy-1bd6d73d365081509a28fcfdd9024a8b) by [Unito](https://www.unito.io)
