### PR TITLE
Add command to open signin dialog

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -616,6 +616,15 @@ export function useCoreCommands(): ComfyCommand[] {
       function: () => {
         dialogService.showManagerProgressDialog()
       }
+    },
+    {
+      id: 'Comfy.User.OpenSignInDialog',
+      icon: 'pi pi-user',
+      label: 'Open Sign In Dialog',
+      versionAdded: '1.17.6',
+      function: async () => {
+        await dialogService.showSignInDialog()
+      }
     }
   ]
 

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "Undo"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "Open Sign In Dialog"
+  },
   "Workspace_CloseWorkflow": {
     "label": "Close Current Workflow"
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -661,6 +661,7 @@
     "Show Settings Dialog": "Show Settings Dialog",
     "Toggle Theme (Dark/Light)": "Toggle Theme (Dark/Light)",
     "Undo": "Undo",
+    "Open Sign In Dialog": "Open Sign In Dialog",
     "Close Current Workflow": "Close Current Workflow",
     "Next Opened Workflow": "Next Opened Workflow",
     "Previous Opened Workflow": "Previous Opened Workflow",

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "Deshacer"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "Abrir diálogo de inicio de sesión"
+  },
   "Workspace_CloseWorkflow": {
     "label": "Cerrar Flujo de Trabajo Actual"
   },

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -613,6 +613,7 @@
     "Open Logs Folder": "Abrir carpeta de registros",
     "Open Models Folder": "Abrir carpeta de modelos",
     "Open Outputs Folder": "Abrir carpeta de salidas",
+    "Open Sign In Dialog": "Abrir diálogo de inicio de sesión",
     "Open extra_model_paths_yaml": "Abrir extra_model_paths.yaml",
     "Pin/Unpin Selected Items": "Anclar/Desanclar elementos seleccionados",
     "Pin/Unpin Selected Nodes": "Anclar/Desanclar nodos seleccionados",

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "Annuler"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "Ouvrir la boîte de dialogue de connexion"
+  },
   "Workspace_CloseWorkflow": {
     "label": "Fermer le flux de travail actuel"
   },

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -613,6 +613,7 @@
     "Open Logs Folder": "Ouvrir le dossier des journaux",
     "Open Models Folder": "Ouvrir le dossier des modèles",
     "Open Outputs Folder": "Ouvrir le dossier des sorties",
+    "Open Sign In Dialog": "Ouvrir la boîte de dialogue de connexion",
     "Open extra_model_paths_yaml": "Ouvrir extra_model_paths.yaml",
     "Pin/Unpin Selected Items": "Épingler/Désépingler les éléments sélectionnés",
     "Pin/Unpin Selected Nodes": "Épingler/Désépingler les nœuds sélectionnés",

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "元に戻す"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "サインインダイアログを開く"
+  },
   "Workspace_CloseWorkflow": {
     "label": "現在のワークフローを閉じる"
   },

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -613,6 +613,7 @@
     "Open Logs Folder": "ログフォルダを開く",
     "Open Models Folder": "モデルフォルダを開く",
     "Open Outputs Folder": "出力フォルダを開く",
+    "Open Sign In Dialog": "サインインダイアログを開く",
     "Open extra_model_paths_yaml": "extra_model_paths.yamlを開く",
     "Pin/Unpin Selected Items": "選択したアイテムのピン留め/ピン留め解除",
     "Pin/Unpin Selected Nodes": "選択したノードのピン留め/ピン留め解除",

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "실행 취소"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "로그인 대화상자 열기"
+  },
   "Workspace_CloseWorkflow": {
     "label": "현재 워크플로우 닫기"
   },

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -613,6 +613,7 @@
     "Open Logs Folder": "로그 폴더 열기",
     "Open Models Folder": "모델 폴더 열기",
     "Open Outputs Folder": "출력 폴더 열기",
+    "Open Sign In Dialog": "로그인 대화 상자 열기",
     "Open extra_model_paths_yaml": "extra_model_paths.yaml 열기",
     "Pin/Unpin Selected Items": "선택한 항목 고정/고정 해제",
     "Pin/Unpin Selected Nodes": "선택한 노드 고정/고정 해제",

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "Отменить"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "Открыть окно входа"
+  },
   "Workspace_CloseWorkflow": {
     "label": "Закрыть текущий рабочий процесс"
   },

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -613,6 +613,7 @@
     "Open Logs Folder": "Открыть папку журналов",
     "Open Models Folder": "Открыть папку моделей",
     "Open Outputs Folder": "Открыть папку выходных данных",
+    "Open Sign In Dialog": "Открыть окно входа",
     "Open extra_model_paths_yaml": "Открыть extra_model_paths.yaml",
     "Pin/Unpin Selected Items": "Закрепить/открепить выбранные элементы",
     "Pin/Unpin Selected Nodes": "Закрепить/открепить выбранные ноды",

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -173,6 +173,9 @@
   "Comfy_Undo": {
     "label": "撤销"
   },
+  "Comfy_User_OpenSignInDialog": {
+    "label": "打开登录对话框"
+  },
   "Workspace_CloseWorkflow": {
     "label": "关闭当前工作流"
   },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -613,6 +613,7 @@
     "Open Logs Folder": "打开日志文件夹",
     "Open Models Folder": "打开模型文件夹",
     "Open Outputs Folder": "打开输出文件夹",
+    "Open Sign In Dialog": "打开登录对话框",
     "Open extra_model_paths_yaml": "打开 extra_model_paths.yaml",
     "Pin/Unpin Selected Items": "固定/取消固定选定项目",
     "Pin/Unpin Selected Nodes": "固定/取消固定选定节点",


### PR DESCRIPTION
Adds command to core commands that opens signin dialog, such that it can be mapped to a keybinding.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3556-Add-command-to-open-signin-dialog-1dd6d73d365081999502df4d39854f52) by [Unito](https://www.unito.io)
