### PR TITLE
add audio preview widgets to new save nodes

### DIFF
--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -90,7 +90,13 @@ app.registerExtension({
   name: 'Comfy.AudioWidget',
   async beforeRegisterNodeDef(nodeType, nodeData) {
     if (
-      ['LoadAudio', 'SaveAudio', 'PreviewAudio'].includes(
+      [
+        'LoadAudio',
+        'SaveAudio',
+        'PreviewAudio',
+        'SaveAudioMP3',
+        'SaveAudioOpus'
+      ].includes(
         // @ts-expect-error fixme ts strict error
         nodeType.prototype.comfyClass
       )


### PR DESCRIPTION
add play widget to new per-filetype save nodes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3840-add-audio-preview-widgets-to-new-save-nodes-1ee6d73d365081e9baf6e73629a1c4b7) by [Unito](https://www.unito.io)
