### PR TITLE
[fix] ensure consistent link release behavior for subgraph IO nodes

### DIFF
--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -640,7 +640,10 @@ export class LinkConnector {
 
     if (connectingTo === 'input' && ioNode instanceof SubgraphOutputNode) {
       const output = ioNode.getSlotInPosition(canvasX, canvasY)
-      if (!output) throw new Error('No output slot found for link.')
+      if (!output) {
+        this.dropOnNothing(event)
+        return
+      }
 
       // Track the actual slot to use for all connections
       let targetSlot = output
@@ -669,7 +672,10 @@ export class LinkConnector {
       ioNode instanceof SubgraphInputNode
     ) {
       const input = ioNode.getSlotInPosition(canvasX, canvasY)
-      if (!input) throw new Error('No input slot found for link.')
+      if (!input) {
+        this.dropOnNothing(event)
+        return
+      }
 
       // Same logic for SubgraphInputNode if needed
       let targetSlot = input


### PR DESCRIPTION
When 'Link Release Action' is set to 'No Action', links should be deleted when dropped on empty canvas. SubgraphInputNode connections were incorrectly snapping back instead of being deleted.

This minimal fix replaces error throws with calls to `dropOnNothing()` when no valid slot is found, ensuring consistent behavior across all node types.

Fixes #4848

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4931-fix-ensure-consistent-link-release-behavior-for-subgraph-IO-nodes-24c6d73d365081fd9637c7508d29c5c6) by [Unito](https://www.unito.io)
