### PR TITLE
[3d] add record video support for load3d animation node

### DIFF
--- a/src/components/load3d/Load3DAnimationScene.vue
+++ b/src/components/load3d/Load3DAnimationScene.vue
@@ -20,6 +20,7 @@
     @camera-type-change="listenCameraTypeChange"
     @show-grid-change="listenShowGridChange"
     @show-preview-change="listenShowPreviewChange"
+    @recording-status-change="listenRecordingStatusChange"
   />
 </template>
 <script setup lang="ts">
@@ -148,6 +149,15 @@ watch(
 
 const emit = defineEmits<{
   (e: 'animationListChange', animationList: string): void
+  (e: 'materialModeChange', materialMode: string): void
+  (e: 'backgroundColorChange', color: string): void
+  (e: 'lightIntensityChange', lightIntensity: number): void
+  (e: 'fovChange', fov: number): void
+  (e: 'cameraTypeChange', cameraType: string): void
+  (e: 'showGridChange', showGrid: boolean): void
+  (e: 'showPreviewChange', showPreview: boolean): void
+  (e: 'upDirectionChange', direction: string): void
+  (e: 'recording-status-change', status: boolean): void
 }>()
 
 const listenMaterialModeChange = (mode: MaterialMode) => {
@@ -180,6 +190,10 @@ const listenShowGridChange = (value: boolean) => {
 
 const listenShowPreviewChange = (value: boolean) => {
   showPreview.value = value
+}
+
+const listenRecordingStatusChange = (value: boolean) => {
+  emit('recording-status-change', value)
 }
 
 const animationListeners = {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -229,6 +229,7 @@ class Load3d {
     return (
       this.STATUS_MOUSE_ON_NODE ||
       this.STATUS_MOUSE_ON_SCENE ||
+      this.isRecording() ||
       !this.INITIAL_RENDER_DONE
     )
   }
@@ -461,7 +462,7 @@ class Load3d {
   }
 
   public isRecording(): boolean {
-    return this.recordingManager.hasRecording()
+    return this.recordingManager.getIsRecording()
   }
 
   public getRecordingDuration(): number {

--- a/src/extensions/core/load3d/RecordingManager.ts
+++ b/src/extensions/core/load3d/RecordingManager.ts
@@ -106,12 +106,16 @@ export class RecordingManager {
       return
     }
 
-    this.recordingDuration = (Date.now() - this.recordingStartTime) / 1000 // In seconds
+    this.recordingDuration = (Date.now() - this.recordingStartTime) / 1000
 
     this.mediaRecorder.stop()
     if (this.recordingStream) {
       this.recordingStream.getTracks().forEach((track) => track.stop())
     }
+  }
+
+  public getIsRecording(): boolean {
+    return this.isRecording
   }
 
   public hasRecording(): boolean {


### PR DESCRIPTION
add record video support for load3d animation node, here is demo

https://github.com/user-attachments/assets/9b2b2daa-e3f0-4f4c-89df-ca9391df1427

sent BE change in the same PR https://github.com/comfyanonymous/ComfyUI/pull/7927

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3798-3d-add-record-video-support-for-load3d-animation-node-1ec6d73d3650810bba83c40bc0b01def) by [Unito](https://www.unito.io)
