### PR TITLE
[Feature Request]: Add resize keybinding

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -405,6 +405,19 @@ export function useCoreCommands(): ComfyCommand[] {
       }
     },
     {
+      id: 'Comfy.Canvas.Resize',
+      icon: 'pi pi-minus',
+      label: 'Resize Selected Nodes',
+      versionAdded: '',
+      function: () => {
+        getSelectedNodes().forEach((node) => {
+          const optimalSize = node.computeSize()
+          node.setSize([optimalSize[0], optimalSize[1]])
+        })
+        app.canvas.setDirty(true, true)
+      }
+    },
+    {
       id: 'Comfy.Canvas.ToggleSelectedNodes.Collapse',
       icon: 'pi pi-minus',
       label: 'Collapse/Expand Selected Nodes',


### PR DESCRIPTION
Allows you to bind resize to a key.

Resolves issue [#2871](https://github.com/Comfy-Org/ComfyUI_frontend/issues/2871)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3356-Feature-Request-Add-resize-keybinding-1d06d73d365081b0a0e5df3ce425fdc5) by [Unito](https://www.unito.io)
