### PR TITLE
fix: hide More menu when no submenu items are visible

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -188,17 +188,8 @@ const showVersionUpdates = computed(() =>
   settingStore.get('Comfy.Notification.ShowVersionUpdates')
 )
 
-const moreMenuItem = computed(() =>
-  menuItems.value.find((item) => item.key === 'more')
-)
-
-const hasVisibleMoreItems = computed(() => {
-  // Check if there are any visible items in the more submenu
-  return isElectron() // Since all moreItems depend on isElectron()
-})
-
-const menuItems = computed<MenuItem[]>(() => {
-  const moreItems: MenuItem[] = [
+const moreItems = computed<MenuItem[]>(() => {
+  const allMoreItems: MenuItem[] = [
     {
       key: 'desktop-guide',
       type: 'item',
@@ -236,6 +227,19 @@ const menuItems = computed<MenuItem[]>(() => {
     }
   ]
 
+  // Filter for visible items only
+  return allMoreItems.filter((item) => item.visible !== false)
+})
+
+const hasVisibleMoreItems = computed(() => {
+  return !!moreItems.value.length
+})
+
+const moreMenuItem = computed(() =>
+  menuItems.value.find((item) => item.key === 'more')
+)
+
+const menuItems = computed<MenuItem[]>(() => {
   return [
     {
       key: 'docs',
@@ -284,7 +288,7 @@ const menuItems = computed<MenuItem[]>(() => {
       label: t('helpCenter.more'),
       visible: hasVisibleMoreItems.value,
       action: () => {}, // No action for more item
-      items: moreItems
+      items: moreItems.value
     }
   ]
 })

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -192,12 +192,18 @@ const moreMenuItem = computed(() =>
   menuItems.value.find((item) => item.key === 'more')
 )
 
+const hasVisibleMoreItems = computed(() => {
+  // Check if there are any visible items in the more submenu
+  return isElectron() // Since all moreItems depend on isElectron()
+})
+
 const menuItems = computed<MenuItem[]>(() => {
   const moreItems: MenuItem[] = [
     {
       key: 'desktop-guide',
       type: 'item',
       label: t('helpCenter.desktopUserGuide'),
+      visible: isElectron(),
       action: () => {
         openExternalLink(EXTERNAL_LINKS.DESKTOP_GUIDE)
         emit('close')
@@ -276,6 +282,7 @@ const menuItems = computed<MenuItem[]>(() => {
       type: 'item',
       icon: '',
       label: t('helpCenter.more'),
+      visible: hasVisibleMoreItems.value,
       action: () => {}, // No action for more item
       items: moreItems
     }


### PR DESCRIPTION
- Added visible: isElectron() to desktop-guide submenu item
- Added hasVisibleMoreItems computed property to check submenu visibility
- Added visible property to More menu item that depends on hasVisibleMoreItems
- This prevents empty More menu from appearing in web builds where all submenu items are electron-only


Desktop:
<img width="747" height="540" alt="image" src="https://github.com/user-attachments/assets/0ad58197-a1a5-4a68-83dc-70d83bf61482" />

web:
<img width="747" height="540" alt="image" src="https://github.com/user-attachments/assets/953ddfb2-a5fe-4674-b737-7ecf2eaf28bb" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4837-fix-hide-More-menu-when-no-submenu-items-are-visible-2496d73d365081dc9d41fccb4a2531bf) by [Unito](https://www.unito.io)

follow up fix #https://github.com/Comfy-Org/ComfyUI_frontend/issues/4816