### PR TITLE
fix: Add guards for _listenerController.abort() calls in SubgraphNode

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -171,7 +171,12 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     subgraphInput: SubgraphInput,
     input: INodeInputSlot & Partial<ISubgraphInput>
   ) {
-    input._listenerController?.abort()
+    if (
+      input._listenerController &&
+      typeof input._listenerController.abort === 'function'
+    ) {
+      input._listenerController.abort()
+    }
     input._listenerController = new AbortController()
     const { signal } = input._listenerController
 
@@ -207,7 +212,12 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override configure(info: ExportedSubgraphInstance): void {
     for (const input of this.inputs) {
-      input._listenerController?.abort()
+      if (
+        input._listenerController &&
+        typeof input._listenerController.abort === 'function'
+      ) {
+        input._listenerController.abort()
+      }
     }
 
     this.inputs.length = 0
@@ -518,7 +528,12 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     }
 
     for (const input of this.inputs) {
-      input._listenerController?.abort()
+      if (
+        input._listenerController &&
+        typeof input._listenerController.abort === 'function'
+      ) {
+        input._listenerController.abort()
+      }
     }
   }
 }


### PR DESCRIPTION
This fix adds guards before calling `_listenerController.abort()` to prevent runtime errors when loading workflows. The guards check that `_listenerController` exists and has an `abort` function before calling it, matching the pattern used in Comfy-Org/litegraph.js#1134.

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/4907

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4968-fix-Add-guards-for-_listenerController-abort-calls-in-SubgraphNode-24e6d73d3650813ebeeed69ee676faeb) by [Unito](https://www.unito.io)
