### PR TITLE
fix: add cleanup for graphChanged listener in useWorkflowPersistence

### DIFF
--- a/src/composables/useWorkflowPersistence.ts
+++ b/src/composables/useWorkflowPersistence.ts
@@ -1,3 +1,4 @@
+import { tryOnScopeDispose } from '@vueuse/core'
 import { computed, watch } from 'vue'
 
 import { api } from '@/scripts/api'
@@ -87,6 +88,11 @@ export function useWorkflowPersistence() {
     }
   )
   api.addEventListener('graphChanged', persistCurrentWorkflow)
+
+  // Clean up event listener when component unmounts
+  tryOnScopeDispose(() => {
+    api.removeEventListener('graphChanged', persistCurrentWorkflow)
+  })
 
   // Restore workflow tabs states
   const openWorkflows = computed(() => workflowStore.openWorkflows)


### PR DESCRIPTION
## Summary
- Added proper cleanup for the `graphChanged` event listener in `useWorkflowPersistence` composable
- Uses VueUse's `tryOnScopeDispose` to automatically remove the listener when the component unmounts

## Context
This fixes a memory leak identified where the `graphChanged` listener was never cleaned up, potentially causing memory issues when components using this composable were mounted/unmounted repeatedly.


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4947-fix-add-cleanup-for-graphChanged-listener-in-useWorkflowPersistence-24d6d73d3650813b9fcafcfd9469e307) by [Unito](https://www.unito.io)
