### PR TITLE
[Not ready for review] Add client ID parameter to audio output view URL

### DIFF
--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -36,7 +36,7 @@ function getResourceURL(
     app.getRandParam().substring(1)
   ].join('&')
 
-  return `/view?${params}`
+  return `/view?${params}${app.getClientIdParam()}`
 }
 
 async function uploadFile(


### PR DESCRIPTION
Fixes the audio upload functionality by ensuring the client ID parameter is properly included in the output view URL.

**Changes:**
- Modified `getResourceURL()` in `uploadAudio.ts` to append client ID parameter to the view URL
- Ensures consistent URL formatting with other output view endpoints

**Technical Details:**
- Updated `/view?${params}` to `/view?${params}${app.getClientIdParam()}`
- Single line change for improved URL parameter handling

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4434-Not-ready-for-review-Add-client-ID-parameter-to-audio-output-view-URL-22e6d73d3650819897a2fbdeff486583) by [Unito](https://www.unito.io)
