### PR TITLE
[fix] Add type guard for SubgraphDefinition to improve TypeScript inference

### DIFF
--- a/src/schemas/comfyWorkflowSchema.ts
+++ b/src/schemas/comfyWorkflowSchema.ts
@@ -458,6 +458,24 @@ export type WorkflowJSON10 = z.infer<typeof zComfyWorkflow1>
 export type ComfyWorkflowJSON = z.infer<
   typeof zComfyWorkflow | typeof zComfyWorkflow1
 >
+export type SubgraphDefinition = z.infer<typeof zSubgraphDefinition>
+
+/**
+ * Type guard to check if an object is a SubgraphDefinition.
+ * This helps TypeScript understand the type when z.lazy() breaks inference.
+ */
+export function isSubgraphDefinition(obj: any): obj is SubgraphDefinition {
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    'id' in obj &&
+    'name' in obj &&
+    'nodes' in obj &&
+    Array.isArray(obj.nodes) &&
+    'inputNode' in obj &&
+    'outputNode' in obj
+  )
+}
 
 const zWorkflowVersion = z.object({
   version: z.number()


### PR DESCRIPTION
## Summary

This PR adds a type guard function for SubgraphDefinition to work around TypeScript inference issues caused by the z.lazy() wrapper in the schema.

## Background

The z.lazy() wrapper is necessary to handle circular references in subgraph definitions (subgraphs can contain nested subgraphs), but it breaks TypeScript's type inference. This forces developers to use unsafe `as any[]` casts throughout the codebase when working with subgraphs.

## Changes

- Added `SubgraphDefinition` type export
- Added `isSubgraphDefinition()` type guard function

## Usage

Instead of:
```typescript
for (const subgraph of graphData.definitions.subgraphs as any[]) {
  if (subgraph.nodes) { /* ... */ }
}
```

Use:
```typescript
for (const subgraph of graphData.definitions.subgraphs) {
  if (isSubgraphDefinition(subgraph)) {
    // TypeScript now knows subgraph has nodes, name, id, etc.
  }
}
```

## Benefits

- Eliminates need for unsafe `as any[]` casts
- Provides proper TypeScript IntelliSense for subgraph properties
- Maintains type safety while working around the z.lazy() limitation

Related to #4650

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4651-fix-Add-type-guard-for-SubgraphDefinition-to-improve-TypeScript-inference-2426d73d365081209b74ebbbada07903) by [Unito](https://www.unito.io)
