### PR TITLE
[System Pop Up] Add setting to disable version update notifications

### DIFF
--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -130,4 +130,239 @@ test.describe('Release Notifications', () => {
       whatsNewSection.locator('text=No recent releases')
     ).toBeVisible()
   })
+
+  test('should hide "What\'s New" section when notifications are disabled', async ({
+    comfyPage
+  }) => {
+    // Disable version update notifications
+    await comfyPage.setSetting('Comfy.Notification.ShowVersionUpdates', false)
+
+    // Mock release API with test data
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 1,
+              project: 'comfyui',
+              version: 'v0.3.44',
+              attention: 'high',
+              content: '## New Features\n\n- Added awesome feature',
+              published_at: new Date().toISOString()
+            }
+          ])
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await comfyPage.setup({ mockReleases: false })
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
+    await helpCenterButton.click()
+
+    // Verify help center menu appears
+    const helpMenu = comfyPage.page.locator('.help-center-menu')
+    await expect(helpMenu).toBeVisible()
+
+    // Verify "What's New?" section is hidden
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(whatsNewSection).not.toBeVisible()
+
+    // Should not show any popups or toasts
+    await expect(comfyPage.page.locator('.whats-new-popup')).not.toBeVisible()
+    await expect(
+      comfyPage.page.locator('.release-notification-toast')
+    ).not.toBeVisible()
+  })
+
+  test('should not make API calls when notifications are disabled', async ({
+    comfyPage
+  }) => {
+    // Disable version update notifications
+    await comfyPage.setSetting('Comfy.Notification.ShowVersionUpdates', false)
+
+    // Track API calls
+    let apiCallCount = 0
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        apiCallCount++
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await comfyPage.setup({ mockReleases: false })
+
+    // Wait a bit to ensure any potential API calls would have been made
+    await comfyPage.page.waitForTimeout(1000)
+
+    // Verify no API calls were made
+    expect(apiCallCount).toBe(0)
+  })
+
+  test('should show "What\'s New" section when notifications are enabled', async ({
+    comfyPage
+  }) => {
+    // Enable version update notifications (default behavior)
+    await comfyPage.setSetting('Comfy.Notification.ShowVersionUpdates', true)
+
+    // Mock release API with test data
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 1,
+              project: 'comfyui',
+              version: 'v0.3.44',
+              attention: 'medium',
+              content: '## New Features\n\n- Added awesome feature',
+              published_at: new Date().toISOString()
+            }
+          ])
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await comfyPage.setup({ mockReleases: false })
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
+    await helpCenterButton.click()
+
+    // Verify help center menu appears
+    const helpMenu = comfyPage.page.locator('.help-center-menu')
+    await expect(helpMenu).toBeVisible()
+
+    // Verify "What's New?" section is visible
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(whatsNewSection).toBeVisible()
+
+    // Should show the release
+    await expect(
+      whatsNewSection.locator('text=Comfy v0.3.44 Release')
+    ).toBeVisible()
+  })
+
+  test('should toggle "What\'s New" section when setting changes', async ({
+    comfyPage
+  }) => {
+    // Mock release API with test data
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 1,
+              project: 'comfyui',
+              version: 'v0.3.44',
+              attention: 'low',
+              content: '## Bug Fixes\n\n- Fixed minor issue',
+              published_at: new Date().toISOString()
+            }
+          ])
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // Start with notifications enabled
+    await comfyPage.setSetting('Comfy.Notification.ShowVersionUpdates', true)
+    await comfyPage.setup({ mockReleases: false })
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
+    await helpCenterButton.click()
+
+    // Verify "What's New?" section is visible
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(whatsNewSection).toBeVisible()
+
+    // Close help center
+    await comfyPage.page.click('.help-center-backdrop')
+
+    // Disable notifications
+    await comfyPage.setSetting('Comfy.Notification.ShowVersionUpdates', false)
+
+    // Reopen help center
+    await helpCenterButton.click()
+
+    // Verify "What's New?" section is now hidden
+    await expect(whatsNewSection).not.toBeVisible()
+  })
+
+  test('should handle edge case with empty releases and disabled notifications', async ({
+    comfyPage
+  }) => {
+    // Disable notifications
+    await comfyPage.setSetting('Comfy.Notification.ShowVersionUpdates', false)
+
+    // Mock empty releases
+    await comfyPage.page.route('**/releases**', async (route) => {
+      const url = route.request().url()
+      if (
+        url.includes('api.comfy.org') ||
+        url.includes('stagingapi.comfy.org')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await comfyPage.setup({ mockReleases: false })
+
+    // Open help center
+    const helpCenterButton = comfyPage.page.locator('.comfy-help-center-btn')
+    await helpCenterButton.waitFor({ state: 'visible' })
+    await helpCenterButton.click()
+
+    // Verify help center still works
+    const helpMenu = comfyPage.page.locator('.help-center-menu')
+    await expect(helpMenu).toBeVisible()
+
+    // Section should be hidden regardless of empty releases
+    const whatsNewSection = comfyPage.page.locator('.whats-new-section')
+    await expect(whatsNewSection).not.toBeVisible()
+  })
 })

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -54,7 +54,7 @@
     </Teleport>
 
     <!-- What's New Section -->
-    <section class="whats-new-section">
+    <section v-if="showVersionUpdates" class="whats-new-section">
       <h3 class="section-description">{{ $t('helpCenter.whatsNew') }}</h3>
 
       <!-- Release Items -->
@@ -126,6 +126,7 @@ import { useI18n } from 'vue-i18n'
 import { type ReleaseNote } from '@/services/releaseService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useReleaseStore } from '@/stores/releaseStore'
+import { useSettingStore } from '@/stores/settingStore'
 import { electronAPI, isElectron } from '@/utils/envUtil'
 import { formatVersionAnchor } from '@/utils/formatUtil'
 
@@ -168,6 +169,7 @@ const SUBMENU_CONFIG = {
 const { t, locale } = useI18n()
 const releaseStore = useReleaseStore()
 const commandStore = useCommandStore()
+const settingStore = useSettingStore()
 
 // Emits
 const emit = defineEmits<{
@@ -182,6 +184,9 @@ let hoverTimeout: number | null = null
 
 // Computed
 const hasReleases = computed(() => releaseStore.releases.length > 0)
+const showVersionUpdates = computed(() =>
+  settingStore.get('Comfy.Notification.ShowVersionUpdates')
+)
 
 const moreMenuItem = computed(() =>
   menuItems.value.find((item) => item.key === 'more')

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -331,6 +331,14 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.20.3'
   },
   {
+    id: 'Comfy.Notification.ShowVersionUpdates',
+    category: ['Comfy', 'Notification Preferences'],
+    name: 'Show version updates',
+    tooltip: 'Show updates for new models, and major new features.',
+    type: 'boolean',
+    defaultValue: true
+  },
+  {
     id: 'Comfy.ConfirmClear',
     category: ['Comfy', 'Workflow', 'ConfirmClear'],
     name: 'Require confirmation when clearing workflow',

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -232,6 +232,10 @@
   "Comfy_NodeBadge_ShowApiPricing": {
     "name": "Show API node pricing badge"
   },
+  "Comfy_Notification_ShowVersionUpdates": {
+    "name": "Show version updates",
+    "tooltip": "Show updates for new models, and major new features."
+  },
   "Comfy_NodeSearchBoxImpl": {
     "name": "Node search box implementation",
     "options": {

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -426,6 +426,7 @@ const zSettings = z.object({
   'Comfy.NodeBadge.NodeIdBadgeMode': zNodeBadgeMode,
   'Comfy.NodeBadge.NodeLifeCycleBadgeMode': zNodeBadgeMode,
   'Comfy.NodeBadge.ShowApiPricing': z.boolean(),
+  'Comfy.Notification.ShowVersionUpdates': z.boolean(),
   'Comfy.QueueButton.BatchCountLimit': z.number(),
   'Comfy.Queue.MaxHistoryItems': z.number(),
   'Comfy.Keybinding.UnsetBindings': z.array(zKeybinding),

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -85,7 +85,7 @@ export const useReleaseStore = defineStore('release', () => {
     // Skip if user already skipped or changelog seen
     if (
       releaseVersion.value === recentRelease.value?.version &&
-      !['skipped', 'changelog seen'].includes(releaseStatus.value)
+      ['skipped', 'changelog seen'].includes(releaseStatus.value)
     ) {
       return false
     }

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -32,6 +32,9 @@ export const useReleaseStore = defineStore('release', () => {
   const releaseTimestamp = computed(() =>
     settingStore.get('Comfy.Release.Timestamp')
   )
+  const showVersionUpdates = computed(() =>
+    settingStore.get('Comfy.Notification.ShowVersionUpdates')
+  )
 
   // Most recent release
   const recentRelease = computed(() => {
@@ -73,6 +76,11 @@ export const useReleaseStore = defineStore('release', () => {
 
   // Show toast if needed
   const shouldShowToast = computed(() => {
+    // Skip if notifications are disabled
+    if (!showVersionUpdates.value) {
+      return false
+    }
+
     if (!isNewVersionAvailable.value) {
       return false
     }
@@ -95,6 +103,11 @@ export const useReleaseStore = defineStore('release', () => {
 
   // Show red-dot indicator
   const shouldShowRedDot = computed(() => {
+    // Skip if notifications are disabled
+    if (!showVersionUpdates.value) {
+      return false
+    }
+
     // Already latest → no dot
     if (!isNewVersionAvailable.value) {
       return false
@@ -132,6 +145,11 @@ export const useReleaseStore = defineStore('release', () => {
 
   // Show "What's New" popup
   const shouldShowPopup = computed(() => {
+    // Skip if notifications are disabled
+    if (!showVersionUpdates.value) {
+      return false
+    }
+
     if (!isLatestVersion.value) {
       return false
     }
@@ -183,7 +201,14 @@ export const useReleaseStore = defineStore('release', () => {
 
   // Fetch releases from API
   async function fetchReleases(): Promise<void> {
-    if (isLoading.value) return
+    if (isLoading.value) {
+      return
+    }
+
+    // Skip fetching if notifications are disabled
+    if (!showVersionUpdates.value) {
+      return
+    }
 
     isLoading.value = true
     error.value = null


### PR DESCRIPTION
### Changes
- Added a new user setting "Show version updates" in Notification Preferences
- Users can now disable notifications for new models and major feature updates
- Setting defaults to enabled (true) to maintain current behavior
- Fixed show toast logic for releases

### Implementation Details
- Added `Comfy.Notification.ShowVersionUpdates` setting with localization support
- Updated release store to respect the new notification preference
- Added UI toggle in Help Center menu
- Updated API schema to include the new setting

### Testing
- Added comprehensive unit tests for release store functionality
- Added playwright tests for release notifications behavior
- All existing tests continue to pass

### Files Modified
- `src/constants/coreSettings.ts` - Added new setting definition
- `src/components/helpcenter/HelpCenterMenuContent.vue` - Added UI toggle
- `src/stores/releaseStore.ts` - Updated notification logic
- `src/locales/en/settings.json` - Added localization
- `src/schemas/apiSchema.ts` - Updated API schema
- Test files for comprehensive coverage

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4388-System-Pop-Up-Add-setting-to-disable-version-update-notifications-22a6d73d365081418f9fffb36e21b877) by [Unito](https://www.unito.io)
