### PR TITLE
Prevent node tooltip from breaking pan & zoom

### DIFF
--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -131,6 +131,7 @@ useEventListener(window, 'click', hideTooltip)
 
 <style lang="css" scoped>
 .node-tooltip {
+  pointer-events: none;
   background: var(--comfy-input-bg);
   border-radius: 5px;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
### Current

A tooltip that opens under the pointer will block the next click from registering.  This is particularly frustrating for middle-mouse panning; as the pointerdown event never reaches the canvas, the entire click and drag is ignored.

### Proposed

All pointer events through directly node tooltips to whatever is below.  The component watches events on `window`, so the normal `pointer-events: none` caveats are not relevant to the current impl.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3760-Prevent-node-tooltip-from-breaking-pan-zoom-1ea6d73d365081a08734d6f744fc8f96) by [Unito](https://www.unito.io)
