### PR TITLE
[feat] Add alternative package manager lockfiles to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Package manager lockfiles (allow users to use different package managers)
+bun.lock
+bun.lockb
+pnpm-lock.yaml
+yarn.lock
+
 # ESLint cache
 .eslintcache
 


### PR DESCRIPTION
## Summary
- Add bun.lock, bun.lockb, pnpm-lock.yaml, and yarn.lock to .gitignore
- Allows users to use faster package managers (Bun, pnpm) without making git status dirty
- Maintains npm as the default while supporting developer choice of package manager

## Test plan
- [x] Verify .gitignore changes are correct
- [ ] Test that creating these lockfiles doesn't show in git status
- [ ] Confirm existing npm functionality remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4961-feat-Add-alternative-package-manager-lockfiles-to-gitignore-24e6d73d3650817c8fa4fb8e94df5ac6) by [Unito](https://www.unito.io)
