### PR TITLE
[fix] Detect missing nodes in subgraphs

### DIFF
--- a/browser_tests/assets/missing_nodes_in_subgraph.json
+++ b/browser_tests/assets/missing_nodes_in_subgraph.json
@@ -1,0 +1,182 @@
+{
+  "id": "test-missing-nodes-in-subgraph",
+  "revision": 0,
+  "last_node_id": 2,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "KSampler",
+      "pos": [100, 100],
+      "size": [270, 262],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": null
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [0, "randomize", 20, 8, "euler", "simple", 1]
+    },
+    {
+      "id": 2,
+      "type": "subgraph-with-missing-node",
+      "pos": [400, 100],
+      "size": [144, 46],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "type": "CONDITIONING",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output1",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {},
+      "widgets_values": []
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "subgraph-with-missing-node",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 2,
+          "lastLinkId": 2,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Subgraph with Missing Node",
+        "inputNode": {
+          "id": -10,
+          "bounding": [100, 200, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [500, 200, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "input1-id",
+            "name": "input1",
+            "type": "CONDITIONING",
+            "linkIds": [1],
+            "pos": {
+              "0": 150,
+              "1": 220
+            }
+          }
+        ],
+        "outputs": [
+          {
+            "id": "output1-id",
+            "name": "output1",
+            "type": "LATENT",
+            "linkIds": [2],
+            "pos": {
+              "0": 520,
+              "1": 220
+            }
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1,
+            "type": "MISSING_NODE_TYPE_IN_SUBGRAPH",
+            "pos": [250, 180],
+            "size": [200, 100],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "input",
+                "type": "CONDITIONING",
+                "link": 1
+              }
+            ],
+            "outputs": [
+              {
+                "name": "output",
+                "type": "LATENT",
+                "links": [2]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "MISSING_NODE_TYPE_IN_SUBGRAPH"
+            },
+            "widgets_values": ["some", "widget", "values"]
+          }
+        ],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 2,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "LATENT"
+          }
+        ]
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -13,6 +13,21 @@ test.describe('Load workflow warning', () => {
     const missingNodesWarning = comfyPage.page.locator('.comfy-missing-nodes')
     await expect(missingNodesWarning).toBeVisible()
   })
+
+  test('Should display a warning when loading a workflow with missing nodes in subgraphs', async ({
+    comfyPage
+  }) => {
+    await comfyPage.loadWorkflow('missing_nodes_in_subgraph')
+
+    // Wait for the element with the .comfy-missing-nodes selector to be visible
+    const missingNodesWarning = comfyPage.page.locator('.comfy-missing-nodes')
+    await expect(missingNodesWarning).toBeVisible()
+
+    // Verify the missing node text includes subgraph context
+    const warningText = await missingNodesWarning.textContent()
+    expect(warningText).toContain('MISSING_NODE_TYPE_IN_SUBGRAPH')
+    expect(warningText).toContain('in subgraph')
+  })
 })
 
 test('Does not report warning on undo/redo', async ({ comfyPage }) => {
@@ -369,7 +384,7 @@ test.describe('Signin dialog', () => {
     await textBox.press('Control+c')
 
     await comfyPage.page.evaluate(() => {
-      window['app'].extensionManager.dialog.showSignInDialog()
+      void window['app'].extensionManager.dialog.showSignInDialog()
     })
 
     const input = comfyPage.page.locator('#comfy-org-sign-in-password')

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1104,10 +1104,14 @@ export class ComfyApp {
         // Find missing node types
         if (!(n.type in LiteGraph.registered_node_types)) {
           // Include context about subgraph location if applicable
-          const nodeTypeWithContext = path
-            ? `${n.type} (in subgraph '${path}')`
-            : n.type
-          missingNodeTypes.push(nodeTypeWithContext)
+          if (path) {
+            missingNodeTypes.push({
+              type: n.type,
+              hint: `in subgraph '${path}'`
+            })
+          } else {
+            missingNodeTypes.push(n.type)
+          }
           n.type = sanitizeNodeName(n.type)
         }
 
@@ -1124,8 +1128,9 @@ export class ComfyApp {
 
     // Process nodes in subgraphs
     if (graphData.definitions?.subgraphs) {
-      for (const subgraph of graphData.definitions.subgraphs as any[]) {
-        if (subgraph.nodes) {
+      for (const subgraph of graphData.definitions.subgraphs) {
+        // Subgraph extends workflow schema and includes nodes property
+        if ('nodes' in subgraph && Array.isArray(subgraph.nodes)) {
           processNodesRecursively(subgraph.nodes, subgraph.name || subgraph.id)
         }
       }


### PR DESCRIPTION
## Summary
This PR fixes an issue where missing nodes inside subgraphs were not being detected and reported to users. The missing node warning dialog would only appear for missing nodes at the top level of the workflow, but not for nodes within subgraphs.

## Changes
- Modified `loadGraphData` in `app.ts` to recursively check nodes in subgraphs for missing node types
- Added context to missing node error messages showing the subgraph location (e.g., "MISSING_NODE (in subgraph 'MySubgraph')")
- Created test workflow `missing_nodes_in_subgraph.json` with a missing node inside a subgraph
- Added Playwright test to verify the warning appears for missing nodes in subgraphs

## Testing
- Created new Playwright test that verifies missing nodes in subgraphs are detected
- All existing tests pass
- Manual testing confirms the warning dialog now shows missing nodes from subgraphs with proper context

## Related Issues
Fixes #4618

## Screenshots
[screen-capture.webm](https://github.com/user-attachments/assets/494ae0d4-edd9-4f36-b2c0-03612a6490ba)



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4639-fix-Detect-missing-nodes-in-subgraphs-2426d73d36508160ac5ce8cb558fcb01) by [Unito](https://www.unito.io)
