### PR TITLE
[Desktop] Fix Server-Config panel does not load

### DIFF
--- a/src/composables/setting/useSettingUI.ts
+++ b/src/composables/setting/useSettingUI.ts
@@ -132,7 +132,8 @@ export function useSettingUI(
       creditsPanel,
       userPanel,
       keybindingPanel,
-      extensionPanel
+      extensionPanel,
+      ...(isElectron() ? [serverConfigPanel] : [])
     ].filter((panel) => panel.component)
   )
 


### PR DESCRIPTION
- Resolves https://github.com/Comfy-Org/desktop/issues/1141

Settings in Desktop w/Frontend >=1.18.1:

![image](https://github.com/user-attachments/assets/98531266-bee8-4272-8ba8-e131356a15eb)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3743-Desktop-Fix-Server-Config-panel-does-not-load-1e86d73d365081009db3d5e63bddebff) by [Unito](https://www.unito.io)
