### PR TITLE
[Manager] Fix primevue severity in status messages

### DIFF
--- a/src/components/common/RefreshButton.vue
+++ b/src/components/common/RefreshButton.vue
@@ -32,7 +32,7 @@
 import Button from 'primevue/button'
 import ProgressSpinner from 'primevue/progressspinner'
 
-import { VueSeverity } from '@/types/primeVueTypes'
+import { PrimeVueSeverity } from '@/types/primeVueTypes'
 
 const {
   disabled,
@@ -41,7 +41,7 @@ const {
 } = defineProps<{
   disabled?: boolean
   outlined?: boolean
-  severity?: VueSeverity
+  severity?: PrimeVueSeverity
 }>()
 
 // Model

--- a/src/components/dialog/content/manager/PackStatusMessage.vue
+++ b/src/components/dialog/content/manager/PackStatusMessage.vue
@@ -20,15 +20,16 @@ import Message from 'primevue/message'
 import { computed } from 'vue'
 
 import { components } from '@/types/comfyRegistryTypes'
-import { VueSeverity } from '@/types/primeVueTypes'
 
 type PackVersionStatus = components['schemas']['NodeVersionStatus']
 type PackStatus = components['schemas']['NodeStatus']
 type Status = PackVersionStatus | PackStatus
 
+type MessageProps = InstanceType<typeof Message>['$props']
+type MessageSeverity = MessageProps['severity']
 type StatusProps = {
   label: string
-  severity: VueSeverity
+  severity: MessageSeverity
 }
 
 const { statusType } = defineProps<{
@@ -46,7 +47,7 @@ const statusPropsMap: Record<Status, StatusProps> = {
   },
   NodeStatusBanned: {
     label: 'banned',
-    severity: 'danger'
+    severity: 'error'
   },
   NodeVersionStatusActive: {
     label: 'active',
@@ -62,11 +63,11 @@ const statusPropsMap: Record<Status, StatusProps> = {
   },
   NodeVersionStatusFlagged: {
     label: 'flagged',
-    severity: 'danger'
+    severity: 'error'
   },
   NodeVersionStatusBanned: {
     label: 'banned',
-    severity: 'danger'
+    severity: 'error'
   }
 }
 

--- a/src/components/maintenance/TaskListItem.vue
+++ b/src/components/maintenance/TaskListItem.vue
@@ -45,7 +45,7 @@ import { computed, ref } from 'vue'
 
 import { useMaintenanceTaskStore } from '@/stores/maintenanceTaskStore'
 import type { MaintenanceTask } from '@/types/desktop/maintenanceTypes'
-import { VueSeverity } from '@/types/primeVueTypes'
+import { PrimeVueSeverity } from '@/types/primeVueTypes'
 import { useMinLoadingDurationRef } from '@/utils/refUtil'
 
 import TaskListStatusIcon from './TaskListStatusIcon.vue'
@@ -64,7 +64,7 @@ defineEmits<{
 }>()
 
 // Binding
-const severity = computed<VueSeverity>(() =>
+const severity = computed<PrimeVueSeverity>(() =>
   runner.value.state === 'error' || runner.value.state === 'warning'
     ? 'primary'
     : 'secondary'

--- a/src/types/desktop/maintenanceTypes.ts
+++ b/src/types/desktop/maintenanceTypes.ts
@@ -1,4 +1,4 @@
-import type { VueSeverity } from '../primeVueTypes'
+import type { PrimeVueSeverity } from '../primeVueTypes'
 
 interface MaintenanceTaskButton {
   /** The text to display on the button. */
@@ -32,7 +32,7 @@ export interface MaintenanceTask {
   /** Called by onClick to run the actual task. */
   execute: (args?: unknown[]) => boolean | Promise<boolean>
   /** Show the button with `severity="danger"` */
-  severity?: VueSeverity
+  severity?: PrimeVueSeverity
   /** Whether this task should display the terminal window when run. */
   usesTerminal?: boolean
   /** If `true`, successful completion of this task will refresh install validation and automatically continue if successful. */

--- a/src/types/primeVueTypes.ts
+++ b/src/types/primeVueTypes.ts
@@ -1,5 +1,5 @@
 /** Button, Tag, etc severity type is 'string' instead of this list. */
-export type VueSeverity =
+export type PrimeVueSeverity =
   | 'primary'
   | 'secondary'
   | 'success'


### PR DESCRIPTION
Fixes some status messages not being colored correctly. Before:

![Selection_1162](https://github.com/user-attachments/assets/89dc481a-3719-45d3-ab87-02c4877f80a4)

After:

![Selection_1163](https://github.com/user-attachments/assets/629510b5-336f-44d8-ba78-3e0a8ad4cb11)

Changes `severity` type in `PackStatusMessage` to match the actual type from `Message` component's `severity` prop, instead of using `VueSeverity`. Currently, the `VueSeverity` type includes strings which are not valid for the `Message` and `Button` component. 

Also changes `VueSeverity` => `PrimeVueSeverity`, as severity concept is part of design library not Vue itself.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3324-Manager-Fix-primevue-severity-in-status-messages-1cc6d73d36508136bf99f54e69f858d8) by [Unito](https://www.unito.io)
