### PR TITLE
Use new Algolia proxy

### DIFF
--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -124,7 +124,19 @@ export const useAlgoliaSearchService = (
     maxCacheSize = DEFAULT_MAX_CACHE_SIZE,
     minCharsForSuggestions = DEFAULT_MIN_CHARS_FOR_SUGGESTIONS
   } = options
-  const searchClient = algoliasearch(__ALGOLIA_APP_ID__, __ALGOLIA_API_KEY__)
+  const searchClient = algoliasearch(__ALGOLIA_APP_ID__, __ALGOLIA_API_KEY__, {
+    hosts: [
+      {
+        url: 'search.comfy.org/api/search',
+        accept: 'readWrite',
+        protocol: 'https'
+      }
+    ],
+    baseHeaders: {
+      'X-Algolia-Application-Id': __ALGOLIA_APP_ID__,
+      'X-Algolia-API-Key': __ALGOLIA_API_KEY__
+    }
+  })
   const searchPacksCache = new QuickLRU<string, SearchPacksResult>({
     maxSize: maxCacheSize
   })


### PR DESCRIPTION
Migrate to new Algolia proxy at search.comfy.org

Depends on: https://github.com/Comfy-Org/comfy-algolia-proxy/pull/2

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4030-Use-new-Algolia-proxy-2036d73d365081f7a920d0e7f7a608f4) by [Unito](https://www.unito.io)
