### PR TITLE
[Manager] Fix selection state race condition during pack data merge

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -430,7 +430,13 @@ whenever(selectedNodePack, async () => {
   if (data?.id === pack.id) {
     lastFetchedPackId.value = pack.id
     const mergedPack = merge({}, pack, data)
-    selectedNodePacks.value = [mergedPack]
+    // Update the pack in current selection without changing selection state
+    const packIndex = selectedNodePacks.value.findIndex(
+      (p) => p.id === mergedPack.id
+    )
+    if (packIndex !== -1) {
+      selectedNodePacks.value.splice(packIndex, 1, mergedPack)
+    }
     // Replace pack in displayPacks so that children receive a fresh prop reference
     const idx = displayPacks.value.findIndex((p) => p.id === mergedPack.id)
     if (idx !== -1) {


### PR DESCRIPTION
Continuation of https://github.com/Comfy-Org/ComfyUI_frontend/pull/4158: Fixes race condition where rapidly switching pack selections could cause the info panel to snap back to previous selections when slower API requests resolved after faster ones. Now preserves user selection state during data merge operations while still updating pack data with enhanced registry information.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4165-Manager-Fix-selection-state-race-condition-during-pack-data-merge-2126d73d365081fdb9a4ccaa3e6ebd2b) by [Unito](https://www.unito.io)
