### PR TITLE
Show error message on drop error

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -437,39 +437,44 @@ export class ComfyApp {
   #addDropHandler() {
     // Get prompt from dropped PNG or json
     document.addEventListener('drop', async (event) => {
-      event.preventDefault()
-      event.stopPropagation()
+      try {
+        event.preventDefault()
+        event.stopPropagation()
 
-      const n = this.dragOverNode
-      this.dragOverNode = null
-      // Node handles file drop, we dont use the built in onDropFile handler as its buggy
-      // If you drag multiple files it will call it multiple times with the same file
-      if (n && n.onDragDrop && (await n.onDragDrop(event))) {
-        return
-      }
-      // Dragging from Chrome->Firefox there is a file but its a bmp, so ignore that
-      if (
-        // @ts-expect-error fixme ts strict error
-        event.dataTransfer.files.length &&
-        // @ts-expect-error fixme ts strict error
-        event.dataTransfer.files[0].type !== 'image/bmp'
-      ) {
-        // @ts-expect-error fixme ts strict error
-        await this.handleFile(event.dataTransfer.files[0])
-      } else {
-        // Try loading the first URI in the transfer list
-        const validTypes = ['text/uri-list', 'text/x-moz-url']
-        // @ts-expect-error fixme ts strict error
-        const match = [...event.dataTransfer.types].find((t) =>
-          validTypes.find((v) => t === v)
-        )
-        if (match) {
+        const n = this.dragOverNode
+        this.dragOverNode = null
+        // Node handles file drop, we dont use the built in onDropFile handler as its buggy
+        // If you drag multiple files it will call it multiple times with the same file
+        if (n && n.onDragDrop && (await n.onDragDrop(event))) {
+          return
+        }
+        // Dragging from Chrome->Firefox there is a file but its a bmp, so ignore that
+        if (
           // @ts-expect-error fixme ts strict error
-          const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
-          if (uri) {
-            await this.handleFile(await (await fetch(uri)).blob())
+          event.dataTransfer.files.length &&
+          // @ts-expect-error fixme ts strict error
+          event.dataTransfer.files[0].type !== 'image/bmp'
+        ) {
+          // @ts-expect-error fixme ts strict error
+          await this.handleFile(event.dataTransfer.files[0])
+        } else {
+          // Try loading the first URI in the transfer list
+          const validTypes = ['text/uri-list', 'text/x-moz-url']
+          // @ts-expect-error fixme ts strict error
+          const match = [...event.dataTransfer.types].find((t) =>
+            validTypes.find((v) => t === v)
+          )
+          if (match) {
+            // @ts-expect-error fixme ts strict error
+            const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
+            if (uri) {
+              await this.handleFile(await (await fetch(uri)).blob())
+            }
           }
         }
+      } catch (err: any) {
+        console.error(err)
+        useToastStore().addAlert(err)
       }
     })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -473,8 +473,8 @@ export class ComfyApp {
           }
         }
       } catch (err: any) {
-        console.error(err)
-        useToastStore().addAlert(err)
+        console.error('Unable to process dropped item:', err)
+        useToastStore().addAlert(`Unable to process dropped item: ${err}`)
       }
     })
 


### PR DESCRIPTION
Drop operation may fail in various reasons.
I think it's better to notify the user in such cases, instead of just staying silent. 

This fix simply adds error handling to the drop event handler.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3189-Show-error-message-on-drop-error-1be6d73d365081ffac3ad18c4d2ef17c) by [Unito](https://www.unito.io)
