### PR TITLE
Implement version check for template workflows (#3649) ready for review

### DIFF
--- a/src/components/templates/TemplateWorkflowCard.spec.ts
+++ b/src/components/templates/TemplateWorkflowCard.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import TemplateWorkflowCard from '@/components/templates/TemplateWorkflowCard.vue'
@@ -109,6 +110,10 @@ vi.mock('@/composables/useTemplateWorkflows', () => ({
 }))
 
 describe('TemplateWorkflowCard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
   const createTemplate = (overrides = {}): TemplateInfo => ({
     name: 'test-template',
     mediaType: 'image',

--- a/src/components/templates/TemplateWorkflowsContent.vue
+++ b/src/components/templates/TemplateWorkflowsContent.vue
@@ -56,12 +56,13 @@ import { useAsyncState } from '@vueuse/core'
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
 import ProgressSpinner from 'primevue/progressspinner'
-import { watch } from 'vue'
+import { onMounted, watch } from 'vue'
 
 import TemplateWorkflowView from '@/components/templates/TemplateWorkflowView.vue'
 import TemplateWorkflowsSideNav from '@/components/templates/TemplateWorkflowsSideNav.vue'
 import { useResponsiveCollapse } from '@/composables/element/useResponsiveCollapse'
 import { useTemplateWorkflows } from '@/composables/useTemplateWorkflows'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { WorkflowTemplates } from '@/types/workflowTemplateTypes'
 
 const {
@@ -82,6 +83,14 @@ const {
 } = useTemplateWorkflows()
 
 const { isReady } = useAsyncState(loadTemplates, null)
+const systemStatsStore = useSystemStatsStore()
+
+// Initialize system stats when component mounts
+onMounted(async () => {
+  if (!systemStatsStore.systemStats) {
+    await systemStatsStore.fetchSystemStats()
+  }
+})
 
 watch(
   isReady,

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -501,6 +501,9 @@
   },
   "templateWorkflows": {
     "title": "Get Started with a Template",
+    "requiresUpgrade": "Requires ComfyUI v{version} or higher",
+    "upgradeToUse": "Upgrade to use this template",
+    "currentVersion": "Current version: v{version}",
     "category": {
       "ComfyUI Examples": "ComfyUI Examples",
       "Custom Nodes": "Custom Nodes",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -1152,8 +1152,6 @@
       "Video": "Video",
       "Video API": "API de Video"
     },
-    "currentVersion": "Versión actual: v{version}",
-    "requiresUpgrade": "Requiere ComfyUI v{version} o superior",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D 2.0 MV",
@@ -1356,8 +1354,7 @@
         "api_veo2_i2v": "Usa la API Google Veo2 para generar videos a partir de imágenes."
       }
     },
-    "title": "Comienza con una Plantilla",
-    "upgradeToUse": "Actualiza para usar esta plantilla"
+    "title": "Comienza con una Plantilla"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "No se pudo determinar el tipo de archivo",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -1152,6 +1152,8 @@
       "Video": "Video",
       "Video API": "API de Video"
     },
+    "currentVersion": "Versión actual: v{version}",
+    "requiresUpgrade": "Requiere ComfyUI v{version} o superior",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D 2.0 MV",
@@ -1354,7 +1356,8 @@
         "api_veo2_i2v": "Usa la API Google Veo2 para generar videos a partir de imágenes."
       }
     },
-    "title": "Comienza con una Plantilla"
+    "title": "Comienza con una Plantilla",
+    "upgradeToUse": "Actualiza para usar esta plantilla"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "No se pudo determinar el tipo de archivo",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -1152,6 +1152,8 @@
       "Video": "Vidéo",
       "Video API": "API vidéo"
     },
+    "currentVersion": "Version actuelle : v{version}",
+    "requiresUpgrade": "Nécessite ComfyUI v{version} ou supérieur",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D Multivue",
@@ -1354,7 +1356,8 @@
         "api_veo2_i2v": "Utilisez l'API Google Veo2 pour générer des vidéos à partir d'images."
       }
     },
-    "title": "Commencez avec un modèle"
+    "title": "Commencez avec un modèle",
+    "upgradeToUse": "Mettez à jour pour utiliser ce modèle"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "Impossible de déterminer le type de fichier",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -1152,8 +1152,6 @@
       "Video": "Vidéo",
       "Video API": "API vidéo"
     },
-    "currentVersion": "Version actuelle : v{version}",
-    "requiresUpgrade": "Nécessite ComfyUI v{version} ou supérieur",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D Multivue",
@@ -1356,8 +1354,7 @@
         "api_veo2_i2v": "Utilisez l'API Google Veo2 pour générer des vidéos à partir d'images."
       }
     },
-    "title": "Commencez avec un modèle",
-    "upgradeToUse": "Mettez à jour pour utiliser ce modèle"
+    "title": "Commencez avec un modèle"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "Impossible de déterminer le type de fichier",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -1152,8 +1152,6 @@
       "Video": "ビデオ",
       "Video API": "動画API"
     },
-    "currentVersion": "現在のバージョン: v{version}",
-    "requiresUpgrade": "ComfyUI v{version} 以上が必要です",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D マルチビュー",
@@ -1356,8 +1354,7 @@
         "api_veo2_i2v": "Google Veo2 APIで画像から動画を生成します。"
       }
     },
-    "title": "テンプレートを利用して開始",
-    "upgradeToUse": "このテンプレートを使用するにはアップグレードしてください"
+    "title": "テンプレートを利用して開始"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "ファイルタイプを判断できませんでした",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -1152,6 +1152,8 @@
       "Video": "ビデオ",
       "Video API": "動画API"
     },
+    "currentVersion": "現在のバージョン: v{version}",
+    "requiresUpgrade": "ComfyUI v{version} 以上が必要です",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D マルチビュー",
@@ -1354,7 +1356,8 @@
         "api_veo2_i2v": "Google Veo2 APIで画像から動画を生成します。"
       }
     },
-    "title": "テンプレートを利用して開始"
+    "title": "テンプレートを利用して開始",
+    "upgradeToUse": "このテンプレートを使用するにはアップグレードしてください"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "ファイルタイプを判断できませんでした",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1152,8 +1152,6 @@
       "Video": "비디오",
       "Video API": "비디오 API"
     },
-    "currentVersion": "현재 버전: v{version}",
-    "requiresUpgrade": "ComfyUI v{version} 이상이 필요합니다",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D 다중뷰",
@@ -1356,8 +1354,7 @@
         "api_veo2_i2v": "Google Veo2 API로 이미지에서 비디오를 생성합니다."
       }
     },
-    "title": "템플릿으로 시작하기",
-    "upgradeToUse": "이 템플릿을 사용하려면 업그레이드하세요"
+    "title": "템플릿으로 시작하기"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "파일 유형을 결정할 수 없습니다",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1152,6 +1152,8 @@
       "Video": "비디오",
       "Video API": "비디오 API"
     },
+    "currentVersion": "현재 버전: v{version}",
+    "requiresUpgrade": "ComfyUI v{version} 이상이 필요합니다",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D 다중뷰",
@@ -1354,7 +1356,8 @@
         "api_veo2_i2v": "Google Veo2 API로 이미지에서 비디오를 생성합니다."
       }
     },
-    "title": "템플릿으로 시작하기"
+    "title": "템플릿으로 시작하기",
+    "upgradeToUse": "이 템플릿을 사용하려면 업그레이드하세요"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "파일 유형을 결정할 수 없습니다",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -1152,6 +1152,8 @@
       "Video": "Видео",
       "Video API": "Video API"
     },
+    "currentVersion": "Текущая версия: v{version}",
+    "requiresUpgrade": "Требуется ComfyUI версии {version} или выше",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D Многовидовой",
@@ -1354,7 +1356,8 @@
         "api_veo2_i2v": "Используйте Google Veo2 API для генерации видео из изображений."
       }
     },
-    "title": "Начните с шаблона"
+    "title": "Начните с шаблона",
+    "upgradeToUse": "Обновите, чтобы использовать этот шаблон"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "Не удалось определить тип файла",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -1152,8 +1152,6 @@
       "Video": "Видео",
       "Video API": "Video API"
     },
-    "currentVersion": "Текущая версия: v{version}",
-    "requiresUpgrade": "Требуется ComfyUI версии {version} или выше",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "Hunyuan3D Многовидовой",
@@ -1356,8 +1354,7 @@
         "api_veo2_i2v": "Используйте Google Veo2 API для генерации видео из изображений."
       }
     },
-    "title": "Начните с шаблона",
-    "upgradeToUse": "Обновите, чтобы использовать этот шаблон"
+    "title": "Начните с шаблона"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "Не удалось определить тип файла",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1152,6 +1152,8 @@
       "Video": "视频",
       "Video API": "视频 API"
     },
+    "currentVersion": "当前版本：v{version}",
+    "requiresUpgrade": "需要 ComfyUI v{version} 或更高版本",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "混元3D多视图",
@@ -1354,7 +1356,8 @@
         "api_veo2_i2v": "使用 Google Veo2 API 通过图像生成视频。"
       }
     },
-    "title": "从模板开始"
+    "title": "从模板开始",
+    "upgradeToUse": "升级以使用此模板"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "无法确定文件类型",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1152,8 +1152,6 @@
       "Video": "视频",
       "Video API": "视频 API"
     },
-    "currentVersion": "当前版本：v{version}",
-    "requiresUpgrade": "需要 ComfyUI v{version} 或更高版本",
     "template": {
       "3D": {
         "hunyuan-3d-multiview-elf": "混元3D多视图",
@@ -1356,8 +1354,7 @@
         "api_veo2_i2v": "使用 Google Veo2 API 通过图像生成视频。"
       }
     },
-    "title": "从模板开始",
-    "upgradeToUse": "升级以使用此模板"
+    "title": "从模板开始"
   },
   "toastMessages": {
     "couldNotDetermineFileType": "无法确定文件类型",

--- a/src/types/workflowTemplateTypes.ts
+++ b/src/types/workflowTemplateTypes.ts
@@ -12,6 +12,10 @@ export interface TemplateInfo {
   localizedTitle?: string
   localizedDescription?: string
   sourceModule?: string
+  /**
+   * Minimum version of ComfyUI required to use this template
+   */
+  versionRequired?: string
 }
 
 export interface WorkflowTemplates {


### PR DESCRIPTION
### Summary
Implement version check for template workflows, based on issue #3649.

### Changes
Added a `versionRequired?: string` field in /src/types/workflowTemplateTypes.ts to define the minimum required ComfyUI version for each template.

In `TemplateWorkflowCard`, check if the user's current ComfyUI version satisfies versionRequired:

Case 1. If yes, the template behaves normally.

Case 2. If not, the template card is grayed out, disabled from interaction, and displays a message encouraging the user to upgrade.


### Reproduction:
![image](https://github.com/user-attachments/assets/8b6eb141-4189-488e-90e8-6f282a7fb393)

![1749756311277](https://github.com/user-attachments/assets/6893cbce-acbb-4f12-8aeb-379ce21d8660)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4144-check-template-version-2106d73d36508173a12fc2c2de05a3c3) by [Unito](https://www.unito.io)
