### PR TITLE
Fix bug: Virtual Grid increments page size when no results left to render

### DIFF
--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -70,11 +70,12 @@ const state = computed<GridState>(() => {
   const fromCol = fromRow * cols.value
   const toCol = toRow * cols.value
   const remainingCol = items.length - toCol
+  const hasMoreToRender = remainingCol >= 0
 
   return {
     start: clamp(fromCol, 0, items?.length),
     end: clamp(toCol, fromCol, items?.length),
-    isNearEnd: remainingCol <= cols.value * bufferRows
+    isNearEnd: hasMoreToRender && remainingCol <= cols.value * bufferRows
   }
 })
 const renderedItems = computed(() =>


### PR DESCRIPTION
Fixes issue that occurs when there are no items left to render but the VirtualGrid still emits `approach-end`, causing parent components to increment page size.

To reproduce issue:

- Load items into VirtualGrid such that they don't fully fill the available space but still add items near the buffer rows.
- The VirtualGrid will emit `approach-end`. However, we are not approaching the end -- the end is already there.
- As a result, a new query is made for the next page of items (asssuming parent component has it), which will naturally be empty. I.e., the results are empty because they are showing page 2 of a query that returns <1 page of results.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3877-Fix-bug-Virtual-Grid-increments-page-size-when-no-results-left-to-render-1f26d73d3650815c96c5d21c2db92c7f) by [Unito](https://www.unito.io)
