### PR TITLE
Fix copyToClipboard NullGraphError with dynamic inputs

### DIFF
--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -114,4 +114,31 @@ test.describe('Copy Paste', () => {
     const undoCount = await comfyPage.getGraphNodesCount()
     expect(undoCount).toBe(initialCount)
   })
+
+  /**
+   * Test for https://github.com/Comfy-Org/ComfyUI_frontend/issues/4666
+   * Copying nodes with dynamic inputs should not throw console error
+   */
+  test('Can copy node with dynamic inputs without error', async ({ comfyPage }) => {
+    await comfyPage.loadWorkflow('dynamically_added_input')
+    
+    // Select the node with dynamic inputs
+    await comfyPage.canvas.click({
+      position: {
+        x: 157, // Center of the KSampler node
+        y: 161
+      }
+    })
+    
+    // Copy the node - this should not throw a NullGraphError
+    await comfyPage.ctrlC()
+    
+    // Paste the node to verify the copy worked
+    await comfyPage.page.mouse.move(300, 300)
+    await comfyPage.ctrlV()
+    
+    // Verify we now have 2 nodes
+    const nodeCount = await comfyPage.getGraphNodesCount()
+    expect(nodeCount).toBe(2)
+  })
 })

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -27,7 +27,7 @@ export const useCopy = () => {
 
     // copy nodes and clear clipboard
     const canvas = canvasStore.canvas
-    if (isTargetInGraph && canvas?.selectedItems) {
+    if (isTargetInGraph && canvas?.selected_nodes) {
       canvas.copyToClipboard()
       // clearData doesn't remove images from clipboard
       e.clipboardData?.setData('text', ' ')


### PR DESCRIPTION
- Changed canvas?.selectedItems to canvas?.selected_nodes in useCopy.ts
- This fixes the NullGraphError thrown when copying nodes with dynamic inputs
- Added test case for copying nodes with dynamic inputs
- Resolves issue #4666

The issue occurred because the copyToClipboard method expects the LiteGraph selected_nodes object, but the code was checking for selectedItems instead. The selected_nodes property is the correct LiteGraph API for accessing selected nodes and is used consistently throughout the codebase.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4669-Fix-copyToClipboard-NullGraphError-with-dynamic-inputs-2446d73d3650815a95aae6fc7f3f30a4) by [Unito](https://www.unito.io)
