### PR TITLE
fix: node migration TypeError

### DIFF
--- a/src/schemas/nodeDef/migration.ts
+++ b/src/schemas/nodeDef/migration.ts
@@ -45,23 +45,27 @@ export function transformNodeDefV1ToV2(
   // Transform outputs
   const outputs: OutputSpecV2[] = []
 
-  if (nodeDefV1.output && Array.isArray(nodeDefV1.output)) {
-    nodeDefV1.output.forEach((outputType, index) => {
-      const outputSpec: OutputSpecV2 = {
-        index,
-        name: nodeDefV1.output_name?.[index] || `output_${index}`,
-        type: Array.isArray(outputType) ? 'COMBO' : outputType,
-        is_list: nodeDefV1.output_is_list?.[index] || false,
-        tooltip: nodeDefV1.output_tooltips?.[index]
-      }
+  if (nodeDefV1.output) {
+    if (Array.isArray(nodeDefV1.output)) {
+      nodeDefV1.output.forEach((outputType, index) => {
+        const outputSpec: OutputSpecV2 = {
+          index,
+          name: nodeDefV1.output_name?.[index] || `output_${index}`,
+          type: Array.isArray(outputType) ? 'COMBO' : outputType,
+          is_list: nodeDefV1.output_is_list?.[index] || false,
+          tooltip: nodeDefV1.output_tooltips?.[index]
+        }
 
-      // Add options for combo outputs
-      if (Array.isArray(outputType)) {
-        outputSpec.options = outputType
-      }
+        // Add options for combo outputs
+        if (Array.isArray(outputType)) {
+          outputSpec.options = outputType
+        }
 
-      outputs.push(outputSpec)
-    })
+        outputs.push(outputSpec)
+      })
+    } else {
+      console.warn('nodeDefV1.output is not an array:', nodeDefV1.output)
+    }
   }
 
   // Create the V2 node definition

--- a/src/schemas/nodeDef/migration.ts
+++ b/src/schemas/nodeDef/migration.ts
@@ -45,7 +45,7 @@ export function transformNodeDefV1ToV2(
   // Transform outputs
   const outputs: OutputSpecV2[] = []
 
-  if (nodeDefV1.output) {
+  if (nodeDefV1.output && Array.isArray(nodeDefV1.output)) {
     nodeDefV1.output.forEach((outputType, index) => {
       const outputSpec: OutputSpecV2 = {
         index,


### PR DESCRIPTION
**Context**
[Slack Threads](https://comfy-organization.slack.com/archives/C075ANWQ8KS/p1750756579849109)

Added a guard clause for cases where a custom node defines RETURN_TYPES = ("BOOLEAN") instead of a proper tuple like ("BOOLEAN",).
Without the trailing comma, it’s interpreted as a string rather than an array, which causes issues on the frontend.
This fix ensures the frontend can handle such cases more gracefully.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4260-fix-node-migration-TypeError-21c6d73d365081c7aee4f1b125924744) by [Unito](https://www.unito.io)
