### PR TITLE
Prevent video output nodes from showing edit model button

### DIFF
--- a/src/components/graph/selectionToolbox/EditModelButton.vue
+++ b/src/components/graph/selectionToolbox/EditModelButton.vue
@@ -19,7 +19,7 @@ import { useI18n } from 'vue-i18n'
 
 import { useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
-import { isLGraphNode } from '@/utils/litegraphUtil'
+import { isImageNode, isLGraphNode } from '@/utils/litegraphUtil'
 
 const { t } = useI18n()
 const commandStore = useCommandStore()
@@ -27,7 +27,7 @@ const canvasStore = useCanvasStore()
 
 const isImageOutputOrEditModelNode = (node: unknown) =>
   isLGraphNode(node) &&
-  (node.images?.length || node.type === 'workflow>FLUX.1 Kontext Image Edit')
+  (isImageNode(node) || node.type === 'workflow>FLUX.1 Kontext Image Edit')
 
 const isImageOutputSelected = computed(
   () =>


### PR DESCRIPTION
Re-uses existing predicate.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4278-Prevent-video-nodes-from-being-active-for-edit-model-21e6d73d365081ea9423d29dc85715f2) by [Unito](https://www.unito.io)
