### PR TITLE
Fix primevue overlay component z-index might be incorrect

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -1,14 +1,12 @@
 <!-- The main global dialog to show various things -->
 <template>
   <Dialog
-    v-for="(item, index) in dialogStore.dialogStack"
+    v-for="item in dialogStore.dialogStack"
     :key="item.key"
     v-model:visible="item.visible"
     class="global-dialog"
     v-bind="item.dialogComponentProps"
-    :auto-z-index="false"
     :pt="item.dialogComponentProps.pt"
-    :pt:mask:style="{ zIndex: baseZIndex + index + 1 }"
     :aria-labelledby="item.key"
   >
     <template #header>
@@ -35,25 +33,11 @@
 </template>
 
 <script setup lang="ts">
-import { ZIndex } from '@primeuix/utils/zindex'
-import { usePrimeVue } from '@primevue/core'
 import Dialog from 'primevue/dialog'
-import { computed, onMounted } from 'vue'
 
 import { useDialogStore } from '@/stores/dialogStore'
 
 const dialogStore = useDialogStore()
-
-const primevue = usePrimeVue()
-
-const baseZIndex = computed(() => {
-  return primevue?.config?.zIndex?.modal ?? 1100
-})
-
-onMounted(() => {
-  const mask = document.createElement('div')
-  ZIndex.set('model', mask, baseZIndex.value)
-})
 </script>
 
 <style>


### PR DESCRIPTION
Remove manual management z-index.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4074-Fix-primevue-overlay-component-z-index-might-be-incorrect-2086d73d36508129a18cf1001d61ef0f) by [Unito](https://www.unito.io)
