### PR TITLE
Show user avatar on top menu if available

### DIFF
--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -3,14 +3,14 @@
   <Button
     v-if="isAuthenticated"
     v-tooltip="{ value: $t('userSettings.title'), showDelay: 300 }"
-    class="user-profile-button px-1"
+    class="user-profile-button p-1"
     severity="secondary"
     text
     :aria-label="$t('userSettings.title')"
     @click="openUserSettings"
   >
     <div
-      class="flex items-center gap-2 px-1 rounded-full bg-[var(--p-content-background)]"
+      class="flex items-center gap-2 pr-2 rounded-full bg-[var(--p-content-background)]"
     >
       <!-- User Avatar if available -->
       <div v-if="user?.photoURL" class="flex items-center gap-1">

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -10,7 +10,18 @@
     @click="openUserSettings"
   >
     <template #icon>
+      <!-- User Avatar if available -->
+      <div v-if="user?.photoURL" class="flex items-center gap-2">
+        <img
+          :src="user.photoURL"
+          :alt="user.displayName || ''"
+          class="w-8 h-8 rounded-full"
+        />
+      </div>
+
+      <!-- User Icon if no avatar -->
       <div
+        v-else
         class="w-6 h-6 rounded-full bg-neutral-100 dark:bg-neutral-700 flex items-center justify-center"
       >
         <i class="pi pi-user text-sm" />
@@ -29,6 +40,7 @@ import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 const authStore = useFirebaseAuthStore()
 const dialogService = useDialogService()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+const user = computed(() => authStore.currentUser)
 
 const openUserSettings = () => {
   dialogService.showSettingsDialog('user')

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -3,15 +3,17 @@
   <Button
     v-if="isAuthenticated"
     v-tooltip="{ value: $t('userSettings.title'), showDelay: 300 }"
-    class="flex-shrink-0 user-profile-button"
+    class="user-profile-button px-1"
     severity="secondary"
     text
     :aria-label="$t('userSettings.title')"
     @click="openUserSettings"
   >
-    <template #icon>
+    <div
+      class="flex items-center gap-2 px-1 rounded-full bg-[var(--p-content-background)]"
+    >
       <!-- User Avatar if available -->
-      <div v-if="user?.photoURL" class="flex items-center gap-2">
+      <div v-if="user?.photoURL" class="flex items-center gap-1">
         <img
           :src="user.photoURL"
           :alt="user.displayName || ''"
@@ -20,13 +22,12 @@
       </div>
 
       <!-- User Icon if no avatar -->
-      <div
-        v-else
-        class="w-6 h-6 rounded-full bg-neutral-100 dark:bg-neutral-700 flex items-center justify-center"
-      >
+      <div v-else class="w-8 h-8 rounded-full flex items-center justify-center">
         <i class="pi pi-user text-sm" />
       </div>
-    </template>
+
+      <i class="pi pi-chevron-down" :style="{ fontSize: '0.5rem' }" />
+    </div>
   </Button>
 </template>
 

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -1,0 +1,36 @@
+<!-- A button that shows current authenticated user's avatar -->
+<template>
+  <Button
+    v-if="isAuthenticated"
+    v-tooltip="{ value: $t('userSettings.title'), showDelay: 300 }"
+    class="flex-shrink-0 user-profile-button"
+    severity="secondary"
+    text
+    :aria-label="$t('userSettings.title')"
+    @click="openUserSettings"
+  >
+    <template #icon>
+      <div
+        class="w-6 h-6 rounded-full bg-neutral-100 dark:bg-neutral-700 flex items-center justify-center"
+      >
+        <i class="pi pi-user text-sm" />
+      </div>
+    </template>
+  </Button>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { computed } from 'vue'
+
+import { useDialogService } from '@/services/dialogService'
+import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
+
+const authStore = useFirebaseAuthStore()
+const dialogService = useDialogService()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+const openUserSettings = () => {
+  dialogService.showSettingsDialog('user')
+}
+</script>

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -12,6 +12,7 @@
     </div>
     <div ref="menuRight" class="comfyui-menu-right flex-shrink-0" />
     <Actionbar />
+    <CurrentUserButton />
     <BottomPanelToggleButton class="flex-shrink-0" />
     <Button
       v-tooltip="{ value: $t('menu.hideMenu'), showDelay: 300 }"
@@ -23,23 +24,6 @@
       @click="workspaceState.focusMode = true"
       @contextmenu="showNativeSystemMenu"
     />
-    <Button
-      v-if="isAuthenticated"
-      v-tooltip="{ value: $t('userSettings.title'), showDelay: 300 }"
-      class="flex-shrink-0 user-profile-button"
-      severity="secondary"
-      text
-      :aria-label="$t('userSettings.title')"
-      @click="openUserSettings"
-    >
-      <template #icon>
-        <div
-          class="w-6 h-6 rounded-full bg-neutral-100 dark:bg-neutral-700 flex items-center justify-center"
-        >
-          <i class="pi pi-user text-sm" />
-        </div>
-      </template>
-    </Button>
     <div
       v-show="menuSetting !== 'Bottom'"
       class="window-actions-spacer flex-shrink-0"
@@ -61,10 +45,9 @@ import { computed, onMounted, provide, ref } from 'vue'
 import Actionbar from '@/components/actionbar/ComfyActionbar.vue'
 import BottomPanelToggleButton from '@/components/topbar/BottomPanelToggleButton.vue'
 import CommandMenubar from '@/components/topbar/CommandMenubar.vue'
+import CurrentUserButton from '@/components/topbar/CurrentUserButton.vue'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import { app } from '@/scripts/app'
-import { useDialogService } from '@/services/dialogService'
-import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import {
@@ -76,10 +59,7 @@ import {
 
 const workspaceState = useWorkspaceStore()
 const settingStore = useSettingStore()
-const authStore = useFirebaseAuthStore()
-const dialogService = useDialogService()
 
-const isAuthenticated = computed(() => authStore.isAuthenticated)
 const workflowTabsPosition = computed(() =>
   settingStore.get('Comfy.Workflow.WorkflowTabsPosition')
 )
@@ -88,10 +68,6 @@ const betaMenuEnabled = computed(() => menuSetting.value !== 'Disabled')
 const showTopMenu = computed(
   () => betaMenuEnabled.value && !workspaceState.focusMode
 )
-
-const openUserSettings = () => {
-  dialogService.showSettingsDialog('user')
-}
 
 const menuRight = ref<HTMLDivElement | null>(null)
 // Menu-right holds legacy topbar elements attached by custom scripts

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -12,7 +12,7 @@
     </div>
     <div ref="menuRight" class="comfyui-menu-right flex-shrink-0" />
     <Actionbar />
-    <CurrentUserButton />
+    <CurrentUserButton class="flex-shrink-0" />
     <BottomPanelToggleButton class="flex-shrink-0" />
     <Button
       v-tooltip="{ value: $t('menu.hideMenu'), showDelay: 300 }"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a220a9f1-b73b-451a-bed2-9750fc0fdda5)

Fallback:

![image](https://github.com/user-attachments/assets/aca7e895-9d30-41af-a302-fb44e38d67d7)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3572-Show-user-avatar-on-top-menu-if-available-1dd6d73d365081e8a833f5d843b590ce) by [Unito](https://www.unito.io)
