### PR TITLE
[TS] Remove frontend-only typing from litegraph

### DIFF
--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -57,6 +57,15 @@ declare module '@comfyorg/litegraph/dist/types/widgets' {
 }
 
 /**
+ * ComfyUI extensions of litegraph interfaces
+ */
+declare module '@comfyorg/litegraph/dist/interfaces' {
+  interface IWidgetLocator {
+    [key: symbol]: unknown
+  }
+}
+
+/**
  *  ComfyUI extensions of litegraph
  */
 declare module '@comfyorg/litegraph' {


### PR DESCRIPTION
Fixes upstreamed type - unused in litegraph.

The augmented type cannot be properly defined in litegraph, as the symbol does not exist.  An indexed type must be used, requiring boilerplate code to reimpl. on any subsequent interfaces.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4325-TS-Remove-frontend-only-typing-from-litegraph-2246d73d365081b39ae4ea2561093a66) by [Unito](https://www.unito.io)
