### PR TITLE
[cleanup] Remove unused manager route enums

### DIFF
--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -27,10 +27,9 @@ enum ManagerRoute {
   UPDATE_ALL = 'manager/queue/update_all',
   UNINSTALL = 'manager/queue/uninstall',
   DISABLE = 'manager/queue/disable',
+  // FIX_NODE is currently unused but kept for potential future implementation
   FIX_NODE = 'manager/queue/fix',
   LIST_INSTALLED = 'customnode/installed',
-  GET_NODES = 'customnode/getmappings',
-  GET_PACKS = 'customnode/getlist',
   IMPORT_FAIL_INFO = 'customnode/import_fail_info',
   REBOOT = 'manager/reboot',
   IS_LEGACY_MANAGER_UI = 'manager/is_legacy_manager_ui'


### PR DESCRIPTION
## Summary
- Removed `GET_NODES` and `GET_PACKS` routes that were defined but never used in the codebase. These routes are removed in the cacheless version of ComfyUI-Manager
- Kept `FIX_NODE` with a comment indicating it may be implemented in the future

Part 2 of https://github.com/Comfy-Org/ComfyUI_frontend/issues/4851

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4875-cleanup-Remove-unused-manager-route-enums-24a6d73d365081eba8cfd436c8bb337a) by [Unito](https://www.unito.io)
