### PR TITLE
[API Node] Sort API templates by name

### DIFF
--- a/src/stores/workflowTemplatesStore.ts
+++ b/src/stores/workflowTemplatesStore.ts
@@ -11,7 +11,13 @@ import type {
 } from '@/types/workflowTemplateTypes'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
-const SHOULD_SORT_CATEGORIES = new Set(['Image API', 'Video API'])
+const SHOULD_SORT_CATEGORIES = new Set([
+  // API Node templates should be strictly sorted by name to avoid any
+  // favoritism or bias towards a particular API. Other categories can
+  // have their ordering specified in index.json freely.
+  'Image API',
+  'Video API'
+])
 
 export const useWorkflowTemplatesStore = defineStore(
   'workflowTemplates',

--- a/src/stores/workflowTemplatesStore.ts
+++ b/src/stores/workflowTemplatesStore.ts
@@ -6,9 +6,12 @@ import { st } from '@/i18n'
 import { api } from '@/scripts/api'
 import type {
   TemplateGroup,
+  TemplateInfo,
   WorkflowTemplates
 } from '@/types/workflowTemplateTypes'
 import { normalizeI18nKey } from '@/utils/formatUtil'
+
+const SHOULD_SORT_CATEGORIES = new Set(['Image API', 'Video API'])
 
 export const useWorkflowTemplatesStore = defineStore(
   'workflowTemplates',
@@ -17,9 +20,30 @@ export const useWorkflowTemplatesStore = defineStore(
     const coreTemplates = shallowRef<WorkflowTemplates[]>([])
     const isLoaded = ref(false)
 
+    /**
+     * Sort a list of templates in alphabetical order by name.
+     */
+    const sortTemplateList = (templates: TemplateInfo[]) =>
+      templates.sort((a, b) => a.name.localeCompare(b.name))
+
+    /**
+     * Sort any template categories (grouped templates) that should be sorted.
+     * Leave other categories' templates in their original order specified in index.json
+     */
+    const sortCategoryTemplates = (categories: WorkflowTemplates[]) =>
+      categories.map((category) => {
+        if (SHOULD_SORT_CATEGORIES.has(category.title)) {
+          return {
+            ...category,
+            templates: sortTemplateList(category.templates)
+          }
+        }
+        return category
+      })
+
     const groupedTemplates = computed<TemplateGroup[]>(() => {
       const allTemplates = [
-        ...coreTemplates.value.map((template) => ({
+        ...sortCategoryTemplates(coreTemplates.value).map((template) => ({
           ...template,
           title: st(
             `templateWorkflows.category.${normalizeI18nKey(template.title)}`,


### PR DESCRIPTION
Sort API node templates by specifying a set of template categories that should have their individual templates sorted by name alphabetically. This ensure that, for API node templates, there is no favoritism or bias in how the templates are ordered. For the existing template categories, maintain the current ordering (allow to be re-arranged by changing the index.json).

Resolves https://github.com/Comfy-Org/workflow_templates/issues/45

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3721-API-Node-Sort-API-templates-by-name-1e66d73d365081d09d01d445c3141af0) by [Unito](https://www.unito.io)
