### PR TITLE
Subgraph testing release v1.22.2-sub.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfyorg/comfyui-frontend",
-  "version": "1.22.2-sub.9",
+  "version": "1.22.2-sub.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfyorg/comfyui-frontend",
-      "version": "1.22.2-sub.9",
+      "version": "1.22.2-sub.10",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.22.2-sub.9",
+  "version": "1.22.2-sub.10",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Alpha testing release: 1.22.2-sub.10

Do not overwrite / save production workflows whilst testing this version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4248-Subgraph-testing-release-v1-22-2-sub-10-21a6d73d36508114bfd2ff5b96453eae) by [Unito](https://www.unito.io)
