### PR TITLE
DO NOT Merge, testing for export vue on window

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -76,9 +76,39 @@ export default defineConfig({
     createHtmlPlugin({}),
     comfyAPIPlugin(IS_DEV),
     generateImportMapPlugin([
-      { name: 'vue', pattern: /[\\/]node_modules[\\/]vue[\\/]/ },
-      { name: 'primevue', pattern: /[\\/]node_modules[\\/]primevue[\\/]/ },
-      { name: 'vue-i18n', pattern: /[\\/]node_modules[\\/]vue-i18n[\\/]/ }
+      {
+        name: 'vue',
+        pattern: 'vue',
+        entry: './dist/vue.esm-browser.prod.js'
+      },
+      {
+        name: 'vue-i18n',
+        pattern: 'vue-i18n',
+        entry: './dist/vue-i18n.esm-browser.prod.js'
+      },
+      {
+        name: 'primevue',
+        pattern: /^primevue\/?.*/,
+        entry: './index.mjs',
+        recursiveDependence: true
+      },
+      {
+        name: '@primevue/themes',
+        pattern: /^@primevue\/themes\/?.*/,
+        entry: './index.mjs',
+        recursiveDependence: true
+      },
+      {
+        name: '@primevue/forms',
+        pattern: /^@primevue\/forms\/?.*/,
+        entry: './index.mjs',
+        recursiveDependence: true,
+        override: {
+          '@primeuix/forms': {
+            entry: ''
+          }
+        }
+      }
     ]),
     addElementVnodeExportPlugin(),
 


### PR DESCRIPTION
A new way to vendor vue and primevue. export vue to importmap.

https://github.com/hayden-fr/ComfyUI-Model-Manager/pull/186

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3913-DO-NOT-Merge-testing-for-export-vue-on-window-1f56d73d365081619420de903e1e5c85) by [Unito](https://www.unito.io)
