### PR TITLE
[API Nodes] Add cost badge for api nodes

### DIFF
--- a/src/components/graph/NodeBadge.vue
+++ b/src/components/graph/NodeBadge.vue
@@ -83,6 +83,29 @@ onMounted(() => {
       })
 
       node.badges.push(() => badge.value)
+
+      if (node.constructor.nodeData?.api_node) {
+        const creditsBadge = computed(() => {
+          return new LGraphBadge({
+            text: '',
+            iconOptions: {
+              unicode: '\ue96b',
+              fontFamily: 'PrimeIcons',
+              color: '#FABC25',
+              bgColor: '#353535',
+              fontSize: 8
+            },
+            fgColor:
+              colorPaletteStore.completedActivePalette.colors.litegraph_base
+                .BADGE_FG_COLOR,
+            bgColor:
+              colorPaletteStore.completedActivePalette.colors.litegraph_base
+                .BADGE_BG_COLOR
+          })
+        })
+
+        node.badges.push(() => creditsBadge.value)
+      }
     }
   })
 })

--- a/src/components/graph/NodeBadge.vue
+++ b/src/components/graph/NodeBadge.vue
@@ -5,9 +5,11 @@
 </template>
 
 <script setup lang="ts">
-import type { LGraphNode } from '@comfyorg/litegraph'
-import { BadgePosition } from '@comfyorg/litegraph'
-import { LGraphBadge } from '@comfyorg/litegraph'
+import {
+  BadgePosition,
+  LGraphBadge,
+  type LGraphNode
+} from '@comfyorg/litegraph'
 import _ from 'lodash'
 import { computed, onMounted, watch } from 'vue'
 


### PR DESCRIPTION
Replaces https://github.com/Comfy-Org/ComfyUI_frontend/pull/3470

Show cost icon on the node. We will add cost estimation there once the cost becomes available.

![image](https://github.com/user-attachments/assets/a07245a7-6286-4b7c-b830-e57cc3f58a84)
![image](https://github.com/user-attachments/assets/2ea4e125-4e9b-4708-b8c0-002e9deb467c)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3768-API-Nodes-Add-cost-badge-for-api-nodes-1ea6d73d36508191bb55cec8a03aab3a) by [Unito](https://www.unito.io)
