### PR TITLE
Allow LGraph.configure to be made recursive

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -143,7 +143,10 @@ export class ComfyApp {
   _nodeOutputs: Record<string, any>
   nodePreviewImages: Record<string, string[]>
   // @ts-expect-error fixme ts strict error
-  graph: LGraph
+  #graph: LGraph
+  get graph() {
+    return this.#graph
+  }
   // @ts-expect-error fixme ts strict error
   canvas: LGraphCanvas
   dragOverNode: LGraphNode | null = null
@@ -756,7 +759,7 @@ export class ComfyApp {
     this.#addConfigureHandler()
     this.#addApiUpdateHandlers()
 
-    this.graph = new LGraph()
+    this.#graph = new LGraph()
 
     this.#addAfterConfigureHandler()
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -152,7 +152,11 @@ export class ComfyApp {
   dragOverNode: LGraphNode | null = null
   // @ts-expect-error fixme ts strict error
   canvasEl: HTMLCanvasElement
-  configuringGraph: boolean = false
+
+  #configuringGraphLevel: number = 0
+  get configuringGraph() {
+    return this.#configuringGraphLevel > 0
+  }
   // @ts-expect-error fixme ts strict error
   ctx: CanvasRenderingContext2D
   bodyTop: HTMLElement
@@ -700,12 +704,12 @@ export class ComfyApp {
     const configure = LGraph.prototype.configure
     // Flag that the graph is configuring to prevent nodes from running checks while its still loading
     LGraph.prototype.configure = function () {
-      app.configuringGraph = true
+      app.#configuringGraphLevel++
       try {
         // @ts-expect-error fixme ts strict error
         return configure.apply(this, arguments)
       } finally {
-        app.configuringGraph = false
+        app.#configuringGraphLevel--
       }
     }
   }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -695,15 +695,13 @@ export class ComfyApp {
     api.init()
   }
 
-  #addConfigureHandler() {
-    const app = this
-    const configure = LGraph.prototype.configure
-    // Flag that the graph is configuring to prevent nodes from running checks while its still loading
-    LGraph.prototype.configure = function () {
+  /** Flag that the graph is configuring to prevent nodes from running checks while its still loading */
+  #addConfigureHandler(graph: LGraph) {
+    const { configure } = graph
+    graph.configure = function (...args) {
       app.configuringGraph = true
       try {
-        // @ts-expect-error fixme ts strict error
-        return configure.apply(this, arguments)
+        return configure.apply(this, args)
       } finally {
         app.configuringGraph = false
       }
@@ -756,10 +754,10 @@ export class ComfyApp {
     await useExtensionService().loadExtensions()
 
     this.#addProcessKeyHandler()
-    this.#addConfigureHandler()
     this.#addApiUpdateHandlers()
 
     this.#graph = new LGraph()
+    this.#addConfigureHandler(this.graph)
 
     this.#addAfterConfigureHandler()
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -695,13 +695,15 @@ export class ComfyApp {
     api.init()
   }
 
-  /** Flag that the graph is configuring to prevent nodes from running checks while its still loading */
-  #addConfigureHandler(graph: LGraph) {
-    const { configure } = graph
-    graph.configure = function (...args) {
+  #addConfigureHandler() {
+    const app = this
+    const configure = LGraph.prototype.configure
+    // Flag that the graph is configuring to prevent nodes from running checks while its still loading
+    LGraph.prototype.configure = function () {
       app.configuringGraph = true
       try {
-        return configure.apply(this, args)
+        // @ts-expect-error fixme ts strict error
+        return configure.apply(this, arguments)
       } finally {
         app.configuringGraph = false
       }
@@ -754,10 +756,10 @@ export class ComfyApp {
     await useExtensionService().loadExtensions()
 
     this.#addProcessKeyHandler()
+    this.#addConfigureHandler()
     this.#addApiUpdateHandlers()
 
     this.#graph = new LGraph()
-    this.#addConfigureHandler(this.graph)
 
     this.#addAfterConfigureHandler()
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -699,15 +699,14 @@ export class ComfyApp {
     api.init()
   }
 
+  /** Flag that the graph is configuring to prevent nodes from running checks while its still loading */
   #addConfigureHandler() {
     const app = this
     const configure = LGraph.prototype.configure
-    // Flag that the graph is configuring to prevent nodes from running checks while its still loading
-    LGraph.prototype.configure = function () {
+    LGraph.prototype.configure = function (...args) {
       app.#configuringGraphLevel++
       try {
-        // @ts-expect-error fixme ts strict error
-        return configure.apply(this, arguments)
+        return configure.apply(this, args)
       } finally {
         app.#configuringGraphLevel--
       }


### PR DESCRIPTION
`app.graph` is currently used as a singleton.

- Replaces property with private-backed getter to reflect usage
  - Null check and throw can be impl. once here, similar to `getCanvas()`
- Updates `configure` monkey patch on LGraph prototype to support recursion
- Removes `@ts-expect-error`

Pre-requisite of subclassing LGraph (for e.g. subgraphs).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3894-Allow-LGraph-configure-to-be-made-recursive-1f46d73d365081df983df53e3bd6559a) by [Unito](https://www.unito.io)
