### PR TITLE
Add vue node feature flag

### DIFF
--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -16,7 +16,6 @@ import { computed } from 'vue'
 
 import DomWidget from '@/components/graph/widgets/DomWidget.vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useCanvasStore } from '@/stores/graphStore'
 
@@ -27,9 +26,6 @@ const widgetStates = computed(() => [...domWidgetStore.widgetStates.values()])
 const updateWidgets = () => {
   const lgCanvas = canvasStore.canvas
   if (!lgCanvas) return
-
-  // Skip updating DOM widgets when Vue nodes mode is enabled
-  if (LiteGraph.vueNodesMode) return
 
   const lowQuality = lgCanvas.low_quality
   const currentGraph = lgCanvas.graph

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -197,7 +197,13 @@ const { shouldRenderVueNodes, isDevModeEnabled } = useFeatureFlags()
 
 // TransformPane enabled when Vue nodes are enabled OR debug override
 const debugOverrideVueNodes = ref(false)
-const debugPanelVisible = ref(false)
+// Persist debug panel visibility in settings so core commands can toggle it
+const debugPanelVisible = computed({
+  get: () => settingStore.get('Comfy.VueNodes.DebugPanel.Visible') ?? false,
+  set: (v: boolean) => {
+    void settingStore.set('Comfy.VueNodes.DebugPanel.Visible', v)
+  }
+})
 const transformPaneEnabled = computed(
   () => shouldRenderVueNodes.value || debugOverrideVueNodes.value
 )
@@ -735,30 +741,6 @@ onMounted(async () => {
   // Restore workflow and workflow tabs state from storage
   await workflowPersistence.restorePreviousWorkflow()
   workflowPersistence.restoreWorkflowTabsState()
-
-  // Register experimental commands (unbound by default)
-  const commandStore = useCommandStore()
-  if (!commandStore.isRegistered('Experimental.ToggleVueNodes')) {
-    commandStore.registerCommand({
-      id: 'Experimental.ToggleVueNodes',
-      label: () =>
-        `Experimental: ${shouldRenderVueNodes.value ? 'Disable' : 'Enable'} Vue Nodes`,
-      function: async () => {
-        const current = settingStore.get('Comfy.VueNodes.Enabled') ?? false
-        await settingStore.set('Comfy.VueNodes.Enabled', !current)
-      }
-    })
-  }
-  if (!commandStore.isRegistered('Experimental.ToggleVueNodeDebugPanel')) {
-    commandStore.registerCommand({
-      id: 'Experimental.ToggleVueNodeDebugPanel',
-      label: () =>
-        `Experimental: ${debugPanelVisible.value ? 'Hide' : 'Show'} Vue Node Debug Panel`,
-      function: () => {
-        debugPanelVisible.value = !debugPanelVisible.value
-      }
-    })
-  }
 
   // Initialize release store to fetch releases from comfy-api (fire-and-forget)
   const { useReleaseStore } = await import('@/stores/releaseStore')

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -68,6 +68,7 @@
 
   <!-- Debug Panel (Development Only) -->
   <VueNodeDebugPanel
+    v-if="debugPanelVisible"
     v-model:debug-override-vue-nodes="debugOverrideVueNodes"
     v-model:show-performance-overlay="showPerformanceOverlay"
     :canvas-viewport="canvasViewport"
@@ -92,7 +93,8 @@
     <SelectionOverlay v-if="selectionToolboxEnabled">
       <SelectionToolbox />
     </SelectionOverlay>
-    <DomWidgets />
+    <!-- Render legacy DOM widgets only when Vue nodes are disabled -->
+    <DomWidgets v-if="!shouldRenderVueNodes" />
   </template>
 </template>
 
@@ -194,7 +196,8 @@ const minimap = useMinimap()
 const { shouldRenderVueNodes, isDevModeEnabled } = useFeatureFlags()
 
 // TransformPane enabled when Vue nodes are enabled OR debug override
-const debugOverrideVueNodes = ref(true) // Default to true for development
+const debugOverrideVueNodes = ref(false)
+const debugPanelVisible = ref(false)
 const transformPaneEnabled = computed(
   () => shouldRenderVueNodes.value || debugOverrideVueNodes.value
 )
@@ -274,6 +277,7 @@ watch(canvasRef, () => {
 
 // Vue node lifecycle management - initialize after graph is ready
 let nodeManager: ReturnType<typeof useGraphNodeManager> | null = null
+let cleanupNodeManager: (() => void) | null = null
 const vueNodeData = ref<ReadonlyMap<string, VueNodeData>>(new Map())
 const nodeState = ref<ReadonlyMap<string, NodeState>>(new Map())
 const nodePositions = ref<ReadonlyMap<string, { x: number; y: number }>>(
@@ -296,31 +300,49 @@ const performanceMetrics = reactive({
 const nodeDataTrigger = ref(0)
 
 const initializeNodeManager = () => {
-  if (!comfyApp.graph || nodeManager) {
-    return
-  }
-
+  if (!comfyApp.graph || nodeManager) return
   nodeManager = useGraphNodeManager(comfyApp.graph)
-
+  cleanupNodeManager = nodeManager.cleanup
   // Use the manager's reactive maps directly
   vueNodeData.value = nodeManager.vueNodeData
   nodeState.value = nodeManager.nodeState
   nodePositions.value = nodeManager.nodePositions
   nodeSizes.value = nodeManager.nodeSizes
-
   detectChangesInRAF = nodeManager.detectChangesInRAF
   Object.assign(performanceMetrics, nodeManager.performanceMetrics)
-
   // Force computed properties to re-evaluate
   nodeDataTrigger.value++
 }
 
-// Watch for graph availability
+const disposeNodeManager = () => {
+  if (!nodeManager) return
+  try {
+    cleanupNodeManager?.()
+  } catch {
+    /* empty */
+  }
+  nodeManager = null
+  cleanupNodeManager = null
+  // Reset reactive maps to inert defaults
+  vueNodeData.value = new Map()
+  nodeState.value = new Map()
+  nodePositions.value = new Map()
+  nodeSizes.value = new Map()
+  // Reset metrics
+  performanceMetrics.frameTime = 0
+  performanceMetrics.updateTime = 0
+  performanceMetrics.nodeCount = 0
+  performanceMetrics.culledCount = 0
+}
+
+// Watch for transformPaneEnabled to gate the node manager lifecycle
 watch(
-  () => comfyApp.graph,
-  (graph) => {
-    if (graph) {
+  () => transformPaneEnabled.value && Boolean(comfyApp.graph),
+  (enabled) => {
+    if (enabled) {
       initializeNodeManager()
+    } else {
+      disposeNodeManager()
     }
   },
   { immediate: true }
@@ -700,11 +722,6 @@ onMounted(async () => {
 
   comfyAppReady.value = true
 
-  // Initialize node manager after setup is complete
-  if (comfyApp.graph) {
-    initializeNodeManager()
-  }
-
   comfyApp.canvas.onSelectionChange = useChainCallback(
     comfyApp.canvas.onSelectionChange,
     () => canvasStore.updateSelectedItems()
@@ -718,6 +735,30 @@ onMounted(async () => {
   // Restore workflow and workflow tabs state from storage
   await workflowPersistence.restorePreviousWorkflow()
   workflowPersistence.restoreWorkflowTabsState()
+
+  // Register experimental commands (unbound by default)
+  const commandStore = useCommandStore()
+  if (!commandStore.isRegistered('Experimental.ToggleVueNodes')) {
+    commandStore.registerCommand({
+      id: 'Experimental.ToggleVueNodes',
+      label: () =>
+        `Experimental: ${shouldRenderVueNodes.value ? 'Disable' : 'Enable'} Vue Nodes`,
+      function: async () => {
+        const current = settingStore.get('Comfy.VueNodes.Enabled') ?? false
+        await settingStore.set('Comfy.VueNodes.Enabled', !current)
+      }
+    })
+  }
+  if (!commandStore.isRegistered('Experimental.ToggleVueNodeDebugPanel')) {
+    commandStore.registerCommand({
+      id: 'Experimental.ToggleVueNodeDebugPanel',
+      label: () =>
+        `Experimental: ${debugPanelVisible.value ? 'Hide' : 'Show'} Vue Node Debug Panel`,
+      function: () => {
+        debugPanelVisible.value = !debugPanelVisible.value
+      }
+    })
+  }
 
   // Initialize release store to fetch releases from comfy-api (fire-and-forget)
   const { useReleaseStore } = await import('@/stores/releaseStore')

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -257,6 +257,33 @@ export function useCoreCommands(): ComfyCommand[] {
       }
     },
     {
+      id: 'Experimental.ToggleVueNodes',
+      label: () =>
+        `Experimental: ${
+          useSettingStore().get('Comfy.VueNodes.Enabled') ? 'Disable' : 'Enable'
+        } Vue Nodes`,
+      function: async () => {
+        const settingStore = useSettingStore()
+        const current = settingStore.get('Comfy.VueNodes.Enabled') ?? false
+        await settingStore.set('Comfy.VueNodes.Enabled', !current)
+      }
+    },
+    {
+      id: 'Experimental.ToggleVueNodeDebugPanel',
+      label: () =>
+        `Experimental: ${
+          useSettingStore().get('Comfy.VueNodes.DebugPanel.Visible')
+            ? 'Hide'
+            : 'Show'
+        } Vue Node Debug Panel`,
+      function: async () => {
+        const settingStore = useSettingStore()
+        const current =
+          settingStore.get('Comfy.VueNodes.DebugPanel.Visible') ?? false
+        await settingStore.set('Comfy.VueNodes.DebugPanel.Visible', !current)
+      }
+    },
+    {
       id: 'Comfy.Canvas.FitView',
       icon: 'pi pi-expand',
       label: 'Fit view to selected nodes',

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -17,21 +17,10 @@ export const useFeatureFlags = () => {
    */
   const isVueNodesEnabled = computed(() => {
     try {
-      return settingStore.get('Comfy.VueNodes.Enabled' as any) ?? true // Default to true for development
+      // Off by default: ensure Vue nodes are disabled unless explicitly enabled
+      return settingStore.get('Comfy.VueNodes.Enabled') ?? false
     } catch {
-      return true // Default to true for development
-    }
-  })
-
-  /**
-   * Enable Vue widget rendering within Vue nodes
-   * When disabled, Vue nodes render without widgets (structure only)
-   */
-  const isVueWidgetsEnabled = computed(() => {
-    try {
-      return settingStore.get('Comfy.VueNodes.Widgets' as any) ?? true
-    } catch {
-      return true
+      return false
     }
   })
 
@@ -74,7 +63,6 @@ export const useFeatureFlags = () => {
 
   return {
     isVueNodesEnabled,
-    isVueWidgetsEnabled,
     isDevModeEnabled,
     shouldRenderVueNodes,
     syncVueNodesFlag

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -893,24 +893,16 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: 0
   },
 
-  // Vue Node System Settings
+  /**
+   * Vue Node System Settings
+   */
   {
-    id: 'Comfy.VueNodes.Enabled' as any,
-    category: ['Comfy', 'Vue Nodes'],
-    experimental: true,
-    name: 'Enable Vue node rendering',
+    id: 'Comfy.VueNodes.Enabled',
+    name: 'Enable Vue node rendering (hidden)',
+    type: 'hidden',
     tooltip:
-      'Render nodes as Vue components instead of canvas elements. Experimental feature.',
-    type: 'boolean',
-    defaultValue: false
-  },
-  {
-    id: 'Comfy.VueNodes.Widgets' as any,
-    category: ['Comfy', 'Vue Nodes', 'Widgets'],
-    experimental: true,
-    name: 'Enable Vue widgets',
-    tooltip: 'Render widgets as Vue components within Vue nodes.',
-    type: 'boolean',
-    defaultValue: true
+      'Render nodes as Vue components instead of canvas. Hidden; toggle via Experimental keybinding.',
+    defaultValue: false,
+    experimental: true
   }
 ]

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -904,5 +904,12 @@ export const CORE_SETTINGS: SettingParams[] = [
       'Render nodes as Vue components instead of canvas. Hidden; toggle via Experimental keybinding.',
     defaultValue: false,
     experimental: true
+  },
+  {
+    id: 'Comfy.VueNodes.DebugPanel.Visible',
+    name: 'Vue Nodes Debug Panel Visible (hidden)',
+    type: 'hidden',
+    defaultValue: false,
+    experimental: true
   }
 ]

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4947,6 +4947,19 @@ export class LGraphCanvas
   drawNode(node: LGraphNode, ctx: CanvasRenderingContext2D): void {
     this.current_node = node
 
+    // When Vue nodes mode is enabled, LiteGraph should not draw node chrome or widgets.
+    // We still need to keep slot metrics and layout in sync for hit-testing and links.
+    // Interaction system changes coming later, chances are vue nodes mode will be mostly broken on land
+    if (LiteGraph.vueNodesMode) {
+      // Prepare concrete slots and compute layout measures without rendering visuals.
+      node._setConcreteSlots()
+      if (!node.collapsed) {
+        node.arrange()
+      }
+      // Skip all node body/widget/title rendering. Vue overlay handles visuals.
+      return
+    }
+
     const color = node.renderingColor
     const bgcolor = node.renderingBgColor
 

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -477,6 +477,7 @@ const zSettings = z.object({
   'Comfy.Node.AllowImageSizeDraw': z.boolean(),
   'Comfy.Minimap.Visible': z.boolean(),
   'Comfy.Canvas.NavigationMode': z.string(),
+  'Comfy.VueNodes.Enabled': z.boolean(),
   'Comfy-Desktop.AutoUpdate': z.boolean(),
   'Comfy-Desktop.SendStatistics': z.boolean(),
   'Comfy-Desktop.WindowStyle': z.string(),

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -478,6 +478,7 @@ const zSettings = z.object({
   'Comfy.Minimap.Visible': z.boolean(),
   'Comfy.Canvas.NavigationMode': z.string(),
   'Comfy.VueNodes.Enabled': z.boolean(),
+  'Comfy.VueNodes.DebugPanel.Visible': z.boolean(),
   'Comfy-Desktop.AutoUpdate': z.boolean(),
   'Comfy-Desktop.SendStatistics': z.boolean(),
   'Comfy-Desktop.WindowStyle': z.string(),


### PR DESCRIPTION
goal is to add a feature flag that properly separates vue node rendering from the classic rendering, which will allow for vue nodes to continue in development for the next few weeks without needing to constantly rebase

also serves as an actual feature flag for beta testing/QA later

will be replaced by a system to properly plug and play rendering systems as part of #4661 whenever that gets implemented

also, important to note, vue nodes can be broken is when going into main, but it cannot break existing functionality
this is important because there are some known bugs that are breaking litegraph right now, like the image preview widget, and possibly the fileupload widget as well. it's known that we'd need more QA before even having vue nodes in main, even after this feature flag PR, as all this PR does is add a feature flag, not fix existing bugs

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4927-Add-vue-node-feature-flag-24c6d73d365081e994e4f276ad610913) by [Unito](https://www.unito.io)
