### PR TITLE
Revert "Allow extensions to define pinia stores"

### DIFF
--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -100,7 +100,6 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     colorPalette,
     dialog,
     bottomPanel,
-    defineStore,
     user: partialUserStore,
 
     registerSidebarTab,


### PR DESCRIPTION
Reverts Comfy-Org/ComfyUI_frontend#4018

Will reland in 1.22.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4027-Revert-Allow-extensions-to-define-pinia-stores-2036d73d365081159c93f8805c58720b) by [Unito](https://www.unito.io)
