### PR TITLE
Fix: Escape closes Settings dialog if login dialog open

### DIFF
--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -272,7 +272,7 @@ export const useDialogService = () => {
           onSuccess: () => resolve(true)
         },
         dialogComponentProps: {
-          closable: false,
+          closable: true,
           onClose: () => resolve(false)
         }
       })

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -26,6 +26,8 @@ interface CustomDialogComponentProps {
   modal?: boolean
   position?: DialogPosition
   pt?: DialogPassThroughOptions
+  closeOnEscape?: boolean
+  dismissableMask?: boolean
 }
 
 type DialogComponentProps = InstanceType<typeof GlobalDialog>['$props'] &
@@ -130,7 +132,7 @@ export const useDialogStore = defineStore('dialog', () => {
       dialogStack.value.shift()
     }
 
-    const dialog: DialogInstance = {
+    const dialog = {
       key: options.key,
       visible: true,
       title: options.title,

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -61,6 +61,11 @@ export interface ShowDialogOptions {
 
 export const useDialogStore = defineStore('dialog', () => {
   const dialogStack = ref<DialogInstance[]>([])
+
+  /**
+   * The key of the currently active (top-most) dialog.
+   * Only the active dialog can be closed with the ESC key.
+   */
   const activeKey = ref<string | null>(null)
 
   const genDialogKey = () => `dialog-${Math.random().toString(36).slice(2, 9)}`
@@ -105,7 +110,7 @@ export const useDialogStore = defineStore('dialog', () => {
 
     activeKey.value =
       dialogStack.value.length > 0
-        ? dialogStack.value[dialogStack.value.length - 1].key
+      ? dialogStack.value[dialogStack.value.length - 1].key
         : null
 
     updateCloseOnEscapeStates()
@@ -235,6 +240,7 @@ export const useDialogStore = defineStore('dialog', () => {
     showDialog,
     closeDialog,
     showExtensionDialog,
-    isDialogOpen
+    isDialogOpen,
+    activeKey
   }
 })

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -110,7 +110,7 @@ export const useDialogStore = defineStore('dialog', () => {
 
     activeKey.value =
       dialogStack.value.length > 0
-      ? dialogStack.value[dialogStack.value.length - 1].key
+        ? dialogStack.value[dialogStack.value.length - 1].key
         : null
 
     updateCloseOnEscapeStates()

--- a/tests-ui/tests/store/dialogStore.test.ts
+++ b/tests-ui/tests/store/dialogStore.test.ts
@@ -172,4 +172,50 @@ describe('dialogStore', () => {
       expect(store.dialogStack[0].title).toBe('Original Title')
     })
   })
+
+  describe('ESC key behavior with multiple dialogs', () => {
+    it('should only allow the active dialog to close with ESC key', () => {
+      const store = useDialogStore()
+  
+      // Create dialogs with different priorities
+      store.showDialog({
+        key: 'dialog-1',
+        component: MockComponent,
+        priority: 1
+      })
+  
+      store.showDialog({
+        key: 'dialog-2',
+        component: MockComponent,
+        priority: 2
+      })
+  
+      store.showDialog({
+        key: 'dialog-3',
+        component: MockComponent,
+        priority: 3
+      })
+  
+      // Only the active dialog should be closable with ESC
+      const activeDialog = store.dialogStack.find(d => d.key === store.activeKey)
+      const inactiveDialogs = store.dialogStack.filter(d => d.key !== store.activeKey)
+  
+      expect(activeDialog?.dialogComponentProps.closeOnEscape).toBe(true)
+      inactiveDialogs.forEach(dialog => {
+        expect(dialog.dialogComponentProps.closeOnEscape).toBe(false)
+      })
+  
+      // Close the active dialog
+      store.closeDialog({ key: store.activeKey! })
+  
+      // The new active dialog should now be closable with ESC
+      const newActiveDialog = store.dialogStack.find(d => d.key === store.activeKey)
+      const newInactiveDialogs = store.dialogStack.filter(d => d.key !== store.activeKey)
+  
+      expect(newActiveDialog?.dialogComponentProps.closeOnEscape).toBe(true)
+      newInactiveDialogs.forEach(dialog => {
+        expect(dialog.dialogComponentProps.closeOnEscape).toBe(false)
+      })
+    })
+  })
 })

--- a/tests-ui/tests/store/dialogStore.test.ts
+++ b/tests-ui/tests/store/dialogStore.test.ts
@@ -176,44 +176,52 @@ describe('dialogStore', () => {
   describe('ESC key behavior with multiple dialogs', () => {
     it('should only allow the active dialog to close with ESC key', () => {
       const store = useDialogStore()
-  
+
       // Create dialogs with different priorities
       store.showDialog({
         key: 'dialog-1',
         component: MockComponent,
         priority: 1
       })
-  
+
       store.showDialog({
         key: 'dialog-2',
         component: MockComponent,
         priority: 2
       })
-  
+
       store.showDialog({
         key: 'dialog-3',
         component: MockComponent,
         priority: 3
       })
-  
+
       // Only the active dialog should be closable with ESC
-      const activeDialog = store.dialogStack.find(d => d.key === store.activeKey)
-      const inactiveDialogs = store.dialogStack.filter(d => d.key !== store.activeKey)
-  
+      const activeDialog = store.dialogStack.find(
+        (d) => d.key === store.activeKey
+      )
+      const inactiveDialogs = store.dialogStack.filter(
+        (d) => d.key !== store.activeKey
+      )
+
       expect(activeDialog?.dialogComponentProps.closeOnEscape).toBe(true)
-      inactiveDialogs.forEach(dialog => {
+      inactiveDialogs.forEach((dialog) => {
         expect(dialog.dialogComponentProps.closeOnEscape).toBe(false)
       })
-  
+
       // Close the active dialog
       store.closeDialog({ key: store.activeKey! })
-  
+
       // The new active dialog should now be closable with ESC
-      const newActiveDialog = store.dialogStack.find(d => d.key === store.activeKey)
-      const newInactiveDialogs = store.dialogStack.filter(d => d.key !== store.activeKey)
-  
+      const newActiveDialog = store.dialogStack.find(
+        (d) => d.key === store.activeKey
+      )
+      const newInactiveDialogs = store.dialogStack.filter(
+        (d) => d.key !== store.activeKey
+      )
+
       expect(newActiveDialog?.dialogComponentProps.closeOnEscape).toBe(true)
-      newInactiveDialogs.forEach(dialog => {
+      newInactiveDialogs.forEach((dialog) => {
         expect(dialog.dialogComponentProps.closeOnEscape).toBe(false)
       })
     })


### PR DESCRIPTION
Fix for: https://github.com/Comfy-Org/ComfyUI_frontend/issues/3996

Problem:

The ESC button closes the dialog opened below rather than top.

Root Cause:

Since there is not close button configured on the login modal, but on the settings modal it have close button configuration.
Prime vue dialog takes only the one first one hence closing that dialog only.
https://github.com/primefaces/primevue/issues/5138

Solution:

Based on discussion in
https://github.com/Comfy-Org/ComfyUI_frontend/pull/4299, I will track the active dialog and based on the **closable** property of the top most dialog, closeOnEsc will also be updated.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4364-WIP-Fix-Escape-closes-Settings-dialog-if-login-dialog-open-2286d73d365081ffbe84cf883ea4eceb) by [Unito](https://www.unito.io)
