### PR TITLE
fix: use selected target_branch for PR base in update-manager-types workflow

### DIFF
--- a/.github/workflows/update-manager-types.yaml
+++ b/.github/workflows/update-manager-types.yaml
@@ -3,6 +3,11 @@ name: Update ComfyUI-Manager API Types
 on:
   # Manual trigger
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch for the PR'
+        required: true
+        default: 'main'
 
 jobs:
   update-manager-types:
@@ -85,7 +90,7 @@ jobs:
 
             These types are automatically generated using openapi-typescript.
           branch: update-manager-types-${{ steps.manager-info.outputs.commit }}
-          base: main
+          base: ${{ inputs.target_branch }}
           labels: Manager
           delete-branch: true
           add-paths: |


### PR DESCRIPTION
## Summary
- Added workflow input parameter `target_branch` to allow selecting the base branch for PR creation
- Updated the workflow to use the selected target branch instead of hardcoded 'main'
- This allows the workflow to create PRs against different branches as needed

## Test plan
- [ ] Trigger the workflow manually with a different target branch
- [ ] Verify that the PR is created against the specified branch
- [ ] Confirm workflow still defaults to 'main' when not specified

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4776-fix-use-selected-target_branch-for-PR-base-in-update-manager-types-workflow-2476d73d3650813cba4ec653a7c25545) by [Unito](https://www.unito.io)
