### PR TITLE
[docs] Remove deprecated comment from registerExtension

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1427,7 +1427,6 @@ export class ComfyApp {
   /**
    * Registers a Comfy web extension with the app
    * @param {ComfyExtension} extension
-   * @deprecated Use useExtensionService().registerExtension instead
    */
   registerExtension(extension: ComfyExtension) {
     useExtensionService().registerExtension(extension)


### PR DESCRIPTION
Removes misleading @deprecated JSDoc comment from app.registerExtension() method as it is still the primary public API for extension registration. Fixes #4080

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4098-docs-Remove-deprecated-comment-from-registerExtension-20c6d73d365081479b10f7baa881bfa3) by [Unito](https://www.unito.io)
