### PR TITLE
[Test] Add explicit timeout to consistently failing test

### DIFF
--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -48,7 +48,7 @@ test.describe('Combo text widget', () => {
     await comfyPage.page.keyboard.press('r')
 
     // Wait for nodes' widgets to be updated
-    await comfyPage.nextFrame()
+    await comfyPage.page.waitForTimeout(500)
 
     const refreshedComboValues = await getComboValues()
     expect(refreshedComboValues).not.toEqual(initialComboValues)


### PR DESCRIPTION
Not best practice, but far more efficient than checking the failure constantly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4485-Test-Add-explicit-timeout-to-consistently-failing-test-2366d73d36508137a3c2e92a11827467) by [Unito](https://www.unito.io)
