### PR TITLE
[Manager] Allowing changing sort field of registry search results

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -29,6 +29,7 @@
           <RegistrySearchBar
             v-model:searchQuery="searchQuery"
             v-model:searchMode="searchMode"
+            v-model:sortField="sortField"
             :search-results="searchResults"
             :suggestions="suggestions"
           />
@@ -166,6 +167,7 @@ const {
   isLoading: isSearchLoading,
   searchResults,
   searchMode,
+  sortField,
   suggestions
 } = useRegistrySearch()
 pageNumber.value = 0

--- a/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
@@ -56,7 +56,10 @@ import { useI18n } from 'vue-i18n'
 
 import SearchFilterDropdown from '@/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue'
 import type { NodesIndexSuggestion } from '@/services/algoliaSearchService'
-import type { PackField, SearchOption } from '@/types/comfyManagerTypes'
+import {
+  type SearchOption,
+  SortableAlgoliaField
+} from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
 
 const { searchResults } = defineProps<{
@@ -66,7 +69,9 @@ const { searchResults } = defineProps<{
 
 const searchQuery = defineModel<string>('searchQuery')
 const searchMode = defineModel<string>('searchMode', { default: 'packs' })
-const sortField = defineModel<PackField>('sortField', { default: 'downloads' })
+const sortField = defineModel<SortableAlgoliaField>('sortField', {
+  default: SortableAlgoliaField.Downloads
+})
 
 const { t } = useI18n()
 
@@ -74,11 +79,12 @@ const hasResults = computed(
   () => searchQuery.value?.trim() && searchResults?.length
 )
 
-const sortOptions: SearchOption<PackField>[] = [
-  { id: 'downloads', label: t('manager.sort.downloads') },
-  { id: 'name', label: t('g.name') },
-  { id: 'rating', label: t('manager.sort.rating') },
-  { id: 'category', label: t('g.category') }
+const sortOptions: SearchOption<SortableAlgoliaField>[] = [
+  { id: SortableAlgoliaField.Downloads, label: t('manager.sort.downloads') },
+  { id: SortableAlgoliaField.Created, label: t('manager.sort.created') },
+  { id: SortableAlgoliaField.Updated, label: t('manager.sort.updated') },
+  { id: SortableAlgoliaField.Publisher, label: t('manager.sort.publisher') },
+  { id: SortableAlgoliaField.Name, label: t('g.name') }
 ]
 const filterOptions: SearchOption<string>[] = [
   { id: 'packs', label: t('manager.filter.nodePack') },

--- a/src/composables/useRegistrySearch.ts
+++ b/src/composables/useRegistrySearch.ts
@@ -13,6 +13,7 @@ import { SortableAlgoliaField } from '@/types/comfyManagerTypes'
 
 const SEARCH_DEBOUNCE_TIME = 256
 const DEFAULT_PAGE_SIZE = 64
+const DEFAULT_SORT_FIELD = SortableAlgoliaField.Downloads // Set in the index configuration
 
 const SORT_DIRECTIONS: Record<SortableAlgoliaField, 'asc' | 'desc'> = {
   [SortableAlgoliaField.Downloads]: 'desc',
@@ -86,7 +87,9 @@ export function useRegistrySearch() {
     )
 
     let sortedPacks = nodePacks
-    if (sortField.value) {
+
+    // Results are sorted by the default field to begin with -- so don't manually sort again
+    if (sortField.value && sortField.value !== DEFAULT_SORT_FIELD) {
       sortedPacks = orderBy(
         nodePacks,
         [getSortValue],

--- a/src/composables/useRegistrySearch.ts
+++ b/src/composables/useRegistrySearch.ts
@@ -22,6 +22,10 @@ const SORT_DIRECTIONS: Record<SortableAlgoliaField, 'asc' | 'desc'> = {
   [SortableAlgoliaField.Name]: 'asc'
 }
 
+const isDateField = (field: SortableAlgoliaField): boolean =>
+  field === SortableAlgoliaField.Created ||
+  field === SortableAlgoliaField.Updated
+
 /**
  * Composable for managing UI state of Comfy Node Registry search.
  */
@@ -57,6 +61,15 @@ export function useRegistrySearch() {
     toRegistryPack,
     (algoliaNode: AlgoliaNodePack) => algoliaNode.id
   )
+  const getSortValue = (pack: Hit<AlgoliaNodePack>) => {
+    if (isDateField(sortField.value)) {
+      const value = pack[sortField.value]
+      return value ? new Date(value).getTime() : 0
+    } else {
+      const value = pack[sortField.value]
+      return value ?? 0
+    }
+  }
 
   const updateSearchResults = async (options: { append?: boolean }) => {
     isLoading.value = true
@@ -74,20 +87,6 @@ export function useRegistrySearch() {
 
     let sortedPacks = nodePacks
     if (sortField.value) {
-      const isDateField = (field: SortableAlgoliaField): boolean =>
-        field === SortableAlgoliaField.Created ||
-        field === SortableAlgoliaField.Updated
-
-      const getSortValue = (pack: Hit<AlgoliaNodePack>) => {
-        if (isDateField(sortField.value)) {
-          const value = pack[sortField.value]
-          return value ? new Date(value).getTime() : 0
-        } else {
-          const value = pack[sortField.value]
-          return value ?? 0
-        }
-      }
-
       sortedPacks = orderBy(
         nodePacks,
         [getSortValue],

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -154,8 +154,10 @@
       "unknown": "Unknown"
     },
     "sort": {
-      "rating": "Rating",
-      "downloads": "Most Popular"
+      "downloads": "Most Popular",
+      "publisher": "Publisher",
+      "created": "Newest",
+      "updated": "Updated Recently"
     },
     "filter": {
       "nodePack": "Node Pack",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -438,8 +438,10 @@
     "searchPlaceholder": "Buscar",
     "selectVersion": "Seleccionar Versión",
     "sort": {
+      "created": "Más reciente",
       "downloads": "Más Popular",
-      "rating": "Calificación"
+      "publisher": "Editor",
+      "updated": "Actualizado recientemente"
     },
     "status": {
       "active": "Activo",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -438,8 +438,10 @@
     "searchPlaceholder": "Recherche",
     "selectVersion": "Sélectionner la version",
     "sort": {
+      "created": "Le plus récent",
       "downloads": "Le plus populaire",
-      "rating": "Évaluation"
+      "publisher": "Éditeur",
+      "updated": "Mis à jour récemment"
     },
     "status": {
       "active": "Actif",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -438,8 +438,10 @@
     "searchPlaceholder": "検索",
     "selectVersion": "バージョンを選択",
     "sort": {
+      "created": "最新",
       "downloads": "最も人気",
-      "rating": "評価"
+      "publisher": "出版社",
+      "updated": "最近更新"
     },
     "status": {
       "active": "アクティブ",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -438,8 +438,10 @@
     "searchPlaceholder": "검색",
     "selectVersion": "버전 선택",
     "sort": {
+      "created": "최신",
       "downloads": "가장 인기 있는",
-      "rating": "평점"
+      "publisher": "출판사",
+      "updated": "최근 업데이트"
     },
     "status": {
       "active": "활성",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -438,8 +438,10 @@
     "searchPlaceholder": "Поиск",
     "selectVersion": "Выберите версию",
     "sort": {
+      "created": "Новейшие",
       "downloads": "Самые популярные",
-      "rating": "Рейтинг"
+      "publisher": "Издатель",
+      "updated": "Недавно обновленные"
     },
     "status": {
       "active": "Активный",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -438,8 +438,10 @@
     "searchPlaceholder": "搜索",
     "selectVersion": "选择版本",
     "sort": {
+      "created": "最新",
       "downloads": "最受欢迎",
-      "rating": "评级"
+      "publisher": "出版商",
+      "updated": "最近更新"
     },
     "status": {
       "active": "活跃",

--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -61,6 +61,7 @@ const RETRIEVE_ATTRIBUTES: SearchAttribute[] = [
   'status',
   'publisher_id',
   'total_install',
+  'create_time',
   'update_time',
   'license',
   'repository_url',

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -18,6 +18,14 @@ export enum ManagerTab {
   UpdateAvailable = 'updateAvailable'
 }
 
+export enum SortableAlgoliaField {
+  Downloads = 'total_install',
+  Created = 'create_time',
+  Updated = 'update_time',
+  Publisher = 'publisher_id',
+  Name = 'name'
+}
+
 export interface TabItem {
   id: string
   label: string


### PR DESCRIPTION
Implements sorting of Algolia search results using the dropdown below the search bar, per the original design:

![Selection_1189](https://github.com/user-attachments/assets/57a7dd4c-bbcd-4932-a820-710f4c7e9f26)

Sorting can also be done by passing custom ranking args in Algolia request, with syntax similar to SQL. But it's not really necessary to put extra burden on the paid service when we don't require any complex ranking algorithms and therefore can do sorting client-side easily.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3409-Manager-Allowing-changing-sort-field-of-registry-search-results-1d26d73d365081459fc7c10286d12d84) by [Unito](https://www.unito.io)
