### PR TITLE
[3d] Add translations for material modes controls

### DIFF
--- a/src/components/load3d/controls/ModelControls.vue
+++ b/src/components/load3d/controls/ModelControls.vue
@@ -234,7 +234,7 @@ const selectMaterialMode = (mode: MaterialMode) => {
 }
 
 const formatMaterialMode = (mode: MaterialMode) => {
-  return mode.charAt(0).toUpperCase() + mode.slice(1)
+  return t(`load3d.materialModes.${mode}`)
 }
 
 const toggleEdgeThreshold = () => {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1002,7 +1002,13 @@
     "exportModel": "Export Model",
     "exportingModel": "Exporting model...",
     "uploadTexture": "Upload Texture",
-    "applyingTexture": "Applying Texture..."
+    "applyingTexture": "Applying Texture...",
+    "materialModes": {
+      "normal": "Normal",
+      "wireframe": "Wireframe",
+      "original": "Original",
+      "depth": "Depth"
+    }
   },
   "toastMessages": {
     "no3dScene": "No 3D scene to apply texture",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -372,6 +372,12 @@
     "lightIntensity": "Intensidad de luz",
     "loadingModel": "Cargando modelo 3D...",
     "materialMode": "Modo de material",
+    "materialModes": {
+      "depth": "Profundidad",
+      "normal": "Normal",
+      "original": "Original",
+      "wireframe": "Malla"
+    },
     "model": "Modelo",
     "previewOutput": "Vista previa de salida",
     "removeBackgroundImage": "Eliminar imagen de fondo",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -372,6 +372,12 @@
     "lightIntensity": "Intensité de la lumière",
     "loadingModel": "Chargement du modèle 3D...",
     "materialMode": "Mode Matériel",
+    "materialModes": {
+      "depth": "Profondeur",
+      "normal": "Normal",
+      "original": "Original",
+      "wireframe": "Fil de fer"
+    },
     "model": "Modèle",
     "previewOutput": "Aperçu de la sortie",
     "removeBackgroundImage": "Supprimer l'image de fond",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -372,6 +372,12 @@
     "lightIntensity": "光の強度",
     "loadingModel": "3Dモデルを読み込んでいます...",
     "materialMode": "マテリアルモード",
+    "materialModes": {
+      "depth": "深度",
+      "normal": "ノーマル",
+      "original": "オリジナル",
+      "wireframe": "ワイヤーフレーム"
+    },
     "model": "モデル",
     "previewOutput": "出力のプレビュー",
     "removeBackgroundImage": "背景画像を削除",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -372,6 +372,12 @@
     "lightIntensity": "조명 강도",
     "loadingModel": "3D 모델 로딩 중...",
     "materialMode": "재질 모드",
+    "materialModes": {
+      "depth": "깊이",
+      "normal": "정상",
+      "original": "원본",
+      "wireframe": "와이어프레임"
+    },
     "model": "모델",
     "previewOutput": "출력 미리보기",
     "removeBackgroundImage": "배경 이미지 제거",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -372,6 +372,12 @@
     "lightIntensity": "Интенсивность света",
     "loadingModel": "Загрузка 3D модели...",
     "materialMode": "Режим Материала",
+    "materialModes": {
+      "depth": "Глубина",
+      "normal": "Нормальный",
+      "original": "Оригинал",
+      "wireframe": "Каркас"
+    },
     "model": "Модель",
     "previewOutput": "Предварительный просмотр",
     "removeBackgroundImage": "Удалить фоновое изображение",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -372,6 +372,12 @@
     "lightIntensity": "光照强度",
     "loadingModel": "正在加载3D模型...",
     "materialMode": "材料模式",
+    "materialModes": {
+      "depth": "深度",
+      "normal": "正常",
+      "original": "原始",
+      "wireframe": "线框"
+    },
     "model": "模型",
     "previewOutput": "预览输出",
     "removeBackgroundImage": "移除背景图片",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -362,7 +362,7 @@
   "load3d": {
     "applyingTexture": "应用纹理中...",
     "backgroundColor": "背景颜色",
-    "camera": "相机",
+    "camera": "摄影机",
     "edgeThreshold": "边缘阈值",
     "export": "导出",
     "exportModel": "导出模型",
@@ -371,10 +371,10 @@
     "light": "灯光",
     "lightIntensity": "光照强度",
     "loadingModel": "正在加载3D模型...",
-    "materialMode": "材料模式",
+    "materialMode": "材质模式",
     "materialModes": {
       "depth": "深度",
-      "normal": "正常",
+      "normal": "法线",
       "original": "原始",
       "wireframe": "线框"
     },
@@ -383,9 +383,9 @@
     "removeBackgroundImage": "移除背景图片",
     "scene": "场景",
     "showGrid": "显示网格",
-    "switchCamera": "切换摄像头",
+    "switchCamera": "切换摄影机类型",
     "switchingMaterialMode": "切换材质模式中...",
-    "upDirection": "向上方向",
+    "upDirection": "上方向",
     "uploadBackgroundImage": "上传背景图片",
     "uploadTexture": "上传纹理"
   },
@@ -923,10 +923,10 @@
     },
     "template": {
       "3D": {
-        "hunyuan-3d-multiview-elf": "Hunyuan3D多视图",
-        "hunyuan-3d-turbo": "Hunyuan3D Turbo",
-        "hunyuan3d-non-multiview-train": "Hunyuan3D",
-        "stable_zero123_example": "稳定Zero123"
+        "hunyuan-3d-multiview-elf": "混元3D多视图",
+        "hunyuan-3d-turbo": "混元3D Turbo",
+        "hunyuan3d-non-multiview-train": "混元3D",
+        "stable_zero123_example": "Stable Zero123"
       },
       "Area Composition": {
         "area_composition": "区域构成",
@@ -934,7 +934,7 @@
         "area_composition_square_area_for_subject": "主题的方形区域构成"
       },
       "Audio": {
-        "stable_audio_example": "稳定音频"
+        "stable_audio_example": "Stable Audio"
       },
       "Basics": {
         "default": "图像生成",
@@ -982,7 +982,7 @@
         "latent_upscale_different_prompt_model": "潜在升级不同提示模型"
       },
       "Video": {
-        "hunyuan_video_text_to_video": "Hunyuan视频文本到视频",
+        "hunyuan_video_text_to_video": "混元视频文本到视频",
         "image_to_video": "图像到视频",
         "image_to_video_wan": "Wan 2.1 图像到视频",
         "ltxv_image_to_video": "LTXV图像到视频",


### PR DESCRIPTION
These translations were added in order to demo the 3d nodes at Comfy Con 2025 in Shanghai. All other aspects of the 3d nodes UI seemed to already be translated.

https://github.com/user-attachments/assets/0ce5de49-8321-4895-a416-6c383b455e34

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3325-3d-Add-translations-for-material-modes-controls-1cc6d73d365081468970d8e8f8452cba) by [Unito](https://www.unito.io)
