### PR TITLE
[api] update getHistory to call history_v2

### DIFF
--- a/browser_tests/fixtures/utils/taskHistory.ts
+++ b/browser_tests/fixtures/utils/taskHistory.ts
@@ -34,17 +34,21 @@ const getContentType = (filename: string, fileType: OutputFileType) => {
 }
 
 const setQueueIndex = (task: TaskItem) => {
-  task.prompt[0] = TaskHistory.queueIndex++
+  task.prompt.priority = TaskHistory.queueIndex++
 }
 
 const setPromptId = (task: TaskItem) => {
-  task.prompt[1] = uuidv4()
+  task.prompt.prompt_id = uuidv4()
 }
 
 export default class TaskHistory {
   static queueIndex = 0
   static readonly defaultTask: Readonly<HistoryTaskItem> = {
-    prompt: [0, 'prompt-id', {}, { client_id: uuidv4() }, []],
+    prompt: {
+      priority: 0,
+      prompt_id: 'prompt-id',
+      extra_data: { client_id: uuidv4() }
+    },
     outputs: {},
     status: {
       status_str: 'success',
@@ -75,7 +79,7 @@ export default class TaskHistory {
 
   private async handleGetView(route: Route) {
     const fileName = getFilenameParam(route.request())
-    if (!this.outputContentTypes.has(fileName)) route.continue()
+    if (!this.outputContentTypes.has(fileName)) return route.continue()
 
     const asset = this.loadAsset(fileName)
     return route.fulfill({

--- a/browser_tests/fixtures/utils/taskHistory.ts
+++ b/browser_tests/fixtures/utils/taskHistory.ts
@@ -73,7 +73,7 @@ export default class TaskHistory {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(this.tasks)
+      body: JSON.stringify({ history: this.tasks })
     })
   }
 
@@ -95,7 +95,7 @@ export default class TaskHistory {
 
   async setupRoutes() {
     return this.comfyPage.page.route(
-      /.*\/api\/(view|history)(\?.*)?$/,
+      /.*\/api\/(view|history|history_v2)(\?.*)?$/,
       async (route) => {
         const request = route.request()
         const method = request.method()

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -187,12 +187,14 @@ test.describe('Workflows sidebar', () => {
 
   test('Can save workflow as with same name', async ({ comfyPage }) => {
     await comfyPage.menu.topbar.saveWorkflow('workflow5.json')
+    await comfyPage.nextFrame()
     expect(await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()).toEqual([
       'workflow5.json'
     ])
 
     await comfyPage.menu.topbar.saveWorkflowAs('workflow5.json')
     await comfyPage.confirmDialog.click('overwrite')
+    await comfyPage.nextFrame()
     expect(await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()).toEqual([
       'workflow5.json'
     ])

--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -214,12 +214,11 @@ const menuItems = computed<MenuItem[]>(() => {
           void workflowService.loadTaskWorkflow(menuTargetTask.value)
         }
       },
-      disabled:
-        !menuTargetTask.value?.workflow &&
-        !(
-          menuTargetTask.value?.isHistory &&
-          menuTargetTask.value?.prompt.prompt_id
-        )
+      disabled: !(
+        menuTargetTask.value?.workflow ||
+        (menuTargetTask.value?.isHistory &&
+          menuTargetTask.value?.prompt.prompt_id)
+      )
     },
     {
       label: t('g.goToNode'),

--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -106,8 +106,8 @@ import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import { ComfyNode } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
-import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
+import { useWorkflowService } from '@/services/workflowService'
 import { useCommandStore } from '@/stores/commandStore'
 import {
   ResultItemImpl,
@@ -126,6 +126,7 @@ const toast = useToast()
 const queueStore = useQueueStore()
 const settingStore = useSettingStore()
 const commandStore = useCommandStore()
+const workflowService = useWorkflowService()
 const { t } = useI18n()
 
 // Expanded view: show all outputs in a flat list.
@@ -208,8 +209,17 @@ const menuItems = computed<MenuItem[]>(() => {
     {
       label: t('g.loadWorkflow'),
       icon: 'pi pi-file-export',
-      command: () => menuTargetTask.value?.loadWorkflow(app),
-      disabled: !menuTargetTask.value?.workflow
+      command: () => {
+        if (menuTargetTask.value) {
+          void workflowService.loadTaskWorkflow(menuTargetTask.value)
+        }
+      },
+      disabled:
+        !menuTargetTask.value?.workflow &&
+        !(
+          menuTargetTask.value?.isHistory &&
+          menuTargetTask.value?.prompt.prompt_id
+        )
     },
     {
       label: t('g.goToNode'),

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -743,13 +743,13 @@ export class ComfyApi extends EventTarget {
       const json = await res.json()
 
       // The /history_v2/{prompt_id} endpoint returns data for a specific prompt
-      // The response format is: { prompt_id: { prompt: [...], outputs: {...}, status: {...} } }
+      // The response format is: { prompt_id: { prompt: {priority, prompt_id, extra_data}, outputs: {...}, status: {...} } }
       const historyItem = json[prompt_id]
       if (!historyItem) return null
 
-      // Extract workflow from the prompt array
-      // prompt[3] contains extra_data which has extra_pnginfo.workflow
-      const workflow = historyItem.prompt?.[3]?.extra_pnginfo?.workflow
+      // Extract workflow from the prompt object
+      // prompt.extra_data contains extra_pnginfo.workflow
+      const workflow = historyItem.prompt?.extra_data?.extra_pnginfo?.workflow
       return workflow || null
     } catch (error) {
       console.error(`Failed to fetch workflow for prompt ${prompt_id}:`, error)

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -264,15 +264,16 @@ class ComfyList {
                   ? item.remove
                   : {
                       name: 'Delete',
-                      cb: () => api.deleteItem(this.#type, item.prompt[1])
+                      cb: () =>
+                        api.deleteItem(this.#type, item.prompt.prompt_id)
                     }
-              return $el('div', { textContent: item.prompt[0] + ': ' }, [
+              return $el('div', { textContent: item.prompt.priority + ': ' }, [
                 $el('button', {
                   textContent: 'Load',
                   onclick: async () => {
                     await app.loadGraphData(
                       // @ts-expect-error fixme ts strict error
-                      item.prompt[3].extra_pnginfo.workflow,
+                      item.prompt.extra_data.extra_pnginfo.workflow,
                       true,
                       false
                     )

--- a/src/services/workflowService.ts
+++ b/src/services/workflowService.ts
@@ -4,10 +4,12 @@ import { toRaw } from 'vue'
 
 import { t } from '@/i18n'
 import { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
+import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'
 import { downloadBlob } from '@/scripts/utils'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { TaskItemImpl } from '@/stores/queueStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useToastStore } from '@/stores/toastStore'
 import { ComfyWorkflow, useWorkflowStore } from '@/stores/workflowStore'
@@ -150,6 +152,32 @@ export const useWorkflowService = () => {
    */
   const loadBlankWorkflow = async () => {
     await app.loadGraphData(blankGraph)
+  }
+
+  /**
+   * Load a workflow from a task item (queue/history)
+   * For history items, fetches workflow data from /history_v2/{prompt_id}
+   * @param task The task item to load the workflow from
+   */
+  const loadTaskWorkflow = async (task: TaskItemImpl) => {
+    let workflowData = task.workflow
+
+    // History items don't include workflow data - fetch from API
+    if (task.isHistory) {
+      const promptId = task.prompt.prompt_id
+      if (promptId) {
+        workflowData = (await api.getWorkflowFromHistory(promptId)) || undefined
+      }
+    }
+
+    if (!workflowData) {
+      return
+    }
+
+    await app.loadGraphData(toRaw(workflowData))
+    if (task.outputs) {
+      app.nodeOutputs = toRaw(task.outputs)
+    }
   }
 
   /**
@@ -394,6 +422,7 @@ export const useWorkflowService = () => {
     saveWorkflow,
     loadDefaultWorkflow,
     loadBlankWorkflow,
+    loadTaskWorkflow,
     reloadCurrentWorkflow,
     openWorkflow,
     closeWorkflow,

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -269,23 +269,15 @@ export class TaskItemImpl {
   }
 
   get queueIndex() {
-    return this.prompt[0]
+    return this.prompt.priority
   }
 
   get promptId() {
-    return this.prompt[1]
-  }
-
-  get promptInputs() {
-    return this.prompt[2]
+    return this.prompt.prompt_id
   }
 
   get extraData() {
-    return this.prompt[3]
-  }
-
-  get outputsToExecute() {
-    return this.prompt[4]
+    return this.prompt.extra_data
   }
 
   get extraPngInfo() {
@@ -390,13 +382,11 @@ export class TaskItemImpl {
       (output: ResultItemImpl, i: number) =>
         new TaskItemImpl(
           this.taskType,
-          [
-            this.queueIndex,
-            `${this.promptId}-${i}`,
-            this.promptInputs,
-            this.extraData,
-            this.outputsToExecute
-          ],
+          {
+            priority: this.queueIndex,
+            prompt_id: `${this.promptId}-${i}`,
+            extra_data: this.extraData
+          },
           this.status,
           {
             [output.nodeId]: {
@@ -461,11 +451,11 @@ export const useQueueStore = defineStore('queue', () => {
       pendingTasks.value = toClassAll(queue.Pending)
 
       const allIndex = new Set<number>(
-        history.History.map((item: TaskItem) => item.prompt[0])
+        history.History.map((item: TaskItem) => item.prompt.priority)
       )
       const newHistoryItems = toClassAll(
         history.History.filter(
-          (item) => item.prompt[0] > lastHistoryQueueIndex.value
+          (item) => item.prompt.priority > lastHistoryQueueIndex.value
         )
       )
       const existingHistoryItems = historyTasks.value.filter((item) =>

--- a/tests-ui/tests/scripts/api.test.ts
+++ b/tests-ui/tests/scripts/api.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  HistoryResponse,
+  RawHistoryItem
+} from '../../../src/schemas/apiSchema'
+import { ComfyApi } from '../../../src/scripts/api'
+
+describe('ComfyApi getHistory', () => {
+  let api: ComfyApi
+
+  beforeEach(() => {
+    api = new ComfyApi()
+  })
+
+  const mockHistoryItem: RawHistoryItem = {
+    prompt_id: 'test_prompt_id',
+    prompt: {
+      priority: 0,
+      prompt_id: 'test_prompt_id',
+      extra_data: {
+        extra_pnginfo: {
+          workflow: {
+            last_node_id: 1,
+            last_link_id: 0,
+            nodes: [],
+            links: [],
+            groups: [],
+            config: {},
+            extra: {},
+            version: 0.4
+          }
+        },
+        client_id: 'test_client_id'
+      }
+    },
+    outputs: {},
+    status: {
+      status_str: 'success',
+      completed: true,
+      messages: []
+    }
+  }
+
+  describe('history v2 API format', () => {
+    it('should handle history array format from /history_v2', async () => {
+      const historyResponse: HistoryResponse = {
+        history: [
+          { ...mockHistoryItem, prompt_id: 'prompt_id_1' },
+          { ...mockHistoryItem, prompt_id: 'prompt_id_2' }
+        ]
+      }
+
+      // Mock fetchApi to return the v2 format
+      const mockFetchApi = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(historyResponse)
+      })
+      api.fetchApi = mockFetchApi
+
+      const result = await api.getHistory(10)
+
+      expect(result.History).toHaveLength(2)
+      expect(result.History[0]).toEqual({
+        ...mockHistoryItem,
+        prompt_id: 'prompt_id_1',
+        taskType: 'History'
+      })
+      expect(result.History[1]).toEqual({
+        ...mockHistoryItem,
+        prompt_id: 'prompt_id_2',
+        taskType: 'History'
+      })
+    })
+
+    it('should handle empty history array', async () => {
+      const historyResponse: HistoryResponse = {
+        history: []
+      }
+
+      const mockFetchApi = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(historyResponse)
+      })
+      api.fetchApi = mockFetchApi
+
+      const result = await api.getHistory(10)
+
+      expect(result.History).toHaveLength(0)
+      expect(result.History).toEqual([])
+    })
+  })
+
+  describe('error handling', () => {
+    it('should return empty history on error', async () => {
+      const mockFetchApi = vi.fn().mockRejectedValue(new Error('Network error'))
+      api.fetchApi = mockFetchApi
+
+      const result = await api.getHistory()
+
+      expect(result.History).toEqual([])
+    })
+  })
+
+  describe('API call parameters', () => {
+    it('should call fetchApi with correct v2 endpoint and parameters', async () => {
+      const mockFetchApi = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue({ history: [] })
+      })
+      api.fetchApi = mockFetchApi
+
+      await api.getHistory(50)
+
+      expect(mockFetchApi).toHaveBeenCalledWith('/history_v2?max_items=50')
+    })
+
+    it('should use default max_items parameter with v2 endpoint', async () => {
+      const mockFetchApi = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue({ history: [] })
+      })
+      api.fetchApi = mockFetchApi
+
+      await api.getHistory()
+
+      expect(mockFetchApi).toHaveBeenCalledWith('/history_v2?max_items=200')
+    })
+  })
+})

--- a/tests-ui/tests/store/queueStore.test.ts
+++ b/tests-ui/tests/store/queueStore.test.ts
@@ -3,6 +3,86 @@ import { describe, expect, it } from 'vitest'
 import { TaskItemImpl } from '@/stores/queueStore'
 
 describe('TaskItemImpl', () => {
+  describe('prompt property accessors', () => {
+    it('should correctly access queueIndex from priority', () => {
+      const taskItem = new TaskItemImpl('Pending', {
+        priority: 5,
+        prompt_id: 'test-id',
+        extra_data: { client_id: 'client-id' }
+      })
+
+      expect(taskItem.queueIndex).toBe(5)
+    })
+
+    it('should correctly access promptId from prompt_id', () => {
+      const taskItem = new TaskItemImpl('History', {
+        priority: 0,
+        prompt_id: 'unique-prompt-id',
+        extra_data: { client_id: 'client-id' }
+      })
+
+      expect(taskItem.promptId).toBe('unique-prompt-id')
+    })
+
+    it('should correctly access extraData', () => {
+      const extraData = {
+        client_id: 'client-id',
+        extra_pnginfo: {
+          workflow: {
+            last_node_id: 1,
+            last_link_id: 0,
+            nodes: [],
+            links: [],
+            groups: [],
+            config: {},
+            extra: {},
+            version: 0.4
+          }
+        }
+      }
+      const taskItem = new TaskItemImpl('Running', {
+        priority: 1,
+        prompt_id: 'test-id',
+        extra_data: extraData
+      })
+
+      expect(taskItem.extraData).toEqual(extraData)
+    })
+
+    it('should correctly access workflow from extraPngInfo', () => {
+      const workflow = {
+        last_node_id: 1,
+        last_link_id: 0,
+        nodes: [],
+        links: [],
+        groups: [],
+        config: {},
+        extra: {},
+        version: 0.4
+      }
+      const taskItem = new TaskItemImpl('History', {
+        priority: 0,
+        prompt_id: 'test-id',
+        extra_data: {
+          client_id: 'client-id',
+          extra_pnginfo: { workflow }
+        }
+      })
+
+      expect(taskItem.workflow).toEqual(workflow)
+    })
+
+    it('should return undefined workflow when extraPngInfo is missing', () => {
+      const taskItem = new TaskItemImpl('History', {
+        priority: 0,
+        prompt_id: 'test-id',
+        extra_data: { client_id: 'client-id' }
+      })
+
+      expect(taskItem.workflow).toBeUndefined()
+    })
+  })
+
   it('should remove animated property from outputs during construction', () => {
     const taskItem = new TaskItemImpl(
       'History',

--- a/tests-ui/tests/store/queueStore.test.ts
+++ b/tests-ui/tests/store/queueStore.test.ts
@@ -6,7 +6,11 @@ describe('TaskItemImpl', () => {
   it('should remove animated property from outputs during construction', () => {
     const taskItem = new TaskItemImpl(
       'History',
-      [0, 'prompt-id', {}, { client_id: 'client-id' }, []],
+      {
+        priority: 0,
+        prompt_id: 'prompt-id',
+        extra_data: { client_id: 'client-id' }
+      },
       { status_str: 'success', messages: [], completed: true },
       {
         'node-1': {
@@ -26,7 +30,11 @@ describe('TaskItemImpl', () => {
   it('should handle outputs without animated property', () => {
     const taskItem = new TaskItemImpl(
       'History',
-      [0, 'prompt-id', {}, { client_id: 'client-id' }, []],
+      {
+        priority: 0,
+        prompt_id: 'prompt-id',
+        extra_data: { client_id: 'client-id' }
+      },
       { status_str: 'success', messages: [], completed: true },
       {
         'node-1': {
@@ -42,7 +50,11 @@ describe('TaskItemImpl', () => {
   it('should recognize webm video from core', () => {
     const taskItem = new TaskItemImpl(
       'History',
-      [0, 'prompt-id', {}, { client_id: 'client-id' }, []],
+      {
+        priority: 0,
+        prompt_id: 'prompt-id',
+        extra_data: { client_id: 'client-id' }
+      },
       { status_str: 'success', messages: [], completed: true },
       {
         'node-1': {
@@ -64,7 +76,11 @@ describe('TaskItemImpl', () => {
   it('should recognize webm video from VHS', () => {
     const taskItem = new TaskItemImpl(
       'History',
-      [0, 'prompt-id', {}, { client_id: 'client-id' }, []],
+      {
+        priority: 0,
+        prompt_id: 'prompt-id',
+        extra_data: { client_id: 'client-id' }
+      },
       { status_str: 'success', messages: [], completed: true },
       {
         'node-1': {
@@ -93,7 +109,11 @@ describe('TaskItemImpl', () => {
   it('should recognize mp4 video from core', () => {
     const taskItem = new TaskItemImpl(
       'History',
-      [0, 'prompt-id', {}, { client_id: 'client-id' }, []],
+      {
+        priority: 0,
+        prompt_id: 'prompt-id',
+        extra_data: { client_id: 'client-id' }
+      },
       { status_str: 'success', messages: [], completed: true },
       {
         'node-1': {
@@ -128,7 +148,11 @@ describe('TaskItemImpl', () => {
       it(`should recognize ${extension} audio`, () => {
         const taskItem = new TaskItemImpl(
           'History',
-          [0, 'prompt-id', {}, { client_id: 'client-id' }, []],
+          {
+            priority: 0,
+            prompt_id: 'prompt-id',
+            extra_data: { client_id: 'client-id' }
+          },
           { status_str: 'success', messages: [], completed: true },
           {
             'node-1': {


### PR DESCRIPTION
## Summary
  Updates the history API to use a cleaner array format where each history item contains its `prompt_id` as a property rather than being wrapped in an
  object with the `prompt_id` as a key.

Backend PR: https://github.com/comfyanonymous/ComfyUI/pull/8844

  ## Changes Made

  ### API Response Format Update
  - **Before**: `{history: [{"prompt_id_1": {...}}, {"prompt_id_2": {...}}]}`
  - **After**: `{history: [{prompt_id: "prompt_id_1", ...}, {prompt_id: "prompt_id_2", ...}]}`

  ### Schema Changes (`src/schemas/apiSchema.ts`)
  - Added `prompt_id` field to `zRawHistoryItem` schema
  - Updated `zHistoryResponse` to expect a direct array of history items instead of an array of objects with dynamic keys
  - Added proper TypeScript types for the new response format

  ### API Implementation (`src/scripts/api.ts`)
  - Updated `getHistory()` method to use the new `/history_v2` endpoint
  - Simplified data extraction logic to directly map the history array
  - Removed unnecessary object key extraction since `prompt_id` is now a direct property
  - Removed unused `RawHistoryItem` import

  ### Test Coverage (`tests-ui/tests/scripts/api.test.ts`)
  - Added comprehensive test suite for the new history API format
  - Tests cover:
    - Array format handling from `/history_v2`
    - Empty history arrays
    - Error handling
    - Correct API endpoint usage
    - Default parameter behavior

  ## Test Results
  All tests pass successfully, confirming the API correctly handles the new format while maintaining backward compatibility for error scenarios.

![image](https://github.com/user-attachments/assets/32e1fea6-4d41-4285-939a-100d7658fbe3)
