### PR TITLE
Implement subgraph unpacking

### DIFF
--- a/src/components/graph/selectionToolbox/ConvertToSubgraphButton.vue
+++ b/src/components/graph/selectionToolbox/ConvertToSubgraphButton.vue
@@ -1,6 +1,20 @@
 <template>
   <Button
-    v-show="isVisible"
+    v-if="isUnpackVisible"
+    v-tooltip.top="{
+      value: t('commands.Comfy_Graph_UnpackSubgraph.label'),
+      showDelay: 1000
+    }"
+    severity="secondary"
+    text
+    @click="() => commandStore.execute('Comfy.Graph.UnpackSubgraph')"
+  >
+    <template #icon>
+      <i-lucide:expand />
+    </template>
+  </Button>
+  <Button
+    v-else-if="isConvertVisible"
     v-tooltip.top="{
       value: t('commands.Comfy_Graph_ConvertToSubgraph.label'),
       showDelay: 1000
@@ -20,6 +34,7 @@ import Button from 'primevue/button'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
 import { useCommandStore } from '@/stores/commandStore'
 import { useCanvasStore } from '@/stores/graphStore'
 
@@ -27,7 +42,13 @@ const { t } = useI18n()
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
 
-const isVisible = computed(() => {
+const isUnpackVisible = computed(() => {
+  return (
+    canvasStore.selectedItems?.length === 1 &&
+    canvasStore.selectedItems[0] instanceof SubgraphNode
+  )
+})
+const isConvertVisible = computed(() => {
   return (
     canvasStore.groupSelected ||
     canvasStore.rerouteSelected ||

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -21,6 +21,7 @@ import { useWorkflowService } from '@/services/workflowService'
 import type { ComfyCommand } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useCanvasStore, useTitleEditorStore } from '@/stores/graphStore'
+import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 import { useQueueSettingsStore, useQueueStore } from '@/stores/queueStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
@@ -795,6 +796,22 @@ export function useCoreCommands(): ComfyCommand[] {
         }
         const { node } = res
         canvas.select(node)
+      }
+    },
+    {
+      id: 'Comfy.Graph.UnpackSubgraph',
+      icon: 'pi pi-sitemap',
+      label: 'Unpack the selected Subgraph',
+      versionAdded: '1.20.1',
+      category: 'essentials' as const,
+      function: () => {
+        const canvas = canvasStore.getCanvas()
+        const graph = canvas.subgraph ?? canvas.graph
+        if (!graph) throw new TypeError('Canvas has no graph or subgraph set.')
+
+        const subgraphNode = app.canvas.selectedItems.values().next().value
+        useNodeOutputStore().revokeSubgraphPreviews(subgraphNode)
+        graph.unpackSubgraph(subgraphNode)
       }
     },
     {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1846,7 +1846,6 @@ export class LGraph
         reroute.pos[1] + offsetY
       ])
       rerouteIdMap.set(reroute.id, migratedReroute.id)
-      //TODO: check if needed?
       this.reroutes.set(migratedReroute.id, migratedReroute)
     }
     //iterate over newly created links to update reroute parentIds
@@ -1859,7 +1858,7 @@ export class LGraph
       let parentId: RerouteId | undefined = newLink[6]
       if (newLink[7]) {
         parentId = newLink[6]
-        //TODO: recursion check/helper method? probably already exists somewhere
+        //TODO: recursion check/helper method? Probably exists, but wouldn't mesh with the reference tracking used by this implementation
         while (parentId) {
           instance.parentId = parentId
           instance = this.reroutes.get(parentId)

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1686,14 +1686,14 @@ export class LGraph
         throw new Error('Node not found')
       }
 
-      node.pos[0] += offsetX
-      node.pos[1] += offsetY
       nodeIdMap.set(n_info.id, ++this.last_node_id)
       node.id = this.last_node_id
       n_info.id = this.last_node_id
 
       this.add(node, true)
       node.configure(n_info)
+      node.pos[0] += offsetX
+      node.pos[1] += offsetY
     }
 
     const newLinks: [NodeId, number, NodeId, number, LinkId][] = []
@@ -1784,7 +1784,7 @@ export class LGraph
       const migratedReroute = new Reroute(
         ++this.state.lastRerouteId,
         this,
-        reroute.pos,
+        [reroute.pos[0] + offsetX, reroute.pos[1] + offsetY],
         reroute.parentId ? rerouteIdMap.get(reroute.parentId) : undefined,
         linkIds
       )

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1694,6 +1694,9 @@ export class LGraph
       node.configure(n_info)
       node.pos[0] += offsetX
       node.pos[1] += offsetY
+      for (const input of node.inputs) {
+        input.link = null
+      }
     }
     //cleanup reoute.linkIds now, but leave link.parentIds dangling
     for (const islot of subgraphNode.inputs) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1748,11 +1748,34 @@ export class LGraph
     this.subgraphs.delete(subgraphNode.subgraph.id)
     const linkIdMap = new Map<LinkId, LinkId[]>()
     for (const newLink of newLinks) {
-      const created = this._nodes_by_id[newLink[0]].connect(
-        newLink[1],
-        this._nodes_by_id[newLink[2]],
-        newLink[3]
-      )
+      let created: LLink | null | undefined
+      if (newLink[0] == SUBGRAPH_INPUT_ID) {
+        if (!(this instanceof Subgraph)) {
+          console.error('Ignoring link to subgraph outside subgraph')
+          continue
+        }
+        const tnode = this._nodes_by_id[newLink[2]]
+        created = this.inputNode.slots[newLink[1]].connect(
+          tnode.inputs[newLink[3]],
+          tnode
+        )
+      } else if (newLink[2] == SUBGRAPH_OUTPUT_ID) {
+        if (!(this instanceof Subgraph)) {
+          console.error('Ignoring link to subgraph outside subgraph')
+          continue
+        }
+        const tnode = this._nodes_by_id[newLink[0]]
+        created = this.outputNode.slots[newLink[3]].connect(
+          tnode.outputs[newLink[1]],
+          tnode
+        )
+      } else {
+        created = this._nodes_by_id[newLink[0]].connect(
+          newLink[1],
+          this._nodes_by_id[newLink[2]],
+          newLink[3]
+        )
+      }
       if (!created) {
         console.error('Failed to create link')
         continue

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1768,11 +1768,14 @@ export class LGraph
         newLink[3]
       )
     }
+    const nodes: LGraphNode[] = []
     for (const nodeId of nodeIdMap.values()) {
       const node = this._nodes_by_id[nodeId]
+      nodes.push(node)
       node._setConcreteSlots()
       node.arrange()
     }
+    this.canvasAction((c) => c.selectItems(nodes))
   }
 
   /**

--- a/src/lib/litegraph/test/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/test/subgraph/SubgraphConversion.test.ts
@@ -39,20 +39,6 @@ function createNode(
   graph.add(node)
   return node
 }
-function log_state(graph: LGraph) {
-  console.log([
-    ...[...graph.links.values()].map((l) => [
-      l.id,
-      l.origin_id,
-      l.origin_slot,
-      l.target_id,
-      l.target_slot
-    ])
-  ])
-  console.log([...[...graph.reroutes.values()].map((r) => [r.id, r.linkIds])])
-  console.log([...graph.nodes.map((n) => [n.id, n.type])])
-}
-
 describe('SubgraphConversion', () => {
   describe('Subgraph Unpacking Functionality', () => {
     it('Should keep interior nodes and links', () => {
@@ -193,14 +179,11 @@ describe('SubgraphConversion', () => {
       const outerLink2 = outer.connect(0, subgraphNode, 1)
       assert(outerLink1 && outerLink2)
 
-      subgraph.createReroute([10, 10], outerLink1)
-      subgraph.createReroute([10, 20], outerLink2)
-      graph.createReroute([10, 10], innerLink1)
+      graph.createReroute([10, 10], outerLink1)
+      graph.createReroute([10, 20], outerLink2)
+      subgraph.createReroute([10, 10], innerLink1)
 
-      log_state(subgraph)
-      log_state(graph)
       graph.unpackSubgraph(subgraphNode)
-      log_state(graph)
 
       expect(graph.reroutes.size).toBe(3)
       expect(graph.links.size).toBe(3)

--- a/src/lib/litegraph/test/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/test/subgraph/SubgraphConversion.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ISlotType,
+  LGraph,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
+
+import {
+  createTestSubgraph,
+  createTestSubgraphNode
+} from './fixtures/subgraphHelpers'
+
+function createNode(
+  graph: LGraph,
+  inputs: ISlotType[] = [],
+  outputs: ISlotType[] = []
+) {
+  const type = JSON.stringify({ inputs, outputs })
+  if (!LiteGraph.registered_node_types[type]) {
+    class testnode extends LGraphNode {
+      constructor(title: string) {
+        super(title)
+        let i_count = 0
+        for (const input of inputs) this.addInput('input_' + i_count++, input)
+        let o_count = 0
+        for (const output of outputs)
+          this.addOutput('output_' + o_count++, output)
+      }
+    }
+    LiteGraph.registered_node_types[type] = testnode
+  }
+  const node = LiteGraph.createNode(type)
+  if (!node) {
+    throw new Error('Failed to create node')
+  }
+  graph.add(node)
+  return node
+}
+
+describe('SubgraphConversion', () => {
+  describe('Subgraph Unpacking Functionality', () => {
+    it('Should keep interior nodes and links', () => {
+      const subgraph = createTestSubgraph()
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph
+      graph.add(subgraphNode)
+
+      const node1 = createNode(subgraph, [], ['number'])
+      const node2 = createNode(subgraph, ['number'])
+      node1.connect(0, node2, 0)
+
+      graph.unpackSubgraph(subgraphNode)
+
+      expect(graph.nodes.length).toBe(2)
+      expect(graph.links.size).toBe(1)
+    })
+    it('Should merge boundry links', () => {
+      return
+      const subgraph = createTestSubgraph({
+        inputs: [{ name: 'value', type: 'number' }],
+        outputs: [{ name: 'value', type: 'number' }]
+      })
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph
+      graph.add(subgraphNode)
+
+      const innerNode1 = createNode(subgraph, [], ['number'])
+      const innerNode2 = createNode(subgraph, ['number'])
+      subgraph.inputNode.slots[0].connect(innerNode2.inputs[0], innerNode1)
+      subgraph.outputNode.slots[0].connect(innerNode1.outputs[0], innerNode1)
+
+      const outerNode1 = createNode(graph, [], ['number'])
+      const outerNode2 = createNode(graph, ['number'])
+      outerNode1.connect(0, subgraphNode, 0)
+      subgraphNode.connect(0, outerNode2, 0)
+
+      graph.unpackSubgraph(subgraphNode)
+
+      expect(graph.nodes.length).toBe(4)
+      expect(graph.links.size).toBe(2)
+    })
+  })
+})

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -125,6 +125,9 @@
   "Comfy_Graph_ExitSubgraph": {
     "label": "Exit Subgraph"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "Unpack the selected Subgraph"
+  },
   "Comfy_Graph_FitGroupToContents": {
     "label": "Fit Group To Contents"
   },

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -809,6 +809,7 @@ export const useLitegraphService = () => {
         options.unshift({
           content: 'Unpack Subgraph',
           callback: () => {
+            useNodeOutputStore().revokeSubgraphPreviews(this)
             this.graph.unpackSubgraph(this)
           }
         })

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -805,6 +805,14 @@ export const useLitegraphService = () => {
           })
         }
       }
+      if (this instanceof SubgraphNode) {
+        options.unshift({
+          content: 'Unpack Subgraph',
+          callback: () => {
+            this.graph.unpackSubgraph(this)
+          }
+        })
+      }
 
       return []
     }

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode, SubgraphNode } from '@/lib/litegraph/src/litegraph'
 import {
   ExecutedWsMessage,
   ResultItem,
@@ -268,6 +268,19 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     app.nodePreviewImages = {}
   }
 
+  /**
+   * Revoke all preview of a subgraph node and the graph it contains.
+   * Does not recurse to contents of nested subgraphs.
+   */
+  function revokeSubgraphPreviews(subgraphNode: SubgraphNode) {
+    const graphId =
+      subgraphNode.graph == app.graph ? '' : subgraphNode.graph.id + ':'
+    revokePreviewsByExecutionId(graphId + subgraphNode.id)
+    for (const node of subgraphNode.subgraph.nodes) {
+      revokePreviewsByExecutionId(subgraphNode.subgraph.id + node.id)
+    }
+  }
+
   return {
     getNodeOutputs,
     getNodeImageUrls,
@@ -279,6 +292,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     setNodePreviewsByNodeId,
     revokePreviewsByExecutionId,
     revokeAllPreviews,
+    revokeSubgraphPreviews,
     getPreviewParam
   }
 })

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -273,11 +273,12 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
    * Does not recurse to contents of nested subgraphs.
    */
   function revokeSubgraphPreviews(subgraphNode: SubgraphNode) {
-    const graphId =
-      subgraphNode.graph == app.graph ? '' : subgraphNode.graph.id + ':'
-    revokePreviewsByExecutionId(graphId + subgraphNode.id)
+    const graphId = subgraphNode.graph.isRootGraph
+      ? ''
+      : subgraphNode.graph.id + ':'
+    revokePreviewsByLocatorId(graphId + subgraphNode.id)
     for (const node of subgraphNode.subgraph.nodes) {
-      revokePreviewsByExecutionId(subgraphNode.subgraph.id + node.id)
+      revokePreviewsByLocatorId(subgraphNode.subgraph.id + node.id)
     }
   }
 


### PR DESCRIPTION
![unpacking](https://github.com/user-attachments/assets/914c66a8-2092-4a57-bd5b-bea146ad2878)

Known Issues:
- [x] ~~Reroutes on links connecting to the subgraph node are left dangling~~
- [x] ~~Widget related errors when destorying a subgraph node nested inside another subgraph.~~

Resolves #4866 by changing the convert to subgraph button to an unpack button

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4840-Implement-subgraph-unpacking-2496d73d365081668119e83072e8211f) by [Unito](https://www.unito.io)
