### PR TITLE
[Manager] Handle display of git hash versions for NIGHTLY node packs

### DIFF
--- a/src/components/dialog/content/manager/PackVersionBadge.vue
+++ b/src/components/dialog/content/manager/PackVersionBadge.vue
@@ -39,6 +39,9 @@ import PackVersionSelectorPopover from '@/components/dialog/content/manager/Pack
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import { SelectedVersion } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
+import { isSemVer } from '@/utils/formatUtil'
+
+const TRUNCATED_HASH_LENGTH = 7
 
 const { nodePack } = defineProps<{
   nodePack: components['schemas']['Node']
@@ -50,11 +53,13 @@ const managerStore = useComfyManagerStore()
 
 const installedVersion = computed(() => {
   if (!nodePack.id) return SelectedVersion.NIGHTLY
-  return (
+  const version =
     managerStore.installedPacks[nodePack.id]?.ver ??
     nodePack.latest_version?.version ??
     SelectedVersion.NIGHTLY
-  )
+
+  // If Git hash, truncate to 7 characters
+  return isSemVer(version) ? version : version.slice(0, TRUNCATED_HASH_LENGTH)
 })
 
 const toggleVersionSelector = (event: Event) => {

--- a/src/components/dialog/content/manager/__tests__/PackVersionSelectorPopover.test.ts
+++ b/src/components/dialog/content/manager/__tests__/PackVersionSelectorPopover.test.ts
@@ -43,7 +43,9 @@ vi.mock('@/stores/comfyManagerStore', () => ({
     installPack: {
       call: mockInstallPack,
       clear: vi.fn()
-    }
+    },
+    isPackInstalled: vi.fn(() => false),
+    getInstalledPackVersion: vi.fn(() => undefined)
   }))
 }))
 


### PR DESCRIPTION
When a node pack is installed using NIGHTLY version selector, the installed version is a git commit hash. This PR truncates the display to the shortened hash and also automatically selects NIGHTLY when opening version selection popover.

![Selection_1177](https://github.com/user-attachments/assets/e63452f1-9089-4692-8eee-bf6d5caf4805)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3359-Manager-Handle-display-of-git-hash-versions-for-NIGHTLY-node-packs-1d06d73d3650812bb48ed367fc54cc36) by [Unito](https://www.unito.io)
