### PR TITLE
[Manager] Fix race condition in pack selection

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/NodesTabPanel.vue
@@ -51,6 +51,7 @@ const isLoading = ref(false)
 const registryNodeDefs = shallowRef<ListComfyNodesResponse | null>(null)
 
 const fetchNodeDefs = async () => {
+  getNodeDefs.cancel()
   isLoading.value = true
 
   const { id: packId } = nodePack


### PR DESCRIPTION
Fixes race condition where rapidly switching between pack selections would cause the info panel to snap back to the previous selection when a slower API request resolved after a faster one.

The fix cancels any in-flight node definition requests before starting a new fetch, ensuring only the most recent selection's data is displayed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4158-Manager-Fix-race-condition-in-pack-selection-2126d73d3650819b928af76237c17f3b) by [Unito](https://www.unito.io)
