### PR TITLE
[manager] Release 1.23.1-man.1 for manager migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.23.1",
+  "version": "1.23.1-man.1",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
## Summary
- Bumps version to 1.23.1-man.1 for the manager menu items migration release

## Release Info
- Version: 1.23.1-man.1
- Base branch: manager/menu-items-migration
- Purpose: Pre-release for testing manager migration changes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4243-manager-Release-1-23-1-man-1-for-manager-migration-21a6d73d365081328900cb789f7e6506) by [Unito](https://www.unito.io)
