### PR TITLE
[bugfix] Handle backend error messages with appended content

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -667,15 +667,18 @@ export class ComfyApp {
     })
 
     api.addEventListener('execution_error', ({ detail }) => {
+      console.log('execution_error', detail)
       // Check if this is an auth-related error or credits-related error
       if (
-        detail.exception_message ===
-        'Unauthorized: Please login first to use this node.'
+        detail.exception_message?.includes(
+          'Unauthorized: Please login first to use this node.'
+        )
       ) {
         useDialogService().showApiNodesSignInDialog([detail.node_type])
       } else if (
-        detail.exception_message ===
-        'Payment Required: Please add credits to your account to use this node.'
+        detail.exception_message?.includes(
+          'Payment Required: Please add credits to your account to use this node.'
+        )
       ) {
         useDialogService().showTopUpCreditsDialog({
           isInsufficientCredits: true

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -667,7 +667,6 @@ export class ComfyApp {
     })
 
     api.addEventListener('execution_error', ({ detail }) => {
-      console.log('execution_error', detail)
       // Check if this is an auth-related error or credits-related error
       if (
         detail.exception_message?.includes(


### PR DESCRIPTION
Updates error detection to use .includes() instead of exact string matching, allowing proper handling of auth/payment errors when backend appends additional information like OOM tips.

Fixes comfyanonymous/ComfyUI#8574

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4283-bugfix-Handle-backend-error-messages-with-appended-content-21f6d73d365081bd84b2e94c158d19d0) by [Unito](https://www.unito.io)
