### PR TITLE
Fix video previews not displayed if VHS previously installed but disabled or uninstalled

### DIFF
--- a/src/components/sidebar/tabs/queue/ResultVideo.vue
+++ b/src/components/sidebar/tabs/queue/ResultVideo.vue
@@ -8,6 +8,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+import { useExtensionStore } from '@/stores/extensionStore'
 import { ResultItemImpl } from '@/stores/queueStore'
 import { useSettingStore } from '@/stores/settingStore'
 
@@ -16,9 +17,16 @@ const props = defineProps<{
 }>()
 
 const settingStore = useSettingStore()
-const vhsAdvancedPreviews = computed(() =>
-  settingStore.get('VHS.AdvancedPreviews')
-)
+const { isExtensionInstalled, isExtensionEnabled } = useExtensionStore()
+
+const vhsAdvancedPreviews = computed(() => {
+  return (
+    isExtensionInstalled('VideoHelperSuite.Core') &&
+    isExtensionEnabled('VideoHelperSuite.Core') &&
+    settingStore.get('VHS.AdvancedPreviews') &&
+    settingStore.get('VHS.AdvancedPreviews') !== 'Never'
+  )
+})
 
 const url = computed(() =>
   vhsAdvancedPreviews.value

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -451,7 +451,7 @@ const zSettings = z.object({
   'Comfy.Load3D.CameraType': z.enum(['perspective', 'orthographic']),
   'pysssss.SnapToGrid': z.boolean(),
   /** VHS setting is used for queue video preview support. */
-  'VHS.AdvancedPreviews': z.boolean(),
+  'VHS.AdvancedPreviews': z.string(),
   /** Settings used for testing */
   'test.setting': z.any(),
   'main.sub.setting.name': z.any(),

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -36,6 +36,8 @@ export const useExtensionStore = defineStore('extension', () => {
     )
   })
 
+  const isExtensionInstalled = (name: string) => name in extensionByName.value
+
   const isExtensionEnabled = (name: string) =>
     !disabledExtensionNames.value.has(name)
   const enabledExtensions = computed(() => {
@@ -96,6 +98,7 @@ export const useExtensionStore = defineStore('extension', () => {
     extensions,
     enabledExtensions,
     inactiveDisabledExtensionNames,
+    isExtensionInstalled,
     isExtensionEnabled,
     isExtensionReadOnly,
     registerExtension,


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/3843

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3844-Fix-video-previews-not-displayed-if-VHS-previously-installed-but-disabled-or-uninstalled-1ef6d73d36508134ba87c02256d1c620) by [Unito](https://www.unito.io)
