### PR TITLE
Update the Compare slider start position to the middle

### DIFF
--- a/src/components/templates/thumbnails/CompareSliderThumbnail.spec.ts
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.spec.ts
@@ -63,7 +63,7 @@ describe('CompareSliderThumbnail', () => {
   it('positions slider based on default value', () => {
     const wrapper = mountThumbnail()
     const divider = wrapper.find('.bg-white\\/30')
-    expect(divider.attributes('style')).toContain('left: 21%')
+    expect(divider.attributes('style')).toContain('left: 50%')
   })
 
   it('passes isHovered prop to BaseThumbnail', () => {

--- a/src/components/templates/thumbnails/CompareSliderThumbnail.vue
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.vue
@@ -38,7 +38,7 @@ import { ref, watch } from 'vue'
 
 import BaseThumbnail from '@/components/templates/thumbnails/BaseThumbnail.vue'
 
-const SLIDER_START_POSITION = 21
+const SLIDER_START_POSITION = 50
 
 const { baseImageSrc, overlayImageSrc, isHovered, isVideo } = defineProps<{
   baseImageSrc: string


### PR DESCRIPTION
Update the Compare slider start position to the middle
This PR is to address this feature request: https://github.com/Comfy-Org/ComfyUI_frontend/issues/3964

![image](https://github.com/user-attachments/assets/d9721179-c774-4dc8-89f9-f765311fedf6)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4052-Update-the-Compare-slider-start-position-to-the-middle-2066d73d365081c8bd76f128acfb5f40) by [Unito](https://www.unito.io)
