### PR TITLE
[TS] Update callbacks using CanvasMouseEvent #1104

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -4854,7 +4854,7 @@ class KeyboardManager {
   private maskEditor: MaskEditorDialog
   private messageBroker: MessageBroker
 
-  // Binded functions, for use in addListeners and removeListeners
+  // Bound functions, for use in addListeners and removeListeners
   private handleKeyDownBound = this.handleKeyDown.bind(this)
   private handleKeyUpBound = this.handleKeyUp.bind(this)
   private clearKeysBound = this.clearKeys.bind(this)

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -6,7 +6,7 @@ import type {
   LLink,
   Vector2
 } from '@comfyorg/litegraph'
-import type { CanvasMouseEvent } from '@comfyorg/litegraph/dist/types/events'
+import type { CanvasPointerEvent } from '@comfyorg/litegraph/dist/types/events'
 import type { IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import {
@@ -78,7 +78,7 @@ export class PrimitiveNode extends LGraphNode {
         app.canvas,
         node,
         app.canvas.graph_mouse,
-        {} as CanvasMouseEvent
+        {} as CanvasPointerEvent
       )
     }
   }


### PR DESCRIPTION
- Replaces all internal usage of `CanvasMouseEvent` with `CanvasPointerEvent`
- Spelling nit (functions may be "bound")

Note: branch started as general nits, but became focused on the mouse/pointer change. Not deemed worth the time to correct.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4358-TS-Update-callbacks-using-CanvasMouseEvent-1104-2276d73d365081b1baa2d9585757c1ac) by [Unito](https://www.unito.io)
