### PR TITLE
fix: correct branch protection status contexts for RC branches

### DIFF
--- a/.github/workflows/create-release-candidate-branch.yaml
+++ b/.github/workflows/create-release-candidate-branch.yaml
@@ -145,7 +145,7 @@ jobs:
             -d '{
               "required_status_checks": {
                 "strict": true,
-                "contexts": ["build", "test"]
+                "contexts": ["lint-and-format", "test", "playwright-tests"]
               },
               "enforce_admins": false,
               "required_pull_request_reviews": {


### PR DESCRIPTION
- Replace non-existent 'build' context with existing job names
- Update contexts to match actual CI workflow jobs:
  - 'lint-and-format' (from lint-and-format.yaml)
  - 'test' (from vitest.yaml)
  - 'playwright-tests' (from test-ui.yaml)
- This ensures RC branches have proper protection rules

Fixes #4824

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4829-fix-correct-branch-protection-status-contexts-for-RC-branches-2486d73d36508112bc85c7218cfcd8b0) by [Unito](https://www.unito.io)
