### PR TITLE
[Style] Increase template card elevation in dark mode

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -2,7 +2,7 @@
   <Card
     ref="cardRef"
     :data-testid="`template-workflow-${template.name}`"
-    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-1 h-full"
+    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-2 h-full"
     :pt="{
       body: { class: 'p-0 h-full flex flex-col' }
     }"

--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -2,7 +2,7 @@
   <Card
     ref="cardRef"
     :data-testid="`template-workflow-${template.name}`"
-    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-2 h-full"
+    class="w-64 template-card rounded-2xl overflow-hidden cursor-pointer shadow-elevation-2 dark-theme:bg-dark-elevation-1.5 h-full"
     :pt="{
       body: { class: 'p-0 h-full flex flex-col' }
     }"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -189,6 +189,8 @@ export default {
         'elevation-0': 'none',
         'elevation-1':
           '0 0 2px 0px rgb(0 0 0 / 0.01), 0 1px 2px -1px rgb(0 0 0 / 0.03), 0 1px 1px -1px rgb(0 0 0 / 0.01)',
+        'elevation-1.5':
+          '0 0 2px 0px rgb(0 0 0 / 0.025), 0 1px 2px -1px rgb(0 0 0 / 0.03), 0 1px 1px -1px rgb(0 0 0 / 0.01)',
         'elevation-2':
           '0 0 10px 0px rgb(0 0 0 / 0.06), 0 6px 8px -2px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.04)',
         'elevation-3':
@@ -206,10 +208,11 @@ export default {
       backgroundColor: {
         'dark-elevation-0': 'rgba(255, 255, 255, 0)',
         'dark-elevation-1': 'rgba(255, 255, 255, 0.01)',
+        'dark-elevation-1.5': 'rgba(255, 255, 255, 0.015)',
         'dark-elevation-2': 'rgba(255, 255, 255, 0.03)',
         'dark-elevation-3': 'rgba(255, 255, 255, 0.04)',
         'dark-elevation-4': 'rgba(255, 255, 255, 0.08)',
-        'dark-elevation-5': 'rgba(255, 255, 255, 0.12)'
+        'dark-elevation-5': 'rgba(2 55, 255, 255, 0.12)'
       }
     }
   },


### PR DESCRIPTION
Implement design changes requested [here](https://comfy-organization.slack.com/archives/C08NYSK0K0A/p1747723297240379?thread_ts=1746509319.458529&cid=C08NYSK0K0A): Increases elevation of template card, as, despite Material Design guidelines, it is currently too hard to distinguish the card background from the dialog background.

Before:

![Selection_1428](https://github.com/user-attachments/assets/fd43e2f5-9060-4681-a7c9-1b92412b4495)



After:

![Selection_1427](https://github.com/user-attachments/assets/4d296699-db50-4dbd-a113-1ffe6aedfd63)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3946-Style-Increase-template-card-elevation-in-dark-mode-1f96d73d365081498613f14742c5b860) by [Unito](https://www.unito.io)
