### PR TITLE
[refactor] Add ResultItemType and improve image upload typing

### DIFF
--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -5,14 +5,13 @@ import { useNodeDragAndDrop } from '@/composables/node/useNodeDragAndDrop'
 import { useNodeFileInput } from '@/composables/node/useNodeFileInput'
 import { useNodePaste } from '@/composables/node/useNodePaste'
 import { t } from '@/i18n'
+import type { ResultItemType } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { DOMWidget } from '@/scripts/domWidget'
 import { useToastStore } from '@/stores/toastStore'
 
 import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
-
-type FolderType = 'input' | 'output' | 'temp'
 
 function splitFilePath(path: string): [string, string] {
   const folder_separator = path.lastIndexOf('/')
@@ -28,7 +27,7 @@ function splitFilePath(path: string): [string, string] {
 function getResourceURL(
   subfolder: string,
   filename: string,
-  type: FolderType = 'input'
+  type: ResultItemType = 'input'
 ): string {
   const params = [
     'filename=' + encodeURIComponent(filename),

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -11,10 +11,13 @@ import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 const zNodeType = z.string()
 const zQueueIndex = z.number()
 const zPromptId = z.string()
+export const resultItemType = z.enum(['input', 'output', 'temp'])
+export type ResultItemType = z.infer<typeof resultItemType>
+
 const zResultItem = z.object({
   filename: z.string().optional(),
   subfolder: z.string().optional(),
-  type: z.string().optional()
+  type: resultItemType.optional()
 })
 export type ResultItem = z.infer<typeof zResultItem>
 const zOutputs = z

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
+import { resultItemType } from '@/schemas/apiSchema'
+
 const zComboOption = z.union([z.string(), z.number()])
 const zRemoteWidgetConfig = z.object({
   route: z.string().url().or(z.string().startsWith('/')),
@@ -72,7 +74,7 @@ export const zStringInputOptions = zBaseInputOptions.extend({
 export const zComboInputOptions = zBaseInputOptions.extend({
   control_after_generate: z.boolean().optional(),
   image_upload: z.boolean().optional(),
-  image_folder: z.enum(['input', 'output', 'temp']).optional(),
+  image_folder: resultItemType.optional(),
   allow_batch: z.boolean().optional(),
   video_upload: z.boolean().optional(),
   animated_image_upload: z.boolean().optional(),

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -1,7 +1,11 @@
 import { LGraphNode } from '@comfyorg/litegraph'
 import { defineStore } from 'pinia'
 
-import { ExecutedWsMessage, ResultItem } from '@/schemas/apiSchema'
+import {
+  ExecutedWsMessage,
+  ResultItem,
+  ResultItemType
+} from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { parseFilePath } from '@/utils/formatUtil'
@@ -9,7 +13,7 @@ import { isVideoNode } from '@/utils/litegraphUtil'
 
 const createOutputs = (
   filenames: string[],
-  type: string,
+  type: ResultItemType,
   isAnimated: boolean
 ): ExecutedWsMessage['output'] => {
   return {
@@ -88,7 +92,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     {
       folder = 'input',
       isAnimated = false
-    }: { folder?: string; isAnimated?: boolean } = {}
+    }: { folder?: ResultItemType; isAnimated?: boolean } = {}
   ) {
     if (!filenames || !node) return
 


### PR DESCRIPTION
This PR adds the ResultItemType enum for proper typing of image folder values, completing part of the image upload type refactoring that was split after PR #4185 was reverted in PR #4190.

## Context

PR #4185 originally attempted to improve type safety for image upload functionality but was reverted because it mixed backend API types with frontend-only runtime properties in the schema. The refactor was then split into multiple parts:

1. **PR #4192** (merged): Introduced a frontend type augmentation pattern to handle runtime-injected properties like `imageInputName` without modifying the schema
2. **This PR**: Adds the `ResultItemType` enum and updates existing code to use it
3. **PR #4186**: Will add the `ImageUploadFormFields` interface and update `useNodeImageUpload.ts` (to be rebased after this PR merges)

## What this PR does

### 1. Adds `ResultItemType` enum
- Created a proper enum in `apiSchema.ts` for the `type` field values: `'input'  < /dev/null |  'output' | 'temp'`
- These values represent which folder uploaded files should be stored in
- Exported both the zod enum (`resultItemType`) and TypeScript type (`ResultItemType`)

### 2. Updates existing code to use proper types
- `uploadAudio.ts`: Replaced local `FolderType` with shared `ResultItemType`
- `imagePreviewStore.ts`: Updated function signatures to use `ResultItemType` instead of `string`
- `nodeDefSchema.ts`: Updated `image_folder` to use the imported `resultItemType` zod enum

## Why this approach is better

- **Type safety**: Ensures folder types are constrained to valid values at compile time
- **Single source of truth**: The `ResultItemType` enum is defined once and reused everywhere
- **Clear separation**: Backend API types are separate from frontend augmentations
- **No schema pollution**: Only properties that exist in the backend are included in the schema

## Testing

- ✅ All TypeScript checks pass (`npm run typecheck`)
- ✅ All linting checks pass (`npm run lint`)
- ✅ All unit tests pass (`npm run test:unit`)
- ✅ No regressions in existing functionality

Note: The changes to `useNodeImageUpload.ts` have been moved to PR #4186 to keep this PR focused on just the type definitions.