### PR TITLE
Drag-and-drop functionality for text in HTML <textarea> tag

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -441,6 +441,9 @@ export class ComfyApp {
     // Get prompt from dropped PNG or json
     document.addEventListener('drop', async (event) => {
       try {
+        // It does not disable the drag and drop of the text within TextArea.
+        if (event.target && event.target.type === 'textarea') return
+        
         event.preventDefault()
         event.stopPropagation()
 


### PR DESCRIPTION
This code enables drag-and-drop functionality for text within a <textarea> element.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3776-Drag-and-drop-functionality-for-text-in-HTML-textarea-tag-1eb6d73d365081e59edffa3a52394780) by [Unito](https://www.unito.io)
