### PR TITLE
[nit] Show error message from response

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -156,11 +156,12 @@ export class PromptExecutionError extends Error {
   }
 
   override toString() {
-    let message = super.message
+    let message = ''
     if (typeof this.response.error === 'string') {
-      message += ': ' + this.response.error
-    } else if (this.response.error.details) {
-      message += ': ' + this.response.error.details
+      message += this.response.error
+    } else if (this.response.error) {
+      message +=
+        this.response.error.message + ': ' + this.response.error.details
     }
 
     for (const [_, nodeError] of Object.entries(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/31a3f6ea-ba9e-4ba7-9d2a-42a475932572)

```
got prompt
invalid prompt: {'type': 'prompt_no_outputs', 'message': 'Prompt has no outputs', 'details': '', 'extra_info': {}}
```