### PR TITLE
Improve bg color image logic

### DIFF
--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -104,9 +104,7 @@ class Load3d {
       this.getActiveCamera.bind(this),
       this.getControls.bind(this),
       () => this.renderer,
-      this.eventManager,
-      this.sceneManager.backgroundScene,
-      this.sceneManager.backgroundCamera
+      this.eventManager
     )
 
     this.modelManager = new ModelManager(
@@ -183,7 +181,6 @@ class Load3d {
     this.renderer.setScissor(0, 0, width, height)
     this.renderer.setScissorTest(true)
 
-    this.renderer.clear()
     this.sceneManager.renderBackground()
     this.renderer.render(
       this.sceneManager.scene,
@@ -321,6 +318,9 @@ class Load3d {
 
   setBackgroundColor(color: string): void {
     this.sceneManager.setBackgroundColor(color)
+
+    this.previewManager.setPreviewBackgroundColor(color)
+
     this.forceRender()
   }
 
@@ -337,9 +337,9 @@ class Load3d {
   removeBackgroundImage(): void {
     this.sceneManager.removeBackgroundImage()
 
-    if (this.previewManager.previewCamera) {
-      this.previewManager.updateBackgroundTexture(null)
-    }
+    this.previewManager.setPreviewBackgroundColor(
+      this.sceneManager.currentBackgroundColor
+    )
 
     this.forceRender()
   }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -104,7 +104,9 @@ class Load3d {
       this.getActiveCamera.bind(this),
       this.getControls.bind(this),
       () => this.renderer,
-      this.eventManager
+      this.eventManager,
+      this.sceneManager.backgroundScene,
+      this.sceneManager.backgroundCamera
     )
 
     this.modelManager = new ModelManager(
@@ -161,7 +163,7 @@ class Load3d {
     this.renderMainScene()
 
     if (this.previewManager.showPreview) {
-      this.renderPreviewScene()
+      this.previewManager.renderPreview()
     }
 
     this.resetViewport()
@@ -186,10 +188,6 @@ class Load3d {
       this.sceneManager.scene,
       this.cameraManager.activeCamera
     )
-  }
-
-  renderPreviewScene(): void {
-    this.previewManager.renderPreview()
   }
 
   resetViewport(): void {
@@ -228,7 +226,7 @@ class Load3d {
       this.renderMainScene()
 
       if (this.previewManager.showPreview) {
-        this.renderPreviewScene()
+        this.previewManager.renderPreview()
       }
 
       this.resetViewport()
@@ -365,10 +363,6 @@ class Load3d {
 
   setCameraState(state: CameraState): void {
     this.cameraManager.setCameraState(state)
-
-    if (this.previewManager.showPreview) {
-      this.previewManager.syncWithMainCamera()
-    }
 
     this.forceRender()
   }

--- a/src/extensions/core/load3d/Load3dAnimation.ts
+++ b/src/extensions/core/load3d/Load3dAnimation.ts
@@ -53,7 +53,7 @@ class Load3dAnimation extends Load3d {
       this.renderMainScene()
 
       if (this.previewManager.showPreview) {
-        this.renderPreviewScene()
+        this.previewManager.renderPreview()
       }
 
       this.resetViewport()

--- a/src/extensions/core/load3d/PreviewManager.ts
+++ b/src/extensions/core/load3d/PreviewManager.ts
@@ -194,8 +194,6 @@ export class PreviewManager implements PreviewManagerInterface {
     const viewport = this.getPreviewViewport()
     if (!viewport) return
 
-    console.log(123)
-
     const renderer = this.getRenderer()
 
     const originalClearColor = renderer.getClearColor(new THREE.Color())
@@ -233,11 +231,15 @@ export class PreviewManager implements PreviewManagerInterface {
 
       previewOrtho.updateProjectionMatrix()
     } else {
-      ;(this.previewCamera as THREE.PerspectiveCamera).aspect = aspect
-      ;(this.previewCamera as THREE.PerspectiveCamera).fov = (
+      const activePerspective =
         this.getActiveCamera() as THREE.PerspectiveCamera
-      ).fov
-      ;(this.previewCamera as THREE.PerspectiveCamera).updateProjectionMatrix()
+      const previewPerspective = this.previewCamera as THREE.PerspectiveCamera
+
+      previewPerspective.fov = activePerspective.fov
+      previewPerspective.zoom = activePerspective.zoom
+      previewPerspective.aspect = aspect
+
+      previewPerspective.updateProjectionMatrix()
     }
 
     this.previewCamera.lookAt(this.getControls().target)

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -106,7 +106,6 @@ export interface PreviewManagerInterface extends BaseManager {
   previewWidth: number
   createCapturePreview(container: Element | HTMLElement): void
   updatePreviewSize(): void
-  updatePreviewRender(): void
   togglePreview(showPreview: boolean): void
   setTargetSize(width: number, height: number): void
   handleResize(): void
@@ -118,7 +117,6 @@ export interface PreviewManagerInterface extends BaseManager {
     height: number
   } | null
   renderPreview(): void
-  syncWithMainCamera(): void
 }
 
 export interface EventManagerInterface {


### PR DESCRIPTION
no feature changed, but a logic improvement.

Previously the logic of setting background color and image are two different parts, this PR merged them into one.

in fact, this is a prerequisite of while I invesigating integrate Forge https://github.com/Comfy-Org/ComfyUI_frontend/issues/4061, the previous logic has conflict to Forge render system.

Also included one bugfix in this PR for preview camera caused by previous changes 

No releated to Frontend core.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4095-Improve-bg-color-image-logic-20b6d73d365081069e4bcf6b92b0af79) by [Unito](https://www.unito.io)
