### PR TITLE
[Manager] Fix bug: opening modal when last focused tab was 'Installed' always shows empty list

### DIFF
--- a/src/composables/nodePack/useInstalledPacks.ts
+++ b/src/composables/nodePack/useInstalledPacks.ts
@@ -18,6 +18,11 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
   const filterInstalledPack = (packs: components['schemas']['Node'][]) =>
     packs.filter((pack) => comfyManagerStore.isPackInstalled(pack.id))
 
+  const startFetchInstalled = async () => {
+    await comfyManagerStore.refreshInstalledList()
+    await startFetch()
+  }
+
   onUnmounted(() => {
     cleanup()
   })
@@ -27,7 +32,7 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
     isLoading,
     isReady,
     installedPacks: nodePacks,
-    startFetchInstalled: startFetch,
+    startFetchInstalled,
     filterInstalledPack
   }
 }

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -213,6 +213,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     isPackInstalled: isInstalledPackId,
     isPackEnabled: isEnabledPackId,
     getInstalledPackVersion,
+    refreshInstalledList,
 
     // Pack actions
     installPack,


### PR DESCRIPTION
Fixes bug introduced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/4180: If opening the modal straight on the installed tab, the fetch for the metadata of each installed pack begins before the list of installed packs is resolved by the Manager.

The correct sequence should be:

1. Fetch list of the installed packs via `/api/customnode/installed`
2. After the list of installed packs is resolved, THEN
3. Fetch the full metadata from the registry via `https://api.comfy.org/nodes&node_id=`

The bug fixed here caused **1** and **3** to start in parallel.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4252-Manager-Fix-bug-opening-modal-when-last-focused-tab-was-Installed-always-shows-empty-21b6d73d365081859844ef098430073a) by [Unito](https://www.unito.io)
