### PR TITLE
Add the copy URL button for the missing models dialog to Desktop

### DIFF
--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -88,6 +88,10 @@ test.describe('Missing models warning', () => {
 
     const downloadButton = missingModelsWarning.getByLabel('Download')
     await expect(downloadButton).toBeVisible()
+
+    // Check that the copy URL button is also visible for Desktop environment
+    const copyUrlButton = missingModelsWarning.getByLabel('Copy URL')
+    await expect(copyUrlButton).toBeVisible()
   })
 
   test('Should display a warning when missing models are found in node properties', async ({
@@ -101,6 +105,10 @@ test.describe('Missing models warning', () => {
 
     const downloadButton = missingModelsWarning.getByLabel('Download')
     await expect(downloadButton).toBeVisible()
+
+    // Check that the copy URL button is also visible for Desktop environment
+    const copyUrlButton = missingModelsWarning.getByLabel('Copy URL')
+    await expect(copyUrlButton).toBeVisible()
   })
 
   test('Should not display a warning when no missing models are found', async ({

--- a/src/components/common/ElectronFileDownload.vue
+++ b/src/components/common/ElectronFileDownload.vue
@@ -23,6 +23,14 @@
           icon="pi pi-download"
           @click="triggerDownload"
         />
+        <Button
+          v-if="status === null || status === 'error'"
+          :label="$t('g.copyURL')"
+          size="small"
+          outlined
+          :disabled="!!props.error"
+          @click="copyURL"
+        />
       </div>
     </div>
     <div
@@ -80,6 +88,7 @@ import ProgressBar from 'primevue/progressbar'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { useDownload } from '@/composables/useDownload'
 import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
 import { formatSize } from '@/utils/formatUtil'
@@ -100,6 +109,7 @@ const status = ref<string | null>(null)
 const fileSize = computed(() =>
   download.fileSize.value ? formatSize(download.fileSize.value) : '?'
 )
+const { copyToClipboard } = useCopyToClipboard()
 const electronDownloadStore = useElectronDownloadStore()
 // @ts-expect-error fixme ts strict error
 const [savePath, filename] = props.label.split('/')
@@ -126,4 +136,8 @@ const triggerDownload = async () => {
 const triggerCancelDownload = () => electronDownloadStore.cancel(props.url)
 const triggerPauseDownload = () => electronDownloadStore.pause(props.url)
 const triggerResumeDownload = () => electronDownloadStore.resume(props.url)
+
+const copyURL = async () => {
+  await copyToClipboard(props.url)
+}
 </script>

--- a/src/components/common/ElectronFileDownload.vue
+++ b/src/components/common/ElectronFileDownload.vue
@@ -24,11 +24,10 @@
           @click="triggerDownload"
         />
         <Button
-          v-if="status === null || status === 'error'"
+          v-if="(status === null || status === 'error') && !!props.url"
           :label="$t('g.copyURL')"
           size="small"
           outlined
-          :disabled="!!props.error"
           @click="copyURL"
         />
       </div>

--- a/src/components/common/ElectronFileDownload.vue
+++ b/src/components/common/ElectronFileDownload.vue
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="file-action">
+      <div class="file-action flex flex-row items-center gap-2">
         <Button
           v-if="status === null || status === 'error'"
           class="file-action-button"


### PR DESCRIPTION
Terry only add the Copy url to Portable, so I bring this feature to Desktop in order to solved this [issue](https://github.com/comfyanonymous/ComfyUI/issues/8958)

<img width="1356" height="934" alt="image" src="https://github.com/user-attachments/assets/21766551-e69a-4e0e-b3d6-91e2fd15f97f" />

https://github.com/user-attachments/assets/53d4ae33-4229-41c0-8379-0a864b68d37b

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4472-Add-the-copy-url-button-for-Desktop-2346d73d3650816889e2e227f9d797b0) by [Unito](https://www.unito.io)
