### PR TITLE
[Subgraph] Add subgraph store

### DIFF
--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -5,9 +5,8 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
 import { app } from '@/scripts/app'
+import { useWorkflowStore } from '@/stores/workflowStore'
 import { isSubgraph } from '@/utils/typeGuardUtil'
-
-import { useWorkflowStore } from './workflowStore'
 
 export const useSubgraphStore = defineStore('subgraph', () => {
   const workflowStore = useWorkflowStore()
@@ -77,6 +76,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     graphIdPath,
     graphNamePath,
     isSubgraphActive,
+
     updateActiveGraph
   }
 })

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -1,0 +1,83 @@
+import { LGraph } from '@comfyorg/litegraph'
+import { Subgraph } from '@comfyorg/litegraph/dist/subgraphInterfaces'
+import { whenever } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { computed, ref, shallowRef } from 'vue'
+
+import { app } from '@/scripts/app'
+
+import { useWorkflowStore } from './workflowStore'
+
+const isSubgraph = (item: unknown): item is Subgraph =>
+  !!item && typeof item === 'object' && 'parent' in item
+
+const replaceUndefined = (arr: (string | null | undefined)[]) =>
+  arr.map((item) => item ?? 'Unknown')
+
+export const useSubgraphStore = defineStore('subgraph', () => {
+  const workflowStore = useWorkflowStore()
+
+  const activeGraph = shallowRef<Subgraph | LGraph | null>(null)
+  const activeRootGraphName = ref<string | null>(null)
+
+  const graphIdPath = ref<LGraph['id'][]>([])
+  const graphNamePath = ref<string[]>([])
+
+  const isSubgraphActive = computed(
+    () => activeGraph.value !== null && isSubgraph(activeGraph.value)
+  )
+
+  const updateActiveGraph = () => {
+    activeGraph.value = app?.graph
+  }
+
+  const updateRootGraphName = () => {
+    const isNewRoot = !isSubgraph(activeGraph)
+    if (!isNewRoot) return
+
+    const activeWorkflowName = workflowStore.activeWorkflow?.filename
+    activeRootGraphName.value = activeWorkflowName ?? 'Unsaved Workflow'
+  }
+
+  const updateGraphPaths = () => {
+    const currentGraph = app?.graph
+    if (!currentGraph) return
+
+    const namePath = []
+    const idPath = []
+
+    // If it's a subgraph, traverse up the parent chain
+    if (isSubgraph(currentGraph)) {
+      let current: LGraph | Subgraph = currentGraph
+      while (current && isSubgraph(current)) {
+        idPath.unshift(current.id)
+        namePath.unshift(current.name)
+        current = current.parent
+      }
+    } else {
+      // For non-subgraphs, just add the current graph's info
+      idPath.push(currentGraph.id)
+      namePath.push(activeRootGraphName.value)
+    }
+
+    graphIdPath.value = replaceUndefined(idPath)
+    graphNamePath.value = replaceUndefined(namePath)
+  }
+
+  whenever(() => app?.graph, updateActiveGraph, {
+    immediate: true,
+    once: true
+  })
+  whenever(() => workflowStore.activeWorkflow, updateActiveGraph)
+  whenever(activeGraph, () => {
+    updateRootGraphName()
+    updateGraphPaths()
+  })
+
+  return {
+    graphIdPath,
+    graphNamePath,
+    isSubgraphActive,
+    updateActiveGraph
+  }
+})

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -8,6 +8,8 @@ import { app } from '@/scripts/app'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 
+const UNSAVED_WORKFLOW_NAME = 'Unsaved Workflow'
+
 export const useSubgraphStore = defineStore('subgraph', () => {
   const workflowStore = useWorkflowStore()
 
@@ -30,7 +32,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     if (!isNewRoot) return
 
     const activeWorkflowName = workflowStore.activeWorkflow?.filename
-    activeRootGraphName.value = activeWorkflowName ?? 'Unsaved Workflow'
+    activeRootGraphName.value = activeWorkflowName ?? UNSAVED_WORKFLOW_NAME
   }
 
   const updateGraphPaths = () => {
@@ -50,7 +52,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     while (cur) {
       const name = isSubgraph(cur)
         ? cur.name
-        : activeWorkflow?.filename ?? 'Unsaved Workflow'
+        : activeWorkflow?.filename ?? UNSAVED_WORKFLOW_NAME
 
       namePath.unshift(name)
       idPath.unshift(cur.id)

--- a/src/utils/typeGuardUtil.ts
+++ b/src/utils/typeGuardUtil.ts
@@ -1,4 +1,5 @@
-import { LGraphNode } from '@comfyorg/litegraph'
+import { LGraph, LGraphNode } from '@comfyorg/litegraph'
+import { Subgraph } from '@comfyorg/litegraph/dist/subgraphInterfaces'
 
 import type { PrimitiveNode } from '@/extensions/core/widgetInputs'
 
@@ -16,3 +17,6 @@ export const isAbortError = (
   err: unknown
 ): err is DOMException & { name: 'AbortError' } =>
   err instanceof DOMException && err.name === 'AbortError'
+
+export const isSubgraph = (item: LGraph | Subgraph | null): item is Subgraph =>
+  !!item && typeof item === 'object' && 'parent' in item

--- a/tests-ui/tests/store/subgraphStore.test.ts
+++ b/tests-ui/tests/store/subgraphStore.test.ts
@@ -1,0 +1,97 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { app } from '@/scripts/app'
+import { useSubgraphStore } from '@/stores/subgraphStore'
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    graph: null
+  }
+}))
+
+const mockWorkflowStore = {
+  activeWorkflow: {
+    filename: 'test.workflow'
+  }
+}
+
+vi.mock('@/stores/workflowStore', () => ({
+  useWorkflowStore: vi.fn(() => mockWorkflowStore)
+}))
+
+describe('useSubgraphStore', () => {
+  let store: ReturnType<typeof useSubgraphStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useSubgraphStore()
+    vi.clearAllMocks()
+  })
+
+  it('should initialize with default values', () => {
+    expect(store.graphIdPath).toEqual([])
+    expect(store.graphNamePath).toEqual([])
+    expect(store.isSubgraphActive).toBe(false)
+  })
+
+  describe('No Subgraphs exist', () => {
+    it('should update paths when active workflow changes', async () => {
+      const mockName = 'Not a Subgraph'
+      const mockId = 'this-is-not-a-subgraph'
+      const mockRootGraph = {
+        id: mockId
+        // Non-subgraph does not have `parent` or a `name` properties for now
+      }
+
+      mockWorkflowStore.activeWorkflow.filename = mockName
+      vi.spyOn(app, 'graph', 'get').mockReturnValue(mockRootGraph as any)
+
+      store.updateActiveGraph()
+      await nextTick()
+
+      expect(store.graphIdPath).toEqual([mockId])
+      expect(store.graphNamePath).toEqual([mockName])
+    })
+  })
+
+  describe('Subgraphs exist', () => {
+    it('should update paths when active workflow changes', async () => {
+      const mockSubgraph = {
+        id: 'subgraph-2',
+        name: 'Subgraph 2',
+        parent: {
+          id: 'subgraph-1',
+          name: 'Subgraph 1',
+          parent: {
+            id: 'root-graph',
+            name: 'Root Graph',
+            parent: null
+          }
+        }
+      }
+
+      // Update the active workflow name
+      mockWorkflowStore.activeWorkflow.filename = 'test.workflow'
+
+      // Mock the app.graph getter
+      vi.spyOn(app, 'graph', 'get').mockReturnValue(mockSubgraph as any)
+
+      // Trigger the update
+      store.updateActiveGraph()
+      await nextTick()
+
+      expect(store.graphIdPath).toEqual([
+        'root-graph',
+        'subgraph-1',
+        'subgraph-2'
+      ])
+      expect(store.graphNamePath).toEqual([
+        'Root Graph',
+        'Subgraph 1',
+        'Subgraph 2'
+      ])
+    })
+  })
+})

--- a/tests-ui/tests/store/subgraphStore.test.ts
+++ b/tests-ui/tests/store/subgraphStore.test.ts
@@ -13,7 +13,8 @@ vi.mock('@/scripts/app', () => ({
 
 const mockWorkflowStore = {
   activeWorkflow: {
-    filename: 'test.workflow'
+    filename: 'test.workflow',
+    path: 'test.workflow'
   }
 }
 
@@ -46,6 +47,7 @@ describe('useSubgraphStore', () => {
       }
 
       mockWorkflowStore.activeWorkflow.filename = mockName
+      mockWorkflowStore.activeWorkflow.path = mockId
       vi.spyOn(app, 'graph', 'get').mockReturnValue(mockRootGraph as any)
 
       store.updateActiveGraph()
@@ -65,15 +67,13 @@ describe('useSubgraphStore', () => {
           id: 'subgraph-1',
           name: 'Subgraph 1',
           parent: {
-            id: 'root-graph',
-            name: 'Root Graph',
-            parent: null
+            id: 'root-graph'
           }
         }
       }
 
       // Update the active workflow name
-      mockWorkflowStore.activeWorkflow.filename = 'test.workflow'
+      mockWorkflowStore.activeWorkflow.filename = 'Root Graph'
 
       // Mock the app.graph getter
       vi.spyOn(app, 'graph', 'get').mockReturnValue(mockSubgraph as any)


### PR DESCRIPTION
Adds store for tracking state of active subgraphs, including name and ID paths (e.g., `['Workflow Name', 'Subgraph Name', 'Name of Subgraph inside Subgraph']`).

See:

- https://github.com/Comfy-Org/litegraph.js/pull/851

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3240-Subgraph-Add-subgraph-store-1c26d73d365081fcad90f673a7c1061f) by [Unito](https://www.unito.io)
