### PR TITLE
[bugfix] Fix pre-commit hook cross-platform compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,4 @@
-if [[ "$OS" == "Windows_NT" ]]; then
-  npx.cmd lint-staged
-  # Check for unused i18n keys in staged files
-  npx.cmd tsx scripts/check-unused-i18n-keys.ts
-else
-  npx lint-staged
-  # Check for unused i18n keys in staged files
-  npx tsx scripts/check-unused-i18n-keys.ts
-fi
+#!/usr/bin/env bash
+
+npx lint-staged
+npx tsx scripts/check-unused-i18n-keys.ts


### PR DESCRIPTION
## Summary
- Fixed pre-commit hook shebang to use `#\!/usr/bin/env bash` for better cross-platform compatibility
- Simplified script by removing OS-specific logic since `npx` works on both Windows and Unix systems
- Ensures the hook is executable

## Problem
The pre-commit hook was failing with "command not found" errors due to:
1. Missing proper shebang line
2. Windows line endings (CRLF) causing shebang parsing issues
3. Unnecessary OS detection logic

Sample error messages:
```
.husky/pre-commit: line 10: syntax error: unexpected end of file
husky - pre-commit script failed (code 2)
```

## Solution
- Use `#\!/usr/bin/env bash` shebang for cross-platform compatibility
- Remove OS-specific branching since `npx` works universally
- Ensure proper Unix line endings

## Test plan
- [x] Verify pre-commit hook executes without errors on macOS
- [x] Test on Windows environment
- [x] Test on Linux environment

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4643-bugfix-Fix-pre-commit-hook-cross-platform-compatibility-2426d73d365081ffbca5d7c59de631f5) by [Unito](https://www.unito.io)
