### PR TITLE
[fix] Mock release API in browser tests to prevent UI interference

### DIFF
--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -29,6 +29,16 @@ A template with helpful information can be found in `.env_example`.
 ### Multiple Tests
 If you are running Playwright tests in parallel or running the same test multiple times, the flag `--multi-user` must be added to the main ComfyUI process.
 
+### Release API Mocking
+By default, all tests mock the release API (`api.comfy.org/releases`) to prevent release notification popups from interfering with test execution. This is necessary because the release notifications can appear over UI elements and block test interactions.
+
+To test with real release data, you can disable mocking:
+```typescript
+await comfyPage.setup({ mockReleases: false });
+```
+
+For tests that specifically need to test release functionality, see the example in `tests/releaseNotifications.spec.ts`.
+
 ## Running Tests
 
 There are multiple ways to run the tests:


### PR DESCRIPTION
Fixes intermittent test failures where release notification popups block test interactions with UI elements in the bottom-left area. The fix mocks the /releases endpoint by default while allowing tests to disable mocking when needed for release-specific functionality.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4310-fix-Mock-release-API-in-browser-tests-to-prevent-UI-interference-2226d73d365081768473e708698278cd) by [Unito](https://www.unito.io)
