### PR TITLE
[Performance] Avoid per-frame workflow persistence

### DIFF
--- a/src/composables/useWorkflowPersistence.ts
+++ b/src/composables/useWorkflowPersistence.ts
@@ -1,4 +1,4 @@
-import { computed, watch, watchEffect } from 'vue'
+import { computed, watch } from 'vue'
 
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
@@ -70,15 +70,16 @@ export function useWorkflowPersistence() {
   }
 
   // Setup watchers
-  watchEffect(() => {
-    if (workflowStore.activeWorkflow) {
-      const workflow = workflowStore.activeWorkflow
-      setStorageValue('Comfy.PreviousWorkflow', workflow.key)
+  watch(
+    () => workflowStore.activeWorkflow,
+    (activeWorkflow) => {
+      if (!activeWorkflow) return
+      setStorageValue('Comfy.PreviousWorkflow', activeWorkflow.key)
       // When the activeWorkflow changes, the graph has already been loaded.
       // Saving the current state of the graph to the localStorage.
       persistCurrentWorkflow()
     }
-  })
+  )
   api.addEventListener('graphChanged', persistCurrentWorkflow)
 
   // Restore workflow tabs states


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d62d9bcc-2fe0-4d5b-b7da-54afc1f55e0a)

After:
![image](https://github.com/user-attachments/assets/38c904b3-3172-4891-aa0a-6213c238a85a)

Reducing 6~10ms per frame on workflow persistence task that is not necessary.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3301-Performance-Avoid-per-frame-workflow-persistence-1c86d73d3650815f8810f769668630ba) by [Unito](https://www.unito.io)
