### PR TITLE
Increase template card titles' line height to 2 lines

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -2,9 +2,9 @@
   <Card
     ref="cardRef"
     :data-testid="`template-workflow-${template.name}`"
-    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-1"
+    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-1 h-full"
     :pt="{
-      body: { class: 'p-0' }
+      body: { class: 'p-0 h-full flex flex-col' }
     }"
     @click="$emit('loadWorkflow', template.name)"
   >
@@ -51,11 +51,11 @@
     </template>
     <template #content>
       <div class="flex items-center px-4 py-3">
-        <div class="flex-1">
-          <h3 class="line-clamp-1 text-lg font-normal" :title="title">
+        <div class="flex-1 flex flex-col">
+          <h3 class="line-clamp-2 text-lg font-normal mb-0 h-10" :title="title">
             {{ title }}
           </h3>
-          <p class="line-clamp-2 text-sm text-muted" :title="description">
+          <p class="line-clamp-2 text-sm text-muted grow" :title="description">
             {{ description }}
           </p>
         </div>

--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -43,9 +43,13 @@
             </h2>
           </div>
           <div
-            class="grid grid-cols-[repeat(auto-fill,minmax(16rem,1fr))] gap-8 justify-items-center"
+            class="grid grid-cols-[repeat(auto-fill,minmax(16rem,1fr))] auto-rows-fr gap-8 justify-items-center"
           >
-            <div v-for="template in selectedTab.templates" :key="template.name">
+            <div
+              v-for="template in selectedTab.templates"
+              :key="template.name"
+              class="h-full"
+            >
               <TemplateWorkflowCard
                 :source-module="selectedTab.moduleName"
                 :template="template"


### PR DESCRIPTION
The template cards' titles were previously clamped at 1 line to ensure all cards were the same height. However, it's causing too much confusion with certain titles that don't make sense when truncated/clamped. This PR ensures the original styling is maintained while increasing clamp to 2 lines.

The additional style changes are necessary to account for cases when a title cannot fill 2 lines and needs to be extended to have same height as other cards.

![Workspace 2_022](https://github.com/user-attachments/assets/cf447dfd-35c1-4003-b345-c425138f0d0a)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3722-Increase-template-card-titles-line-height-to-2-lines-1e66d73d36508180b675f52421ac2a5c) by [Unito](https://www.unito.io)
