### PR TITLE
[Manager] Implement search filters

### DIFF
--- a/browser_tests/assets/save_animated_png.json
+++ b/browser_tests/assets/save_animated_png.json
@@ -1,0 +1,190 @@
+{
+  "id": "cffcce2d-a13c-4a5f-929b-82f274bacc36",
+  "revision": 0,
+  "last_node_id": 14,
+  "last_link_id": 14,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "LoadImage",
+      "pos": [
+        -361.02374267578125,
+        -40.05255126953125
+      ],
+      "size": [
+        274.080078125,
+        314
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            11
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "ComfyUI_00137_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "ImageBatch",
+      "pos": [
+        146.92184448242188,
+        104.8472671508789
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image1",
+          "type": "IMAGE",
+          "link": 11
+        },
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 12
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            14
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ImageBatch"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 14,
+      "type": "SaveAnimatedPNG",
+      "pos": [
+        457.4212646484375,
+        39.56276321411133
+      ],
+      "size": [
+        270,
+        368
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 14
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "ComfyUI",
+        6,
+        4
+      ]
+    },
+    {
+      "id": 11,
+      "type": "LoadImage",
+      "pos": [
+        -360.4931640625,
+        326.1943664550781
+      ],
+      "size": [
+        274.080078125,
+        314
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            12
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "ComfyUI_00153_.png",
+        "image"
+      ]
+    }
+  ],
+  "links": [
+    [
+      11,
+      10,
+      0,
+      12,
+      0,
+      "IMAGE"
+    ],
+    [
+      12,
+      11,
+      0,
+      12,
+      1,
+      "IMAGE"
+    ],
+    [
+      14,
+      12,
+      0,
+      14,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.129559245649766,
+      "offset": [
+        768.6140137916129,
+        203.6152852376302
+      ]
+    },
+    "frontendVersion": "1.22.2"
+  },
+  "version": 0.4
+}

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -30,9 +30,11 @@
             v-model:searchQuery="searchQuery"
             v-model:searchMode="searchMode"
             v-model:sortField="sortField"
+            v-model:activeFilters="activeFilters"
             :search-results="searchResults"
             :suggestions="suggestions"
             :sort-options="sortOptions"
+            :filter-options="filterOptions"
           />
           <div class="flex-1 overflow-auto">
             <div
@@ -121,6 +123,7 @@ import { useWorkflowPacks } from '@/composables/nodePack/useWorkflowPacks'
 import { useRegistrySearch } from '@/composables/useRegistrySearch'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { TabItem } from '@/types/comfyManagerTypes'
 import { ManagerTab } from '@/types/comfyManagerTypes'
 import { components } from '@/types/comfyRegistryTypes'
@@ -132,6 +135,7 @@ const { initialTab } = defineProps<{
 const { t } = useI18n()
 const comfyManagerStore = useComfyManagerStore()
 const { getPackById } = useComfyRegistryStore()
+const systemStatsStore = useSystemStatsStore()
 const persistedState = useManagerStatePersistence()
 const initialState = persistedState.loadStoredState()
 
@@ -181,7 +185,9 @@ const {
   searchMode,
   sortField,
   suggestions,
-  sortOptions
+  sortOptions,
+  activeFilters,
+  filterOptions
 } = useRegistrySearch({
   initialSortField: initialState.sortField,
   initialSearchMode: initialState.searchMode,
@@ -464,8 +470,13 @@ whenever(selectedNodePack, async () => {
 })
 
 let gridContainer: HTMLElement | null = null
-onMounted(() => {
+onMounted(async () => {
   gridContainer = document.getElementById('results-grid')
+
+  // Fetch system stats if not already loaded
+  if (!systemStatsStore.systemStats && !systemStatsStore.isLoading) {
+    await systemStatsStore.fetchSystemStats()
+  }
 })
 watch(searchQuery, () => {
   gridContainer ??= document.getElementById('results-grid')

--- a/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/RegistrySearchBar.vue
@@ -47,56 +47,13 @@
       </div>
       <!-- Add search refinement dropdowns if provider supports them -->
       <div v-if="filterOptions?.length" class="flex gap-3 ml-1 text-sm">
-        <template v-for="filterOption in filterOptions" :key="filterOption.id">
-          <div class="flex items-center gap-1">
-            <span class="text-muted">{{ filterOption.label }}:</span>
-            <Dropdown
-              v-if="filterOption.type === 'single-select'"
-              :model-value="selectedFilters[filterOption.id] as string"
-              :options="filterOption.options || []"
-              option-label="label"
-              option-value="value"
-              placeholder="Any"
-              :show-clear="true"
-              class="min-w-[6rem] border-none bg-transparent shadow-none"
-              :pt="{
-                input: { class: 'py-0 px-1 border-none' },
-                trigger: { class: 'hidden' },
-                panel: { class: 'shadow-md' },
-                item: { class: 'py-2 px-3 text-sm' }
-              }"
-              @update:model-value="
-                $event
-                  ? (selectedFilters[filterOption.id] = $event)
-                  : delete selectedFilters[filterOption.id]
-              "
-            />
-            <MultiSelect
-              v-else-if="filterOption.type === 'multi-select'"
-              :model-value="selectedFilters[filterOption.id] as string[]"
-              :options="filterOption.options || []"
-              option-label="label"
-              option-value="value"
-              display="chip"
-              class="min-w-[6rem] border-none bg-transparent shadow-none"
-              :pt="{
-                input: { class: 'py-0 px-1 border-none' },
-                trigger: { class: 'hidden' },
-                panel: { class: 'shadow-md' },
-                item: { class: 'py-2 px-3 text-sm' },
-                label: { class: 'py-0 px-1 text-sm' },
-                header: { class: 'p-2' },
-                filterInput: { class: 'text-sm' },
-                emptyMessage: { class: 'text-sm text-muted p-3' }
-              }"
-              @update:model-value="
-                $event?.length > 0
-                  ? (selectedFilters[filterOption.id] = $event)
-                  : delete selectedFilters[filterOption.id]
-              "
-            />
-          </div>
-        </template>
+        <SearchFilterDropdown
+          v-for="filterOption in filterOptions"
+          :key="filterOption.id"
+          v-model:modelValue="selectedFilters[filterOption.id]"
+          :options="availableFilterOptions(filterOption)"
+          :label="filterOption.label"
+        />
       </div>
     </div>
   </div>
@@ -107,8 +64,6 @@ import { stubTrue } from 'lodash'
 import AutoComplete, {
   AutoCompleteOptionSelectEvent
 } from 'primevue/autocomplete'
-import Dropdown from 'primevue/dropdown'
-import MultiSelect from 'primevue/multiselect'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -156,6 +111,17 @@ const searchModeOptions: SearchOption<SearchMode>[] = [
   { id: 'packs', label: t('manager.filter.nodePack') },
   { id: 'nodes', label: t('g.nodes') }
 ]
+
+// Convert filter options to SearchOption format for SearchFilterDropdown
+const availableFilterOptions = (
+  filter: SearchFilter
+): SearchOption<string>[] => {
+  if (!filter.options) return []
+  return filter.options.map((option) => ({
+    id: option.value,
+    label: option.label
+  }))
+}
 
 // When a dropdown query suggestion is selected, update the search query
 const onOptionSelect = (event: AutoCompleteOptionSelectEvent) => {

--- a/src/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue
+++ b/src/components/dialog/content/manager/registrySearchBar/SearchFilterDropdown.vue
@@ -6,6 +6,7 @@
       :options="options"
       option-label="label"
       option-value="id"
+      placeholder="Any"
       class="min-w-[6rem] border-none bg-transparent shadow-none"
       :pt="{
         input: { class: 'py-0 px-1 border-none' },

--- a/src/composables/useRegistrySearch.ts
+++ b/src/composables/useRegistrySearch.ts
@@ -108,25 +108,6 @@ export function useRegistrySearch(
     return getFilterableFields()
   })
 
-  // Initialize filters with default values when they become available
-  const filterOptionsInitialized = ref(false)
-  watch(
-    filterOptions,
-    (newOptions) => {
-      if (!filterOptionsInitialized.value && newOptions.length > 0) {
-        const defaultFilters: ActiveFilters = {}
-        for (const option of newOptions) {
-          if (option.defaultValue !== undefined) {
-            defaultFilters[option.id] = option.defaultValue
-          }
-        }
-        activeFilters.value = { ...activeFilters.value, ...defaultFilters }
-        filterOptionsInitialized.value = true
-      }
-    },
-    { immediate: true }
-  )
-
   return {
     isLoading,
     pageNumber,

--- a/src/services/providers/algoliaSearchProvider.ts
+++ b/src/services/providers/algoliaSearchProvider.ts
@@ -20,6 +20,7 @@ import { SortableAlgoliaField } from '@/types/comfyManagerTypes'
 import type { components } from '@/types/comfyRegistryTypes'
 import type {
   NodePackSearchProvider,
+  SearchFilter,
   SearchPacksResult,
   SortableField
 } from '@/types/searchServiceTypes'
@@ -105,7 +106,14 @@ export const useAlgoliaSearchProvider = (): NodePackSearchProvider => {
     params: SearchNodePacksParams
   ): Promise<SearchPacksResult> => {
     const { pageSize, pageNumber } = params
-    const rest = omit(params, ['pageSize', 'pageNumber'])
+    const rest = omit(params, [
+      'pageSize',
+      'pageNumber',
+      'sortField',
+      'sortDirection',
+      'filters'
+    ])
+    // TODO:'filters', `sortField` and `sortDirection` need to be mapped to the appropriate Algolia syntax later
 
     const requests: SearchQuery[] = [
       {
@@ -223,10 +231,16 @@ export const useAlgoliaSearchProvider = (): NodePackSearchProvider => {
     ]
   }
 
+  const getFilterableFields = (): SearchFilter[] => {
+    // Algolia provider doesn't support filters yet, returning empty array
+    return []
+  }
+
   return {
     searchPacks,
     clearSearchCache,
     getSortValue,
-    getSortableFields
+    getSortableFields,
+    getFilterableFields
   }
 }

--- a/src/services/providers/registrySearchProvider.ts
+++ b/src/services/providers/registrySearchProvider.ts
@@ -86,6 +86,10 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
 
       // Apply sort if provided (only supported by list endpoint)
       if (sortField) {
+        // Validate sort field to prevent malformed API requests
+        if (!/^[a-zA-Z_]+$/.test(sortField)) {
+          throw new Error(`Invalid sort field: ${sortField}`)
+        }
         const sortParam =
           sortDirection === 'desc' ? `${sortField};desc` : sortField
         listParams.sort = [sortParam]
@@ -161,12 +165,15 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
     const stats = systemStatsStore.systemStats
     if (!stats?.devices || stats.devices.length === 0) return undefined
 
-    // Look for the first GPU device
+    // Look for the first GPU device - check for additional patterns
     for (const device of stats.devices) {
       const deviceType = device.type.toLowerCase()
-      if (deviceType.includes('cuda')) return 'cuda'
-      if (deviceType.includes('mps')) return 'mps'
-      if (deviceType.includes('rocm')) return 'rocm'
+      if (deviceType.includes('nvidia') || deviceType.includes('cuda'))
+        return 'cuda'
+      if (deviceType.includes('apple') || deviceType.includes('mps'))
+        return 'mps'
+      if (deviceType.includes('amd') || deviceType.includes('rocm'))
+        return 'rocm'
       if (deviceType.includes('directml')) return 'directml'
     }
     return undefined

--- a/src/services/providers/registrySearchProvider.ts
+++ b/src/services/providers/registrySearchProvider.ts
@@ -1,13 +1,17 @@
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { SearchNodePacksParams } from '@/types/algoliaTypes'
-import type { components } from '@/types/comfyRegistryTypes'
+import type { components, operations } from '@/types/comfyRegistryTypes'
 import type {
   NodePackSearchProvider,
+  SearchFilter,
   SearchPacksResult,
   SortableField
 } from '@/types/searchServiceTypes'
 
 type RegistryNodePack = components['schemas']['Node']
+type ListNodesParams = operations['listAllNodes']['parameters']['query']
+type SearchNodesParams = operations['searchNodes']['parameters']['query']
 
 /**
  * Search provider for the Comfy Registry.
@@ -15,6 +19,7 @@ type RegistryNodePack = components['schemas']['Node']
  */
 export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
   const registryStore = useComfyRegistryStore()
+  const systemStatsStore = useSystemStatsStore()
 
   /**
    * Search for node packs using the Comfy Registry API.
@@ -23,19 +28,71 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
     query: string,
     params: SearchNodePacksParams
   ): Promise<SearchPacksResult> => {
-    const { pageSize, pageNumber, restrictSearchableAttributes } = params
+    const {
+      pageSize,
+      pageNumber,
+      restrictSearchableAttributes,
+      filters,
+      sortField,
+      sortDirection
+    } = params
 
     // Determine search mode based on searchable attributes
     const isNodeSearch = restrictSearchableAttributes?.includes('comfy_nodes')
+    const hasSearchQuery = query && query.trim().length > 0
 
-    const searchParams = {
-      search: isNodeSearch ? undefined : query,
-      comfy_node_search: isNodeSearch ? query : undefined,
-      limit: pageSize,
-      offset: pageNumber * pageSize
+    let searchResult: { nodes?: RegistryNodePack[] } | null = null
+
+    if (hasSearchQuery) {
+      // Use /nodes/search endpoint when there's a search query
+      const searchParams: SearchNodesParams = {
+        search: isNodeSearch ? undefined : query,
+        comfy_node_search: isNodeSearch ? query : undefined,
+        limit: pageSize,
+        page: pageNumber + 1 // API uses 1-based page numbers
+      }
+
+      // Apply filters that are supported by search endpoint
+      if (filters) {
+        if (typeof filters.supported_os === 'string') {
+          searchParams.supported_os = filters.supported_os
+        }
+        // Map from our unified filter name to the search endpoint's parameter name
+        if (typeof filters.supported_accelerator === 'string') {
+          searchParams.supported_accelerator = filters.supported_accelerator
+        }
+      }
+
+      searchResult = await registryStore.search.call(searchParams)
+    } else {
+      // Use /nodes endpoint when there's no search query (supports more parameters)
+      const listParams: ListNodesParams = {
+        limit: pageSize,
+        page: pageNumber + 1 // API uses 1-based page numbers
+      }
+
+      // Apply filters that are supported by list endpoint
+      if (filters) {
+        if (typeof filters.supported_os === 'string') {
+          listParams.supported_os = filters.supported_os
+        }
+        if (typeof filters.supported_accelerator === 'string') {
+          listParams.supported_accelerator = filters.supported_accelerator
+        }
+        if (typeof filters.timestamp === 'string') {
+          listParams.timestamp = filters.timestamp
+        }
+      }
+
+      // Apply sort if provided (only supported by list endpoint)
+      if (sortField) {
+        const sortParam =
+          sortDirection === 'desc' ? `${sortField};desc` : sortField
+        listParams.sort = [sortParam]
+      }
+
+      searchResult = await registryStore.listAllPacks.call(listParams)
     }
-
-    const searchResult = await registryStore.search.call(searchParams)
 
     if (!searchResult || !searchResult.nodes) {
       return {
@@ -59,13 +116,13 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
     sortField: string
   ): string | number => {
     switch (sortField) {
-      case 'downloads':
+      case 'total_install':
         return pack.downloads ?? 0
       case 'name':
         return pack.name ?? ''
-      case 'publisher':
+      case 'publisher_name':
         return pack.publisher?.name ?? ''
-      case 'updated':
+      case 'last_updated':
         return pack.latest_version?.createdAt
           ? new Date(pack.latest_version.createdAt).getTime()
           : 0
@@ -76,10 +133,111 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
 
   const getSortableFields = (): SortableField[] => {
     return [
-      { id: 'downloads', label: 'Downloads', direction: 'desc' },
+      { id: 'total_install', label: 'Downloads', direction: 'desc' },
       { id: 'name', label: 'Name', direction: 'asc' },
-      { id: 'publisher', label: 'Publisher', direction: 'asc' },
-      { id: 'updated', label: 'Updated', direction: 'desc' }
+      { id: 'publisher_name', label: 'Publisher', direction: 'asc' },
+      { id: 'last_updated', label: 'Updated', direction: 'desc' }
+    ]
+  }
+
+  /**
+   * Map system OS to filter value
+   */
+  const getDefaultOSFilter = (): string | undefined => {
+    const stats = systemStatsStore.systemStats
+    if (!stats?.system?.os) return undefined
+
+    const osLower = stats.system.os.toLowerCase()
+    if (osLower.includes('windows')) return 'windows'
+    if (osLower.includes('darwin') || osLower.includes('mac')) return 'macos'
+    if (osLower.includes('linux')) return 'linux'
+    return undefined
+  }
+
+  /**
+   * Map system GPU to filter value
+   */
+  const getDefaultAcceleratorFilter = (): string | undefined => {
+    const stats = systemStatsStore.systemStats
+    if (!stats?.devices || stats.devices.length === 0) return undefined
+
+    // Look for the first GPU device
+    for (const device of stats.devices) {
+      const deviceType = device.type.toLowerCase()
+      if (deviceType.includes('cuda')) return 'cuda'
+      if (deviceType.includes('mps')) return 'mps'
+      if (deviceType.includes('rocm')) return 'rocm'
+      if (deviceType.includes('directml')) return 'directml'
+    }
+    return undefined
+  }
+
+  const getFilterableFields = (): SearchFilter[] => {
+    return [
+      {
+        id: 'supported_os',
+        label: 'Operating System',
+        type: 'single-select',
+        options: [
+          { value: 'windows', label: 'Windows' },
+          { value: 'macos', label: 'macOS' },
+          { value: 'linux', label: 'Linux' }
+        ],
+        defaultValue: getDefaultOSFilter()
+      },
+      {
+        // Note: search endpoint uses singular, list endpoint uses plural
+        id: 'supported_accelerator',
+        label: 'GPU Support',
+        type: 'single-select',
+        options: [
+          { value: 'cuda', label: 'CUDA (NVIDIA)' },
+          { value: 'directml', label: 'DirectML' },
+          { value: 'rocm', label: 'ROCm (AMD)' },
+          { value: 'mps', label: 'Metal (Apple)' }
+        ],
+        defaultValue: getDefaultAcceleratorFilter()
+      },
+      {
+        // Note: timestamp filter is only available on the list endpoint (no search query)
+        id: 'timestamp',
+        label: 'Updated Since',
+        type: 'single-select',
+        options: [
+          {
+            value: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+            label: 'Last 24 hours'
+          },
+          {
+            value: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+            label: 'Last week'
+          },
+          {
+            value: new Date(
+              Date.now() - 30 * 24 * 60 * 60 * 1000
+            ).toISOString(),
+            label: 'Last month'
+          },
+          {
+            value: new Date(
+              Date.now() - 90 * 24 * 60 * 60 * 1000
+            ).toISOString(),
+            label: 'Last 3 months'
+          },
+          {
+            value: new Date(
+              Date.now() - 180 * 24 * 60 * 60 * 1000
+            ).toISOString(),
+            label: 'Last 6 months'
+          },
+          {
+            value: new Date(
+              Date.now() - 365 * 24 * 60 * 60 * 1000
+            ).toISOString(),
+            label: 'Last year'
+          }
+        ]
+      }
     ]
   }
 
@@ -87,6 +245,7 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
     searchPacks,
     clearSearchCache,
     getSortValue,
-    getSortableFields
+    getSortableFields,
+    getFilterableFields
   }
 }

--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -1,10 +1,12 @@
 import QuickLRU from '@alloc/quick-lru'
 import { partition } from 'lodash'
 import { defineStore } from 'pinia'
+import { ref } from 'vue'
 
 import { useCachedRequest } from '@/composables/useCachedRequest'
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
 import type { components, operations } from '@/types/comfyRegistryTypes'
+import type { ProviderState } from '@/types/searchServiceTypes'
 
 const PACK_LIST_CACHE_SIZE = 20
 const PACK_BY_ID_CACHE_SIZE = 64
@@ -33,6 +35,11 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
   const getPacksByIdCache = new QuickLRU<NodePack['id'], NodePack>({
     maxSize: PACK_BY_ID_CACHE_SIZE
   })
+
+  // Search gateway state
+  const searchProviders = ref<ProviderState[]>([])
+  const activeSearchProviderIndex = ref(0)
+  const isSearchGatewayInitialized = ref(false)
 
   /**
    * Get a list of all node packs from the registry
@@ -137,6 +144,11 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     cancelRequests,
 
     isLoading: registryService.isLoading,
-    error: registryService.error
+    error: registryService.error,
+
+    // Search gateway state
+    searchProviders,
+    activeSearchProviderIndex,
+    isSearchGatewayInitialized
   }
 })

--- a/src/types/algoliaTypes.ts
+++ b/src/types/algoliaTypes.ts
@@ -1,7 +1,4 @@
-import type {
-  BaseSearchParamsWithoutQuery,
-  Hit
-} from 'algoliasearch/dist/lite/browser'
+import type { Hit } from 'algoliasearch/dist/lite/browser'
 
 import type { components } from '@/types/comfyRegistryTypes'
 
@@ -86,8 +83,11 @@ export interface NodesIndexSuggestion {
 /**
  * Parameters for searching the Algolia index.
  */
-export type SearchNodePacksParams = BaseSearchParamsWithoutQuery & {
+export interface SearchNodePacksParams {
   pageSize: number
   pageNumber: number
   restrictSearchableAttributes?: SearchAttribute[]
+  filters?: Record<string, string | string[] | boolean>
+  sortField?: string
+  sortDirection?: 'asc' | 'desc'
 }

--- a/src/types/searchServiceTypes.ts
+++ b/src/types/searchServiceTypes.ts
@@ -70,3 +70,15 @@ export interface NodePackSearchProvider {
    */
   getFilterableFields(): SearchFilter[]
 }
+
+/**
+ * State of a search provider
+ */
+export interface ProviderState {
+  provider: NodePackSearchProvider
+  name: string
+  isHealthy: boolean
+  lastError?: Error
+  lastAttempt?: Date
+  consecutiveFailures: number
+}

--- a/src/types/searchServiceTypes.ts
+++ b/src/types/searchServiceTypes.ts
@@ -16,9 +16,9 @@ export type QuerySuggestion = {
 export interface SearchFilter {
   id: string
   label: string
-  type: 'multi-select' | 'single-select' | 'boolean'
+  type: 'single-select' | 'boolean'
   options?: FilterOption[]
-  defaultValue?: string | string[] | boolean
+  defaultValue?: string | boolean
 }
 
 export interface FilterOption {
@@ -27,7 +27,7 @@ export interface FilterOption {
   icon?: string
 }
 
-export type ActiveFilters = Record<string, string | string[] | boolean>
+export type ActiveFilters = Record<string, string | boolean>
 
 export interface SearchPacksResult {
   nodePacks: RegistryNodePack[]

--- a/src/types/searchServiceTypes.ts
+++ b/src/types/searchServiceTypes.ts
@@ -7,10 +7,27 @@ type RegistryNodePack = components['schemas']['Node']
  * Search mode for filtering results
  */
 export type SearchMode = 'nodes' | 'packs'
+
 export type QuerySuggestion = {
   query: string
   popularity: number
 }
+
+export interface SearchFilter {
+  id: string
+  label: string
+  type: 'multi-select' | 'single-select' | 'boolean'
+  options?: FilterOption[]
+  defaultValue?: string | string[] | boolean
+}
+
+export interface FilterOption {
+  value: string
+  label: string
+  icon?: string
+}
+
+export type ActiveFilters = Record<string, string | string[] | boolean>
 
 export interface SearchPacksResult {
   nodePacks: RegistryNodePack[]
@@ -46,4 +63,10 @@ export interface NodePackSearchProvider {
    * Get the list of sortable fields supported by this provider
    */
   getSortableFields(): SortableField[]
+
+  /**
+   * Get the list of filterable fields supported by this provider
+   * Providers that don't support filters should return an empty array
+   */
+  getFilterableFields(): SearchFilter[]
 }

--- a/tests-ui/tests/services/registrySearchGateway.test.ts
+++ b/tests-ui/tests/services/registrySearchGateway.test.ts
@@ -1,3 +1,4 @@
+import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useRegistrySearchGateway } from '@/services/gateway/registrySearchGateway'
@@ -14,6 +15,7 @@ describe('useRegistrySearchGateway', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    setActivePinia(createPinia())
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
   })

--- a/tests-ui/tests/services/registrySearchGateway.test.ts
+++ b/tests-ui/tests/services/registrySearchGateway.test.ts
@@ -30,14 +30,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -63,7 +65,8 @@ describe('useRegistrySearchGateway', () => {
           .mockResolvedValue({ nodePacks: [], querySuggestions: [] }),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useComfyRegistrySearchProvider).mockReturnValue(
@@ -101,14 +104,16 @@ describe('useRegistrySearchGateway', () => {
           .mockRejectedValueOnce(new Error('Algolia failed')),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn().mockResolvedValue(registryResult),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -138,14 +143,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn().mockRejectedValue(new Error('Algolia failed')),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn().mockRejectedValue(new Error('Registry failed')),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -173,14 +180,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn().mockRejectedValue(new Error('Algolia failed')),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn().mockResolvedValue(registryResult),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -214,7 +223,8 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn().mockRejectedValue(new Error('Persistent failure')),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
@@ -223,7 +233,8 @@ describe('useRegistrySearchGateway', () => {
           .mockResolvedValue({ nodePacks: [], querySuggestions: [] }),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -242,14 +253,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -271,14 +284,16 @@ describe('useRegistrySearchGateway', () => {
           throw new Error('Cache clear failed')
         }),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -307,14 +322,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue(algoliaFields)
+        getSortableFields: vi.fn().mockReturnValue(algoliaFields),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -338,7 +355,8 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn().mockRejectedValue(new Error('Algolia failed')),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue(algoliaFields)
+        getSortableFields: vi.fn().mockReturnValue(algoliaFields),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
@@ -347,7 +365,8 @@ describe('useRegistrySearchGateway', () => {
           .mockResolvedValue({ nodePacks: [], querySuggestions: [] }),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue(registryFields)
+        getSortableFields: vi.fn().mockReturnValue(registryFields),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -372,14 +391,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn().mockReturnValue(100),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn(),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)
@@ -412,14 +433,16 @@ describe('useRegistrySearchGateway', () => {
         searchPacks: vi.fn().mockRejectedValue(algoliaError),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       const mockRegistryProvider = {
         searchPacks: vi.fn().mockResolvedValue(registryResult),
         clearSearchCache: vi.fn(),
         getSortValue: vi.fn(),
-        getSortableFields: vi.fn().mockReturnValue([])
+        getSortableFields: vi.fn().mockReturnValue([]),
+        getFilterableFields: vi.fn().mockReturnValue([])
       }
 
       vi.mocked(useAlgoliaSearchProvider).mockReturnValue(mockAlgoliaProvider)

--- a/tests-ui/tests/services/registrySearchProvider.test.ts
+++ b/tests-ui/tests/services/registrySearchProvider.test.ts
@@ -1,3 +1,4 @@
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useComfyRegistrySearchProvider } from '@/services/providers/registrySearchProvider'
@@ -14,6 +15,7 @@ describe('useComfyRegistrySearchProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    setActivePinia(createPinia())
 
     // Setup store mock
     vi.mocked(useComfyRegistryStore).mockReturnValue({
@@ -45,7 +47,7 @@ describe('useComfyRegistrySearchProvider', () => {
         search: 'test',
         comfy_node_search: undefined,
         limit: 10,
-        offset: 0
+        page: 1
       })
       expect(result.nodePacks).toEqual(mockResults.nodes)
       expect(result.querySuggestions).toEqual([])
@@ -68,7 +70,7 @@ describe('useComfyRegistrySearchProvider', () => {
         search: undefined,
         comfy_node_search: 'LoadImage',
         limit: 20,
-        offset: 20
+        page: 2
       })
       expect(result.nodePacks).toEqual(mockResults.nodes)
     })
@@ -136,7 +138,7 @@ describe('useComfyRegistrySearchProvider', () => {
 
     it('should return download count for downloads field', () => {
       const provider = useComfyRegistrySearchProvider()
-      expect(provider.getSortValue(testPack, 'downloads')).toBe(100)
+      expect(provider.getSortValue(testPack, 'total_install')).toBe(100)
     })
 
     it('should return pack name for name field', () => {
@@ -146,22 +148,24 @@ describe('useComfyRegistrySearchProvider', () => {
 
     it('should return publisher name for publisher field', () => {
       const provider = useComfyRegistrySearchProvider()
-      expect(provider.getSortValue(testPack, 'publisher')).toBe('Publisher One')
+      expect(provider.getSortValue(testPack, 'publisher_name')).toBe(
+        'Publisher One'
+      )
     })
 
     it('should return timestamp for updated field', () => {
       const provider = useComfyRegistrySearchProvider()
       const timestamp = new Date('2024-01-15T10:00:00Z').getTime()
-      expect(provider.getSortValue(testPack, 'updated')).toBe(timestamp)
+      expect(provider.getSortValue(testPack, 'last_updated')).toBe(timestamp)
     })
 
     it('should handle missing values gracefully', () => {
       const incompletePack = { id: '1', name: 'Incomplete' }
       const provider = useComfyRegistrySearchProvider()
 
-      expect(provider.getSortValue(incompletePack, 'downloads')).toBe(0)
-      expect(provider.getSortValue(incompletePack, 'publisher')).toBe('')
-      expect(provider.getSortValue(incompletePack, 'updated')).toBe(0)
+      expect(provider.getSortValue(incompletePack, 'total_install')).toBe(0)
+      expect(provider.getSortValue(incompletePack, 'publisher_name')).toBe('')
+      expect(provider.getSortValue(incompletePack, 'last_updated')).toBe(0)
     })
 
     it('should return 0 for unknown sort fields', () => {
@@ -176,10 +180,10 @@ describe('useComfyRegistrySearchProvider', () => {
       const fields = provider.getSortableFields()
 
       expect(fields).toEqual([
-        { id: 'downloads', label: 'Downloads', direction: 'desc' },
+        { id: 'total_install', label: 'Downloads', direction: 'desc' },
         { id: 'name', label: 'Name', direction: 'asc' },
-        { id: 'publisher', label: 'Publisher', direction: 'asc' },
-        { id: 'updated', label: 'Updated', direction: 'desc' }
+        { id: 'publisher_name', label: 'Publisher', direction: 'asc' },
+        { id: 'last_updated', label: 'Updated', direction: 'desc' }
       ])
     })
   })


### PR DESCRIPTION
Adds `getFilterableFields(): SearchFilter[]` to node pack search provider interface, which all search providers must implement.

Implements search filtering for Comfy Registry search provider, adjusting logic based on whether targeting `/nodes` or `/nodes/search` ([openapi spec](https://github.com/Comfy-Org/comfy-api/blob/91d72e6f9df8625d2e5858a1bb88b1edcef92fc9/openapi.yml#L2130-L2253)) endpoints. Current filters are:

- Supported OS
- Supported GPU
- Updated after

OS and GPU filters should be auto-populated based on user's system.

![Selection_1516](https://github.com/user-attachments/assets/fe1488d5-dc13-442e-833a-24dfc3210cc5)

Algolia filter implementation will be done in followup PR. When provider gives empty list of filters, the component is simply not rendered.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4193-Manager-Implement-search-filters-2146d73d365081769f46cf4ee3c5231b) by [Unito](https://www.unito.io)
