### PR TITLE
[Manager] Fix: fetch repeated infitely if no node packs installed

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -232,7 +232,11 @@ watch(
 
     if (!isEmptySearch.value) {
       displayPacks.value = filterOutdatedPacks(installedPacks.value)
-    } else if (!installedPacks.value.length) {
+    } else if (
+      !installedPacks.value.length &&
+      !installedPacksReady.value &&
+      !isLoadingInstalled.value
+    ) {
       await startFetchInstalled()
     } else {
       displayPacks.value = filterOutdatedPacks(installedPacks.value)


### PR DESCRIPTION
Fixes bug in which `!installedPacks.value.length` condition is true even after fetching (due to no node packs being installed). The condition should also be reliant on the `ready` state of the `useAsyncState` composable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4145-Manager-Fix-fetch-repeated-infitely-if-no-node-packs-installed-2106d73d36508194b15ad0d7f9f4f4c9) by [Unito](https://www.unito.io)
