### PR TITLE
Allow STRING link to connect to converted COMBO socket

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -582,7 +582,7 @@ function getWidgetType(config: InputSpec) {
   // Special handling for COMBO so we restrict links based on the entries
   let type = config[0]
   if (type instanceof Array) {
-    type = 'COMBO'
+    type = 'COMBO,STRING'
   }
   return { type }
 }
@@ -667,11 +667,13 @@ app.registerExtension({
     }
   ],
   setup() {
-    app.canvas.getWidgetLinkType = function (widget, node) {
+    app.canvas.getWidgetLinkType = function (widget, node): string | undefined {
       const nodeDefStore = useNodeDefStore()
       const nodeDef = nodeDefStore.nodeDefsByName[node.type]
-      const input = nodeDef.inputs[widget.name]
-      return input?.type
+      const inputSpec = nodeDef.inputs[widget.name]
+      if (!inputSpec) return
+
+      return inputSpec.type === 'COMBO' ? 'COMBO,STRING' : inputSpec.type
     }
 
     app.canvas.linkConnector.events.addEventListener(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/67cf1f83-bd27-4648-935e-9bbcde7c97d7)

As COMBO widget is essentially selecting a specific string from a set of strings, we should allow connection of STRING link to converted COMBO socket for more dynamic workflow manipulation, i.e. dynamically generate a COMBO input option from other nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3236-Allow-STRING-link-to-connect-to-converted-COMBO-socket-1c16d73d3650817c8c61dc9d86ef5e1c) by [Unito](https://www.unito.io)
