### PR TITLE
[feat] Remove default `Backspace` keybinding to clear workflow

### DIFF
--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -70,12 +70,6 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
-      key: 'Backspace'
-    },
-    commandId: 'Comfy.ClearWorkflow'
-  },
-  {
-    combo: {
       key: 'g',
       ctrl: true
     },


### PR DESCRIPTION
The shortcut to clear the workflow is Backspace, and when users want to delete a node, they also need to use Backspace after selecting the node. So sometimes users will accidentally clear the workflow. Even though they can use Ctrl+Z to undo it, it still feels annoying.

This PR removes the keybinding from the defaults.

It's generally safe to just completely remove a keybinding from coreKeybindings.ts since https://github.com/Comfy-Org/ComfyUI_frontend/pull/1630 as demonstrated by https://github.com/Comfy-Org/ComfyUI_frontend/pull/1643

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4586-feat-Remove-default-Backspace-keybinding-to-clear-workflow-2406d73d365081d7aa91f43e3454fc81) by [Unito](https://www.unito.io)
