### PR TITLE
Add a button to selection toolbox to open mask editor

### DIFF
--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -10,6 +10,7 @@
     <ColorPickerButton />
     <BypassButton />
     <PinButton />
+    <MaskEditorButton />
     <DeleteButton />
     <RefreshButton />
     <ExtensionCommandButton
@@ -24,17 +25,17 @@
 import Panel from 'primevue/panel'
 import { computed } from 'vue'
 
+import BypassButton from '@/components/graph/selectionToolbox/BypassButton.vue'
 import ColorPickerButton from '@/components/graph/selectionToolbox/ColorPickerButton.vue'
+import DeleteButton from '@/components/graph/selectionToolbox/DeleteButton.vue'
 import ExecuteButton from '@/components/graph/selectionToolbox/ExecuteButton.vue'
+import ExtensionCommandButton from '@/components/graph/selectionToolbox/ExtensionCommandButton.vue'
+import MaskEditorButton from '@/components/graph/selectionToolbox/MaskEditorButton.vue'
+import PinButton from '@/components/graph/selectionToolbox/PinButton.vue'
+import RefreshButton from '@/components/graph/selectionToolbox/RefreshButton.vue'
 import { useExtensionService } from '@/services/extensionService'
 import { type ComfyCommandImpl, useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
-
-import BypassButton from './selectionToolbox/BypassButton.vue'
-import DeleteButton from './selectionToolbox/DeleteButton.vue'
-import ExtensionCommandButton from './selectionToolbox/ExtensionCommandButton.vue'
-import PinButton from './selectionToolbox/PinButton.vue'
-import RefreshButton from './selectionToolbox/RefreshButton.vue'
 
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()

--- a/src/components/graph/selectionToolbox/MaskEditorButton.vue
+++ b/src/components/graph/selectionToolbox/MaskEditorButton.vue
@@ -1,0 +1,35 @@
+<template>
+  <Button
+    v-show="isSingleImageNode"
+    v-tooltip.top="{
+      value: t('commands.Comfy_MaskEditor_OpenMaskEditor.label'),
+      showDelay: 1000
+    }"
+    severity="secondary"
+    text
+    icon="pi pi-pencil"
+    @click="openMaskEditor"
+  />
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { computed } from 'vue'
+
+import { t } from '@/i18n'
+import { useCommandStore } from '@/stores/commandStore'
+import { useCanvasStore } from '@/stores/graphStore'
+import { isImageNode, isLGraphNode } from '@/utils/litegraphUtil'
+
+const commandStore = useCommandStore()
+const canvasStore = useCanvasStore()
+
+const isSingleImageNode = computed(() => {
+  const nodes = canvasStore.selectedItems.filter(isLGraphNode)
+  return nodes.length === 1 && nodes.some(isImageNode)
+})
+
+const openMaskEditor = () => {
+  void commandStore.execute('Comfy.MaskEditor.OpenMaskEditor')
+}
+</script>

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -12,7 +12,7 @@ import {
 } from '@/constants/coreColorPalettes'
 import { t } from '@/i18n'
 import { api } from '@/scripts/api'
-import { app } from '@/scripts/app'
+import { ComfyApp, app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useWorkflowService } from '@/services/workflowService'
@@ -26,6 +26,7 @@ import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { isImageNode } from '@/utils/litegraphUtil'
 
 export function useCoreCommands(): ComfyCommand[] {
   const workflowService = useWorkflowService()
@@ -430,6 +431,23 @@ export function useCoreCommands(): ComfyCommand[] {
           }
         }
         app.canvas.setDirty(true, true)
+      }
+    },
+    {
+      id: 'Comfy.Canvas.SelectedNode.OpenMaskEditor',
+      icon: 'pi pi-pencil',
+      label: 'Open Mask Editor for Selected Node',
+      versionAdded: '',
+      function: () => {
+        const nodes = getSelectedNodes()
+        const firstImageNode = nodes.find((node) => isImageNode(node))
+        if (firstImageNode) {
+          ComfyApp.copyToClipspace(firstImageNode)
+          // @ts-expect-error fixme ts strict error
+          ComfyApp.clipspace_return_node = firstImageNode
+          // @ts-expect-error fixme ts strict error
+          ComfyApp.open_maskeditor()
+        }
       }
     },
     {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -12,7 +12,7 @@ import {
 } from '@/constants/coreColorPalettes'
 import { t } from '@/i18n'
 import { api } from '@/scripts/api'
-import { ComfyApp, app } from '@/scripts/app'
+import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useWorkflowService } from '@/services/workflowService'
@@ -26,7 +26,6 @@ import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { isImageNode } from '@/utils/litegraphUtil'
 
 export function useCoreCommands(): ComfyCommand[] {
   const workflowService = useWorkflowService()
@@ -431,24 +430,6 @@ export function useCoreCommands(): ComfyCommand[] {
           }
         }
         app.canvas.setDirty(true, true)
-      }
-    },
-    {
-      id: 'Comfy.Canvas.SelectedNode.OpenMaskEditor',
-      icon: 'pi pi-pencil',
-      label: 'Open Mask Editor for Selected Node',
-      versionAdded: '',
-      function: () => {
-        const nodes = getSelectedNodes()
-        const isTheOnlyNode = nodes.length === 1
-        if (!isTheOnlyNode) return
-        const selectedNode = nodes[0]
-        if (!isImageNode(selectedNode)) return
-        ComfyApp.copyToClipspace(selectedNode)
-        // @ts-expect-error fixme ts strict error
-        ComfyApp.clipspace_return_node = selectedNode
-        // @ts-expect-error fixme ts strict error
-        ComfyApp.open_maskeditor()
       }
     },
     {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -440,14 +440,15 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '',
       function: () => {
         const nodes = getSelectedNodes()
-        const firstImageNode = nodes.find((node) => isImageNode(node))
-        if (firstImageNode) {
-          ComfyApp.copyToClipspace(firstImageNode)
-          // @ts-expect-error fixme ts strict error
-          ComfyApp.clipspace_return_node = firstImageNode
-          // @ts-expect-error fixme ts strict error
-          ComfyApp.open_maskeditor()
-        }
+        const isTheOnlyNode = nodes.length === 1
+        if (!isTheOnlyNode) return
+        const selectedNode = nodes[0]
+        if (!isImageNode(selectedNode)) return
+        ComfyApp.copyToClipspace(selectedNode)
+        // @ts-expect-error fixme ts strict error
+        ComfyApp.clipspace_return_node = selectedNode
+        // @ts-expect-error fixme ts strict error
+        ComfyApp.open_maskeditor()
       }
     },
     {

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelectedNodes_Pin": {
     "label": "Pin/Unpin Selected Nodes"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "Open Mask Editor for Selected Node"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Zoom In"
   },

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelectedNodes_Pin": {
     "label": "Pin/Unpin Selected Nodes"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "Open Mask Editor for Selected Node"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Anclar/Desanclar elementos seleccionados"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "Abrir editor de máscara para el nodo seleccionado"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Acercar"
   },

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Anclar/Desanclar elementos seleccionados"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "Abrir editor de máscara para el nodo seleccionado"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Épingler/Désépingler les éléments sélectionnés"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "Ouvrir l'éditeur de masque pour le nœud sélectionné"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Épingler/Désépingler les éléments sélectionnés"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "Ouvrir l'éditeur de masque pour le nœud sélectionné"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Zoom avant"
   },

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "選択したアイテムのピン留め/ピン留め解除"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "選択したノードのマスクエディタを開く"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "ズームイン"
   },

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "選択したアイテムのピン留め/ピン留め解除"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "選択したノードのマスクエディタを開く"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "선택한 항목 고정/고정 해제"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "선택한 노드 마스크 편집기 열기"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "확대"
   },

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "선택한 항목 고정/고정 해제"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "선택한 노드 마스크 편집기 열기"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Закрепить/Открепить выбранных нод"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "Открыть редактор масок для выбранной ноды"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Увеличить"
   },

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Закрепить/Открепить выбранных нод"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "Открыть редактор масок для выбранной ноды"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -71,7 +71,7 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "固定/取消固定选中项"
   },
-  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+  "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "打开选中节点的遮罩编辑器"
   },
   "Comfy_Canvas_ZoomIn": {

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -71,6 +71,9 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "固定/取消固定选中项"
   },
+  "Comfy_Canvas_SelectedNode_OpenMaskEditor": {
+    "label": "打开选中节点的遮罩编辑器"
+  },
   "Comfy_Canvas_ZoomIn": {
     "label": "放大"
   },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae8ebfb8-a421-4e15-ad5d-074c5d11c345)

I really can't figure out how to open the context menu on iPad. If there is a way, please let me know.

I add a button for open the mask editor in toolbox. I use this feature frequently and it's really great !

Let more people see it and use it, not just hide it in the context menu below.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3603-Add-a-button-to-selection-toolbox-to-open-mask-editor-1df6d73d36508104843bc73890271e0e) by [Unito](https://www.unito.io)
