### PR TITLE
[Manager] Modal UI Adjustment (Align with Design)

### DIFF
--- a/src/components/common/ContentDivider.vue
+++ b/src/components/common/ContentDivider.vue
@@ -34,6 +34,8 @@ const isLightTheme = computed(
   padding: 0;
   border: none;
   flex-shrink: 0;
+  position: relative;
+  z-index: 1;
 }
 
 .content-divider--horizontal {

--- a/src/components/common/ContentDivider.vue
+++ b/src/components/common/ContentDivider.vue
@@ -1,15 +1,12 @@
 <template>
-  <hr
+  <div
     :class="{
-      'm-0': true,
-      'border-t': orientation === 'horizontal',
-      'border-l': orientation === 'vertical',
-      'h-full': orientation === 'vertical',
-      'w-full': orientation === 'horizontal'
+      'content-divider': true,
+      'content-divider--horizontal': orientation === 'horizontal',
+      'content-divider--vertical': orientation === 'vertical'
     }"
     :style="{
-      borderColor: isLightTheme ? '#DCDAE1' : '#2C2C2C',
-      borderWidth: `${width}px !important`
+      backgroundColor: isLightTheme ? '#DCDAE1' : '#2C2C2C'
     }"
   />
 </template>
@@ -29,3 +26,23 @@ const isLightTheme = computed(
   () => colorPaletteStore.completedActivePalette.light_theme
 )
 </script>
+
+<style scoped>
+.content-divider {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  border: none;
+  flex-shrink: 0;
+}
+
+.content-divider--horizontal {
+  width: 100%;
+  height: v-bind('width + "px"');
+}
+
+.content-divider--vertical {
+  height: 100%;
+  width: v-bind('width + "px"');
+}
+</style>

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -50,4 +50,9 @@ const dialogStore = useDialogStore()
   @apply p-2 2xl:p-[var(--p-dialog-content-padding)];
   @apply pt-0;
 }
+
+.manager-dialog {
+  max-width: 1724px;
+  max-height: 1026px;
+}
 </style>

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -52,6 +52,7 @@ const dialogStore = useDialogStore()
 }
 
 .manager-dialog {
+  height: 80vh;
   max-width: 1724px;
   max-height: 1026px;
 }
@@ -59,7 +60,7 @@ const dialogStore = useDialogStore()
 @media (min-width: 3000px) {
   .manager-dialog {
     max-width: 2200px;
-    max-height: 1300px;
+    max-height: 1320px;
   }
 }
 </style>

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -55,4 +55,11 @@ const dialogStore = useDialogStore()
   max-width: 1724px;
   max-height: 1026px;
 }
+
+@media (min-width: 3000px) {
+  .manager-dialog {
+    max-width: 2200px;
+    max-height: 1300px;
+  }
+}
 </style>

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col mx-auto overflow-hidden h-[83vh] max-h-[956px]"
+    class="h-full flex flex-col mx-auto overflow-hidden"
     :aria-label="$t('manager.title')"
   >
     <ContentDivider :width="0.3" />

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -1,14 +1,16 @@
 <template>
   <div
-    class="flex flex-col mx-auto overflow-hidden h-[83vh] relative"
+    class="flex flex-col mx-auto overflow-hidden h-[83vh]"
     :aria-label="$t('manager.title')"
   >
+    <ContentDivider :width="0.3" />
     <Button
       v-if="isSmallScreen"
       :icon="isSideNavOpen ? 'pi pi-chevron-left' : 'pi pi-chevron-right'"
-      text
+      severity="secondary"
+      filled
       class="absolute top-1/2 -translate-y-1/2 z-10"
-      :class="isSideNavOpen ? 'left-[19rem]' : 'left-2'"
+      :class="isSideNavOpen ? 'left-[12rem]' : 'left-2'"
       @click="toggleSideNav"
     />
     <div class="flex flex-1 relative overflow-hidden">
@@ -18,14 +20,12 @@
         :tabs="tabs"
       />
       <div
-        class="flex-1 overflow-auto pr-80"
+        class="flex-1 overflow-auto bg-[#F7F7F7]"
         :class="{
-          'transition-all duration-300': isSmallScreen,
-          'pl-80': isSideNavOpen || !isSmallScreen,
-          'pl-8': !isSideNavOpen && isSmallScreen
+          'transition-all duration-300': isSmallScreen
         }"
       >
-        <div class="px-6 pt-6 flex flex-col h-full">
+        <div class="px-6 flex flex-col h-full">
           <RegistrySearchBar
             v-model:searchQuery="searchQuery"
             v-model:searchMode="searchMode"
@@ -77,9 +77,9 @@
           </div>
         </div>
       </div>
-      <div class="w-80 border-l-0 absolute right-0 top-0 bottom-0 flex z-20">
+      <div class="max-w-[306px] w-4/12 border-l-0 flex z-20">
         <ContentDivider orientation="vertical" :width="0.2" />
-        <div class="flex-1 flex flex-col isolate">
+        <div class="w-full flex flex-col isolate">
           <InfoPanel
             v-if="!hasMultipleSelections && selectedNodePack"
             :node-pack="selectedNodePack"

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col mx-auto overflow-hidden h-[83vh]"
+    class="flex flex-col mx-auto overflow-hidden h-[83vh] max-h-[956px]"
     :aria-label="$t('manager.title')"
   >
     <ContentDivider :width="0.3" />

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -77,7 +77,7 @@
           </div>
         </div>
       </div>
-      <div class="max-w-[306px] w-4/12 border-l-0 flex z-20">
+      <div class="w-[clamp(250px,33%,306px)] border-l-0 flex z-20">
         <ContentDivider orientation="vertical" :width="0.2" />
         <div class="w-full flex flex-col isolate">
           <InfoPanel

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -20,7 +20,7 @@
         :tabs="tabs"
       />
       <div
-        class="flex-1 overflow-auto bg-[#F7F7F7]"
+        class="flex-1 overflow-auto bg-gray-50 dark-theme:bg-neutral-900"
         :class="{
           'transition-all duration-300': isSmallScreen
         }"

--- a/src/components/dialog/content/manager/ManagerHeader.vue
+++ b/src/components/dialog/content/manager/ManagerHeader.vue
@@ -1,14 +1,9 @@
 <template>
   <div class="w-full">
-    <div class="px-6 py-4">
+    <div class="flex items-center">
       <h2 class="text-lg font-normal text-left">
         {{ $t('manager.discoverCommunityContent') }}
       </h2>
     </div>
-    <ContentDivider :width="0.3" />
   </div>
 </template>
-
-<script setup lang="ts">
-import ContentDivider from '@/components/common/ContentDivider.vue'
-</script>

--- a/src/components/dialog/content/manager/ManagerNavSidebar.vue
+++ b/src/components/dialog/content/manager/ManagerNavSidebar.vue
@@ -1,8 +1,8 @@
 <template>
   <aside
-    class="absolute translate-x-0 top-0 left-0 h-full w-80 shadow-md z-5 transition-transform duration-300 ease-in-out flex"
+    class="flex translate-x-0 max-w-[250px] w-3/12 z-5 transition-transform duration-300 ease-in-out"
   >
-    <ScrollPanel class="w-80 mt-7">
+    <ScrollPanel class="flex-1">
       <Listbox
         v-model="selectedTab"
         :options="tabs"
@@ -10,20 +10,20 @@
         list-style="max-height:unset"
         class="w-full border-0 bg-transparent shadow-none"
         :pt="{
-          list: { class: 'p-5' },
-          option: { class: 'px-8 py-3 text-lg rounded-xl' },
+          list: { class: 'p-3 gap-2' },
+          option: { class: 'px-4 py-2 text-lg rounded-xl' },
           optionGroup: { class: 'p-0 text-left text-inherit' }
         }"
       >
         <template #option="slotProps">
           <div class="text-left flex items-center">
-            <i :class="['pi', slotProps.option.icon, 'mr-3']" />
-            <span class="text-lg">{{ slotProps.option.label }}</span>
+            <i :class="['pi', slotProps.option.icon, 'text-sm mr-2']" />
+            <span class="text-sm">{{ slotProps.option.label }}</span>
           </div>
         </template>
       </Listbox>
     </ScrollPanel>
-    <ContentDivider orientation="vertical" />
+    <ContentDivider orientation="vertical" :width="0.3" />
   </aside>
 </template>
 

--- a/src/components/dialog/content/manager/ManagerNavSidebar.vue
+++ b/src/components/dialog/content/manager/ManagerNavSidebar.vue
@@ -11,7 +11,7 @@
         class="w-full border-0 bg-transparent shadow-none"
         :pt="{
           list: { class: 'p-3 gap-2' },
-          option: { class: 'px-4 py-2 text-lg rounded-xl' },
+          option: { class: 'px-4 py-2 text-lg rounded-lg' },
           optionGroup: { class: 'p-0 text-left text-inherit' }
         }"
       >

--- a/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="nodePack">
-    <div class="flex flex-col h-full z-40 w-80 overflow-hidden relative">
+    <div class="flex flex-col h-full z-40 overflow-hidden relative">
       <div class="top-0 z-10 px-6 pt-6 w-full">
         <InfoPanelHeader :node-packs="[nodePack]" />
       </div>
@@ -42,7 +42,7 @@
     </div>
   </template>
   <template v-else>
-    <div class="mt-4 mx-8 flex-1 overflow-hidden text-sm">
+    <div class="pt-4 px-8 flex-1 overflow-hidden text-sm">
       {{ $t('manager.infoPanelEmpty') }}
     </div>
   </template>

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -138,7 +138,10 @@ export const useDialogService = () => {
         closable: true,
         pt: {
           pcCloseButton: {
-            root: { class: 'bg-gray-500 w-9 h-9 p-1.5 rounded-full text-white' }
+            root: {
+              class:
+                'bg-gray-500 dark-theme:bg-neutral-700 w-9 h-9 p-1.5 rounded-full text-white'
+            }
           },
           header: { class: '!py-0 px-6 !m-0 h-[68px]' },
           content: {

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -137,6 +137,9 @@ export const useDialogService = () => {
       dialogComponentProps: {
         closable: true,
         pt: {
+          pcCloseButton: {
+            root: { class: 'bg-gray-500 w-9 h-9 p-1.5 rounded-full text-white' }
+          },
           header: { class: '!py-0 px-6 !m-0 h-[68px]' },
           content: {
             class: '!px-0 h-[83vh] w-[90vw] max-w-full flex-1 overflow-y-hidden'

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -137,8 +137,11 @@ export const useDialogService = () => {
       dialogComponentProps: {
         closable: true,
         pt: {
-          header: { class: '!p-0 !m-0' },
-          content: { class: '!px-0 h-[83vh] w-[90vw] overflow-y-hidden' }
+          header: { class: '!py-0 px-6 !m-0 h-[68px]' },
+          content: {
+            class: '!px-0 h-[83vh] w-[90vw] max-w-full flex-1 overflow-y-hidden'
+          },
+          root: { class: 'manager-dialog' }
         }
       },
       props

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -145,8 +145,7 @@ export const useDialogService = () => {
           },
           header: { class: '!py-0 px-6 !m-0 h-[68px]' },
           content: {
-            class:
-              '!px-0 h-[83vh] max-h-[956px] w-[90vw] max-w-full flex-1 overflow-y-hidden'
+            class: '!p-0 h-full w-[90vw] max-w-full flex-1 overflow-hidden'
           },
           root: { class: 'manager-dialog' }
         }

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -142,7 +142,8 @@ export const useDialogService = () => {
           },
           header: { class: '!py-0 px-6 !m-0 h-[68px]' },
           content: {
-            class: '!px-0 h-[83vh] w-[90vw] max-w-full flex-1 overflow-y-hidden'
+            class:
+              '!px-0 h-[83vh] max-h-[956px] w-[90vw] max-w-full flex-1 overflow-y-hidden'
           },
           root: { class: 'manager-dialog' }
         }


### PR DESCRIPTION
## Summary

Enhanced Manager Dialog interface and fixed ContentDivider component styling issues. Added responsive layout optimization and proper size constraints for better cross-device experience.

Key improvements:
- Fixed Manager Dialog oversizing on large displays (max-width: 1724px)
- Resolved ContentDivider double-line rendering issue  
- Enhanced responsive layout for mobile/tablet devices
- Improved component isolation and maintainability

## Behavior

**Before:**
- Manager Dialog could become oversized on large screens
- ContentDivider showed double lines due to browser default hr styling conflicts
- Fixed pixel widths caused poor responsiveness
- Sidebar was too wide (320px) for smaller screens

**After:**
- Manager Dialog constrained to max-width: 1724px, max-height: 1026px
- ContentDivider displays clean single lines with proper theme colors
- Responsive layout using relative units (w-3/12, w-4/12)
- Compact sidebar design optimized for all screen sizes

## Components

**ContentDivider.vue** - Complete rewrite
- Replaced `<hr>` with `<div>` to eliminate browser style conflicts
- Used background-color instead of border-color for cleaner rendering
- Added CSS v-bind for dynamic sizing and scoped styles

**GlobalDialog.vue** - Manager-specific styling
- Added `.manager-dialog` class with size constraints

**ManagerDialogContent.vue** - Layout improvements
- Converted fixed widths to responsive units
- Added background color and optimized spacing
- Improved main content area layout

**ManagerNavSidebar.vue** - Responsive sidebar
- Changed from w-80 fixed to max-w-[250px] w-3/12 responsive
- Reduced padding and text sizes for compact design
- Switched from absolute to flex-based positioning

**InfoPanel.vue** - Flexible panel sizing
- Removed fixed width constraints for better responsiveness
- Optimized spacing and positioning

**dialogService.ts** - Manager dialog configuration  
- Added manager-dialog class and improved header styling
- Enhanced content area configuration


[As-is]
![스크린샷 2025-06-20 오후 7 01 05](https://github.com/user-attachments/assets/56fc3b51-b664-429e-ae3c-d5cc19f92fc8)

[To-be]
![스크린샷 2025-06-20 오후 6 58 55](https://github.com/user-attachments/assets/8c072d01-bc96-4f35-b902-26a28910d3b7)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4222-Manager-Modal-UI-Adjustment-Align-with-Design-2186d73d365081079bfbe26233855f66) by [Unito](https://www.unito.io)
