### PR TITLE
Add check to see if user defined keybind still exists

### DIFF
--- a/src/services/keybindingService.ts
+++ b/src/services/keybindingService.ts
@@ -1,3 +1,5 @@
+import log from 'loglevel'
+
 import { CORE_KEYBINDINGS } from '@/constants/coreKeybindings'
 import { useCommandStore } from '@/stores/commandStore'
 import {
@@ -75,7 +77,13 @@ export const useKeybindingService = () => {
     }
     const newBindings = settingStore.get('Comfy.Keybinding.NewBindings')
     for (const keybinding of newBindings) {
-      keybindingStore.addUserKeybinding(new KeybindingImpl(keybinding))
+      if (commandStore.isRegistered(keybinding.commandId)) {
+        keybindingStore.addUserKeybinding(new KeybindingImpl(keybinding))
+      } else {
+        log.warn(
+          `Skipped binding user defined keybind with invalid commandId: ${keybinding.commandId}, combo: ${new KeyComboImpl(keybinding.combo).toString()}`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
This only checks onGraphReady, and not during runtime.

Resolves #2407

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3398-Add-check-to-see-if-user-defined-keybind-still-exists-1d26d73d3650810e80ccd51f25725395) by [Unito](https://www.unito.io)
