### PR TITLE
[API Node] Remove mailto on own address

### DIFF
--- a/src/components/dialog/content/setting/UserPanel.vue
+++ b/src/components/dialog/content/setting/UserPanel.vue
@@ -26,9 +26,9 @@
           <h3 class="font-medium">
             {{ $t('userSettings.email') }}
           </h3>
-          <a :href="'mailto:' + userEmail" class="hover:underline">
+          <span class="text-muted">
             {{ userEmail }}
-          </a>
+          </span>
         </div>
 
         <div class="flex flex-col gap-0.5">


### PR DESCRIPTION
Removes `mailto` hyperlink on user's own address, as it doesn't make sense to have. 

Before:

![Selection_1361](https://github.com/user-attachments/assets/bc20e34b-d525-4e3a-bcae-4ec812016f72)

After:

![Selection_1360](https://github.com/user-attachments/assets/96b3ff7b-a6fb-4a1e-b531-a48f3077f7df)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3852-API-Node-Remove-mailto-on-own-address-1f06d73d365081398acaff09952e4d58) by [Unito](https://www.unito.io)
