### PR TITLE
[API Node] Use staging platform url while in dev environment

### DIFF
--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -94,7 +94,7 @@
         <small class="text-muted text-center">
           {{ t('auth.apiKey.helpText') }}
           <a
-            href="https://platform.comfy.org/login"
+            :href="`${COMFY_PLATFORM_BASE_URL}/login`"
             target="_blank"
             class="text-blue-500 cursor-pointer"
           >
@@ -137,6 +137,7 @@ import Message from 'primevue/message'
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { COMFY_PLATFORM_BASE_URL } from '@/config/comfyApi'
 import { SignInData, SignUpData } from '@/schemas/signInSchema'
 import { useFirebaseAuthService } from '@/services/firebaseAuthService'
 import { isInChina } from '@/utils/networkUtil'

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -9,6 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { COMFY_PLATFORM_BASE_URL } from '@/config/comfyApi'
+
 import ApiKeyForm from './ApiKeyForm.vue'
 
 const mockStoreApiKey = vi.fn()
@@ -39,7 +41,8 @@ const i18n = createI18n({
           error: 'Invalid API Key',
           helpText: 'Need an API key?',
           generateKey: 'Get one here',
-          whitelistInfo: 'About non-whitelisted sites'
+          whitelistInfo: 'About non-whitelisted sites',
+          description: 'Use your Comfy API key to enable API Nodes'
         }
       },
       g: {
@@ -108,7 +111,7 @@ describe('ApiKeyForm', () => {
     const helpText = wrapper.find('small')
     expect(helpText.text()).toContain('Need an API key?')
     expect(helpText.find('a').attributes('href')).toBe(
-      'https://platform.comfy.org/login'
+      `${COMFY_PLATFORM_BASE_URL}/login`
     )
   })
 })

--- a/src/components/dialog/content/signin/ApiKeyForm.vue
+++ b/src/components/dialog/content/signin/ApiKeyForm.vue
@@ -48,7 +48,7 @@
           <small class="text-muted">
             {{ t('auth.apiKey.helpText') }}
             <a
-              href="https://platform.comfy.org/login"
+              :href="`${COMFY_PLATFORM_BASE_URL}/login`"
               target="_blank"
               class="text-blue-500 cursor-pointer"
             >
@@ -87,6 +87,7 @@ import Message from 'primevue/message'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { COMFY_PLATFORM_BASE_URL } from '@/config/comfyApi'
 import { apiKeySchema } from '@/schemas/signInSchema'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'

--- a/src/config/comfyApi.ts
+++ b/src/config/comfyApi.ts
@@ -1,3 +1,7 @@
 export const COMFY_API_BASE_URL = __USE_PROD_CONFIG__
   ? 'https://api.comfy.org'
   : 'https://stagingapi.comfy.org'
+
+export const COMFY_PLATFORM_BASE_URL = __USE_PROD_CONFIG__
+  ? 'https://platform.comfy.org'
+  : 'https://stagingplatform.comfy.org'


### PR DESCRIPTION
Use the staging platform url (https://stagingplatform.comfy.org) while in non-packaged version of app. The stagingplatform app is wired to the staging api.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3846-API-Node-Use-staging-platform-url-while-in-dev-environment-1ef6d73d3650819ab330fe1ad9ab38a9) by [Unito](https://www.unito.io)
