### PR TITLE
[CI] Pin third party GH actions to specific SHAs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -19,7 +19,7 @@ jobs:
       should-proceed: ${{ steps.check-status.outputs.proceed }}
     steps:
       - name: Wait for other CI checks
-        uses: lewagon/wait-on-check-action@v1.3.1
+        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-regexp: '^(lint-and-format|test|playwright-tests)'

--- a/.github/workflows/update-manager-types.yaml
+++ b/.github/workflows/update-manager-types.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ secrets.PR_GH_TOKEN }}
           commit-message: '[chore] Update ComfyUI-Manager API types from ComfyUI-Manager@${{ steps.manager-info.outputs.commit }}'


### PR DESCRIPTION
Pins the following actions to specific SHAs:

- peter-evans/create-pull-request
- lewagon/wait-on-check-action

Remaining actions (pin not required) are from Comfy-Org, GitHub, and Anthropic.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4878-CI-Pin-third-party-GH-actions-to-specific-SHAs-24a6d73d365081958c90cd3cebb1887b) by [Unito](https://www.unito.io)
