### PR TITLE
fix `2_pass_pose_worship` zh translation

### DIFF
--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1000,7 +1000,7 @@
         "lora_multiple": "Lora多个"
       },
       "ControlNet": {
-        "2_pass_pose_worship": "2通道姿势崇拜",
+        "2_pass_pose_worship": "双通道姿势处理",
         "controlnet_example": "ControlNet",
         "depth_controlnet": "深度ControlNet",
         "depth_t2i_adapter": "深度T2I适配器",


### PR DESCRIPTION
Description:
The current Chinese translation of "2_pass_pose_worship" as "2通道姿势崇拜" is linguistically awkward and potentially incorrect. The term "崇拜" (worship) appears to be a mistranslation or possible typo (e.g., intended as "workshop" or technical terminology).

While I cannot confirm whether the original term "worship" is a spelling error or intentional, this Chinese translation is semantically nonsensical in technical/localization contexts. For safety, I have only modified the Chinese translation while leaving other language files unchanged pending further verification.

![Snipaste_2025-04-16_21-24-58](https://github.com/user-attachments/assets/fe154598-3d1e-4464-9c70-4e28ef73b0bf)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3474-fix-2_pass_pose_worship-zh-translation-1d76d73d365081899cb7d2f039833de6) by [Unito](https://www.unito.io)
