### PR TITLE
[Style] Use icon for experimental setting tag

### DIFF
--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -7,7 +7,17 @@
   >
     <template #name-prefix>
       <Tag v-if="setting.id === 'Comfy.Locale'" class="pi pi-language" />
-      <Tag v-if="setting.experimental" :value="$t('g.experimental')" />
+      <Tag
+        v-if="setting.experimental"
+        v-tooltip="{
+          value: $t('g.experimental'),
+          showDelay: 600
+        }"
+      >
+        <template #icon>
+          <i-material-symbols:experiment-outline />
+        </template>
+      </Tag>
       <Tag
         v-if="setting.deprecated"
         :value="$t('g.deprecated')"


### PR DESCRIPTION
Save space, and create less visual noise.

Before:
![image](https://github.com/user-attachments/assets/4f99035a-dfbe-45ee-af71-7e9af30a868c)

After:
![image](https://github.com/user-attachments/assets/97dca0be-5a07-4b61-b794-cdd621a69231)
