### PR TITLE
[Types] Move enum to types file

### DIFF
--- a/src/composables/useManagerQueue.ts
+++ b/src/composables/useManagerQueue.ts
@@ -2,6 +2,7 @@ import { useEventListener, whenever } from '@vueuse/core'
 import { computed, readonly, ref } from 'vue'
 
 import { api } from '@/scripts/api'
+import { ManagerWsQueueStatus } from '@/types/comfyManagerTypes'
 
 type QueuedTask<T> = {
   task: () => Promise<T>
@@ -9,11 +10,6 @@ type QueuedTask<T> = {
 }
 
 const MANAGER_WS_MSG_TYPE = 'cm-queue-status'
-
-enum ManagerWsQueueStatus {
-  DONE = 'done',
-  IN_PROGRESS = 'in_progress'
-}
 
 export const useManagerQueue = () => {
   const clientQueueItems = ref<QueuedTask<unknown>[]>([])

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -10,6 +10,11 @@ export type PackField = keyof RegistryPack | null
 export const IsInstallingKey: InjectionKey<Ref<boolean>> =
   Symbol('isInstalling')
 
+export enum ManagerWsQueueStatus {
+  DONE = 'done',
+  IN_PROGRESS = 'in_progress'
+}
+
 export enum ManagerTab {
   All = 'all',
   Installed = 'installed',


### PR DESCRIPTION
Moves manager websocket message enum to types file. Fixes issue that currently occurs when publishing types:

```
src/stores/comfyManagerStore.ts:23:14 - error TS4023: Exported variable 'useComfyManagerStore' has or is using name 'ManagerWsQueueStatus' from external module "/home/c_byrne/projects/comfyui-frontend-testing/ComfyUI_frontend-clone/src/composables/useManagerQueue" but cannot be named.
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3416-Types-Move-enum-to-types-file-1d36d73d365081ba8b83e73e17b910fd) by [Unito](https://www.unito.io)
