### PR TITLE
[Manager] Fix loading state on uninstall button

### DIFF
--- a/src/components/dialog/content/manager/button/PackActionButton.vue
+++ b/src/components/dialog/content/manager/button/PackActionButton.vue
@@ -6,12 +6,12 @@
       'w-full': fullWidth,
       'w-min-content': !fullWidth
     }"
-    :disabled="isInstalling"
+    :disabled="loading"
     v-bind="$attrs"
     @click="onClick"
   >
     <span class="py-2.5 px-3">
-      <template v-if="isInstalling">
+      <template v-if="loading">
         {{ loadingMessage ?? $t('g.loading') }}
       </template>
       <template v-else>
@@ -23,9 +23,6 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button'
-import { inject, ref } from 'vue'
-
-import { IsInstallingKey } from '@/types/comfyManagerTypes'
 
 const {
   label,
@@ -33,6 +30,7 @@ const {
   fullWidth = false
 } = defineProps<{
   label: string
+  loading?: boolean
   loadingMessage?: string
   fullWidth?: boolean
 }>()
@@ -45,10 +43,7 @@ defineOptions({
   inheritAttrs: false
 })
 
-const isInstalling = inject(IsInstallingKey, ref(false))
-
 const onClick = (): void => {
-  isInstalling.value = true
   emit('action')
 }
 </script>

--- a/src/components/dialog/content/manager/button/PackInstallButton.vue
+++ b/src/components/dialog/content/manager/button/PackInstallButton.vue
@@ -5,8 +5,10 @@
       nodePacks.length > 1 ? $t('manager.installSelected') : $t('g.install')
     "
     severity="secondary"
+    :loading="isInstalling"
     :loading-message="$t('g.installing')"
     @action="installAllPacks"
+    @click="onClick"
   />
 </template>
 
@@ -30,6 +32,10 @@ const { nodePacks } = defineProps<{
 }>()
 
 const isInstalling = inject(IsInstallingKey, ref(false))
+
+const onClick = (): void => {
+  isInstalling.value = true
+}
 
 const managerStore = useComfyManagerStore()
 

--- a/src/components/dialog/content/manager/infoPanel/InfoPanelHeader.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanelHeader.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, watch } from 'vue'
 
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import PackInstallButton from '@/components/dialog/content/manager/button/PackInstallButton.vue'
@@ -46,7 +46,14 @@ const { nodePacks } = defineProps<{
 
 const managerStore = useComfyManagerStore()
 
-const isAllInstalled = computed(() =>
-  nodePacks.every((nodePack) => managerStore.isPackInstalled(nodePack.id))
+const isAllInstalled = ref(false)
+watch(
+  [() => nodePacks, () => managerStore.installedPacks],
+  () => {
+    isAllInstalled.value = nodePacks.every((nodePack) =>
+      managerStore.isPackInstalled(nodePack.id)
+    )
+  },
+  { immediate: true }
 )
 </script>


### PR DESCRIPTION
This PR makes loading state of `PackActionButton` be determined by parent component, instead of dependent on `isInstalling` injected ref. `PackInstallButton` then passes loading state to `PackActionButton`. Fixes bug where action button is left in loading state when uninstalling (or doing actions other than install).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3413-Manager-Fix-loading-state-on-uninstall-button-1d26d73d365081d4918dd77e07293b5b) by [Unito](https://www.unito.io)
