### PR TITLE
Rename subgraph widgets when slot is renamed

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -125,6 +125,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         if (!input) throw new Error('Subgraph input not found')
 
         input.label = newName
+        if (input._widget) {
+          input._widget.label = newName
+        }
       },
       { signal }
     )


### PR DESCRIPTION
When a slot is renamed inside a subgraph, the corresponding slots on a subgraph Node are also renamed. However, widgets on subgraph nodes were not updated. Since the slot name is not shown when there is a linked widget, this would give the impression that the rename was not functional.

If a widget exists on a subgraph node when a rename event is received, the label on that widget is also set.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4821-Rename-subgraph-widgets-when-slot-is-renamed-2486d73d3650813493e9e26600f75bc7) by [Unito](https://www.unito.io)
