### PR TITLE
[Manager] Fix build env vars

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,8 @@
 declare const __COMFYUI_FRONTEND_VERSION__: string
 declare const __SENTRY_ENABLED__: boolean
 declare const __SENTRY_DSN__: string
+declare const __ALGOLIA_APP_ID__: string
+declare const __ALGOLIA_API_KEY__: string
 
 interface Navigator {
   /**

--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -8,9 +8,6 @@ import { omit } from 'lodash'
 
 import { components } from '@/types/comfyRegistryTypes'
 
-declare const __ALGOLIA_APP_ID__: string
-declare const __ALGOLIA_API_KEY__: string
-
 type SafeNestedProperty<
   T,
   K1 extends keyof T,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -183,8 +183,8 @@ export default defineConfig({
       !(process.env.NODE_ENV === 'development' || !process.env.SENTRY_DSN)
     ),
     __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
-    __ALGOLIA_APP_ID__: JSON.stringify(process.env.VITE_ALGOLIA_APP_ID || ''),
-    __ALGOLIA_API_KEY__: JSON.stringify(process.env.VITE_ALGOLIA_API_KEY || '')
+    __ALGOLIA_APP_ID__: JSON.stringify(process.env.ALGOLIA_APP_ID || ''),
+    __ALGOLIA_API_KEY__: JSON.stringify(process.env.ALGOLIA_API_KEY || '')
   },
 
   resolve: {


### PR DESCRIPTION
Fixes Algolia env vars in vite config. Currently, they are not being correctly added at build time.

In Vite, env vars prefixed with `VITE_` are exposed to client-side code, while others are only available on the server side. For the vite.config.mts file during build time, we should use the env vars without the VITE_ prefix.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3238-Manager-Fix-build-env-vars-1c26d73d3650811887efcbe7d2824e22) by [Unito](https://www.unito.io)
