### PR TITLE
Fix client => canvas position conversion

### DIFF
--- a/src/composables/element/useCanvasPositionConversion.ts
+++ b/src/composables/element/useCanvasPositionConversion.ts
@@ -16,8 +16,8 @@ export const useCanvasPositionConversion = (
   const clientPosToCanvasPos = (pos: Vector2): Vector2 => {
     const { offset, scale } = lgCanvas.ds
     return [
-      (pos[0] - left.value) / scale + offset[0],
-      (pos[1] - top.value) / scale + offset[1]
+      (pos[0] - left.value) / scale - offset[0],
+      (pos[1] - top.value) / scale - offset[1]
     ]
   }
 

--- a/src/composables/useCanvasDrop.ts
+++ b/src/composables/useCanvasDrop.ts
@@ -29,12 +29,10 @@ export const useCanvasDrop = (canvasRef: Ref<HTMLCanvasElement>) => {
         const node = dndData.data as RenderedTreeExplorerNode
         if (node.data instanceof ComfyNodeDefImpl) {
           const nodeDef = node.data
-          // Add an offset on x to make sure after adding the node, the cursor
+          const pos = comfyApp.clientPosToCanvasPos([loc.clientX, loc.clientY])
+          // Add an offset on y to make sure after adding the node, the cursor
           // is on the node (top left corner)
-          const pos = comfyApp.clientPosToCanvasPos([
-            loc.clientX,
-            loc.clientY + LiteGraph.NODE_TITLE_HEIGHT
-          ])
+          pos[1] += LiteGraph.NODE_TITLE_HEIGHT
           litegraphService.addNodeOnGraph(nodeDef, { pos })
         } else if (node.data instanceof ComfyModelDef) {
           const model = node.data


### PR DESCRIPTION

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/3539 and Fixes https://github.com/comfyanonymous/ComfyUI/issues/7616 which was caused by a typo in https://github.com/Comfy-Org/ComfyUI_frontend/pull/3302.

https://github.com/Comfy-Org/ComfyUI_frontend/pull/3302 refactored `clientPosToCanvasPos` from

```ts
  clientPosToCanvasPos(pos: Vector2): Vector2 {
    const rect = this.canvasContainer.getBoundingClientRect()
    const containerOffsets = [rect.left, rect.top]
    return _.zip(pos, this.canvas.ds.offset, containerOffsets).map(
      // @ts-expect-error fixme ts strict error
      ([p, o1, o2]) => (p - o2) / this.canvas.ds.scale - o1
    ) as Vector2
  }
```

to

```ts

  const clientPosToCanvasPos = (pos: Vector2): Vector2 => {
    const { offset, scale } = lgCanvas.ds
    return [
      (pos[0] - left.value) / scale + offset[0],
      (pos[1] - top.value) / scale + offset[1]
    ]
  }
```

which adds offset instead of subtracts.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3540-Fix-client-canvas-position-conversion-1dc6d73d3650813a9b97dd37fbf5384c) by [Unito](https://www.unito.io)
