### PR TITLE
Update component widget props type to exclude reserved props 

### DIFF
--- a/src/composables/widgets/useChatHistoryWidget.ts
+++ b/src/composables/widgets/useChatHistoryWidget.ts
@@ -3,14 +3,23 @@ import { ref } from 'vue'
 
 import ChatHistoryWidget from '@/components/graph/widgets/ChatHistoryWidget.vue'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import {
+  ComponentWidgetImpl,
+  type ComponentWidgetStandardProps,
+  addWidget
+} from '@/scripts/domWidget'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+
+type ChatHistoryCustomProps = Omit<
+  InstanceType<typeof ChatHistoryWidget>['$props'],
+  ComponentWidgetStandardProps
+>
 
 const PADDING = 16
 
 export const useChatHistoryWidget = (
   options: {
-    props?: Omit<InstanceType<typeof ChatHistoryWidget>['$props'], 'widget'>
+    props?: ChatHistoryCustomProps
   } = {}
 ) => {
   const widgetConstructor: ComfyWidgetConstructorV2 = (
@@ -20,7 +29,7 @@ export const useChatHistoryWidget = (
     const widgetValue = ref<string>('')
     const widget = new ComponentWidgetImpl<
       string | object,
-      InstanceType<typeof ChatHistoryWidget>['$props']
+      ChatHistoryCustomProps
     >({
       node,
       name: inputSpec.name,

--- a/src/composables/widgets/useProgressTextWidget.ts
+++ b/src/composables/widgets/useProgressTextWidget.ts
@@ -3,8 +3,17 @@ import { ref } from 'vue'
 
 import TextPreviewWidget from '@/components/graph/widgets/TextPreviewWidget.vue'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
-import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import {
+  ComponentWidgetImpl,
+  type ComponentWidgetStandardProps,
+  addWidget
+} from '@/scripts/domWidget'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+
+type TextPreviewCustomProps = Omit<
+  InstanceType<typeof TextPreviewWidget>['$props'],
+  ComponentWidgetStandardProps
+>
 
 const PADDING = 16
 
@@ -18,12 +27,15 @@ export const useTextPreviewWidget = (
     inputSpec: InputSpec
   ) => {
     const widgetValue = ref<string>('')
-    const widget = new ComponentWidgetImpl<string | object>({
+    const widget = new ComponentWidgetImpl<
+      string | object,
+      TextPreviewCustomProps
+    >({
       node,
       name: inputSpec.name,
       component: TextPreviewWidget,
       inputSpec,
-      componentProps: {
+      props: {
         nodeId: node.id
       },
       options: {

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -45,9 +45,6 @@ export interface DOMWidget<T extends HTMLElement, V extends object | string>
 }
 
 /**
- * A DOM widget that wraps a Vue component as a litegraph widget.
- */
-/**
  * Additional props that can be passed to component widgets.
  * These are in addition to the standard props that are always provided:
  * - modelValue: The widget's value (handled by v-model)
@@ -65,6 +62,9 @@ export type ComponentWidgetStandardProps =
   | 'widget'
   | 'onUpdate:modelValue'
 
+/**
+ * A DOM widget that wraps a Vue component as a litegraph widget.
+ */
 export interface ComponentWidget<
   V extends object | string,
   P extends ComponentWidgetCustomProps = ComponentWidgetCustomProps

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -47,9 +47,27 @@ export interface DOMWidget<T extends HTMLElement, V extends object | string>
 /**
  * A DOM widget that wraps a Vue component as a litegraph widget.
  */
+/**
+ * Additional props that can be passed to component widgets.
+ * These are in addition to the standard props that are always provided:
+ * - modelValue: The widget's value (handled by v-model)
+ * - widget: Reference to the widget instance
+ * - onUpdate:modelValue: The update handler for v-model
+ */
+export type ComponentWidgetCustomProps = Record<string, unknown>
+
+/**
+ * Standard props that are handled separately by DomWidget.vue and should be
+ * omitted when defining custom props for component widgets
+ */
+export type ComponentWidgetStandardProps =
+  | 'modelValue'
+  | 'widget'
+  | 'onUpdate:modelValue'
+
 export interface ComponentWidget<
   V extends object | string,
-  P = Record<string, unknown>
+  P extends ComponentWidgetCustomProps = ComponentWidgetCustomProps
 > extends BaseDOMWidget<V> {
   readonly component: Component
   readonly inputSpec: InputSpec
@@ -222,7 +240,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
 
 export class ComponentWidgetImpl<
     V extends object | string,
-    P = Record<string, unknown>
+    P extends ComponentWidgetCustomProps = ComponentWidgetCustomProps
   >
   extends BaseDOMWidgetImpl<V>
   implements ComponentWidget<V, P>
@@ -237,7 +255,6 @@ export class ComponentWidgetImpl<
     component: Component
     inputSpec: InputSpec
     props?: P
-    componentProps?: Partial<P>
     options: DOMWidgetOptions<V>
   }) {
     super({
@@ -246,9 +263,7 @@ export class ComponentWidgetImpl<
     })
     this.component = obj.component
     this.inputSpec = obj.inputSpec
-    this.props = obj.componentProps
-      ? ({ ...obj.props, ...obj.componentProps } as P)
-      : obj.props
+    this.props = obj.props
   }
 
   override computeLayoutSize() {


### PR DESCRIPTION
## Summary
- Removed the `componentProps` parameter from ComponentWidgetImpl
- Added ComponentWidgetStandardProps type to clearly define which props are reserved by the framework
- Updated widget implementations to use local type extraction pattern for better type safety

This approach provides better type safety while maintaining the ability to pass custom props to Vue component widgets.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4499-Update-component-widget-props-type-to-exclude-reserved-props-2386d73d36508100bf2fd7854142fc15) by [Unito](https://www.unito.io)
