### PR TITLE
Fix two undo steps on add node via context menu

### DIFF
--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -49,6 +49,7 @@ import { useLitegraphService } from '@/services/litegraphService'
 import { useCanvasStore } from '@/stores/graphStore'
 import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSettingStore } from '@/stores/settingStore'
+import { useWorkflowStore } from '@/stores/workflowStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 import { FuseFilterWithValue } from '@/utils/fuseUtil'
@@ -101,6 +102,8 @@ const addNode = (nodeDef: ComfyNodeDefImpl) => {
 
   canvasStore.getCanvas().linkConnector.connectToNode(node, triggerEvent)
 
+  // Notify changeTracker - new step should be added
+  useWorkflowStore().activeWorkflow?.changeTracker?.checkState()
   window.requestAnimationFrame(closeDialog)
 }
 

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -1,5 +1,4 @@
 import { LGraphCanvas, LiteGraph } from '@comfyorg/litegraph'
-import { LGraphNode } from '@comfyorg/litegraph'
 import * as jsondiffpatch from 'jsondiffpatch'
 import _ from 'lodash'
 import log from 'loglevel'

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -308,17 +308,6 @@ export class ChangeTracker {
       return v
     }
 
-    // Detects nodes being added via the node search dialog
-    const onNodeAdded = LiteGraph.LGraph.prototype.onNodeAdded
-    LiteGraph.LGraph.prototype.onNodeAdded = function (node: LGraphNode) {
-      const v = onNodeAdded?.apply(this, [node])
-      if (!app?.configuringGraph) {
-        logger.debug('checkState on onNodeAdded')
-        checkState()
-      }
-      return v
-    }
-
     // Handle multiple commands as a single transaction
     document.addEventListener('litegraph:canvas', (e: Event) => {
       const detail = (e as CustomEvent).detail


### PR DESCRIPTION
Removes change tracker monkey patch on `LGraph.onNodeAdded`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3674-Fix-two-undo-steps-on-add-node-via-context-menu-1e36d73d365081768329f0d0ca108da5) by [Unito](https://www.unito.io)
