### PR TITLE
[bugfix]: Clicking textarea DOM widget triggers selection update causing toolbar remount animation

### DIFF
--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -140,8 +140,13 @@ const setupDOMEventListeners = () => {
   for (const evt of widget.options.selectOn ?? ['focus', 'click']) {
     useEventListener(widget.element, evt, () => {
       const lgCanvas = canvasStore.canvas
-      lgCanvas?.selectNode(widget.node)
-      lgCanvas?.bringToFront(widget.node)
+      if (!lgCanvas) return
+
+      const node = widget.node
+      if (!node.is_selected) {
+        lgCanvas.selectItems([node])
+      }
+      lgCanvas.bringToFront(node)
     })
   }
 }

--- a/src/locales/ar/commands.json
+++ b/src/locales/ar/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "تجميع العقد المحددة"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "فك تجميع الرسم الفرعي المحدد"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "تحويل العقد المحددة إلى عقدة مجموعة"
   },

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "تبديل شريط تقدم مدير العقد المخصصة",
     "Undo": "تراجع",
     "Ungroup selected group nodes": "فك تجميع عقد المجموعة المحددة",
+    "Unpack the selected Subgraph": "فك تجميع الرسم الفرعي المحدد",
     "Workflow": "سير العمل",
     "Zoom In": "تكبير",
     "Zoom Out": "تصغير"

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -125,14 +125,14 @@
   "Comfy_Graph_ExitSubgraph": {
     "label": "Exit Subgraph"
   },
-  "Comfy_Graph_UnpackSubgraph": {
-    "label": "Unpack the selected Subgraph"
-  },
   "Comfy_Graph_FitGroupToContents": {
     "label": "Fit Group To Contents"
   },
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "Group Selected Nodes"
+  },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "Unpack the selected Subgraph"
   },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "Convert selected nodes to group node"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -979,6 +979,7 @@
     "Exit Subgraph": "Exit Subgraph",
     "Fit Group To Contents": "Fit Group To Contents",
     "Group Selected Nodes": "Group Selected Nodes",
+    "Unpack the selected Subgraph": "Unpack the selected Subgraph",
     "Convert selected nodes to group node": "Convert selected nodes to group node",
     "Manage group nodes": "Manage group nodes",
     "Ungroup selected group nodes": "Ungroup selected group nodes",

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "Agrupar nodos seleccionados"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "Desempaquetar el subgrafo seleccionado"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "Convertir nodos seleccionados en nodo de grupo"
   },

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "Alternar la Barra de Progreso del Administrador de Nodos Personalizados",
     "Undo": "Deshacer",
     "Ungroup selected group nodes": "Desagrupar nodos de grupo seleccionados",
+    "Unpack the selected Subgraph": "Desempaquetar el Subgrafo seleccionado",
     "Workflow": "Flujo de trabajo",
     "Zoom In": "Acercar",
     "Zoom Out": "Alejar"

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "Grouper les nœuds sélectionnés"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "Décompresser le sous-graphe sélectionné"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "Convertir les nœuds sélectionnés en nœud de groupe"
   },

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "Basculer la barre de progression du gestionnaire de nœuds personnalisés",
     "Undo": "Annuler",
     "Ungroup selected group nodes": "Dégrouper les nœuds de groupe sélectionnés",
+    "Unpack the selected Subgraph": "Décompresser le Subgraph sélectionné",
     "Workflow": "Flux de travail",
     "Zoom In": "Zoom avant",
     "Zoom Out": "Zoom arrière"

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "選択したノードをグループ化"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "選択したサブグラフを展開"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "選択したノードをグループノードに変換"
   },

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "カスタムノードマネージャーの進行状況バーを切り替え",
     "Undo": "元に戻す",
     "Ungroup selected group nodes": "選択したグループノードのグループ解除",
+    "Unpack the selected Subgraph": "選択したサブグラフを展開",
     "Workflow": "ワークフロー",
     "Zoom In": "ズームイン",
     "Zoom Out": "ズームアウト"

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "선택한 노드 그룹화"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "선택한 서브그래프 풀기"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "선택한 노드를 그룹 노드로 변환"
   },

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "커스텀 노드 매니저 진행률 표시줄 전환",
     "Undo": "실행 취소",
     "Ungroup selected group nodes": "선택한 그룹 노드 그룹 해제",
+    "Unpack the selected Subgraph": "선택한 서브그래프 풀기",
     "Workflow": "워크플로",
     "Zoom In": "확대",
     "Zoom Out": "축소"

--- a/src/locales/ru/commands.json
+++ b/src/locales/ru/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "Группировать выбранные ноды"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "Распаковать выбранный подграф"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "Преобразовать выбранные ноды в групповую ноду"
   },

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "Переключить индикатор выполнения менеджера пользовательских узлов",
     "Undo": "Отменить",
     "Ungroup selected group nodes": "Разгруппировать выбранные групповые ноды",
+    "Unpack the selected Subgraph": "Распаковать выбранный Subgraph",
     "Workflow": "Рабочий процесс",
     "Zoom In": "Увеличить",
     "Zoom Out": "Уменьшить"

--- a/src/locales/zh-TW/commands.json
+++ b/src/locales/zh-TW/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "群組所選節點"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "解開所選子圖"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "將選取的節點轉換為群組節點"
   },

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "切換自訂節點管理器進度條",
     "Undo": "復原",
     "Ungroup selected group nodes": "取消群組選取的群組節點",
+    "Unpack the selected Subgraph": "解開所選子圖",
     "Workflow": "工作流程",
     "Zoom In": "放大",
     "Zoom Out": "縮小"

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -131,6 +131,9 @@
   "Comfy_Graph_GroupSelectedNodes": {
     "label": "添加框到选中节点"
   },
+  "Comfy_Graph_UnpackSubgraph": {
+    "label": "解開所選子圖"
+  },
   "Comfy_GroupNode_ConvertSelectedNodesToGroupNode": {
     "label": "将选中节点转换为组节点"
   },

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -849,6 +849,7 @@
     "Toggle the Custom Nodes Manager Progress Bar": "切换自定义节点管理器进度条",
     "Undo": "撤销",
     "Ungroup selected group nodes": "解散选中组节点",
+    "Unpack the selected Subgraph": "解包所選子圖",
     "Workflow": "工作流",
     "Zoom In": "放大画面",
     "Zoom Out": "缩小画面"


### PR DESCRIPTION
## Summary

- Fixed toolbar remount animation when clicking on textarea DOM widgets
- Prevents redundant selection updates for already-selected nodes
- Maintains proper selection behavior for unselected nodes

## Problem

When clicking on a textarea DOM widget on a node, it was triggering a selection update which caused the toolbar to re-animate unnecessarily. This happened because the widget's focus/click event handlers were calling `selectNode` even when the node was already selected.

## Solution

Modified the `DomWidget.vue` component to check if the node is already selected before calling `selectNode`. This prevents redundant selection changes while still allowing proper node selection when clicking on unselected nodes.

## Test plan

1. Load a workflow with textarea widgets (e.g., CLIP Text Encode nodes)
2. Select a node
3. Click on its textarea - toolbar should not re-animate
4. Click on an unselected node's textarea - node should be selected with toolbar animation
5. Verify `bringToFront` still works when clicking on selected nodes

Fixes #4953

## Future work

`LGraphCanvas.selectItems` should not cause `selectionChange` if the final selection state is same as initial selection state.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4955-Bug-Clicking-textarea-DOM-widget-triggers-selection-update-causing-toolbar-remount-ani-24e6d73d3650812c9815f3b0dcf1cfc7) by [Unito](https://www.unito.io)
