### PR TITLE
[fix] Display dynamic keybinding in minimap tooltip

### DIFF
--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -58,7 +58,7 @@
       @click="() => commandStore.execute('Comfy.Canvas.ToggleLinkVisibility')"
     />
     <Button
-      v-tooltip.left="t('graphCanvasMenu.toggleMinimap') + ' (Alt + m)'"
+      v-tooltip.left="minimapTooltip"
       severity="secondary"
       :icon="'pi pi-map'"
       :aria-label="$t('graphCanvasMenu.toggleMinimap')"
@@ -79,15 +79,24 @@ import { useCanvasInteractions } from '@/composables/graph/useCanvasInteractions
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
+import { useKeybindingStore } from '@/stores/keybindingStore'
 import { useSettingStore } from '@/stores/settingStore'
 
 const { t } = useI18n()
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
+const keybindingStore = useKeybindingStore()
 const settingStore = useSettingStore()
 const canvasInteractions = useCanvasInteractions()
 
 const minimapVisible = computed(() => settingStore.get('Comfy.Minimap.Visible'))
+const minimapTooltip = computed(() => {
+  const baseText = t('graphCanvasMenu.toggleMinimap')
+  const keybinding = keybindingStore.getKeybindingByCommandId(
+    'Comfy.Canvas.ToggleMinimap'
+  )
+  return keybinding ? `${baseText} (${keybinding.combo.toString()})` : baseText
+})
 const linkHidden = computed(
   () => settingStore.get('Comfy.LinkRenderMode') === LiteGraph.HIDDEN_LINK
 )


### PR DESCRIPTION
Updates the minimap tooltip to show the current user-configured keybinding instead of hardcoded 'Alt+M'. The tooltip now dynamically updates when users customize the keybinding.

Fixes #4802

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4805-fix-Display-dynamic-keybinding-in-minimap-tooltip-2486d73d36508151a4ddfb9e82276c0b) by [Unito](https://www.unito.io)
