### PR TITLE
[fix] Fix "Require confirmation before clearing workflow" setting not working

### DIFF
--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -264,12 +264,14 @@ test.describe('Group Node', () => {
     test('Copies and pastes group node after clearing workflow', async ({
       comfyPage
     }) => {
+      // Set setting
+      await comfyPage.setSetting('Comfy.ClearWorkflow.Confirmation', false)
+
+      // Clear workflow
       await comfyPage.menu.topbar.triggerTopbarCommand([
         'Edit',
         'Clear Workflow'
       ])
-      // Handle the dialog
-      comfyPage.page.on('dialog', (dialog) => dialog.accept())
 
       await comfyPage.ctrlV()
       await verifyNodeLoaded(comfyPage, 1)

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -268,6 +268,9 @@ test.describe('Group Node', () => {
         'Edit',
         'Clear Workflow'
       ])
+      // Handle the dialog
+      comfyPage.page.on('dialog', (dialog) => dialog.accept())
+
       await comfyPage.ctrlV()
       await verifyNodeLoaded(comfyPage, 1)
     })

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -265,7 +265,7 @@ test.describe('Group Node', () => {
       comfyPage
     }) => {
       // Set setting
-      await comfyPage.setSetting('Comfy.ClearWorkflow.Confirmation', false)
+      await comfyPage.setSetting('Comfy.ConfirmClear', false)
 
       // Clear workflow
       await comfyPage.menu.topbar.triggerTopbarCommand([

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -168,7 +168,7 @@ export function useCoreCommands(): ComfyCommand[] {
       function: () => {
         const settingStore = useSettingStore()
         if (
-          !settingStore.get('Comfy.ComfirmClear') ||
+          !settingStore.get('Comfy.ConfirmClear') ||
           confirm('Clear workflow?')
         ) {
           app.clean()

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -468,7 +468,6 @@ const zSettings = z.object({
   'LiteGraph.Canvas.LowQualityRenderingZoomThreshold': z.number(),
   'Comfy.Canvas.SelectionToolbox': z.boolean(),
   'LiteGraph.Node.TooltipDelay': z.number(),
-  'Comfy.ComfirmClear': z.boolean(),
   'LiteGraph.ContextMenu.Scaling': z.boolean(),
   'LiteGraph.Reroute.SplineOffset': z.number(),
   'Comfy.Toast.DisableReconnectingToast': z.boolean(),


### PR DESCRIPTION
## Description

Fixes the "Require confirmation when clearing workflow" setting (`Comfy.ConfirmClear`) not working with:
- The subgraph breadcrumb dropdown menu
- The new V3 menu system
- Keybindings assigned to the clear workflow command

The setting only worked correctly in the old UI menu.

## Root Cause Analysis

**The Original Issue**: A typo in `src/composables/useCoreCommands.ts` line 171
```typescript
!settingStore.get('Comfy.ComfirmClear') // ❌ Typo: 'ComfirmClear'
```

**Why TypeScript Didn't Catch It**: Instead of fixing the typo in the code, someone added the typo as a valid setting to `src/schemas/apiSchema.ts`
```typescript
'Comfy.ConfirmClear': z.boolean(),   // ✅ Correct spelling (line 379)
'Comfy.ComfirmClear': z.boolean(),   // ❌ Typo added to schema (line 471)
```

## Changes

1. **Fixed the typo** in `src/composables/useCoreCommands.ts`:
   - `'Comfy.ComfirmClear'` → `'Comfy.ConfirmClear'`

2. **Removed the duplicate typo setting** from `src/schemas/apiSchema.ts`:
   - Removed `'Comfy.ComfirmClear': z.boolean(),`
   - Kept the correct `'Comfy.ConfirmClear': z.boolean(),`

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4585

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4587-fix-Remove-duplicate-Comfy-ConfirmClear-setting-and-fix-typo-in-useCoreCommands-2406d73d3650810f9091f2437a8d676c) by [Unito](https://www.unito.io)
