### PR TITLE
Fix drag new link from reroute to widget

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -690,11 +690,7 @@ app.registerExtension({
         if (!inputSpec) return
 
         const input = convertToInput(node, widget, inputSpec)
-        if (!input) return
-
-        const originNode = link.node
-
-        originNode.connectSlots(link.fromSlot, node, input, undefined)
+        link.node.connectSlots(link.fromSlot, node, input, undefined)
       }
     )
   },

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -532,7 +532,7 @@ export function convertToInput(
   node: LGraphNode,
   widget: IWidget,
   config: InputSpec
-) {
+): INodeInputSlot {
   hideWidget(node, widget)
 
   const { type } = getWidgetType(config)

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -690,7 +690,7 @@ app.registerExtension({
         if (!inputSpec) return
 
         const input = convertToInput(node, widget, inputSpec)
-        link.node.connectSlots(link.fromSlot, node, input, undefined)
+        link.node.connectSlots(link.fromSlot, node, input, link.fromReroute?.id)
       }
     )
   },


### PR DESCRIPTION
Now connects from reroute to widget instead of going direct from the node output.

![image](https://github.com/user-attachments/assets/208d8453-2c74-458d-9034-817cdcbf04c0)

![image](https://github.com/user-attachments/assets/da0c602d-bc0d-492c-bcd0-5447394a8cef)

- Resolves https://github.com/Comfy-Org/litegraph.js/issues/360

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3214-Fix-drag-new-link-from-reroute-to-widget-1c06d73d365081bfa692f3660e4cecca) by [Unito](https://www.unito.io)
