### PR TITLE
expose Vue

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -15,3 +15,7 @@ interface Navigator {
     visible: boolean
   }
 }
+
+interface Window {
+  Vue: typeof import('vue')
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import ConfirmationService from 'primevue/confirmationservice'
 import ToastService from 'primevue/toastservice'
 import Tooltip from 'primevue/tooltip'
 import { createApp } from 'vue'
+import * as Vue from 'vue'
 
 import '@/assets/css/style.css'
 import router from '@/router'
@@ -59,3 +60,5 @@ app
   .use(pinia)
   .use(i18n)
   .mount('#vue-app')
+
+window.Vue = Vue


### PR DESCRIPTION
in order to support Vue in custom node, we need to expose Vue as globel object, more details see https://github.com/jtydhr88/ComfyUI_frontend_vue_basic/issues/3
![image](https://github.com/user-attachments/assets/653693e5-6052-4c96-a610-21133624c3ed)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3442-expose-Vue-1d46d73d3650810892a7fd433c0f7d26) by [Unito](https://www.unito.io)
