### PR TITLE
Re-style TopUpCreditDialog to match design

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1148,12 +1148,12 @@
     "messageSupport": "Message Support",
     "lastUpdated": "Last updated",
     "topUp": {
-      "title": "Add to Credit Balance",
       "insufficientTitle": "Insufficient Credits",
       "insufficientMessage": "You don't have enough credits to run this workflow.",
-      "addCredits": "Add credits to your balance",
+      "quickPurchase": "Quick Purchase",
       "maxAmount": "(Max. $1,000 USD)",
-      "buyNow": "Buy now"
+      "buyNow": "Buy now",
+      "seeDetails": "See details"
     }
   },
   "userSettings": {

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -110,12 +110,12 @@
     "messageSupport": "Contactar soporte",
     "purchaseCredits": "Comprar créditos",
     "topUp": {
-      "addCredits": "Agregar créditos a tu saldo",
       "buyNow": "Comprar ahora",
       "insufficientMessage": "No tienes suficientes créditos para ejecutar este flujo de trabajo.",
       "insufficientTitle": "Créditos insuficientes",
       "maxAmount": "(Máx. $1,000 USD)",
-      "title": "Agregar al saldo de créditos"
+      "quickPurchase": "Compra rápida",
+      "seeDetails": "Ver detalles"
     },
     "yourCreditBalance": "Tu saldo de créditos"
   },

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -110,12 +110,12 @@
     "messageSupport": "Contacter le support",
     "purchaseCredits": "Acheter des crédits",
     "topUp": {
-      "addCredits": "Ajouter des crédits à votre solde",
       "buyNow": "Acheter maintenant",
       "insufficientMessage": "Vous n'avez pas assez de crédits pour exécuter ce workflow.",
       "insufficientTitle": "Crédits insuffisants",
       "maxAmount": "(Max. 1 000 $ US)",
-      "title": "Ajouter au solde de crédits"
+      "quickPurchase": "Achat rapide",
+      "seeDetails": "Voir les détails"
     },
     "yourCreditBalance": "Votre solde de crédits"
   },

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -110,12 +110,12 @@
     "messageSupport": "サポートにメッセージ",
     "purchaseCredits": "クレジットを購入",
     "topUp": {
-      "addCredits": "残高にクレジットを追加",
       "buyNow": "今すぐ購入",
       "insufficientMessage": "このワークフローを実行するのに十分なクレジットがありません。",
       "insufficientTitle": "クレジット不足",
       "maxAmount": "（最大 $1,000 USD）",
-      "title": "クレジット残高を追加"
+      "quickPurchase": "クイック購入",
+      "seeDetails": "詳細を見る"
     },
     "yourCreditBalance": "あなたのクレジット残高"
   },

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -110,12 +110,12 @@
     "messageSupport": "지원 문의",
     "purchaseCredits": "크레딧 구매",
     "topUp": {
-      "addCredits": "잔액에 크레딧 추가",
       "buyNow": "지금 구매",
       "insufficientMessage": "이 워크플로우를 실행하기에 크레딧이 부족합니다.",
       "insufficientTitle": "크레딧 부족",
       "maxAmount": "(최대 $1,000 USD)",
-      "title": "크레딧 잔액 충전"
+      "quickPurchase": "빠른 구매",
+      "seeDetails": "자세히 보기"
     },
     "yourCreditBalance": "보유 크레딧 잔액"
   },

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -110,12 +110,12 @@
     "messageSupport": "Связаться с поддержкой",
     "purchaseCredits": "Купить кредиты",
     "topUp": {
-      "addCredits": "Добавить кредиты на баланс",
       "buyNow": "Купить сейчас",
       "insufficientMessage": "У вас недостаточно кредитов для запуска этого рабочего процесса.",
       "insufficientTitle": "Недостаточно кредитов",
       "maxAmount": "(Макс. $1,000 USD)",
-      "title": "Пополнить баланс кредитов"
+      "quickPurchase": "Быстрая покупка",
+      "seeDetails": "Смотреть детали"
     },
     "yourCreditBalance": "Ваш баланс кредитов"
   },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -110,12 +110,12 @@
     "messageSupport": "联系客服",
     "purchaseCredits": "购买积分",
     "topUp": {
-      "addCredits": "为您的余额充值",
       "buyNow": "立即购买",
       "insufficientMessage": "您的积分不足，无法运行此工作流。",
       "insufficientTitle": "积分不足",
       "maxAmount": "（最高 $1,000 美元）",
-      "title": "充值余额"
+      "quickPurchase": "快速购买",
+      "seeDetails": "查看详情"
     },
     "yourCreditBalance": "您的积分余额"
   },


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/6f808a83-b626-4262-8f2e-171241e6c987)

After:
![image](https://github.com/user-attachments/assets/cb194c56-5bd6-4d0a-a77a-d7adbbc81243)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3597-Re-style-TopUpCreditDialog-to-match-design-1df6d73d365081fa84a6cb7f9b189752) by [Unito](https://www.unito.io)
