### PR TITLE
[Manager] Remove outdated comment

### DIFF
--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -48,7 +48,6 @@ export interface AlgoliaNodePack {
     'latest_version',
     'comfy_node_extract_status'
   >
-  /** `total_install` index only */
   icon_url: RegistryNodePack['icon']
 }
 


### PR DESCRIPTION
`icon_url` attribute is in fact included in the nodes_index index, making this comment no longer accurate.