### PR TITLE
Remove refresh button when all nodes are selected

### DIFF
--- a/browser_tests/tests/selectionToolbox.spec.ts
+++ b/browser_tests/tests/selectionToolbox.spec.ts
@@ -99,18 +99,6 @@ test.describe('Selection Toolbox', () => {
     ).not.toBeVisible()
   })
 
-  test('displays refresh button in toolbox when all nodes are selected', async ({
-    comfyPage
-  }) => {
-    // Select all nodes
-    await comfyPage.page.focus('canvas')
-    await comfyPage.page.keyboard.press('Control+A')
-
-    await expect(
-      comfyPage.page.locator('.selection-toolbox .pi-refresh')
-    ).toBeVisible()
-  })
-
   test('displays bypass button in toolbox when nodes are selected', async ({
     comfyPage
   }) => {

--- a/src/composables/useRefreshableSelection.ts
+++ b/src/composables/useRefreshableSelection.ts
@@ -1,8 +1,6 @@
-import type { LGraphNode } from '@comfyorg/litegraph'
-import type { IWidget } from '@comfyorg/litegraph'
+import type { IWidget, LGraphNode } from '@comfyorg/litegraph'
 import { computed, ref, watchEffect } from 'vue'
 
-import { useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
 import { isLGraphNode } from '@/utils/litegraphUtil'
 
@@ -20,14 +18,10 @@ const isRefreshableWidget = (widget: IWidget): widget is RefreshableWidget =>
  */
 export const useRefreshableSelection = () => {
   const graphStore = useCanvasStore()
-  const commandStore = useCommandStore()
   const selectedNodes = ref<LGraphNode[]>([])
-  const isAllNodesSelected = ref(false)
 
   watchEffect(() => {
     selectedNodes.value = graphStore.selectedItems.filter(isLGraphNode)
-    isAllNodesSelected.value =
-      graphStore.canvas?.graph?.nodes?.every((node) => !!node.selected) ?? false
   })
 
   const refreshableWidgets = computed(() =>
@@ -36,18 +30,12 @@ export const useRefreshableSelection = () => {
     )
   )
 
-  const isRefreshable = computed(
-    () => refreshableWidgets.value.length > 0 || isAllNodesSelected.value
-  )
+  const isRefreshable = computed(() => refreshableWidgets.value.length > 0)
 
   async function refreshSelected() {
     if (!isRefreshable.value) return
 
-    if (isAllNodesSelected.value) {
-      await commandStore.execute('Comfy.RefreshNodeDefinitions')
-    } else {
-      await Promise.all(refreshableWidgets.value.map((item) => item.refresh()))
-    }
+    await Promise.all(refreshableWidgets.value.map((item) => item.refresh()))
   }
 
   return {


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/3391

The refresh button triggers different actions on different selections can be confusing. This is especially true when there is only a single node on the graph. User won't be able to know whether it would be all node def refresh or just refresh the node that has remote widget.

This PR removes the refresh button when all nodes are selected.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3690-Remove-refresh-button-when-all-nodes-are-selected-1e46d73d365081acab2cdda7587bb515) by [Unito](https://www.unito.io)
