### PR TITLE
[fix] Remove optional designation from issue report details field

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -196,7 +196,7 @@
   "issueReport": {
     "submitErrorReport": "Submit Error Report (Optional)",
     "provideEmail": "Give us your email (optional)",
-    "provideAdditionalDetails": "Provide additional details (optional)",
+    "provideAdditionalDetails": "Provide additional details",
     "stackTrace": "Stack Trace",
     "systemStats": "System Stats",
     "contactFollowUp": "Contact me for follow up",


### PR DESCRIPTION
Removes "(optional)" from the additional details field translation in issue reports since this field is now required since https://github.com/Comfy-Org/ComfyUI_frontend/pull/3939.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4355-fix-Remove-optional-designation-from-issue-report-details-field-2276d73d3650812f83dbe5ecbec17357) by [Unito](https://www.unito.io)
