### PR TITLE
show group self color in minimap

### DIFF
--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -102,6 +102,9 @@ export function useMinimap() {
   const groupColor = computed(() =>
     isLightTheme.value ? '#A2D3EC' : '#1F547A'
   )
+  const groupColorDefault = computed(
+    () => (isLightTheme.value ? '#283640' : '#B3C1CB') // this is the default group color when using nodeColors setting
+  )
   const bypassColor = computed(() =>
     isLightTheme.value ? '#DBDBDB' : '#4B184B'
   )
@@ -249,7 +252,17 @@ export function useMinimap() {
       const w = group.size[0] * scale.value
       const h = group.size[1] * scale.value
 
-      ctx.fillStyle = groupColor.value
+      let color = groupColor.value
+
+      if (nodeColors.value) {
+        color = group.color ?? groupColorDefault.value
+
+        if (isLightTheme.value) {
+          color = adjustColor(color, { opacity: 0.5 })
+        }
+      }
+
+      ctx.fillStyle = color
       ctx.fillRect(x, y, w, h)
     }
   }


### PR DESCRIPTION
a tiny fix that show group self color in minimap when checking node color

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4954-show-group-self-color-in-minimap-24e6d73d3650812dbc58e9b134805f2d) by [Unito](https://www.unito.io)
