### PR TITLE
[Design] Update PackVersionSelectorPopover styling

### DIFF
--- a/src/components/dialog/content/manager/PackVersionBadge.vue
+++ b/src/components/dialog/content/manager/PackVersionBadge.vue
@@ -21,7 +21,7 @@
     <Popover
       ref="popoverRef"
       :pt="{
-        content: { class: 'px-0' }
+        content: { class: 'p-0 shadow-lg' }
       }"
     >
       <PackVersionSelectorPopover

--- a/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
+++ b/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="w-64 mt-2">
-    <span class="pl-3 text-muted text-md font-semibold text-neutral-500">
-      {{ $t('manager.selectVersion') }}
-    </span>
+  <div class="w-64 pt-1">
+    <div class="py-2">
+      <span class="pl-3 text-md font-semibold text-neutral-500">
+        {{ $t('manager.selectVersion') }}
+      </span>
+    </div>
     <div
       v-if="isLoadingVersions || isQueueing"
       class="text-center text-muted py-4 flex flex-col items-center"
@@ -25,7 +27,10 @@
       option-value="value"
       :options="versionOptions"
       :highlight-on-select="false"
-      class="my-3 w-full max-h-[50vh] border-none shadow-none rounded-md"
+      class="w-full max-h-[50vh] border-none shadow-none rounded-md"
+      :pt="{
+        listContainer: { class: 'scrollbar-hide' }
+      }"
     >
       <template #option="slotProps">
         <div class="flex justify-between items-center w-full p-1">
@@ -59,9 +64,10 @@
       </template>
     </Listbox>
     <ContentDivider class="my-2" />
-    <div class="flex justify-end gap-2 p-1 px-3">
+    <div class="flex justify-end gap-2 py-1 px-3">
       <Button
         text
+        class="text-sm"
         severity="secondary"
         :label="$t('g.cancel')"
         :disabled="isQueueing"
@@ -70,7 +76,7 @@
       <Button
         severity="secondary"
         :label="$t('g.install')"
-        class="py-3 px-4 dark-theme:bg-unset bg-black/80 dark-theme:text-unset text-neutral-100 rounded-lg"
+        class="py-2.5 px-4 text-sm dark-theme:bg-unset bg-black/80 dark-theme:text-unset text-neutral-100 rounded-lg"
         :disabled="isQueueing"
         @click="handleSubmit"
       />


### PR DESCRIPTION
## Summary
- Remove margin and improve spacing for cleaner layout
- Add shadow to popover content for better visual separation
- Update button styling and sizing for consistency
- Add scrollbar-hide to listbox container
- Improve overall visual hierarchy and spacing

## Changes
- Updated PackVersionBadge.vue to add shadow styling to popover content
- Improved PackVersionSelectorPopover.vue layout and spacing
- Enhanced button styling for better consistency
- Added scrollbar hiding to listbox container

## Test plan
- [ ] Verify popover displays with improved shadow and spacing
- [ ] Check button styling is consistent across components
- [ ] Confirm scrollbar is hidden in listbox container
- [ ] Test visual hierarchy improvements

[Before]
<img width="250" height="355" alt="스크린샷 2025-07-28 오후 4 19 21" src="https://github.com/user-attachments/assets/758433bd-dc32-4215-b1d9-61e34204c759" />

[After]
<img width="274" height="346" alt="스크린샷 2025-07-28 오후 4 16 45" src="https://github.com/user-attachments/assets/56fdbc65-8b1d-4dc3-9976-c557604f2b7b" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4554-Design-Update-PackVersionSelectorPopover-styling-23d6d73d365081beb5f3cdf8b6f18712) by [Unito](https://www.unito.io)
