### PR TITLE
Subgraph testing release v1.22.0-sub.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfyorg/comfyui-frontend",
-  "version": "1.22.0-sub.3",
+  "version": "1.22.0-sub.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfyorg/comfyui-frontend",
-      "version": "1.22.0-sub.3",
+      "version": "1.22.0-sub.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.22.0-sub.3",
+  "version": "1.22.0-sub.4",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Alpha testing release: 1.22.0-sub.4

Do not overwrite / save production workflows whilst testing this version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4171-Subgraph-testing-release-v1-22-0-sub-4-2126d73d36508114bc1ac5c76dbf9e77) by [Unito](https://www.unito.io)
