### PR TITLE
[DevExperience] Add recommended extensions to .vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,6 +13,13 @@
     "lokalise.i18n-ally",
     "ms-playwright.playwright",
     "vitest.explorer",
-    "vue.volar"
+    "vue.volar",
+    "sonarsource.sonarlint-vscode",
+    "deque-systems.vscode-axe-linter",
+    "kisstkondoros.vscode-codemetrics",
+    "donjayamanne.githistory",
+    "wix.vscode-import-cost",
+    "prograhammer.tslint-vue",
+    "antfu.vite"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,18 @@
+{
+  "recommendations": [
+    "austenc.tailwind-docs",
+    "bradlc.vscode-tailwindcss",
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "figma.figma-vscode-extension",
+    "github.vscode-github-actions",
+    "github.vscode-pull-request-github",
+    "hbenl.vscode-test-explorer",
+    "lokalise.i18n-ally",
+    "ms-playwright.playwright",
+    "vitest.explorer",
+    "vue.volar"
+  ]
+}


### PR DESCRIPTION
Add recommended extensions to .vscode to help new developers come up to speed faster.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3459-DevExperience-Add-recommended-extensions-to-vscode-1d56d73d36508193b6f4ddc0d8482abd) by [Unito](https://www.unito.io)
