### PR TITLE
Apply filename text replacements (e.g., `%date:hh:mm:ss%`) in all save nodes

### DIFF
--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -2,16 +2,26 @@ import { applyTextReplacements } from '@/utils/searchAndReplace'
 
 import { app } from '../../scripts/app'
 
+const saveNodeTypes = new Set([
+  'SaveImage',
+  'SaveAnimatedWEBP',
+  'SaveWEBM',
+  'SaveAudio',
+  'SaveGLB',
+  'SaveAnimatedPNG',
+  'CLIPSave',
+  'VAESave',
+  'ModelSave',
+  'LoraSave',
+  'SaveLatent'
+])
+
 // Use widget values and dates in output filenames
 
 app.registerExtension({
   name: 'Comfy.SaveImageExtraOutput',
   async beforeRegisterNodeDef(nodeType, nodeData, app) {
-    if (
-      nodeData.name === 'SaveImage' ||
-      nodeData.name === 'SaveAnimatedWEBP' ||
-      nodeData.name === 'SaveWEBM'
-    ) {
+    if (saveNodeTypes.has(nodeData.name)) {
       const onNodeCreated = nodeType.prototype.onNodeCreated
       // When the SaveImage node is created we want to override the serialization of the output name widget to run our S&R
       nodeType.prototype.onNodeCreated = function () {


### PR DESCRIPTION
Applies filename text replacement logic (e.g., interpolate date in output filename using syntax like `%date:hh:mm:ss%`) to all save output nodes. Otherwise, the experience is very inconsistent and confusing.

Issue reported [here](https://reddit.com/r/comfyui/comments/1k2vog1/filename_control_on_saves/mo1l9pm/).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3523-Apply-filename-text-replacements-e-g-date-hh-mm-ss-in-all-save-nodes-1db6d73d365081a78b66c39cc1d25909) by [Unito](https://www.unito.io)
