### PR TITLE
Fix corrupt workflow permanently corrupts session

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -60,13 +60,24 @@ export class PrimitiveNode extends LGraphNode {
     for (const linkInfo of links) {
       const node = this.graph?.getNodeById(linkInfo.target_id)
       const input = node?.inputs[linkInfo.target_slot]
-      if (!input) continue
+      if (!input) {
+        console.warn('Unable to resolve node or input for link', linkInfo)
+        continue
+      }
 
       const widgetName = input.widget?.name
-      if (!widgetName) continue
+      if (!widgetName) {
+        console.warn('Invalid widget or widget name', input.widget)
+        continue
+      }
 
       const widget = node.widgets?.find((w) => w.name === widgetName)
-      if (!widget) continue
+      if (!widget) {
+        console.warn(
+          `Unable to find widget "${widgetName}" on node [${node.id}]`
+        )
+        continue
+      }
 
       widget.value = v
       widget.callback?.(

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -58,15 +58,14 @@ export class PrimitiveNode extends LGraphNode {
 
     // For each output link copy our value over the original widget value
     for (const linkInfo of links) {
-      // @ts-expect-error fixme ts strict error
-      const node = this.graph.getNodeById(linkInfo.target_id)
-      // @ts-expect-error fixme ts strict error
-      const input = node.inputs[linkInfo.target_slot]
+      const node = this.graph?.getNodeById(linkInfo.target_id)
+      const input = node?.inputs[linkInfo.target_slot]
+      if (!input) continue
+
       let widget: IWidget | undefined
-      const widgetName = (input.widget as { name: string }).name
+      const widgetName = input.widget?.name
       if (widgetName) {
-        // @ts-expect-error fixme ts strict error
-        widget = node.widgets.find((w) => w.name === widgetName)
+        widget = node.widgets?.find((w) => w.name === widgetName)
       }
 
       if (widget) {
@@ -75,7 +74,6 @@ export class PrimitiveNode extends LGraphNode {
           widget.callback(
             widget.value,
             app.canvas,
-            // @ts-expect-error fixme ts strict error
             node,
             app.canvas.graph_mouse,
             {} as CanvasMouseEvent

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -47,7 +47,7 @@ export class PrimitiveNode extends LGraphNode {
   applyToGraph(extraLinks: LLink[] = []) {
     if (!this.outputs[0].links?.length) return
 
-    let links = [
+    const links = [
       ...this.outputs[0].links.map((l) => app.graph.links[l]),
       ...extraLinks
     ]
@@ -62,24 +62,20 @@ export class PrimitiveNode extends LGraphNode {
       const input = node?.inputs[linkInfo.target_slot]
       if (!input) continue
 
-      let widget: IWidget | undefined
       const widgetName = input.widget?.name
-      if (widgetName) {
-        widget = node.widgets?.find((w) => w.name === widgetName)
-      }
+      if (!widgetName) continue
 
-      if (widget) {
-        widget.value = v
-        if (widget.callback) {
-          widget.callback(
-            widget.value,
-            app.canvas,
-            node,
-            app.canvas.graph_mouse,
-            {} as CanvasMouseEvent
-          )
-        }
-      }
+      const widget = node.widgets?.find((w) => w.name === widgetName)
+      if (!widget) continue
+
+      widget.value = v
+      widget.callback?.(
+        widget.value,
+        app.canvas,
+        node,
+        app.canvas.graph_mouse,
+        {} as CanvasMouseEvent
+      )
     }
   }
 


### PR DESCRIPTION
- Replaces @ts-expect-error with optional chaining
- Refactor / clean up
- Adds warning logs

Below report generated in workflow with minor corruption.

In certain circumstances this corruption caused a critical failure where frontend crashes during startup.  A new/saved workflow cannot be opened and no tabs are loaded.  Required `workflow` value be manually removed from localStorage to resolve.

# ComfyUI Error Report
## Error Details
- **Node ID:** N/A
- **Node Type:** N/A
- **Exception Type:** Loading aborted due to error reloading workflow data
- **Exception Message:** TypeError: Cannot read properties of undefined (reading 'name')
## Stack Trace
```
TypeError: Cannot read properties of undefined (reading 'name')
    at PrimitiveNode.applyToGraph (http://localhost:5173/src/extensions/core/widgetInputs.ts:46:39)
    at NumberWidget.<anonymous> (http://localhost:5173/src/extensions/core/widgetInputs.ts:194:12)
    at http://localhost:5173/src/composables/functional/useChainCallback.ts:4:46
    at Array.forEach (<anonymous>)
    at NumberWidget.callback (http://localhost:5173/src/composables/functional/useChainCallback.ts:4:15)
    at PrimitiveNode.mergeIfValid (http://localhost:5173/src/extensions/core/widgetInputs.ts:365:14)
    at #isValidConnection (http://localhost:5173/src/extensions/core/widgetInputs.ts:265:27)
    at #mergeWidgetConfig (http://localhost:5173/src/extensions/core/widgetInputs.ts:246:30)
    at PrimitiveNode.onAfterGraphConfigured (http://localhost:5173/src/extensions/core/widgetInputs.ts:86:30)
    at app2.graph.onConfigure (http://localhost:5173/src/scripts/app.ts:556:38)
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3484-Fix-corrupt-workflow-permanently-corrupts-session-1d86d73d3650818ba1faf11e9c2c48c7) by [Unito](https://www.unito.io)
