### PR TITLE
Revert "Subgraph testing release v1.22.0-sub.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfyorg/comfyui-frontend",
-  "version": "1.22.0-sub.7",
+  "version": "1.22.0-sub.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfyorg/comfyui-frontend",
-      "version": "1.22.0-sub.7",
+      "version": "1.22.0-sub.6",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.22.0-sub.7",
+  "version": "1.22.0-sub.6",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Reverts Comfy-Org/ComfyUI_frontend#4205

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4206-Revert-Subgraph-testing-release-v1-22-0-sub-7-2156d73d365081f0ad55e29ab429e30a) by [Unito](https://www.unito.io)
