### PR TITLE
Fix cannot check widget value if undefined

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -145,9 +145,9 @@ export const graphToPrompt = async (
       const resolvedInput = node.resolveInput(i)
       if (!resolvedInput) continue
 
-      // Input resolved to a SubgraphNode widget
-      const { value } = resolvedInput
-      if (value) {
+      // Resolved to an actual widget value rather than a node connection
+      if (resolvedInput.widgetInfo) {
+        const { value } = resolvedInput.widgetInfo
         inputs[input.name] = Array.isArray(value) ? { __value__: value } : value
         continue
       }


### PR DESCRIPTION
Implements upstream litegraph changes to value check API.  Allows any widget value to be used by boxing the value.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4433-Fix-cannot-check-widget-value-if-undefined-22d6d73d3650811ab0a1d80f1a353934) by [Unito](https://www.unito.io)
