### PR TITLE
[ci] Add chromium-0.5x to test matrix

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, chromium-2x, mobile-chrome]
+        browser: [chromium, chromium-2x, chromium-0.5x, mobile-chrome]
     steps:
       - name: Wait for cache propagation
         run: sleep 10


### PR DESCRIPTION
## Summary
- Adds chromium-0.5x to the CI test matrix to run 0.5x DPI tests as a separate job

## Test plan
- CI should now show chromium-0.5x as a separate check in PR status
- Tests at 0.5x DPI will run in parallel with other browser tests

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4880-ci-Add-chromium-0-5x-to-test-matrix-24a6d73d365081f583a8cbfcab714e05) by [Unito](https://www.unito.io)
