### PR TITLE
[Style] Fix user icon size

### DIFF
--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -7,7 +7,7 @@
         <Avatar
           class="mb-3"
           :image="user?.photoURL ?? undefined"
-          :icon="user?.photoURL ? undefined : 'pi pi-user'"
+          :icon="user?.photoURL ? undefined : 'pi pi-user !text-2xl'"
           shape="circle"
           size="large"
           aria-label="User Avatar"


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/8d23dd5e-1f73-42f3-b1fc-148747d543f2)

After:
![image](https://github.com/user-attachments/assets/500b7f50-4105-44a1-9c28-7af0733ca2c0)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3701-Style-Fix-user-icon-size-1e56d73d36508106b9b7caeb96fc52e4) by [Unito](https://www.unito.io)
