### PR TITLE
[Manager] Check if node is core node when inferring node pack

### DIFF
--- a/src/composables/nodePack/useWorkflowPacks.ts
+++ b/src/composables/nodePack/useWorkflowPacks.ts
@@ -5,6 +5,8 @@ import { useNodePacks } from '@/composables/nodePack/useNodePacks'
 import { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import { app } from '@/scripts/app'
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { SelectedVersion, UseNodePacksOptions } from '@/types/comfyManagerTypes'
 import type { components } from '@/types/comfyRegistryTypes'
 
@@ -22,6 +24,8 @@ const CORE_NODES_PACK_NAME = 'comfy-core'
  * associated node packs from the registry
  */
 export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
+  const nodeDefStore = useNodeDefStore()
+  const systemStatsStore = useSystemStatsStore()
   const { search } = useComfyRegistryStore()
 
   const workflowPacks = ref<WorkflowPack[]>([])
@@ -51,6 +55,22 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
     node: LGraphNode
   ): Promise<WorkflowPack | undefined> => {
     const nodeName = node.type
+
+    // Check if node is a core node
+    const nodeDef = nodeDefStore.nodeDefsByName[nodeName]
+    if (nodeDef?.nodeSource.type === 'core') {
+      if (!systemStatsStore.systemStats) {
+        await systemStatsStore.fetchSystemStats()
+      }
+      return {
+        id: CORE_NODES_PACK_NAME,
+        version:
+          systemStatsStore.systemStats?.system?.comfyui_version ??
+          SelectedVersion.NIGHTLY
+      }
+    }
+
+    // Search the registry for non-core nodes
     const searchResult = await search.call({
       comfy_node_search: nodeName,
       limit: 1


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI-Manager/issues/1762.

To reproduce issue:

1. Uninstall or disable the manager in order to disable the serializing of node pack name/version
2. Create a workflow that has both core nodes and custom nodes
3. After saving, uninstall the custom nodes
4. Reload then load the workflow
5. When the Manager sees that there are missing custom nodes but no node pack metadata in the worfklow, it will search the registry by node class name and use the first result.
6. Since there is no check to skip/ignore core nodes, this search is also performend for core nodes when they are alongisde missing custom nodes
7. As a result, a lot of packs are shown as "missing" when they are not in the workflow to begin with

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3521-Manager-Check-if-node-is-core-node-when-inferring-node-pack-1db6d73d3650812c98d7e7948629b2b0) by [Unito](https://www.unito.io)
