### PR TITLE
Introduce widgetType option to inputSpec

### DIFF
--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -25,6 +25,7 @@ export const zBaseInputOptions = z
     tooltip: z.string().optional(),
     hidden: z.boolean().optional(),
     advanced: z.boolean().optional(),
+    widgetType: z.string().optional(),
     /** Backend-only properties. */
     rawLink: z.boolean().optional(),
     lazy: z.boolean().optional()

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -113,7 +113,9 @@ export const useLitegraphService = () => {
       #addInputSocket(inputSpec: InputSpec) {
         const inputName = inputSpec.name
         const nameKey = `${this.#nodeKey}.inputs.${normalizeI18nKey(inputName)}.name`
-        const widgetConstructor = widgetStore.widgets.get(inputSpec.type)
+        const widgetConstructor = widgetStore.widgets.get(
+          inputSpec.widgetType ?? inputSpec.type
+        )
         if (widgetConstructor && !inputSpec.forceInput) return
 
         this.addInput(inputName, inputSpec.type, {
@@ -127,9 +129,13 @@ export const useLitegraphService = () => {
        * (unless `socketless`), an input socket is also added.
        */
       #addInputWidget(inputSpec: InputSpec) {
+        const widgetInputSpec = { ...inputSpec }
+        if (inputSpec.widgetType) {
+          widgetInputSpec.type = inputSpec.widgetType
+        }
         const inputName = inputSpec.name
         const nameKey = `${this.#nodeKey}.inputs.${normalizeI18nKey(inputName)}.name`
-        const widgetConstructor = widgetStore.widgets.get(inputSpec.type)
+        const widgetConstructor = widgetStore.widgets.get(widgetInputSpec.type)
         if (!widgetConstructor || inputSpec.forceInput) return
 
         const {
@@ -139,7 +145,7 @@ export const useLitegraphService = () => {
         } = widgetConstructor(
           this,
           inputName,
-          transformInputSpecV2ToV1(inputSpec),
+          transformInputSpecV2ToV1(widgetInputSpec),
           app
         ) ?? {}
 
@@ -153,7 +159,7 @@ export const useLitegraphService = () => {
         }
 
         if (!widget?.options?.socketless) {
-          const inputSpecV1 = transformInputSpecV2ToV1(inputSpec)
+          const inputSpecV1 = transformInputSpecV2ToV1(widgetInputSpec)
           this.addInput(inputName, inputSpec.type, {
             shape: inputSpec.isOptional ? RenderShape.HollowCircle : undefined,
             localized_name: st(nameKey, inputName),


### PR DESCRIPTION
EDIT: This PR originally proposed using the first listed type of union types to determine the widget constructor. This original proposal has been left in place.

When an input has a comma separated list of types, use first type to determine if the input can be represented by a widget.

This allows for input types such as `"FLOAT,INT"` to produce a float widget that also allow for connection of ints.

Additionally, when an extension introduces a new widget type, any supported base type can now be specified in the python node definition, such as `"VHS_PATH,STRING"`. The workarounds previously used to accomplish this are comparatively fragile and don't translate well to the addition of widget input sockets.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3550-Introduce-widgetType-option-to-inputSpec-1dc6d73d36508126a1dac7b09aec9175) by [Unito](https://www.unito.io)
