### PR TITLE
Add a markdown image preview for the node help menu.

### DIFF
--- a/src/components/sidebar/tabs/nodeLibrary/MarkdownImageGallery.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/MarkdownImageGallery.vue
@@ -1,0 +1,148 @@
+<template>
+  <Galleria
+    v-model:visible="galleryVisible"
+    :active-index="activeIndex"
+    :value="imageItems"
+    :show-indicators="false"
+    change-item-on-indicator-hover
+    show-item-navigators
+    full-screen
+    circular
+    :show-thumbnails="false"
+    :pt="{
+      mask: {
+        onMousedown: onMaskMouseDown,
+        onMouseup: onMaskMouseUp,
+        'data-mask': true
+      },
+      prevButton: {
+        style: 'position: fixed !important'
+      },
+      nextButton: {
+        style: 'position: fixed !important'
+      }
+    }"
+    @update:visible="handleVisibilityChange"
+    @update:active-index="handleActiveIndexChange"
+  >
+    <template #item="{ item }">
+      <img
+        :src="item.url"
+        :alt="item.filename"
+        class="galleria-image"
+      />
+    </template>
+  </Galleria>
+</template>
+
+<script setup lang="ts">
+import Galleria from 'primevue/galleria'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+
+interface ImageItem {
+  url: string
+  filename: string
+}
+
+const props = defineProps<{
+  imageItems: ImageItem[]
+  activeIndex: number
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:activeIndex', value: number): void
+}>()
+
+const galleryVisible = ref(false)
+let maskMouseDownTarget: EventTarget | null = null
+
+const onMaskMouseDown = (event: MouseEvent) => {
+  maskMouseDownTarget = event.target
+}
+
+const onMaskMouseUp = (event: MouseEvent) => {
+  const maskEl = document.querySelector('[data-mask]')
+  if (
+    galleryVisible.value &&
+    maskMouseDownTarget === event.target &&
+    maskMouseDownTarget === maskEl
+  ) {
+    galleryVisible.value = false
+    handleVisibilityChange(false)
+  }
+}
+
+watch(
+  () => props.activeIndex,
+  (index) => {
+    if (index !== -1) {
+      galleryVisible.value = true
+    }
+  }
+)
+
+const handleVisibilityChange = (visible: boolean) => {
+  if (!visible) {
+    emit('update:activeIndex', -1)
+  }
+}
+
+const handleActiveIndexChange = (index: number) => {
+  emit('update:activeIndex', index)
+}
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (!galleryVisible.value) return
+
+  switch (event.key) {
+    case 'ArrowLeft':
+      navigateImage(-1)
+      break
+    case 'ArrowRight':
+      navigateImage(1)
+      break
+    case 'Escape':
+      galleryVisible.value = false
+      handleVisibilityChange(false)
+      break
+  }
+}
+
+const navigateImage = (direction: number) => {
+  const newIndex =
+    (props.activeIndex + direction + props.imageItems.length) %
+    props.imageItems.length
+  emit('update:activeIndex', newIndex)
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeyDown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeyDown)
+})
+</script>
+
+<style>
+/* PrimeVue's galleria teleports the fullscreen gallery out of subtree so we
+cannot use scoped style here. */
+img.galleria-image {
+  max-width: 100vw;
+  max-height: 100vh;
+  object-fit: contain;
+}
+
+.p-galleria-close-button {
+  /* Set z-index so the close button doesn't get hidden behind the image when image is large */
+  z-index: 1;
+}
+
+/* Mobile/tablet specific fixes */
+@media screen and (max-width: 768px) {
+  .p-galleria-prev-button,
+  .p-galleria-next-button {
+    z-index: 2;
+  }
+}
+</style> 

--- a/src/components/sidebar/tabs/nodeLibrary/MarkdownImageGallery.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/MarkdownImageGallery.vue
@@ -26,11 +26,7 @@
     @update:active-index="handleActiveIndexChange"
   >
     <template #item="{ item }">
-      <img
-        :src="item.url"
-        :alt="item.filename"
-        class="galleria-image"
-      />
+      <img :src="item.url" :alt="item.filename" class="galleria-image" />
     </template>
   </Galleria>
 </template>
@@ -145,4 +141,4 @@ img.galleria-image {
     z-index: 2;
   }
 }
-</style> 
+</style>

--- a/src/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue
@@ -84,9 +84,9 @@
   </div>
 
   <!-- Image Gallery for markdown images -->
-  <ResultGallery
+  <MarkdownImageGallery
     v-model:activeIndex="galleryActiveIndex"
-    :all-gallery-items="galleryItems"
+    :image-items="imageItems"
   />
 </template>
 
@@ -97,33 +97,13 @@ import ProgressSpinner from 'primevue/progressspinner'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
-import { ResultItemImpl } from '@/stores/queueStore'
 import { useNodeHelpStore } from '@/stores/workspace/nodeHelpStore'
 
-import ResultGallery from '../queue/ResultGallery.vue'
+import MarkdownImageGallery from './MarkdownImageGallery.vue'
 
-// Custom class for external markdown images
-class MarkdownImageItem extends ResultItemImpl {
-  private _externalUrl: string
-
-  constructor(externalUrl: string, filename: string, index: number) {
-    super({
-      filename,
-      subfolder: '',
-      type: 'output',
-      nodeId: `markdown-${index}`,
-      mediaType: 'images'
-    })
-    this._externalUrl = externalUrl
-  }
-
-  override get url(): string {
-    return this._externalUrl
-  }
-
-  override get urlWithTimestamp(): string {
-    return this._externalUrl
-  }
+interface ImageItem {
+  url: string
+  filename: string
 }
 
 const { node } = defineProps<{ node: ComfyNodeDefImpl }>()
@@ -137,7 +117,7 @@ defineEmits<{
 
 // Gallery state for image preview
 const markdownContainer = ref<HTMLElement | null>(null)
-const galleryItems = ref<MarkdownImageItem[]>([])
+const imageItems = ref<ImageItem[]>([])
 const galleryActiveIndex = ref(-1)
 
 const inputList = computed(() =>
@@ -168,13 +148,16 @@ function setupImagePreview() {
   // Only setup if there are images
   if (imgs.length === 0) return
 
-  // Update gallery items - create proper MarkdownImageItem instances
-  galleryItems.value = imgs.map((img, index) => {
+  // Update gallery items - create simple image items
+  imageItems.value = imgs.map((img, index) => {
     // Extract filename from URL
     const url = new URL(img.src, window.location.origin)
     const filename = url.pathname.split('/').pop() || `image-${index}.jpg`
 
-    return new MarkdownImageItem(img.src, filename, index)
+    return {
+      url: img.src,
+      filename
+    }
   })
 
   // Add click handlers to images
@@ -192,7 +175,7 @@ function setupImagePreview() {
 // Reset setup flag when content changes
 function resetImagePreviewSetup() {
   imagePreviewSetup.value = false
-  galleryItems.value = []
+  imageItems.value = []
   galleryActiveIndex.value = -1
 }
 

--- a/src/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue
@@ -85,7 +85,7 @@
 
   <!-- Image Gallery for markdown images -->
   <MarkdownImageGallery
-    v-model:activeIndex="galleryActiveIndex"
+    v-model:active-index="galleryActiveIndex"
     :image-items="imageItems"
   />
 </template>

--- a/src/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue
@@ -21,6 +21,7 @@
       <!-- Markdown fetched successfully -->
       <div
         v-else-if="!error"
+        ref="markdownContainer"
         class="markdown-content"
         v-html="renderedHelpHtml"
       />
@@ -81,16 +82,49 @@
       </div>
     </div>
   </div>
+
+  <!-- Image Gallery for markdown images -->
+  <ResultGallery
+    v-model:activeIndex="galleryActiveIndex"
+    :all-gallery-items="galleryItems"
+  />
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import Button from 'primevue/button'
 import ProgressSpinner from 'primevue/progressspinner'
-import { computed } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { ResultItemImpl } from '@/stores/queueStore'
 import { useNodeHelpStore } from '@/stores/workspace/nodeHelpStore'
+
+import ResultGallery from '../queue/ResultGallery.vue'
+
+// Custom class for external markdown images
+class MarkdownImageItem extends ResultItemImpl {
+  private _externalUrl: string
+
+  constructor(externalUrl: string, filename: string, index: number) {
+    super({
+      filename,
+      subfolder: '',
+      type: 'output',
+      nodeId: `markdown-${index}`,
+      mediaType: 'images'
+    })
+    this._externalUrl = externalUrl
+  }
+
+  override get url(): string {
+    return this._externalUrl
+  }
+
+  override get urlWithTimestamp(): string {
+    return this._externalUrl
+  }
+}
 
 const { node } = defineProps<{ node: ComfyNodeDefImpl }>()
 
@@ -100,6 +134,11 @@ const { renderedHelpHtml, isLoading, error } = storeToRefs(nodeHelpStore)
 defineEmits<{
   (e: 'close'): void
 }>()
+
+// Gallery state for image preview
+const markdownContainer = ref<HTMLElement | null>(null)
+const galleryItems = ref<MarkdownImageItem[]>([])
+const galleryActiveIndex = ref(-1)
 
 const inputList = computed(() =>
   Object.values(node.inputs).map((spec) => ({
@@ -116,6 +155,63 @@ const outputList = computed(() =>
     tooltip: spec.tooltip || ''
   }))
 )
+
+// Track if we've already setup image preview to avoid re-setup
+const imagePreviewSetup = ref(false)
+
+// Function to setup image preview functionality
+function setupImagePreview() {
+  if (!markdownContainer.value || imagePreviewSetup.value) return
+
+  const imgs = Array.from(markdownContainer.value.querySelectorAll('img'))
+
+  // Only setup if there are images
+  if (imgs.length === 0) return
+
+  // Update gallery items - create proper MarkdownImageItem instances
+  galleryItems.value = imgs.map((img, index) => {
+    // Extract filename from URL
+    const url = new URL(img.src, window.location.origin)
+    const filename = url.pathname.split('/').pop() || `image-${index}.jpg`
+
+    return new MarkdownImageItem(img.src, filename, index)
+  })
+
+  // Add click handlers to images
+  imgs.forEach((img, index) => {
+    img.style.cursor = 'zoom-in'
+    img.onclick = (e) => {
+      e.preventDefault()
+      galleryActiveIndex.value = index
+    }
+  })
+
+  imagePreviewSetup.value = true
+}
+
+// Reset setup flag when content changes
+function resetImagePreviewSetup() {
+  imagePreviewSetup.value = false
+  galleryItems.value = []
+  galleryActiveIndex.value = -1
+}
+
+// Watch for changes in rendered HTML and setup image preview
+watch(renderedHelpHtml, async () => {
+  resetImagePreviewSetup()
+  await nextTick()
+  setupImagePreview()
+})
+
+// Watch for loading state changes
+watch([isLoading, error], () => {
+  resetImagePreviewSetup()
+})
+
+onMounted(async () => {
+  await nextTick()
+  setupImagePreview()
+})
 </script>
 
 <style scoped>
@@ -241,5 +337,14 @@ const outputList = computed(() =>
     @apply bg-transparent p-0;
     color: var(--p-text-color);
   }
+}
+
+/* Add hover effect for clickable images */
+.markdown-content :deep(img) {
+  transition: opacity 0.2s ease;
+}
+
+.markdown-content :deep(img:hover) {
+  opacity: 0.8;
 }
 </style>


### PR DESCRIPTION
When updating the node docs, I found sometimes it's hard to preview the image, so I made this PR.
The code was written by Claude. I'm not good at development.


https://github.com/user-attachments/assets/667c8922-f4cc-49b2-99ab-6fe4aa2a9987


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4417-Add-a-markdown-image-preview-for-the-node-help-menu-22c6d73d3650818abf67d9f563525af2) by [Unito](https://www.unito.io)
