### PR TITLE
Custom node thumbnail variant

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -14,7 +14,7 @@
           <template v-if="template.mediaType === 'audio'">
             <AudioThumbnail :src="baseThumbnailSrc" />
           </template>
-          <template v-else-if="template.thumbnailVariant === 'compareSlider'">
+          <template v-else-if="thumbnailVariant === 'compareSlider'">
             <CompareSliderThumbnail
               :base-image-src="baseThumbnailSrc"
               :overlay-image-src="overlayThumbnailSrc"
@@ -22,7 +22,7 @@
               :is-hovered="isHovered"
             />
           </template>
-          <template v-else-if="template.thumbnailVariant === 'hoverDissolve'">
+          <template v-else-if="thumbnailVariant === 'hoverDissolve'">
             <HoverDissolveThumbnail
               :base-image-src="baseThumbnailSrc"
               :overlay-image-src="overlayThumbnailSrc"
@@ -36,7 +36,7 @@
               :alt="title"
               :is-hovered="isHovered"
               :hover-zoom="
-                template.thumbnailVariant === 'zoomHover'
+                thumbnailVariant === 'zoomHover'
                   ? UPSCALE_ZOOM_SCALE
                   : DEFAULT_ZOOM_SCALE
               "
@@ -104,17 +104,40 @@ const getThumbnailUrl = (index = '') => {
       : api.apiURL(`/workflow_templates/${sourceModule}/${template.name}`)
 
   // For templates from custom nodes, multiple images is not yet supported
-  const indexSuffix = sourceModule === 'default' && index ? `-${index}` : ''
+  const indexSuffix = !!template.thumbnailVariant && index ? `-${index}` : ''
 
   return `${basePath}${indexSuffix}.${template.mediaSubtype}`
 }
 
 const baseThumbnailSrc = computed(() =>
-  getThumbnailUrl(sourceModule === 'default' ? '1' : '')
+  getThumbnailUrl(template.thumbnailVariant ? '1' : '')
 )
 const overlayThumbnailSrc = computed(() =>
-  getThumbnailUrl(sourceModule === 'default' ? '2' : '')
+  getThumbnailUrl(template.thumbnailVariant ? '2' : '')
 )
+
+const thumbnailVariant = computed(() => {
+  if (template.thumbnailVariant !== undefined) {
+    return template.thumbnailVariant
+  }
+  console.log(template.name)
+  const thumbnailVariantRe = /.*\.(?<variant>[^\.]+)/
+  const thumbnailVariantList = ['compareSlider', 'hoverDissolve']
+  const variant = template.name.match(thumbnailVariantRe)
+
+  if (variant === null) {
+    return undefined
+  }
+
+  if (
+    variant.groups.variant &&
+    thumbnailVariantList.indexOf(variant.groups.variant) > -1
+  ) {
+    console.log(`${variant.groups.variant} detected`)
+    template.thumbnailVariant = variant.groups.variant
+  }
+  return undefined
+})
 
 const title = computed(() => {
   const fallback = template.title ?? template.name ?? `${sourceModule} Template`

--- a/tests-ui/tests/components/templates/templateWorkflowCard.test.ts
+++ b/tests-ui/tests/components/templates/templateWorkflowCard.test.ts
@@ -1,0 +1,128 @@
+import { shallowMount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import TemplateWorkflowCard from '@/components/templates/TemplateWorkflowCard.vue'
+
+describe('correctThumbnailVariant', () => {
+  it('core default variant', async () => {
+    const data = {
+      sourceModule: 'default',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'thumbnailVariant is computed'
+    expect(wrapper.vm.thumbnailVariant).toBe(undefined)
+  })
+
+  it('core thumbnail variant', async () => {
+    const data = {
+      sourceModule: 'default',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp',
+        thumbnailVariant: 'compareSlider'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'thumbnailVariant is computed'
+    expect(wrapper.vm.thumbnailVariant).toBe('compareSlider')
+  })
+
+  it('custom node default variant', async () => {
+    const data = {
+      sourceModule: 'custom_node',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'thumbnailVariant is computed'
+    expect(wrapper.vm.thumbnailVariant).toBe(undefined)
+  })
+
+  it('custom node thumbnail variant', async () => {
+    const data = {
+      sourceModule: 'custom_node',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test.compareSlider',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'thumbnailVariant is computed'
+    expect(wrapper.vm.thumbnailVariant).toBe('compareSlider')
+  })
+})
+
+describe('correctNamingFromVariant', () => {
+  it('core', async () => {
+    const data = {
+      sourceModule: 'default',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'title is computed'
+    expect(wrapper.vm.title).toBe('test')
+  })
+
+  it('custom node name without default variant', async () => {
+    const data = {
+      sourceModule: 'custom_node',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'title is computed'
+    expect(wrapper.vm.title).toBe('test')
+  })
+
+  it('custom node name with thumbnail variant', async () => {
+    const data = {
+      sourceModule: 'custom_node',
+      categoryTitle: '',
+      loading: false,
+      template: {
+        name: 'test.compareSlider',
+        description: 'test',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    }
+    const wrapper = shallowMount(TemplateWorkflowCard, { propsData: data })
+    // @ts-expect-error 'title is computed'
+    expect(wrapper.vm.title).toBe('test')
+  })
+})


### PR DESCRIPTION
I wanted to use the thumbnail variant in a custom node I am doing but noticed it was not available.  
So I wanted to propose a simple setup for this leveraging the workflow name extensions.  
Cf  https://github.com/Comfy-Org/ComfyUI_frontend/issues/3684

If a custom node provides a thumbnail Variant at the end of the filename. For instance  
`workflow_1.compareSlider.json`
Then the front can toggle it's display for the relevant variant.  

The title and description are then cleaned of the variant suffix.  

It is a bit heavy on string computation, Do you think it is relevant to add caching/optimisations ?
If it is ok for integration I'll do a MR to update the documentation for this.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3682-Custom-node-thumbnail-variant-1e46d73d36508170a142dd6ae3e70717) by [Unito](https://www.unito.io)
