### PR TITLE
[refactor] Refactor file handling

### DIFF
--- a/src/utils/fileHandlers.ts
+++ b/src/utils/fileHandlers.ts
@@ -1,0 +1,336 @@
+/**
+ * Maps MIME types and file extensions to handler functions for extracting
+ * workflow data from various file formats. Uses supportedWorkflowFormats.ts
+ * as the source of truth for supported formats.
+ */
+import {
+  AUDIO_WORKFLOW_FORMATS,
+  DATA_WORKFLOW_FORMATS,
+  IMAGE_WORKFLOW_FORMATS,
+  MODEL_WORKFLOW_FORMATS,
+  VIDEO_WORKFLOW_FORMATS
+} from '@/constants/supportedWorkflowFormats'
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
+} from '@/schemas/comfyWorkflowSchema'
+import { getFromWebmFile } from '@/scripts/metadata/ebml'
+import { getGltfBinaryMetadata } from '@/scripts/metadata/gltf'
+import { getFromIsobmffFile } from '@/scripts/metadata/isobmff'
+import { getMp3Metadata } from '@/scripts/metadata/mp3'
+import { getOggMetadata } from '@/scripts/metadata/ogg'
+import { getSvgMetadata } from '@/scripts/metadata/svg'
+import {
+  getFlacMetadata,
+  getLatentMetadata,
+  getPngMetadata,
+  getWebpMetadata
+} from '@/scripts/pnginfo'
+
+/**
+ * Type for the file handler function
+ */
+export type WorkflowFileHandler = (file: File) => Promise<{
+  workflow?: ComfyWorkflowJSON
+  prompt?: ComfyApiWorkflow
+  parameters?: string
+  jsonTemplateData?: any // For template JSON data
+}>
+
+/**
+ * Maps MIME types to file handlers for loading workflows from different file formats
+ */
+export const mimeTypeHandlers = new Map<string, WorkflowFileHandler>()
+
+/**
+ * Maps file extensions to file handlers for loading workflows
+ * Used as a fallback when MIME type detection fails
+ */
+export const extensionHandlers = new Map<string, WorkflowFileHandler>()
+
+/**
+ * Handler for PNG files
+ */
+const handlePngFile: WorkflowFileHandler = async (file) => {
+  const pngInfo = await getPngMetadata(file)
+  return {
+    workflow: pngInfo?.workflow ? JSON.parse(pngInfo.workflow) : undefined,
+    prompt: pngInfo?.prompt ? JSON.parse(pngInfo.prompt) : undefined,
+    parameters: pngInfo?.parameters
+  }
+}
+
+/**
+ * Handler for WebP files
+ */
+const handleWebpFile: WorkflowFileHandler = async (file) => {
+  const pngInfo = await getWebpMetadata(file)
+  // Support loading workflows from that webp custom node.
+  const workflow = pngInfo?.workflow || pngInfo?.Workflow
+  const prompt = pngInfo?.prompt || pngInfo?.Prompt
+
+  return {
+    workflow: workflow ? JSON.parse(workflow) : undefined,
+    prompt: prompt ? JSON.parse(prompt) : undefined
+  }
+}
+
+/**
+ * Handler for SVG files
+ */
+const handleSvgFile: WorkflowFileHandler = async (file) => {
+  const svgInfo = await getSvgMetadata(file)
+  return {
+    workflow: svgInfo.workflow,
+    prompt: svgInfo.prompt
+  }
+}
+
+/**
+ * Handler for MP3 files
+ */
+const handleMp3File: WorkflowFileHandler = async (file) => {
+  const { workflow, prompt } = await getMp3Metadata(file)
+  return { workflow, prompt }
+}
+
+/**
+ * Handler for OGG files
+ */
+const handleOggFile: WorkflowFileHandler = async (file) => {
+  const { workflow, prompt } = await getOggMetadata(file)
+  return { workflow, prompt }
+}
+
+/**
+ * Handler for FLAC files
+ */
+const handleFlacFile: WorkflowFileHandler = async (file) => {
+  const pngInfo = await getFlacMetadata(file)
+  const workflow = pngInfo?.workflow || pngInfo?.Workflow
+  const prompt = pngInfo?.prompt || pngInfo?.Prompt
+
+  return {
+    workflow: workflow ? JSON.parse(workflow) : undefined,
+    prompt: prompt ? JSON.parse(prompt) : undefined
+  }
+}
+
+/**
+ * Handler for WebM files
+ */
+const handleWebmFile: WorkflowFileHandler = async (file) => {
+  const webmInfo = await getFromWebmFile(file)
+  return {
+    workflow: webmInfo.workflow,
+    prompt: webmInfo.prompt
+  }
+}
+
+/**
+ * Handler for MP4/MOV/M4V files
+ */
+const handleMp4File: WorkflowFileHandler = async (file) => {
+  const mp4Info = await getFromIsobmffFile(file)
+  return {
+    workflow: mp4Info.workflow,
+    prompt: mp4Info.prompt
+  }
+}
+
+/**
+ * Handler for GLB files
+ */
+const handleGlbFile: WorkflowFileHandler = async (file) => {
+  const gltfInfo = await getGltfBinaryMetadata(file)
+  return {
+    workflow: gltfInfo.workflow,
+    prompt: gltfInfo.prompt
+  }
+}
+
+/**
+ * Handler for JSON files
+ */
+const handleJsonFile: WorkflowFileHandler = async (file) => {
+  // For JSON files, we need to preserve the exact behavior from app.ts
+  // This code intentionally mirrors the original implementation
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const readerResult = reader.result as string
+        const jsonContent = JSON.parse(readerResult)
+
+        if (jsonContent?.templates) {
+          // This case will be handled separately in handleFile
+          resolve({
+            workflow: undefined,
+            prompt: undefined,
+            jsonTemplateData: jsonContent
+          })
+        } else if (isApiJson(jsonContent)) {
+          // API JSON format
+          resolve({ workflow: undefined, prompt: jsonContent })
+        } else {
+          // Regular workflow JSON
+          resolve({ workflow: JSON.parse(readerResult), prompt: undefined })
+        }
+      } catch (error) {
+        reject(error)
+      }
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(file)
+  })
+}
+
+/**
+ * Handler for .latent and .safetensors files
+ */
+const handleLatentFile: WorkflowFileHandler = async (file) => {
+  // Preserve the exact behavior from app.ts for latent files
+  const info = await getLatentMetadata(file)
+
+  // Direct port of the original code, preserving behavior for TS compatibility
+  if (info && typeof info === 'object' && 'workflow' in info && info.workflow) {
+    return {
+      workflow: JSON.parse(info.workflow as string),
+      prompt: undefined
+    }
+  } else if (
+    info &&
+    typeof info === 'object' &&
+    'prompt' in info &&
+    info.prompt
+  ) {
+    return {
+      workflow: undefined,
+      prompt: JSON.parse(info.prompt as string)
+    }
+  } else {
+    return { workflow: undefined, prompt: undefined }
+  }
+}
+
+/**
+ * Helper function to determine if a JSON object is in the API JSON format
+ */
+function isApiJson(data: unknown) {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    Object.values(data as Record<string, any>).every((v) => v.class_type)
+  )
+}
+
+// Register image format handlers
+IMAGE_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+  if (mimeType === 'image/png') {
+    mimeTypeHandlers.set(mimeType, handlePngFile)
+  } else if (mimeType === 'image/webp') {
+    mimeTypeHandlers.set(mimeType, handleWebpFile)
+  } else if (mimeType === 'image/svg+xml') {
+    mimeTypeHandlers.set(mimeType, handleSvgFile)
+  }
+})
+
+IMAGE_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+  if (ext === '.png') {
+    extensionHandlers.set(ext, handlePngFile)
+  } else if (ext === '.webp') {
+    extensionHandlers.set(ext, handleWebpFile)
+  } else if (ext === '.svg') {
+    extensionHandlers.set(ext, handleSvgFile)
+  }
+})
+
+// Register audio format handlers
+AUDIO_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+  if (mimeType === 'audio/mpeg') {
+    mimeTypeHandlers.set(mimeType, handleMp3File)
+  } else if (mimeType === 'audio/ogg') {
+    mimeTypeHandlers.set(mimeType, handleOggFile)
+  } else if (mimeType === 'audio/flac' || mimeType === 'audio/x-flac') {
+    mimeTypeHandlers.set(mimeType, handleFlacFile)
+  }
+})
+
+AUDIO_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+  if (ext === '.mp3') {
+    extensionHandlers.set(ext, handleMp3File)
+  } else if (ext === '.ogg') {
+    extensionHandlers.set(ext, handleOggFile)
+  } else if (ext === '.flac') {
+    extensionHandlers.set(ext, handleFlacFile)
+  }
+})
+
+// Register video format handlers
+VIDEO_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+  if (mimeType === 'video/webm') {
+    mimeTypeHandlers.set(mimeType, handleWebmFile)
+  } else if (
+    mimeType === 'video/mp4' ||
+    mimeType === 'video/quicktime' ||
+    mimeType === 'video/x-m4v'
+  ) {
+    mimeTypeHandlers.set(mimeType, handleMp4File)
+  }
+})
+
+VIDEO_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+  if (ext === '.webm') {
+    extensionHandlers.set(ext, handleWebmFile)
+  } else if (ext === '.mp4' || ext === '.mov' || ext === '.m4v') {
+    extensionHandlers.set(ext, handleMp4File)
+  }
+})
+
+// Register 3D model format handlers
+MODEL_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+  if (mimeType === 'model/gltf-binary') {
+    mimeTypeHandlers.set(mimeType, handleGlbFile)
+  }
+})
+
+MODEL_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+  if (ext === '.glb') {
+    extensionHandlers.set(ext, handleGlbFile)
+  }
+})
+
+// Register data format handlers
+DATA_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+  if (mimeType === 'application/json') {
+    mimeTypeHandlers.set(mimeType, handleJsonFile)
+  }
+})
+
+DATA_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+  if (ext === '.json') {
+    extensionHandlers.set(ext, handleJsonFile)
+  } else if (ext === '.latent' || ext === '.safetensors') {
+    extensionHandlers.set(ext, handleLatentFile)
+  }
+})
+
+/**
+ * Gets the appropriate file handler for a given file based on mime type or extension
+ */
+export function getFileHandler(file: File): WorkflowFileHandler | null {
+  // First try to match by MIME type
+  if (file.type && mimeTypeHandlers.has(file.type)) {
+    return mimeTypeHandlers.get(file.type) || null
+  }
+
+  // If no MIME type match, try to match by file extension
+  if (file.name) {
+    const extension = '.' + file.name.split('.').pop()?.toLowerCase()
+    if (extension && extensionHandlers.has(extension)) {
+      return extensionHandlers.get(extension) || null
+    }
+  }
+
+  return null
+}

--- a/tests-ui/tests/utils/fileHandlers.test.ts
+++ b/tests-ui/tests/utils/fileHandlers.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUDIO_WORKFLOW_FORMATS,
+  DATA_WORKFLOW_FORMATS,
+  IMAGE_WORKFLOW_FORMATS,
+  MODEL_WORKFLOW_FORMATS,
+  VIDEO_WORKFLOW_FORMATS
+} from '../../../src/constants/supportedWorkflowFormats'
+import {
+  extensionHandlers,
+  getFileHandler,
+  mimeTypeHandlers
+} from '../../../src/utils/fileHandlers'
+
+describe('fileHandlers', () => {
+  describe('handler registrations', () => {
+    it('should register handlers for all image MIME types', () => {
+      IMAGE_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+        expect(mimeTypeHandlers.has(mimeType)).toBe(true)
+        expect(mimeTypeHandlers.get(mimeType)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all image extensions', () => {
+      IMAGE_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+        expect(extensionHandlers.has(ext)).toBe(true)
+        expect(extensionHandlers.get(ext)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all audio MIME types', () => {
+      AUDIO_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+        expect(mimeTypeHandlers.has(mimeType)).toBe(true)
+        expect(mimeTypeHandlers.get(mimeType)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all audio extensions', () => {
+      AUDIO_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+        expect(extensionHandlers.has(ext)).toBe(true)
+        expect(extensionHandlers.get(ext)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all video MIME types', () => {
+      VIDEO_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+        expect(mimeTypeHandlers.has(mimeType)).toBe(true)
+        expect(mimeTypeHandlers.get(mimeType)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all video extensions', () => {
+      VIDEO_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+        expect(extensionHandlers.has(ext)).toBe(true)
+        expect(extensionHandlers.get(ext)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all 3D model MIME types', () => {
+      MODEL_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+        expect(mimeTypeHandlers.has(mimeType)).toBe(true)
+        expect(mimeTypeHandlers.get(mimeType)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all 3D model extensions', () => {
+      MODEL_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+        expect(extensionHandlers.has(ext)).toBe(true)
+        expect(extensionHandlers.get(ext)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all data MIME types', () => {
+      DATA_WORKFLOW_FORMATS.mimeTypes.forEach((mimeType) => {
+        expect(mimeTypeHandlers.has(mimeType)).toBe(true)
+        expect(mimeTypeHandlers.get(mimeType)).toBeTypeOf('function')
+      })
+    })
+
+    it('should register handlers for all data extensions', () => {
+      DATA_WORKFLOW_FORMATS.extensions.forEach((ext) => {
+        expect(extensionHandlers.has(ext)).toBe(true)
+        expect(extensionHandlers.get(ext)).toBeTypeOf('function')
+      })
+    })
+  })
+
+  describe('getFileHandler', () => {
+    it('should return a handler when a file with a recognized MIME type is provided', () => {
+      const file = new File(['test content'], 'test.png', { type: 'image/png' })
+      const handler = getFileHandler(file)
+      expect(handler).not.toBeNull()
+      expect(handler).toBeTypeOf('function')
+    })
+
+    it('should return a handler when a file with a recognized extension but no MIME type is provided', () => {
+      // File with empty MIME type but recognizable extension
+      const file = new File(['test content'], 'test.webp', { type: '' })
+      const handler = getFileHandler(file)
+      expect(handler).not.toBeNull()
+      expect(handler).toBeTypeOf('function')
+    })
+
+    it('should return null when no handler is found for the file type', () => {
+      const file = new File(['test content'], 'test.txt', {
+        type: 'text/plain'
+      })
+      const handler = getFileHandler(file)
+      expect(handler).toBeNull()
+    })
+
+    it('should prioritize MIME type over extension when both are present and different', () => {
+      // A file with a JSON MIME type but SVG extension
+      const file = new File(['{}'], 'test.svg', { type: 'application/json' })
+      const handler = getFileHandler(file)
+
+      // Make a shadow copy of the handlers for comparison
+      const jsonHandler = mimeTypeHandlers.get('application/json')
+      const svgHandler = extensionHandlers.get('.svg')
+
+      // The handler should match the JSON handler, not the SVG handler
+      expect(handler).toBe(jsonHandler)
+      expect(handler).not.toBe(svgHandler)
+    })
+  })
+})


### PR DESCRIPTION
Refactors file drop handling to use the supportedWorkflowFormats.ts constants as a source of truth. This makes extending file format support more maintainable by centralizing MIME types in a single location. Fixes #3651.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3955-refactor-Refactor-file-handling-1fa6d73d365081c3b1b2e701f25081d5) by [Unito](https://www.unito.io)
