### PR TITLE
Subgraph testing release v1.22.0-sub.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfyorg/comfyui-frontend",
-  "version": "1.22.0-sub.6",
+  "version": "1.22.0-sub.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfyorg/comfyui-frontend",
-      "version": "1.22.0-sub.6",
+      "version": "1.22.0-sub.7",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.22.0-sub.6",
+  "version": "1.22.0-sub.7",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Alpha testing release: 1.22.0-sub.7

Do not overwrite / save production workflows whilst testing this version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4205-Subgraph-testing-release-v1-22-0-sub-7-2156d73d365081a3b9e6edb36542afb1) by [Unito](https://www.unito.io)
