### PR TITLE
feat: Add smooth slide-up animation to SelectionToolbox

### DIFF
--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -28,9 +28,8 @@ const { getSelectableItems } = useSelectedLiteGraphItems()
 const visible = ref(false)
 const showBorder = ref(false)
 // Increment counter to notify child components of position/visibility change
+// This does not include viewport changes.
 const overlayUpdateCount = ref(0)
-
-// Provide visibility state and update counter to child components
 provide('selectionOverlayState', {
   visible: readonly(visible),
   updateCount: readonly(overlayUpdateCount)

--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -61,7 +61,6 @@ whenever(
     requestAnimationFrame(() => {
       positionSelectionOverlay()
       overlayUpdateCount.value++
-      console.log('selectionChanged', overlayUpdateCount.value)
       canvasStore.getCanvas().state.selectionChanged = false
     })
   },

--- a/src/components/graph/SelectionOverlay.vue
+++ b/src/components/graph/SelectionOverlay.vue
@@ -20,6 +20,7 @@ import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteG
 import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
 import { createBounds } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/stores/graphStore'
+import { SelectionOverlayInjectionKey } from '@/types/selectionOverlayTypes'
 
 const canvasStore = useCanvasStore()
 const { style, updatePosition } = useAbsolutePosition()
@@ -30,7 +31,7 @@ const showBorder = ref(false)
 // Increment counter to notify child components of position/visibility change
 // This does not include viewport changes.
 const overlayUpdateCount = ref(0)
-provide('selectionOverlayState', {
+provide(SelectionOverlayInjectionKey, {
   visible: readonly(visible),
   updateCount: readonly(overlayUpdateCount)
 })

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -53,10 +53,7 @@ const canvasStore = useCanvasStore()
 const extensionService = useExtensionService()
 const canvasInteractions = useCanvasInteractions()
 
-// Inject the selection overlay state
 const selectionOverlayState = inject(SelectionOverlayInjectionKey)
-
-// Use the reusable animation hook
 const { shouldAnimate } = useRetriggerableAnimation(
   selectionOverlayState?.updateCount,
   { animateOnMount: true }

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -1,33 +1,37 @@
 <template>
-  <Panel
-    class="selection-toolbox absolute left-1/2 rounded-lg"
-    :pt="{
-      header: 'hidden',
-      content: 'p-0 flex flex-row'
-    }"
-    @wheel="canvasInteractions.handleWheel"
-  >
-    <ExecuteButton />
-    <ColorPickerButton />
-    <BypassButton />
-    <PinButton />
-    <EditModelButton />
-    <MaskEditorButton />
-    <ConvertToSubgraphButton />
-    <DeleteButton />
-    <RefreshSelectionButton />
-    <ExtensionCommandButton
-      v-for="command in extensionToolboxCommands"
-      :key="command.id"
-      :command="command"
-    />
-    <HelpButton />
-  </Panel>
+  <Transition name="slide-up" appear>
+    <Panel
+      :key="animationKey"
+      class="selection-toolbox absolute left-1/2 rounded-lg"
+      :pt="{
+        header: 'hidden',
+        content: 'p-0 flex flex-row'
+      }"
+      @wheel="canvasInteractions.handleWheel"
+    >
+      <ExecuteButton />
+      <ColorPickerButton />
+      <BypassButton />
+      <PinButton />
+      <EditModelButton />
+      <MaskEditorButton />
+      <ConvertToSubgraphButton />
+      <DeleteButton />
+      <RefreshSelectionButton />
+      <ExtensionCommandButton
+        v-for="command in extensionToolboxCommands"
+        :key="command.id"
+        :command="command"
+      />
+      <HelpButton />
+    </Panel>
+  </Transition>
 </template>
 
 <script setup lang="ts">
 import Panel from 'primevue/panel'
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
+import type { Ref } from 'vue'
 
 import BypassButton from '@/components/graph/selectionToolbox/BypassButton.vue'
 import ColorPickerButton from '@/components/graph/selectionToolbox/ColorPickerButton.vue'
@@ -50,6 +54,17 @@ const canvasStore = useCanvasStore()
 const extensionService = useExtensionService()
 const canvasInteractions = useCanvasInteractions()
 
+// Inject the selection overlay state
+const selectionOverlayState = inject<{
+  visible: Readonly<Ref<boolean>>
+  updateCount: Readonly<Ref<number>>
+}>('selectionOverlayState')
+
+// Animation control
+const animationKey = computed(
+  () => selectionOverlayState?.updateCount.value ?? 0
+)
+
 const extensionToolboxCommands = computed<ComfyCommandImpl[]>(() => {
   const commandIds = new Set<string>(
     canvasStore.selectedItems
@@ -70,5 +85,20 @@ const extensionToolboxCommands = computed<ComfyCommandImpl[]>(() => {
 <style scoped>
 .selection-toolbox {
   transform: translateX(-50%) translateY(-120%);
+}
+
+/* Slide up animation */
+.slide-up-enter-active {
+  transition: all 0.3s ease-out;
+}
+
+.slide-up-enter-from {
+  transform: translateX(-50%) translateY(-100%);
+  opacity: 0;
+}
+
+.slide-up-enter-to {
+  transform: translateX(-50%) translateY(-120%);
+  opacity: 1;
 }
 </style>

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import Panel from 'primevue/panel'
-import { computed, inject, onMounted, ref, watch } from 'vue'
+import { computed, inject } from 'vue'
 
 import BypassButton from '@/components/graph/selectionToolbox/BypassButton.vue'
 import ColorPickerButton from '@/components/graph/selectionToolbox/ColorPickerButton.vue'
@@ -41,6 +41,7 @@ import HelpButton from '@/components/graph/selectionToolbox/HelpButton.vue'
 import MaskEditorButton from '@/components/graph/selectionToolbox/MaskEditorButton.vue'
 import PinButton from '@/components/graph/selectionToolbox/PinButton.vue'
 import RefreshSelectionButton from '@/components/graph/selectionToolbox/RefreshSelectionButton.vue'
+import { useRetriggerableAnimation } from '@/composables/element/useRetriggerableAnimation'
 import { useCanvasInteractions } from '@/composables/graph/useCanvasInteractions'
 import { useExtensionService } from '@/services/extensionService'
 import { type ComfyCommandImpl, useCommandStore } from '@/stores/commandStore'
@@ -55,26 +56,11 @@ const canvasInteractions = useCanvasInteractions()
 // Inject the selection overlay state
 const selectionOverlayState = inject(SelectionOverlayInjectionKey)
 
-// Animation control
-const shouldAnimate = ref(false)
-
-// Trigger animation on mount
-onMounted(() => {
-  shouldAnimate.value = true
-})
-
-// Watch for update count changes to retrigger animation
-if (selectionOverlayState) {
-  watch(selectionOverlayState.updateCount, () => {
-    // Reset animation by removing and re-adding the class
-    shouldAnimate.value = false
-    // Force browser reflow
-    void document.body.offsetHeight
-    requestAnimationFrame(() => {
-      shouldAnimate.value = true
-    })
-  })
-}
+// Use the reusable animation hook
+const { shouldAnimate } = useRetriggerableAnimation(
+  selectionOverlayState?.updateCount,
+  { animateOnMount: true }
+)
 
 const extensionToolboxCommands = computed<ComfyCommandImpl[]>(() => {
   const commandIds = new Set<string>(

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -29,7 +29,6 @@
 <script setup lang="ts">
 import Panel from 'primevue/panel'
 import { computed, inject, onMounted, ref, watch } from 'vue'
-import type { Ref } from 'vue'
 
 import BypassButton from '@/components/graph/selectionToolbox/BypassButton.vue'
 import ColorPickerButton from '@/components/graph/selectionToolbox/ColorPickerButton.vue'
@@ -46,6 +45,7 @@ import { useCanvasInteractions } from '@/composables/graph/useCanvasInteractions
 import { useExtensionService } from '@/services/extensionService'
 import { type ComfyCommandImpl, useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
+import { SelectionOverlayInjectionKey } from '@/types/selectionOverlayTypes'
 
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
@@ -53,10 +53,7 @@ const extensionService = useExtensionService()
 const canvasInteractions = useCanvasInteractions()
 
 // Inject the selection overlay state
-const selectionOverlayState = inject<{
-  visible: Readonly<Ref<boolean>>
-  updateCount: Readonly<Ref<number>>
-}>('selectionOverlayState')
+const selectionOverlayState = inject(SelectionOverlayInjectionKey)
 
 // Animation control
 const shouldAnimate = ref(false)

--- a/src/composables/element/useRetriggerableAnimation.ts
+++ b/src/composables/element/useRetriggerableAnimation.ts
@@ -1,0 +1,80 @@
+import { onMounted, ref, watch } from 'vue'
+import type { Ref, WatchSource } from 'vue'
+
+/**
+ * A composable that manages retriggerable CSS animations.
+ * Provides a boolean ref that can be toggled to restart CSS animations.
+ *
+ * @param trigger - Optional reactive source that triggers the animation when it changes
+ * @param options - Configuration options
+ * @returns An object containing the animation state ref
+ *
+ * @example
+ * ```vue
+ * <template>
+ *   <div :class="{ 'animate-slide-up': shouldAnimate }">
+ *     Content
+ *   </div>
+ * </template>
+ *
+ * <script setup>
+ * const { shouldAnimate } = useRetriggerableAnimation(someReactiveTrigger)
+ * </script>
+ * ```
+ */
+export function useRetriggerableAnimation<T = any>(
+  trigger?: WatchSource<T> | Ref<T>,
+  options: {
+    animateOnMount?: boolean
+    animationDelay?: number
+  } = {}
+) {
+  const { animateOnMount = true, animationDelay = 0 } = options
+
+  const shouldAnimate = ref(false)
+
+  /**
+   * Retriggers the animation by removing and re-adding the animation class
+   */
+  const retriggerAnimation = () => {
+    // Remove animation class
+    shouldAnimate.value = false
+    // Force browser reflow to ensure the class removal is processed
+    void document.body.offsetHeight
+    // Re-add animation class in the next frame
+    requestAnimationFrame(() => {
+      if (animationDelay > 0) {
+        setTimeout(() => {
+          shouldAnimate.value = true
+        }, animationDelay)
+      } else {
+        shouldAnimate.value = true
+      }
+    })
+  }
+
+  // Trigger animation on mount if requested
+  if (animateOnMount) {
+    onMounted(() => {
+      if (animationDelay > 0) {
+        setTimeout(() => {
+          shouldAnimate.value = true
+        }, animationDelay)
+      } else {
+        shouldAnimate.value = true
+      }
+    })
+  }
+
+  // Watch for trigger changes to retrigger animation
+  if (trigger) {
+    watch(trigger, () => {
+      retriggerAnimation()
+    })
+  }
+
+  return {
+    shouldAnimate,
+    retriggerAnimation
+  }
+}

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4130,6 +4130,7 @@ export class LGraphCanvas
     const selected = this.selectedItems
     if (!selected.size) return
 
+    const initialSelectionSize = selected.size
     let wasSelected: Positionable | undefined
     for (const sel of selected) {
       if (sel === keepSelected) {
@@ -4170,8 +4171,12 @@ export class LGraphCanvas
       }
     }
 
-    this.state.selectionChanged = true
-    this.onSelectionChange?.(this.selected_nodes)
+    // Only set selectionChanged if selection actually changed
+    const finalSelectionSize = selected.size
+    if (initialSelectionSize !== finalSelectionSize) {
+      this.state.selectionChanged = true
+      this.onSelectionChange?.(this.selected_nodes)
+    }
   }
 
   /** @deprecated See {@link LGraphCanvas.deselectAll} */

--- a/src/types/selectionOverlayTypes.ts
+++ b/src/types/selectionOverlayTypes.ts
@@ -1,0 +1,9 @@
+import type { InjectionKey, Ref } from 'vue'
+
+export interface SelectionOverlayState {
+  visible: Readonly<Ref<boolean>>
+  updateCount: Readonly<Ref<number>>
+}
+
+export const SelectionOverlayInjectionKey: InjectionKey<SelectionOverlayState> =
+  Symbol('selectionOverlayState')


### PR DESCRIPTION
## Summary
- Add smooth slide-up animation to the SelectionToolbox component
- Animation triggers on selection changes and when dragging ends
- Refactored animation logic into reusable `useRetriggerableAnimation` composable
- Uses Vue's dependency injection system for communication between SelectionOverlay and SelectionToolbox
- Fixed bug where clicking the same node would unnecessarily trigger selection change events


https://github.com/user-attachments/assets/2bca012f-acfb-4daf-9536-6a3bd9ab8de1


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4832-feat-Add-smooth-slide-up-animation-to-SelectionToolbox-2496d73d36508134b87bfdaffe6751fd) by [Unito](https://www.unito.io)
