### PR TITLE
Fix subgraph reroute serialization

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2331,6 +2331,9 @@ export class Subgraph
       nodes: this.nodes.map((node) => node.serialize()),
       groups: this.groups.map((group) => group.serialize()),
       links: [...this.links.values()].map((x) => x.asSerialisable()),
+      reroutes: this.reroutes.size
+        ? [...this.reroutes.values()].map((x) => x.asSerialisable())
+        : undefined,
       extra: this.extra
     }
   }


### PR DESCRIPTION
Resolves #4903

Reroutes in subgraphs were simply not being serialized at all.

EDIT: Fixed mislink to 4603

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4911-Fix-subgraph-reroute-serialization-24c6d73d365081ad96b7da5cf82d9f32) by [Unito](https://www.unito.io)
