### PR TITLE
[Cleanup] Remove extra.info from workflow schema

### DIFF
--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -207,18 +207,6 @@ const zGroup = z
   })
   .passthrough()
 
-const zInfo = z
-  .object({
-    name: z.string(),
-    author: z.string(),
-    description: z.string(),
-    version: z.string(),
-    created: z.string(),
-    modified: z.string(),
-    software: z.string()
-  })
-  .passthrough()
-
 const zDS = z
   .object({
     scale: z.number(),
@@ -236,7 +224,6 @@ const zConfig = z
 const zExtra = z
   .object({
     ds: zDS.optional(),
-    info: zInfo.optional(),
     linkExtensions: z.array(zComfyLinkExtension).optional(),
     reroutes: z.array(zReroute).optional()
   })

--- a/tests-ui/workflows/default_workflow.json
+++ b/tests-ui/workflows/default_workflow.json
@@ -370,15 +370,6 @@
         565.6800000000005,
         -43.919999999999995
       ]
-    },
-    "info": {
-      "name": "workflow",
-      "author": "",
-      "description": "",
-      "version": "1",
-      "created": "2024-06-02T20:17:02.243Z",
-      "modified": "2024-06-02T20:17:11.438Z",
-      "software": "ComfyUI"
     }
   },
   "version": 0.4

--- a/tests-ui/workflows/workflow_disconnected.json
+++ b/tests-ui/workflows/workflow_disconnected.json
@@ -363,15 +363,6 @@
         127.07026983402625,
         138.77779138162384
       ]
-    },
-    "info": {
-      "name": "workflow",
-      "author": "",
-      "description": "",
-      "version": "1",
-      "created": "2024-06-11T23:37:08.326Z",
-      "modified": "2024-06-12T13:25:28.857Z",
-      "software": "ComfyUI"
     }
   },
   "version": 0.4

--- a/tests-ui/workflows/workflow_with_group.json
+++ b/tests-ui/workflows/workflow_with_group.json
@@ -383,15 +383,6 @@
         323.87991710157155,
         235.75066665118254
       ]
-    },
-    "info": {
-      "name": "workflow",
-      "author": "",
-      "description": "",
-      "version": "1",
-      "created": "2024-06-11T23:37:08.326Z",
-      "modified": "2024-06-11T23:37:08.327Z",
-      "software": "ComfyUI"
     }
   },
   "version": 0.4


### PR DESCRIPTION
extra.info is added by custom node so we should not try to validate the format in core.