### PR TITLE
Fix non-serialized widget values included in graph state check

### DIFF
--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -192,3 +192,19 @@ test.describe('Load audio widget', () => {
     await expect(comfyPage.canvas).toHaveScreenshot('load_audio_widget.png')
   })
 })
+
+test.describe('Unserialized widgets', () => {
+  test('Unserialized widgets values do not mark graph as modified', async ({
+    comfyPage
+  }) => {
+    // Add workflow w/ LoadImage node, which contains file upload and image preview widgets (not serialized)
+    await comfyPage.loadWorkflow('widgets/load_image_widget')
+
+    // Move mouse and click to trigger the `graphEqual` check in `changeTracker.ts`
+    await comfyPage.page.mouse.move(10, 10)
+    await comfyPage.page.mouse.click(10, 10)
+
+    // Expect the graph to not be modified
+    expect(await comfyPage.isCurrentWorkflowModified()).toBe(false)
+  })
+})

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -8,6 +8,7 @@ import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 import type { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import { useExecutionStore } from '@/stores/executionStore'
 import { ComfyWorkflow, useWorkflowStore } from '@/stores/workflowStore'
+import { filterSerializedWidgetValues } from '@/utils/litegraphUtil'
 
 import { api } from './api'
 import type { ComfyApp } from './app'
@@ -385,7 +386,10 @@ export class ChangeTracker {
       if (
         !_.isEqualWith(a.nodes, b.nodes, (arrA, arrB) => {
           if (Array.isArray(arrA) && Array.isArray(arrB)) {
-            return _.isEqual(new Set(arrA), new Set(arrB))
+            // Filter non-serializable widget values before comparison
+            const filteredArrA = filterSerializedWidgetValues(arrA, app.graph)
+            const filteredArrB = filterSerializedWidgetValues(arrB, app.graph)
+            return _.isEqual(new Set(filteredArrA), new Set(filteredArrB))
           }
         })
       ) {


### PR DESCRIPTION
Changes `graphEqual` comparison to ignore non-serialized widget values. These values are not part of the restorable state of the graph, so it does not make sense for them to influence the state check comparison. 

~~Previously, this issue did not surface because either (a) the widget was not properly set to be non-serialized or (b) the non-serialized widget was added prior to the graph being configured. In https://github.com/Comfy-Org/ComfyUI_frontend/pull/2689, one instance of (a) was fixed with the LoadImage node, which caused this bug to surface.~~ This issue is not actually caused by `serialize` widget option. See update in comments.

Afterwards, any graph with LoadImage nodes would be marked dirty upon first opening, which casued countless issues, including interfering with tab restore (as unsaved tabs are not restored) and causing manual confirmation when closing otherwise unmodified tabs.

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/3313, https://github.com/Comfy-Org/ComfyUI_frontend/issues/3254, https://github.com/comfyanonymous/ComfyUI/issues/7475

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3323-Fix-non-serialized-widget-values-included-in-graph-state-check-1cc6d73d365081abb4dce5057eb4f8dd) by [Unito](https://www.unito.io)
