### PR TITLE
Models download configuration electron

### DIFF
--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -67,6 +67,13 @@ const doNotAskAgain = ref(false)
 const modelDownloads = ref<Record<string, ModelInfo>>({})
 const missingModels = computed(() => {
   return props.missingModels.map((model) => {
+    
+    // Custom models sources, extension and whitelist can be customized during eletron install.
+    const allowedSources = MODELS_DOWNLOAD_SETTINGS.allowedSources || []
+    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+      allowedSources.push('http://localhost:')
+    }
+    
     const paths = props.paths[model.directory]
     if (model.directory_invalid || !paths) {
       return {
@@ -87,11 +94,11 @@ const missingModels = computed(() => {
     }
     modelDownloads.value[model.name] = downloadInfo
     if (!MODELS_DOWNLOAD_SETTINGS.whiteListedUrls.has(model.url)) {
-      if (!MODELS_DOWNLOAD_SETTINGS.allowedSources.some((source) => model.url.startsWith(source))) {
+      if (!allowedSources.some((source) => model.url.startsWith(source))) {
         return {
           label: `${model.directory} / ${model.name}`,
           url: model.url,
-          error: `Download not allowed from source '${model.url}', only allowed from '${MODELS_DOWNLOAD_SETTINGS.allowedSources.join("', '")}'`
+          error: `Download not allowed from source '${model.url}', only allowed from '${allowedSources.join("', '")}'`
         }
       }
       if (!MODELS_DOWNLOAD_SETTINGS.allowedSuffixes.some((suffix) => model.name.endsWith(suffix))) {

--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -36,25 +36,12 @@ import ListBox from 'primevue/listbox'
 import { computed, onBeforeUnmount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { MODELS_DOWNLOAD_SETTINGS } from '@/constants/modelsDownloadSettings'
 import FileDownload from '@/components/common/FileDownload.vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import { useSettingStore } from '@/stores/settingStore'
 import { isElectron } from '@/utils/envUtil'
 
-// TODO: Read this from server internal API rather than hardcoding here
-// as some installations may wish to use custom sources
-const allowedSources = [
-  'https://civitai.com/',
-  'https://huggingface.co/',
-  'http://localhost:' // Included for testing usage only
-]
-const allowedSuffixes = ['.safetensors', '.sft']
-// Models that fail above conditions but are still allowed
-const whiteListedUrls = new Set([
-  'https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt',
-  'https://huggingface.co/TencentARC/T2I-Adapter/resolve/main/models/t2iadapter_depth_sd14v1.pth?download=true',
-  'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth'
-])
 
 interface ModelInfo {
   name: string
@@ -99,19 +86,19 @@ const missingModels = computed(() => {
       folder_path: paths[0]
     }
     modelDownloads.value[model.name] = downloadInfo
-    if (!whiteListedUrls.has(model.url)) {
-      if (!allowedSources.some((source) => model.url.startsWith(source))) {
+    if (!MODELS_DOWNLOAD_SETTINGS.whiteListedUrls.has(model.url)) {
+      if (!MODELS_DOWNLOAD_SETTINGS.allowedSources.some((source) => model.url.startsWith(source))) {
         return {
           label: `${model.directory} / ${model.name}`,
           url: model.url,
-          error: `Download not allowed from source '${model.url}', only allowed from '${allowedSources.join("', '")}'`
+          error: `Download not allowed from source '${model.url}', only allowed from '${MODELS_DOWNLOAD_SETTINGS.allowedSources.join("', '")}'`
         }
       }
-      if (!allowedSuffixes.some((suffix) => model.name.endsWith(suffix))) {
+      if (!MODELS_DOWNLOAD_SETTINGS.allowedSuffixes.some((suffix) => model.name.endsWith(suffix))) {
         return {
           label: `${model.directory} / ${model.name}`,
           url: model.url,
-          error: `Only allowed suffixes are: '${allowedSuffixes.join("', '")}'`
+          error: `Only allowed suffixes are: '${MODELS_DOWNLOAD_SETTINGS.allowedSuffixes.join("', '")}'`
         }
       }
     }

--- a/src/components/install/ModelsDownloadConfiguration.vue
+++ b/src/components/install/ModelsDownloadConfiguration.vue
@@ -1,0 +1,67 @@
+<template>
+  <Panel
+    :header="$t('install.settings.modelsDownloadSettings')"
+    toggleable
+    :collapsed="!showModelsDownloadInputs"
+    pt:root="bg-neutral-800 border-none w-[600px]"
+  >
+    <template>
+
+      <MirrorItem
+        :item="extraAllowedSource"
+        v-model="extraAllowedSource.value"
+        @state-change="validationState = $event"
+      />
+    </template>
+    <template #icons>
+      <i
+        :class="{
+          'pi pi-spin pi-spinner text-neutral-400':
+            validationState === ValidationState.LOADING,
+          'pi pi-check text-green-500':
+            validationState === ValidationState.VALID,
+          'pi pi-times text-red-500':
+            validationState === ValidationState.INVALID
+        }"
+        v-tooltip="validationStateTooltip"
+      />
+    </template>
+  </Panel>
+</template>
+
+<script setup lang="ts">
+import Panel from 'primevue/panel'
+import { ModelRef, computed, ref } from 'vue'
+
+import MirrorItem from '@/components/install/mirror/MirrorItem.vue'
+import { MODELS_DOWNLOAD_SETTINGS, ModelsDownloadSettings } from '@/constants/modelsDownloadSettings'
+import { t } from '@/i18n'
+import { ValidationState } from '@/utils/validationUtil'
+
+const showModelsDownloadInputs = ref(false)
+const extraAllowedSource = defineModel<string>('extraAllowedSource', { required: true })
+
+const extraAllowedUrl = computed<[ModelsDownloadSettings, ModelRef<string>][]>(() =>
+  (
+    [
+      [MODELS_DOWNLOAD_SETTINGS, extraAllowedSource]
+    ] as [ModelsDownloadSettings, ModelRef<string>][]
+  ).map(([item, modelValue]) => [
+    item,
+    modelValue
+  ])
+)
+
+const validationState = ref<ValidationState>(ValidationState.IDLE)
+
+const validationStateTooltip = computed(() => {
+  switch (validationState.value) {
+    case ValidationState.INVALID:
+      return t('install.settings.mirrorsUnreachable')
+    case ValidationState.VALID:
+      return t('install.settings.mirrorsReachable')
+    default:
+      return t('install.settings.checkingMirrors')
+  }
+})
+</script>

--- a/src/constants/modelsDownloadSettings.ts
+++ b/src/constants/modelsDownloadSettings.ts
@@ -1,0 +1,26 @@
+export interface ModelsDownloadSettings {
+    settingId: string
+      /**
+     * Sources from we comfy can download models + optional customized download url during install
+     */
+    allowedSources: Array<string>
+    /**
+     * models extensions allowed to download
+     */
+    allowedSuffixes: Array<string>
+    /**
+     * Models that fail above conditions but are still allowed
+     */
+    whiteListedUrls: Set<string>
+  }
+
+  export const MODELS_DOWNLOAD_SETTINGS: ModelsDownloadSettings = {
+    settingId: 'Comfy-Desktop.ModelsDownload.ExtraAllowedSource',
+    allowedSources: ['https://civitai.com/', 'https://huggingface.co/', 'http://localhost:'],
+    allowedSuffixes:['.safetensors', '.sft'],
+    whiteListedUrls: new Set([
+        'https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt',
+        'https://huggingface.co/TencentARC/T2I-Adapter/resolve/main/models/t2iadapter_depth_sd14v1.pth?download=true',
+        'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth'
+    ])
+  }

--- a/src/constants/modelsDownloadSettings.ts
+++ b/src/constants/modelsDownloadSettings.ts
@@ -16,7 +16,7 @@ export interface ModelsDownloadSettings {
 
   export const MODELS_DOWNLOAD_SETTINGS: ModelsDownloadSettings = {
     settingId: 'Comfy-Desktop.ModelsDownload.ExtraAllowedSource',
-    allowedSources: ['https://civitai.com/', 'https://huggingface.co/', 'http://localhost:'],
+    allowedSources: ['https://civitai.com/', 'https://huggingface.co/'],
     allowedSuffixes:['.safetensors', '.sft'],
     whiteListedUrls: new Set([
         'https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt',

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -90,7 +90,17 @@ import { checkMirrorReachable } from '@/utils/networkUtil'
         attrs: {
           validateUrlFn: checkMirrorReachable
         }
-      }
+      },
+      {
+        id: 'Comfy-Desktop.ModelsDownload.ModelsDownloadSettings',
+        name: 'Models Download Allowed Sources',
+        tooltip: `Allow to whitelist an additional models download server where Comfy can download models automatically on workflow load. The provided URL will be added to https://civitai.com/ and https://huggingface.co. ie https://myserver.io/models`,
+        type: 'url',
+        defaultValue: '',
+        attrs: {
+          validateUrlFn: checkMirrorReachable
+        }
+      },
     ],
 
     commands: [

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -364,7 +364,8 @@
       "checkingMirrors": "Checking network access to python mirrors...",
       "mirrorsReachable": "Network access to python mirrors is good",
       "mirrorsUnreachable": "Network access to some python mirrors is bad",
-      "mirrorSettings": "Mirror Settings"
+      "mirrorSettings": "Mirror Settings",
+      "modelsDownloadSettings": "Models Download Settings"
     },
     "customNodes": "Custom Nodes",
     "customNodesDescription": "Reinstall custom nodes from existing ComfyUI installations.",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -411,6 +411,7 @@
       "mirrorSettings": "Paramètres du Miroir",
       "mirrorsReachable": "L'accès réseau aux miroirs python est bon",
       "mirrorsUnreachable": "L'accès au réseau à certains miroirs python est mauvais",
+      "modelsDownloadSettings": "Paramètres de telechargement de models",
       "pypiMirrorPlaceholder": "Entrez l'URL du miroir PyPI",
       "pythonMirrorPlaceholder": "Entrez l'URL du miroir Python"
     },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -409,6 +409,7 @@
       "errorUpdatingConsentDetail": "无法更新度量同意设置",
       "learnMoreAboutData": "了解更多关于数据收集的信息",
       "mirrorSettings": "镜像设置",
+      "modelsDownloadSettings": "模型下载设置",
       "mirrorsReachable": "到Python镜像的网络访问良好",
       "mirrorsUnreachable": "对某些python镜像的网络访问不佳",
       "pypiMirrorPlaceholder": "输入PyPI镜像URL",

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -432,6 +432,7 @@ const zSettings = z.object({
   'Comfy.TutorialCompleted': z.boolean(),
   'Comfy.Node.AllowImageSizeDraw': z.boolean(),
   'Comfy-Desktop.AutoUpdate': z.boolean(),
+  'Comfy-Desktop.ModelsDownload.ExtraAllowedSource': z.string(),
   'Comfy-Desktop.SendStatistics': z.boolean(),
   'Comfy-Desktop.WindowStyle': z.string(),
   'Comfy-Desktop.UV.PythonInstallMirror': z.string(),

--- a/src/views/InstallView.vue
+++ b/src/views/InstallView.vue
@@ -88,6 +88,10 @@
             :device="device"
             class="mt-6"
           />
+          <ModelsDownloadConfiguration
+            v-model:extraAllowedSource="extraAllowedSource"
+            class="mt-6"
+          />
           <div class="flex mt-6 justify-between">
             <Button
               :label="$t('g.back')"
@@ -128,6 +132,7 @@ import GpuPicker from '@/components/install/GpuPicker.vue'
 import InstallLocationPicker from '@/components/install/InstallLocationPicker.vue'
 import MigrationPicker from '@/components/install/MigrationPicker.vue'
 import MirrorsConfiguration from '@/components/install/MirrorsConfiguration.vue'
+import ModelsDownloadConfiguration from '@/components/install/ModelsDownloadConfiguration.vue'
 import { electronAPI } from '@/utils/envUtil'
 import BaseViewTemplate from '@/views/templates/BaseViewTemplate.vue'
 
@@ -144,6 +149,7 @@ const allowMetrics = ref(true)
 const pythonMirror = ref('')
 const pypiMirror = ref('')
 const torchMirror = ref('')
+const extraAllowedSource = ref('')
 
 /** Forces each install step to be visited at least once. */
 const highestStep = ref(0)
@@ -176,6 +182,7 @@ const install = async () => {
     pythonMirror: pythonMirror.value,
     pypiMirror: pypiMirror.value,
     torchMirror: torchMirror.value,
+    extraAllowedSource: extraAllowedSource.value,
     // @ts-expect-error fixme ts strict error
     device: device.value
   }


### PR DESCRIPTION
Trying to setup the extra allowed download source in electron settings in case we do not want this in the server API

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3638-Models-download-configuration-electron-1e16d73d3650818c9538cc7aa6d407c4) by [Unito](https://www.unito.io)
