### PR TITLE
[feat] Add PR creation automation command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,131 @@
+# Create PR
+
+Automate PR creation with proper tags, labels, and concise summary.
+
+## Step 1: Check Prerequisites
+
+```bash
+# Ensure you have uncommitted changes
+git status
+
+# If changes exist, commit them first
+git add .
+git commit -m "[tag] Your commit message"
+```
+
+## Step 2: Push and Create PR
+
+You'll create the PR with the following structure:
+
+### PR Tags (use in title)
+
+- `[feat]` - New features → label: `enhancement`
+- `[bugfix]` - Bug fixes → label: `verified bug`
+- `[refactor]` - Code restructuring → label: `enhancement`
+- `[docs]` - Documentation → label: `documentation`
+- `[test]` - Test changes → label: `enhancement`
+- `[ci]` - CI/CD changes → label: `enhancement`
+
+### Label Mapping
+
+#### General Labels
+
+- Feature/Enhancement: `enhancement`
+- Bug fixes: `verified bug`
+- Documentation: `documentation`
+- Dependencies: `dependencies`
+- Performance: `Performance`
+- Desktop app: `Electron`
+
+#### Product Area Labels
+
+**Core Features**
+
+- `area:nodes` - Node-related functionality
+- `area:workflows` - Workflow management
+- `area:queue` - Queue system
+- `area:models` - Model handling
+- `area:templates` - Template system
+- `area:subgraph` - Subgraph functionality
+
+**UI Components**
+
+- `area:ui` - General user interface improvements
+- `area:widgets` - Widget system
+- `area:dom-widgets` - DOM-based widgets
+- `area:links` - Connection links between nodes
+- `area:groups` - Node grouping functionality
+- `area:reroutes` - Reroute nodes
+- `area:previews` - Preview functionality
+- `area:minimap` - Minimap navigation
+- `area:floating-toolbox` - Floating toolbar
+- `area:mask-editor` - Mask editing tools
+
+**Navigation & Organization**
+
+- `area:navigation` - Navigation system
+- `area:search` - Search functionality
+- `area:workspace-management` - Workspace features
+- `area:topbar-menu` - Top bar menu
+- `area:help-menu` - Help menu system
+
+**System Features**
+
+- `area:settings` - Settings/preferences
+- `area:hotkeys` - Keyboard shortcuts
+- `area:undo-redo` - Undo/redo system
+- `area:customization` - Customization features
+- `area:auth` - Authentication
+- `area:comms` - Communication/networking
+
+**Development & Infrastructure**
+
+- `area:CI/CD` - CI/CD pipeline
+- `area:testing` - Testing infrastructure
+- `area:vue-migration` - Vue migration work
+- `area:manager` - ComfyUI Manager integration
+
+**Platform-Specific**
+
+- `area:mobile` - Mobile support
+- `area:3d` - 3D-related features
+
+**Special Areas**
+
+- `area:i18n` - Translation/internationalization
+- `area:CNR` - Comfy Node Registry
+
+## Step 3: Execute PR Creation
+
+```bash
+# First, push your branch
+git push -u origin $(git branch --show-current)
+
+# Then create the PR (replace placeholders)
+gh pr create \
+  --title "[TAG] Brief description" \
+  --body "$(cat <<'EOF'
+## Summary
+One sentence describing what changed and why.
+
+## Changes
+- **What**: Core functionality added/modified
+- **Breaking**: Any breaking changes (if none, omit this line)
+- **Dependencies**: New dependencies (if none, omit this line)
+
+## Review Focus
+- Critical design decisions or edge cases that need attention
+
+Fixes #ISSUE_NUMBER
+EOF
+)" \
+  --label "APPROPRIATE_LABEL" \
+  --base main
+```
+
+## Additional Options
+
+- Add multiple labels: `--label "enhancement,Performance"`
+- Request reviewers: `--reviewer @username`
+- Mark as draft: `--draft`
+- Open in browser after creation: `--web`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+<!-- One sentence describing what changed and why. -->
+
+## Changes
+- **What**: <!-- Core functionality added/modified -->
+- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
+- **Dependencies**: <!-- New dependencies (if none, remove this line) -->
+
+## Review Focus
+<!-- Critical design decisions or edge cases that need attention -->
+
+<!-- If this PR fixes an issue, uncomment and update the line below -->
+<!-- Fixes #ISSUE_NUMBER -->
+
+## PR Checklist
+<!-- Please check all applicable items -->
+- [ ] Tests added/updated (if applicable)
+- [ ] Documentation updated (if applicable)
+- [ ] Breaking changes documented (if applicable)
+- [ ] Ran `npm run typecheck`
+- [ ] Ran `npm run lint`
+- [ ] Ran `npm run format`
+
+## PR Type
+<!-- Please delete options that are not relevant -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Test improvement
+- [ ] CI/CD improvement
+
+## Testing Instructions
+<!-- Provide detailed steps to test your changes -->
+1. 
+2. 
+3. 
+
+## Screenshots (if applicable)
+<!-- Add screenshots to help explain your changes -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,42 +1,20 @@
 ## Summary
+
 <!-- One sentence describing what changed and why. -->
 
 ## Changes
+
 - **What**: <!-- Core functionality added/modified -->
 - **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
 - **Dependencies**: <!-- New dependencies (if none, remove this line) -->
 
 ## Review Focus
+
 <!-- Critical design decisions or edge cases that need attention -->
 
 <!-- If this PR fixes an issue, uncomment and update the line below -->
 <!-- Fixes #ISSUE_NUMBER -->
 
-## PR Checklist
-<!-- Please check all applicable items -->
-- [ ] Tests added/updated (if applicable)
-- [ ] Documentation updated (if applicable)
-- [ ] Breaking changes documented (if applicable)
-- [ ] Ran `npm run typecheck`
-- [ ] Ran `npm run lint`
-- [ ] Ran `npm run format`
-
-## PR Type
-<!-- Please delete options that are not relevant -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Test improvement
-- [ ] CI/CD improvement
-
-## Testing Instructions
-<!-- Provide detailed steps to test your changes -->
-1. 
-2. 
-3. 
-
 ## Screenshots (if applicable)
-<!-- Add screenshots to help explain your changes -->
+
+<!-- Add screenshots or video recording to help explain your changes -->


### PR DESCRIPTION
## Summary
Added a Claude command to automate PR creation with proper tags and labels.

## Changes
- **What**: Added `.claude/commands/pr.md` that provides guidelines for creating PRs with standardized tags and labels
- **Purpose**: Streamlines PR creation process with consistent formatting and labeling

## Review Focus
- Command documentation structure and clarity
- Label mapping accuracy for ComfyUI project areas

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4892-feat-Add-PR-creation-automation-command-24b6d73d365081fa93fde3a5f3089614) by [Unito](https://www.unito.io)
