### PR TITLE
Fix two undo steps on alt-click to add reroute

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -275,13 +275,6 @@ export class ChangeTracker {
       checkState()
       return v
     }
-    const processMouseDown = LGraphCanvas.prototype.processMouseDown
-    LGraphCanvas.prototype.processMouseDown = function (e) {
-      const v = processMouseDown.apply(this, [e])
-      logger.debug('checkState on processMouseDown')
-      checkState()
-      return v
-    }
 
     // Handle litegraph dialog popup for number/string widgets
     const prompt = LGraphCanvas.prototype.prompt


### PR DESCRIPTION
Change tracker checks the entire workflow on every pointer click, on top of the programmatic checks and notifications.

Was unable to find a reason to check workflow state on both pointer down an pointer up.

- Removes change tracker state check from `processMouseDown`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3675-Fix-two-undo-steps-on-alt-click-to-add-reroute-1e36d73d3650815f8bfaedef96ce468c) by [Unito](https://www.unito.io)
