### PR TITLE
feat: ✨ support frontend node description

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -832,7 +832,8 @@ export class ComfyApp {
           output_is_list: [],
           output_node: false,
           python_module: 'custom_nodes.frontend_only',
-          description: `Frontend only node for ${name}`
+          // @ts-expect-error description doesn't exist in core LT types
+          description: node.description || `Frontend only node for ${name}`
         } as ComfyNodeDefV1
       ])
     )

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -124,6 +124,9 @@ declare module '@comfyorg/litegraph' {
 
     comfyClass?: string
 
+    /** An optional description for frontend only nodes (shown in tooltips)*/
+    description?: string
+
     /**
      * If the node is a frontend only node and should not be serialized into the prompt.
      */


### PR DESCRIPTION
I'm not sure if it's enough as I did not test it yet but I think we should be able to set custom description for frontend nodes.


<img width="466" alt="image" src="https://github.com/user-attachments/assets/d7347b7e-61da-45b0-88ad-24c3d020b632" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4109-feat-support-frontend-node-description-20c6d73d3650819d9318d19f4046bf5c) by [Unito](https://www.unito.io)
