### PR TITLE
fix: hide Desktop User Guide menu item in web builds

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -198,6 +198,7 @@ const menuItems = computed<MenuItem[]>(() => {
       key: 'desktop-guide',
       type: 'item',
       label: t('helpCenter.desktopUserGuide'),
+      visible: isElectron(),
       action: () => {
         openExternalLink(EXTERNAL_LINKS.DESKTOP_GUIDE)
         emit('close')


### PR DESCRIPTION
Changes Made:
File: src/components/helpcenter/HelpCenterMenuContent.vue

```bash
const moreItems: MenuItem[] = [
  {
    key: 'desktop-guide',
    type: 'item',
    label: t('helpCenter.desktopUserGuide'),
+   visible: isElectron(),
    action: () => {
      openExternalLink(EXTERNAL_LINKS.DESKTOP_GUIDE)
      emit('close')
    }
  },
```

Fix #4816

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4828-fix-hide-Desktop-User-Guide-menu-item-in-web-builds-2486d73d3650813687b5f2d640b1043e) by [Unito](https://www.unito.io)
