### PR TITLE
Fix execution error message overflowing out of screen

### DIFF
--- a/src/components/common/NoResultsPlaceholder.vue
+++ b/src/components/common/NoResultsPlaceholder.vue
@@ -5,7 +5,7 @@
         <div class="flex flex-col items-center">
           <i :class="icon" style="font-size: 3rem; margin-bottom: 1rem" />
           <h3>{{ title }}</h3>
-          <p class="whitespace-pre-line text-center">
+          <p :class="textClass" class="whitespace-pre-line text-center">
             {{ message }}
           </p>
           <Button
@@ -29,6 +29,7 @@ const props = defineProps<{
   icon?: string
   title: string
   message: string
+  textClass?: string
   buttonLabel?: string
 }>()
 

--- a/src/components/dialog/content/ErrorDialogContent.vue
+++ b/src/components/dialog/content/ErrorDialogContent.vue
@@ -5,6 +5,7 @@
       icon="pi pi-exclamation-circle"
       :title="title"
       :message="error.exceptionMessage"
+      :text-class="'break-words max-w-[60vw]'"
     />
     <template v-if="error.extensionFile">
       <span>{{ t('errorDialog.extensionFileHint') }}:</span>


### PR DESCRIPTION
Before:

![Selection_1311](https://github.com/user-attachments/assets/393c362e-7e52-4e51-97c4-6a0d1a27e1ea)

After:

![Selection_1310](https://github.com/user-attachments/assets/bef2396f-1a60-4f5a-ac96-6dcd794309af)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3762-Fix-execution-error-message-overflowing-out-of-screen-1ea6d73d3650816aa804de475eb4e299) by [Unito](https://www.unito.io)
