### PR TITLE
Add reset individual keybind button

### DIFF
--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -263,11 +263,12 @@ async function saveKeybinding() {
 }
 
 async function resetKeybinding(commandData: ICommandData) {
-  if (keybindingStore.isCommandKeybindingModified(commandData.id)) {
-    const changed = keybindingStore.resetKeybindingForCommand(commandData.id)
-    if (changed) {
-      await keybindingService.persistUserKeybindings()
-    }
+  if (keybindingStore.resetKeybindingForCommand(commandData.id)) {
+    await keybindingService.persistUserKeybindings()
+  } else {
+    console.warn(
+      `No changes made when resetting keybinding for command: ${commandData.id}`
+    )
   }
 }
 

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -264,31 +264,8 @@ async function saveKeybinding() {
 
 async function resetKeybinding(commandData: ICommandData) {
   if (keybindingStore.isCommandKeybindingModified(commandData.id)) {
-    const commandId = commandData.id
-    let changed = false
-
-    // Check and remove from user-defined bindings
-    const userBindings = keybindingStore.getUserKeybindings()
-    const userBindingToRemove = Object.values(userBindings).find(
-      (kb) => kb.commandId === commandId
-    )
-    if (userBindingToRemove) {
-      delete userBindings[userBindingToRemove.combo.serialize()]
-      changed = true
-    }
-
-    // Check and remove from user-unset bindings
-    const unsetBindings = keybindingStore.getUserUnsetKeybindings()
-    const unsetBindingToRemove = Object.values(unsetBindings).find(
-      (kb) => kb.commandId === commandId
-    )
-    if (unsetBindingToRemove) {
-      delete unsetBindings[unsetBindingToRemove.combo.serialize()]
-      changed = true
-    }
-
+    const changed = keybindingStore.resetKeybindingForCommand(commandData.id)
     if (changed) {
-      // Persist the changes if any were made
       await keybindingService.persistUserKeybindings()
     }
   }

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -283,6 +283,37 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     userUnsetKeybindings.value = {}
   }
 
+  /**
+   * Reset keybinding for a specific command to its default value.
+   * Removes any user-defined or user-unset keybindings for this command.
+   *
+   * @param commandId - The ID of the command to reset
+   * @returns true if any changes were made, false otherwise
+   */
+  function resetKeybindingForCommand(commandId: string): boolean {
+    let changed = false
+
+    // Check and remove from user-defined bindings
+    const userBindingToRemove = Object.values(userKeybindings.value).find(
+      (kb) => kb.commandId === commandId
+    )
+    if (userBindingToRemove) {
+      delete userKeybindings.value[userBindingToRemove.combo.serialize()]
+      changed = true
+    }
+
+    // Check and remove from user-unset bindings
+    const unsetBindingToRemove = Object.values(userUnsetKeybindings.value).find(
+      (kb) => kb.commandId === commandId
+    )
+    if (unsetBindingToRemove) {
+      delete userUnsetKeybindings.value[unsetBindingToRemove.combo.serialize()]
+      changed = true
+    }
+
+    return changed
+  }
+
   function isCommandKeybindingModified(commandId: string): boolean {
     const currentKeybinding: KeybindingImpl | undefined =
       getKeybindingByCommandId(commandId)
@@ -307,6 +338,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     unsetKeybinding,
     updateKeybindingOnCommand,
     resetAllKeybindings,
+    resetKeybindingForCommand,
     isCommandKeybindingModified
   }
 })

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -284,9 +284,10 @@ export const useKeybindingStore = defineStore('keybinding', () => {
   }
 
   /**
-   * Reset keybinding for a specific command to its default value.
+   * Resets the keybinding for a given command to its default value.
    *
-   * @returns true if any changes were made, false otherwise
+   * @param commandId - The commandId of the keybind to be reset
+   * @returns `true` if changes were made, and vice versa
    */
   function resetKeybindingForCommand(commandId: string): boolean {
     const currentKeybinding = getKeybindingByCommandId(commandId)

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -287,7 +287,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
    * Resets the keybinding for a given command to its default value.
    *
    * @param commandId - The commandId of the keybind to be reset
-   * @returns `true` if changes were made, and vice versa
+   * @returns `true` if changes were made, `false` if not
    */
   function resetKeybindingForCommand(commandId: string): boolean {
     const currentKeybinding = getKeybindingByCommandId(commandId)

--- a/tests-ui/tests/store/keybindingStore.test.ts
+++ b/tests-ui/tests/store/keybindingStore.test.ts
@@ -369,6 +369,13 @@ describe('useKeybindingStore', () => {
     store.unsetKeybinding(defaultKeybinding)
     expect(store.keybindings).toHaveLength(0)
 
+    const serializedCombo = defaultKeybinding.combo.serialize()
+    const userUnsetKeybindings = store.getUserUnsetKeybindings()
+    expect(userUnsetKeybindings[serializedCombo]).toBeTruthy()
+    expect(
+      userUnsetKeybindings[serializedCombo].equals(defaultKeybinding)
+    ).toBe(true)
+
     const result = store.resetKeybindingForCommand('test.command')
 
     expect(result).toBe(true)
@@ -376,6 +383,8 @@ describe('useKeybindingStore', () => {
     expect(store.getKeybindingByCommandId('test.command')).toEqual(
       defaultKeybinding
     )
+
+    expect(store.getUserUnsetKeybindings()[serializedCombo]).toBeUndefined()
   })
 
   it('should handle complex scenario with both unset and user keybindings', () => {

--- a/tests-ui/tests/store/keybindingStore.test.ts
+++ b/tests-ui/tests/store/keybindingStore.test.ts
@@ -286,4 +286,130 @@ describe('useKeybindingStore', () => {
     expect(store.getKeybinding(newKeybinding.combo)?.commandId).toBe('command2')
     expect(store.getKeybindingsByCommandId('command1')).toHaveLength(0)
   })
+
+  it('should return false when no default or current keybinding exists during reset', () => {
+    const store = useKeybindingStore()
+    const result = store.resetKeybindingForCommand('nonexistent.command')
+    expect(result).toBe(false)
+  })
+
+  it('should return false when current keybinding equals default keybinding', () => {
+    const store = useKeybindingStore()
+    const defaultKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'L', ctrl: true }
+    })
+
+    store.addDefaultKeybinding(defaultKeybinding)
+    const result = store.resetKeybindingForCommand('test.command')
+
+    expect(result).toBe(false)
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybindingByCommandId('test.command')).toEqual(
+      defaultKeybinding
+    )
+  })
+
+  it('should unset user keybinding when no default keybinding exists and return true', () => {
+    const store = useKeybindingStore()
+    const userKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'M', ctrl: true }
+    })
+
+    store.addUserKeybinding(userKeybinding)
+    expect(store.keybindings).toHaveLength(1)
+
+    const result = store.resetKeybindingForCommand('test.command')
+
+    expect(result).toBe(true)
+    expect(store.keybindings).toHaveLength(0)
+  })
+
+  it('should restore default keybinding when user has overridden it and return true', () => {
+    const store = useKeybindingStore()
+
+    const defaultKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'N', ctrl: true }
+    })
+
+    const userKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'O', alt: true }
+    })
+
+    store.addDefaultKeybinding(defaultKeybinding)
+    store.updateKeybindingOnCommand(userKeybinding)
+
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybindingByCommandId('test.command')).toEqual(
+      userKeybinding
+    )
+
+    const result = store.resetKeybindingForCommand('test.command')
+
+    expect(result).toBe(true)
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybindingByCommandId('test.command')).toEqual(
+      defaultKeybinding
+    )
+  })
+
+  it('should remove unset record and restore default keybinding when user has unset it', () => {
+    const store = useKeybindingStore()
+
+    const defaultKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'P', ctrl: true }
+    })
+
+    store.addDefaultKeybinding(defaultKeybinding)
+
+    store.unsetKeybinding(defaultKeybinding)
+    expect(store.keybindings).toHaveLength(0)
+
+    const result = store.resetKeybindingForCommand('test.command')
+
+    expect(result).toBe(true)
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybindingByCommandId('test.command')).toEqual(
+      defaultKeybinding
+    )
+  })
+
+  it('should handle complex scenario with both unset and user keybindings', () => {
+    const store = useKeybindingStore()
+
+    // Create default keybinding
+    const defaultKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'Q', ctrl: true }
+    })
+    store.addDefaultKeybinding(defaultKeybinding)
+
+    // Unset default keybinding
+    store.unsetKeybinding(defaultKeybinding)
+    expect(store.keybindings).toHaveLength(0)
+
+    // Add user keybinding with different combo
+    const userKeybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'R', alt: true }
+    })
+    store.addUserKeybinding(userKeybinding)
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybindingByCommandId('test.command')).toEqual(
+      userKeybinding
+    )
+
+    // Reset keybinding to default
+    const result = store.resetKeybindingForCommand('test.command')
+
+    expect(result).toBe(true)
+    expect(store.keybindings).toHaveLength(1)
+    expect(store.getKeybindingByCommandId('test.command')).toEqual(
+      defaultKeybinding
+    )
+  })
 })


### PR DESCRIPTION
This new button squishes everything in the keybinding panel.

![image](https://github.com/user-attachments/assets/bb2143a3-0555-464d-90ec-0ba9dfce86f0)

I think this PR requires another PR that can add the horizontal scrollbar to the keybinds.

Resolves #3390

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3423-Add-reset-individual-keybind-button-1d36d73d365081cca343c7f84398eb70) by [Unito](https://www.unito.io)
