### PR TITLE
Add delay to breadcrumb and workflow tab tooltips

### DIFF
--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -1,7 +1,10 @@
 <template>
   <a
     ref="wrapperRef"
-    v-tooltip.bottom="item.label"
+    v-tooltip.bottom="{
+      value: item.label,
+      showDelay: 512
+    }"
     href="#"
     class="cursor-pointer p-breadcrumb-item-link"
     :class="{

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -3,7 +3,8 @@
     <span
       v-tooltip.bottom="{
         value: workflowOption.workflow.key,
-        class: 'workflow-tab-tooltip'
+        class: 'workflow-tab-tooltip',
+        showDelay: 512
       }"
       class="workflow-label text-sm max-w-[150px] min-w-[30px] truncate inline-block"
     >


### PR DESCRIPTION
Add 512ms delay to the tooltip that shows when hovering breadcrumbs or workflow tabs in the new menu system. Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/4526.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4559-Add-delay-to-breadcrumb-and-workflow-tab-tooltips-23e6d73d36508114b8fad5c08e8b3f88) by [Unito](https://www.unito.io)
