### PR TITLE
[Bug] Remove default dialog close button on news dialog

### DIFF
--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -399,6 +399,7 @@ export const useDialogService = () => {
         }
       },
       dialogComponentProps: {
+        closable: false,
         modal: false,
         position: 'bottomright'
       }


### PR DESCRIPTION
Remove the default `x` button on the top, as it won't set localStorage, and is extra noise to user. User is supposed to close/dismiss the dialog by clicking the blue `Close` button.

![image](https://github.com/user-attachments/assets/cf85529e-ee15-48e5-b78d-2138b7d2a8e0)
