### PR TITLE
[Manager] Fix: When using registry search provider, results not properly paginated'

### DIFF
--- a/src/services/providers/registrySearchProvider.ts
+++ b/src/services/providers/registrySearchProvider.ts
@@ -32,7 +32,7 @@ export const useComfyRegistrySearchProvider = (): NodePackSearchProvider => {
       search: isNodeSearch ? undefined : query,
       comfy_node_search: isNodeSearch ? query : undefined,
       limit: pageSize,
-      offset: pageNumber * pageSize
+      page: pageNumber + 1 // Registry API uses 1-based pagination
     }
 
     const searchResult = await registryStore.search.call(searchParams)

--- a/tests-ui/tests/services/registrySearchProvider.test.ts
+++ b/tests-ui/tests/services/registrySearchProvider.test.ts
@@ -45,7 +45,7 @@ describe('useComfyRegistrySearchProvider', () => {
         search: 'test',
         comfy_node_search: undefined,
         limit: 10,
-        offset: 0
+        page: 1
       })
       expect(result.nodePacks).toEqual(mockResults.nodes)
       expect(result.querySuggestions).toEqual([])
@@ -68,7 +68,7 @@ describe('useComfyRegistrySearchProvider', () => {
         search: undefined,
         comfy_node_search: 'LoadImage',
         limit: 20,
-        offset: 20
+        page: 2
       })
       expect(result.nodePacks).toEqual(mockResults.nodes)
     })


### PR DESCRIPTION
Fixes bug introduced in https://github.com/Comfy-Org/ComfyUI_frontend/issues/4183 in which the registry search provider's results are not properly paginated (keeps getting the first page of results over and over).

The `offset` parameter was being used in search query, but the API expects `page` (`offset` is not specified in the [spec](https://api.comfy.org/openapi) at all). See also [generated types](https://github.com/Comfy-Org/ComfyUI_frontend/blob/3a1bd1829a06518dde21be80614be69fd129d52a/src/types/comfyRegistryTypes.ts#L10838-L10907)


https://github.com/user-attachments/assets/3c255993-294a-4acf-96bc-c6835efc1361

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4249-Manager-Fix-When-using-registry-search-provider-results-not-properly-paginated-21b6d73d3650812f8423cd850538d7f8) by [Unito](https://www.unito.io)
