### PR TITLE
[TS] Fix event type for executing listener

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -62,6 +62,7 @@ import { usePaste } from '@/composables/usePaste'
 import { useWorkflowPersistence } from '@/composables/useWorkflowPersistence'
 import { CORE_SETTINGS } from '@/constants/coreSettings'
 import { i18n } from '@/i18n'
+import type { NodeId } from '@/schemas/comfyWorkflowSchema'
 import { UnauthorizedError, api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { ChangeTracker } from '@/scripts/changeTracker'
@@ -165,7 +166,7 @@ watch(
 watch(
   () =>
     [executionStore.executingNodeId, executionStore.executingNodeProgress] as [
-      string | null,
+      NodeId | null,
       number | null
     ],
   ([executingNodeId, executingNodeProgress]) => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -162,7 +162,7 @@ export class ComfyApp {
   /**
    * @deprecated Use useExecutionStore().executingNodeId instead
    */
-  get runningNodeId(): string | null {
+  get runningNodeId(): NodeId | null {
     return useExecutionStore().executingNodeId
   }
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -151,7 +151,7 @@ export const useExecutionStore = defineStore('execution', () => {
       // Seems sometimes nodes that are cached fire executing but not executed
       activePrompt.value.nodes[executingNodeId.value] = true
     }
-    executingNodeId.value = e.detail ? e.detail : null
+    executingNodeId.value = e.detail || null
     if (!executingNodeId.value) {
       if (activePromptId.value) {
         delete queuedPrompts.value[activePromptId.value]

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -3,7 +3,6 @@ import { computed, ref } from 'vue'
 
 import type {
   ExecutedWsMessage,
-  ExecutingWsMessage,
   ExecutionCachedWsMessage,
   ExecutionErrorWsMessage,
   ExecutionStartWsMessage,
@@ -37,7 +36,7 @@ export const useExecutionStore = defineStore('execution', () => {
   const queuedPrompts = ref<Record<NodeId, QueuedPrompt>>({})
   const lastNodeErrors = ref<Record<NodeId, NodeError> | null>(null)
   const lastExecutionError = ref<ExecutionErrorWsMessage | null>(null)
-  const executingNodeId = ref<string | null>(null)
+  const executingNodeId = ref<NodeId | null>(null)
   const executingNode = computed<ComfyNode | null>(() => {
     if (!executingNodeId.value) return null
 
@@ -142,7 +141,7 @@ export const useExecutionStore = defineStore('execution', () => {
     activePrompt.value.nodes[e.detail.node] = true
   }
 
-  function handleExecuting(e: CustomEvent<ExecutingWsMessage>) {
+  function handleExecuting(e: CustomEvent<NodeId>) {
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
 
@@ -152,7 +151,7 @@ export const useExecutionStore = defineStore('execution', () => {
       // Seems sometimes nodes that are cached fire executing but not executed
       activePrompt.value.nodes[executingNodeId.value] = true
     }
-    executingNodeId.value = e.detail ? String(e.detail) : null
+    executingNodeId.value = e.detail ? e.detail : null
     if (!executingNodeId.value) {
       if (activePromptId.value) {
         delete queuedPrompts.value[activePromptId.value]

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -141,7 +141,7 @@ export const useExecutionStore = defineStore('execution', () => {
     activePrompt.value.nodes[e.detail.node] = true
   }
 
-  function handleExecuting(e: CustomEvent<NodeId>) {
+  function handleExecuting(e: CustomEvent<NodeId | null>) {
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
 
@@ -151,8 +151,8 @@ export const useExecutionStore = defineStore('execution', () => {
       // Seems sometimes nodes that are cached fire executing but not executed
       activePrompt.value.nodes[executingNodeId.value] = true
     }
-    executingNodeId.value = e.detail || null
-    if (!executingNodeId.value) {
+    executingNodeId.value = e.detail
+    if (executingNodeId.value === null) {
       if (activePromptId.value) {
         delete queuedPrompts.value[activePromptId.value]
       }


### PR DESCRIPTION
`api.ts` unwraps the nodeId from the raw ws message, so the event listener should be receiving `NodeId | null` instead.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3310-TS-Fix-event-type-for-executing-listener-1c96d73d36508184bc9ae5903821583c) by [Unito](https://www.unito.io)
