### PR TITLE
[Manager] Fix node pack icons not displaying in search results

### DIFF
--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -67,7 +67,8 @@ const RETRIEVE_ATTRIBUTES: SearchAttribute[] = [
   'repository_url',
   'latest_version_status',
   'comfy_node_extract_status',
-  'id'
+  'id',
+  'icon_url'
 ]
 
 export interface NodesIndexSuggestion {


### PR DESCRIPTION
Fixes issue in which `icon_url` field is not retrieved from Algolia search results. There was a mistaken assumption that `icon_url` was not part of Algolia index, but in fact it was just not being retrieved. 

After this PR, custom node search shows the node pack icons correctly:

![Selection_1179](https://github.com/user-attachments/assets/714fe8de-2efc-4448-840a-8c7dde45d6be)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3366-Manager-Fix-node-pack-icons-not-displaying-in-search-results-1d06d73d365081f68dccee29b4794d39) by [Unito](https://www.unito.io)
