### PR TITLE
[fix] TypeScript errors in manager/compatibility branch

### DIFF
--- a/src/components/dialog/content/manager/PackVersionSelectorPopover.test.ts
+++ b/src/components/dialog/content/manager/PackVersionSelectorPopover.test.ts
@@ -18,8 +18,8 @@ import PackVersionSelectorPopover from './PackVersionSelectorPopover.vue'
 
 // Default mock versions for reference
 const defaultMockVersions = [
-  { 
-    version: '1.0.0', 
+  {
+    version: '1.0.0',
     createdAt: '2023-01-01',
     supported_os: ['windows', 'linux'],
     supported_accelerators: ['CPU'],
@@ -36,7 +36,7 @@ const defaultMockVersions = [
 const mockNodePack = {
   id: 'test-pack',
   name: 'Test Pack',
-  latest_version: { 
+  latest_version: {
     version: '1.0.0',
     supported_os: ['windows', 'linux'],
     supported_accelerators: ['CPU'],
@@ -471,7 +471,7 @@ describe('PackVersionSelectorPopover', () => {
 
       // Clear previous calls from component mounting/rendering
       mockCheckNodeCompatibility.mockClear()
-      
+
       // Trigger compatibility check by accessing getVersionCompatibility
       const vm = wrapper.vm as any
       vm.getVersionCompatibility('1.0.0')
@@ -581,7 +581,7 @@ describe('PackVersionSelectorPopover', () => {
 
       // Clear for next test call
       mockCheckNodeCompatibility.mockClear()
-      
+
       // Test nightly version
       vm.getVersionCompatibility('nightly')
       expect(mockCheckNodeCompatibility).toHaveBeenCalledWith({
@@ -595,7 +595,7 @@ describe('PackVersionSelectorPopover', () => {
         has_registry_data: true,
         latest_version: {
           supported_os: ['windows'],
-          supported_accelerators: ['CPU'], 
+          supported_accelerators: ['CPU'],
           supported_python_version: '>=3.8',
           is_banned: false,
           has_registry_data: true,
@@ -605,7 +605,6 @@ describe('PackVersionSelectorPopover', () => {
         }
       })
     })
-
 
     it('shows banned package warnings', async () => {
       // Set up the mock for versions

--- a/src/components/dialog/content/manager/button/PackEnableToggle.vue
+++ b/src/components/dialog/content/manager/button/PackEnableToggle.vue
@@ -147,7 +147,7 @@ const onToggle = debounce(
 const handleToggleInteraction = async (event: Event) => {
   if (!canToggleDirectly.value) {
     event.preventDefault()
-    showConflictModal()
+    showConflictModal(false)
   }
 }
 </script>

--- a/src/components/dialog/content/manager/infoPanel/tabs/WarningTabPanel.vue
+++ b/src/components/dialog/content/manager/infoPanel/tabs/WarningTabPanel.vue
@@ -35,7 +35,7 @@ import { getConflictMessage } from '@/utils/conflictMessageUtil'
 
 const { nodePack, conflictResult } = defineProps<{
   nodePack: components['schemas']['Node']
-  conflictResult: ConflictDetectionResult | null
+  conflictResult: ConflictDetectionResult | null | undefined
 }>()
 
 const packageId = computed(() => nodePack?.id || '')

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -28,6 +28,7 @@ import {
   type ShowDialogOptions,
   useDialogStore
 } from '@/stores/dialogStore'
+import type { ConflictDetectionResult } from '@/types/conflictDetectionTypes'
 
 export type ConfirmationDialogType =
   | 'default'
@@ -434,6 +435,7 @@ export const useDialogService = () => {
   function showNodeConflictDialog(
     options: {
       showAfterWhatsNew?: boolean
+      conflictedPackages?: ConflictDetectionResult[]
       dialogComponentProps?: DialogComponentProps
       buttonText?: string
       onButtonClick?: () => void
@@ -443,7 +445,8 @@ export const useDialogService = () => {
       dialogComponentProps,
       buttonText,
       onButtonClick,
-      showAfterWhatsNew
+      showAfterWhatsNew,
+      conflictedPackages
     } = options
 
     return dialogStore.showDialog({
@@ -467,7 +470,8 @@ export const useDialogService = () => {
         ...dialogComponentProps
       },
       props: {
-        showAfterWhatsNew
+        showAfterWhatsNew,
+        conflictedPackages
       },
       footerProps: {
         buttonText,

--- a/tests-ui/tests/components/dialog/content/manager/NodeConflictDialogContent.test.ts
+++ b/tests-ui/tests/components/dialog/content/manager/NodeConflictDialogContent.test.ts
@@ -9,7 +9,7 @@ import type { ConflictDetectionResult } from '@/types/conflictDetectionTypes'
 
 // Mock getConflictMessage utility
 vi.mock('@/utils/conflictMessageUtil', () => ({
-  getConflictMessage: vi.fn((conflict, t) => {
+  getConflictMessage: vi.fn((conflict) => {
     return `${conflict.type}: ${conflict.current_value} vs ${conflict.required_value}`
   })
 }))

--- a/tests-ui/tests/composables/useConflictDetection.test.ts
+++ b/tests-ui/tests/composables/useConflictDetection.test.ts
@@ -907,9 +907,7 @@ describe.skip('useConflictDetection with Registry Store', () => {
     })
 
     it('should expose conflict modal display method', () => {
-      const {
-        shouldShowConflictModalAfterUpdate
-      } = useConflictDetection()
+      const { shouldShowConflictModalAfterUpdate } = useConflictDetection()
 
       expect(shouldShowConflictModalAfterUpdate).toBeDefined()
     })
@@ -968,7 +966,6 @@ describe.skip('useConflictDetection with Registry Store', () => {
       const result = await shouldShowConflictModalAfterUpdate()
       expect(result).toBe(true) // Should show modal when conflicts exist and not dismissed
     })
-
 
     it('should detect system environment correctly', async () => {
       // Mock system environment


### PR DESCRIPTION
## Summary
- Add conflictedPackages parameter to showNodeConflictDialog function with proper ConflictDetectionResult[] type
- Fix showConflictModal call with missing parameter in PackEnableToggle
- Update WarningTabPanel conflictResult prop to accept undefined
- Remove unused parameter in NodeConflictDialogContent test mock

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint and Prettier checks pass
- [x] All existing tests continue to pass

This PR fixes the CI errors that were preventing the manager/compatibility branch from passing type checks.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4625-fix-TypeScript-errors-in-manager-compatibility-branch-2416d73d36508128b65bdb39fa7463a2) by [Unito](https://www.unito.io)
