### PR TITLE
[Auth] Allow user select google account on login

### DIFF
--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -56,6 +56,9 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
 
   // Providers
   const googleProvider = new GoogleAuthProvider()
+  googleProvider.setCustomParameters({
+    prompt: 'select_account'
+  })
   const githubProvider = new GithubAuthProvider()
 
   // Getters

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -52,7 +52,9 @@ vi.mock('firebase/auth', () => ({
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
   signInWithPopup: vi.fn(),
-  GoogleAuthProvider: vi.fn(),
+  GoogleAuthProvider: class {
+    setCustomParameters = vi.fn()
+  },
   GithubAuthProvider: vi.fn(),
   browserLocalPersistence: 'browserLocalPersistence',
   setPersistence: vi.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
When login, currently we directly choose the active google account even when multiple accounts are available. This PR chagnes the behaviour to always prompt user to select google account on login.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3777-Auth-Allow-user-select-google-account-on-login-1eb6d73d3650813f800fdf0a15be570e) by [Unito](https://www.unito.io)
