### PR TITLE
Fix LoadImage bleeds values between subgraphs

### DIFF
--- a/src/composables/widgets/useImageUploadWidget.ts
+++ b/src/composables/widgets/useImageUploadWidget.ts
@@ -100,7 +100,8 @@ export const useImageUploadWidget = () => {
     // Add our own callback to the combo widget to render an image when it changes
     fileComboWidget.callback = function () {
       nodeOutputStore.setNodeOutputs(node, fileComboWidget.value, {
-        isAnimated
+        isAnimated,
+        isInitialLoad: true
       })
       node.graph?.setDirtyCanvas(true)
     }
@@ -110,7 +111,8 @@ export const useImageUploadWidget = () => {
     // No change callbacks seem to be fired on initial setting of the value
     requestAnimationFrame(() => {
       nodeOutputStore.setNodeOutputs(node, fileComboWidget.value, {
-        isAnimated
+        isAnimated,
+        isInitialLoad: true
       })
       showPreview({ block: false })
     })

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -98,12 +98,23 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     filenames: string | string[] | ResultItem,
     {
       folder = 'input',
-      isAnimated = false
-    }: { folder?: ResultItemType; isAnimated?: boolean } = {}
+      isAnimated = false,
+      isInitialLoad = false
+    }: {
+      folder?: ResultItemType
+      isAnimated?: boolean
+      isInitialLoad?: boolean
+    } = {}
   ) {
     if (!filenames || !node) return
 
-    const nodeId = getMostRecentExecutionId(node)
+    const nodeId = isInitialLoad
+      ? executionStore.getNodeLocatorId(node)
+      : getMostRecentExecutionId(node)
+
+    if (isInitialLoad) {
+      executionStore.locatorIdToExecutionIdMap.set(nodeId, nodeId)
+    }
 
     if (typeof filenames === 'string') {
       app.nodeOutputs[nodeId] = createOutputs([filenames], folder, isAnimated)


### PR DESCRIPTION
- Follow up on #4506
- Resolves issue where LoadImage for e.g. node Id 1 would display on any subgraph node with ID 1

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4507-Fix-LoadImage-bleeds-values-between-subgraphs-2396d73d36508124bb15f74e5c6cb8ff) by [Unito](https://www.unito.io)
