### PR TITLE
Fix: Scroll event leak after scrolling to the top of a text widget #3990

### DIFF
--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -54,37 +54,24 @@ function addMultilineWidget(
     }
   })
 
-  /** Timer reference. `null` when the timer completes. */
-  let ignoreEventsTimer: ReturnType<typeof setTimeout> | null = null
-  /** Total number of events ignored since the timer started. */
-  let ignoredEvents = 0
-
-  // Pass wheel events to the canvas when appropriate
   inputEl.addEventListener('wheel', (event: WheelEvent) => {
-    if (!Object.is(event.deltaX, -0)) return
-
-    // If the textarea has focus, require more effort to activate pass-through
-    const multiplier = document.activeElement === inputEl ? 2 : 1
     const maxScrollHeight = inputEl.scrollHeight - inputEl.clientHeight
+    const isScrollable = inputEl.scrollHeight > inputEl.clientHeight
+    const isAtTop = inputEl.scrollTop === 0
+    const isAtBottom = inputEl.scrollTop === maxScrollHeight
 
-    if (
-      (event.deltaY < 0 && inputEl.scrollTop === 0) ||
-      (event.deltaY > 0 && inputEl.scrollTop === maxScrollHeight)
-    ) {
-      // Attempting to scroll past the end of the textarea
-      if (!ignoreEventsTimer || ignoredEvents > 25 * multiplier) {
-        app.canvas.processMouseWheel(event)
-      } else {
-        ignoredEvents++
-      }
-    } else if (event.deltaY !== 0) {
-      // Start timer whenever a successful scroll occurs
-      ignoredEvents = 0
-      if (ignoreEventsTimer) clearTimeout(ignoreEventsTimer)
+    if (isScrollable) {
+      // Do not pass wheel to canvas if text can scroll
+      event.stopPropagation()
+      return
+    }
 
-      ignoreEventsTimer = setTimeout(() => {
-        ignoreEventsTimer = null
-      }, 800 * multiplier)
+    if ((event.deltaY < 0 && isAtTop) || (event.deltaY > 0 && isAtBottom)) {
+      app.canvas.processMouseWheel(event)
+    }
+
+    if (event.ctrlKey) {
+      event.stopPropagation()
     }
   })
 

--- a/src/composables/widgets/useStringWidget.ts
+++ b/src/composables/widgets/useStringWidget.ts
@@ -8,6 +8,8 @@ import { app } from '@/scripts/app'
 import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
 import { useSettingStore } from '@/stores/settingStore'
 
+const TRACKPAD_DETECTION_THRESHOLD = 50
+
 function addMultilineWidget(
   node: LGraphNode,
   name: string,
@@ -73,9 +75,10 @@ function addMultilineWidget(
     }
 
     // Detect if this is likely a trackpad gesture vs mouse wheel
-    // Trackpads usually have deltaX or smaller deltaY values (< 50)
-    // Mouse wheels typically have larger discrete deltaY values (>= 50)
-    const isLikelyTrackpad = Math.abs(deltaX) > 0 || Math.abs(deltaY) < 50
+    // Trackpads usually have deltaX or smaller deltaY values (< TRACKPAD_DETECTION_THRESHOLD)
+    // Mouse wheels typically have larger discrete deltaY values (>= TRACKPAD_DETECTION_THRESHOLD)
+    const isLikelyTrackpad =
+      Math.abs(deltaX) > 0 || Math.abs(deltaY) < TRACKPAD_DETECTION_THRESHOLD
 
     // Trackpad gestures: when enabled, trackpad panning goes to canvas
     if (gesturesEnabled && isLikelyTrackpad) {


### PR DESCRIPTION
[Bug]: Scroll event leak after scrolling to the top of a text widget #3990

The current changes focus on scrolling only when the text is scrollable and zooms in when there is nothing to scroll.

The earlier implementation seems to be a workaround to handle an earlier issue(https://github.com/Comfy-Org/ComfyUI_frontend/pull/3422).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4231-Fix-Scroll-event-leak-after-scrolling-to-the-top-of-a-text-widget-3990-2196d73d3650818eaf45e868e8012b8f) by [Unito](https://www.unito.io)
