### PR TITLE
refactor: address some `noUncheckedIndexedAccess` errors

### DIFF
--- a/src/components/common/ElectronFileDownload.vue
+++ b/src/components/common/ElectronFileDownload.vue
@@ -87,7 +87,7 @@ import { formatSize } from '@/utils/formatUtil'
 const props = defineProps<{
   url: string
   hint?: string
-  label?: string
+  label: `${string}/${string}`
   error?: string
 }>()
 
@@ -101,8 +101,7 @@ const fileSize = computed(() =>
   download.fileSize.value ? formatSize(download.fileSize.value) : '?'
 )
 const electronDownloadStore = useElectronDownloadStore()
-// @ts-expect-error fixme ts strict error
-const [savePath, filename] = props.label.split('/')
+const [savePath, filename] = props.label.split('/') as [string, string]
 
 electronDownloadStore.$subscribe((_, { downloads }) => {
   const download = downloads.find((download) => props.url === download.url)

--- a/src/components/common/InputKnob.vue
+++ b/src/components/common/InputKnob.vue
@@ -77,9 +77,7 @@ const updateValue = (newValue: number | null) => {
 const displayValue = (value: number): string => {
   updateValue(value)
   const stepString = (props.step ?? 1).toString()
-  const resolution = stepString.includes('.')
-    ? stepString.split('.')[1].length
-    : 0
+  const resolution = stepString.split('.')[1]?.length ?? 0
   return value.toFixed(props.resolution ?? resolution)
 }
 

--- a/src/components/common/SystemStatsPanel.vue
+++ b/src/components/common/SystemStatsPanel.vue
@@ -30,7 +30,10 @@
           <DeviceInfo :device="device" />
         </TabPanel>
       </TabView>
-      <DeviceInfo v-else :device="props.stats.devices[0]" />
+      <DeviceInfo
+        v-else-if="props.stats.devices[0]"
+        :device="props.stats.devices[0]"
+      />
     </div>
   </div>
 </template>

--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -92,7 +92,7 @@ const missingModels = computed(() => {
       downloading: false,
       completed: false,
       progress: 0,
-      error: null,
+      error: undefined,
       name: model.name,
       directory: model.directory,
       url: model.url,

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -149,7 +149,7 @@ const {
   toggle: toggleSideNav
 } = useResponsiveCollapse()
 
-const tabs = ref<TabItem[]>([
+const tabs = ref<[TabItem, ...TabItem[]]>([
   { id: ManagerTab.All, label: t('g.all'), icon: 'pi-list' },
   { id: ManagerTab.Installed, label: t('g.installed'), icon: 'pi-box' },
   {
@@ -368,7 +368,7 @@ const resultsWithKeys = computed(
 
 const selectedNodePacks = ref<components['schemas']['Node'][]>([])
 const selectedNodePack = computed<components['schemas']['Node'] | null>(() =>
-  selectedNodePacks.value.length === 1 ? selectedNodePacks.value[0] : null
+  selectedNodePacks.value.length === 1 ? selectedNodePacks.value[0]! : null
 )
 
 const getLoadingCount = () => {

--- a/src/components/dialog/content/manager/infoPanel/InfoPanelHeader.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoPanelHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="nodePacks?.length" class="flex flex-col items-center mb-6">
+  <div v-if="nodePacks[0]" class="flex flex-col items-center mb-6">
     <slot name="thumbnail">
       <PackIcon :node-pack="nodePacks[0]" width="24" height="24" />
     </slot>

--- a/src/components/dialog/content/manager/infoPanel/MarkdownText.vue
+++ b/src/components/dialog/content/manager/infoPanel/MarkdownText.vue
@@ -68,8 +68,8 @@ const parsedSegments = computed(() => {
     // Add the link
     segments.push({
       type: 'link',
-      text: linkMatch[1],
-      url: linkMatch[2]
+      text: linkMatch[1]!,
+      url: linkMatch[2]!
     })
 
     lastIndex = linkMatch.index + linkMatch[0].length

--- a/src/components/dialog/content/manager/infoPanel/tabs/DescriptionTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/DescriptionTabPanel.vue
@@ -47,7 +47,7 @@ const isLicenseFile = (filename: string): boolean => {
 const extractBaseRepoUrl = (repoUrl: string): string => {
   const githubRepoPattern = /^(https?:\/\/github\.com\/[^/]+\/[^/]+)/i
   const match = repoUrl.match(githubRepoPattern)
-  return match ? match[1] : repoUrl
+  return match?.[1] ?? repoUrl
 }
 
 const createLicenseUrl = (filename: string, repoUrl: string): string => {

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -177,7 +177,7 @@ const commandsData = computed<ICommandData[]>(() => {
       `commands.${normalizeI18nKey(command.id)}.label`,
       command.label ?? ''
     ),
-    keybinding: keybindingStore.getKeybindingByCommandId(command.id),
+    keybinding: keybindingStore.getKeybindingByCommandId(command.id) ?? null,
     source: command.source
   }))
 })
@@ -206,7 +206,7 @@ const existingKeybindingOnCombo = computed<KeybindingImpl | null>(() => {
     return null
   }
 
-  return keybindingStore.getKeybinding(newBindingKeyCombo.value)
+  return keybindingStore.getKeybinding(newBindingKeyCombo.value) ?? null
 })
 
 function editKeybinding(commandData: ICommandData) {

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -230,7 +230,7 @@ watch(
       for (const error of nodeErrors.errors) {
         if (error.extra_info && error.extra_info.input_name) {
           const inputIndex = node.findInputSlot(error.extra_info.input_name)
-          if (inputIndex !== -1) {
+          if (inputIndex !== -1 && node.inputs[inputIndex]) {
             node.inputs[inputIndex].hasErrors = true
           }
         }

--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -63,6 +63,7 @@ const onIdle = () => {
 
   const ctor = node.constructor as { title_mode?: 0 | 1 | 2 | 3 }
   const nodeDef = nodeDefStore.nodeDefsByName[node.type ?? '']
+  if (!nodeDef) return
 
   if (
     ctor.title_mode !== LiteGraph.NO_TITLE &&
@@ -79,7 +80,7 @@ const onIdle = () => {
     canvas.graph_mouse[1],
     [0, 0]
   )
-  if (inputSlot !== -1) {
+  if (inputSlot !== -1 && node.inputs[inputSlot]) {
     const inputName = node.inputs[inputSlot].name
     const translatedTooltip = st(
       `nodeDefs.${normalizeI18nKey(node.type ?? '')}.inputs.${normalizeI18nKey(inputName)}.tooltip`,

--- a/src/components/graph/TitleEditor.vue
+++ b/src/components/graph/TitleEditor.vue
@@ -71,7 +71,7 @@ watch(
       inputFontStyle.value = { fontSize: `${group.font_size * scale}px` }
     } else if (target instanceof LGraphNode) {
       const node = target
-      const [x, y] = node.getBounding()
+      const [x, y] = node.getBounding() as [number, number, number, number]
       updatePosition({
         pos: [x, y],
         size: [node.width, LiteGraph.NODE_TITLE_HEIGHT]
@@ -88,7 +88,7 @@ const canvasEventHandler = (event: LiteGraphCanvasEvent) => {
     }
 
     const group: LGraphGroup = event.detail.group
-    const [_, y] = group.pos
+    const [_, y] = group.pos as [number, number]
 
     const e = event.detail.originalEvent
     const relativeY = e.canvasY - y
@@ -102,7 +102,7 @@ const canvasEventHandler = (event: LiteGraphCanvasEvent) => {
     }
 
     const node: LGraphNode = event.detail.node
-    const [_, y] = node.pos
+    const [_, y] = node.pos as [number, number]
 
     const e = event.detail.originalEvent
     const relativeY = e.canvasY - y

--- a/src/components/graph/selectionToolbox/ColorPickerButton.vue
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.vue
@@ -100,7 +100,7 @@ const applyColor = (colorOption: ColorOption | null) => {
   const canvasColorOption =
     colorName === NO_COLOR_OPTION.name
       ? null
-      : LGraphCanvas.node_colors[colorName]
+      : LGraphCanvas.node_colors[colorName] ?? null
 
   for (const item of canvasStore.selectedItems) {
     if (isColorable(item)) {

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -132,7 +132,8 @@ const props = defineProps<{
 
 const isMenuOpen = ref(false)
 const activeCategory = ref<string>('scene')
-const categoryLabels: Record<string, string> = {
+type Category = 'scene' | 'model' | 'camera' | 'light' | 'export'
+const categoryLabels: Record<Category, string> = {
   scene: 'load3d.scene',
   model: 'load3d.model',
   camera: 'load3d.camera',
@@ -140,11 +141,11 @@ const categoryLabels: Record<string, string> = {
   export: 'load3d.export'
 }
 
-const availableCategories = computed(() => {
-  const baseCategories = ['scene', 'model', 'camera', 'light']
+const availableCategories = computed<Category[]>(() => {
+  const baseCategories = ['scene', 'model', 'camera', 'light'] as Category[]
 
   if (!props.inputSpec.isAnimation) {
-    return [...baseCategories, 'export']
+    return [...baseCategories, 'export'] as Category[]
   }
 
   return baseCategories

--- a/src/components/load3d/controls/RecordingControls.vue
+++ b/src/components/load3d/controls/RecordingControls.vue
@@ -103,7 +103,7 @@ const resizeNodeMatchOutput = () => {
   const outputHeight = node.widgets?.find((w) => w.name === 'height')
 
   if (outputWidth && outputHeight && outputHeight.value && outputWidth.value) {
-    const [oldWidth, oldHeight] = node.size
+    const [oldWidth, oldHeight] = node.size as [number, number]
 
     const scene = node.widgets?.find((w) => w.name === 'image')
 

--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -164,7 +164,7 @@ const setHoverSuggestion = (index: number) => {
     hoveredSuggestion.value = null
     return
   }
-  const value = suggestions.value[index]
+  const value = suggestions.value[index] ?? null
   hoveredSuggestion.value = value
 }
 </script>

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -237,7 +237,7 @@ const canvasEventHandler = (e: LiteGraphCanvasEvent) => {
     showSearchBox(e.detail.originalEvent)
   } else if (e.detail.subType === 'group-double-click') {
     const group = e.detail.group
-    const [_, y] = group.pos
+    const [_, y] = group.pos as [number, number]
     const relativeY = e.detail.originalEvent.canvasY - y
     // Show search box if the click is NOT on the title bar
     if (relativeY > group.titleHeight) {

--- a/src/components/searchbox/NodeSearchFilter.vue
+++ b/src/components/searchbox/NodeSearchFilter.vue
@@ -53,7 +53,7 @@ const updateSelectedFilterValue = () => {
   if (filterValues.value.includes(selectedFilterValue.value)) {
     return
   }
-  selectedFilterValue.value = filterValues.value[0]
+  selectedFilterValue.value = filterValues.value[0] ?? ''
 }
 
 const submit = () => {

--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -38,7 +38,7 @@ export function useAbsolutePosition(options: { useTransform?: boolean } = {}) {
   const computeStyle = (position: PositionConfig): CSSProperties => {
     const { pos, size, scale = lgCanvas.ds.scale } = position
     const [left, top] = canvasPosToClientPos(pos)
-    const [width, height] = size
+    const [width, height] = size as [number, number]
 
     return useTransform
       ? {

--- a/src/composables/node/useNodeAnimatedImage.ts
+++ b/src/composables/node/useNodeAnimatedImage.ts
@@ -68,7 +68,7 @@ export function useNodeAnimatedImage() {
     )
 
     if (widgetIdx > -1) {
-      node.widgets[widgetIdx].onRemove?.()
+      node.widgets[widgetIdx]?.onRemove?.()
       node.widgets.splice(widgetIdx, 1)
     }
   }

--- a/src/composables/node/useNodeCanvasImagePreview.ts
+++ b/src/composables/node/useNodeCanvasImagePreview.ts
@@ -36,7 +36,7 @@ export function useNodeCanvasImagePreview() {
     )
 
     if (widgetIdx > -1) {
-      node.widgets[widgetIdx].onRemove?.()
+      node.widgets[widgetIdx]?.onRemove?.()
       node.widgets.splice(widgetIdx, 1)
     }
   }

--- a/src/composables/node/useNodeChatHistory.ts
+++ b/src/composables/node/useNodeChatHistory.ts
@@ -47,7 +47,7 @@ export function useNodeChatHistory(
     )
 
     if (widgetIdx > -1) {
-      node.widgets[widgetIdx].onRemove?.()
+      node.widgets[widgetIdx]?.onRemove?.()
       node.widgets.splice(widgetIdx, 1)
     }
   }

--- a/src/composables/node/useNodeProgressText.ts
+++ b/src/composables/node/useNodeProgressText.ts
@@ -41,7 +41,7 @@ export function useNodeProgressText() {
     )
 
     if (widgetIdx > -1) {
-      node.widgets[widgetIdx].onRemove?.()
+      node.widgets[widgetIdx]?.onRemove?.()
       node.widgets.splice(widgetIdx, 1)
     }
   }

--- a/src/composables/setting/useSettingSearch.ts
+++ b/src/composables/setting/useSettingSearch.ts
@@ -101,10 +101,11 @@ export function useSettingSearch() {
       const groupLabel = info.subCategory
 
       if (activeCategory === null || activeCategory.label === info.category) {
-        if (!groupedSettings[groupLabel]) {
+        if (groupedSettings[groupLabel] === undefined) {
           groupedSettings[groupLabel] = []
         }
-        groupedSettings[groupLabel].push(setting)
+        if (!setting) return
+        groupedSettings[groupLabel]!.push(setting)
       }
     })
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -48,7 +48,7 @@ export function useCoreCommands(): ComfyCommand[] {
     const result: LGraphNode[] = []
     if (selectedNodes) {
       for (const i in selectedNodes) {
-        const node = selectedNodes[i]
+        const node = selectedNodes[i]!
         result.push(node)
       }
     }
@@ -66,14 +66,14 @@ export function useCoreCommands(): ComfyCommand[] {
   }
 
   const moveSelectedNodes = (
-    positionUpdater: (pos: Point, gridSize: number) => Point
+    positionUpdater: (pos: [number, number], gridSize: number) => Point
   ) => {
     const selectedNodes = getSelectedNodes()
     if (selectedNodes.length === 0) return
 
     const gridSize = useSettingStore().get('Comfy.SnapToGrid.GridSize')
     selectedNodes.forEach((node) => {
-      node.pos = positionUpdater(node.pos, gridSize)
+      node.pos = positionUpdater(node.pos as [number, number], gridSize)
     })
     app.canvas.state.selectionChanged = true
     app.canvas.setDirty(true, true)

--- a/src/stores/settingStore.ts
+++ b/src/stores/settingStore.ts
@@ -9,11 +9,11 @@ import type { SettingParams } from '@/types/settingTypes'
 import type { TreeNode } from '@/types/treeExplorerTypes'
 import { compareVersions, isSemVer } from '@/utils/formatUtil'
 
-export const getSettingInfo = (setting: SettingParams) => {
-  const parts = setting.category || setting.id.split('.')
+export const getSettingInfo = (setting?: SettingParams) => {
+  const parts = setting?.category || setting?.id.split('.')
   return {
-    category: parts[0] ?? 'Other',
-    subCategory: parts[1] ?? 'Other'
+    category: parts?.[0] ?? 'Other',
+    subCategory: parts?.[1] ?? 'Other'
   }
 }
 

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -218,10 +218,13 @@ export const useWorkflowStore = defineStore('workflow', () => {
   const openWorkflowPaths = ref<string[]>([])
   const openWorkflowPathSet = computed(() => new Set(openWorkflowPaths.value))
   const openWorkflows = computed(() =>
-    openWorkflowPaths.value.map((path) => workflowLookup.value[path])
+    openWorkflowPaths.value
+      .map((path) => workflowLookup.value[path])
+      .filter((workflow): workflow is ComfyWorkflow => workflow !== undefined)
   )
   const reorderWorkflows = (from: number, to: number) => {
     const movedTab = openWorkflowPaths.value[from]
+    if (movedTab === undefined) return
     openWorkflowPaths.value.splice(from, 1)
     openWorkflowPaths.value.splice(to, 0, movedTab)
   }

--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -15,7 +15,7 @@ export function buildTree<T>(items: T[], key: (item: T) => string[]): TreeNode {
     const keys = key(item)
     let parent = root
     for (let i = 0; i < keys.length; i++) {
-      const k = keys[i]
+      const k = keys[i]!
       // 'a/b/c/' represents an empty folder 'c' in folder 'b' in folder 'a'
       // 'a/b/c/' is split into ['a', 'b', 'c', '']
       if (k === '' && i === keys.length - 1) break


### PR DESCRIPTION
Tentative refactor addressing ~10% of errors arising from enabling the TypeScript compiler option [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/noUncheckedIndexedAccess.html), with the tentative goal of enabling it permanently, after gradually fixing the remaining errors. This PR makes the error count go from 567 to 506. The idea is to continue in small chunks. We can adjust the size and frequency.

Enabling `noUncheckedIndexAccess` also allows for safely enabling the ESLint rule [`no-unnecessary-condition`](https://typescript-eslint.io/rules/no-unnecessary-condition/) which will eliminate undefined/boolean checks for values that are statically known to never be nullish/falsy.

Idea originally proposed in #4366

This is an experiment, if you find that my methodology is too high-risk or requires too much supervision, feel free to not continue.

### General methodology

- Changes are purely to fix `noUncheckedIndexedAccess`-related compiler errors.
- Sometimes, the code can be made to typecheck with no logic changes, only narrower type annotations
   - e.g. from `const names: string[] = ["John", "Mary"]; const name = names[0]`
   - to `const names: [string, ...string[]] = ["John", "Mary"]; const name = names[0]`
- Sometimes, the code logic is safe but the guards need to be swapped to something equivalent that enables type narrowing
   - e.g. from `arr.length && foo(arr[0])`
   - to `arr[0] && foo(arr[0])`
- Sometimes, values which `noUncheckedIndexedAccess` reveals to be undefinable must be coalesced to `null` if they're used in places that were typed to only accept `null`
- Sometimes, the code is trivially safe but the type system needs a little unsafe casting
   - e.g. `arr.length === 1 && arr[0]!`
   - or destructuring litegraph `Point`, `Size`, and `Rect`, which have fixed length but are a type system blind spot due to the fact they can be `TypedArray`s
- Sometimes adding a new guard with a default value or early return is necessary, in which case I make sure that the previous behaviour of throwing an exception would not be preferable due to other pieces of code relying on it
- If a default value, additional guard or early return doesn't make sense, and a large refactor is advisable to explicitly handle the undefined case, I will leave the error untouched in order to keep the commit as simple as possible. At the very end of the process, these errors can be addressed, or a `// @ts-expect-error fixme noUncheckedIndexedAccess error` comment can be added before permanently enabling the compiler option

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4428-refactor-address-some-noUncheckedIndexedAccess-errors-22d6d73d3650811f9822c6e6b8ce5e03) by [Unito](https://www.unito.io)
