### PR TITLE
Fix parsing workflows from mp4 (isobmff)

### DIFF
--- a/src/scripts/metadata/isobmff.ts
+++ b/src/scripts/metadata/isobmff.ts
@@ -9,7 +9,10 @@ import {
   IsobmffBoxContentRange
 } from '@/types/metadataTypes'
 
-const MAX_READ_BYTES = 2 * 1024 * 1024
+// Set max read high, as atoms are stored near end of file
+// while search is made to be efficient.
+const MAX_READ_BYTES = 64 * 1024 * 1024
+
 const BOX_TYPES = {
   USER_DATA: [0x75, 0x64, 0x74, 0x61],
   META_DATA: [0x6d, 0x65, 0x74, 0x61],


### PR DESCRIPTION
Fixes issue where workflows cannot be parsed from outputs greater than 2MB. 

Fixe https://github.com/Comfy-Org/ComfyUI-private/issues/45

----

**Context:**

> MP4 files typically have a structure where the main metadata container (called the "moov" atom) is often placed at the end of the file, but the format is actually designed with a hierarchical structure that allows for efficient searching from the beginning.
> 
> MP4 files have a hierarchical structure made up of "boxes" (also called "atoms"). The most important metadata box is called the "moov" atom, which contains information about video resolution, frame rates, orientation, display characteristics, and more. 
> 
> The structure is designed to be efficient either way - the file format defines a clear hierarchical organization that allows for location and access of specific components.
> 
> The MP4 format is based on the ISO Base Media File Format, which provides the framework for this efficient structure regardless of where the moov atom is placed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3707-Fix-parsing-workflows-from-mp4-isobmff-1e66d73d365081ecae2ccd47494b8718) by [Unito](https://www.unito.io)
