### PR TITLE
[Manager] Add enable/disable toggle for installed node packs

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -6,7 +6,8 @@
       <i class="pi pi-download text-muted"></i>
       <span>{{ formattedDownloads }}</span>
     </div>
-    <PackInstallButton :node-packs="[nodePack]" />
+    <PackInstallButton v-if="!isInstalled" :node-packs="[nodePack]" />
+    <PackEnableToggle v-else :node-pack="nodePack" />
   </div>
 </template>
 
@@ -14,12 +15,17 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import PackEnableToggle from '@/components/dialog/content/manager/button/PackEnableToggle.vue'
 import PackInstallButton from '@/components/dialog/content/manager/button/PackInstallButton.vue'
+import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import type { components } from '@/types/comfyRegistryTypes'
 
 const { nodePack } = defineProps<{
   nodePack: components['schemas']['Node']
 }>()
+
+const { isPackInstalled } = useComfyManagerStore()
+const isInstalled = computed(() => isPackInstalled(nodePack?.id))
 
 const { n } = useI18n()
 


### PR DESCRIPTION
This functionality existed before but was removed in https://github.com/Comfy-Org/ComfyUI_frontend/pull/4065 mistakenly.

Replaces the install button with an enable/disable toggle when a node pack is already installed, providing users with better control over installed packages directly from the pack card.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4157-Manager-Add-enable-disable-toggle-for-installed-node-packs-2126d73d365081a6aa79ef73504b591e) by [Unito](https://www.unito.io)
