### PR TITLE
[feat] Move partial execution to the backend and make work with subgraphs

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -33,7 +33,7 @@ import {
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes
 } from '@/utils/graphTraversalUtil'
-import { getSelectedOutputNodes } from '@/utils/nodeFilterUtil'
+import { filterOutputNodes } from '@/utils/nodeFilterUtil'
 
 const moveSelectedNodesVersionAdded = '1.22.2'
 
@@ -368,7 +368,7 @@ export function useCoreCommands(): ComfyCommand[] {
       function: async () => {
         const batchCount = useQueueSettingsStore().batchCount
         const selectedNodes = getSelectedNodes()
-        const selectedOutputNodes = getSelectedOutputNodes(selectedNodes)
+        const selectedOutputNodes = filterOutputNodes(selectedNodes)
 
         if (selectedOutputNodes.length === 0) {
           toastStore.add({

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -29,7 +29,10 @@ import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { getAllNonIoNodesInSubgraph } from '@/utils/graphTraversalUtil'
+import {
+  getAllNonIoNodesInSubgraph,
+  getExecutionIdsForSelectedNodes
+} from '@/utils/graphTraversalUtil'
 
 const moveSelectedNodesVersionAdded = '1.22.2'
 
@@ -363,10 +366,11 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.19.6',
       function: async () => {
         const batchCount = useQueueSettingsStore().batchCount
-        const queueNodeIds = getSelectedNodes()
-          .filter((node) => node.constructor.nodeData?.output_node)
-          .map((node) => node.id)
-        if (queueNodeIds.length === 0) {
+        const selectedOutputNodes = getSelectedNodes().filter(
+          (node) => node.constructor.nodeData?.output_node
+        )
+
+        if (selectedOutputNodes.length === 0) {
           toastStore.add({
             severity: 'error',
             summary: t('toastMessages.nothingToQueue'),
@@ -375,7 +379,11 @@ export function useCoreCommands(): ComfyCommand[] {
           })
           return
         }
-        await app.queuePrompt(0, batchCount, queueNodeIds)
+
+        // Get execution IDs for all selected output nodes and their descendants
+        const executionIds =
+          getExecutionIdsForSelectedNodes(selectedOutputNodes)
+        await app.queuePrompt(0, batchCount, executionIds)
       }
     },
     {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -33,6 +33,7 @@ import {
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes
 } from '@/utils/graphTraversalUtil'
+import { getSelectedOutputNodes } from '@/utils/nodeFilterUtil'
 
 const moveSelectedNodesVersionAdded = '1.22.2'
 
@@ -366,9 +367,8 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.19.6',
       function: async () => {
         const batchCount = useQueueSettingsStore().batchCount
-        const selectedOutputNodes = getSelectedNodes().filter(
-          (node) => node.constructor.nodeData?.output_node
-        )
+        const selectedNodes = getSelectedNodes()
+        const selectedOutputNodes = getSelectedOutputNodes(selectedNodes)
 
         if (selectedOutputNodes.length === 0) {
           toastStore.add({

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -40,6 +40,7 @@ import { WorkflowTemplates } from '@/types/workflowTemplateTypes'
 interface QueuePromptRequestBody {
   client_id: string
   prompt: ComfyApiWorkflow
+  partial_execution_targets?: string[]
   extra_data: {
     extra_pnginfo: {
       workflow: ComfyWorkflowJSON
@@ -611,17 +612,22 @@ export class ComfyApi extends EventTarget {
    * Queues a prompt to be executed
    * @param {number} number The index at which to queue the prompt, passing -1 will insert the prompt at the front of the queue
    * @param {object} prompt The prompt data to queue
+   * @param {string[]} partialExecutionTargets Optional list of node IDs to execute (partial execution)
    * @throws {PromptExecutionError} If the prompt fails to execute
    */
   async queuePrompt(
     number: number,
-    data: { output: ComfyApiWorkflow; workflow: ComfyWorkflowJSON }
+    data: { output: ComfyApiWorkflow; workflow: ComfyWorkflowJSON },
+    partialExecutionTargets?: string[]
   ): Promise<PromptResponse> {
     const { output: prompt, workflow } = data
 
     const body: QueuePromptRequestBody = {
       client_id: this.clientId ?? '', // TODO: Unify clientId access
       prompt,
+      ...(partialExecutionTargets && {
+        partial_execution_targets: partialExecutionTargets
+      }),
       extra_data: {
         auth_token_comfy_org: this.authToken,
         api_key_comfy_org: this.apiKey,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -59,6 +59,7 @@ import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 import { ExtensionManager } from '@/types/extensionTypes'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
 import {
@@ -127,7 +128,7 @@ export class ComfyApp {
   #queueItems: {
     number: number
     batchCount: number
-    queueNodeIds?: NodeId[]
+    queueNodeIds?: NodeExecutionId[]
   }[] = []
   /**
    * If the queue is currently being processed
@@ -1248,7 +1249,7 @@ export class ComfyApp {
   async queuePrompt(
     number: number,
     batchCount: number = 1,
-    queueNodeIds?: NodeId[]
+    queueNodeIds?: NodeExecutionId[]
   ): Promise<boolean> {
     this.#queueItems.push({ number, batchCount, queueNodeIds })
 
@@ -1283,11 +1284,9 @@ export class ComfyApp {
             api.authToken = comfyOrgAuthToken
             api.apiKey = comfyOrgApiKey ?? undefined
             // Pass queueNodeIds as partial_execution_targets to backend
-            const res = await api.queuePrompt(
-              number,
-              p,
-              queueNodeIds?.map(String)
-            )
+            const res = await api.queuePrompt(number, p, {
+              partialExecutionTargets: queueNodeIds
+            })
             delete api.authToken
             delete api.apiKey
             executionStore.lastNodeErrors = res.node_errors ?? null

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1278,12 +1278,10 @@ export class ComfyApp {
             executeWidgetsCallback(subgraph.nodes, 'beforeQueued')
           }
 
-          // Don't pass queueNodeIds to graphToPrompt anymore - let backend handle partial execution
           const p = await this.graphToPrompt(this.graph)
           try {
             api.authToken = comfyOrgAuthToken
             api.apiKey = comfyOrgApiKey ?? undefined
-            // Pass queueNodeIds as partial_execution_targets to backend
             const res = await api.queuePrompt(number, p, {
               partialExecutionTargets: queueNodeIds
             })

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -1,6 +1,6 @@
 import type { LGraph, LGraphNode, Subgraph } from '@comfyorg/litegraph'
 
-import type { NodeLocatorId } from '@/types/nodeIdentification'
+import type { NodeExecutionId, NodeLocatorId } from '@/types/nodeIdentification'
 import { parseNodeLocatorId } from '@/types/nodeIdentification'
 
 import { isSubgraphIoNode } from './typeGuardUtil'
@@ -436,11 +436,11 @@ export function collectFromNodes<T, C>(
  */
 export function getExecutionIdsForSelectedNodes(
   selectedNodes: LGraphNode[]
-): string[] {
+): NodeExecutionId[] {
   return collectFromNodes(
     selectedNodes,
     // Collector: build execution ID for each node
-    (node, parentExecutionId: string) => {
+    (node, parentExecutionId: string): NodeExecutionId => {
       const nodeId = String(node.id)
       return parentExecutionId ? `${parentExecutionId}:${nodeId}` : nodeId
     },

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -383,10 +383,11 @@ export function traverseNodesDepthFirst<T>(
 
     // If it's a subgraph and we should expand, add children to stack
     if (expandSubgraphs && node.isSubgraphNode?.() && node.subgraph) {
-      // Add in reverse order to maintain left-to-right processing
-      const children = Array.from(node.subgraph.nodes).reverse()
-      for (const childNode of children) {
-        stack.push({ node: childNode, context: childContext })
+      // Process children in reverse order to maintain left-to-right DFS processing
+      // when popping from stack (LIFO). Iterate backwards to avoid array reversal.
+      const children = node.subgraph.nodes
+      for (let i = children.length - 1; i >= 0; i--) {
+        stack.push({ node: children[i], context: childContext })
       }
     }
   }

--- a/src/utils/nodeFilterUtil.ts
+++ b/src/utils/nodeFilterUtil.ts
@@ -1,25 +1,21 @@
 import type { LGraphNode } from '@comfyorg/litegraph'
 
 /**
+ * Checks if a node is an output node.
+ * Output nodes are nodes that have the output_node flag set in their nodeData.
+ *
+ * @param node - The node to check
+ * @returns True if the node is an output node, false otherwise
+ */
+export const isOutputNode = (node: LGraphNode) =>
+  node.constructor.nodeData?.output_node
+
+/**
  * Filters nodes to find only output nodes.
  * Output nodes are nodes that have the output_node flag set in their nodeData.
  *
  * @param nodes - Array of nodes to filter
  * @returns Array of output nodes only
  */
-export function filterOutputNodes(nodes: LGraphNode[]): LGraphNode[] {
-  return nodes.filter((node) => node.constructor.nodeData?.output_node)
-}
-
-/**
- * Gets selected output nodes from an array of selected nodes.
- * This is a convenience function that combines node filtering with output node detection.
- *
- * @param selectedNodes - Array of selected nodes
- * @returns Array of selected nodes that are output nodes
- */
-export function getSelectedOutputNodes(
-  selectedNodes: LGraphNode[]
-): LGraphNode[] {
-  return filterOutputNodes(selectedNodes)
-}
+export const filterOutputNodes = (nodes: LGraphNode[]): LGraphNode[] =>
+  nodes.filter(isOutputNode)

--- a/src/utils/nodeFilterUtil.ts
+++ b/src/utils/nodeFilterUtil.ts
@@ -1,0 +1,25 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+
+/**
+ * Filters nodes to find only output nodes.
+ * Output nodes are nodes that have the output_node flag set in their nodeData.
+ *
+ * @param nodes - Array of nodes to filter
+ * @returns Array of output nodes only
+ */
+export function filterOutputNodes(nodes: LGraphNode[]): LGraphNode[] {
+  return nodes.filter((node) => node.constructor.nodeData?.output_node)
+}
+
+/**
+ * Gets selected output nodes from an array of selected nodes.
+ * This is a convenience function that combines node filtering with output node detection.
+ *
+ * @param selectedNodes - Array of selected nodes
+ * @returns Array of selected nodes that are output nodes
+ */
+export function getSelectedOutputNodes(
+  selectedNodes: LGraphNode[]
+): LGraphNode[] {
+  return filterOutputNodes(selectedNodes)
+}

--- a/tests-ui/tests/utils/graphTraversalUtil.test.ts
+++ b/tests-ui/tests/utils/graphTraversalUtil.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   collectAllNodes,
+  collectFromNodes,
   findNodeInHierarchy,
   findSubgraphByUuid,
   forEachNode,
   forEachSubgraphNode,
   getAllNonIoNodesInSubgraph,
+  getExecutionIdsForSelectedNodes,
   getLocalNodeIdFromExecutionId,
   getNodeByExecutionId,
   getNodeByLocatorId,
@@ -16,6 +18,7 @@ import {
   mapAllNodes,
   mapSubgraphNodes,
   parseExecutionId,
+  traverseNodesDepthFirst,
   traverseSubgraphPath,
   triggerCallbackOnAllNodes,
   visitGraphNodes
@@ -805,6 +808,265 @@ describe('graphTraversalUtil', () => {
         const nonIoNodes = getAllNonIoNodesInSubgraph(subgraph)
 
         expect(nonIoNodes).toHaveLength(0)
+      })
+    })
+
+    describe('traverseNodesDepthFirst', () => {
+      it('should traverse nodes in depth-first order', () => {
+        const visited: string[] = []
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2'),
+          createMockNode('3')
+        ]
+
+        traverseNodesDepthFirst(
+          nodes,
+          (node, context) => {
+            visited.push(`${node.id}:${context}`)
+            return `${context}-${node.id}`
+          },
+          'root'
+        )
+
+        expect(visited).toEqual(['3:root', '2:root', '1:root']) // DFS processes in LIFO order
+      })
+
+      it('should traverse into subgraphs when expandSubgraphs is true', () => {
+        const visited: string[] = []
+        const subNode = createMockNode('sub1')
+        const subgraph = createMockSubgraph('sub-uuid', [subNode])
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph })
+        ]
+
+        traverseNodesDepthFirst(
+          nodes,
+          (node, depth: number) => {
+            visited.push(`${node.id}:${depth}`)
+            return depth + 1
+          },
+          0
+        )
+
+        expect(visited).toEqual(['2:0', 'sub1:1', '1:0']) // DFS: last node first, then its children
+      })
+
+      it('should skip subgraphs when expandSubgraphs is false', () => {
+        const visited: string[] = []
+        const subNode = createMockNode('sub1')
+        const subgraph = createMockSubgraph('sub-uuid', [subNode])
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph })
+        ]
+
+        traverseNodesDepthFirst(
+          nodes,
+          (node, context) => {
+            visited.push(String(node.id))
+            return context
+          },
+          null,
+          false
+        )
+
+        expect(visited).toEqual(['2', '1']) // DFS processes in LIFO order
+        expect(visited).not.toContain('sub1')
+      })
+
+      it('should handle deeply nested subgraphs', () => {
+        const visited: string[] = []
+
+        const deepNode = createMockNode('300')
+        const deepSubgraph = createMockSubgraph('deep-uuid', [deepNode])
+
+        const midNode = createMockNode('200', {
+          isSubgraph: true,
+          subgraph: deepSubgraph
+        })
+        const midSubgraph = createMockSubgraph('mid-uuid', [midNode])
+
+        const topNode = createMockNode('100', {
+          isSubgraph: true,
+          subgraph: midSubgraph
+        })
+
+        traverseNodesDepthFirst(
+          [topNode],
+          (node, path: string) => {
+            visited.push(`${node.id}:${path}`)
+            return path ? `${path}/${node.id}` : String(node.id)
+          },
+          ''
+        )
+
+        expect(visited).toEqual(['100:', '200:100', '300:100/200'])
+      })
+    })
+
+    describe('collectFromNodes', () => {
+      it('should collect data from all nodes', () => {
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2'),
+          createMockNode('3')
+        ]
+
+        const results = collectFromNodes(
+          nodes,
+          (node) => `node-${node.id}`,
+          (_node, context) => context,
+          null
+        )
+
+        expect(results).toEqual(['node-3', 'node-2', 'node-1']) // DFS processes in LIFO order
+      })
+
+      it('should filter out null results', () => {
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2'),
+          createMockNode('3')
+        ]
+
+        const results = collectFromNodes(
+          nodes,
+          (node) => (Number(node.id) > 1 ? `node-${node.id}` : null),
+          (_node, context) => context,
+          null
+        )
+
+        expect(results).toEqual(['node-3', 'node-2']) // DFS processes in LIFO order, node-1 filtered out
+      })
+
+      it('should collect from subgraphs with context', () => {
+        const subNodes = [createMockNode('10'), createMockNode('11')]
+        const subgraph = createMockSubgraph('sub-uuid', subNodes)
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph })
+        ]
+
+        const results = collectFromNodes(
+          nodes,
+          (node, prefix: string) => `${prefix}${node.id}`,
+          (node, prefix: string) => `${prefix}${node.id}-`,
+          'node-',
+          true
+        )
+
+        expect(results).toEqual([
+          'node-2',
+          'node-2-10', // Actually processes in original order within subgraph
+          'node-2-11',
+          'node-1'
+        ])
+      })
+
+      it('should not expand subgraphs when expandSubgraphs is false', () => {
+        const subNodes = [createMockNode('10'), createMockNode('11')]
+        const subgraph = createMockSubgraph('sub-uuid', subNodes)
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph })
+        ]
+
+        const results = collectFromNodes(
+          nodes,
+          (node) => String(node.id),
+          (_node, context) => context,
+          null,
+          false
+        )
+
+        expect(results).toEqual(['2', '1']) // DFS processes in LIFO order
+      })
+    })
+
+    describe('getExecutionIdsForSelectedNodes', () => {
+      it('should return simple IDs for top-level nodes', () => {
+        const nodes = [
+          createMockNode('123'),
+          createMockNode('456'),
+          createMockNode('789')
+        ]
+
+        const executionIds = getExecutionIdsForSelectedNodes(nodes)
+
+        expect(executionIds).toEqual(['789', '456', '123']) // DFS processes in LIFO order
+      })
+
+      it('should expand subgraph nodes to include all children', () => {
+        const subNodes = [createMockNode('10'), createMockNode('11')]
+        const subgraph = createMockSubgraph('sub-uuid', subNodes)
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph })
+        ]
+
+        const executionIds = getExecutionIdsForSelectedNodes(nodes)
+
+        expect(executionIds).toEqual(['2', '2:10', '2:11', '1']) // DFS: node 2 first, then its children
+      })
+
+      it('should handle deeply nested subgraphs correctly', () => {
+        const deepNodes = [createMockNode('30'), createMockNode('31')]
+        const deepSubgraph = createMockSubgraph('deep-uuid', deepNodes)
+
+        const midNode = createMockNode('20', {
+          isSubgraph: true,
+          subgraph: deepSubgraph
+        })
+        const midSubgraph = createMockSubgraph('mid-uuid', [midNode])
+
+        const topNode = createMockNode('10', {
+          isSubgraph: true,
+          subgraph: midSubgraph
+        })
+
+        const executionIds = getExecutionIdsForSelectedNodes([topNode])
+
+        expect(executionIds).toEqual(['10', '10:20', '10:20:30', '10:20:31'])
+      })
+
+      it('should handle mixed selection of regular and subgraph nodes', () => {
+        const subNodes = [createMockNode('100'), createMockNode('101')]
+        const subgraph = createMockSubgraph('sub-uuid', subNodes)
+
+        const nodes = [
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph }),
+          createMockNode('3')
+        ]
+
+        const executionIds = getExecutionIdsForSelectedNodes(nodes)
+
+        expect(executionIds).toEqual([
+          '3',
+          '2',
+          '2:100', // Subgraph children in original order
+          '2:101',
+          '1'
+        ])
+      })
+
+      it('should handle empty selection', () => {
+        const executionIds = getExecutionIdsForSelectedNodes([])
+        expect(executionIds).toEqual([])
+      })
+
+      it('should handle subgraph with no children', () => {
+        const emptySubgraph = createMockSubgraph('empty-uuid', [])
+        const node = createMockNode('1', {
+          isSubgraph: true,
+          subgraph: emptySubgraph
+        })
+
+        const executionIds = getExecutionIdsForSelectedNodes([node])
+
+        expect(executionIds).toEqual(['1'])
       })
     })
   })

--- a/tests-ui/tests/utils/graphTraversalUtil.test.ts
+++ b/tests-ui/tests/utils/graphTraversalUtil.test.ts
@@ -1143,7 +1143,7 @@ describe('graphTraversalUtil', () => {
 
         expect(executionIds).toHaveLength(101)
         expect(executionIds[0]).toBe('parent')
-        expect(executionIds[100]).toBe('parent:child-0') // Due to DFS LIFO order
+        expect(executionIds[100]).toBe('parent:child-99') // Due to backward iteration optimization
 
         // Should complete quickly even with many nodes
         expect(duration).toBeLessThan(50)

--- a/tests-ui/tests/utils/nodeFilterUtil.test.ts
+++ b/tests-ui/tests/utils/nodeFilterUtil.test.ts
@@ -1,0 +1,116 @@
+import { LGraphNode } from '@comfyorg/litegraph'
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterOutputNodes,
+  getSelectedOutputNodes
+} from '@/utils/nodeFilterUtil'
+
+describe('nodeFilterUtil', () => {
+  // Helper to create a mock node
+  const createMockNode = (
+    id: number,
+    isOutputNode: boolean = false
+  ): LGraphNode => {
+    // Create a custom class with the nodeData static property
+    class MockNode extends LGraphNode {
+      static nodeData = isOutputNode ? { output_node: true } : {}
+    }
+
+    const node = new MockNode('')
+    node.id = id
+    return node
+  }
+
+  describe('filterOutputNodes', () => {
+    it('should return empty array when given empty array', () => {
+      const result = filterOutputNodes([])
+      expect(result).toEqual([])
+    })
+
+    it('should filter out non-output nodes', () => {
+      const nodes = [
+        createMockNode(1, false),
+        createMockNode(2, true),
+        createMockNode(3, false),
+        createMockNode(4, true)
+      ]
+
+      const result = filterOutputNodes(nodes)
+      expect(result).toHaveLength(2)
+      expect(result.map((n) => n.id)).toEqual([2, 4])
+    })
+
+    it('should return all nodes if all are output nodes', () => {
+      const nodes = [
+        createMockNode(1, true),
+        createMockNode(2, true),
+        createMockNode(3, true)
+      ]
+
+      const result = filterOutputNodes(nodes)
+      expect(result).toHaveLength(3)
+      expect(result).toEqual(nodes)
+    })
+
+    it('should return empty array if no output nodes', () => {
+      const nodes = [
+        createMockNode(1, false),
+        createMockNode(2, false),
+        createMockNode(3, false)
+      ]
+
+      const result = filterOutputNodes(nodes)
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle nodes without nodeData', () => {
+      // Create a plain LGraphNode without custom constructor
+      const node = new LGraphNode('')
+      node.id = 1
+
+      const result = filterOutputNodes([node])
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle nodes with undefined output_node', () => {
+      class MockNodeWithOtherData extends LGraphNode {
+        static nodeData = { someOtherProperty: true }
+      }
+
+      const node = new MockNodeWithOtherData('')
+      node.id = 1
+
+      const result = filterOutputNodes([node])
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getSelectedOutputNodes', () => {
+    it('should filter selected nodes to only output nodes', () => {
+      const selectedNodes = [
+        createMockNode(1, false),
+        createMockNode(2, true),
+        createMockNode(3, false),
+        createMockNode(4, true),
+        createMockNode(5, false)
+      ]
+
+      const result = getSelectedOutputNodes(selectedNodes)
+      expect(result).toHaveLength(2)
+      expect(result.map((n) => n.id)).toEqual([2, 4])
+    })
+
+    it('should handle empty selection', () => {
+      const result = getSelectedOutputNodes([])
+      expect(result).toEqual([])
+    })
+
+    it('should handle selection with no output nodes', () => {
+      const selectedNodes = [createMockNode(1, false), createMockNode(2, false)]
+
+      const result = getSelectedOutputNodes(selectedNodes)
+      expect(result).toHaveLength(0)
+    })
+  })
+})

--- a/tests-ui/tests/utils/nodeFilterUtil.test.ts
+++ b/tests-ui/tests/utils/nodeFilterUtil.test.ts
@@ -1,10 +1,7 @@
 import { LGraphNode } from '@comfyorg/litegraph'
 import { describe, expect, it } from 'vitest'
 
-import {
-  filterOutputNodes,
-  getSelectedOutputNodes
-} from '@/utils/nodeFilterUtil'
+import { filterOutputNodes, isOutputNode } from '@/utils/nodeFilterUtil'
 
 describe('nodeFilterUtil', () => {
   // Helper to create a mock node
@@ -86,7 +83,7 @@ describe('nodeFilterUtil', () => {
     })
   })
 
-  describe('getSelectedOutputNodes', () => {
+  describe('isOutputNode', () => {
     it('should filter selected nodes to only output nodes', () => {
       const selectedNodes = [
         createMockNode(1, false),
@@ -96,20 +93,21 @@ describe('nodeFilterUtil', () => {
         createMockNode(5, false)
       ]
 
-      const result = getSelectedOutputNodes(selectedNodes)
+      const result = selectedNodes.filter(isOutputNode)
       expect(result).toHaveLength(2)
       expect(result.map((n) => n.id)).toEqual([2, 4])
     })
 
     it('should handle empty selection', () => {
-      const result = getSelectedOutputNodes([])
+      const emptyNodes: LGraphNode[] = []
+      const result = emptyNodes.filter(isOutputNode)
       expect(result).toEqual([])
     })
 
     it('should handle selection with no output nodes', () => {
       const selectedNodes = [createMockNode(1, false), createMockNode(2, false)]
 
-      const result = getSelectedOutputNodes(selectedNodes)
+      const result = selectedNodes.filter(isOutputNode)
       expect(result).toHaveLength(0)
     })
   })


### PR DESCRIPTION
This PR updates the frontend to use the backend partial execution API introduced in https://github.com/comfyanonymous/ComfyUI/pull/9123.

https://github.com/user-attachments/assets/8bc9496b-8580-4b3d-a2d6-874b73a544dc

Fixes #4581
Fixes https://github.com/Comfy-Org/ComfyUI-Manager/issues/2046
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4581
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/3987

### Previous Implementation of Partial Execution

1. UI (ExecuteButton.vue) - Filters selected nodes to only show button when output nodes selected
2. Command Handler - Filters selected nodes to only output nodes: `filter((node) => node.constructor.nodeData?.output_node)`
3. `app.queuePrompt` - Receives already-filtered output node IDs
4. `graphToPrompt` - Passes these IDs to recursiveAddNodes
5. `recrusiveAddNodes` - In single traversal, discovers the node set (finds transitive closure of "is-input-to" relation on output nodes) and builds the subgraph structure (induced subgraph). Then sends that subgraph as `prompt` (full workflow stil sent in `extra_data`)

### New Implementation of Partial Execution

Now, the frontend simply collects the execution IDs of all selected nodes (including all nodes within selected subgraphs) and passes them as a `partial_execution_targets` parameter, letting the backend handle the actual partial execution logic far more efficiently (excluding output nodes not in targets) and with access to cache info.

### Added Utilities

The implementation adds efficient graph traversal utilities using iterative depth-first search to collect execution IDs in the hierarchical format required for nested subgraph nodes (e.g., "123:456:789"). The generic traversal functions `traverseNodesDepthFirst` and `collectFromNodes` provide a reusable foundation for graph operations, while `getExecutionIdsForSelectedNodes` specifically handles the execution ID collection. This approach ensures proper handling of subgraphs where selecting a subgraph node executes all nodes within it recursively.


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4624-feat-Move-partial-execution-to-the-backend-and-make-work-with-subgraphs-2416d73d365081989d2de336d16b7f69) by [Unito](https://www.unito.io)
