### PR TITLE
Add prompt ID to interrupt API call

### DIFF
--- a/src/components/sidebar/tabs/QueueSidebarTab.vue
+++ b/src/components/sidebar/tabs/QueueSidebarTab.vue
@@ -159,7 +159,7 @@ const toggleExpanded = () => {
 
 const removeTask = async (task: TaskItemImpl) => {
   if (task.isRunning) {
-    await api.interrupt()
+    await api.interrupt(task.promptId)
   }
   await queueStore.delete(task)
 }

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -19,6 +19,7 @@ import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useWorkflowService } from '@/services/workflowService'
 import type { ComfyCommand } from '@/stores/commandStore'
+import { useExecutionStore } from '@/stores/executionStore'
 import { useCanvasStore, useTitleEditorStore } from '@/stores/graphStore'
 import { useQueueSettingsStore, useQueueStore } from '@/stores/queueStore'
 import { useSettingStore } from '@/stores/settingStore'
@@ -39,6 +40,7 @@ export function useCoreCommands(): ComfyCommand[] {
   const firebaseAuthActions = useFirebaseAuthActions()
   const toastStore = useToastStore()
   const canvasStore = useCanvasStore()
+  const executionStore = useExecutionStore()
   const getTracker = () => workflowStore.activeWorkflow?.changeTracker
 
   const getSelectedNodes = (): LGraphNode[] => {
@@ -203,7 +205,7 @@ export function useCoreCommands(): ComfyCommand[] {
       icon: 'pi pi-stop',
       label: 'Interrupt',
       function: async () => {
-        await api.interrupt()
+        await api.interrupt(executionStore.activePromptId)
         toastStore.add({
           severity: 'info',
           summary: t('g.interrupted'),

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -689,7 +689,8 @@ export class ComfyApi extends EventTarget {
         Running: data.queue_running.map((prompt: Record<number, any>) => ({
           taskType: 'Running',
           prompt,
-          remove: { name: 'Cancel', cb: () => api.interrupt() }
+          // prompt[1] is the prompt id
+          remove: { name: 'Cancel', cb: () => api.interrupt(prompt[1]) }
         })),
         Pending: data.queue_pending.map((prompt: Record<number, any>) => ({
           taskType: 'Pending',
@@ -770,10 +771,15 @@ export class ComfyApi extends EventTarget {
   }
 
   /**
-   * Interrupts the execution of the running prompt
+   * Interrupts the execution of the running prompt. If runningPromptId is provided,
+   * it is included in the payload as a helpful hint to the backend.
+   * @param {string | null} [runningPromptId] Optional Running Prompt ID to interrupt
    */
-  async interrupt() {
-    await this.#postItem('interrupt', null)
+  async interrupt(runningPromptId: string | null) {
+    await this.#postItem(
+      'interrupt',
+      runningPromptId ? { prompt_id: runningPromptId } : undefined
+    )
   }
 
   /**


### PR DESCRIPTION
The Comfy UI backend currently ignores the post body.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4393-Add-prompt-ID-to-interrupt-API-call-22b6d73d365081d4b9b1e82dcc3b3c27) by [Unito](https://www.unito.io)
