### PR TITLE
[feat] Add automatic backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -31,17 +31,18 @@ jobs:
         run: |
           # Extract version labels (e.g., "1.24", "1.22")
           VERSIONS=""
-          for label in ${{ join(github.event.pull_request.labels.*.name, ' ') }}; do
+          LABELS='${{ toJSON(github.event.pull_request.labels) }}'
+          for label in $(echo "$LABELS" | jq -r '.[].name'); do
             if [[ "$label" =~ ^[0-9]+\.[0-9]+$ ]]; then
               VERSIONS="${VERSIONS}${label} "
             fi
           done
-          
+
           if [ -z "$VERSIONS" ]; then
             echo "::error::No version labels found (e.g., 1.24, 1.22)"
             exit 1
           fi
-          
+
           echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
           echo "Found version labels: ${VERSIONS}"
 
@@ -54,13 +55,13 @@ jobs:
         run: |
           FAILED=""
           SUCCESS=""
-          
+
           for version in ${{ steps.versions.outputs.versions }}; do
             echo "::group::Backporting to core/${version}"
-            
+
             TARGET_BRANCH="core/${version}"
             BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${version}"
-            
+
             # Fetch target branch (fail if doesn't exist)
             if ! git fetch origin "${TARGET_BRANCH}"; then
               echo "::error::Target branch ${TARGET_BRANCH} does not exist"
@@ -68,10 +69,10 @@ jobs:
               echo "::endgroup::"
               continue
             fi
-            
+
             # Create backport branch
             git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
-            
+
             # Try cherry-pick
             if git cherry-pick "${MERGE_COMMIT}"; then
               git push origin "${BACKPORT_BRANCH}"
@@ -81,26 +82,26 @@ jobs:
               # Get conflict info
               CONFLICTS=$(git diff --name-only --diff-filter=U)
               git cherry-pick --abort
-              
+
               echo "::error::Cherry-pick failed due to conflicts"
               FAILED="${FAILED}${version}:conflicts "
-              
+
               # Save conflict info for comment
               echo "CONFLICTS_${version}<<EOF" >> $GITHUB_ENV
               echo "${CONFLICTS}" >> $GITHUB_ENV
               echo "EOF" >> $GITHUB_ENV
             fi
-            
+
             # Return to main
             git checkout main
             git branch -D "${BACKPORT_BRANCH}" 2>/dev/null || true
-            
+
             echo "::endgroup::"
           done
-          
+
           echo "success=${SUCCESS}" >> $GITHUB_OUTPUT
           echo "failed=${FAILED}" >> $GITHUB_OUTPUT
-          
+
           if [ -n "${FAILED}" ]; then
             exit 1
           fi
@@ -110,24 +111,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+
           for backport in ${{ steps.backport.outputs.success }}; do
             IFS=':' read -r version branch <<< "${backport}"
-            
-            # Create PR using GitHub CLI
-            PR_URL=$(gh pr create \
+
+            gh pr create \
               --base "core/${version}" \
               --head "${branch}" \
-              --title "[backport ${version}] ${{ github.event.pull_request.title }}" \
-              --body "Backport of #${{ github.event.pull_request.number }} to \`core/${version}\`
+              --title "[backport ${version}] ${PR_TITLE}" \
+              --body "Backport of #${PR_NUMBER} to \`core/${version}\`"$'\n\n'"Automatically created by backport workflow."
 
-Automatically created by backport workflow." \
-              2>&1) || true
-            
-            if [[ "${PR_URL}" =~ pull/[0-9]+ ]]; then
-              PR_NUM=$(echo "${PR_URL}" | grep -o 'pull/[0-9]*' | grep -o '[0-9]*')
-              
-              # Comment on original PR about success
-              gh pr comment ${{ github.event.pull_request.number }} --body "@${{ github.event.pull_request.user.login }} ✅ Successfully backported to #${PR_NUM}"
+            PR_NUM=$(gh pr list --head "${branch}" --json number --jq '.[0].number')
+
+            if [ -n "${PR_NUM}" ]; then
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}"
             fi
           done
 
@@ -136,16 +136,20 @@ Automatically created by backport workflow." \
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
+
           for failure in ${{ steps.backport.outputs.failed }}; do
             IFS=':' read -r version reason <<< "${failure}"
-            
+
             if [ "${reason}" = "branch-missing" ]; then
-              gh pr comment ${{ github.event.pull_request.number }} --body "@${{ github.event.pull_request.user.login }} ❌ Backport failed: Branch \`core/${version}\` does not exist"
-            
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport failed: Branch \`core/${version}\` does not exist"
+
             elif [ "${reason}" = "conflicts" ]; then
               CONFLICTS_VAR="CONFLICTS_${version}"
               CONFLICTS="${!CONFLICTS_VAR}"
-              
-              gh pr comment ${{ github.event.pull_request.number }} --body "@${{ github.event.pull_request.user.login }} ❌ Backport to \`core/${version}\` failed: Merge conflicts detected. Please manually cherry-pick commit \`${{ github.event.pull_request.merge_commit_sha }}\` to the \`core/${version}\` branch. Conflicting files: ${CONFLICTS}"
+
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`core/${version}\` failed: Merge conflicts detected. Please manually cherry-pick commit \`${MERGE_COMMIT}\` to the \`core/${version}\` branch. Conflicting files: ${CONFLICTS}"
             fi
           done

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
@@ -33,8 +32,14 @@ jobs:
           VERSIONS=""
           LABELS='${{ toJSON(github.event.pull_request.labels) }}'
           for label in $(echo "$LABELS" | jq -r '.[].name'); do
+            # Match version labels like "1.24" (major.minor only)
             if [[ "$label" =~ ^[0-9]+\.[0-9]+$ ]]; then
-              VERSIONS="${VERSIONS}${label} "
+              # Validate the branch exists before adding to list
+              if git ls-remote --exit-code origin "core/${label}" >/dev/null 2>&1; then
+                VERSIONS="${VERSIONS}${label} "
+              else
+                echo "::warning::Label '${label}' found but branch 'core/${label}' does not exist"
+              fi
             fi
           done
 
@@ -78,23 +83,20 @@ jobs:
               git push origin "${BACKPORT_BRANCH}"
               SUCCESS="${SUCCESS}${version}:${BACKPORT_BRANCH} "
               echo "Successfully created backport branch: ${BACKPORT_BRANCH}"
+              # Return to main (keep the branch, we need it for PR)
+              git checkout main
             else
               # Get conflict info
-              CONFLICTS=$(git diff --name-only --diff-filter=U)
+              CONFLICTS=$(git diff --name-only --diff-filter=U | tr '\n' ',')
               git cherry-pick --abort
 
               echo "::error::Cherry-pick failed due to conflicts"
-              FAILED="${FAILED}${version}:conflicts "
+              FAILED="${FAILED}${version}:conflicts:${CONFLICTS} "
 
-              # Save conflict info for comment
-              echo "CONFLICTS_${version}<<EOF" >> $GITHUB_ENV
-              echo "${CONFLICTS}" >> $GITHUB_ENV
-              echo "EOF" >> $GITHUB_ENV
+              # Clean up the failed branch
+              git checkout main
+              git branch -D "${BACKPORT_BRANCH}"
             fi
-
-            # Return to main
-            git checkout main
-            git branch -D "${BACKPORT_BRANCH}" 2>/dev/null || true
 
             echo "::endgroup::"
           done
@@ -109,7 +111,7 @@ jobs:
       - name: Create PR for each successful backport
         if: steps.backport.outputs.success
         env:
-          GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -118,17 +120,23 @@ jobs:
           for backport in ${{ steps.backport.outputs.success }}; do
             IFS=':' read -r version branch <<< "${backport}"
 
-            gh pr create \
+            if PR_URL=$(gh pr create \
               --base "core/${version}" \
               --head "${branch}" \
               --title "[backport ${version}] ${PR_TITLE}" \
               --body "Backport of #${PR_NUMBER} to \`core/${version}\`"$'\n\n'"Automatically created by backport workflow." \
-              --label "backport"
+              --label "backport" 2>&1); then
 
-            PR_NUM=$(gh pr list --head "${branch}" --json number --jq '.[0].number')
+              # Extract PR number from URL
+              PR_NUM=$(echo "${PR_URL}" | grep -o '[0-9]*$')
 
-            if [ -n "${PR_NUM}" ]; then
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}"
+              if [ -n "${PR_NUM}" ]; then
+                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}"
+              fi
+            else
+              echo "::error::Failed to create PR for ${version}: ${PR_URL}"
+              # Still try to comment on the original PR about the failure
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`core/${version}\`. Please create the PR manually from branch \`${branch}\`"
             fi
           done
 
@@ -142,15 +150,16 @@ jobs:
           MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
 
           for failure in ${{ steps.backport.outputs.failed }}; do
-            IFS=':' read -r version reason <<< "${failure}"
+            IFS=':' read -r version reason conflicts <<< "${failure}"
 
             if [ "${reason}" = "branch-missing" ]; then
               gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport failed: Branch \`core/${version}\` does not exist"
 
             elif [ "${reason}" = "conflicts" ]; then
-              CONFLICTS_VAR="CONFLICTS_${version}"
-              CONFLICTS="${!CONFLICTS_VAR}"
+              # Convert comma-separated conflicts back to newlines for display
+              CONFLICTS_LIST=$(echo "${conflicts}" | tr ',' '\n' | sed 's/^/- /')
 
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`core/${version}\` failed: Merge conflicts detected. Please manually cherry-pick commit \`${MERGE_COMMIT}\` to the \`core/${version}\` branch. Conflicting files: ${CONFLICTS}"
+              COMMENT_BODY="@${PR_AUTHOR} Backport to \`core/${version}\` failed: Merge conflicts detected."$'\n\n'"Please manually cherry-pick commit \`${MERGE_COMMIT}\` to the \`core/${version}\` branch."$'\n\n'"<details><summary>Conflicting files</summary>"$'\n\n'"${CONFLICTS_LIST}"$'\n\n'"</details>"
+              gh pr comment "${PR_NUMBER}" --body "${COMMENT_BODY}"
             fi
           done

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,7 +1,7 @@
 name: Auto Backport
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 
@@ -122,7 +122,8 @@ jobs:
               --base "core/${version}" \
               --head "${branch}" \
               --title "[backport ${version}] ${PR_TITLE}" \
-              --body "Backport of #${PR_NUMBER} to \`core/${version}\`"$'\n\n'"Automatically created by backport workflow."
+              --body "Backport of #${PR_NUMBER} to \`core/${version}\`"$'\n\n'"Automatically created by backport workflow." \
+              --label "backport"
 
             PR_NUM=$(gh pr list --head "${branch}" --json number --jq '.[0].number')
 

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,151 @@
+name: Auto Backport
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'needs-backport')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version labels
+        id: versions
+        run: |
+          # Extract version labels (e.g., "1.24", "1.22")
+          VERSIONS=""
+          for label in ${{ join(github.event.pull_request.labels.*.name, ' ') }}; do
+            if [[ "$label" =~ ^[0-9]+\.[0-9]+$ ]]; then
+              VERSIONS="${VERSIONS}${label} "
+            fi
+          done
+          
+          if [ -z "$VERSIONS" ]; then
+            echo "::error::No version labels found (e.g., 1.24, 1.22)"
+            exit 1
+          fi
+          
+          echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
+          echo "Found version labels: ${VERSIONS}"
+
+      - name: Backport commits
+        id: backport
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          FAILED=""
+          SUCCESS=""
+          
+          for version in ${{ steps.versions.outputs.versions }}; do
+            echo "::group::Backporting to core/${version}"
+            
+            TARGET_BRANCH="core/${version}"
+            BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${version}"
+            
+            # Fetch target branch (fail if doesn't exist)
+            if ! git fetch origin "${TARGET_BRANCH}"; then
+              echo "::error::Target branch ${TARGET_BRANCH} does not exist"
+              FAILED="${FAILED}${version}:branch-missing "
+              echo "::endgroup::"
+              continue
+            fi
+            
+            # Create backport branch
+            git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
+            
+            # Try cherry-pick
+            if git cherry-pick "${MERGE_COMMIT}"; then
+              git push origin "${BACKPORT_BRANCH}"
+              SUCCESS="${SUCCESS}${version}:${BACKPORT_BRANCH} "
+              echo "Successfully created backport branch: ${BACKPORT_BRANCH}"
+            else
+              # Get conflict info
+              CONFLICTS=$(git diff --name-only --diff-filter=U)
+              git cherry-pick --abort
+              
+              echo "::error::Cherry-pick failed due to conflicts"
+              FAILED="${FAILED}${version}:conflicts "
+              
+              # Save conflict info for comment
+              echo "CONFLICTS_${version}<<EOF" >> $GITHUB_ENV
+              echo "${CONFLICTS}" >> $GITHUB_ENV
+              echo "EOF" >> $GITHUB_ENV
+            fi
+            
+            # Return to main
+            git checkout main
+            git branch -D "${BACKPORT_BRANCH}" 2>/dev/null || true
+            
+            echo "::endgroup::"
+          done
+          
+          echo "success=${SUCCESS}" >> $GITHUB_OUTPUT
+          echo "failed=${FAILED}" >> $GITHUB_OUTPUT
+          
+          if [ -n "${FAILED}" ]; then
+            exit 1
+          fi
+
+      - name: Create PR for each successful backport
+        if: steps.backport.outputs.success
+        env:
+          GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          for backport in ${{ steps.backport.outputs.success }}; do
+            IFS=':' read -r version branch <<< "${backport}"
+            
+            # Create PR using GitHub CLI
+            PR_URL=$(gh pr create \
+              --base "core/${version}" \
+              --head "${branch}" \
+              --title "[backport ${version}] ${{ github.event.pull_request.title }}" \
+              --body "Backport of #${{ github.event.pull_request.number }} to \`core/${version}\`
+
+Automatically created by backport workflow." \
+              2>&1) || true
+            
+            if [[ "${PR_URL}" =~ pull/[0-9]+ ]]; then
+              PR_NUM=$(echo "${PR_URL}" | grep -o 'pull/[0-9]*' | grep -o '[0-9]*')
+              
+              # Comment on original PR about success
+              gh pr comment ${{ github.event.pull_request.number }} --body "@${{ github.event.pull_request.user.login }} ✅ Successfully backported to #${PR_NUM}"
+            fi
+          done
+
+      - name: Comment on failures
+        if: failure() && steps.backport.outputs.failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for failure in ${{ steps.backport.outputs.failed }}; do
+            IFS=':' read -r version reason <<< "${failure}"
+            
+            if [ "${reason}" = "branch-missing" ]; then
+              gh pr comment ${{ github.event.pull_request.number }} --body "@${{ github.event.pull_request.user.login }} ❌ Backport failed: Branch \`core/${version}\` does not exist"
+            
+            elif [ "${reason}" = "conflicts" ]; then
+              CONFLICTS_VAR="CONFLICTS_${version}"
+              CONFLICTS="${!CONFLICTS_VAR}"
+              
+              gh pr comment ${{ github.event.pull_request.number }} --body "@${{ github.event.pull_request.user.login }} ❌ Backport to \`core/${version}\` failed: Merge conflicts detected. Please manually cherry-pick commit \`${{ github.event.pull_request.merge_commit_sha }}\` to the \`core/${version}\` branch. Conflicting files: ${CONFLICTS}"
+            fi
+          done


### PR DESCRIPTION
Implements automated backporting for merged PRs to release-candidate branches. When a PR is merged with 'needs-backport' label and version labels (e.g., '1.24'), the workflow automatically cherry-picks to the corresponding core branches and creates backport PRs.

Fixes #4770

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4778-feat-Add-automatic-backport-workflow-2476d73d365081e3828aed93ab8e2084) by [Unito](https://www.unito.io)
