### PR TITLE
[Types] Make more types available directly in `@comfyorg/comfyui-frontend-types` package

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,57 @@
+import type {
+  DeviceStats,
+  EmbeddingsResponse,
+  ExtensionsResponse,
+  LogEntry,
+  LogsRawResponse,
+  NodeError,
+  PromptResponse,
+  Settings,
+  SystemStats,
+  TerminalSize,
+  User,
+  UserData,
+  UserDataFullInfo
+} from '@/schemas/apiSchema'
 import { ComfyApp } from '@/scripts/app'
+
+import type {
+  BottomPanelExtension,
+  CommandManager,
+  ExtensionManager,
+  SidebarTabExtension,
+  ToastManager,
+  ToastMessageOptions
+} from './extensionTypes'
 
 export type { ComfyExtension } from './comfy'
 export type { ComfyApi } from '@/scripts/api'
 export type { ComfyApp } from '@/scripts/app'
+export type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+export type { InputSpec } from '@/schemas/nodeDefSchema'
+export type {
+  EmbeddingsResponse,
+  ExtensionsResponse,
+  PromptResponse,
+  NodeError,
+  Settings,
+  DeviceStats,
+  SystemStats,
+  User,
+  UserData,
+  UserDataFullInfo,
+  TerminalSize,
+  LogEntry,
+  LogsRawResponse
+}
+export type {
+  SidebarTabExtension,
+  BottomPanelExtension,
+  ToastManager,
+  ExtensionManager,
+  CommandManager,
+  ToastMessageOptions
+}
 
 declare global {
   const app: ComfyApp


### PR DESCRIPTION
Makes API schema types, extension manager types, comfy node def type, and input spec type available by name in published types.

This is the diff of how the published `@comfyorg/comfyui-frontend-types` types file changes after this PR (use 'Collapse lines' toggle on left):

https://www.diffchecker.com/GUEWVkmh/

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2083

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3418-Types-Make-more-types-available-directly-in-comfyorg-comfyui-frontend-types-package-1d36d73d3650810d8d2af7c873841ea8) by [Unito](https://www.unito.io)
