### PR TITLE
include litegraph augmentation in generated declarations

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export type {
   parseNodeExecutionId,
   createNodeExecutionId
 } from './nodeIdentification'
+export type { DOMWidget, DOMWidgetOptions } from '@/scripts/domWidget'
 export type {
   EmbeddingsResponse,
   ExtensionsResponse,

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -1,5 +1,7 @@
 import '@comfyorg/litegraph'
 import type { LLink, Size } from '@comfyorg/litegraph'
+import type { ExecutableLGraphNode, ExecutionId } from '@comfyorg/litegraph'
+import type { IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
 
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
@@ -69,9 +71,6 @@ declare module '@comfyorg/litegraph/dist/interfaces' {
  *  ComfyUI extensions of litegraph
  */
 declare module '@comfyorg/litegraph' {
-  import type { ExecutableLGraphNode, ExecutionId } from '@comfyorg/litegraph'
-  import type { IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
-
   interface LGraphNodeConstructor<T extends LGraphNode = LGraphNode> {
     type?: string
     comfyClass: string


### PR DESCRIPTION
Resolves #4120 

Augmentations to `@comfyorg/litegraph` and DOMWidget interfaces from the frontend are not currently present in `@comfyorg/comfyui-frontend-types`

Checking the diff between the types generated by `npm run build:types` after moving/adding the imports, the litegraph augmentations made by the frontend are present.

[diff.txt](https://github.com/user-attachments/files/21519913/diff.txt)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4614-include-litegraph-augmentation-in-generated-declarations-2416d73d365081a59b8ef5eee3d5cb28) by [Unito](https://www.unito.io)
