### PR TITLE
[Manager] Update Algolia mappings

### DIFF
--- a/src/services/providers/algoliaSearchProvider.ts
+++ b/src/services/providers/algoliaSearchProvider.ts
@@ -42,7 +42,14 @@ const RETRIEVE_ATTRIBUTES: SearchAttribute[] = [
   'latest_version_status',
   'comfy_node_extract_status',
   'id',
-  'icon_url'
+  'icon_url',
+  'github_stars',
+  'supported_os',
+  'supported_comfyui_version',
+  'supported_comfyui_frontend_version',
+  'supported_accelerators',
+  'tags',
+  'banner_url'
 ]
 
 const searchPacksCache = new QuickLRU<string, SearchPacksResult>({
@@ -86,9 +93,17 @@ const toRegistryPack = memoize(
       icon: algoliaNode.icon_url,
       latest_version: toRegistryLatestVersion(algoliaNode),
       publisher: toRegistryPublisher(algoliaNode),
+      created_at: algoliaNode.create_time,
+      category: algoliaNode.category,
+      author: algoliaNode.author,
+      tags: algoliaNode.tags,
+      github_stars: algoliaNode.github_stars,
+      supported_os: algoliaNode.supported_os,
+      supported_comfyui_version: algoliaNode.supported_comfyui_version,
+      supported_comfyui_frontend_version:
+        algoliaNode.supported_comfyui_frontend_version,
       // @ts-expect-error comfy_nodes also not in node info
-      comfy_nodes: algoliaNode.comfy_nodes,
-      create_time: algoliaNode.create_time
+      comfy_nodes: algoliaNode.comfy_nodes
     }
   },
   (algoliaNode: AlgoliaNodePack) => algoliaNode.id

--- a/src/services/providers/algoliaSearchProvider.ts
+++ b/src/services/providers/algoliaSearchProvider.ts
@@ -203,9 +203,7 @@ export const useAlgoliaSearchProvider = (): NodePackSearchProvider => {
       case SortableAlgoliaField.Downloads:
         return pack.downloads ?? 0
       case SortableAlgoliaField.Created: {
-        // TODO: add create time to backend return type
-        // @ts-expect-error create_time is not in the RegistryNodePack type
-        const createTime = pack.create_time
+        const createTime = pack.created_at
         return createTime ? new Date(createTime).getTime() : 0
       }
       case SortableAlgoliaField.Updated:

--- a/src/services/providers/algoliaSearchProvider.ts
+++ b/src/services/providers/algoliaSearchProvider.ts
@@ -48,7 +48,6 @@ const RETRIEVE_ATTRIBUTES: SearchAttribute[] = [
   'supported_comfyui_version',
   'supported_comfyui_frontend_version',
   'supported_accelerators',
-  'tags',
   'banner_url'
 ]
 
@@ -102,6 +101,8 @@ const toRegistryPack = memoize(
       supported_comfyui_version: algoliaNode.supported_comfyui_version,
       supported_comfyui_frontend_version:
         algoliaNode.supported_comfyui_frontend_version,
+      supported_accelerators: algoliaNode.supported_accelerators,
+      banner_url: algoliaNode.banner_url,
       // @ts-expect-error comfy_nodes also not in node info
       comfy_nodes: algoliaNode.comfy_nodes
     }

--- a/src/types/algoliaTypes.ts
+++ b/src/types/algoliaTypes.ts
@@ -59,6 +59,15 @@ export interface AlgoliaNodePack {
     'comfy_node_extract_status'
   >
   icon_url: RegistryNodePack['icon']
+  category: RegistryNodePack['category']
+  author: RegistryNodePack['author']
+  tags: RegistryNodePack['tags']
+  github_stars: RegistryNodePack['github_stars']
+  supported_os: RegistryNodePack['supported_os']
+  supported_comfyui_version: RegistryNodePack['supported_comfyui_version']
+  supported_comfyui_frontend_version: RegistryNodePack['supported_comfyui_frontend_version']
+  supported_accelerators: RegistryNodePack['supported_accelerators']
+  banner_url: RegistryNodePack['banner_url']
 }
 
 /**

--- a/tests-ui/tests/services/algoliaSearchProvider.test.ts
+++ b/tests-ui/tests/services/algoliaSearchProvider.test.ts
@@ -108,8 +108,17 @@ describe('useAlgoliaSearchProvider', () => {
           id: 'publisher-1',
           name: 'publisher-1'
         },
-        create_time: '2024-01-01T00:00:00Z',
-        comfy_nodes: ['LoadImage', 'SaveImage']
+        created_at: '2024-01-01T00:00:00Z',
+        comfy_nodes: ['LoadImage', 'SaveImage'],
+        category: undefined,
+        author: undefined,
+        tags: undefined,
+        github_stars: undefined,
+        supported_os: undefined,
+        supported_comfyui_version: undefined,
+        supported_comfyui_frontend_version: undefined,
+        supported_accelerators: undefined,
+        banner_url: undefined
       })
     })
 
@@ -253,7 +262,7 @@ describe('useAlgoliaSearchProvider', () => {
         version: '1.0.0',
         createdAt: '2024-01-15T10:00:00Z'
       },
-      create_time: '2024-01-01T10:00:00Z'
+      created_at: '2024-01-01T10:00:00Z'
     }
 
     it('should return correct values for each sort field', () => {


### PR DESCRIPTION
Update retrieved attributes and Algolia => Comfy Registry mapper to incorporate new attributes:

- **Create time**. is added to the Registry pack schema https://github.com/Comfy-Org/comfy-api/pull/488
  - and it was already returned by Algolia, so now we can include it in the Algolia => Registry mapper
- **GitHub star count**. added to Registry and Algolia in https://github.com/Comfy-Org/comfy-api/pull/470
- **Banner url**. added to Registry in https://github.com/Comfy-Org/comfy-api/pull/461
- **Compatibilities**. supported OS, ComfyUI version, ComfyUI_frontend version, supported accelerators added in https://github.com/Comfy-Org/comfy-api/pull/446

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4230-Manager-Update-Algolia-mappings-2186d73d36508132895dcde6373da4b3) by [Unito](https://www.unito.io)
