### PR TITLE
Add selection changed state watcher

### DIFF
--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -14,12 +14,10 @@
 
 <script setup lang="ts">
 import { createBounds } from '@comfyorg/litegraph'
-import type { LGraphCanvas } from '@comfyorg/litegraph'
 import { whenever } from '@vueuse/core'
 import { ref, watch } from 'vue'
 
 import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
-import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useCanvasStore } from '@/stores/graphStore'
 
 const canvasStore = useCanvasStore()
@@ -48,21 +46,6 @@ const positionSelectionOverlay = () => {
 }
 
 // Register listener on canvas creation.
-watch(
-  () => canvasStore.canvas as LGraphCanvas | null,
-  (canvas: LGraphCanvas | null) => {
-    if (!canvas) return
-
-    canvas.onSelectionChange = useChainCallback(
-      canvas.onSelectionChange,
-      // Wait for next frame as sometimes the selected items haven't been
-      // rendered yet, so the boundingRect is not available on them.
-      () => requestAnimationFrame(positionSelectionOverlay)
-    )
-  },
-  { immediate: true }
-)
-
 whenever(
   () => canvasStore.getCanvas().state.selectionHasChanged,
   () => {

--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -47,11 +47,11 @@ const positionSelectionOverlay = () => {
 
 // Register listener on canvas creation.
 whenever(
-  () => canvasStore.getCanvas().state.selectionHasChanged,
+  () => canvasStore.getCanvas().state.selectionChanged,
   () => {
     requestAnimationFrame(() => {
       positionSelectionOverlay()
-      canvasStore.getCanvas().state.selectionHasChanged = false
+      canvasStore.getCanvas().state.selectionChanged = false
     })
   },
   { immediate: true }

--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -63,6 +63,17 @@ watch(
   { immediate: true }
 )
 
+whenever(
+  () => canvasStore.getCanvas().state.selectionHasChanged,
+  () => {
+    requestAnimationFrame(() => {
+      positionSelectionOverlay()
+      canvasStore.getCanvas().state.selectionHasChanged = false
+    })
+  },
+  { immediate: true }
+)
+
 whenever(() => canvasStore.getCanvas().ds.state, positionSelectionOverlay, {
   deep: true
 })

--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -28,8 +28,8 @@ const { style, updatePosition } = useAbsolutePosition()
 const visible = ref(false)
 const showBorder = ref(false)
 
-const positionSelectionOverlay = (canvas: LGraphCanvas) => {
-  const selectedItems = canvas.selectedItems
+const positionSelectionOverlay = () => {
+  const { selectedItems } = canvasStore.getCanvas()
   showBorder.value = selectedItems.size > 1
 
   if (!selectedItems.size) {
@@ -57,17 +57,15 @@ watch(
       canvas.onSelectionChange,
       // Wait for next frame as sometimes the selected items haven't been
       // rendered yet, so the boundingRect is not available on them.
-      () => requestAnimationFrame(() => positionSelectionOverlay(canvas))
+      () => requestAnimationFrame(positionSelectionOverlay)
     )
   },
   { immediate: true }
 )
 
-whenever(
-  () => canvasStore.getCanvas().ds.state,
-  () => positionSelectionOverlay(canvasStore.getCanvas()),
-  { deep: true }
-)
+whenever(() => canvasStore.getCanvas().ds.state, positionSelectionOverlay, {
+  deep: true
+})
 
 watch(
   () => canvasStore.canvas?.state?.draggingItems,
@@ -79,7 +77,7 @@ watch(
     if (draggingItems === false) {
       setTimeout(() => {
         visible.value = true
-        positionSelectionOverlay(canvasStore.getCanvas())
+        positionSelectionOverlay()
       }, 100)
     } else {
       // Selection change update to visible state is delayed by a frame. Here

--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -75,10 +75,10 @@ watch(
     // the correct position.
     // https://github.com/Comfy-Org/ComfyUI_frontend/issues/2656
     if (draggingItems === false) {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         visible.value = true
         positionSelectionOverlay()
-      }, 100)
+      })
     } else {
       // Selection change update to visible state is delayed by a frame. Here
       // we also delay a frame so that the order of events is correct when


### PR DESCRIPTION
SelectionOverlay is now updated whenever Litegraph canvas selected items is changed via the LGraphCanvas API.

Programmatic removal of items results in a single update on the next frame.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3899-Add-selection-changed-state-watcher-1f46d73d3650811e96dfdb2fa280bb37) by [Unito](https://www.unito.io)
