### PR TITLE
[CI] Fix frontend package release skipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.24.0-1",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Allows version release action to be rerun normally.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4404-CI-Fix-frontend-package-release-skipped-22b6d73d365081a5b850ef5e06de70e7) by [Unito](https://www.unito.io)
