### PR TITLE
[fix] Preserve per-workflow subgraph navigation state

### DIFF
--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -115,6 +115,21 @@ export function useMinimap() {
     () => workflowStore.activeSubgraph,
     () => {
       graph.value = app.canvas?.graph
+      // Force viewport update when switching subgraphs
+      if (initialized.value && visible.value) {
+        updateViewport()
+      }
+    }
+  )
+
+  // Update viewport when switching workflows
+  watch(
+    () => workflowStore.activeWorkflow,
+    () => {
+      // Force viewport update when switching workflows
+      if (initialized.value && visible.value) {
+        updateViewport()
+      }
     }
   )
 

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -73,7 +73,8 @@ export class ChangeTracker {
       offset: [app.canvas.ds.offset[0], app.canvas.ds.offset[1]]
     }
     const navigation = useSubgraphNavigationStore().exportState()
-    this.subgraphState = navigation.length ? { navigation } : undefined
+    // Always store the navigation state, even if empty (root level)
+    this.subgraphState = { navigation }
   }
 
   restore() {
@@ -90,8 +91,14 @@ export class ChangeTracker {
 
       const activeId = navigation.at(-1)
       if (activeId) {
+        // Navigate to the saved subgraph
         const subgraph = app.graph.subgraphs.get(activeId)
-        if (subgraph) app.canvas.setGraph(subgraph)
+        if (subgraph) {
+          app.canvas.setGraph(subgraph)
+        }
+      } else {
+        // Empty navigation array means root level
+        app.canvas.setGraph(app.graph)
       }
     }
   }

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -105,11 +105,25 @@ export const useSubgraphNavigationStore = defineStore(
     /**
      * Update the navigation stack when the active subgraph changes.
      * @param subgraph The new active subgraph.
+     * @param prevSubgraph The previous active subgraph.
      */
-    const onNavigated = (subgraph: Subgraph | undefined) => {
+    const onNavigated = (
+      subgraph: Subgraph | undefined,
+      prevSubgraph: Subgraph | undefined
+    ) => {
+      // Save viewport state for the graph we're leaving
+      if (prevSubgraph) {
+        // Leaving a subgraph
+        saveViewport(prevSubgraph.id)
+      } else if (!prevSubgraph && subgraph) {
+        // Leaving root graph to enter a subgraph
+        saveViewport('root')
+      }
+
       const isInRootGraph = !subgraph
       if (isInRootGraph) {
         idStack.value.length = 0
+        restoreViewport('root')
         return
       }
 
@@ -121,6 +135,9 @@ export const useSubgraphNavigationStore = defineStore(
         // Treat as if opening a new subgraph
         idStack.value = [subgraph.id]
       }
+
+      // Always try to restore viewport for the target subgraph
+      restoreViewport(subgraph.id)
     }
 
     // Update navigation stack when opened subgraph changes (also triggers when switching workflows)

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -141,7 +141,12 @@ export const useSubgraphNavigationStore = defineStore(
     }
 
     // Update navigation stack when opened subgraph changes (also triggers when switching workflows)
-    watch(() => workflowStore.activeSubgraph, onNavigated)
+    watch(
+      () => workflowStore.activeSubgraph,
+      (newValue, oldValue) => {
+        onNavigated(newValue, oldValue)
+      }
+    )
 
     return {
       activeSubgraph,

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -602,7 +602,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
         return path
       }
 
-      for (const node of graph._nodes) {
+      for (const node of graph.nodes) {
         if (node.isSubgraphNode() && node.subgraph) {
           const result = findSubgraphPath(node.subgraph, targetUuid, [
             ...path,

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -602,7 +602,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
         return path
       }
 
-      for (const node of graph.nodes) {
+      for (const node of graph._nodes) {
         if (node.isSubgraphNode() && node.subgraph) {
           const result = findSubgraphPath(node.subgraph, targetUuid, [
             ...path,

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -205,7 +205,7 @@ export function findSubgraphByUuid(
   targetUuid: string
 ): Subgraph | null {
   // Check all nodes in the current graph
-  for (const node of graph._nodes) {
+  for (const node of graph.nodes) {
     if (node.isSubgraphNode?.() && node.subgraph) {
       if (node.subgraph.id === targetUuid) {
         return node.subgraph
@@ -235,7 +235,7 @@ export function findSubgraphPathById(
   while (stack.length > 0) {
     const { graph, path } = stack.pop()!
 
-    for (const node of graph._nodes) {
+    for (const node of graph.nodes) {
       if (node.isSubgraphNode?.() && node.subgraph) {
         const newPath = [...path, String(node.subgraph.id)]
         if (node.subgraph.id === targetId) {

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -219,6 +219,37 @@ export function findSubgraphByUuid(
 }
 
 /**
+ * Iteratively finds the path of node IDs to a subgraph.
+ * @param rootGraph The graph to start searching from.
+ * @param targetId The ID of the subgraph to find.
+ * @returns An array of subgraph IDs representing the path, or `null` if not found.
+ */
+export function findSubgraphPathById(
+  rootGraph: LGraph,
+  targetId: string
+): string[] | null {
+  const stack: { graph: LGraph | Subgraph; path: string[] }[] = [
+    { graph: rootGraph, path: [] }
+  ]
+
+  while (stack.length > 0) {
+    const { graph, path } = stack.pop()!
+
+    for (const node of graph._nodes) {
+      if (node.isSubgraphNode?.() && node.subgraph) {
+        const newPath = [...path, String(node.subgraph.id)]
+        if (node.subgraph.id === targetId) {
+          return newPath
+        }
+        stack.push({ graph: node.subgraph, path: newPath })
+      }
+    }
+  }
+
+  return null
+}
+
+/**
  * Get a node by its execution ID from anywhere in the graph hierarchy.
  * Execution IDs use hierarchical format like "123:456:789" for nested nodes.
  *

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -235,12 +235,12 @@ export function findSubgraphPathById(
   while (stack.length > 0) {
     const { graph, path } = stack.pop()!
 
-    // Check if graph exists and has nodes property
-    if (!graph || !graph.nodes || !Array.isArray(graph.nodes)) {
+    // Check if graph exists and has _nodes property
+    if (!graph || !graph._nodes || !Array.isArray(graph._nodes)) {
       continue
     }
 
-    for (const node of graph.nodes) {
+    for (const node of graph._nodes) {
       if (node.isSubgraphNode?.() && node.subgraph) {
         const newPath = [...path, String(node.subgraph.id)]
         if (node.subgraph.id === targetId) {

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -219,7 +219,7 @@ export function findSubgraphByUuid(
 }
 
 /**
- * Iteratively finds the path of node IDs to a subgraph.
+ * Iteratively finds the path of subgraph IDs to a target subgraph.
  * @param rootGraph The graph to start searching from.
  * @param targetId The ID of the subgraph to find.
  * @returns An array of subgraph IDs representing the path, or `null` if not found.

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -235,6 +235,11 @@ export function findSubgraphPathById(
   while (stack.length > 0) {
     const { graph, path } = stack.pop()!
 
+    // Check if graph exists and has nodes property
+    if (!graph || !graph.nodes || !Array.isArray(graph.nodes)) {
+      continue
+    }
+
     for (const node of graph.nodes) {
       if (node.isSubgraphNode?.() && node.subgraph) {
         const newPath = [...path, String(node.subgraph.id)]

--- a/tests-ui/tests/store/subgraphNavigationStore.test.ts
+++ b/tests-ui/tests/store/subgraphNavigationStore.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/scripts/app', () => {
   return {
     app: {
       graph: {
+        _nodes: [],
         nodes: [],
         subgraphs: new Map(),
         getNodeById: vi.fn()
@@ -141,7 +142,8 @@ describe('useSubgraphNavigationStore', () => {
     const mockSubgraph = {
       id: 'subgraph-1',
       rootGraph: (app as any).graph,
-      nodes: [] // Add nodes property
+      _nodes: [],
+      nodes: []
     }
 
     // Add the subgraph to the graph's subgraphs map

--- a/tests-ui/tests/store/subgraphNavigationStore.test.ts
+++ b/tests-ui/tests/store/subgraphNavigationStore.test.ts
@@ -7,17 +7,36 @@ import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { useWorkflowStore } from '@/stores/workflowStore'
 import type { ComfyWorkflow } from '@/stores/workflowStore'
 
-vi.mock('@/scripts/app', () => ({
-  app: {
-    graph: {
-      nodes: [],
-      subgraphs: new Map(),
-      getNodeById: vi.fn()
+vi.mock('@/scripts/app', () => {
+  const mockCanvas = {
+    subgraph: null,
+    ds: {
+      scale: 1,
+      offset: [0, 0],
+      state: {
+        scale: 1,
+        offset: [0, 0]
+      }
     },
-    canvas: {
-      subgraph: null
+    setDirty: vi.fn()
+  }
+
+  return {
+    app: {
+      graph: {
+        nodes: [],
+        subgraphs: new Map(),
+        getNodeById: vi.fn()
+      },
+      canvas: mockCanvas
     }
   }
+})
+
+vi.mock('@/stores/graphStore', () => ({
+  useCanvasStore: () => ({
+    getCanvas: () => (app as any).canvas
+  })
 }))
 
 vi.mock('@/utils/graphTraversalUtil', () => ({

--- a/tests-ui/tests/store/subgraphNavigationStore.viewport.test.ts
+++ b/tests-ui/tests/store/subgraphNavigationStore.viewport.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/scripts/app', () => {
   return {
     app: {
       graph: {
+        nodes: [],
         subgraphs: new Map(),
         getNodeById: vi.fn()
       },
@@ -173,12 +174,26 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       const navigationStore = useSubgraphNavigationStore()
       const workflowStore = useWorkflowStore()
 
+      // Create mock subgraph with nodes property
+      const mockRootGraph = {
+        nodes: [],
+        subgraphs: new Map(),
+        getNodeById: vi.fn()
+      }
+      const subgraph1 = {
+        id: 'sub1',
+        rootGraph: mockRootGraph,
+        nodes: []
+      }
+
       // Start at root with custom viewport
       mockCanvas.ds.state.scale = 2
       mockCanvas.ds.state.offset = [100, 100]
 
+      // Manually save root viewport before navigating
+      navigationStore.saveViewport('root')
+
       // Navigate to subgraph
-      const subgraph1 = { id: 'sub1' }
       workflowStore.activeSubgraph = subgraph1 as any
       await nextTick()
 
@@ -192,6 +207,9 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       mockCanvas.ds.state.scale = 0.5
       mockCanvas.ds.state.offset = [-50, -50]
 
+      // Manually save subgraph viewport before navigating back
+      navigationStore.saveViewport('sub1')
+
       // Navigate back to root
       workflowStore.activeSubgraph = undefined
       await nextTick()
@@ -201,6 +219,9 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       expect(sub1Viewport).toBeDefined()
       expect(sub1Viewport?.scale).toBe(0.5)
       expect(sub1Viewport?.offset).toEqual([-50, -50])
+
+      // Manually restore root viewport
+      navigationStore.restoreViewport('root')
 
       // Root viewport should be restored
       expect(mockCanvas.ds.scale).toBe(2)

--- a/tests-ui/tests/store/subgraphNavigationStore.viewport.test.ts
+++ b/tests-ui/tests/store/subgraphNavigationStore.viewport.test.ts
@@ -190,14 +190,11 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       mockCanvas.ds.state.scale = 2
       mockCanvas.ds.state.offset = [100, 100]
 
-      // Manually save root viewport before navigating
-      navigationStore.saveViewport('root')
-
       // Navigate to subgraph
       workflowStore.activeSubgraph = subgraph1 as any
       await nextTick()
 
-      // Root viewport should have been saved
+      // Root viewport should have been saved automatically
       const rootViewport = navigationStore.viewportCache.get('root')
       expect(rootViewport).toBeDefined()
       expect(rootViewport?.scale).toBe(2)
@@ -207,23 +204,17 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       mockCanvas.ds.state.scale = 0.5
       mockCanvas.ds.state.offset = [-50, -50]
 
-      // Manually save subgraph viewport before navigating back
-      navigationStore.saveViewport('sub1')
-
       // Navigate back to root
       workflowStore.activeSubgraph = undefined
       await nextTick()
 
-      // Subgraph viewport should have been saved
+      // Subgraph viewport should have been saved automatically
       const sub1Viewport = navigationStore.viewportCache.get('sub1')
       expect(sub1Viewport).toBeDefined()
       expect(sub1Viewport?.scale).toBe(0.5)
       expect(sub1Viewport?.offset).toEqual([-50, -50])
 
-      // Manually restore root viewport
-      navigationStore.restoreViewport('root')
-
-      // Root viewport should be restored
+      // Root viewport should be restored automatically
       expect(mockCanvas.ds.scale).toBe(2)
       expect(mockCanvas.ds.offset).toEqual([100, 100])
     })

--- a/tests-ui/tests/store/subgraphNavigationStore.viewport.test.ts
+++ b/tests-ui/tests/store/subgraphNavigationStore.viewport.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/scripts/app', () => {
   return {
     app: {
       graph: {
+        _nodes: [],
         nodes: [],
         subgraphs: new Map(),
         getNodeById: vi.fn()
@@ -174,8 +175,9 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       const navigationStore = useSubgraphNavigationStore()
       const workflowStore = useWorkflowStore()
 
-      // Create mock subgraph with nodes property
+      // Create mock subgraph with both _nodes and nodes properties
       const mockRootGraph = {
+        _nodes: [],
         nodes: [],
         subgraphs: new Map(),
         getNodeById: vi.fn()
@@ -183,6 +185,7 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       const subgraph1 = {
         id: 'sub1',
         rootGraph: mockRootGraph,
+        _nodes: [],
         nodes: []
       }
 

--- a/tests-ui/tests/store/workflowStore.test.ts
+++ b/tests-ui/tests/store/workflowStore.test.ts
@@ -598,6 +598,7 @@ describe('useWorkflowStore', () => {
       const mockSubgraph = {
         id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         rootGraph: null as any,
+        _nodes: [],
         nodes: []
       }
 
@@ -608,6 +609,7 @@ describe('useWorkflowStore', () => {
       }
 
       const mockRootGraph = {
+        _nodes: [mockNode],
         nodes: [mockNode],
         subgraphs: new Map([[mockSubgraph.id, mockSubgraph]]),
         getNodeById: (id: string | number) => {

--- a/tests-ui/tests/store/workflowStore.test.ts
+++ b/tests-ui/tests/store/workflowStore.test.ts
@@ -597,7 +597,8 @@ describe('useWorkflowStore', () => {
       // Setup mock graph structure with subgraphs
       const mockSubgraph = {
         id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-        _nodes: []
+        rootGraph: null as any,
+        nodes: []
       }
 
       const mockNode = {
@@ -607,13 +608,15 @@ describe('useWorkflowStore', () => {
       }
 
       const mockRootGraph = {
-        _nodes: [mockNode],
+        nodes: [mockNode],
         subgraphs: new Map([[mockSubgraph.id, mockSubgraph]]),
         getNodeById: (id: string | number) => {
           if (String(id) === '123') return mockNode
           return null
         }
       }
+
+      mockSubgraph.rootGraph = mockRootGraph as any
 
       vi.mocked(comfyApp).graph = mockRootGraph as any
       vi.mocked(comfyApp.canvas).subgraph = mockSubgraph as any


### PR DESCRIPTION
## Summary
• Fixes subgraph navigation not preserving position when switching between workflow tabs
• Each workflow now remembers its own subgraph navigation state independently

## Changes
• Store/restore subgraph navigation state per workflow in changeTracker
• Store navigation state before switching workflows in WorkflowTabs  
• Always store navigation state explicitly (empty array for root level)
• Fix canvas not returning to root when restoring empty navigation

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4605, Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4602

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4616-fix-Preserve-per-workflow-subgraph-navigation-state-2416d73d365081fcbe2eee938206d1d8) by [Unito](https://www.unito.io)
