### PR TITLE
api_nodes: added prices for gpt-5 series models

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1352,6 +1352,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           return '$0.0004/$0.0016 per 1K tokens'
         } else if (model.includes('gpt-4.1')) {
           return '$0.002/$0.008 per 1K tokens'
+        } else if (model.includes('gpt-5-nano')) {
+          return '$0.00005/$0.0004 per 1K tokens'
+        } else if (model.includes('gpt-5-mini')) {
+          return '$0.00025/$0.002 per 1K tokens'
+        } else if (model.includes('gpt-5')) {
+          return '$0.00125/$0.01 per 1K tokens'
         }
         return 'Token-based'
       }

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -1502,7 +1502,10 @@ describe('useNodePricing', () => {
           { model: 'gpt-4o', expected: '$0.0025/$0.01 per 1K tokens' },
           { model: 'gpt-4.1-nano', expected: '$0.0001/$0.0004 per 1K tokens' },
           { model: 'gpt-4.1-mini', expected: '$0.0004/$0.0016 per 1K tokens' },
-          { model: 'gpt-4.1', expected: '$0.002/$0.008 per 1K tokens' }
+          { model: 'gpt-4.1', expected: '$0.002/$0.008 per 1K tokens' },
+          { model: 'gpt-5-nano', expected: '$0.00005/$0.0004 per 1K tokens' },
+          { model: 'gpt-5-mini', expected: '$0.00025/$0.002 per 1K tokens' },
+          { model: 'gpt-5', expected: '$0.00125/$0.01 per 1K tokens' }
         ]
 
         testCases.forEach(({ model, expected }) => {


### PR DESCRIPTION
## Summary

Adding support  for gpt-5 series models.

Prices was taken from here: https://openai.com/api/pricing/

## Review Focus

Double-check the pricing.

## Screenshots (if applicable)

<img width="975" height="887" alt="Screenshot from 2025-08-13 10-01-43" src="https://github.com/user-attachments/assets/7c415b81-0b31-4c2f-9f52-66eb01a9f851" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4958-api_nodes-added-prices-for-gpt-5-series-models-24e6d73d365081b3897de84633fcd1e6) by [Unito](https://www.unito.io)
