### PR TITLE
[fix] Fix graph configuration callbacks not reaching subgraph nodes

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -752,16 +752,12 @@ export class ComfyApp {
       fixLinkInputSlots(this)
 
       // Fire callbacks before the onConfigure, this is used by widget inputs to setup the config
-      for (const node of graph.nodes) {
-        node.onGraphConfigured?.()
-      }
+      triggerCallbackOnAllNodes(this, 'onGraphConfigured')
 
       const r = onConfigure?.apply(this, args)
 
       // Fire after onConfigure, used by primitives to generate widget using input nodes config
-      for (const node of graph.nodes) {
-        node.onAfterGraphConfigured?.()
-      }
+      triggerCallbackOnAllNodes(this, 'onAfterGraphConfigured')
 
       return r
     }


### PR DESCRIPTION
## Summary
Fixed a critical issue where `onGraphConfigured` and `onAfterGraphConfigured` callbacks were only being triggered on root graph nodes, missing nodes within subgraphs.

## Impact
This bug caused several functionality issues in subgraphs:
- Widget input configurations not set up properly
- Primitive nodes failing to initialize
- Reroute nodes not propagating type changes
- Audio upload widgets not restoring saved file paths

## Changes
- Updated `#addAfterConfigureHandler` in `app.ts` to use `triggerCallbackOnAllNodes`
- This ensures callbacks reach all nodes in the graph hierarchy recursively

## Testing
- Existing tests pass
- Pre-commit hooks (ESLint, Prettier) pass

Fixes #4569

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4572-fix-Fix-graph-configuration-callbacks-not-reaching-subgraph-nodes-23f6d73d3650812394efde0aaf988004) by [Unito](https://www.unito.io)
