### PR TITLE
[fix] Prevent error when deleting nodes with missing definitions

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -506,7 +506,12 @@ export function mergeIfValid(
     }
   }
 
-  return { customConfig: customSpec?.[1] ?? {} }
+  return {
+    customConfig:
+      customSpec && Array.isArray(customSpec) && customSpec[1]
+        ? customSpec[1]
+        : {}
+  }
 }
 
 app.registerExtension({


### PR DESCRIPTION
Adds defensive array access checks to handle cases where customSpec is not a valid array when merging widget configurations. This resolves the 'Cannot read properties of null (reading "1")' error that occurs when attempting to delete nodes whose definitions have been removed.

Fixes #8338

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4105-fix-Prevent-error-when-deleting-nodes-with-missing-definitions-20c6d73d36508137b9bdfb4dfc1ccae0) by [Unito](https://www.unito.io)
