### PR TITLE
[fix] Remove dynamic import timing issue causing Playwright test flakiness

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -52,6 +52,7 @@ import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
+import { getFileHandler } from '@/utils/fileHandlers'
 import {
   executeWidgetsCallback,
   fixLinkInputSlots,
@@ -1262,7 +1263,6 @@ export class ComfyApp {
    * @param {File} file
    */
   async handleFile(file: File) {
-    const { getFileHandler } = await import('@/utils/fileHandlers')
     const removeExt = (f: string) => {
       if (!f) return f
       const p = f.lastIndexOf('.')


### PR DESCRIPTION
Fixes the deferred timing condition introduced in PR #3955 that was causing multiple Playwright tests to become flaky.

**Problem:**
PR #3955 refactored file handling by introducing a dynamic import in the `handleFile` method:
```typescript
const { getFileHandler } = await import('@/utils/fileHandlers')
```

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4029.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4031-fix-Remove-dynamic-import-race-condition-causing-Playwright-test-flakiness-2036d73d3650813daa24e7204860b077) by [Unito](https://www.unito.io)
