### PR TITLE
Fix dragging preview image does nothing

### DIFF
--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -1,10 +1,11 @@
-import { type LGraphNode, LegacyWidget, LiteGraph } from '@comfyorg/litegraph'
+import { BaseWidget, type LGraphNode, LiteGraph } from '@comfyorg/litegraph'
 import type {
   IBaseWidget,
   IWidgetOptions
 } from '@comfyorg/litegraph/dist/types/widgets'
 
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { app } from '@/scripts/app'
 import { calculateImageGrid } from '@/scripts/ui/imagePreview'
 import { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
 import { useCanvasStore } from '@/stores/graphStore'
@@ -234,7 +235,7 @@ const renderPreview = (
   }
 }
 
-class ImagePreviewWidget extends LegacyWidget {
+class ImagePreviewWidget extends BaseWidget {
   constructor(
     node: LGraphNode,
     name: string,
@@ -256,6 +257,12 @@ class ImagePreviewWidget extends LegacyWidget {
 
   override drawWidget(ctx: CanvasRenderingContext2D): void {
     renderPreview(ctx, this.node, this.y)
+  }
+
+  override onClick(): void {}
+
+  override onDrag(): void {
+    app.canvas.dragging_canvas = true
   }
 
   override computeLayoutSize() {

--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -266,25 +266,27 @@ class ImagePreviewWidget extends BaseWidget {
 
   override onPointerDown(pointer: CanvasPointer, node: LGraphNode): boolean {
     pointer.onDragStart = () => {
-      app.canvas.emitBeforeChange()
-      app.canvas.graph?.beforeChange()
+      const { canvas } = app
+      const { graph } = canvas
+      canvas.emitBeforeChange()
+      graph?.beforeChange()
       // Ensure that dragging is properly cleaned up, on success or failure.
       pointer.finally = () => {
-        app.canvas.isDragging = false
-        app.canvas.graph?.afterChange()
-        app.canvas.emitAfterChange()
+        canvas.isDragging = false
+        graph?.afterChange()
+        canvas.emitAfterChange()
       }
 
-      app.canvas.processSelect(node, pointer.eDown)
-      app.canvas.isDragging = true
+      canvas.processSelect(node, pointer.eDown)
+      canvas.isDragging = true
     }
 
     pointer.onDragEnd = (e) => {
-      const { graph } = app.canvas
+      const { canvas } = app
       if (e.shiftKey || LiteGraph.alwaysSnapToGrid)
-        graph?.snapToGrid(app.canvas.selectedItems)
+        canvas.graph?.snapToGrid(canvas.selectedItems)
 
-      app.canvas.setDirty(true, true)
+      canvas.setDirty(true, true)
     }
 
     return true

--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -1,6 +1,6 @@
-import { type LGraphNode, LiteGraph } from '@comfyorg/litegraph'
+import { type LGraphNode, LegacyWidget, LiteGraph } from '@comfyorg/litegraph'
 import type {
-  ICustomWidget,
+  IBaseWidget,
   IWidgetOptions
 } from '@comfyorg/litegraph/dist/types/widgets'
 
@@ -234,30 +234,31 @@ const renderPreview = (
   }
 }
 
-class ImagePreviewWidget implements ICustomWidget {
-  readonly type = 'custom'
-  /** Dummy value to satisfy type requirements. */
-  value: string = ''
-  y: number = 0
-  /** Don't serialize the widget value. */
-  serialize: boolean = false
-
+class ImagePreviewWidget extends LegacyWidget {
   constructor(
-    readonly name: string,
-    readonly options: IWidgetOptions<string | object>
-  ) {}
-
-  draw(
-    ctx: CanvasRenderingContext2D,
     node: LGraphNode,
-    _width: number,
-    y: number,
-    _height: number
-  ): void {
-    renderPreview(ctx, node, y)
+    name: string,
+    options: IWidgetOptions<string | object>
+  ) {
+    const widget: IBaseWidget = {
+      name,
+      options,
+      type: 'custom',
+      /** Dummy value to satisfy type requirements. */
+      value: '',
+      y: 0
+    }
+    super(widget, node)
+
+    // Don't serialize the widget value
+    this.serialize = false
   }
 
-  computeLayoutSize() {
+  override drawWidget(ctx: CanvasRenderingContext2D): void {
+    renderPreview(ctx, this.node, this.y)
+  }
+
+  override computeLayoutSize() {
     return {
       minHeight: 220,
       minWidth: 1
@@ -271,7 +272,7 @@ export const useImagePreviewWidget = () => {
     inputSpec: InputSpec
   ) => {
     return node.addCustomWidget(
-      new ImagePreviewWidget(inputSpec.name, {
+      new ImagePreviewWidget(node, inputSpec.name, {
         serialize: false
       })
     )

--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -1,6 +1,5 @@
 import { type LGraphNode, LiteGraph } from '@comfyorg/litegraph'
 import type {
-  IBaseWidget,
   ICustomWidget,
   IWidgetOptions
 } from '@comfyorg/litegraph/dist/types/widgets'
@@ -236,21 +235,17 @@ const renderPreview = (
 }
 
 class ImagePreviewWidget implements ICustomWidget {
-  readonly type: 'custom'
-  readonly name: string
-  readonly options: IWidgetOptions<string | object>
+  readonly type = 'custom'
   /** Dummy value to satisfy type requirements. */
-  value: string
+  value: string = ''
   y: number = 0
   /** Don't serialize the widget value. */
   serialize: boolean = false
 
-  constructor(name: string, options: IWidgetOptions<string | object>) {
-    this.type = 'custom'
-    this.name = name
-    this.options = options
-    this.value = ''
-  }
+  constructor(
+    readonly name: string,
+    readonly options: IWidgetOptions<string | object>
+  ) {}
 
   draw(
     ctx: CanvasRenderingContext2D,
@@ -262,7 +257,7 @@ class ImagePreviewWidget implements ICustomWidget {
     renderPreview(ctx, node, y)
   }
 
-  computeLayoutSize(this: IBaseWidget) {
+  computeLayoutSize() {
     return {
       minHeight: 220,
       minWidth: 1


### PR DESCRIPTION
Restores the ability to drag nodes that have image widgets.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4009-Fix-preview-image-drag-does-nothing-2016d73d365081549026e3f079ba4662) by [Unito](https://www.unito.io)
