### PR TITLE
Only show reroute migration dialog when native reroute is not present

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -989,7 +989,10 @@ export class ComfyApp {
       // Ideally we should not block users from loading the workflow.
       graphData = validatedGraphData ?? graphData
     }
-
+    // Only show the reroute migration warning if the workflow does not have native
+    // reroutes. Merging reroute network has great complexity, and it is not supported
+    // for now.
+    // See: https://github.com/Comfy-Org/ComfyUI_frontend/issues/3317
     if (
       checkForRerouteMigration &&
       graphData.version === 0.4 &&

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -48,7 +48,10 @@ import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
 import { executeWidgetsCallback, isImageNode } from '@/utils/litegraphUtil'
-import { findLegacyRerouteNodes } from '@/utils/migration/migrateReroute'
+import {
+  findLegacyRerouteNodes,
+  noNativeReroutes
+} from '@/utils/migration/migrateReroute'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, PromptExecutionError, api } from './api'
@@ -990,7 +993,8 @@ export class ComfyApp {
     if (
       checkForRerouteMigration &&
       graphData.version === 0.4 &&
-      findLegacyRerouteNodes(graphData).length
+      findLegacyRerouteNodes(graphData).length &&
+      noNativeReroutes(graphData)
     ) {
       useToastStore().add({
         group: 'reroute-migration',

--- a/src/utils/migration/migrateReroute.ts
+++ b/src/utils/migration/migrateReroute.ts
@@ -29,6 +29,15 @@ export function findLegacyRerouteNodes(
 }
 
 /**
+ * Checks if the workflow has no native reroutes
+ */
+export function noNativeReroutes(workflow: WorkflowJSON04): boolean {
+  return (
+    !workflow.extra?.reroutes?.length && !workflow.extra?.linkExtensions?.length
+  )
+}
+
+/**
  * Gets the center position of a node
  */
 function getNodeCenter(node: ComfyNode): [number, number] {


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/3317

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3318-Only-show-reroute-migration-dialog-when-native-reroute-is-not-present-1cb6d73d3650810cbb98f6c3685d3370) by [Unito](https://www.unito.io)
