### PR TITLE
[feat] Add bulk import failure info API and improve conflict detection

### DIFF
--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -27,6 +27,7 @@ enum ManagerRoute {
   LIST_INSTALLED = 'v2/customnode/installed',
   GET_NODES = 'v2/customnode/getmappings',
   IMPORT_FAIL_INFO = 'v2/customnode/import_fail_info',
+  IMPORT_FAIL_INFO_BULK = 'v2/customnode/import_fail_info_bulk',
   REBOOT = 'v2/manager/reboot',
   IS_LEGACY_MANAGER_UI = 'v2/manager/is_legacy_manager_ui',
   TASK_HISTORY = 'v2/manager/queue/history',
@@ -144,6 +145,21 @@ export const useComfyManagerService = () => {
     return executeRequest<any>(
       () =>
         managerApiClient.post(ManagerRoute.IMPORT_FAIL_INFO, params, {
+          signal
+        }),
+      { errorContext }
+    )
+  }
+
+  const getImportFailInfoBulk = async (
+    params: { cnr_ids?: string[]; urls?: string[] } = {},
+    signal?: AbortSignal
+  ) => {
+    const errorContext = 'Fetching bulk import failure information'
+
+    return executeRequest<Record<string, any>>(
+      () =>
+        managerApiClient.post(ManagerRoute.IMPORT_FAIL_INFO_BULK, params, {
           signal
         }),
       { errorContext }
@@ -289,6 +305,7 @@ export const useComfyManagerService = () => {
     // Pack management
     listInstalledPacks,
     getImportFailInfo,
+    getImportFailInfoBulk,
     installPack,
     uninstallPack,
     enablePack: installPack, // enable is done via install


### PR DESCRIPTION
## Summary
- Add bulk API endpoint for import failure info to reduce API calls from N to 1
- Implement conflict detection optimization for installed packages
- Fix InfoPanel to use stored conflict data instead of recalculating

## Changes
### Backend (ComfyUI-Manager)
- Added `import_fail_info_bulk` endpoint to both glob and legacy manager servers
- Supports bulk processing of `cnr_ids` and `urls` arrays
- Maintains same error handling pattern as original API

### Frontend
- Added bulk API method to `comfyManagerService.ts`
- Updated `useConflictDetection.ts` to use single bulk call instead of batch processing
- Modified `InfoPanel.vue` to use stored conflict data for installed packages
- Performance improvement: reduced potential 100+ API calls to 1 bulk request

## Test plan
- [x] Verify bulk API works for multiple package IDs
- [x] Test import failure detection with intentionally broken custom nodes
- [x] Confirm InfoPanel shows proper conflict data for installed packages
- [x] Validate compatibility with both legacy and current manager versions

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4550-feat-Add-bulk-import-failure-info-API-and-improve-conflict-detection-23d6d73d36508179a19ce7be97613f96) by [Unito](https://www.unito.io)
