### PR TITLE
Trigger updateSelectedItems on subgraph conversion

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -795,6 +795,7 @@ export function useCoreCommands(): ComfyCommand[] {
         }
         const { node } = res
         canvas.select(node)
+        canvasStore.updateSelectedItems()
       }
     },
     {

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -299,6 +299,7 @@
     "disabling": "جارٍ التعطيل",
     "dismiss": "تجاهل",
     "download": "تنزيل",
+    "duplicate": "تكرار",
     "edit": "تعديل",
     "empty": "فارغ",
     "enableAll": "تمكين الكل",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -299,6 +299,7 @@
     "disabling": "Deshabilitando",
     "dismiss": "Descartar",
     "download": "Descargar",
+    "duplicate": "Duplicar",
     "edit": "Editar",
     "empty": "Vacío",
     "enableAll": "Habilitar todo",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "Advertencia de compatibilidad de versión",
     "versionMismatchWarningMessage": "{warning}: {detail} Visita https://docs.comfy.org/installation/update_comfyui#common-update-issues para obtener instrucciones de actualización.",
     "videoFailedToLoad": "Falló la carga del video",
-    "workflow": "Flujo de trabajo",
-    "duplicate": "Duplicar"
+    "workflow": "Flujo de trabajo"
   },
   "graphCanvasMenu": {
     "fitView": "Ajustar vista",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -299,6 +299,7 @@
     "disabling": "Désactivation",
     "dismiss": "Fermer",
     "download": "Télécharger",
+    "duplicate": "Dupliquer",
     "edit": "Modifier",
     "empty": "Vide",
     "enableAll": "Activer tout",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "Avertissement de compatibilité de version",
     "versionMismatchWarningMessage": "{warning} : {detail} Consultez https://docs.comfy.org/installation/update_comfyui#common-update-issues pour les instructions de mise à jour.",
     "videoFailedToLoad": "Échec du chargement de la vidéo",
-    "workflow": "Flux de travail",
-    "duplicate": "Dupliquer"
+    "workflow": "Flux de travail"
   },
   "graphCanvasMenu": {
     "fitView": "Adapter la vue",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -299,6 +299,7 @@
     "disabling": "無効化",
     "dismiss": "閉じる",
     "download": "ダウンロード",
+    "duplicate": "複製",
     "edit": "編集",
     "empty": "空",
     "enableAll": "すべて有効にする",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "バージョン互換性の警告",
     "versionMismatchWarningMessage": "{warning}: {detail} 更新手順については https://docs.comfy.org/installation/update_comfyui#common-update-issues をご覧ください。",
     "videoFailedToLoad": "ビデオの読み込みに失敗しました",
-    "workflow": "ワークフロー",
-    "duplicate": "複製"
+    "workflow": "ワークフロー"
   },
   "graphCanvasMenu": {
     "fitView": "ビューに合わせる",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -299,6 +299,7 @@
     "disabling": "비활성화 중",
     "dismiss": "닫기",
     "download": "다운로드",
+    "duplicate": "복제",
     "edit": "편집",
     "empty": "비어 있음",
     "enableAll": "모두 활성화",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "버전 호환성 경고",
     "versionMismatchWarningMessage": "{warning}: {detail} 업데이트 지침은 https://docs.comfy.org/installation/update_comfyui#common-update-issues 를 방문하세요.",
     "videoFailedToLoad": "비디오를 로드하지 못했습니다.",
-    "workflow": "워크플로",
-    "duplicate": "복제"
+    "workflow": "워크플로"
   },
   "graphCanvasMenu": {
     "fitView": "보기 맞춤",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -299,6 +299,7 @@
     "disabling": "Отключение",
     "dismiss": "Закрыть",
     "download": "Скачать",
+    "duplicate": "Дублировать",
     "edit": "Редактировать",
     "empty": "Пусто",
     "enableAll": "Включить все",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "Предупреждение о несовместимости версий",
     "versionMismatchWarningMessage": "{warning}: {detail} Посетите https://docs.comfy.org/installation/update_comfyui#common-update-issues для инструкций по обновлению.",
     "videoFailedToLoad": "Не удалось загрузить видео",
-    "workflow": "Рабочий процесс",
-    "duplicate": "Дублировать"
+    "workflow": "Рабочий процесс"
   },
   "graphCanvasMenu": {
     "fitView": "Подгонять под выделенные",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -299,6 +299,7 @@
     "disabling": "停用中",
     "dismiss": "關閉",
     "download": "下載",
+    "duplicate": "複製",
     "edit": "編輯",
     "empty": "空",
     "enableAll": "全部啟用",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "版本相容性警告",
     "versionMismatchWarningMessage": "{warning}：{detail} 請參閱 https://docs.comfy.org/installation/update_comfyui#common-update-issues 以取得更新說明。",
     "videoFailedToLoad": "無法載入影片",
-    "workflow": "工作流程",
-    "duplicate": "複製"
+    "workflow": "工作流程"
   },
   "graphCanvasMenu": {
     "fitView": "適合視窗",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -299,6 +299,7 @@
     "disabling": "禁用中",
     "dismiss": "關閉",
     "download": "下载",
+    "duplicate": "复制",
     "edit": "编辑",
     "empty": "空",
     "enableAll": "启用全部",
@@ -402,8 +403,7 @@
     "versionMismatchWarning": "版本相容性警告",
     "versionMismatchWarningMessage": "{warning}：{detail} 請參閱 https://docs.comfy.org/installation/update_comfyui#common-update-issues 以取得更新說明。",
     "videoFailedToLoad": "视频加载失败",
-    "workflow": "工作流",
-    "duplicate": "复制"
+    "workflow": "工作流"
   },
   "graphCanvasMenu": {
     "fitView": "适应视图",


### PR DESCRIPTION
Resolves #4925 

The ConvertToSubgraph core command (used by the selection toolbox) would update the selection without triggering any watches for the current selection. This is fixed by manually calling updateSelectedItems afterwards.

![selection-fix](https://github.com/user-attachments/assets/49b06362-ae45-47cc-ba74-847e82966caf)
(Example uses subgraph-unpacking for demonstration, but is not included with this PR.)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4949-Trigger-updateSelectedItems-on-subgraph-conversion-24d6d73d365081359a5ace565b4f0b70) by [Unito](https://www.unito.io)
