### PR TITLE
[Manager] Don't show empty suggestions dropdown

### DIFF
--- a/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
@@ -20,6 +20,7 @@
             style: 'display: none'
           }
         }"
+        :show-empty-message="false"
         @complete="stubTrue"
         @option-select="onOptionSelect"
       />


### PR DESCRIPTION
Changes registry search bar UI: If no search suggestions are found, don't show a dropdown with "No results found"; instead, just don't render the dropdown.

![Selection_1385](https://github.com/user-attachments/assets/b56c64d0-9427-4c9a-a246-16a0551f677b)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3878-Manager-Don-t-show-empty-suggestions-dropdown-1f26d73d365081718afbd6c7ff14677b) by [Unito](https://www.unito.io)
