### PR TITLE
[Manager] Fix: failed tasks logs not correctly partitioned in UI

### DIFF
--- a/src/composables/useServerLogs.ts
+++ b/src/composables/useServerLogs.ts
@@ -7,8 +7,10 @@ import { components } from '@/types/generatedManagerTypes'
 
 const LOGS_MESSAGE_TYPE = 'logs'
 const MANAGER_WS_TASK_DONE_NAME = 'cm-task-completed'
+const MANAGER_WS_TASK_STARTED_NAME = 'cm-task-started'
 
 type ManagerWsTaskDoneMsg = components['schemas']['MessageTaskDone']
+type ManagerWsTaskStartedMsg = components['schemas']['MessageTaskStarted']
 
 interface UseServerLogsOptions {
   ui_id: string
@@ -23,8 +25,10 @@ export const useServerLogs = (options: UseServerLogsOptions) => {
   } = options
 
   const logs = ref<string[]>([])
+  const isTaskStarted = ref(false)
   let stopLogs: ReturnType<typeof useEventListener> | null = null
   let stopTaskDone: ReturnType<typeof useEventListener> | null = null
+  let stopTaskStarted: ReturnType<typeof useEventListener> | null = null
 
   const isValidLogEvent = (event: CustomEvent<LogsWsMessage>) =>
     event?.type === LOGS_MESSAGE_TYPE && event.detail?.entries?.length > 0
@@ -33,6 +37,9 @@ export const useServerLogs = (options: UseServerLogsOptions) => {
     event.detail.entries.map((e) => e.m).filter(messageFilter)
 
   const handleLogMessage = (event: CustomEvent<LogsWsMessage>) => {
+    // Only capture logs if this task has started
+    if (!isTaskStarted.value) return
+
     if (isValidLogEvent(event)) {
       const messages = parseLogMessage(event)
       if (messages.length > 0) {
@@ -41,11 +48,24 @@ export const useServerLogs = (options: UseServerLogsOptions) => {
     }
   }
 
+  const handleTaskStarted = (event: CustomEvent<ManagerWsTaskStartedMsg>) => {
+    if (event?.type === MANAGER_WS_TASK_STARTED_NAME) {
+      // Check if this is our task starting
+      const isOurTask = event.detail.ui_id === options.ui_id
+      if (isOurTask) {
+        isTaskStarted.value = true
+        void stopTaskStarted?.()
+      }
+    }
+  }
+
   const handleTaskDone = (event: CustomEvent<ManagerWsTaskDoneMsg>) => {
     if (event?.type === MANAGER_WS_TASK_DONE_NAME) {
       const { state } = event.detail
       // Check if our task is now in the history (completed)
-      if (state.history[options.ui_id]) {
+      const isOurTaskDone = state.history[options.ui_id]
+      if (isOurTaskDone) {
+        isTaskStarted.value = false
         void stopListening()
       }
     }
@@ -54,6 +74,11 @@ export const useServerLogs = (options: UseServerLogsOptions) => {
   const startListening = async () => {
     await api.subscribeLogs(true)
     stopLogs = useEventListener(api, LOGS_MESSAGE_TYPE, handleLogMessage)
+    stopTaskStarted = useEventListener(
+      api,
+      MANAGER_WS_TASK_STARTED_NAME,
+      handleTaskStarted
+    )
     stopTaskDone = useEventListener(
       api,
       MANAGER_WS_TASK_DONE_NAME,
@@ -62,10 +87,11 @@ export const useServerLogs = (options: UseServerLogsOptions) => {
   }
 
   const stopListening = async () => {
-    console.log('stopListening')
     stopLogs?.()
+    stopTaskStarted?.()
     stopTaskDone?.()
     stopLogs = null
+    stopTaskStarted = null
     stopTaskDone = null
     await api.subscribeLogs(false)
   }
@@ -77,6 +103,7 @@ export const useServerLogs = (options: UseServerLogsOptions) => {
   const cleanup = async () => {
     await stopListening()
     logs.value = []
+    isTaskStarted.value = false
   }
 
   return {

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -90,7 +90,6 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     () => {
       partitionTasks()
       partitionTaskLogs()
-      console.log('installed pack ids', installedPacksIds.value)
     },
     { deep: true }
   )
@@ -154,26 +153,12 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
 
   const updateInstalledIds = (packs: ManagerPackInstalled[]) => {
     const newIds = packsToIdSet(packs)
-    console.log('updateInstalledIds: creating set with:', Array.from(newIds))
     installedPacksIds.value = newIds
-    console.log(
-      'updateInstalledIds: final installedPacksIds:',
-      Array.from(installedPacksIds.value)
-    )
   }
 
   const onPacksChanged = () => {
     const packs = Object.values(installedPacks.value)
-    console.log(
-      'onPacksChanged called with packs:',
-      packs.map((p) => ({
-        key: Object.keys(installedPacks.value).find(
-          (k) => installedPacks.value[k] === p
-        ),
-        cnr_id: p.cnr_id,
-        aux_id: p.aux_id
-      }))
-    )
+
     updateDisabledIds(packs)
     updateInstalledIds(packs)
   }
@@ -336,7 +321,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     failedTasksIds,
     succeededTasksLogs,
     failedTasksLogs,
-    managerQueue, // Expose full queue composable for advanced usage
+    managerQueue,
 
     // Pack actions
     installPack,


### PR DESCRIPTION
Fix bug where task logs bleed into one another. Start listening when receiving the task started WS message.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4242-Manager-Fix-failed-tasks-logs-not-correctly-partitioned-in-UI-21a6d73d3650818e9c3af9989e541ad1) by [Unito](https://www.unito.io)
