### PR TITLE
Refactor canvas transform sync to composable

### DIFF
--- a/src/composables/canvas/useCanvasTransformSync.ts
+++ b/src/composables/canvas/useCanvasTransformSync.ts
@@ -1,0 +1,101 @@
+import { onUnmounted, ref } from 'vue'
+
+export interface TransformSyncOptions {
+  onStart?: () => void
+  onStop?: () => void
+}
+
+interface CanvasTransform {
+  scale: number
+  offsetX: number
+  offsetY: number
+}
+
+/**
+ * Composable for syncing canvas transform changes with RAF
+ * Only calls the sync function when the canvas state transform actually changes
+ */
+export function useCanvasTransformSync<
+  T extends { ds: { scale: number; offset: [number, number] } }
+>(
+  getCanvas: () => T | null,
+  syncFn: (canvas: T) => void,
+  options: TransformSyncOptions = {}
+) {
+  const { onStart, onStop } = options
+
+  const isActive = ref(false)
+  let rafId: number | null = null
+  let lastTransform: CanvasTransform = {
+    scale: 0,
+    offsetX: 0,
+    offsetY: 0
+  }
+
+  const hasTransformChanged = (canvas: T): boolean => {
+    const ds = canvas.ds
+    return (
+      ds.scale !== lastTransform.scale ||
+      ds.offset[0] !== lastTransform.offsetX ||
+      ds.offset[1] !== lastTransform.offsetY
+    )
+  }
+
+  const sync = () => {
+    if (!isActive.value) return
+
+    const canvas = getCanvas()
+    if (!canvas) {
+      rafId = requestAnimationFrame(sync)
+      return
+    }
+
+    try {
+      // Only run sync if transform actually changed
+      if (hasTransformChanged(canvas)) {
+        lastTransform = {
+          scale: canvas.ds.scale,
+          offsetX: canvas.ds.offset[0],
+          offsetY: canvas.ds.offset[1]
+        }
+
+        syncFn(canvas)
+      }
+    } catch (error) {
+      console.error('Canvas transform sync error:', error)
+    }
+
+    rafId = requestAnimationFrame(sync)
+  }
+
+  const startSync = () => {
+    if (isActive.value) return
+
+    isActive.value = true
+    onStart?.()
+
+    // Reset last transform to force initial sync
+    lastTransform = { scale: 0, offsetX: 0, offsetY: 0 }
+
+    sync()
+  }
+
+  const stopSync = () => {
+    isActive.value = false
+
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+
+    onStop?.()
+  }
+
+  onUnmounted(stopSync)
+
+  return {
+    isActive,
+    startSync,
+    stopSync
+  }
+}

--- a/src/composables/canvas/useCanvasTransformSync.ts
+++ b/src/composables/canvas/useCanvasTransformSync.ts
@@ -31,17 +31,21 @@ interface CanvasTransform {
  * This composable provides a clean way to sync Vue transform state with LiteGraph canvas
  * on every frame. It handles RAF lifecycle management, and ensures proper cleanup.
  *
- * The sync function typically reads canvas.ds (draw state) properties like offset and scale
- * to keep Vue components aligned with the canvas coordinate system.
+ * The sync function typically reads canvas.ds properties like offset and scale to keep
+ * Vue components aligned with the canvas coordinate system.
  *
  * @example
  * ```ts
+ * const syncWithCanvas = (canvas: LGraphCanvas) => {
+ *   canvas.ds.scale
+ *   canvas.ds.offset
+ * }
+ *
  * const { isActive, startSync, stopSync } = useCanvasTransformSync(
- *   canvas,
- *   (canvas) => syncWithCanvas(canvas),
+ *   syncWithCanvas,
  *   {
+ *     autoStart: false,
  *     onStart: () => emit('rafStatusChange', true),
- *     onUpdate: (time) => emit('transformUpdate', time),
  *     onStop: () => emit('rafStatusChange', false)
  *   }
  * )

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -1,6 +1,7 @@
 import { useRafFn, useThrottleFn } from '@vueuse/core'
 import { computed, nextTick, ref, watch } from 'vue'
 
+import { useCanvasTransformSync } from '@/composables/canvas/useCanvasTransformSync'
 import type { NodeId } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
 import { useCanvasStore } from '@/stores/graphStore'
@@ -356,12 +357,11 @@ export function useMinimap() {
       { immediate: false }
     )
 
-  const { pause: pauseViewportUpdate, resume: resumeViewportUpdate } = useRafFn(
-    () => {
-      updateViewport()
-    },
-    { immediate: false, fpsLimit: 60 }
-  )
+  const { startSync: startViewportSync, stopSync: stopViewportSync } =
+    useCanvasTransformSync(
+      () => canvas.value,
+      () => updateViewport()
+    )
 
   const handleMouseDown = (e: MouseEvent) => {
     isDragging.value = true
@@ -534,7 +534,7 @@ export function useMinimap() {
 
       if (visible.value) {
         resumeChangeDetection()
-        resumeViewportUpdate()
+        startViewportSync()
       }
       initialized.value = true
     }
@@ -542,7 +542,7 @@ export function useMinimap() {
 
   const destroy = () => {
     pauseChangeDetection()
-    pauseViewportUpdate()
+    stopViewportSync()
     cleanupEventListeners()
 
     api.removeEventListener('graphChanged', handleGraphChanged)
@@ -561,7 +561,7 @@ export function useMinimap() {
       if (oldCanvas) {
         cleanupEventListeners()
         pauseChangeDetection()
-        pauseViewportUpdate()
+        stopViewportSync()
         api.removeEventListener('graphChanged', handleGraphChanged)
         window.removeEventListener('resize', updateContainerRect)
         window.removeEventListener('scroll', updateContainerRect)
@@ -592,10 +592,10 @@ export function useMinimap() {
       updateMinimap()
       updateViewport()
       resumeChangeDetection()
-      resumeViewportUpdate()
+      startViewportSync()
     } else {
       pauseChangeDetection()
-      pauseViewportUpdate()
+      stopViewportSync()
     }
   })
 

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -358,10 +358,7 @@ export function useMinimap() {
     )
 
   const { startSync: startViewportSync, stopSync: stopViewportSync } =
-    useCanvasTransformSync(
-      () => canvas.value,
-      () => updateViewport()
-    )
+    useCanvasTransformSync(updateViewport, { autoStart: false })
 
   const handleMouseDown = (e: MouseEvent) => {
     isDragging.value = true

--- a/tests-ui/tests/composables/canvas/useCanvasTransformSync.test.ts
+++ b/tests-ui/tests/composables/canvas/useCanvasTransformSync.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { useCanvasTransformSync } from '@/composables/canvas/useCanvasTransformSync'
+
+describe('useCanvasTransformSync', () => {
+  let mockCanvas: { ds: { scale: number; offset: [number, number] } }
+  let syncFn: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockCanvas = {
+      ds: {
+        scale: 1,
+        offset: [0, 0]
+      }
+    }
+    syncFn = vi.fn()
+    vi.clearAllMocks()
+  })
+
+  it('should not call syncFn when transform has not changed', async () => {
+    const { startSync } = useCanvasTransformSync(() => mockCanvas, syncFn)
+
+    startSync()
+    await nextTick()
+
+    // Should call once initially
+    expect(syncFn).toHaveBeenCalledTimes(1)
+
+    // Wait for next RAF cycle
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    // Should not call again since transform didn't change
+    expect(syncFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call syncFn when scale changes', async () => {
+    const { startSync } = useCanvasTransformSync(() => mockCanvas, syncFn)
+
+    startSync()
+    await nextTick()
+
+    expect(syncFn).toHaveBeenCalledTimes(1)
+
+    // Change scale
+    mockCanvas.ds.scale = 2
+
+    // Wait for next RAF cycle
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(syncFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should call syncFn when offset changes', async () => {
+    const { startSync } = useCanvasTransformSync(() => mockCanvas, syncFn)
+
+    startSync()
+    await nextTick()
+
+    expect(syncFn).toHaveBeenCalledTimes(1)
+
+    // Change offset
+    mockCanvas.ds.offset = [10, 20]
+
+    // Wait for next RAF cycles
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(syncFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should stop calling syncFn after stopSync is called', async () => {
+    const { startSync, stopSync } = useCanvasTransformSync(
+      () => mockCanvas,
+      syncFn
+    )
+
+    startSync()
+    await nextTick()
+
+    expect(syncFn).toHaveBeenCalledTimes(1)
+
+    stopSync()
+
+    // Change transform after stopping
+    mockCanvas.ds.scale = 2
+
+    // Wait for RAF cycle
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    // Should not call again
+    expect(syncFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle null canvas gracefully', async () => {
+    const { startSync } = useCanvasTransformSync(() => null, syncFn)
+
+    startSync()
+    await nextTick()
+
+    // Should not call syncFn with null canvas
+    expect(syncFn).not.toHaveBeenCalled()
+  })
+
+  it('should call onStart and onStop callbacks', () => {
+    const onStart = vi.fn()
+    const onStop = vi.fn()
+
+    const { startSync, stopSync } = useCanvasTransformSync(
+      () => mockCanvas,
+      syncFn,
+      { onStart, onStop }
+    )
+
+    startSync()
+    expect(onStart).toHaveBeenCalledTimes(1)
+
+    stopSync()
+    expect(onStop).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests-ui/tests/composables/useMinimap.test.ts
+++ b/tests-ui/tests/composables/useMinimap.test.ts
@@ -95,7 +95,8 @@ const setupMocks = () => {
 setupMocks()
 
 const defaultCanvasStore = {
-  canvas: mockCanvas
+  canvas: mockCanvas,
+  getCanvas: () => defaultCanvasStore.canvas
 }
 
 const defaultSettingStore = {


### PR DESCRIPTION
Adds composable to sync transform state of canvas. Call with a `sync` function that gets called on the canvas only when the transform state has actually changed.

This utility will be used by future components, and having the syncing happen in a single place will be much more efficient because we won't need to have multiple observers each diffing the state themselves.

This also changes the implementation from calling `updateViewport` 60 times per second to only calling on change.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4527-Refactor-canvas-transform-sync-to-composable-23a6d73d3650816a993bc69b9abb2279) by [Unito](https://www.unito.io)
