### PR TITLE
[Test] Add missing plugins in component tests

### DIFF
--- a/src/components/common/TreeExplorerTreeNode.spec.ts
+++ b/src/components/common/TreeExplorerTreeNode.spec.ts
@@ -32,6 +32,8 @@ describe('TreeExplorerTreeNode', () => {
     handleRename: () => {}
   } as RenderedTreeExplorerNode
 
+  const mockHandleEditLabel = vi.fn()
+
   beforeAll(() => {
     // Create a Vue app instance for PrimeVuePrimeVue
     const app = createApp({})
@@ -48,7 +50,10 @@ describe('TreeExplorerTreeNode', () => {
       props: { node: mockNode },
       global: {
         components: { EditableText, Badge },
-        plugins: [createTestingPinia(), i18n]
+        plugins: [createTestingPinia(), i18n],
+        provide: {
+          [InjectKeyHandleEditLabelFunction]: mockHandleEditLabel
+        }
       }
     })
 
@@ -72,7 +77,10 @@ describe('TreeExplorerTreeNode', () => {
       },
       global: {
         components: { EditableText, Badge, InputText },
-        plugins: [createTestingPinia(), i18n, PrimeVue]
+        plugins: [createTestingPinia(), i18n, PrimeVue],
+        provide: {
+          [InjectKeyHandleEditLabelFunction]: mockHandleEditLabel
+        }
       }
     })
 

--- a/src/components/dialog/content/setting/SettingItem.spec.ts
+++ b/src/components/dialog/content/setting/SettingItem.spec.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
+import Tag from 'primevue/tag'
+import Tooltip from 'primevue/tooltip'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -19,7 +21,16 @@ describe('SettingItem', () => {
   const mountComponent = (props: any, options = {}): any => {
     return mount(SettingItem, {
       global: {
-        plugins: [PrimeVue, i18n, createPinia()]
+        plugins: [PrimeVue, i18n, createPinia()],
+        components: {
+          Tag
+        },
+        directives: {
+          tooltip: Tooltip
+        },
+        stubs: {
+          'i-material-symbols:experiment-outline': true
+        }
       },
       props,
       ...options


### PR DESCRIPTION
Fixes missing plugins (tooltip directive, inject key, iconify icon) in component tests to fix warnings:

```
stderr | src/components/common/TreeExplorerTreeNode.spec.ts > TreeExplorerTreeNode > renders correctly
[Vue warn]: injection "Symbol()" not found. 
  at <TreeExplorerTreeNode node= {
  key: '1',
  label: 'Test Node',
  leaf: false,
  totalLeaves: 3,
  icon: 'pi pi-folder',
  type: 'folder',
  handleRename: [Function: handleRename]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | src/components/common/TreeExplorerTreeNode.spec.ts > TreeExplorerTreeNode > makes node label editable when renamingEditingNode matches
[Vue warn]: injection "Symbol()" not found. 
  at <TreeExplorerTreeNode node= {
  key: '1',
  label: 'Test Node',
  leaf: false,
  totalLeaves: 3,
  icon: 'pi pi-folder',
  type: 'folder',
  handleRename: [Function: handleRename],
  isEditingLabel: true
} ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | src/components/dialog/content/setting/SettingItem.spec.ts > SettingItem > translates options that use legacy type
[Vue warn]: Failed to resolve component: i-material-symbols:experiment-outline
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <SettingItem setting= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [Function: options]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve directive: tooltip 
  at <SettingItem setting= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [Function: options]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>
[intlify] Not found 'settings.undefined.name' key in 'en' locale messages.
[intlify] Not found 'settings.undefined.options.undefined' key in 'en' locale messages.
[Vue warn]: Failed to resolve directive: tooltip 
  at <FormItem id="Comfy.NodeInputConversionSubmenus" item= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [ { text: 'Correctly Translated', value: 'Correctly Translated' } ],
  tooltip: undefined
} form-value=undefined  ... > 
  at <SettingItem setting= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [Function: options]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | src/components/common/TreeExplorerTreeNode.spec.ts > TreeExplorerTreeNode > renders correctly
[Vue warn]: injection "Symbol()" not found. 
  at <TreeExplorerTreeNode node= {
  key: '1',
  label: 'Test Node',
  leaf: false,
  totalLeaves: 3,
  icon: 'pi pi-folder',
  type: 'folder',
  handleRename: [Function: handleRename]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | src/components/common/TreeExplorerTreeNode.spec.ts > TreeExplorerTreeNode > makes node label editable when renamingEditingNode matches
[Vue warn]: injection "Symbol()" not found. 
  at <TreeExplorerTreeNode node= {
  key: '1',
  label: 'Test Node',
  leaf: false,
  totalLeaves: 3,
  icon: 'pi pi-folder',
  type: 'folder',
  handleRename: [Function: handleRename],
  isEditingLabel: true
} ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | src/components/dialog/content/setting/SettingItem.spec.ts > SettingItem > translates options that use legacy type
[Vue warn]: Failed to resolve component: i-material-symbols:experiment-outline
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <SettingItem setting= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [Function: options]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve directive: tooltip 
  at <SettingItem setting= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [Function: options]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve directive: tooltip 
  at <FormItem id="Comfy.NodeInputConversionSubmenus" item= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [ { text: 'Correctly Translated', value: 'Correctly Translated' } ],
  tooltip: undefined
} form-value=undefined  ... > 
  at <SettingItem setting= {
  id: 'Comfy.NodeInputConversionSubmenus',
  name: 'Node Input Conversion Submenus',
  type: 'combo',
  value: 'Top',
  options: [Function: options]
} ref="VTU_COMPONENT" > 
  at <VTUROOT>
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3847-Test-Add-missing-plugins-in-component-tests-1ef6d73d36508170b6a2d18dade3ed70) by [Unito](https://www.unito.io)
