### PR TITLE
[Bug] Fix progress bar display on last output node

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -169,7 +169,6 @@ watch(
       number | null
     ],
   ([executingNodeId, executingNodeProgress]) => {
-    if (!executingNodeId) return
     for (const node of comfyApp.graph.nodes) {
       if (node.id == executingNodeId) {
         node.progress = executingNodeProgress ?? undefined


### PR DESCRIPTION
Clear `node.progress` for all nodes when finishing execution. (`executingNodeId` set to null)

Bugged workflow:
![image](https://github.com/user-attachments/assets/dfbaddde-e3a1-42dd-b6e8-2e454810fb62)

The progress bar does not disappear even when the node finishes execution.
