### PR TITLE
[feat] Add Upstash Context7 MCP server to .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "playwright": {
       "command": "npx",
       "args": ["-y", "@executeautomation/playwright-mcp-server"]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary
Added Upstash [Context7 MCP server](https://github.com/upstash/context7) configuration to `.mcp.json`. This MCP enables more efficient external documentation lookup / context management.

<img width="720" height="207" alt="Screenshot 2025-08-02 at 8 29 31 PM" src="https://github.com/user-attachments/assets/c19ddb3c-09db-427c-b629-fc0f44d0ad4c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4656-feat-Add-Upstash-Context7-MCP-server-to-mcp-json-2446d73d365081dcac26dcd828345a0c) by [Unito](https://www.unito.io)
