### PR TITLE
[fix] Clear CSS background variable when canvas background image is removed

### DIFF
--- a/src/services/colorPaletteService.ts
+++ b/src/services/colorPaletteService.ts
@@ -137,6 +137,8 @@ export const useColorPaletteService = () => {
           '--bg-img',
           `url('${backgroundImage}') no-repeat center /cover`
         )
+      } else {
+        rootStyle.removeProperty('--bg-img')
       }
     }
   }


### PR DESCRIPTION
Fixes issue where background images persisted when zooming after clearing the canvas background setting. The `--bg-img` CSS variable was not being removed, causing the old background to remain visible at high zoom levels. The issue is demonstrated below (fixed by this PR):


https://github.com/user-attachments/assets/1cd45c4d-535c-4379-a7d6-a39b92102169

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4034-fix-Clear-CSS-background-variable-when-canvas-background-image-is-removed-2046d73d365081108802d35071c21da7) by [Unito](https://www.unito.io)
