### PR TITLE
Add copy url button

### DIFF
--- a/src/components/common/FileDownload.vue
+++ b/src/components/common/FileDownload.vue
@@ -30,15 +30,25 @@
         @click="download.triggerBrowserDownload"
       />
     </div>
+    <div>
+      <Button
+        :label="copyURLLabel"
+        size="small"
+        outlined
+        :disabled="!!props.error"
+        @click="copyURL"
+      />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import Button from 'primevue/button'
 import Message from 'primevue/message'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import { useDownload } from '@/composables/useDownload'
+import { t } from '@/i18n'
 import { formatSize } from '@/utils/formatUtil'
 
 const props = defineProps<{
@@ -49,9 +59,18 @@ const props = defineProps<{
 }>()
 
 const label = computed(() => props.label || props.url.split('/').pop())
+const copiedURL = ref(false)
+const copyURLLabel = computed(() =>
+  copiedURL.value ? t('g.copied') : t('g.copyURL')
+)
+
 const hint = computed(() => props.hint || props.url)
 const download = useDownload(props.url)
 const fileSize = computed(() =>
   download.fileSize.value ? formatSize(download.fileSize.value) : '?'
 )
+const copyURL = () => {
+  void navigator.clipboard.writeText(props.url)
+  copiedURL.value = true
+}
 </script>

--- a/src/components/common/FileDownload.vue
+++ b/src/components/common/FileDownload.vue
@@ -32,7 +32,7 @@
     </div>
     <div>
       <Button
-        :label="copyURLLabel"
+        :label="$t('g.copyURL')"
         size="small"
         outlined
         :disabled="!!props.error"
@@ -45,10 +45,10 @@
 <script setup lang="ts">
 import Button from 'primevue/button'
 import Message from 'primevue/message'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { useDownload } from '@/composables/useDownload'
-import { t } from '@/i18n'
 import { formatSize } from '@/utils/formatUtil'
 
 const props = defineProps<{
@@ -59,18 +59,15 @@ const props = defineProps<{
 }>()
 
 const label = computed(() => props.label || props.url.split('/').pop())
-const copiedURL = ref(false)
-const copyURLLabel = computed(() =>
-  copiedURL.value ? t('g.copied') : t('g.copyURL')
-)
 
 const hint = computed(() => props.hint || props.url)
 const download = useDownload(props.url)
 const fileSize = computed(() =>
   download.fileSize.value ? formatSize(download.fileSize.value) : '?'
 )
-const copyURL = () => {
-  void navigator.clipboard.writeText(props.url)
-  copiedURL.value = true
+const copyURL = async () => {
+  await copyToClipboard(props.url)
 }
+
+const { copyToClipboard } = useCopyToClipboard()
 </script>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -121,7 +121,9 @@
     "edit": "Edit",
     "copy": "Copy",
     "imageUrl": "Image URL",
-    "clear": "Clear"
+    "clear": "Clear",
+    "copyURL": "Copy URL",
+    "copied": "Copied"
   },
   "manager": {
     "title": "Custom Nodes Manager",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -122,8 +122,7 @@
     "copy": "Copy",
     "imageUrl": "Image URL",
     "clear": "Clear",
-    "copyURL": "Copy URL",
-    "copied": "Copied"
+    "copyURL": "Copy URL"
   },
   "manager": {
     "title": "Custom Nodes Manager",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -268,6 +268,7 @@
     "control_before_generate": "control antes de generar",
     "copy": "Copiar",
     "copyToClipboard": "Copiar al portapapeles",
+    "copyURL": "Copiar URL",
     "currentUser": "Usuario actual",
     "customBackground": "Fondo personalizado",
     "customize": "Personalizar",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -268,6 +268,7 @@
     "control_before_generate": "contrôle avant génération",
     "copy": "Copier",
     "copyToClipboard": "Copier dans le presse-papiers",
+    "copyURL": "Copier l’URL",
     "currentUser": "Utilisateur actuel",
     "customBackground": "Arrière-plan personnalisé",
     "customize": "Personnaliser",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -268,6 +268,7 @@
     "control_before_generate": "生成前の制御",
     "copy": "コピー",
     "copyToClipboard": "クリップボードにコピー",
+    "copyURL": "URLをコピー",
     "currentUser": "現在のユーザー",
     "customBackground": "カスタム背景",
     "customize": "カスタマイズ",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -268,6 +268,7 @@
     "control_before_generate": "생성 전 제어",
     "copy": "복사",
     "copyToClipboard": "클립보드에 복사",
+    "copyURL": "URL 복사",
     "currentUser": "현재 사용자",
     "customBackground": "맞춤 배경",
     "customize": "사용자 정의",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -268,6 +268,7 @@
     "control_before_generate": "управление до генерации",
     "copy": "Копировать",
     "copyToClipboard": "Скопировать в буфер обмена",
+    "copyURL": "Скопировать URL",
     "currentUser": "Текущий пользователь",
     "customBackground": "Пользовательский фон",
     "customize": "Настроить",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -268,6 +268,7 @@
     "control_before_generate": "生成前控制",
     "copy": "复制",
     "copyToClipboard": "复制到剪贴板",
+    "copyURL": "复制链接",
     "currentUser": "当前用户",
     "customBackground": "自定义背景",
     "customize": "自定义",


### PR DESCRIPTION
add copy url button,
UI improvement requested in https://github.com/Comfy-Org/ComfyUI_frontend/issues/3984
![image](https://github.com/user-attachments/assets/c568aa2d-8314-4edb-bfce-49948b09f5a7)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4000-Add-copy-url-button-2016d73d365081569390dc0e1ebf6ef1) by [Unito](https://www.unito.io)
