### PR TITLE
[Dev Tools] Add more claude directives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
+
+- Be sure to run unit tests, component tests, browser tests then typecheck, lint, format (with prettier) when you're done making a series of code changes. You can find the scripts for all these things in the package.json.
 - When referencing PrimeVue, you can get all the docs here: https://primevue.org. Do this instead of making up or inferring names of Components
 - Never add lines to PR descriptions that say "Generated with Claude Code"
 - When making PR names and commit messages, if you are going to add a prefix like "docs:", "feat:", "bugfix:", use square brackets around the prefix term and do not use a colon (e.g., should be "[docs]" rather than "docs:").
 - When I reference GitHub Repos related to Comfy-Org, you should proactively fetch or read the associated information in the repo. To do so, you should exhaust all options: (1) Check if we have a local copy of the repo, (2) Use the GitHub API to fetch the information; you may want to do this IN ADDITION to the other options, especially for reading speicifc branches/PRs/comments/reviews/metadata, and (3) curl the GitHub website and parse the html or json responses
+- For information about ComfyUI, ComfyUI_frontend, or ComfyUI-Manager, you can web search or download these wikis: https://deepwiki.com/Comfy-Org/ComfyUI-Manager, https://deepwiki.com/Comfy-Org/ComfyUI_frontend/1-overview, https://deepwiki.com/comfyanonymous/ComfyUI/2-core-architecture
 - If a question/project is related to Comfy-Org, Comfy, or ComfyUI ecosystem, you should proactively use the Comfy docs to answer the question. The docs may be referenced with URLs like https://docs.comfy.org
 - When operating inside a repo, check for README files at key locations in the repo detailing info about the contents of that folder. E.g., top-level key folders like tests-ui, browser_tests, composables, extensions/core, stores, services often have their own README.md files. When writing code, make sure to frequently reference these README files to understand the overall architecture and design of the project. Pay close attention to the snippets to learn particular patterns that seem to be there for a reason, as you should emulate those.
-- Be sure to typecheck when you're done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance
 - If using a lesser known or complex CLI tool, run the --help to see the documentation before deciding what to run, even if just for double-checking or verifying things.
 - IMPORTANT: the most important goal when writing code is to create clean, best-practices, sustainable, and scalable public APIs and interfaces. Our app is used by thousands of users and we have thousands of mods/extensions that are constantly changing and updating; and we are also always updating. That's why it is IMPORTANT that we design systems and write code that follows practices of domain-driven design, object-oriented design, and design patterns (such that you can assure stability while allowing for all components around you to change and evolve). We ABSOLUTELY prioritize clean APIs and public interfaces that clearly define and restrict how/what the mods/extensions can access.
@@ -18,7 +20,7 @@
 - Use watch and watchEffect for side effects
 - Implement lifecycle hooks with onMounted, onUpdated, etc.
 - Utilize provide/inject for dependency injection
-- Use vue 3.5 style of default prop declaration.
+- Use vue 3.5 style of default prop declaration. Do not define a `props` variable; instead, destructure props. Since vue 3.5, destructuring props does not strip them of reactivity.
 - Use Tailwind CSS for styling
 - Leverage VueUse functions for performance-enhancing styles
 - Use lodash for utility functions

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelectedNodes_Pin": {
     "label": "Pin/Unpin Selected Nodes"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "Open Mask Editor for Selected Node"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Zoom In"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "Toggle Progress Dialog"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "Open Mask Editor for Selected Node"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "New Blank Workflow"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -802,6 +802,7 @@
     "Load Default Workflow": "Load Default Workflow",
     "Custom Nodes Manager": "Custom Nodes Manager",
     "Toggle Progress Dialog": "Toggle Progress Dialog",
+    "Open Mask Editor for Selected Node": "Open Mask Editor for Selected Node",
     "New": "New",
     "Clipspace": "Clipspace",
     "Open": "Open",

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Anclar/Desanclar elementos seleccionados"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "Abrir editor de máscara para el nodo seleccionado"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Acercar"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "Alternar diálogo de progreso del administrador"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "Abrir editor de máscara para el nodo seleccionado"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "Nuevo flujo de trabajo en blanco"

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -710,6 +710,7 @@
     "Open DevTools": "Abrir DevTools",
     "Open Inputs Folder": "Abrir carpeta de entradas",
     "Open Logs Folder": "Abrir carpeta de registros",
+    "Open Mask Editor for Selected Node": "Abrir el editor de mask para el nodo seleccionado",
     "Open Models Folder": "Abrir carpeta de modelos",
     "Open Outputs Folder": "Abrir carpeta de salidas",
     "Open Sign In Dialog": "Abrir diálogo de inicio de sesión",

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Épingler/Désépingler les éléments sélectionnés"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "Ouvrir l'éditeur de masque pour le nœud sélectionné"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Zoom avant"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "Basculer la boîte de dialogue de progression"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "Ouvrir l'éditeur de masque pour le nœud sélectionné"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "Nouveau flux de travail vierge"

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -710,6 +710,7 @@
     "Open DevTools": "Ouvrir DevTools",
     "Open Inputs Folder": "Ouvrir le dossier des entrées",
     "Open Logs Folder": "Ouvrir le dossier des journaux",
+    "Open Mask Editor for Selected Node": "Ouvrir l’éditeur de mask pour le nœud sélectionné",
     "Open Models Folder": "Ouvrir le dossier des modèles",
     "Open Outputs Folder": "Ouvrir le dossier des sorties",
     "Open Sign In Dialog": "Ouvrir la boîte de dialogue de connexion",

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "選択したアイテムのピン留め/ピン留め解除"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "選択したノードのマスクエディタを開く"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "ズームイン"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "プログレスダイアログの切り替え"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "選択したノードのマスクエディタを開く"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "新しい空のワークフロー"

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -710,6 +710,7 @@
     "Open DevTools": "DevToolsを開く",
     "Open Inputs Folder": "入力フォルダを開く",
     "Open Logs Folder": "ログフォルダを開く",
+    "Open Mask Editor for Selected Node": "選択したノードのマスクエディタを開く",
     "Open Models Folder": "モデルフォルダを開く",
     "Open Outputs Folder": "出力フォルダを開く",
     "Open Sign In Dialog": "サインインダイアログを開く",

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "선택한 항목 고정/고정 해제"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "선택한 노드 마스크 편집기 열기"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "확대"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "진행 상황 대화 상자 전환"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "선택한 노드 마스크 편집기 열기"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "새로운 빈 워크플로"

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -710,6 +710,7 @@
     "Open DevTools": "개발자 도구 열기",
     "Open Inputs Folder": "입력 폴더 열기",
     "Open Logs Folder": "로그 폴더 열기",
+    "Open Mask Editor for Selected Node": "선택한 노드의 마스크 에디터 열기",
     "Open Models Folder": "모델 폴더 열기",
     "Open Outputs Folder": "출력 폴더 열기",
     "Open Sign In Dialog": "로그인 대화 상자 열기",

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "Закрепить/Открепить выбранных нод"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "Открыть редактор масок для выбранной ноды"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "Увеличить"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "Переключить диалоговое окно прогресса"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "Открыть редактор масок для выбранной ноды"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "Новый пустой рабочий процесс"

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -710,6 +710,7 @@
     "Open DevTools": "Открыть инструменты разработчика",
     "Open Inputs Folder": "Открыть папку входных данных",
     "Open Logs Folder": "Открыть папку журналов",
+    "Open Mask Editor for Selected Node": "Открыть редактор масок для выбранного узла",
     "Open Models Folder": "Открыть папку моделей",
     "Open Outputs Folder": "Открыть папку выходных данных",
     "Open Sign In Dialog": "Открыть окно входа",

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -71,9 +71,6 @@
   "Comfy_Canvas_ToggleSelected_Pin": {
     "label": "固定/取消固定选中项"
   },
-  "Comfy_MaskEditor_OpenMaskEditor": {
-    "label": "打开选中节点的遮罩编辑器"
-  },
   "Comfy_Canvas_ZoomIn": {
     "label": "放大"
   },
@@ -142,6 +139,9 @@
   },
   "Comfy_Manager_ToggleManagerProgressDialog": {
     "label": "切换进度对话框"
+  },
+  "Comfy_MaskEditor_OpenMaskEditor": {
+    "label": "打开选中节点的遮罩编辑器"
   },
   "Comfy_NewBlankWorkflow": {
     "label": "新建空白工作流"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -710,6 +710,7 @@
     "Open DevTools": "打开开发者工具",
     "Open Inputs Folder": "打开输入文件夹",
     "Open Logs Folder": "打开日志文件夹",
+    "Open Mask Editor for Selected Node": "为选中节点打开 Mask 编辑器",
     "Open Models Folder": "打开模型文件夹",
     "Open Outputs Folder": "打开输出文件夹",
     "Open Sign In Dialog": "打开登录对话框",


### PR DESCRIPTION
Add rules:

- Be sure to run unit tests, component tests, browser tests then typecheck, lint, format (with prettier) when you're done making a series of code changes. You can find the scripts for all these things in the package.json.
- Use vue 3.5 style of default prop declaration. Do not define a `props` variable; instead, destructure props. Since vue 3.5, destructuring props does not strip them of reactivity.
- For information about ComfyUI, ComfyUI_frontend, or ComfyUI-Manager, you can web search or download these wikis: https://deepwiki.com/Comfy-Org/ComfyUI-Manager, https://deepwiki.com/Comfy-Org/ComfyUI_frontend/1-overview, https://deepwiki.com/comfyanonymous/ComfyUI/2-core-architecture

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3948-Dev-Tools-Add-more-claude-directives-1f96d73d3650810094e6f04c8e793585) by [Unito](https://www.unito.io)
