### PR TITLE
[nit] Remove tab index on canvas element

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -21,12 +21,7 @@
   </LiteGraphCanvasSplitterOverlay>
   <TitleEditor />
   <GraphCanvasMenu v-if="!betaMenuEnabled && canvasMenuEnabled" />
-  <canvas
-    id="graph-canvas"
-    ref="canvasRef"
-    tabindex="1"
-    class="w-full h-full touch-none"
-  />
+  <canvas id="graph-canvas" ref="canvasRef" class="w-full h-full touch-none" />
   <NodeSearchboxPopover />
   <SelectionOverlay v-if="selectionToolboxEnabled">
     <SelectionToolbox />


### PR DESCRIPTION
Using positive values for the `tabIndex` attribute is generally discouraged in web development for several important reasons:

1. **Disrupts the natural DOM order**: Positive `tabIndex` values override the natural tab order of elements in the document, which normally follows the DOM structure. This can create confusing navigation patterns that don't match the visual layout of the page.

2. **Accessibility problems**: Screen reader users and keyboard-only users rely on a logical tab sequence. When you manually set positive tab indices, you risk creating an unpredictable navigation experience that doesn't match their expectations or the visual flow of the page.

3. **Maintenance challenges**: As your interface evolves, maintaining a custom tab order with positive indices becomes increasingly difficult. Each time you add, remove, or rearrange elements, you may need to reassign multiple tab indices to maintain the desired order.

4. **Hard to debug**: When navigation issues arise, a custom tab order makes troubleshooting much more complex as you need to track every manual index assignment.

### Better alternatives:

- **Use `tabIndex="0"`**: This adds elements to the natural tab order without disrupting it. Elements become focusable in their DOM order.
  
- **Use `tabIndex="-1"`**: This makes elements programmatically focusable (via JavaScript) but removes them from the keyboard tab sequence.

- **Structure your HTML logically**: The best approach is to arrange your HTML elements in a sequence that naturally creates the desired tab order, eliminating the need for tabIndex manipulation entirely.

If you need to influence tab order, consider restructuring your HTML rather than using positive tabIndex values.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3563-nit-Remove-tab-index-on-canvas-element-1dd6d73d36508137b5bace8cc02dd07b) by [Unito](https://www.unito.io)
