### PR TITLE
[CI] Exclude `vue-nodes-migration` branch from playwright tests

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -3,7 +3,6 @@ name: Tests CI
 on:
   push:
     branches: [main, master, core/*, desktop/*]
-    branches-ignore: [vue-nodes-migration]
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*, vue-nodes-migration]
 

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -3,8 +3,9 @@ name: Tests CI
 on:
   push:
     branches: [main, master, core/*, desktop/*]
+    branches-ignore: [vue-nodes-migration]
   pull_request:
-    branches-ignore: [wip/*, draft/*, temp/*]
+    branches-ignore: [wip/*, draft/*, temp/*, vue-nodes-migration]
 
 jobs:
   setup:


### PR DESCRIPTION
This prevents the playwright-tests workflow from running on the vue-nodes-migration branch while keeping other tests (vitest, lint-and-format) active. The branch will be making a lot of changes that are incompatible with majority of current Playwright tests and we don't want to run them needlessly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4844-CI-Exclude-vue-nodes-migration-branch-from-playwright-tests-2496d73d365081b8a18dee35604d6f09) by [Unito](https://www.unito.io)
