### PR TITLE
Fix flaky tests v2

### DIFF
--- a/browser_tests/tests/remoteWidgets.spec.ts
+++ b/browser_tests/tests/remoteWidgets.spec.ts
@@ -240,7 +240,8 @@ test.describe('Remote COMBO Widget', () => {
         () => {
           const node = window['app'].graph.nodes.find(n => n.title === 'Remote Widget Node With 300ms Refresh')
           const values = node?.widgets[0]?.options?.values || []
-          return values.length > 0 && values[0] !== 'request-1-' + timestamps[0]
+          // Check if we got a new request (requestCount should be >= 2)
+          return values.length > 0 && values[0] && values[0].startsWith('request-2-')
         },
         { timeout: 5000 }
       )

--- a/browser_tests/tests/remoteWidgets.spec.ts
+++ b/browser_tests/tests/remoteWidgets.spec.ts
@@ -226,7 +226,8 @@ test.describe('Remote COMBO Widget', () => {
       
       const initialOptions = await getWidgetOptions(comfyPage, nodeName)
       expect(initialOptions).toBeDefined()
-      expect(requestCount).toBe(1)
+      // Store the initial request count (could be 1 or 2 depending on timing)
+      const initialRequestCount = requestCount
 
       // Wait for the refresh (TTL) to expire - use longer timeout to ensure expiration
       await comfyPage.page.waitForTimeout(800)
@@ -248,7 +249,8 @@ test.describe('Remote COMBO Widget', () => {
 
       const refreshedOptions = await getWidgetOptions(comfyPage, nodeName)
       expect(refreshedOptions).not.toEqual(initialOptions)
-      expect(requestCount).toBeGreaterThanOrEqual(2)
+      // Verify we made at least one additional request after the initial ones
+      expect(requestCount).toBeGreaterThan(initialRequestCount)
     })
 
     test('does not refresh when TTL is not set', async ({ comfyPage }) => {

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -187,12 +187,30 @@ test.describe('Workflows sidebar', () => {
 
   test('Can save workflow as with same name', async ({ comfyPage }) => {
     await comfyPage.menu.topbar.saveWorkflow('workflow5.json')
+    
+    // Wait for the save operation to complete
+    await comfyPage.page.waitForTimeout(500)
+    
     expect(await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()).toEqual([
       'workflow5.json'
     ])
 
     await comfyPage.menu.topbar.saveWorkflowAs('workflow5.json')
+    
+    // Wait for the confirmation dialog to appear
+    await expect(comfyPage.page.locator('.comfy-modal-content:visible')).toBeVisible({
+      timeout: 5000
+    })
+    
     await comfyPage.confirmDialog.click('overwrite')
+    
+    // Wait for the dialog to close and the operation to complete
+    await expect(comfyPage.page.locator('.comfy-modal-content:visible')).toHaveCount(0, {
+      timeout: 5000
+    })
+    
+    await comfyPage.page.waitForTimeout(500)
+    
     expect(await comfyPage.menu.workflowsTab.getOpenedWorkflowNames()).toEqual([
       'workflow5.json'
     ])

--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -257,6 +257,20 @@ test.describe('Animated image widget', () => {
       dropPosition: { x, y }
     })
 
+    // Wait for the file upload to complete and DOM updates
+    await comfyPage.page.waitForTimeout(1000)
+    
+    // Wait for the widget to be updated with the new filename
+    await comfyPage.page.waitForFunction(
+      () => {
+        const nodes = window['app'].graph.nodes.filter(n => n.type === 'DevToolsLoadAnimatedImageTest')
+        if (nodes.length === 0) return false
+        const widget = nodes[0].widgets?.[0]
+        return widget?.value && widget.value.includes('animated_webp.webp')
+      },
+      { timeout: 5000 }
+    )
+
     // Expect the filename combo value to be updated
     const fileComboWidget = await loadAnimatedWebpNode.getWidget(0)
     const filename = await fileComboWidget.getValue()


### PR DESCRIPTION
additional fixes #4658


Feature Flags Test Fix
•  Added robust WebSocket connection handling with polling fallback
•  Improved wait conditions for app initialization
•  Added timeout handling to prevent infinite waits

Remote Widgets TTL Test Fix  
•  Fixed request count expectations to handle variable initial request behavior
•  Used relative comparison instead of hardcoded expectations
•  Made the test more resilient to timing variations

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4674-Fix-flaky-tests-v2-2456d73d365081b38944fa6a36b4a40a) by [Unito](https://www.unito.io)
