### PR TITLE
Fix parsing workflows from 3d outputs on Windows

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1457,7 +1457,10 @@ export class ComfyApp {
       } else {
         this.showErrorOnFileLoad(file)
       }
-    } else if (file.type === 'model/gltf-binary') {
+    } else if (
+      file.type === 'model/gltf-binary' ||
+      file.name?.endsWith('.glb')
+    ) {
       const gltfInfo = await getGltfBinaryMetadata(file)
       if (gltfInfo.workflow) {
         this.loadGraphData(gltfInfo.workflow, true, true, fileName)


### PR DESCRIPTION
Windows does not set the `type` field to `model/gltf-binary`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3196-Fix-parsing-workflows-from-3d-outputs-on-Windows-1bf6d73d365081109f3be91849613429) by [Unito](https://www.unito.io)
