### PR TITLE
Move `user.css` to user data

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>ComfyUI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <link rel="stylesheet" type="text/css" href="user.css" />
+    <link rel="stylesheet" type="text/css" href="custom_css/user.css" />
     <link rel="stylesheet" type="text/css" href="materialdesignicons.min.css" />
     
     <!-- Fullscreen mode on iOS -->

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>ComfyUI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <link rel="stylesheet" type="text/css" href="custom_css/user.css" />
+    <link rel="stylesheet" type="text/css" href="api/userdata/user.css" />
     <link rel="stylesheet" type="text/css" href="materialdesignicons.min.css" />
     
     <!-- Fullscreen mode on iOS -->

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8">
     <title>ComfyUI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <link rel="stylesheet" type="text/css" href="api/userdata/user.css" />
     <link rel="stylesheet" type="text/css" href="materialdesignicons.min.css" />
+    <link rel="stylesheet" type="text/css" href="user.css" />
+    <link rel="stylesheet" type="text/css" href="api/userdata/user.css" />
     
     <!-- Fullscreen mode on iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Set path of `user.css` to `userdata`, so it can be served from per-user static folder set on the server.

Resolves https://github.com/comfyanonymous/ComfyUI/issues/6544
Resolves https://github.com/comfyanonymous/ComfyUI/discussions/3349
Resolves https://github.com/comfyanonymous/ComfyUI/issues/6544
Resolves https://github.com/comfyanonymous/ComfyUI/issues/1999
Resolves https://github.com/comfyanonymous/ComfyUI/issues/4405
Resolves https://github.com/comfyanonymous/ComfyUI/issues/4387


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3952-Migrate-user-css-file-to-upstream-2-2-Prefix-user-css-path-1fa6d73d36508177a232e90073c70ae7) by [Unito](https://www.unito.io)
