### PR TITLE
build vue and primevue separately and generate importmap

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     "src/**/*.vue",
     "src/types/**/*.d.ts",
     "tests-ui/**/*",
-    "global.d.ts"
+    "global.d.ts",
+    "vite.config.mts"
   ]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -98,16 +98,13 @@ function addElementVnodeExportPlugin(): Plugin {
  * 3. Injects an import map script tag into the HTML head
  * 4. Configures manual chunk splitting for vendor libraries
  *
+ * @param vendorLibraries - An array of vendor libraries to split into separate chunks
  * @returns {Plugin} A Vite plugin that generates and injects an import map
  */
-function generateImportMapPlugin(): Plugin {
+function generateImportMapPlugin(
+  vendorLibraries: { name: string; pattern: string }[]
+): Plugin {
   const importMapEntries: Record<string, string> = {}
-
-  // Define the libraries that should be split into separate chunks
-  const vendorLibraries = [
-    { name: 'vue', pattern: 'node_modules/vue/' },
-    { name: 'primevue', pattern: 'node_modules/primevue/' }
-  ]
 
   return {
     name: 'generate-import-map-plugin',
@@ -295,7 +292,10 @@ export default defineConfig({
   plugins: [
     vue(),
     comfyAPIPlugin(),
-    generateImportMapPlugin(),
+    generateImportMapPlugin([
+      { name: 'vue', pattern: 'node_modules/vue/' },
+      { name: 'primevue', pattern: 'node_modules/primevue/' }
+    ]),
     addElementVnodeExportPlugin(),
 
     Icons({


### PR DESCRIPTION
prepare to support running vue inside custom nodes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3473-build-vue-and-primevue-separately-and-generate-importmap-1d76d73d36508144bd20cec2df3c4a02) by [Unito](https://www.unito.io)
