### PR TITLE
[System Pop Up] Improve help center menu behavior and Electron compatibility

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -123,8 +123,8 @@ import Button from 'primevue/button'
 import { type CSSProperties, computed, nextTick, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useCoreCommands } from '@/composables/useCoreCommands'
 import { type ReleaseNote } from '@/services/releaseService'
+import { useCommandStore } from '@/stores/commandStore'
 import { useReleaseStore } from '@/stores/releaseStore'
 import { electronAPI, isElectron } from '@/utils/envUtil'
 import { formatVersionAnchor } from '@/utils/formatUtil'
@@ -167,7 +167,7 @@ const SUBMENU_CONFIG = {
 // Composables
 const { t, locale } = useI18n()
 const releaseStore = useReleaseStore()
-const coreCommands = useCoreCommands()
+const commandStore = useCommandStore()
 
 // Emits
 const emit = defineEmits<{
@@ -262,12 +262,7 @@ const menuItems = computed<MenuItem[]>(() => {
       icon: 'pi pi-question-circle',
       label: t('helpCenter.helpFeedback'),
       action: () => {
-        const feedbackCommand = coreCommands.find(
-          (cmd) => cmd.id === 'Comfy.Feedback'
-        )
-        if (feedbackCommand) {
-          void feedbackCommand.function()
-        }
+        void commandStore.execute('Comfy.Feedback')
         emit('close')
       }
     },

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -166,6 +166,11 @@ const { t, locale } = useI18n()
 const releaseStore = useReleaseStore()
 const coreCommands = useCoreCommands()
 
+// Emits
+const emit = defineEmits<{
+  close: []
+}>()
+
 // State
 const isSubmenuVisible = ref(false)
 const submenuRef = ref<HTMLElement | null>(null)
@@ -180,19 +185,28 @@ const menuItems = computed<MenuItem[]>(() => [
     key: 'docs',
     icon: 'pi pi-book',
     label: t('helpCenter.docs'),
-    action: () => openExternalLink(EXTERNAL_LINKS.DOCS)
+    action: () => {
+      openExternalLink(EXTERNAL_LINKS.DOCS)
+      emit('close')
+    }
   },
   {
     key: 'discord',
     icon: 'pi pi-discord',
     label: 'Discord',
-    action: () => openExternalLink(EXTERNAL_LINKS.DISCORD)
+    action: () => {
+      openExternalLink(EXTERNAL_LINKS.DISCORD)
+      emit('close')
+    }
   },
   {
     key: 'github',
     icon: 'pi pi-github',
     label: t('helpCenter.github'),
-    action: () => openExternalLink(EXTERNAL_LINKS.GITHUB)
+    action: () => {
+      openExternalLink(EXTERNAL_LINKS.GITHUB)
+      emit('close')
+    }
   },
   {
     key: 'help',
@@ -205,6 +219,7 @@ const menuItems = computed<MenuItem[]>(() => [
       if (feedbackCommand) {
         void feedbackCommand.function()
       }
+      emit('close')
     }
   },
   {
@@ -221,13 +236,19 @@ const submenuItems = computed<SubmenuItem[]>(() => [
     key: 'desktop-guide',
     type: 'item',
     label: t('helpCenter.desktopUserGuide'),
-    action: () => openExternalLink(EXTERNAL_LINKS.DESKTOP_GUIDE)
+    action: () => {
+      openExternalLink(EXTERNAL_LINKS.DESKTOP_GUIDE)
+      emit('close')
+    }
   },
   {
     key: 'dev-tools',
     type: 'item',
     label: t('helpCenter.openDevTools'),
-    action: openDevTools
+    action: () => {
+      openDevTools()
+      emit('close')
+    }
   },
   {
     key: 'divider-1',
@@ -237,7 +258,10 @@ const submenuItems = computed<SubmenuItem[]>(() => [
     key: 'reinstall',
     type: 'item',
     label: t('helpCenter.reinstall'),
-    action: onReinstall
+    action: () => {
+      onReinstall()
+      emit('close')
+    }
   }
 ])
 
@@ -386,10 +410,12 @@ const onReleaseClick = (release: ReleaseNote): void => {
   const versionAnchor = formatVersionAnchor(release.version)
   const changelogUrl = `${getChangelogUrl()}#${versionAnchor}`
   openExternalLink(changelogUrl)
+  emit('close')
 }
 
 const onUpdate = (_: ReleaseNote): void => {
   openExternalLink(EXTERNAL_LINKS.UPDATE_GUIDE)
+  emit('close')
 }
 
 // Generate language-aware changelog URL


### PR DESCRIPTION
### Changes
- Fix menu item visibility for Electron-specific features
- Close help center menu automatically after action selection  
- Update help & feedback action to use core commands instead of direct Discord link
- Hide unavailable menu items instead of showing them as disabled
- Improve submenu positioning and item management

### Details
- Menu items now properly hide based on environment (web vs Electron)
- All menu actions now emit close event for better UX
- Submenu items are filtered by visibility rather than disabled state
- Help & feedback now triggers the proper feedback command

**Fixes**: Menu behavior inconsistencies in help center, particularly for Electron desktop users