### PR TITLE
Fix `node.widgets` undefined on refresh

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1520,15 +1520,16 @@ export class ComfyApp {
 
       if (!def?.input) continue
 
-      // @ts-expect-error fixme ts strict error
-      for (const widget of node.widgets) {
-        if (widget.type === 'combo') {
-          if (def['input'].required?.[widget.name] !== undefined) {
-            // @ts-expect-error Requires discriminated union
-            widget.options.values = def['input'].required[widget.name][0]
-          } else if (def['input'].optional?.[widget.name] !== undefined) {
-            // @ts-expect-error Requires discriminated union
-            widget.options.values = def['input'].optional[widget.name][0]
+      if (node.widgets) {
+        for (const widget of node.widgets) {
+          if (widget.type === 'combo') {
+            if (def['input'].required?.[widget.name] !== undefined) {
+              // @ts-expect-error Requires discriminated union
+              widget.options.values = def['input'].required[widget.name][0]
+            } else if (def['input'].optional?.[widget.name] !== undefined) {
+              // @ts-expect-error Requires discriminated union
+              widget.options.values = def['input'].optional[widget.name][0]
+            }
           }
         }
       }


### PR DESCRIPTION
To reproduce issue:

- Load workflow with missing node that contains no widgets
- Install missing node, don't refresh browser
- Press `R` key to refresh node definitions

This occurs when installing missing node packs through the new Manager UI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3515-Fix-node-widgets-undefined-on-refresh-1da6d73d3650815a9fcce200aeaf1c8d) by [Unito](https://www.unito.io)
