### PR TITLE
[API] Add sockets to custom widgets by default

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -124,7 +124,8 @@ export const useLitegraphService = () => {
       }
 
       /**
-       * @internal Add a widget to the node. For primitive types, an input socket is also added.
+       * @internal Add a widget to the node. For both primitive types and custom widgets
+       * (unless `socketless`), an input socket is also added.
        */
       #addInputWidget(inputSpec: InputSpec) {
         const inputName = inputSpec.name
@@ -152,7 +153,10 @@ export const useLitegraphService = () => {
           })
         }
 
-        if (PRIMITIVE_TYPES.has(inputSpec.type)) {
+        if (
+          PRIMITIVE_TYPES.has(inputSpec.type) ||
+          !widget?.options?.socketless
+        ) {
           const inputSpecV1 = transformInputSpecV2ToV1(inputSpec)
           this.addInput(inputName, inputSpec.type, {
             shape: inputSpec.isOptional ? RenderShape.HollowCircle : undefined,

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -41,7 +41,6 @@ import {
 
 import { useExtensionService } from './extensionService'
 
-const PRIMITIVE_TYPES = new Set(['INT', 'FLOAT', 'BOOLEAN', 'STRING', 'COMBO'])
 export const CONFIG = Symbol()
 export const GET_CONFIG = Symbol()
 

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -153,10 +153,7 @@ export const useLitegraphService = () => {
           })
         }
 
-        if (
-          PRIMITIVE_TYPES.has(inputSpec.type) ||
-          !widget?.options?.socketless
-        ) {
+        if (!widget?.options?.socketless) {
           const inputSpecV1 = transformInputSpecV2ToV1(inputSpec)
           this.addInput(inputName, inputSpec.type, {
             shape: inputSpec.isOptional ? RenderShape.HollowCircle : undefined,


### PR DESCRIPTION
### Current

Users with third party extensions cannot connect input links to custom widgets.

### Proposed

By default, enable input sockets for all custom widgets.

Widget constructors may **opt-out** by specifying:

```ts
widget.options.socketless = true
```

#### Example: Jovimetrix

![image](https://github.com/user-attachments/assets/26346592-7022-49ab-8295-a70ca99f6332)