### PR TITLE
[fix] resolve @ symbol parsing errors in extension tooltips

### DIFF
--- a/src/components/dialog/content/setting/SettingItem.spec.ts
+++ b/src/components/dialog/content/setting/SettingItem.spec.ts
@@ -17,6 +17,11 @@ vi.mock('@/utils/formatUtil', () => ({
   normalizeI18nKey: vi.fn()
 }))
 
+vi.mock('@/i18n', () => ({
+  st: vi.fn((_key: string, fallback: string) => fallback),
+  t: vi.fn((key: string) => key)
+}))
+
 describe('SettingItem', () => {
   const mountComponent = (props: any, options = {}): any => {
     return mount(SettingItem, {
@@ -53,5 +58,22 @@ describe('SettingItem', () => {
     expect(options).toEqual([
       { text: 'Correctly Translated', value: 'Correctly Translated' }
     ])
+  })
+
+  it('handles tooltips with @ symbols without errors', () => {
+    const wrapper = mountComponent({
+      setting: {
+        id: 'TestSetting',
+        name: 'Test Setting',
+        type: 'boolean',
+        tooltip:
+          'This will load a larger version of @mtb/markdown-parser that bundles shiki'
+      }
+    })
+
+    // Should not throw an error and tooltip should be preserved as-is
+    expect(wrapper.vm.formItem.tooltip).toBe(
+      'This will load a larger version of @mtb/markdown-parser that bundles shiki'
+    )
   })
 })

--- a/src/components/dialog/content/setting/SettingItem.spec.ts
+++ b/src/components/dialog/content/setting/SettingItem.spec.ts
@@ -17,11 +17,6 @@ vi.mock('@/utils/formatUtil', () => ({
   normalizeI18nKey: vi.fn()
 }))
 
-vi.mock('@/i18n', () => ({
-  st: vi.fn((_key: string, fallback: string) => fallback),
-  t: vi.fn((key: string) => key)
-}))
-
 describe('SettingItem', () => {
   const mountComponent = (props: any, options = {}): any => {
     return mount(SettingItem, {

--- a/src/components/dialog/content/setting/SettingItem.vue
+++ b/src/components/dialog/content/setting/SettingItem.vue
@@ -28,6 +28,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FormItem from '@/components/common/FormItem.vue'
+import { st } from '@/i18n'
 import { useSettingStore } from '@/stores/settingStore'
 import type { SettingOption, SettingParams } from '@/types/settingTypes'
 import { normalizeI18nKey } from '@/utils/formatUtil'
@@ -64,7 +65,7 @@ const formItem = computed(() => {
     ...props.setting,
     name: t(`settings.${normalizedId}.name`, props.setting.name),
     tooltip: props.setting.tooltip
-      ? t(`settings.${normalizedId}.tooltip`, props.setting.tooltip)
+      ? st(`settings.${normalizedId}.tooltip`, props.setting.tooltip)
       : undefined,
     options: props.setting.options
       ? translateOptions(props.setting.options)


### PR DESCRIPTION
Fixes extension settings tooltips containing @ symbols causing Vue i18n "Invalid linked format" errors by using the safe translation function that bypasses i18n parsing for fallback text.

Fixes #4063

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4100-fix-resolve-symbol-parsing-errors-in-extension-tooltips-20c6d73d365081ad8ccccfadf77bb2f7) by [Unito](https://www.unito.io)
