### PR TITLE
[3d] some improvement for load3d recording video

### DIFF
--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -28,6 +28,7 @@
       @background-image-change="listenBackgroundImageChange"
       @up-direction-change="listenUpDirectionChange"
       @edge-threshold-change="listenEdgeThresholdChange"
+      @recording-status-change="listenRecordingStatusChange"
     />
     <Load3DControls
       :input-spec="inputSpec"
@@ -287,6 +288,15 @@ const listenUpDirectionChange = (value: UpDirection) => {
 
 const listenEdgeThresholdChange = (value: number) => {
   edgeThreshold.value = value
+}
+
+const listenRecordingStatusChange = (value: boolean) => {
+  isRecording.value = value
+
+  if (!value && load3DSceneRef.value?.load3d) {
+    hasRecording.value = true
+    recordingDuration.value = load3DSceneRef.value.load3d.getRecordingDuration()
+  }
 }
 
 const listenBackgroundColorChange = (value: string) => {

--- a/src/components/load3d/Load3DScene.vue
+++ b/src/components/load3d/Load3DScene.vue
@@ -68,7 +68,9 @@ const eventConfig = {
   },
   textureLoadingStart: () =>
     loadingOverlayRef.value?.startLoading(t('load3d.applyingTexture')),
-  textureLoadingEnd: () => loadingOverlayRef.value?.endLoading()
+  textureLoadingEnd: () => loadingOverlayRef.value?.endLoading(),
+  recordingStatusChange: (value: boolean) =>
+    emit('recordingStatusChange', value)
 } as const
 
 watchEffect(async () => {
@@ -120,6 +122,7 @@ const emit = defineEmits<{
   (e: 'backgroundImageChange', backgroundImage: string): void
   (e: 'upDirectionChange', upDirection: string): void
   (e: 'edgeThresholdChange', threshold: number): void
+  (e: 'recordingStatusChange', status: boolean): void
 }>()
 
 const handleEvents = (action: 'add' | 'remove') => {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -456,6 +456,8 @@ class Load3d {
     this.viewHelperManager.visibleViewHelper(true)
 
     this.recordingManager.stopRecording()
+
+    this.eventManager.emitEvent('recordingStatusChange', false)
   }
 
   public isRecording(): boolean {


### PR DESCRIPTION
some improvments for load3d recording video:
1. improve resize function
2. blinking recording button when recording is in progress
3. emit event if run workflow when recording is in progress

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3794-3d-some-improvement-for-load3d-recording-video-1ec6d73d365081ebaff3e6a8b2811405) by [Unito](https://www.unito.io)
