### PR TITLE
[nit] Adjust font size of User Panel header

### DIFF
--- a/src/components/dialog/content/setting/UserPanel.vue
+++ b/src/components/dialog/content/setting/UserPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <TabPanel value="User" class="user-settings-container h-full">
     <div class="flex flex-col h-full">
-      <h2 class="text-xl font-bold mb-2">{{ $t('userSettings.title') }}</h2>
+      <h2 class="text-2xl font-bold mb-2">{{ $t('userSettings.title') }}</h2>
       <Divider class="mb-3" />
 
       <div v-if="user" class="flex flex-col gap-2">


### PR DESCRIPTION
Align the font size with `CreditPanel` to avoid layout shift when switching between the 2 panels. https://github.com/Comfy-Org/ComfyUI_frontend/blob/cdddf359a8d6561704437ebff339ec8de28f0787/src/components/dialog/content/setting/CreditsPanel.vue#L4