### PR TITLE
Allow scrolling on .settings-content

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -293,6 +293,10 @@ watch(activeCategory, (_, oldValue) => {
   overflow: hidden;
 }
 
+.settings-content {
+  overflow-x: auto;
+}
+
 @media (max-width: 768px) {
   .settings-container {
     flex-direction: column;


### PR DESCRIPTION
There are still plenty of other styling issues inside of SettingDialogContent and its children, but at least this will let users in certain cases be able to see the entirety of .settings-content instead of just having it be hidden.

![image](https://github.com/user-attachments/assets/4498a695-e7ac-41e9-96bc-ae3dbe68dcc9)


Resolves #3424

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3427-Allow-scrolling-on-settings-content-1d36d73d3650813d8eb0dcb0b1eee743) by [Unito](https://www.unito.io)
