### PR TITLE
[fix] Adjust API node badge colors for light theme

### DIFF
--- a/src/composables/node/useNodeBadge.ts
+++ b/src/composables/node/useNodeBadge.ts
@@ -96,13 +96,17 @@ export const useNodeBadge = () => {
 
         if (node.constructor.nodeData?.api_node) {
           const creditsBadge = computed(() => {
+            // Use dynamic background color based on the theme
+            const isLightTheme =
+              colorPaletteStore.completedActivePalette.light_theme
             return new LGraphBadge({
               text: '',
               iconOptions: {
                 unicode: '\ue96b',
                 fontFamily: 'PrimeIcons',
                 color: '#FABC25',
-                bgColor: '#353535',
+                // Lighter background for light theme, darker for dark theme
+                bgColor: isLightTheme ? '#777777' : '#353535',
                 fontSize: 8
               },
               fgColor:

--- a/src/composables/node/useNodeBadge.ts
+++ b/src/composables/node/useNodeBadge.ts
@@ -12,6 +12,7 @@ import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { NodeBadgeMode } from '@/types/nodeSource'
+import { adjustColor } from '@/utils/colorUtil'
 
 /**
  * Add LGraphBadge to LGraphNode based on settings.
@@ -104,17 +105,20 @@ export const useNodeBadge = () => {
               iconOptions: {
                 unicode: '\ue96b',
                 fontFamily: 'PrimeIcons',
-                color: '#FABC25',
-                // Lighter background for light theme, darker for dark theme
-                bgColor: isLightTheme ? '#777777' : '#353535',
+                color: isLightTheme
+                  ? adjustColor('#FABC25', { lightness: 0.5 })
+                  : '#FABC25',
+                bgColor: isLightTheme
+                  ? adjustColor('#654020', { lightness: 0.5 })
+                  : '#654020',
                 fontSize: 8
               },
               fgColor:
                 colorPaletteStore.completedActivePalette.colors.litegraph_base
                   .BADGE_FG_COLOR,
-              bgColor:
-                colorPaletteStore.completedActivePalette.colors.litegraph_base
-                  .BADGE_BG_COLOR
+              bgColor: isLightTheme
+                ? adjustColor('#8D6932', { lightness: 0.5 })
+                : '#8D6932'
             })
           })
 


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/3943: Changes API node badge visibility in light theme by dynamically adjusting background and text colors based on the current theme.

Before:

![Selection_1422](https://github.com/user-attachments/assets/de130d7a-5136-4db4-a870-4780304e45a4)

After:

![Selection_1421](https://github.com/user-attachments/assets/c7bdc0e3-2dfe-4d40-b68e-6ee3cfc82f83)
