### PR TITLE
Revert test PR for backport workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 **Official front-end implementation of [ComfyUI](https://github.com/comfyanonymous/ComfyUI).**
 
-<!-- Testing automatic backport workflow -->
-
 [![Website][website-shield]][website-url]
 [![Discord][discord-shield]][discord-url]
 [![Matrix][matrix-shield]][matrix-url]


### PR DESCRIPTION
This reverts the test commit that was used to verify the automatic backport workflow.

The backport workflow has been verified to work correctly, so we can now clean up the test change.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4794-Revert-test-PR-for-backport-workflow-2476d73d3650817ca56ad8f8b32ab96b) by [Unito](https://www.unito.io)
