### PR TITLE
[feat] Support Markdown rendering for node descriptions in NodePreview

### DIFF
--- a/src/components/node/NodePreview.spec.ts
+++ b/src/components/node/NodePreview.spec.ts
@@ -174,7 +174,9 @@ describe('NodePreview', () => {
 
     it('does not render description element when description is undefined', () => {
       const { description, ...nodeDefWithoutDescription } = mockNodeDef
-      const wrapper = mountComponent(nodeDefWithoutDescription as ComfyNodeDefV2)
+      const wrapper = mountComponent(
+        nodeDefWithoutDescription as ComfyNodeDefV2
+      )
       const descriptionElement = wrapper.find('._sb_description')
 
       expect(descriptionElement.exists()).toBe(false)
@@ -183,7 +185,7 @@ describe('NodePreview', () => {
     it('calls renderMarkdownToHtml utility function', () => {
       const spy = vi.spyOn(markdownRendererUtil, 'renderMarkdownToHtml')
       const testDescription = 'Test **markdown** description'
-      
+
       const nodeDefWithDescription: ComfyNodeDefV2 = {
         ...mockNodeDef,
         description: testDescription

--- a/src/components/node/NodePreview.spec.ts
+++ b/src/components/node/NodePreview.spec.ts
@@ -134,7 +134,6 @@ describe('NodePreview', () => {
   describe('Description Rendering', () => {
     it('renders plain text description as HTML', () => {
       const plainTextNodeDef: ComfyNodeDefV2 = {
-
         ...mockNodeDef,
         description: 'This is a plain text description'
       }
@@ -201,7 +200,8 @@ describe('NodePreview', () => {
     it('handles potentially unsafe markdown content safely', () => {
       const unsafeNodeDef: ComfyNodeDefV2 = {
         ...mockNodeDef,
-        description: 'Safe **markdown** content <script>alert("xss")</script> with `code` blocks'
+        description:
+          'Safe **markdown** content <script>alert("xss")</script> with `code` blocks'
       }
 
       const wrapper = mountComponent(unsafeNodeDef)
@@ -273,7 +273,8 @@ describe('NodePreview', () => {
     it('prevents XSS attacks by sanitizing dangerous HTML elements', () => {
       const maliciousNodeDef: ComfyNodeDefV2 = {
         ...mockNodeDef,
-        description: 'Normal text <img src="x" onerror="alert(\'XSS\')" /> and **bold** text'
+        description:
+          'Normal text <img src="x" onerror="alert(\'XSS\')" /> and **bold** text'
       }
 
       const wrapper = mountComponent(maliciousNodeDef)

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -90,7 +90,7 @@ import { useWidgetStore } from '@/stores/widgetStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { renderMarkdownToHtml } from '@/utils/markdownRendererUtil'
 
-const props = defineProps<{
+const { nodeDef } = defineProps<{
   nodeDef: ComfyNodeDefV2
 }>()
 
@@ -101,14 +101,14 @@ const litegraphColors = computed(
 
 const widgetStore = useWidgetStore()
 
-const { description } = props.nodeDef
+const { description } = nodeDef
 const renderedDescription = computed(() => {
   if (!description) return ''
   return renderMarkdownToHtml(description)
 })
 
-const allInputDefs = Object.values(props.nodeDef.inputs)
-const allOutputDefs = props.nodeDef.outputs
+const allInputDefs = Object.values(nodeDef.inputs)
+const allOutputDefs = nodeDef.outputs
 const slotInputDefs = allInputDefs.filter(
   (input) => !widgetStore.inputIsWidget(input)
 )

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -5,18 +5,25 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 <template>
   <div class="_sb_node_preview">
     <div class="_sb_table">
-      <div class="node_header overflow-ellipsis mr-4" :title="nodeDef.display_name" :style="{
-        backgroundColor: litegraphColors.NODE_DEFAULT_COLOR,
-        color: litegraphColors.NODE_TITLE_COLOR
-      }">
+      <div
+        class="node_header overflow-ellipsis mr-4"
+        :title="nodeDef.display_name"
+        :style="{
+          backgroundColor: litegraphColors.NODE_DEFAULT_COLOR,
+          color: litegraphColors.NODE_TITLE_COLOR
+        }"
+      >
         <div class="_sb_dot headdot pr-3" />
         {{ nodeDef.display_name }}
       </div>
       <div class="_sb_preview_badge">{{ $t('g.preview') }}</div>
 
       <!-- Node slot I/O -->
-      <div v-for="[slotInput, slotOutput] in _.zip(slotInputDefs, allOutputDefs)"
-        :key="(slotInput?.name || '') + (slotOutput?.index.toString() || '')" class="_sb_row slot_row">
+      <div
+        v-for="[slotInput, slotOutput] in _.zip(slotInputDefs, allOutputDefs)"
+        :key="(slotInput?.name || '') + (slotOutput?.index.toString() || '')"
+        class="_sb_row slot_row"
+      >
         <div class="_sb_col">
           <div v-if="slotInput" :class="['_sb_dot', slotInput.type]" />
         </div>
@@ -24,9 +31,12 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
           {{ slotInput ? slotInput.name : '' }}
         </div>
         <div class="_sb_col middle-column" />
-        <div class="_sb_col _sb_inherit" :style="{
-          color: litegraphColors.NODE_TEXT_COLOR
-        }">
+        <div
+          class="_sb_col _sb_inherit"
+          :style="{
+            color: litegraphColors.NODE_TEXT_COLOR
+          }"
+        >
           {{ slotOutput ? slotOutput.name : '' }}
         </div>
         <div class="_sb_col">
@@ -35,24 +45,39 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
       </div>
 
       <!-- Node widget inputs -->
-      <div v-for="widgetInput in widgetInputDefs" :key="widgetInput.name" class="_sb_row _long_field">
+      <div
+        v-for="widgetInput in widgetInputDefs"
+        :key="widgetInput.name"
+        class="_sb_row _long_field"
+      >
         <div class="_sb_col _sb_arrow">&#x25C0;</div>
-        <div class="_sb_col" :style="{
-          color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR
-        }">
+        <div
+          class="_sb_col"
+          :style="{
+            color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR
+          }"
+        >
           {{ widgetInput.name }}
         </div>
         <div class="_sb_col middle-column" />
-        <div class="_sb_col _sb_inherit" :style="{ color: litegraphColors.WIDGET_TEXT_COLOR }">
+        <div
+          class="_sb_col _sb_inherit"
+          :style="{ color: litegraphColors.WIDGET_TEXT_COLOR }"
+        >
           {{ truncateDefaultValue(widgetInput.default) }}
         </div>
         <div class="_sb_col _sb_arrow">&#x25B6;</div>
       </div>
     </div>
-    <div v-if="renderedDescription" class="_sb_description" :style="{
-      color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR,
-      backgroundColor: litegraphColors.WIDGET_BGCOLOR
-    }" v-html="renderedDescription" />
+    <div
+      v-if="renderedDescription"
+      class="_sb_description"
+      :style="{
+        color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR,
+        backgroundColor: litegraphColors.WIDGET_BGCOLOR
+      }"
+      v-html="renderedDescription"
+    />
   </div>
 </template>
 

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -101,15 +101,14 @@ const litegraphColors = computed(
 
 const widgetStore = useWidgetStore()
 
-// Always use DOMPurify-sanitized rendering for descriptions
+const { description } = props.nodeDef
 const renderedDescription = computed(() => {
-  if (!nodeDef.description) return ''
-  return renderMarkdownToHtml(nodeDef.description)
+  if (!description) return ''
+  return renderMarkdownToHtml(description)
 })
 
-const nodeDef = props.nodeDef
-const allInputDefs = Object.values(nodeDef.inputs)
-const allOutputDefs = nodeDef.outputs
+const allInputDefs = Object.values(props.nodeDef.inputs)
+const allOutputDefs = props.nodeDef.outputs
 const slotInputDefs = allInputDefs.filter(
   (input) => !widgetStore.inputIsWidget(input)
 )

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -5,25 +5,18 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 <template>
   <div class="_sb_node_preview">
     <div class="_sb_table">
-      <div
-        class="node_header overflow-ellipsis mr-4"
-        :title="nodeDef.display_name"
-        :style="{
-          backgroundColor: litegraphColors.NODE_DEFAULT_COLOR,
-          color: litegraphColors.NODE_TITLE_COLOR
-        }"
-      >
+      <div class="node_header overflow-ellipsis mr-4" :title="nodeDef.display_name" :style="{
+        backgroundColor: litegraphColors.NODE_DEFAULT_COLOR,
+        color: litegraphColors.NODE_TITLE_COLOR
+      }">
         <div class="_sb_dot headdot pr-3" />
         {{ nodeDef.display_name }}
       </div>
       <div class="_sb_preview_badge">{{ $t('g.preview') }}</div>
 
       <!-- Node slot I/O -->
-      <div
-        v-for="[slotInput, slotOutput] in _.zip(slotInputDefs, allOutputDefs)"
-        :key="(slotInput?.name || '') + (slotOutput?.index.toString() || '')"
-        class="_sb_row slot_row"
-      >
+      <div v-for="[slotInput, slotOutput] in _.zip(slotInputDefs, allOutputDefs)"
+        :key="(slotInput?.name || '') + (slotOutput?.index.toString() || '')" class="_sb_row slot_row">
         <div class="_sb_col">
           <div v-if="slotInput" :class="['_sb_dot', slotInput.type]" />
         </div>
@@ -31,12 +24,9 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
           {{ slotInput ? slotInput.name : '' }}
         </div>
         <div class="_sb_col middle-column" />
-        <div
-          class="_sb_col _sb_inherit"
-          :style="{
-            color: litegraphColors.NODE_TEXT_COLOR
-          }"
-        >
+        <div class="_sb_col _sb_inherit" :style="{
+          color: litegraphColors.NODE_TEXT_COLOR
+        }">
           {{ slotOutput ? slotOutput.name : '' }}
         </div>
         <div class="_sb_col">
@@ -45,40 +35,24 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
       </div>
 
       <!-- Node widget inputs -->
-      <div
-        v-for="widgetInput in widgetInputDefs"
-        :key="widgetInput.name"
-        class="_sb_row _long_field"
-      >
+      <div v-for="widgetInput in widgetInputDefs" :key="widgetInput.name" class="_sb_row _long_field">
         <div class="_sb_col _sb_arrow">&#x25C0;</div>
-        <div
-          class="_sb_col"
-          :style="{
-            color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR
-          }"
-        >
+        <div class="_sb_col" :style="{
+          color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR
+        }">
           {{ widgetInput.name }}
         </div>
         <div class="_sb_col middle-column" />
-        <div
-          class="_sb_col _sb_inherit"
-          :style="{ color: litegraphColors.WIDGET_TEXT_COLOR }"
-        >
+        <div class="_sb_col _sb_inherit" :style="{ color: litegraphColors.WIDGET_TEXT_COLOR }">
           {{ truncateDefaultValue(widgetInput.default) }}
         </div>
         <div class="_sb_col _sb_arrow">&#x25B6;</div>
       </div>
     </div>
-    <div
-      v-if="nodeDef.description"
-      class="_sb_description"
-      :style="{
-        color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR,
-        backgroundColor: litegraphColors.WIDGET_BGCOLOR
-      }"
-    >
-      {{ nodeDef.description }}
-    </div>
+    <div v-if="renderedDescription" class="_sb_description" :style="{
+      color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR,
+      backgroundColor: litegraphColors.WIDGET_BGCOLOR
+    }" v-html="renderedDescription" />
   </div>
 </template>
 
@@ -89,6 +63,7 @@ import { computed } from 'vue'
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { useWidgetStore } from '@/stores/widgetStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+import { renderMarkdownToHtml } from '@/utils/markdownRendererUtil'
 
 const props = defineProps<{
   nodeDef: ComfyNodeDefV2
@@ -100,6 +75,12 @@ const litegraphColors = computed(
 )
 
 const widgetStore = useWidgetStore()
+
+// Always use DOMPurify-sanitized rendering for descriptions
+const renderedDescription = computed(() => {
+  if (!nodeDef.description) return ''
+  return renderMarkdownToHtml(nodeDef.description)
+})
 
 const nodeDef = props.nodeDef
 const allInputDefs = Object.values(nodeDef.inputs)


### PR DESCRIPTION
## Summary
- Add markdown rendering support to NodePreview component descriptions
- Import and use renderMarkdownToHtml utility for secure HTML rendering
- Replace plain text description display with sanitized HTML using v-html
- Maintain existing styling and conditional display logic
- Enables rich formatting in node descriptions while ensuring security through DOMPurify sanitization

## Test plan
- [x] Verify node descriptions render correctly in NodePreview
- [x] Test both plain text and markdown formatted descriptions  
- [x] Confirm HTML content is properly sanitized via DOMPurify
- [x] Check that existing styling is preserved
- [x] Test against XSS atttack

## Feat Screenshot

plain text docs:

<img width="1190" height="595" alt="image" src="https://github.com/user-attachments/assets/9369ab5b-3d51-4ea5-b98f-faff3173868a" />


html docs:

node preview (light)

<img width="883" height="1001" alt="image" src="https://github.com/user-attachments/assets/325c90cb-09b9-4ce3-a869-04e57369555a" />

node preview (light) (longer)

<img width="1252" height="2252" alt="image" src="https://github.com/user-attachments/assets/df4592d4-fe20-49ac-884c-7a5683c5d2a9" />

node preview (dark)

<img width="1301" height="1486" alt="image" src="https://github.com/user-attachments/assets/3d8b895c-111b-4072-849b-02afbe77d8eb" />

node helper menu (light)

<img width="827" height="1203" alt="image" src="https://github.com/user-attachments/assets/079e1045-56a6-48cb-91f7-6f687ba95207" />

node helper menu (dark)

<img width="759" height="930" alt="image" src="https://github.com/user-attachments/assets/f4028407-c75c-4742-955a-abb76112e0ed" />

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4684-Use-DOMPurify-sanitized-HTML-rendering-for-node-descriptions-in-NodePreview-2466d73d365081868eddd8d221764cba) by [Unito](https://www.unito.io)