### PR TITLE
feat: Enable double-click on subgraph slot labels for renaming

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1035,12 +1035,40 @@ export class ComfyPage {
       }
 
       const input = inputsToTry[0]
-      if (!input.pos) {
-        throw new Error('Input slot position not found')
+      if (!input.boundingRect) {
+        throw new Error('Input slot bounding rect not found')
       }
 
-      const testX = input.pos[0]
-      const testY = input.pos[1]
+      // Use center of bounding rect for reliable clicking
+      const rect = input.boundingRect
+      const testX = rect[0] + rect[2] / 2 // x + width/2
+      const testY = rect[1] + rect[3] / 2 // y + height/2
+
+      // Simulate double-click directly through pointer events
+      const leftClickEvent = {
+        canvasX: testX,
+        canvasY: testY,
+        button: 0, // Left mouse button
+        preventDefault: () => {},
+        stopPropagation: () => {}
+      }
+
+      // Trigger the input node's pointer down handler
+      if (inputNode.onPointerDown) {
+        inputNode.onPointerDown(
+          leftClickEvent,
+          app.canvas.pointer,
+          app.canvas.linkConnector
+        )
+
+        // Trigger double-click if pointer has the handler
+        if (app.canvas.pointer.onDoubleClick) {
+          app.canvas.pointer.onDoubleClick(leftClickEvent)
+        }
+      }
+
+      // Wait briefly for dialog to appear
+      await new Promise((resolve) => setTimeout(resolve, 200))
 
       return { success: true, inputName: input.name, x: testX, y: testY }
     }, inputName)
@@ -1053,17 +1081,7 @@ export class ComfyPage {
       )
     }
 
-    // Perform the actual double-click at the slot position
-    await this.canvas.dblclick({
-      position: { x: foundSlot.x, y: foundSlot.y }
-    })
     await this.nextFrame()
-
-    // Wait for the rename dialog to appear
-    await this.page.waitForSelector('.graphdialog input', {
-      state: 'visible',
-      timeout: 5000
-    })
   }
 
   /**
@@ -1112,12 +1130,40 @@ export class ComfyPage {
       }
 
       const output = outputsToTry[0]
-      if (!output.pos) {
-        throw new Error('Output slot position not found')
+      if (!output.boundingRect) {
+        throw new Error('Output slot bounding rect not found')
       }
 
-      const testX = output.pos[0]
-      const testY = output.pos[1]
+      // Use center of bounding rect for reliable clicking
+      const rect = output.boundingRect
+      const testX = rect[0] + rect[2] / 2 // x + width/2
+      const testY = rect[1] + rect[3] / 2 // y + height/2
+
+      // Simulate double-click directly through pointer events
+      const leftClickEvent = {
+        canvasX: testX,
+        canvasY: testY,
+        button: 0, // Left mouse button
+        preventDefault: () => {},
+        stopPropagation: () => {}
+      }
+
+      // Trigger the output node's pointer down handler
+      if (outputNode.onPointerDown) {
+        outputNode.onPointerDown(
+          leftClickEvent,
+          app.canvas.pointer,
+          app.canvas.linkConnector
+        )
+
+        // Trigger double-click if pointer has the handler
+        if (app.canvas.pointer.onDoubleClick) {
+          app.canvas.pointer.onDoubleClick(leftClickEvent)
+        }
+      }
+
+      // Wait briefly for dialog to appear
+      await new Promise((resolve) => setTimeout(resolve, 200))
 
       return { success: true, outputName: output.name, x: testX, y: testY }
     }, outputName)
@@ -1130,17 +1176,7 @@ export class ComfyPage {
       )
     }
 
-    // Perform the actual double-click at the slot position
-    await this.canvas.dblclick({
-      position: { x: foundSlot.x, y: foundSlot.y }
-    })
     await this.nextFrame()
-
-    // Wait for the rename dialog to appear
-    await this.page.waitForSelector('.graphdialog input', {
-      state: 'visible',
-      timeout: 5000
-    })
   }
 
   /**

--- a/browser_tests/tests/subgraph.spec.ts
+++ b/browser_tests/tests/subgraph.spec.ts
@@ -155,6 +155,108 @@ test.describe('Subgraph Operations', () => {
       expect(newInputName).toBe(RENAMED_INPUT_NAME)
       expect(newInputName).not.toBe(initialInputLabel)
     })
+
+    test('Can rename input slots via double-click', async ({ comfyPage }) => {
+      await comfyPage.loadWorkflow('basic-subgraph')
+
+      const subgraphNode = await comfyPage.getNodeRefById('2')
+      await subgraphNode.navigateIntoSubgraph()
+
+      const initialInputLabel = await comfyPage.page.evaluate(() => {
+        const graph = window['app'].canvas.graph
+        return graph.inputs?.[0]?.label || null
+      })
+
+      await comfyPage.doubleClickSubgraphInputSlot(initialInputLabel)
+
+      await comfyPage.page.waitForSelector(SELECTORS.promptDialog, {
+        state: 'visible'
+      })
+      await comfyPage.page.fill(SELECTORS.promptDialog, RENAMED_INPUT_NAME)
+      await comfyPage.page.keyboard.press('Enter')
+
+      // Force re-render
+      await comfyPage.canvas.click({ position: { x: 100, y: 100 } })
+      await comfyPage.nextFrame()
+
+      const newInputName = await comfyPage.page.evaluate(() => {
+        const graph = window['app'].canvas.graph
+        return graph.inputs?.[0]?.label || null
+      })
+
+      expect(newInputName).toBe(RENAMED_INPUT_NAME)
+      expect(newInputName).not.toBe(initialInputLabel)
+    })
+
+    test('Can rename output slots via double-click', async ({ comfyPage }) => {
+      await comfyPage.loadWorkflow('basic-subgraph')
+
+      const subgraphNode = await comfyPage.getNodeRefById('2')
+      await subgraphNode.navigateIntoSubgraph()
+
+      const initialOutputLabel = await comfyPage.page.evaluate(() => {
+        const graph = window['app'].canvas.graph
+        return graph.outputs?.[0]?.label || null
+      })
+
+      await comfyPage.doubleClickSubgraphOutputSlot(initialOutputLabel)
+
+      await comfyPage.page.waitForSelector(SELECTORS.promptDialog, {
+        state: 'visible'
+      })
+      const renamedOutputName = 'renamed_output'
+      await comfyPage.page.fill(SELECTORS.promptDialog, renamedOutputName)
+      await comfyPage.page.keyboard.press('Enter')
+
+      // Force re-render
+      await comfyPage.canvas.click({ position: { x: 100, y: 100 } })
+      await comfyPage.nextFrame()
+
+      const newOutputName = await comfyPage.page.evaluate(() => {
+        const graph = window['app'].canvas.graph
+        return graph.outputs?.[0]?.label || null
+      })
+
+      expect(newOutputName).toBe(renamedOutputName)
+      expect(newOutputName).not.toBe(initialOutputLabel)
+    })
+
+    test('Right-click context menu still works alongside double-click', async ({
+      comfyPage
+    }) => {
+      await comfyPage.loadWorkflow('basic-subgraph')
+
+      const subgraphNode = await comfyPage.getNodeRefById('2')
+      await subgraphNode.navigateIntoSubgraph()
+
+      const initialInputLabel = await comfyPage.page.evaluate(() => {
+        const graph = window['app'].canvas.graph
+        return graph.inputs?.[0]?.label || null
+      })
+
+      // Test that right-click still works for renaming
+      await comfyPage.rightClickSubgraphInputSlot(initialInputLabel)
+      await comfyPage.clickLitegraphContextMenuItem('Rename Slot')
+
+      await comfyPage.page.waitForSelector(SELECTORS.promptDialog, {
+        state: 'visible'
+      })
+      const rightClickRenamedName = 'right_click_renamed'
+      await comfyPage.page.fill(SELECTORS.promptDialog, rightClickRenamedName)
+      await comfyPage.page.keyboard.press('Enter')
+
+      // Force re-render
+      await comfyPage.canvas.click({ position: { x: 100, y: 100 } })
+      await comfyPage.nextFrame()
+
+      const newInputName = await comfyPage.page.evaluate(() => {
+        const graph = window['app'].canvas.graph
+        return graph.inputs?.[0]?.label || null
+      })
+
+      expect(newInputName).toBe(rightClickRenamedName)
+      expect(newInputName).not.toBe(initialInputLabel)
+    })
   })
 
   test.describe('Subgraph Creation and Deletion', () => {

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -171,6 +171,21 @@ export abstract class SubgraphIONodeBase<
   }
 
   /**
+   * Handles double-click on an IO slot to rename it.
+   * @param slot The slot that was double-clicked.
+   * @param event The event that triggered the double-click.
+   */
+  protected handleSlotDoubleClick(
+    slot: TSlot,
+    event: CanvasPointerEvent
+  ): void {
+    // Only allow renaming non-empty slots
+    if (slot !== this.emptySlot) {
+      this.#promptForSlotRename(slot, event)
+    }
+  }
+
+  /**
    * Shows the context menu for an IO slot.
    * @param slot The slot to show the context menu for.
    * @param event The event that triggered the context menu.
@@ -239,21 +254,30 @@ export abstract class SubgraphIONodeBase<
       // Rename the slot
       case 'rename':
         if (slot !== this.emptySlot) {
-          this.subgraph.canvasAction((c) =>
-            c.prompt(
-              'Slot name',
-              slot.name,
-              (newName: string) => {
-                if (newName) this.renameSlot(slot, newName)
-              },
-              event
-            )
-          )
+          this.#promptForSlotRename(slot, event)
         }
         break
     }
 
     this.subgraph.setDirtyCanvas(true)
+  }
+
+  /**
+   * Prompts the user to rename a slot.
+   * @param slot The slot to rename.
+   * @param event The event that triggered the rename.
+   */
+  #promptForSlotRename(slot: TSlot, event: CanvasPointerEvent): void {
+    this.subgraph.canvasAction((c) =>
+      c.prompt(
+        'Slot name',
+        slot.name,
+        (newName: string) => {
+          if (newName) this.renameSlot(slot, newName)
+        },
+        event
+      )
+    )
   }
 
   /** Arrange the slots in this node. */

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -63,6 +63,9 @@ export class SubgraphInputNode
           pointer.onDragEnd = (eUp) => {
             linkConnector.dropLinks(this.subgraph, eUp)
           }
+          pointer.onDoubleClick = () => {
+            this.handleSlotDoubleClick(slot, e)
+          }
           pointer.finally = () => {
             linkConnector.reset(true)
           }

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -4,7 +4,6 @@ import { LLink } from '@/lib/litegraph/src/LLink'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
-import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
 import type {
   DefaultConnectionColors,
   INodeInputSlot,
@@ -51,12 +50,8 @@ export class SubgraphInputNode
     // Left-click handling for dragging connections
     if (e.button === 0) {
       for (const slot of this.allSlots) {
-        const slotBounds = Rectangle.fromCentre(
-          slot.pos,
-          slot.boundingRect.height
-        )
-
-        if (slotBounds.containsXy(e.canvasX, e.canvasY)) {
+        // Check if click is within the full slot area (including label)
+        if (slot.boundingRect.containsXy(e.canvasX, e.canvasY)) {
           pointer.onDragStart = () => {
             linkConnector.dragNewFromSubgraphInput(this.subgraph, this, slot)
           }

--- a/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
@@ -63,6 +63,9 @@ export class SubgraphOutputNode
           pointer.onDragEnd = (eUp) => {
             linkConnector.dropLinks(this.subgraph, eUp)
           }
+          pointer.onDoubleClick = () => {
+            this.handleSlotDoubleClick(slot, e)
+          }
           pointer.finally = () => {
             linkConnector.reset(true)
           }

--- a/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
@@ -4,7 +4,6 @@ import type { LLink } from '@/lib/litegraph/src/LLink'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
-import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
 import type {
   DefaultConnectionColors,
   INodeInputSlot,
@@ -51,12 +50,8 @@ export class SubgraphOutputNode
     // Left-click handling for dragging connections
     if (e.button === 0) {
       for (const slot of this.allSlots) {
-        const slotBounds = Rectangle.fromCentre(
-          slot.pos,
-          slot.boundingRect.height
-        )
-
-        if (slotBounds.containsXy(e.canvasX, e.canvasY)) {
+        // Check if click is within the full slot area (including label)
+        if (slot.boundingRect.containsXy(e.canvasX, e.canvasY)) {
           pointer.onDragStart = () => {
             linkConnector.dragNewFromSubgraphOutput(this.subgraph, this, slot)
           }


### PR DESCRIPTION
Fixes #4830

## Summary
- Enable double-click renaming functionality on subgraph I/O slot labels, not just the slot connectors
- Expand clickable area for double-click rename to include the full slot area (connector + text label)
- Add comprehensive test coverage for label-specific clicking

https://github.com/user-attachments/assets/16a44ac9-7c49-41ea-b593-f58aad4496c4

Note: stale label value in the edit box is unrelated to this PR. Filed https://github.com/Comfy-Org/ComfyUI_frontend/issues/4834

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4833-feat-Enable-double-click-on-subgraph-slot-labels-for-renaming-2496d73d365081f1af1feb56626c0268) by [Unito](https://www.unito.io)
