### PR TITLE
Fix execution output & previews not displayed

### DIFF
--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -1,4 +1,4 @@
-import type { LGraph, Subgraph } from '@comfyorg/litegraph'
+import type { LGraph, LGraphNode, Subgraph } from '@comfyorg/litegraph'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
@@ -24,7 +24,7 @@ import type {
 } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import type { NodeLocatorId } from '@/types/nodeIdentification'
+import type { NodeExecutionId, NodeLocatorId } from '@/types/nodeIdentification'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 import { useCanvasStore } from './graphStore'
@@ -53,6 +53,22 @@ export const useExecutionStore = defineStore('execution', () => {
   const lastExecutionError = ref<ExecutionErrorWsMessage | null>(null)
   // This is the progress of all nodes in the currently executing workflow
   const nodeProgressStates = ref<Record<string, NodeProgressState>>({})
+
+  /**
+   * @deprecated Workaround for Subgraph phase 1 - execution IDs may share locator IDs.
+   * The most recently executed execution ID for each node locator ID.
+   */
+  const locatorIdToExecutionIdMap = new Map<NodeLocatorId, NodeExecutionId>()
+
+  /**
+   * Get the NodeLocatorId for a node.
+   * @param node The node
+   * @returns The NodeLocatorId
+   */
+  const getNodeLocatorId = (node: LGraphNode): NodeLocatorId =>
+    node.graph?.isRootGraph
+      ? node.id.toString()
+      : [node.graph?.id, node.id].join(':')
 
   /**
    * Convert execution context node IDs to NodeLocatorIds
@@ -468,6 +484,8 @@ export const useExecutionStore = defineStore('execution', () => {
     _executingNodeProgress,
     // NodeLocatorId conversion helpers
     executionIdToNodeLocatorId,
-    nodeLocatorIdToExecutionId
+    nodeLocatorIdToExecutionId,
+    locatorIdToExecutionIdMap,
+    getNodeLocatorId
   }
 })


### PR DESCRIPTION
Creates a temporary map of locator ID to execution ID during execution, to be used until subgraph phase 2 is complete.

- Replaces https://github.com/Comfy-Org/ComfyUI_frontend/pull/4500

https://github.com/user-attachments/assets/19b347d1-9949-4d51-8dfe-84b0d9ad5f41

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4506-Fix-execution-output-previews-not-displayed-2396d73d36508107993ef6f43b957189) by [Unito](https://www.unito.io)
