### PR TITLE
[bugfix] Fix queue not updating with completed task images

### DIFF
--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -189,6 +189,10 @@ const onStatus = async (e: CustomEvent<StatusWsMessageStatus>) => {
   await queueStore.update()
 }
 
+const onExecutionSuccess = async () => {
+  await queueStore.update()
+}
+
 const reconnectingMessage: ToastMessageOptions = {
   severity: 'error',
   summary: t('g.reconnecting')
@@ -214,6 +218,7 @@ const onReconnected = () => {
 
 onMounted(() => {
   api.addEventListener('status', onStatus)
+  api.addEventListener('execution_success', onExecutionSuccess)
   api.addEventListener('reconnecting', onReconnecting)
   api.addEventListener('reconnected', onReconnected)
   executionStore.bindExecutionEvents()
@@ -227,6 +232,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   api.removeEventListener('status', onStatus)
+  api.removeEventListener('execution_success', onExecutionSuccess)
   api.removeEventListener('reconnecting', onReconnecting)
   api.removeEventListener('reconnected', onReconnected)
   executionStore.unbindExecutionEvents()


### PR DESCRIPTION
## Summary

Fixes bug where task item in queue would sometimes not update after completing and stay as a spinner

## Changes

Add execution_success event listener to trigger queue updates when tasks complete. This ensures that completed task images are displayed in the queue UI after execution finishes in development mode.

Fixes the issue where WebSocket execution events would store image data correctly but the queue UI would never refresh to show the completed status and images.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4936-bugfix-Fix-queue-not-updating-with-completed-task-images-24d6d73d365081528b35faffb12c85f7) by [Unito](https://www.unito.io)
