### PR TITLE
[i18n] Use gpt-o4-mini for translation

### DIFF
--- a/.i18nrc.cjs
+++ b/.i18nrc.cjs
@@ -4,7 +4,7 @@
 const { defineConfig } = require('@lobehub/i18n-cli');
 
 module.exports = defineConfig({
-  modelName: 'gpt-4',
+  modelName: 'gpt-o4-mini',
   splitToken: 1024,
   entry: 'src/locales/en',
   entryLocale: 'en',


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/3492

Use more up-to-date model as GPT-4 is being deprecated.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3529-i18n-Use-gpt-o4-mini-for-translation-1db6d73d3650812f8b66c97f5104e021) by [Unito](https://www.unito.io)
