### PR TITLE
Don't translate 'Stable Zero'

### DIFF
--- a/.i18nrc.cjs
+++ b/.i18nrc.cjs
@@ -10,7 +10,7 @@ module.exports = defineConfig({
   entryLocale: 'en',
   output: 'src/locales',
   outputLocales: ['zh', 'ru', 'ja', 'ko', 'fr', 'es'],
-  reference: `Special names to keep untranslated: flux, photomaker, clip, vae, cfg, stable audio, stable cascade, controlnet, lora.
+  reference: `Special names to keep untranslated: flux, photomaker, clip, vae, cfg, stable audio, stable cascade, stable zero, controlnet, lora.
   'latent' is the short form of 'latent space'.
   'mask' is in the context of image processing.
   `


### PR DESCRIPTION
Adds 'stable zero' to "Special names to keep untranslated" in .i18nrc.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3352-Don-t-translate-Stable-Zero-1cf6d73d36508107a40ecaf58417f156) by [Unito](https://www.unito.io)
