### PR TITLE
[Manager] Fix "total nodes" count when selecting multiple packs

### DIFF
--- a/src/components/dialog/content/manager/infoPanel/InfoPanelMultiItem.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanelMultiItem.vue
@@ -51,7 +51,11 @@ const getPackNodes = async (pack: components['schemas']['Node']) => {
   if (!pack.latest_version?.version) return []
   const nodeDefs = await getNodeDefs.call({
     packId: pack.id,
-    version: pack.latest_version?.version
+    version: pack.latest_version?.version,
+    // Fetch all nodes.
+    // TODO: Render all nodes previews and handle pagination.
+    // For determining length, use the `totalNumberOfPages` field of response
+    limit: 8192
   })
   return nodeDefs?.comfy_nodes ?? []
 }


### PR DESCRIPTION
Fixes the displayed "total nodes" count in the info panel when selecting multiple nodes at once.

![Selection_1541](https://github.com/user-attachments/assets/f84f6b41-7af5-48a4-9052-d03c58887d0e)


`api.comfy.org/nodes/{node_id}/comfy_nodes` has paginated responses. When not setting `limit` in request, it defaults to 10. The component therefore always displayed packs with more than 10 individual nodes as having only 10. Fix by setting limit to high value for now.

In followup, we will display concatenated preview of all nodes with lazy loading and infinite scroll. For determining length we will use the `totalNumberOfPages` field in the response. [Task](https://www.notion.so/drip-art/Show-Active-Workflow-and-Node-Count-in-Header-2176d73d3650809bb6cde20fd0c2f9f4?source=copy_link)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4228-Manager-Fix-total-nodes-count-when-selecting-multiple-packs-2186d73d36508197a94ec3418649a2fb) by [Unito](https://www.unito.io)
