### PR TITLE
[update] Video to Video API node pricing

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -954,7 +954,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'length'
         ) as IComboWidget
 
-        if (!lengthWidget) return '$1.50-3.00/Run (varies with length)'
+        // If no length widget exists, default to 5s pricing
+        if (!lengthWidget) return '$1.50/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {
@@ -972,7 +973,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'length'
         ) as IComboWidget
 
-        if (!lengthWidget) return '$1.50-3.00/Run (varies with length)'
+        // If no length widget exists, default to 5s pricing
+        if (!lengthWidget) return '$1.50/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {
@@ -990,7 +992,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'length'
         ) as IComboWidget
 
-        if (!lengthWidget) return '$2.00-4.00/Run (varies with length)'
+        // If no length widget exists, default to 5s pricing
+        if (!lengthWidget) return '$2.00/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {

--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -993,16 +993,16 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         ) as IComboWidget
 
         // If no length widget exists, default to 5s pricing
-        if (!lengthWidget) return '$2.00/Run'
+        if (!lengthWidget) return '$2.25/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {
-          return '$2.00/Run'
+          return '$2.25/Run'
         } else if (length === '10s') {
           return '$4.00/Run'
         }
 
-        return '$2.00/Run'
+        return '$2.25/Run'
       }
     }
   }


### PR DESCRIPTION
Update pricing for 5s video generation from $2.00 to $2.25 per provider's latest pricing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4378-update-Video-to-Video-API-node-pricing-22a6d73d365081bfb869ef4289a80af0) by [Unito](https://www.unito.io)
