### PR TITLE
[Auth] Allow user select GitHub account on login

### DIFF
--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -60,6 +60,9 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     prompt: 'select_account'
   })
   const githubProvider = new GithubAuthProvider()
+  githubProvider.setCustomParameters({
+    prompt: 'select_account'
+  })
 
   // Getters
   const isAuthenticated = computed(() => !!currentUser.value)

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -55,7 +55,9 @@ vi.mock('firebase/auth', () => ({
   GoogleAuthProvider: class {
     setCustomParameters = vi.fn()
   },
-  GithubAuthProvider: vi.fn(),
+  GithubAuthProvider: class {
+    setCustomParameters = vi.fn()
+  },
   browserLocalPersistence: 'browserLocalPersistence',
   setPersistence: vi.fn().mockResolvedValue(undefined)
 }))


### PR DESCRIPTION
Continuation of https://github.com/Comfy-Org/ComfyUI_frontend/pull/3777. Allow using multiple GitHub accounts per client.

OAuth parameters: https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3801-Auth-Allow-user-select-GitHub-account-on-login-1ec6d73d365081a9855be493264c1e55) by [Unito](https://www.unito.io)
