### PR TITLE
[API Nodes] Add auth_token_comfy_org to queue prompt request body

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1173,8 +1173,16 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     executionStore.lastNodeErrors = null
 
-    const comfyOrgAuthToken =
+    let comfyOrgAuthToken =
       (await useFirebaseAuthStore().getIdToken()) ?? undefined
+    // Check if we're in a secure context before using the auth token
+    if (comfyOrgAuthToken && !window.isSecureContext) {
+      comfyOrgAuthToken = undefined
+      console.warn(
+        'Auth token not used: Not in a secure context (HTTPS). Authentication requires a secure connection.'
+      )
+    }
+
     try {
       while (this.#queueItems.length) {
         const { number, batchCount } = this.#queueItems.pop()!

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1179,7 +1179,7 @@ export class ComfyApp {
     if (comfyOrgAuthToken && !window.isSecureContext) {
       comfyOrgAuthToken = undefined
       console.warn(
-        'Auth token not used: Not in a secure context (HTTPS). Authentication requires a secure connection.'
+        'Auth token not used: Not in a secure context. Authentication requires a secure connection.'
       )
     }
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -34,6 +34,7 @@ import { useWorkflowService } from '@/services/workflowService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useExtensionStore } from '@/stores/extensionStore'
+import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import { KeyComboImpl, useKeybindingStore } from '@/stores/keybindingStore'
 import { useModelStore } from '@/stores/modelStore'
 import { SYSTEM_NODE_DEFS, useNodeDefStore } from '@/stores/nodeDefStore'
@@ -1172,6 +1173,8 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     executionStore.lastNodeErrors = null
 
+    const comfyOrgAuthToken =
+      (await useFirebaseAuthStore().getIdToken()) ?? undefined
     try {
       while (this.#queueItems.length) {
         const { number, batchCount } = this.#queueItems.pop()!
@@ -1183,7 +1186,7 @@ export class ComfyApp {
 
           const p = await this.graphToPrompt()
           try {
-            const res = await api.queuePrompt(number, p)
+            const res = await api.queuePrompt(number, p, comfyOrgAuthToken)
             executionStore.lastNodeErrors = res.node_errors ?? null
             if (executionStore.lastNodeErrors?.length) {
               this.canvas.draw(true, true)


### PR DESCRIPTION
Pass auth token to backend.

The auth token for the comfy org account if the user is logged in.

Backend node can access this token by specifying following input:
```python
      @classmethod
      def INPUT_TYPES(s):
        return {
          "hidden": { "auth_token": "AUTH_TOKEN_COMFY_ORG"}
        }
      def execute(self, auth_token: str):
        print(f"Auth token: {auth_token}")
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3477-API-Nodes-Add-auth_token_comfy_org-to-queue-prompt-request-body-1d76d73d365081a4ae01cc5a749d138c) by [Unito](https://www.unito.io)
