### PR TITLE
Generate a new workflow id when using "save as"

### DIFF
--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -94,10 +94,14 @@ export const useWorkflowService = () => {
       await renameWorkflow(workflow, newPath)
       await workflowStore.saveWorkflow(workflow)
     } else {
-      const tempWorkflow = workflowStore.createTemporary(
-        newKey,
-        workflow.activeState as ComfyWorkflowJSON
-      )
+      // Generate new id when saving existing workflow as a new file
+      const id = crypto.randomUUID()
+      const state = JSON.parse(
+        JSON.stringify(workflow.activeState)
+      ) as ComfyWorkflowJSON
+      state.id = id
+
+      const tempWorkflow = workflowStore.createTemporary(newKey, state)
       await openWorkflow(tempWorkflow)
       await workflowStore.saveWorkflow(tempWorkflow)
     }

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -441,7 +441,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     getWorkflowByPath,
     syncWorkflows
   }
-}) as unknown as () => WorkflowStore
+}) as () => WorkflowStore
 
 export const useWorkflowBookmarkStore = defineStore('workflowBookmark', () => {
   const bookmarks = ref<Set<string>>(new Set())


### PR DESCRIPTION
Replaces workflow ID when duplicating an existing workflow via `Save As`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3407-Generate-a-new-workflow-id-when-using-save-as-1d26d73d365081cd964ec746714a349e) by [Unito](https://www.unito.io)
