### PR TITLE
fix(queryRegex): safe escape for query regex

### DIFF
--- a/src/utils/formatUtil.ts
+++ b/src/utils/formatUtil.ts
@@ -39,7 +39,11 @@ export function trimJsonExt(path?: string) {
 
 export function highlightQuery(text: string, query: string) {
   if (!query) return text
-  const regex = new RegExp(`(${query})`, 'gi')
+
+  // Escape special regex characters in the query string
+  const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+  const regex = new RegExp(`(${escapedQuery})`, 'gi')
   return text.replace(regex, '<span class="highlight">$1</span>')
 }
 


### PR DESCRIPTION
This PR updates the highlightQuery function to safely escape the special characters before forming the query regex.

fixes [4466](https://github.com/Comfy-Org/ComfyUI_frontend/issues/4466)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4493-fix-queryRegex-safe-escape-for-query-regex-2376d73d365081cbae56c4bca656b47a) by [Unito](https://www.unito.io)
