### PR TITLE
docs: improve README development section organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Have another idea? Drop into Discord or open an issue, and let's chat!
 
 ## Development
 
-### Technical Stack & Prerequisites
+### Prerequisites & Technology Stack
 
 - **Required Software**:
   - Node.js (v16 or later) and npm

--- a/README.md
+++ b/README.md
@@ -526,11 +526,20 @@ Have another idea? Drop into Discord or open an issue, and let's chat!
 
 ## Development
 
-### Prerequisites
+### Technical Stack & Prerequisites
 
-- Node.js (v16 or later) and npm must be installed
-- Git for version control
-- A running ComfyUI backend instance
+- **Required Software**:
+  - Node.js (v16 or later) and npm
+  - Git for version control
+  - A running ComfyUI backend instance
+  
+- **Tech Stack**:
+  - [Vue 3](https://vuejs.org/) with [TypeScript](https://www.typescriptlang.org/)
+  - [Pinia](https://pinia.vuejs.org/) for state management
+  - [PrimeVue](https://primevue.org/) with [TailwindCSS](https://tailwindcss.com/) for UI
+  - [litegraph.js](https://github.com/Comfy-Org/litegraph.js) for node editor
+  - [zod](https://zod.dev/) for schema validation
+  - [vue-i18n](https://github.com/intlify/vue-i18n) for internationalization
 
 ### Initial Setup
 
@@ -558,15 +567,6 @@ To launch ComfyUI and have it connect to your development server:
 python main.py --port 8188
 ```
 
-### Tech Stack
-
-- [Vue 3](https://vuejs.org/) with [TypeScript](https://www.typescriptlang.org/)
-- [Pinia](https://pinia.vuejs.org/) for state management
-- [PrimeVue](https://primevue.org/) with [TailwindCSS](https://tailwindcss.com/) for UI
-- [litegraph.js](https://github.com/Comfy-Org/litegraph.js) for node editor
-- [zod](https://zod.dev/) for schema validation
-- [vue-i18n](https://github.com/intlify/vue-i18n) for internationalization
-
 ### Git pre-commit hooks
 
 Run `npm run prepare` to install Git pre-commit hooks. Currently, the pre-commit
@@ -579,6 +579,7 @@ core extensions will be loaded.
 
 - Start local ComfyUI backend at `localhost:8188`
 - Run `npm run dev` to start the dev server
+- Run `npm run dev:electron` to start the dev server with electron API mocked
 
 #### Access dev server on touch devices
 


### PR DESCRIPTION
Followup from https://github.com/Comfy-Org/ComfyUI_frontend/pull/3920: Combined Prerequisites and Tech Stack sections into one concise section at the top of the Development section, and added a note about using `npm run dev:electron` for running with Electron API mocked (inadvertently removed in https://github.com/Comfy-Org/ComfyUI_frontend/pull/3920)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3929-docs-improve-README-development-section-organization-1f76d73d3650811a8328c354df12b35c) by [Unito](https://www.unito.io)
