### PR TITLE
[Test] Fix vitest scope overlaps playwright tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: [
+      'tests-ui/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'src/components/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
+    ],
     coverage: {
       reporter: ['text', 'json', 'html']
     }


### PR DESCRIPTION
Narrows vitest test scope to `components` & `tests-ui`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4218-Test-Fix-vitest-scope-overlaps-playwright-tests-2166d73d3650815fa1f8daa598e2b6fe) by [Unito](https://www.unito.io)
