### PR TITLE
[Release] v1.23.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.23.4",
+  "version": "1.23.5",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
## Release v1.23.5

**Version**: 1.23.4 → 1.23.5

### Included Fixes

This hotfix release includes critical pricing display fixes for API nodes:

- #4351: Dynamic pricing for Ideogram nodes based on num_images parameter
- #4362: Dynamic pricing for API nodes with quantity parameters (n, num_images)
- #4367: Dynamic pricing support for new API nodes (Moonvalley)
- #4378: Updated Video to Video API node pricing ($2.00 → $2.25)

### Impact

These changes ensure users see accurate, real-time pricing information that updates based on their selected parameters (quantity, duration, quality settings). This is critical for cost transparency when using paid API nodes.

### Testing

All changes have been tested and validated on the core/1.23 branch.

Fixes #4383

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4384-Release-v1-23-5-22a6d73d365081238567d546784b56f6) by [Unito](https://www.unito.io)
