### PR TITLE
[Manager] Fix card selection highlight z-index and border radius issues

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCard.vue
+++ b/src/components/dialog/content/manager/packCard/PackCard.vue
@@ -2,7 +2,7 @@
   <Card
     class="w-full h-full inline-flex flex-col justify-between items-start overflow-hidden rounded-2xl shadow-elevation-3 dark-theme:bg-dark-elevation-2 transition-all duration-200"
     :class="{
-      'outline outline-[6px] outline-[var(--p-primary-color)]': isSelected,
+      'selected-card': isSelected,
       'opacity-60': isDisabled
     }"
     :pt="{
@@ -158,3 +158,22 @@ const formattedLatestVersionDate = computed(() => {
   })
 })
 </script>
+
+<style scoped>
+.selected-card {
+  position: relative;
+}
+
+.selected-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 6px solid var(--p-primary-color);
+  border-radius: 1rem;
+  pointer-events: none;
+  z-index: 100;
+}
+</style>


### PR DESCRIPTION
Fixes selection highlight display issues introduced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/4065 where the blue outline had gaps around rounded corners and was hidden behind header images. Uses pseudo-element approach for proper stacking and border radius compliance.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4160-Manager-Fix-card-selection-highlight-z-index-and-border-radius-issues-2126d73d3650812c9d9ac3480dd0a9c7) by [Unito](https://www.unito.io)
