### PR TITLE
[API Node] Sort API templates by localized display name

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -532,6 +532,32 @@
         "wan2_1_fun_inp": "Wan 2.1 Inpainting",
         "wan2_1_fun_control": "Wan 2.1 ControlNet"
       },
+      "Image API": {
+        "api_openai_image_1_t2i": "OpenAI Image-1 Text to Image",
+        "api_openai_image_1_i2i": "OpenAI Image-1 Image to Image",
+        "api_openai_image_1_inpaint": "OpenAI Image-1 Inpaint",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1 Multi Inputs",
+        "api-openai-dall-e-2-t2i": "Dall-E 2 Text to Image",
+        "api-openai-dall-e-2-inpaint": "Dall-E 2 Inpaint",
+        "api-openai-dall-e-3-t2i": "Dall-E 3 Text to Image",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro] Text to Image",
+        "api_stability_sd3_t2i": "Stability SD3 Text to Image",
+        "api_ideogram_v3_t2i": "Ideogram V3 Text to Image",
+        "api_luma_photon_i2i": "Luma Photon Image to Image",
+        "api_luma_photon_style_ref": "Luma Photon Style Reference",
+        "api_recraft_image_gen_with_color_control": "Recraft Color Control Image Generation",
+        "api_recraft_image_gen_with_style_control": "Recraft Style Control Image Generation",
+        "api_recraft_vector_gen": "Recraft Vector Generation"
+      },
+      "Video API": {
+        "api_luma_i2v": "Luma Image to Video",
+        "api_kling_i2v": "Kling Image to Video",
+        "api_veo2_i2v": "Veo2 Image to Video",
+        "api_hailuo_minimax_i2v": "MiniMax Image to Video",
+        "api_pika_scene": "Pika Scenes: Images to Video",
+        "api_pixverse_template_i2v": "PixVerse Templates: Image to Video",
+        "api_pixverse_t2v": "PixVerse Text to Video"
+      },
       "Image": {
         "sd3_5_simple_example": "SD3.5 Simple",
         "sd3_5_large_canny_controlnet_example": "SD3.5 Large Canny ControlNet",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -1120,6 +1120,23 @@
         "sdxl_simple_example": "SDXL Simple",
         "sdxlturbo_example": "SDXL Turbo"
       },
+      "Image API": {
+        "api-openai-dall-e-2-inpaint": "Dall-E 2 Rellenar",
+        "api-openai-dall-e-2-t2i": "Dall-E 2 Texto a Imagen",
+        "api-openai-dall-e-3-t2i": "Dall-E 3 Texto a Imagen",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro] Texto a Imagen",
+        "api_ideogram_v3_t2i": "Ideogram V3 Texto a Imagen",
+        "api_luma_photon_i2i": "Luma Photon Imagen a Imagen",
+        "api_luma_photon_style_ref": "Luma Photon Referencia de Estilo",
+        "api_openai_image_1_i2i": "OpenAI Image-1 Imagen a Imagen",
+        "api_openai_image_1_inpaint": "OpenAI Image-1 Rellenar",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1 Múltiples Entradas",
+        "api_openai_image_1_t2i": "OpenAI Image-1 Texto a Imagen",
+        "api_recraft_image_gen_with_color_control": "Recraft Generación de Imagen con Control de Color",
+        "api_recraft_image_gen_with_style_control": "Recraft Generación de Imagen con Control de Estilo",
+        "api_recraft_vector_gen": "Recraft Generación de Vectores",
+        "api_stability_sd3_t2i": "Stability SD3 Texto a Imagen"
+      },
       "Upscaling": {
         "esrgan_example": "ESRGAN",
         "hiresfix_esrgan_workflow": "Flujo de Trabajo HiresFix ESRGAN",
@@ -1137,6 +1154,15 @@
         "txt_to_image_to_video": "SVD Texto a Imagen a Video",
         "wan2_1_fun_control": "Wan 2.1 ControlNet",
         "wan2_1_fun_inp": "Wan 2.1 Relleno"
+      },
+      "Video API": {
+        "api_hailuo_minimax_i2v": "MiniMax Imagen a Video",
+        "api_kling_i2v": "Kling Imagen a Video",
+        "api_luma_i2v": "Luma Imagen a Video",
+        "api_pika_scene": "Pika Escenas: Imágenes a Video",
+        "api_pixverse_t2v": "PixVerse Texto a Video",
+        "api_pixverse_template_i2v": "PixVerse Plantillas: Imagen a Video",
+        "api_veo2_i2v": "Veo2 Imagen a Video"
       }
     },
     "title": "Comienza con una Plantilla"

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -1120,6 +1120,23 @@
         "sdxl_simple_example": "SDXL Simple",
         "sdxlturbo_example": "SDXL Turbo"
       },
+      "Image API": {
+        "api-openai-dall-e-2-inpaint": "Dall-E 2 Inpainting",
+        "api-openai-dall-e-2-t2i": "Dall-E 2 Texte vers Image",
+        "api-openai-dall-e-3-t2i": "Dall-E 3 Texte vers Image",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro] Texte vers Image",
+        "api_ideogram_v3_t2i": "Ideogram V3 Texte vers Image",
+        "api_luma_photon_i2i": "Luma Photon Image vers Image",
+        "api_luma_photon_style_ref": "Luma Photon Référence de Style",
+        "api_openai_image_1_i2i": "OpenAI Image-1 Image vers Image",
+        "api_openai_image_1_inpaint": "OpenAI Image-1 Inpainting",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1 Entrées Multiples",
+        "api_openai_image_1_t2i": "OpenAI Image-1 Texte vers Image",
+        "api_recraft_image_gen_with_color_control": "Recraft Génération d’Image avec Contrôle des Couleurs",
+        "api_recraft_image_gen_with_style_control": "Recraft Génération d’Image avec Contrôle du Style",
+        "api_recraft_vector_gen": "Recraft Génération de Vecteur",
+        "api_stability_sd3_t2i": "Stability SD3 Texte vers Image"
+      },
       "Upscaling": {
         "esrgan_example": "ESRGAN",
         "hiresfix_esrgan_workflow": "Flux de Travail ESRGAN HiresFix",
@@ -1137,6 +1154,15 @@
         "txt_to_image_to_video": "Texte à Image à Vidéo",
         "wan2_1_fun_control": "Wan 2.1 ControlNet",
         "wan2_1_fun_inp": "Wan 2.1 Inpainting"
+      },
+      "Video API": {
+        "api_hailuo_minimax_i2v": "MiniMax Image vers Vidéo",
+        "api_kling_i2v": "Kling Image vers Vidéo",
+        "api_luma_i2v": "Luma Image vers Vidéo",
+        "api_pika_scene": "Pika Scènes : Images vers Vidéo",
+        "api_pixverse_t2v": "PixVerse Texte vers Vidéo",
+        "api_pixverse_template_i2v": "PixVerse Modèles : Image vers Vidéo",
+        "api_veo2_i2v": "Veo2 Image vers Vidéo"
       }
     },
     "title": "Commencez avec un modèle"

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -1120,6 +1120,23 @@
         "sdxl_simple_example": "SDXLシンプル",
         "sdxlturbo_example": "SDXLターボ"
       },
+      "Image API": {
+        "api-openai-dall-e-2-inpaint": "Dall-E 2 インペイント",
+        "api-openai-dall-e-2-t2i": "Dall-E 2 テキストから画像へ",
+        "api-openai-dall-e-3-t2i": "Dall-E 3 テキストから画像へ",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro] テキストから画像へ",
+        "api_ideogram_v3_t2i": "Ideogram V3 テキストから画像へ",
+        "api_luma_photon_i2i": "Luma Photon 画像から画像へ",
+        "api_luma_photon_style_ref": "Luma Photon スタイル参照",
+        "api_openai_image_1_i2i": "OpenAI Image-1 画像から画像へ",
+        "api_openai_image_1_inpaint": "OpenAI Image-1 インペイント",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1 複数入力",
+        "api_openai_image_1_t2i": "OpenAI Image-1 テキストから画像へ",
+        "api_recraft_image_gen_with_color_control": "Recraft カラーコントロール画像生成",
+        "api_recraft_image_gen_with_style_control": "Recraft スタイルコントロール画像生成",
+        "api_recraft_vector_gen": "Recraft ベクター生成",
+        "api_stability_sd3_t2i": "Stability SD3 テキストから画像へ"
+      },
       "Upscaling": {
         "esrgan_example": "ESRGAN",
         "hiresfix_esrgan_workflow": "HiresFix ESRGANワークフロー",
@@ -1137,6 +1154,15 @@
         "txt_to_image_to_video": "テキストから画像へ、画像からビデオへ",
         "wan2_1_fun_control": "Wan 2.1 ControlNet",
         "wan2_1_fun_inp": "Wan 2.1 インペインティング"
+      },
+      "Video API": {
+        "api_hailuo_minimax_i2v": "MiniMax 画像から動画へ",
+        "api_kling_i2v": "Kling 画像から動画へ",
+        "api_luma_i2v": "Luma 画像から動画へ",
+        "api_pika_scene": "Pika シーン: 画像から動画へ",
+        "api_pixverse_t2v": "PixVerse テキストから動画へ",
+        "api_pixverse_template_i2v": "PixVerse テンプレート: 画像から動画へ",
+        "api_veo2_i2v": "Veo2 画像から動画へ"
       }
     },
     "title": "テンプレートを利用して開始"

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1120,6 +1120,23 @@
         "sdxl_simple_example": "간단한 SDXL 예제",
         "sdxlturbo_example": "SDXL 터보"
       },
+      "Image API": {
+        "api-openai-dall-e-2-inpaint": "Dall-E 2 인페인트",
+        "api-openai-dall-e-2-t2i": "Dall-E 2 텍스트 투 이미지",
+        "api-openai-dall-e-3-t2i": "Dall-E 3 텍스트 투 이미지",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro] 텍스트 투 이미지",
+        "api_ideogram_v3_t2i": "Ideogram V3 텍스트 투 이미지",
+        "api_luma_photon_i2i": "Luma Photon 이미지 투 이미지",
+        "api_luma_photon_style_ref": "Luma Photon 스타일 참조",
+        "api_openai_image_1_i2i": "OpenAI Image-1 이미지 투 이미지",
+        "api_openai_image_1_inpaint": "OpenAI Image-1 인페인트",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1 멀티 입력",
+        "api_openai_image_1_t2i": "OpenAI Image-1 텍스트 투 이미지",
+        "api_recraft_image_gen_with_color_control": "Recraft 색상 제어 이미지 생성",
+        "api_recraft_image_gen_with_style_control": "Recraft 스타일 제어 이미지 생성",
+        "api_recraft_vector_gen": "Recraft 벡터 생성",
+        "api_stability_sd3_t2i": "Stability SD3 텍스트 투 이미지"
+      },
       "Upscaling": {
         "esrgan_example": "ESRGAN",
         "hiresfix_esrgan_workflow": "HiresFix ESRGAN 워크플로우",
@@ -1137,6 +1154,15 @@
         "txt_to_image_to_video": "텍스트 -> 이미지 -> 동영상",
         "wan2_1_fun_control": "Wan 2.1 컨트롤넷",
         "wan2_1_fun_inp": "Wan 2.1 인페인트"
+      },
+      "Video API": {
+        "api_hailuo_minimax_i2v": "MiniMax 이미지 투 비디오",
+        "api_kling_i2v": "Kling 이미지 투 비디오",
+        "api_luma_i2v": "Luma 이미지 투 비디오",
+        "api_pika_scene": "Pika 장면: 이미지 투 비디오",
+        "api_pixverse_t2v": "PixVerse 텍스트 투 비디오",
+        "api_pixverse_template_i2v": "PixVerse 템플릿: 이미지 투 비디오",
+        "api_veo2_i2v": "Veo2 이미지 투 비디오"
       }
     },
     "title": "템플릿으로 시작하기"

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -1120,6 +1120,23 @@
         "sdxl_simple_example": "SDXL Простой",
         "sdxlturbo_example": "SDXL Turbo"
       },
+      "Image API": {
+        "api-openai-dall-e-2-inpaint": "Dall-E 2: дорисовка",
+        "api-openai-dall-e-2-t2i": "Dall-E 2: текст в изображение",
+        "api-openai-dall-e-3-t2i": "Dall-E 3: текст в изображение",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro]: текст в изображение",
+        "api_ideogram_v3_t2i": "Ideogram V3: текст в изображение",
+        "api_luma_photon_i2i": "Luma Photon: изображение в изображение",
+        "api_luma_photon_style_ref": "Luma Photon: стиль по образцу",
+        "api_openai_image_1_i2i": "OpenAI Image-1: изображение в изображение",
+        "api_openai_image_1_inpaint": "OpenAI Image-1: дорисовка",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1: несколько входов",
+        "api_openai_image_1_t2i": "OpenAI Image-1: текст в изображение",
+        "api_recraft_image_gen_with_color_control": "Recraft: генерация изображения с управлением цветом",
+        "api_recraft_image_gen_with_style_control": "Recraft: генерация изображения с управлением стилем",
+        "api_recraft_vector_gen": "Recraft: генерация векторного изображения",
+        "api_stability_sd3_t2i": "Stability SD3: текст в изображение"
+      },
       "Upscaling": {
         "esrgan_example": "ESRGAN",
         "hiresfix_esrgan_workflow": "HiresFix ESRGAN Workflow",
@@ -1137,6 +1154,15 @@
         "txt_to_image_to_video": "Текст в изображение в видео",
         "wan2_1_fun_control": "Wan 2.1 ControlNet",
         "wan2_1_fun_inp": "Wan 2.1 Inpainting"
+      },
+      "Video API": {
+        "api_hailuo_minimax_i2v": "MiniMax: изображение в видео",
+        "api_kling_i2v": "Kling: изображение в видео",
+        "api_luma_i2v": "Luma: изображение в видео",
+        "api_pika_scene": "Pika Scenes: изображения в видео",
+        "api_pixverse_t2v": "PixVerse: текст в видео",
+        "api_pixverse_template_i2v": "PixVerse Templates: изображение в видео",
+        "api_veo2_i2v": "Veo2: изображение в видео"
       }
     },
     "title": "Начните с шаблона"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1120,6 +1120,23 @@
         "sdxl_simple_example": "SDXL简单",
         "sdxlturbo_example": "SDXL Turbo"
       },
+      "Image API": {
+        "api-openai-dall-e-2-inpaint": "Dall-E 2 局部修复",
+        "api-openai-dall-e-2-t2i": "Dall-E 2 文生图",
+        "api-openai-dall-e-3-t2i": "Dall-E 3 文生图",
+        "api_bfl_flux_pro_t2i": "BFL Flux[Pro] 文生图",
+        "api_ideogram_v3_t2i": "Ideogram V3 文生图",
+        "api_luma_photon_i2i": "Luma Photon 图生图",
+        "api_luma_photon_style_ref": "Luma Photon 风格参考",
+        "api_openai_image_1_i2i": "OpenAI Image-1 图生图",
+        "api_openai_image_1_inpaint": "OpenAI Image-1 局部修复",
+        "api_openai_image_1_multi_inputs": "OpenAI Image-1 多输入",
+        "api_openai_image_1_t2i": "OpenAI Image-1 文生图",
+        "api_recraft_image_gen_with_color_control": "Recraft 颜色控制图像生成",
+        "api_recraft_image_gen_with_style_control": "Recraft 风格控制图像生成",
+        "api_recraft_vector_gen": "Recraft 矢量生成",
+        "api_stability_sd3_t2i": "Stability SD3 文生图"
+      },
       "Upscaling": {
         "esrgan_example": "ESRGAN",
         "hiresfix_esrgan_workflow": "HiresFix ESRGAN工作流",
@@ -1137,6 +1154,15 @@
         "txt_to_image_to_video": "文本到图像到视频",
         "wan2_1_fun_control": "Wan 2.1 ControlNet",
         "wan2_1_fun_inp": "Wan 2.1 图像修复"
+      },
+      "Video API": {
+        "api_hailuo_minimax_i2v": "MiniMax 图生视频",
+        "api_kling_i2v": "Kling 图生视频",
+        "api_luma_i2v": "Luma 图生视频",
+        "api_pika_scene": "Pika 场景：图转视频",
+        "api_pixverse_t2v": "PixVerse 文转视频",
+        "api_pixverse_template_i2v": "PixVerse 模板：图转视频",
+        "api_veo2_i2v": "Veo2 图生视频"
       }
     },
     "title": "从模板开始"

--- a/src/stores/workflowTemplatesStore.ts
+++ b/src/stores/workflowTemplatesStore.ts
@@ -27,10 +27,20 @@ export const useWorkflowTemplatesStore = defineStore(
     const isLoaded = ref(false)
 
     /**
-     * Sort a list of templates in alphabetical order by name.
+     * Sort a list of templates in alphabetical order by localized display name.
      */
     const sortTemplateList = (templates: TemplateInfo[]) =>
-      templates.sort((a, b) => a.name.localeCompare(b.name))
+      templates.sort((a, b) => {
+        const aName = st(
+          `templateWorkflows.name.${normalizeI18nKey(a.name)}`,
+          a.title ?? a.name
+        )
+        const bName = st(
+          `templateWorkflows.name.${normalizeI18nKey(b.name)}`,
+          b.name
+        )
+        return aName.localeCompare(bName)
+      })
 
     /**
      * Sort any template categories (grouped templates) that should be sorted.


### PR DESCRIPTION
Currently, API templates are sorted alphabetically to prevent favoritism/bias. However, they need to sorted by display name rather than key name. Otherwise, there could be discrepancies between display name sorting and keyname sorting result -- and the fact that they are alphabetically sorted would no longer come through in the UI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3765-API-Node-Sort-API-templates-by-localized-display-name-1ea6d73d365081b1858fcc09674eeef4) by [Unito](https://www.unito.io)
