### PR TITLE
Bug Fix issue where inner groups become unresponsive after nesting (#2154)

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -446,6 +446,9 @@ export function useCoreCommands(): ComfyCommand[] {
         )
         group.resizeTo(canvas.selectedItems, padding)
         canvas.graph?.add(group)
+
+        group.recomputeInsideNodes()
+
         useTitleEditorStore().titleEditorTarget = group
       }
     },

--- a/src/extensions/core/groupOptions.ts
+++ b/src/extensions/core/groupOptions.ts
@@ -42,6 +42,8 @@ app.registerExtension({
               this.graph.add(group)
               // @ts-expect-error fixme ts strict error
               this.graph.change()
+
+              group.recomputeInsideNodes()
             }
           })
         }


### PR DESCRIPTION
Description
This PR fixes the issue described in #2154 where inner groups become unresponsive after adding nested groups from the outside.
Fix:
Simply calling group.recomputeInsideNodes() whenever a new group is added could resolve this issue.

https://github.com/user-attachments/assets/d8a5e0b2-1979-4b4a-a89c-4523612338cd

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4156-Bug-Fix-issue-where-inner-groups-become-unresponsive-after-nesting-2154-2126d73d3650819d94c9f1605344e641) by [Unito](https://www.unito.io)
