### PR TITLE
fix(float-precision): correct float widget rounding

### DIFF
--- a/src/composables/widgets/useFloatWidget.ts
+++ b/src/composables/widgets/useFloatWidget.ts
@@ -62,7 +62,7 @@ export const useFloatWidget = () => {
         max: inputSpec.max ?? 2048,
         round:
           enableRounding && precision && !inputSpec.round
-            ? (1_000_000 * Math.pow(0.1, precision)) / 1_000_000
+            ? Math.pow(10, -precision)
             : (inputSpec.round as number),
         /** @deprecated Use step2 instead. The 10x value is a legacy implementation. */
         step: step * 10.0,

--- a/src/composables/widgets/useFloatWidget.ts
+++ b/src/composables/widgets/useFloatWidget.ts
@@ -10,14 +10,19 @@ import { type ComfyWidgetConstructorV2 } from '@/scripts/widgets'
 import { useSettingStore } from '@/stores/settingStore'
 
 function onFloatValueChange(this: INumericWidget, v: number) {
-  this.value = this.options.round
-    ? _.clamp(
-        Math.round((v + Number.EPSILON) / this.options.round) *
-          this.options.round,
-        this.options.min ?? -Infinity,
-        this.options.max ?? Infinity
-      )
-    : v
+  const round = this.options.round
+  if (round) {
+    const precision =
+      this.options.precision ?? Math.max(0, -Math.floor(Math.log10(round)))
+    const rounded = Math.round(v / round) * round
+    this.value = _.clamp(
+      Number(rounded.toFixed(precision)),
+      this.options.min ?? -Infinity,
+      this.options.max ?? Infinity
+    )
+  } else {
+    this.value = v
+  }
 }
 
 export const _for_testing = {


### PR DESCRIPTION
This PR addresses a long-standing floating-point precision issue that causes float values like `0.1` to be saved incorrectly as `0.10000000000000002` in workflows.

Closes: 
 * https://github.com/comfyanonymous/ComfyUI/issues/8515
 * https://github.com/comfyanonymous/ComfyUI/issues/8658
 
 
---

When a float widget's rounding value was calculated, it was using `Math.pow(0.1, precision)`. Since `0.1` cannot be perfectly represented in binary, this introduced a tiny error that propagated into the final widget value.

The original code tried to mitigate this with a multiplication/division trick, but the error was already present before that trick could be effective.

_This PR was not fully tested, I run tests myself only on a few workflows to prove that there is no such error anymore as in the issues._

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4291-fix-float-precision-correct-float-widget-rounding-2206d73d365081cb8407f95ab34816f3) by [Unito](https://www.unito.io)
