### PR TITLE
[Cleanup] Remove WidgetOptions.forceInput

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -433,8 +433,7 @@ function getConfig(this: LGraphNode, widgetName: string) {
 function isConvertibleWidget(widget: IWidget, config: InputSpec): boolean {
   return (
     // @ts-expect-error InputSpec is not typed correctly
-    (VALID_TYPES.includes(widget.type) || VALID_TYPES.includes(config[0])) &&
-    !widget.options?.forceInput
+    VALID_TYPES.includes(widget.type) || VALID_TYPES.includes(config[0])
   )
 }
 

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -147,7 +147,6 @@ export const useLitegraphService = () => {
           widget.label = st(nameKey, widget.label ?? inputName)
           widget.options ??= {}
           Object.assign(widget.options, {
-            forceInput: inputSpec.forceInput,
             advanced: inputSpec.advanced,
             hidden: inputSpec.hidden
           })

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -27,10 +27,6 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
      */
     minNodeSize?: Size
     /**
-     * Whether the widget is forced to be an input.
-     */
-    forceInput?: boolean
-    /**
      * Whether the widget defaults to input state. Can still be converted back
      * to widget state.
      * @deprecated Widget to input conversion is no longer necessary, as they co-exist now.


### PR DESCRIPTION
forceInput input is no longer created as widget, so remove it property from `WidgetOptions`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3362-Cleanup-Remove-WidgetOptions-forceInput-1d06d73d36508109afbbe41155361739) by [Unito](https://www.unito.io)
