### PR TITLE
[Types] Remove outdated type intersection

### DIFF
--- a/src/components/dialog/content/manager/packBanner/PackBanner.vue
+++ b/src/components/dialog/content/manager/packBanner/PackBanner.vue
@@ -46,7 +46,7 @@ const {
   width = '100%',
   height = '12rem'
 } = defineProps<{
-  nodePack: components['schemas']['Node'] & { banner?: string } // Temporary measure until banner is in backend
+  nodePack: components['schemas']['Node']
   width?: string
   height?: string
 }>()


### PR DESCRIPTION
The `banner_url` field was added to the backend already and the types were re-generated accordingly, making this type intersection workaround no longer necessary.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4146-Types-Remove-outdated-type-assertion-2106d73d365081d19a37ea27bb5bb91b) by [Unito](https://www.unito.io)
