### PR TITLE
[Bug] Fix staging tag shown in prod

### DIFF
--- a/src/components/dialog/header/SettingDialogHeader.vue
+++ b/src/components/dialog/header/SettingDialogHeader.vue
@@ -15,8 +15,9 @@
 <script setup lang="ts">
 import Tag from 'primevue/tag'
 
-// @ts-expect-error: Global variable from vite build defined in global.d.ts
-const isStaging = !window.__USE_PROD_CONFIG__
+// Global variable from vite build defined in global.d.ts
+// eslint-disable-next-line no-undef
+const isStaging = !__USE_PROD_CONFIG__
 </script>
 
 <style scoped>


### PR DESCRIPTION
`__USE_PROD_CONFIG__` is not bound on `window`. We should directly use it and vite will replace it as literal at build time.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3705-Bug-Fix-staging-tag-shown-in-prod-1e56d73d365081faa218ca55b8ba9c2f) by [Unito](https://www.unito.io)
