### PR TITLE
[Manager] Fix infinite fetch attempts when response is empty

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -185,14 +185,16 @@ const {
   startFetchInstalled,
   filterInstalledPack,
   installedPacks,
-  isLoading: isLoadingInstalled
+  isLoading: isLoadingInstalled,
+  isReady: installedPacksReady
 } = useInstalledPacks()
 
 const {
   startFetchWorkflowPacks,
   filterWorkflowPack,
   workflowPacks,
-  isLoading: isLoadingWorkflow
+  isLoading: isLoadingWorkflow,
+  isReady: workflowPacksReady
 } = useWorkflowPacks()
 
 const filterMissingPacks = (packs: components['schemas']['Node'][]) =>
@@ -236,7 +238,11 @@ watch([isInstalledTab, installedPacks], () => {
 
   if (!isEmptySearch.value) {
     displayPacks.value = filterInstalledPack(searchResults.value)
-  } else if (!installedPacks.value.length) {
+  } else if (
+    !installedPacks.value.length &&
+    !installedPacksReady.value &&
+    !isLoadingInstalled.value
+  ) {
     startFetchInstalled()
   } else {
     displayPacks.value = installedPacks.value
@@ -250,7 +256,11 @@ watch([isMissingTab, isWorkflowTab, workflowPacks], () => {
     displayPacks.value = isMissingTab.value
       ? filterMissingPacks(filterWorkflowPack(searchResults.value))
       : filterWorkflowPack(searchResults.value)
-  } else if (!workflowPacks.value.length) {
+  } else if (
+    !workflowPacks.value.length &&
+    !isLoadingWorkflow.value &&
+    !workflowPacksReady.value
+  ) {
     startFetchWorkflowPacks()
   } else {
     displayPacks.value = isMissingTab.value

--- a/src/composables/nodePack/useInstalledPacks.ts
+++ b/src/composables/nodePack/useInstalledPacks.ts
@@ -12,10 +12,8 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
     Array.from(comfyManagerStore.installedPacksIds)
   )
 
-  const { startFetch, cleanup, error, isLoading, nodePacks } = useNodePacks(
-    installedPackIds,
-    options
-  )
+  const { startFetch, cleanup, error, isLoading, nodePacks, isReady } =
+    useNodePacks(installedPackIds, options)
 
   const filterInstalledPack = (packs: components['schemas']['Node'][]) =>
     packs.filter((pack) => comfyManagerStore.isPackInstalled(pack.id))
@@ -27,6 +25,7 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
   return {
     error,
     isLoading,
+    isReady,
     installedPacks: nodePacks,
     startFetchInstalled: startFetch,
     filterInstalledPack

--- a/src/composables/nodePack/useWorkflowPacks.ts
+++ b/src/composables/nodePack/useWorkflowPacks.ts
@@ -62,10 +62,8 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
     Array.from(packsToUniqueIds(workflowPacks.value))
   )
 
-  const { startFetch, cleanup, error, isLoading, nodePacks } = useNodePacks(
-    workflowPacksIds,
-    options
-  )
+  const { startFetch, cleanup, error, isLoading, nodePacks, isReady } =
+    useNodePacks(workflowPacksIds, options)
 
   const isIdInWorkflow = (packId: string) =>
     workflowPacksIds.value.includes(packId)
@@ -80,6 +78,7 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
   return {
     error,
     isLoading,
+    isReady,
     workflowPacks: nodePacks,
     startFetchWorkflowPacks: startFetch,
     filterWorkflowPack


### PR DESCRIPTION
When a Manager tab (e.g., "Installed") is selected, the fetch is started to retrieve the installed node packs. Currently, the watcher that determines if the fetch has been started before or not makes the determination based on if result is empty. This causes a bug in which naturally empty result causes infinite fetch attempts.

Fix by changing watcher to check the state variables of the fetcher composable `isReady` and `isLoading`.