### PR TITLE
Fix graph.change called twice on keypress

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -507,11 +507,7 @@ export class ComfyApp {
   #addProcessKeyHandler() {
     const origProcessKey = LGraphCanvas.prototype.processKey
     LGraphCanvas.prototype.processKey = function (e: KeyboardEvent) {
-      if (!this.graph) {
-        return
-      }
-
-      var block_default = false
+      if (!this.graph) return
 
       if (e.target instanceof Element && e.target.localName == 'input') {
         return
@@ -521,15 +517,19 @@ export class ComfyApp {
         const keyCombo = KeyComboImpl.fromEvent(e)
         const keybindingStore = useKeybindingStore()
         const keybinding = keybindingStore.getKeybinding(keyCombo)
+
         if (keybinding && keybinding.targetElementId === 'graph-canvas') {
           useCommandStore().execute(keybinding.commandId)
-          block_default = true
+
+          this.graph.change()
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          return
         }
 
         // Ctrl+C Copy
         if (e.key === 'c' && (e.metaKey || e.ctrlKey)) {
-          // Trigger onCopy
-          return true
+          return
         }
 
         // Ctrl+V Paste
@@ -538,17 +538,8 @@ export class ComfyApp {
           (e.metaKey || e.ctrlKey) &&
           !e.shiftKey
         ) {
-          // Trigger onPaste
-          return true
+          return
         }
-      }
-
-      this.graph.change()
-
-      if (block_default) {
-        e.preventDefault()
-        e.stopImmediatePropagation()
-        return false
       }
 
       // Fall through to Litegraph defaults


### PR DESCRIPTION
#addProcessKeyHandler adds a call to `LGraph.change()`, however this is already performed by the default litegraph key handler.

Also removes deprecated event handler boolean return.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3695-Fix-graph-change-called-twice-on-keypress-1e56d73d365081798145ce78c26ecddc) by [Unito](https://www.unito.io)
