### PR TITLE
Fix workflow Export missing viewport scale/offset

### DIFF
--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -36,6 +36,21 @@ export const useWorkflowService = () => {
     }
     return defaultName
   }
+
+  /**
+   * Adds scale and offset from litegraph canvas to the workflow JSON.
+   * @param workflow The workflow to add the view restore data to
+   */
+  function addViewRestore(workflow: ComfyWorkflowJSON) {
+    if (!settingStore.get('Comfy.EnableWorkflowViewRestore')) return
+
+    const { offset, scale } = app.canvas.ds
+    const [x, y] = offset
+
+    workflow.extra ??= {}
+    workflow.extra.ds = { scale, offset: [x, y] }
+  }
+
   /**
    * Export the current workflow as a JSON file
    * @param filename The filename to save the workflow as
@@ -50,6 +65,8 @@ export const useWorkflowService = () => {
       filename = workflow.filename
     }
     const p = await app.graphToPrompt()
+
+    addViewRestore(p.workflow)
     const json = JSON.stringify(p[promptProperty], null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const file = await getFilename(filename)


### PR DESCRIPTION
Fixes regression introduced in #3673 - "Export" option does not include current canvas viewport state (offset/scale).

- Resolves #3821

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3828-Fix-workflow-Export-missing-viewport-scale-offset-1ee6d73d365081f89591c671d78a15e2) by [Unito](https://www.unito.io)
