### PR TITLE
[chore] Mark generated TypeScript files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 *.ts text eol=lf
 *.vue text eol=lf
 *.js text eol=lf
+
+# Generated files
+src/types/comfyRegistryTypes.ts linguist-generated=true
+src/types/generatedManagerTypes.ts linguist-generated=true


### PR DESCRIPTION
Marks  and  as generated files to exclude them from language statistics and collapse them by default in PR diffs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4592-chore-Mark-generated-TypeScript-files-in-gitattributes-2406d73d365081319d16f6ffd3889dea) by [Unito](https://www.unito.io)
