### PR TITLE
[feat] Implement versioned defaults for link release actions

### DIFF
--- a/browser_tests/tests/nodeSearchBox.spec.ts
+++ b/browser_tests/tests/nodeSearchBox.spec.ts
@@ -27,6 +27,21 @@ test.describe('Node search box', () => {
     await expect(comfyPage.searchBox.input).toHaveCount(1)
   })
 
+  test('New user (1.24.1+) gets search box by default on link release', async ({
+    comfyPage
+  }) => {
+    // Start fresh to test new user behavior
+    await comfyPage.setup({ clearStorage: true })
+    // Simulate new user with 1.24.1+ installed version
+    await comfyPage.setSetting('Comfy.InstalledVersion', '1.24.1')
+    await comfyPage.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+    // Don't set LinkRelease settings explicitly to test versioned defaults
+
+    await comfyPage.disconnectEdge()
+    await expect(comfyPage.searchBox.input).toHaveCount(1)
+    await expect(comfyPage.searchBox.input).toBeVisible()
+  })
+
   test('Can add node', async ({ comfyPage }) => {
     await comfyPage.doubleClickCanvas()
     await expect(comfyPage.searchBox.input).toHaveCount(1)
@@ -172,10 +187,10 @@ test.describe('Node search box', () => {
       await comfyPage.page.mouse.click(panelBounds!.x - 10, panelBounds!.y - 10)
 
       // Verify the filter selection panel is hidden
-      expect(panel.header).not.toBeVisible()
+      await expect(panel.header).not.toBeVisible()
 
       // Verify the node search dialog is still visible
-      expect(comfyPage.searchBox.input).toBeVisible()
+      await expect(comfyPage.searchBox.input).toBeVisible()
     })
 
     test('Can add multiple filters', async ({ comfyPage }) => {
@@ -263,5 +278,39 @@ test.describe('Release context menu', () => {
     await expect(comfyPage.canvas).toHaveScreenshot(
       'link-context-menu-search.png'
     )
+  })
+
+  test('Existing user (pre-1.24.1) gets context menu by default on link release', async ({
+    comfyPage
+  }) => {
+    // Start fresh to test existing user behavior
+    await comfyPage.setup({ clearStorage: true })
+    // Simulate existing user with pre-1.24.1 version
+    await comfyPage.setSetting('Comfy.InstalledVersion', '1.23.0')
+    await comfyPage.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+    // Don't set LinkRelease settings explicitly to test versioned defaults
+
+    await comfyPage.disconnectEdge()
+    // Context menu should appear, search box should not
+    await expect(comfyPage.searchBox.input).toHaveCount(0)
+    const contextMenu = comfyPage.page.locator('.litecontextmenu')
+    await expect(contextMenu).toBeVisible()
+  })
+
+  test('Explicit setting overrides versioned defaults', async ({
+    comfyPage
+  }) => {
+    // Start fresh and simulate new user who should get search box by default
+    await comfyPage.setup({ clearStorage: true })
+    await comfyPage.setSetting('Comfy.InstalledVersion', '1.24.1')
+    // But explicitly set to context menu (overriding versioned default)
+    await comfyPage.setSetting('Comfy.LinkRelease.Action', 'context menu')
+    await comfyPage.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+
+    await comfyPage.disconnectEdge()
+    // Context menu should appear due to explicit setting, not search box
+    await expect(comfyPage.searchBox.input).toHaveCount(0)
+    const contextMenu = comfyPage.page.locator('.litecontextmenu')
+    await expect(contextMenu).toBeVisible()
   })
 })

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -35,7 +35,10 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Action on link release (No modifier)',
     type: 'combo',
     options: Object.values(LinkReleaseTriggerAction),
-    defaultValue: LinkReleaseTriggerAction.CONTEXT_MENU
+    defaultValue: LinkReleaseTriggerAction.CONTEXT_MENU,
+    defaultsByInstallVersion: {
+      '1.24.1': LinkReleaseTriggerAction.SEARCH_BOX
+    }
   },
   {
     id: 'Comfy.LinkRelease.ActionShift',
@@ -43,7 +46,10 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Action on link release (Shift)',
     type: 'combo',
     options: Object.values(LinkReleaseTriggerAction),
-    defaultValue: LinkReleaseTriggerAction.SEARCH_BOX
+    defaultValue: LinkReleaseTriggerAction.SEARCH_BOX,
+    defaultsByInstallVersion: {
+      '1.24.1': LinkReleaseTriggerAction.CONTEXT_MENU
+    }
   },
   {
     id: 'Comfy.NodeSearchBoxImpl.NodePreview',


### PR DESCRIPTION
Implements versioned defaults for link release behavior using the new settings system from #4337 and #4354. New users (v1.24.1+) get search box as default while existing users maintain context menu for backward compatibility.

Fixes #3652

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4489-feat-Implement-versioned-defaults-for-link-release-actions-2376d73d365081cabeb7c5f34cad620d) by [Unito](https://www.unito.io)
