### PR TITLE
Show staging tag for staging firebase

### DIFF
--- a/src/components/dialog/header/SettingDialogHeader.vue
+++ b/src/components/dialog/header/SettingDialogHeader.vue
@@ -3,9 +3,21 @@
     <h2 class="px-4">
       <i class="pi pi-cog" />
       <span>{{ $t('g.settings') }}</span>
+      <Tag
+        v-if="isStaging"
+        value="staging"
+        severity="warn"
+        class="ml-2 text-xs"
+      />
     </h2>
   </div>
 </template>
+<script setup lang="ts">
+import Tag from 'primevue/tag'
+
+// @ts-expect-error: Global variable from vite build defined in global.d.ts
+const isStaging = !window.__USE_PROD_CONFIG__
+</script>
 
 <style scoped>
 .pi-cog {

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -11,10 +11,7 @@
         :class="tab.id + '-tab-button'"
         @click="onTabClick(tab)"
       />
-      <div
-        class="side-tool-bar-end mt-auto self-end w-full flex flex-col items-center"
-      >
-        <Tag v-if="isStaging" value="staging" severity="warn" class="text-xs" />
+      <div class="side-tool-bar-end">
         <SidebarLogoutIcon v-if="userStore.isMultiUserServer" />
         <SidebarThemeToggleIcon />
         <SidebarSettingsToggleIcon />
@@ -30,7 +27,6 @@
 </template>
 
 <script setup lang="ts">
-import Tag from 'primevue/tag'
 import { computed } from 'vue'
 
 import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
@@ -48,9 +44,6 @@ import SidebarThemeToggleIcon from './SidebarThemeToggleIcon.vue'
 const workspaceStore = useWorkspaceStore()
 const settingStore = useSettingStore()
 const userStore = useUserStore()
-
-// @ts-expect-error: Global variable from vite build defined in global.d.ts
-const isStaging = !window.__USE_PROD_CONFIG__
 
 const teleportTarget = computed(() =>
   settingStore.get('Comfy.Sidebar.Location') === 'left'
@@ -96,5 +89,10 @@ const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
 .side-tool-bar-container.small-sidebar {
   --sidebar-width: 2.5rem;
   --sidebar-icon-size: 1rem;
+}
+
+.side-tool-bar-end {
+  align-self: flex-end;
+  margin-top: auto;
 }
 </style>

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -12,6 +12,7 @@
         @click="onTabClick(tab)"
       />
       <div class="side-tool-bar-end">
+        <Tag v-if="isStaging" value="staging" severity="warn" />
         <SidebarLogoutIcon v-if="userStore.isMultiUserServer" />
         <SidebarThemeToggleIcon />
         <SidebarSettingsToggleIcon />
@@ -27,6 +28,7 @@
 </template>
 
 <script setup lang="ts">
+import Tag from 'primevue/tag'
 import { computed } from 'vue'
 
 import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
@@ -44,6 +46,9 @@ import SidebarThemeToggleIcon from './SidebarThemeToggleIcon.vue'
 const workspaceStore = useWorkspaceStore()
 const settingStore = useSettingStore()
 const userStore = useUserStore()
+
+// @ts-expect-error: Global variable from vite build defined in global.d.ts
+const isStaging = !window.__USE_PROD_CONFIG__
 
 const teleportTarget = computed(() =>
   settingStore.get('Comfy.Sidebar.Location') === 'left'

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -11,8 +11,10 @@
         :class="tab.id + '-tab-button'"
         @click="onTabClick(tab)"
       />
-      <div class="side-tool-bar-end">
-        <Tag v-if="isStaging" value="staging" severity="warn" />
+      <div
+        class="side-tool-bar-end mt-auto self-end w-full flex flex-col items-center"
+      >
+        <Tag v-if="isStaging" value="staging" severity="warn" class="text-xs" />
         <SidebarLogoutIcon v-if="userStore.isMultiUserServer" />
         <SidebarThemeToggleIcon />
         <SidebarSettingsToggleIcon />
@@ -94,10 +96,5 @@ const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
 .side-tool-bar-container.small-sidebar {
   --sidebar-width: 2.5rem;
   --sidebar-icon-size: 1rem;
-}
-
-.side-tool-bar-end {
-  align-self: flex-end;
-  margin-top: auto;
 }
 </style>


### PR DESCRIPTION
Show `staging` status of frontend firebase configuration on UI to indicate test environment. Backend would also need to be in staging when frontend is in staging config.

This change helps tester aligns frontend/backend configs.

![image](https://github.com/user-attachments/assets/580f6d64-fc27-49d5-a3de-9550bd1821db)


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3693-Show-staging-tag-for-staging-firebase-1e56d73d365081d8bc8af584be78ac77) by [Unito](https://www.unito.io)
