### PR TITLE
[fix] move i18n pre-commit check inside Windows conditional block

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,9 @@
 if [[ "$OS" == "Windows_NT" ]]; then
   npx.cmd lint-staged
+  # Check for unused i18n keys in staged files
+  npx.cmd tsx scripts/check-unused-i18n-keys.ts
 else
   npx lint-staged
+  # Check for unused i18n keys in staged files
+  npx tsx scripts/check-unused-i18n-keys.ts
 fi
-
-# Check for unused i18n keys in staged files
-npx tsx scripts/check-unused-i18n-keys.ts


### PR DESCRIPTION
Fixes Windows compatibility issue with the i18n unused keys check in pre-commit hook by using npx.cmd on Windows. Addresses review feedback from #4328.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4353-fix-move-i18n-pre-commit-check-inside-Windows-conditional-block-2276d73d365081baad65c688d63bf1be) by [Unito](https://www.unito.io)
