### PR TITLE
[v3] added filtering for ImageUpload

### DIFF
--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -22,16 +22,35 @@ const isMediaUploadComboInput = (inputSpec: InputSpec) => {
   )
 }
 
+const ALLOWED_UPLOAD_KEYS = new Set([
+  'image_upload',
+  'video_upload',
+  'animated_image_upload',
+  'display_name',
+  'control_after_generate',
+  'allow_batch',
+  'image_folder'
+])
+
 const createUploadInput = (
   imageInputName: string,
-  imageInputOptions: InputSpec
-): InputSpec => [
-  'IMAGEUPLOAD',
-  {
-    ...imageInputOptions[1],
-    imageInputName
-  }
-]
+  imageInputSpec: InputSpec
+): InputSpec => {
+  const [, opts] = imageInputSpec
+
+  // retain only the flags that make sense for IMAGEUPLOAD
+  const cleanOpts = Object.fromEntries(
+    Object.entries(opts ?? {}).filter(([k]) => ALLOWED_UPLOAD_KEYS.has(k))
+  )
+
+  return [
+    'IMAGEUPLOAD',
+    {
+      ...cleanOpts,
+      imageInputName
+    }
+  ]
+}
 
 app.registerExtension({
   name: 'Comfy.UploadImage',


### PR DESCRIPTION
The frontend changes for this  [[v3] Migrate LoadImage and SaveImage nodes to v3 schema](https://github.com/comfyanonymous/ComfyUI/pull/8833) PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4386-v3-added-filtering-for-ImageUpload-22a6d73d3650814d8e19e4fe0e3327ca) by [Unito](https://www.unito.io)
