### PR TITLE
[refactor] Streamline create-frontend-release command

### DIFF
--- a/.claude/commands/create-frontend-release.md
+++ b/.claude/commands/create-frontend-release.md
@@ -137,8 +137,7 @@ echo "Last stable release: $LAST_STABLE"
 1. Run complete test suite:
    ```bash
    npm run test:unit
-   npm run test:component  
-   npm run test:browser
+   npm run test:component
    ```
 2. Run type checking:
    ```bash
@@ -170,7 +169,7 @@ echo "Last stable release: $LAST_STABLE"
 3. Generate breaking change summary
 4. **COMPATIBILITY REVIEW**: Breaking changes documented and justified?
 
-### Step 7: Generate and Save Changelog
+### Step 7: Generate Comprehensive Release Notes
 
 1. Extract commit messages since base release:
    ```bash
@@ -185,44 +184,25 @@ echo "Last stable release: $LAST_STABLE"
        echo "WARNING: PR #$PR not on main branch!"
    done
    ```
-3. Group by type:
-   - 🚀 **Features** (feat:)
-   - 🐛 **Bug Fixes** (fix:)
-   - 💥 **Breaking Changes** (BREAKING CHANGE)
-   - 📚 **Documentation** (docs:)
-   - 🔧 **Maintenance** (chore:, refactor:)
-   - ⬆️ **Dependencies** (deps:, dependency updates)
-4. Include PR numbers and links
-5. Add issue references (Fixes #123)
-6. **Save changelog locally:**
-   ```bash
-   # Save to dated file for history
-   echo "$CHANGELOG" > release-notes-${NEW_VERSION}-$(date +%Y%m%d).md
-   
-   # Save to current for easy access
-   echo "$CHANGELOG" > CURRENT_RELEASE_NOTES.md
-   ```
-7. **CHANGELOG REVIEW**: Verify all PRs listed are actually on main branch
-
-### Step 8: Create Enhanced Release Notes
-
-1. Create comprehensive user-facing release notes including:
-   - **What's New**: Major features and improvements
-   - **Bug Fixes**: User-visible fixes
-   - **Breaking Changes**: Migration guide if applicable
-   - **Dependencies**: Major dependency updates
-   - **Performance**: Notable performance improvements
-   - **Contributors**: Thank contributors for their work
-2. Reference related documentation updates
-3. Include screenshots for UI changes (if available)
+3. Create comprehensive release notes including:
+   - **Version Change**: Show version bump details
+   - **Changelog** grouped by type:
+     - 🚀 **Features** (feat:)
+     - 🐛 **Bug Fixes** (fix:)
+     - 💥 **Breaking Changes** (BREAKING CHANGE)
+     - 📚 **Documentation** (docs:)
+     - 🔧 **Maintenance** (chore:, refactor:)
+     - ⬆️ **Dependencies** (deps:, dependency updates)
+   - Include PR numbers and links
+   - Add issue references (Fixes #123)
 4. **Save release notes:**
    ```bash
-   # Enhanced release notes for GitHub
-   echo "$RELEASE_NOTES" > github-release-notes-${NEW_VERSION}.md
+   # Save release notes for PR and GitHub release
+   echo "$RELEASE_NOTES" > release-notes-${NEW_VERSION}.md
    ```
-5. **CONTENT REVIEW**: Release notes clear and helpful for users?
+5. **CONTENT REVIEW**: Release notes clear and comprehensive?
 
-### Step 9: Create Version Bump PR
+### Step 8: Create Version Bump PR
 
 **For standard version bumps (patch/minor/major):**
 ```bash
@@ -258,25 +238,20 @@ echo "Workflow triggered. Waiting for PR creation..."
    
    # For manual PRs
    gh pr create --title "${NEW_VERSION}" \
-     --body-file enhanced-pr-description.md \
+     --body-file release-notes-${NEW_VERSION}.md \
      --label "Release"
    ```
-3. **Create enhanced PR description:**
+3. **Add required sections to PR body:**
    ```bash
-   cat > enhanced-pr-description.md << EOF
-   # Release v${NEW_VERSION}
-
-   ## Version Change
-   \`${CURRENT_VERSION}\` → \`${NEW_VERSION}\` (${VERSION_TYPE})
-
-   ## Changelog
-   ${CHANGELOG}
+   # Create PR body with release notes plus required sections
+   cat > pr-body.md << EOF
+   ${RELEASE_NOTES}
 
    ## Breaking Changes
-   ${BREAKING_CHANGES}
+   ${BREAKING_CHANGES:-None}
 
    ## Testing Performed
-   - ✅ Full test suite (unit, component, browser)
+   - ✅ Full test suite (unit, component)
    - ✅ TypeScript compilation
    - ✅ Linting checks
    - ✅ Build verification
@@ -295,15 +270,11 @@ echo "Workflow triggered. Waiting for PR creation..."
    ```
 4. Update PR with enhanced description:
    ```bash
-   gh pr edit ${PR_NUMBER} --body-file enhanced-pr-description.md
+   gh pr edit ${PR_NUMBER} --body-file pr-body.md
    ```
-5. Add changelog as comment for easy reference:
-   ```bash
-   gh pr comment ${PR_NUMBER} --body-file CURRENT_RELEASE_NOTES.md
-   ```
-6. **PR REVIEW**: Version bump PR created and enhanced correctly?
+5. **PR REVIEW**: Version bump PR created and enhanced correctly?
 
-### Step 11: Critical Release PR Verification
+### Step 9: Critical Release PR Verification
 
 1. **CRITICAL**: Verify PR has "Release" label:
    ```bash
@@ -325,7 +296,7 @@ echo "Workflow triggered. Waiting for PR creation..."
    ```
 7. **FINAL CODE REVIEW**: Release label present and no [skip ci]?
 
-### Step 12: Pre-Merge Validation
+### Step 10: Pre-Merge Validation
 
 1. **Review Requirements**: Release PRs require approval
 2. Monitor CI checks - watch for update-locales
@@ -333,7 +304,7 @@ echo "Workflow triggered. Waiting for PR creation..."
 4. Check no new commits to main since PR creation
 5. **DEPLOYMENT READINESS**: Ready to merge?
 
-### Step 13: Execute Release
+### Step 11: Execute Release
 
 1. **FINAL CONFIRMATION**: Merge PR to trigger release?
 2. Merge the Release PR:
@@ -358,7 +329,7 @@ echo "Workflow triggered. Waiting for PR creation..."
    gh run watch ${WORKFLOW_RUN_ID}
    ```
 
-### Step 14: Enhance GitHub Release
+### Step 12: Enhance GitHub Release
 
 1. Wait for automatic release creation:
    ```bash
@@ -371,10 +342,10 @@ echo "Workflow triggered. Waiting for PR creation..."
 
 2. **Enhance the GitHub release:**
    ```bash
-   # Update release with our enhanced notes
+   # Update release with our release notes
    gh release edit v${NEW_VERSION} \
      --title "🚀 ComfyUI Frontend v${NEW_VERSION}" \
-     --notes-file github-release-notes-${NEW_VERSION}.md \
+     --notes-file release-notes-${NEW_VERSION}.md \
      --latest
    
    # Add any additional assets if needed
@@ -386,7 +357,7 @@ echo "Workflow triggered. Waiting for PR creation..."
    gh release view v${NEW_VERSION}
    ```
 
-### Step 15: Verify Multi-Channel Distribution
+### Step 13: Verify Multi-Channel Distribution
 
 1. **GitHub Release:**
    ```bash
@@ -424,7 +395,7 @@ echo "Workflow triggered. Waiting for PR creation..."
 
 4. **DISTRIBUTION VERIFICATION**: All channels published successfully?
 
-### Step 16: Post-Release Monitoring Setup
+### Step 14: Post-Release Monitoring Setup
 
 1. **Monitor immediate release health:**
    ```bash
@@ -492,8 +463,7 @@ echo "Workflow triggered. Waiting for PR creation..."
    - Plan next release cycle
 
    ## Files Generated
-   - \`release-notes-${NEW_VERSION}-$(date +%Y%m%d).md\` - Detailed changelog
-   - \`github-release-notes-${NEW_VERSION}.md\` - GitHub release notes
+   - \`release-notes-${NEW_VERSION}.md\` - Comprehensive release notes
    - \`post-release-checklist.md\` - Follow-up tasks
    EOF
    ```
@@ -544,7 +514,7 @@ echo "- GitHub: Update release with warning notes"
 The command implements multiple quality gates:
 
 1. **🔒 Security Gate**: Vulnerability scanning, secret detection
-2. **🧪 Quality Gate**: Full test suite, linting, type checking
+2. **🧪 Quality Gate**: Unit and component tests, linting, type checking
 3. **📋 Content Gate**: Changelog accuracy, release notes quality
 4. **🔄 Process Gate**: Release timing verification
 5. **✅ Verification Gate**: Multi-channel publishing confirmation


### PR DESCRIPTION
Simplifies the release command workflow by consolidating multiple redundant markdown files into a single comprehensive release notes file, and removes browser test requirement per team feedback.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4546-refactor-Streamline-create-frontend-release-command-23d6d73d3650819285c0d170714bbc2e) by [Unito](https://www.unito.io)
