### PR TITLE
Revert Algolia proxy changes

### DIFF
--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -128,7 +128,7 @@ export const useAlgoliaSearchService = (
     hosts: [
       {
         url: 'search.comfy.org/api/search',
-        accept: 'read',
+        accept: 'readWrite',
         protocol: 'https'
       }
     ],

--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -124,19 +124,7 @@ export const useAlgoliaSearchService = (
     maxCacheSize = DEFAULT_MAX_CACHE_SIZE,
     minCharsForSuggestions = DEFAULT_MIN_CHARS_FOR_SUGGESTIONS
   } = options
-  const searchClient = algoliasearch(__ALGOLIA_APP_ID__, __ALGOLIA_API_KEY__, {
-    hosts: [
-      {
-        url: 'search.comfy.org/api/search',
-        accept: 'readWrite',
-        protocol: 'https'
-      }
-    ],
-    baseHeaders: {
-      'X-Algolia-Application-Id': __ALGOLIA_APP_ID__,
-      'X-Algolia-API-Key': __ALGOLIA_API_KEY__
-    }
-  })
+  const searchClient = algoliasearch(__ALGOLIA_APP_ID__, __ALGOLIA_API_KEY__)
   const searchPacksCache = new QuickLRU<string, SearchPacksResult>({
     maxSize: maxCacheSize
   })


### PR DESCRIPTION
Reverts the Algolia proxy configuration changes from #4030 and #4058, restoring the direct Algolia client connection.

Fixes issues with the proxy configuration by reverting to the original implementation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4133-Revert-Algolia-proxy-changes-20f6d73d3650815f8543f397e0794e83) by [Unito](https://www.unito.io)
