### PR TITLE
[feat] Add theme-aware colors to minimap

### DIFF
--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -8,8 +8,8 @@ import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
-import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
 interface GraphCallbacks {
   onNodeAdded?: (node: LGraphNode) => void

--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -7,6 +7,7 @@ import type { NodeId } from '@/schemas/comfyWorkflowSchema'
 import { api } from '@/scripts/api'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
 interface GraphCallbacks {
   onNodeAdded?: (node: LGraphNode) => void
@@ -17,6 +18,7 @@ interface GraphCallbacks {
 export function useMinimap() {
   const settingStore = useSettingStore()
   const canvasStore = useCanvasStore()
+  const colorPaletteStore = useColorPaletteStore()
 
   const containerRef = ref<HTMLDivElement>()
   const canvasRef = ref<HTMLCanvasElement>()
@@ -52,12 +54,18 @@ export function useMinimap() {
 
   const width = 250
   const height = 200
-  const nodeColor = '#0B8CE999'
-  const linkColor = '#F99614'
-  const slotColor = '#F99614'
-  const viewportColor = '#FFF'
-  const backgroundColor = '#15161C'
-  const borderColor = '#333'
+
+  // Theme-aware colors for canvas drawing
+  const isLightTheme = computed(
+    () => colorPaletteStore.completedActivePalette.light_theme
+  )
+  const nodeColor = computed(
+    () => (isLightTheme.value ? '#3DA8E099' : '#0B8CE999') // lighter blue for light theme
+  )
+  const linkColor = computed(
+    () => (isLightTheme.value ? '#FFB347' : '#F99614') // lighter orange for light theme
+  )
+  const slotColor = computed(() => linkColor.value)
 
   const containerRect = ref({
     left: 0,
@@ -102,8 +110,8 @@ export function useMinimap() {
   const containerStyles = computed(() => ({
     width: `${width}px`,
     height: `${height}px`,
-    backgroundColor: backgroundColor,
-    border: `1px solid ${borderColor}`,
+    backgroundColor: isLightTheme.value ? '#FAF9F5' : '#15161C',
+    border: `1px solid ${isLightTheme.value ? '#ccc' : '#333'}`,
     borderRadius: '8px'
   }))
 
@@ -111,8 +119,8 @@ export function useMinimap() {
     transform: `translate(${viewportTransform.value.x}px, ${viewportTransform.value.y}px)`,
     width: `${viewportTransform.value.width}px`,
     height: `${viewportTransform.value.height}px`,
-    border: `2px solid ${viewportColor}`,
-    backgroundColor: `${viewportColor}33`,
+    border: `2px solid ${isLightTheme.value ? '#E0E0E0' : '#FFF'}`,
+    backgroundColor: `#FFF33`,
     willChange: 'transform',
     backfaceVisibility: 'hidden' as const,
     perspective: '1000px',
@@ -195,7 +203,7 @@ export function useMinimap() {
       const h = node.size[1] * scale.value
 
       // Render solid node blocks
-      ctx.fillStyle = nodeColor
+      ctx.fillStyle = nodeColor.value
       ctx.fillRect(x, y, w, h)
     }
   }
@@ -208,7 +216,7 @@ export function useMinimap() {
     const g = graph.value
     if (!g) return
 
-    ctx.strokeStyle = linkColor
+    ctx.strokeStyle = linkColor.value
     ctx.lineWidth = 1.4
 
     const slotRadius = 3.7 * Math.max(scale.value, 0.5) // Larger slots that scale
@@ -257,7 +265,7 @@ export function useMinimap() {
     }
 
     // Render connection slots on top
-    ctx.fillStyle = slotColor
+    ctx.fillStyle = slotColor.value
     for (const conn of connections) {
       // Output slot
       ctx.beginPath()

--- a/tests-ui/tests/composables/useMinimap.test.ts
+++ b/tests-ui/tests/composables/useMinimap.test.ts
@@ -112,6 +112,14 @@ vi.mock('@/stores/settingStore', () => ({
   useSettingStore: vi.fn(() => defaultSettingStore)
 }))
 
+vi.mock('@/stores/workspace/colorPaletteStore', () => ({
+  useColorPaletteStore: vi.fn(() => ({
+    completedActivePalette: {
+      light_theme: false
+    }
+  }))
+}))
+
 vi.mock('@/scripts/api', () => ({
   api: {
     addEventListener: vi.fn(),
@@ -736,7 +744,7 @@ describe('useMinimap', () => {
   })
 
   describe('container styles', () => {
-    it('should provide correct container styles', () => {
+    it('should provide correct container styles for dark theme', () => {
       const minimap = useMinimap()
       const styles = minimap.containerStyles.value
 


### PR DESCRIPTION
Adds automatic light/dark theme adaptation to the minimap component. The minimap now uses appropriate colors that automatically switch when users change between light and dark themes, improving visual consistency and readability across all theme modes.

<img width="3822" height="2040" alt="Selection_1844" src="https://github.com/user-attachments/assets/27d172f0-52fa-4fd5-b9dc-b3eead3c9f31" />



**Changes:**
- Container background: ivory for light theme, dark for dark theme
- Node and link colors: lighter shades for light theme, original colors for dark theme  
- Border colors: theme-appropriate contrast levels
- All colors update automatically when theme changes via color palette settings

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4598-feat-Add-theme-aware-colors-to-minimap-2406d73d365081cba80dea0c3c44b734) by [Unito](https://www.unito.io)
