### PR TITLE
Enable double clicking keybind row to edit bind (#2924)

### DIFF
--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -17,6 +17,7 @@
       :pt="{
         header: 'px-0'
       }"
+      @rowDblclick="editKeybinding($event.data)"
     >
       <Column field="actions" header="">
         <template #body="slotProps">


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3315-Enable-double-clicking-keybind-row-to-edit-bind-2924-1ca6d73d365081f2a5eae973c51660e3) by [Unito](https://www.unito.io)
