### PR TITLE
Add GH types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,7 +1,9 @@
 name: Bug Report
-description: "Something is not behaving as expected."
-title: "[Bug]: "
+description: 'Something is not behaving as expected.'
+title: '[Bug]: '
 labels: ['Potential Bug']
+type: Bug
+
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,7 +1,8 @@
 name: Feature Request
 description: Suggest an idea for this project
-title: "[Feature Request]: "
-labels: ["enhancement"]
+title: '[Feature Request]: '
+labels: ['enhancement']
+type: Feature
 
 body:
   - type: checkboxes


### PR DESCRIPTION
Adds Bug and Feature types to issue templates.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-3991-Add-GH-types-to-issue-templates-2006d73d3650813f8e40ce0e592d7284) by [Unito](https://www.unito.io)
