### PR TITLE
[debug] Conflict detection debugging

### DIFF
--- a/src/composables/useManagerQueue.ts
+++ b/src/composables/useManagerQueue.ts
@@ -1,5 +1,5 @@
 import { useEventListener, whenever } from '@vueuse/core'
-import { pickBy } from 'lodash'
+import { mapKeys, pickBy } from 'lodash'
 import { Ref, computed, ref } from 'vue'
 
 import { app } from '@/scripts/app'
@@ -90,7 +90,15 @@ export const useManagerQueue = (
     taskHistory.value = filterHistoryByClientId(state.history)
 
     if (state.installed_packs) {
-      installedPacks.value = state.installed_packs
+      // The keys are 'cleaned' by stripping the version suffix.
+      // The pack object itself (the value) still contains the version info.
+      const packsWithCleanedKeys = mapKeys(
+        state.installed_packs,
+        (_value, key) => {
+          return key.split('@')[0]
+        }
+      )
+      installedPacks.value = packsWithCleanedKeys
     }
     updateProcessingState()
   }

--- a/src/stores/comfyManagerStore.ts
+++ b/src/stores/comfyManagerStore.ts
@@ -1,4 +1,5 @@
 import { whenever } from '@vueuse/core'
+import { mapKeys } from 'lodash'
 import { defineStore } from 'pinia'
 import { v4 as uuidv4 } from 'uuid'
 import { ref, watch } from 'vue'
@@ -167,7 +168,14 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
 
   const refreshInstalledList = async () => {
     const packs = await managerService.listInstalledPacks()
-    if (packs) installedPacks.value = packs
+    if (packs) {
+      // The keys are 'cleaned' by stripping the version suffix.
+      // The pack object itself (the value) still contains the version info.
+      const packsWithCleanedKeys = mapKeys(packs, (_value, key) => {
+        return key.split('@')[0]
+      })
+      installedPacks.value = packsWithCleanedKeys
+    }
     isStale.value = false
   }
 


### PR DESCRIPTION
## Summary
- Fix pack object keys to remove version suffix (@version) for consistent data handling
- Ensure checkmark is displayed correctly for 'Latest' version in version selector
- Remove duplicating conflict logic for cleaner code

## Changes
### Pack Object Key Cleaning (26d83b56)
- **useManagerQueue.ts**: Use `mapKeys` to strip version suffix from installed pack keys
- **comfyManagerStore.ts**: Update pack object handling to work with cleaned keys
- Fixes issue where pack objects had inconsistent key formats like `package@1_0_3`

### Version Selector UI Fix (ae98273f)
- **PackVersionSelectorPopover.vue**: Add helper to correctly handle 'latest' version alias
- Improve rendering performance with computed property to prevent popover closing unexpectedly
- Ensures checkmark appears for 'Latest' version option

### Code Cleanup (ef2ac684)
- **ManagerDialogContent.vue**: Remove duplicating conflict logic
- Streamline conflict detection code paths

## Test Results
- ✅ Pack keys are now consistent (without version suffix)
- ✅ Latest version shows checkmark correctly in version selector
- ✅ Conflict detection works with cleaned pack data structure

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4577-debug-Add-console-logs-for-conflict-detection-debugging-23f6d73d365081469a66c12f761aa453) by [Unito](https://www.unito.io)
