### PR TITLE
[feat] Add logout button to user popover

### DIFF
--- a/src/components/topbar/CurrentUserPopover.spec.ts
+++ b/src/components/topbar/CurrentUserPopover.spec.ts
@@ -50,9 +50,11 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 }))
 
 // Mock the useFirebaseAuthActions composable
+const mockLogout = vi.fn()
 vi.mock('@/composables/auth/useFirebaseAuthActions', () => ({
   useFirebaseAuthActions: vi.fn(() => ({
-    fetchBalance: vi.fn().mockResolvedValue(undefined)
+    fetchBalance: vi.fn().mockResolvedValue(undefined),
+    logout: mockLogout
   }))
 }))
 
@@ -100,8 +102,7 @@ describe('CurrentUserPopover', () => {
       global: {
         plugins: [i18n],
         stubs: {
-          Divider: true,
-          Button: true
+          Divider: true
         }
       }
     })
@@ -112,6 +113,18 @@ describe('CurrentUserPopover', () => {
 
     expect(wrapper.text()).toContain('Test User')
     expect(wrapper.text()).toContain('test@example.com')
+  })
+
+  it('renders logout button with correct props', () => {
+    const wrapper = mountComponent()
+
+    // Find all buttons and get the logout button (second one)
+    const buttons = wrapper.findAllComponents(Button)
+    const logoutButton = buttons[1]
+
+    // Check that logout button has correct props
+    expect(logoutButton.props('label')).toBe('Log Out')
+    expect(logoutButton.props('icon')).toBe('pi pi-sign-out')
   })
 
   it('opens user settings and emits close event when settings button is clicked', async () => {
@@ -132,12 +145,30 @@ describe('CurrentUserPopover', () => {
     expect(wrapper.emitted('close')!.length).toBe(1)
   })
 
+  it('calls logout function and emits close event when logout button is clicked', async () => {
+    const wrapper = mountComponent()
+
+    // Find all buttons and get the logout button (second one)
+    const buttons = wrapper.findAllComponents(Button)
+    const logoutButton = buttons[1]
+
+    // Click the logout button
+    await logoutButton.trigger('click')
+
+    // Verify logout was called
+    expect(mockLogout).toHaveBeenCalled()
+
+    // Verify close event was emitted
+    expect(wrapper.emitted('close')).toBeTruthy()
+    expect(wrapper.emitted('close')!.length).toBe(1)
+  })
+
   it('opens API pricing docs and emits close event when API pricing button is clicked', async () => {
     const wrapper = mountComponent()
 
-    // Find all buttons and get the API pricing button (second one)
+    // Find all buttons and get the API pricing button (third one now)
     const buttons = wrapper.findAllComponents(Button)
-    const apiPricingButton = buttons[1]
+    const apiPricingButton = buttons[2]
 
     // Click the API pricing button
     await apiPricingButton.trigger('click')

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -39,6 +39,18 @@
 
     <Button
       class="justify-start"
+      :label="$t('auth.signOut.signOut')"
+      icon="pi pi-sign-out"
+      text
+      fluid
+      severity="secondary"
+      @click="handleLogout"
+    />
+
+    <Divider class="my-2" />
+
+    <Button
+      class="justify-start"
       :label="$t('credits.apiPricing')"
       icon="pi pi-external-link"
       text
@@ -87,6 +99,11 @@ const handleOpenUserSettings = () => {
 
 const handleTopUp = () => {
   dialogService.showTopUpCreditsDialog()
+  emit('close')
+}
+
+const handleLogout = async () => {
+  await authActions.logout()
   emit('close')
 }
 


### PR DESCRIPTION
Add logout button positioned between User Settings and API Pricing options in CurrentUserPopover component. Uses existing Firebase auth logout functionality with success toast notifications.

Before:

![Selection_1446](https://github.com/user-attachments/assets/33fa8145-92e8-4a04-aed5-a34c3a6bb33d)

After:

![Selection_1445](https://github.com/user-attachments/assets/81179e84-1657-4dcc-b9b6-b053cfbbd5a3)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4022-feat-Add-logout-button-to-user-popover-2036d73d365081a696d3c2bfb844718e) by [Unito](https://www.unito.io)
