### PR TITLE
Fix typo in 3D settings

### DIFF
--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1040,7 +1040,7 @@
     "Graph": "画面",
     "Group": "组节点",
     "Keybinding": "快捷键",
-    "Light": "浅色",
+    "Light": "光照",
     "Link": "连线",
     "LinkRelease": "释放链接",
     "LiteGraph": "画面",


### PR DESCRIPTION
"浅色" means "light color". The correct translation for "light"  is "光照"

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4224-Fix-typo-in-3D-settings-2186d73d36508196852cc9e82f368afd) by [Unito](https://www.unito.io)
