### PR TITLE
[feat] Add v2/ prefix to manager service base URL

### DIFF
--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -19,25 +19,25 @@ const GENERIC_SECURITY_ERR_MSG =
  * API routes for ComfyUI Manager
  */
 enum ManagerRoute {
-  START_QUEUE = 'v2/manager/queue/start',
-  RESET_QUEUE = 'v2/manager/queue/reset',
-  QUEUE_STATUS = 'v2/manager/queue/status',
-  INSTALL = 'v2/manager/queue/install',
-  UPDATE = 'v2/manager/queue/update',
-  UPDATE_ALL = 'v2/manager/queue/update_all',
-  UNINSTALL = 'v2/manager/queue/uninstall',
-  DISABLE = 'v2/manager/queue/disable',
-  FIX_NODE = 'v2/manager/queue/fix',
-  LIST_INSTALLED = 'v2/customnode/installed',
-  GET_NODES = 'v2/customnode/getmappings',
-  GET_PACKS = 'v2/customnode/getlist',
-  IMPORT_FAIL_INFO = 'v2/customnode/import_fail_info',
-  REBOOT = 'v2/manager/reboot',
-  IS_LEGACY_MANAGER_UI = 'v2/manager/is_legacy_manager_ui'
+  START_QUEUE = 'manager/queue/start',
+  RESET_QUEUE = 'manager/queue/reset',
+  QUEUE_STATUS = 'manager/queue/status',
+  INSTALL = 'manager/queue/install',
+  UPDATE = 'manager/queue/update',
+  UPDATE_ALL = 'manager/queue/update_all',
+  UNINSTALL = 'manager/queue/uninstall',
+  DISABLE = 'manager/queue/disable',
+  FIX_NODE = 'manager/queue/fix',
+  LIST_INSTALLED = 'customnode/installed',
+  GET_NODES = 'customnode/getmappings',
+  GET_PACKS = 'customnode/getlist',
+  IMPORT_FAIL_INFO = 'customnode/import_fail_info',
+  REBOOT = 'manager/reboot',
+  IS_LEGACY_MANAGER_UI = 'manager/is_legacy_manager_ui'
 }
 
 const managerApiClient = axios.create({
-  baseURL: api.apiURL(''),
+  baseURL: api.apiURL('v2/'),
   headers: {
     'Content-Type': 'application/json'
   }


### PR DESCRIPTION
- Moved the `v2/` prefix from individual route enums to the axios client baseURL configuration
- This provides cleaner and more maintainable code by centralizing the API version prefix


Fixes #4851

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4872-feat-Add-v2-prefix-to-manager-service-base-URL-24a6d73d365081caa2abc21feb802e14) by [Unito](https://www.unito.io)
