### PR TITLE
[Cleanup] Remove unnecessary null check on auth

### DIFF
--- a/src/components/dialog/content/error/__tests__/ReportIssuePanel.spec.ts
+++ b/src/components/dialog/content/error/__tests__/ReportIssuePanel.spec.ts
@@ -142,6 +142,14 @@ vi.mock('@primevue/forms', () => ({
   }
 }))
 
+vi.mock('@/stores/firebaseAuthStore', () => ({
+  useFirebaseAuthStore: () => ({
+    currentUser: {
+      email: 'test@example.com'
+    }
+  })
+}))
+
 describe('ReportIssuePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -59,22 +59,21 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   const userId = computed(() => currentUser.value?.uid)
 
   // Get auth from VueFire and listen for auth state changes
-  const auth = useFirebaseAuth()
-  if (auth) {
-    // Set persistence to localStorage (works in both browser and Electron)
-    void setPersistence(auth, browserLocalPersistence)
+  // From useFirebaseAuth docs:
+  // Retrieves the Firebase Auth instance. Returns `null` on the server.
+  // When using this function on the client in TypeScript, you can force the type with `useFirebaseAuth()!`.
+  const auth = useFirebaseAuth()!
+  // Set persistence to localStorage (works in both browser and Electron)
+  void setPersistence(auth, browserLocalPersistence)
 
-    onAuthStateChanged(auth, (user) => {
-      currentUser.value = user
-      isInitialized.value = true
+  onAuthStateChanged(auth, (user) => {
+    currentUser.value = user
+    isInitialized.value = true
 
-      // Reset balance when auth state changes
-      balance.value = null
-      lastBalanceUpdateTime.value = null
-    })
-  } else {
-    error.value = 'Firebase Auth not available from VueFire'
-  }
+    // Reset balance when auth state changes
+    balance.value = null
+    lastBalanceUpdateTime.value = null
+  })
 
   const showAuthErrorToast = () => {
     useToastStore().add({

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -171,23 +171,6 @@ describe('useFirebaseAuthStore', () => {
     expect(store.error).toBe(null)
   })
 
-  it('should handle auth initialization failure', async () => {
-    // Mock auth as null to simulate initialization failure
-    vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(null)
-
-    // Create a new store instance
-    setActivePinia(createPinia())
-    const uninitializedStore = useFirebaseAuthStore()
-
-    // Check that isInitialized is false
-    expect(uninitializedStore.isInitialized).toBe(false)
-
-    // Verify store actions throw appropriate errors
-    await expect(
-      uninitializedStore.login('test@example.com', 'password')
-    ).rejects.toThrow('Firebase Auth not initialized')
-  })
-
   describe('login', () => {
     it('should login with valid credentials', async () => {
       const mockUserCredential = { user: mockUser }


### PR DESCRIPTION
From useFirebaseAuth docs:

> Retrieves the Firebase Auth instance. Returns `null` on the server.
> When using this function on the client in TypeScript, you can force the type with `useFirebaseAuth()!

We can skip the null value check as the code runs in client not server.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3610-Cleanup-Remove-unnecessary-null-check-on-auth-1df6d73d36508110a503e772c32ffe44) by [Unito](https://www.unito.io)
