### PR TITLE
[fix] Fix viewport sync in minimap and subgraphs navigation

### DIFF
--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -167,15 +167,6 @@ export function useMinimap() {
       currentHeight = minViewportHeight
     }
 
-    console.log('calculateGraphBounds', {
-      minX,
-      minY,
-      maxX,
-      maxY,
-      width: currentWidth,
-      height: currentHeight
-    })
-
     return {
       minX,
       minY,
@@ -355,10 +346,6 @@ export function useMinimap() {
   }
 
   const updateMinimap = () => {
-    console.log('updateMinimap', {
-      needsBoundsUpdate: needsBoundsUpdate.value,
-      updateFlags: updateFlags.value
-    })
     if (needsBoundsUpdate.value || updateFlags.value.bounds) {
       bounds.value = calculateGraphBounds()
       scale.value = calculateScale()
@@ -430,7 +417,6 @@ export function useMinimap() {
     }
 
     if (structureChanged || positionChanged || connectionChanged) {
-      console.log('checkForChanges:updateMinimap')
       updateMinimap()
     }
   }, 500)
@@ -439,7 +425,6 @@ export function useMinimap() {
     useRafFn(
       async () => {
         if (visible.value) {
-          console.log('pauseChangeDetection:checkForChanges')
           await checkForChanges()
         }
       },
@@ -543,7 +528,6 @@ export function useMinimap() {
     updateFlags.value.bounds = true
     updateFlags.value.nodes = true
     updateFlags.value.connections = true
-    console.log('handleGraphChanged:updateMinimap')
     updateMinimap()
   }, 500)
 
@@ -616,14 +600,8 @@ export function useMinimap() {
       updateFlags.value.connections = true
       updateFlags.value.viewport = true
 
-      console.log('init:updateMinimap')
       updateMinimap()
       updateViewport()
-      console.log('init', {
-        bounds: bounds.value,
-        scale: scale.value,
-        viewport: viewportTransform.value
-      })
 
       if (visible.value) {
         resumeChangeDetection()
@@ -684,14 +662,8 @@ export function useMinimap() {
 
       await nextTick()
 
-      console.log('watch:visible:updateMinimap')
       updateMinimap()
       updateViewport()
-      console.log('watch:visible', {
-        bounds: bounds.value,
-        scale: scale.value,
-        viewport: viewportTransform.value
-      })
       resumeChangeDetection()
       startViewportSync()
     } else {

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -91,7 +91,6 @@ export const useSubgraphNavigationStore = defineStore(
      */
     const saveViewport = (graphId: string) => {
       const viewport = getCurrentViewport()
-      console.log('saveViewport', graphId, viewport)
       if (!viewport) return
 
       viewportCache.set(graphId, viewport)
@@ -103,7 +102,6 @@ export const useSubgraphNavigationStore = defineStore(
      */
     const restoreViewport = (graphId: string) => {
       const viewport = viewportCache.get(graphId)
-      console.log('restoreViewport', graphId, viewport)
       if (!viewport) return
 
       const canvas = app.canvas

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -34,6 +34,17 @@ export const useSubgraphNavigationStore = defineStore(
     })
 
     /**
+     * Get the ID of the root graph for the currently active workflow.
+     * @returns The ID of the root graph for the currently active workflow.
+     */
+    const getCurrentRootGraphId = () => {
+      const canvas = canvasStore.getCanvas()
+      if (!canvas) return 'root'
+
+      return canvas.graph?.rootGraph?.id ?? 'root'
+    }
+
+    /**
      * A stack representing subgraph navigation history from the root graph to
      * the current opened subgraph.
      */
@@ -80,6 +91,7 @@ export const useSubgraphNavigationStore = defineStore(
      */
     const saveViewport = (graphId: string) => {
       const viewport = getCurrentViewport()
+      console.log('saveViewport', graphId, viewport)
       if (!viewport) return
 
       viewportCache.set(graphId, viewport)
@@ -91,6 +103,7 @@ export const useSubgraphNavigationStore = defineStore(
      */
     const restoreViewport = (graphId: string) => {
       const viewport = viewportCache.get(graphId)
+      console.log('restoreViewport', graphId, viewport)
       if (!viewport) return
 
       const canvas = app.canvas
@@ -117,13 +130,13 @@ export const useSubgraphNavigationStore = defineStore(
         saveViewport(prevSubgraph.id)
       } else if (!prevSubgraph && subgraph) {
         // Leaving root graph to enter a subgraph
-        saveViewport('root')
+        saveViewport(getCurrentRootGraphId())
       }
 
       const isInRootGraph = !subgraph
       if (isInRootGraph) {
         idStack.value.length = 0
-        restoreViewport('root')
+        restoreViewport(getCurrentRootGraphId())
         return
       }
 


### PR DESCRIPTION
Fix viewport persistence and minimap syncing:

- Don't use singular 'root' key when persisting viewport, as each workflow tab has its own 'root' so there will be collisions
- The minimap viewport indicator was not updating when graph bounds changed after the canvas was fully loaded. This happened because calculateGraphBounds() would run with new bounds but the viewport position wouldn't recalculate with those new bounds, causing the white viewport box to remain at its initial position until user interaction triggered an update. The fix ensures that when bounds change in updateMinimap(), it also sets the viewport update flag to trigger updateViewport(), keeping the viewport indicator synchronized with the actual graph bounds. This also removes the workaround watchers added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/4597 which were patching the symptom but are now unnecessary since the core issue is resolved.

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4605.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4644-fix-Update-minimap-viewport-when-graph-bounds-change-2426d73d3650813b9957f308fd0d86bc) by [Unito](https://www.unito.io)
