### PR TITLE
[test] Add release notification browser tests

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -285,7 +285,6 @@ export class ComfyPage {
           url.includes('api.comfy.org') ||
           url.includes('stagingapi.comfy.org')
         ) {
-          console.log('Mocking releases API')
           await route.fulfill({
             status: 200,
             contentType: 'application/json',

--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -1,0 +1,126 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Release Notifications', () => {
+  test('should show help center with release information', async ({
+    comfyPage
+  }) => {
+    // Mock release API with test data instead of empty array
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 1,
+              project: 'comfyui',
+              version: 'v0.3.44',
+              attention: 'medium',
+              content:
+                '## New Features\n\n- Added awesome feature\n- Fixed important bug',
+              published_at: new Date().toISOString()
+            }
+          ])
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // Setup with release mocking disabled for this test
+    await comfyPage.setup({ mockReleases: false })
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.click()
+
+    // Verify help center menu appears
+    const helpMenu = comfyPage.page.locator('.help-center-menu')
+    await expect(helpMenu).toBeVisible()
+
+    // Verify "What's New?" section shows the release
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(whatsNewSection).toBeVisible()
+
+    // Should show the release version
+    await expect(
+      whatsNewSection.locator('text=Comfy v0.3.44 Release')
+    ).toBeVisible()
+
+    // Close help center by dismissable mask
+    await comfyPage.page.click('.help-center-backdrop')
+    await expect(helpMenu).not.toBeVisible()
+  })
+
+  test('should not show release notifications when mocked (default behavior)', async ({
+    comfyPage
+  }) => {
+    // Use default setup (mockReleases: true)
+    await comfyPage.setup()
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.click()
+
+    // Verify help center menu appears
+    const helpMenu = comfyPage.page.locator('.help-center-menu')
+    await expect(helpMenu).toBeVisible()
+
+    // Verify "What's New?" section shows no releases
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(whatsNewSection).toBeVisible()
+
+    // Should show "No recent releases" message
+    await expect(
+      whatsNewSection.locator('text=No recent releases')
+    ).toBeVisible()
+
+    // Should not show any popups or toasts
+    await expect(comfyPage.page.locator('.whats-new-popup')).not.toBeVisible()
+    await expect(
+      comfyPage.page.locator('.release-notification-toast')
+    ).not.toBeVisible()
+  })
+
+  test('should handle release API errors gracefully', async ({ comfyPage }) => {
+    // Mock API to return an error
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Server error' })
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // Setup with release mocking disabled
+    await comfyPage.setup({ mockReleases: false })
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.click()
+
+    // Verify help center still works despite API error
+    const helpMenu = comfyPage.page.locator('.help-center-menu')
+    await expect(helpMenu).toBeVisible()
+
+    // Should show no releases due to error
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(
+      whatsNewSection.locator('text=No recent releases')
+    ).toBeVisible()
+  })
+})

--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -38,6 +38,7 @@ test.describe('Release Notifications', () => {
 
     // Open help center
     const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
     await helpCenterButton.click()
 
     // Verify help center menu appears
@@ -66,6 +67,7 @@ test.describe('Release Notifications', () => {
 
     // Open help center
     const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
     await helpCenterButton.click()
 
     // Verify help center menu appears
@@ -111,6 +113,7 @@ test.describe('Release Notifications', () => {
 
     // Open help center
     const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
     await helpCenterButton.click()
 
     // Verify help center still works despite API error

--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -3,6 +3,10 @@ import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 
 test.describe('Release Notifications', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
+  })
+
   test('should show help center with release information', async ({
     comfyPage
   }) => {


### PR DESCRIPTION
## Summary

Add comprehensive test suite for testing release notification behavior. This is a follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/4310 that adds tests demonstrating how to work with the release API mocking.

## Test plan

The PR adds new browser tests that verify:
- Default mocking behavior prevents release popups
- Tests can disable mocking to test with real data
- Error handling when release API fails

Fixes #4256

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4311-test-Add-release-notification-browser-tests-2236d73d365081c79b91c28663294a22) by [Unito](https://www.unito.io)
