### PR TITLE
[fix] Correct API node pricing discrepancies

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -954,7 +954,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'length'
         ) as IComboWidget
 
-        if (!lengthWidget) return '$1.50-3.00/Run (varies with length)'
+        // If no length widget exists, default to 5s pricing
+        if (!lengthWidget) return '$1.50/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {
@@ -972,7 +973,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'length'
         ) as IComboWidget
 
-        if (!lengthWidget) return '$1.50-3.00/Run (varies with length)'
+        // If no length widget exists, default to 5s pricing
+        if (!lengthWidget) return '$1.50/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {
@@ -990,7 +992,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'length'
         ) as IComboWidget
 
-        if (!lengthWidget) return '$2.00-4.00/Run (varies with length)'
+        // If no length widget exists, default to 5s pricing
+        if (!lengthWidget) return '$2.00/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {

--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -151,7 +151,7 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
 
         const renderingSpeed = String(renderingSpeedWidget.value)
         if (renderingSpeed.toLowerCase().includes('quality')) {
-          basePrice = 0.08
+          basePrice = 0.09
         } else if (renderingSpeed.toLowerCase().includes('balanced')) {
           basePrice = 0.06
         } else if (renderingSpeed.toLowerCase().includes('turbo')) {
@@ -322,15 +322,15 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         const effectScene = String(effectSceneWidget.value)
         if (
           effectScene.includes('fuzzyfuzzy') ||
-          effectScene.includes('squish') ||
-          effectScene.includes('expansion')
+          effectScene.includes('squish')
         ) {
           return '$0.28/Run'
-        } else if (
-          effectScene.includes('dizzydizzy') ||
-          effectScene.includes('bloombloom')
-        ) {
+        } else if (effectScene.includes('dizzydizzy')) {
           return '$0.49/Run'
+        } else if (effectScene.includes('bloombloom')) {
+          return '$0.49/Run'
+        } else if (effectScene.includes('expansion')) {
+          return '$0.28/Run'
         }
 
         return '$0.28/Run'
@@ -448,12 +448,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         } else if (model.includes('ray-2')) {
           if (duration.includes('5s')) {
             if (resolution.includes('4k')) return '$6.37/Run'
-            if (resolution.includes('1080p')) return '$2.30/Run'
+            if (resolution.includes('1080p')) return '$1.59/Run'
             if (resolution.includes('720p')) return '$0.71/Run'
             if (resolution.includes('540p')) return '$0.40/Run'
           } else if (duration.includes('9s')) {
             if (resolution.includes('4k')) return '$11.47/Run'
-            if (resolution.includes('1080p')) return '$4.14/Run'
+            if (resolution.includes('1080p')) return '$2.87/Run'
             if (resolution.includes('720p')) return '$1.28/Run'
             if (resolution.includes('540p')) return '$0.72/Run'
           }
@@ -499,12 +499,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         } else if (model.includes('ray-2')) {
           if (duration.includes('5s')) {
             if (resolution.includes('4k')) return '$6.37/Run'
-            if (resolution.includes('1080p')) return '$2.30/Run'
+            if (resolution.includes('1080p')) return '$1.59/Run'
             if (resolution.includes('720p')) return '$0.71/Run'
             if (resolution.includes('540p')) return '$0.40/Run'
           } else if (duration.includes('9s')) {
             if (resolution.includes('4k')) return '$11.47/Run'
-            if (resolution.includes('1080p')) return '$4.14/Run'
+            if (resolution.includes('1080p')) return '$2.87/Run'
             if (resolution.includes('720p')) return '$1.28/Run'
             if (resolution.includes('540p')) return '$0.72/Run'
           }

--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -993,16 +993,16 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         ) as IComboWidget
 
         // If no length widget exists, default to 5s pricing
-        if (!lengthWidget) return '$2.00/Run'
+        if (!lengthWidget) return '$2.25/Run'
 
         const length = String(lengthWidget.value)
         if (length === '5s') {
-          return '$2.00/Run'
+          return '$2.25/Run'
         } else if (length === '10s') {
           return '$4.00/Run'
         }
 
-        return '$2.00/Run'
+        return '$2.25/Run'
       }
     }
   }

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -300,14 +300,14 @@ describe('useNodePricing', () => {
   })
 
   describe('dynamic pricing - IdeogramV3', () => {
-    it('should return $0.08 for Quality rendering speed', () => {
+    it('should return $0.09 for Quality rendering speed', () => {
       const { getNodeDisplayPrice } = useNodePricing()
       const node = createMockNode('IdeogramV3', [
         { name: 'rendering_speed', value: 'Quality' }
       ])
 
       const price = getNodeDisplayPrice(node)
-      expect(price).toBe('$0.08/Run')
+      expect(price).toBe('$0.09/Run')
     })
 
     it('should return $0.06 for Balanced rendering speed', () => {

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -348,7 +348,7 @@ describe('useNodePricing', () => {
       ])
 
       const price = getNodeDisplayPrice(node)
-      expect(price).toBe('$0.24/Run') // 0.08 * 3
+      expect(price).toBe('$0.27/Run') // 0.09 * 3
     })
 
     it('should multiply price by num_images for Turbo rendering speed', () => {


### PR DESCRIPTION
## Summary
Corrects pricing for several API nodes based on the official pricing sheet and manual tester feedback.

## Changes
- **IdeogramV3**: Fixed quality pricing from $0.08 to $0.09
- **Kling video effects**: Fixed bloombloom to remain at $0.49, expansion at $0.28 (was incorrectly grouped)
- **Luma ray-2 1080p**: Fixed pricing for 5s ($2.30 → $1.59) and 9s ($4.14 → $2.87)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4381-fix-Correct-API-node-pricing-discrepancies-22a6d73d365081f4b039d5db3b8a6d36) by [Unito](https://www.unito.io)
