### PR TITLE
expose user loggedin in extensionManager

### DIFF
--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -6,7 +6,9 @@ import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useDialogService } from '@/services/dialogService'
 import type { SidebarTabExtension, ToastManager } from '@/types/extensionTypes'
 
+import { useApiKeyAuthStore } from './apiKeyAuthStore'
 import { useCommandStore } from './commandStore'
+import { useFirebaseAuthStore } from './firebaseAuthStore'
 import { useQueueSettingsStore } from './queueStore'
 import { useSettingStore } from './settingStore'
 import { useToastStore } from './toastStore'
@@ -42,6 +44,18 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   const colorPalette = useColorPaletteService()
   const dialog = useDialogService()
   const bottomPanel = useBottomPanelStore()
+
+  const authStore = useFirebaseAuthStore()
+  const apiKeyStore = useApiKeyAuthStore()
+
+  const firebaseUser = computed(() => authStore.currentUser)
+  const isApiKeyLogin = computed(() => apiKeyStore.isAuthenticated)
+  const isLoggedIn = computed(
+    () => !!isApiKeyLogin.value || firebaseUser.value !== null
+  )
+  const partialUserStore = {
+    isLoggedIn
+  }
 
   /**
    * Registers a sidebar tab.
@@ -86,6 +100,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     colorPalette,
     dialog,
     bottomPanel,
+    user: partialUserStore,
 
     registerSidebarTab,
     unregisterSidebarTab,


### PR DESCRIPTION
Idk if it is safe to expose the entire userstore now.

So only isLoggedin is exposed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3871-expose-user-loggedin-in-extensionManager-1f26d73d36508110872ac3960c8326b8) by [Unito](https://www.unito.io)
