### PR TITLE
Attach frontend version metadata on workflow export

### DIFF
--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -224,6 +224,7 @@ const zConfig = z
 const zExtra = z
   .object({
     ds: zDS.optional(),
+    frontendVersion: z.string().optional(),
     linkExtensions: z.array(zComfyLinkExtension).optional(),
     reroutes: z.array(zReroute).optional()
   })

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -41,6 +41,8 @@ export const graphToPrompt = async (
   }
 
   compressWidgetInputSlots(workflow)
+  workflow.extra ??= {}
+  workflow.extra.frontendVersion = __COMFYUI_FRONTEND_VERSION__
 
   const output: ComfyApiWorkflow = {}
   // Process nodes in order of execution


### PR DESCRIPTION
Attach extra metadata for debugging/migration purpose.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3386-Attach-frontend-version-metadata-on-workflow-export-1d16d73d3650819e95aad98fb4ef5d3b) by [Unito](https://www.unito.io)
