### PR TITLE
[Bug] Identify api nodes as core nodes

### DIFF
--- a/src/types/nodeSource.ts
+++ b/src/types/nodeSource.ts
@@ -29,7 +29,7 @@ export const getNodeSource = (python_module?: string): NodeSource => {
     return UNKNOWN_NODE_SOURCE
   }
   const modules = python_module.split('.')
-  if (['nodes', 'comfy_extras'].includes(modules[0])) {
+  if (['nodes', 'comfy_extras', 'comfy_api_nodes'].includes(modules[0])) {
     return {
       type: NodeSourceType.Core,
       className: 'comfy-core',

--- a/tests-ui/tests/nodeSource.test.ts
+++ b/tests-ui/tests/nodeSource.test.ts
@@ -33,6 +33,16 @@ describe('getNodeSource', () => {
     })
   })
 
+  it('should identify core nodes from comfy_api_nodes module', () => {
+    const result = getNodeSource('comfy_api_nodes.some_module')
+    expect(result).toEqual({
+      type: NodeSourceType.Core,
+      className: 'comfy-core',
+      displayText: 'Comfy Core',
+      badgeText: '🦊'
+    })
+  })
+
   it('should identify custom nodes and format their names', () => {
     const result = getNodeSource('custom_nodes.ComfyUI-Example')
     expect(result).toEqual({


### PR DESCRIPTION
Ref: https://github.com/comfyanonymous/ComfyUI/pull/7726

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3683-Bug-Identify-api-nodes-as-core-nodes-1e46d73d3650812bb71ce4bbc539b8a1) by [Unito](https://www.unito.io)
