### PR TITLE
[fix] Fix Danger CI permissions for PRs from forks

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -23,5 +23,4 @@ jobs:
       - name: Run Danger
         run: npx danger ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -1,7 +1,13 @@
 name: Danger PR Review
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  issues: write # What Danger needs to comment on PRs
+  pull-requests: write
+  statuses: write
 
 jobs:
   danger:
@@ -10,6 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -30,4 +30,5 @@ jobs:
       - name: Run Danger
         run: npx danger ci
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR fixes the Danger CI workflow to properly handle PRs from forks by updating permissions and using `pull_request_target`.

## Changes
- Switch from `pull_request` to `pull_request_target` event
- Add explicit permissions for issues, pull-requests, and statuses
- Update checkout to use the PR's head SHA

This resolves the "Resource not accessible by integration" error that occurs when Danger tries to post comments on PRs from external contributors.

Fixes #4448

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4449-fix-Fix-Danger-CI-permissions-for-PRs-from-forks-2306d73d3650810a82baffbcd0397856) by [Unito](https://www.unito.io)
