### PR TITLE
test(ci): skip transformPerformance suite on CI

### DIFF
--- a/tests-ui/tests/performance/transformPerformance.test.ts
+++ b/tests-ui/tests/performance/transformPerformance.test.ts
@@ -10,7 +10,11 @@ const createMockCanvasContext = () => ({
   }
 })
 
-describe('Transform Performance', () => {
+// Skip this entire suite on CI to avoid flaky performance timing
+const isCI = Boolean(process.env.CI)
+const describeIfNotCI = isCI ? describe.skip : describe
+
+describeIfNotCI('Transform Performance', () => {
   let transformState: ReturnType<typeof useTransformState>
   let mockCanvas: any
 


### PR DESCRIPTION
Skip performance test during CI to avoid flakiness.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4843-test-ci-skip-transformPerformance-suite-on-CI-2496d73d3650813184b0c0c2febdcb36) by [Unito](https://www.unito.io)
