### PR TITLE
export dialogStore to custom node

### DIFF
--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -227,6 +227,10 @@ export const useDialogService = () => {
     })
   }
 
+  function showCustomDialog(options: ShowDialogOptions) {
+    dialogStore.showDialog(options)
+  }
+
   /**
    * Shows a dialog requiring sign in for API nodes
    * @returns Promise that resolves to true if user clicks login, false if cancelled
@@ -394,6 +398,7 @@ export const useDialogService = () => {
     showSignInDialog,
     showTopUpCreditsDialog,
     showUpdatePasswordDialog,
+    showCustomDialog,
     prompt,
     confirm
   }

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import type { Settings } from '@/schemas/apiSchema'
 import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useDialogService } from '@/services/dialogService'
+import { useDialogStore } from '@/stores/dialogStore'
 import type { SidebarTabExtension, ToastManager } from '@/types/extensionTypes'
 
 import { useApiKeyAuthStore } from './apiKeyAuthStore'
@@ -43,6 +44,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   const workflow = computed(() => useWorkflowStore())
   const colorPalette = useColorPaletteService()
   const dialog = useDialogService()
+  const dialogStore = useDialogStore()
   const bottomPanel = useBottomPanelStore()
 
   const authStore = useFirebaseAuthStore()
@@ -99,6 +101,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     workflow,
     colorPalette,
     dialog,
+    dialogStore,
     bottomPanel,
     user: partialUserStore,
 

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -4,7 +4,6 @@ import { computed, ref } from 'vue'
 import type { Settings } from '@/schemas/apiSchema'
 import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useDialogService } from '@/services/dialogService'
-import { useDialogStore } from '@/stores/dialogStore'
 import type { SidebarTabExtension, ToastManager } from '@/types/extensionTypes'
 
 import { useApiKeyAuthStore } from './apiKeyAuthStore'
@@ -44,7 +43,6 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   const workflow = computed(() => useWorkflowStore())
   const colorPalette = useColorPaletteService()
   const dialog = useDialogService()
-  const dialogStore = useDialogStore()
   const bottomPanel = useBottomPanelStore()
 
   const authStore = useFirebaseAuthStore()
@@ -101,7 +99,6 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     workflow,
     colorPalette,
     dialog,
-    dialogStore,
     bottomPanel,
     user: partialUserStore,
 


### PR DESCRIPTION
As a custom node developer, I would like to ComfyUI export dialogStore to allow using something like 
```
app.extensionManager.dialogStore.showDialog({
      key: 'global-gopainter',
      title: 'global-gopainter',
      component: App,
      dialogComponentProps: {
        style: 'width: 80vw; height: 80vh;',
        maximizable: true
      }
    })
```
App.vue is my custom Vue compoment, which I want to open in ComfyUI dialog
┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3980-export-dialogStore-to-custom-node-1ff6d73d365081639164cd7d29f5d55e) by [Unito](https://www.unito.io)
