### PR TITLE
 gemini-2.5-pro and flash models; corrected prices

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1278,9 +1278,13 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         // Google Veo video generation
         if (model.includes('veo-2.0')) {
           return '$0.5/second'
-        } else if (model.includes('gemini-2.5-pro-preview-05-06')) {
-          return '$0.00016/$0.0006 per 1K tokens'
         } else if (model.includes('gemini-2.5-flash-preview-04-17')) {
+          return '$0.0003/$0.0025 per 1K tokens'
+        } else if (model.includes('gemini-2.5-flash')) {
+          return '$0.0003/$0.0025 per 1K tokens'
+        } else if (model.includes('gemini-2.5-pro-preview-05-06')) {
+          return '$0.00125/$0.01 per 1K tokens'
+        } else if (model.includes('gemini-2.5-pro')) {
           return '$0.00125/$0.01 per 1K tokens'
         }
         // For other Gemini models, show token-based pricing info

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -1384,11 +1384,19 @@ describe('useNodePricing', () => {
         const testCases = [
           {
             model: 'gemini-2.5-pro-preview-05-06',
-            expected: '$0.00016/$0.0006 per 1K tokens'
+            expected: '$0.00125/$0.01 per 1K tokens'
+          },
+          {
+            model: 'gemini-2.5-pro',
+            expected: '$0.00125/$0.01 per 1K tokens'
           },
           {
             model: 'gemini-2.5-flash-preview-04-17',
-            expected: '$0.00125/$0.01 per 1K tokens'
+            expected: '$0.0003/$0.0025 per 1K tokens'
+          },
+          {
+            model: 'gemini-2.5-flash',
+            expected: '$0.0003/$0.0025 per 1K tokens'
           },
           { model: 'unknown-gemini-model', expected: 'Token-based' }
         ]


### PR DESCRIPTION
## Summary

Just added release versions of the models, and corrected pricing based on this link: https://cloud.google.com/vertex-ai/generative-ai/pricing#token-based-pricing

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4945-gemini-2-5-pro-and-flash-models-corrected-prices-24d6d73d36508178bd9fd12ba0808c9f) by [Unito](https://www.unito.io)
