### PR TITLE
Show warning toast when no items are selected

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -45,6 +45,7 @@
 
 <script setup lang="ts">
 import type { LGraphNode } from '@comfyorg/litegraph'
+import { useEventListener } from '@vueuse/core'
 import { computed, onMounted, ref, watch, watchEffect } from 'vue'
 
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
@@ -83,6 +84,7 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSettingStore } from '@/stores/settingStore'
+import { useToastStore } from '@/stores/toastStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
@@ -95,6 +97,7 @@ const nodeDefStore = useNodeDefStore()
 const workspaceStore = useWorkspaceStore()
 const canvasStore = useCanvasStore()
 const executionStore = useExecutionStore()
+const toastStore = useToastStore()
 const betaMenuEnabled = computed(
   () => settingStore.get('Comfy.UseNewMenu') !== 'Disabled'
 )
@@ -246,6 +249,19 @@ watch(
       delete extra.ds
     }
   }
+)
+
+useEventListener(
+  canvasRef,
+  'litegraph:no-items-selected',
+  () => {
+    toastStore.add({
+      severity: 'warn',
+      summary: 'No items selected',
+      life: 2000
+    })
+  },
+  { passive: true }
 )
 
 const loadCustomNodesI18n = async () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -755,6 +755,14 @@ export class ComfyApp {
     this.canvas.state = reactive(this.canvas.state)
     this.canvas.ds.state = reactive(this.canvas.ds.state)
 
+    canvasEl.addEventListener('litegraph:no-items-selected', () => {
+      useToastStore().add({
+        severity: 'warn',
+        summary: 'No items selected',
+        life: 2000
+      })
+    })
+
     // @ts-expect-error fixme ts strict error
     this.ctx = canvasEl.getContext('2d')
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -755,14 +755,6 @@ export class ComfyApp {
     this.canvas.state = reactive(this.canvas.state)
     this.canvas.ds.state = reactive(this.canvas.ds.state)
 
-    canvasEl.addEventListener('litegraph:no-items-selected', () => {
-      useToastStore().add({
-        severity: 'warn',
-        summary: 'No items selected',
-        life: 2000
-      })
-    })
-
     // @ts-expect-error fixme ts strict error
     this.ctx = canvasEl.getContext('2d')
 


### PR DESCRIPTION
Pressing delete with no items selected shows a toast:

![image](https://github.com/user-attachments/assets/a6d997ea-0ea9-4680-9fca-8dd612bb9bc5)

Intended as an immediate response to any actual user interaction (keyboard, mouse).  A generic message works perfectly, as the user already has context.

- Requires https://github.com/Comfy-Org/litegraph.js/pull/1004
- Can be merged ahead of time with no impact