### PR TITLE
[Manager] Fix flush timing issue when switching tabs

### DIFF
--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -106,7 +106,7 @@ const updateItemSize = () => {
 }
 const onResize = debounce(updateItemSize, resizeDebounce)
 watch([width, height], onResize, { flush: 'post' })
-whenever(() => items, updateItemSize)
+whenever(() => items, updateItemSize, { flush: 'post' })
 onBeforeUnmount(() => {
   onResize.cancel() // Clear pending debounced calls
 })

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -59,7 +59,7 @@
               <VirtualGrid
                 id="results-grid"
                 :items="resultsWithKeys"
-                :buffer-rows="3"
+                :buffer-rows="4"
                 :grid-style="GRID_STYLE"
                 @approach-end="onApproachEnd"
               >


### PR DESCRIPTION
Follow-up from https://github.com/Comfy-Org/ComfyUI_frontend/pull/4251.

`VirtualGrid` items are rendered from the `items` array.

We want to update the item size when `items` changes by watching `items`. But we need to wait for Vue to update the DOM with the new `items` before we can query their width/height and update the size refs. This is the prototypical use case for `flush: 'post'`.

See https://vuejs.org/guide/essentials/watchers.html#post-watchers

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4253-Manager-Fix-flush-timing-issue-when-switching-tabs-21b6d73d36508144a77aca498237f464) by [Unito](https://www.unito.io)
