### PR TITLE
[Performance] Avoid layout thrashing

### DIFF
--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -17,7 +17,6 @@
 </template>
 
 <script setup lang="ts">
-import type { LGraphNode } from '@comfyorg/litegraph'
 import { useEventListener } from '@vueuse/core'
 import { CSSProperties, computed, onMounted, ref, watch } from 'vue'
 
@@ -63,9 +62,9 @@ const updateDomClipping = () => {
   const lgCanvas = canvasStore.canvas
   if (!lgCanvas || !widgetElement.value) return
 
-  const selectedNode = Object.values(
-    lgCanvas.selected_nodes ?? {}
-  )[0] as LGraphNode
+  const selectedNode = Object.values(lgCanvas.selected_nodes ?? {})[0]
+  if (!selectedNode) return
+
   const node = widget.node
   const isSelected = selectedNode === node
   const renderArea = selectedNode?.renderArea

--- a/src/composables/element/useCanvasPositionConversion.ts
+++ b/src/composables/element/useCanvasPositionConversion.ts
@@ -1,0 +1,36 @@
+import type { LGraphCanvas, Vector2 } from '@comfyorg/litegraph'
+import { useElementBounding } from '@vueuse/core'
+
+/**
+ * Convert between canvas and client positions
+ * @param canvasElement - The canvas element
+ * @param lgCanvas - The litegraph canvas
+ * @returns The canvas position conversion functions
+ */
+export const useCanvasPositionConversion = (
+  canvasElement: Parameters<typeof useElementBounding>[0],
+  lgCanvas: LGraphCanvas
+) => {
+  const { left, top } = useElementBounding(canvasElement)
+
+  const clientPosToCanvasPos = (pos: Vector2): Vector2 => {
+    const { offset, scale } = lgCanvas.ds
+    return [
+      (pos[0] - left.value) / scale + offset[0],
+      (pos[1] - top.value) / scale + offset[1]
+    ]
+  }
+
+  const canvasPosToClientPos = (pos: Vector2): Vector2 => {
+    const { offset, scale } = lgCanvas.ds
+    return [
+      (pos[0] + offset[0]) * scale + left.value,
+      (pos[1] + offset[1]) * scale + top.value
+    ]
+  }
+
+  return {
+    clientPosToCanvasPos,
+    canvasPosToClientPos
+  }
+}


### PR DESCRIPTION
What is layout thrashing: https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing?utm_source=devtools#avoid_layout_thrashing

This PR fixes layout thrashing by avoid calling `getBoundingClientRect` during the layout. Now the canvas bounding rect is cached. This is 2~3ms saved per frame.

Before:
![image](https://github.com/user-attachments/assets/5be01e2a-6ac3-452b-b8be-4c9f6aeb8b56)

After:
![屏幕截图 2025-04-01 121316](https://github.com/user-attachments/assets/70930beb-0c56-4ea7-850f-a054c959d146)


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3302-Performance-Avoid-layout-thrashing-1c86d73d365081799a0ee80211ed1efb) by [Unito](https://www.unito.io)
