### PR TITLE
[feat] Hide subgraph nodes from node library and search

### DIFF
--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -374,6 +374,21 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
         'Hides nodes marked as experimental unless explicitly enabled',
       predicate: (nodeDef) => showExperimental.value || !nodeDef.experimental
     })
+
+    // Subgraph nodes filter
+    // @todo Remove this filter when subgraph v2 is released
+    registerNodeDefFilter({
+      id: 'core.subgraph',
+      name: 'Hide Subgraph Nodes',
+      description:
+        'Temporarily hides subgraph nodes from node library and search',
+      predicate: (nodeDef) => {
+        // Hide subgraph nodes (identified by category='subgraph' and python_module='nodes')
+        return !(
+          nodeDef.category === 'subgraph' && nodeDef.python_module === 'nodes'
+        )
+      }
+    })
   }
 
   // Register core filters on store initialization

--- a/tests-ui/tests/store/nodeDefStore.test.ts
+++ b/tests-ui/tests/store/nodeDefStore.test.ts
@@ -236,6 +236,45 @@ describe('useNodeDefStore', () => {
 
       expect(store.visibleNodeDefs).toHaveLength(2)
     })
+
+    it('should hide subgraph nodes by default', () => {
+      const normalNode = createMockNodeDef({
+        name: 'normal',
+        category: 'conditioning',
+        python_module: 'nodes'
+      })
+      const subgraphNode = createMockNodeDef({
+        name: 'MySubgraph',
+        category: 'subgraph',
+        python_module: 'nodes'
+      })
+
+      store.updateNodeDefs([normalNode, subgraphNode])
+
+      expect(store.visibleNodeDefs).toHaveLength(1)
+      expect(store.visibleNodeDefs[0].name).toBe('normal')
+    })
+
+    it('should show non-subgraph nodes with subgraph category', () => {
+      const normalNode = createMockNodeDef({
+        name: 'normal',
+        category: 'conditioning',
+        python_module: 'custom_extension'
+      })
+      const fakeSubgraphNode = createMockNodeDef({
+        name: 'FakeSubgraph',
+        category: 'subgraph',
+        python_module: 'custom_extension' // Different python_module
+      })
+
+      store.updateNodeDefs([normalNode, fakeSubgraphNode])
+
+      expect(store.visibleNodeDefs).toHaveLength(2)
+      expect(store.visibleNodeDefs.map((n) => n.name)).toEqual([
+        'normal',
+        'FakeSubgraph'
+      ])
+    })
   })
 
   describe('performance', () => {


### PR DESCRIPTION
## Summary
Temporarily hides subgraph nodes from the node library sidebar and search results to prevent confusion while subgraph v2 development is in progress.

- **Subgraph filter**: Adds `core.subgraph` filter that hides nodes with `category='subgraph'` and `python_module='nodes'`
- **No settings overhead**: Simple filter implementation without additional configuration
- **Temporary solution**: Marked with `@todo` for removal when subgraph v2 is released
- **Unit tests**: Added 2 tests covering subgraph node detection and filtering behavior

Uses the filter registry system from PR #4497. Existing subgraphs in workflows will continue to work regardless of this change.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4498-feat-Hide-subgraph-nodes-from-node-library-and-search-2386d73d365081779e26d34cccfc41f9) by [Unito](https://www.unito.io)
