### PR TITLE
Translate action history items

### DIFF
--- a/src/components/dialog/header/ManagerProgressHeader.vue
+++ b/src/components/dialog/header/ManagerProgressHeader.vue
@@ -28,6 +28,6 @@ const activeTabIndex = ref(0)
 const { t } = useI18n()
 const tabs = [
   { label: t('manager.installationQueue') },
-  { label: t('g.failed', { count: 0 }) }
+  { label: t('manager.failed', { count: 0 }) }
 ]
 </script>

--- a/src/components/dialog/header/ManagerProgressHeader.vue
+++ b/src/components/dialog/header/ManagerProgressHeader.vue
@@ -19,11 +19,15 @@
 <script setup lang="ts">
 import TabMenu from 'primevue/tabmenu'
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { useManagerProgressDialogStore } from '@/stores/comfyManagerStore'
 
 const progressDialogContent = useManagerProgressDialogStore()
 const activeTabIndex = ref(0)
-
-const tabs = [{ label: 'Installation Queue' }, { label: 'Failed (0)' }]
+const { t } = useI18n()
+const tabs = [
+  { label: t('manager.installationQueue') },
+  { label: t('g.failed', { count: 0 }) }
+]
 </script>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -101,10 +101,14 @@
     "missing": "Missing",
     "inProgress": "In progress",
     "completed": "Completed",
-    "interrupted": "Interrupted"
+    "interrupted": "Interrupted",
+    "enabling": "Enabling",
+    "disabling": "Disabling",
+    "updating": "Updating"
   },
   "manager": {
     "title": "Custom Nodes Manager",
+    "changingVersion": "Changing version from {from} to {to}",
     "dependencies": "Dependencies",
     "inWorkflow": "In Workflow",
     "infoPanelEmpty": "Click an item to see the info",
@@ -117,6 +121,7 @@
     "uninstalling": "Uninstalling",
     "update": "Update",
     "uninstallSelected": "Uninstall Selected",
+    "updatingAllPacks": "Updating all packages",
     "license": "License",
     "nightlyVersion": "Nightly",
     "latestVersion": "Latest",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -108,6 +108,8 @@
   },
   "manager": {
     "title": "Custom Nodes Manager",
+    "failed": "Failed ({count})",
+    "installationQueue": "Installation Queue",
     "changingVersion": "Changing version from {from} to {to}",
     "dependencies": "Dependencies",
     "inWorkflow": "In Workflow",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -151,10 +151,12 @@
     "description": "Descripción",
     "devices": "Dispositivos",
     "disableAll": "Deshabilitar todo",
+    "disabling": "Deshabilitando",
     "download": "Descargar",
     "empty": "Vacío",
     "enableAll": "Habilitar todo",
     "enabled": "Habilitado",
+    "enabling": "Habilitando",
     "error": "Error",
     "experimental": "BETA",
     "export": "Exportar",
@@ -221,6 +223,7 @@
     "terminal": "Terminal",
     "update": "Actualizar",
     "updated": "Actualizado",
+    "updating": "Actualizando",
     "upload": "Subir",
     "videoFailedToLoad": "Falló la carga del video",
     "workflow": "Flujo de trabajo"
@@ -399,6 +402,7 @@
     "title": "Mantenimiento"
   },
   "manager": {
+    "changingVersion": "Cambiando versión de {from} a {to}",
     "createdBy": "Creado Por",
     "dependencies": "Dependencias",
     "discoverCommunityContent": "Descubre paquetes de nodos, extensiones y más creados por la comunidad...",
@@ -445,6 +449,7 @@
     "uninstallSelected": "Desinstalar Seleccionado",
     "uninstalling": "Desinstalando",
     "update": "Actualizar",
+    "updatingAllPacks": "Actualizando todos los paquetes",
     "version": "Versión"
   },
   "maskEditor": {

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -408,6 +408,7 @@
     "discoverCommunityContent": "Descubre paquetes de nodos, extensiones y más creados por la comunidad...",
     "downloads": "Descargas",
     "errorConnecting": "Error al conectar con el Registro de Nodos Comfy.",
+    "failed": "Falló ({count})",
     "filter": {
       "disabled": "Deshabilitado",
       "enabled": "Habilitado",
@@ -416,6 +417,7 @@
     "inWorkflow": "En Flujo de Trabajo",
     "infoPanelEmpty": "Haz clic en un elemento para ver la información",
     "installSelected": "Instalar Seleccionado",
+    "installationQueue": "Cola de Instalación",
     "lastUpdated": "Última Actualización",
     "latestVersion": "Última",
     "license": "Licencia",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -408,6 +408,7 @@
     "discoverCommunityContent": "Découvrez les packs de nœuds, extensions et plus encore créés par la communauté...",
     "downloads": "Téléchargements",
     "errorConnecting": "Erreur de connexion au registre de nœuds Comfy.",
+    "failed": "Échoué ({count})",
     "filter": {
       "disabled": "Désactivé",
       "enabled": "Activé",
@@ -416,6 +417,7 @@
     "inWorkflow": "Dans le flux de travail",
     "infoPanelEmpty": "Cliquez sur un élément pour voir les informations",
     "installSelected": "Installer sélectionné",
+    "installationQueue": "File d'attente d'installation",
     "lastUpdated": "Dernière mise à jour",
     "latestVersion": "Dernière",
     "license": "Licence",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -151,10 +151,12 @@
     "description": "Description",
     "devices": "Appareils",
     "disableAll": "Désactiver tout",
+    "disabling": "Désactivation",
     "download": "Télécharger",
     "empty": "Vide",
     "enableAll": "Activer tout",
     "enabled": "Activé",
+    "enabling": "Activation",
     "error": "Erreur",
     "experimental": "BETA",
     "export": "Exportation",
@@ -221,6 +223,7 @@
     "terminal": "Terminal",
     "update": "Mettre à jour",
     "updated": "Mis à jour",
+    "updating": "Mise à jour",
     "upload": "Téléverser",
     "videoFailedToLoad": "Échec du chargement de la vidéo",
     "workflow": "Flux de travail"
@@ -399,6 +402,7 @@
     "title": "Maintenance"
   },
   "manager": {
+    "changingVersion": "Changement de version de {from} à {to}",
     "createdBy": "Créé par",
     "dependencies": "Dépendances",
     "discoverCommunityContent": "Découvrez les packs de nœuds, extensions et plus encore créés par la communauté...",
@@ -445,6 +449,7 @@
     "uninstallSelected": "Désinstaller sélectionné",
     "uninstalling": "Désinstallation",
     "update": "Mettre à jour",
+    "updatingAllPacks": "Mise à jour de tous les paquets",
     "version": "Version"
   },
   "maskEditor": {

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -151,10 +151,12 @@
     "description": "説明",
     "devices": "デバイス",
     "disableAll": "すべて無効にする",
+    "disabling": "無効化",
     "download": "ダウンロード",
     "empty": "空",
     "enableAll": "すべて有効にする",
     "enabled": "有効",
+    "enabling": "有効化",
     "error": "エラー",
     "experimental": "ベータ",
     "export": "エクスポート",
@@ -221,6 +223,7 @@
     "terminal": "ターミナル",
     "update": "更新",
     "updated": "更新済み",
+    "updating": "更新中",
     "upload": "アップロード",
     "videoFailedToLoad": "ビデオの読み込みに失敗しました",
     "workflow": "ワークフロー"
@@ -399,6 +402,7 @@
     "title": "メンテナンス"
   },
   "manager": {
+    "changingVersion": "バージョンを {from} から {to} に変更",
     "createdBy": "作成者",
     "dependencies": "依存関係",
     "discoverCommunityContent": "コミュニティが作成したノードパック、拡張機能などを探す...",
@@ -445,6 +449,7 @@
     "uninstallSelected": "選択したものをアンインストール",
     "uninstalling": "アンインストール中",
     "update": "更新",
+    "updatingAllPacks": "すべてのパッケージを更新中",
     "version": "バージョン"
   },
   "maskEditor": {

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -408,6 +408,7 @@
     "discoverCommunityContent": "コミュニティが作成したノードパック、拡張機能などを探す...",
     "downloads": "ダウンロード",
     "errorConnecting": "Comfy Node Registryへの接続エラー。",
+    "failed": "失敗しました ({count})",
     "filter": {
       "disabled": "無効",
       "enabled": "有効",
@@ -416,6 +417,7 @@
     "inWorkflow": "ワークフロー内",
     "infoPanelEmpty": "アイテムをクリックして情報を表示します",
     "installSelected": "選択したものをインストール",
+    "installationQueue": "インストールキュー",
     "lastUpdated": "最終更新日",
     "latestVersion": "最新",
     "license": "ライセンス",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -408,6 +408,7 @@
     "discoverCommunityContent": "커뮤니티에서 만든 노드 팩 및 확장 프로그램을 찾아보세요...",
     "downloads": "다운로드",
     "errorConnecting": "Comfy Node Registry에 연결하는 중 오류가 발생했습니다.",
+    "failed": "실패 ({count})",
     "filter": {
       "disabled": "비활성화",
       "enabled": "활성화",
@@ -416,6 +417,7 @@
     "inWorkflow": "워크플로우 내",
     "infoPanelEmpty": "정보를 보려면 항목을 클릭하세요",
     "installSelected": "선택한 항목 설치",
+    "installationQueue": "설치 대기열",
     "lastUpdated": "마지막 업데이트",
     "latestVersion": "최신",
     "license": "라이선스",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -151,10 +151,12 @@
     "description": "설명",
     "devices": "장치",
     "disableAll": "모두 비활성화",
+    "disabling": "비활성화 중",
     "download": "다운로드",
     "empty": "비어 있음",
     "enableAll": "모두 활성화",
     "enabled": "활성화됨",
+    "enabling": "활성화 중",
     "error": "오류",
     "experimental": "베타",
     "export": "내보내기",
@@ -221,6 +223,7 @@
     "terminal": "터미널",
     "update": "업데이트",
     "updated": "업데이트 됨",
+    "updating": "업데이트 중",
     "upload": "업로드",
     "videoFailedToLoad": "비디오를 로드하지 못했습니다.",
     "workflow": "워크플로"
@@ -399,6 +402,7 @@
     "title": "유지 보수"
   },
   "manager": {
+    "changingVersion": "{from}에서 {to}로 버전 변경 중",
     "createdBy": "작성자",
     "dependencies": "의존성",
     "discoverCommunityContent": "커뮤니티에서 만든 노드 팩 및 확장 프로그램을 찾아보세요...",
@@ -445,6 +449,7 @@
     "uninstallSelected": "선택 항목 제거",
     "uninstalling": "제거 중",
     "update": "업데이트",
+    "updatingAllPacks": "모든 패키지 업데이트 중",
     "version": "버전"
   },
   "maskEditor": {

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -408,6 +408,7 @@
     "discoverCommunityContent": "Откройте для себя пакеты узлов, расширения и многое другое, созданные сообществом...",
     "downloads": "Загрузки",
     "errorConnecting": "Ошибка подключения к реестру Comfy Node.",
+    "failed": "Не удалось ({count})",
     "filter": {
       "disabled": "Отключено",
       "enabled": "Включено",
@@ -416,6 +417,7 @@
     "inWorkflow": "В рабочем процессе",
     "infoPanelEmpty": "Нажмите на элемент, чтобы увидеть информацию",
     "installSelected": "Установить выбранное",
+    "installationQueue": "Очередь установки",
     "lastUpdated": "Последнее обновление",
     "latestVersion": "Последняя",
     "license": "Лицензия",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -151,10 +151,12 @@
     "description": "Описание",
     "devices": "Устройства",
     "disableAll": "Отключить все",
+    "disabling": "Отключение",
     "download": "Скачать",
     "empty": "Пусто",
     "enableAll": "Включить все",
     "enabled": "Включено",
+    "enabling": "Включение",
     "error": "Ошибка",
     "experimental": "БЕТА",
     "export": "Экспорт",
@@ -221,6 +223,7 @@
     "terminal": "Терминал",
     "update": "Обновить",
     "updated": "Обновлено",
+    "updating": "Обновление",
     "upload": "Загрузить",
     "videoFailedToLoad": "Не удалось загрузить видео",
     "workflow": "Рабочий процесс"
@@ -399,6 +402,7 @@
     "title": "Обслуживание"
   },
   "manager": {
+    "changingVersion": "Изменение версии с {from} на {to}",
     "createdBy": "Создано",
     "dependencies": "Зависимости",
     "discoverCommunityContent": "Откройте для себя пакеты узлов, расширения и многое другое, созданные сообществом...",
@@ -445,6 +449,7 @@
     "uninstallSelected": "Удалить выбранное",
     "uninstalling": "Удаление",
     "update": "Обновить",
+    "updatingAllPacks": "Обновление всех пакетов",
     "version": "Версия"
   },
   "maskEditor": {

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -151,10 +151,12 @@
     "description": "描述",
     "devices": "设备",
     "disableAll": "禁用全部",
+    "disabling": "禁用中",
     "download": "下载",
     "empty": "空",
     "enableAll": "启用全部",
     "enabled": "已启用",
+    "enabling": "启用中",
     "error": "错误",
     "experimental": "测试版",
     "export": "导出",
@@ -221,6 +223,7 @@
     "terminal": "终端",
     "update": "更新",
     "updated": "已更新",
+    "updating": "更新中",
     "upload": "上传",
     "videoFailedToLoad": "视频加载失败",
     "workflow": "工作流"
@@ -399,6 +402,7 @@
     "title": "维护"
   },
   "manager": {
+    "changingVersion": "将版本从 {from} 更改为 {to}",
     "createdBy": "创建者",
     "dependencies": "依赖关系",
     "discoverCommunityContent": "发现社区制作的节点包，扩展等等...",
@@ -445,6 +449,7 @@
     "uninstallSelected": "卸载所选",
     "uninstalling": "正在卸载",
     "update": "更新",
+    "updatingAllPacks": "更新所有包",
     "version": "版本"
   },
   "maskEditor": {

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -408,6 +408,7 @@
     "discoverCommunityContent": "发现社区制作的节点包，扩展等等...",
     "downloads": "下载",
     "errorConnecting": "连接到Comfy节点注册表时出错。",
+    "failed": "失败 ({count})",
     "filter": {
       "disabled": "已禁用",
       "enabled": "已启用",
@@ -416,6 +417,7 @@
     "inWorkflow": "在工作流中",
     "infoPanelEmpty": "点击一个项目查看信息",
     "installSelected": "安装选定",
+    "installationQueue": "安装队列",
     "lastUpdated": "最后更新",
     "latestVersion": "最新",
     "license": "许可证",

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -1,6 +1,7 @@
 import { whenever } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { useCachedRequest } from '@/composables/useCachedRequest'
 import { useManagerQueue } from '@/composables/useManagerQueue'
@@ -20,6 +21,7 @@ import {
  * Store for state of installed node packs
  */
 export const useComfyManagerStore = defineStore('comfyManager', () => {
+  const { t } = useI18n()
   const managerService = useComfyManagerService()
   const { showManagerProgressDialog } = useDialogService()
 
@@ -136,14 +138,17 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     async (params: InstallPackParams, signal?: AbortSignal) => {
       if (!params.id) return
 
-      let actionDescription = 'Installing'
+      let actionDescription = t('g.installing')
       if (installedPacksIds.value.has(params.id)) {
         const installedPack = installedPacks.value[params.id]
 
         if (installedPack && installedPack.ver !== params.selected_version) {
-          actionDescription = `Changing version from ${installedPack.ver} to ${params.selected_version}:`
+          actionDescription = t('manager.changingVersion', {
+            from: installedPack.ver,
+            to: params.selected_version
+          })
         } else {
-          actionDescription = 'Enabling'
+          actionDescription = t('g.enabling')
         }
       }
 
@@ -157,14 +162,14 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     installPack.clear()
     installPack.cancel()
     const task = () => managerService.uninstallPack(params, signal)
-    enqueueTask(withLogs(task, `Uninstalling ${params.id}`))
+    enqueueTask(withLogs(task, t('manager.uninstalling', { id: params.id })))
   }
 
   const updatePack = useCachedRequest<ManagerPackInfo, void>(
     async (params: ManagerPackInfo, signal?: AbortSignal) => {
       updateAllPacks.cancel()
       const task = () => managerService.updatePack(params, signal)
-      enqueueTask(withLogs(task, `Updating ${params.id}`))
+      enqueueTask(withLogs(task, t('g.updating', { id: params.id })))
     },
     { maxSize: 1 }
   )
@@ -172,14 +177,14 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
   const updateAllPacks = useCachedRequest<UpdateAllPacksParams, void>(
     async (params: UpdateAllPacksParams, signal?: AbortSignal) => {
       const task = () => managerService.updateAllPacks(params, signal)
-      enqueueTask(withLogs(task, 'Updating all packs'))
+      enqueueTask(withLogs(task, t('manager.updatingAllPacks')))
     },
     { maxSize: 1 }
   )
 
   const disablePack = (params: ManagerPackInfo, signal?: AbortSignal) => {
     const task = () => managerService.disablePack(params, signal)
-    enqueueTask(withLogs(task, `Disabling ${params.id}`))
+    enqueueTask(withLogs(task, t('g.disabling', { id: params.id })))
   }
 
   const getInstalledPackVersion = (packId: string) => {

--- a/tests-ui/tests/store/comfyManagerStore.test.ts
+++ b/tests-ui/tests/store/comfyManagerStore.test.ts
@@ -13,6 +13,17 @@ vi.mock('@/services/comfyManagerService', () => ({
   useComfyManagerService: vi.fn()
 }))
 
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: vi.fn((key) => key)
+  }),
+  createI18n: vi.fn(() => ({
+    global: {
+      t: vi.fn((key) => key)
+    }
+  }))
+}))
+
 interface EnabledDisabledTestCase {
   desc: string
   installed: Record<string, ManagerPackInstalled>


### PR DESCRIPTION
Adds missing `i18n` strings:

![Screenshot 2025-03-27 155907](https://github.com/user-attachments/assets/2948255d-35f2-442f-a2b8-a44668ef560b)


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3249-Translate-action-history-items-1c36d73d3650815b858bddd116b92a04) by [Unito](https://www.unito.io)
