### PR TITLE
1.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.24.1",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
# Release v1.24.1

## Version Change
`1.24.0` → `1.24.1` (patch release)

This patch release triggers the automated release workflow that was skipped for v1.24.0 due to `[skip ci]` in the update-locales commit.

## Content
This release contains the same content as v1.24.0 - all 51 commits since v1.23.4.

## Purpose
- Trigger automated release workflow
- Publish to PyPI and npm
- Create GitHub release with dist.zip

No code changes - version bump only.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4403-1-24-1-22b6d73d36508105a52ac2de8551bb09) by [Unito](https://www.unito.io)
