### PR TITLE
[TS] Fix weak ds.offset type breaks litegraph CI

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import type { LGraphNode } from '@comfyorg/litegraph'
+import type { LGraphNode, Point } from '@comfyorg/litegraph'
 import { useEventListener } from '@vueuse/core'
 import { computed, onMounted, ref, watch, watchEffect } from 'vue'
 
@@ -242,7 +242,7 @@ watch(
         },
         get offset() {
           const [x, y] = canvas.ds.offset
-          return [x, y]
+          return [x, y] satisfies Point
         }
       }
     } else {


### PR DESCRIPTION
Upstream of viewport save feature requires this type to be fixed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3861-TS-Fix-weak-ds-offset-type-breaks-litegraph-CI-1f16d73d365081dd91c9e332cc74d7ec) by [Unito](https://www.unito.io)
