### PR TITLE
[Performance] Avoid graph state check on panning

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -106,10 +106,17 @@ export class ChangeTracker {
   }
 
   checkState() {
-    if (!this.app.graph || this.changeCount) return
+    if (
+      !this.app.graph ||
+      this.changeCount ||
+      this.app.canvas.read_only ||
+      this.app.canvas.isDragging
+    )
+      return
     // @ts-expect-error zod type issue on ComfyWorkflowJSON. ComfyWorkflowJSON
     // is stricter than LiteGraph's serialisation schema.
     const currentState = clone(this.app.graph.serialize()) as ComfyWorkflowJSON
+    logger.debug('checkState')
     if (!this.activeState) {
       this.activeState = currentState
       return


### PR DESCRIPTION
Profiling shows no visible change in rendering time per frame, as these events only happen very few times per second during drawing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3300-Performance-Avoid-graph-state-check-on-panning-1c86d73d36508185a588e36300ebcb98) by [Unito](https://www.unito.io)
