### PR TITLE
[CI] Skip i18n in unrelated PRs

### DIFF
--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -3,6 +3,12 @@ name: Update Locales
 on:
   pull_request:
     branches: [ main, master, dev* ]
+    paths-ignore:
+      - '.github/**'
+      - '.husky/**'
+      - '.vscode/**'
+      - 'browser_tests/**'
+      - 'tests-ui/**'
 
 jobs:
   update-locales:


### PR DESCRIPTION
The i18n CI "Update Locales" will fail if a PR is merged before it completes.

It will no longer be run when updating CI files or other supporting infrastructure.