### PR TITLE
[fix] Fix link input slots not being updated in subgraphs

### DIFF
--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -154,6 +154,7 @@ export function migrateWidgetsValues<TWidgetValue>(
  */
 export function fixLinkInputSlots(graph: LGraph) {
   for (const node of graph.nodes) {
+    // Fix links for the current node
     for (const [inputIndex, input] of node.inputs.entries()) {
       const linkId = input.link
       if (!linkId) continue
@@ -162,6 +163,11 @@ export function fixLinkInputSlots(graph: LGraph) {
       if (!link) continue
 
       link.target_slot = inputIndex
+    }
+
+    // Recursively fix links in subgraphs
+    if (node.isSubgraphNode?.() && node.subgraph) {
+      fixLinkInputSlots(node.subgraph)
     }
   }
 }

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -153,6 +153,8 @@ export function migrateWidgetsValues<TWidgetValue>(
  * @param graph - The graph to fix links for.
  */
 export function fixLinkInputSlots(graph: LGraph) {
+  // Note: We can't use forEachNode here because we need access to the graph's
+  // links map at each level. Links are stored in their respective graph/subgraph.
   for (const node of graph.nodes) {
     // Fix links for the current node
     for (const [inputIndex, input] of node.inputs.entries()) {


### PR DESCRIPTION
## Summary
Fixed `fixLinkInputSlots` function to recursively process subgraphs when fixing link slot indices.

## Problem
The function was only processing nodes at the root graph level, missing nodes within subgraphs. This could cause incorrect link slot indices in subgraphs after node input modifications.

## Solution
Updated `fixLinkInputSlots` to recursively process subgraphs, matching the pattern used in `compressWidgetInputSlots` which already handles subgraphs correctly.

## Testing
- Unit tests pass
- Pre-commit hooks pass

Related to #4569

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4575-fix-Fix-link-input-slots-not-being-updated-in-subgraphs-23f6d73d3650814ea41fc9515d3c35eb) by [Unito](https://www.unito.io)
