### PR TITLE
Do not trigger autosave on workflows that are not persisted

### DIFF
--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -61,19 +61,24 @@ const autoSaveDelay = computed(() =>
 )
 
 const shouldShowStatusIndicator = computed(() => {
-  // 1. Never show if shift key is pressed down, otherwise:
-  // 2. Always show if not persisted, otherwise:
-  // 3. If the workflow is modified, only show the indicator when:
-  //    - Autosave is turned off, OR
-  //    - Autosave is enabled and the delay is longer than 3000ms.
-  return (
-    !workspaceStore.shiftDown &&
-    (!props.workflowOption.workflow.isPersisted ||
-      (props.workflowOption.workflow.isModified &&
-        (autoSaveSetting.value === 'off' ||
-          (autoSaveSetting.value === 'after delay' &&
-            autoSaveDelay.value > 3000))))
-  )
+  if (workspaceStore.shiftDown) {
+    return false
+  } else if (!props.workflowOption.workflow.isPersisted) {
+    return true
+  } else if (props.workflowOption.workflow.isModified) {
+    if (autoSaveSetting.value === 'off') {
+      return true
+    } else if (
+      autoSaveSetting.value === 'after delay' &&
+      autoSaveDelay.value > 3000
+    ) {
+      return true
+    } else {
+      return false
+    }
+  } else {
+    return false
+  }
 })
 
 const closeWorkflows = async (options: WorkflowOption[]) => {

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -61,17 +61,21 @@ const autoSaveDelay = computed(() =>
 )
 
 const shouldShowStatusIndicator = computed(() => {
-  // Return true if:
-  // 1. The shift key is not pressed (hence no override).
-  // 2. The workflow is either modified or not yet persisted.
-  // 3. AutoSave is either turned off, or set to 'after delay'
-  //    with a delay longer than 3000ms.
+  // Explanation:
+  // 1. Check if the shift key is not pressed (!workspaceStore.shiftDown). If the shift key is pressed,
+  //    we may want to override the status display.
+  // 2. If the workflow is not persisted (!props.workflowOption.workflow.isPersisted),
+  //    always show the indicator.
+  // 3. Otherwise, if the workflow is modified, only show the indicator when:
+  //    - Autosave is turned off, OR
+  //    - Autosave is enabled ('after delay') and the delay is longer than 3000ms.
   return (
     !workspaceStore.shiftDown &&
-    (props.workflowOption.workflow.isModified ||
-      !props.workflowOption.workflow.isPersisted) &&
-    (autoSaveSetting.value === 'off' ||
-      (autoSaveSetting.value === 'after delay' && autoSaveDelay.value > 3000))
+    (!props.workflowOption.workflow.isPersisted ||
+      (props.workflowOption.workflow.isModified &&
+        (autoSaveSetting.value === 'off' ||
+          (autoSaveSetting.value === 'after delay' &&
+            autoSaveDelay.value > 3000))))
   )
 })
 

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -61,14 +61,11 @@ const autoSaveDelay = computed(() =>
 )
 
 const shouldShowStatusIndicator = computed(() => {
-  // Explanation:
-  // 1. Check if the shift key is not pressed (!workspaceStore.shiftDown). If the shift key is pressed,
-  //    we may want to override the status display.
-  // 2. If the workflow is not persisted (!props.workflowOption.workflow.isPersisted),
-  //    always show the indicator.
-  // 3. Otherwise, if the workflow is modified, only show the indicator when:
+  // 1. Never show if shift key is pressed down, otherwise:
+  // 2. Always show if not persisted, otherwise:
+  // 3. If the workflow is modified, only show the indicator when:
   //    - Autosave is turned off, OR
-  //    - Autosave is enabled ('after delay') and the delay is longer than 3000ms.
+  //    - Autosave is enabled and the delay is longer than 3000ms.
   return (
     !workspaceStore.shiftDown &&
     (!props.workflowOption.workflow.isPersisted ||

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -62,23 +62,28 @@ const autoSaveDelay = computed(() =>
 
 const shouldShowStatusIndicator = computed(() => {
   if (workspaceStore.shiftDown) {
-    return false
-  } else if (!props.workflowOption.workflow.isPersisted) {
-    return true
-  } else if (props.workflowOption.workflow.isModified) {
-    if (autoSaveSetting.value === 'off') {
-      return true
-    } else if (
-      autoSaveSetting.value === 'after delay' &&
-      autoSaveDelay.value > 3000
-    ) {
-      return true
-    } else {
-      return false
-    }
-  } else {
+    // Branch 1: Shift key is held down, do not show the status indicator.
     return false
   }
+  if (!props.workflowOption.workflow.isPersisted) {
+    // Branch 2: Workflow is not persisted, show the status indicator.
+    return true
+  }
+  if (props.workflowOption.workflow.isModified) {
+    // Branch 3: Workflow is modified.
+    if (autoSaveSetting.value === 'off') {
+      // Sub-branch 3a: Autosave is off, so show the status indicator.
+      return true
+    }
+    if (autoSaveSetting.value === 'after delay' && autoSaveDelay.value > 3000) {
+      // Sub-branch 3b: Autosave delay is too high, so show the status indicator.
+      return true
+    }
+    // Sub-branch 3c: Workflow is modified but no condition applies, do not show the status indicator.
+    return false
+  }
+  // Default: do not show the status indicator. This should not be reachable.
+  return false
 })
 
 const closeWorkflows = async (options: WorkflowOption[]) => {

--- a/src/composables/useWorkflowAutoSave.ts
+++ b/src/composables/useWorkflowAutoSave.ts
@@ -39,7 +39,7 @@ export function useWorkflowAutoSave() {
       const delay = autoSaveDelay.value
       autoSaveTimeout = setTimeout(async () => {
         const activeWorkflow = workflowStore.activeWorkflow
-        if (activeWorkflow?.isModified) {
+        if (activeWorkflow?.isModified && activeWorkflow.isPersisted) {
           try {
             isSaving = true
             await workflowService.saveWorkflow(activeWorkflow)


### PR DESCRIPTION
Previously, users with autosave on would have a saveworkflowas popup show given a new unpersisted workflow.

This was unintended and did not serve as good user experience.

Autosave should only trigger on persisted and modified workflows.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3400-Do-not-trigger-autosave-on-workflows-that-are-not-persisted-1d26d73d3650810ca1fcd1984cf5369f) by [Unito](https://www.unito.io)
