### PR TITLE
Fix SubgraphNode widget values ignored

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -145,6 +145,13 @@ export const graphToPrompt = async (
       const resolvedInput = node.resolveInput(i)
       if (!resolvedInput) continue
 
+      // Input resolved to a SubgraphNode widget
+      const { value } = resolvedInput
+      if (value) {
+        inputs[input.name] = Array.isArray(value) ? { __value__: value } : value
+        continue
+      }
+
       inputs[input.name] = [
         String(resolvedInput.origin_id),
         // @ts-expect-error link.origin_slot is already number.


### PR DESCRIPTION
Allows cleaner application of widget values to the execution result. Removes requirement to iterate over all links / widgets prior to mapping input links, by simply returning the value as part of the input resolution.

- Ref: https://github.com/Comfy-Org/litegraph.js/pull/1114

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4429-Return-SubgraphNode-widget-values-during-execution-22d6d73d3650815fbd1dfc6c1212b5ee) by [Unito](https://www.unito.io)
