### PR TITLE
Fix DTO return type to allow clean test/merge

### DIFF
--- a/src/utils/executableGroupNodeChildDTO.ts
+++ b/src/utils/executableGroupNodeChildDTO.ts
@@ -46,7 +46,7 @@ export class ExecutableGroupNodeChildDTO extends ExecutableNodeDTO {
 
     return {
       node: inputNodeDto,
-      origin_id: inputNode.id,
+      origin_id: String(inputNode.id),
       origin_slot: link.origin_slot
     }
   }


### PR DESCRIPTION
Ensures the DTO override for group nodes always return strings.

Pre-requisite for subgraph widget patch:
- https://github.com/Comfy-Org/litegraph.js/pull/1114

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4426-Fix-DTO-return-type-to-allow-clean-test-merge-22d6d73d365081fc8e3bcf2e05307a67) by [Unito](https://www.unito.io)
