### PR TITLE
Fix: fix typo in `Lite Graph` settings

### DIFF
--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1043,7 +1043,7 @@
     "Extension": "扩展",
     "General": "常规",
     "Graph": "画面",
-    "Group": "组节点",
+    "Group": "组",
     "Keybinding": "快捷键",
     "Light": "光照",
     "Link": "连线",


### PR DESCRIPTION
The Chinese term “组节点” means "group node". The correct translation should be  "组".

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4245-Fix-fix-typo-in-Lite-Graph-settings-21a6d73d365081cfb9b4fd4a87488517) by [Unito](https://www.unito.io)
