### PR TITLE
add importmap for vue-i18n

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -64,7 +64,8 @@ export default defineConfig({
     comfyAPIPlugin(IS_DEV),
     generateImportMapPlugin([
       { name: 'vue', pattern: /[\\/]node_modules[\\/]vue[\\/]/ },
-      { name: 'primevue', pattern: /[\\/]node_modules[\\/]primevue[\\/]/ }
+      { name: 'primevue', pattern: /[\\/]node_modules[\\/]primevue[\\/]/ },
+      { name: 'vue-i18n', pattern: /[\\/]node_modules[\\/]vue-i18n[\\/]/ }
     ]),
     addElementVnodeExportPlugin(),
 


### PR DESCRIPTION
in order to support vue-i18n in custom node, we need to add it into importmap, using in https://github.com/jtydhr88/ComfyUI_frontend_vue_basic/pull/4/commits/7067c96cd64fcc325fcdb55645a485690a0c3786

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3595-add-importmap-for-vue-i18n-1df6d73d365081029c06db34c2570b49) by [Unito](https://www.unito.io)
