### PR TITLE
[Manager] Add Manager API v2 types

### DIFF
--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -32,7 +32,13 @@ enum ManagerRoute {
   GET_NODES = 'customnode/getmappings',
   GET_PACKS = 'customnode/getlist',
   IMPORT_FAIL_INFO = 'customnode/import_fail_info',
-  REBOOT = 'manager/reboot'
+  REBOOT = 'manager/reboot',
+
+  // v2 endpoints
+  BATCH = 'v2/manager/queue/batch',
+  HISTORY_LIST = 'v2/manager/queue/history_list',
+  HISTORY_ITEM = 'v2/manager/queue/history',
+  ABORT_CURRENT = 'v2/manager/queue/abort_current'
 }
 
 const managerApiClient = axios.create({

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -32,13 +32,7 @@ enum ManagerRoute {
   GET_NODES = 'customnode/getmappings',
   GET_PACKS = 'customnode/getlist',
   IMPORT_FAIL_INFO = 'customnode/import_fail_info',
-  REBOOT = 'manager/reboot',
-
-  // v2 endpoints
-  BATCH = 'v2/manager/queue/batch',
-  HISTORY_LIST = 'v2/manager/queue/history_list',
-  HISTORY_ITEM = 'v2/manager/queue/history',
-  ABORT_CURRENT = 'v2/manager/queue/abort_current'
+  REBOOT = 'manager/reboot'
 }
 
 const managerApiClient = axios.create({

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -214,3 +214,31 @@ export interface InstallPackParams extends ManagerPackInfo {
 export interface UpdateAllPacksParams {
   mode?: ManagerDatabaseSource
 }
+
+/**
+ * Params for `/v2/manager/queue/batch` and returned by `/v2/manager/queue/history?id={batch_id}`
+ */
+export interface ManagerBatchParams {
+  batch_id: string[]
+  update?: ManagerPackInfo[]
+  install?: InstallPackParams[]
+  uninstall?: ManagerPackInfo[]
+  disable?: ManagerPackInfo[]
+  enable?: ManagerPackInfo[]
+}
+
+/**
+ * Returned by `/v2/manager/queue/history_list`
+ */
+export interface ManagerHistoryItem {
+  batch: ManagerBatchParams
+  /** Maps pack id to result. If not `skip` or `success`, the value is the error message. */
+  nodepack_result: {
+    [key: string]: 'skip' | 'success' | string
+  }
+  model_result: {
+    [key: string]: string
+  }
+  /** `ui_ids` of the lists that failed during the pre-screening stage before entering the task queue */
+  failed: string[]
+}


### PR DESCRIPTION
Ref: https://github.com/Comfy-Org/ComfyUI-Manager/commit/212b8e7ed2bcc6ca199e799eab61a683ac001b28

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3251-Manager-Add-Manager-API-v2-types-1c36d73d3650816fb132ee1b38cb4347) by [Unito](https://www.unito.io)
