### PR TITLE
[chore] Update litegraph to 0.16.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@alloc/quick-lru": "^5.2.0",
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.43",
-        "@comfyorg/litegraph": "^0.16.11",
+        "@comfyorg/litegraph": "^0.16.13",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -949,10 +949,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.16.11.tgz",
-      "integrity": "sha512-/KOzNrhA5yrLdGlNBW4VHYA4Z+RzhnEI0W7km0/5at75OyJmJsczUR0mFUyOCFdatWd1HoTp1uC7/KHt4deFKw==",
-      "license": "MIT"
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.16.13.tgz",
+      "integrity": "sha512-Y65YDyX/X/gqxtEa3IS5jb/1UUETCZXnrxM7YwSTIdzq3SHqwnDNstVBvhe+MtQUYRYqURzlg6sSrCO/BoKwkQ=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@alloc/quick-lru": "^5.2.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.43",
-    "@comfyorg/litegraph": "^0.16.11",
+    "@comfyorg/litegraph": "^0.16.13",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",


### PR DESCRIPTION
Automated update of litegraph to version 0.16.13.
Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.16.13

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4490-chore-Update-litegraph-to-0-16-13-2376d73d365081b4adacc79292a53544) by [Unito](https://www.unito.io)
