### PR TITLE
[Bug] Fixes workflow save inconsistent with export

### DIFF
--- a/src/components/toast/RerouteMigrationToast.vue
+++ b/src/components/toast/RerouteMigrationToast.vue
@@ -33,7 +33,7 @@ const toast = useToast()
 
 const workflowStore = useWorkflowStore()
 const migrateToLitegraphReroute = () => {
-  const workflowJSON = app.serializeGraph() as unknown as WorkflowJSON04
+  const workflowJSON = app.graph.serialize() as unknown as WorkflowJSON04
   const migratedWorkflowJSON = migrateLegacyRerouteNodes(workflowJSON)
   app.loadGraphData(
     migratedWorkflowJSON,

--- a/src/composables/useWorkflowPersistence.ts
+++ b/src/composables/useWorkflowPersistence.ts
@@ -18,7 +18,7 @@ export function useWorkflowPersistence() {
 
   const persistCurrentWorkflow = () => {
     if (!workflowPersistenceEnabled.value) return
-    const workflow = JSON.stringify(comfyApp.serializeGraph())
+    const workflow = JSON.stringify(comfyApp.graph.serialize())
     localStorage.setItem('workflow', workflow)
     if (api.clientId) {
       sessionStorage.setItem(`workflow:${api.clientId}`, workflow)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1147,22 +1147,11 @@ export class ComfyApp {
     )
     await useWorkflowService().afterLoadNewGraph(
       workflow,
-      // @ts-expect-error zod types issue. Will be fixed after we enable ts-strict
-      this.graph.serialize()
+      this.graph.serialize() as unknown as ComfyWorkflowJSON
     )
     requestAnimationFrame(() => {
       this.graph.setDirtyCanvas(true, true)
     })
-  }
-
-  /**
-   * Serializes a graph using preferred user settings.
-   * @param graph The litegraph to serialize.
-   * @returns A serialized graph (aka workflow) with preferred user settings.
-   */
-  serializeGraph(graph: LGraph = this.graph) {
-    const sortNodes = useSettingStore().get('Comfy.Workflow.SortNodeIdOnSave')
-    return graph.serialize({ sortNodes })
   }
 
   async graphToPrompt(graph = this.graph) {
@@ -1276,8 +1265,10 @@ export class ComfyApp {
         // by external callers, and `importA1111` has no access to `app`.
         useWorkflowService().beforeLoadNewGraph()
         importA1111(this.graph, pngInfo.parameters)
-        // @ts-expect-error zod type issue on ComfyWorkflowJSON. Should be resolved after enabling ts-strict globally.
-        useWorkflowService().afterLoadNewGraph(fileName, this.serializeGraph())
+        useWorkflowService().afterLoadNewGraph(
+          fileName,
+          this.graph.serialize() as unknown as ComfyWorkflowJSON
+        )
       } else {
         this.showErrorOnFileLoad(file)
       }
@@ -1479,9 +1470,10 @@ export class ComfyApp {
 
     app.graph.arrange()
 
-    // @ts-expect-error zod type issue on ComfyWorkflowJSON. ComfyWorkflowJSON
-    // is stricter than LiteGraph's serialisation schema.
-    useWorkflowService().afterLoadNewGraph(fileName, this.serializeGraph())
+    useWorkflowService().afterLoadNewGraph(
+      fileName,
+      this.graph.serialize() as unknown as ComfyWorkflowJSON
+    )
   }
 
   /**

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -6,6 +6,7 @@ import { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import { defaultGraphJSON } from '@/scripts/defaultGraph'
+import { processWorkflowForExport } from '@/utils/executionUtil'
 import { getPathDetails } from '@/utils/formatUtil'
 import { syncEntities } from '@/utils/syncUtil'
 
@@ -90,7 +91,9 @@ export class ComfyWorkflow extends UserFile {
   }
 
   async save() {
-    this.content = JSON.stringify(this.activeState)
+    this.content = this.activeState
+      ? JSON.stringify(processWorkflowForExport(this.activeState))
+      : ''
     // Force save to ensure the content is updated in remote storage incase
     // the isModified state is screwed by changeTracker.
     const ret = await super.save({ force: true })
@@ -105,7 +108,9 @@ export class ComfyWorkflow extends UserFile {
    * @returns this
    */
   async saveAs(path: string) {
-    this.content = JSON.stringify(this.activeState)
+    this.content = this.activeState
+      ? JSON.stringify(processWorkflowForExport(this.activeState))
+      : ''
     return await super.saveAs(path)
   }
 }
@@ -288,7 +293,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     })
 
     workflow.originalContent = workflow.content = workflowData
-      ? JSON.stringify(workflowData)
+      ? JSON.stringify(processWorkflowForExport(workflowData))
       : defaultGraphJSON
 
     workflowLookup.value[workflow.path] = workflow

--- a/tests-ui/tests/utils/executionUtil.test.ts
+++ b/tests-ui/tests/utils/executionUtil.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
+import { processWorkflowForExport } from '@/utils/executionUtil'
+
+describe('processWorkflowForExport', () => {
+  it('should remove localized_name from inputs and outputs', () => {
+    const workflow = {
+      nodes: [
+        {
+          id: 1,
+          inputs: [
+            { name: 'input1', type: 'INT', localized_name: 'Input One' },
+            { name: 'input2', type: 'FLOAT', localized_name: 'Input Two' }
+          ],
+          outputs: [
+            { name: 'output1', type: 'STRING', localized_name: 'Output One' },
+            { name: 'output2', type: 'BOOLEAN', localized_name: 'Output Two' }
+          ]
+        }
+      ],
+      links: []
+    } as unknown as ComfyWorkflowJSON
+
+    const processed = processWorkflowForExport(workflow)
+
+    // Check inputs
+    expect(processed.nodes[0].inputs?.[0]).not.toHaveProperty('localized_name')
+    expect(processed.nodes[0].inputs?.[1]).not.toHaveProperty('localized_name')
+    // Check outputs
+    expect(processed.nodes[0].outputs?.[0]).not.toHaveProperty('localized_name')
+    expect(processed.nodes[0].outputs?.[1]).not.toHaveProperty('localized_name')
+    // Verify other properties remain unchanged
+    expect(processed.nodes[0].inputs?.[0].name).toBe('input1')
+    expect(processed.nodes[0].outputs?.[0].name).toBe('output1')
+  })
+
+  it('should compress widget input slots', () => {
+    const workflow: ComfyWorkflowJSON = {
+      nodes: [
+        {
+          id: 1,
+          inputs: [
+            { widget: true, link: null },
+            { widget: true, link: 2 },
+            { widget: false, link: null },
+            { widget: true, link: 3 }
+          ],
+          outputs: []
+        }
+      ],
+      links: [
+        [2, 2, 0, 1, 1],
+        [3, 3, 0, 1, 3]
+      ]
+    } as unknown as ComfyWorkflowJSON
+
+    const processed = processWorkflowForExport(workflow)
+
+    // Check that unconnected widget inputs are removed
+    expect(processed.nodes[0].inputs).toEqual([
+      { widget: true, link: 2 },
+      { widget: false, link: null },
+      { widget: true, link: 3 }
+    ])
+
+    // Check that link target slots are updated
+    expect(processed.links).toEqual([
+      [2, 2, 0, 1, 0],
+      [3, 3, 0, 1, 2]
+    ])
+  })
+
+  it('should handle empty workflow', () => {
+    const workflow: ComfyWorkflowJSON = {
+      nodes: [],
+      links: []
+    } as unknown as ComfyWorkflowJSON
+
+    const processed = processWorkflowForExport(workflow)
+
+    expect(processed).toEqual({
+      nodes: [],
+      links: []
+    })
+  })
+
+  it('should preserve other node properties', () => {
+    const workflow: ComfyWorkflowJSON = {
+      nodes: [
+        {
+          id: 1,
+          type: 'TestNode',
+          pos: [100, 100],
+          size: [200, 150],
+          flags: {},
+          order: 0,
+          mode: 0,
+          inputs: [{ widget: true, link: 2 }],
+          outputs: [{ name: 'output1', type: 'INT' }],
+          properties: { customProp: 'value' }
+        }
+      ],
+      links: [[2, 2, 0, 1, 0]]
+    } as unknown as ComfyWorkflowJSON
+
+    const processed = processWorkflowForExport(workflow)
+
+    expect(processed.nodes[0]).toMatchObject({
+      id: 1,
+      type: 'TestNode',
+      pos: [100, 100],
+      size: [200, 150],
+      flags: {},
+      order: 0,
+      mode: 0,
+      properties: { customProp: 'value' }
+    })
+  })
+})


### PR DESCRIPTION
Previously localized_name on node i/o slot are persisted to saved workflows, while getting removed from exported workflows. This PR aligns the behavior of the 2.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3382-Bug-Fixes-workflow-save-inconsistent-with-export-1d16d73d36508112b1b3c37aa9dc1fc6) by [Unito](https://www.unito.io)
