### PR TITLE
[Style] Hide deprecated settings on UI

### DIFF
--- a/src/components/dialog/content/setting/SettingGroup.vue
+++ b/src/components/dialog/content/setting/SettingGroup.vue
@@ -7,7 +7,7 @@
       }}
     </h3>
     <div
-      v-for="setting in group.settings"
+      v-for="setting in group.settings.filter((s) => !s.deprecated)"
       :key="setting.id"
       class="setting-item mb-4"
     >

--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -18,11 +18,6 @@
           <i-material-symbols:experiment-outline />
         </template>
       </Tag>
-      <Tag
-        v-if="setting.deprecated"
-        :value="$t('g.deprecated')"
-        severity="danger"
-      />
     </template>
   </FormItem>
 </template>

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -7,11 +7,11 @@ import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 import type { SettingParams } from '@/types/settingTypes'
 
 /**
- * Core settings are settings that are required for the core functionality of ComfyUI.
- * These settings are not optional and must be present in the settings store.
+ * Core settings are essential configuration parameters required for ComfyUI's basic functionality.
+ * These settings must be present in the settings store and cannot be omitted.
  *
- * Note: When a setting is no longer needed, it should be marked as deprecated
- * to avoid future setting id conflicts.
+ * IMPORTANT: To prevent ID conflicts, settings should be marked as deprecated rather than removed
+ * when they are no longer needed.
  */
 export const CORE_SETTINGS: SettingParams[] = [
   {

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -1,5 +1,4 @@
-import { LinkMarkerShape } from '@comfyorg/litegraph'
-import { LiteGraph } from '@comfyorg/litegraph'
+import { LinkMarkerShape, LiteGraph } from '@comfyorg/litegraph'
 
 import type { ColorPalettes } from '@/schemas/colorPaletteSchema'
 import type { Keybinding } from '@/schemas/keyBindingSchema'
@@ -7,6 +6,13 @@ import { NodeBadgeMode } from '@/types/nodeSource'
 import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 import type { SettingParams } from '@/types/settingTypes'
 
+/**
+ * Core settings are settings that are required for the core functionality of ComfyUI.
+ * These settings are not optional and must be present in the settings store.
+ *
+ * Note: When a setting is no longer needed, it should be marked as deprecated
+ * to avoid future setting id conflicts.
+ */
 export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Validation.Workflows',


### PR DESCRIPTION
Instead of showing a deprecated tag, now we directly hide deprecated settings.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3688-Style-Hide-deprecated-settings-on-UI-1e46d73d365081d18a11f667d26d4e09) by [Unito](https://www.unito.io)
