### PR TITLE
Hide manager button in missing nodes dialog when manager is not installed

### DIFF
--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -30,7 +30,7 @@
       </div>
     </template>
   </ListBox>
-  <div class="flex justify-end py-3">
+  <div v-if="isManagerInstalled" class="flex justify-end py-3">
     <Button label="Open Manager" size="small" outlined @click="openManager" />
   </div>
 </template>
@@ -42,12 +42,26 @@ import { computed } from 'vue'
 
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import { useDialogService } from '@/services/dialogService'
+import { useAboutPanelStore } from '@/stores/aboutPanelStore'
 import type { MissingNodeType } from '@/types/comfy'
 import { ManagerTab } from '@/types/comfyManagerTypes'
 
 const props = defineProps<{
   missingNodeTypes: MissingNodeType[]
 }>()
+
+const aboutPanelStore = useAboutPanelStore()
+
+// Determines if ComfyUI-Manager is installed by checking for its badge in the about panel
+// This allows us to conditionally show the Manager button only when the extension is available
+// TODO: Remove this check when Manager functionality is fully migrated into core
+const isManagerInstalled = computed(() => {
+  return aboutPanelStore.badges.some(
+    (badge) =>
+      badge.label.includes('ComfyUI-Manager') ||
+      badge.url.includes('ComfyUI-Manager')
+  )
+})
 
 const uniqueNodes = computed(() => {
   const seenTypes = new Set()


### PR DESCRIPTION
Conditionally shows the 'Open Manager' button in the missing nodes warning dialog only when the ComfyUI-Manager extension is installed. Uses the about panel badge registration to detect if manager is available without requiring additional API calls.

Fixes https://github.com/comfyanonymous/ComfyUI/issues/8185.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3925-Hide-manager-button-in-missing-nodes-dialog-when-manager-is-not-installed-1f76d73d365081bfae37e51fc04b6449) by [Unito](https://www.unito.io)
