### PR TITLE
[fix] Prevent incorrect 'frontend_only' badges in subgraphs

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -887,26 +887,33 @@ export class ComfyApp {
   private updateVueAppNodeDefs(defs: Record<string, ComfyNodeDefV1>) {
     // Frontend only nodes registered by custom nodes.
     // Example: https://github.com/rgthree/rgthree-comfy/blob/dd534e5384be8cf0c0fa35865afe2126ba75ac55/src_web/comfyui/fast_groups_bypasser.ts#L10
-    const rawDefs: Record<string, ComfyNodeDefV1> = Object.fromEntries(
-      Object.entries(LiteGraph.registered_node_types).map(([name, node]) => [
+
+    // Only create frontend_only definitions for nodes that don't have backend definitions
+    const frontendOnlyDefs: Record<string, ComfyNodeDefV1> = {}
+    for (const [name, node] of Object.entries(
+      LiteGraph.registered_node_types
+    )) {
+      // Skip if we already have a backend definition or system definition
+      if (name in defs || name in SYSTEM_NODE_DEFS) {
+        continue
+      }
+
+      frontendOnlyDefs[name] = {
         name,
-        {
-          name,
-          display_name: name,
-          category: node.category || '__frontend_only__',
-          input: { required: {}, optional: {} },
-          output: [],
-          output_name: [],
-          output_is_list: [],
-          output_node: false,
-          python_module: 'custom_nodes.frontend_only',
-          description: `Frontend only node for ${name}`
-        } as ComfyNodeDefV1
-      ])
-    )
+        display_name: name,
+        category: node.category || '__frontend_only__',
+        input: { required: {}, optional: {} },
+        output: [],
+        output_name: [],
+        output_is_list: [],
+        output_node: false,
+        python_module: 'custom_nodes.frontend_only',
+        description: `Frontend only node for ${name}`
+      } as ComfyNodeDefV1
+    }
 
     const allNodeDefs = {
-      ...rawDefs,
+      ...frontendOnlyDefs,
       ...defs,
       ...SYSTEM_NODE_DEFS
     }

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -334,8 +334,10 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   }
   function fromLGraphNode(node: LGraphNode): ComfyNodeDefImpl | null {
     // Frontend-only nodes don't have nodeDef
-    // @ts-expect-error Optional chaining used in index
-    return nodeDefsByName.value[node.constructor?.nodeData?.name] ?? null
+    const nodeTypeName = node.constructor?.nodeData?.name
+    if (!nodeTypeName) return null
+    const nodeDef = nodeDefsByName.value[nodeTypeName] ?? null
+    return nodeDef
   }
 
   /**


### PR DESCRIPTION
Fixes #4566

This PR fixes an issue where pressing 'r' in a subgraph would cause all nodes to incorrectly display 'frontend_only' badges. The root cause was a fragile pattern in `updateVueAppNodeDefs()` that created frontend_only definitions for ALL nodes first, then relied on object spreading to overwrite them - which could fail in certain conditions.

The fix ensures frontend_only definitions are only created for nodes that genuinely lack backend definitions, eliminating the reliance on object spread ordering.

**Related:**
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/493 (introduced the fragile pattern)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4571-fix-Prevent-incorrect-frontend_only-badges-in-subgraphs-23f6d73d365081eaa249edfb3ab9d339) by [Unito](https://www.unito.io)
