### PR TITLE
add defaultsByInstallVersion

### DIFF
--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -35,7 +35,10 @@ export interface Setting {
 export interface SettingParams extends FormItem {
   id: keyof Settings
   defaultValue: any | (() => any)
-  defaultsByInstallVersion?: Record<string, any | (() => any)>
+  defaultsByInstallVersion?: Record<
+    `${number}.${number}.${number}`,
+    any | (() => any)
+  >
   onChange?: (newValue: any, oldValue?: any) => void
   // By default category is id.split('.'). However, changing id to assign
   // new category has poor backward compatibility. Use this field to overwrite

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -35,6 +35,7 @@ export interface Setting {
 export interface SettingParams extends FormItem {
   id: keyof Settings
   defaultValue: any | (() => any)
+  defaultsByInstallVersion?: Record<string, any | (() => any)>
   onChange?: (newValue: any, oldValue?: any) => void
   // By default category is id.split('.'). However, changing id to assign
   // new category has poor backward compatibility. Use this field to overwrite

--- a/tests-ui/tests/store/settingStore.test.ts
+++ b/tests-ui/tests/store/settingStore.test.ts
@@ -109,6 +109,241 @@ describe('useSettingStore', () => {
     })
   })
 
+  describe('getDefaultValue', () => {
+    beforeEach(() => {
+      // Set up installed version for most tests
+      store.settingValues['Comfy.InstalledVersion'] = '1.30.0'
+    })
+
+    it('should return regular default value when no defaultsByInstallVersion', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default'
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      expect(result).toBe('regular-default')
+    })
+
+    it('should return versioned default when user version matches', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      // installedVersion is 1.30.0, so should get 1.21.3 default
+      expect(result).toBe('version-1.21.3-default')
+    })
+
+    it('should return latest versioned default when user version is higher', () => {
+      store.settingValues['Comfy.InstalledVersion'] = '1.50.0'
+
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      // installedVersion is 1.50.0, so should get 1.40.3 default
+      expect(result).toBe('version-1.40.3-default')
+    })
+
+    it('should return regular default when user version is lower than all versioned defaults', () => {
+      store.settingValues['Comfy.InstalledVersion'] = '1.10.0'
+
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      // installedVersion is 1.10.0, lower than all versioned defaults
+      expect(result).toBe('regular-default')
+    })
+
+    it('should return regular default when no installed version (existing users)', () => {
+      // Clear installed version to simulate existing user
+      delete store.settingValues['Comfy.InstalledVersion']
+
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      // No installed version, should use backward compatibility
+      expect(result).toBe('regular-default')
+    })
+
+    it('should handle function-based versioned defaults', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': () => 'dynamic-version-1.21.3-default',
+          '1.40.3': () => 'dynamic-version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      // installedVersion is 1.30.0, so should get 1.21.3 default (executed)
+      expect(result).toBe('dynamic-version-1.21.3-default')
+    })
+
+    it('should handle function-based regular defaults with versioned defaults', () => {
+      store.settingValues['Comfy.InstalledVersion'] = '1.10.0'
+
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: () => 'dynamic-regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      const result = store.getDefaultValue('test.setting')
+      // installedVersion is 1.10.0, should fallback to function-based regular default
+      expect(result).toBe('dynamic-regular-default')
+    })
+
+    it('should handle complex version comparison correctly', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.21.10': 'version-1.21.10-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      // Test with 1.21.5 - should get 1.21.3 default
+      store.settingValues['Comfy.InstalledVersion'] = '1.21.5'
+      expect(store.getDefaultValue('test.setting')).toBe(
+        'version-1.21.3-default'
+      )
+
+      // Test with 1.21.15 - should get 1.21.10 default
+      store.settingValues['Comfy.InstalledVersion'] = '1.21.15'
+      expect(store.getDefaultValue('test.setting')).toBe(
+        'version-1.21.10-default'
+      )
+
+      // Test with 1.21.3 exactly - should get 1.21.3 default
+      store.settingValues['Comfy.InstalledVersion'] = '1.21.3'
+      expect(store.getDefaultValue('test.setting')).toBe(
+        'version-1.21.3-default'
+      )
+    })
+
+    it('should work with get() method using versioned defaults', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': 'version-1.21.3-default',
+          '1.40.3': 'version-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      // get() should use getDefaultValue internally
+      const result = store.get('test.setting')
+      expect(result).toBe('version-1.21.3-default')
+    })
+
+    it('should handle mixed function and static versioned defaults', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.21.3': () => 'dynamic-1.21.3-default',
+          '1.40.3': 'static-1.40.3-default'
+        }
+      }
+      store.addSetting(setting)
+
+      // Test with 1.30.0 - should get dynamic 1.21.3 default
+      store.settingValues['Comfy.InstalledVersion'] = '1.30.0'
+      expect(store.getDefaultValue('test.setting')).toBe(
+        'dynamic-1.21.3-default'
+      )
+
+      // Test with 1.50.0 - should get static 1.40.3 default
+      store.settingValues['Comfy.InstalledVersion'] = '1.50.0'
+      expect(store.getDefaultValue('test.setting')).toBe(
+        'static-1.40.3-default'
+      )
+    })
+
+    it('should handle version sorting correctly', () => {
+      const setting: SettingParams = {
+        id: 'test.setting',
+        name: 'Test Setting',
+        type: 'text',
+        defaultValue: 'regular-default',
+        defaultsByInstallVersion: {
+          '1.40.3': 'version-1.40.3-default',
+          '1.21.3': 'version-1.21.3-default', // Unsorted order
+          '1.35.0': 'version-1.35.0-default'
+        }
+      }
+      store.addSetting(setting)
+
+      // Test with 1.37.0 - should get 1.35.0 default (highest version <= 1.37.0)
+      store.settingValues['Comfy.InstalledVersion'] = '1.37.0'
+      expect(store.getDefaultValue('test.setting')).toBe(
+        'version-1.35.0-default'
+      )
+    })
+  })
+
   describe('get and set', () => {
     it('should get default value when setting not exists', () => {
       const setting: SettingParams = {


### PR DESCRIPTION
second part of https://github.com/Comfy-Org/ComfyUI_frontend/issues/4073 to add versionedDefalutSettings. 
Main logic comes from parts of https://github.com/Comfy-Org/ComfyUI_frontend/pull/4135 but implemented more unit tests.

For each cases, please refer to unit tests

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4354-add-defaultsByInstallVersion-2276d73d365081c6bffdcc0bfa61e5f9) by [Unito](https://www.unito.io)
