### PR TITLE
Fix: loading workflows from images when metadata stripped during drag

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -52,7 +52,7 @@ import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 import { ExtensionManager } from '@/types/extensionTypes'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
-import { getFileHandler } from '@/utils/fileHandlers'
+import { getFileHandler, resolveDragDropFile } from '@/utils/fileHandlers'
 import {
   executeWidgetsCallback,
   fixLinkInputSlots,
@@ -463,20 +463,11 @@ export class ComfyApp {
           event.dataTransfer.files.length &&
           event.dataTransfer.files[0].type !== 'image/bmp'
         ) {
-          await this.handleFile(event.dataTransfer.files[0])
-        } else {
-          // Try loading the first URI in the transfer list
-          const validTypes = ['text/uri-list', 'text/x-moz-url']
-          const match = [...event.dataTransfer.types].find((t) =>
-            validTypes.find((v) => t === v)
+          const resolvedFile = await resolveDragDropFile(
+            event.dataTransfer.files[0],
+            event.dataTransfer
           )
-          if (match) {
-            const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
-            if (uri) {
-              const blob = await (await fetch(uri)).blob()
-              await this.handleFile(new File([blob], uri, { type: blob.type }))
-            }
-          }
+          await this.handleFile(resolvedFile)
         }
       } catch (err: any) {
         useToastStore().addAlert(

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -468,6 +468,19 @@ export class ComfyApp {
             event.dataTransfer
           )
           await this.handleFile(resolvedFile)
+        } else {
+          // Try loading the first URI in the transfer list (handles Chrome->Firefox BMP case)
+          const validTypes = ['text/uri-list', 'text/x-moz-url']
+          const match = [...event.dataTransfer.types].find((t) =>
+            validTypes.find((v) => t === v)
+          )
+          if (match) {
+            const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
+            if (uri) {
+              const blob = await (await fetch(uri)).blob()
+              await this.handleFile(new File([blob], uri, { type: blob.type }))
+            }
+          }
         }
       } catch (err: any) {
         useToastStore().addAlert(


### PR DESCRIPTION
Some system or browser strip metadata when dragging, such as Firefox, so the URI fallback approach should always happen.

Fixes https://github.com/comfyanonymous/ComfyUI/issues/8375, Fixes https://github.com/comfyanonymous/ComfyUI/issues/7529#issuecomment-2926129565

Related:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3519
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3955


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4044-Fix-loading-workflows-from-images-when-metadata-stripped-during-drag-2056d73d3650813b9064f4bfbd7af928) by [Unito](https://www.unito.io)
