### PR TITLE
[CI] Fix intermittent failure when using actions/cache

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -47,7 +47,7 @@ jobs:
         run: echo "key=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Cache setup
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             ComfyUI
@@ -63,7 +63,7 @@ jobs:
         browser: [chromium, chromium-2x, mobile-chrome]
     steps:
       - name: Restore cached setup
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             ComfyUI


### PR DESCRIPTION
- Update GH action to use cache v4.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4219-CI-Fix-intermittent-failure-when-using-actions-cache-2166d73d36508142a34fed8c2ec14a36) by [Unito](https://www.unito.io)
