### PR TITLE
Fix disconnection from subgraph inputs

### DIFF
--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -795,7 +795,10 @@ export class LinkConnector {
    */
   disconnectLinks(): void {
     for (const link of this.renderLinks) {
-      if (link instanceof MovingLinkBase) {
+      if (
+        link instanceof MovingLinkBase ||
+        link instanceof ToInputFromIoNodeLink
+      ) {
         link.disconnect()
       }
     }

--- a/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
+++ b/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
@@ -135,4 +135,9 @@ export class ToInputFromIoNodeLink implements RenderLink {
   connectToRerouteOutput() {
     throw new Error('ToInputRenderLink cannot connect to an output.')
   }
+  disconnect(): boolean {
+    if (!this.existingLink) return false
+    this.existingLink.disconnect(this.network, 'input')
+    return true
+  }
 }


### PR DESCRIPTION
Fixes the inability to disconnect a link from a subgraph input node by dragging it off of the target side and dropping it onto the canvas.

Making ToInputFromIoNodeLink inherit from MovingLinkBase was considered, but the latter has quite a few other required functions and implementations that are undesirable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4800-Fix-disconnection-from-subgraph-inputs-2486d73d365081a4bb69ce6de7927dac) by [Unito](https://www.unito.io)
