### PR TITLE
[test] Fix failing test case that uses old subgraph breadcrumb element

### DIFF
--- a/browser_tests/tests/subgraph.spec.ts
+++ b/browser_tests/tests/subgraph.spec.ts
@@ -397,7 +397,8 @@ test.describe('Subgraph Operations', () => {
       // Enable new menu for breadcrumb navigation
       await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
 
-      await comfyPage.loadWorkflow('subgraph-with-promoted-text-widget')
+      const workflowName = 'subgraph-with-promoted-text-widget'
+      await comfyPage.loadWorkflow(workflowName)
 
       const textareaCount = await comfyPage.page
         .locator(SELECTORS.domWidget)
@@ -420,8 +421,13 @@ test.describe('Subgraph Operations', () => {
       })
 
       // Click breadcrumb to navigate back to parent graph
-      const breadcrumb = comfyPage.page.locator(SELECTORS.breadcrumb).first()
-      await breadcrumb.click()
+      const homeBreadcrumb = comfyPage.page.getByRole('link', {
+        // In the subgraph navigation breadcrumbs, the home/top level
+        // breadcrumb is just the workflow name
+        name: workflowName
+      })
+      await homeBreadcrumb.waitFor({ state: 'visible' })
+      await homeBreadcrumb.click()
       await comfyPage.nextFrame()
       await comfyPage.page.waitForTimeout(300)
 


### PR DESCRIPTION
This subgraph browser test case was using locator based on old breacrumb component that was replaced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/4374 and has been failing since https://github.com/Comfy-Org/ComfyUI_frontend/pull/4374 was merged. This updates to work with new menu component.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4537-fix-improve-subgraph-breadcrumb-navigation-test-reliability-23b6d73d3650811ea373efd2eb355e06) by [Unito](https://www.unito.io)
