### PR TITLE
Replace reactive DragAndScale proxy with callback

### DIFF
--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -57,9 +57,7 @@ whenever(
   { immediate: true }
 )
 
-whenever(() => canvasStore.getCanvas().ds.state, positionSelectionOverlay, {
-  deep: true
-})
+canvasStore.getCanvas().ds.onChanged = positionSelectionOverlay
 
 watch(
   () => canvasStore.canvas?.state?.draggingItems,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -769,7 +769,6 @@ export class ComfyApp {
     this.canvas = new LGraphCanvas(canvasEl, this.graph)
     // Make canvas states reactive so we can observe changes on them.
     this.canvas.state = reactive(this.canvas.state)
-    this.canvas.ds.state = reactive(this.canvas.ds.state)
 
     // @ts-expect-error fixme ts strict error
     this.ctx = canvasEl.getContext('2d')


### PR DESCRIPTION
Allows structuredClone and removes other proxy-related constraints on litegraph code.

- Ref: https://github.com/Comfy-Org/litegraph.js/pull/1055

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3915-Replace-reactive-DragAndScale-proxy-with-callback-1f56d73d365081709bfaf875d958d032) by [Unito](https://www.unito.io)
