### PR TITLE
feat: add keyboard shortcut to move selected nodes (unbound by default)

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1086,7 +1086,7 @@ export const comfyPageFixture = base.extend<{
   },
   comfyMouse: async ({ comfyPage }, use) => {
     const comfyMouse = new ComfyMouse(comfyPage)
-    void use(comfyMouse)
+    use(comfyMouse)
   }
 })
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -762,7 +762,7 @@ export class ComfyPage {
         y: 625
       }
     })
-    this.page.mouse.move(10, 10)
+    void this.page.mouse.move(10, 10)
     await this.nextFrame()
   }
 
@@ -774,7 +774,7 @@ export class ComfyPage {
       },
       button: 'right'
     })
-    this.page.mouse.move(10, 10)
+    void this.page.mouse.move(10, 10)
     await this.nextFrame()
   }
 
@@ -1046,6 +1046,8 @@ export class ComfyPage {
   }
 }
 
+export const testComfySnapToGridGridSize = 50
+
 export const comfyPageFixture = base.extend<{
   comfyPage: ComfyPage
   comfyMouse: ComfyMouse
@@ -1072,7 +1074,8 @@ export const comfyPageFixture = base.extend<{
         'Comfy.EnableTooltips': false,
         'Comfy.userId': userId,
         // Set tutorial completed to true to avoid loading the tutorial workflow.
-        'Comfy.TutorialCompleted': true
+        'Comfy.TutorialCompleted': true,
+        'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize
       })
     } catch (e) {
       console.error(e)
@@ -1083,7 +1086,7 @@ export const comfyPageFixture = base.extend<{
   },
   comfyMouse: async ({ comfyPage }, use) => {
     const comfyMouse = new ComfyMouse(comfyPage)
-    use(comfyMouse)
+    void use(comfyMouse)
   }
 })
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -762,7 +762,7 @@ export class ComfyPage {
         y: 625
       }
     })
-    void this.page.mouse.move(10, 10)
+    await this.page.mouse.move(10, 10)
     await this.nextFrame()
   }
 
@@ -774,7 +774,7 @@ export class ComfyPage {
       },
       button: 'right'
     })
-    void this.page.mouse.move(10, 10)
+    await this.page.mouse.move(10, 10)
     await this.nextFrame()
   }
 

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -92,7 +92,7 @@ test.describe('Node Interaction', () => {
       )
     })
 
-    test('Can move selected nodes with CTRL + arrow keys', async ({
+    test('Can move selected nodes using the Comfy.Canvas.MoveSelectedNodes.{Up|Down|Left|Right} commands', async ({
       comfyPage
     }) => {
       const clipNodes = await comfyPage.getNodeRefsByType('CLIPTextEncode')
@@ -107,6 +107,9 @@ test.describe('Node Interaction', () => {
       }) => {
         const originalPositions = await getPositions()
         await dragSelectNodes(comfyPage, clipNodes)
+        await comfyPage.executeCommand(
+          `Comfy.Canvas.MoveSelectedNodes.${direction}`
+        )
         await comfyPage.canvas.press(`Control+Arrow${direction}`)
         const newPositions = await getPositions()
         expect(newPositions).toEqual(originalPositions.map(expectedPosition))

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -1,6 +1,12 @@
 import { expect } from '@playwright/test'
+import { Position } from '@vueuse/core'
 
-import { type ComfyPage, comfyPageFixture as test } from '../fixtures/ComfyPage'
+import {
+  type ComfyPage,
+  comfyPageFixture as test,
+  testComfySnapToGridGridSize
+} from '../fixtures/ComfyPage'
+import { type NodeReference } from '../fixtures/utils/litegraphUtils'
 
 test.describe('Item Interaction', () => {
   test('Can select/delete all items', async ({ comfyPage }) => {
@@ -57,8 +63,10 @@ test.describe('Node Interaction', () => {
       await expect(comfyPage.canvas).toHaveScreenshot('selected-node2.png')
     })
 
-    test('Can drag-select nodes with Meta (mac)', async ({ comfyPage }) => {
-      const clipNodes = await comfyPage.getNodeRefsByType('CLIPTextEncode')
+    const dragSelectNodes = async (
+      comfyPage: ComfyPage,
+      clipNodes: NodeReference[]
+    ) => {
       const clipNode1Pos = await clipNodes[0].getPosition()
       const clipNode2Pos = await clipNodes[1].getPosition()
       const offset = 64
@@ -74,9 +82,63 @@ test.describe('Node Interaction', () => {
         }
       )
       await comfyPage.page.keyboard.up('Meta')
+    }
+
+    test('Can drag-select nodes with Meta (mac)', async ({ comfyPage }) => {
+      const clipNodes = await comfyPage.getNodeRefsByType('CLIPTextEncode')
+      await dragSelectNodes(comfyPage, clipNodes)
       expect(await comfyPage.getSelectedGraphNodesCount()).toBe(
         clipNodes.length
       )
+    })
+
+    test('Can move selected nodes with CTRL + arrow keys', async ({
+      comfyPage
+    }) => {
+      const clipNodes = await comfyPage.getNodeRefsByType('CLIPTextEncode')
+      const getPositions = () =>
+        Promise.all(clipNodes.map((node) => node.getPosition()))
+      const testDirection = async ({
+        direction,
+        expectedPosition
+      }: {
+        direction: string
+        expectedPosition: (originalPosition: Position) => Position
+      }) => {
+        const originalPositions = await getPositions()
+        await dragSelectNodes(comfyPage, clipNodes)
+        await comfyPage.canvas.press(`Control+Arrow${direction}`)
+        const newPositions = await getPositions()
+        expect(newPositions).toEqual(originalPositions.map(expectedPosition))
+      }
+      await testDirection({
+        direction: 'Down',
+        expectedPosition: (originalPosition) => ({
+          ...originalPosition,
+          y: originalPosition.y + testComfySnapToGridGridSize
+        })
+      })
+      await testDirection({
+        direction: 'Right',
+        expectedPosition: (originalPosition) => ({
+          ...originalPosition,
+          x: originalPosition.x + testComfySnapToGridGridSize
+        })
+      })
+      await testDirection({
+        direction: 'Up',
+        expectedPosition: (originalPosition) => ({
+          ...originalPosition,
+          y: originalPosition.y - testComfySnapToGridGridSize
+        })
+      })
+      await testDirection({
+        direction: 'Left',
+        expectedPosition: (originalPosition) => ({
+          ...originalPosition,
+          x: originalPosition.x - testComfySnapToGridGridSize
+        })
+      })
     })
   })
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -4,6 +4,7 @@ import {
   LGraphNode,
   LiteGraph
 } from '@comfyorg/litegraph'
+import { Point } from '@comfyorg/litegraph'
 
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import {
@@ -26,6 +27,8 @@ import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
+
+const moveSelectedNodesVersionAdded = '1.22.1'
 
 export function useCoreCommands(): ComfyCommand[] {
   const workflowService = useWorkflowService()
@@ -56,6 +59,20 @@ export function useCoreCommands(): ComfyCommand[] {
         node.mode = mode
       }
     })
+  }
+
+  const moveSelectedNodes = (
+    positionUpdater: (pos: Point, gridSize: number) => Point
+  ) => {
+    const selectedNodes = getSelectedNodes()
+    if (selectedNodes.length === 0) return
+
+    const gridSize = useSettingStore().get('Comfy.SnapToGrid.GridSize')
+    selectedNodes.forEach((node) => {
+      node.pos = positionUpdater(node.pos, gridSize)
+    })
+    app.canvas.state.selectionChanged = true
+    app.canvas.setDirty(true, true)
   }
 
   const commands = [
@@ -673,6 +690,34 @@ export function useCoreCommands(): ComfyCommand[] {
       function: async () => {
         await firebaseAuthActions.logout()
       }
+    },
+    {
+      id: 'Comfy.Canvas.MoveSelectedNodes.Up',
+      icon: 'pi pi-arrow-up',
+      label: 'Move Selected Nodes Up',
+      versionAdded: moveSelectedNodesVersionAdded,
+      function: () => moveSelectedNodes(([x, y], gridSize) => [x, y - gridSize])
+    },
+    {
+      id: 'Comfy.Canvas.MoveSelectedNodes.Down',
+      icon: 'pi pi-arrow-down',
+      label: 'Move Selected Nodes Down',
+      versionAdded: moveSelectedNodesVersionAdded,
+      function: () => moveSelectedNodes(([x, y], gridSize) => [x, y + gridSize])
+    },
+    {
+      id: 'Comfy.Canvas.MoveSelectedNodes.Left',
+      icon: 'pi pi-arrow-left',
+      label: 'Move Selected Nodes Left',
+      versionAdded: moveSelectedNodesVersionAdded,
+      function: () => moveSelectedNodes(([x, y], gridSize) => [x - gridSize, y])
+    },
+    {
+      id: 'Comfy.Canvas.MoveSelectedNodes.Right',
+      icon: 'pi pi-arrow-right',
+      label: 'Move Selected Nodes Right',
+      versionAdded: moveSelectedNodesVersionAdded,
+      function: () => moveSelectedNodes(([x, y], gridSize) => [x + gridSize, y])
     }
   ]
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -28,7 +28,7 @@ import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
-const moveSelectedNodesVersionAdded = '1.22.1'
+const moveSelectedNodesVersionAdded = '1.22.2'
 
 export function useCoreCommands(): ComfyCommand[] {
   const workflowService = useWorkflowService()

--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -173,37 +173,5 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       key: 'f'
     },
     commandId: 'Workspace.ToggleFocusMode'
-  },
-  {
-    combo: {
-      ctrl: true,
-      key: 'ArrowUp'
-    },
-    commandId: 'Comfy.Canvas.MoveSelectedNodes.Up',
-    targetElementId: 'graph-canvas'
-  },
-  {
-    combo: {
-      ctrl: true,
-      key: 'ArrowDown'
-    },
-    commandId: 'Comfy.Canvas.MoveSelectedNodes.Down',
-    targetElementId: 'graph-canvas'
-  },
-  {
-    combo: {
-      ctrl: true,
-      key: 'ArrowLeft'
-    },
-    commandId: 'Comfy.Canvas.MoveSelectedNodes.Left',
-    targetElementId: 'graph-canvas'
-  },
-  {
-    combo: {
-      ctrl: true,
-      key: 'ArrowRight'
-    },
-    commandId: 'Comfy.Canvas.MoveSelectedNodes.Right',
-    targetElementId: 'graph-canvas'
   }
 ]

--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -173,5 +173,37 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       key: 'f'
     },
     commandId: 'Workspace.ToggleFocusMode'
+  },
+  {
+    combo: {
+      ctrl: true,
+      key: 'ArrowUp'
+    },
+    commandId: 'Comfy.Canvas.MoveSelectedNodes.Up',
+    targetElementId: 'graph-canvas'
+  },
+  {
+    combo: {
+      ctrl: true,
+      key: 'ArrowDown'
+    },
+    commandId: 'Comfy.Canvas.MoveSelectedNodes.Down',
+    targetElementId: 'graph-canvas'
+  },
+  {
+    combo: {
+      ctrl: true,
+      key: 'ArrowLeft'
+    },
+    commandId: 'Comfy.Canvas.MoveSelectedNodes.Left',
+    targetElementId: 'graph-canvas'
+  },
+  {
+    combo: {
+      ctrl: true,
+      key: 'ArrowRight'
+    },
+    commandId: 'Comfy.Canvas.MoveSelectedNodes.Right',
+    targetElementId: 'graph-canvas'
   }
 ]


### PR DESCRIPTION
closes #1265

## Summary

This PR adds four new keyboard shortcuts ~~(CTRL + Up/Down/Left/Right Arrow Key)~~ (unbound by default) which allow moving selected nodes by a set number of pixels, configured by the `Comfy.SnapToGrid.GridSize` setting.

## Video demonstration

[comfy_ctrl_arrow-2025-06-03_21.35.51.webm](https://github.com/user-attachments/assets/074c6568-8aa2-4355-aae8-2f4f9e9f568f)

## The shortcuts in the shortcut settings

![1748979403](https://github.com/user-attachments/assets/b6088699-f717-4a0c-a4bc-d367c9a4b1e0)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4066-feat-add-keyboard-shortcut-to-move-selected-nodes-with-CTRL-ArrowKey-2076d73d365081dca12bc0c2fb2b9802) by [Unito](https://www.unito.io)
