### PR TITLE
[Bug] Apply link fixes regardless of fixed state

### DIFF
--- a/src/composables/useWorkflowValidation.ts
+++ b/src/composables/useWorkflowValidation.ts
@@ -69,17 +69,17 @@ export function useWorkflowValidation() {
       if (linkValidation.fixed) {
         if (!silent) {
           toastStore.add({
-            severity: 'info',
+            severity: 'success',
             summary: 'Workflow Links Fixed',
             detail: `Fixed ${linkValidation.patched} node connections and removed ${linkValidation.deleted} invalid links.`
           })
         }
+      }
 
-        validatedData = linkValidation.graph as unknown as ComfyWorkflowJSON
-        linksFixes = {
-          patched: linkValidation.patched,
-          deleted: linkValidation.deleted
-        }
+      validatedData = linkValidation.graph as unknown as ComfyWorkflowJSON
+      linksFixes = {
+        patched: linkValidation.patched,
+        deleted: linkValidation.deleted
       }
     }
 


### PR DESCRIPTION
Apply link fixes even when the graph is partially fixed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3376-Bug-Apply-link-fixes-regardless-of-fixed-state-1d16d73d365081659269eba0642c96ff) by [Unito](https://www.unito.io)
