### PR TITLE
[Manager] Fetch lists of node packs in single request

### DIFF
--- a/src/composables/nodePack/useNodePacks.ts
+++ b/src/composables/nodePack/useNodePacks.ts
@@ -1,5 +1,5 @@
-import { useAsyncState } from '@vueuse/core'
-import { Ref, unref } from 'vue'
+import { get, useAsyncState } from '@vueuse/core'
+import { Ref } from 'vue'
 
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
 import { UseNodePacksOptions } from '@/types/comfyManagerTypes'
@@ -14,7 +14,7 @@ export const useNodePacks = (
   const { immediate = false } = options
   const { getPacksByIds } = useComfyRegistryStore()
 
-  const fetchPacks = () => getPacksByIds.call(unref(packsIds).filter(Boolean))
+  const fetchPacks = () => getPacksByIds.call(get(packsIds).filter(Boolean))
 
   const {
     isReady,

--- a/src/composables/nodePack/useNodePacks.ts
+++ b/src/composables/nodePack/useNodePacks.ts
@@ -1,14 +1,8 @@
 import { useAsyncState } from '@vueuse/core'
-import { chunk } from 'lodash'
-import { Ref, computed, isRef, ref } from 'vue'
+import { Ref, unref } from 'vue'
 
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
 import { UseNodePacksOptions } from '@/types/comfyManagerTypes'
-import { components } from '@/types/comfyRegistryTypes'
-
-const DEFAULT_MAX_CONCURRENT = 6
-
-type NodePack = components['schemas']['Node']
 
 /**
  * Handles fetching node packs from the registry given a list of node pack IDs
@@ -17,54 +11,25 @@ export const useNodePacks = (
   packsIds: string[] | Ref<string[]>,
   options: UseNodePacksOptions = {}
 ) => {
-  const { immediate = false, maxConcurrent = DEFAULT_MAX_CONCURRENT } = options
-  const { getPackById } = useComfyRegistryStore()
+  const { immediate = false } = options
+  const { getPacksByIds } = useComfyRegistryStore()
 
-  const nodePacks = ref<NodePack[]>([])
-  const processedIds = ref<Set<string>>(new Set())
+  const fetchPacks = () => getPacksByIds.call(unref(packsIds).filter(Boolean))
 
-  const queuedPackIds = isRef(packsIds) ? packsIds : ref<string[]>(packsIds)
-  const remainingIds = computed(() =>
-    queuedPackIds.value?.filter((id) => !processedIds.value.has(id))
-  )
-  const chunks = computed(() =>
-    remainingIds.value?.length ? chunk(remainingIds.value, maxConcurrent) : []
-  )
-
-  const fetchPack = (id: Parameters<typeof getPackById.call>[0]) =>
-    id ? getPackById.call(id) : null
-
-  const toRequestBatch = async (ids: string[]) =>
-    Promise.all(ids.map(fetchPack))
-
-  const isValidResponse = (response: NodePack | null) => response !== null
-
-  const fetchPacks = async () => {
-    for (const chunk of chunks.value) {
-      const resolvedChunk = await toRequestBatch(chunk)
-      chunk.forEach((id) => processedIds.value.add(id))
-      if (!resolvedChunk) continue
-      nodePacks.value.push(...resolvedChunk.filter(isValidResponse))
-    }
-  }
-
-  const { isReady, isLoading, error, execute } = useAsyncState(
-    fetchPacks,
-    null,
-    {
-      immediate
-    }
-  )
-
-  const clear = () => {
-    queuedPackIds.value = []
-    isReady.value = false
-    isLoading.value = false
-  }
+  const {
+    isReady,
+    isLoading,
+    error,
+    execute,
+    state: nodePacks
+  } = useAsyncState(fetchPacks, [], {
+    immediate
+  })
 
   const cleanup = () => {
-    getPackById.cancel()
-    clear()
+    getPacksByIds.cancel()
+    isReady.value = false
+    isLoading.value = false
   }
 
   return {

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -11,6 +11,10 @@ const registryApiClient = axios.create({
   baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json'
+  },
+  paramsSerializer: {
+    // Disables PHP-style notation (e.g. param[]=value) in favor of repeated params (e.g. param=value1&param=value2)
+    indexes: null
   }
 })
 

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -1,3 +1,5 @@
+import QuickLRU from '@alloc/quick-lru'
+import { partition } from 'lodash'
 import { defineStore } from 'pinia'
 
 import { useCachedRequest } from '@/composables/useCachedRequest'
@@ -5,7 +7,7 @@ import { useComfyRegistryService } from '@/services/comfyRegistryService'
 import type { components, operations } from '@/types/comfyRegistryTypes'
 
 const PACK_LIST_CACHE_SIZE = 20
-const PACK_BY_ID_CACHE_SIZE = 50
+const PACK_BY_ID_CACHE_SIZE = 64
 
 type NodePack = components['schemas']['Node']
 type ListPacksParams = operations['listAllNodes']['parameters']['query']
@@ -14,11 +16,20 @@ type ListPacksResult =
 type ComfyNode = components['schemas']['ComfyNode']
 type GetPackByIdPath = operations['getNode']['parameters']['path']['nodeId']
 
+const isNodePack = (pack: NodePack | undefined): pack is NodePack => {
+  return pack !== undefined && 'id' in pack
+}
+
 /**
  * Store for managing remote custom nodes
  */
 export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
   const registryService = useComfyRegistryService()
+
+  let getPacksByIdController: AbortController | null = null
+  const getPacksByIdCache = new QuickLRU<NodePack['id'], NodePack>({
+    maxSize: PACK_BY_ID_CACHE_SIZE
+  })
 
   /**
    * Get a list of all node packs from the registry
@@ -38,6 +49,41 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     },
     { maxSize: PACK_BY_ID_CACHE_SIZE }
   )
+
+  /**
+   * Get a list of packs by their IDs from the registry
+   */
+  const getPacksByIds = async (ids: NodePack['id'][]): Promise<NodePack[]> => {
+    const [cachedPacksIds, uncachedPacksIds] = partition(ids, (id) =>
+      getPacksByIdCache.has(id)
+    )
+
+    const resolvedPacks = cachedPacksIds
+      .map((id) => getPacksByIdCache.get(id))
+      .filter(isNodePack)
+
+    if (uncachedPacksIds.length) {
+      getPacksByIdController = new AbortController()
+      const uncachedPacks = await registryService.listAllPacks(
+        {
+          node_id: uncachedPacksIds.filter(
+            (id): id is string => id !== undefined
+          )
+        },
+        getPacksByIdController.signal
+      )
+
+      const { nodes = [] } = uncachedPacks ?? {}
+      nodes.forEach((pack) => {
+        if (pack?.id) {
+          getPacksByIdCache.set(pack.id, pack)
+          resolvedPacks.push(pack)
+        }
+      })
+    }
+
+    return resolvedPacks
+  }
 
   /**
    * Get the node definitions for a pack
@@ -63,11 +109,16 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     getNodeDefs.cancel()
     listAllPacks.cancel()
     getPackById.cancel()
+    getPacksByIdController?.abort()
   }
 
   return {
     listAllPacks,
     getPackById,
+    getPacksByIds: {
+      call: getPacksByIds,
+      cancel: () => getPacksByIdController?.abort()
+    },
     getNodeDefs,
 
     clearCache,


### PR DESCRIPTION
Removes the mechanism in `useNodePacks` that created chunked request batches when fetching a list of node packs from the registry, as it is now possible to query a list of node packs in a single request. Navigating the different tabs of the Custom Nodes Manager is much faster under this PR.

Ref:

- https://github.com/Comfy-Org/comfy-api/pull/76

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3250-Manager-Fetch-lists-of-node-packs-in-single-request-1c36d73d36508116b096ea96fa78e5ff) by [Unito](https://www.unito.io)
