### PR TITLE
[Cleanup] Remove tooltip on current user button

### DIFF
--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -6,7 +6,7 @@
       class="user-profile-button p-1"
       severity="secondary"
       text
-      :aria-label="$t('userSettings.title')"
+      aria-label="user profile"
       @click="popover?.toggle($event)"
     >
       <div

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -3,7 +3,6 @@
   <div>
     <Button
       v-if="isAuthenticated"
-      v-tooltip="{ value: $t('userSettings.title'), showDelay: 300 }"
       class="user-profile-button p-1"
       severity="secondary"
       text


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/3631

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3636-Cleanup-Remove-tooltip-on-current-user-button-1e06d73d3650813384f5d6cd680594f7) by [Unito](https://www.unito.io)
