### PR TITLE
Improve execution logic / Fix group node execution

### DIFF
--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -69,7 +69,7 @@ declare module '@comfyorg/litegraph/dist/interfaces' {
  *  ComfyUI extensions of litegraph
  */
 declare module '@comfyorg/litegraph' {
-  import type { ExecutableLGraphNode } from '@comfyorg/litegraph'
+  import type { ExecutableLGraphNode, ExecutionId } from '@comfyorg/litegraph'
   import type { IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
   interface LGraphNodeConstructor<T extends LGraphNode = LGraphNode> {
@@ -99,8 +99,10 @@ declare module '@comfyorg/litegraph' {
     setInnerNodes?(nodes: LGraphNode[]): void
     /** Originally a group node API. */
     getInnerNodes?(
+      nodesByExecutionId: Map<ExecutionId, ExecutableLGraphNode>,
+      subgraphNodePath?: readonly NodeId[],
       nodes?: ExecutableLGraphNode[],
-      subgraphs?: WeakSet<LGraphNode>
+      subgraphs?: Set<LGraphNode>
     ): ExecutableLGraphNode[]
     /** @deprecated groupNode */
     convertToNodes?(): LGraphNode[]

--- a/src/utils/executableGroupNodeChildDTO.ts
+++ b/src/utils/executableGroupNodeChildDTO.ts
@@ -1,0 +1,53 @@
+import {
+  type ExecutableLGraphNode,
+  ExecutableNodeDTO,
+  type ExecutionId,
+  type LGraphNode,
+  type NodeId,
+  type SubgraphNode
+} from '@comfyorg/litegraph'
+
+import type { GroupNodeHandler } from '@/extensions/core/groupNode'
+
+export class ExecutableGroupNodeChildDTO extends ExecutableNodeDTO {
+  groupNodeHandler?: GroupNodeHandler
+
+  constructor(
+    /** The actual node that this DTO wraps. */
+    node: LGraphNode | SubgraphNode,
+    /** A list of subgraph instance node IDs from the root graph to the containing instance. @see {@link id} */
+    subgraphNodePath: readonly NodeId[],
+    /** A flattened map of all DTOs in this node network. Subgraph instances have been expanded into their inner nodes. */
+    nodesByExecutionId: Map<ExecutionId, ExecutableLGraphNode>,
+    /** The actual subgraph instance that contains this node, otherise undefined. */
+    subgraphNode?: SubgraphNode | undefined,
+    groupNodeHandler?: GroupNodeHandler
+  ) {
+    super(node, subgraphNodePath, nodesByExecutionId, subgraphNode)
+    this.groupNodeHandler = groupNodeHandler
+  }
+
+  override resolveInput(slot: number) {
+    const inputNode = this.node.getInputNode(slot)
+    if (!inputNode) return
+
+    const link = this.node.getInputLink(slot)
+    if (!link) throw new Error('Failed to get input link')
+
+    const id = String(inputNode.id).split(':').at(-1)
+    if (id === undefined) throw new Error('Invalid input node id')
+
+    const inputNodeDto = this.nodesByExecutionId?.get(id)
+    if (!inputNodeDto) {
+      throw new Error(
+        `Failed to get input node ${id} for group node child ${this.id} with slot ${slot}`
+      )
+    }
+
+    return {
+      node: inputNodeDto,
+      origin_id: inputNode.id,
+      origin_slot: link.origin_slot
+    }
+  }
+}

--- a/src/utils/executableGroupNodeDto.ts
+++ b/src/utils/executableGroupNodeDto.ts
@@ -1,0 +1,71 @@
+import {
+  type ExecutableLGraphNode,
+  ExecutableNodeDTO,
+  type ISlotType,
+  LGraphEventMode,
+  type LGraphNode
+} from '@comfyorg/litegraph'
+
+export const GROUP = Symbol()
+
+export function isGroupNode(node: LGraphNode): boolean {
+  return node.constructor?.nodeData?.[GROUP] !== undefined
+}
+
+export class ExecutableGroupNodeDTO extends ExecutableNodeDTO {
+  override get isVirtualNode(): true {
+    return true
+  }
+
+  override getInnerNodes(): ExecutableLGraphNode[] {
+    return this.node.getInnerNodes?.(this.nodesByExecutionId) ?? []
+  }
+
+  override resolveOutput(slot: number, type: ISlotType, visited: Set<string>) {
+    // Temporary duplication: Bypass nodes are bypassed using the first input with matching type
+    if (this.mode === LGraphEventMode.BYPASS) {
+      const { inputs } = this
+
+      // Bypass nodes by finding first input with matching type
+      const parentInputIndexes = Object.keys(inputs).map(Number)
+      // Prioritise exact slot index
+      const indexes = [slot, ...parentInputIndexes]
+      const matchingIndex = indexes.find((i) => inputs[i]?.type === type)
+
+      // No input types match
+      if (matchingIndex === undefined) return
+
+      return this.resolveInput(matchingIndex, visited)
+    }
+
+    const linkId = this.node.outputs[slot]?.links?.at(0)
+    const link = this.node.graph?.getLink(linkId)
+    if (!link) {
+      throw new Error(
+        `Failed to get link for group node ${this.node.id} with link ${linkId}`
+      )
+    }
+
+    const updated = this.node.updateLink?.(link)
+    if (!updated) {
+      throw new Error(
+        `Failed to update link for group node ${this.node.id} with link ${linkId}`
+      )
+    }
+
+    const node = this.node
+      .getInnerNodes?.(this.nodesByExecutionId)
+      .find((node) => node.id === updated.origin_id)
+    if (!node) {
+      throw new Error(
+        `Failed to get node for group node ${this.node.id} with link ${linkId}`
+      )
+    }
+
+    return {
+      node,
+      origin_id: `${this.id}:${(updated.origin_id as string).split(':').at(-1)}`,
+      origin_slot: updated.origin_slot
+    }
+  }
+}

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -1,4 +1,9 @@
-import type { LGraph, NodeId } from '@comfyorg/litegraph'
+import type {
+  ExecutableLGraphNode,
+  ExecutionId,
+  LGraph,
+  NodeId
+} from '@comfyorg/litegraph'
 import {
   ExecutableNodeDTO,
   LGraphEventMode,
@@ -10,6 +15,7 @@ import type {
   ComfyWorkflowJSON
 } from '@/schemas/comfyWorkflowSchema'
 
+import { ExecutableGroupNodeDTO, isGroupNode } from './executableGroupNodeDto'
 import { compressWidgetInputSlots } from './litegraphUtil'
 
 /**
@@ -54,7 +60,9 @@ export const graphToPrompt = async (
   const { sortNodes = false, queueNodeIds } = options
 
   for (const node of graph.computeExecutionOrder(false)) {
-    const innerNodes = node.getInnerNodes ? node.getInnerNodes() : [node]
+    const innerNodes = node.getInnerNodes
+      ? node.getInnerNodes(new Map())
+      : [node]
     for (const innerNode of innerNodes) {
       if (innerNode.isVirtualNode) {
         innerNode.applyToGraph?.()
@@ -78,82 +86,80 @@ export const graphToPrompt = async (
   workflow.extra ??= {}
   workflow.extra.frontendVersion = __COMFYUI_FRONTEND_VERSION__
 
-  const computedNodeDtos = graph
-    .computeExecutionOrder(false)
-    .map(
-      (node) =>
-        new ExecutableNodeDTO(
+  const nodeDtoMap = new Map<ExecutionId, ExecutableLGraphNode>()
+  for (const node of graph.computeExecutionOrder(false)) {
+    const dto: ExecutableLGraphNode = isGroupNode(node)
+      ? new ExecutableGroupNodeDTO(node, [], nodeDtoMap)
+      : new ExecutableNodeDTO(
           node,
           [],
+          nodeDtoMap,
           node instanceof SubgraphNode ? node : undefined
         )
-    )
+
+    for (const innerNode of dto.getInnerNodes()) {
+      nodeDtoMap.set(innerNode.id, innerNode)
+    }
+
+    nodeDtoMap.set(dto.id, dto)
+  }
 
   let output: ComfyApiWorkflow = {}
   // Process nodes in order of execution
-  for (const outerNode of computedNodeDtos) {
+  for (const node of nodeDtoMap.values()) {
     // Don't serialize muted nodes
     if (
-      outerNode.mode === LGraphEventMode.NEVER ||
-      outerNode.mode === LGraphEventMode.BYPASS
+      node.isVirtualNode ||
+      node.mode === LGraphEventMode.NEVER ||
+      node.mode === LGraphEventMode.BYPASS
     ) {
       continue
     }
 
-    for (const node of outerNode.getInnerNodes()) {
-      if (
-        node.isVirtualNode ||
-        node.mode === LGraphEventMode.NEVER ||
-        node.mode === LGraphEventMode.BYPASS
-      ) {
-        continue
+    const inputs: ComfyApiWorkflow[string]['inputs'] = {}
+    const { widgets } = node
+
+    // Store all widget values
+    if (widgets) {
+      for (const [i, widget] of widgets.entries()) {
+        if (!widget.name || widget.options?.serialize === false) continue
+
+        const widgetValue = widget.serializeValue
+          ? await widget.serializeValue(node, i)
+          : widget.value
+        // By default, Array values are reserved to represent node connections.
+        // We need to wrap the array as an object to avoid the misinterpretation
+        // of the array as a node connection.
+        // The backend automatically unwraps the object to an array during
+        // execution.
+        inputs[widget.name] = Array.isArray(widgetValue)
+          ? {
+              __value__: widgetValue
+            }
+          : widgetValue
       }
+    }
 
-      const inputs: ComfyApiWorkflow[string]['inputs'] = {}
-      const { widgets } = node
+    // Store all node links
+    for (const [i, input] of node.inputs.entries()) {
+      const resolvedInput = node.resolveInput(i)
+      if (!resolvedInput) continue
 
-      // Store all widget values
-      if (widgets) {
-        for (const [i, widget] of widgets.entries()) {
-          if (!widget.name || widget.options?.serialize === false) continue
+      inputs[input.name] = [
+        String(resolvedInput.origin_id),
+        // @ts-expect-error link.origin_slot is already number.
+        parseInt(resolvedInput.origin_slot)
+      ]
+    }
 
-          const widgetValue = widget.serializeValue
-            ? await widget.serializeValue(node, i)
-            : widget.value
-          // By default, Array values are reserved to represent node connections.
-          // We need to wrap the array as an object to avoid the misinterpretation
-          // of the array as a node connection.
-          // The backend automatically unwraps the object to an array during
-          // execution.
-          inputs[widget.name] = Array.isArray(widgetValue)
-            ? {
-                __value__: widgetValue
-              }
-            : widgetValue
-        }
-      }
-
-      // Store all node links
-      for (const [i, input] of node.inputs.entries()) {
-        const resolvedInput = node.resolveInput(i)
-        if (!resolvedInput) continue
-
-        inputs[input.name] = [
-          String(resolvedInput.origin_id),
-          // @ts-expect-error link.origin_slot is already number.
-          parseInt(resolvedInput.origin_slot)
-        ]
-      }
-
-      output[String(node.id)] = {
-        inputs,
-        // TODO(huchenlei): Filter out all nodes that cannot be mapped to a
-        // comfyClass.
-        class_type: node.comfyClass!,
-        // Ignored by the backend.
-        _meta: {
-          title: node.title
-        }
+    output[String(node.id)] = {
+      inputs,
+      // TODO(huchenlei): Filter out all nodes that cannot be mapped to a
+      // comfyClass.
+      class_type: node.comfyClass!,
+      // Ignored by the backend.
+      _meta: {
+        title: node.title
       }
     }
   }


### PR DESCRIPTION
### Execution update 

- Requires https://github.com/Comfy-Org/litegraph.js/pull/1112
- Updates execution logic to match above litegraph changes
- Resolves group node execution issues
- Fixes types to match actual usage

### Architectural overview

#### From Litegraph [#1112](https://github.com/Comfy-Org/litegraph.js/pull/1112)

> Previously, the execution DTOs were dynamically instantiating sibling DTOs when resolving links. This has been removed, as it was not part of the original design.  All DTOs are now generated recursively prior to running any link resolution, allowing all DTOs to simply look up the targets via the shared map object.

#### Frontend

Two adapters were implemented to handle most of the changes to group nodes.  As group nodes are now deprecated, completely isolating the API changes with adapters was unnecessary.  Execution is now fully encapsulated using DTOs rather than raw litegraph objects.

The DTOs resolve links using new, purpose-built methods, rather than monkey patching Litegraph methods.  This removes the need for multiple layers of workarounds, as the original Litegraph interfaces were simply not designed for execution.

### Known limitation

- Group nodes will fail execution when inputs are connected to subgraph nodes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4422-Improve-execution-logic-Fix-group-node-execution-22d6d73d365081218800fa1bde1a76ec) by [Unito](https://www.unito.io)
