### PR TITLE
Use PrimeVue Avatar component

### DIFF
--- a/src/components/dialog/content/setting/UserPanel.vue
+++ b/src/components/dialog/content/setting/UserPanel.vue
@@ -5,14 +5,13 @@
       <Divider class="mb-3" />
 
       <div v-if="user" class="flex flex-col gap-2">
-        <!-- User Avatar if available -->
-        <div v-if="user.photoURL" class="flex items-center gap-2">
-          <img
-            :src="user.photoURL"
-            :alt="user.displayName || ''"
-            class="w-8 h-8 rounded-full"
-          />
-        </div>
+        <Avatar
+          v-if="user.photoURL"
+          :image="user.photoURL"
+          shape="circle"
+          size="large"
+          aria-label="User Avatar"
+        />
 
         <div class="flex flex-col gap-0.5">
           <h3 class="font-medium">
@@ -77,6 +76,7 @@
 </template>
 
 <script setup lang="ts">
+import Avatar from 'primevue/avatar'
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
 import ProgressSpinner from 'primevue/progressspinner'

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -16,6 +16,7 @@
         :image="photoURL"
         :icon="photoURL ? undefined : 'pi pi-user'"
         shape="circle"
+        aria-label="User Avatar"
       />
 
       <i class="pi pi-chevron-down px-1" :style="{ fontSize: '0.5rem' }" />

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -10,28 +10,21 @@
     @click="openUserSettings"
   >
     <div
-      class="flex items-center gap-2 pr-2 rounded-full bg-[var(--p-content-background)]"
+      class="flex items-center rounded-full bg-[var(--p-content-background)]"
     >
-      <!-- User Avatar if available -->
-      <div v-if="user?.photoURL" class="flex items-center gap-1">
-        <img
-          :src="user.photoURL"
-          :alt="user.displayName || ''"
-          class="w-8 h-8 rounded-full"
-        />
-      </div>
+      <Avatar
+        :image="photoURL"
+        :icon="photoURL ? undefined : 'pi pi-user'"
+        shape="circle"
+      />
 
-      <!-- User Icon if no avatar -->
-      <div v-else class="w-8 h-8 rounded-full flex items-center justify-center">
-        <i class="pi pi-user text-sm" />
-      </div>
-
-      <i class="pi pi-chevron-down" :style="{ fontSize: '0.5rem' }" />
+      <i class="pi pi-chevron-down px-1" :style="{ fontSize: '0.5rem' }" />
     </div>
   </Button>
 </template>
 
 <script setup lang="ts">
+import Avatar from 'primevue/avatar'
 import Button from 'primevue/button'
 import { computed } from 'vue'
 
@@ -41,7 +34,9 @@ import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 const authStore = useFirebaseAuthStore()
 const dialogService = useDialogService()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
-const user = computed(() => authStore.currentUser)
+const photoURL = computed<string | undefined>(
+  () => authStore.currentUser?.photoURL ?? undefined
+)
 
 const openUserSettings = () => {
   dialogService.showSettingsDialog('user')


### PR DESCRIPTION
This PR introduces several improvements to the user interface components:

1. **Avatar Component Standardization**:
   - Replaced custom avatar implementations with PrimeVue's `Avatar` component
   - Applied consistent styling and behavior across user-related components
   - Improved accessibility with proper `aria-label` attributes

2. **CurrentUserButton Improvements**:
   - Simplified the button structure and styling
   - Replaced manual avatar/icon handling with PrimeVue's Avatar component
   - Improved computed property for photoURL with proper type safety
   - Added padding to the chevron icon for better spacing

3. **UserPanel Refinements**:
   - Updated avatar display to use PrimeVue's Avatar component
   - Improved layout and spacing in the user information section
   - Maintained consistent styling with the rest of the application

The changes focus on standardizing the user interface components, improving code maintainability, and enhancing the visual consistency of the application.

![屏幕截图 2025-04-24 211332](https://github.com/user-attachments/assets/d9eca15f-2e50-4c9a-b362-64d04f3ae6cb)
![屏幕截图 2025-04-24 211346](https://github.com/user-attachments/assets/9ea483b0-cb0e-4ac6-8d09-1a47a7e226a2)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3615-Use-PrimeVue-Avatar-component-1e06d73d365081e59947dc076fcf0fee) by [Unito](https://www.unito.io)
