### PR TITLE
[chore] Update litegraph to 0.16.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@alloc/quick-lru": "^5.2.0",
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@comfyorg/comfyui-electron-types": "^0.4.43",
-        "@comfyorg/litegraph": "^0.16.13",
+        "@comfyorg/litegraph": "^0.16.14",
         "@primevue/forms": "^4.2.5",
         "@primevue/themes": "^4.2.5",
         "@sentry/vue": "^8.48.0",
@@ -949,9 +949,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@comfyorg/litegraph": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.16.13.tgz",
-      "integrity": "sha512-Y65YDyX/X/gqxtEa3IS5jb/1UUETCZXnrxM7YwSTIdzq3SHqwnDNstVBvhe+MtQUYRYqURzlg6sSrCO/BoKwkQ=="
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@comfyorg/litegraph/-/litegraph-0.16.14.tgz",
+      "integrity": "sha512-lZqWVmwfZuK0l8L8v1TGuZK7b0uZl7d0P0vcdShZ8LUTVNPA+hgjmc201yHOPFmvttYLW+GlZ7ZamE2ASPXgTw=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@alloc/quick-lru": "^5.2.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "^0.4.43",
-    "@comfyorg/litegraph": "^0.16.13",
+    "@comfyorg/litegraph": "^0.16.14",
     "@primevue/forms": "^4.2.5",
     "@primevue/themes": "^4.2.5",
     "@sentry/vue": "^8.48.0",

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -109,7 +109,7 @@ export const useLitegraphService = () => {
         })
 
         // Set up event listener for promoted widget removal
-        subgraph.events.addEventListener('widget-unpromoted', (event) => {
+        subgraph.events.addEventListener('widget-demoted', (event) => {
           const { widget } = event.detail
           // Only handle DOM widgets
           if (!isDOMWidget(widget) && !isComponentWidget(widget)) return


### PR DESCRIPTION
Automated update of litegraph to version 0.16.14.
Ref: https://github.com/Comfy-Org/litegraph.js/releases/tag/v0.16.14

Changes:
- Change widget demoted event name
- Remove parentSubgraphNode property from widgets

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4494-chore-Update-litegraph-to-0-16-14-2376d73d36508171a078e1d0941c13e6) by [Unito](https://www.unito.io)
