### PR TITLE
[Style] Update "convert to subgraph" icon

### DIFF
--- a/src/components/graph/selectionToolbox/ConvertToSubgraphButton.vue
+++ b/src/components/graph/selectionToolbox/ConvertToSubgraphButton.vue
@@ -10,7 +10,7 @@
     @click="() => commandStore.execute('Comfy.Graph.ConvertToSubgraph')"
   >
     <template #icon>
-      <i-comfy:workflow />
+      <i-lucide:shrink />
     </template>
   </Button>
 </template>


### PR DESCRIPTION
Updates selection toolbox icon for converting to subgraph to the `lucide-shrink` icon.

Before:

<img width="828" height="934" alt="Selection_1849" src="https://github.com/user-attachments/assets/f44e27ff-c713-4cb5-af92-b5a8cf683ecc" />


After:

<img width="1088" height="1066" alt="Selection_1845" src="https://github.com/user-attachments/assets/85415950-1e36-4ad1-89c9-3bd1996d1c77" />

<img width="1088" height="1066" alt="Selection_1848" src="https://github.com/user-attachments/assets/54cb9e61-5822-4055-8d3d-be705ddd5622" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4611-Style-Update-convert-to-subgraph-icon-2406d73d365081a7bbf8eca4530ccf28) by [Unito](https://www.unito.io)
