### PR TITLE
[fix] Disable serialization for text preview widget

### DIFF
--- a/src/composables/widgets/useProgressTextWidget.ts
+++ b/src/composables/widgets/useProgressTextWidget.ts
@@ -28,7 +28,8 @@ export const useTextPreviewWidget = (
         setValue: (value: string | object) => {
           widgetValue.value = typeof value === 'string' ? value : String(value)
         },
-        getMinHeight: () => options.minHeight ?? 42 + PADDING
+        getMinHeight: () => options.minHeight ?? 42 + PADDING,
+        serialize: false
       }
     })
     addWidget(node, widget)


### PR DESCRIPTION
- Prevented API nodes from benefiting from execution engine cache. The node inputs would always be dirty because it would send the result url from the previous run.
- Adds serialize: false property to text preview widget to prevent its content from being included in workflow serialization

Fixed https://github.com/Comfy-Org/ComfyUI_frontend/issues/4001

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4004-fix-Disable-serialization-for-text-preview-widget-2016d73d36508189be79f3380530f007) by [Unito](https://www.unito.io)
