### PR TITLE
[API Node] Show error toast

### DIFF
--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -245,6 +245,7 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     if (!response.ok) {
       const errorData = await response.json()
       error.value = `Failed to initiate credit purchase: ${errorData.message}`
+      showAuthErrorToast()
       return null
     }
 
@@ -287,6 +288,7 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     if (!response.ok) {
       const errorData = await response.json()
       error.value = `Failed to access billing portal: ${errorData.message}`
+      showAuthErrorToast()
       return null
     }
 


### PR DESCRIPTION
Two functions are not wrapped with `executeAuthAction` and can therefore fail silently. Fix by showing error toast manually.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3576-API-Node-Show-error-toast-1de6d73d36508171a5d7c27ad8008cfc) by [Unito](https://www.unito.io)
