### PR TITLE
pen tablet input support

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -2382,7 +2382,6 @@ class BrushTool {
     const isErasing = maskCtx.globalCompositeOperation === 'destination-out'
 
     if (hardness === 1) {
-      console.log(sliderOpacity, opacity)
       gradient.addColorStop(
         0,
         isErasing
@@ -4295,12 +4294,8 @@ class PanAndZoomManager {
   handleTouchStart(event: TouchEvent) {
     event.preventDefault()
 
-    // for pen tablet device, if drawing with pen, do not move the canvas
+    // for pen device, if drawing with pen, do not move the canvas
     if (this.penPointerIdList.length > 0) return
-
-    // for ios only, stylus touch should not move the canvas
-    const touchType = (event.touches[0] as any)?.touchType
-    if (touchType === 'stylus') return
 
     this.messageBroker.publish('setBrushVisibility', false)
     if (event.touches.length === 2) {
@@ -4331,12 +4326,8 @@ class PanAndZoomManager {
   async handleTouchMove(event: TouchEvent) {
     event.preventDefault()
 
-    // for pen tablet device, if drawing with pen, do not move the canvas
+    // for pen device, if drawing with pen, do not move the canvas
     if (this.penPointerIdList.length > 0) return
-
-    // for ios only, stylus touch should not move the canvas
-    const touchType = (event.touches[0] as any)?.touchType
-    if (touchType === 'stylus') return
 
     this.lastTwoFingerTap = 0
     if (this.isTouchZooming && event.touches.length === 2) {
@@ -4605,6 +4596,8 @@ class PanAndZoomManager {
 
     this.zoom_ratio = Math.min(zoomRatioWidth, zoomRatioHeight)
     this.pan_offset = pan_offset
+
+    this.penPointerIdList = []
 
     await this.invalidatePanZoom()
   }


### PR DESCRIPTION
relative issues:
https://github.com/Comfy-Org/ComfyUI_frontend/issues/1887

pc test:
![image](https://github.com/user-attachments/assets/6cf72032-416b-46e0-8107-164d6569807c)


ipad test:
![image](https://github.com/user-attachments/assets/2ec80fb9-9ab5-496c-b009-bf0f1c0b1fbc)

From my observations, I can conclude that the `touchType` property for detecting touch device information is only available on iOS.

In Windows and other non-iOS environments. We should rely on the `pointerType` property in `PointerEvents` to determine the input source type.

The implementation now uses a `penPointerIdList` to check for active stylus inputs. When pen contacts are present, canvas panning and zooming functionalities are disabled.

This approach effectively replaces the previous logic that depended on `touchType` detection.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3201-pen-tablet-input-support-1bf6d73d3650818a99a0fbf9f26ed252) by [Unito](https://www.unito.io)
