### PR TITLE
Allow disabling proxy of `/template` path via env

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -18,3 +18,10 @@ TEST_COMFYUI_DIR=/home/ComfyUI
 
 # Whether to enable minification of the frontend code.
 ENABLE_MINIFY=true
+
+# Whether to disable proxying the `/templates` route. If true, allows you to 
+# serve templates from the ComfyUI_frontend/public/templates folder (for 
+# locally testing changes to templates). When false or nonexistent, the 
+# templates are served via the normal method from the server's python site 
+# packages.
+DISABLE_TEMPLATES_PROXY=false

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -18,6 +18,7 @@ const IS_DEV = process.env.NODE_ENV === 'development'
 const SHOULD_MINIFY = process.env.ENABLE_MINIFY === 'true'
 // vite dev server will listen on all addresses, including LAN and public addresses
 const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
+const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 
 const DEV_SERVER_COMFYUI_URL =
   process.env.DEV_SERVER_COMFYUI_URL || 'http://127.0.0.1:8188'
@@ -52,9 +53,13 @@ export default defineConfig({
         target: DEV_SERVER_COMFYUI_URL
       },
 
-      '/templates': {
-        target: DEV_SERVER_COMFYUI_URL
-      },
+      ...(!DISABLE_TEMPLATES_PROXY
+        ? {
+            '/templates': {
+              target: DEV_SERVER_COMFYUI_URL
+            }
+          }
+        : {}),
 
       '/testsubrouteindex': {
         target: 'http://localhost:5173',


### PR DESCRIPTION
In https://github.com/Comfy-Org/ComfyUI_frontend/pull/3710, the `/templates` route is proxied, which is good because it allows testing templates component changes while using frontend dev server. This PR adds env var to allow disabling the proxy in the case that you need to test changes to templates locally (changes made to the static template files themselves, rather than a ComfyUI_frontend component that handles the templates) and find it difficult to locate the python site package where they are located. 

This is needed as there are numerous people who edit the templates with varying OS and programming skills.