### PR TITLE
[bugfix] Filter model metadata by current widget selection

### DIFF
--- a/browser_tests/assets/model_metadata_widget_mismatch.json
+++ b/browser_tests/assets/model_metadata_widget_mismatch.json
@@ -1,0 +1,59 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [256, 256],
+      "size": [315, 98],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": null
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": null
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "outdated_model.safetensors",
+            "url": "http://localhost:8188/api/devtools/fake_model.safetensors",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "another_outdated_model.safetensors",
+            "url": "http://localhost:8188/api/devtools/fake_model.safetensors",
+            "directory": "text_encoders"
+          }
+        ]
+      },
+      "widgets_values": ["current_selected_model.safetensors"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -103,7 +103,7 @@ test.describe('Missing models warning', () => {
         }
       ])
     }
-    comfyPage.page.route(
+    await comfyPage.page.route(
       '**/api/experiment/models',
       (route) => route.fulfill(modelFoldersRes),
       { times: 1 }
@@ -121,7 +121,7 @@ test.describe('Missing models warning', () => {
         }
       ])
     }
-    comfyPage.page.route(
+    await comfyPage.page.route(
       '**/api/experiment/models/text_encoders',
       (route) => route.fulfill(clipModelsRes),
       { times: 1 }
@@ -129,6 +129,18 @@ test.describe('Missing models warning', () => {
 
     await comfyPage.loadWorkflow('missing_models')
 
+    const missingModelsWarning = comfyPage.page.locator('.comfy-missing-models')
+    await expect(missingModelsWarning).not.toBeVisible()
+  })
+
+  test('Should not display warning when model metadata exists but widget values have changed', async ({
+    comfyPage
+  }) => {
+    // This tests the scenario where outdated model metadata exists in the workflow
+    // but the actual selected models (widget values) have changed
+    await comfyPage.loadWorkflow('model_metadata_widget_mismatch')
+
+    // The missing models warning should NOT appear
     const missingModelsWarning = comfyPage.page.locator('.comfy-missing-models')
     await expect(missingModelsWarning).not.toBeVisible()
   })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1037,7 +1037,7 @@ export class ComfyApp {
         n.type = sanitizeNodeName(n.type)
       }
 
-      // Collect models metadata from node if the model names are present in the widget values
+      // Collect models metadata from node
       const selectedModels = getSelectedModelsMetadata(n)
       if (selectedModels && selectedModels.length > 0) {
         embeddedModels.push(...selectedModels)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -67,6 +67,7 @@ import {
   findLegacyRerouteNodes,
   noNativeReroutes
 } from '@/utils/migration/migrateReroute'
+import { getSelectedModelsMetadata } from '@/utils/modelMetadataUtil'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { type ComfyApi, PromptExecutionError, api } from './api'
@@ -1036,9 +1037,11 @@ export class ComfyApp {
         n.type = sanitizeNodeName(n.type)
       }
 
-      // Collect models metadata from node
-      if (n.properties?.models?.length)
-        embeddedModels.push(...n.properties.models)
+      // Collect models metadata from node if the model names are present in the widget values
+      const selectedModels = getSelectedModelsMetadata(n)
+      if (selectedModels && selectedModels.length > 0) {
+        embeddedModels.push(...selectedModels)
+      }
     }
 
     // Merge models from the workflow's root-level 'models' field

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1039,7 +1039,7 @@ export class ComfyApp {
 
       // Collect models metadata from node
       const selectedModels = getSelectedModelsMetadata(n)
-      if (selectedModels && selectedModels.length > 0) {
+      if (selectedModels?.length) {
         embeddedModels.push(...selectedModels)
       }
     }

--- a/src/utils/modelMetadataUtil.ts
+++ b/src/utils/modelMetadataUtil.ts
@@ -25,8 +25,8 @@ export function getSelectedModelsMetadata(node: {
   properties?: { models?: ModelFile[] }
 }): ModelFile[] {
   try {
-    if (!node.properties?.models?.length) return []
-    if (!node.widgets_values) return []
+    if (!node.properties?.models?.length) return
+    if (!node.widgets_values) return
 
     const widgetValues = Array.isArray(node.widgets_values)
       ? node.widgets_values

--- a/src/utils/modelMetadataUtil.ts
+++ b/src/utils/modelMetadataUtil.ts
@@ -23,7 +23,7 @@ export function getSelectedModelsMetadata(node: {
   type: string
   widgets_values?: unknown[] | Record<string, unknown>
   properties?: { models?: ModelFile[] }
-}): ModelFile[] {
+}): ModelFile[] | undefined {
   try {
     if (!node.properties?.models?.length) return
     if (!node.widgets_values) return

--- a/src/utils/modelMetadataUtil.ts
+++ b/src/utils/modelMetadataUtil.ts
@@ -1,0 +1,42 @@
+import type { ModelFile } from '@/schemas/comfyWorkflowSchema'
+
+/**
+ * Filters model metadata to only include models currently selected in the node's widget values.
+ * This prevents false positives in the missing models dialog when outdated model metadata
+ * exists but the actual selected models have changed.
+ *
+ * @param node - The workflow node to process
+ * @returns Filtered array containing only models that are currently selected
+ */
+export function getSelectedModelsMetadata(node: {
+  type: string
+  widgets_values?: unknown[] | Record<string, unknown>
+  properties?: { models?: ModelFile[] }
+}): ModelFile[] {
+  try {
+    if (!node.properties?.models?.length) return []
+    if (!node.widgets_values) return []
+
+    const widgetValues = Array.isArray(node.widgets_values)
+      ? node.widgets_values
+      : Object.values(node.widgets_values)
+
+    if (!widgetValues.length) return []
+
+    // Create set of selected model names from widget values (only process combo inputs)
+    const selectedModelNames = new Set<string>()
+    for (const widgetValue of widgetValues) {
+      if (typeof widgetValue === 'string' && widgetValue.trim()) {
+        selectedModelNames.add(widgetValue)
+      }
+    }
+
+    // Filter models to only include those currently selected
+    return node.properties.models.filter((model) =>
+      selectedModelNames.has(model.name)
+    )
+  } catch (error) {
+    console.error('Error filtering models by current selection:', error)
+    return []
+  }
+}

--- a/src/utils/modelMetadataUtil.ts
+++ b/src/utils/modelMetadataUtil.ts
@@ -1,9 +1,20 @@
 import type { ModelFile } from '@/schemas/comfyWorkflowSchema'
 
 /**
- * Filters model metadata to only include models currently selected in the node's widget values.
- * This prevents false positives in the missing models dialog when outdated model metadata
- * exists but the actual selected models have changed.
+ * Gets models from the node's `properties.models` field, excluding those
+ * not currently selected in at least 1 of the node's widget values.
+ *
+ * @example
+ * ```ts
+ * const node = {
+ *   type: 'CheckpointLoaderSimple',
+ *   widgets_values: ['model1', 'model2'],
+ *   properties: { models: [{ name: 'model1' }, { name: 'model2' }, { name: 'model3' }] }
+ *   ... other properties
+ * }
+ * const selectedModels = getSelectedModelsMetadata(node)
+ * // selectedModels = [{ name: 'model1' }, { name: 'model2' }]
+ * ```
  *
  * @param node - The workflow node to process
  * @returns Filtered array containing only models that are currently selected
@@ -23,17 +34,16 @@ export function getSelectedModelsMetadata(node: {
 
     if (!widgetValues.length) return []
 
-    // Create set of selected model names from widget values (only process combo inputs)
-    const selectedModelNames = new Set<string>()
+    const stringWidgetValues = new Set<string>()
     for (const widgetValue of widgetValues) {
       if (typeof widgetValue === 'string' && widgetValue.trim()) {
-        selectedModelNames.add(widgetValue)
+        stringWidgetValues.add(widgetValue)
       }
     }
 
-    // Filter models to only include those currently selected
+    // Return the node's models that are present in the widget values
     return node.properties.models.filter((model) =>
-      selectedModelNames.has(model.name)
+      stringWidgetValues.has(model.name)
     )
   } catch (error) {
     console.error('Error filtering models by current selection:', error)

--- a/src/utils/modelMetadataUtil.ts
+++ b/src/utils/modelMetadataUtil.ts
@@ -47,6 +47,5 @@ export function getSelectedModelsMetadata(node: {
     )
   } catch (error) {
     console.error('Error filtering models by current selection:', error)
-    return []
   }
 }

--- a/src/utils/modelMetadataUtil.ts
+++ b/src/utils/modelMetadataUtil.ts
@@ -32,7 +32,7 @@ export function getSelectedModelsMetadata(node: {
       ? node.widgets_values
       : Object.values(node.widgets_values)
 
-    if (!widgetValues.length) return []
+    if (!widgetValues.length) return
 
     const stringWidgetValues = new Set<string>()
     for (const widgetValue of widgetValues) {

--- a/tests-ui/utils/modelMetadataUtil.test.ts
+++ b/tests-ui/utils/modelMetadataUtil.test.ts
@@ -27,7 +27,7 @@ describe('modelMetadataUtil', () => {
       const result = getSelectedModelsMetadata(node)
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('model_a.safetensors')
+      expect(result![0].name).toBe('model_a.safetensors')
     })
 
     it('should return empty array when no models match selection', () => {
@@ -78,7 +78,7 @@ describe('modelMetadataUtil', () => {
       const result = getSelectedModelsMetadata(node)
 
       expect(result).toHaveLength(2)
-      expect(result.map((m) => m.name)).toEqual([
+      expect(result!.map((m) => m.name)).toEqual([
         'model_a.safetensors',
         'model_c.ckpt'
       ])
@@ -102,7 +102,7 @@ describe('modelMetadataUtil', () => {
       const result = getSelectedModelsMetadata(node)
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('model_a.safetensors')
+      expect(result![0].name).toBe('model_a.safetensors')
     })
 
     it('should ignore empty strings', () => {
@@ -123,10 +123,10 @@ describe('modelMetadataUtil', () => {
       const result = getSelectedModelsMetadata(node)
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('model_a.safetensors')
+      expect(result![0].name).toBe('model_a.safetensors')
     })
 
-    it('should return empty array for nodes without model metadata', () => {
+    it('should return undefined for nodes without model metadata', () => {
       const node = {
         type: 'SomeNode',
         widgets_values: ['model_a.safetensors']
@@ -134,10 +134,10 @@ describe('modelMetadataUtil', () => {
 
       const result = getSelectedModelsMetadata(node)
 
-      expect(result).toHaveLength(0)
+      expect(result).toBeUndefined()
     })
 
-    it('should return empty array for nodes without widgets_values', () => {
+    it('should return undefined for nodes without widgets_values', () => {
       const node = {
         type: 'SomeNode',
         properties: {
@@ -153,10 +153,10 @@ describe('modelMetadataUtil', () => {
 
       const result = getSelectedModelsMetadata(node)
 
-      expect(result).toHaveLength(0)
+      expect(result).toBeUndefined()
     })
 
-    it('should return empty array for nodes with empty widgets_values', () => {
+    it('should return undefined for nodes with empty widgets_values', () => {
       const node = {
         type: 'SomeNode',
         widgets_values: [],
@@ -173,10 +173,10 @@ describe('modelMetadataUtil', () => {
 
       const result = getSelectedModelsMetadata(node)
 
-      expect(result).toHaveLength(0)
+      expect(result).toBeUndefined()
     })
 
-    it('should return empty array for nodes with empty models array', () => {
+    it('should return undefined for nodes with empty models array', () => {
       const node = {
         type: 'SomeNode',
         widgets_values: ['model_a.safetensors'],
@@ -187,7 +187,7 @@ describe('modelMetadataUtil', () => {
 
       const result = getSelectedModelsMetadata(node)
 
-      expect(result).toHaveLength(0)
+      expect(result).toBeUndefined()
     })
 
     it('should handle object widget values', () => {
@@ -216,7 +216,7 @@ describe('modelMetadataUtil', () => {
       const result = getSelectedModelsMetadata(node)
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('model_a.safetensors')
+      expect(result![0].name).toBe('model_a.safetensors')
     })
 
     it('should work end-to-end to filter outdated metadata', () => {

--- a/tests-ui/utils/modelMetadataUtil.test.ts
+++ b/tests-ui/utils/modelMetadataUtil.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSelectedModelsMetadata } from '@/utils/modelMetadataUtil'
+
+describe('modelMetadataUtil', () => {
+  describe('filterModelsByCurrentSelection', () => {
+    it('should filter models to only include those selected in widget values', () => {
+      const node = {
+        type: 'CheckpointLoaderSimple',
+        widgets_values: ['model_a.safetensors'],
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            },
+            {
+              name: 'model_b.safetensors',
+              url: 'https://example.com/model_b.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('model_a.safetensors')
+    })
+
+    it('should return empty array when no models match selection', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: ['unmatched_model.safetensors'],
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle multiple widget values', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: ['model_a.safetensors', 42, 'model_c.ckpt'],
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            },
+            {
+              name: 'model_b.safetensors',
+              url: 'https://example.com/model_b.safetensors',
+              directory: 'checkpoints'
+            },
+            {
+              name: 'model_c.ckpt',
+              url: 'https://example.com/model_c.ckpt',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(2)
+      expect(result.map((m) => m.name)).toEqual([
+        'model_a.safetensors',
+        'model_c.ckpt'
+      ])
+    })
+
+    it('should ignore non-string widget values', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: [42, true, null, undefined, 'model_a.safetensors'],
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('model_a.safetensors')
+    })
+
+    it('should ignore empty strings', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: ['', '  ', 'model_a.safetensors'],
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('model_a.safetensors')
+    })
+
+    it('should return empty array for nodes without model metadata', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: ['model_a.safetensors']
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should return empty array for nodes without widgets_values', () => {
+      const node = {
+        type: 'SomeNode',
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should return empty array for nodes with empty widgets_values', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: [],
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should return empty array for nodes with empty models array', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: ['model_a.safetensors'],
+        properties: {
+          models: []
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle object widget values', () => {
+      const node = {
+        type: 'SomeNode',
+        widgets_values: {
+          ckpt_name: 'model_a.safetensors',
+          seed: 42
+        },
+        properties: {
+          models: [
+            {
+              name: 'model_a.safetensors',
+              url: 'https://example.com/model_a.safetensors',
+              directory: 'checkpoints'
+            },
+            {
+              name: 'model_b.safetensors',
+              url: 'https://example.com/model_b.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('model_a.safetensors')
+    })
+
+    it('should work end-to-end to filter outdated metadata', () => {
+      const node = {
+        type: 'CheckpointLoaderSimple',
+        widgets_values: ['current_model.safetensors'],
+        properties: {
+          models: [
+            {
+              name: 'current_model.safetensors',
+              url: 'https://example.com/current_model.safetensors',
+              directory: 'checkpoints'
+            },
+            {
+              name: 'old_model.safetensors',
+              url: 'https://example.com/old_model.safetensors',
+              directory: 'checkpoints'
+            }
+          ]
+        }
+      }
+
+      const result = getSelectedModelsMetadata(node)
+
+      expect(result).toHaveLength(1)
+      expect(result![0].name).toBe('current_model.safetensors')
+    })
+  })
+})


### PR DESCRIPTION
Filter models in workflow metadata to only include those actually selected in node widgets. Prevents false positives in the missing models dialog when nodes contain outdated metadata.

Fixes #3664

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4021-bugfix-Filter-model-metadata-by-current-widget-selection-2036d73d365081bdb416c3c3f584d4a4) by [Unito](https://www.unito.io)
