### PR TITLE
Support preview display on subgraphNodes

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -727,7 +727,12 @@ export class ComfyApp {
       revokePreviewsByExecutionId(displayNodeId)
       const blobUrl = URL.createObjectURL(blob)
       // Preview cleanup is handled in progress_state event to support multiple concurrent previews
-      setNodePreviewsByExecutionId(displayNodeId, [blobUrl])
+      const nodeParents = displayNodeId.split(':')
+      for (let i = 1; i <= nodeParents.length; i++) {
+        setNodePreviewsByExecutionId(nodeParents.slice(0, i).join(':'), [
+          blobUrl
+        ])
+      }
     })
 
     api.init()


### PR DESCRIPTION
Resolves #4808

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4814-Support-preview-display-on-subgraphNodes-2486d73d365081f3a6a0e9704b424a3f) by [Unito](https://www.unito.io)
