### PR TITLE
Ensure all command executtions are awaited

### DIFF
--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -135,12 +135,12 @@ const hasPendingTasks = computed(
 )
 
 const commandStore = useCommandStore()
-const queuePrompt = (e: Event) => {
+const queuePrompt = async (e: Event) => {
   const commandId =
     'shiftKey' in e && e.shiftKey
       ? 'Comfy.QueuePromptFront'
       : 'Comfy.QueuePrompt'
-  commandStore.execute(commandId)
+  await commandStore.execute(commandId)
 }
 </script>
 

--- a/src/components/actionbar/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyQueueButton.vue
@@ -47,7 +47,7 @@
         :disabled="!executingPrompt"
         text
         :aria-label="$t('menu.interrupt')"
-        @click="() => commandStore.execute('Comfy.Interrupt')"
+        @click="async () => await commandStore.execute('Comfy.Interrupt')"
       >
       </Button>
       <Button
@@ -61,9 +61,9 @@
         text
         :aria-label="$t('sideToolbar.queueTab.clearPendingTasks')"
         @click="
-          () => {
+          async () => {
             if (queueCountStore.count.value > 1) {
-              commandStore.execute('Comfy.ClearPendingTasks')
+              await commandStore.execute('Comfy.ClearPendingTasks')
             }
             queueMode = 'disabled'
           }

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -23,7 +23,7 @@
       icon="pi pi-expand"
       v-tooltip.left="t('graphCanvasMenu.fitView')"
       :aria-label="$t('graphCanvasMenu.fitView')"
-      @click="() => commandStore.execute('Comfy.Canvas.FitView')"
+      @click="async () => await commandStore.execute('Comfy.Canvas.FitView')"
     />
     <Button
       severity="secondary"
@@ -39,7 +39,7 @@
             (canvasStore.canvas?.read_only ? 'panMode' : 'selectMode')
         )
       "
-      @click="() => commandStore.execute('Comfy.Canvas.ToggleLock')"
+      @click="async () => await commandStore.execute('Comfy.Canvas.ToggleLock')"
     >
       <template #icon>
         <i-material-symbols:pan-tool-outline
@@ -53,7 +53,10 @@
       :icon="linkHidden ? 'pi pi-eye-slash' : 'pi pi-eye'"
       v-tooltip.left="t('graphCanvasMenu.toggleLinkVisibility')"
       :aria-label="$t('graphCanvasMenu.toggleLinkVisibility')"
-      @click="() => commandStore.execute('Comfy.Canvas.ToggleLinkVisibility')"
+      @click="
+        async () =>
+          await commandStore.execute('Comfy.Canvas.ToggleLinkVisibility')
+      "
       data-testid="toggle-link-visibility-button"
     />
   </ButtonGroup>

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -12,7 +12,8 @@
       severity="secondary"
       text
       @click="
-        () => commandStore.execute('Comfy.Canvas.ToggleSelectedNodes.Bypass')
+        async () =>
+          await commandStore.execute('Comfy.Canvas.ToggleSelectedNodes.Bypass')
       "
       data-testid="bypass-button"
       v-tooltip.top="{
@@ -29,7 +30,10 @@
       severity="secondary"
       text
       icon="pi pi-thumbtack"
-      @click="() => commandStore.execute('Comfy.Canvas.ToggleSelected.Pin')"
+      @click="
+        async () =>
+          await commandStore.execute('Comfy.Canvas.ToggleSelected.Pin')
+      "
       v-tooltip.top="{
         value: t('commands.Comfy_Canvas_ToggleSelectedNodes_Pin.label'),
         showDelay: 1000
@@ -39,7 +43,10 @@
       severity="danger"
       text
       icon="pi pi-trash"
-      @click="() => commandStore.execute('Comfy.Canvas.DeleteSelectedItems')"
+      @click="
+        async () =>
+          await commandStore.execute('Comfy.Canvas.DeleteSelectedItems')
+      "
       v-tooltip.top="{
         value: t('commands.Comfy_Canvas_DeleteSelectedItems.label'),
         showDelay: 1000

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -65,7 +65,7 @@
       severity="secondary"
       text
       :icon="typeof command.icon === 'function' ? command.icon() : command.icon"
-      @click="() => commandStore.execute(command.id)"
+      @click="async () => await commandStore.execute(command.id)"
       v-tooltip.top="{
         value:
           st(`commands.${normalizeI18nKey(command.id)}.label`, '') || undefined,

--- a/src/components/sidebar/SidebarThemeToggleIcon.vue
+++ b/src/components/sidebar/SidebarThemeToggleIcon.vue
@@ -23,7 +23,7 @@ const icon = computed(() =>
 )
 
 const commandStore = useCommandStore()
-const toggleTheme = () => {
-  commandStore.execute('Comfy.ToggleTheme')
+const toggleTheme = async () => {
+  await commandStore.execute('Comfy.ToggleTheme')
 }
 </script>

--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -36,7 +36,9 @@
           icon="pi pi-stop"
           severity="danger"
           text
-          @click="() => commandStore.execute('Comfy.ClearPendingTasks')"
+          @click="
+            async () => await commandStore.execute('Comfy.ClearPendingTasks')
+          "
           v-tooltip.bottom="$t('sideToolbar.queueTab.clearPendingTasks')"
         />
         <Button

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -34,7 +34,7 @@
       text
       severity="secondary"
       :aria-label="$t('sideToolbar.newBlankWorkflow')"
-      @click="() => commandStore.execute('Comfy.NewBlankWorkflow')"
+      @click="async () => await commandStore.execute('Comfy.NewBlankWorkflow')"
     />
     <ContextMenu ref="menu" :model="contextMenuItems" />
   </div>

--- a/src/composables/useRefreshableSelection.ts
+++ b/src/composables/useRefreshableSelection.ts
@@ -44,7 +44,7 @@ export const useRefreshableSelection = () => {
     if (!isRefreshable.value) return
 
     if (isAllNodesSelected.value) {
-      commandStore.execute('Comfy.RefreshNodeDefinitions')
+      await commandStore.execute('Comfy.RefreshNodeDefinitions')
     } else {
       await Promise.all(refreshableWidgets.value.map((item) => item.refresh()))
     }


### PR DESCRIPTION
Ensures all command executions are awaited. Resolves https://github.com/Comfy-Org/ComfyUI_frontend/pull/3397#pullrequestreview-2760418182.

See `execute` function of command store for context:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/59e20964a07819125139222ea00e32a797fe3b95/src/stores/commandStore.ts#L89-L99

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3401-Ensure-all-command-executtions-are-awaited-1d26d73d36508112bf5ed93a38d7c4c9) by [Unito](https://www.unito.io)
