### PR TITLE
Remove subgraphs from add node context menu

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -363,6 +363,7 @@ export const useLitegraphService = () => {
     // Note: Do not following assignments before `LiteGraph.registerNodeType`
     // because `registerNodeType` will overwrite the assignments.
     node.category = nodeDef.category
+    node.skip_list = true
     node.title = nodeDef.display_name || nodeDef.name
   }
 


### PR DESCRIPTION
When subgraph nodes are added from the Right Click -> Add Node menu, the newly created subgraph node shares an already existing subgraph. This causes many unexpected bugs.

Additionally, this subgraph category can quickly become polluted by duplicated name entries.

As a heavy-handed fix, subgraphs are simply removed from being displayed in this menu. They can be reintroduced once the above problems are addressed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4820-Remove-subgraphs-from-add-node-context-menu-2486d73d3650816eace8d5a64a08a70a) by [Unito](https://www.unito.io)
