### PR TITLE
[CodeHealth] Simplify code as follow-up to #4354

### DIFF
--- a/src/scripts/ui/settings.ts
+++ b/src/scripts/ui/settings.ts
@@ -65,7 +65,9 @@ export class ComfySettingsDialog extends ComfyDialog<HTMLDialogElement> {
   /**
    * @deprecated Use `settingStore.getDefaultValue` instead.
    */
-  getSettingDefaultValue<K extends keyof Settings>(id: K): Settings[K] {
+  getSettingDefaultValue<K extends keyof Settings>(
+    id: K
+  ): Settings[K] | undefined {
     return useSettingStore().getDefaultValue(id)
   }
 

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -23,15 +23,15 @@ export interface SettingTreeNode extends TreeNode {
 
 function tryMigrateDeprecatedValue(
   setting: SettingParams | undefined,
-  value: any
+  value: unknown
 ) {
   return setting?.migrateDeprecatedValue?.(value) ?? value
 }
 
 function onChange(
   setting: SettingParams | undefined,
-  newValue: any,
-  oldValue: any
+  newValue: unknown,
+  oldValue: unknown
 ) {
   if (setting?.onChange) {
     setting.onChange(newValue, oldValue)

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -98,7 +98,7 @@ export const useSettingStore = defineStore('setting', () => {
 
   function getVersionedDefaultValue<K extends keyof Settings>(
     key: K,
-    param: SettingParams
+    param: SettingParams | undefined
   ): Settings[K] | null {
     // get default versioned value, skipping if the key is 'Comfy.InstalledVersion' to prevent infinite loop
     if (param?.defaultsByInstallVersion && key !== 'Comfy.InstalledVersion') {

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -102,11 +102,12 @@ export const useSettingStore = defineStore('setting', () => {
    * @param key - The key of the setting to get.
    * @returns The default value of the setting.
    */
-  function getDefaultValue<K extends keyof Settings>(key: K): Settings[K] {
+  function getDefaultValue<K extends keyof Settings>(
+    key: K
+  ): Settings[K] | undefined {
     // Assertion: settingsById is not typed.
     const param = getSettingById(key)
 
-    // @ts-expect-error `undefined` is not valid
     if (param === undefined) return
 
     const versionedDefault = getVersionedDefaultValue(key, param)

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -21,16 +21,24 @@ export interface SettingTreeNode extends TreeNode {
   data?: SettingParams
 }
 
-function tryMigrateDeprecatedValue(setting: SettingParams, value: any) {
+function tryMigrateDeprecatedValue(
+  setting: SettingParams | undefined,
+  value: any
+) {
   return setting?.migrateDeprecatedValue?.(value) ?? value
 }
 
-function onChange(setting: SettingParams, newValue: any, oldValue: any) {
+function onChange(
+  setting: SettingParams | undefined,
+  newValue: any,
+  oldValue: any
+) {
   if (setting?.onChange) {
     setting.onChange(newValue, oldValue)
   }
   // Backward compatibility with old settings dialog.
   // Some extensions still listens event emitted by the old settings dialog.
+  // @ts-expect-error 'setting' is possibly 'undefined'.ts(18048)
   app.ui.settings.dispatchChange(setting.id, newValue, oldValue)
 }
 
@@ -112,10 +120,10 @@ export const useSettingStore = defineStore('setting', () => {
       : param.defaultValue
   }
 
-  function getVersionedDefaultValue<K extends keyof Settings>(
-    key: K,
-    param: SettingParams | undefined
-  ): Settings[K] | null {
+  function getVersionedDefaultValue<
+    K extends keyof Settings,
+    TValue = Settings[K]
+  >(key: K, param: SettingParams<TValue> | undefined): TValue | null {
     // get default versioned value, skipping if the key is 'Comfy.InstalledVersion' to prevent infinite loop
     const defaultsByInstallVersion = param?.defaultsByInstallVersion
     if (defaultsByInstallVersion && key !== 'Comfy.InstalledVersion') {

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -106,10 +106,10 @@ export const useSettingStore = defineStore('setting', () => {
 
       if (installedVersion) {
         const sortedVersions = Object.keys(param.defaultsByInstallVersion).sort(
-          (a, b) => compareVersions(a, b)
+          (a, b) => compareVersions(b, a)
         )
 
-        for (const version of sortedVersions.reverse()) {
+        for (const version of sortedVersions) {
           // Ensure the version is in a valid format before comparing
           if (!isValidVersionFormat(version)) {
             continue

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -78,12 +78,28 @@ export const useSettingStore = defineStore('setting', () => {
   }
 
   /**
+   * Gets the setting params, asserting the type that is intentionally left off
+   * of {@link settingsById}.
+   * @param key The key of the setting to get.
+   * @returns The setting.
+   */
+  function getSettingById<K extends keyof Settings>(
+    key: K
+  ): SettingParams<Settings[K]> | undefined {
+    return settingsById.value[key] as SettingParams<Settings[K]> | undefined
+  }
+
+  /**
    * Get the default value of a setting.
    * @param key - The key of the setting to get.
    * @returns The default value of the setting.
    */
   function getDefaultValue<K extends keyof Settings>(key: K): Settings[K] {
-    const param = settingsById.value[key]
+    // Assertion: settingsById is not typed.
+    const param = getSettingById(key)
+
+    // @ts-expect-error `undefined` is not valid
+    if (param === undefined) return
 
     const versionedDefault = getVersionedDefaultValue(key, param)
 
@@ -91,9 +107,9 @@ export const useSettingStore = defineStore('setting', () => {
       return versionedDefault
     }
 
-    return typeof param?.defaultValue === 'function'
+    return typeof param.defaultValue === 'function'
       ? param.defaultValue()
-      : param?.defaultValue
+      : param.defaultValue
   }
 
   function getVersionedDefaultValue<K extends keyof Settings>(

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -7,7 +7,7 @@ import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import type { SettingParams } from '@/types/settingTypes'
 import type { TreeNode } from '@/types/treeExplorerTypes'
-import { compareVersions } from '@/utils/formatUtil'
+import { compareVersions, isSemVer } from '@/utils/formatUtil'
 
 export const getSettingInfo = (setting: SettingParams) => {
   const parts = setting.category || setting.id.split('.')
@@ -112,7 +112,7 @@ export const useSettingStore = defineStore('setting', () => {
 
         for (const version of sortedVersions) {
           // Ensure the version is in a valid format before comparing
-          if (!isValidVersionFormat(version)) {
+          if (!isSemVer(version)) {
             continue
           }
 
@@ -127,12 +127,6 @@ export const useSettingStore = defineStore('setting', () => {
     }
 
     return null
-  }
-
-  function isValidVersionFormat(
-    version: string
-  ): version is `${number}.${number}.${number}` {
-    return /^\d+\.\d+\.\d+$/.test(version)
   }
 
   /**

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -101,11 +101,12 @@ export const useSettingStore = defineStore('setting', () => {
     param: SettingParams | undefined
   ): Settings[K] | null {
     // get default versioned value, skipping if the key is 'Comfy.InstalledVersion' to prevent infinite loop
-    if (param?.defaultsByInstallVersion && key !== 'Comfy.InstalledVersion') {
+    const defaultsByInstallVersion = param?.defaultsByInstallVersion
+    if (defaultsByInstallVersion && key !== 'Comfy.InstalledVersion') {
       const installedVersion = get('Comfy.InstalledVersion')
 
       if (installedVersion) {
-        const sortedVersions = Object.keys(param.defaultsByInstallVersion).sort(
+        const sortedVersions = Object.keys(defaultsByInstallVersion).sort(
           (a, b) => compareVersions(b, a)
         )
 
@@ -116,7 +117,7 @@ export const useSettingStore = defineStore('setting', () => {
           }
 
           if (compareVersions(installedVersion, version) >= 0) {
-            const versionedDefault = param.defaultsByInstallVersion[version]
+            const versionedDefault = defaultsByInstallVersion[version]
             return typeof versionedDefault === 'function'
               ? versionedDefault()
               : versionedDefault

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -35,10 +35,7 @@ export interface Setting {
 export interface SettingParams extends FormItem {
   id: keyof Settings
   defaultValue: any | (() => any)
-  defaultsByInstallVersion?: Record<
-    `${number}.${number}.${number}`,
-    any | (() => any)
-  >
+  defaultsByInstallVersion?: Record<`${number}.${number}.${number}`, unknown>
   onChange?: (newValue: any, oldValue?: any) => void
   // By default category is id.split('.'). However, changing id to assign
   // new category has poor backward compatibility. Use this field to overwrite

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -32,10 +32,10 @@ export interface Setting {
   render: () => HTMLElement
 }
 
-export interface SettingParams extends FormItem {
+export interface SettingParams<TValue = unknown> extends FormItem {
   id: keyof Settings
   defaultValue: any | (() => any)
-  defaultsByInstallVersion?: Record<`${number}.${number}.${number}`, unknown>
+  defaultsByInstallVersion?: Record<`${number}.${number}.${number}`, TValue>
   onChange?: (newValue: any, oldValue?: any) => void
   // By default category is id.split('.'). However, changing id to assign
   // new category has poor backward compatibility. Use this field to overwrite

--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -389,7 +389,7 @@ export const downloadUrlToHfRepoUrl = (url: string): string => {
 export const isSemVer = (
   version: string
 ): version is `${number}.${number}.${number}` => {
-  const regex = /^(\d+)\.(\d+)\.(\d+)$/
+  const regex = /^\d+\.\d+\.\d+$/
   return regex.test(version)
 }
 

--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -386,7 +386,9 @@ export const downloadUrlToHfRepoUrl = (url: string): string => {
   }
 }
 
-export const isSemVer = (version: string) => {
+export const isSemVer = (
+  version: string
+): version is `${number}.${number}.${number}` => {
   const regex = /^(\d+)\.(\d+)\.(\d+)$/
   return regex.test(version)
 }


### PR DESCRIPTION
- Follow-up on #4354

Summary:

- Removes redundant code
- Fixes types to match actual usage
- Removes duplicate function
- Removes `any` type

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4400-CodeHealth-Simplify-code-as-follow-up-to-4354-22b6d73d36508146a6faee031ae43eed) by [Unito](https://www.unito.io)
