### PR TITLE
Address minimap review comments and design updates

### DIFF
--- a/src/components/graph/MiniMap.vue
+++ b/src/components/graph/MiniMap.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="visible"
+    v-if="visible && initialized"
     ref="containerRef"
     class="litegraph-minimap absolute bottom-[20px] right-[90px] z-[1000]"
     :style="containerStyles"

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -7,20 +7,15 @@ import { api } from '@/scripts/api'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
 
-const globalState = {
-  visible: ref(true),
-  minimapRef: ref<any>(null),
-  initialized: false
-}
-
 export function useMinimap() {
   const settingStore = useSettingStore()
   const canvasStore = useCanvasStore()
 
   const containerRef = ref<HTMLDivElement>()
   const canvasRef = ref<HTMLCanvasElement>()
+  const minimapRef = ref<any>(null)
 
-  const visible = globalState.visible
+  const visible = ref(true)
 
   const initialized = ref(false)
   const bounds = ref({
@@ -602,7 +597,7 @@ export function useMinimap() {
   }
 
   const setMinimapRef = (ref: any) => {
-    globalState.minimapRef.value = ref
+    minimapRef.value = ref
   }
 
   return {

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -141,8 +141,8 @@ export function useMinimap() {
     let currentHeight = maxY - minY
 
     // Enforce minimum viewport dimensions for better visualization
-    const minViewportWidth = 300
-    const minViewportHeight = 200
+    const minViewportWidth = 2500
+    const minViewportHeight = 2000
 
     if (currentWidth < minViewportWidth) {
       const padding = (minViewportWidth - currentWidth) / 2
@@ -276,6 +276,12 @@ export function useMinimap() {
 
     const ctx = canvasRef.value.getContext('2d')
     if (!ctx) return
+
+    // Fast path for 0 nodes - just show background
+    if (!graph.value._nodes || graph.value._nodes.length === 0) {
+      ctx.clearRect(0, 0, width, height)
+      return
+    }
 
     const needsRedraw =
       needsFullRedraw.value ||

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -152,6 +152,7 @@ export function useMinimap() {
     const scaleX = width / bounds.value.width
     const scaleY = height / bounds.value.height
 
+    // Apply 0.9 factor to provide padding/gap between nodes and minimap borders
     return Math.min(scaleX, scaleY) * 0.9
   }
 

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -137,13 +137,34 @@ export function useMinimap() {
       maxY = Math.max(maxY, node.pos[1] + node.size[1])
     }
 
+    let currentWidth = maxX - minX
+    let currentHeight = maxY - minY
+
+    // Enforce minimum viewport dimensions for better visualization
+    const minViewportWidth = 300
+    const minViewportHeight = 200
+
+    if (currentWidth < minViewportWidth) {
+      const padding = (minViewportWidth - currentWidth) / 2
+      minX -= padding
+      maxX += padding
+      currentWidth = minViewportWidth
+    }
+
+    if (currentHeight < minViewportHeight) {
+      const padding = (minViewportHeight - currentHeight) / 2
+      minY -= padding
+      maxY += padding
+      currentHeight = minViewportHeight
+    }
+
     return {
       minX,
       minY,
       maxX,
       maxY,
-      width: maxX - minX,
-      height: maxY - minY
+      width: currentWidth,
+      height: currentHeight
     }
   }
 

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -1,3 +1,4 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
 import { useRafFn, useThrottleFn } from '@vueuse/core'
 import { computed, nextTick, ref, watch } from 'vue'
 
@@ -6,6 +7,12 @@ import type { NodeId } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
+
+interface GraphCallbacks {
+  onNodeAdded?: (node: LGraphNode) => void
+  onNodeRemoved?: (node: LGraphNode) => void
+  onConnectionChange?: (node: LGraphNode) => void
+}
 
 export function useMinimap() {
   const settingStore = useSettingStore()
@@ -442,7 +449,7 @@ export function useMinimap() {
     c.setDirty(true, true)
   }
 
-  let originalCallbacks: any = {}
+  let originalCallbacks: GraphCallbacks = {}
 
   const handleGraphChanged = useThrottleFn(() => {
     needsFullRedraw.value = true


### PR DESCRIPTION
Address all review comments from PR #4520 and update minimap visual styling to match Figma design.

- **Review fixes**: Proper TypeScript types, global state refactoring, initialization checks, documentation
- **Visual design**: Blue nodes (#0B8CE999), orange connections/slots (#F99614), charcoal background (#15161C), 8px border radius  
- **Single node handling**: Minimum viewport dimensions to prevent tiny nodes filling entire minimap
- **Performance**: Fast path rendering for 0 nodes case