### PR TITLE
[refactor] Replace manual clamp function with lodash

### DIFF
--- a/src/lib/litegraph/src/CurveEditor.ts
+++ b/src/lib/litegraph/src/CurveEditor.ts
@@ -1,5 +1,7 @@
+import { clamp } from 'lodash'
+
 import type { Point, Rect } from './interfaces'
-import { LGraphCanvas, clamp } from './litegraph'
+import { LGraphCanvas } from './litegraph'
 import { distance } from './measure'
 
 // used by some widgets to render a curve editor

--- a/src/lib/litegraph/src/infrastructure/ConstrainedSize.ts
+++ b/src/lib/litegraph/src/infrastructure/ConstrainedSize.ts
@@ -1,9 +1,10 @@
+import { clamp } from 'lodash'
+
 import type {
   ReadOnlyRect,
   ReadOnlySize,
   Size
 } from '@/lib/litegraph/src/interfaces'
-import { clamp } from '@/lib/litegraph/src/litegraph'
 
 /**
  * Basic width and height, with min/max constraints.

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -134,7 +134,7 @@ export { LGraphCanvas, type LGraphCanvasState } from './LGraphCanvas'
 export { LGraphGroup } from './LGraphGroup'
 export { LGraphNode, type NodeId } from './LGraphNode'
 export { type LinkId, LLink } from './LLink'
-export { clamp, createBounds } from './measure'
+export { createBounds } from './measure'
 export { Reroute, type RerouteId } from './Reroute'
 export {
   type ExecutableLGraphNode,

--- a/src/lib/litegraph/src/measure.ts
+++ b/src/lib/litegraph/src/measure.ts
@@ -450,7 +450,3 @@ export function alignOutsideContainer(
   }
   return rect
 }
-
-export function clamp(value: number, min: number, max: number): number {
-  return value < min ? min : value > max ? max : value
-}

--- a/src/lib/litegraph/src/widgets/ComboWidget.ts
+++ b/src/lib/litegraph/src/widgets/ComboWidget.ts
@@ -1,5 +1,7 @@
+import { clamp } from 'lodash'
+
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LiteGraph, clamp } from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   IComboWidget,
   IStringComboWidget

--- a/src/lib/litegraph/src/widgets/KnobWidget.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.ts
@@ -1,4 +1,5 @@
-import { clamp } from '@/lib/litegraph/src/litegraph'
+import { clamp } from 'lodash'
+
 import type { IKnobWidget } from '@/lib/litegraph/src/types/widgets'
 import { getWidgetStep } from '@/lib/litegraph/src/utils/widget'
 

--- a/src/lib/litegraph/src/widgets/SliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.ts
@@ -1,4 +1,5 @@
-import { clamp } from '@/lib/litegraph/src/litegraph'
+import { clamp } from 'lodash'
+
 import type { ISliderWidget } from '@/lib/litegraph/src/types/widgets'
 
 import {

--- a/src/lib/litegraph/test/litegraph.test.ts
+++ b/src/lib/litegraph/test/litegraph.test.ts
@@ -1,7 +1,8 @@
+import { clamp } from 'lodash'
 import { beforeEach, describe, expect, vi } from 'vitest'
 
 import { LiteGraphGlobal } from '@/lib/litegraph/src/LiteGraphGlobal'
-import { LGraphCanvas, LiteGraph, clamp } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 
 import { test } from './testExtensions'
 


### PR DESCRIPTION
## Summary
- Replace manual clamp implementation with lodash's `_.clamp` which handles more edge cases and requires less maintenance
- No functional changes, just using well-tested lodash utility


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4874-feat-Replace-manual-clamp-function-with-lodash-24a6d73d365081adb299f309b452d604) by [Unito](https://www.unito.io)
