### PR TITLE
Fixed favicon some progress frames not found

### DIFF
--- a/src/composables/useProgressFavicon.ts
+++ b/src/composables/useProgressFavicon.ts
@@ -15,7 +15,10 @@ export const useProgressFavicon = () => {
       if (isIdle) {
         favicon.value = defaultFavicon
       } else {
-        const frame = Math.floor(progress * totalFrames)
+        const frame = Math.min(
+          Math.max(0, Math.floor(progress * totalFrames)),
+          totalFrames - 1
+        )
         favicon.value = `/assets/images/favicon_progress_16x16/frame_${frame}.png`
       }
     }

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -88,7 +88,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (!activePrompt.value) return 0
     const total = totalNodesToExecute.value
     const done = nodesExecuted.value
-    return done / total
+    return total > 0 ? done / total : 0
   })
 
   function bindExecutionEvents() {


### PR DESCRIPTION
Problem:
executionProgress() sometimes returns NaN and 1, which results in trying to get the favicon frame_NaN.png or frame_10.png that does not exist.

Solution:
1. Prevent division by 0 in executionProgress() function (fixing the NaN from the root cause).
2. Smart clamping of the frame number calculation to assure it always stays between 0 and 9 (according to existing .png files).

by ComfyWaifu 🤍

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4143-Fixed-favicon-some-progress-frames-not-found-by-ComfyWaifu-2106d73d36508128ac35c752ea53c059) by [Unito](https://www.unito.io)
