### PR TITLE
Remove duplication from bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -12,8 +12,6 @@ body:
 
         - **1:** You are running the latest version of ComfyUI.
         - **2:** You have looked at the existing bug reports and made sure this isn't already reported.
-        - **3:** You confirmed that the bug is not caused by a custom node. You can disable all custom nodes by passing
-        `--disable-all-custom-nodes` command line argument.
 
   - type: checkboxes
     id: custom-nodes-test


### PR DESCRIPTION
- Follow-up on #4041

Removes the now-duplicate requirement to check custom nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4043-Remove-duplication-from-bug-report-form-2056d73d36508197b5edd576e06a43f4) by [Unito](https://www.unito.io)
