### PR TITLE
[Test] Convert all widget to Vue components (test)

### DIFF
--- a/.claude/commands/create-widget.md
+++ b/.claude/commands/create-widget.md
@@ -1,0 +1,53 @@
+# Create a Vue Widget for ComfyUI
+
+Your task is to create a new Vue widget for ComfyUI based on the widget specification: $ARGUMENTS
+
+## Instructions
+
+Follow the comprehensive guide in `vue-widget-conversion/vue-widget-guide.md` to create the widget. This guide contains step-by-step instructions, examples from actual PRs, and best practices.
+
+### Key Steps to Follow:
+
+1. **Understand the Widget Type**
+   - Analyze what type of widget is needed: $ARGUMENTS
+   - Identify the data type (string, number, array, object, etc.)
+   - Determine if it needs special behaviors (execution state awareness, dynamic management, etc.)
+
+2. **Component Creation**
+   - Create Vue component in `src/components/graph/widgets/`
+   - REQUIRED: Use PrimeVue components (reference `vue-widget-conversion/primevue-components.md`)
+   - Use Composition API with `<script setup>`
+   - Implement proper v-model binding with `defineModel`
+
+3. **Composable Pattern**
+   - Always create widget constructor composable in `src/composables/widgets/`
+   - Only create node-level composable in `src/composables/node/` if the widget needs dynamic management
+   - Follow the dual composable pattern explained in the guide
+
+4. **Registration**
+   - Register in `src/scripts/widgets.ts`
+   - Use appropriate widget type name
+
+5. **Testing**
+   - Create unit tests for composables
+   - Test with actual nodes that use the widget
+
+### Important Requirements:
+
+- **Always use PrimeVue components** - Check `vue-widget-conversion/primevue-components.md` for available components
+- Use TypeScript with proper types
+- Follow Vue 3 Composition API patterns
+- Use Tailwind CSS for styling (no custom CSS unless absolutely necessary)
+- Implement proper error handling and validation
+- Consider performance (use v-show vs v-if appropriately)
+
+### Before Starting:
+
+1. First read through the entire guide at `vue-widget-conversion/vue-widget-guide.md`
+2. Check existing widget implementations for similar patterns
+3. Identify which PrimeVue component(s) best fit the widget requirements
+
+### Widget Specification to Implement:
+$ARGUMENTS
+
+Begin by analyzing the widget requirements and proposing an implementation plan based on the guide.

--- a/copy-widget-resources.sh
+++ b/copy-widget-resources.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Script to copy vue-widget-conversion folder and .claude/commands/create-widget.md 
+# to another local copy of the same repository
+
+# Check if destination directory was provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <destination-repo-path>"
+    echo "Example: $0 /home/c_byrne/projects/comfyui-frontend-testing/ComfyUI_frontend-clone-8"
+    exit 1
+fi
+
+# Get the destination directory from first argument
+DEST_DIR="$1"
+
+# Source files/directories (relative to script location)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_WIDGET_DIR="$SCRIPT_DIR/vue-widget-conversion"
+SOURCE_COMMAND_FILE="$SCRIPT_DIR/.claude/commands/create-widget.md"
+
+# Destination paths
+DEST_WIDGET_DIR="$DEST_DIR/vue-widget-conversion"
+DEST_COMMAND_DIR="$DEST_DIR/.claude/commands"
+DEST_COMMAND_FILE="$DEST_COMMAND_DIR/create-widget.md"
+
+# Check if destination directory exists
+if [ ! -d "$DEST_DIR" ]; then
+    echo "Error: Destination directory does not exist: $DEST_DIR"
+    exit 1
+fi
+
+# Check if source vue-widget-conversion directory exists
+if [ ! -d "$SOURCE_WIDGET_DIR" ]; then
+    echo "Error: Source vue-widget-conversion directory not found: $SOURCE_WIDGET_DIR"
+    exit 1
+fi
+
+# Check if source command file exists
+if [ ! -f "$SOURCE_COMMAND_FILE" ]; then
+    echo "Error: Source command file not found: $SOURCE_COMMAND_FILE"
+    exit 1
+fi
+
+echo "Copying widget resources to: $DEST_DIR"
+
+# Copy vue-widget-conversion directory
+echo "Copying vue-widget-conversion directory..."
+if [ -d "$DEST_WIDGET_DIR" ]; then
+    echo "  Warning: Destination vue-widget-conversion already exists. Overwriting..."
+    rm -rf "$DEST_WIDGET_DIR"
+fi
+cp -r "$SOURCE_WIDGET_DIR" "$DEST_WIDGET_DIR"
+echo "  ✓ Copied vue-widget-conversion directory"
+
+# Create .claude/commands directory if it doesn't exist
+echo "Creating .claude/commands directory structure..."
+mkdir -p "$DEST_COMMAND_DIR"
+echo "  ✓ Created .claude/commands directory"
+
+# Copy create-widget.md command
+echo "Copying create-widget.md command..."
+cp "$SOURCE_COMMAND_FILE" "$DEST_COMMAND_FILE"
+echo "  ✓ Copied create-widget.md command"
+
+# Verify the copy was successful
+echo ""
+echo "Verification:"
+if [ -d "$DEST_WIDGET_DIR" ] && [ -f "$DEST_WIDGET_DIR/vue-widget-guide.md" ] && [ -f "$DEST_WIDGET_DIR/primevue-components.md" ]; then
+    echo "  ✓ vue-widget-conversion directory copied successfully"
+    echo "    - vue-widget-guide.md exists"
+    echo "    - primevue-components.md exists"
+    if [ -f "$DEST_WIDGET_DIR/primevue-components.json" ]; then
+        echo "    - primevue-components.json exists"
+    fi
+else
+    echo "  ✗ Error: vue-widget-conversion directory copy may have failed"
+fi
+
+if [ -f "$DEST_COMMAND_FILE" ]; then
+    echo "  ✓ create-widget.md command copied successfully"
+else
+    echo "  ✗ Error: create-widget.md command copy may have failed"
+fi
+
+echo ""
+echo "Copy complete! Widget resources are now available in: $DEST_DIR"
+echo ""
+echo "You can now use the widget creation command in the destination repo:"
+echo "  /project:create-widget <widget specification>"

--- a/src/components/graph/widgets/BadgedNumberInput.vue
+++ b/src/components/graph/widgets/BadgedNumberInput.vue
@@ -2,17 +2,17 @@
   <div class="badged-number-input relative w-full">
     <InputGroup class="w-full rounded-lg">
       <!-- State badge prefix -->
-      <InputGroupAddon v-if="badgeState !== 'normal'" class="!p-1 rounded-l-lg">
-        <Badge
-          :value="badgeIcon"
-          :severity="badgeSeverity"
-          class="text-xs font-medium"
+      <InputGroupAddon v-if="badgeState !== 'normal'" class="rounded-l-lg">
+        <i
+          :class="badgeIcon"
           :title="badgeTooltip"
-        />
+          :style="{ color: badgeColor }"
+        ></i>
       </InputGroupAddon>
 
-      <!-- Number input -->
+      <!-- Number input for non-slider mode -->
       <InputNumber
+        v-if="!isSliderMode"
         v-model="numericValue"
         :min="min"
         :max="max"
@@ -29,15 +29,44 @@
         :increment-button-icon="'pi pi-plus'"
         :decrement-button-icon="'pi pi-minus'"
       />
+
+      <!-- Slider mode -->
+      <div
+        v-else
+        :class="{
+          'rounded-r-lg': badgeState !== 'normal',
+          'rounded-lg': badgeState === 'normal'
+        }"
+        class="flex-1 flex items-center gap-2 px-3 py-2 bg-surface-0 border border-surface-300"
+      >
+        <Slider
+          v-model="numericValue"
+          :min="min"
+          :max="max"
+          :step="step"
+          :disabled="disabled"
+          class="flex-1"
+        />
+        <InputNumber
+          v-model="numericValue"
+          :min="min"
+          :max="max"
+          :step="step"
+          :disabled="disabled"
+          class="w-16"
+          :show-buttons="false"
+          size="small"
+        />
+      </div>
     </InputGroup>
   </div>
 </template>
 
 <script setup lang="ts">
-import Badge from 'primevue/badge'
 import InputGroup from 'primevue/inputgroup'
 import InputGroupAddon from 'primevue/inputgroupaddon'
 import InputNumber from 'primevue/inputnumber'
+import Slider from 'primevue/slider'
 import { computed } from 'vue'
 
 import type { ComponentWidget } from '@/scripts/domWidget'
@@ -71,34 +100,40 @@ const max = (inputSpec as any).max ?? 100
 const step = (inputSpec as any).step ?? 1
 const placeholder = (inputSpec as any).placeholder ?? 'Enter number'
 
+// Check if slider mode should be enabled
+const isSliderMode = computed(() => {
+  console.log('inputSpec', inputSpec)
+  return (inputSpec as any).slider === true
+})
+
 // Badge configuration
 const badgeIcon = computed(() => {
   switch (badgeState) {
     case 'random':
-      return '🎲'
+      return 'pi pi-refresh'
     case 'lock':
-      return '🔒'
+      return 'pi pi-lock'
     case 'increment':
-      return '⬆️'
+      return 'pi pi-arrow-up'
     case 'decrement':
-      return '⬇️'
+      return 'pi pi-arrow-down'
     default:
       return ''
   }
 })
 
-const badgeSeverity = computed(() => {
+const badgeColor = computed(() => {
   switch (badgeState) {
     case 'random':
-      return 'info'
+      return 'var(--p-primary-color)'
     case 'lock':
-      return 'warn'
+      return 'var(--p-orange-500)'
     case 'increment':
-      return 'success'
+      return 'var(--p-green-500)'
     case 'decrement':
-      return 'danger'
+      return 'var(--p-red-500)'
     default:
-      return 'info'
+      return 'var(--p-text-color)'
   }
 })
 

--- a/src/components/graph/widgets/BadgedNumberInput.vue
+++ b/src/components/graph/widgets/BadgedNumberInput.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="badged-number-input relative w-full">
+    <InputGroup class="w-full rounded-lg">
+      <!-- State badge prefix -->
+      <InputGroupAddon v-if="badgeState !== 'normal'" class="!p-1 rounded-l-lg">
+        <Badge
+          :value="badgeIcon"
+          :severity="badgeSeverity"
+          class="text-xs font-medium"
+          :title="badgeTooltip"
+        />
+      </InputGroupAddon>
+
+      <!-- Number input -->
+      <InputNumber
+        v-model="numericValue"
+        :min="min"
+        :max="max"
+        :step="step"
+        :placeholder="placeholder"
+        :disabled="disabled"
+        :class="{
+          'rounded-r-lg': badgeState !== 'normal',
+          'rounded-lg': badgeState === 'normal'
+        }"
+        class="flex-1"
+        show-buttons
+        button-layout="horizontal"
+        :increment-button-icon="'pi pi-plus'"
+        :decrement-button-icon="'pi pi-minus'"
+      />
+    </InputGroup>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Badge from 'primevue/badge'
+import InputGroup from 'primevue/inputgroup'
+import InputGroupAddon from 'primevue/inputgroupaddon'
+import InputNumber from 'primevue/inputnumber'
+import { computed } from 'vue'
+
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+type BadgeState = 'normal' | 'random' | 'lock' | 'increment' | 'decrement'
+
+const modelValue = defineModel<string>({ required: true })
+
+const {
+  widget,
+  badgeState = 'normal',
+  disabled = false
+} = defineProps<{
+  widget: ComponentWidget<string>
+  badgeState?: BadgeState
+  disabled?: boolean
+}>()
+
+// Convert string model value to/from number for the InputNumber component
+const numericValue = computed({
+  get: () => parseFloat(modelValue.value) || 0,
+  set: (value: number) => {
+    modelValue.value = value.toString()
+  }
+})
+
+// Extract options from input spec
+const inputSpec = widget.inputSpec
+const min = (inputSpec as any).min ?? 0
+const max = (inputSpec as any).max ?? 100
+const step = (inputSpec as any).step ?? 1
+const placeholder = (inputSpec as any).placeholder ?? 'Enter number'
+
+// Badge configuration
+const badgeIcon = computed(() => {
+  switch (badgeState) {
+    case 'random':
+      return '🎲'
+    case 'lock':
+      return '🔒'
+    case 'increment':
+      return '⬆️'
+    case 'decrement':
+      return '⬇️'
+    default:
+      return ''
+  }
+})
+
+const badgeSeverity = computed(() => {
+  switch (badgeState) {
+    case 'random':
+      return 'info'
+    case 'lock':
+      return 'warn'
+    case 'increment':
+      return 'success'
+    case 'decrement':
+      return 'danger'
+    default:
+      return 'info'
+  }
+})
+
+const badgeTooltip = computed(() => {
+  switch (badgeState) {
+    case 'random':
+      return 'Random mode: Value randomizes after each run'
+    case 'lock':
+      return 'Locked: Value never changes'
+    case 'increment':
+      return 'Auto-increment: Value increases after each run'
+    case 'decrement':
+      return 'Auto-decrement: Value decreases after each run'
+    default:
+      return ''
+  }
+})
+</script>
+
+<style scoped>
+.badged-number-input {
+  padding: 4px;
+}
+
+/* Ensure proper styling for the input group */
+:deep(.p-inputgroup) {
+  border-radius: 0.5rem;
+}
+
+:deep(.p-inputnumber) {
+  flex: 1;
+}
+
+:deep(.p-inputnumber-input) {
+  border-radius: inherit;
+}
+
+/* Badge styling */
+:deep(.p-badge) {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+}
+</style>

--- a/src/components/graph/widgets/BadgedNumberInput.vue
+++ b/src/components/graph/widgets/BadgedNumberInput.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="badged-number-input relative w-full">
-    <InputGroup class="w-full rounded-lg">
+    <InputGroup class="w-full rounded-lg border-none px-0.5">
       <!-- State badge prefix -->
-      <InputGroupAddon v-if="badgeState !== 'normal'" class="rounded-l-lg">
+      <InputGroupAddon
+        v-if="badgeState !== 'normal'"
+        class="rounded-l-lg bg-[#222222] border-[#222222] shadow-none border-r-[#A0A1A2] rounded-r-none"
+      >
         <i
-          :class="badgeIcon"
+          :class="badgeIcon + ' text-xs'"
           :title="badgeTooltip"
           :style="{ color: badgeColor }"
         ></i>
@@ -19,11 +22,26 @@
         :step="step"
         :placeholder="placeholder"
         :disabled="disabled"
-        :class="{
-          'rounded-r-lg': badgeState !== 'normal',
-          'rounded-lg': badgeState === 'normal'
+        size="small"
+        :pt="{
+          pcInputText: {
+            root: {
+              class: 'bg-[#222222] text-xs shadow-none rounded-none !border-0'
+            }
+          },
+          incrementButton: {
+            class: 'text-xs shadow-none bg-[#222222] rounded-l-none !border-0'
+          },
+          decrementButton: {
+            class: {
+              'text-xs shadow-none bg-[#222222] rounded-r-none !border-0':
+                badgeState === 'normal',
+              'text-xs shadow-none bg-[#222222] rounded-none !border-0':
+                badgeState !== 'normal'
+            }
+          }
         }"
-        class="flex-1"
+        class="flex-1 rounded-none"
         show-buttons
         button-layout="horizontal"
         :increment-button-icon="'pi pi-plus'"
@@ -37,7 +55,7 @@
           'rounded-r-lg': badgeState !== 'normal',
           'rounded-lg': badgeState === 'normal'
         }"
-        class="flex-1 flex items-center gap-2 px-3 py-2 bg-surface-0 border border-surface-300"
+        class="flex-1 flex items-center gap-2 px-1 bg-surface-0 border border-surface-300"
       >
         <Slider
           v-model="numericValue"
@@ -53,7 +71,14 @@
           :max="max"
           :step="step"
           :disabled="disabled"
-          class="w-16"
+          class="w-16 rounded-md"
+          :pt="{
+            pcInputText: {
+              root: {
+                class: 'bg-[#222222] text-xs shadow-none border-[#222222]'
+              }
+            }
+          }"
           :show-buttons="false"
           size="small"
         />

--- a/src/components/graph/widgets/ColorPickerWidget.vue
+++ b/src/components/graph/widgets/ColorPickerWidget.vue
@@ -1,0 +1,551 @@
+<template>
+  <div class="color-picker-widget">
+    <div
+      :style="{ width: widgetWidth }"
+      class="flex items-center gap-2 p-2 rounded-lg border border-surface-300 bg-surface-0 w-full"
+    >
+      <!-- Color picker preview and popup trigger -->
+      <div class="relative">
+        <div
+          :style="{ backgroundColor: parsedColor.hex }"
+          class="w-4 h-4 rounded border-2 border-surface-400 cursor-pointer hover:border-surface-500 transition-colors"
+          title="Click to edit color"
+          @click="toggleColorPicker"
+        />
+
+        <!-- Color picker popover -->
+        <Popover ref="colorPickerPopover" class="!p-0">
+          <ColorPicker
+            v-model="colorValue"
+            format="hex"
+            class="border-none"
+            @update:model-value="updateColorFromPicker"
+          />
+        </Popover>
+      </div>
+
+      <!-- Color component inputs -->
+      <div class="flex gap-5">
+        <InputNumber
+          v-for="component in colorComponents"
+          :key="component.name"
+          v-model="component.value"
+          :min="component.min"
+          :max="component.max"
+          :step="component.step"
+          :placeholder="component.name"
+          class="flex-1 text-xs max-w-8"
+          :pt="{
+            pcInputText: {
+              root: {
+                class: 'max-w-12'
+              }
+            }
+          }"
+          :show-buttons="false"
+          size="small"
+          @update:model-value="updateColorFromComponents"
+        />
+      </div>
+
+      <!-- Format dropdown -->
+      <Select
+        v-model="currentFormat"
+        :options="colorFormats"
+        option-label="label"
+        option-value="value"
+        class="w-24 ml-3"
+        size="small"
+        :pt="{
+          pcInputText: {
+            root: {
+              class: 'max-w-12'
+            }
+          }
+        }"
+        @update:model-value="handleFormatChange"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ColorPicker from 'primevue/colorpicker'
+import InputNumber from 'primevue/inputnumber'
+import Popover from 'primevue/popover'
+import Select from 'primevue/select'
+import { computed, ref, watch } from 'vue'
+
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+interface ColorComponent {
+  name: string
+  value: number
+  min: number
+  max: number
+  step: number
+}
+
+interface ParsedColor {
+  hex: string
+  rgb: { r: number; g: number; b: number; a: number }
+  hsl: { h: number; s: number; l: number; a: number }
+  hsv: { h: number; s: number; v: number; a: number }
+}
+
+type ColorFormat = 'rgba' | 'hsla' | 'hsva' | 'hex'
+
+const modelValue = defineModel<string>({ required: true })
+
+const { widget } = defineProps<{
+  widget: ComponentWidget<string>
+}>()
+
+// Color format options
+const colorFormats = [
+  { label: 'RGBA', value: 'rgba' },
+  { label: 'HSLA', value: 'hsla' },
+  { label: 'HSVA', value: 'hsva' },
+  { label: 'HEX', value: 'hex' }
+]
+
+// Current format state
+const currentFormat = ref<ColorFormat>('rgba')
+
+// Color picker popover reference
+const colorPickerPopover = ref()
+
+// Internal color value for the PrimeVue ColorPicker
+const colorValue = ref<string>('#ff0000')
+
+// Calculate widget width based on node size with padding
+const widgetWidth = computed(() => {
+  if (!widget?.node?.size) return 'auto'
+
+  const nodeWidth = widget.node.size[0]
+  const WIDGET_PADDING = 16 // Account for padding around the widget
+  const maxWidth = Math.max(200, nodeWidth - WIDGET_PADDING) // Minimum 200px, but scale with node
+
+  return `${maxWidth}px`
+})
+
+// Parse color string to various formats
+const parsedColor = computed<ParsedColor>(() => {
+  const value = modelValue.value || '#ff0000'
+
+  // Handle different input formats
+  if (value.startsWith('#')) {
+    return parseHexColor(value)
+  } else if (value.startsWith('rgb')) {
+    return parseRgbaColor(value)
+  } else if (value.startsWith('hsl')) {
+    return parseHslaColor(value)
+  } else if (value.startsWith('hsv')) {
+    return parseHsvaColor(value)
+  }
+
+  return parseHexColor('#ff0000') // Default fallback
+})
+
+// Get color components based on current format
+const colorComponents = computed<ColorComponent[]>(() => {
+  const { rgb, hsl, hsv } = parsedColor.value
+
+  switch (currentFormat.value) {
+    case 'rgba':
+      return [
+        { name: 'R', value: rgb.r, min: 0, max: 255, step: 1 },
+        { name: 'G', value: rgb.g, min: 0, max: 255, step: 1 },
+        { name: 'B', value: rgb.b, min: 0, max: 255, step: 1 },
+        { name: 'A', value: rgb.a, min: 0, max: 1, step: 0.01 }
+      ]
+    case 'hsla':
+      return [
+        { name: 'H', value: hsl.h, min: 0, max: 360, step: 1 },
+        { name: 'S', value: hsl.s, min: 0, max: 100, step: 1 },
+        { name: 'L', value: hsl.l, min: 0, max: 100, step: 1 },
+        { name: 'A', value: hsl.a, min: 0, max: 1, step: 0.01 }
+      ]
+    case 'hsva':
+      return [
+        { name: 'H', value: hsv.h, min: 0, max: 360, step: 1 },
+        { name: 'S', value: hsv.s, min: 0, max: 100, step: 1 },
+        { name: 'V', value: hsv.v, min: 0, max: 100, step: 1 },
+        { name: 'A', value: hsv.a, min: 0, max: 1, step: 0.01 }
+      ]
+    case 'hex':
+      return [] // No components for hex format
+    default:
+      return []
+  }
+})
+
+// Watch for changes in modelValue to update colorValue
+watch(
+  () => modelValue.value,
+  (newValue) => {
+    if (newValue && newValue !== colorValue.value) {
+      colorValue.value = parsedColor.value.hex
+    }
+  },
+  { immediate: true }
+)
+
+// Toggle color picker popover
+function toggleColorPicker(event: Event) {
+  colorPickerPopover.value.toggle(event)
+}
+
+// Update color from picker
+function updateColorFromPicker(value: string) {
+  colorValue.value = value
+  updateModelValue(parseHexColor(value))
+}
+
+// Update color from component inputs
+function updateColorFromComponents() {
+  const components = colorComponents.value
+  if (components.length === 0) return
+
+  let newColor: ParsedColor
+  const rgbFromHsl = hslToRgb(
+    components[0].value,
+    components[1].value,
+    components[2].value,
+    components[3].value
+  )
+  const rgbFromHsv = hsvToRgb(
+    components[0].value,
+    components[1].value,
+    components[2].value,
+    components[3].value
+  )
+
+  switch (currentFormat.value) {
+    case 'rgba':
+      newColor = {
+        hex: rgbToHex(
+          components[0].value,
+          components[1].value,
+          components[2].value
+        ),
+        rgb: {
+          r: components[0].value,
+          g: components[1].value,
+          b: components[2].value,
+          a: components[3].value
+        },
+        hsl: rgbToHsl(
+          components[0].value,
+          components[1].value,
+          components[2].value,
+          components[3].value
+        ),
+        hsv: rgbToHsv(
+          components[0].value,
+          components[1].value,
+          components[2].value,
+          components[3].value
+        )
+      }
+      break
+    case 'hsla':
+      newColor = {
+        hex: rgbToHex(rgbFromHsl.r, rgbFromHsl.g, rgbFromHsl.b),
+        rgb: rgbFromHsl,
+        hsl: {
+          h: components[0].value,
+          s: components[1].value,
+          l: components[2].value,
+          a: components[3].value
+        },
+        hsv: rgbToHsv(rgbFromHsl.r, rgbFromHsl.g, rgbFromHsl.b, rgbFromHsl.a)
+      }
+      break
+    case 'hsva':
+      newColor = {
+        hex: rgbToHex(rgbFromHsv.r, rgbFromHsv.g, rgbFromHsv.b),
+        rgb: rgbFromHsv,
+        hsl: rgbToHsl(rgbFromHsv.r, rgbFromHsv.g, rgbFromHsv.b, rgbFromHsv.a),
+        hsv: {
+          h: components[0].value,
+          s: components[1].value,
+          v: components[2].value,
+          a: components[3].value
+        }
+      }
+      break
+    default:
+      return
+  }
+
+  updateModelValue(newColor)
+}
+
+// Handle format change
+function handleFormatChange() {
+  updateModelValue(parsedColor.value)
+}
+
+// Update the model value based on current format
+function updateModelValue(color: ParsedColor) {
+  switch (currentFormat.value) {
+    case 'rgba':
+      modelValue.value = `rgba(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, ${color.rgb.a})`
+      break
+    case 'hsla':
+      modelValue.value = `hsla(${color.hsl.h}, ${color.hsl.s}%, ${color.hsl.l}%, ${color.hsl.a})`
+      break
+    case 'hsva':
+      modelValue.value = `hsva(${color.hsv.h}, ${color.hsv.s}%, ${color.hsv.v}%, ${color.hsv.a})`
+      break
+    case 'hex':
+      modelValue.value = color.hex
+      break
+  }
+
+  colorValue.value = color.hex
+}
+
+// Color parsing functions
+function parseHexColor(hex: string): ParsedColor {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const a = hex.length === 9 ? parseInt(hex.slice(7, 9), 16) / 255 : 1
+
+  return {
+    hex,
+    rgb: { r, g, b, a },
+    hsl: rgbToHsl(r, g, b, a),
+    hsv: rgbToHsv(r, g, b, a)
+  }
+}
+
+function parseRgbaColor(rgba: string): ParsedColor {
+  const match = rgba.match(/rgba?\(([^)]+)\)/)
+  if (!match) return parseHexColor('#ff0000')
+
+  const [r, g, b, a = 1] = match[1].split(',').map((v) => parseFloat(v.trim()))
+
+  return {
+    hex: rgbToHex(r, g, b),
+    rgb: { r, g, b, a },
+    hsl: rgbToHsl(r, g, b, a),
+    hsv: rgbToHsv(r, g, b, a)
+  }
+}
+
+function parseHslaColor(hsla: string): ParsedColor {
+  const match = hsla.match(/hsla?\(([^)]+)\)/)
+  if (!match) return parseHexColor('#ff0000')
+
+  const [h, s, l, a = 1] = match[1]
+    .split(',')
+    .map((v) => parseFloat(v.trim().replace('%', '')))
+  const rgb = hslToRgb(h, s, l, a)
+
+  return {
+    hex: rgbToHex(rgb.r, rgb.g, rgb.b),
+    rgb,
+    hsl: { h, s, l, a },
+    hsv: rgbToHsv(rgb.r, rgb.g, rgb.b, rgb.a)
+  }
+}
+
+function parseHsvaColor(hsva: string): ParsedColor {
+  const match = hsva.match(/hsva?\(([^)]+)\)/)
+  if (!match) return parseHexColor('#ff0000')
+
+  const [h, s, v, a = 1] = match[1]
+    .split(',')
+    .map((val) => parseFloat(val.trim().replace('%', '')))
+  const rgb = hsvToRgb(h, s, v, a)
+
+  return {
+    hex: rgbToHex(rgb.r, rgb.g, rgb.b),
+    rgb,
+    hsl: rgbToHsl(rgb.r, rgb.g, rgb.b, rgb.a),
+    hsv: { h, s, v, a }
+  }
+}
+
+// Color conversion utility functions
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    '#' +
+    [r, g, b].map((x) => Math.round(x).toString(16).padStart(2, '0')).join('')
+  )
+}
+
+function rgbToHsl(r: number, g: number, b: number, a: number) {
+  r /= 255
+  g /= 255
+  b /= 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h: number, s: number
+  const l = (max + min) / 2
+
+  if (max === min) {
+    h = s = 0
+  } else {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0)
+        break
+      case g:
+        h = (b - r) / d + 2
+        break
+      case b:
+        h = (r - g) / d + 4
+        break
+      default:
+        h = 0
+    }
+    h /= 6
+  }
+
+  return {
+    h: Math.round(h * 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+    a
+  }
+}
+
+function rgbToHsv(r: number, g: number, b: number, a: number) {
+  r /= 255
+  g /= 255
+  b /= 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h: number
+  const v = max
+  const s = max === 0 ? 0 : (max - min) / max
+
+  if (max === min) {
+    h = 0
+  } else {
+    const d = max - min
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0)
+        break
+      case g:
+        h = (b - r) / d + 2
+        break
+      case b:
+        h = (r - g) / d + 4
+        break
+      default:
+        h = 0
+    }
+    h /= 6
+  }
+
+  return {
+    h: Math.round(h * 360),
+    s: Math.round(s * 100),
+    v: Math.round(v * 100),
+    a
+  }
+}
+
+function hslToRgb(h: number, s: number, l: number, a: number) {
+  h /= 360
+  s /= 100
+  l /= 100
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1
+    if (t > 1) t -= 1
+    if (t < 1 / 6) return p + (q - p) * 6 * t
+    if (t < 1 / 2) return q
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+    return p
+  }
+
+  let r: number, g: number, b: number
+
+  if (s === 0) {
+    r = g = b = l
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+    const p = 2 * l - q
+    r = hue2rgb(p, q, h + 1 / 3)
+    g = hue2rgb(p, q, h)
+    b = hue2rgb(p, q, h - 1 / 3)
+  }
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+    a
+  }
+}
+
+function hsvToRgb(h: number, s: number, v: number, a: number) {
+  h /= 360
+  s /= 100
+  v /= 100
+
+  const c = v * s
+  const x = c * (1 - Math.abs(((h * 6) % 2) - 1))
+  const m = v - c
+
+  let r: number, g: number, b: number
+
+  if (h < 1 / 6) {
+    ;[r, g, b] = [c, x, 0]
+  } else if (h < 2 / 6) {
+    ;[r, g, b] = [x, c, 0]
+  } else if (h < 3 / 6) {
+    ;[r, g, b] = [0, c, x]
+  } else if (h < 4 / 6) {
+    ;[r, g, b] = [0, x, c]
+  } else if (h < 5 / 6) {
+    ;[r, g, b] = [x, 0, c]
+  } else {
+    ;[r, g, b] = [c, 0, x]
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+    a
+  }
+}
+</script>
+
+<style scoped>
+.color-picker-widget {
+  min-height: 40px;
+  overflow: hidden; /* Prevent overflow outside node bounds */
+}
+
+/* Ensure proper styling for small inputs */
+:deep(.p-inputnumber-input) {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+:deep(.p-select) {
+  font-size: 0.75rem;
+}
+
+:deep(.p-select .p-select-label) {
+  padding: 0.25rem 0.5rem;
+}
+
+:deep(.p-colorpicker) {
+  border: none;
+}
+</style>

--- a/src/components/graph/widgets/ColorPickerWidget.vue
+++ b/src/components/graph/widgets/ColorPickerWidget.vue
@@ -38,7 +38,8 @@
           :pt="{
             pcInputText: {
               root: {
-                class: 'max-w-12'
+                class:
+                  'max-w-12 bg-[#222222] text-xs shadow-none border-[#222222]'
               }
             }
           }"
@@ -54,15 +55,8 @@
         :options="colorFormats"
         option-label="label"
         option-value="value"
-        class="w-24 ml-3"
+        class="w-24 ml-3 bg-[#222222] text-xs shadow-none border-none p-0"
         size="small"
-        :pt="{
-          pcInputText: {
-            root: {
-              class: 'max-w-12'
-            }
-          }
-        }"
         @update:model-value="handleFormatChange"
       />
     </div>

--- a/src/components/graph/widgets/DropdownComboWidget.vue
+++ b/src/components/graph/widgets/DropdownComboWidget.vue
@@ -4,7 +4,7 @@
       v-model="selectedValue"
       :options="computedOptions"
       :placeholder="placeholder"
-      class="w-full rounded-lg"
+      class="w-full rounded-lg bg-[#222222] text-xs border-[#222222] shadow-none"
       :disabled="isLoading"
     />
   </div>

--- a/src/components/graph/widgets/DropdownComboWidget.vue
+++ b/src/components/graph/widgets/DropdownComboWidget.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="px-2">
+    <Select
+      v-model="selectedValue"
+      :options="computedOptions"
+      :placeholder="placeholder"
+      class="w-full rounded-lg"
+      :disabled="isLoading"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import Select from 'primevue/select'
+import { computed } from 'vue'
+
+import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+const selectedValue = defineModel<string>()
+const { widget } = defineProps<{
+  widget?: ComponentWidget<string>
+}>()
+
+const inputSpec = (widget?.inputSpec ?? {}) as ComboInputSpec
+const placeholder = 'Select option'
+const isLoading = computed(() => selectedValue.value === 'Loading...')
+
+// For remote widgets, we need to dynamically get options
+const computedOptions = computed(() => {
+  if (inputSpec.remote) {
+    // For remote widgets, the options may be dynamically updated
+    // The useRemoteWidget will update the inputSpec.options
+    return inputSpec.options ?? []
+  }
+  return inputSpec.options ?? []
+})
+
+// Tooltip support is available via inputSpec.tooltip if needed in the future
+</script>

--- a/src/components/graph/widgets/ImagePreviewWidget.vue
+++ b/src/components/graph/widgets/ImagePreviewWidget.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="image-preview-widget relative w-full">
+    <!-- Single image or grid view -->
+    <div
+      v-if="images.length > 0"
+      class="relative rounded-lg overflow-hidden bg-gray-100 dark-theme:bg-gray-800"
+      :style="{ minHeight: `${minHeight}px` }"
+    >
+      <!-- Single image view -->
+      <div
+        v-if="selectedImageIndex !== null && images[selectedImageIndex]"
+        class="relative flex items-center justify-center w-full h-full"
+      >
+        <img
+          :src="images[selectedImageIndex].src"
+          :alt="`Preview ${selectedImageIndex + 1}`"
+          class="max-w-full max-h-full object-contain"
+          @error="handleImageError"
+        />
+
+        <!-- Action buttons overlay -->
+        <div class="absolute top-2 right-2 flex gap-1">
+          <Button
+            v-if="images.length > 1"
+            icon="pi pi-times"
+            size="small"
+            severity="secondary"
+            class="w-8 h-8 rounded-lg bg-black/60 text-white border-none hover:bg-black/80"
+            @click="showGrid"
+          />
+          <Button
+            icon="pi pi-pencil"
+            size="small"
+            severity="secondary"
+            class="w-8 h-8 rounded-lg bg-black/60 text-white border-none hover:bg-black/80"
+            @click="handleEdit"
+          />
+          <Button
+            icon="pi pi-sun"
+            size="small"
+            severity="secondary"
+            class="w-8 h-8 rounded-lg bg-black/60 text-white border-none hover:bg-black/80"
+            @click="handleBrightness"
+          />
+          <Button
+            icon="pi pi-download"
+            size="small"
+            severity="secondary"
+            class="w-8 h-8 rounded-lg bg-black/60 text-white border-none hover:bg-black/80"
+            @click="handleSave"
+          />
+        </div>
+
+        <!-- Navigation for multiple images -->
+        <div
+          v-if="images.length > 1"
+          class="absolute bottom-2 right-2 bg-black/60 text-white px-2 py-1 rounded text-sm cursor-pointer hover:bg-black/80"
+          @click="nextImage"
+        >
+          {{ selectedImageIndex + 1 }}/{{ images.length }}
+        </div>
+      </div>
+
+      <!-- Grid view for multiple images -->
+      <div
+        v-else-if="allowBatch && images.length > 1"
+        class="grid gap-1 p-2"
+        :style="gridStyle"
+      >
+        <div
+          v-for="(image, index) in images"
+          :key="index"
+          class="relative aspect-square bg-gray-200 dark-theme:bg-gray-700 rounded cursor-pointer overflow-hidden hover:ring-2 hover:ring-blue-500"
+          @click="selectImage(index)"
+        >
+          <img
+            :src="image.src"
+            :alt="`Thumbnail ${index + 1}`"
+            class="w-full h-full object-cover"
+            @error="handleImageError"
+          />
+        </div>
+      </div>
+
+      <!-- Single image in grid mode -->
+      <div v-else-if="images.length === 1" class="p-2">
+        <div
+          class="relative bg-gray-200 dark-theme:bg-gray-700 rounded cursor-pointer overflow-hidden"
+          @click="selectImage(0)"
+        >
+          <img
+            :src="images[0].src"
+            :alt="'Preview'"
+            class="w-full h-auto object-contain"
+            @error="handleImageError"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else
+      class="flex items-center justify-center w-full bg-gray-100 dark-theme:bg-gray-800 rounded-lg"
+      :style="{ minHeight: `${minHeight}px` }"
+    >
+      <div class="text-gray-500 text-sm">No images to preview</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { computed, ref } from 'vue'
+
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+interface ImageData {
+  src: string
+  width?: number
+  height?: number
+}
+
+const modelValue = defineModel<string | string[]>({ required: true })
+const { widget } = defineProps<{
+  widget: ComponentWidget<string | string[]>
+}>()
+
+// Widget configuration
+const inputSpec = widget.inputSpec
+const allowBatch = computed(() => Boolean(inputSpec.allow_batch))
+const imageFolder = computed(() => inputSpec.image_folder || 'input')
+
+// State
+const selectedImageIndex = ref<number | null>(null)
+const minHeight = 320
+
+// Convert model value to image data
+const images = computed<ImageData[]>(() => {
+  const value = modelValue.value
+  if (!value) return []
+
+  const paths = Array.isArray(value) ? value : [value]
+  return paths.map((path) => ({
+    src: path.startsWith('http')
+      ? path
+      : `api/view?filename=${encodeURIComponent(path)}&type=${imageFolder.value}`, // TODO: add subfolder
+    width: undefined,
+    height: undefined
+  }))
+})
+
+// Grid layout for batch images
+const gridStyle = computed(() => {
+  const count = images.value.length
+  if (count <= 1) return {}
+
+  const cols = Math.ceil(Math.sqrt(count))
+  return {
+    gridTemplateColumns: `repeat(${cols}, 1fr)`
+  }
+})
+
+// Methods
+const selectImage = (index: number) => {
+  selectedImageIndex.value = index
+}
+
+const showGrid = () => {
+  selectedImageIndex.value = null
+}
+
+const nextImage = () => {
+  if (images.value.length === 0) return
+
+  const current = selectedImageIndex.value ?? -1
+  const next = (current + 1) % images.value.length
+  selectedImageIndex.value = next
+}
+
+const handleImageError = (event: Event) => {
+  const img = event.target as HTMLImageElement
+  img.style.display = 'none'
+  console.warn('Failed to load image:', img.src)
+}
+
+// Stub button handlers for now
+const handleEdit = () => {
+  console.log('Edit button clicked - functionality to be implemented')
+}
+
+const handleBrightness = () => {
+  console.log('Brightness button clicked - functionality to be implemented')
+}
+
+const handleSave = () => {
+  console.log('Save button clicked - functionality to be implemented')
+}
+
+// Initialize to show first image if available
+if (images.value.length === 1) {
+  selectedImageIndex.value = 0
+}
+</script>
+
+<style scoped>
+.image-preview-widget {
+  /* Ensure proper dark theme styling */
+}
+</style>

--- a/src/components/graph/widgets/MediaLoaderWidget.vue
+++ b/src/components/graph/widgets/MediaLoaderWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="media-loader-widget w-full px-2">
+  <div class="media-loader-widget w-full px-2 max-h-44">
     <div
       class="upload-area border-2 border-dashed border-surface-300 dark-theme:border-surface-600 rounded-lg p-6 text-center bg-surface-50 dark-theme:bg-surface-800 hover:bg-surface-100 dark-theme:hover:bg-surface-700 transition-colors cursor-pointer"
       :class="{

--- a/src/components/graph/widgets/MediaLoaderWidget.vue
+++ b/src/components/graph/widgets/MediaLoaderWidget.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="media-loader-widget w-full px-2">
+    <div
+      class="upload-area border-2 border-dashed border-surface-300 dark-theme:border-surface-600 rounded-lg p-6 text-center bg-surface-50 dark-theme:bg-surface-800 hover:bg-surface-100 dark-theme:hover:bg-surface-700 transition-colors cursor-pointer"
+      :class="{
+        'border-primary-500 bg-primary-50 dark-theme:bg-primary-950': isDragOver
+      }"
+      @click="triggerFileUpload"
+      @dragover.prevent="onDragOver"
+      @dragleave.prevent="onDragLeave"
+      @drop.prevent="onDrop"
+    >
+      <div class="flex flex-col items-center gap-2">
+        <i
+          class="pi pi-cloud-upload text-2xl text-surface-500 dark-theme:text-surface-400"
+        ></i>
+        <div class="text-sm text-surface-600 dark-theme:text-surface-300">
+          <span>Drop your file here or </span>
+          <span
+            class="text-primary-600 dark-theme:text-primary-400 hover:text-primary-700 dark-theme:hover:text-primary-300 underline cursor-pointer"
+            @click.stop="triggerFileUpload"
+          >
+            browse files
+          </span>
+        </div>
+        <div
+          v-if="accept"
+          class="text-xs text-surface-500 dark-theme:text-surface-400"
+        >
+          Accepted formats: {{ formatAcceptTypes }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Hidden file input -->
+    <input
+      ref="fileInput"
+      type="file"
+      :accept="accept"
+      multiple
+      class="hidden"
+      @change="onFileSelect"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+// Props and model
+const modelValue = defineModel<string[]>({ required: true, default: () => [] })
+const { widget, accept } = defineProps<{
+  widget: ComponentWidget<string[]>
+  accept?: string
+}>()
+
+// Reactive state
+const fileInput = ref<HTMLInputElement>()
+const isDragOver = ref(false)
+
+// Computed properties
+const formatAcceptTypes = computed(() => {
+  if (!accept) return ''
+  return accept
+    .split(',')
+    .map((type) =>
+      type
+        .trim()
+        .replace('image/', '')
+        .replace('video/', '')
+        .replace('audio/', '')
+    )
+    .join(', ')
+})
+
+// Methods
+const triggerFileUpload = () => {
+  fileInput.value?.click()
+}
+
+const onFileSelect = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  if (target.files) {
+    handleFiles(Array.from(target.files))
+  }
+}
+
+const onDragOver = (event: DragEvent) => {
+  event.preventDefault()
+  isDragOver.value = true
+}
+
+const onDragLeave = (event: DragEvent) => {
+  event.preventDefault()
+  isDragOver.value = false
+}
+
+const onDrop = (event: DragEvent) => {
+  event.preventDefault()
+  isDragOver.value = false
+
+  if (event.dataTransfer?.files) {
+    handleFiles(Array.from(event.dataTransfer.files))
+  }
+}
+
+const handleFiles = (files: File[]) => {
+  // Filter files based on accept prop if provided
+  let validFiles = files
+  if (accept) {
+    const acceptTypes = accept
+      .split(',')
+      .map((type) => type.trim().toLowerCase())
+    validFiles = files.filter((file) => {
+      return acceptTypes.some((acceptType) => {
+        if (acceptType.includes('*')) {
+          // Handle wildcard types like "image/*"
+          const baseType = acceptType.split('/')[0]
+          return file.type.startsWith(baseType + '/')
+        }
+        return file.type.toLowerCase() === acceptType
+      })
+    })
+  }
+
+  if (validFiles.length > 0) {
+    // Emit files to parent component for handling upload
+    const fileNames = validFiles.map((file) => file.name)
+    modelValue.value = fileNames
+
+    // Trigger the widget's upload handler if available
+    if ((widget.options as any)?.onFilesSelected) {
+      ;(widget.options as any).onFilesSelected(validFiles)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.upload-area {
+  min-height: 80px;
+  transition: all 0.2s ease;
+}
+
+.upload-area:hover {
+  border-color: var(--p-primary-500);
+}
+</style>

--- a/src/components/graph/widgets/StringWidget.vue
+++ b/src/components/graph/widgets/StringWidget.vue
@@ -5,7 +5,7 @@
       v-if="!isMultiline"
       v-model="modelValue"
       :placeholder="placeholder"
-      class="w-full rounded-lg px-3 py-2 text-sm"
+      class="w-full rounded-lg px-3 py-2 text-sm bg-[#222222] text-xs mt-0.5 border-[#222222] shadow-none"
     />
 
     <!-- Multi-line textarea -->
@@ -15,7 +15,7 @@
       :placeholder="placeholder"
       :auto-resize="true"
       :rows="3"
-      class="w-full rounded-lg px-3 py-2 text-sm resize-none"
+      class="w-full rounded-lg px-3 py-2 text-sm resize-none bg-[#222222] text-xs mt-0.5 border-[#222222] shadow-none"
     />
   </div>
 </template>

--- a/src/components/graph/widgets/StringWidget.vue
+++ b/src/components/graph/widgets/StringWidget.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="w-full px-2">
+    <!-- Single line text input -->
+    <InputText
+      v-if="!isMultiline"
+      v-model="modelValue"
+      :placeholder="placeholder"
+      class="w-full rounded-lg px-3 py-2 text-sm"
+    />
+
+    <!-- Multi-line textarea -->
+    <Textarea
+      v-else
+      v-model="modelValue"
+      :placeholder="placeholder"
+      :auto-resize="true"
+      :rows="3"
+      class="w-full rounded-lg px-3 py-2 text-sm resize-none"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import InputText from 'primevue/inputtext'
+import Textarea from 'primevue/textarea'
+import { computed } from 'vue'
+
+import type { StringInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+const modelValue = defineModel<string>({ required: true })
+const { widget } = defineProps<{
+  widget: ComponentWidget<string>
+}>()
+
+const inputSpec = widget.inputSpec as StringInputSpec
+const isMultiline = computed(() => inputSpec.multiline === true)
+const placeholder = computed(
+  () =>
+    inputSpec.placeholder ??
+    inputSpec.default ??
+    inputSpec.defaultVal ??
+    inputSpec.name
+)
+</script>

--- a/src/composables/node/useNodeImagePreview.ts
+++ b/src/composables/node/useNodeImagePreview.ts
@@ -1,0 +1,77 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+
+import { useImagePreviewWidget } from '@/composables/widgets/useImagePreviewWidget'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+const IMAGE_PREVIEW_WIDGET_NAME = '$$node-image-preview'
+
+/**
+ * Composable for handling node-level operations for ImagePreview widget
+ */
+export function useNodeImagePreview() {
+  const imagePreviewWidget = useImagePreviewWidget()
+
+  const findImagePreviewWidget = (node: LGraphNode) =>
+    node.widgets?.find((w) => w.name === IMAGE_PREVIEW_WIDGET_NAME)
+
+  const addImagePreviewWidget = (
+    node: LGraphNode,
+    inputSpec?: Partial<InputSpec>
+  ) =>
+    imagePreviewWidget(node, {
+      name: IMAGE_PREVIEW_WIDGET_NAME,
+      type: 'IMAGEPREVIEW',
+      allow_batch: true,
+      image_folder: 'input',
+      ...inputSpec
+    } as InputSpec)
+
+  /**
+   * Shows image preview widget for a node
+   * @param node The graph node to show the widget for
+   * @param images The images to display (can be single image or array)
+   * @param options Configuration options
+   */
+  function showImagePreview(
+    node: LGraphNode,
+    images: string | string[],
+    options: {
+      allow_batch?: boolean
+      image_folder?: string
+      imageInputName?: string
+    } = {}
+  ) {
+    const widget =
+      findImagePreviewWidget(node) ??
+      addImagePreviewWidget(node, {
+        allow_batch: options.allow_batch,
+        image_folder: options.image_folder || 'input'
+      })
+
+    // Set the widget value
+    widget.value = images
+    node.setDirtyCanvas?.(true)
+  }
+
+  /**
+   * Removes image preview widget from a node
+   * @param node The graph node to remove the widget from
+   */
+  function removeImagePreview(node: LGraphNode) {
+    if (!node.widgets) return
+
+    const widgetIdx = node.widgets.findIndex(
+      (w) => w.name === IMAGE_PREVIEW_WIDGET_NAME
+    )
+
+    if (widgetIdx > -1) {
+      node.widgets[widgetIdx].onRemove?.()
+      node.widgets.splice(widgetIdx, 1)
+    }
+  }
+
+  return {
+    showImagePreview,
+    removeImagePreview
+  }
+}

--- a/src/composables/node/useNodeImageUpload.ts
+++ b/src/composables/node/useNodeImageUpload.ts
@@ -2,7 +2,6 @@ import type { LGraphNode } from '@comfyorg/litegraph'
 
 import { useNodeDragAndDrop } from '@/composables/node/useNodeDragAndDrop'
 import { useNodeFileInput } from '@/composables/node/useNodeFileInput'
-import { useNodeMediaUpload } from '@/composables/node/useNodeMediaUpload'
 import { useNodePaste } from '@/composables/node/useNodePaste'
 import { api } from '@/scripts/api'
 import { useToastStore } from '@/stores/toastStore'
@@ -37,28 +36,16 @@ interface ImageUploadOptions {
    * @example 'image/png,image/jpeg,image/webp,video/webm,video/mp4'
    */
   accept?: string
-  /**
-   * Whether to use the new Vue MediaLoader widget instead of traditional drag/drop/paste
-   * @default true
-   */
-  useMediaLoaderWidget?: boolean
 }
 
 /**
  * Adds image upload to a node via drag & drop, paste, and file input.
- * Optionally can use the new Vue MediaLoader widget.
  */
 export const useNodeImageUpload = (
   node: LGraphNode,
   options: ImageUploadOptions
 ) => {
-  const {
-    fileFilter,
-    onUploadComplete,
-    allow_batch,
-    accept,
-    useMediaLoaderWidget = true
-  } = options
+  const { fileFilter, onUploadComplete, allow_batch, accept } = options
 
   const isPastedFile = (file: File): boolean =>
     file.name === 'image.png' &&
@@ -81,21 +68,8 @@ export const useNodeImageUpload = (
     return validPaths
   }
 
-  // If using the new MediaLoader widget, set it up and return early
-  if (useMediaLoaderWidget) {
-    const { showMediaLoader } = useNodeMediaUpload()
-    const widget = showMediaLoader(node, {
-      fileFilter,
-      onUploadComplete,
-      allow_batch,
-      accept
-    })
-    return {
-      openFileSelection: () => {},
-      handleUpload,
-      mediaLoaderWidget: widget
-    }
-  }
+  // Note: MediaLoader widget functionality is handled directly by
+  // useImageUploadMediaWidget.ts to avoid circular dependencies
 
   // Traditional approach: Handle drag & drop
   useNodeDragAndDrop(node, {

--- a/src/composables/node/useNodeImageUpload.ts
+++ b/src/composables/node/useNodeImageUpload.ts
@@ -2,6 +2,7 @@ import type { LGraphNode } from '@comfyorg/litegraph'
 
 import { useNodeDragAndDrop } from '@/composables/node/useNodeDragAndDrop'
 import { useNodeFileInput } from '@/composables/node/useNodeFileInput'
+import { useNodeMediaUpload } from '@/composables/node/useNodeMediaUpload'
 import { useNodePaste } from '@/composables/node/useNodePaste'
 import { api } from '@/scripts/api'
 import { useToastStore } from '@/stores/toastStore'
@@ -36,16 +37,28 @@ interface ImageUploadOptions {
    * @example 'image/png,image/jpeg,image/webp,video/webm,video/mp4'
    */
   accept?: string
+  /**
+   * Whether to use the new Vue MediaLoader widget instead of traditional drag/drop/paste
+   * @default true
+   */
+  useMediaLoaderWidget?: boolean
 }
 
 /**
  * Adds image upload to a node via drag & drop, paste, and file input.
+ * Optionally can use the new Vue MediaLoader widget.
  */
 export const useNodeImageUpload = (
   node: LGraphNode,
   options: ImageUploadOptions
 ) => {
-  const { fileFilter, onUploadComplete, allow_batch, accept } = options
+  const {
+    fileFilter,
+    onUploadComplete,
+    allow_batch,
+    accept,
+    useMediaLoaderWidget = true
+  } = options
 
   const isPastedFile = (file: File): boolean =>
     file.name === 'image.png' &&
@@ -68,7 +81,23 @@ export const useNodeImageUpload = (
     return validPaths
   }
 
-  // Handle drag & drop
+  // If using the new MediaLoader widget, set it up and return early
+  if (useMediaLoaderWidget) {
+    const { showMediaLoader } = useNodeMediaUpload()
+    const widget = showMediaLoader(node, {
+      fileFilter,
+      onUploadComplete,
+      allow_batch,
+      accept
+    })
+    return {
+      openFileSelection: () => {},
+      handleUpload,
+      mediaLoaderWidget: widget
+    }
+  }
+
+  // Traditional approach: Handle drag & drop
   useNodeDragAndDrop(node, {
     fileFilter,
     onDrop: handleUploadBatch

--- a/src/composables/node/useNodeMediaUpload.ts
+++ b/src/composables/node/useNodeMediaUpload.ts
@@ -1,0 +1,86 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+
+import { useNodeImageUpload } from '@/composables/node/useNodeImageUpload'
+import { useMediaLoaderWidget } from '@/composables/widgets/useMediaLoaderWidget'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+const MEDIA_LOADER_WIDGET_NAME = '$$node-media-loader'
+
+interface MediaUploadOptions {
+  fileFilter?: (file: File) => boolean
+  onUploadComplete: (paths: string[]) => void
+  allow_batch?: boolean
+  accept?: string
+}
+
+/**
+ * Composable for handling media upload with Vue MediaLoader widget
+ */
+export function useNodeMediaUpload() {
+  const mediaLoaderWidget = useMediaLoaderWidget()
+
+  const findMediaLoaderWidget = (node: LGraphNode) =>
+    node.widgets?.find((w) => w.name === MEDIA_LOADER_WIDGET_NAME)
+
+  const addMediaLoaderWidget = (
+    node: LGraphNode,
+    options: MediaUploadOptions
+  ) => {
+    // Set up the file upload handling using existing logic
+    const { handleUpload } = useNodeImageUpload(node, options)
+
+    // Create the MediaLoader widget
+    const widget = mediaLoaderWidget(node, {
+      name: MEDIA_LOADER_WIDGET_NAME,
+      type: 'MEDIA_LOADER'
+    } as InputSpec)
+
+    // Connect the widget to the upload handler
+    if (widget.options) {
+      ;(widget.options as any).onFilesSelected = async (files: File[]) => {
+        const paths = await Promise.all(files.map(handleUpload))
+        const validPaths = paths.filter((p): p is string => !!p)
+        if (validPaths.length) {
+          options.onUploadComplete(validPaths)
+        }
+      }
+    }
+
+    return widget
+  }
+
+  /**
+   * Shows media loader widget for a node
+   * @param node The graph node to show the widget for
+   * @param options Upload configuration options
+   */
+  function showMediaLoader(node: LGraphNode, options: MediaUploadOptions) {
+    const widget =
+      findMediaLoaderWidget(node) ?? addMediaLoaderWidget(node, options)
+    node.setDirtyCanvas?.(true)
+    return widget
+  }
+
+  /**
+   * Removes media loader widget from a node
+   * @param node The graph node to remove the widget from
+   */
+  function removeMediaLoader(node: LGraphNode) {
+    if (!node.widgets) return
+
+    const widgetIdx = node.widgets.findIndex(
+      (w) => w.name === MEDIA_LOADER_WIDGET_NAME
+    )
+
+    if (widgetIdx > -1) {
+      node.widgets[widgetIdx].onRemove?.()
+      node.widgets.splice(widgetIdx, 1)
+    }
+  }
+
+  return {
+    showMediaLoader,
+    removeMediaLoader,
+    addMediaLoaderWidget
+  }
+}

--- a/src/composables/widgets/useBadgedNumberInput.ts
+++ b/src/composables/widgets/useBadgedNumberInput.ts
@@ -43,7 +43,7 @@ export const useBadgedNumberInput = (
   const {
     defaultValue = 0,
     disabled = false,
-    minHeight = 40,
+    minHeight = 32,
     serialize = true,
     mode = 'int'
   } = options
@@ -117,6 +117,8 @@ export const useBadgedNumberInput = (
 
         // Optional: minimum height for the widget
         getMinHeight: () => minHeight + PADDING,
+        // Lock maximum height to prevent oversizing
+        getMaxHeight: () => 45,
 
         // Optional: whether to serialize this widget's value
         serialize

--- a/src/composables/widgets/useBadgedNumberInput.ts
+++ b/src/composables/widgets/useBadgedNumberInput.ts
@@ -1,0 +1,91 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { ref } from 'vue'
+
+import BadgedNumberInput from '@/components/graph/widgets/BadgedNumberInput.vue'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+
+const PADDING = 8
+
+type BadgeState = 'normal' | 'random' | 'lock' | 'increment' | 'decrement'
+
+interface BadgedNumberInputOptions {
+  defaultValue?: number
+  badgeState?: BadgeState
+  disabled?: boolean
+  minHeight?: number
+  serialize?: boolean
+}
+
+export const useBadgedNumberInput = (
+  options: BadgedNumberInputOptions = {}
+) => {
+  const {
+    defaultValue = 0,
+    badgeState = 'normal',
+    disabled = false,
+    minHeight = 40,
+    serialize = true
+  } = options
+
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
+    node: LGraphNode,
+    inputSpec: InputSpec
+  ) => {
+    // Initialize widget value as string to conform to ComponentWidgetImpl requirements
+    const widgetValue = ref<string>(defaultValue.toString())
+
+    // Create the widget instance
+    const widget = new ComponentWidgetImpl<
+      string | object,
+      Omit<
+        InstanceType<typeof BadgedNumberInput>['$props'],
+        'widget' | 'modelValue'
+      >
+    >({
+      node,
+      name: inputSpec.name,
+      component: BadgedNumberInput,
+      inputSpec,
+      props: {
+        badgeState,
+        disabled
+      },
+      options: {
+        // Required: getter for widget value - return as string
+        getValue: () => widgetValue.value as string | object,
+
+        // Required: setter for widget value - accept number, string or object
+        setValue: (value: string | object | number) => {
+          let stringValue: string
+          if (typeof value === 'object') {
+            stringValue = JSON.stringify(value)
+          } else {
+            stringValue = String(value)
+          }
+          const numValue = parseFloat(stringValue)
+          if (!isNaN(numValue)) {
+            widgetValue.value = numValue.toString()
+          }
+        },
+
+        // Optional: minimum height for the widget
+        getMinHeight: () => minHeight + PADDING,
+
+        // Optional: whether to serialize this widget's value
+        serialize
+      }
+    })
+
+    // Register the widget with the node
+    addWidget(node, widget)
+
+    return widget
+  }
+
+  return widgetConstructor
+}
+
+// Export types for use in other modules
+export type { BadgeState, BadgedNumberInputOptions }

--- a/src/composables/widgets/useBadgedNumberInput.ts
+++ b/src/composables/widgets/useBadgedNumberInput.ts
@@ -118,7 +118,7 @@ export const useBadgedNumberInput = (
         // Optional: minimum height for the widget
         getMinHeight: () => minHeight + PADDING,
         // Lock maximum height to prevent oversizing
-        getMaxHeight: () => 45,
+        getMaxHeight: () => 48,
 
         // Optional: whether to serialize this widget's value
         serialize

--- a/src/composables/widgets/useBadgedNumberInput.ts
+++ b/src/composables/widgets/useBadgedNumberInput.ts
@@ -1,14 +1,16 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
-import { ref } from 'vue'
+import { reactive, ref } from 'vue'
 
 import BadgedNumberInput from '@/components/graph/widgets/BadgedNumberInput.vue'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
-import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
 const PADDING = 8
 
 type BadgeState = 'normal' | 'random' | 'lock' | 'increment' | 'decrement'
+
+type NumberWidgetMode = 'int' | 'float'
 
 interface BadgedNumberInputOptions {
   defaultValue?: number
@@ -16,6 +18,23 @@ interface BadgedNumberInputOptions {
   disabled?: boolean
   minHeight?: number
   serialize?: boolean
+  mode?: NumberWidgetMode
+}
+
+// Helper function to map control widget values to badge states
+const mapControlValueToBadgeState = (controlValue: string): BadgeState => {
+  switch (controlValue) {
+    case 'fixed':
+      return 'lock'
+    case 'increment':
+      return 'increment'
+    case 'decrement':
+      return 'decrement'
+    case 'randomize':
+      return 'random'
+    default:
+      return 'normal'
+  }
 }
 
 export const useBadgedNumberInput = (
@@ -23,10 +42,10 @@ export const useBadgedNumberInput = (
 ) => {
   const {
     defaultValue = 0,
-    badgeState = 'normal',
     disabled = false,
     minHeight = 40,
-    serialize = true
+    serialize = true,
+    mode = 'int'
   } = options
 
   const widgetConstructor: ComfyWidgetConstructorV2 = (
@@ -36,7 +55,23 @@ export const useBadgedNumberInput = (
     // Initialize widget value as string to conform to ComponentWidgetImpl requirements
     const widgetValue = ref<string>(defaultValue.toString())
 
-    // Create the widget instance
+    // Determine if we should show control widget and badge
+    const shouldShowControlWidget =
+      inputSpec.control_after_generate ??
+      // Legacy compatibility: seed inputs get control widgets
+      ['seed', 'noise_seed'].includes(inputSpec.name)
+
+    // Create reactive props object for the component
+    const componentProps = reactive({
+      badgeState:
+        options.badgeState ??
+        (shouldShowControlWidget ? 'random' : ('normal' as BadgeState)),
+      disabled
+    })
+
+    const controlWidget: any = null
+
+    // Create the main widget instance
     const widget = new ComponentWidgetImpl<
       string | object,
       Omit<
@@ -48,24 +83,34 @@ export const useBadgedNumberInput = (
       name: inputSpec.name,
       component: BadgedNumberInput,
       inputSpec,
-      props: {
-        badgeState,
-        disabled
-      },
+      props: componentProps,
       options: {
         // Required: getter for widget value - return as string
         getValue: () => widgetValue.value as string | object,
 
         // Required: setter for widget value - accept number, string or object
         setValue: (value: string | object | number) => {
-          let stringValue: string
+          let numValue: number
           if (typeof value === 'object') {
-            stringValue = JSON.stringify(value)
+            numValue = parseFloat(JSON.stringify(value))
           } else {
-            stringValue = String(value)
+            numValue =
+              typeof value === 'number' ? value : parseFloat(String(value))
           }
-          const numValue = parseFloat(stringValue)
+
           if (!isNaN(numValue)) {
+            // Apply int/float specific value processing
+            if (mode === 'int') {
+              const step = (inputSpec as any).step ?? 1
+              if (step === 1) {
+                numValue = Math.round(numValue)
+              } else {
+                const min = (inputSpec as any).min ?? 0
+                const offset = min % step
+                numValue =
+                  Math.round((numValue - offset) / step) * step + offset
+              }
+            }
             widgetValue.value = numValue.toString()
           }
         },
@@ -78,6 +123,41 @@ export const useBadgedNumberInput = (
       }
     })
 
+    // Add control widget if needed - temporarily disabled to fix circular dependency
+    if (shouldShowControlWidget) {
+      // TODO: Re-implement control widget functionality without circular dependency
+      console.warn(
+        'Control widget functionality temporarily disabled due to circular dependency'
+      )
+      // controlWidget = addValueControlWidget(
+      //   node,
+      //   widget as any, // Cast to satisfy the interface
+      //   'randomize',
+      //   undefined,
+      //   undefined,
+      //   transformInputSpecV2ToV1(inputSpec)
+      // )
+
+      // Set up reactivity to update badge state when control widget changes
+      if (controlWidget) {
+        const originalCallback = controlWidget.callback
+        controlWidget.callback = function (value: string) {
+          componentProps.badgeState = mapControlValueToBadgeState(value)
+          if (originalCallback) {
+            originalCallback.call(this, value)
+          }
+        }
+
+        // Initialize badge state
+        componentProps.badgeState = mapControlValueToBadgeState(
+          controlWidget.value || 'randomize'
+        )
+
+        // Link the widgets
+        ;(widget as any).linkedWidgets = [controlWidget]
+      }
+    }
+
     // Register the widget with the node
     addWidget(node, widget)
 
@@ -88,4 +168,4 @@ export const useBadgedNumberInput = (
 }
 
 // Export types for use in other modules
-export type { BadgeState, BadgedNumberInputOptions }
+export type { BadgeState, BadgedNumberInputOptions, NumberWidgetMode }

--- a/src/composables/widgets/useBooleanWidget.ts
+++ b/src/composables/widgets/useBooleanWidget.ts
@@ -4,7 +4,7 @@ import {
   type InputSpec,
   isBooleanInputSpec
 } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
 export const useBooleanWidget = () => {
   const widgetConstructor: ComfyWidgetConstructorV2 = (

--- a/src/composables/widgets/useChatHistoryWidget.ts
+++ b/src/composables/widgets/useChatHistoryWidget.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 import ChatHistoryWidget from '@/components/graph/widgets/ChatHistoryWidget.vue'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
-import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
 const PADDING = 16
 

--- a/src/composables/widgets/useColorPickerWidget.ts
+++ b/src/composables/widgets/useColorPickerWidget.ts
@@ -1,0 +1,207 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { ref } from 'vue'
+
+import ColorPickerWidget from '@/components/graph/widgets/ColorPickerWidget.vue'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
+
+const PADDING = 8
+
+interface ColorPickerWidgetOptions {
+  defaultValue?: string
+  defaultFormat?: 'rgba' | 'hsla' | 'hsva' | 'hex'
+  minHeight?: number
+  serialize?: boolean
+}
+
+export const useColorPickerWidget = (
+  options: ColorPickerWidgetOptions = {}
+) => {
+  const {
+    defaultValue = 'rgba(255, 0, 0, 1)',
+    minHeight = 48,
+    serialize = true
+  } = options
+
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
+    node: LGraphNode,
+    inputSpec: InputSpec
+  ) => {
+    // Initialize widget value as string
+    const widgetValue = ref<string>(defaultValue)
+
+    // Create the main widget instance
+    const widget = new ComponentWidgetImpl<string>({
+      node,
+      name: inputSpec.name,
+      component: ColorPickerWidget,
+      inputSpec,
+      options: {
+        // Required: getter for widget value
+        getValue: () => widgetValue.value,
+
+        // Required: setter for widget value
+        setValue: (value: string | any) => {
+          // Handle different input types
+          if (typeof value === 'string') {
+            // Validate and normalize color string
+            const normalizedValue = normalizeColorString(value)
+            if (normalizedValue) {
+              widgetValue.value = normalizedValue
+            }
+          } else if (typeof value === 'object' && value !== null) {
+            // Handle object input (e.g., from PrimeVue ColorPicker)
+            if (value.hex) {
+              widgetValue.value = value.hex
+            } else {
+              // Try to convert object to string
+              widgetValue.value = String(value)
+            }
+          } else {
+            // Fallback to string conversion
+            widgetValue.value = String(value)
+          }
+        },
+
+        // Optional: minimum height for the widget
+        getMinHeight: () => minHeight + PADDING,
+
+        // Optional: whether to serialize this widget's value
+        serialize
+      }
+    })
+
+    // Register the widget with the node
+    addWidget(node, widget as any)
+
+    return widget
+  }
+
+  return widgetConstructor
+}
+
+/**
+ * Normalizes color string inputs to ensure consistent format
+ * @param colorString - The input color string
+ * @returns Normalized color string or null if invalid
+ */
+function normalizeColorString(colorString: string): string | null {
+  if (!colorString || typeof colorString !== 'string') {
+    return null
+  }
+
+  const trimmed = colorString.trim()
+
+  // Handle hex colors
+  if (trimmed.startsWith('#')) {
+    if (/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/.test(trimmed)) {
+      // Convert 3-digit hex to 6-digit
+      if (trimmed.length === 4) {
+        return (
+          '#' +
+          trimmed[1] +
+          trimmed[1] +
+          trimmed[2] +
+          trimmed[2] +
+          trimmed[3] +
+          trimmed[3]
+        )
+      }
+      return trimmed.toLowerCase()
+    }
+    return null
+  }
+
+  // Handle rgb/rgba colors
+  if (trimmed.startsWith('rgb')) {
+    const rgbaMatch = trimmed.match(
+      /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)/
+    )
+    if (rgbaMatch) {
+      const [, r, g, b, a] = rgbaMatch
+      const red = Math.max(0, Math.min(255, parseInt(r)))
+      const green = Math.max(0, Math.min(255, parseInt(g)))
+      const blue = Math.max(0, Math.min(255, parseInt(b)))
+      const alpha = a ? Math.max(0, Math.min(1, parseFloat(a))) : 1
+
+      if (alpha === 1) {
+        return `rgb(${red}, ${green}, ${blue})`
+      } else {
+        return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+      }
+    }
+    return null
+  }
+
+  // Handle hsl/hsla colors
+  if (trimmed.startsWith('hsl')) {
+    const hslaMatch = trimmed.match(
+      /hsla?\(\s*(\d+)\s*,\s*(\d+)%?\s*,\s*(\d+)%?\s*(?:,\s*([\d.]+))?\s*\)/
+    )
+    if (hslaMatch) {
+      const [, h, s, l, a] = hslaMatch
+      const hue = Math.max(0, Math.min(360, parseInt(h)))
+      const saturation = Math.max(0, Math.min(100, parseInt(s)))
+      const lightness = Math.max(0, Math.min(100, parseInt(l)))
+      const alpha = a ? Math.max(0, Math.min(1, parseFloat(a))) : 1
+
+      if (alpha === 1) {
+        return `hsl(${hue}, ${saturation}%, ${lightness}%)`
+      } else {
+        return `hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha})`
+      }
+    }
+    return null
+  }
+
+  // Handle hsv/hsva colors (custom format)
+  if (trimmed.startsWith('hsv')) {
+    const hsvaMatch = trimmed.match(
+      /hsva?\(\s*(\d+)\s*,\s*(\d+)%?\s*,\s*(\d+)%?\s*(?:,\s*([\d.]+))?\s*\)/
+    )
+    if (hsvaMatch) {
+      const [, h, s, v, a] = hsvaMatch
+      const hue = Math.max(0, Math.min(360, parseInt(h)))
+      const saturation = Math.max(0, Math.min(100, parseInt(s)))
+      const value = Math.max(0, Math.min(100, parseInt(v)))
+      const alpha = a ? Math.max(0, Math.min(1, parseFloat(a))) : 1
+
+      if (alpha === 1) {
+        return `hsv(${hue}, ${saturation}%, ${value}%)`
+      } else {
+        return `hsva(${hue}, ${saturation}%, ${value}%, ${alpha})`
+      }
+    }
+    return null
+  }
+
+  // Handle named colors by converting to hex (basic set)
+  const namedColors: Record<string, string> = {
+    red: '#ff0000',
+    green: '#008000',
+    blue: '#0000ff',
+    white: '#ffffff',
+    black: '#000000',
+    yellow: '#ffff00',
+    cyan: '#00ffff',
+    magenta: '#ff00ff',
+    orange: '#ffa500',
+    purple: '#800080',
+    pink: '#ffc0cb',
+    brown: '#a52a2a',
+    gray: '#808080',
+    grey: '#808080'
+  }
+
+  const lowerTrimmed = trimmed.toLowerCase()
+  if (namedColors[lowerTrimmed]) {
+    return namedColors[lowerTrimmed]
+  }
+
+  // If we can't parse it, return null
+  return null
+}
+
+// Export types for use in other modules
+export type { ColorPickerWidgetOptions }

--- a/src/composables/widgets/useComboWidget.ts
+++ b/src/composables/widgets/useComboWidget.ts
@@ -3,7 +3,6 @@ import type { IComboWidget } from '@comfyorg/litegraph/dist/types/widgets'
 import { ref } from 'vue'
 
 import MultiSelectWidget from '@/components/graph/widgets/MultiSelectWidget.vue'
-import { transformInputSpecV2ToV1 } from '@/schemas/nodeDef/migration'
 import {
   ComboInputSpec,
   type InputSpec,
@@ -14,10 +13,7 @@ import {
   ComponentWidgetImpl,
   addWidget
 } from '@/scripts/domWidget'
-import {
-  type ComfyWidgetConstructorV2,
-  addValueControlWidgets
-} from '@/scripts/widgets'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
 import { useRemoteWidget } from './useRemoteWidget'
 
@@ -82,13 +78,17 @@ const addComboWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
   }
 
   if (inputSpec.control_after_generate) {
-    widget.linkedWidgets = addValueControlWidgets(
-      node,
-      widget,
-      undefined,
-      undefined,
-      transformInputSpecV2ToV1(inputSpec)
+    // TODO: Re-implement control widget functionality without circular dependency
+    console.warn(
+      'Control widget functionality temporarily disabled for combo widgets due to circular dependency'
     )
+    // widget.linkedWidgets = addValueControlWidgets(
+    //   node,
+    //   widget,
+    //   undefined,
+    //   undefined,
+    //   transformInputSpecV2ToV1(inputSpec)
+    // )
   }
 
   return widget

--- a/src/composables/widgets/useComboWidget.ts
+++ b/src/composables/widgets/useComboWidget.ts
@@ -31,9 +31,9 @@ const addMultiSelectWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
         widgetValue.value = value
       },
       // Optional: minimum height for the widget (multiselect needs minimal height)
-      getMinHeight: () => 32,
+      getMinHeight: () => 24,
       // Lock maximum height to prevent oversizing
-      getMaxHeight: () => 45,
+      getMaxHeight: () => 32,
       // Optional: whether to serialize this widget's value
       serialize: true
     }

--- a/src/composables/widgets/useComboWidget.ts
+++ b/src/composables/widgets/useComboWidget.ts
@@ -29,7 +29,13 @@ const addMultiSelectWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
       getValue: () => widgetValue.value,
       setValue: (value: string[]) => {
         widgetValue.value = value
-      }
+      },
+      // Optional: minimum height for the widget (multiselect needs minimal height)
+      getMinHeight: () => 32,
+      // Lock maximum height to prevent oversizing
+      getMaxHeight: () => 45,
+      // Optional: whether to serialize this widget's value
+      serialize: true
     }
   })
   addWidget(node, widget as BaseDOMWidget<object | string>)

--- a/src/composables/widgets/useDropdownComboWidget.ts
+++ b/src/composables/widgets/useDropdownComboWidget.ts
@@ -13,8 +13,6 @@ import { addValueControlWidgets } from '@/scripts/widgets'
 
 import { useRemoteWidget } from './useRemoteWidget'
 
-const PADDING = 8
-
 const getDefaultValue = (inputSpec: ComboInputSpec) => {
   if (inputSpec.default) return inputSpec.default
   if (inputSpec.options?.length) return inputSpec.options[0]
@@ -51,8 +49,10 @@ export const useDropdownComboWidget = (
           widgetValue.value = value
         },
 
-        // Optional: minimum height for the widget (dropdown needs some height)
-        getMinHeight: () => 48 + PADDING,
+        // Optional: minimum height for the widget (dropdown needs minimal height)
+        getMinHeight: () => 48,
+        // Lock maximum height to prevent oversizing
+        getMaxHeight: () => 64,
 
         // Optional: whether to serialize this widget's value
         serialize: true

--- a/src/composables/widgets/useDropdownComboWidget.ts
+++ b/src/composables/widgets/useDropdownComboWidget.ts
@@ -50,9 +50,9 @@ export const useDropdownComboWidget = (
         },
 
         // Optional: minimum height for the widget (dropdown needs minimal height)
-        getMinHeight: () => 48,
+        getMinHeight: () => 32,
         // Lock maximum height to prevent oversizing
-        getMaxHeight: () => 64,
+        getMaxHeight: () => 48,
 
         // Optional: whether to serialize this widget's value
         serialize: true

--- a/src/composables/widgets/useDropdownComboWidget.ts
+++ b/src/composables/widgets/useDropdownComboWidget.ts
@@ -52,7 +52,7 @@ export const useDropdownComboWidget = (
         },
 
         // Optional: minimum height for the widget (dropdown needs some height)
-        getMinHeight: () => 42 + PADDING,
+        getMinHeight: () => 48 + PADDING,
 
         // Optional: whether to serialize this widget's value
         serialize: true

--- a/src/composables/widgets/useDropdownComboWidget.ts
+++ b/src/composables/widgets/useDropdownComboWidget.ts
@@ -1,0 +1,98 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { ref } from 'vue'
+
+import DropdownComboWidget from '@/components/graph/widgets/DropdownComboWidget.vue'
+import { transformInputSpecV2ToV1 } from '@/schemas/nodeDef/migration'
+import type {
+  ComboInputSpec,
+  InputSpec
+} from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
+import { addValueControlWidgets } from '@/scripts/widgets'
+
+import { useRemoteWidget } from './useRemoteWidget'
+
+const PADDING = 8
+
+const getDefaultValue = (inputSpec: ComboInputSpec) => {
+  if (inputSpec.default) return inputSpec.default
+  if (inputSpec.options?.length) return inputSpec.options[0]
+  if (inputSpec.remote) return 'Loading...'
+  return ''
+}
+
+export const useDropdownComboWidget = (
+  options: { defaultValue?: string } = {}
+) => {
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
+    node: LGraphNode,
+    inputSpec: InputSpec
+  ) => {
+    // Type assertion to ComboInputSpec since this is specifically for combo widgets
+    const comboInputSpec = inputSpec as ComboInputSpec
+
+    // Initialize widget value
+    const defaultValue = options.defaultValue ?? getDefaultValue(comboInputSpec)
+    const widgetValue = ref<string>(defaultValue)
+
+    // Create the widget instance
+    const widget = new ComponentWidgetImpl<string>({
+      node,
+      name: inputSpec.name,
+      component: DropdownComboWidget,
+      inputSpec,
+      options: {
+        // Required: getter for widget value
+        getValue: () => widgetValue.value,
+
+        // Required: setter for widget value
+        setValue: (value: string) => {
+          widgetValue.value = value
+        },
+
+        // Optional: minimum height for the widget (dropdown needs some height)
+        getMinHeight: () => 42 + PADDING,
+
+        // Optional: whether to serialize this widget's value
+        serialize: true
+      }
+    })
+
+    // Handle remote widget functionality
+    if (comboInputSpec.remote) {
+      const remoteWidget = useRemoteWidget({
+        remoteConfig: comboInputSpec.remote,
+        defaultValue,
+        node,
+        widget: widget as any // Cast to be compatible with the remote widget interface
+      })
+      if (comboInputSpec.remote.refresh_button) {
+        remoteWidget.addRefreshButton()
+      }
+
+      // Update the widget to use remote data
+      // Note: The remote widget will handle updating the options through the inputSpec
+    }
+
+    // Handle control_after_generate widgets
+    if (comboInputSpec.control_after_generate) {
+      const linkedWidgets = addValueControlWidgets(
+        node,
+        widget as any, // Cast to be compatible with legacy widget interface
+        undefined,
+        undefined,
+        transformInputSpecV2ToV1(comboInputSpec)
+      )
+      // Store reference to linked widgets (mimicking original behavior)
+      ;(widget as any).linkedWidgets = linkedWidgets
+    }
+
+    // Register the widget with the node
+    addWidget(node, widget as any)
+
+    return widget
+  }
+
+  return widgetConstructor
+}

--- a/src/composables/widgets/useFloatWidget.ts
+++ b/src/composables/widgets/useFloatWidget.ts
@@ -6,7 +6,7 @@ import {
   type InputSpec,
   isFloatInputSpec
 } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 import { useSettingStore } from '@/stores/settingStore'
 
 function onFloatValueChange(this: INumericWidget, v: number) {

--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -1,317 +1,53 @@
-import {
-  BaseWidget,
-  type CanvasPointer,
-  type LGraphNode,
-  LiteGraph
-} from '@comfyorg/litegraph'
-import type {
-  IBaseWidget,
-  IWidgetOptions
-} from '@comfyorg/litegraph/dist/types/widgets'
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { ref } from 'vue'
 
+import ImagePreviewWidget from '@/components/graph/widgets/ImagePreviewWidget.vue'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import { app } from '@/scripts/app'
-import { calculateImageGrid } from '@/scripts/ui/imagePreview'
-import { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
-import { useCanvasStore } from '@/stores/graphStore'
-import { useSettingStore } from '@/stores/settingStore'
-import { is_all_same_aspect_ratio } from '@/utils/imageUtil'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
-const renderPreview = (
-  ctx: CanvasRenderingContext2D,
-  node: LGraphNode,
-  shiftY: number
+const PADDING = 8
+
+export const useImagePreviewWidget = (
+  options: { defaultValue?: string | string[] } = {}
 ) => {
-  const canvas = useCanvasStore().getCanvas()
-  const mouse = canvas.graph_mouse
-
-  if (!canvas.pointer_is_down && node.pointerDown) {
-    if (
-      mouse[0] === node.pointerDown.pos[0] &&
-      mouse[1] === node.pointerDown.pos[1]
-    ) {
-      node.imageIndex = node.pointerDown.index
-    }
-    node.pointerDown = null
-  }
-
-  const imgs = node.imgs ?? []
-  let { imageIndex } = node
-  const numImages = imgs.length
-  if (numImages === 1 && !imageIndex) {
-    // This skips the thumbnail render section below
-    node.imageIndex = imageIndex = 0
-  }
-
-  const settingStore = useSettingStore()
-  const allowImageSizeDraw = settingStore.get('Comfy.Node.AllowImageSizeDraw')
-  const IMAGE_TEXT_SIZE_TEXT_HEIGHT = allowImageSizeDraw ? 15 : 0
-  const dw = node.size[0]
-  const dh = node.size[1] - shiftY - IMAGE_TEXT_SIZE_TEXT_HEIGHT
-
-  if (imageIndex == null) {
-    // No image selected; draw thumbnails of all
-    let cellWidth: number
-    let cellHeight: number
-    let shiftX: number
-    let cell_padding: number
-    let cols: number
-
-    const compact_mode = is_all_same_aspect_ratio(imgs)
-    if (!compact_mode) {
-      // use rectangle cell style and border line
-      cell_padding = 2
-      // Prevent infinite canvas2d scale-up
-      const largestDimension = imgs.reduce(
-        (acc, current) =>
-          Math.max(acc, current.naturalWidth, current.naturalHeight),
-        0
-      )
-      const fakeImgs = []
-      fakeImgs.length = imgs.length
-      fakeImgs[0] = {
-        naturalWidth: largestDimension,
-        naturalHeight: largestDimension
-      }
-      ;({ cellWidth, cellHeight, cols, shiftX } = calculateImageGrid(
-        fakeImgs,
-        dw,
-        dh
-      ))
-    } else {
-      cell_padding = 0
-      ;({ cellWidth, cellHeight, cols, shiftX } = calculateImageGrid(
-        imgs,
-        dw,
-        dh
-      ))
-    }
-
-    let anyHovered = false
-    node.imageRects = []
-    for (let i = 0; i < numImages; i++) {
-      const img = imgs[i]
-      const row = Math.floor(i / cols)
-      const col = i % cols
-      const x = col * cellWidth + shiftX
-      const y = row * cellHeight + shiftY
-      if (!anyHovered) {
-        anyHovered = LiteGraph.isInsideRectangle(
-          mouse[0],
-          mouse[1],
-          x + node.pos[0],
-          y + node.pos[1],
-          cellWidth,
-          cellHeight
-        )
-        if (anyHovered) {
-          node.overIndex = i
-          let value = 110
-          if (canvas.pointer_is_down) {
-            if (!node.pointerDown || node.pointerDown.index !== i) {
-              node.pointerDown = { index: i, pos: [...mouse] }
-            }
-            value = 125
-          }
-          ctx.filter = `contrast(${value}%) brightness(${value}%)`
-          canvas.canvas.style.cursor = 'pointer'
-        }
-      }
-      node.imageRects.push([x, y, cellWidth, cellHeight])
-
-      const wratio = cellWidth / img.width
-      const hratio = cellHeight / img.height
-      const ratio = Math.min(wratio, hratio)
-
-      const imgHeight = ratio * img.height
-      const imgY = row * cellHeight + shiftY + (cellHeight - imgHeight) / 2
-      const imgWidth = ratio * img.width
-      const imgX = col * cellWidth + shiftX + (cellWidth - imgWidth) / 2
-
-      ctx.drawImage(
-        img,
-        imgX + cell_padding,
-        imgY + cell_padding,
-        imgWidth - cell_padding * 2,
-        imgHeight - cell_padding * 2
-      )
-      if (!compact_mode) {
-        // rectangle cell and border line style
-        ctx.strokeStyle = '#8F8F8F'
-        ctx.lineWidth = 1
-        ctx.strokeRect(
-          x + cell_padding,
-          y + cell_padding,
-          cellWidth - cell_padding * 2,
-          cellHeight - cell_padding * 2
-        )
-      }
-
-      ctx.filter = 'none'
-    }
-
-    if (!anyHovered) {
-      node.pointerDown = null
-      node.overIndex = null
-    }
-
-    return
-  }
-  // Draw individual
-  const img = imgs[imageIndex]
-  let w = img.naturalWidth
-  let h = img.naturalHeight
-
-  const scaleX = dw / w
-  const scaleY = dh / h
-  const scale = Math.min(scaleX, scaleY, 1)
-
-  w *= scale
-  h *= scale
-
-  const x = (dw - w) / 2
-  const y = (dh - h) / 2 + shiftY
-  ctx.drawImage(img, x, y, w, h)
-
-  // Draw image size text below the image
-  if (allowImageSizeDraw) {
-    ctx.fillStyle = LiteGraph.NODE_TEXT_COLOR
-    ctx.textAlign = 'center'
-    ctx.font = '10px sans-serif'
-    const sizeText = `${Math.round(img.naturalWidth)} × ${Math.round(img.naturalHeight)}`
-    const textY = y + h + 10
-    ctx.fillText(sizeText, x + w / 2, textY)
-  }
-
-  const drawButton = (
-    x: number,
-    y: number,
-    sz: number,
-    text: string
-  ): boolean => {
-    const hovered = LiteGraph.isInsideRectangle(
-      mouse[0],
-      mouse[1],
-      x + node.pos[0],
-      y + node.pos[1],
-      sz,
-      sz
-    )
-    let fill = '#333'
-    let textFill = '#fff'
-    let isClicking = false
-    if (hovered) {
-      canvas.canvas.style.cursor = 'pointer'
-      if (canvas.pointer_is_down) {
-        fill = '#1e90ff'
-        isClicking = true
-      } else {
-        fill = '#eee'
-        textFill = '#000'
-      }
-    }
-
-    ctx.fillStyle = fill
-    ctx.beginPath()
-    ctx.roundRect(x, y, sz, sz, [4])
-    ctx.fill()
-    ctx.fillStyle = textFill
-    ctx.font = '12px Arial'
-    ctx.textAlign = 'center'
-    ctx.fillText(text, x + 15, y + 20)
-
-    return isClicking
-  }
-
-  if (!(numImages > 1)) return
-
-  const imageNum = (node.imageIndex ?? 0) + 1
-  if (drawButton(dw - 40, dh + shiftY - 40, 30, `${imageNum}/${numImages}`)) {
-    const i = imageNum >= numImages ? 0 : imageNum
-    if (!node.pointerDown || node.pointerDown.index !== i) {
-      node.pointerDown = { index: i, pos: [...mouse] }
-    }
-  }
-
-  if (drawButton(dw - 40, shiftY + 10, 30, `x`)) {
-    if (!node.pointerDown || node.pointerDown.index !== null) {
-      node.pointerDown = { index: null, pos: [...mouse] }
-    }
-  }
-}
-
-class ImagePreviewWidget extends BaseWidget {
-  constructor(
-    node: LGraphNode,
-    name: string,
-    options: IWidgetOptions<string | object>
-  ) {
-    const widget: IBaseWidget = {
-      name,
-      options,
-      type: 'custom',
-      /** Dummy value to satisfy type requirements. */
-      value: '',
-      y: 0
-    }
-    super(widget, node)
-
-    // Don't serialize the widget value
-    this.serialize = false
-  }
-
-  override drawWidget(ctx: CanvasRenderingContext2D): void {
-    renderPreview(ctx, this.node, this.y)
-  }
-
-  override onPointerDown(pointer: CanvasPointer, node: LGraphNode): boolean {
-    pointer.onDragStart = () => {
-      const { canvas } = app
-      const { graph } = canvas
-      canvas.emitBeforeChange()
-      graph?.beforeChange()
-      // Ensure that dragging is properly cleaned up, on success or failure.
-      pointer.finally = () => {
-        canvas.isDragging = false
-        graph?.afterChange()
-        canvas.emitAfterChange()
-      }
-
-      canvas.processSelect(node, pointer.eDown)
-      canvas.isDragging = true
-    }
-
-    pointer.onDragEnd = (e) => {
-      const { canvas } = app
-      if (e.shiftKey || LiteGraph.alwaysSnapToGrid)
-        canvas.graph?.snapToGrid(canvas.selectedItems)
-
-      canvas.setDirty(true, true)
-    }
-
-    return true
-  }
-
-  override onClick(): void {}
-
-  override computeLayoutSize() {
-    return {
-      minHeight: 220,
-      minWidth: 1
-    }
-  }
-}
-
-export const useImagePreviewWidget = () => {
   const widgetConstructor: ComfyWidgetConstructorV2 = (
     node: LGraphNode,
     inputSpec: InputSpec
   ) => {
-    return node.addCustomWidget(
-      new ImagePreviewWidget(node, inputSpec.name, {
-        serialize: false
-      })
+    // Initialize widget value
+    const widgetValue = ref<string | string[]>(
+      options.defaultValue ?? (inputSpec.allow_batch ? [] : '')
     )
+
+    // Create the Vue-based widget instance
+    const widget = new ComponentWidgetImpl<string | string[]>({
+      node,
+      name: inputSpec.name,
+      component: ImagePreviewWidget,
+      inputSpec,
+      options: {
+        // Required: getter for widget value
+        getValue: () => widgetValue.value,
+
+        // Required: setter for widget value
+        setValue: (value: string | string[]) => {
+          widgetValue.value = value
+        },
+
+        // Optional: minimum height for the widget
+        getMinHeight: () => 320 + PADDING,
+        getMaxHeight: () => 512 + PADDING,
+
+        // Optional: whether to serialize this widget's value
+        serialize: false
+      }
+    })
+
+    // Register the widget with the node
+    addWidget(node, widget as any)
+
+    return widget
   }
 
   return widgetConstructor

--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -12,7 +12,7 @@ import type {
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
 import { calculateImageGrid } from '@/scripts/ui/imagePreview'
-import { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { is_all_same_aspect_ratio } from '@/utils/imageUtil'

--- a/src/composables/widgets/useImageUploadMediaWidget.ts
+++ b/src/composables/widgets/useImageUploadMediaWidget.ts
@@ -1,0 +1,163 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { IComboWidget } from '@comfyorg/litegraph/dist/types/widgets'
+
+import MediaLoaderWidget from '@/components/graph/widgets/MediaLoaderWidget.vue'
+import { useNodeImage, useNodeVideo } from '@/composables/node/useNodeImage'
+import { useNodeImageUpload } from '@/composables/node/useNodeImageUpload'
+import { useValueTransform } from '@/composables/useValueTransform'
+import type { ResultItem } from '@/schemas/apiSchema'
+import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
+import type { InputSpec } from '@/schemas/nodeDefSchema'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import type { ComfyWidgetConstructor } from '@/scripts/widgets'
+import { useNodeOutputStore } from '@/stores/imagePreviewStore'
+import { createAnnotatedPath } from '@/utils/formatUtil'
+import { addToComboValues } from '@/utils/litegraphUtil'
+
+const ACCEPTED_IMAGE_TYPES = 'image/png,image/jpeg,image/webp'
+const ACCEPTED_VIDEO_TYPES = 'video/webm,video/mp4'
+
+type InternalFile = string | ResultItem
+type InternalValue = InternalFile | InternalFile[]
+type ExposedValue = string | string[]
+
+const isImageFile = (file: File) => file.type.startsWith('image/')
+const isVideoFile = (file: File) => file.type.startsWith('video/')
+
+const findFileComboWidget = (node: LGraphNode, inputName: string) =>
+  node.widgets!.find((w) => w.name === inputName) as IComboWidget & {
+    value: ExposedValue
+  }
+
+export const useImageUploadMediaWidget = () => {
+  const widgetConstructor: ComfyWidgetConstructor = (
+    node: LGraphNode,
+    inputName: string,
+    inputData: InputSpec
+  ) => {
+    const inputOptions = inputData[1] ?? {}
+    const { imageInputName, allow_batch, image_folder = 'input' } = inputOptions
+    const nodeOutputStore = useNodeOutputStore()
+
+    const isAnimated = !!inputOptions.animated_image_upload
+    const isVideo = !!inputOptions.video_upload
+    const accept = isVideo ? ACCEPTED_VIDEO_TYPES : ACCEPTED_IMAGE_TYPES
+    const { showPreview } = isVideo ? useNodeVideo(node) : useNodeImage(node)
+
+    const fileFilter = isVideo ? isVideoFile : isImageFile
+    // @ts-expect-error InputSpec is not typed correctly
+    const fileComboWidget = findFileComboWidget(node, imageInputName)
+    const initialFile = `${fileComboWidget.value}`
+    const formatPath = (value: InternalFile) =>
+      // @ts-expect-error InputSpec is not typed correctly
+      createAnnotatedPath(value, { rootFolder: image_folder })
+
+    const transform = (internalValue: InternalValue): ExposedValue => {
+      if (!internalValue) return initialFile
+      if (Array.isArray(internalValue))
+        return allow_batch
+          ? internalValue.map(formatPath)
+          : formatPath(internalValue[0])
+      return formatPath(internalValue)
+    }
+
+    Object.defineProperty(
+      fileComboWidget,
+      'value',
+      useValueTransform(transform, initialFile)
+    )
+
+    // Convert the V1 input spec to V2 format for the MediaLoader widget
+    const inputSpecV2 = transformInputSpecV1ToV2(inputData, { name: inputName })
+
+    // Handle widget dimensions based on input options
+    const getMinHeight = () => {
+      let baseHeight = 200
+
+      // Handle multiline attribute for expanded height
+      if (inputOptions.multiline) {
+        baseHeight = Math.max(
+          baseHeight,
+          inputOptions.multiline === true
+            ? 120
+            : Number(inputOptions.multiline) || 120
+        )
+      }
+
+      // Handle other height-related attributes
+      if (inputOptions.min_height) {
+        baseHeight = Math.max(baseHeight, Number(inputOptions.min_height))
+      }
+
+      return baseHeight + 8 // Add padding
+    }
+
+    // Create the MediaLoader widget directly
+    const uploadWidget = new ComponentWidgetImpl<string[], { accept?: string }>(
+      {
+        node,
+        name: inputName,
+        component: MediaLoaderWidget,
+        inputSpec: inputSpecV2,
+        props: {
+          accept
+        },
+        options: {
+          getValue: () => [],
+          setValue: () => {},
+          getMinHeight,
+          serialize: false,
+          onFilesSelected: async (files: File[]) => {
+            // Use the existing upload infrastructure
+            const { handleUpload } = useNodeImageUpload(node, {
+              // @ts-expect-error InputSpec is not typed correctly
+              allow_batch,
+              fileFilter,
+              accept,
+              onUploadComplete: (output) => {
+                output.forEach((path) =>
+                  addToComboValues(fileComboWidget, path)
+                )
+                // @ts-expect-error litegraph combo value type does not support arrays yet
+                fileComboWidget.value = output
+                fileComboWidget.callback?.(output)
+              }
+            })
+
+            // Handle each file
+            for (const file of files) {
+              if (fileFilter(file)) {
+                await handleUpload(file)
+              }
+            }
+          }
+        } as any
+      }
+    )
+
+    // Register the widget with the node
+    addWidget(node, uploadWidget as any)
+
+    // Add our own callback to the combo widget to render an image when it changes
+    fileComboWidget.callback = function () {
+      nodeOutputStore.setNodeOutputs(node, fileComboWidget.value, {
+        isAnimated
+      })
+      node.graph?.setDirtyCanvas(true)
+    }
+
+    // On load if we have a value then render the image
+    // The value isnt set immediately so we need to wait a moment
+    // No change callbacks seem to be fired on initial setting of the value
+    requestAnimationFrame(() => {
+      nodeOutputStore.setNodeOutputs(node, fileComboWidget.value, {
+        isAnimated
+      })
+      showPreview({ block: false })
+    })
+
+    return { widget: uploadWidget }
+  }
+
+  return widgetConstructor
+}

--- a/src/composables/widgets/useImageUploadWidget.ts
+++ b/src/composables/widgets/useImageUploadWidget.ts
@@ -2,6 +2,7 @@ import type { LGraphNode } from '@comfyorg/litegraph'
 import { IComboWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import { useNodeImage, useNodeVideo } from '@/composables/node/useNodeImage'
+import { useNodeImagePreview } from '@/composables/node/useNodeImagePreview'
 import { useNodeImageUpload } from '@/composables/node/useNodeImageUpload'
 import { useValueTransform } from '@/composables/useValueTransform'
 import { t } from '@/i18n'
@@ -41,6 +42,7 @@ export const useImageUploadWidget = () => {
     const isVideo = !!inputOptions.video_upload
     const accept = isVideo ? ACCEPTED_VIDEO_TYPES : ACCEPTED_IMAGE_TYPES
     const { showPreview } = isVideo ? useNodeVideo(node) : useNodeImage(node)
+    const { showImagePreview } = useNodeImagePreview()
 
     const fileFilter = isVideo ? isVideoFile : isImageFile
     // @ts-expect-error InputSpec is not typed correctly
@@ -96,6 +98,16 @@ export const useImageUploadWidget = () => {
       nodeOutputStore.setNodeOutputs(node, fileComboWidget.value, {
         isAnimated
       })
+
+      // Use Vue widget for image preview, fallback to DOM widget for video
+      if (!isVideo) {
+        showImagePreview(node, fileComboWidget.value, {
+          allow_batch: allow_batch as boolean,
+          image_folder: image_folder as string,
+          imageInputName: imageInputName as string
+        })
+      }
+
       node.graph?.setDirtyCanvas(true)
     }
 
@@ -106,7 +118,17 @@ export const useImageUploadWidget = () => {
       nodeOutputStore.setNodeOutputs(node, fileComboWidget.value, {
         isAnimated
       })
-      showPreview({ block: false })
+
+      // Use appropriate preview method
+      if (isVideo) {
+        showPreview({ block: false })
+      } else {
+        showImagePreview(node, fileComboWidget.value, {
+          allow_batch: allow_batch as boolean,
+          image_folder: image_folder as string,
+          imageInputName: imageInputName as string
+        })
+      }
     })
 
     return { widget: uploadWidget }

--- a/src/composables/widgets/useIntWidget.ts
+++ b/src/composables/widgets/useIntWidget.ts
@@ -1,15 +1,11 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
 import type { INumericWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
-import { transformInputSpecV2ToV1 } from '@/schemas/nodeDef/migration'
 import {
   type InputSpec,
   isIntInputSpec
 } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import {
-  type ComfyWidgetConstructorV2,
-  addValueControlWidget
-} from '@/scripts/widgets'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 import { useSettingStore } from '@/stores/settingStore'
 
 function onValueChange(this: INumericWidget, v: number) {
@@ -81,15 +77,19 @@ export const useIntWidget = () => {
       ['seed', 'noise_seed'].includes(inputSpec.name)
 
     if (controlAfterGenerate) {
-      const seedControl = addValueControlWidget(
-        node,
-        widget,
-        'randomize',
-        undefined,
-        undefined,
-        transformInputSpecV2ToV1(inputSpec)
+      // TODO: Re-implement control widget functionality without circular dependency
+      console.warn(
+        'Control widget functionality temporarily disabled for int widgets due to circular dependency'
       )
-      widget.linkedWidgets = [seedControl]
+      // const seedControl = addValueControlWidget(
+      //   node,
+      //   widget,
+      //   'randomize',
+      //   undefined,
+      //   undefined,
+      //   transformInputSpecV2ToV1(inputSpec)
+      // )
+      // widget.linkedWidgets = [seedControl]
     }
 
     return widget

--- a/src/composables/widgets/useMarkdownWidget.ts
+++ b/src/composables/widgets/useMarkdownWidget.ts
@@ -10,7 +10,7 @@ import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
 
 import { type InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
-import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
 function addMarkdownWidget(
   node: LGraphNode,

--- a/src/composables/widgets/useMediaLoaderWidget.ts
+++ b/src/composables/widgets/useMediaLoaderWidget.ts
@@ -1,0 +1,70 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { ref } from 'vue'
+
+import MediaLoaderWidget from '@/components/graph/widgets/MediaLoaderWidget.vue'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import {
+  ComponentWidgetImpl,
+  type DOMWidgetOptions,
+  addWidget
+} from '@/scripts/domWidget'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
+
+const PADDING = 8
+
+interface MediaLoaderOptions {
+  defaultValue?: string[]
+  minHeight?: number
+  accept?: string
+  onFilesSelected?: (files: File[]) => void
+}
+
+interface MediaLoaderWidgetOptions extends DOMWidgetOptions<string[]> {
+  onFilesSelected?: (files: File[]) => void
+}
+
+export const useMediaLoaderWidget = (options: MediaLoaderOptions = {}) => {
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
+    node: LGraphNode,
+    inputSpec: InputSpec
+  ) => {
+    // Initialize widget value
+    const widgetValue = ref<string[]>(options.defaultValue ?? [])
+
+    // Create the widget instance
+    const widget = new ComponentWidgetImpl<string[], { accept?: string }>({
+      node,
+      name: inputSpec.name,
+      component: MediaLoaderWidget,
+      inputSpec,
+      props: {
+        accept: options.accept
+      },
+      options: {
+        // Required: getter for widget value
+        getValue: () => widgetValue.value,
+
+        // Required: setter for widget value
+        setValue: (value: string[]) => {
+          widgetValue.value = Array.isArray(value) ? value : []
+        },
+
+        // Optional: minimum height for the widget
+        getMinHeight: () => (options.minHeight ?? 500) + PADDING,
+
+        // Optional: whether to serialize this widget's value
+        serialize: true,
+
+        // Custom option for file selection callback
+        onFilesSelected: options.onFilesSelected
+      } as MediaLoaderWidgetOptions
+    })
+
+    // Register the widget with the node
+    addWidget(node, widget as any)
+
+    return widget
+  }
+
+  return widgetConstructor
+}

--- a/src/composables/widgets/useMediaLoaderWidget.ts
+++ b/src/composables/widgets/useMediaLoaderWidget.ts
@@ -50,7 +50,9 @@ export const useMediaLoaderWidget = (options: MediaLoaderOptions = {}) => {
         },
 
         // Optional: minimum height for the widget
-        getMinHeight: () => (options.minHeight ?? 500) + PADDING,
+        // getMinHeight: () => (options.minHeight ?? 64) + PADDING,
+        getMaxHeight: () => 225 + PADDING,
+        getMinHeight: () => 176 + PADDING,
 
         // Optional: whether to serialize this widget's value
         serialize: true,

--- a/src/composables/widgets/useProgressTextWidget.ts
+++ b/src/composables/widgets/useProgressTextWidget.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 import TextPreviewWidget from '@/components/graph/widgets/TextPreviewWidget.vue'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
-import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 
 const PADDING = 16
 

--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -91,6 +91,55 @@ function addMultilineWidget(
   return widget
 }
 
+function addSingleLineWidget(
+  node: LGraphNode,
+  name: string,
+  opts: { defaultVal: string; placeholder?: string }
+) {
+  const inputEl = document.createElement('input')
+  inputEl.className = 'comfy-text-input'
+  inputEl.type = 'text'
+  inputEl.value = opts.defaultVal
+  inputEl.placeholder = opts.placeholder || name
+
+  const widget = node.addDOMWidget(name, 'text', inputEl, {
+    getValue(): string {
+      return inputEl.value
+    },
+    setValue(v: string) {
+      inputEl.value = v
+    }
+  })
+
+  widget.inputEl = inputEl
+  widget.options.minNodeSize = [200, 40]
+
+  inputEl.addEventListener('input', () => {
+    widget.callback?.(widget.value)
+  })
+
+  // Allow middle mouse button panning
+  inputEl.addEventListener('pointerdown', (event: PointerEvent) => {
+    if (event.button === 1) {
+      app.canvas.processMouseDown(event)
+    }
+  })
+
+  inputEl.addEventListener('pointermove', (event: PointerEvent) => {
+    if ((event.buttons & 4) === 4) {
+      app.canvas.processMouseMove(event)
+    }
+  })
+
+  inputEl.addEventListener('pointerup', (event: PointerEvent) => {
+    if (event.button === 1) {
+      app.canvas.processMouseUp(event)
+    }
+  })
+
+  return widget
+}
+
 export const useStringWidget = () => {
   const widgetConstructor: ComfyWidgetConstructorV2 = (
     node: LGraphNode,
@@ -108,7 +157,10 @@ export const useStringWidget = () => {
           defaultVal,
           placeholder: inputSpec.placeholder
         })
-      : node.addWidget('text', inputSpec.name, defaultVal, () => {}, {})
+      : addSingleLineWidget(node, inputSpec.name, {
+          defaultVal,
+          placeholder: inputSpec.placeholder
+        })
 
     if (typeof inputSpec.dynamicPrompts === 'boolean') {
       widget.dynamicPrompts = inputSpec.dynamicPrompts

--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -5,7 +5,7 @@ import {
   isStringInputSpec
 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
-import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
 import { useSettingStore } from '@/stores/settingStore'
 
 function addMultilineWidget(

--- a/src/composables/widgets/useStringWidgetVue.ts
+++ b/src/composables/widgets/useStringWidgetVue.ts
@@ -1,0 +1,65 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { ref } from 'vue'
+
+import StringWidget from '@/components/graph/widgets/StringWidget.vue'
+import {
+  type InputSpec,
+  isStringInputSpec
+} from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import { type ComfyWidgetConstructorV2 } from '@/scripts/widgetTypes'
+
+const PADDING = 8
+
+export const useStringWidgetVue = (options: { defaultValue?: string } = {}) => {
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
+    node: LGraphNode,
+    inputSpec: InputSpec
+  ) => {
+    if (!isStringInputSpec(inputSpec)) {
+      throw new Error(`Invalid input data: ${inputSpec}`)
+    }
+
+    // Initialize widget value
+    const widgetValue = ref<string>(
+      inputSpec.default ?? options.defaultValue ?? ''
+    )
+
+    // Create the Vue-based widget instance
+    const widget = new ComponentWidgetImpl<string>({
+      node,
+      name: inputSpec.name,
+      component: StringWidget,
+      inputSpec,
+      options: {
+        // Required: getter for widget value
+        getValue: () => widgetValue.value,
+
+        // Required: setter for widget value
+        setValue: (value: string) => {
+          widgetValue.value = value
+        },
+
+        // Optional: minimum height for the widget
+        getMinHeight: () => {
+          return inputSpec.multiline ? 80 + PADDING : 40 + PADDING
+        },
+
+        // Optional: whether to serialize this widget's value
+        serialize: true
+      }
+    })
+
+    // Add dynamic prompts support if specified
+    if (typeof inputSpec.dynamicPrompts === 'boolean') {
+      widget.dynamicPrompts = inputSpec.dynamicPrompts
+    }
+
+    // Register the widget with the node
+    addWidget(node, widget as any)
+
+    return widget
+  }
+
+  return widgetConstructor
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -235,7 +235,7 @@
       "clickToEdit": "Click to edit color",
       "selectColor": "Select a color",
       "formatRGBA": "RGBA",
-      "formatHSLA": "HSLA", 
+      "formatHSLA": "HSLA",
       "formatHSVA": "HSVA",
       "formatHEX": "HEX"
     }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -230,6 +230,16 @@
     "black": "Black",
     "custom": "Custom"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "Click to edit color",
+      "selectColor": "Select a color",
+      "formatRGBA": "RGBA",
+      "formatHSLA": "HSLA", 
+      "formatHSVA": "HSVA",
+      "formatHEX": "HEX"
+    }
+  },
   "contextMenu": {
     "Inputs": "Inputs",
     "Outputs": "Outputs",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -1429,6 +1429,16 @@
     "getStarted": "Empezar",
     "title": "Bienvenido a ComfyUI"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "Haz clic para editar el color",
+      "formatHEX": "HEX",
+      "formatHSLA": "HSLA",
+      "formatHSVA": "HSVA",
+      "formatRGBA": "RGBA",
+      "selectColor": "Selecciona un color"
+    }
+  },
   "workflowService": {
     "enterFilename": "Introduzca el nombre del archivo",
     "exportWorkflow": "Exportar flujo de trabajo",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -1429,6 +1429,16 @@
     "getStarted": "Commencer",
     "title": "Bienvenue sur ComfyUI"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "Cliquez pour modifier la couleur",
+      "formatHEX": "HEX",
+      "formatHSLA": "HSLA",
+      "formatHSVA": "HSVA",
+      "formatRGBA": "RGBA",
+      "selectColor": "Sélectionnez une couleur"
+    }
+  },
   "workflowService": {
     "enterFilename": "Entrez le nom du fichier",
     "exportWorkflow": "Exporter le flux de travail",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -1429,6 +1429,16 @@
     "getStarted": "はじめる",
     "title": "ComfyUIへようこそ"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "色を編集するにはクリックしてください",
+      "formatHEX": "HEX",
+      "formatHSLA": "HSLA",
+      "formatHSVA": "HSVA",
+      "formatRGBA": "RGBA",
+      "selectColor": "色を選択"
+    }
+  },
   "workflowService": {
     "enterFilename": "ファイル名を入力",
     "exportWorkflow": "ワークフローをエクスポート",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1429,6 +1429,16 @@
     "getStarted": "시작하기",
     "title": "ComfyUI에 오신 것을 환영합니다"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "색상 편집하려면 클릭하세요",
+      "formatHEX": "HEX",
+      "formatHSLA": "HSLA",
+      "formatHSVA": "HSVA",
+      "formatRGBA": "RGBA",
+      "selectColor": "색상 선택"
+    }
+  },
   "workflowService": {
     "enterFilename": "파일 이름 입력",
     "exportWorkflow": "워크플로 내보내기",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -1429,6 +1429,16 @@
     "getStarted": "Начать",
     "title": "Добро пожаловать в ComfyUI"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "Нажмите, чтобы изменить цвет",
+      "formatHEX": "HEX",
+      "formatHSLA": "HSLA",
+      "formatHSVA": "HSVA",
+      "formatRGBA": "RGBA",
+      "selectColor": "Выберите цвет"
+    }
+  },
   "workflowService": {
     "enterFilename": "Введите название файла",
     "exportWorkflow": "Экспорт рабочего процесса",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1429,6 +1429,16 @@
     "getStarted": "开始使用",
     "title": "欢迎使用 ComfyUI"
   },
+  "widgets": {
+    "colorPicker": {
+      "clickToEdit": "点击编辑颜色",
+      "formatHEX": "HEX",
+      "formatHSLA": "HSLA",
+      "formatHSVA": "HSVA",
+      "formatRGBA": "RGBA",
+      "selectColor": "选择颜色"
+    }
+  },
   "workflowService": {
     "enterFilename": "输入文件名",
     "exportWorkflow": "导出工作流",

--- a/src/scripts/widgetTypes.ts
+++ b/src/scripts/widgetTypes.ts
@@ -1,0 +1,12 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import type { IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
+
+import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+/**
+ * Constructor function type for ComfyUI widgets using V2 input specification
+ */
+export type ComfyWidgetConstructorV2 = (
+  node: LGraphNode,
+  inputSpec: InputSpecV2
+) => IBaseWidget

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -9,6 +9,7 @@ import { useBadgedNumberInput } from '@/composables/widgets/useBadgedNumberInput
 import { useBooleanWidget } from '@/composables/widgets/useBooleanWidget'
 import { useColorPickerWidget } from '@/composables/widgets/useColorPickerWidget'
 import { useComboWidget } from '@/composables/widgets/useComboWidget'
+import { useImagePreviewWidget } from '@/composables/widgets/useImagePreviewWidget'
 import { useImageUploadMediaWidget } from '@/composables/widgets/useImageUploadMediaWidget'
 import { useMarkdownWidget } from '@/composables/widgets/useMarkdownWidget'
 import { useMediaLoaderWidget } from '@/composables/widgets/useMediaLoaderWidget'
@@ -292,5 +293,6 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
   COLOR: transformWidgetConstructorV2ToV1(useColorPickerWidget()),
   IMAGEUPLOAD: useImageUploadMediaWidget(),
   MEDIA_LOADER: transformWidgetConstructorV2ToV1(useMediaLoaderWidget()),
+  IMAGEPREVIEW: transformWidgetConstructorV2ToV1(useImagePreviewWidget()),
   BADGED_NUMBER: transformWidgetConstructorV2ToV1(useBadgedNumberInput())
 }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -8,25 +8,18 @@ import type {
 import { useBadgedNumberInput } from '@/composables/widgets/useBadgedNumberInput'
 import { useBooleanWidget } from '@/composables/widgets/useBooleanWidget'
 import { useComboWidget } from '@/composables/widgets/useComboWidget'
-import { useFloatWidget } from '@/composables/widgets/useFloatWidget'
 import { useImageUploadWidget } from '@/composables/widgets/useImageUploadWidget'
-import { useIntWidget } from '@/composables/widgets/useIntWidget'
 import { useMarkdownWidget } from '@/composables/widgets/useMarkdownWidget'
 import { useStringWidget } from '@/composables/widgets/useStringWidget'
 import { t } from '@/i18n'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
-import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import { useSettingStore } from '@/stores/settingStore'
 
 import type { ComfyApp } from './app'
 import './domWidget'
 import './errorNodeWidgets'
-
-export type ComfyWidgetConstructorV2 = (
-  node: LGraphNode,
-  inputSpec: InputSpecV2
-) => IBaseWidget
+import type { ComfyWidgetConstructorV2 } from './widgetTypes'
 
 export type ComfyWidgetConstructor = (
   node: LGraphNode,
@@ -284,8 +277,10 @@ export function addValueControlWidgets(
 }
 
 export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
-  INT: transformWidgetConstructorV2ToV1(useIntWidget()),
-  FLOAT: transformWidgetConstructorV2ToV1(useFloatWidget()),
+  INT: transformWidgetConstructorV2ToV1(useBadgedNumberInput({ mode: 'int' })),
+  FLOAT: transformWidgetConstructorV2ToV1(
+    useBadgedNumberInput({ mode: 'float' })
+  ),
   BOOLEAN: transformWidgetConstructorV2ToV1(useBooleanWidget()),
   STRING: transformWidgetConstructorV2ToV1(useStringWidget()),
   MARKDOWN: transformWidgetConstructorV2ToV1(useMarkdownWidget()),

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -11,6 +11,7 @@ import { useComboWidget } from '@/composables/widgets/useComboWidget'
 import { useImageUploadWidget } from '@/composables/widgets/useImageUploadWidget'
 import { useMarkdownWidget } from '@/composables/widgets/useMarkdownWidget'
 import { useStringWidget } from '@/composables/widgets/useStringWidget'
+import { useStringWidgetVue } from '@/composables/widgets/useStringWidgetVue'
 import { t } from '@/i18n'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
@@ -282,7 +283,8 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
     useBadgedNumberInput({ mode: 'float' })
   ),
   BOOLEAN: transformWidgetConstructorV2ToV1(useBooleanWidget()),
-  STRING: transformWidgetConstructorV2ToV1(useStringWidget()),
+  STRING: transformWidgetConstructorV2ToV1(useStringWidgetVue()),
+  STRING_DOM: transformWidgetConstructorV2ToV1(useStringWidget()), // Fallback to DOM-based implementation
   MARKDOWN: transformWidgetConstructorV2ToV1(useMarkdownWidget()),
   COMBO: transformWidgetConstructorV2ToV1(useComboWidget()),
   IMAGEUPLOAD: useImageUploadWidget(),

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -7,6 +7,7 @@ import type {
 
 import { useBadgedNumberInput } from '@/composables/widgets/useBadgedNumberInput'
 import { useBooleanWidget } from '@/composables/widgets/useBooleanWidget'
+import { useColorPickerWidget } from '@/composables/widgets/useColorPickerWidget'
 import { useComboWidget } from '@/composables/widgets/useComboWidget'
 import { useImageUploadWidget } from '@/composables/widgets/useImageUploadWidget'
 import { useMarkdownWidget } from '@/composables/widgets/useMarkdownWidget'
@@ -288,5 +289,6 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
   MARKDOWN: transformWidgetConstructorV2ToV1(useMarkdownWidget()),
   COMBO: transformWidgetConstructorV2ToV1(useComboWidget()),
   IMAGEUPLOAD: useImageUploadWidget(),
-  BADGED_NUMBER: transformWidgetConstructorV2ToV1(useBadgedNumberInput())
+  BADGED_NUMBER: transformWidgetConstructorV2ToV1(useBadgedNumberInput()),
+  COLOR: transformWidgetConstructorV2ToV1(useColorPickerWidget())
 }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -9,8 +9,9 @@ import { useBadgedNumberInput } from '@/composables/widgets/useBadgedNumberInput
 import { useBooleanWidget } from '@/composables/widgets/useBooleanWidget'
 import { useColorPickerWidget } from '@/composables/widgets/useColorPickerWidget'
 import { useComboWidget } from '@/composables/widgets/useComboWidget'
-import { useImageUploadWidget } from '@/composables/widgets/useImageUploadWidget'
+import { useImageUploadMediaWidget } from '@/composables/widgets/useImageUploadMediaWidget'
 import { useMarkdownWidget } from '@/composables/widgets/useMarkdownWidget'
+import { useMediaLoaderWidget } from '@/composables/widgets/useMediaLoaderWidget'
 import { useStringWidget } from '@/composables/widgets/useStringWidget'
 import { useStringWidgetVue } from '@/composables/widgets/useStringWidgetVue'
 import { t } from '@/i18n'
@@ -288,7 +289,8 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
   STRING_DOM: transformWidgetConstructorV2ToV1(useStringWidget()), // Fallback to DOM-based implementation
   MARKDOWN: transformWidgetConstructorV2ToV1(useMarkdownWidget()),
   COMBO: transformWidgetConstructorV2ToV1(useComboWidget()),
-  IMAGEUPLOAD: useImageUploadWidget(),
-  BADGED_NUMBER: transformWidgetConstructorV2ToV1(useBadgedNumberInput()),
-  COLOR: transformWidgetConstructorV2ToV1(useColorPickerWidget())
+  COLOR: transformWidgetConstructorV2ToV1(useColorPickerWidget()),
+  IMAGEUPLOAD: useImageUploadMediaWidget(),
+  MEDIA_LOADER: transformWidgetConstructorV2ToV1(useMediaLoaderWidget()),
+  BADGED_NUMBER: transformWidgetConstructorV2ToV1(useBadgedNumberInput())
 }

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -5,6 +5,7 @@ import type {
   IStringWidget
 } from '@comfyorg/litegraph/dist/types/widgets'
 
+import { useBadgedNumberInput } from '@/composables/widgets/useBadgedNumberInput'
 import { useBooleanWidget } from '@/composables/widgets/useBooleanWidget'
 import { useComboWidget } from '@/composables/widgets/useComboWidget'
 import { useFloatWidget } from '@/composables/widgets/useFloatWidget'
@@ -289,5 +290,6 @@ export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
   STRING: transformWidgetConstructorV2ToV1(useStringWidget()),
   MARKDOWN: transformWidgetConstructorV2ToV1(useMarkdownWidget()),
   COMBO: transformWidgetConstructorV2ToV1(useComboWidget()),
-  IMAGEUPLOAD: useImageUploadWidget()
+  IMAGEUPLOAD: useImageUploadWidget(),
+  BADGED_NUMBER: transformWidgetConstructorV2ToV1(useBadgedNumberInput())
 }

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -552,7 +552,13 @@ export const useLitegraphService = () => {
         showAnimatedPreview(this)
       } else {
         removeAnimatedPreview(this)
-        showCanvasImagePreview(this)
+        // Only show canvas image preview if we don't already have a Vue image preview widget
+        const hasVueImagePreview = this.widgets?.some(
+          (w) => w.name === '$$node-image-preview' || w.type === 'IMAGEPREVIEW'
+        )
+        if (!hasVueImagePreview) {
+          showCanvasImagePreview(this)
+        }
       }
     }
 

--- a/tests-ui/composables/useImagePreviewWidget.test.ts
+++ b/tests-ui/composables/useImagePreviewWidget.test.ts
@@ -1,0 +1,55 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useImagePreviewWidget } from '@/composables/widgets/useImagePreviewWidget'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+// Mock dependencies
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: vi.fn().mockImplementation(() => ({
+    name: 'test-widget',
+    value: ''
+  })),
+  addWidget: vi.fn()
+}))
+
+describe('useImagePreviewWidget', () => {
+  const mockNode = {
+    id: 'test-node',
+    widgets: []
+  } as unknown as LGraphNode
+
+  const mockInputSpec: InputSpec = {
+    name: 'image_preview',
+    type: 'IMAGEPREVIEW',
+    allow_batch: true,
+    image_folder: 'input'
+  }
+
+  it('creates widget constructor with default options', () => {
+    const constructor = useImagePreviewWidget()
+    expect(constructor).toBeDefined()
+    expect(typeof constructor).toBe('function')
+  })
+
+  it('creates widget with custom default value', () => {
+    const constructor = useImagePreviewWidget({
+      defaultValue: 'test-image.png'
+    })
+    expect(constructor).toBeDefined()
+  })
+
+  it('creates widget with array default value for batch mode', () => {
+    const constructor = useImagePreviewWidget({
+      defaultValue: ['image1.png', 'image2.png']
+    })
+    expect(constructor).toBeDefined()
+  })
+
+  it('calls constructor with node and inputSpec', () => {
+    const constructor = useImagePreviewWidget()
+    const widget = constructor(mockNode, mockInputSpec)
+
+    expect(widget).toBeDefined()
+  })
+})

--- a/tests-ui/composables/useMediaLoaderWidget.test.ts
+++ b/tests-ui/composables/useMediaLoaderWidget.test.ts
@@ -1,0 +1,108 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMediaLoaderWidget } from '@/composables/widgets/useMediaLoaderWidget'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+// Mock dependencies
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: class MockComponentWidgetImpl {
+    node: any
+    name: string
+    component: any
+    inputSpec: any
+    props: any
+    options: any
+
+    constructor(config: any) {
+      this.node = config.node
+      this.name = config.name
+      this.component = config.component
+      this.inputSpec = config.inputSpec
+      this.props = config.props
+      this.options = config.options
+    }
+  },
+  addWidget: vi.fn()
+}))
+
+vi.mock('@/components/graph/widgets/MediaLoaderWidget.vue', () => ({
+  default: {}
+}))
+
+describe('useMediaLoaderWidget', () => {
+  let mockNode: LGraphNode
+  let mockInputSpec: InputSpec
+
+  beforeEach(() => {
+    mockNode = {
+      id: 1,
+      widgets: []
+    } as unknown as LGraphNode
+
+    mockInputSpec = {
+      name: 'test_media_loader',
+      type: 'MEDIA_LOADER'
+    }
+  })
+
+  it('creates widget constructor with default options', () => {
+    const constructor = useMediaLoaderWidget()
+    expect(constructor).toBeInstanceOf(Function)
+  })
+
+  it('creates widget with custom options', () => {
+    const onFilesSelected = vi.fn()
+    const constructor = useMediaLoaderWidget({
+      defaultValue: ['test.jpg'],
+      minHeight: 120,
+      accept: 'image/*',
+      onFilesSelected
+    })
+
+    const widget = constructor(mockNode, mockInputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('test_media_loader')
+    expect((widget.options as any)?.getValue()).toEqual(['test.jpg'])
+    expect((widget.options as any)?.getMinHeight()).toBe(128) // 120 + 8 padding
+    expect((widget.options as any)?.onFilesSelected).toBe(onFilesSelected)
+  })
+
+  it('handles value setting with validation', () => {
+    const constructor = useMediaLoaderWidget()
+    const widget = constructor(mockNode, mockInputSpec)
+
+    // Test valid array
+    ;(widget.options as any)?.setValue(['file1.jpg', 'file2.png'])
+    expect((widget.options as any)?.getValue()).toEqual([
+      'file1.jpg',
+      'file2.png'
+    ])
+
+    // Test invalid value conversion
+    ;(widget.options as any)?.setValue('invalid' as any)
+    expect((widget.options as any)?.getValue()).toEqual([])
+  })
+
+  it('sets correct minimum height with padding', () => {
+    const constructor = useMediaLoaderWidget({ minHeight: 150 })
+    const widget = constructor(mockNode, mockInputSpec)
+
+    expect((widget.options as any)?.getMinHeight()).toBe(158) // 150 + 8 padding
+  })
+
+  it('uses default minimum height when not specified', () => {
+    const constructor = useMediaLoaderWidget()
+    const widget = constructor(mockNode, mockInputSpec)
+
+    expect((widget.options as any)?.getMinHeight()).toBe(108) // 100 + 8 padding
+  })
+
+  it('passes accept prop to widget', () => {
+    const constructor = useMediaLoaderWidget({ accept: 'video/*' })
+    const widget = constructor(mockNode, mockInputSpec)
+
+    expect((widget as any).props?.accept).toBe('video/*')
+  })
+})

--- a/tests-ui/composables/useNodeImagePreview.test.ts
+++ b/tests-ui/composables/useNodeImagePreview.test.ts
@@ -1,0 +1,69 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useNodeImagePreview } from '@/composables/node/useNodeImagePreview'
+
+// Mock dependencies
+vi.mock('@/composables/widgets/useImagePreviewWidget', () => ({
+  useImagePreviewWidget: vi.fn(() =>
+    vi.fn(() => ({
+      name: '$$node-image-preview',
+      value: '',
+      onRemove: vi.fn()
+    }))
+  )
+}))
+
+describe('useNodeImagePreview', () => {
+  const mockNode = {
+    id: 'test-node',
+    widgets: [],
+    setDirtyCanvas: vi.fn()
+  } as unknown as LGraphNode
+
+  it('provides showImagePreview and removeImagePreview functions', () => {
+    const { showImagePreview, removeImagePreview } = useNodeImagePreview()
+
+    expect(showImagePreview).toBeDefined()
+    expect(removeImagePreview).toBeDefined()
+    expect(typeof showImagePreview).toBe('function')
+    expect(typeof removeImagePreview).toBe('function')
+  })
+
+  it('shows image preview for single image', () => {
+    const { showImagePreview } = useNodeImagePreview()
+
+    showImagePreview(mockNode, 'test-image.png')
+
+    expect(mockNode.setDirtyCanvas).toHaveBeenCalledWith(true)
+  })
+
+  it('shows image preview for multiple images', () => {
+    const { showImagePreview } = useNodeImagePreview()
+
+    showImagePreview(mockNode, ['image1.png', 'image2.png'], {
+      allow_batch: true
+    })
+
+    expect(mockNode.setDirtyCanvas).toHaveBeenCalledWith(true)
+  })
+
+  it('removes image preview widget', () => {
+    const mockWidget = {
+      name: '$$node-image-preview',
+      onRemove: vi.fn()
+    }
+
+    const nodeWithWidget = {
+      ...mockNode,
+      widgets: [mockWidget]
+    } as unknown as LGraphNode
+
+    const { removeImagePreview } = useNodeImagePreview()
+
+    removeImagePreview(nodeWithWidget)
+
+    expect(mockWidget.onRemove).toHaveBeenCalled()
+    expect(nodeWithWidget.widgets).toHaveLength(0)
+  })
+})

--- a/tests-ui/composables/useNodeMediaUpload.test.ts
+++ b/tests-ui/composables/useNodeMediaUpload.test.ts
@@ -1,0 +1,114 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useNodeMediaUpload } from '@/composables/node/useNodeMediaUpload'
+
+// Mock dependencies
+vi.mock('@/composables/widgets/useMediaLoaderWidget', () => ({
+  useMediaLoaderWidget: vi.fn(() =>
+    vi.fn(() => ({
+      name: '$$node-media-loader',
+      options: {
+        onFilesSelected: null
+      }
+    }))
+  )
+}))
+
+vi.mock('@/composables/node/useNodeImageUpload', () => ({
+  useNodeImageUpload: vi.fn(() => ({
+    handleUpload: vi.fn()
+  }))
+}))
+
+describe('useNodeMediaUpload', () => {
+  let mockNode: LGraphNode
+
+  beforeEach(() => {
+    mockNode = {
+      id: 1,
+      widgets: [],
+      setDirtyCanvas: vi.fn()
+    } as unknown as LGraphNode
+  })
+
+  it('creates composable with required methods', () => {
+    const { showMediaLoader, removeMediaLoader, addMediaLoaderWidget } =
+      useNodeMediaUpload()
+
+    expect(showMediaLoader).toBeInstanceOf(Function)
+    expect(removeMediaLoader).toBeInstanceOf(Function)
+    expect(addMediaLoaderWidget).toBeInstanceOf(Function)
+  })
+
+  it('shows media loader widget with options', () => {
+    const { showMediaLoader } = useNodeMediaUpload()
+    const options = {
+      fileFilter: (file: File) => file.type.startsWith('image/'),
+      onUploadComplete: vi.fn(),
+      allow_batch: true,
+      accept: 'image/*'
+    }
+
+    const widget = showMediaLoader(mockNode, options)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('$$node-media-loader')
+    expect(mockNode.setDirtyCanvas).toHaveBeenCalledWith(true)
+  })
+
+  it('removes media loader widget from node', () => {
+    const { showMediaLoader, removeMediaLoader } = useNodeMediaUpload()
+    const options = {
+      fileFilter: () => true,
+      onUploadComplete: vi.fn()
+    }
+
+    // Add widget
+    showMediaLoader(mockNode, options)
+    mockNode.widgets = [
+      {
+        name: '$$node-media-loader',
+        onRemove: vi.fn()
+      }
+    ] as any
+
+    // Remove widget
+    removeMediaLoader(mockNode)
+
+    expect(mockNode.widgets).toHaveLength(0)
+  })
+
+  it('handles node without widgets gracefully', () => {
+    const { removeMediaLoader } = useNodeMediaUpload()
+    const nodeWithoutWidgets = { id: 1 } as LGraphNode
+
+    expect(() => removeMediaLoader(nodeWithoutWidgets)).not.toThrow()
+  })
+
+  it('does not remove non-matching widgets', () => {
+    const { removeMediaLoader } = useNodeMediaUpload()
+    const otherWidget = { name: 'other-widget' }
+    mockNode.widgets! = [otherWidget] as any
+
+    removeMediaLoader(mockNode)
+
+    expect(mockNode.widgets).toHaveLength(1)
+    expect(mockNode.widgets![0]).toBe(otherWidget)
+  })
+
+  it('calls widget onRemove when removing', () => {
+    const { removeMediaLoader } = useNodeMediaUpload()
+    const onRemove = vi.fn()
+    mockNode.widgets! = [
+      {
+        name: '$$node-media-loader',
+        onRemove
+      }
+    ] as any
+
+    removeMediaLoader(mockNode)
+
+    expect(onRemove).toHaveBeenCalled()
+  })
+})

--- a/tests-ui/composables/useStringWidgetVue.test.ts
+++ b/tests-ui/composables/useStringWidgetVue.test.ts
@@ -1,0 +1,93 @@
+import { LGraphNode } from '@comfyorg/litegraph'
+import { describe, expect, it } from 'vitest'
+
+import { useStringWidgetVue } from '@/composables/widgets/useStringWidgetVue'
+import type { StringInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+describe('useStringWidgetVue', () => {
+  it('creates widget constructor with correct default value', () => {
+    const constructor = useStringWidgetVue({ defaultValue: 'test' })
+    expect(constructor).toBeDefined()
+    expect(typeof constructor).toBe('function')
+  })
+
+  it('creates widget for single-line string input', () => {
+    const constructor = useStringWidgetVue()
+    const node = new LGraphNode('test')
+    const inputSpec: StringInputSpec = {
+      type: 'STRING',
+      name: 'test_input',
+      default: 'default_value',
+      placeholder: 'Enter text...'
+    }
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('test_input')
+    expect(widget.value).toBe('default_value')
+  })
+
+  it('creates widget for multiline string input', () => {
+    const constructor = useStringWidgetVue()
+    const node = new LGraphNode('test')
+    const inputSpec: StringInputSpec = {
+      type: 'STRING',
+      name: 'multiline_input',
+      default: 'default\nvalue',
+      placeholder: 'Enter multiline text...',
+      multiline: true
+    }
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('multiline_input')
+    expect(widget.value).toBe('default\nvalue')
+  })
+
+  it('handles placeholder fallback correctly', () => {
+    const constructor = useStringWidgetVue()
+    const node = new LGraphNode('test')
+    const inputSpec: StringInputSpec = {
+      type: 'STRING',
+      name: 'no_placeholder_input',
+      default: 'default_value'
+    }
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('no_placeholder_input')
+    expect(widget.value).toBe('default_value')
+  })
+
+  it('supports dynamic prompts configuration', () => {
+    const constructor = useStringWidgetVue()
+    const node = new LGraphNode('test')
+    const inputSpec: StringInputSpec = {
+      type: 'STRING',
+      name: 'dynamic_input',
+      default: 'value',
+      dynamicPrompts: true
+    }
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.dynamicPrompts).toBe(true)
+  })
+
+  it('throws error for invalid input spec', () => {
+    const constructor = useStringWidgetVue()
+    const node = new LGraphNode('test')
+    const invalidInputSpec = {
+      type: 'INT',
+      name: 'invalid_input'
+    } as any
+
+    expect(() => constructor(node, invalidInputSpec)).toThrow(
+      'Invalid input data'
+    )
+  })
+})

--- a/tests-ui/tests/composables/useBadgedNumberInput.test.ts
+++ b/tests-ui/tests/composables/useBadgedNumberInput.test.ts
@@ -1,0 +1,73 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useBadgedNumberInput } from '@/composables/widgets/useBadgedNumberInput'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+// Mock dependencies
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: vi.fn().mockImplementation((config) => ({
+    ...config,
+    value: config.options.getValue(),
+    setValue: config.options.setValue,
+    options: config.options,
+    props: config.props
+  })),
+  addWidget: vi.fn()
+}))
+
+describe('useBadgedNumberInput', () => {
+  const createMockNode = (): LGraphNode =>
+    ({
+      id: 1,
+      title: 'Test Node',
+      widgets: [],
+      addWidget: vi.fn()
+    }) as any
+
+  const createInputSpec = (overrides: Partial<InputSpec> = {}): InputSpec => ({
+    name: 'test_input',
+    type: 'number',
+    ...overrides
+  })
+
+  it('creates widget constructor with default options', () => {
+    const constructor = useBadgedNumberInput()
+    expect(constructor).toBeDefined()
+    expect(typeof constructor).toBe('function')
+  })
+
+  it('creates widget with default options', () => {
+    const constructor = useBadgedNumberInput()
+    const node = createMockNode()
+    const inputSpec = createInputSpec()
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe(inputSpec.name)
+  })
+
+  it('creates widget with custom badge state', () => {
+    const constructor = useBadgedNumberInput({ badgeState: 'random' })
+    const node = createMockNode()
+    const inputSpec = createInputSpec()
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    // Widget is created with the props, but accessing them requires the mock structure
+    expect((widget as any).props.badgeState).toBe('random')
+  })
+
+  it('creates widget with disabled state', () => {
+    const constructor = useBadgedNumberInput({ disabled: true })
+    const node = createMockNode()
+    const inputSpec = createInputSpec()
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect((widget as any).props.disabled).toBe(true)
+  })
+})

--- a/tests-ui/tests/composables/useColorPickerWidget.test.ts
+++ b/tests-ui/tests/composables/useColorPickerWidget.test.ts
@@ -1,0 +1,80 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useColorPickerWidget } from '@/composables/widgets/useColorPickerWidget'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+// Mock dependencies
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: vi.fn().mockImplementation((config) => ({
+    ...config,
+    name: config.name,
+    options: {
+      ...config.options,
+      getValue: config.options.getValue,
+      setValue: config.options.setValue,
+      getMinHeight: config.options.getMinHeight
+    }
+  })),
+  addWidget: vi.fn()
+}))
+
+describe('useColorPickerWidget', () => {
+  const createMockNode = (): LGraphNode =>
+    ({
+      id: 1,
+      title: 'Test Node',
+      widgets: [],
+      addWidget: vi.fn()
+    }) as any
+
+  const createInputSpec = (overrides: Partial<InputSpec> = {}): InputSpec => ({
+    name: 'color',
+    type: 'COLOR',
+    ...overrides
+  })
+
+  it('creates widget constructor with default options', () => {
+    const constructor = useColorPickerWidget()
+    expect(constructor).toBeDefined()
+    expect(typeof constructor).toBe('function')
+  })
+
+  it('creates widget with default options', () => {
+    const constructor = useColorPickerWidget()
+    const node = createMockNode()
+    const inputSpec = createInputSpec()
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe(inputSpec.name)
+  })
+
+  it('creates widget with custom default value', () => {
+    const constructor = useColorPickerWidget({
+      defaultValue: '#00ff00'
+    })
+    const node = createMockNode()
+    const inputSpec = createInputSpec()
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe(inputSpec.name)
+  })
+
+  it('creates widget with custom options', () => {
+    const constructor = useColorPickerWidget({
+      minHeight: 60,
+      serialize: false
+    })
+    const node = createMockNode()
+    const inputSpec = createInputSpec()
+
+    const widget = constructor(node, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe(inputSpec.name)
+  })
+})

--- a/tests-ui/tests/composables/useDropdownComboWidget.test.ts
+++ b/tests-ui/tests/composables/useDropdownComboWidget.test.ts
@@ -1,0 +1,109 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDropdownComboWidget } from '@/composables/widgets/useDropdownComboWidget'
+import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+// Mock the domWidget store and related dependencies
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: vi.fn().mockImplementation((config) => ({
+    name: config.name,
+    value: '',
+    options: config.options
+  })),
+  addWidget: vi.fn()
+}))
+
+// Mock the scripts/widgets for control widgets
+vi.mock('@/scripts/widgets', () => ({
+  addValueControlWidgets: vi.fn().mockReturnValue([])
+}))
+
+// Mock the remote widget functionality
+vi.mock('@/composables/widgets/useRemoteWidget', () => ({
+  useRemoteWidget: vi.fn(() => ({
+    addRefreshButton: vi.fn()
+  }))
+}))
+
+const createMockNode = () => {
+  return {
+    widgets: [],
+    graph: {
+      setDirtyCanvas: vi.fn()
+    },
+    addWidget: vi.fn(),
+    addCustomWidget: vi.fn(),
+    setDirtyCanvas: vi.fn()
+  } as unknown as LGraphNode
+}
+
+describe('useDropdownComboWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('creates widget constructor successfully', () => {
+    const constructor = useDropdownComboWidget()
+    expect(constructor).toBeDefined()
+    expect(typeof constructor).toBe('function')
+  })
+
+  it('widget constructor handles input spec correctly', () => {
+    const constructor = useDropdownComboWidget()
+    const mockNode = createMockNode()
+
+    const inputSpec: ComboInputSpec = {
+      name: 'test_dropdown',
+      type: 'COMBO',
+      options: ['option1', 'option2', 'option3']
+    }
+
+    const widget = constructor(mockNode, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('test_dropdown')
+  })
+
+  it('widget constructor accepts default value option', () => {
+    const constructor = useDropdownComboWidget({ defaultValue: 'custom' })
+    expect(constructor).toBeDefined()
+    expect(typeof constructor).toBe('function')
+  })
+
+  it('handles remote widgets correctly', () => {
+    const constructor = useDropdownComboWidget()
+    const mockNode = createMockNode()
+
+    const inputSpec: ComboInputSpec = {
+      name: 'remote_dropdown',
+      type: 'COMBO',
+      options: [],
+      remote: {
+        route: '/api/options',
+        refresh_button: true
+      }
+    }
+
+    const widget = constructor(mockNode, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('remote_dropdown')
+  })
+
+  it('handles control_after_generate widgets correctly', () => {
+    const constructor = useDropdownComboWidget()
+    const mockNode = createMockNode()
+
+    const inputSpec: ComboInputSpec = {
+      name: 'control_dropdown',
+      type: 'COMBO',
+      options: ['option1', 'option2'],
+      control_after_generate: true
+    }
+
+    const widget = constructor(mockNode, inputSpec)
+
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('control_dropdown')
+  })
+})

--- a/tests-ui/tests/composables/widgets/useComboWidget.test.ts
+++ b/tests-ui/tests/composables/widgets/useComboWidget.test.ts
@@ -1,39 +1,89 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useComboWidget } from '@/composables/widgets/useComboWidget'
-import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 
-vi.mock('@/scripts/widgets', () => ({
-  addValueControlWidgets: vi.fn()
+// Mock the dropdown combo widget since COMBO now uses it
+vi.mock('@/composables/widgets/useDropdownComboWidget', () => ({
+  useDropdownComboWidget: vi.fn(() =>
+    vi.fn().mockReturnValue({ name: 'mockWidget' })
+  )
 }))
+
+// Mock the domWidget store and related dependencies
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: vi.fn().mockImplementation((config) => ({
+    name: config.name,
+    value: [],
+    options: config.options
+  })),
+  addWidget: vi.fn()
+}))
+
+const createMockNode = () => {
+  return {
+    widgets: [],
+    graph: {
+      setDirtyCanvas: vi.fn()
+    },
+    addWidget: vi.fn(),
+    addCustomWidget: vi.fn(),
+    setDirtyCanvas: vi.fn()
+  } as unknown as LGraphNode
+}
 
 describe('useComboWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should handle undefined spec', () => {
+  it('should delegate single-selection combo to dropdown widget', () => {
     const constructor = useComboWidget()
-    const mockNode = {
-      addWidget: vi.fn().mockReturnValue({ options: {} } as any)
-    }
+    const mockNode = createMockNode()
 
-    const inputSpec: InputSpec = {
+    const inputSpec: ComboInputSpec = {
       type: 'COMBO',
-      name: 'inputName'
+      name: 'inputName',
+      options: ['option1', 'option2']
     }
 
-    const widget = constructor(mockNode as any, inputSpec)
+    const widget = constructor(mockNode, inputSpec)
 
-    expect(mockNode.addWidget).toHaveBeenCalledWith(
-      'combo',
-      'inputName',
-      undefined, // default value
-      expect.any(Function), // callback
-      expect.objectContaining({
-        values: []
-      })
+    // Should create a widget (delegated to dropdown widget)
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('mockWidget')
+  })
+
+  it('should use multi-select widget for multi_select combo', () => {
+    const constructor = useComboWidget()
+    const mockNode = createMockNode()
+
+    const inputSpec: ComboInputSpec = {
+      type: 'COMBO',
+      name: 'multiSelectInput',
+      options: ['option1', 'option2'],
+      multi_select: { placeholder: 'Select multiple' }
+    }
+
+    const widget = constructor(mockNode, inputSpec)
+
+    // Should create a multi-select widget
+    expect(widget).toBeDefined()
+    expect(widget.name).toBe('multiSelectInput')
+  })
+
+  it('should handle invalid input spec', () => {
+    const constructor = useComboWidget()
+    const mockNode = createMockNode()
+
+    const invalidSpec = {
+      type: 'NOT_COMBO',
+      name: 'invalidInput'
+    } as any
+
+    expect(() => constructor(mockNode, invalidSpec)).toThrow(
+      'Invalid input data'
     )
-    expect(widget).toEqual({ options: {} })
   })
 })

--- a/vue-widget-conversion/primevue-components.json
+++ b/vue-widget-conversion/primevue-components.json
@@ -1,0 +1,919 @@
+{
+  "version": "4.2.5",
+  "generatedAt": "2025-06-09T04:50:20.566Z",
+  "totalComponents": 147,
+  "categories": {
+    "Panel": [
+      {
+        "name": "accordion",
+        "description": "Groups a collection of contents in tabs",
+        "documentationUrl": "https://primevue.org/accordion/",
+        "pascalCase": "Accordion"
+      },
+      {
+        "name": "accordioncontent",
+        "description": "Content container for accordion panels",
+        "documentationUrl": "https://primevue.org/accordion/",
+        "pascalCase": "Accordioncontent"
+      },
+      {
+        "name": "accordionheader",
+        "description": "Header section for accordion panels",
+        "documentationUrl": "https://primevue.org/accordion/",
+        "pascalCase": "Accordionheader"
+      },
+      {
+        "name": "accordionpanel",
+        "description": "Individual panel in an accordion",
+        "documentationUrl": "https://primevue.org/accordion/",
+        "pascalCase": "Accordionpanel"
+      },
+      {
+        "name": "accordiontab",
+        "description": "Legacy accordion tab component",
+        "documentationUrl": "https://primevue.org/accordion/",
+        "pascalCase": "Accordiontab"
+      },
+      {
+        "name": "card",
+        "description": "Flexible content container",
+        "documentationUrl": "https://primevue.org/card/",
+        "pascalCase": "Card"
+      },
+      {
+        "name": "deferredcontent",
+        "description": "Loads content on demand",
+        "documentationUrl": "https://primevue.org/deferredcontent/",
+        "pascalCase": "Deferredcontent"
+      },
+      {
+        "name": "divider",
+        "description": "Separator component",
+        "documentationUrl": "https://primevue.org/divider/",
+        "pascalCase": "Divider"
+      },
+      {
+        "name": "fieldset",
+        "description": "Groups related form elements",
+        "documentationUrl": "https://primevue.org/fieldset/",
+        "pascalCase": "Fieldset"
+      },
+      {
+        "name": "panel",
+        "description": "Collapsible content container",
+        "documentationUrl": "https://primevue.org/panel/",
+        "pascalCase": "Panel"
+      },
+      {
+        "name": "scrollpanel",
+        "description": "Scrollable content container",
+        "documentationUrl": "https://primevue.org/scrollpanel/",
+        "pascalCase": "Scrollpanel"
+      },
+      {
+        "name": "splitter",
+        "description": "Resizable split panels",
+        "documentationUrl": "https://primevue.org/splitter/",
+        "pascalCase": "Splitter"
+      },
+      {
+        "name": "splitterpanel",
+        "description": "Panel within splitter",
+        "documentationUrl": "https://primevue.org/splitter/",
+        "pascalCase": "Splitterpanel"
+      },
+      {
+        "name": "tab",
+        "description": "Individual tab component",
+        "documentationUrl": "https://primevue.org/tabs/",
+        "pascalCase": "Tab"
+      },
+      {
+        "name": "tablist",
+        "description": "Container for tabs",
+        "documentationUrl": "https://primevue.org/tabs/",
+        "pascalCase": "Tablist"
+      },
+      {
+        "name": "tabpanel",
+        "description": "Content panel for tabs",
+        "documentationUrl": "https://primevue.org/tabs/",
+        "pascalCase": "Tabpanel"
+      },
+      {
+        "name": "tabpanels",
+        "description": "Container for tab panels",
+        "documentationUrl": "https://primevue.org/tabs/",
+        "pascalCase": "Tabpanels"
+      },
+      {
+        "name": "tabs",
+        "description": "Modern tab container",
+        "documentationUrl": "https://primevue.org/tabs/",
+        "pascalCase": "Tabs"
+      },
+      {
+        "name": "tabview",
+        "description": "Legacy tabbed interface",
+        "documentationUrl": "https://primevue.org/tabview/",
+        "pascalCase": "Tabview"
+      }
+    ],
+    "Directives": [
+      {
+        "name": "animateonscroll",
+        "description": "Directive to apply animations when element becomes visible",
+        "documentationUrl": "https://primevue.org/animateonscroll/",
+        "pascalCase": "Animateonscroll"
+      },
+      {
+        "name": "badgedirective",
+        "description": "Directive to add badges to any element",
+        "documentationUrl": "https://primevue.org/badge/",
+        "pascalCase": "Badgedirective"
+      },
+      {
+        "name": "focustrap",
+        "description": "Directive to trap focus within element",
+        "documentationUrl": "https://primevue.org/focustrap/",
+        "pascalCase": "Focustrap"
+      },
+      {
+        "name": "keyfilter",
+        "description": "Directive to filter keyboard input",
+        "documentationUrl": "https://primevue.org/keyfilter/",
+        "pascalCase": "Keyfilter"
+      },
+      {
+        "name": "ripple",
+        "description": "Directive for material design ripple effect",
+        "documentationUrl": "https://primevue.org/ripple/",
+        "pascalCase": "Ripple"
+      },
+      {
+        "name": "styleclass",
+        "description": "Directive for dynamic styling",
+        "documentationUrl": "https://primevue.org/styleclass/",
+        "pascalCase": "Styleclass"
+      }
+    ],
+    "Form": [
+      {
+        "name": "autocomplete",
+        "description": "Provides filtered suggestions while typing input, supports multiple selection and custom item templates",
+        "documentationUrl": "https://primevue.org/autocomplete/",
+        "pascalCase": "Autocomplete"
+      },
+      {
+        "name": "calendar",
+        "description": "Input component for date selection (legacy)",
+        "documentationUrl": "https://primevue.org/calendar/",
+        "pascalCase": "Calendar"
+      },
+      {
+        "name": "cascadeselect",
+        "description": "Nested dropdown selection component",
+        "documentationUrl": "https://primevue.org/cascadeselect/",
+        "pascalCase": "Cascadeselect"
+      },
+      {
+        "name": "checkbox",
+        "description": "Binary selection component",
+        "documentationUrl": "https://primevue.org/checkbox/",
+        "pascalCase": "Checkbox"
+      },
+      {
+        "name": "checkboxgroup",
+        "description": "Groups multiple checkboxes",
+        "documentationUrl": "https://primevue.org/checkbox/",
+        "pascalCase": "Checkboxgroup"
+      },
+      {
+        "name": "chips",
+        "description": "Input component for entering multiple values",
+        "documentationUrl": "https://primevue.org/chips/",
+        "pascalCase": "Chips"
+      },
+      {
+        "name": "colorpicker",
+        "description": "Input component for color selection",
+        "documentationUrl": "https://primevue.org/colorpicker/",
+        "pascalCase": "Colorpicker"
+      },
+      {
+        "name": "datepicker",
+        "description": "Input component for date and time selection with calendar popup, supports date ranges and custom formatting",
+        "documentationUrl": "https://primevue.org/datepicker/",
+        "pascalCase": "Datepicker"
+      },
+      {
+        "name": "dropdown",
+        "description": "Single selection dropdown",
+        "documentationUrl": "https://primevue.org/dropdown/",
+        "pascalCase": "Dropdown"
+      },
+      {
+        "name": "editor",
+        "description": "Rich text editor component",
+        "documentationUrl": "https://primevue.org/editor/",
+        "pascalCase": "Editor"
+      },
+      {
+        "name": "floatlabel",
+        "description": "Floating label for input components",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Floatlabel"
+      },
+      {
+        "name": "iconfield",
+        "description": "Input field with icon",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Iconfield"
+      },
+      {
+        "name": "iftalabel",
+        "description": "Input field with top-aligned label",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Iftalabel"
+      },
+      {
+        "name": "inputchips",
+        "description": "Multiple input values as chips",
+        "documentationUrl": "https://primevue.org/chips/",
+        "pascalCase": "Inputchips"
+      },
+      {
+        "name": "inputgroup",
+        "description": "Groups input elements",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputgroup"
+      },
+      {
+        "name": "inputgroupaddon",
+        "description": "Addon for input groups",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputgroupaddon"
+      },
+      {
+        "name": "inputicon",
+        "description": "Icon for input components",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputicon"
+      },
+      {
+        "name": "inputmask",
+        "description": "Input with format masking",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputmask"
+      },
+      {
+        "name": "inputnumber",
+        "description": "Numeric input with spinner",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputnumber"
+      },
+      {
+        "name": "inputotp",
+        "description": "One-time password input",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputotp"
+      },
+      {
+        "name": "inputswitch",
+        "description": "Binary switch component",
+        "documentationUrl": "https://primevue.org/toggleswitch/",
+        "pascalCase": "Inputswitch"
+      },
+      {
+        "name": "inputtext",
+        "description": "Text input component",
+        "documentationUrl": "https://primevue.org/inputtext/",
+        "pascalCase": "Inputtext"
+      },
+      {
+        "name": "knob",
+        "description": "Circular input component",
+        "documentationUrl": "https://primevue.org/knob/",
+        "pascalCase": "Knob"
+      },
+      {
+        "name": "listbox",
+        "description": "Selection component with list interface",
+        "documentationUrl": "https://primevue.org/listbox/",
+        "pascalCase": "Listbox"
+      },
+      {
+        "name": "multiselect",
+        "description": "Multiple selection dropdown",
+        "documentationUrl": "https://primevue.org/multiselect/",
+        "pascalCase": "Multiselect"
+      },
+      {
+        "name": "password",
+        "description": "Password input with strength meter",
+        "documentationUrl": "https://primevue.org/password/",
+        "pascalCase": "Password"
+      },
+      {
+        "name": "radiobutton",
+        "description": "Single selection from group",
+        "documentationUrl": "https://primevue.org/radiobutton/",
+        "pascalCase": "Radiobutton"
+      },
+      {
+        "name": "radiobuttongroup",
+        "description": "Groups radio buttons",
+        "documentationUrl": "https://primevue.org/radiobutton/",
+        "pascalCase": "Radiobuttongroup"
+      },
+      {
+        "name": "rating",
+        "description": "Star rating input component",
+        "documentationUrl": "https://primevue.org/rating/",
+        "pascalCase": "Rating"
+      },
+      {
+        "name": "select",
+        "description": "Modern dropdown selection",
+        "documentationUrl": "https://primevue.org/select/",
+        "pascalCase": "Select"
+      },
+      {
+        "name": "selectbutton",
+        "description": "Button-style selection component",
+        "documentationUrl": "https://primevue.org/selectbutton/",
+        "pascalCase": "Selectbutton"
+      },
+      {
+        "name": "slider",
+        "description": "Range selection component",
+        "documentationUrl": "https://primevue.org/slider/",
+        "pascalCase": "Slider"
+      },
+      {
+        "name": "textarea",
+        "description": "Multi-line text input",
+        "documentationUrl": "https://primevue.org/textarea/",
+        "pascalCase": "Textarea"
+      },
+      {
+        "name": "togglebutton",
+        "description": "Two-state button component",
+        "documentationUrl": "https://primevue.org/togglebutton/",
+        "pascalCase": "Togglebutton"
+      },
+      {
+        "name": "toggleswitch",
+        "description": "Switch component for binary state",
+        "documentationUrl": "https://primevue.org/toggleswitch/",
+        "pascalCase": "Toggleswitch"
+      },
+      {
+        "name": "treeselect",
+        "description": "Tree-structured selection",
+        "documentationUrl": "https://primevue.org/treeselect/",
+        "pascalCase": "Treeselect"
+      }
+    ],
+    "Misc": [
+      {
+        "name": "avatar",
+        "description": "Represents people using icons, labels and images",
+        "documentationUrl": "https://primevue.org/avatar/",
+        "pascalCase": "Avatar"
+      },
+      {
+        "name": "avatargroup",
+        "description": "Groups multiple avatars together",
+        "documentationUrl": "https://primevue.org/avatar/",
+        "pascalCase": "Avatargroup"
+      },
+      {
+        "name": "badge",
+        "description": "Small numeric indicator for other components",
+        "documentationUrl": "https://primevue.org/badge/",
+        "pascalCase": "Badge"
+      },
+      {
+        "name": "blockui",
+        "description": "Blocks user interaction with page elements",
+        "documentationUrl": "https://primevue.org/blockui/",
+        "pascalCase": "Blockui"
+      },
+      {
+        "name": "chip",
+        "description": "Compact element representing input, attribute or action",
+        "documentationUrl": "https://primevue.org/chip/",
+        "pascalCase": "Chip"
+      },
+      {
+        "name": "inplace",
+        "description": "Editable content in place",
+        "documentationUrl": "https://primevue.org/inplace/",
+        "pascalCase": "Inplace"
+      },
+      {
+        "name": "metergroup",
+        "description": "Displays multiple meter values",
+        "documentationUrl": "https://primevue.org/metergroup/",
+        "pascalCase": "Metergroup"
+      },
+      {
+        "name": "overlaybadge",
+        "description": "Badge overlay for components",
+        "documentationUrl": "https://primevue.org/badge/",
+        "pascalCase": "Overlaybadge"
+      },
+      {
+        "name": "progressbar",
+        "description": "Progress indication component",
+        "documentationUrl": "https://primevue.org/progressbar/",
+        "pascalCase": "Progressbar"
+      },
+      {
+        "name": "progressspinner",
+        "description": "Loading spinner component",
+        "documentationUrl": "https://primevue.org/progressspinner/",
+        "pascalCase": "Progressspinner"
+      },
+      {
+        "name": "skeleton",
+        "description": "Placeholder for loading content",
+        "documentationUrl": "https://primevue.org/skeleton/",
+        "pascalCase": "Skeleton"
+      },
+      {
+        "name": "tag",
+        "description": "Label component for categorization",
+        "documentationUrl": "https://primevue.org/tag/",
+        "pascalCase": "Tag"
+      },
+      {
+        "name": "terminal",
+        "description": "Command line interface",
+        "documentationUrl": "https://primevue.org/terminal/",
+        "pascalCase": "Terminal"
+      }
+    ],
+    "Menu": [
+      {
+        "name": "breadcrumb",
+        "description": "Navigation component showing current page location",
+        "documentationUrl": "https://primevue.org/breadcrumb/",
+        "pascalCase": "Breadcrumb"
+      },
+      {
+        "name": "contextmenu",
+        "description": "Right-click context menu",
+        "documentationUrl": "https://primevue.org/contextmenu/",
+        "pascalCase": "Contextmenu"
+      },
+      {
+        "name": "dock",
+        "description": "Dock layout with expandable items",
+        "documentationUrl": "https://primevue.org/dock/",
+        "pascalCase": "Dock"
+      },
+      {
+        "name": "megamenu",
+        "description": "Navigation with grouped menu items",
+        "documentationUrl": "https://primevue.org/megamenu/",
+        "pascalCase": "Megamenu"
+      },
+      {
+        "name": "menu",
+        "description": "Navigation menu component",
+        "documentationUrl": "https://primevue.org/menu/",
+        "pascalCase": "Menu"
+      },
+      {
+        "name": "menubar",
+        "description": "Horizontal navigation menu",
+        "documentationUrl": "https://primevue.org/menubar/",
+        "pascalCase": "Menubar"
+      },
+      {
+        "name": "panelmenu",
+        "description": "Vertical navigation menu",
+        "documentationUrl": "https://primevue.org/panelmenu/",
+        "pascalCase": "Panelmenu"
+      },
+      {
+        "name": "steps",
+        "description": "Step-by-step navigation",
+        "documentationUrl": "https://primevue.org/steps/",
+        "pascalCase": "Steps"
+      },
+      {
+        "name": "tabmenu",
+        "description": "Menu styled as tabs",
+        "documentationUrl": "https://primevue.org/tabmenu/",
+        "pascalCase": "Tabmenu"
+      },
+      {
+        "name": "tieredmenu",
+        "description": "Hierarchical menu component",
+        "documentationUrl": "https://primevue.org/tieredmenu/",
+        "pascalCase": "Tieredmenu"
+      }
+    ],
+    "Button": [
+      {
+        "name": "button",
+        "description": "Standard button component with various styles and severity levels, supports icons and loading states",
+        "documentationUrl": "https://primevue.org/button/",
+        "pascalCase": "Button"
+      },
+      {
+        "name": "buttongroup",
+        "description": "Groups multiple buttons together as a cohesive unit with shared styling",
+        "documentationUrl": "https://primevue.org/button/",
+        "pascalCase": "Buttongroup"
+      },
+      {
+        "name": "speeddial",
+        "description": "Floating action button with expandable menu items, supports radial and linear layouts",
+        "documentationUrl": "https://primevue.org/speeddial/",
+        "pascalCase": "Speeddial"
+      },
+      {
+        "name": "splitbutton",
+        "description": "Button with attached dropdown menu for additional actions",
+        "documentationUrl": "https://primevue.org/splitbutton/",
+        "pascalCase": "Splitbutton"
+      }
+    ],
+    "Data": [
+      {
+        "name": "carousel",
+        "description": "Displays content in a rotating slideshow",
+        "documentationUrl": "https://primevue.org/carousel/",
+        "pascalCase": "Carousel"
+      },
+      {
+        "name": "datatable",
+        "description": "Advanced data table with sorting, filtering, pagination, row selection, and column resizing",
+        "documentationUrl": "https://primevue.org/datatable/",
+        "pascalCase": "Datatable"
+      },
+      {
+        "name": "dataview",
+        "description": "Displays data in list layout",
+        "documentationUrl": "https://primevue.org/dataview/",
+        "pascalCase": "Dataview"
+      },
+      {
+        "name": "orderlist",
+        "description": "Reorderable list component",
+        "documentationUrl": "https://primevue.org/orderlist/",
+        "pascalCase": "Orderlist"
+      },
+      {
+        "name": "organizationchart",
+        "description": "Hierarchical organization display",
+        "documentationUrl": "https://primevue.org/organizationchart/",
+        "pascalCase": "Organizationchart"
+      },
+      {
+        "name": "paginator",
+        "description": "Navigation for paged data",
+        "documentationUrl": "https://primevue.org/paginator/",
+        "pascalCase": "Paginator"
+      },
+      {
+        "name": "picklist",
+        "description": "Dual list for item transfer",
+        "documentationUrl": "https://primevue.org/picklist/",
+        "pascalCase": "Picklist"
+      },
+      {
+        "name": "timeline",
+        "description": "Chronological event display",
+        "documentationUrl": "https://primevue.org/timeline/",
+        "pascalCase": "Timeline"
+      },
+      {
+        "name": "tree",
+        "description": "Hierarchical tree structure",
+        "documentationUrl": "https://primevue.org/tree/",
+        "pascalCase": "Tree"
+      },
+      {
+        "name": "treetable",
+        "description": "Table with tree structure",
+        "documentationUrl": "https://primevue.org/treetable/",
+        "pascalCase": "Treetable"
+      },
+      {
+        "name": "virtualscroller",
+        "description": "Virtual scrolling for large datasets",
+        "documentationUrl": "https://primevue.org/virtualscroller/",
+        "pascalCase": "Virtualscroller"
+      }
+    ],
+    "Chart": [
+      {
+        "name": "chart",
+        "description": "Charts and graphs using Chart.js",
+        "documentationUrl": "https://primevue.org/chart/",
+        "pascalCase": "Chart"
+      }
+    ],
+    "Utilities": [
+      {
+        "name": "column",
+        "description": "Table column component for DataTable",
+        "documentationUrl": "https://primevue.org/datatable/",
+        "pascalCase": "Column"
+      },
+      {
+        "name": "columngroup",
+        "description": "Groups table columns",
+        "documentationUrl": "https://primevue.org/datatable/",
+        "pascalCase": "Columngroup"
+      },
+      {
+        "name": "confirmationservice",
+        "description": "Service for programmatically displaying and managing confirmation dialogs",
+        "documentationUrl": "https://primevue.org/confirmdialog/",
+        "pascalCase": "Confirmationservice"
+      },
+      {
+        "name": "dialogservice",
+        "description": "Service for dynamic dialog creation",
+        "documentationUrl": "https://primevue.org/dialogservice/",
+        "pascalCase": "Dialogservice"
+      },
+      {
+        "name": "fluid",
+        "description": "Container with fluid width",
+        "documentationUrl": "https://primevue.org/fluid/",
+        "pascalCase": "Fluid"
+      },
+      {
+        "name": "portal",
+        "description": "Renders content in different DOM location",
+        "documentationUrl": "https://primevue.org/portal/",
+        "pascalCase": "Portal"
+      },
+      {
+        "name": "row",
+        "description": "Table row component",
+        "documentationUrl": "https://primevue.org/datatable/",
+        "pascalCase": "Row"
+      },
+      {
+        "name": "scrolltop",
+        "description": "Button to scroll to top",
+        "documentationUrl": "https://primevue.org/scrolltop/",
+        "pascalCase": "Scrolltop"
+      },
+      {
+        "name": "terminalservice",
+        "description": "Service for terminal component",
+        "documentationUrl": "https://primevue.org/terminal/",
+        "pascalCase": "Terminalservice"
+      },
+      {
+        "name": "useconfirm",
+        "description": "Composable for confirmation dialogs",
+        "documentationUrl": "https://primevue.org/confirmdialog/",
+        "pascalCase": "Useconfirm"
+      },
+      {
+        "name": "usedialog",
+        "description": "Composable for dynamic dialogs",
+        "documentationUrl": "https://primevue.org/dynamicdialog/",
+        "pascalCase": "Usedialog"
+      },
+      {
+        "name": "usestyle",
+        "description": "Composable for dynamic styling",
+        "documentationUrl": "https://primevue.org/usestyle/",
+        "pascalCase": "Usestyle"
+      },
+      {
+        "name": "usetoast",
+        "description": "Composable for toast notifications",
+        "documentationUrl": "https://primevue.org/toast/",
+        "pascalCase": "Usetoast"
+      }
+    ],
+    "Uncategorized": [
+      {
+        "name": "config",
+        "description": "Configuration utility for global PrimeVue settings including theming, locale, and component options",
+        "documentationUrl": "https://primevue.org/config/",
+        "pascalCase": "Config"
+      },
+      {
+        "name": "confirmationeventbus",
+        "description": "Internal event bus system for managing confirmation dialog events and communication",
+        "documentationUrl": "https://primevue.org/confirmdialog/",
+        "pascalCase": "Confirmationeventbus"
+      },
+      {
+        "name": "confirmationoptions",
+        "description": "TypeScript interface definitions for confirmation dialog configuration options",
+        "documentationUrl": "https://primevue.org/confirmdialog/",
+        "pascalCase": "Confirmationoptions"
+      },
+      {
+        "name": "dynamicdialogeventbus",
+        "description": "Internal event bus system for managing dynamic dialog creation and communication",
+        "documentationUrl": "https://primevue.org/dynamicdialog/",
+        "pascalCase": "Dynamicdialogeventbus"
+      },
+      {
+        "name": "dynamicdialogoptions",
+        "description": "TypeScript interface definitions for dynamic dialog configuration options",
+        "documentationUrl": "https://primevue.org/dynamicdialog/",
+        "pascalCase": "Dynamicdialogoptions"
+      },
+      {
+        "name": "menuitem",
+        "description": "TypeScript interface definitions for menu item configuration shared across menu components",
+        "documentationUrl": "https://primevue.org/menuitem/",
+        "pascalCase": "Menuitem"
+      },
+      {
+        "name": "overlayeventbus",
+        "description": "Internal event bus system for managing overlay component events and communication",
+        "documentationUrl": "https://primevue.org/overlaypanel/",
+        "pascalCase": "Overlayeventbus"
+      },
+      {
+        "name": "passthrough",
+        "description": "Utility for customizing component styling and attributes through pass-through properties",
+        "documentationUrl": "https://primevue.org/passthrough/",
+        "pascalCase": "Passthrough"
+      },
+      {
+        "name": "toasteventbus",
+        "description": "Internal event bus system for managing toast notification events and communication",
+        "documentationUrl": "https://primevue.org/toast/",
+        "pascalCase": "Toasteventbus"
+      },
+      {
+        "name": "toastservice",
+        "description": "Service for programmatically displaying and managing toast notifications",
+        "documentationUrl": "https://primevue.org/toast/",
+        "pascalCase": "Toastservice"
+      },
+      {
+        "name": "toolbar",
+        "description": "Container for action buttons",
+        "documentationUrl": "https://primevue.org/toolbar/",
+        "pascalCase": "Toolbar"
+      },
+      {
+        "name": "treenode",
+        "description": "Individual node in tree",
+        "documentationUrl": "https://primevue.org/tree/",
+        "pascalCase": "Treenode"
+      }
+    ],
+    "Overlay": [
+      {
+        "name": "confirmdialog",
+        "description": "Modal dialog for user confirmation",
+        "documentationUrl": "https://primevue.org/confirmdialog/",
+        "pascalCase": "Confirmdialog"
+      },
+      {
+        "name": "confirmpopup",
+        "description": "Popup for user confirmation",
+        "documentationUrl": "https://primevue.org/confirmdialog/",
+        "pascalCase": "Confirmpopup"
+      },
+      {
+        "name": "dialog",
+        "description": "Modal dialog component",
+        "documentationUrl": "https://primevue.org/dialog/",
+        "pascalCase": "Dialog"
+      },
+      {
+        "name": "drawer",
+        "description": "Sliding panel overlay",
+        "documentationUrl": "https://primevue.org/drawer/",
+        "pascalCase": "Drawer"
+      },
+      {
+        "name": "dynamicdialog",
+        "description": "Programmatically created dialogs",
+        "documentationUrl": "https://primevue.org/dynamicdialog/",
+        "pascalCase": "Dynamicdialog"
+      },
+      {
+        "name": "overlaypanel",
+        "description": "Overlay panel component",
+        "documentationUrl": "https://primevue.org/overlaypanel/",
+        "pascalCase": "Overlaypanel"
+      },
+      {
+        "name": "popover",
+        "description": "Overlay component triggered by user interaction",
+        "documentationUrl": "https://primevue.org/popover/",
+        "pascalCase": "Popover"
+      },
+      {
+        "name": "sidebar",
+        "description": "Side panel overlay",
+        "documentationUrl": "https://primevue.org/sidebar/",
+        "pascalCase": "Sidebar"
+      },
+      {
+        "name": "tooltip",
+        "description": "Informational popup on hover",
+        "documentationUrl": "https://primevue.org/tooltip/",
+        "pascalCase": "Tooltip"
+      }
+    ],
+    "File": [
+      {
+        "name": "fileupload",
+        "description": "File upload component with drag-drop",
+        "documentationUrl": "https://primevue.org/fileupload/",
+        "pascalCase": "Fileupload"
+      }
+    ],
+    "Media": [
+      {
+        "name": "galleria",
+        "description": "Image gallery with thumbnails",
+        "documentationUrl": "https://primevue.org/galleria/",
+        "pascalCase": "Galleria"
+      },
+      {
+        "name": "image",
+        "description": "Enhanced image component with preview",
+        "documentationUrl": "https://primevue.org/image/",
+        "pascalCase": "Image"
+      },
+      {
+        "name": "imagecompare",
+        "description": "Before/after image comparison slider",
+        "documentationUrl": "https://primevue.org/imagecompare/",
+        "pascalCase": "Imagecompare"
+      }
+    ],
+    "Messages": [
+      {
+        "name": "inlinemessage",
+        "description": "Inline message display",
+        "documentationUrl": "https://primevue.org/inlinemessage/",
+        "pascalCase": "Inlinemessage"
+      },
+      {
+        "name": "message",
+        "description": "Message component for notifications",
+        "documentationUrl": "https://primevue.org/message/",
+        "pascalCase": "Message"
+      },
+      {
+        "name": "toast",
+        "description": "Temporary message notifications",
+        "documentationUrl": "https://primevue.org/toast/",
+        "pascalCase": "Toast"
+      }
+    ],
+    "Stepper": [
+      {
+        "name": "step",
+        "description": "Individual step in stepper",
+        "documentationUrl": "https://primevue.org/stepper/",
+        "pascalCase": "Step"
+      },
+      {
+        "name": "stepitem",
+        "description": "Item within step",
+        "documentationUrl": "https://primevue.org/stepper/",
+        "pascalCase": "Stepitem"
+      },
+      {
+        "name": "steplist",
+        "description": "List of steps",
+        "documentationUrl": "https://primevue.org/stepper/",
+        "pascalCase": "Steplist"
+      },
+      {
+        "name": "steppanel",
+        "description": "Content panel for stepper",
+        "documentationUrl": "https://primevue.org/stepper/",
+        "pascalCase": "Steppanel"
+      },
+      {
+        "name": "steppanels",
+        "description": "Container for step panels",
+        "documentationUrl": "https://primevue.org/stepper/",
+        "pascalCase": "Steppanels"
+      },
+      {
+        "name": "stepper",
+        "description": "Multi-step process navigation",
+        "documentationUrl": "https://primevue.org/stepper/",
+        "pascalCase": "Stepper"
+      }
+    ]
+  }
+}

--- a/vue-widget-conversion/primevue-components.md
+++ b/vue-widget-conversion/primevue-components.md
@@ -1,0 +1,2261 @@
+# PrimeVue Component Reference
+
+This document provides a comprehensive list of all PrimeVue components available in this project.
+
+**PrimeVue Version:** 4.2.5
+
+**Total Components:** 147
+
+## Table of Contents
+
+- [Button](#button)
+- [Chart](#chart)
+- [Data](#data)
+- [Directives](#directives)
+- [File](#file)
+- [Form](#form)
+- [Media](#media)
+- [Menu](#menu)
+- [Messages](#messages)
+- [Misc](#misc)
+- [Overlay](#overlay)
+- [Panel](#panel)
+- [Stepper](#stepper)
+- [Uncategorized](#uncategorized)
+- [Utilities](#utilities)
+
+## Button
+
+### Button
+
+**Name:** `button`
+
+**Description:** Standard button component with various styles and severity levels, supports icons and loading states
+
+**Documentation:** [https://primevue.org/button/](https://primevue.org/button/)
+
+**Usage Example:**
+```vue
+import Button from 'primevue/button';
+```
+
+---
+
+### Buttongroup
+
+**Name:** `buttongroup`
+
+**Description:** Groups multiple buttons together as a cohesive unit with shared styling
+
+**Documentation:** [https://primevue.org/button/](https://primevue.org/button/)
+
+**Usage Example:**
+```vue
+import Buttongroup from 'primevue/buttongroup';
+```
+
+---
+
+### Speeddial
+
+**Name:** `speeddial`
+
+**Description:** Floating action button with expandable menu items, supports radial and linear layouts
+
+**Documentation:** [https://primevue.org/speeddial/](https://primevue.org/speeddial/)
+
+**Usage Example:**
+```vue
+import Speeddial from 'primevue/speeddial';
+```
+
+---
+
+### Splitbutton
+
+**Name:** `splitbutton`
+
+**Description:** Button with attached dropdown menu for additional actions
+
+**Documentation:** [https://primevue.org/splitbutton/](https://primevue.org/splitbutton/)
+
+**Usage Example:**
+```vue
+import Splitbutton from 'primevue/splitbutton';
+```
+
+---
+
+## Chart
+
+### Chart
+
+**Name:** `chart`
+
+**Description:** Charts and graphs using Chart.js
+
+**Documentation:** [https://primevue.org/chart/](https://primevue.org/chart/)
+
+**Usage Example:**
+```vue
+import Chart from 'primevue/chart';
+```
+
+---
+
+## Data
+
+### Carousel
+
+**Name:** `carousel`
+
+**Description:** Displays content in a rotating slideshow
+
+**Documentation:** [https://primevue.org/carousel/](https://primevue.org/carousel/)
+
+**Usage Example:**
+```vue
+import Carousel from 'primevue/carousel';
+```
+
+---
+
+### Datatable
+
+**Name:** `datatable`
+
+**Description:** Advanced data table with sorting, filtering, pagination, row selection, and column resizing
+
+**Documentation:** [https://primevue.org/datatable/](https://primevue.org/datatable/)
+
+**Usage Example:**
+```vue
+import Datatable from 'primevue/datatable';
+```
+
+---
+
+### Dataview
+
+**Name:** `dataview`
+
+**Description:** Displays data in list layout
+
+**Documentation:** [https://primevue.org/dataview/](https://primevue.org/dataview/)
+
+**Usage Example:**
+```vue
+import Dataview from 'primevue/dataview';
+```
+
+---
+
+### Orderlist
+
+**Name:** `orderlist`
+
+**Description:** Reorderable list component
+
+**Documentation:** [https://primevue.org/orderlist/](https://primevue.org/orderlist/)
+
+**Usage Example:**
+```vue
+import Orderlist from 'primevue/orderlist';
+```
+
+---
+
+### Organizationchart
+
+**Name:** `organizationchart`
+
+**Description:** Hierarchical organization display
+
+**Documentation:** [https://primevue.org/organizationchart/](https://primevue.org/organizationchart/)
+
+**Usage Example:**
+```vue
+import Organizationchart from 'primevue/organizationchart';
+```
+
+---
+
+### Paginator
+
+**Name:** `paginator`
+
+**Description:** Navigation for paged data
+
+**Documentation:** [https://primevue.org/paginator/](https://primevue.org/paginator/)
+
+**Usage Example:**
+```vue
+import Paginator from 'primevue/paginator';
+```
+
+---
+
+### Picklist
+
+**Name:** `picklist`
+
+**Description:** Dual list for item transfer
+
+**Documentation:** [https://primevue.org/picklist/](https://primevue.org/picklist/)
+
+**Usage Example:**
+```vue
+import Picklist from 'primevue/picklist';
+```
+
+---
+
+### Timeline
+
+**Name:** `timeline`
+
+**Description:** Chronological event display
+
+**Documentation:** [https://primevue.org/timeline/](https://primevue.org/timeline/)
+
+**Usage Example:**
+```vue
+import Timeline from 'primevue/timeline';
+```
+
+---
+
+### Tree
+
+**Name:** `tree`
+
+**Description:** Hierarchical tree structure
+
+**Documentation:** [https://primevue.org/tree/](https://primevue.org/tree/)
+
+**Usage Example:**
+```vue
+import Tree from 'primevue/tree';
+```
+
+---
+
+### Treetable
+
+**Name:** `treetable`
+
+**Description:** Table with tree structure
+
+**Documentation:** [https://primevue.org/treetable/](https://primevue.org/treetable/)
+
+**Usage Example:**
+```vue
+import Treetable from 'primevue/treetable';
+```
+
+---
+
+### Virtualscroller
+
+**Name:** `virtualscroller`
+
+**Description:** Virtual scrolling for large datasets
+
+**Documentation:** [https://primevue.org/virtualscroller/](https://primevue.org/virtualscroller/)
+
+**Usage Example:**
+```vue
+import Virtualscroller from 'primevue/virtualscroller';
+```
+
+---
+
+## Directives
+
+### Animateonscroll
+
+**Name:** `animateonscroll`
+
+**Description:** Directive to apply animations when element becomes visible
+
+**Documentation:** [https://primevue.org/animateonscroll/](https://primevue.org/animateonscroll/)
+
+**Usage Example:**
+```vue
+import Animateonscroll from 'primevue/animateonscroll';
+```
+
+---
+
+### Badgedirective
+
+**Name:** `badgedirective`
+
+**Description:** Directive to add badges to any element
+
+**Documentation:** [https://primevue.org/badge/](https://primevue.org/badge/)
+
+**Usage Example:**
+```vue
+import Badgedirective from 'primevue/badgedirective';
+```
+
+---
+
+### Focustrap
+
+**Name:** `focustrap`
+
+**Description:** Directive to trap focus within element
+
+**Documentation:** [https://primevue.org/focustrap/](https://primevue.org/focustrap/)
+
+**Usage Example:**
+```vue
+import Focustrap from 'primevue/focustrap';
+```
+
+---
+
+### Keyfilter
+
+**Name:** `keyfilter`
+
+**Description:** Directive to filter keyboard input
+
+**Documentation:** [https://primevue.org/keyfilter/](https://primevue.org/keyfilter/)
+
+**Usage Example:**
+```vue
+import Keyfilter from 'primevue/keyfilter';
+```
+
+---
+
+### Ripple
+
+**Name:** `ripple`
+
+**Description:** Directive for material design ripple effect
+
+**Documentation:** [https://primevue.org/ripple/](https://primevue.org/ripple/)
+
+**Usage Example:**
+```vue
+import Ripple from 'primevue/ripple';
+```
+
+---
+
+### Styleclass
+
+**Name:** `styleclass`
+
+**Description:** Directive for dynamic styling
+
+**Documentation:** [https://primevue.org/styleclass/](https://primevue.org/styleclass/)
+
+**Usage Example:**
+```vue
+import Styleclass from 'primevue/styleclass';
+```
+
+---
+
+## File
+
+### Fileupload
+
+**Name:** `fileupload`
+
+**Description:** File upload component with drag-drop
+
+**Documentation:** [https://primevue.org/fileupload/](https://primevue.org/fileupload/)
+
+**Usage Example:**
+```vue
+import Fileupload from 'primevue/fileupload';
+```
+
+---
+
+## Form
+
+### Autocomplete
+
+**Name:** `autocomplete`
+
+**Description:** Provides filtered suggestions while typing input, supports multiple selection and custom item templates
+
+**Documentation:** [https://primevue.org/autocomplete/](https://primevue.org/autocomplete/)
+
+**Usage Example:**
+```vue
+import Autocomplete from 'primevue/autocomplete';
+```
+
+---
+
+### Calendar
+
+**Name:** `calendar`
+
+**Description:** Input component for date selection (legacy)
+
+**Documentation:** [https://primevue.org/calendar/](https://primevue.org/calendar/)
+
+**Usage Example:**
+```vue
+import Calendar from 'primevue/calendar';
+```
+
+---
+
+### Cascadeselect
+
+**Name:** `cascadeselect`
+
+**Description:** Nested dropdown selection component
+
+**Documentation:** [https://primevue.org/cascadeselect/](https://primevue.org/cascadeselect/)
+
+**Usage Example:**
+```vue
+import Cascadeselect from 'primevue/cascadeselect';
+```
+
+---
+
+### Checkbox
+
+**Name:** `checkbox`
+
+**Description:** Binary selection component
+
+**Documentation:** [https://primevue.org/checkbox/](https://primevue.org/checkbox/)
+
+**Usage Example:**
+```vue
+import Checkbox from 'primevue/checkbox';
+```
+
+---
+
+### Checkboxgroup
+
+**Name:** `checkboxgroup`
+
+**Description:** Groups multiple checkboxes
+
+**Documentation:** [https://primevue.org/checkbox/](https://primevue.org/checkbox/)
+
+**Usage Example:**
+```vue
+import Checkboxgroup from 'primevue/checkboxgroup';
+```
+
+---
+
+### Chips
+
+**Name:** `chips`
+
+**Description:** Input component for entering multiple values
+
+**Documentation:** [https://primevue.org/chips/](https://primevue.org/chips/)
+
+**Usage Example:**
+```vue
+import Chips from 'primevue/chips';
+```
+
+---
+
+### Colorpicker
+
+**Name:** `colorpicker`
+
+**Description:** Input component for color selection
+
+**Documentation:** [https://primevue.org/colorpicker/](https://primevue.org/colorpicker/)
+
+**Usage Example:**
+```vue
+import Colorpicker from 'primevue/colorpicker';
+```
+
+---
+
+### Datepicker
+
+**Name:** `datepicker`
+
+**Description:** Input component for date and time selection with calendar popup, supports date ranges and custom formatting
+
+**Documentation:** [https://primevue.org/datepicker/](https://primevue.org/datepicker/)
+
+**Usage Example:**
+```vue
+import Datepicker from 'primevue/datepicker';
+```
+
+---
+
+### Dropdown
+
+**Name:** `dropdown`
+
+**Description:** Single selection dropdown
+
+**Documentation:** [https://primevue.org/dropdown/](https://primevue.org/dropdown/)
+
+**Usage Example:**
+```vue
+import Dropdown from 'primevue/dropdown';
+```
+
+---
+
+### Editor
+
+**Name:** `editor`
+
+**Description:** Rich text editor component
+
+**Documentation:** [https://primevue.org/editor/](https://primevue.org/editor/)
+
+**Usage Example:**
+```vue
+import Editor from 'primevue/editor';
+```
+
+---
+
+### Floatlabel
+
+**Name:** `floatlabel`
+
+**Description:** Floating label for input components
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Floatlabel from 'primevue/floatlabel';
+```
+
+---
+
+### Iconfield
+
+**Name:** `iconfield`
+
+**Description:** Input field with icon
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Iconfield from 'primevue/iconfield';
+```
+
+---
+
+### Iftalabel
+
+**Name:** `iftalabel`
+
+**Description:** Input field with top-aligned label
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Iftalabel from 'primevue/iftalabel';
+```
+
+---
+
+### Inputchips
+
+**Name:** `inputchips`
+
+**Description:** Multiple input values as chips
+
+**Documentation:** [https://primevue.org/chips/](https://primevue.org/chips/)
+
+**Usage Example:**
+```vue
+import Inputchips from 'primevue/inputchips';
+```
+
+---
+
+### Inputgroup
+
+**Name:** `inputgroup`
+
+**Description:** Groups input elements
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputgroup from 'primevue/inputgroup';
+```
+
+---
+
+### Inputgroupaddon
+
+**Name:** `inputgroupaddon`
+
+**Description:** Addon for input groups
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputgroupaddon from 'primevue/inputgroupaddon';
+```
+
+---
+
+### Inputicon
+
+**Name:** `inputicon`
+
+**Description:** Icon for input components
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputicon from 'primevue/inputicon';
+```
+
+---
+
+### Inputmask
+
+**Name:** `inputmask`
+
+**Description:** Input with format masking
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputmask from 'primevue/inputmask';
+```
+
+---
+
+### Inputnumber
+
+**Name:** `inputnumber`
+
+**Description:** Numeric input with spinner
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputnumber from 'primevue/inputnumber';
+```
+
+---
+
+### Inputotp
+
+**Name:** `inputotp`
+
+**Description:** One-time password input
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputotp from 'primevue/inputotp';
+```
+
+---
+
+### Inputswitch
+
+**Name:** `inputswitch`
+
+**Description:** Binary switch component
+
+**Documentation:** [https://primevue.org/toggleswitch/](https://primevue.org/toggleswitch/)
+
+**Usage Example:**
+```vue
+import Inputswitch from 'primevue/inputswitch';
+```
+
+---
+
+### Inputtext
+
+**Name:** `inputtext`
+
+**Description:** Text input component
+
+**Documentation:** [https://primevue.org/inputtext/](https://primevue.org/inputtext/)
+
+**Usage Example:**
+```vue
+import Inputtext from 'primevue/inputtext';
+```
+
+---
+
+### Knob
+
+**Name:** `knob`
+
+**Description:** Circular input component
+
+**Documentation:** [https://primevue.org/knob/](https://primevue.org/knob/)
+
+**Usage Example:**
+```vue
+import Knob from 'primevue/knob';
+```
+
+---
+
+### Listbox
+
+**Name:** `listbox`
+
+**Description:** Selection component with list interface
+
+**Documentation:** [https://primevue.org/listbox/](https://primevue.org/listbox/)
+
+**Usage Example:**
+```vue
+import Listbox from 'primevue/listbox';
+```
+
+---
+
+### Multiselect
+
+**Name:** `multiselect`
+
+**Description:** Multiple selection dropdown
+
+**Documentation:** [https://primevue.org/multiselect/](https://primevue.org/multiselect/)
+
+**Usage Example:**
+```vue
+import Multiselect from 'primevue/multiselect';
+```
+
+---
+
+### Password
+
+**Name:** `password`
+
+**Description:** Password input with strength meter
+
+**Documentation:** [https://primevue.org/password/](https://primevue.org/password/)
+
+**Usage Example:**
+```vue
+import Password from 'primevue/password';
+```
+
+---
+
+### Radiobutton
+
+**Name:** `radiobutton`
+
+**Description:** Single selection from group
+
+**Documentation:** [https://primevue.org/radiobutton/](https://primevue.org/radiobutton/)
+
+**Usage Example:**
+```vue
+import Radiobutton from 'primevue/radiobutton';
+```
+
+---
+
+### Radiobuttongroup
+
+**Name:** `radiobuttongroup`
+
+**Description:** Groups radio buttons
+
+**Documentation:** [https://primevue.org/radiobutton/](https://primevue.org/radiobutton/)
+
+**Usage Example:**
+```vue
+import Radiobuttongroup from 'primevue/radiobuttongroup';
+```
+
+---
+
+### Rating
+
+**Name:** `rating`
+
+**Description:** Star rating input component
+
+**Documentation:** [https://primevue.org/rating/](https://primevue.org/rating/)
+
+**Usage Example:**
+```vue
+import Rating from 'primevue/rating';
+```
+
+---
+
+### Select
+
+**Name:** `select`
+
+**Description:** Modern dropdown selection
+
+**Documentation:** [https://primevue.org/select/](https://primevue.org/select/)
+
+**Usage Example:**
+```vue
+import Select from 'primevue/select';
+```
+
+---
+
+### Selectbutton
+
+**Name:** `selectbutton`
+
+**Description:** Button-style selection component
+
+**Documentation:** [https://primevue.org/selectbutton/](https://primevue.org/selectbutton/)
+
+**Usage Example:**
+```vue
+import Selectbutton from 'primevue/selectbutton';
+```
+
+---
+
+### Slider
+
+**Name:** `slider`
+
+**Description:** Range selection component
+
+**Documentation:** [https://primevue.org/slider/](https://primevue.org/slider/)
+
+**Usage Example:**
+```vue
+import Slider from 'primevue/slider';
+```
+
+---
+
+### Textarea
+
+**Name:** `textarea`
+
+**Description:** Multi-line text input
+
+**Documentation:** [https://primevue.org/textarea/](https://primevue.org/textarea/)
+
+**Usage Example:**
+```vue
+import Textarea from 'primevue/textarea';
+```
+
+---
+
+### Togglebutton
+
+**Name:** `togglebutton`
+
+**Description:** Two-state button component
+
+**Documentation:** [https://primevue.org/togglebutton/](https://primevue.org/togglebutton/)
+
+**Usage Example:**
+```vue
+import Togglebutton from 'primevue/togglebutton';
+```
+
+---
+
+### Toggleswitch
+
+**Name:** `toggleswitch`
+
+**Description:** Switch component for binary state
+
+**Documentation:** [https://primevue.org/toggleswitch/](https://primevue.org/toggleswitch/)
+
+**Usage Example:**
+```vue
+import Toggleswitch from 'primevue/toggleswitch';
+```
+
+---
+
+### Treeselect
+
+**Name:** `treeselect`
+
+**Description:** Tree-structured selection
+
+**Documentation:** [https://primevue.org/treeselect/](https://primevue.org/treeselect/)
+
+**Usage Example:**
+```vue
+import Treeselect from 'primevue/treeselect';
+```
+
+---
+
+## Media
+
+### Galleria
+
+**Name:** `galleria`
+
+**Description:** Image gallery with thumbnails
+
+**Documentation:** [https://primevue.org/galleria/](https://primevue.org/galleria/)
+
+**Usage Example:**
+```vue
+import Galleria from 'primevue/galleria';
+```
+
+---
+
+### Image
+
+**Name:** `image`
+
+**Description:** Enhanced image component with preview
+
+**Documentation:** [https://primevue.org/image/](https://primevue.org/image/)
+
+**Usage Example:**
+```vue
+import Image from 'primevue/image';
+```
+
+---
+
+### Imagecompare
+
+**Name:** `imagecompare`
+
+**Description:** Before/after image comparison slider
+
+**Documentation:** [https://primevue.org/imagecompare/](https://primevue.org/imagecompare/)
+
+**Usage Example:**
+```vue
+import Imagecompare from 'primevue/imagecompare';
+```
+
+---
+
+## Menu
+
+### Breadcrumb
+
+**Name:** `breadcrumb`
+
+**Description:** Navigation component showing current page location
+
+**Documentation:** [https://primevue.org/breadcrumb/](https://primevue.org/breadcrumb/)
+
+**Usage Example:**
+```vue
+import Breadcrumb from 'primevue/breadcrumb';
+```
+
+---
+
+### Contextmenu
+
+**Name:** `contextmenu`
+
+**Description:** Right-click context menu
+
+**Documentation:** [https://primevue.org/contextmenu/](https://primevue.org/contextmenu/)
+
+**Usage Example:**
+```vue
+import Contextmenu from 'primevue/contextmenu';
+```
+
+---
+
+### Dock
+
+**Name:** `dock`
+
+**Description:** Dock layout with expandable items
+
+**Documentation:** [https://primevue.org/dock/](https://primevue.org/dock/)
+
+**Usage Example:**
+```vue
+import Dock from 'primevue/dock';
+```
+
+---
+
+### Megamenu
+
+**Name:** `megamenu`
+
+**Description:** Navigation with grouped menu items
+
+**Documentation:** [https://primevue.org/megamenu/](https://primevue.org/megamenu/)
+
+**Usage Example:**
+```vue
+import Megamenu from 'primevue/megamenu';
+```
+
+---
+
+### Menu
+
+**Name:** `menu`
+
+**Description:** Navigation menu component
+
+**Documentation:** [https://primevue.org/menu/](https://primevue.org/menu/)
+
+**Usage Example:**
+```vue
+import Menu from 'primevue/menu';
+```
+
+---
+
+### Menubar
+
+**Name:** `menubar`
+
+**Description:** Horizontal navigation menu
+
+**Documentation:** [https://primevue.org/menubar/](https://primevue.org/menubar/)
+
+**Usage Example:**
+```vue
+import Menubar from 'primevue/menubar';
+```
+
+---
+
+### Panelmenu
+
+**Name:** `panelmenu`
+
+**Description:** Vertical navigation menu
+
+**Documentation:** [https://primevue.org/panelmenu/](https://primevue.org/panelmenu/)
+
+**Usage Example:**
+```vue
+import Panelmenu from 'primevue/panelmenu';
+```
+
+---
+
+### Steps
+
+**Name:** `steps`
+
+**Description:** Step-by-step navigation
+
+**Documentation:** [https://primevue.org/steps/](https://primevue.org/steps/)
+
+**Usage Example:**
+```vue
+import Steps from 'primevue/steps';
+```
+
+---
+
+### Tabmenu
+
+**Name:** `tabmenu`
+
+**Description:** Menu styled as tabs
+
+**Documentation:** [https://primevue.org/tabmenu/](https://primevue.org/tabmenu/)
+
+**Usage Example:**
+```vue
+import Tabmenu from 'primevue/tabmenu';
+```
+
+---
+
+### Tieredmenu
+
+**Name:** `tieredmenu`
+
+**Description:** Hierarchical menu component
+
+**Documentation:** [https://primevue.org/tieredmenu/](https://primevue.org/tieredmenu/)
+
+**Usage Example:**
+```vue
+import Tieredmenu from 'primevue/tieredmenu';
+```
+
+---
+
+## Messages
+
+### Inlinemessage
+
+**Name:** `inlinemessage`
+
+**Description:** Inline message display
+
+**Documentation:** [https://primevue.org/inlinemessage/](https://primevue.org/inlinemessage/)
+
+**Usage Example:**
+```vue
+import Inlinemessage from 'primevue/inlinemessage';
+```
+
+---
+
+### Message
+
+**Name:** `message`
+
+**Description:** Message component for notifications
+
+**Documentation:** [https://primevue.org/message/](https://primevue.org/message/)
+
+**Usage Example:**
+```vue
+import Message from 'primevue/message';
+```
+
+---
+
+### Toast
+
+**Name:** `toast`
+
+**Description:** Temporary message notifications
+
+**Documentation:** [https://primevue.org/toast/](https://primevue.org/toast/)
+
+**Usage Example:**
+```vue
+import Toast from 'primevue/toast';
+```
+
+---
+
+## Misc
+
+### Avatar
+
+**Name:** `avatar`
+
+**Description:** Represents people using icons, labels and images
+
+**Documentation:** [https://primevue.org/avatar/](https://primevue.org/avatar/)
+
+**Usage Example:**
+```vue
+import Avatar from 'primevue/avatar';
+```
+
+---
+
+### Avatargroup
+
+**Name:** `avatargroup`
+
+**Description:** Groups multiple avatars together
+
+**Documentation:** [https://primevue.org/avatar/](https://primevue.org/avatar/)
+
+**Usage Example:**
+```vue
+import Avatargroup from 'primevue/avatargroup';
+```
+
+---
+
+### Badge
+
+**Name:** `badge`
+
+**Description:** Small numeric indicator for other components
+
+**Documentation:** [https://primevue.org/badge/](https://primevue.org/badge/)
+
+**Usage Example:**
+```vue
+import Badge from 'primevue/badge';
+```
+
+---
+
+### Blockui
+
+**Name:** `blockui`
+
+**Description:** Blocks user interaction with page elements
+
+**Documentation:** [https://primevue.org/blockui/](https://primevue.org/blockui/)
+
+**Usage Example:**
+```vue
+import Blockui from 'primevue/blockui';
+```
+
+---
+
+### Chip
+
+**Name:** `chip`
+
+**Description:** Compact element representing input, attribute or action
+
+**Documentation:** [https://primevue.org/chip/](https://primevue.org/chip/)
+
+**Usage Example:**
+```vue
+import Chip from 'primevue/chip';
+```
+
+---
+
+### Inplace
+
+**Name:** `inplace`
+
+**Description:** Editable content in place
+
+**Documentation:** [https://primevue.org/inplace/](https://primevue.org/inplace/)
+
+**Usage Example:**
+```vue
+import Inplace from 'primevue/inplace';
+```
+
+---
+
+### Metergroup
+
+**Name:** `metergroup`
+
+**Description:** Displays multiple meter values
+
+**Documentation:** [https://primevue.org/metergroup/](https://primevue.org/metergroup/)
+
+**Usage Example:**
+```vue
+import Metergroup from 'primevue/metergroup';
+```
+
+---
+
+### Overlaybadge
+
+**Name:** `overlaybadge`
+
+**Description:** Badge overlay for components
+
+**Documentation:** [https://primevue.org/badge/](https://primevue.org/badge/)
+
+**Usage Example:**
+```vue
+import Overlaybadge from 'primevue/overlaybadge';
+```
+
+---
+
+### Progressbar
+
+**Name:** `progressbar`
+
+**Description:** Progress indication component
+
+**Documentation:** [https://primevue.org/progressbar/](https://primevue.org/progressbar/)
+
+**Usage Example:**
+```vue
+import Progressbar from 'primevue/progressbar';
+```
+
+---
+
+### Progressspinner
+
+**Name:** `progressspinner`
+
+**Description:** Loading spinner component
+
+**Documentation:** [https://primevue.org/progressspinner/](https://primevue.org/progressspinner/)
+
+**Usage Example:**
+```vue
+import Progressspinner from 'primevue/progressspinner';
+```
+
+---
+
+### Skeleton
+
+**Name:** `skeleton`
+
+**Description:** Placeholder for loading content
+
+**Documentation:** [https://primevue.org/skeleton/](https://primevue.org/skeleton/)
+
+**Usage Example:**
+```vue
+import Skeleton from 'primevue/skeleton';
+```
+
+---
+
+### Tag
+
+**Name:** `tag`
+
+**Description:** Label component for categorization
+
+**Documentation:** [https://primevue.org/tag/](https://primevue.org/tag/)
+
+**Usage Example:**
+```vue
+import Tag from 'primevue/tag';
+```
+
+---
+
+### Terminal
+
+**Name:** `terminal`
+
+**Description:** Command line interface
+
+**Documentation:** [https://primevue.org/terminal/](https://primevue.org/terminal/)
+
+**Usage Example:**
+```vue
+import Terminal from 'primevue/terminal';
+```
+
+---
+
+## Overlay
+
+### Confirmdialog
+
+**Name:** `confirmdialog`
+
+**Description:** Modal dialog for user confirmation
+
+**Documentation:** [https://primevue.org/confirmdialog/](https://primevue.org/confirmdialog/)
+
+**Usage Example:**
+```vue
+import Confirmdialog from 'primevue/confirmdialog';
+```
+
+---
+
+### Confirmpopup
+
+**Name:** `confirmpopup`
+
+**Description:** Popup for user confirmation
+
+**Documentation:** [https://primevue.org/confirmdialog/](https://primevue.org/confirmdialog/)
+
+**Usage Example:**
+```vue
+import Confirmpopup from 'primevue/confirmpopup';
+```
+
+---
+
+### Dialog
+
+**Name:** `dialog`
+
+**Description:** Modal dialog component
+
+**Documentation:** [https://primevue.org/dialog/](https://primevue.org/dialog/)
+
+**Usage Example:**
+```vue
+import Dialog from 'primevue/dialog';
+```
+
+---
+
+### Drawer
+
+**Name:** `drawer`
+
+**Description:** Sliding panel overlay
+
+**Documentation:** [https://primevue.org/drawer/](https://primevue.org/drawer/)
+
+**Usage Example:**
+```vue
+import Drawer from 'primevue/drawer';
+```
+
+---
+
+### Dynamicdialog
+
+**Name:** `dynamicdialog`
+
+**Description:** Programmatically created dialogs
+
+**Documentation:** [https://primevue.org/dynamicdialog/](https://primevue.org/dynamicdialog/)
+
+**Usage Example:**
+```vue
+import Dynamicdialog from 'primevue/dynamicdialog';
+```
+
+---
+
+### Overlaypanel
+
+**Name:** `overlaypanel`
+
+**Description:** Overlay panel component
+
+**Documentation:** [https://primevue.org/overlaypanel/](https://primevue.org/overlaypanel/)
+
+**Usage Example:**
+```vue
+import Overlaypanel from 'primevue/overlaypanel';
+```
+
+---
+
+### Popover
+
+**Name:** `popover`
+
+**Description:** Overlay component triggered by user interaction
+
+**Documentation:** [https://primevue.org/popover/](https://primevue.org/popover/)
+
+**Usage Example:**
+```vue
+import Popover from 'primevue/popover';
+```
+
+---
+
+### Sidebar
+
+**Name:** `sidebar`
+
+**Description:** Side panel overlay
+
+**Documentation:** [https://primevue.org/sidebar/](https://primevue.org/sidebar/)
+
+**Usage Example:**
+```vue
+import Sidebar from 'primevue/sidebar';
+```
+
+---
+
+### Tooltip
+
+**Name:** `tooltip`
+
+**Description:** Informational popup on hover
+
+**Documentation:** [https://primevue.org/tooltip/](https://primevue.org/tooltip/)
+
+**Usage Example:**
+```vue
+import Tooltip from 'primevue/tooltip';
+```
+
+---
+
+## Panel
+
+### Accordion
+
+**Name:** `accordion`
+
+**Description:** Groups a collection of contents in tabs
+
+**Documentation:** [https://primevue.org/accordion/](https://primevue.org/accordion/)
+
+**Usage Example:**
+```vue
+import Accordion from 'primevue/accordion';
+```
+
+---
+
+### Accordioncontent
+
+**Name:** `accordioncontent`
+
+**Description:** Content container for accordion panels
+
+**Documentation:** [https://primevue.org/accordion/](https://primevue.org/accordion/)
+
+**Usage Example:**
+```vue
+import Accordioncontent from 'primevue/accordioncontent';
+```
+
+---
+
+### Accordionheader
+
+**Name:** `accordionheader`
+
+**Description:** Header section for accordion panels
+
+**Documentation:** [https://primevue.org/accordion/](https://primevue.org/accordion/)
+
+**Usage Example:**
+```vue
+import Accordionheader from 'primevue/accordionheader';
+```
+
+---
+
+### Accordionpanel
+
+**Name:** `accordionpanel`
+
+**Description:** Individual panel in an accordion
+
+**Documentation:** [https://primevue.org/accordion/](https://primevue.org/accordion/)
+
+**Usage Example:**
+```vue
+import Accordionpanel from 'primevue/accordionpanel';
+```
+
+---
+
+### Accordiontab
+
+**Name:** `accordiontab`
+
+**Description:** Legacy accordion tab component
+
+**Documentation:** [https://primevue.org/accordion/](https://primevue.org/accordion/)
+
+**Usage Example:**
+```vue
+import Accordiontab from 'primevue/accordiontab';
+```
+
+---
+
+### Card
+
+**Name:** `card`
+
+**Description:** Flexible content container
+
+**Documentation:** [https://primevue.org/card/](https://primevue.org/card/)
+
+**Usage Example:**
+```vue
+import Card from 'primevue/card';
+```
+
+---
+
+### Deferredcontent
+
+**Name:** `deferredcontent`
+
+**Description:** Loads content on demand
+
+**Documentation:** [https://primevue.org/deferredcontent/](https://primevue.org/deferredcontent/)
+
+**Usage Example:**
+```vue
+import Deferredcontent from 'primevue/deferredcontent';
+```
+
+---
+
+### Divider
+
+**Name:** `divider`
+
+**Description:** Separator component
+
+**Documentation:** [https://primevue.org/divider/](https://primevue.org/divider/)
+
+**Usage Example:**
+```vue
+import Divider from 'primevue/divider';
+```
+
+---
+
+### Fieldset
+
+**Name:** `fieldset`
+
+**Description:** Groups related form elements
+
+**Documentation:** [https://primevue.org/fieldset/](https://primevue.org/fieldset/)
+
+**Usage Example:**
+```vue
+import Fieldset from 'primevue/fieldset';
+```
+
+---
+
+### Panel
+
+**Name:** `panel`
+
+**Description:** Collapsible content container
+
+**Documentation:** [https://primevue.org/panel/](https://primevue.org/panel/)
+
+**Usage Example:**
+```vue
+import Panel from 'primevue/panel';
+```
+
+---
+
+### Scrollpanel
+
+**Name:** `scrollpanel`
+
+**Description:** Scrollable content container
+
+**Documentation:** [https://primevue.org/scrollpanel/](https://primevue.org/scrollpanel/)
+
+**Usage Example:**
+```vue
+import Scrollpanel from 'primevue/scrollpanel';
+```
+
+---
+
+### Splitter
+
+**Name:** `splitter`
+
+**Description:** Resizable split panels
+
+**Documentation:** [https://primevue.org/splitter/](https://primevue.org/splitter/)
+
+**Usage Example:**
+```vue
+import Splitter from 'primevue/splitter';
+```
+
+---
+
+### Splitterpanel
+
+**Name:** `splitterpanel`
+
+**Description:** Panel within splitter
+
+**Documentation:** [https://primevue.org/splitter/](https://primevue.org/splitter/)
+
+**Usage Example:**
+```vue
+import Splitterpanel from 'primevue/splitterpanel';
+```
+
+---
+
+### Tab
+
+**Name:** `tab`
+
+**Description:** Individual tab component
+
+**Documentation:** [https://primevue.org/tabs/](https://primevue.org/tabs/)
+
+**Usage Example:**
+```vue
+import Tab from 'primevue/tab';
+```
+
+---
+
+### Tablist
+
+**Name:** `tablist`
+
+**Description:** Container for tabs
+
+**Documentation:** [https://primevue.org/tabs/](https://primevue.org/tabs/)
+
+**Usage Example:**
+```vue
+import Tablist from 'primevue/tablist';
+```
+
+---
+
+### Tabpanel
+
+**Name:** `tabpanel`
+
+**Description:** Content panel for tabs
+
+**Documentation:** [https://primevue.org/tabs/](https://primevue.org/tabs/)
+
+**Usage Example:**
+```vue
+import Tabpanel from 'primevue/tabpanel';
+```
+
+---
+
+### Tabpanels
+
+**Name:** `tabpanels`
+
+**Description:** Container for tab panels
+
+**Documentation:** [https://primevue.org/tabs/](https://primevue.org/tabs/)
+
+**Usage Example:**
+```vue
+import Tabpanels from 'primevue/tabpanels';
+```
+
+---
+
+### Tabs
+
+**Name:** `tabs`
+
+**Description:** Modern tab container
+
+**Documentation:** [https://primevue.org/tabs/](https://primevue.org/tabs/)
+
+**Usage Example:**
+```vue
+import Tabs from 'primevue/tabs';
+```
+
+---
+
+### Tabview
+
+**Name:** `tabview`
+
+**Description:** Legacy tabbed interface
+
+**Documentation:** [https://primevue.org/tabview/](https://primevue.org/tabview/)
+
+**Usage Example:**
+```vue
+import Tabview from 'primevue/tabview';
+```
+
+---
+
+## Stepper
+
+### Step
+
+**Name:** `step`
+
+**Description:** Individual step in stepper
+
+**Documentation:** [https://primevue.org/stepper/](https://primevue.org/stepper/)
+
+**Usage Example:**
+```vue
+import Step from 'primevue/step';
+```
+
+---
+
+### Stepitem
+
+**Name:** `stepitem`
+
+**Description:** Item within step
+
+**Documentation:** [https://primevue.org/stepper/](https://primevue.org/stepper/)
+
+**Usage Example:**
+```vue
+import Stepitem from 'primevue/stepitem';
+```
+
+---
+
+### Steplist
+
+**Name:** `steplist`
+
+**Description:** List of steps
+
+**Documentation:** [https://primevue.org/stepper/](https://primevue.org/stepper/)
+
+**Usage Example:**
+```vue
+import Steplist from 'primevue/steplist';
+```
+
+---
+
+### Steppanel
+
+**Name:** `steppanel`
+
+**Description:** Content panel for stepper
+
+**Documentation:** [https://primevue.org/stepper/](https://primevue.org/stepper/)
+
+**Usage Example:**
+```vue
+import Steppanel from 'primevue/steppanel';
+```
+
+---
+
+### Steppanels
+
+**Name:** `steppanels`
+
+**Description:** Container for step panels
+
+**Documentation:** [https://primevue.org/stepper/](https://primevue.org/stepper/)
+
+**Usage Example:**
+```vue
+import Steppanels from 'primevue/steppanels';
+```
+
+---
+
+### Stepper
+
+**Name:** `stepper`
+
+**Description:** Multi-step process navigation
+
+**Documentation:** [https://primevue.org/stepper/](https://primevue.org/stepper/)
+
+**Usage Example:**
+```vue
+import Stepper from 'primevue/stepper';
+```
+
+---
+
+## Uncategorized
+
+### Config
+
+**Name:** `config`
+
+**Description:** Configuration utility for global PrimeVue settings including theming, locale, and component options
+
+**Documentation:** [https://primevue.org/config/](https://primevue.org/config/)
+
+**Usage Example:**
+```vue
+import Config from 'primevue/config';
+```
+
+---
+
+### Confirmationeventbus
+
+**Name:** `confirmationeventbus`
+
+**Description:** Internal event bus system for managing confirmation dialog events and communication
+
+**Documentation:** [https://primevue.org/confirmdialog/](https://primevue.org/confirmdialog/)
+
+**Usage Example:**
+```vue
+import Confirmationeventbus from 'primevue/confirmationeventbus';
+```
+
+---
+
+### Confirmationoptions
+
+**Name:** `confirmationoptions`
+
+**Description:** TypeScript interface definitions for confirmation dialog configuration options
+
+**Documentation:** [https://primevue.org/confirmdialog/](https://primevue.org/confirmdialog/)
+
+**Usage Example:**
+```vue
+import Confirmationoptions from 'primevue/confirmationoptions';
+```
+
+---
+
+### Dynamicdialogeventbus
+
+**Name:** `dynamicdialogeventbus`
+
+**Description:** Internal event bus system for managing dynamic dialog creation and communication
+
+**Documentation:** [https://primevue.org/dynamicdialog/](https://primevue.org/dynamicdialog/)
+
+**Usage Example:**
+```vue
+import Dynamicdialogeventbus from 'primevue/dynamicdialogeventbus';
+```
+
+---
+
+### Dynamicdialogoptions
+
+**Name:** `dynamicdialogoptions`
+
+**Description:** TypeScript interface definitions for dynamic dialog configuration options
+
+**Documentation:** [https://primevue.org/dynamicdialog/](https://primevue.org/dynamicdialog/)
+
+**Usage Example:**
+```vue
+import Dynamicdialogoptions from 'primevue/dynamicdialogoptions';
+```
+
+---
+
+### Menuitem
+
+**Name:** `menuitem`
+
+**Description:** TypeScript interface definitions for menu item configuration shared across menu components
+
+**Documentation:** [https://primevue.org/menuitem/](https://primevue.org/menuitem/)
+
+**Usage Example:**
+```vue
+import Menuitem from 'primevue/menuitem';
+```
+
+---
+
+### Overlayeventbus
+
+**Name:** `overlayeventbus`
+
+**Description:** Internal event bus system for managing overlay component events and communication
+
+**Documentation:** [https://primevue.org/overlaypanel/](https://primevue.org/overlaypanel/)
+
+**Usage Example:**
+```vue
+import Overlayeventbus from 'primevue/overlayeventbus';
+```
+
+---
+
+### Passthrough
+
+**Name:** `passthrough`
+
+**Description:** Utility for customizing component styling and attributes through pass-through properties
+
+**Documentation:** [https://primevue.org/passthrough/](https://primevue.org/passthrough/)
+
+**Usage Example:**
+```vue
+import Passthrough from 'primevue/passthrough';
+```
+
+---
+
+### Toasteventbus
+
+**Name:** `toasteventbus`
+
+**Description:** Internal event bus system for managing toast notification events and communication
+
+**Documentation:** [https://primevue.org/toast/](https://primevue.org/toast/)
+
+**Usage Example:**
+```vue
+import Toasteventbus from 'primevue/toasteventbus';
+```
+
+---
+
+### Toastservice
+
+**Name:** `toastservice`
+
+**Description:** Service for programmatically displaying and managing toast notifications
+
+**Documentation:** [https://primevue.org/toast/](https://primevue.org/toast/)
+
+**Usage Example:**
+```vue
+import Toastservice from 'primevue/toastservice';
+```
+
+---
+
+### Toolbar
+
+**Name:** `toolbar`
+
+**Description:** Container for action buttons
+
+**Documentation:** [https://primevue.org/toolbar/](https://primevue.org/toolbar/)
+
+**Usage Example:**
+```vue
+import Toolbar from 'primevue/toolbar';
+```
+
+---
+
+### Treenode
+
+**Name:** `treenode`
+
+**Description:** Individual node in tree
+
+**Documentation:** [https://primevue.org/tree/](https://primevue.org/tree/)
+
+**Usage Example:**
+```vue
+import Treenode from 'primevue/treenode';
+```
+
+---
+
+## Utilities
+
+### Column
+
+**Name:** `column`
+
+**Description:** Table column component for DataTable
+
+**Documentation:** [https://primevue.org/datatable/](https://primevue.org/datatable/)
+
+**Usage Example:**
+```vue
+import Column from 'primevue/column';
+```
+
+---
+
+### Columngroup
+
+**Name:** `columngroup`
+
+**Description:** Groups table columns
+
+**Documentation:** [https://primevue.org/datatable/](https://primevue.org/datatable/)
+
+**Usage Example:**
+```vue
+import Columngroup from 'primevue/columngroup';
+```
+
+---
+
+### Confirmationservice
+
+**Name:** `confirmationservice`
+
+**Description:** Service for programmatically displaying and managing confirmation dialogs
+
+**Documentation:** [https://primevue.org/confirmdialog/](https://primevue.org/confirmdialog/)
+
+**Usage Example:**
+```vue
+import Confirmationservice from 'primevue/confirmationservice';
+```
+
+---
+
+### Dialogservice
+
+**Name:** `dialogservice`
+
+**Description:** Service for dynamic dialog creation
+
+**Documentation:** [https://primevue.org/dialogservice/](https://primevue.org/dialogservice/)
+
+**Usage Example:**
+```vue
+import Dialogservice from 'primevue/dialogservice';
+```
+
+---
+
+### Fluid
+
+**Name:** `fluid`
+
+**Description:** Container with fluid width
+
+**Documentation:** [https://primevue.org/fluid/](https://primevue.org/fluid/)
+
+**Usage Example:**
+```vue
+import Fluid from 'primevue/fluid';
+```
+
+---
+
+### Portal
+
+**Name:** `portal`
+
+**Description:** Renders content in different DOM location
+
+**Documentation:** [https://primevue.org/portal/](https://primevue.org/portal/)
+
+**Usage Example:**
+```vue
+import Portal from 'primevue/portal';
+```
+
+---
+
+### Row
+
+**Name:** `row`
+
+**Description:** Table row component
+
+**Documentation:** [https://primevue.org/datatable/](https://primevue.org/datatable/)
+
+**Usage Example:**
+```vue
+import Row from 'primevue/row';
+```
+
+---
+
+### Scrolltop
+
+**Name:** `scrolltop`
+
+**Description:** Button to scroll to top
+
+**Documentation:** [https://primevue.org/scrolltop/](https://primevue.org/scrolltop/)
+
+**Usage Example:**
+```vue
+import Scrolltop from 'primevue/scrolltop';
+```
+
+---
+
+### Terminalservice
+
+**Name:** `terminalservice`
+
+**Description:** Service for terminal component
+
+**Documentation:** [https://primevue.org/terminal/](https://primevue.org/terminal/)
+
+**Usage Example:**
+```vue
+import Terminalservice from 'primevue/terminalservice';
+```
+
+---
+
+### Useconfirm
+
+**Name:** `useconfirm`
+
+**Description:** Composable for confirmation dialogs
+
+**Documentation:** [https://primevue.org/confirmdialog/](https://primevue.org/confirmdialog/)
+
+**Usage Example:**
+```vue
+import Useconfirm from 'primevue/useconfirm';
+```
+
+---
+
+### Usedialog
+
+**Name:** `usedialog`
+
+**Description:** Composable for dynamic dialogs
+
+**Documentation:** [https://primevue.org/dynamicdialog/](https://primevue.org/dynamicdialog/)
+
+**Usage Example:**
+```vue
+import Usedialog from 'primevue/usedialog';
+```
+
+---
+
+### Usestyle
+
+**Name:** `usestyle`
+
+**Description:** Composable for dynamic styling
+
+**Documentation:** [https://primevue.org/usestyle/](https://primevue.org/usestyle/)
+
+**Usage Example:**
+```vue
+import Usestyle from 'primevue/usestyle';
+```
+
+---
+
+### Usetoast
+
+**Name:** `usetoast`
+
+**Description:** Composable for toast notifications
+
+**Documentation:** [https://primevue.org/toast/](https://primevue.org/toast/)
+
+**Usage Example:**
+```vue
+import Usetoast from 'primevue/usetoast';
+```
+
+---
+

--- a/vue-widget-conversion/vue-widget-guide.md
+++ b/vue-widget-conversion/vue-widget-guide.md
@@ -1,0 +1,552 @@
+# Step-by-Step Guide: Converting Widgets to Vue Components in ComfyUI
+
+## Overview
+This guide explains how to convert existing DOM widgets or create new widgets using Vue components in ComfyUI. The Vue widget system provides better reactivity, type safety, and maintainability compared to traditional DOM manipulation.
+
+## Prerequisites
+- Understanding of Vue 3 Composition API
+- Basic knowledge of TypeScript
+- Familiarity with ComfyUI widget system
+
+## Step 1: Create the Vue Component
+
+Create a new Vue component in `src/components/graph/widgets/`:
+
+```vue
+<!-- src/components/graph/widgets/YourWidget.vue -->
+<template>
+  <div class="your-widget-container">
+    <!-- Your widget UI here -->
+    <input 
+      v-model="modelValue" 
+      type="text"
+      class="w-full px-2 py-1 rounded"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineModel, defineProps } from 'vue'
+import type { ComponentWidget } from '@/types'
+
+// Define two-way binding for the widget value
+const modelValue = defineModel<string>({ required: true })
+
+// Receive widget configuration
+const { widget } = defineProps<{
+  widget: ComponentWidget<string>
+}>()
+
+// Access widget properties
+const inputSpec = widget.inputSpec
+const options = inputSpec.options || {}
+
+// Add any logic necessary here to make a functional, feature-rich widget.
+// You can use the vueuse library for helper functions.
+// You can take liberty in things to add, as this is just a prototype.
+</script>
+
+<style scoped>
+/* Use Tailwind classes in template, custom CSS here if needed */
+</style>
+```
+
+## Step 2: Create the Widget Composables (Dual Pattern)
+
+The Vue widget system uses a **dual composable pattern** for separation of concerns:
+
+### 2a. Create the Widget Constructor Composable
+
+Create the core widget constructor in `src/composables/widgets/`:
+
+```typescript
+// src/composables/widgets/useYourWidget.ts
+import { ref } from 'vue'
+import type { LGraphNode } from '@comfyorg/litegraph'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import YourWidget from '@/components/graph/widgets/YourWidget.vue'
+
+const PADDING = 8
+
+export const useYourWidget = (options: { defaultValue?: string } = {}) => {
+  const widgetConstructor: ComfyWidgetConstructorV2 = (
+    node: LGraphNode,
+    inputSpec: InputSpec
+  ) => {
+    // Initialize widget value
+    const widgetValue = ref<string>(options.defaultValue ?? '')
+    
+    // Create the widget instance
+    const widget = new ComponentWidgetImpl<string>({
+      node,
+      name: inputSpec.name,
+      component: YourWidget,
+      inputSpec,
+      options: {
+        // Required: getter for widget value
+        getValue: () => widgetValue.value,
+        
+        // Required: setter for widget value
+        setValue: (value: string) => {
+          widgetValue.value = value
+        },
+        
+        // Optional: minimum height for the widget
+        getMinHeight: () => options.minHeight ?? 40 + PADDING,
+        
+        // Optional: whether to serialize this widget's value
+        serialize: true,
+        
+        // Optional: custom serialization
+        serializeValue: (value: string) => {
+          return { yourWidget: value }
+        }
+      }
+    })
+    
+    // Register the widget with the node
+    addWidget(node, widget)
+    
+    return widget
+  }
+  
+  return widgetConstructor
+}
+```
+
+### 2b. Create the Node-Level Logic Composable (When Needed)
+
+**Only create this if your widget needs dynamic management** (showing/hiding widgets based on events, execution state, etc.). Most standard widgets only need the widget constructor composable.
+
+For widgets that need node-level operations (like showing/hiding widgets dynamically), create a separate composable in `src/composables/node/`:
+
+```typescript
+// src/composables/node/useNodeYourWidget.ts
+import type { LGraphNode } from '@comfyorg/litegraph'
+import { useYourWidget } from '@/composables/widgets/useYourWidget'
+
+const YOUR_WIDGET_NAME = '$$node-your-widget'
+
+/**
+ * Composable for handling node-level operations for YourWidget
+ */
+export function useNodeYourWidget() {
+  const yourWidget = useYourWidget()
+
+  const findYourWidget = (node: LGraphNode) =>
+    node.widgets?.find((w) => w.name === YOUR_WIDGET_NAME)
+
+  const addYourWidget = (node: LGraphNode) =>
+    yourWidget(node, {
+      name: YOUR_WIDGET_NAME,
+      type: 'yourWidgetType'
+    })
+
+  /**
+   * Shows your widget for a node
+   * @param node The graph node to show the widget for
+   * @param value The value to set
+   */
+  function showYourWidget(node: LGraphNode, value: string) {
+    const widget = findYourWidget(node) ?? addYourWidget(node)
+    widget.value = value
+    node.setDirtyCanvas?.(true)
+  }
+
+  /**
+   * Removes your widget from a node
+   * @param node The graph node to remove the widget from
+   */
+  function removeYourWidget(node: LGraphNode) {
+    if (!node.widgets) return
+
+    const widgetIdx = node.widgets.findIndex(
+      (w) => w.name === YOUR_WIDGET_NAME
+    )
+
+    if (widgetIdx > -1) {
+      node.widgets[widgetIdx].onRemove?.()
+      node.widgets.splice(widgetIdx, 1)
+    }
+  }
+
+  return {
+    showYourWidget,
+    removeYourWidget
+  }
+}
+```
+
+## Step 3: Register the Widget
+
+Add your widget to the global widget registry in `src/scripts/widgets.ts`:
+
+```typescript
+// src/scripts/widgets.ts
+import { useYourWidget } from '@/composables/widgets/useYourWidget'
+import { transformWidgetConstructorV2ToV1 } from '@/scripts/utils'
+
+export const ComfyWidgets: Record<string, ComfyWidgetConstructor> = {
+  // ... existing widgets ...
+  YOUR_WIDGET: transformWidgetConstructorV2ToV1(useYourWidget()),
+}
+```
+
+## Step 4: Handle Widget-Specific Logic
+
+For widgets that need special handling (e.g., listening to execution events):
+
+```typescript
+// In your composable or a separate composable
+import { useExecutionStore } from '@/stores/executionStore'
+import { watchEffect, onUnmounted } from 'vue'
+
+export const useYourWidgetLogic = (nodeId: string) => {
+  const executionStore = useExecutionStore()
+  
+  // Watch for execution state changes
+  const stopWatcher = watchEffect(() => {
+    if (executionStore.isNodeExecuting(nodeId)) {
+      // Handle execution start
+    }
+  })
+  
+  // Cleanup
+  onUnmounted(() => {
+    stopWatcher()
+  })
+}
+```
+
+## Step 5: Handle Complex Widget Types
+
+For widgets with complex data types or special requirements:
+
+```typescript
+// Multi-value widget example
+const widget = new ComponentWidgetImpl<string[]>({
+  node,
+  name: inputSpec.name,
+  component: MultiSelectWidget,
+  inputSpec,
+  options: {
+    getValue: () => widgetValue.value,
+    setValue: (value: string[]) => {
+      widgetValue.value = Array.isArray(value) ? value : []
+    },
+    getMinHeight: () => 40 + PADDING,
+    
+    // Custom validation
+    isValid: (value: string[]) => {
+      return Array.isArray(value) && value.length > 0
+    }
+  }
+})
+```
+
+## Step 6: Add Widget Props (Optional)
+
+Pass additional props to your Vue component:
+
+```typescript
+const widget = new ComponentWidgetImpl<string, { placeholder: string }>({
+  node,
+  name: inputSpec.name,
+  component: YourWidget,
+  inputSpec,
+  props: {
+    placeholder: 'Enter value...'
+  },
+  options: {
+    // ... options
+  }
+})
+```
+
+## Step 7: Handle Widget Lifecycle
+
+For widgets that need cleanup or special lifecycle handling:
+
+```typescript
+// In your widget component
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+
+onMounted(() => {
+  // Initialize resources
+})
+
+onUnmounted(() => {
+  // Cleanup resources
+})
+</script>
+```
+
+## Step 8: Test Your Widget
+
+1. Create a test node that uses your widget:
+```python
+class TestYourWidget:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value": ("YOUR_WIDGET", {"default": "test"})
+            }
+        }
+```
+
+2. Write unit tests for your composable:
+```typescript
+// tests-ui/composables/useYourWidget.test.ts
+import { describe, it, expect } from 'vitest'
+import { useYourWidget } from '@/composables/widgets/useYourWidget'
+
+describe('useYourWidget', () => {
+  it('creates widget with correct default value', () => {
+    const constructor = useYourWidget({ defaultValue: 'test' })
+    // ... test implementation
+  })
+})
+```
+
+## Common Patterns and Best Practices
+
+### 1. Use PrimeVue Components (REQUIRED)
+
+**Always use PrimeVue components** for UI elements to maintain consistency across the application. ComfyUI includes PrimeVue 4.2.5 with 147 available components.
+
+**Reference Documentation**: 
+- See `primevue-components.md` in the project root directory for a complete list of all available PrimeVue components with descriptions and documentation links
+- Alternative location: `vue-widget-conversion/primevue-components.md` (if working in a conversion branch)
+- This reference includes all 147 components organized by category (Form, Button, Data, Panel, etc.) with enhanced descriptions
+
+**Important**: When deciding how to create a widget, always consult the PrimeVue components reference first to find the most appropriate component for your use case.
+
+Common widget components include:
+
+```vue
+<template>
+  <!-- Text input -->
+  <InputText v-model="modelValue" class="w-full" />
+  
+  <!-- Number input -->
+  <InputNumber v-model="modelValue" class="w-full" />
+  
+  <!-- Dropdown selection -->
+  <Dropdown v-model="modelValue" :options="options" class="w-full" />
+  
+  <!-- Multi-selection -->
+  <MultiSelect v-model="modelValue" :options="options" class="w-full" />
+  
+  <!-- Toggle switch -->
+  <ToggleSwitch v-model="modelValue" />
+  
+  <!-- Slider -->
+  <Slider v-model="modelValue" class="w-full" />
+  
+  <!-- Text area -->
+  <Textarea v-model="modelValue" class="w-full" />
+  
+  <!-- File upload -->
+  <FileUpload mode="basic" />
+  
+  <!-- Color picker -->
+  <ColorPicker v-model="modelValue" />
+  
+  <!-- Rating -->
+  <Rating v-model="modelValue" />
+</template>
+
+<script setup lang="ts">
+import InputText from 'primevue/inputtext'
+import InputNumber from 'primevue/inputnumber'
+import Dropdown from 'primevue/dropdown'
+import MultiSelect from 'primevue/multiselect'
+import ToggleSwitch from 'primevue/toggleswitch'
+import Slider from 'primevue/slider'
+import Textarea from 'primevue/textarea'
+import FileUpload from 'primevue/fileupload'
+import ColorPicker from 'primevue/colorpicker'
+import Rating from 'primevue/rating'
+</script>
+```
+
+**Important**: Always import PrimeVue components individually as shown above, not from the main primevue package.
+
+### 2. Handle Type Conversions
+Ensure proper type handling:
+```typescript
+setValue: (value: string | number) => {
+  widgetValue.value = String(value)
+}
+```
+
+### 3. Responsive Design
+Use Tailwind classes for responsive widgets:
+```vue
+<div class="w-full min-h-[40px] max-h-[200px] overflow-y-auto">
+```
+
+### 4. Error Handling
+Add validation and error states:
+```vue
+<template>
+  <div :class="{ 'border-red-500': hasError }">
+    <!-- widget content -->
+  </div>
+</template>
+```
+
+### 5. Performance
+Use `v-show` instead of `v-if` for frequently toggled content:
+```vue
+<div v-show="isExpanded">...</div>
+```
+
+## File References
+
+- **Widget components**: `src/components/graph/widgets/`
+- **Widget composables**: `src/composables/widgets/`
+- **Widget registration**: `src/scripts/widgets.ts`
+- **DOM widget implementation**: `src/scripts/domWidget.ts`
+- **Widget store**: `src/stores/domWidgetStore.ts`
+- **Widget container**: `src/components/graph/DomWidgets.vue`
+- **Widget wrapper**: `src/components/graph/widgets/DomWidget.vue`
+
+## Real Examples from PRs
+
+### Example 1: Text Progress Widget (PR #3824)
+
+**Component** (`src/components/graph/widgets/TextPreviewWidget.vue`):
+```vue
+<template>
+  <div class="relative w-full text-xs min-h-[28px] max-h-[200px] rounded-lg px-4 py-2 overflow-y-auto">
+    <div class="flex items-center gap-2">
+      <div class="flex-1 break-all flex items-center gap-2">
+        <span v-html="formattedText"></span>
+        <Skeleton v-if="isParentNodeExecuting" class="!flex-1 !h-4" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNodeProgressText } from '@/composables/node/useNodeProgressText'
+import { formatMarkdownValue } from '@/utils/formatUtil'
+import Skeleton from 'primevue/skeleton'
+
+const modelValue = defineModel<string>({ required: true })
+const { widget } = defineProps<{ widget?: object }>()
+
+const { isParentNodeExecuting } = useNodeProgressText(widget?.node)
+const formattedText = computed(() => formatMarkdownValue(modelValue.value || ''))
+</script>
+```
+
+### Example 2: Multi-Select Widget (PR #2987)
+
+**Component** (`src/components/graph/widgets/MultiSelectWidget.vue`):
+```vue
+<template>
+  <div>
+    <MultiSelect
+      v-model="selectedItems"
+      :options="options"
+      filter
+      :placeholder="placeholder"
+      :max-selected-labels="3"
+      :display="display"
+      class="w-full"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import MultiSelect from 'primevue/multiselect'
+import type { ComponentWidget } from '@/types'
+import type { ComboInputSpec } from '@/types/apiTypes'
+
+const selectedItems = defineModel<string[]>({ required: true })
+const { widget } = defineProps<{ widget: ComponentWidget<string[]> }>()
+
+const inputSpec = widget.inputSpec as ComboInputSpec
+const options = inputSpec.options ?? []
+const placeholder = inputSpec.multi_select?.placeholder ?? 'Select items'
+const display = inputSpec.multi_select?.chip ? 'chip' : 'comma'
+</script>
+```
+
+## Migration Checklist
+
+When converting an existing widget:
+
+- [ ] Identify the widget type and its current implementation
+- [ ] Create Vue component with proper v-model binding using PrimeVue components
+- [ ] Create widget constructor composable in `src/composables/widgets/`
+- [ ] Create node-level composable in `src/composables/node/` (only if widget needs dynamic management)
+- [ ] Implement getValue/setValue logic with Vue reactivity
+- [ ] Handle any special widget behavior (events, validation, execution state)
+- [ ] Register widget in ComfyWidgets registry
+- [ ] Test with actual nodes that use the widget type
+- [ ] Add unit tests for both composables
+- [ ] Update documentation if needed
+
+## Key Implementation Patterns
+
+### 1. Vue Component Definition
+- Use Composition API with `<script setup>`
+- Use `defineModel` for two-way binding
+- Accept `widget` prop to access configuration
+- Use Tailwind CSS for styling
+
+### 2. Dual Composable Pattern
+- **Widget Composable** (`src/composables/widgets/`): Always required - creates widget constructor, handles component instantiation and value management
+- **Node Composable** (`src/composables/node/`): Only needed for dynamic widget management (showing/hiding based on events/state)
+- Return `ComfyWidgetConstructorV2` from widget composable
+- Use `ComponentWidgetImpl` class as bridge between Vue and LiteGraph
+- Handle value initialization and updates with Vue reactivity
+
+### 3. Widget Registration
+- Use `ComponentWidgetImpl` as bridge between Vue and LiteGraph
+- Register in `domWidgetStore` for state management
+- Add to `ComfyWidgets` registry
+
+### 4. Integration Points
+- **DomWidgets.vue**: Main container for all widgets
+- **DomWidget.vue**: Wrapper handling positioning and rendering
+- **domWidgetStore**: Centralized widget state management
+- **executionStore**: For widgets reacting to execution state
+
+This guide provides a complete pathway for creating Vue-based widgets in ComfyUI, following the patterns established in PRs #3824 and #2987.
+
+The system uses:
+- Cloud Scheduler → HTTP POST → Cloud Run API endpoints
+- Pub/Sub is only for event-driven tasks (file uploads, deletions)
+- Direct HTTP approach for scheduled tasks with OIDC authentication
+
+Existing Scheduled Tasks
+
+1. Node Reindexing - Daily at midnight
+2. Security Scanning - Hourly
+3. Comfy Node Pack Backfill - Every 6 hours
+
+Standard Approach for GitHub Stars Update
+
+Following the established pattern, you would:
+
+1. Add API endpoint to openapi.yml
+2. Implement handler in server/implementation/registry.go
+3. Add Cloud Scheduler job in infrastructure/modules/compute/cloud_scheduler.tf
+4. Update authentication rules
+
+The scheduler would be configured like:
+schedule = "0 2 */2 * *"  # Every 2 days at 2 AM PST
+uri = "${var.registry_backend_url}/packs/update-github-stars?max_packs=100"
+
+This follows the exact same HTTP-based pattern as the existing reindex-nodes, security-scan, and
+comfy-node-pack-backfill jobs. The infrastructure is designed around direct HTTP calls rather than
+pub/sub orchestration for scheduled tasks.


### PR DESCRIPTION
This branch hosts the prototype of a change where all widgets are converted to Vue components rendered without the Canvas. The actual implementation and design would not follow this format. This branch is just for prototyping, testing performance, and considering affects on extensions.

![Selection_1488](https://github.com/user-attachments/assets/aa552570-d722-48ae-b16d-907999fe23af)



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4111-Test-Convert-all-widget-to-Vue-components-test-20d6d73d36508198a2d6daf8b4f15586) by [Unito](https://www.unito.io)
