### PR TITLE
Feat: add duplicate workflow on sidebar

### DIFF
--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -317,6 +317,25 @@ test.describe('Workflows sidebar', () => {
     ])
   })
 
+  test('Can duplicate workflow from context menu', async ({ comfyPage }) => {
+    await comfyPage.setupWorkflowsDirectory({
+      'workflow1.json': 'default.json'
+    })
+
+    const { workflowsTab } = comfyPage.menu
+    await workflowsTab.open()
+
+    await workflowsTab
+      .getPersistedItem('workflow1.json')
+      .click({ button: 'right' })
+    await comfyPage.clickContextMenuItem('Duplicate')
+
+    expect(await workflowsTab.getOpenedWorkflowNames()).toEqual([
+      '*Unsaved Workflow.json',
+      '*workflow1 (Copy).json'
+    ])
+  })
+
   test('Can drop workflow from workflows sidebar', async ({ comfyPage }) => {
     await comfyPage.setupWorkflowsDirectory({
       'workflow1.json': 'default.json'

--- a/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/WorkflowsSidebarTab.vue
@@ -265,6 +265,14 @@ const renderTreeNode = (
                 const workflow = node.data
                 await workflowService.insertWorkflow(workflow)
               }
+            },
+            {
+              label: t('g.duplicate'),
+              icon: 'pi pi-file-export',
+              command: async () => {
+                const workflow = node.data
+                await workflowService.duplicateWorkflow(workflow)
+              }
             }
           ]
         },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -145,7 +145,8 @@
     "stopRecording": "Stop Recording",
     "micPermissionDenied": "Microphone permission denied",
     "noAudioRecorded": "No audio recorded",
-    "nodesRunning": "nodes running"
+    "nodesRunning": "nodes running",
+    "duplicate": "Duplicate"
   },
   "manager": {
     "title": "Custom Nodes Manager",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "Advertencia de compatibilidad de versión",
     "versionMismatchWarningMessage": "{warning}: {detail} Visita https://docs.comfy.org/installation/update_comfyui#common-update-issues para obtener instrucciones de actualización.",
     "videoFailedToLoad": "Falló la carga del video",
-    "workflow": "Flujo de trabajo"
+    "workflow": "Flujo de trabajo",
+    "duplicate": "Duplicar"
   },
   "graphCanvasMenu": {
     "fitView": "Ajustar vista",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "Avertissement de compatibilité de version",
     "versionMismatchWarningMessage": "{warning} : {detail} Consultez https://docs.comfy.org/installation/update_comfyui#common-update-issues pour les instructions de mise à jour.",
     "videoFailedToLoad": "Échec du chargement de la vidéo",
-    "workflow": "Flux de travail"
+    "workflow": "Flux de travail",
+    "duplicate": "Dupliquer"
   },
   "graphCanvasMenu": {
     "fitView": "Adapter la vue",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "バージョン互換性の警告",
     "versionMismatchWarningMessage": "{warning}: {detail} 更新手順については https://docs.comfy.org/installation/update_comfyui#common-update-issues をご覧ください。",
     "videoFailedToLoad": "ビデオの読み込みに失敗しました",
-    "workflow": "ワークフロー"
+    "workflow": "ワークフロー",
+    "duplicate": "複製"
   },
   "graphCanvasMenu": {
     "fitView": "ビューに合わせる",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "버전 호환성 경고",
     "versionMismatchWarningMessage": "{warning}: {detail} 업데이트 지침은 https://docs.comfy.org/installation/update_comfyui#common-update-issues 를 방문하세요.",
     "videoFailedToLoad": "비디오를 로드하지 못했습니다.",
-    "workflow": "워크플로"
+    "workflow": "워크플로",
+    "duplicate": "복제"
   },
   "graphCanvasMenu": {
     "fitView": "보기 맞춤",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "Предупреждение о несовместимости версий",
     "versionMismatchWarningMessage": "{warning}: {detail} Посетите https://docs.comfy.org/installation/update_comfyui#common-update-issues для инструкций по обновлению.",
     "videoFailedToLoad": "Не удалось загрузить видео",
-    "workflow": "Рабочий процесс"
+    "workflow": "Рабочий процесс",
+    "duplicate": "Дублировать"
   },
   "graphCanvasMenu": {
     "fitView": "Подгонять под выделенные",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "版本相容性警告",
     "versionMismatchWarningMessage": "{warning}：{detail} 請參閱 https://docs.comfy.org/installation/update_comfyui#common-update-issues 以取得更新說明。",
     "videoFailedToLoad": "無法載入影片",
-    "workflow": "工作流程"
+    "workflow": "工作流程",
+    "duplicate": "複製"
   },
   "graphCanvasMenu": {
     "fitView": "適合視窗",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -402,7 +402,8 @@
     "versionMismatchWarning": "版本相容性警告",
     "versionMismatchWarningMessage": "{warning}：{detail} 請參閱 https://docs.comfy.org/installation/update_comfyui#common-update-issues 以取得更新說明。",
     "videoFailedToLoad": "视频加载失败",
-    "workflow": "工作流"
+    "workflow": "工作流",
+    "duplicate": "复制"
   },
   "graphCanvasMenu": {
     "fitView": "适应视图",


### PR DESCRIPTION
Feature Requested Here:
https://github.com/Comfy-Org/ComfyUI_frontend/issues/4536

Approach:
Since a duplicate workflow already exist, I have used the same function for the sidebar as well.

<img width="627" height="400" alt="image" src="https://github.com/user-attachments/assets/5c563394-8868-48de-a8b1-912884585710" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4895-Feat-add-duplicate-workflow-on-sidebar-24b6d73d365081d6aebac939169f9e3b) by [Unito](https://www.unito.io)
