### PR TITLE
[3d] add support to output camera state

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -153,7 +153,8 @@ useExtensionService().registerExtension({
             image: `threed/${data.name} [temp]`,
             mask: `threed/${dataMask.name} [temp]`,
             normal: `threed/${dataNormal.name} [temp]`,
-            lineart: `threed/${dataLineart.name} [temp]`
+            lineart: `threed/${dataLineart.name} [temp]`,
+            camera_info: node.properties['Camera Info']
           }
         }
       }
@@ -293,7 +294,8 @@ useExtensionService().registerExtension({
         return {
           image: `threed/${data.name} [temp]`,
           mask: `threed/${dataMask.name} [temp]`,
-          normal: `threed/${dataNormal.name} [temp]`
+          normal: `threed/${dataNormal.name} [temp]`,
+          camera_info: node.properties['Camera Info']
         }
       }
     }
@@ -350,7 +352,7 @@ useExtensionService().registerExtension({
     node.onExecuted = function (message: any) {
       onExecuted?.apply(this, arguments as any)
 
-      let filePath = message.model_file[0]
+      let filePath = message.result[0]
 
       if (!filePath) {
         const msg = t('toastMessages.unableToGetModelFilePath')
@@ -359,6 +361,8 @@ useExtensionService().registerExtension({
       }
 
       const load3d = useLoad3dService().getLoad3d(node)
+
+      let cameraState = message.result[1]
 
       const modelWidget = node.widgets?.find(
         (w: IWidget) => w.name === 'model_file'
@@ -369,7 +373,7 @@ useExtensionService().registerExtension({
 
         const config = new Load3DConfiguration(load3d)
 
-        config.configure('output', modelWidget)
+        config.configure('output', modelWidget, cameraState)
       }
     }
   }
@@ -425,13 +429,15 @@ useExtensionService().registerExtension({
     node.onExecuted = function (message: any) {
       onExecuted?.apply(this, arguments as any)
 
-      let filePath = message.model_file[0]
+      let filePath = message.result[0]
 
       if (!filePath) {
         const msg = t('toastMessages.unableToGetModelFilePath')
         console.error(msg)
         useToastStore().addAlert(msg)
       }
+
+      let cameraState = message.result[1]
 
       const load3d = useLoad3dService().getLoad3d(node)
 
@@ -443,7 +449,7 @@ useExtensionService().registerExtension({
 
         const config = new Load3DConfiguration(load3d)
 
-        config.configure('output', modelWidget)
+        config.configure('output', modelWidget, cameraState)
       }
     }
   }


### PR DESCRIPTION
allow outputing camera state from load3d, and pass into preview3d, need https://github.com/comfyanonymous/ComfyUI/pull/7582 as BE
the demo is 

https://github.com/user-attachments/assets/99217d9a-6604-437d-8034-eac80b0f4a9a

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3421-3d-add-support-to-output-camera-state-1d36d73d3650810fba1ad64acfa5d8f1) by [Unito](https://www.unito.io)
