### PR TITLE
[API Node] Set auth persistence in local stoarge

### DIFF
--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -4,8 +4,10 @@ import {
   GoogleAuthProvider,
   type User,
   type UserCredential,
+  browserLocalPersistence,
   createUserWithEmailAndPassword,
   onAuthStateChanged,
+  setPersistence,
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut
@@ -33,6 +35,9 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   // Get auth from VueFire and listen for auth state changes
   const auth = useFirebaseAuth()
   if (auth) {
+    // Set persistence to localStorage (works in both browser and Electron)
+    void setPersistence(auth, browserLocalPersistence)
+
     onAuthStateChanged(auth, (user) => {
       currentUser.value = user
       isInitialized.value = true

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -16,7 +16,9 @@ vi.mock('firebase/auth', () => ({
   onAuthStateChanged: vi.fn(),
   signInWithPopup: vi.fn(),
   GoogleAuthProvider: vi.fn(),
-  GithubAuthProvider: vi.fn()
+  GithubAuthProvider: vi.fn(),
+  browserLocalPersistence: 'browserLocalPersistence',
+  setPersistence: vi.fn().mockResolvedValue(undefined)
 }))
 
 describe('useFirebaseAuthStore', () => {
@@ -62,6 +64,13 @@ describe('useFirebaseAuthStore', () => {
     expect(store.userId).toBe('test-user-id')
     expect(store.loading).toBe(false)
     expect(store.error).toBe(null)
+  })
+
+  it('should set persistence to local storage on initialization', () => {
+    expect(firebaseAuth.setPersistence).toHaveBeenCalledWith(
+      mockAuth,
+      firebaseAuth.browserLocalPersistence
+    )
   })
 
   it('should properly clean up error state between operations', async () => {


### PR DESCRIPTION
See: [Firebase Authentification State Persistence docs](https://firebase.google.com/docs/auth/web/auth-state-persistence#supported_types_of_auth_state_persistence)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3514-API-Node-Set-auth-persistence-in-local-stoarge-1da6d73d365081da995cd0212bdbaeb5) by [Unito](https://www.unito.io)
