### PR TITLE
Add debouncedPersistCurrentWorkflow

### DIFF
--- a/src/composables/useWorkflowPersistence.ts
+++ b/src/composables/useWorkflowPersistence.ts
@@ -1,5 +1,5 @@
-import { computed, watch, watchEffect } from 'vue'
 import { debounce } from 'lodash'
+import { computed, watch, watchEffect } from 'vue'
 
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
@@ -34,7 +34,7 @@ export function useWorkflowPersistence() {
       debouncedPersistCurrentWorkflow()
     }
   })
-  
+
   // Use the same debounced version for the event listener
   api.addEventListener('graphChanged', debouncedPersistCurrentWorkflow)
 


### PR DESCRIPTION
perhaps affecting #3180?

currently we see a pretty expensive `const workflow = JSON.stringify(comfyApp.serializeGraph())` being ran with every pointermove (triggered graphChanged). this includes when the user is panning around their workflow, and hinders performance greatly.

![image](https://github.com/user-attachments/assets/c6bb7407-bbe7-489e-8969-31399b301421)
![image](https://github.com/user-attachments/assets/25139386-70c1-4a16-b83d-14a82ed5d653)

assuming we don't need to persist the current workflow on every frame, we can debounce this event by 1s to improve fps by 30-40%.

![image](https://github.com/user-attachments/assets/3e095cf1-6d94-4457-940e-651e4de45f3d)

profiles captured at 4x cpu slowdown, fully zoomed out on ap workflow v10, 7700x 5070 ti, on latest stable google chrome.

the original persistCurrentWorkflow is kept. i have worries that this is not the best solution, as there may be cases where changes within that 1s period are not persisted if the user happens to shut down the app/tab.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3297-Add-debouncedPersistCurrentWorkflow-1c86d73d3650813faec1d8a8922ae58b) by [Unito](https://www.unito.io)
