### PR TITLE
[Cleanup] Remove WidgetOptions.inputIsOptional

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -147,7 +147,6 @@ export const useLitegraphService = () => {
           widget.label = st(nameKey, widget.label ?? inputName)
           widget.options ??= {}
           Object.assign(widget.options, {
-            inputIsOptional: inputSpec.isOptional,
             forceInput: inputSpec.forceInput,
             advanced: inputSpec.advanced,
             hidden: inputSpec.hidden
@@ -210,7 +209,7 @@ export const useLitegraphService = () => {
        */
       #setInitialSize() {
         const s = this.computeSize()
-        s[0] = Math.max(this.#initialMinSize.width, s[0] * 1.5)
+        s[0] = Math.max(this.#initialMinSize.width, s[0])
         s[1] = Math.max(this.#initialMinSize.height, s[1])
         this.setSize(s)
       }

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -209,7 +209,7 @@ export const useLitegraphService = () => {
        */
       #setInitialSize() {
         const s = this.computeSize()
-        s[0] = Math.max(this.#initialMinSize.width, s[0])
+        s[0] = Math.max(this.#initialMinSize.width, s[0] * 1.5)
         s[1] = Math.max(this.#initialMinSize.height, s[1])
         this.setSize(s)
       }

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -27,10 +27,6 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
      */
     minNodeSize?: Size
     /**
-     * Whether the widget is optional.
-     */
-    inputIsOptional?: boolean
-    /**
      * Whether the widget is forced to be an input.
      */
     forceInput?: boolean


### PR DESCRIPTION
The property is not used by external callers. https://cs.comfy.org/search?q=context:global+inputIsOptional&patternType=keyword&sm=0

The information is now accessible directly on `InputSpec`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3361-Cleanup-Remove-WidgetOptions-inputIsOptional-1d06d73d365081c9878bd626d07531eb) by [Unito](https://www.unito.io)
