### PR TITLE
Only shown in the desktop version of the app

### DIFF
--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -114,6 +114,11 @@ export const useReleaseStore = defineStore('release', () => {
       return false
     }
 
+    // Only show on desktop version
+    if (!isElectron()) {
+      return false
+    }
+
     // Already latest → no dot
     if (!isNewVersionAvailable.value) {
       return false

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -223,7 +223,9 @@ export const useReleaseStore = defineStore('release', () => {
 
     // Skip fetching if API nodes are disabled via argv
     if (
-      systemStatsStore.systemStats?.system?.argv?.includes('disable-api-nodes')
+      systemStatsStore.systemStats?.system?.argv?.includes(
+        '--disable-api-nodes'
+      )
     ) {
       return
     }

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -221,6 +221,13 @@ export const useReleaseStore = defineStore('release', () => {
       return
     }
 
+    // Skip fetching if API nodes are disabled via argv
+    if (
+      systemStatsStore.systemStats?.system?.argv?.includes('disable-api-nodes')
+    ) {
+      return
+    }
+
     isLoading.value = true
     error.value = null
 

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import { type ReleaseNote, useReleaseService } from '@/services/releaseService'
 import { useSettingStore } from '@/stores/settingStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { isElectron } from '@/utils/envUtil'
 import { compareVersions, stringToLocale } from '@/utils/formatUtil'
 
 // Store for managing release notes
@@ -78,6 +79,11 @@ export const useReleaseStore = defineStore('release', () => {
   const shouldShowToast = computed(() => {
     // Skip if notifications are disabled
     if (!showVersionUpdates.value) {
+      return false
+    }
+
+    // Only show toast on desktop version
+    if (!isElectron()) {
       return false
     }
 


### PR DESCRIPTION
This pull request updates the release notification logic in the `releaseStore` to ensure that certain UI elements (such as update toasts and notification dots) are only shown in the desktop version of the app. This prevents unnecessary notifications from appearing in non-desktop environments.

Desktop-only notification logic:

* Imported the `isElectron` utility from `envUtil` to detect if the app is running in the desktop environment.
* Added checks using `isElectron()` to ensure that update toasts and notification dots are only displayed in the desktop version, avoiding these elements in web or mobile environments. [[1]](diffhunk://#diff-2424b33707972e50d470b0f0f6d893b2e023b9a1fee16b2ffb99cb74edae0471R85-R89) [[2]](diffhunk://#diff-2424b33707972e50d470b0f0f6d893b2e023b9a1fee16b2ffb99cb74edae0471R117-R121)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4786-Only-shown-in-the-desktop-version-of-the-app-2476d73d365081aeb79dd0399b173c4e) by [Unito](https://www.unito.io)
