### PR TITLE
Fix widget display on subgraph nodes

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1554,6 +1554,9 @@ export class LGraph
       outputs: structuredClone(outputs)
     })
     if (!subgraphNode) throw new Error('Failed to create subgraph node')
+    for (let i = 0; i < inputs.length; i++) {
+      Object.assign(subgraphNode.inputs[i], inputs[i])
+    }
 
     // Resize to inputs/outputs
     subgraphNode.setSize(subgraphNode.computeSize())
@@ -1655,6 +1658,8 @@ export class LGraph
       }
     }
 
+    subgraphNode._setConcreteSlots()
+    subgraphNode.arrange()
     return { subgraph, node: subgraphNode as SubgraphNode }
   }
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1551,7 +1551,6 @@ export class LGraph
 
     // Create subgraph node object
     const subgraphNode = LiteGraph.createNode(subgraph.id, subgraph.name, {
-      inputs: structuredClone(inputs),
       outputs: structuredClone(outputs)
     })
     if (!subgraphNode) throw new Error('Failed to create subgraph node')

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -72,7 +72,14 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       (e) => {
         const subgraphInput = e.detail.input
         const { name, type } = subgraphInput
-        if (this.inputs.some((i) => i.name == name)) return
+        const existingInput = this.inputs.find((i) => i.name == name)
+        if (existingInput) {
+          const linkId = subgraphInput.linkIds[0]
+          const { inputNode } = subgraph.links[linkId].resolve(subgraph)
+          const widget = inputNode?.widgets?.find?.((w) => w.name == name)
+          if (widget) this.#setWidget(subgraphInput, existingInput, widget)
+          return
+        }
         const input = this.addInput(name, type)
 
         this.#addSubgraphInputListeners(subgraphInput, input)


### PR DESCRIPTION
Resolves #4692

This adds a workaround for widget data being clobbered when converting to subgraph and adds a path for widget data to still bubble upwards when a graph is loaded before dependent graphs with connected widgets.

Additionally, it recalculates input positions so that links are correctly displayed after conversion.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4798-Fix-widget-display-on-subgraph-nodes-2486d73d3650817b8414ff45456f9cba) by [Unito](https://www.unito.io)
