### PR TITLE
Add tests for ChatHistoryWidget and related features

### DIFF
--- a/browser_tests/tests/chatHistory.spec.ts
+++ b/browser_tests/tests/chatHistory.spec.ts
@@ -1,19 +1,22 @@
 import { expect } from '@playwright/test'
+
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 
 test.describe('Chat History Widget', () => {
-  test('displays chat history when receiving display_component message', async ({ comfyPage }) => {
+  test('displays chat history when receiving display_component message', async ({
+    comfyPage
+  }) => {
     // Load default workflow to get a node to work with
     await comfyPage.setup()
-    
+
     // Get first node's ID from the graph
     const nodeId = await comfyPage.page.evaluate(() => {
       return window['app'].graph.nodes[0]?.id
     })
-    
+
     // Make sure we have a node
     expect(nodeId).toBeDefined()
-    
+
     // Simulate API sending display_component message
     await comfyPage.page.evaluate((nodeId) => {
       const event = new CustomEvent('display_component', {
@@ -29,45 +32,45 @@ test.describe('Chat History Widget', () => {
       })
       window['app'].api.dispatchEvent(event)
     }, nodeId)
-    
+
     // Wait for chat history to be rendered
     await comfyPage.page.waitForSelector('.pi-pencil')
-    
+
     // Take screenshot to verify visual appearance
     await expect(comfyPage.canvas).toHaveScreenshot('chat-history-widget.png')
-    
+
     // Test copy functionality
     const copyButton = comfyPage.page.locator('.pi-copy').first()
     await copyButton.click()
-    
+
     // Verify tooltip displayed "Copied"
     await expect(comfyPage.page.getByText('Copied')).toBeVisible()
   })
-  
+
   test('handles message editing interaction', async ({ comfyPage }) => {
     await comfyPage.setup()
-    
+
     // Get first node's ID
     const nodeId = await comfyPage.page.evaluate(() => {
       const node = window['app'].graph.nodes[0]
-      
+
       // Make sure the node has a prompt widget (for editing functionality)
       if (!node.widgets) {
         node.widgets = []
       }
-      
+
       // Add a prompt widget if it doesn't exist
-      if (!node.widgets.find(w => w.name === 'prompt')) {
+      if (!node.widgets.find((w) => w.name === 'prompt')) {
         node.widgets.push({
-          name: 'prompt', 
+          name: 'prompt',
           type: 'text',
           value: 'Original prompt'
         })
       }
-      
+
       return node.id
     })
-    
+
     // Send display_component message with chat history
     await comfyPage.page.evaluate((nodeId) => {
       const event = new CustomEvent('display_component', {
@@ -76,47 +79,55 @@ test.describe('Chat History Widget', () => {
           component: 'ChatHistoryWidget',
           props: {
             history: JSON.stringify([
-              { prompt: 'Message 1', response: 'Response 1', response_id: '123' },
-              { prompt: 'Message 2', response: 'Response 2', response_id: '456' }
+              {
+                prompt: 'Message 1',
+                response: 'Response 1',
+                response_id: '123'
+              },
+              {
+                prompt: 'Message 2',
+                response: 'Response 2',
+                response_id: '456'
+              }
             ])
           }
         }
       })
       window['app'].api.dispatchEvent(event)
     }, nodeId)
-    
+
     // Wait for rendering
     await comfyPage.page.waitForSelector('.pi-pencil')
-    
+
     // Click edit button on first message
     const editButtons = await comfyPage.page.locator('.pi-pencil').all()
     await editButtons[0].click()
-    
+
     // Verify cancel button appears
     await expect(comfyPage.page.locator('.pi-times')).toBeVisible()
-    
+
     // Verify older messages are dimmed
     await expect(comfyPage.page.locator('.opacity-25')).toBeVisible()
     await expect(comfyPage.page.locator('.opacity-40')).toBeVisible()
-    
+
     // Click cancel edit
     await comfyPage.page.locator('.pi-times').click()
-    
+
     // Verify cancel button disappears
     await expect(comfyPage.page.locator('.pi-times')).toBeHidden()
-    
+
     // Take screenshot of final state
     await expect(comfyPage.canvas).toHaveScreenshot('chat-history-editing.png')
   })
-  
+
   test('handles real-time updates to chat history', async ({ comfyPage }) => {
     await comfyPage.setup()
-    
+
     // Get first node's ID
     const nodeId = await comfyPage.page.evaluate(() => {
       return window['app'].graph.nodes[0]?.id
     })
-    
+
     // Send initial history
     await comfyPage.page.evaluate((nodeId) => {
       const event = new CustomEvent('display_component', {
@@ -125,20 +136,24 @@ test.describe('Chat History Widget', () => {
           component: 'ChatHistoryWidget',
           props: {
             history: JSON.stringify([
-              { prompt: 'Initial message', response: 'Initial response', response_id: '123' }
+              {
+                prompt: 'Initial message',
+                response: 'Initial response',
+                response_id: '123'
+              }
             ])
           }
         }
       })
       window['app'].api.dispatchEvent(event)
     }, nodeId)
-    
+
     // Wait for initial rendering
     await comfyPage.page.waitForSelector('.pi-pencil')
-    
+
     // Take screenshot of initial state
     await expect(comfyPage.canvas).toHaveScreenshot('chat-history-initial.png')
-    
+
     // Update history with additional messages
     await comfyPage.page.evaluate((nodeId) => {
       const event = new CustomEvent('display_component', {
@@ -147,19 +162,27 @@ test.describe('Chat History Widget', () => {
           component: 'ChatHistoryWidget',
           props: {
             history: JSON.stringify([
-              { prompt: 'Initial message', response: 'Initial response', response_id: '123' },
-              { prompt: 'Follow-up', response: 'New response', response_id: '456' }
+              {
+                prompt: 'Initial message',
+                response: 'Initial response',
+                response_id: '123'
+              },
+              {
+                prompt: 'Follow-up',
+                response: 'New response',
+                response_id: '456'
+              }
             ])
           }
         }
       })
       window['app'].api.dispatchEvent(event)
     }, nodeId)
-    
+
     // Verify new messages appear
     await expect(comfyPage.page.getByText('Follow-up')).toBeVisible()
     await expect(comfyPage.page.getByText('New response')).toBeVisible()
-    
+
     // Take screenshot of updated state
     await expect(comfyPage.canvas).toHaveScreenshot('chat-history-updated.png')
   })

--- a/browser_tests/tests/chatHistory.spec.ts
+++ b/browser_tests/tests/chatHistory.spec.ts
@@ -1,0 +1,166 @@
+import { expect } from '@playwright/test'
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Chat History Widget', () => {
+  test('displays chat history when receiving display_component message', async ({ comfyPage }) => {
+    // Load default workflow to get a node to work with
+    await comfyPage.setup()
+    
+    // Get first node's ID from the graph
+    const nodeId = await comfyPage.page.evaluate(() => {
+      return window['app'].graph.nodes[0]?.id
+    })
+    
+    // Make sure we have a node
+    expect(nodeId).toBeDefined()
+    
+    // Simulate API sending display_component message
+    await comfyPage.page.evaluate((nodeId) => {
+      const event = new CustomEvent('display_component', {
+        detail: {
+          node_id: nodeId,
+          component: 'ChatHistoryWidget',
+          props: {
+            history: JSON.stringify([
+              { prompt: 'Hello', response: 'World', response_id: '123' }
+            ])
+          }
+        }
+      })
+      window['app'].api.dispatchEvent(event)
+    }, nodeId)
+    
+    // Wait for chat history to be rendered
+    await comfyPage.page.waitForSelector('.pi-pencil')
+    
+    // Take screenshot to verify visual appearance
+    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-widget.png')
+    
+    // Test copy functionality
+    const copyButton = comfyPage.page.locator('.pi-copy').first()
+    await copyButton.click()
+    
+    // Verify tooltip displayed "Copied"
+    await expect(comfyPage.page.getByText('Copied')).toBeVisible()
+  })
+  
+  test('handles message editing interaction', async ({ comfyPage }) => {
+    await comfyPage.setup()
+    
+    // Get first node's ID
+    const nodeId = await comfyPage.page.evaluate(() => {
+      const node = window['app'].graph.nodes[0]
+      
+      // Make sure the node has a prompt widget (for editing functionality)
+      if (!node.widgets) {
+        node.widgets = []
+      }
+      
+      // Add a prompt widget if it doesn't exist
+      if (!node.widgets.find(w => w.name === 'prompt')) {
+        node.widgets.push({
+          name: 'prompt', 
+          type: 'text',
+          value: 'Original prompt'
+        })
+      }
+      
+      return node.id
+    })
+    
+    // Send display_component message with chat history
+    await comfyPage.page.evaluate((nodeId) => {
+      const event = new CustomEvent('display_component', {
+        detail: {
+          node_id: nodeId,
+          component: 'ChatHistoryWidget',
+          props: {
+            history: JSON.stringify([
+              { prompt: 'Message 1', response: 'Response 1', response_id: '123' },
+              { prompt: 'Message 2', response: 'Response 2', response_id: '456' }
+            ])
+          }
+        }
+      })
+      window['app'].api.dispatchEvent(event)
+    }, nodeId)
+    
+    // Wait for rendering
+    await comfyPage.page.waitForSelector('.pi-pencil')
+    
+    // Click edit button on first message
+    const editButtons = await comfyPage.page.locator('.pi-pencil').all()
+    await editButtons[0].click()
+    
+    // Verify cancel button appears
+    await expect(comfyPage.page.locator('.pi-times')).toBeVisible()
+    
+    // Verify older messages are dimmed
+    await expect(comfyPage.page.locator('.opacity-25')).toBeVisible()
+    await expect(comfyPage.page.locator('.opacity-40')).toBeVisible()
+    
+    // Click cancel edit
+    await comfyPage.page.locator('.pi-times').click()
+    
+    // Verify cancel button disappears
+    await expect(comfyPage.page.locator('.pi-times')).toBeHidden()
+    
+    // Take screenshot of final state
+    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-editing.png')
+  })
+  
+  test('handles real-time updates to chat history', async ({ comfyPage }) => {
+    await comfyPage.setup()
+    
+    // Get first node's ID
+    const nodeId = await comfyPage.page.evaluate(() => {
+      return window['app'].graph.nodes[0]?.id
+    })
+    
+    // Send initial history
+    await comfyPage.page.evaluate((nodeId) => {
+      const event = new CustomEvent('display_component', {
+        detail: {
+          node_id: nodeId,
+          component: 'ChatHistoryWidget',
+          props: {
+            history: JSON.stringify([
+              { prompt: 'Initial message', response: 'Initial response', response_id: '123' }
+            ])
+          }
+        }
+      })
+      window['app'].api.dispatchEvent(event)
+    }, nodeId)
+    
+    // Wait for initial rendering
+    await comfyPage.page.waitForSelector('.pi-pencil')
+    
+    // Take screenshot of initial state
+    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-initial.png')
+    
+    // Update history with additional messages
+    await comfyPage.page.evaluate((nodeId) => {
+      const event = new CustomEvent('display_component', {
+        detail: {
+          node_id: nodeId,
+          component: 'ChatHistoryWidget',
+          props: {
+            history: JSON.stringify([
+              { prompt: 'Initial message', response: 'Initial response', response_id: '123' },
+              { prompt: 'Follow-up', response: 'New response', response_id: '456' }
+            ])
+          }
+        }
+      })
+      window['app'].api.dispatchEvent(event)
+    }, nodeId)
+    
+    // Verify new messages appear
+    await expect(comfyPage.page.getByText('Follow-up')).toBeVisible()
+    await expect(comfyPage.page.getByText('New response')).toBeVisible()
+    
+    // Take screenshot of updated state
+    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-updated.png')
+  })
+})

--- a/browser_tests/tests/chatHistory.spec.ts
+++ b/browser_tests/tests/chatHistory.spec.ts
@@ -1,57 +1,58 @@
-import { expect } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 
-test.describe('Chat History Widget', () => {
-  test('displays chat history when receiving display_component message', async ({
-    comfyPage
-  }) => {
-    // Load default workflow to get a node to work with
-    await comfyPage.setup()
+interface ChatHistoryEntry {
+  prompt: string
+  response: string
+  response_id: string
+}
 
-    // Get first node's ID from the graph
-    const nodeId = await comfyPage.page.evaluate(() => {
-      return window['app'].graph.nodes[0]?.id
-    })
-
-    // Make sure we have a node
-    expect(nodeId).toBeDefined()
-
-    // Simulate API sending display_component message
-    await comfyPage.page.evaluate((nodeId) => {
+async function renderChatHistory(page: Page, history: ChatHistoryEntry[]) {
+  const nodeId = await page.evaluate(() => window['app'].graph.nodes[0]?.id)
+  // Simulate API sending display_component message
+  await page.evaluate(
+    ({ nodeId, history }) => {
       const event = new CustomEvent('display_component', {
         detail: {
           node_id: nodeId,
           component: 'ChatHistoryWidget',
           props: {
-            history: JSON.stringify([
-              { prompt: 'Hello', response: 'World', response_id: '123' }
-            ])
+            history: JSON.stringify(history)
           }
         }
       })
       window['app'].api.dispatchEvent(event)
-    }, nodeId)
+      return true
+    },
+    { nodeId, history }
+  )
 
+  return nodeId
+}
+
+test.describe('Chat History Widget', () => {
+  let nodeId: string
+
+  test.beforeEach(async ({ comfyPage }) => {
+    nodeId = await renderChatHistory(comfyPage.page, [
+      { prompt: 'Hello', response: 'World', response_id: '123' }
+    ])
     // Wait for chat history to be rendered
     await comfyPage.page.waitForSelector('.pi-pencil')
+  })
 
-    // Take screenshot to verify visual appearance
-    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-widget.png')
-
-    // Test copy functionality
-    const copyButton = comfyPage.page.locator('.pi-copy').first()
-    await copyButton.click()
-
-    // Verify tooltip displayed "Copied"
-    await expect(comfyPage.page.getByText('Copied')).toBeVisible()
+  test('displays chat history when receiving display_component message', async ({
+    comfyPage
+  }) => {
+    // Verify the chat history is displayed correctly
+    await expect(comfyPage.page.getByText('Hello')).toBeVisible()
+    await expect(comfyPage.page.getByText('World')).toBeVisible()
   })
 
   test('handles message editing interaction', async ({ comfyPage }) => {
-    await comfyPage.setup()
-
     // Get first node's ID
-    const nodeId = await comfyPage.page.evaluate(() => {
+    nodeId = await comfyPage.page.evaluate(() => {
       const node = window['app'].graph.nodes[0]
 
       // Make sure the node has a prompt widget (for editing functionality)
@@ -71,119 +72,68 @@ test.describe('Chat History Widget', () => {
       return node.id
     })
 
-    // Send display_component message with chat history
-    await comfyPage.page.evaluate((nodeId) => {
-      const event = new CustomEvent('display_component', {
-        detail: {
-          node_id: nodeId,
-          component: 'ChatHistoryWidget',
-          props: {
-            history: JSON.stringify([
-              {
-                prompt: 'Message 1',
-                response: 'Response 1',
-                response_id: '123'
-              },
-              {
-                prompt: 'Message 2',
-                response: 'Response 2',
-                response_id: '456'
-              }
-            ])
-          }
-        }
-      })
-      window['app'].api.dispatchEvent(event)
-    }, nodeId)
-
-    // Wait for rendering
+    await renderChatHistory(comfyPage.page, [
+      {
+        prompt: 'Message 1',
+        response: 'Response 1',
+        response_id: '123'
+      },
+      {
+        prompt: 'Message 2',
+        response: 'Response 2',
+        response_id: '456'
+      }
+    ])
     await comfyPage.page.waitForSelector('.pi-pencil')
 
+    const originalTextAreaInput = await comfyPage.page
+      .getByPlaceholder('text')
+      .nth(1)
+      .inputValue()
+
     // Click edit button on first message
-    const editButtons = await comfyPage.page.locator('.pi-pencil').all()
-    await editButtons[0].click()
+    await comfyPage.page.getByLabel('Edit').first().click()
+    await comfyPage.nextFrame()
 
     // Verify cancel button appears
-    await expect(comfyPage.page.locator('.pi-times')).toBeVisible()
-
-    // Verify older messages are dimmed
-    await expect(comfyPage.page.locator('.opacity-25')).toBeVisible()
-    await expect(comfyPage.page.locator('.opacity-40')).toBeVisible()
+    await expect(comfyPage.page.getByLabel('Cancel')).toBeVisible()
 
     // Click cancel edit
-    await comfyPage.page.locator('.pi-times').click()
+    await comfyPage.page.getByLabel('Cancel').click()
 
-    // Verify cancel button disappears
-    await expect(comfyPage.page.locator('.pi-times')).toBeHidden()
-
-    // Take screenshot of final state
-    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-editing.png')
+    // Verify prompt input is restored
+    await expect(comfyPage.page.getByPlaceholder('text').nth(1)).toHaveValue(
+      originalTextAreaInput
+    )
   })
 
   test('handles real-time updates to chat history', async ({ comfyPage }) => {
-    await comfyPage.setup()
-
-    // Get first node's ID
-    const nodeId = await comfyPage.page.evaluate(() => {
-      return window['app'].graph.nodes[0]?.id
-    })
-
     // Send initial history
-    await comfyPage.page.evaluate((nodeId) => {
-      const event = new CustomEvent('display_component', {
-        detail: {
-          node_id: nodeId,
-          component: 'ChatHistoryWidget',
-          props: {
-            history: JSON.stringify([
-              {
-                prompt: 'Initial message',
-                response: 'Initial response',
-                response_id: '123'
-              }
-            ])
-          }
-        }
-      })
-      window['app'].api.dispatchEvent(event)
-    }, nodeId)
-
-    // Wait for initial rendering
+    await renderChatHistory(comfyPage.page, [
+      {
+        prompt: 'Initial message',
+        response: 'Initial response',
+        response_id: '123'
+      }
+    ])
     await comfyPage.page.waitForSelector('.pi-pencil')
 
-    // Take screenshot of initial state
-    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-initial.png')
-
     // Update history with additional messages
-    await comfyPage.page.evaluate((nodeId) => {
-      const event = new CustomEvent('display_component', {
-        detail: {
-          node_id: nodeId,
-          component: 'ChatHistoryWidget',
-          props: {
-            history: JSON.stringify([
-              {
-                prompt: 'Initial message',
-                response: 'Initial response',
-                response_id: '123'
-              },
-              {
-                prompt: 'Follow-up',
-                response: 'New response',
-                response_id: '456'
-              }
-            ])
-          }
-        }
-      })
-      window['app'].api.dispatchEvent(event)
-    }, nodeId)
+    await renderChatHistory(comfyPage.page, [
+      {
+        prompt: 'Follow-up',
+        response: 'New response',
+        response_id: '456'
+      }
+    ])
+    await comfyPage.page.waitForSelector('.pi-pencil')
+
+    // Move mouse over the canvas to force update
+    await comfyPage.page.mouse.move(100, 100)
+    await comfyPage.nextFrame()
 
     // Verify new messages appear
     await expect(comfyPage.page.getByText('Follow-up')).toBeVisible()
     await expect(comfyPage.page.getByText('New response')).toBeVisible()
-
-    // Take screenshot of updated state
-    await expect(comfyPage.canvas).toHaveScreenshot('chat-history-updated.png')
   })
 })

--- a/src/components/graph/widgets/ChatHistoryWidget.vue
+++ b/src/components/graph/widgets/ChatHistoryWidget.vue
@@ -96,8 +96,7 @@ const setPromptInput = (text: string, previousResponseId?: string | null) => {
 }
 
 const handleEdit = (index: number) => {
-  if (!promptInput) return
-
+  promptInput ??= widget?.node.widgets?.find((w) => w.name === 'prompt')
   editIndex.value = index
   const prevResponseId = index === 0 ? 'start' : getPreviousResponseId(index)
   const promptText = parsedHistory.value[index]?.prompt ?? ''

--- a/src/composables/node/useNodeChatHistory.ts
+++ b/src/composables/node/useNodeChatHistory.ts
@@ -16,9 +16,6 @@ export function useNodeChatHistory(
 ) {
   const chatHistoryWidget = useChatHistoryWidget(options)
 
-  const findChatHistoryWidget = (node: LGraphNode) =>
-    node.widgets?.find((w) => w.name === CHAT_HISTORY_WIDGET_NAME)
-
   const addChatHistoryWidget = (node: LGraphNode) =>
     chatHistoryWidget(node, {
       name: CHAT_HISTORY_WIDGET_NAME,
@@ -30,9 +27,11 @@ export function useNodeChatHistory(
    * @param node The graph node to show the chat history for
    */
   function showChatHistory(node: LGraphNode) {
-    if (!findChatHistoryWidget(node)) {
-      addChatHistoryWidget(node)
-    }
+    // First remove any existing widget
+    removeChatHistory(node)
+
+    // Then add the widget with new history
+    addChatHistoryWidget(node)
     node.setDirtyCanvas?.(true)
   }
 

--- a/tests-ui/tests/components/ChatHistoryWidget.spec.ts
+++ b/tests-ui/tests/components/ChatHistoryWidget.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
 import ChatHistoryWidget from '@/components/graph/widgets/ChatHistoryWidget.vue'
 
 const i18n = createI18n({
@@ -37,55 +38,58 @@ describe('ChatHistoryWidget.vue', () => {
   const mockHistory = JSON.stringify([
     { prompt: 'Test prompt', response: 'Test response', response_id: '123' }
   ])
-  
-  const mountWidget = (props = {}) => {
+
+  const mountWidget = (props: { history: string; widget?: any }) => {
     return mount(ChatHistoryWidget, {
       props,
       global: {
         plugins: [i18n],
         stubs: {
-          Button: { template: '<button><slot /></button>', props: ['icon', 'aria-label'] },
+          Button: {
+            template: '<button><slot /></button>',
+            props: ['icon', 'aria-label']
+          },
           ScrollPanel: { template: '<div><slot /></div>' }
         }
       }
     })
   }
-  
+
   it('renders chat history correctly', () => {
     const wrapper = mountWidget({ history: mockHistory })
     expect(wrapper.text()).toContain('Test prompt')
     expect(wrapper.text()).toContain('Test response')
   })
-  
+
   it('handles empty history', () => {
     const wrapper = mountWidget({ history: '[]' })
     expect(wrapper.find('.mb-4').exists()).toBe(false)
   })
-  
+
   it('edits previous prompts', () => {
     const mockWidget = {
       node: { widgets: [{ name: 'prompt', value: '' }] }
     }
-    
+
     const wrapper = mountWidget({ history: mockHistory, widget: mockWidget })
     const vm = wrapper.vm as any
     vm.handleEdit(0)
-    
+
     expect(mockWidget.node.widgets[0].value).toContain('Test prompt')
     expect(mockWidget.node.widgets[0].value).toContain('starting_point_id')
   })
-  
+
   it('cancels editing correctly', () => {
     const mockWidget = {
       node: { widgets: [{ name: 'prompt', value: 'Original value' }] }
     }
-    
+
     const wrapper = mountWidget({ history: mockHistory, widget: mockWidget })
     const vm = wrapper.vm as any
-    
+
     vm.handleEdit(0)
     vm.handleCancelEdit()
-    
+
     expect(mockWidget.node.widgets[0].value).toBe('Original value')
   })
 })

--- a/tests-ui/tests/components/ChatHistoryWidget.spec.ts
+++ b/tests-ui/tests/components/ChatHistoryWidget.spec.ts
@@ -1,0 +1,91 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import ChatHistoryWidget from '@/components/graph/widgets/ChatHistoryWidget.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { edit: 'Edit' },
+      chatHistory: {
+        cancelEdit: 'Cancel edit',
+        cancelEditTooltip: 'Cancel edit'
+      }
+    }
+  }
+})
+
+vi.mock('@/components/graph/widgets/chatHistory/CopyButton.vue', () => ({
+  default: {
+    name: 'CopyButton',
+    template: '<div class="mock-copy-button"></div>',
+    props: ['text']
+  }
+}))
+
+vi.mock('@/components/graph/widgets/chatHistory/ResponseBlurb.vue', () => ({
+  default: {
+    name: 'ResponseBlurb',
+    template: '<div class="mock-response-blurb"><slot /></div>',
+    props: ['text']
+  }
+}))
+
+describe('ChatHistoryWidget.vue', () => {
+  const mockHistory = JSON.stringify([
+    { prompt: 'Test prompt', response: 'Test response', response_id: '123' }
+  ])
+  
+  const mountWidget = (props = {}) => {
+    return mount(ChatHistoryWidget, {
+      props,
+      global: {
+        plugins: [i18n],
+        stubs: {
+          Button: { template: '<button><slot /></button>', props: ['icon', 'aria-label'] },
+          ScrollPanel: { template: '<div><slot /></div>' }
+        }
+      }
+    })
+  }
+  
+  it('renders chat history correctly', () => {
+    const wrapper = mountWidget({ history: mockHistory })
+    expect(wrapper.text()).toContain('Test prompt')
+    expect(wrapper.text()).toContain('Test response')
+  })
+  
+  it('handles empty history', () => {
+    const wrapper = mountWidget({ history: '[]' })
+    expect(wrapper.find('.mb-4').exists()).toBe(false)
+  })
+  
+  it('edits previous prompts', () => {
+    const mockWidget = {
+      node: { widgets: [{ name: 'prompt', value: '' }] }
+    }
+    
+    const wrapper = mountWidget({ history: mockHistory, widget: mockWidget })
+    const vm = wrapper.vm as any
+    vm.handleEdit(0)
+    
+    expect(mockWidget.node.widgets[0].value).toContain('Test prompt')
+    expect(mockWidget.node.widgets[0].value).toContain('starting_point_id')
+  })
+  
+  it('cancels editing correctly', () => {
+    const mockWidget = {
+      node: { widgets: [{ name: 'prompt', value: 'Original value' }] }
+    }
+    
+    const wrapper = mountWidget({ history: mockHistory, widget: mockWidget })
+    const vm = wrapper.vm as any
+    
+    vm.handleEdit(0)
+    vm.handleCancelEdit()
+    
+    expect(mockWidget.node.widgets[0].value).toBe('Original value')
+  })
+})

--- a/tests-ui/tests/composables/useNodeChatHistory.test.ts
+++ b/tests-ui/tests/composables/useNodeChatHistory.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LGraphNode } from '@comfyorg/litegraph'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNodeChatHistory } from '@/composables/node/useNodeChatHistory'
 
@@ -23,10 +23,10 @@ vi.mock('@/composables/widgets/useChatHistoryWidget', () => ({
 
 // Mock LGraphNode type
 type MockNode = {
-  widgets: Array<{ name: string; type: string }>;
-  setDirtyCanvas: ReturnType<typeof vi.fn>;
-  addCustomWidget: ReturnType<typeof vi.fn>;
-  [key: string]: any;
+  widgets: Array<{ name: string; type: string }>
+  setDirtyCanvas: ReturnType<typeof vi.fn>
+  addCustomWidget: ReturnType<typeof vi.fn>
+  [key: string]: any
 }
 
 describe('useNodeChatHistory', () => {

--- a/tests-ui/tests/composables/useNodeChatHistory.test.ts
+++ b/tests-ui/tests/composables/useNodeChatHistory.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useNodeChatHistory } from '@/composables/node/useNodeChatHistory'
+
+vi.mock('@/composables/widgets/useChatHistoryWidget', () => ({
+  useChatHistoryWidget: () => {
+    return (node: any, inputSpec: any) => {
+      const widget = {
+        name: inputSpec.name,
+        type: inputSpec.type
+      }
+      
+      if (!node.widgets) {
+        node.widgets = []
+      }
+      node.widgets.push(widget)
+      
+      return widget
+    }
+  }
+}))
+
+describe('useNodeChatHistory', () => {
+  const mockNode = {
+    widgets: [],
+    setDirtyCanvas: vi.fn(),
+    addCustomWidget: vi.fn()
+  }
+  
+  beforeEach(() => {
+    mockNode.widgets = []
+    mockNode.setDirtyCanvas.mockClear()
+    mockNode.addCustomWidget.mockClear()
+  })
+  
+  it('adds chat history widget to node', () => {
+    const { showChatHistory } = useNodeChatHistory()
+    showChatHistory(mockNode)
+    
+    expect(mockNode.widgets.length).toBe(1)
+    expect(mockNode.widgets[0].name).toBe('$$node-chat-history')
+    expect(mockNode.setDirtyCanvas).toHaveBeenCalled()
+  })
+  
+  it('removes chat history widget from node', () => {
+    const { showChatHistory, removeChatHistory } = useNodeChatHistory()
+    showChatHistory(mockNode)
+    
+    expect(mockNode.widgets.length).toBe(1)
+    
+    removeChatHistory(mockNode)
+    expect(mockNode.widgets.length).toBe(0)
+  })
+})

--- a/tests-ui/tests/composables/useNodeChatHistory.test.ts
+++ b/tests-ui/tests/composables/useNodeChatHistory.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LGraphNode } from '@comfyorg/litegraph'
+
 import { useNodeChatHistory } from '@/composables/node/useNodeChatHistory'
 
 vi.mock('@/composables/widgets/useChatHistoryWidget', () => ({
@@ -8,45 +10,53 @@ vi.mock('@/composables/widgets/useChatHistoryWidget', () => ({
         name: inputSpec.name,
         type: inputSpec.type
       }
-      
+
       if (!node.widgets) {
         node.widgets = []
       }
       node.widgets.push(widget)
-      
+
       return widget
     }
   }
 }))
+
+// Mock LGraphNode type
+type MockNode = {
+  widgets: Array<{ name: string; type: string }>;
+  setDirtyCanvas: ReturnType<typeof vi.fn>;
+  addCustomWidget: ReturnType<typeof vi.fn>;
+  [key: string]: any;
+}
 
 describe('useNodeChatHistory', () => {
   const mockNode = {
     widgets: [],
     setDirtyCanvas: vi.fn(),
     addCustomWidget: vi.fn()
-  }
-  
+  } as unknown as LGraphNode & MockNode
+
   beforeEach(() => {
     mockNode.widgets = []
     mockNode.setDirtyCanvas.mockClear()
     mockNode.addCustomWidget.mockClear()
   })
-  
+
   it('adds chat history widget to node', () => {
     const { showChatHistory } = useNodeChatHistory()
     showChatHistory(mockNode)
-    
+
     expect(mockNode.widgets.length).toBe(1)
     expect(mockNode.widgets[0].name).toBe('$$node-chat-history')
     expect(mockNode.setDirtyCanvas).toHaveBeenCalled()
   })
-  
+
   it('removes chat history widget from node', () => {
     const { showChatHistory, removeChatHistory } = useNodeChatHistory()
     showChatHistory(mockNode)
-    
+
     expect(mockNode.widgets.length).toBe(1)
-    
+
     removeChatHistory(mockNode)
     expect(mockNode.widgets.length).toBe(0)
   })

--- a/tests-ui/tests/store/executionStore.test.ts
+++ b/tests-ui/tests/store/executionStore.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const mockShowChatHistory = vi.fn()
+vi.mock('@/composables/node/useNodeChatHistory', () => ({
+  useNodeChatHistory: () => ({
+    showChatHistory: mockShowChatHistory
+  })
+}))
+
+vi.mock('@/composables/node/useNodeProgressText', () => ({
+  useNodeProgressText: () => ({
+    showTextPreview: vi.fn()
+  })
+}))
+
+global.app = {
+  graph: {
+    getNodeById: vi.fn()
+  }
+} as any
+
+describe('executionStore - display_component handling', () => {
+  function createDisplayComponentEvent(nodeId: string, component = 'ChatHistoryWidget') {
+    return new CustomEvent('display_component', {
+      detail: {
+        node_id: nodeId,
+        component,
+        props: {
+          history: JSON.stringify([{ prompt: 'Test', response: 'Response' }])
+        }
+      }
+    })
+  }
+  
+  function handleDisplayComponentMessage(event: CustomEvent) {
+    const { node_id, component } = event.detail
+    const node = app.graph.getNodeById(node_id)
+    if (node && component === 'ChatHistoryWidget') {
+      mockShowChatHistory(node)
+    }
+  }
+  
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    useExecutionStore()
+    vi.clearAllMocks()
+  })
+  
+  it('handles ChatHistoryWidget display_component messages', () => {
+    const mockNode = { id: '123' }
+    global.app.graph.getNodeById.mockReturnValue(mockNode)
+    
+    const event = createDisplayComponentEvent('123')
+    handleDisplayComponentMessage(event)
+    
+    expect(global.app.graph.getNodeById).toHaveBeenCalledWith('123')
+    expect(mockShowChatHistory).toHaveBeenCalledWith(mockNode)
+  })
+  
+  it('does nothing if node is not found', () => {
+    global.app.graph.getNodeById.mockReturnValue(null)
+    
+    const event = createDisplayComponentEvent('non-existent')
+    handleDisplayComponentMessage(event)
+    
+    expect(global.app.graph.getNodeById).toHaveBeenCalledWith('non-existent')
+    expect(mockShowChatHistory).not.toHaveBeenCalled()
+  })
+})

--- a/tests-ui/tests/store/executionStore.test.ts
+++ b/tests-ui/tests/store/executionStore.test.ts
@@ -1,6 +1,13 @@
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { setActivePinia, createPinia } from 'pinia'
+
 import { useExecutionStore } from '@/stores/executionStore'
+
+// Remove any previous global types
+declare global {
+  // Empty interface to override any previous declarations
+  interface Window {}
+}
 
 const mockShowChatHistory = vi.fn()
 vi.mock('@/composables/node/useNodeChatHistory', () => ({
@@ -15,14 +22,18 @@ vi.mock('@/composables/node/useNodeProgressText', () => ({
   })
 }))
 
-global.app = {
+// Create a local mock instead of using global to avoid conflicts
+const mockApp = {
   graph: {
     getNodeById: vi.fn()
   }
-} as any
+}
 
 describe('executionStore - display_component handling', () => {
-  function createDisplayComponentEvent(nodeId: string, component = 'ChatHistoryWidget') {
+  function createDisplayComponentEvent(
+    nodeId: string,
+    component = 'ChatHistoryWidget'
+  ) {
     return new CustomEvent('display_component', {
       detail: {
         node_id: nodeId,
@@ -33,39 +44,39 @@ describe('executionStore - display_component handling', () => {
       }
     })
   }
-  
+
   function handleDisplayComponentMessage(event: CustomEvent) {
     const { node_id, component } = event.detail
-    const node = app.graph.getNodeById(node_id)
+    const node = mockApp.graph.getNodeById(node_id)
     if (node && component === 'ChatHistoryWidget') {
       mockShowChatHistory(node)
     }
   }
-  
+
   beforeEach(() => {
     setActivePinia(createPinia())
     useExecutionStore()
     vi.clearAllMocks()
   })
-  
+
   it('handles ChatHistoryWidget display_component messages', () => {
     const mockNode = { id: '123' }
-    global.app.graph.getNodeById.mockReturnValue(mockNode)
-    
+    mockApp.graph.getNodeById.mockReturnValue(mockNode)
+
     const event = createDisplayComponentEvent('123')
     handleDisplayComponentMessage(event)
-    
-    expect(global.app.graph.getNodeById).toHaveBeenCalledWith('123')
+
+    expect(mockApp.graph.getNodeById).toHaveBeenCalledWith('123')
     expect(mockShowChatHistory).toHaveBeenCalledWith(mockNode)
   })
-  
+
   it('does nothing if node is not found', () => {
-    global.app.graph.getNodeById.mockReturnValue(null)
-    
+    mockApp.graph.getNodeById.mockReturnValue(null)
+
     const event = createDisplayComponentEvent('non-existent')
     handleDisplayComponentMessage(event)
-    
-    expect(global.app.graph.getNodeById).toHaveBeenCalledWith('non-existent')
+
+    expect(mockApp.graph.getNodeById).toHaveBeenCalledWith('non-existent')
     expect(mockShowChatHistory).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Adds comprehensive test coverage for the new ChatHistoryWidget component and related functionality. Follow-up to PR #3907.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3921-Add-tests-for-ChatHistoryWidget-and-related-features-1f66d73d365081cb8c99e203054047a1) by [Unito](https://www.unito.io)
