### PR TITLE
[API Node] Update FAQ link to docs.comfy

### DIFF
--- a/src/components/dialog/content/ApiNodesSignInContent.vue
+++ b/src/components/dialog/content/ApiNodesSignInContent.vue
@@ -39,6 +39,6 @@ const { apiNodeNames, onLogin, onCancel } = defineProps<{
 }>()
 
 const handleLearnMoreClick = () => {
-  window.open('https://www.comfy.org/faq', '_blank')
+  window.open('https://docs.comfy.org/tutorials/api-nodes/faq', '_blank')
 }
 </script>

--- a/src/components/dialog/content/setting/CreditsPanel.vue
+++ b/src/components/dialog/content/setting/CreditsPanel.vue
@@ -157,7 +157,7 @@ const handleMessageSupport = () => {
 }
 
 const handleFaqClick = () => {
-  window.open('https://www.comfy.org/faq', '_blank')
+  window.open('https://docs.comfy.org/tutorials/api-nodes/faq', '_blank')
 }
 
 const creditHistory = ref<CreditHistoryItemData[]>([])


### PR DESCRIPTION
As requested [here](https://comfy-organization.slack.com/archives/C08NYSK0K0A/p1745896364780399?thread_ts=1745896116.603129&cid=C08NYSK0K0A), update doc links from:

https://www.comfy.org/faq

to

https://docs.comfy.org/tutorials/api-nodes/faq

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3691-API-Node-Update-FAQ-link-to-docs-comfy-1e46d73d3650810b8afbe3534c68a399) by [Unito](https://www.unito.io)
