### PR TITLE
[API Nodes] Apply yellow color to api nodes by default

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -62,9 +62,6 @@ export const useLitegraphService = () => {
       static override category: string
       static nodeData: ComfyNodeDefV1 & ComfyNodeDefV2
 
-      declare color?: string
-      declare bgcolor?: string
-
       /**
        * @internal The initial minimum size of the node.
        */

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -1,5 +1,6 @@
 import {
   type IContextMenuValue,
+  LGraphCanvas,
   LGraphEventMode,
   LGraphNode,
   LiteGraph,
@@ -61,6 +62,9 @@ export const useLitegraphService = () => {
       static override category: string
       static nodeData: ComfyNodeDefV1 & ComfyNodeDefV2
 
+      declare color?: string
+      declare bgcolor?: string
+
       /**
        * @internal The initial minimum size of the node.
        */
@@ -79,6 +83,13 @@ export const useLitegraphService = () => {
         this.#addOutputs(ComfyNode.nodeData.outputs)
         this.#setInitialSize()
         this.serialize_widgets = true
+
+        // Mark API Nodes yellow by default to distinguish with other nodes.
+        if (ComfyNode.nodeData.api_node) {
+          this.color = LGraphCanvas.node_colors.yellow.color
+          this.bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
+        }
+
         void extensionService.invokeExtensionsAsync('nodeCreated', this)
       }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0165b5d1-2b4d-4c41-a824-c6b0999e0d9a)

Apply color to better distinguish API nodes and normal nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3766-API-Nodes-Apply-yellow-color-to-api-nodes-by-default-1ea6d73d3650813f8e71dcaa62ddb798) by [Unito](https://www.unito.io)
