### PR TITLE
[nit] Use TorchMirrorUrl

### DIFF
--- a/src/components/install/MirrorsConfiguration.vue
+++ b/src/components/install/MirrorsConfiguration.vue
@@ -35,8 +35,6 @@
 
 <script setup lang="ts">
 import {
-  CUDA_TORCH_URL,
-  NIGHTLY_CPU_TORCH_URL,
   TorchDeviceType,
   TorchMirrorUrl
 } from '@comfyorg/comfyui-electron-types'
@@ -74,8 +72,8 @@ const getTorchMirrorItem = (device: TorchDeviceType): UVMirror => {
     case 'mps':
       return {
         settingId,
-        mirror: NIGHTLY_CPU_TORCH_URL,
-        fallbackMirror: NIGHTLY_CPU_TORCH_URL
+        mirror: TorchMirrorUrl.NightlyCpu,
+        fallbackMirror: TorchMirrorUrl.NightlyCpu
       }
     case 'nvidia':
       if (isBlackwellArchitecture.value) {
@@ -87,8 +85,8 @@ const getTorchMirrorItem = (device: TorchDeviceType): UVMirror => {
       }
       return {
         settingId,
-        mirror: CUDA_TORCH_URL,
-        fallbackMirror: CUDA_TORCH_URL
+        mirror: TorchMirrorUrl.Cuda,
+        fallbackMirror: TorchMirrorUrl.Cuda
       }
     case 'cpu':
     default:


### PR DESCRIPTION
NIGHTLY_CPU_TORCH_URL and CUDA_TORCH_URL is deprecated. This migrates them to TorchMirrorUrl, which was already being used after a redirect.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3617-nit-Use-TorchMirrorUrl-1e06d73d365081ccb649d90ace48c5c7) by [Unito](https://www.unito.io)
