### PR TITLE
[feat] Update node output system to use NodeLocatorIds

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -644,12 +644,9 @@ export class ComfyApp {
       const nodeOutputStore = useNodeOutputStore()
       const executionId = String(detail.display_node || detail.node)
 
-      // Store the output using the new method
       nodeOutputStore.setNodeOutputsByExecutionId(executionId, detail.output, {
         merge: detail.merge
       })
-
-      // Call onExecuted callback (unchanged)
       const node = this.graph.getNodeById(detail.display_node || detail.node)
       if (node) {
         if (node.onExecuted) node.onExecuted(detail.output)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -24,6 +24,7 @@ import type {
 } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 
@@ -229,9 +230,9 @@ export const useExecutionStore = defineStore('execution', () => {
     api.addEventListener('progress_state', handleProgressState)
     api.addEventListener('status', handleStatus)
     api.addEventListener('execution_error', handleExecutionError)
+    api.addEventListener('progress_text', handleProgressText)
+    api.addEventListener('display_component', handleDisplayComponent)
   }
-  api.addEventListener('progress_text', handleProgressText)
-  api.addEventListener('display_component', handleDisplayComponent)
 
   function unbindExecutionEvents() {
     api.removeEventListener('execution_start', handleExecutionStart)
@@ -244,6 +245,7 @@ export const useExecutionStore = defineStore('execution', () => {
     api.removeEventListener('status', handleStatus)
     api.removeEventListener('execution_error', handleExecutionError)
     api.removeEventListener('progress_text', handleProgressText)
+    api.removeEventListener('display_component', handleDisplayComponent)
   }
 
   function handleExecutionStart(e: CustomEvent<ExecutionStartWsMessage>) {
@@ -294,8 +296,8 @@ export const useExecutionStore = defineStore('execution', () => {
         // Note that we're doing the *actual* node id instead of the display node id
         // here intentionally. That way, we don't clear the preview every time a new node
         // within an expanded graph starts executing.
-        app.revokePreviews(nodeId)
-        delete app.nodePreviewImages[nodeId]
+        const { revokePreviewsByExecutionId } = useNodeOutputStore()
+        revokePreviewsByExecutionId(nodeId)
       }
     }
 

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -133,19 +133,17 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
   ) {
     if (!filenames || !node) return
 
-    const nodeLocatorId = nodeIdToNodeLocatorId(node.id)
-
     if (typeof filenames === 'string') {
-      setOutputsByLocatorId(
-        nodeLocatorId,
+      setNodeOutputsByNodeId(
+        node.id,
         createOutputs([filenames], folder, isAnimated)
       )
     } else if (!Array.isArray(filenames)) {
-      setOutputsByLocatorId(nodeLocatorId, filenames)
+      setNodeOutputsByNodeId(node.id, filenames)
     } else {
       const resultItems = createOutputs(filenames, folder, isAnimated)
       if (!resultItems?.images?.length) return
-      setOutputsByLocatorId(nodeLocatorId, resultItems)
+      setNodeOutputsByNodeId(node.id, resultItems)
     }
   }
 

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -25,6 +25,10 @@ const createOutputs = (
   }
 }
 
+interface SetOutputOptions {
+  merge?: boolean
+}
+
 export const useNodeOutputStore = defineStore('nodeOutput', () => {
   const { nodeIdToNodeLocatorId } = useWorkflowStore()
   const { executionIdToNodeLocatorId } = useExecutionStore()
@@ -88,10 +92,6 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
       const imgUrlPart = new URLSearchParams(image)
       return api.apiURL(`/view?${imgUrlPart}${previewParam}${rand}`)
     })
-  }
-
-  interface SetOutputOptions {
-    merge?: boolean
   }
 
   /**

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -1,0 +1,254 @@
+import type { LGraph, LGraphNode, Subgraph } from '@comfyorg/litegraph'
+
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { parseNodeLocatorId } from '@/types/nodeIdentification'
+
+// Pure utility functions with no dependencies on graph objects
+
+/**
+ * Parses an execution ID into its component parts.
+ * Pure function with no side effects.
+ *
+ * @param executionId - The execution ID (e.g., "123:456:789" or "789")
+ * @returns Array of node IDs in the path, or null if invalid
+ */
+export function parseExecutionId(executionId: string): string[] | null {
+  if (!executionId || typeof executionId !== 'string') return null
+  return executionId.split(':').filter((part) => part.length > 0)
+}
+
+/**
+ * Extracts the local node ID from an execution ID.
+ * Pure function with no side effects.
+ *
+ * @param executionId - The execution ID (e.g., "123:456:789" or "789")
+ * @returns The local node ID or null if invalid
+ */
+export function getLocalNodeIdFromExecutionId(
+  executionId: string
+): string | null {
+  const parts = parseExecutionId(executionId)
+  return parts ? parts[parts.length - 1] : null
+}
+
+/**
+ * Extracts the subgraph path from an execution ID.
+ * Pure function with no side effects.
+ *
+ * @param executionId - The execution ID (e.g., "123:456:789" or "789")
+ * @returns Array of subgraph node IDs (excluding the final node ID), or empty array
+ */
+export function getSubgraphPathFromExecutionId(executionId: string): string[] {
+  const parts = parseExecutionId(executionId)
+  return parts ? parts.slice(0, -1) : []
+}
+
+// Graph traversal helper functions
+
+/**
+ * Visits each node in a graph (non-recursive, single level).
+ * Pure function that doesn't modify the graph.
+ *
+ * @param graph - The graph to visit nodes from
+ * @param visitor - Function called for each node
+ */
+export function visitGraphNodes(
+  graph: LGraph | Subgraph,
+  visitor: (node: LGraphNode) => void
+): void {
+  for (const node of graph.nodes) {
+    visitor(node)
+  }
+}
+
+/**
+ * Traverses a path of subgraphs to reach a target graph.
+ * Pure function that only reads graph properties.
+ *
+ * @param startGraph - The graph to start from
+ * @param path - Array of subgraph node IDs to traverse
+ * @returns The target graph or null if path is invalid
+ */
+export function traverseSubgraphPath(
+  startGraph: LGraph | Subgraph,
+  path: string[]
+): LGraph | Subgraph | null {
+  let currentGraph: LGraph | Subgraph = startGraph
+
+  for (const nodeId of path) {
+    const node = currentGraph.getNodeById(nodeId)
+    if (!node?.isSubgraphNode?.() || !node.subgraph) return null
+    currentGraph = node.subgraph
+  }
+
+  return currentGraph
+}
+
+// Main exported functions refactored to use pure utilities
+
+/**
+ * Traverses all nodes in a graph hierarchy (including subgraphs) and invokes
+ * a callback on each node that has the specified property.
+ *
+ * @param graph - The root graph to start traversal from
+ * @param callbackProperty - The name of the callback property to invoke on each node
+ */
+export function triggerCallbackOnAllNodes(
+  graph: LGraph | Subgraph,
+  callbackProperty: keyof LGraphNode
+): void {
+  visitGraphNodes(graph, (node) => {
+    // Recursively process subgraphs first
+    if (node.isSubgraphNode?.() && node.subgraph) {
+      triggerCallbackOnAllNodes(node.subgraph, callbackProperty)
+    }
+
+    // Invoke callback if it exists on the node
+    const callback = node[callbackProperty]
+    if (typeof callback === 'function') {
+      callback.call(node)
+    }
+  })
+}
+
+/**
+ * Collects all nodes in a graph hierarchy (including subgraphs) into a flat array.
+ *
+ * @param graph - The root graph to collect nodes from
+ * @param filter - Optional filter function to include only specific nodes
+ * @returns Array of all nodes in the graph hierarchy
+ */
+export function collectAllNodes(
+  graph: LGraph | Subgraph,
+  filter?: (node: LGraphNode) => boolean
+): LGraphNode[] {
+  const nodes: LGraphNode[] = []
+
+  visitGraphNodes(graph, (node) => {
+    // Recursively collect from subgraphs
+    if (node.isSubgraphNode?.() && node.subgraph) {
+      nodes.push(...collectAllNodes(node.subgraph, filter))
+    }
+
+    // Add node if it passes the filter (or no filter provided)
+    if (!filter || filter(node)) {
+      nodes.push(node)
+    }
+  })
+
+  return nodes
+}
+
+/**
+ * Finds a node by ID anywhere in the graph hierarchy.
+ *
+ * @param graph - The root graph to search
+ * @param nodeId - The ID of the node to find
+ * @returns The node if found, null otherwise
+ */
+export function findNodeInHierarchy(
+  graph: LGraph | Subgraph,
+  nodeId: string | number
+): LGraphNode | null {
+  // Check current graph
+  const node = graph.getNodeById(nodeId)
+  if (node) return node
+
+  // Search in subgraphs
+  for (const node of graph.nodes) {
+    if (node.isSubgraphNode?.() && node.subgraph) {
+      const found = findNodeInHierarchy(node.subgraph, nodeId)
+      if (found) return found
+    }
+  }
+
+  return null
+}
+
+/**
+ * Find a subgraph by its UUID anywhere in the graph hierarchy.
+ *
+ * @param graph - The root graph to search
+ * @param targetUuid - The UUID of the subgraph to find
+ * @returns The subgraph if found, null otherwise
+ */
+export function findSubgraphByUuid(
+  graph: LGraph | Subgraph,
+  targetUuid: string
+): Subgraph | null {
+  // Check all nodes in the current graph
+  for (const node of graph._nodes) {
+    if (node.isSubgraphNode?.() && node.subgraph) {
+      if (node.subgraph.id === targetUuid) {
+        return node.subgraph
+      }
+      // Recursively search in nested subgraphs
+      const found = findSubgraphByUuid(node.subgraph, targetUuid)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+/**
+ * Get a node by its execution ID from anywhere in the graph hierarchy.
+ * Execution IDs use hierarchical format like "123:456:789" for nested nodes.
+ *
+ * @param rootGraph - The root graph to search from
+ * @param executionId - The execution ID (e.g., "123:456:789" or "789")
+ * @returns The node if found, null otherwise
+ */
+export function getNodeByExecutionId(
+  rootGraph: LGraph,
+  executionId: string
+): LGraphNode | null {
+  if (!rootGraph) return null
+
+  const localNodeId = getLocalNodeIdFromExecutionId(executionId)
+  if (!localNodeId) return null
+
+  const subgraphPath = getSubgraphPathFromExecutionId(executionId)
+
+  // If no subgraph path, it's in the root graph
+  if (subgraphPath.length === 0) {
+    return rootGraph.getNodeById(localNodeId) || null
+  }
+
+  // Traverse to the target subgraph
+  const targetGraph = traverseSubgraphPath(rootGraph, subgraphPath)
+  if (!targetGraph) return null
+
+  // Get the node from the target graph
+  return targetGraph.getNodeById(localNodeId) || null
+}
+
+/**
+ * Get a node by its locator ID from anywhere in the graph hierarchy.
+ * Locator IDs use UUID format like "uuid:nodeId" for subgraph nodes.
+ *
+ * @param rootGraph - The root graph to search from
+ * @param locatorId - The locator ID (e.g., "uuid:123" or "123")
+ * @returns The node if found, null otherwise
+ */
+export function getNodeByLocatorId(
+  rootGraph: LGraph,
+  locatorId: NodeLocatorId | string
+): LGraphNode | null {
+  if (!rootGraph) return null
+
+  const parsedIds = parseNodeLocatorId(locatorId)
+  if (!parsedIds) return null
+
+  const { subgraphUuid, localNodeId } = parsedIds
+
+  // If no subgraph UUID, it's in the root graph
+  if (!subgraphUuid) {
+    return rootGraph.getNodeById(localNodeId) || null
+  }
+
+  // Find the subgraph with the matching UUID
+  const targetSubgraph = findSubgraphByUuid(rootGraph, subgraphUuid)
+  if (!targetSubgraph) return null
+
+  return targetSubgraph.getNodeById(localNodeId) || null
+}

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -3,11 +3,8 @@ import type { LGraph, LGraphNode, Subgraph } from '@comfyorg/litegraph'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { parseNodeLocatorId } from '@/types/nodeIdentification'
 
-// Pure utility functions with no dependencies on graph objects
-
 /**
  * Parses an execution ID into its component parts.
- * Pure function with no side effects.
  *
  * @param executionId - The execution ID (e.g., "123:456:789" or "789")
  * @returns Array of node IDs in the path, or null if invalid
@@ -19,7 +16,6 @@ export function parseExecutionId(executionId: string): string[] | null {
 
 /**
  * Extracts the local node ID from an execution ID.
- * Pure function with no side effects.
  *
  * @param executionId - The execution ID (e.g., "123:456:789" or "789")
  * @returns The local node ID or null if invalid
@@ -33,7 +29,6 @@ export function getLocalNodeIdFromExecutionId(
 
 /**
  * Extracts the subgraph path from an execution ID.
- * Pure function with no side effects.
  *
  * @param executionId - The execution ID (e.g., "123:456:789" or "789")
  * @returns Array of subgraph node IDs (excluding the final node ID), or empty array
@@ -43,11 +38,8 @@ export function getSubgraphPathFromExecutionId(executionId: string): string[] {
   return parts ? parts.slice(0, -1) : []
 }
 
-// Graph traversal helper functions
-
 /**
  * Visits each node in a graph (non-recursive, single level).
- * Pure function that doesn't modify the graph.
  *
  * @param graph - The graph to visit nodes from
  * @param visitor - Function called for each node
@@ -63,7 +55,6 @@ export function visitGraphNodes(
 
 /**
  * Traverses a path of subgraphs to reach a target graph.
- * Pure function that only reads graph properties.
  *
  * @param startGraph - The graph to start from
  * @param path - Array of subgraph node IDs to traverse
@@ -83,8 +74,6 @@ export function traverseSubgraphPath(
 
   return currentGraph
 }
-
-// Main exported functions refactored to use pure utilities
 
 /**
  * Traverses all nodes in a graph hierarchy (including subgraphs) and invokes

--- a/tests-ui/tests/utils/graphTraversalUtil.test.ts
+++ b/tests-ui/tests/utils/graphTraversalUtil.test.ts
@@ -1,0 +1,486 @@
+import type { LGraph, LGraphNode, Subgraph } from '@comfyorg/litegraph'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  collectAllNodes,
+  findNodeInHierarchy,
+  findSubgraphByUuid,
+  getLocalNodeIdFromExecutionId,
+  getNodeByExecutionId,
+  getNodeByLocatorId,
+  getSubgraphPathFromExecutionId,
+  parseExecutionId,
+  traverseSubgraphPath,
+  triggerCallbackOnAllNodes,
+  visitGraphNodes
+} from '@/utils/graphTraversalUtil'
+
+// Mock node factory
+function createMockNode(
+  id: string | number,
+  options: {
+    isSubgraph?: boolean
+    subgraph?: Subgraph
+    callback?: () => void
+  } = {}
+): LGraphNode {
+  return {
+    id,
+    isSubgraphNode: options.isSubgraph ? () => true : undefined,
+    subgraph: options.subgraph,
+    onExecutionStart: options.callback
+  } as unknown as LGraphNode
+}
+
+// Mock graph factory
+function createMockGraph(nodes: LGraphNode[]): LGraph {
+  return {
+    _nodes: nodes,
+    nodes: nodes,
+    getNodeById: (id: string | number) =>
+      nodes.find((n) => String(n.id) === String(id)) || null
+  } as unknown as LGraph
+}
+
+// Mock subgraph factory
+function createMockSubgraph(id: string, nodes: LGraphNode[]): Subgraph {
+  return {
+    id,
+    _nodes: nodes,
+    nodes: nodes,
+    getNodeById: (nodeId: string | number) =>
+      nodes.find((n) => String(n.id) === String(nodeId)) || null
+  } as unknown as Subgraph
+}
+
+describe('graphTraversalUtil', () => {
+  describe('Pure utility functions', () => {
+    describe('parseExecutionId', () => {
+      it('should parse simple execution ID', () => {
+        expect(parseExecutionId('123')).toEqual(['123'])
+      })
+
+      it('should parse complex execution ID', () => {
+        expect(parseExecutionId('123:456:789')).toEqual(['123', '456', '789'])
+      })
+
+      it('should handle empty parts', () => {
+        expect(parseExecutionId('123::789')).toEqual(['123', '789'])
+      })
+
+      it('should return null for invalid input', () => {
+        expect(parseExecutionId('')).toBeNull()
+        expect(parseExecutionId(null as any)).toBeNull()
+        expect(parseExecutionId(undefined as any)).toBeNull()
+      })
+    })
+
+    describe('getLocalNodeIdFromExecutionId', () => {
+      it('should extract local node ID from simple ID', () => {
+        expect(getLocalNodeIdFromExecutionId('123')).toBe('123')
+      })
+
+      it('should extract local node ID from complex ID', () => {
+        expect(getLocalNodeIdFromExecutionId('123:456:789')).toBe('789')
+      })
+
+      it('should return null for invalid input', () => {
+        expect(getLocalNodeIdFromExecutionId('')).toBeNull()
+      })
+    })
+
+    describe('getSubgraphPathFromExecutionId', () => {
+      it('should return empty array for root node', () => {
+        expect(getSubgraphPathFromExecutionId('123')).toEqual([])
+      })
+
+      it('should return subgraph path for nested node', () => {
+        expect(getSubgraphPathFromExecutionId('123:456:789')).toEqual([
+          '123',
+          '456'
+        ])
+      })
+
+      it('should return empty array for invalid input', () => {
+        expect(getSubgraphPathFromExecutionId('')).toEqual([])
+      })
+    })
+
+    describe('visitGraphNodes', () => {
+      it('should visit all nodes in graph', () => {
+        const visited: number[] = []
+        const nodes = [createMockNode(1), createMockNode(2), createMockNode(3)]
+        const graph = createMockGraph(nodes)
+
+        visitGraphNodes(graph, (node) => {
+          visited.push(node.id as number)
+        })
+
+        expect(visited).toEqual([1, 2, 3])
+      })
+
+      it('should handle empty graph', () => {
+        const visited: number[] = []
+        const graph = createMockGraph([])
+
+        visitGraphNodes(graph, (node) => {
+          visited.push(node.id as number)
+        })
+
+        expect(visited).toEqual([])
+      })
+    })
+
+    describe('traverseSubgraphPath', () => {
+      it('should return start graph for empty path', () => {
+        const graph = createMockGraph([])
+        const result = traverseSubgraphPath(graph, [])
+        expect(result).toBe(graph)
+      })
+
+      it('should traverse single level', () => {
+        const subgraph = createMockSubgraph('sub-uuid', [])
+        const node = createMockNode('1', { isSubgraph: true, subgraph })
+        const graph = createMockGraph([node])
+
+        const result = traverseSubgraphPath(graph, ['1'])
+        expect(result).toBe(subgraph)
+      })
+
+      it('should traverse multiple levels', () => {
+        const deepSubgraph = createMockSubgraph('deep-uuid', [])
+        const midNode = createMockNode('2', {
+          isSubgraph: true,
+          subgraph: deepSubgraph
+        })
+        const midSubgraph = createMockSubgraph('mid-uuid', [midNode])
+        const topNode = createMockNode('1', {
+          isSubgraph: true,
+          subgraph: midSubgraph
+        })
+        const graph = createMockGraph([topNode])
+
+        const result = traverseSubgraphPath(graph, ['1', '2'])
+        expect(result).toBe(deepSubgraph)
+      })
+
+      it('should return null for invalid path', () => {
+        const graph = createMockGraph([createMockNode('1')])
+        const result = traverseSubgraphPath(graph, ['999'])
+        expect(result).toBeNull()
+      })
+    })
+  })
+
+  describe('Main functions', () => {
+    describe('triggerCallbackOnAllNodes', () => {
+      it('should trigger callbacks on all nodes in a flat graph', () => {
+        const callback1 = vi.fn()
+        const callback2 = vi.fn()
+
+        const node1 = createMockNode(1, { callback: callback1 })
+        const node2 = createMockNode(2, { callback: callback2 })
+        const node3 = createMockNode(3) // No callback
+
+        const graph = createMockGraph([node1, node2, node3])
+
+        triggerCallbackOnAllNodes(graph, 'onExecutionStart')
+
+        expect(callback1).toHaveBeenCalledOnce()
+        expect(callback2).toHaveBeenCalledOnce()
+      })
+
+      it('should trigger callbacks on nodes in subgraphs', () => {
+        const callback1 = vi.fn()
+        const callback2 = vi.fn()
+        const callback3 = vi.fn()
+
+        // Create a subgraph with one node
+        const subNode = createMockNode(100, { callback: callback3 })
+        const subgraph = createMockSubgraph('sub-uuid', [subNode])
+
+        // Create main graph with two nodes, one being a subgraph
+        const node1 = createMockNode(1, { callback: callback1 })
+        const node2 = createMockNode(2, {
+          isSubgraph: true,
+          subgraph,
+          callback: callback2
+        })
+
+        const graph = createMockGraph([node1, node2])
+
+        triggerCallbackOnAllNodes(graph, 'onExecutionStart')
+
+        expect(callback1).toHaveBeenCalledOnce()
+        expect(callback2).toHaveBeenCalledOnce()
+        expect(callback3).toHaveBeenCalledOnce()
+      })
+
+      it('should handle nested subgraphs', () => {
+        const callbacks = [vi.fn(), vi.fn(), vi.fn(), vi.fn()]
+
+        // Create deeply nested structure
+        const deepNode = createMockNode(300, { callback: callbacks[3] })
+        const deepSubgraph = createMockSubgraph('deep-uuid', [deepNode])
+
+        const midNode1 = createMockNode(200, { callback: callbacks[2] })
+        const midNode2 = createMockNode(201, {
+          isSubgraph: true,
+          subgraph: deepSubgraph
+        })
+        const midSubgraph = createMockSubgraph('mid-uuid', [midNode1, midNode2])
+
+        const node1 = createMockNode(1, { callback: callbacks[0] })
+        const node2 = createMockNode(2, {
+          isSubgraph: true,
+          subgraph: midSubgraph,
+          callback: callbacks[1]
+        })
+
+        const graph = createMockGraph([node1, node2])
+
+        triggerCallbackOnAllNodes(graph, 'onExecutionStart')
+
+        callbacks.forEach((cb) => expect(cb).toHaveBeenCalledOnce())
+      })
+    })
+
+    describe('collectAllNodes', () => {
+      it('should collect all nodes from a flat graph', () => {
+        const nodes = [createMockNode(1), createMockNode(2), createMockNode(3)]
+
+        const graph = createMockGraph(nodes)
+        const collected = collectAllNodes(graph)
+
+        expect(collected).toHaveLength(3)
+        expect(collected.map((n) => n.id)).toEqual([1, 2, 3])
+      })
+
+      it('should collect nodes from subgraphs', () => {
+        const subNode = createMockNode(100)
+        const subgraph = createMockSubgraph('sub-uuid', [subNode])
+
+        const nodes = [
+          createMockNode(1),
+          createMockNode(2, { isSubgraph: true, subgraph })
+        ]
+
+        const graph = createMockGraph(nodes)
+        const collected = collectAllNodes(graph)
+
+        expect(collected).toHaveLength(3)
+        expect(collected.map((n) => n.id)).toContain(100)
+      })
+
+      it('should filter nodes when filter function provided', () => {
+        const nodes = [createMockNode(1), createMockNode(2), createMockNode(3)]
+
+        const graph = createMockGraph(nodes)
+        const collected = collectAllNodes(graph, (node) => Number(node.id) > 1)
+
+        expect(collected).toHaveLength(2)
+        expect(collected.map((n) => n.id)).toEqual([2, 3])
+      })
+    })
+
+    describe('findNodeInHierarchy', () => {
+      it('should find node in root graph', () => {
+        const nodes = [createMockNode(1), createMockNode(2), createMockNode(3)]
+
+        const graph = createMockGraph(nodes)
+        const found = findNodeInHierarchy(graph, 2)
+
+        expect(found).toBeTruthy()
+        expect(found?.id).toBe(2)
+      })
+
+      it('should find node in subgraph', () => {
+        const subNode = createMockNode(100)
+        const subgraph = createMockSubgraph('sub-uuid', [subNode])
+
+        const nodes = [
+          createMockNode(1),
+          createMockNode(2, { isSubgraph: true, subgraph })
+        ]
+
+        const graph = createMockGraph(nodes)
+        const found = findNodeInHierarchy(graph, 100)
+
+        expect(found).toBeTruthy()
+        expect(found?.id).toBe(100)
+      })
+
+      it('should return null for non-existent node', () => {
+        const nodes = [createMockNode(1), createMockNode(2)]
+        const graph = createMockGraph(nodes)
+
+        const found = findNodeInHierarchy(graph, 999)
+        expect(found).toBeNull()
+      })
+    })
+
+    describe('findSubgraphByUuid', () => {
+      it('should find subgraph by UUID', () => {
+        const targetUuid = 'target-uuid'
+        const subgraph = createMockSubgraph(targetUuid, [])
+
+        const nodes = [
+          createMockNode(1),
+          createMockNode(2, { isSubgraph: true, subgraph })
+        ]
+
+        const graph = createMockGraph(nodes)
+        const found = findSubgraphByUuid(graph, targetUuid)
+
+        expect(found).toBe(subgraph)
+        expect(found?.id).toBe(targetUuid)
+      })
+
+      it('should find nested subgraph', () => {
+        const targetUuid = 'deep-uuid'
+        const deepSubgraph = createMockSubgraph(targetUuid, [])
+
+        const midSubgraph = createMockSubgraph('mid-uuid', [
+          createMockNode(200, { isSubgraph: true, subgraph: deepSubgraph })
+        ])
+
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: midSubgraph })
+        ])
+
+        const found = findSubgraphByUuid(graph, targetUuid)
+
+        expect(found).toBe(deepSubgraph)
+        expect(found?.id).toBe(targetUuid)
+      })
+
+      it('should return null for non-existent UUID', () => {
+        const subgraph = createMockSubgraph('some-uuid', [])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph })
+        ])
+
+        const found = findSubgraphByUuid(graph, 'non-existent-uuid')
+        expect(found).toBeNull()
+      })
+    })
+
+    describe('getNodeByExecutionId', () => {
+      it('should find node in root graph', () => {
+        const nodes = [createMockNode('123'), createMockNode('456')]
+
+        const graph = createMockGraph(nodes)
+        const found = getNodeByExecutionId(graph, '123')
+
+        expect(found).toBeTruthy()
+        expect(found?.id).toBe('123')
+      })
+
+      it('should find node in subgraph using execution path', () => {
+        const targetNode = createMockNode('789')
+        const subgraph = createMockSubgraph('sub-uuid', [targetNode])
+
+        const subgraphNode = createMockNode('456', {
+          isSubgraph: true,
+          subgraph
+        })
+
+        const graph = createMockGraph([createMockNode('123'), subgraphNode])
+
+        const found = getNodeByExecutionId(graph, '456:789')
+
+        expect(found).toBe(targetNode)
+        expect(found?.id).toBe('789')
+      })
+
+      it('should handle deeply nested execution paths', () => {
+        const targetNode = createMockNode('999')
+        const deepSubgraph = createMockSubgraph('deep-uuid', [targetNode])
+
+        const midNode = createMockNode('456', {
+          isSubgraph: true,
+          subgraph: deepSubgraph
+        })
+        const midSubgraph = createMockSubgraph('mid-uuid', [midNode])
+
+        const topNode = createMockNode('123', {
+          isSubgraph: true,
+          subgraph: midSubgraph
+        })
+
+        const graph = createMockGraph([topNode])
+
+        const found = getNodeByExecutionId(graph, '123:456:999')
+
+        expect(found).toBe(targetNode)
+        expect(found?.id).toBe('999')
+      })
+
+      it('should return null for invalid path', () => {
+        const subgraph = createMockSubgraph('sub-uuid', [createMockNode('789')])
+        const graph = createMockGraph([
+          createMockNode('456', { isSubgraph: true, subgraph })
+        ])
+
+        // Wrong path - node 123 doesn't exist
+        const found = getNodeByExecutionId(graph, '123:789')
+        expect(found).toBeNull()
+      })
+
+      it('should return null for invalid execution ID', () => {
+        const graph = createMockGraph([createMockNode('123')])
+        const found = getNodeByExecutionId(graph, '')
+        expect(found).toBeNull()
+      })
+    })
+
+    describe('getNodeByLocatorId', () => {
+      it('should find node in root graph', () => {
+        const nodes = [createMockNode('123'), createMockNode('456')]
+
+        const graph = createMockGraph(nodes)
+        const found = getNodeByLocatorId(graph, '123')
+
+        expect(found).toBeTruthy()
+        expect(found?.id).toBe('123')
+      })
+
+      it('should find node in subgraph using UUID format', () => {
+        const targetUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+        const targetNode = createMockNode('789')
+        const subgraph = createMockSubgraph(targetUuid, [targetNode])
+
+        const graph = createMockGraph([
+          createMockNode('123'),
+          createMockNode('456', { isSubgraph: true, subgraph })
+        ])
+
+        const locatorId = `${targetUuid}:789`
+        const found = getNodeByLocatorId(graph, locatorId)
+
+        expect(found).toBe(targetNode)
+        expect(found?.id).toBe('789')
+      })
+
+      it('should return null for invalid locator ID', () => {
+        const graph = createMockGraph([createMockNode('123')])
+
+        const found = getNodeByLocatorId(graph, 'invalid:::format')
+        expect(found).toBeNull()
+      })
+
+      it('should return null when subgraph UUID not found', () => {
+        const subgraph = createMockSubgraph('some-uuid', [
+          createMockNode('789')
+        ])
+        const graph = createMockGraph([
+          createMockNode('456', { isSubgraph: true, subgraph })
+        ])
+
+        const locatorId = 'non-existent-uuid:789'
+        const found = getNodeByLocatorId(graph, locatorId)
+        expect(found).toBeNull()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Updates the global node outputs store to use node locator IDs instead of execution IDs using foundation established in https://github.com/Comfy-Org/ComfyUI_frontend/pull/4382.

The `executed` WS message sends messages mapping hierarchical node IDs (based on execution context) to outputs (file references). This PR changes to using locator IDs (immediate parent graph ID : node ID).

During rendering logic, we won't know the execution context of node instances, but we know the node instance's parents graph. So, we can query the store using the active parent graph ID prefixed with the node instance ID.

https://github.com/user-attachments/assets/6225b9dd-ffbb-4b03-99e3-b0dcb10ac65c

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4500-feat-Update-node-output-system-to-use-NodeLocatorIds-2396d73d365081af8ceff78e31497af2) by [Unito](https://www.unito.io)
