### PR TITLE
Fix inconsistent subgraphNode usage

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -3,11 +3,7 @@ import type {
   ExecutionId,
   LGraph
 } from '@comfyorg/litegraph'
-import {
-  ExecutableNodeDTO,
-  LGraphEventMode,
-  SubgraphNode
-} from '@comfyorg/litegraph'
+import { ExecutableNodeDTO, LGraphEventMode } from '@comfyorg/litegraph'
 
 import type {
   ComfyApiWorkflow,
@@ -63,12 +59,7 @@ export const graphToPrompt = async (
   for (const node of graph.computeExecutionOrder(false)) {
     const dto: ExecutableLGraphNode = isGroupNode(node)
       ? new ExecutableGroupNodeDTO(node, [], nodeDtoMap)
-      : new ExecutableNodeDTO(
-          node,
-          [],
-          nodeDtoMap,
-          node instanceof SubgraphNode ? node : undefined
-        )
+      : new ExecutableNodeDTO(node, [], nodeDtoMap)
 
     for (const innerNode of dto.getInnerNodes()) {
       nodeDtoMap.set(innerNode.id, innerNode)


### PR DESCRIPTION
Prior to this commit, subgraphNode inconsistently refers to either the parent graph, or to indicate the current node is a subgraph.

This corrects the usage of subgraphNode to consistently refer to the subgraph instance as defined in the constructor.

This requires the corresponding comfy-org/litegraph.js#1193 commit to function, and solves a bug where graph serialization fails due to an incorrectly reported infinite loop.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4688-Fix-inconsistent-subgraphNode-usage-2466d73d3650812399d5ffc1d7b4f7cc) by [Unito](https://www.unito.io)
