### PR TITLE
Log errors in generic error handler

### DIFF
--- a/src/composables/useErrorHandling.ts
+++ b/src/composables/useErrorHandling.ts
@@ -5,6 +5,7 @@ export function useErrorHandling() {
   const toast = useToastStore()
 
   const toastErrorHandler = (error: any) => {
+    console.error(error)
     toast.add({
       severity: 'error',
       summary: t('g.error'),


### PR DESCRIPTION
### Current

Any caught errors are displayed in a toast, without stack or file information. This can be generic and virtually impossible to trace using `error.message` alone.

![unhelpful error message](https://github.com/user-attachments/assets/cf3266d9-5705-412b-8252-43fa8f0bff93)

### Proposed

On top of the existing toast, first log the error via `console.error`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3482-Log-errors-in-generic-error-handler-1d86d73d3650815792b1f61243147093) by [Unito](https://www.unito.io)
