### PR TITLE
Fix:  Alt+click reroute creation on high-DPI displays

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2384,7 +2384,6 @@ export class LGraphCanvas
       // Set the width of the line for isPointInStroke checks
       const { lineWidth } = this.ctx
       this.ctx.lineWidth = this.connections_width + 7
-      const dpi = window?.devicePixelRatio || 1
 
       for (const linkSegment of this.renderedPaths) {
         const centre = linkSegment._pos
@@ -2394,7 +2393,7 @@ export class LGraphCanvas
         if (
           (e.shiftKey || e.altKey) &&
           linkSegment.path &&
-          this.ctx.isPointInStroke(linkSegment.path, x * dpi, y * dpi)
+          this.ctx.isPointInStroke(linkSegment.path, x, y)
         ) {
           this.ctx.lineWidth = lineWidth
 


### PR DESCRIPTION
- Removed devicePixelRatio scaling from isPointInStroke coordinates
- Coordinates were being double-scaled causing hit detection failures
- Fixes issue #4803 where Alt+click reroute creation failed on high-DPI screens
- Ensures consistent coordinate system between rendering and hit detection

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4831-Fix-Alt-click-reroute-creation-on-high-DPI-displays-2496d73d3650819982d2d560f80a5fed) by [Unito](https://www.unito.io)
