### PR TITLE
[Dev] Allow Vue dev tools to be disabled

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -25,3 +25,7 @@ ENABLE_MINIFY=true
 # templates are served via the normal method from the server's python site 
 # packages.
 DISABLE_TEMPLATES_PROXY=false
+
+# If playwright tests are being run via vite dev server, Vue plugins will
+# invalidate screenshots.  When `true`, vite plugins will not be loaded.
+DISABLE_VUE_PLUGINS=false

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -21,6 +21,7 @@ const SHOULD_MINIFY = process.env.ENABLE_MINIFY === 'true'
 // vite dev server will listen on all addresses, including LAN and public addresses
 const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
+const DISABLE_VUE_PLUGINS = process.env.DISABLE_VUE_PLUGINS === 'true'
 
 const DEV_SERVER_COMFYUI_URL =
   process.env.DEV_SERVER_COMFYUI_URL || 'http://127.0.0.1:8188'
@@ -71,9 +72,9 @@ export default defineConfig({
   },
 
   plugins: [
-    vueDevTools(),
-    vue(),
-    createHtmlPlugin({}),
+    ...(!DISABLE_VUE_PLUGINS
+      ? [vueDevTools(), vue(), createHtmlPlugin({})]
+      : [vue()]),
     comfyAPIPlugin(IS_DEV),
     generateImportMapPlugin([
       { name: 'vue', pattern: /[\\/]node_modules[\\/]vue[\\/]/ },


### PR DESCRIPTION
On by default, the Vue vite plugins are great for dev experience.  However, they should not be enabled when running playwright tests (they are never present at runtime).

This change adds an env var to disable them - a manual solution, but provides flexibility.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3911-Dev-Allow-Vue-dev-tools-to-be-disabled-1f56d73d3650810897fddcaf4d5945f4) by [Unito](https://www.unito.io)
