### PR TITLE
[System Pop Up] Fix settings search showing hidden items and release toast logic bug

### DIFF
--- a/src/composables/setting/useSettingSearch.ts
+++ b/src/composables/setting/useSettingSearch.ts
@@ -53,6 +53,11 @@ export function useSettingSearch() {
     const queryLower = query.toLocaleLowerCase()
     const allSettings = Object.values(settingStore.settingsById)
     const filteredSettings = allSettings.filter((setting) => {
+      // Filter out hidden and deprecated settings, just like in normal settings tree
+      if (setting.type === 'hidden' || setting.deprecated) {
+        return false
+      }
+
       const idLower = setting.id.toLowerCase()
       const nameLower = setting.name.toLowerCase()
       const translatedName = st(

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -85,7 +85,7 @@ export const useReleaseStore = defineStore('release', () => {
     // Skip if user already skipped or changelog seen
     if (
       releaseVersion.value === recentRelease.value?.version &&
-      !['skipped', 'changelog seen'].includes(releaseStatus.value)
+      ['skipped', 'changelog seen'].includes(releaseStatus.value)
     ) {
       return false
     }


### PR DESCRIPTION
## What's Fixed

### Settings Search
- Fixed search showing hidden/deprecated settings that shouldn't be visible to users
- Now properly filters out `hidden` and `deprecated` settings during search, matching the behavior of the normal settings tree

### Release Toast Logic  
- Fixed inverted logic in `shouldShowToast` that was hiding toasts when it should show them
- The condition was checking if user had NOT skipped/seen changelog, but then returning false (hiding toast)
- Removed the negation operator so it correctly hides the toast when user has already skipped or seen the changelog

## Testing
- Search for settings - should only show user-configurable settings now
- Release toasts should now properly respect user's skip/seen status

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4341-System-Pop-Up-Fix-settings-search-showing-hidden-items-and-release-toast-logic-bug-2256d73d36508126a8d0e9e1534cfa8e) by [Unito](https://www.unito.io)
