### PR TITLE
[refactor] Replace stringOrEmpty with lodash toString

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1,3 +1,5 @@
+import { toString } from 'lodash'
+
 import {
   SUBGRAPH_INPUT_ID,
   SUBGRAPH_OUTPUT_ID
@@ -34,7 +36,6 @@ import {
   alignToContainer,
   createBounds
 } from './measure'
-import { stringOrEmpty } from './strings'
 import { SubgraphInput } from './subgraph/SubgraphInput'
 import { SubgraphInputNode } from './subgraph/SubgraphInputNode'
 import { SubgraphOutput } from './subgraph/SubgraphOutput'
@@ -2027,7 +2028,7 @@ export class LGraph
     if (url instanceof Blob || url instanceof File) {
       const reader = new FileReader()
       reader.addEventListener('load', (event) => {
-        const result = stringOrEmpty(event.target?.result)
+        const result = toString(event.target?.result)
         const data = JSON.parse(result)
         this.configure(data)
         callback?.()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1,3 +1,5 @@
+import { toString } from 'lodash'
+
 import { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 
 import { CanvasPointer } from './CanvasPointer'
@@ -55,7 +57,6 @@ import {
   snapPoint
 } from './measure'
 import { NodeInputSlot } from './node/NodeInputSlot'
-import { stringOrEmpty } from './strings'
 import { Subgraph } from './subgraph/Subgraph'
 import { SubgraphIONodeBase } from './subgraph/SubgraphIONodeBase'
 import { SubgraphInputNode } from './subgraph/SubgraphInputNode'
@@ -1244,7 +1245,7 @@ export class LGraphCanvas
         value = LGraphCanvas.getPropertyPrintableValue(value, info.values)
 
       // value could contain invalid html characters, clean that
-      value = LGraphCanvas.decodeHTML(stringOrEmpty(value))
+      value = LGraphCanvas.decodeHTML(toString(value))
       entries.push({
         content:
           `<span class='property_name'>${info.label || i}</span>` +
@@ -6065,7 +6066,7 @@ export class LGraphCanvas
       }
       ctx.fillStyle = '#FFF'
       ctx.fillText(
-        stringOrEmpty(node.order),
+        toString(node.order),
         node.pos[0] + LiteGraph.NODE_TITLE_HEIGHT * -0.5,
         node.pos[1] - 6
       )

--- a/src/lib/litegraph/src/strings.ts
+++ b/src/lib/litegraph/src/strings.ts
@@ -1,23 +1,5 @@
 import type { ISlotType } from './litegraph'
 
-/**
- * Uses the standard String() function to coerce to string, unless the value is null or undefined - then null.
- * @param value The value to convert
- * @returns String(value) or null
- */
-export function stringOrNull(value: unknown): string | null {
-  return value == null ? null : String(value)
-}
-
-/**
- * Uses the standard String() function to coerce to string, unless the value is null or undefined - then an empty string
- * @param value The value to convert
- * @returns String(value) or ""
- */
-export function stringOrEmpty(value: unknown): string {
-  return value == null ? '' : String(value)
-}
-
 export function parseSlotTypes(type: ISlotType): string[] {
   return type == '' || type == '0'
     ? ['*']


### PR DESCRIPTION
## Summary
- Replace stringOrEmpty with lodash's toString function
- Remove unused stringOrNull function  
- Remove stringOrEmpty implementation from strings.ts
- Keep domain-specific functions (parseSlotTypes, nextUniqueName)
- No functional changes as behavior is identical (except -0 edge case which doesn't apply here)

## Test plan
- [x] Type checking passes
- [x] Linting passes
- [x] Verified identical behavior between stringOrEmpty and _.toString

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4917-feat-Replace-stringOrEmpty-with-lodash-toString-24c6d73d365081a5b534ed779cb937f0) by [Unito](https://www.unito.io)
