### PR TITLE
ignore Vite timestamped config modules in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ dist.zip
 
 # Temporary repository directory
 templates_repo/
+
+# Vite’s timestamped config modules
+vite.config.mts.timestamp-*.mjs


### PR DESCRIPTION
Add `vite.config.mts.timestamp-*.mjs` pattern to `.gitignore` so that the ephemeral, timestamped Vite config files aren’t tracked by Git.

They sometimes get persisted as an unintended bug, and screws over some code editors notices by saying that there are changes for half a second.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3614-ignore-Vite-timestamped-config-modules-in-gitignore-1df6d73d365081f9a3add164d8f57c2b) by [Unito](https://www.unito.io)
