### PR TITLE
Allow extensions to define pinia stores

### DIFF
--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -100,6 +100,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     colorPalette,
     dialog,
     bottomPanel,
+    defineStore,
     user: partialUserStore,
 
     registerSidebarTab,


### PR DESCRIPTION
As a vue developer for custom node, I want to use pinia on my node.
We need to expose defineStore from ComfyUI platform, then we could use it on custom as:
```
const defineStore = app.extensionManager.defineStore

export const useLineartStore = defineStore('lineart', () => {
  
  const prompt = ref<string>('')

  function setPrompt(value: string) {
    console.log('Setting prompt:', value)
    prompt.value = value
  }

  return {
    prompt,
    setPrompt
  }
})
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4018-expose-pinia-defineStore-to-extentions-2026d73d3650814c966ae1143496553e) by [Unito](https://www.unito.io)
