### PR TITLE
[types] Add proper types for ImportFailInfo API endpoints

### DIFF
--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -3,6 +3,8 @@ import { ref } from 'vue'
 
 import { api } from '@/scripts/api'
 import {
+  type ImportFailInfoBulkRequest,
+  type ImportFailInfoBulkResponse,
   type InstallPackParams,
   type InstalledPacksResponse,
   type ManagerPackInfo,
@@ -157,12 +159,12 @@ export const useComfyManagerService = () => {
   }
 
   const getImportFailInfoBulk = async (
-    params: { cnr_ids?: string[]; urls?: string[] } = {},
+    params: ImportFailInfoBulkRequest = {},
     signal?: AbortSignal
   ) => {
     const errorContext = 'Fetching bulk import failure information'
 
-    return executeRequest<Record<string, any>>(
+    return executeRequest<ImportFailInfoBulkResponse>(
       () =>
         managerApiClient.post(ManagerRoute.IMPORT_FAIL_INFO_BULK, params, {
           signal

--- a/src/types/comfyManagerTypes.ts
+++ b/src/types/comfyManagerTypes.ts
@@ -3,6 +3,7 @@ import type { InjectionKey, Ref } from 'vue'
 import type { ComfyWorkflowJSON } from '@/schemas/comfyWorkflowSchema'
 import type { AlgoliaNodePack } from '@/types/algoliaTypes'
 import type { components } from '@/types/comfyRegistryTypes'
+import type { components as managerComponents } from '@/types/generatedManagerTypes'
 import type { SearchMode } from '@/types/searchServiceTypes'
 
 type WorkflowNodeProperties = ComfyWorkflowJSON['nodes'][0]['properties']
@@ -242,3 +243,13 @@ export interface ManagerState {
   searchMode: SearchMode
   sortField: string
 }
+
+/**
+ * Types for import failure information API
+ */
+export type ImportFailInfoBulkRequest =
+  managerComponents['schemas']['ImportFailInfoBulkRequest']
+export type ImportFailInfoBulkResponse =
+  managerComponents['schemas']['ImportFailInfoBulkResponse']
+export type ImportFailInfoItem =
+  managerComponents['schemas']['ImportFailInfoItem']


### PR DESCRIPTION
## Summary
- Added proper TypeScript types for the ImportFailInfo bulk API endpoints
- Created type aliases following the existing pattern in the codebase
- Updated the comfyManagerService to use the new type definitions

## Changes
- Added `ImportFailInfoBulkRequest`, `ImportFailInfoBulkResponse`, and `ImportFailInfoItem` type aliases in `comfyManagerTypes.ts`
- Updated `getImportFailInfoBulk` function to use proper types instead of generic `any` and inline type definitions
- Follows the established pattern of importing from generated types and re-exporting as aliases

## Test plan
- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] Pre-commit hooks pass

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4783-types-Add-proper-types-for-ImportFailInfo-API-endpoints-2476d73d36508196a83fffb59191ae0f) by [Unito](https://www.unito.io)
