### PR TITLE
[3d] bugfix for preview manager

### DIFF
--- a/src/extensions/core/load3d/PreviewManager.ts
+++ b/src/extensions/core/load3d/PreviewManager.ts
@@ -5,7 +5,7 @@ import { EventManagerInterface, PreviewManagerInterface } from './interfaces'
 
 export class PreviewManager implements PreviewManagerInterface {
   previewCamera: THREE.Camera
-  previewContainer: HTMLDivElement = {} as HTMLDivElement
+  previewContainer: HTMLDivElement = null!
   showPreview: boolean = true
   previewWidth: number = 120
 


### PR DESCRIPTION
a tiny but serious bugfix. we need to set previewContainer as null as default value rather than empty {}

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4147-3d-bugfix-for-preview-manager-2116d73d365081adbb7efd91c3b2e92e) by [Unito](https://www.unito.io)
