### PR TITLE
[Manager] Persist/Restore Manager UI state 

### DIFF
--- a/src/composables/manager/useManagerStatePersistence.ts
+++ b/src/composables/manager/useManagerStatePersistence.ts
@@ -1,0 +1,54 @@
+import {
+  ManagerState,
+  ManagerTab,
+  SortableAlgoliaField
+} from '@/types/comfyManagerTypes'
+
+const STORAGE_KEY = 'Comfy.Manager.UI.State'
+
+export const useManagerStatePersistence = () => {
+  /**
+   * Load the UI state from localStorage.
+   */
+  const loadStoredState = (): ManagerState => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        return JSON.parse(stored)
+      }
+    } catch (e) {
+      console.error('Failed to load manager UI state:', e)
+    }
+    return {
+      selectedTabId: ManagerTab.All,
+      searchQuery: '',
+      searchMode: 'packs',
+      sortField: SortableAlgoliaField.Downloads
+    }
+  }
+
+  /**
+   * Persist the UI state to localStorage.
+   */
+  const persistState = (state: ManagerState) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  }
+
+  /**
+   * Reset the UI state to the default values.
+   */
+  const reset = () => {
+    persistState({
+      selectedTabId: ManagerTab.All,
+      searchQuery: '',
+      searchMode: 'packs',
+      sortField: SortableAlgoliaField.Downloads
+    })
+  }
+
+  return {
+    loadStoredState,
+    persistState,
+    reset
+  }
+}

--- a/src/services/algoliaSearchService.ts
+++ b/src/services/algoliaSearchService.ts
@@ -41,12 +41,6 @@ const RETRIEVE_ATTRIBUTES: SearchAttribute[] = [
 
 interface AlgoliaSearchServiceOptions {
   /**
-   * Maximum number of search results to store in the cache.
-   * The cache is automatically cleared when the component is unmounted.
-   * @default 64
-   */
-  maxCacheSize?: number
-  /**
    * Minimum number of characters for suggestions. An additional query
    * will be made to the suggestions/completions index for queries that
    * are this length or longer.
@@ -55,17 +49,15 @@ interface AlgoliaSearchServiceOptions {
   minCharsForSuggestions?: number
 }
 
+const searchPacksCache = new QuickLRU<string, SearchPacksResult>({
+  maxSize: DEFAULT_MAX_CACHE_SIZE
+})
+
 export const useAlgoliaSearchService = (
   options: AlgoliaSearchServiceOptions = {}
 ) => {
-  const {
-    maxCacheSize = DEFAULT_MAX_CACHE_SIZE,
-    minCharsForSuggestions = DEFAULT_MIN_CHARS_FOR_SUGGESTIONS
-  } = options
+  const { minCharsForSuggestions = DEFAULT_MIN_CHARS_FOR_SUGGESTIONS } = options
   const searchClient = algoliasearch(__ALGOLIA_APP_ID__, __ALGOLIA_API_KEY__)
-  const searchPacksCache = new QuickLRU<string, SearchPacksResult>({
-    maxSize: maxCacheSize
-  })
 
   const toRegistryLatestVersion = (
     algoliaNode: AlgoliaNodePack

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -21,7 +21,6 @@ import TemplateWorkflowsDialogHeader from '@/components/templates/TemplateWorkfl
 import { t } from '@/i18n'
 import type { ExecutionErrorWsMessage } from '@/schemas/apiSchema'
 import { type ShowDialogOptions, useDialogStore } from '@/stores/dialogStore'
-import { ManagerTab } from '@/types/comfyManagerTypes'
 
 export type ConfirmationDialogType =
   | 'default'
@@ -129,9 +128,7 @@ export const useDialogService = () => {
   }
 
   function showManagerDialog(
-    props: InstanceType<typeof ManagerDialogContent>['$props'] = {
-      initialTab: ManagerTab.All
-    }
+    props: InstanceType<typeof ManagerDialogContent>['$props'] = {}
   ) {
     dialogStore.showDialog({
       key: 'global-manager',

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -39,7 +39,7 @@ export enum SortableAlgoliaField {
 }
 
 export interface TabItem {
-  id: string
+  id: ManagerTab
   label: string
   icon: string
 }
@@ -233,4 +233,11 @@ export interface InstallPackParams extends ManagerPackInfo {
  */
 export interface UpdateAllPacksParams {
   mode?: ManagerDatabaseSource
+}
+
+export interface ManagerState {
+  selectedTabId: ManagerTab
+  searchQuery: string
+  searchMode: 'nodes' | 'packs'
+  sortField: SortableAlgoliaField
 }


### PR DESCRIPTION
Makes the UI state of the Custom Nodes Manager persist across usage.

Implementation:

- On unmount of dialog, save UI state to local storage
- On mount of dialog, load previous state from local storage (with defaults as fallback)
- Adjust other components/composables to accept optional initial values

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/4162

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4180-Manager-Persist-Restore-Manager-UI-state-2126d73d365081eda64de25dfc7b0954) by [Unito](https://www.unito.io)
