### PR TITLE
Fix dynamic screen height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <router-view />
   <ProgressSpinner
     v-if="isLoading"
-    class="absolute inset-0 flex justify-center items-center h-screen"
+    class="absolute inset-0 flex justify-center items-center h-[unset]"
   />
   <GlobalDialog />
   <BlockUI full-screen :blocked="isLoading" />

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="comfyui-body grid h-screen w-screen overflow-hidden">
+  <div class="comfyui-body grid h-full w-full overflow-hidden">
     <div id="comfyui-body-top" class="comfyui-body-top">
       <TopMenubar v-if="useNewMenu === 'Top'" />
     </div>

--- a/src/views/layouts/LayoutDefault.vue
+++ b/src/views/layouts/LayoutDefault.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="w-full min-h-screen overflow-hidden relative">
+  <main class="w-full h-full overflow-hidden relative">
     <router-view />
   </main>
 </template>


### PR DESCRIPTION
Relate to #3447

![0bf90fa726a7670e82748cb750070c2f](https://github.com/user-attachments/assets/ddbf413a-42f2-4f1d-ba51-b3f420f9d42c)

I noticed that when mobile devices display the navigation bar, it occupies a certain screen height, causing scrollbars to appear when using 100vh.
However, based on previous discussion records in PRs, directly using 100dvh for all devices might not be a great ideal.

I adopted an alternative approach to resolve this issue:
1. Set the `<main />` tag's width and height to 100% to fill the `body`
2. Similarly, set the `grid` container's width and height to 100% to fill the `<main />` tag
3. I found out that the `ProgressSpinner`  `inset-0` wasn't behaving as expected due to its initial height configuration. So I set its height to `unset` allows it to automatically fill the container

This approach maximizes both compatibility and performance.
Now it resize correctly
![604df252d61ae4e89dcff74989d85d12](https://github.com/user-attachments/assets/41d705d7-28c4-4d9d-bb25-8c574d03c7b7)


However, I don't have an Android device. @benceruleanlu Can you help me a double check? :)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3626-Fix-dynamic-screen-height-1e06d73d365081939516e4f86bbfdc63) by [Unito](https://www.unito.io)
