### PR TITLE
[API Node] Add API node identifier to node schema and add `credits_cost` during init

### DIFF
--- a/src/components/graph/NodeBadge.vue
+++ b/src/components/graph/NodeBadge.vue
@@ -83,6 +83,31 @@ onMounted(() => {
       })
 
       node.badges.push(() => badge.value)
+
+      // Add credits badge if node has credits_cost
+      if (node.constructor.nodeData?.credits_cost) {
+        node.badges.push(
+          () =>
+            new LGraphBadge({
+              text: String(node.constructor.nodeData.credits_cost),
+              fgColor: '#fff',
+              bgColor: '#4E4E4E',
+              fontSize: 12,
+              padding: 5,
+              height: 21,
+              cornerRadius: 6,
+              xOffset: -4,
+              yOffset: 28,
+              iconOptions: {
+                unicode: '\ue96b',
+                fontFamily: 'PrimeIcons',
+                color: '#FABC25',
+                bgColor: '#353535',
+                fontSize: 8
+              }
+            })
+        )
+      }
     }
   })
 })

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -221,7 +221,8 @@ export const zComfyNodeDef = z.object({
   output_node: z.boolean(),
   python_module: z.string(),
   deprecated: z.boolean().optional(),
-  experimental: z.boolean().optional()
+  experimental: z.boolean().optional(),
+  comfy_api_node_name: z.string().optional()
 })
 
 // `/object_info`

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -222,7 +222,7 @@ export const zComfyNodeDef = z.object({
   python_module: z.string(),
   deprecated: z.boolean().optional(),
   experimental: z.boolean().optional(),
-  comfy_api_node_name: z.string().optional()
+  api_node: z.boolean().optional()
 })
 
 // `/object_info`

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -31,6 +31,7 @@ import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useWorkflowService } from '@/services/workflowService'
+import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useExtensionStore } from '@/stores/extensionStore'
@@ -872,6 +873,7 @@ export class ComfyApp {
    * Registers nodes with the graph
    */
   async registerNodes() {
+    await useComfyRegistryStore().initializeApiNodeCosts()
     // Load node definitions from the backend
     const defs = await this.#getNodeDefs()
     await this.registerNodesFromDefs(defs)

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -318,6 +318,16 @@ export const useComfyRegistryService = () => {
     )
   }
 
+  /**
+   * Get the costs of all API nodes
+   */
+  const getApiNodeCosts = async () => {
+    // TODO: when the endpoint is defined, implement it here
+    return {
+      ImageGenerator: 20
+    }
+  }
+
   return {
     isLoading,
     error,
@@ -330,6 +340,7 @@ export const useComfyRegistryService = () => {
     getPublisherById,
     listPacksForPublisher,
     getNodeDefs,
-    postPackReview
+    postPackReview,
+    getApiNodeCosts
   }
 }

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -288,6 +288,7 @@ export const useLitegraphService = () => {
     )
 
     const nodeDef = new ComfyNodeDefImpl(nodeDefV1)
+    await nodeDef.initApiNodeFields()
     node.nodeData = nodeDef
     LiteGraph.registerNodeType(nodeId, node)
     // Note: Do not following assignments before `LiteGraph.registerNodeType`

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -288,7 +288,6 @@ export const useLitegraphService = () => {
     )
 
     const nodeDef = new ComfyNodeDefImpl(nodeDefV1)
-    await nodeDef.initApiNodeFields()
     node.nodeData = nodeDef
     LiteGraph.registerNodeType(nodeId, node)
     // Note: Do not following assignments before `LiteGraph.registerNodeType`

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -1,6 +1,7 @@
 import QuickLRU from '@alloc/quick-lru'
 import { partition } from 'lodash'
 import { defineStore } from 'pinia'
+import { ref } from 'vue'
 
 import { useCachedRequest } from '@/composables/useCachedRequest'
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
@@ -33,6 +34,9 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
   const getPacksByIdCache = new QuickLRU<NodePack['id'], NodePack>({
     maxSize: PACK_BY_ID_CACHE_SIZE
   })
+
+  // TODO: type when the endpoint is defined in comfy-api OpenAPI spec
+  const apiNodeCosts = ref<Record<string, number>>({})
 
   /**
    * Get a list of all node packs from the registry
@@ -88,10 +92,14 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     return resolvedPacks
   }
 
-  const getAPINodePrice = async () => {
-    // TODO: when the endpoint is created in comfy-api
-    return 20
+  const initializeApiNodeCosts = async () => {
+    const costs = await registryService.getApiNodeCosts()
+    if (costs) {
+      apiNodeCosts.value = costs
+    }
   }
+
+  const getAPINodePrice = (nodeId: string) => apiNodeCosts.value[nodeId]
 
   /**
    * Get the node definitions for a pack
@@ -138,7 +146,7 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     getNodeDefs,
     search,
     getAPINodePrice,
-
+    initializeApiNodeCosts,
     clearCache,
     cancelRequests,
 

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -88,6 +88,11 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     return resolvedPacks
   }
 
+  const getAPINodePrice = async () => {
+    // TODO: when the endpoint is created in comfy-api
+    return 20
+  }
+
   /**
    * Get the node definitions for a pack
    */
@@ -132,6 +137,7 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     },
     getNodeDefs,
     search,
+    getAPINodePrice,
 
     clearCache,
     cancelRequests,

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -43,7 +43,7 @@ export class ComfyNodeDefImpl
   readonly deprecated: boolean
   readonly experimental: boolean
   readonly output_node: boolean
-  readonly comfy_api_node_name?: string
+  readonly api_node?: boolean
   credits_cost?: number
   /**
    * @deprecated Use `inputs` instead
@@ -125,7 +125,6 @@ export class ComfyNodeDefImpl
     this.experimental =
       obj.experimental ?? obj.category.startsWith('_for_testing')
     this.output_node = obj.output_node
-    this.comfy_api_node_name = obj.comfy_api_node_name
     this.input = obj.input ?? {}
     this.output = obj.output ?? []
     this.output_is_list = obj.output_is_list
@@ -140,14 +139,10 @@ export class ComfyNodeDefImpl
 
     // Initialize node source
     this.nodeSource = getNodeSource(obj.python_module)
-  }
 
-  /**
-   * Initializes API node fields
-   */
-  async initApiNodeFields() {
-    if (this.comfy_api_node_name) {
-      this.credits_cost = await useComfyRegistryStore().getAPINodePrice()
+    // Initialize API node fields
+    if (obj.api_node) {
+      this.credits_cost = useComfyRegistryStore().getAPINodePrice(this.name)
     }
   }
 
@@ -299,7 +294,6 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   }
   async function addNodeDef(nodeDef: ComfyNodeDefV1) {
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
-    await nodeDefImpl.initApiNodeFields()
     nodeDefsByName.value[nodeDef.name] = nodeDefImpl
     nodeDefsByDisplayName.value[nodeDef.display_name] = nodeDefImpl
   }


### PR DESCRIPTION
If a node's python class has `COMFY_API_NODE_NAME`, use the property to retrieve the `credits_cost` from comfy api.

![Selection_1231](https://github.com/user-attachments/assets/55c93cc2-909b-42f9-9b4a-8a1bcf7bdb13)

Related:

- https://github.com/Comfy-Org/ComfyUI-private/pull/2
- https://github.com/Comfy-Org/litegraph.js/pull/930
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3470


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3470-API-Node-Add-API-node-identifier-to-node-schema-and-add-credits_cost-during-init-1d66d73d365081ce9570fe6aa84402b3) by [Unito](https://www.unito.io)
