### PR TITLE
Fix dynamicPrompt value in serialization

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2399,6 +2399,16 @@ export class ComfyApp {
               inputs[widget.name] = widget.serializeValue
                 ? await widget.serializeValue(node, i)
                 : widget.value
+
+              // Fix selected tokens via dynamicPrompts in workflow
+              if (widget.dynamicPrompts) {
+                const serializedNode = workflow.nodes.find(
+                  (item) => item.id === node.id
+                )
+                if (serializedNode && serializedNode.widgets_values[i]) {
+                  serializedNode.widgets_values[i] = inputs[widget.name]
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
[Bug]: Selected token is not saved in workflow via Dynamic Prompt https://github.com/Comfy-Org/ComfyUI_frontend/issues/3269

Previously, Export (API) was serialize dynamicPrompt, but Export was not serialize dynamicPrompt.
Now synchronize prompt(output) values with workflow values.

In my opinion, Export and Export(API) should do not serialize dynamic prompt and apply to generated image only.

![Screenshot](https://github.com/user-attachments/assets/8d5c24aa-84fa-49a0-869c-410f8c5a274c)

- Workflow  > Export (API)

[export-api.json](https://github.com/user-attachments/files/19524926/export-api.json)

- Workflow > Export

[export-workflow.json](https://github.com/user-attachments/files/19524927/export-workflow.json)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3277-Fix-dynamicPrompt-value-in-serialization-1c66d73d365081b9b25dcb66948ec648) by [Unito](https://www.unito.io)
