### PR TITLE
Fix TransformPane pos/size

### DIFF
--- a/src/components/graph/TransformPane.vue
+++ b/src/components/graph/TransformPane.vue
@@ -11,7 +11,7 @@
 
     <!-- DEV ONLY: Viewport bounds visualization -->
     <div
-      v-if="props.showDebugOverlay && false"
+      v-if="props.showDebugOverlay"
       class="viewport-debug-overlay"
       :style="{
         position: 'absolute',

--- a/src/components/graph/TransformPane.vue
+++ b/src/components/graph/TransformPane.vue
@@ -11,7 +11,7 @@
 
     <!-- DEV ONLY: Viewport bounds visualization -->
     <div
-      v-if="props.showDebugOverlay"
+      v-if="props.showDebugOverlay && false"
       class="viewport-debug-overlay"
       :style="{
         position: 'absolute',
@@ -120,6 +120,10 @@ useCanvasTransformSync(props.canvas, syncWithCanvas, {
   contain: layout style paint;
   transform-origin: 0 0;
   pointer-events: none;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .transform-pane--interacting {


### PR DESCRIPTION
Was being offset causing the culling to be miscalculated. Doesn't cause reflow.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4826-Fix-TransformPane-pos-size-2486d73d365081909e84ceaeee83e359) by [Unito](https://www.unito.io)
