### PR TITLE
[feat] Improve SubgraphNode badge with sitemap icon and primary color

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -129,9 +129,15 @@ export const useLitegraphService = () => {
         void extensionService.invokeExtensionsAsync('nodeCreated', this)
         this.badges.push(
           new LGraphBadge({
-            text: '⇌',
-            fgColor: '#dad0de',
-            bgColor: '#b3b'
+            text: '',
+            iconOptions: {
+              unicode: '\ue96e',
+              fontFamily: 'PrimeIcons',
+              color: '#ffffff',
+              fontSize: 12
+            },
+            fgColor: '#ffffff',
+            bgColor: '#3b82f6'
           })
         )
       }


### PR DESCRIPTION
Enhances SubgraphNode visual identification by replacing the generic double arrow (⇌) with a meaningful sitemap icon from PrimeIcons and updating colors to use the primary blue theme for better consistency with the UI design system.

Before:

<img width="372" height="234" alt="Selection_1834" src="https://github.com/user-attachments/assets/44c3e01d-f0c3-434f-b00a-32501e92f290" />

After:

<img width="326" height="234" alt="Selection_1833" src="https://github.com/user-attachments/assets/a064ca70-f5b5-4155-88fe-b325d5d4730f" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4596-feat-Improve-SubgraphNode-badge-with-sitemap-icon-and-primary-color-2406d73d365081bc897ac8af0298648e) by [Unito](https://www.unito.io)
