### PR TITLE
[API Node] Workaround custom node hijack on api.queuePrompt

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -223,6 +223,9 @@ export class ComfyApi extends EventTarget {
    * in the function call chain.
    *
    * Ref: https://cs.comfy.org/search?q=context:global+%22api.queuePrompt+%3D%22&patternType=keyword&sm=0
+   *
+   * TODO: Move this field to parameter of {@link queuePrompt} once all
+   * custom nodes are patched.
    */
   authToken?: string
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -215,6 +215,17 @@ export class ComfyApi extends EventTarget {
 
   reportedUnknownMessageTypes = new Set<string>()
 
+  /**
+   * The auth token for the comfy org account if the user is logged in.
+   * This is only used for {@link queuePrompt} now. It is not directly
+   * passed as parameter to the function because some custom nodes are hijacking
+   * {@link queuePrompt} improperly, which causes extra parameters to be lost
+   * in the function call chain.
+   *
+   * Ref: https://cs.comfy.org/search?q=context:global+%22api.queuePrompt+%3D%22&patternType=keyword&sm=0
+   */
+  authToken?: string
+
   constructor() {
     super()
     this.user = ''
@@ -517,13 +528,11 @@ export class ComfyApi extends EventTarget {
    * Queues a prompt to be executed
    * @param {number} number The index at which to queue the prompt, passing -1 will insert the prompt at the front of the queue
    * @param {object} prompt The prompt data to queue
-   * @param {string} authToken The auth token for the comfy org account if the user is logged in
    * @throws {PromptExecutionError} If the prompt fails to execute
    */
   async queuePrompt(
     number: number,
-    data: { output: ComfyApiWorkflow; workflow: ComfyWorkflowJSON },
-    authToken?: string
+    data: { output: ComfyApiWorkflow; workflow: ComfyWorkflowJSON }
   ): Promise<PromptResponse> {
     const { output: prompt, workflow } = data
 
@@ -531,7 +540,7 @@ export class ComfyApi extends EventTarget {
       client_id: this.clientId ?? '', // TODO: Unify clientId access
       prompt,
       extra_data: {
-        auth_token_comfy_org: authToken,
+        auth_token_comfy_org: this.authToken,
         extra_pnginfo: { workflow }
       }
     }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1210,6 +1210,7 @@ export class ComfyApp {
           try {
             api.authToken = comfyOrgAuthToken
             const res = await api.queuePrompt(number, p)
+            delete api.authToken
             executionStore.lastNodeErrors = res.node_errors ?? null
             if (executionStore.lastNodeErrors?.length) {
               this.canvas.draw(true, true)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1208,7 +1208,8 @@ export class ComfyApp {
 
           const p = await this.graphToPrompt()
           try {
-            const res = await api.queuePrompt(number, p, comfyOrgAuthToken)
+            api.authToken = comfyOrgAuthToken
+            const res = await api.queuePrompt(number, p)
             executionStore.lastNodeErrors = res.node_errors ?? null
             if (executionStore.lastNodeErrors?.length) {
               this.canvas.draw(true, true)


### PR DESCRIPTION
Many custom nodes are hijacking `api.queuePrompt` without forwarding all params. This PR workarounds this issue.

Ref: https://cs.comfy.org/search?q=context:global+%22api.queuePrompt+%3D%22&patternType=keyword&sm=0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3589-API-Node-Workaround-custom-node-hijack-on-api-queuePrompt-1de6d73d365081f78474dd8149ac62cd) by [Unito](https://www.unito.io)
