### PR TITLE
[Manager] Fix search results render incorrectly when scrolling pages then changing query or tab

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -55,6 +55,7 @@
             />
             <div v-else class="h-full" @click="handleGridContainerClick">
               <VirtualGrid
+                id="results-grid"
                 :items="resultsWithKeys"
                 :buffer-rows="3"
                 :grid-style="GRID_STYLE"
@@ -92,7 +93,7 @@
 import { whenever } from '@vueuse/core'
 import { merge } from 'lodash'
 import Button from 'primevue/button'
-import { computed, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import ContentDivider from '@/components/common/ContentDivider.vue'
@@ -198,6 +199,10 @@ const {
 
 const filterMissingPacks = (packs: components['schemas']['Node'][]) =>
   packs.filter((pack) => !comfyManagerStore.isPackInstalled(pack.id))
+
+whenever(selectedTab, () => {
+  pageNumber.value = 0
+})
 
 const isUpdateAvailableTab = computed(
   () => selectedTab.value?.id === ManagerTab.UpdateAvailable
@@ -416,6 +421,17 @@ whenever(selectedNodePack, async () => {
   if (data?.id === selectedNodePack.value?.id) {
     // If selected node hasn't changed since request, merge registry & Algolia data
     selectedNodePacks.value = [merge(selectedNodePack.value, data)]
+  }
+})
+
+let gridContainer: HTMLElement | null = null
+onMounted(() => {
+  gridContainer = document.getElementById('results-grid')
+})
+watch(searchQuery, () => {
+  gridContainer ??= document.getElementById('results-grid')
+  if (gridContainer) {
+    gridContainer.scrollTop = 0
   }
 })
 


### PR DESCRIPTION
Fixes issue that occurs when scrolling multiple pages then changing the search (either by changing tab or changing search query).

To reproduce issue:

1. Scroll down a search result page with a lot of items
2. Change query to another query with a lot of results
3. The items are added sequentially due to render loop: items loaded in page 0 by default => scroll position is still very far down => tells VirtualGrid to emit event asking for more items => more items added => repeat until enough pages are loaded to hit the persisted scroll position.
4. The effect is that if you scrolled 10 pages in query 1, you would also request and scroll 10 pages in query 2 but it would happen within 1 second causing uncomfortable visual bug with super fast uncontrollable scrolling.

Fix by reseting scroll position to top when changing query or tab.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3879-Manager-Fix-search-results-render-incorrectly-when-scrolling-pages-then-changing-query--1f26d73d365081e7b608f73a2da9a7b9) by [Unito](https://www.unito.io)
