### PR TITLE
Correct the translation for 'Credits' in the zh-TW locale.

### DIFF
--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -1076,7 +1076,7 @@
     "Comfy": "Comfy",
     "Comfy-Desktop": "Comfy-Desktop",
     "ContextMenu": "右鍵選單",
-    "Credits": "製作團隊",
+    "Credits": "點數",
     "CustomColorPalettes": "自訂色彩調色盤",
     "DevMode": "開發者模式",
     "EditTokenWeight": "編輯權重",


### PR DESCRIPTION
Corrected the translation of "credits" from "製作團隊" to "點數".

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4415-Correct-the-translation-for-Credits-in-the-zh-TW-locale-22c6d73d365081fe8395f7337e1e40a1) by [Unito](https://www.unito.io)
