### PR TITLE
[Bug] Fix converted widget compression on export

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -6,6 +6,8 @@ import type {
   ComfyWorkflowJSON
 } from '@/schemas/comfyWorkflowSchema'
 
+import { compressWidgetInputSlots } from './litegraphUtil'
+
 /**
  * Converts the current graph workflow for sending to the API.
  * Note: Node widgets are updated before serialization to prepare queueing.
@@ -38,12 +40,7 @@ export const graphToPrompt = async (
     }
   }
 
-  // Remove all unconnected widget input slots
-  for (const node of workflow.nodes) {
-    node.inputs = node.inputs?.filter(
-      (input) => !(input.widget && input.link === null)
-    )
-  }
+  compressWidgetInputSlots(workflow)
 
   const output: ComfyApiWorkflow = {}
   // Process nodes in order of execution

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -1,5 +1,6 @@
 import type { ColorOption, LGraph } from '@comfyorg/litegraph'
 import { LGraphGroup, LGraphNode, isColorable } from '@comfyorg/litegraph'
+import type { ISerialisedGraph } from '@comfyorg/litegraph/dist/types/serialisation'
 import type {
   IComboWidget,
   IWidget
@@ -141,6 +142,29 @@ export function fixLinkInputSlots(graph: LGraph) {
       if (!link) continue
 
       link.target_slot = inputIndex
+    }
+  }
+}
+
+/**
+ * Compress widget input slots by removing all unconnected widget input slots.
+ * This should match the serialization format of legacy widget conversion.
+ *
+ * @param graph - The graph to compress widget input slots for.
+ */
+export function compressWidgetInputSlots(graph: ISerialisedGraph) {
+  for (const node of graph.nodes) {
+    node.inputs = node.inputs?.filter(
+      (input) => !(input.widget && input.link === null)
+    )
+
+    for (const [inputIndex, input] of node.inputs?.entries() ?? []) {
+      if (input.link) {
+        const link = graph.links.find((link) => link[0] === input.link)
+        if (link) {
+          link[4] = inputIndex
+        }
+      }
     }
   }
 }

--- a/tests-ui/tests/utils/litegraphUtil.test.ts
+++ b/tests-ui/tests/utils/litegraphUtil.test.ts
@@ -1,8 +1,12 @@
+import { ISerialisedGraph } from '@comfyorg/litegraph/dist/types/serialisation'
 import type { IWidget } from '@comfyorg/litegraph/dist/types/widgets'
 import { describe, expect, it } from 'vitest'
 
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import { migrateWidgetsValues } from '@/utils/litegraphUtil'
+import {
+  compressWidgetInputSlots,
+  migrateWidgetsValues
+} from '@/utils/litegraphUtil'
 
 describe('migrateWidgetsValues', () => {
   it('should remove widget values for forceInput inputs', () => {
@@ -84,5 +88,87 @@ describe('migrateWidgetsValues', () => {
 
     const result = migrateWidgetsValues(inputDefs, widgets, widgetValues)
     expect(result).toEqual(['first value', 'last value'])
+  })
+})
+
+describe('compressWidgetInputSlots', () => {
+  it('should remove unconnected widget input slots', () => {
+    const graph: ISerialisedGraph = {
+      nodes: [
+        {
+          id: 1,
+          type: 'foo',
+          pos: [0, 0],
+          size: [100, 100],
+          flags: {},
+          order: 0,
+          mode: 0,
+          inputs: [
+            { widget: { name: 'foo' }, link: null, type: 'INT', name: 'foo' },
+            { widget: { name: 'bar' }, link: 2, type: 'INT', name: 'bar' },
+            { widget: { name: 'baz' }, link: null, type: 'INT', name: 'baz' }
+          ],
+          outputs: []
+        }
+      ],
+      links: [[2, 1, 0, 1, 0, 'INT']]
+    } as unknown as ISerialisedGraph
+
+    compressWidgetInputSlots(graph)
+
+    expect(graph.nodes[0].inputs).toEqual([
+      { widget: true, link: 2 },
+      { widget: false, link: null }
+    ])
+  })
+
+  it('should update link target slots correctly', () => {
+    const graph: ISerialisedGraph = {
+      nodes: [
+        {
+          id: 1,
+          type: 'foo',
+          pos: [0, 0],
+          size: [100, 100],
+          flags: {},
+          order: 0,
+          mode: 0,
+          inputs: [
+            { widget: { name: 'foo' }, link: null, type: 'INT', name: 'foo' },
+            { widget: { name: 'bar' }, link: 2, type: 'INT', name: 'bar' },
+            { widget: { name: 'baz' }, link: 3, type: 'INT', name: 'baz' }
+          ],
+          outputs: []
+        }
+      ],
+      links: [
+        [2, 1, 0, 1, 1, 'INT'],
+        [3, 1, 0, 1, 2, 'INT']
+      ]
+    } as unknown as ISerialisedGraph
+
+    compressWidgetInputSlots(graph)
+
+    expect(graph.nodes[0].inputs).toEqual([
+      { widget: { name: 'bar' }, link: 2, type: 'INT', name: 'bar' },
+      { widget: { name: 'baz' }, link: 3, type: 'INT', name: 'baz' }
+    ])
+
+    expect(graph.links).toEqual([
+      [2, 1, 0, 1, 0, 'INT'],
+      [3, 1, 0, 1, 1, 'INT']
+    ])
+  })
+
+  it('should handle graphs with no nodes gracefully', () => {
+    const graph: ISerialisedGraph = {
+      nodes: [],
+      links: []
+    } as unknown as ISerialisedGraph
+
+    compressWidgetInputSlots(graph)
+
+    expect(graph.nodes).toEqual([])
+    expect(graph.links).toEqual([])
   })
 })

--- a/tests-ui/tests/utils/litegraphUtil.test.ts
+++ b/tests-ui/tests/utils/litegraphUtil.test.ts
@@ -117,8 +117,7 @@ describe('compressWidgetInputSlots', () => {
     compressWidgetInputSlots(graph)
 
     expect(graph.nodes[0].inputs).toEqual([
-      { widget: true, link: 2 },
-      { widget: false, link: null }
+      { widget: { name: 'bar' }, link: 2, type: 'INT', name: 'bar' }
     ])
   })
 


### PR DESCRIPTION
Previous serialization method will cause invalid link.

Note:
The compression is necessary as if we don't do the compression, all widgets will be treated as `defaultInput` when the workflow is loaded by frontend version < 1.16.

loaded in 1.15
![image](https://github.com/user-attachments/assets/f9aca876-3dd6-497a-ba5c-3bb7329dcec8)

loaded in 1.16
![image](https://github.com/user-attachments/assets/8f552054-ce83-4f5b-b514-2b92f15a138f)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3354-Bug-Fix-converted-widget-compression-on-export-1cf6d73d365081158b5fdafbf2f34e7c) by [Unito](https://www.unito.io)
