### PR TITLE
Add option to disable reconnecting toasts

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -764,5 +764,12 @@ export const CORE_SETTINGS: SettingParams[] = [
       max: 400
     },
     versionAdded: '1.15.7'
+  },
+  {
+    id: 'Comfy.Toast.DisableReconnectingToast',
+    name: 'Disable toasts when reconnecting or reconnected',
+    type: 'hidden',
+    defaultValue: false,
+    versionAdded: '1.15.12'
   }
 ]

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -176,17 +176,21 @@ const reconnectingMessage: ToastMessageOptions = {
 }
 
 const onReconnecting = () => {
-  toast.remove(reconnectingMessage)
-  toast.add(reconnectingMessage)
+  if (!settingStore.get('Comfy.Toast.DisableReconnectingToast')) {
+    toast.remove(reconnectingMessage)
+    toast.add(reconnectingMessage)
+  }
 }
 
 const onReconnected = () => {
-  toast.remove(reconnectingMessage)
-  toast.add({
-    severity: 'success',
-    summary: t('g.reconnected'),
-    life: 2000
-  })
+  if (!settingStore.get('Comfy.Toast.DisableReconnectingToast')) {
+    toast.remove(reconnectingMessage)
+    toast.add({
+      severity: 'success',
+      summary: t('g.reconnected'),
+      life: 2000
+    })
+  }
 }
 
 onMounted(() => {


### PR DESCRIPTION
There are multiple services that keep a single ComfyUI server instance warm and connect a queue/rotation of frontend clients based on user activity. (Or, there is generally a pattern of 1 kept-alive backend server instance per group of frontend clients.) Depending on the implementation, this may result in the backend/frontend disconnecting/reconnecting repeatedly, as the clients will get a few moments to connect to the server, send their prompt, and then be moved to the back of the queue.

This PR adds a setting to disable the reconnecting toasts, so the frontends of these services (and future services) can avoid having the toast show up every second (or more).