### PR TITLE
[Manager] Fix bug: installed packs metadata not re-fetched after installations

### DIFF
--- a/src/composables/nodePack/useInstalledPacks.ts
+++ b/src/composables/nodePack/useInstalledPacks.ts
@@ -1,3 +1,4 @@
+import { whenever } from '@vueuse/core'
 import { computed, onUnmounted } from 'vue'
 
 import { useNodePacks } from '@/composables/nodePack/useNodePacks'
@@ -22,6 +23,11 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
     await comfyManagerStore.refreshInstalledList()
     await startFetch()
   }
+
+  // When installedPackIds changes, we need to update the nodePacks
+  whenever(installedPackIds, async () => {
+    await startFetch()
+  })
 
   onUnmounted(() => {
     cleanup()


### PR DESCRIPTION
Fixes bug in which, after installing a pack, the pack is not visible in the *Installed* tab of the custom nodes manager modal.

`useInstalledPacks` uses the set of installed pack IDs (from the Manager API - `api/customnode/installed`) to fetch the full metadata for each pack from the Comfy Registry (using `https://api.comfy.org/nodes?node_id=`).

However, if a node pack is installed during runtime, we should re-fetch the metadata.

Note: Triggering the entire fetch is fine because the reigstry service functions already handling per-pack caching.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4254-Manager-Fix-bug-installed-packs-metadata-not-re-fetched-after-installations-21b6d73d365081a8865ee7e1ea00a1a6) by [Unito](https://www.unito.io)
