### PR TITLE
Use upstreamed viewport serialisation

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import type { LGraphNode, Point } from '@comfyorg/litegraph'
+import type { LGraphNode } from '@comfyorg/litegraph'
 import { useEventListener } from '@vueuse/core'
 import { computed, onMounted, ref, watch, watchEffect } from 'vue'
 

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -225,32 +225,6 @@ watch(
   }
 )
 
-// Save the drag & scale info in the serialized workflow if the setting is enabled
-watch(
-  [
-    () => canvasStore.canvas,
-    () => settingStore.get('Comfy.EnableWorkflowViewRestore')
-  ],
-  ([canvas, enableWorkflowViewRestore]) => {
-    const extra = canvas?.graph?.extra
-    if (!extra) return
-
-    if (enableWorkflowViewRestore) {
-      extra.ds = {
-        get scale() {
-          return canvas.ds.scale
-        },
-        get offset() {
-          const [x, y] = canvas.ds.offset
-          return [x, y] satisfies Point
-        }
-      }
-    } else {
-      delete extra.ds
-    }
-  }
-)
-
 useEventListener(
   canvasRef,
   'litegraph:no-items-selected',

--- a/src/composables/useLitegraphSettings.ts
+++ b/src/composables/useLitegraphSettings.ts
@@ -128,4 +128,10 @@ export const useLitegraphSettings = () => {
       'LiteGraph.Pointer.TrackpadGestures'
     )
   })
+
+  watchEffect(() => {
+    LiteGraph.saveViewportWithGraph = settingStore.get(
+      'Comfy.EnableWorkflowViewRestore'
+    )
+  })
 }


### PR DESCRIPTION
Uses the upstreamed viewport save system from Litegraph.

- Resolves: #3862
- Ref: https://github.com/Comfy-Org/litegraph.js/pull/1042

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3864-Use-upstreamed-viewport-serialisation-1f16d73d365081d9b8c1ebcc4d8557f5) by [Unito](https://www.unito.io)
