### PR TITLE
[Manager] Fix banned status logic to only check Registry status

### DIFF
--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -280,14 +280,7 @@ export function useConflictDetection() {
             // Status information
             registry_status: undefined, // Node status - not critical for conflict detection
             version_status: versionData.status,
-            is_banned:
-              versionData.status === 'NodeVersionStatusBanned' || !isEnabled,
-            ban_reason:
-              versionData.status === 'NodeVersionStatusBanned'
-                ? 'Version is banned in Registry'
-                : !isEnabled
-                  ? 'Package is disabled locally'
-                  : undefined,
+            is_banned: versionData.status === 'NodeVersionStatusBanned',
 
             // Metadata
             registry_fetch_time: new Date().toISOString(),
@@ -306,8 +299,7 @@ export function useConflictDetection() {
             package_name: pack.name || packageId,
             installed_version: pack.latest_version?.version || 'unknown',
             is_enabled: isEnabled,
-            is_banned: !isEnabled,
-            ban_reason: !isEnabled ? 'Package is disabled locally' : undefined,
+            is_banned: false,
             registry_fetch_time: new Date().toISOString(),
             has_registry_data: false
           }

--- a/src/types/conflictDetectionTypes.ts
+++ b/src/types/conflictDetectionTypes.ts
@@ -89,8 +89,6 @@ export interface NodePackRequirements {
     | 'NodeVersionStatusFlagged'
   /** @description Whether package is banned (derived from status) */
   is_banned: boolean
-  /** @description Reason for ban if applicable */
-  ban_reason?: string
 
   // Metadata
   /** @description Registry data fetch timestamp */


### PR DESCRIPTION
## Summary
- Fixed `is_banned` logic in conflict detection to only check `NodeVersionStatusBanned` from Registry
- Removed local enabled/disabled state from banned determination  
- Updated tests to reflect correct banned status behavior

## Changes
- Modified `useConflictDetection.ts` to set `is_banned` based only on Registry status
- Updated test cases to verify locally disabled packages are NOT treated as banned
- Added test coverage for `NodeVersionStatusPending` and `NodeVersionStatusFlagged` states

## Context
Previously, packages were incorrectly marked as "banned" when they were simply disabled locally (`enabled: false`). This caused confusion as normal packages appeared with banned status in the UI.

Now the logic correctly distinguishes between:
- **Registry banned**: `versionData.status === 'NodeVersionStatusBanned'` - Actually banned by Registry
- **Locally disabled**: User disabled the package locally (not a ban)

## Test plan
- [x] Unit tests updated and passing
- [x] Verified locally disabled packages no longer show as banned
- [x] Confirmed Registry-banned packages still correctly identified

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4535-Manager-Fix-banned-status-logic-to-only-check-Registry-status-23b6d73d365081999948c673f0e1759a) by [Unito](https://www.unito.io)
