### PR TITLE
Allow `git describe` formatted versions of node packs in workflows

### DIFF
--- a/src/composables/nodePack/useWorkflowPacks.ts
+++ b/src/composables/nodePack/useWorkflowPacks.ts
@@ -37,6 +37,13 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
   }
 
   /**
+   * Clean the version string to be used in the registry search.
+   * Removes the leading 'v' and trims whitespace and line terminators.
+   */
+  const cleanVersionString = (version: string) =>
+    version.replace(/^v/, '').trim()
+
+  /**
    * Infer the pack for a node by searching the registry for packs that have nodes
    * with the same name.
    */
@@ -70,7 +77,9 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
     if (packId === CORE_NODES_PACK_NAME) return undefined
 
     const version =
-      typeof node.properties.ver === 'string' ? node.properties.ver : undefined
+      typeof node.properties.ver === 'string'
+        ? cleanVersionString(node.properties.ver)
+        : undefined
 
     return {
       id: packId,

--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -160,12 +160,17 @@ const zAuxId = z
   )
   .transform(([username, repo]) => `${username}/${repo}`)
 
-const zSemVer = z.union([
-  z.string().regex(semverPattern, 'Invalid semantic version (x.y.z)'),
+const zSemVer = z
+  .string()
+  .regex(semverPattern, 'Invalid semantic version (x.y.z)')
+const zGitHash = z.string().regex(gitHashPattern, 'Invalid Git commit hash')
+const zVersion = z.union([
+  z
+    .string()
+    .transform((ver) => ver.replace(/^v/, '')) // Strip leading 'v'
+    .pipe(z.union([zSemVer, zGitHash])),
   z.literal('unknown')
 ])
-const zGitHash = z.string().regex(gitHashPattern, 'Invalid Git commit hash')
-const zVersion = z.union([zSemVer, zGitHash])
 
 const zProperties = z
   .object({

--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -160,10 +160,22 @@ const zAuxId = z
   )
   .transform(([username, repo]) => `${username}/${repo}`)
 
-const zSemVer = z
-  .string()
-  .regex(semverPattern, 'Invalid semantic version (x.y.z)')
-const zGitHash = z.string().regex(gitHashPattern, 'Invalid Git commit hash')
+const zGitHash = z.string().superRefine((val: string, ctx) => {
+  if (!gitHashPattern.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Node pack version has invalid Git commit hash: "${val}"`
+    })
+  }
+})
+const zSemVer = z.string().superRefine((val: string, ctx) => {
+  if (!semverPattern.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Node pack version has invalid semantic version: "${val}"`
+    })
+  }
+})
 const zVersion = z.union([
   z
     .string()

--- a/tests-ui/tests/comfyWorkflow.test.ts
+++ b/tests-ui/tests/comfyWorkflow.test.ts
@@ -178,7 +178,10 @@ describe('parseComfyWorkflow', () => {
       // Git hash
       '080e6d4af809a46852d1c4b7ed85f06e8a3a72be',
       // Special case
-      'unknown'
+      'unknown',
+      // Git describe
+      'v0.3.9-7-g1419dee',
+      'v0.3.9-7-g1419dee-dirty'
     ]
     it.each(validVersionStrings)('valid version: %s', async (ver) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))


### PR DESCRIPTION
Currently, node pack versions are embedded in workflows (in `properties` of nodes). The supported formats are git commit hashes and semantic versions. This PR extends support to `git describe` output format.

Reasons:

- [This user](https://github.com/comfyanonymous/ComfyUI/issues/7309#issuecomment-2816761186) reported a workflow from civitai that already has this format. Likely because it was made with a distribution of ComfyUI that changes `pyproject.toml`, `comfyui_version.py` or the `/system_stats` route.
- [Initial draft](https://gist.github.com/guill/290b6e864f7bce453d482eef08636eec) of `.comfy` file format proposes using `git describe` when a nightly node pack has a tagged version available (in favor of always using commit hash).
- Easy to support, as it just requires stripping the leading `v`

Also updates the error message to show the violating string when validation errors occur. We have been fixing various instances of node pack name and version validation errors [here](https://github.com/comfyanonymous/ComfyUI/issues/7309), and it's difficult to diagnose the problem without knowing which node exactly has the invalid metadata.


---

Manual for `git describe`:

```
GIT-DESCRIBE(1)                                   Git Manual                                  GIT-DESCRIBE(1)

NAME
       git-describe - Give an object a human readable name based on an available ref

SYNOPSIS
       git describe [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]
       git describe [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]
       git describe <blob>

DESCRIPTION
       The command finds the most recent tag that is reachable from a commit. If the tag points to the
       commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional
       commits on top of the tagged object and the abbreviated object name of the most recent commit. The
       result is a "human-readable" object name which can also be used to identify the commit to other git
       commands.

       By default (without --all or --tags) git describe only shows annotated tags. For more information
       about creating annotated tags see the -a and -s options to git-tag(1).

       If the given object refers to a blob, it will be described as <commit-ish>:<path>, such that the blob
       can be found at <path> in the <commit-ish>, which itself describes the first commit in which this blob
       occurs in a reverse revision walk from HEAD.
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3518-Allow-git-describe-formatted-versions-of-node-packs-in-workflows-1da6d73d36508178b7ddd4dc6e65deeb) by [Unito](https://www.unito.io)
