### PR TITLE
[Schema] Add api_node flag to node def schema

### DIFF
--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -77,7 +77,8 @@ export const zComfyNodeDef = z.object({
   output_node: z.boolean(),
   python_module: z.string(),
   deprecated: z.boolean().optional(),
-  experimental: z.boolean().optional()
+  experimental: z.boolean().optional(),
+  api_node: z.boolean().optional()
 })
 
 // Export types

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -222,7 +222,13 @@ export const zComfyNodeDef = z.object({
   output_node: z.boolean(),
   python_module: z.string(),
   deprecated: z.boolean().optional(),
-  experimental: z.boolean().optional()
+  experimental: z.boolean().optional(),
+  /**
+   * Whether the node is an API node. Running API nodes requires login to
+   * Comfy Org account.
+   * https://www.comfy.org/faq
+   */
+  api_node: z.boolean().optional()
 })
 
 // `/object_info`

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -41,6 +41,7 @@ export class ComfyNodeDefImpl
   readonly deprecated: boolean
   readonly experimental: boolean
   readonly output_node: boolean
+  readonly api_node: boolean
   /**
    * @deprecated Use `inputs` instead
    */
@@ -121,6 +122,7 @@ export class ComfyNodeDefImpl
     this.experimental =
       obj.experimental ?? obj.category.startsWith('_for_testing')
     this.output_node = obj.output_node
+    this.api_node = !!obj.api_node
     this.input = obj.input ?? {}
     this.output = obj.output ?? []
     this.output_is_list = obj.output_is_list

--- a/tests-ui/tests/nodeDef.test.ts
+++ b/tests-ui/tests/nodeDef.test.ts
@@ -518,4 +518,23 @@ describe('ComfyNodeDefImpl', () => {
     expect(result.inputs['booleanInput']).toBeDefined()
     expect(result.inputs['floatInput']).toBeDefined()
   })
+
+  it.each([
+    { api_node: true, expected: true },
+    { api_node: false, expected: false },
+    { api_node: undefined, expected: false }
+  ] as { api_node: boolean | undefined; expected: boolean }[])(
+    'should handle api_node field: $api_node',
+    ({ api_node, expected }) => {
+      const result = new ComfyNodeDefImpl({
+        name: 'ApiNode',
+        display_name: 'API Node',
+        category: 'Test',
+        python_module: 'test_module',
+        description: 'A node with API',
+        api_node
+      } as ComfyNodeDefV1)
+      expect(result.api_node).toBe(expected)
+    }
+  )
 })


### PR DESCRIPTION
Ref: https://github.com/comfyanonymous/ComfyUI/pull/7726

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3586-Schema-Add-api_node-flag-to-node-def-schema-1de6d73d3650815abbf1ee416bb0af68) by [Unito](https://www.unito.io)
