### PR TITLE
[TS] Fix strict type on chain callback, widgetInput

### DIFF
--- a/src/composables/functional/useChainCallback.ts
+++ b/src/composables/functional/useChainCallback.ts
@@ -14,6 +14,6 @@ export const useChainCallback = <
 ) => {
   return function (this: O, ...args: Parameters<T>) {
     originalCallback?.call(this, ...args)
-    callbacks.forEach((callback) => callback.call(this, ...args))
+    for (const callback of callbacks) callback.call(this, ...args)
   }
 }

--- a/src/composables/functional/useChainCallback.ts
+++ b/src/composables/functional/useChainCallback.ts
@@ -1,4 +1,20 @@
 /**
+ * Shorthand for {@link Parameters} of optional callbacks.
+ *
+ * @example
+ * ```ts
+ * const { onClick } = CustomClass.prototype
+ * CustomClass.prototype.onClick = function (...args: CallbackParams<typeof onClick>) {
+ *   const r = onClick?.apply(this, args)
+ *   // ...
+ *   return r
+ * }
+ * ```
+ */
+export type CallbackParams<T extends ((...args: any) => any) | undefined> =
+  Parameters<Exclude<T, undefined>>
+
+/**
  * Chain multiple callbacks together.
  *
  * @param originalCallback - The original callback to chain.

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -569,9 +569,7 @@ app.registerExtension({
       this: LGraphNode,
       ...[slot, ...args]: CallbackParams<typeof origOnInputDblClick>
     ) {
-      const r = origOnInputDblClick
-        ? origOnInputDblClick.apply(this, [slot, ...args])
-        : undefined
+      const r = origOnInputDblClick?.apply(this, [slot, ...args])
 
       const input = this.inputs[slot]
       if (!input.widget) {

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -9,7 +9,10 @@ import type {
 } from '@comfyorg/litegraph'
 import type { CanvasMouseEvent } from '@comfyorg/litegraph/dist/types/events'
 
-import { useChainCallback } from '@/composables/functional/useChainCallback'
+import {
+  type CallbackParams,
+  useChainCallback
+} from '@/composables/functional/useChainCallback'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { ComfyWidgets, addValueControlWidgets } from '@/scripts/widgets'
@@ -564,11 +567,10 @@ app.registerExtension({
     const origOnInputDblClick = nodeType.prototype.onInputDblClick
     nodeType.prototype.onInputDblClick = function (
       this: LGraphNode,
-      slot: number
+      ...[slot, ...args]: CallbackParams<typeof origOnInputDblClick>
     ) {
       const r = origOnInputDblClick
-        ? // @ts-expect-error fixme ts strict error
-          origOnInputDblClick.apply(this, arguments)
+        ? origOnInputDblClick.apply(this, [slot, ...args])
         : undefined
 
       const input = this.inputs[slot]


### PR DESCRIPTION
- Removes `@ts-expect-error`
- Converts `.forEach` to `for..of`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3727-TS-Fix-strict-type-on-chain-callback-widgetInput-1e76d73d36508108b342f1c7154f574a) by [Unito](https://www.unito.io)
