### PR TITLE
[DevTask] Add custom node testing checkbox to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -15,6 +15,15 @@ body:
         - **3:** You confirmed that the bug is not caused by a custom node. You can disable all custom nodes by passing
         `--disable-all-custom-nodes` command line argument.
 
+  - type: checkboxes
+    id: custom-nodes-test
+    attributes:
+      label: Custom Node Testing
+      description: Please confirm you have tried to reproduce the issue with all custom nodes disabled.
+      options:
+        - label: I have tried disabling custom nodes and the issue persists (see [how to disable custom nodes](https://docs.comfy.org/troubleshooting/custom-node-issues#step-1%3A-test-with-all-custom-nodes-disabled) if you need help)
+          required: true
+
   - type: textarea
     attributes:
       label: Frontend Version


### PR DESCRIPTION
Add required checkbox asking users to confirm they have tested with custom nodes disabled before submitting bug reports. Links directly to troubleshooting documentation to help users disable custom nodes and save triage time.

Fixes #4033

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4041-DevTask-Add-custom-node-testing-checkbox-to-issue-template-2056d73d36508158a980f199470b3d9d) by [Unito](https://www.unito.io)
