### PR TITLE
[fix] Toggle bypass/mute of subgraph nodes applies mode to all children recursively

### DIFF
--- a/src/composables/canvas/useSelectedLiteGraphItems.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.ts
@@ -1,5 +1,11 @@
-import { Positionable, Reroute } from '@comfyorg/litegraph'
+import {
+  LGraphEventMode,
+  LGraphNode,
+  Positionable,
+  Reroute
+} from '@comfyorg/litegraph'
 
+import { app } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 
 /**
@@ -61,11 +67,46 @@ export function useSelectedLiteGraphItems() {
     return getSelectableItems().size > 1
   }
 
+  /**
+   * Get only the selected nodes (LGraphNode instances) from the canvas.
+   * This filters out other types of selected items like groups or reroutes.
+   * @returns Array of selected LGraphNode instances.
+   */
+  const getSelectedNodes = (): LGraphNode[] => {
+    const selectedNodes = app.canvas.selected_nodes
+    const result: LGraphNode[] = []
+    if (selectedNodes) {
+      for (const i in selectedNodes) {
+        const node = selectedNodes[i]
+        result.push(node)
+      }
+    }
+    return result
+  }
+
+  /**
+   * Toggle the execution mode of all selected nodes.
+   * If a node is already in the specified mode, it will be set to ALWAYS.
+   * Otherwise, it will be set to the specified mode.
+   * @param mode - The LGraphEventMode to toggle to.
+   */
+  const toggleSelectedNodesMode = (mode: LGraphEventMode): void => {
+    getSelectedNodes().forEach((node) => {
+      if (node.mode === mode) {
+        node.mode = LGraphEventMode.ALWAYS
+      } else {
+        node.mode = mode
+      }
+    })
+  }
+
   return {
     isIgnoredItem,
     filterSelectableItems,
     getSelectableItems,
     hasSelectableItems,
-    hasMultipleSelectableItems
+    hasMultipleSelectableItems,
+    getSelectedNodes,
+    toggleSelectedNodesMode
   }
 }

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -7,6 +7,7 @@ import {
 import { Point } from '@comfyorg/litegraph'
 
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
+import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
 import {
   DEFAULT_DARK_COLOR_PALETTE,
   DEFAULT_LIGHT_COLOR_PALETTE
@@ -46,29 +47,9 @@ export function useCoreCommands(): ComfyCommand[] {
   const toastStore = useToastStore()
   const canvasStore = useCanvasStore()
   const executionStore = useExecutionStore()
+  const { getSelectedNodes, toggleSelectedNodesMode } =
+    useSelectedLiteGraphItems()
   const getTracker = () => workflowStore.activeWorkflow?.changeTracker
-
-  const getSelectedNodes = (): LGraphNode[] => {
-    const selectedNodes = app.canvas.selected_nodes
-    const result: LGraphNode[] = []
-    if (selectedNodes) {
-      for (const i in selectedNodes) {
-        const node = selectedNodes[i]
-        result.push(node)
-      }
-    }
-    return result
-  }
-
-  const toggleSelectedNodesMode = (mode: LGraphEventMode) => {
-    getSelectedNodes().forEach((node) => {
-      if (node.mode === mode) {
-        node.mode = LGraphEventMode.ALWAYS
-      } else {
-        node.mode = mode
-      }
-    })
-  }
 
   const moveSelectedNodes = (
     positionUpdater: (pos: Point, gridSize: number) => Point

--- a/tests-ui/tests/utils/graphTraversalUtil.test.ts
+++ b/tests-ui/tests/utils/graphTraversalUtil.test.ts
@@ -820,14 +820,13 @@ describe('graphTraversalUtil', () => {
           createMockNode('3')
         ]
 
-        traverseNodesDepthFirst(
-          nodes,
-          (node, context) => {
+        traverseNodesDepthFirst(nodes, {
+          visitor: (node, context) => {
             visited.push(`${node.id}:${context}`)
             return `${context}-${node.id}`
           },
-          'root'
-        )
+          initialContext: 'root'
+        })
 
         expect(visited).toEqual(['3:root', '2:root', '1:root']) // DFS processes in LIFO order
       })
@@ -841,14 +840,13 @@ describe('graphTraversalUtil', () => {
           createMockNode('2', { isSubgraph: true, subgraph })
         ]
 
-        traverseNodesDepthFirst(
-          nodes,
-          (node, depth: number) => {
+        traverseNodesDepthFirst(nodes, {
+          visitor: (node, depth: number) => {
             visited.push(`${node.id}:${depth}`)
             return depth + 1
           },
-          0
-        )
+          initialContext: 0
+        })
 
         expect(visited).toEqual(['2:0', 'sub1:1', '1:0']) // DFS: last node first, then its children
       })
@@ -862,15 +860,14 @@ describe('graphTraversalUtil', () => {
           createMockNode('2', { isSubgraph: true, subgraph })
         ]
 
-        traverseNodesDepthFirst(
-          nodes,
-          (node, context) => {
+        traverseNodesDepthFirst(nodes, {
+          visitor: (node, context) => {
             visited.push(String(node.id))
             return context
           },
-          null,
-          false
-        )
+          initialContext: null,
+          expandSubgraphs: false
+        })
 
         expect(visited).toEqual(['2', '1']) // DFS processes in LIFO order
         expect(visited).not.toContain('sub1')
@@ -893,14 +890,13 @@ describe('graphTraversalUtil', () => {
           subgraph: midSubgraph
         })
 
-        traverseNodesDepthFirst(
-          [topNode],
-          (node, path: string) => {
+        traverseNodesDepthFirst([topNode], {
+          visitor: (node, path: string) => {
             visited.push(`${node.id}:${path}`)
             return path ? `${path}/${node.id}` : String(node.id)
           },
-          ''
-        )
+          initialContext: ''
+        })
 
         expect(visited).toEqual(['100:', '200:100', '300:100/200'])
       })
@@ -914,12 +910,11 @@ describe('graphTraversalUtil', () => {
           createMockNode('3')
         ]
 
-        const results = collectFromNodes(
-          nodes,
-          (node) => `node-${node.id}`,
-          (_node, context) => context,
-          null
-        )
+        const results = collectFromNodes(nodes, {
+          collector: (node) => `node-${node.id}`,
+          contextBuilder: (_node, context) => context,
+          initialContext: null
+        })
 
         expect(results).toEqual(['node-3', 'node-2', 'node-1']) // DFS processes in LIFO order
       })
@@ -931,12 +926,11 @@ describe('graphTraversalUtil', () => {
           createMockNode('3')
         ]
 
-        const results = collectFromNodes(
-          nodes,
-          (node) => (Number(node.id) > 1 ? `node-${node.id}` : null),
-          (_node, context) => context,
-          null
-        )
+        const results = collectFromNodes(nodes, {
+          collector: (node) => (Number(node.id) > 1 ? `node-${node.id}` : null),
+          contextBuilder: (_node, context) => context,
+          initialContext: null
+        })
 
         expect(results).toEqual(['node-3', 'node-2']) // DFS processes in LIFO order, node-1 filtered out
       })
@@ -949,13 +943,12 @@ describe('graphTraversalUtil', () => {
           createMockNode('2', { isSubgraph: true, subgraph })
         ]
 
-        const results = collectFromNodes(
-          nodes,
-          (node, prefix: string) => `${prefix}${node.id}`,
-          (node, prefix: string) => `${prefix}${node.id}-`,
-          'node-',
-          true
-        )
+        const results = collectFromNodes(nodes, {
+          collector: (node, prefix: string) => `${prefix}${node.id}`,
+          contextBuilder: (node, prefix: string) => `${prefix}${node.id}-`,
+          initialContext: 'node-',
+          expandSubgraphs: true
+        })
 
         expect(results).toEqual([
           'node-2',
@@ -973,13 +966,12 @@ describe('graphTraversalUtil', () => {
           createMockNode('2', { isSubgraph: true, subgraph })
         ]
 
-        const results = collectFromNodes(
-          nodes,
-          (node) => String(node.id),
-          (_node, context) => context,
-          null,
-          false
-        )
+        const results = collectFromNodes(nodes, {
+          collector: (node) => String(node.id),
+          contextBuilder: (_node, context) => context,
+          initialContext: null,
+          expandSubgraphs: false
+        })
 
         expect(results).toEqual(['2', '1']) // DFS processes in LIFO order
       })


### PR DESCRIPTION
## Summary
Adjust `useSelectedLiteGraphItems` composable to allow applying modes recursively then change the toggle mode functionality to apply to subgraphs when target(s) are subgraph node(s).


https://github.com/user-attachments/assets/8cfc8d26-6997-49f1-8462-e5a48bc10d73



## Changes
- Add `getSelectedNodes()` method that returns only selected LGraphNode instances
- Add `toggleSelectedNodesMode()` method for toggling node execution modes
- Refactor `useCoreCommands.ts` to use these new methods instead of local implementations
- Add comprehensive unit tests for the new functionality

This is a follow-up to #4634 which created the initial composable for selection filtering.

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4620.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4636-refactor-Extend-useSelectedLiteGraphItems-with-node-specific-methods-2426d73d365081ea88ead6c200f39e11) by [Unito](https://www.unito.io)
