### PR TITLE
[refactor] Replace removeFromArray with lodash pull

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -1,3 +1,5 @@
+import { pull } from 'lodash'
+
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
@@ -9,7 +11,6 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
-import { removeFromArray } from '@/lib/litegraph/src/utils/collections'
 
 import type { SubgraphInput } from './SubgraphInput'
 import type { SubgraphOutputNode } from './SubgraphOutputNode'
@@ -59,7 +60,7 @@ export class SubgraphOutput extends SubgraphSlot {
       existingLink.disconnect(subgraph, 'input')
       const resolved = existingLink.resolve(subgraph)
       const links = resolved.output?.links
-      if (links) removeFromArray(links, existingLink.id)
+      if (links) pull(links, existingLink.id)
     }
 
     const link = new LLink(

--- a/src/lib/litegraph/src/utils/collections.ts
+++ b/src/lib/litegraph/src/utils/collections.ts
@@ -112,11 +112,3 @@ export function findFreeSlotOfType<T extends { type: ISlotType }>(
   }
   return wildSlot ?? occupiedSlot ?? occupiedWildSlot
 }
-
-export function removeFromArray<T>(array: T[], value: T): boolean {
-  const index = array.indexOf(value)
-  const found = index !== -1
-
-  if (found) array.splice(index, 1)
-  return found
-}


### PR DESCRIPTION
## Summary
- Replace manual removeFromArray implementation with lodash's pull
- Update SubgraphOutput.ts to use pull directly  
- Remove unused removeFromArray function from collections.ts
- Behavioral note: pull removes ALL occurrences vs first only, but in this context only one occurrence is expected (see "just in case" comment)

## Test plan
- [x] Type checking passes
- [x] Linting passes
- [x] Tests pass (failing tests are pre-existing on main branch)
- [x] Verified the behavioral difference doesn't matter in this context

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4906-feat-Replace-removeFromArray-with-lodash-pull-24c6d73d36508194957ac41e4b67fa64) by [Unito](https://www.unito.io)
