### PR TITLE
[Reroute] Migrate floating link

### DIFF
--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -83,9 +83,11 @@ const zReroute = z
     parentId: z.number().optional(),
     pos: zVector2,
     linkIds: z.array(z.number()).nullish(),
-    floating: z.object({
-      slotType: z.enum(['input', 'output'])
-    }).optional()
+    floating: z
+      .object({
+        slotType: z.enum(['input', 'output'])
+      })
+      .optional()
   })
   .passthrough()
 

--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -82,7 +82,10 @@ const zReroute = z
     id: z.number(),
     parentId: z.number().optional(),
     pos: zVector2,
-    linkIds: z.array(z.number()).nullish()
+    linkIds: z.array(z.number()).nullish(),
+    floating: z.object({
+      slotType: z.enum(['input', 'output'])
+    }).optional()
   })
   .passthrough()
 
@@ -277,6 +280,7 @@ export type ModelFile = z.infer<typeof zModelFile>
 export type NodeInput = z.infer<typeof zNodeInput>
 export type NodeOutput = z.infer<typeof zNodeOutput>
 export type ComfyLink = z.infer<typeof zComfyLink>
+export type ComfyLinkObject = z.infer<typeof zComfyLinkObject>
 export type ComfyNode = z.infer<typeof zComfyNode>
 export type Reroute = z.infer<typeof zReroute>
 export type WorkflowJSON04 = z.infer<typeof zComfyWorkflow>

--- a/src/utils/migration/migrateReroute.ts
+++ b/src/utils/migration/migrateReroute.ts
@@ -287,7 +287,7 @@ class ConversionContext {
         link.target_slot,
         link.type
       ]),
-      floatLinks: floatingLinks.length > 0 ? floatingLinks : undefined,
+      floatingLinks: floatingLinks.length > 0 ? floatingLinks : undefined,
       extra: {
         ...this.workflow.extra,
         reroutes: Array.from(this.validReroutes).map(

--- a/tests-ui/tests/utils/migration/migrateReroute.test.ts
+++ b/tests-ui/tests/utils/migration/migrateReroute.test.ts
@@ -14,22 +14,24 @@ describe('migrateReroute', () => {
       return JSON.parse(fileContent) as WorkflowJSON04
     }
 
-    it.each(['branching.json', 'single_connected.json', 'floating.json'])(
-      'should correctly migrate %s',
-      (fileName) => {
-        // Load the legacy workflow
-        const legacyWorkflow = loadWorkflow(
-          `workflows/reroute/legacy/${fileName}`
-        )
+    it.each([
+      'branching.json',
+      'single_connected.json',
+      'floating.json',
+      'floating_branch.json'
+    ])('should correctly migrate %s', (fileName) => {
+      // Load the legacy workflow
+      const legacyWorkflow = loadWorkflow(
+        `workflows/reroute/legacy/${fileName}`
+      )
 
-        // Migrate the workflow
-        const migratedWorkflow = migrateLegacyRerouteNodes(legacyWorkflow)
+      // Migrate the workflow
+      const migratedWorkflow = migrateLegacyRerouteNodes(legacyWorkflow)
 
-        // Compare with snapshot
-        expect(JSON.stringify(migratedWorkflow, null, 2)).toMatchFileSnapshot(
-          `workflows/reroute/native/${fileName}`
-        )
-      }
-    )
+      // Compare with snapshot
+      expect(JSON.stringify(migratedWorkflow, null, 2)).toMatchFileSnapshot(
+        `workflows/reroute/native/${fileName}`
+      )
+    })
   })
 })

--- a/tests-ui/tests/utils/migration/workflows/reroute/legacy/floating_branch.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/legacy/floating_branch.json
@@ -1,0 +1,253 @@
+{
+  "last_node_id": 36,
+  "last_link_id": 44,
+  "nodes": [
+    {
+      "id": 33,
+      "type": "Reroute",
+      "pos": [
+        492.768310546875,
+        274.761962890625
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 41
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VAE",
+          "links": [
+            40
+          ]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 32,
+      "type": "Reroute",
+      "pos": [
+        362.8304138183594,
+        275.12872314453125
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 39
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VAE",
+          "links": [
+            41,
+            42
+          ]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -0.6348835229873657,
+        238.0631866455078
+      ],
+      "size": [
+        315,
+        98
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": []
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [
+            39
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.26",
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "v1-5-pruned-emaonly.safetensors"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "VAEDecode",
+      "pos": [
+        611.6028442382812,
+        254.6018524169922
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 40
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.26",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 34,
+      "type": "Reroute",
+      "pos": [
+        490.8152770996094,
+        364.4836730957031
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 42
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VAE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    }
+  ],
+  "links": [
+    [
+      39,
+      4,
+      2,
+      32,
+      0,
+      "*"
+    ],
+    [
+      40,
+      33,
+      0,
+      12,
+      1,
+      "VAE"
+    ],
+    [
+      41,
+      32,
+      0,
+      33,
+      0,
+      "*"
+    ],
+    [
+      42,
+      32,
+      0,
+      34,
+      0,
+      "*"
+    ]
+  ],
+  "floatingLinks": [
+    {
+      "id": 8,
+      "origin_id": 4,
+      "origin_slot": 2,
+      "target_id": -1,
+      "target_slot": -1,
+      "type": "*"
+    }
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.6672297511789418,
+      "offset": [
+        262.0504372113823,
+        124.35120995663942
+      ]
+    },
+    "linkExtensions": []
+  },
+  "version": 0.4
+}

--- a/tests-ui/tests/utils/migration/workflows/reroute/native/branching.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/native/branching.json
@@ -35,8 +35,8 @@
           "type": "VAE",
           "slot_index": 2,
           "links": [
-            13,
-            21
+            21,
+            34
           ]
         }
       ],
@@ -77,7 +77,7 @@
         {
           "name": "IMAGE",
           "type": "IMAGE",
-          "links": null
+          "links": []
         }
       ],
       "properties": {
@@ -115,7 +115,7 @@
         {
           "name": "IMAGE",
           "type": "IMAGE",
-          "links": null
+          "links": []
         }
       ],
       "properties": {

--- a/tests-ui/tests/utils/migration/workflows/reroute/native/floating.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/native/floating.json
@@ -34,10 +34,7 @@
           "name": "VAE",
           "type": "VAE",
           "slot_index": 2,
-          "links": [
-            13,
-            31
-          ]
+          "links": []
         }
       ],
       "properties": {
@@ -72,14 +69,14 @@
         {
           "name": "vae",
           "type": "VAE",
-          "link": 21
+          "link": null
         }
       ],
       "outputs": [
         {
           "name": "IMAGE",
           "type": "IMAGE",
-          "links": null
+          "links": []
         }
       ],
       "properties": {
@@ -101,8 +98,30 @@
         200.06933385457722
       ]
     },
-    "reroutes": [],
+    "reroutes": [
+      {
+        "id": 1,
+        "pos": [
+          547.5,
+          293
+        ],
+        "linkIds": [],
+        "floating": {
+          "slotType": "input"
+        }
+      }
+    ],
     "linkExtensions": []
   },
-  "version": 0.4
+  "version": 0.4,
+  "floatLinks": [
+    {
+      "id": 21,
+      "origin_id": -1,
+      "origin_slot": -1,
+      "target_id": 12,
+      "target_slot": 1,
+      "type": "VAE"
+    }
+  ]
 }

--- a/tests-ui/tests/utils/migration/workflows/reroute/native/floating.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/native/floating.json
@@ -109,6 +109,17 @@
         "floating": {
           "slotType": "input"
         }
+      },
+      {
+        "id": 2,
+        "pos": [
+          438.99267578125,
+          291.96600341796875
+        ],
+        "linkIds": [],
+        "floating": {
+          "slotType": "output"
+        }
       }
     ],
     "linkExtensions": []
@@ -116,12 +127,22 @@
   "version": 0.4,
   "floatLinks": [
     {
-      "id": 21,
+      "id": 7,
       "origin_id": -1,
       "origin_slot": -1,
       "target_id": 12,
       "target_slot": 1,
-      "type": "VAE"
+      "type": "VAE",
+      "parentId": 1
+    },
+    {
+      "id": 8,
+      "origin_id": 4,
+      "origin_slot": 2,
+      "target_id": -1,
+      "target_slot": -1,
+      "type": "*",
+      "parentId": 2
     }
   ]
 }

--- a/tests-ui/tests/utils/migration/workflows/reroute/native/floating.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/native/floating.json
@@ -125,7 +125,7 @@
     "linkExtensions": []
   },
   "version": 0.4,
-  "floatLinks": [
+  "floatingLinks": [
     {
       "id": 7,
       "origin_id": -1,

--- a/tests-ui/tests/utils/migration/workflows/reroute/native/floating_branch.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/native/floating_branch.json
@@ -1,0 +1,166 @@
+{
+  "last_node_id": 36,
+  "last_link_id": 44,
+  "nodes": [
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -0.6348835229873657,
+        238.0631866455078
+      ],
+      "size": [
+        315,
+        98
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": []
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [
+            40
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.26",
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "v1-5-pruned-emaonly.safetensors"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "VAEDecode",
+      "pos": [
+        611.6028442382812,
+        254.6018524169922
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 40
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.26",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      40,
+      4,
+      2,
+      12,
+      1,
+      "VAE"
+    ]
+  ],
+  "floatingLinks": [
+    {
+      "id": 4,
+      "origin_id": 4,
+      "origin_slot": 2,
+      "target_id": -1,
+      "target_slot": -1,
+      "type": "*",
+      "parentId": 3
+    }
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.6672297511789418,
+      "offset": [
+        262.0504372113823,
+        124.35120995663942
+      ]
+    },
+    "linkExtensions": [
+      {
+        "id": 40,
+        "parentId": 1
+      }
+    ],
+    "reroutes": [
+      {
+        "id": 1,
+        "pos": [
+          530.268310546875,
+          287.761962890625
+        ],
+        "linkIds": [
+          40
+        ],
+        "parentId": 2
+      },
+      {
+        "id": 2,
+        "pos": [
+          400.3304138183594,
+          288.12872314453125
+        ],
+        "linkIds": [
+          40
+        ]
+      },
+      {
+        "id": 3,
+        "pos": [
+          528.3152770996094,
+          377.4836730957031
+        ],
+        "linkIds": [],
+        "parentId": 2,
+        "floating": {
+          "slotType": "output"
+        }
+      }
+    ]
+  },
+  "version": 0.4
+}

--- a/tests-ui/tests/utils/migration/workflows/reroute/native/single_connected.json
+++ b/tests-ui/tests/utils/migration/workflows/reroute/native/single_connected.json
@@ -76,7 +76,7 @@
         {
           "name": "IMAGE",
           "type": "IMAGE",
-          "links": null
+          "links": []
         }
       ],
       "properties": {


### PR DESCRIPTION
Migrate floating reroutes
Before
![image](https://github.com/user-attachments/assets/a10e6293-dcc4-44f3-8d5a-4a4b37632965)
After
![image](https://github.com/user-attachments/assets/001cb924-388d-43c6-860e-46f8d478dac2)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3260-Reroute-Migrate-floating-link-1c46d73d3650813cb742c45bcaa8f5aa) by [Unito](https://www.unito.io)
