### PR TITLE
[Manager] Fix package version matching in conflict detection

### DIFF
--- a/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
+++ b/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
@@ -252,20 +252,25 @@ const getVersionData = (version: string) => {
         nodePack.supported_comfyui_frontend_version,
       supported_python_version:
         (latestVersionData && 'supported_python_version' in latestVersionData
-          ? latestVersionData.supported_python_version as string | undefined
+          ? (latestVersionData.supported_python_version as string | undefined)
           : undefined) ??
         ('supported_python_version' in nodePack
-          ? nodePack.supported_python_version as string | undefined
+          ? (nodePack.supported_python_version as string | undefined)
           : undefined),
       is_banned:
         (latestVersionData && 'is_banned' in latestVersionData
-          ? latestVersionData.is_banned as boolean | undefined
-          : undefined) ?? ('is_banned' in nodePack ? nodePack.is_banned as boolean | undefined : false),
+          ? (latestVersionData.is_banned as boolean | undefined)
+          : undefined) ??
+        ('is_banned' in nodePack
+          ? (nodePack.is_banned as boolean | undefined)
+          : false),
       has_registry_data:
         (latestVersionData && 'has_registry_data' in latestVersionData
-          ? latestVersionData.has_registry_data as boolean | undefined
+          ? (latestVersionData.has_registry_data as boolean | undefined)
           : undefined) ??
-        ('has_registry_data' in nodePack ? nodePack.has_registry_data as boolean | undefined : false)
+        ('has_registry_data' in nodePack
+          ? (nodePack.has_registry_data as boolean | undefined)
+          : false)
     }
   }
 
@@ -281,7 +286,7 @@ const getVersionData = (version: string) => {
         nodePack.supported_comfyui_frontend_version, // Use latest known requirement
       supported_python_version:
         'supported_python_version' in nodePack
-          ? nodePack.supported_python_version as string | undefined
+          ? (nodePack.supported_python_version as string | undefined)
           : undefined,
       is_banned: false, // Nightly versions from repositories are typically not banned
       has_registry_data: false // Nightly doesn't come from registry
@@ -299,12 +304,15 @@ const getVersionData = (version: string) => {
         versionData.supported_comfyui_frontend_version,
       supported_python_version:
         'supported_python_version' in versionData
-          ? versionData.supported_python_version as string | undefined
+          ? (versionData.supported_python_version as string | undefined)
           : undefined,
-      is_banned: 'is_banned' in versionData ? versionData.is_banned as boolean | undefined : false,
+      is_banned:
+        'is_banned' in versionData
+          ? (versionData.is_banned as boolean | undefined)
+          : false,
       has_registry_data:
         'has_registry_data' in versionData
-          ? versionData.has_registry_data as boolean | undefined
+          ? (versionData.has_registry_data as boolean | undefined)
           : false
     }
   }
@@ -318,11 +326,16 @@ const getVersionData = (version: string) => {
       nodePack.supported_comfyui_frontend_version,
     supported_python_version:
       'supported_python_version' in nodePack
-        ? nodePack.supported_python_version as string | undefined
+        ? (nodePack.supported_python_version as string | undefined)
         : undefined,
-    is_banned: 'is_banned' in nodePack ? nodePack.is_banned as boolean | undefined : false,
+    is_banned:
+      'is_banned' in nodePack
+        ? (nodePack.is_banned as boolean | undefined)
+        : false,
     has_registry_data:
-      'has_registry_data' in nodePack ? nodePack.has_registry_data as boolean | undefined : false
+      'has_registry_data' in nodePack
+        ? (nodePack.has_registry_data as boolean | undefined)
+        : false
   }
 }
 

--- a/src/components/dialog/content/manager/button/PackEnableToggle.vue
+++ b/src/components/dialog/content/manager/button/PackEnableToggle.vue
@@ -42,7 +42,7 @@ const { nodePack, hasConflict } = defineProps<{
 
 const { t } = useI18n()
 const { isPackEnabled, enablePack, disablePack } = useComfyManagerStore()
-const conflictStore = useConflictDetectionStore()
+const { getConflictsForPackageByID } = useConflictDetectionStore()
 const { showNodeConflictDialog } = useDialogService()
 const { acknowledgeConflict, isConflictAcknowledged } =
   useConflictAcknowledgment()
@@ -87,7 +87,7 @@ const handleToggle = async (enable: boolean, skipConflictCheck = false) => {
 
   // Check for conflicts when enabling
   if (enable && hasConflict && !skipConflictCheck) {
-    const conflicts = conflictStore.getConflictsForPackage(nodePack.id || '')
+    const conflicts = getConflictsForPackageByID(nodePack.id || '')
     if (conflicts) {
       // Check if conflicts have been acknowledged
       const hasUnacknowledgedConflicts = conflicts.conflicts.some(
@@ -141,7 +141,7 @@ const onToggle = debounce(
 
 // Show conflict modal when warning icon is clicked
 const showConflictModal = () => {
-  const conflicts = conflictStore.getConflictsForPackage(nodePack.id || '')
+  const conflicts = getConflictsForPackageByID(nodePack.id || '')
   if (conflicts) {
     showNodeConflictDialog({
       conflictedPackages: [conflicts],

--- a/src/components/dialog/content/manager/infoPanel/InfoTabs.vue
+++ b/src/components/dialog/content/manager/infoPanel/InfoTabs.vue
@@ -62,12 +62,15 @@ const nodeNames = computed(() => {
 const activeTab = ref('description')
 
 // Watch for compatibility issues and automatically switch to warning tab
-watchEffect(() => {
-  if (hasCompatibilityIssues) {
-    activeTab.value = 'warning'
-  } else if (activeTab.value === 'warning') {
-    // If currently on warning tab but no issues, switch to description
-    activeTab.value = 'description'
-  }
-}, { flush: 'post' })
+watchEffect(
+  () => {
+    if (hasCompatibilityIssues) {
+      activeTab.value = 'warning'
+    } else if (activeTab.value === 'warning') {
+      // If currently on warning tab but no issues, switch to description
+      activeTab.value = 'description'
+    }
+  },
+  { flush: 'post' }
+)
 </script>

--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -44,20 +44,16 @@ const formattedDownloads = computed(() =>
   nodePack.downloads ? n(nodePack.downloads) : ''
 )
 
-const conflictStore = useConflictDetectionStore()
+const { getConflictsForPackageByID } = useConflictDetectionStore()
 const { checkVersionCompatibility } = useConflictDetection()
 
-// TODO: Package version mismatch issue - Package IDs include version suffixes (@1_0_3)
-// but UI searches without version. This causes conflict detection failures.
-// Once getConflictsForPackage is improved to handle version matching properly,
-// all the complex fallback logic below can be removed.
 const hasConflict = computed(() => {
   if (!nodePack.id) return false
 
   // For installed packages, check conflicts from store
   if (isInstalled.value) {
     // Try exact match first
-    let conflicts = conflictStore.getConflictsForPackage(nodePack.id)
+    let conflicts = getConflictsForPackageByID(nodePack.id)
     if (conflicts) return true
 
     return false

--- a/src/components/dialog/content/manager/packCard/PackCardHeader.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardHeader.vue
@@ -46,13 +46,13 @@ const { nodePack } = defineProps<{
 }>()
 
 const { isPackInstalled } = useComfyManagerStore()
-const conflictStore = useConflictDetectionStore()
+const { getConflictsForPackageByID } = useConflictDetectionStore()
 const isInstalled = computed(() => isPackInstalled(nodePack?.id))
 
 const packageConflicts = computed(() => {
   if (!nodePack.id || !isInstalled.value) return null
 
   // For installed packages, check conflicts from store
-  return conflictStore.getConflictsForPackage(nodePack.id)
+  return getConflictsForPackageByID(nodePack.id)
 })
 </script>

--- a/src/composables/nodePack/useInstalledPacks.ts
+++ b/src/composables/nodePack/useInstalledPacks.ts
@@ -20,7 +20,10 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
     packs.filter((pack) => comfyManagerStore.isPackInstalled(pack.id))
 
   const startFetchInstalled = async () => {
-    await comfyManagerStore.refreshInstalledList()
+    // Only refresh if store doesn't have data yet
+    if (comfyManagerStore.installedPacksIds.size === 0) {
+      await comfyManagerStore.refreshInstalledList()
+    }
     await startFetch()
   }
 

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -15,13 +15,6 @@ import type { SettingParams } from '@/types/settingTypes'
  */
 export const CORE_SETTINGS: SettingParams[] = [
   {
-    id: 'Comfy.Memory.AllowManualUnload',
-    name: 'Allow manual unload of models and execution cache via user command',
-    type: 'hidden',
-    defaultValue: true,
-    versionAdded: '1.18.0'
-  },
-  {
     id: 'Comfy.Validation.Workflows',
     name: 'Validate workflows',
     type: 'boolean',

--- a/src/stores/conflictDetectionStore.ts
+++ b/src/stores/conflictDetectionStore.ts
@@ -18,7 +18,7 @@ export const useConflictDetectionStore = defineStore(
 
     const getConflictsForPackage = computed(
       () => (packageId: string) =>
-        conflictedPackages.value.find((pkg) => pkg.package_id === packageId)
+        conflictedPackages.value.find((pkg) => pkg.package_name === packageId)
     )
 
     const bannedPackages = computed(() =>

--- a/src/stores/conflictDetectionStore.ts
+++ b/src/stores/conflictDetectionStore.ts
@@ -16,9 +16,9 @@ export const useConflictDetectionStore = defineStore(
       conflictedPackages.value.some((pkg) => pkg.has_conflict)
     )
 
-    const getConflictsForPackage = computed(
+    const getConflictsForPackageByID = computed(
       () => (packageId: string) =>
-        conflictedPackages.value.find((pkg) => pkg.package_name === packageId)
+        conflictedPackages.value.find((pkg) => pkg.package_id === packageId)
     )
 
     const bannedPackages = computed(() =>
@@ -57,7 +57,7 @@ export const useConflictDetectionStore = defineStore(
       lastDetectionTime,
       // Getters
       hasConflicts,
-      getConflictsForPackage,
+      getConflictsForPackageByID,
       bannedPackages,
       securityPendingPackages,
       // Actions

--- a/tests-ui/tests/stores/conflictDetectionStore.test.ts
+++ b/tests-ui/tests/stores/conflictDetectionStore.test.ts
@@ -83,12 +83,12 @@ describe('useConflictDetectionStore', () => {
     })
   })
 
-  describe('getConflictsForPackage', () => {
+  describe('getConflictsForPackageByID', () => {
     it('should find package by exact ID match', () => {
       const store = useConflictDetectionStore()
       store.setConflictedPackages(mockConflictedPackages)
 
-      const result = store.getConflictsForPackage('ComfyUI-Manager')
+      const result = store.getConflictsForPackageByID('ComfyUI-Manager')
 
       expect(result).toBeDefined()
       expect(result?.package_id).toBe('ComfyUI-Manager')
@@ -99,7 +99,7 @@ describe('useConflictDetectionStore', () => {
       const store = useConflictDetectionStore()
       store.setConflictedPackages(mockConflictedPackages)
 
-      const result = store.getConflictsForPackage('non-existent-package')
+      const result = store.getConflictsForPackageByID('non-existent-package')
 
       expect(result).toBeUndefined()
     })


### PR DESCRIPTION
## Summary
- Fix package version matching issues in conflict detection system
- Refactor to use composables instead of direct API calls for better performance
- Remove duplicate setting causing \"Setting must have a unique ID\" error

## Changes Made

### 1. Architectural Improvements
- **Replace direct API calls with composables**: Use `useInstalledPacks()` composable instead of calling `comfyManagerService.listInstalledPacks()` directly
- **Performance optimization**: Prevent duplicate `/api/v2/customnode/installed` API calls by checking if data already exists in store
- **Better separation of concerns**: Conflict detection now uses centralized data management through composables

### 2. Fixed Registry API Lookup Issues
- Prevents 404 errors when calling `/api/v2/nodes/package@1_0_3/versions/1.0.3`
- Now correctly calls `/api/v2/nodes/package/versions/1.0.3`

### 3. Updated Conflict Detection Logic
- Changed from `getConflictsForPackage` to `getConflictsForPackageByID` for ID-based lookup
- Updated conflict detection to use package IDs instead of names for more reliable matching
- Normalized package names in conflict merging to remove version suffixes (`@1_0_3`)

### 4. Removed Duplicate Setting
- Fixed duplicate `Comfy.Memory.AllowManualUnload` setting definition in coreSettings.ts
- Resolves \"Setting must have a unique ID\" runtime error

## Performance Improvements
- **Before**: Multiple components calling `/api/v2/customnode/installed` API directly, causing duplicate requests
- **After**: Single API call through composable with smart caching - subsequent calls use store data
- **Impact**: Reduced network requests and improved page load performance

## Test Results
- ✅ All unit tests passing (related to our changes)
- ✅ All component tests passing 
- ⚠️ Some unrelated API feature flag tests failing (pre-existing issues)

## Behavior Changes
- **Before**: Warning icons not showing in Installed Tab due to package ID mismatch
- **After**: Warning icons properly display for conflicted packages
- **Before**: Registry API calls failing with 404 for versioned package names
- **After**: Registry API calls succeed using normalized package names
- **Before**: Multiple duplicate API calls on page load
- **After**: Single API call with intelligent caching

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4530-Manager-Fix-package-version-matching-in-conflict-detection-23b6d73d36508139b8b7e79108997ec2) by [Unito](https://www.unito.io)