### PR TITLE
[ci] Enable CI tests for all feature branch PRs

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -2,7 +2,7 @@ name: ESLint
 
 on:
   pull_request:
-    branches: [ main, master, dev*, core/*, desktop/* ]
+    branches-ignore: [ wip/*, draft/*, temp/* ]
 
 jobs:
   eslint:

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -2,7 +2,7 @@ name: Prettier Check
 
 on:
   pull_request:
-    branches: [ main, master, dev*, core/*, desktop/* ]
+    branches-ignore: [ wip/*, draft/*, temp/* ]
 
 jobs:
   prettier:

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master, core/*, desktop/*]
   pull_request:
-    branches: [main, master, dev*, core/*, desktop/*]
+    branches-ignore: [wip/*, draft/*, temp/*]
 
 jobs:
   setup:

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, master, dev*, core/*, desktop/* ]
   pull_request:
-    branches: [ main, master, dev*, core/*, desktop/* ]
+    branches-ignore: [ wip/*, draft/*, temp/* ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
This PR updates our GitHub Actions workflows to run CI tests on all pull requests (except obvious WIP branches), not just PRs targeting specific branches.

## Problem
Currently, CI only runs on PRs targeting main, master, dev*, core/*, or desktop/* branches. This means:
- Collaborators working on feature branches (like manager/refactor/*) don't get test feedback
- Issues are only discovered when merging to main branches
- No early validation of code quality

## Solution
Changed all test workflows to use `branches-ignore` pattern instead of explicit branch allowlist:
- Runs CI on ALL pull requests by default
- Excludes only: wip/*, draft/*, temp/* branches
- Gives immediate test feedback to all contributors

## Changes
- Updated test-ui.yaml (Playwright tests)
- Updated vitest.yaml (Unit/Component tests)  
- Updated eslint.yaml (Linting)

This ensures collaborators get test suite feedback on feature branches while still allowing them to skip CI for work-in-progress branches.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4591-ci-Enable-CI-tests-for-all-feature-branch-PRs-2406d73d365081328909d372698fb8e9) by [Unito](https://www.unito.io)
