### PR TITLE
Fix: latent preview format is read from wrong byte of header

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -381,7 +381,7 @@ export class ComfyApi extends EventTarget {
           const view = new DataView(event.data)
           const eventType = view.getUint32(0)
           const imageType = view.getUint32(4)
-          const buffer = event.data.slice(4)
+          const imageData = event.data.slice(8)
 
           let imageMime
           switch (eventType) {
@@ -395,7 +395,7 @@ export class ComfyApi extends EventTarget {
                   imageMime = 'image/jpeg'
                   break
               }
-              const imageBlob = new Blob([buffer.slice(4)], {
+              const imageBlob = new Blob([imageData], {
                 type: imageMime
               })
               this.dispatchCustomEvent('b_preview', imageBlob)

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -84,7 +84,7 @@ interface BackendApiCalls {
   execution_interrupted: ExecutionInterruptedWsMessage
   execution_cached: ExecutionCachedWsMessage
   logs: LogsWsMessage
-  /** Mr Blob Preview, I presume? */
+  /** Binary preview/progress data */
   b_preview: Blob
 }
 
@@ -380,19 +380,20 @@ export class ComfyApi extends EventTarget {
         if (event.data instanceof ArrayBuffer) {
           const view = new DataView(event.data)
           const eventType = view.getUint32(0)
+          const imageType = view.getUint32(4)
           const buffer = event.data.slice(4)
+
+          let imageMime
           switch (eventType) {
             case 1:
-              const view2 = new DataView(event.data)
-              const imageType = view2.getUint32(0)
-              let imageMime
               switch (imageType) {
+                case 2:
+                  imageMime = 'image/png'
+                  break
                 case 1:
                 default:
                   imageMime = 'image/jpeg'
                   break
-                case 2:
-                  imageMime = 'image/png'
               }
               const imageBlob = new Blob([buffer.slice(4)], {
                 type: imageMime


### PR DESCRIPTION
Fixes parsing image type from binary preview messages. Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/3545

Preview image headers follow format:

```
[ First 4 bytes: event type ] [ Next 4 bytes: image format ] [ Remaining bytes: image data ]
```

The code currently reads event type and image format from the same dword, which is obviously wrong.

To verify, you can repro a bug by doing:

1. Change [this code](https://github.com/Comfy-Org/ComfyUI-private/blob/master/latent_preview.py#L92) to send png images as latent previews
2. Start ComfyUI and specify a preview method like `--preview-method taesd`
3. Open the default workflow, replace the `SaveImage` node with a `SaveImageWebSocket` node
4. Open Network panel, go to `WS`, find the binary event messages and read the header in hex editor. Or just right click on the preview images and try to save and see the file extension


### Background

Process for sending latent previews from the server:

1. `latent_preview.py` module decodes latent using user's specified preview-method then adds the decoded latent and its format into message queue using [`send_sync`](https://github.com/Comfy-Org/ComfyUI-private/blob/master/server.py#L820-L822)
5. [`hijack_progress`](https://github.com/Comfy-Org/ComfyUI-private/blob/master/main.py#L229-L239) processes the message and adds back to queue, specifying the message type (binary unencoded preview)
6. [`publish_loop`](https://github.com/Comfy-Org/ComfyUI-private/blob/master/server.py#L827-L830) pops message and passes to `PromptServer`'s [`send`](https://github.com/Comfy-Org/ComfyUI-private/blob/master/server.py#L759-L761) which checks that the message is of type `BinaryEventTypes.UNENCODED_PREVIEW_IMAGE` and then passes the message to [`send_image`](https://github.com/Comfy-Org/ComfyUI-private/blob/master/server.py#L776-L798), which prepends a dword to the data to indicate the type (1 = jpeg, 2 = png).
7. `send_image` encodes the image in the given format using PIL then calls [`send_bytes`](https://github.com/Comfy-Org/ComfyUI-private/blob/master/server.py#L800-L808) which [prepends another dword indicating the event type](https://github.com/Comfy-Org/ComfyUI-private/blob/master/server.py#L767-L774) (in this case, `1` to denote `BinaryEventTypes.PREVIEW_IMAGE`
8. `send_bytes` sends the data to all attached WS sockets

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3761-Fix-latent-preview-format-is-read-from-wrong-byte-of-header-1ea6d73d3650817ba58ecc70e9b5f0e9) by [Unito](https://www.unito.io)
