### PR TITLE
Add tag pi-language icon for Comfy.Locale setting

### DIFF
--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -6,7 +6,7 @@
     @update:formValue="updateSettingValue"
   >
     <template #name-prefix>
-      <Tag v-if="setting.id === 'Comfy.Locale'" class="pi pi-language"/>
+      <Tag v-if="setting.id === 'Comfy.Locale'" class="pi pi-language" />
       <Tag v-if="setting.experimental" :value="$t('g.experimental')" />
       <Tag
         v-if="setting.deprecated"

--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -6,6 +6,7 @@
     @update:formValue="updateSettingValue"
   >
     <template #name-prefix>
+      <Tag v-if="setting.id === 'Comfy.Locale'" class="pi pi-language"/>
       <Tag v-if="setting.experimental" :value="$t('g.experimental')" />
       <Tag
         v-if="setting.deprecated"


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/15db903b-45f2-4957-829c-e5a96d5496e2)


Resolves #3353

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3378-Add-tag-pi-language-icon-for-Comfy-Locale-setting-1d16d73d36508194bedac07cc421a036) by [Unito](https://www.unito.io)
