### PR TITLE
[feat] Implement getNodeByComfyNodeName API integration

### DIFF
--- a/src/stores/comfyRegistryStore.ts
+++ b/src/stores/comfyRegistryStore.ts
@@ -105,12 +105,24 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
   >(registryService.search, { maxSize: PACK_LIST_CACHE_SIZE })
 
   /**
+   * Get the node pack that contains a specific ComfyUI node by its name.
+   * Results are cached to avoid redundant API calls.
+   *
+   * @see {@link useComfyRegistryService.inferPackFromNodeName} for details on the ranking algorithm
+   */
+  const inferPackFromNodeName = useCachedRequest<
+    operations['getNodeByComfyNodeName']['parameters']['path']['comfyNodeName'],
+    NodePack
+  >(registryService.inferPackFromNodeName, { maxSize: PACK_BY_ID_CACHE_SIZE })
+
+  /**
    * Clear all cached data
    */
   const clearCache = () => {
     getNodeDefs.clear()
     listAllPacks.clear()
     getPackById.clear()
+    inferPackFromNodeName.clear()
   }
 
   /**
@@ -120,6 +132,7 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     getNodeDefs.cancel()
     listAllPacks.cancel()
     getPackById.cancel()
+    inferPackFromNodeName.cancel()
     getPacksByIdController?.abort()
   }
 
@@ -132,6 +145,7 @@ export const useComfyRegistryStore = defineStore('comfyRegistry', () => {
     },
     getNodeDefs,
     search,
+    inferPackFromNodeName,
 
     clearCache,
     cancelRequests,


### PR DESCRIPTION
Adds support for the new backend route that finds node packs by ComfyUI node name, replacing usage of `/nodes/search` with `comfy_nodes_search` param. The performance is ~12x faster, going from 850ms to 70ms on average.

Details:

- Replaces `/nodes/search?comfy_nodes_search` with `/comfy-nodes/:nodeName/node` 
- Integrates `useCachedRequest` wrapper for performance
- Adds tests for new functions
- The new route also has Cache-Control headers, so there is now 3-tiered cache (1) in-memory browser caching (<1ms) => (2) browser caching (<50ms) => (3) server in-memory caching (<100ms) => (4) DB call (~300ms-500ms)

:heavy_check_mark: Requires https://github.com/Comfy-Org/comfy-api/pull/531 to be deployed to prod (done).