### PR TITLE
[Manager] Optimize conflict detection with bulk API and version support

### DIFF
--- a/src/composables/nodePack/useInstalledPacks.ts
+++ b/src/composables/nodePack/useInstalledPacks.ts
@@ -36,11 +36,29 @@ export const useInstalledPacks = (options: UseNodePacksOptions = {}) => {
     cleanup()
   })
 
+  // Create a computed property that provides installed pack info with versions
+  const installedPacksWithVersions = computed(() => {
+    const result: Array<{ id: string; version: string }> = []
+
+    for (const pack of Object.values(comfyManagerStore.installedPacks)) {
+      const id = pack.cnr_id || pack.aux_id
+      if (id) {
+        result.push({
+          id,
+          version: pack.ver
+        })
+      }
+    }
+
+    return result
+  })
+
   return {
     error,
     isLoading,
     isReady,
     installedPacks: nodePacks,
+    installedPacksWithVersions,
     startFetchInstalled,
     filterInstalledPack
   }

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -359,6 +359,55 @@ export const useComfyRegistryService = () => {
     )
   }
 
+  /**
+   * Get multiple pack versions in a single bulk request.
+   * This is more efficient than making individual requests for each pack version.
+   *
+   * @param nodeVersions - Array of node ID and version pairs to retrieve
+   * @param signal - Optional AbortSignal for request cancellation
+   * @returns Bulk response containing the requested node versions or null on error
+   *
+   * @example
+   * ```typescript
+   * const versions = await getBulkNodeVersions([
+   *   { node_id: 'ComfyUI-Manager', version: '1.0.0' },
+   *   { node_id: 'ComfyUI-Impact-Pack', version: '2.0.0' }
+   * ])
+   * if (versions) {
+   *   versions.node_versions.forEach(result => {
+   *     if (result.status === 'success' && result.node_version) {
+   *       console.log(`Retrieved ${result.identifier.node_id}@${result.identifier.version}`)
+   *     }
+   *   })
+   * }
+   * ```
+   */
+  const getBulkNodeVersions = async (
+    nodeVersions: components['schemas']['NodeVersionIdentifier'][],
+    signal?: AbortSignal
+  ) => {
+    const endpoint = '/bulk/nodes/versions'
+    const errorContext = 'Failed to get bulk node versions'
+    const routeSpecificErrors = {
+      400: 'Bad request: Invalid node version identifiers provided'
+    }
+
+    const requestBody: components['schemas']['BulkNodeVersionsRequest'] = {
+      node_versions: nodeVersions
+    }
+
+    return executeApiRequest(
+      () =>
+        registryApiClient.post<
+          components['schemas']['BulkNodeVersionsResponse']
+        >(endpoint, requestBody, {
+          signal
+        }),
+      errorContext,
+      routeSpecificErrors
+    )
+  }
+
   return {
     isLoading,
     error,
@@ -372,6 +421,7 @@ export const useComfyRegistryService = () => {
     listPacksForPublisher,
     getNodeDefs,
     postPackReview,
-    inferPackFromNodeName
+    inferPackFromNodeName,
+    getBulkNodeVersions
   }
 }


### PR DESCRIPTION
## Summary
- Add `installedPacksWithVersions` computed property to useInstalledPacks to include version information
- Replace individual version API calls with bulk API in conflict detection
- Add `getBulkNodeVersions` API method to comfyRegistryService for efficient batch requests
- Use actual installed package versions instead of latest versions for compatibility checks

## Changes
- **src/composables/nodePack/useInstalledPacks.ts**: Added installedPacksWithVersions computed property that combines nodepack id with version info
- **src/composables/useConflictDetection.ts**: Refactored to use bulk API calls instead of individual requests, significantly reducing API overhead
- **src/services/comfyRegistryService.ts**: Added getBulkNodeVersions method for batch version fetching

## Why this change?
The existing `installedPacks` doesn't include version information, which was needed for accurate conflict detection. This change improves performance by reducing API calls from N individual requests to N/30 bulk requests while ensuring compatibility checks use actually installed versions.

Performance improvement: Reduces API calls significantly for conflict detection operations.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4538-Manager-Optimize-conflict-detection-with-bulk-API-and-version-support-23b6d73d3650819ebe2cdf9c47ed4e4b) by [Unito](https://www.unito.io)
