### PR TITLE
keep user input on top of selection toolbox

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -398,7 +398,7 @@ button.comfy-queue-btn {
 .graphdialog {
   min-height: 1em;
   background-color: var(--comfy-menu-bg);
-  z-index: 41;
+  z-index: 41; /* z-index is set to 41 here in order to appear over selection-overlay-container which should have a z-index of 40 */
 }
 
 .graphdialog .name {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -398,6 +398,7 @@ button.comfy-queue-btn {
 .graphdialog {
   min-height: 1em;
   background-color: var(--comfy-menu-bg);
+  z-index: 41;
 }
 
 .graphdialog .name {


### PR DESCRIPTION
i think we should prioritize user input over the selection toolbox

before:
![image](https://github.com/user-attachments/assets/a2b69b71-9bcc-401d-a181-d3d2d43b5ace)

after:
![image](https://github.com/user-attachments/assets/f8b28f06-9bdb-46e1-bd81-6279a6e6badd)

is there a more sustainable approach?

![image](https://github.com/user-attachments/assets/7f1698e3-41f6-4eaa-a448-a9fc3d5daa1f)



resolves #2894

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3389-keep-user-input-on-top-of-selection-toolbox-1d16d73d36508108b4b5e1a251077e70) by [Unito](https://www.unito.io)
