### PR TITLE
Follow-up on #4870 - reorder subgraph context menu

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -191,7 +191,7 @@ export abstract class SubgraphIONodeBase<
    * @param event The event that triggered the context menu.
    */
   protected showSlotContextMenu(slot: TSlot, event: CanvasPointerEvent): void {
-    const options: IContextMenuValue[] = this.#getSlotMenuOptions(slot)
+    const options = this.#getSlotMenuOptions(slot)
     if (!(options.length > 0)) return
 
     new LiteGraph.ContextMenu(options, {
@@ -208,8 +208,8 @@ export abstract class SubgraphIONodeBase<
    * @param slot The slot to get the context menu options for.
    * @returns The context menu options.
    */
-  #getSlotMenuOptions(slot: TSlot): IContextMenuValue[] {
-    const options: IContextMenuValue[] = []
+  #getSlotMenuOptions(slot: TSlot): (IContextMenuValue | null)[] {
+    const options: (IContextMenuValue | null)[] = []
 
     // Disconnect option if slot has connections
     if (slot !== this.emptySlot && slot.linkIds.length > 0) {
@@ -218,10 +218,10 @@ export abstract class SubgraphIONodeBase<
 
     // Remove / rename slot option (except for the empty slot)
     if (slot !== this.emptySlot) {
-      options.push(
-        { content: 'Remove Slot', value: 'remove' },
-        { content: 'Rename Slot', value: 'rename' }
-      )
+      options.push({ content: 'Rename Slot', value: 'rename' }, null, {
+        content: 'Remove Slot',
+        value: 'remove'
+      })
     }
 
     return options


### PR DESCRIPTION
- Follow-up on #4870

Original PR is incomplete; the changes in this follow-up PR were what was tested, however the last commit did not get pushed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4919-Follow-up-on-4870-reorder-subgraph-context-menu-24c6d73d36508161911bdffe86336161) by [Unito](https://www.unito.io)
