### PR TITLE
Fix: virtual grid scrolling bug when container is rendered with emtpy items (switching tabs)

### DIFF
--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -92,12 +92,21 @@ whenever(
 const updateItemSize = () => {
   if (container.value) {
     const firstItem = container.value.querySelector('[data-virtual-grid-item]')
-    itemHeight.value = firstItem?.clientHeight || defaultItemHeight
-    itemWidth.value = firstItem?.clientWidth || defaultItemWidth
+
+    // Don't update item size if the first item is not rendered yet
+    if (!firstItem?.clientHeight || !firstItem?.clientWidth) return
+
+    if (itemHeight.value !== firstItem.clientHeight) {
+      itemHeight.value = firstItem.clientHeight
+    }
+    if (itemWidth.value !== firstItem.clientWidth) {
+      itemWidth.value = firstItem.clientWidth
+    }
   }
 }
 const onResize = debounce(updateItemSize, resizeDebounce)
 watch([width, height], onResize, { flush: 'post' })
+whenever(() => items, updateItemSize)
 onBeforeUnmount(() => {
   onResize.cancel() // Clear pending debounced calls
 })

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -219,10 +219,6 @@ const {
 const filterMissingPacks = (packs: components['schemas']['Node'][]) =>
   packs.filter((pack) => !comfyManagerStore.isPackInstalled(pack.id))
 
-whenever(selectedTab, () => {
-  pageNumber.value = 0
-})
-
 const isUpdateAvailableTab = computed(
   () => selectedTab.value?.id === ManagerTab.UpdateAvailable
 )
@@ -468,9 +464,10 @@ let gridContainer: HTMLElement | null = null
 onMounted(() => {
   gridContainer = document.getElementById('results-grid')
 })
-watch(searchQuery, () => {
+watch([searchQuery, selectedTab], () => {
   gridContainer ??= document.getElementById('results-grid')
   if (gridContainer) {
+    pageNumber.value = 0
     gridContainer.scrollTop = 0
   }
 })


### PR DESCRIPTION
### Reproduction Steps

1. Open the manager
2. Focus the **Missing** tab (make sure nothing shows -- no nodes missing in active workflow)
3. Close the manager modal
4. Re-open the manager modal, the **Missing** tab is focused (restored state)
5. The VirtualGrid will try to calculate the size of its items. Since there are no items, it will use the default value (200x200)
6. Switch to a tab that has items (e.g., **All** tab)
7. The VirtualGrid does not re-calculate the item size. If 200x200 is far off from the actual size, the scroll virtualization logic will break and it will appear to be constantly re-rendering and scrolling

### Fix

- Whenever `items` change, update item size (previously, size only updated when the reactive `height` and `width` from `useElementSize` triggered)
- If `items` changes to an empty list, don't overwrite previous size

https://github.com/user-attachments/assets/64f7d643-e877-47af-8609-6ecc86d48cd3

### Additional performance improvements

- don't trigger downstream computeds if items changes but itemsize has not changed
- consolidate tab/query watcher in `ManagerDialogContent`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4251-Fix-virtual-grid-scrolling-bug-when-container-is-rendered-with-emtpy-items-switching-ta-21b6d73d36508135b67bde719e1dd545) by [Unito](https://www.unito.io)
