### PR TITLE
[refactor] Remove unused omitBy function

### DIFF
--- a/src/lib/litegraph/src/utils/object.ts
+++ b/src/lib/litegraph/src/utils/object.ts
@@ -1,8 +1,0 @@
-export function omitBy<T extends object>(
-  obj: T,
-  predicate: (value: any) => boolean
-): Partial<T> {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([_key, value]) => !predicate(value))
-  ) as Partial<T>
-}


### PR DESCRIPTION
## Summary
- Remove unused omitBy function from object.ts
- Remove entire object.ts file as it only contained this unused function
- No imports or usages found in the codebase
- Future code can use lodash's omitBy directly when needed

## Context

- Was used in singular location -- added in https://github.com/Comfy-Org/litegraph.js/pull/622 then removed in https://github.com/Comfy-Org/litegraph.js/pull/732


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4886-feat-Remove-unused-omitBy-function-24b6d73d36508159b3efc27f8735f726) by [Unito](https://www.unito.io)
