### PR TITLE
Convert Group Nodes to Subgraph

### DIFF
--- a/src/constants/groupNodeConstants.ts
+++ b/src/constants/groupNodeConstants.ts
@@ -1,0 +1,8 @@
+/**
+ * Constants for group node type prefixes and separators
+ *
+ * v1 Prefix + Separator: workflow/
+ * v2 Prefix + Separator: workflow> (ComfyUI_frontend v1.2.63)
+ */
+export const PREFIX = 'workflow'
+export const SEPARATOR = '>'

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -1,3 +1,4 @@
+import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
 import { t } from '@/i18n'
 import { type NodeId } from '@/lib/litegraph/src/LGraphNode'
 import {
@@ -34,11 +35,6 @@ type GroupNodeWorkflowData = {
   links: ComfyLink[]
   nodes: ComfyNode[]
 }
-
-// v1 Prefix + Separator: workflow/
-// v2 Prefix + Separator: workflow> (ComfyUI_frontend v1.2.63)
-const PREFIX = 'workflow'
-const SEPARATOR = '>'
 
 const Workflow = {
   InUse: {

--- a/src/extensions/core/groupNodeManage.ts
+++ b/src/extensions/core/groupNodeManage.ts
@@ -1,3 +1,4 @@
+import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
 import {
   type LGraphNode,
   type LGraphNodeConstructor,
@@ -13,8 +14,6 @@ import { GroupNodeConfig, GroupNodeHandler } from './groupNode'
 import './groupNodeManage.css'
 
 const ORDER: symbol = Symbol()
-const PREFIX = 'workflow'
-const SEPARATOR = '>'
 
 // @ts-expect-error fixme ts strict error
 function merge(target, source) {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1,5 +1,6 @@
 import { toString } from 'es-toolkit/compat'
 
+import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
 import { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 
 import { CanvasPointer } from './CanvasPointer'
@@ -8069,7 +8070,6 @@ export class LGraphCanvas
       | IContextMenuValue<(typeof LiteGraph.VALID_SHAPES)[number]>
       | null
     )[]
-
     if (node.getMenuOptions) {
       options = node.getMenuOptions(this)
     } else {
@@ -8077,6 +8077,19 @@ export class LGraphCanvas
         {
           content: 'Convert to Subgraph 🆕',
           callback: () => {
+            // find groupnodes, degroup and select children
+            if (this.selectedItems.size) {
+              for (const item of this.selectedItems) {
+                const node = item as LGraphNode
+                const isGroup =
+                  typeof node.type === 'string' &&
+                  node.type.startsWith(`${PREFIX}${SEPARATOR}`)
+                if (isGroup && node.convertToNodes) {
+                  const nodes = node.convertToNodes()
+                  this.selectItems(nodes)
+                }
+              }
+            }
             if (!this.selectedItems.size)
               throw new Error('Convert to Subgraph: Nothing selected.')
             this._graph.convertToSubgraph(this.selectedItems)

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -8079,20 +8079,36 @@ export class LGraphCanvas
           callback: () => {
             // find groupnodes, degroup and select children
             if (this.selectedItems.size) {
+              let hasGroups = false
               for (const item of this.selectedItems) {
                 const node = item as LGraphNode
                 const isGroup =
                   typeof node.type === 'string' &&
                   node.type.startsWith(`${PREFIX}${SEPARATOR}`)
                 if (isGroup && node.convertToNodes) {
+                  hasGroups = true
                   const nodes = node.convertToNodes()
-                  this.selectItems(nodes)
+
+                  requestAnimationFrame(() => {
+                    this.selectItems(nodes, true)
+
+                    if (!this.selectedItems.size)
+                      throw new Error('Convert to Subgraph: Nothing selected.')
+                    this._graph.convertToSubgraph(this.selectedItems)
+                  })
+                  return
                 }
               }
-            }
-            if (!this.selectedItems.size)
+
+              // If no groups were found, continue normally
+              if (!hasGroups) {
+                if (!this.selectedItems.size)
+                  throw new Error('Convert to Subgraph: Nothing selected.')
+                this._graph.convertToSubgraph(this.selectedItems)
+              }
+            } else {
               throw new Error('Convert to Subgraph: Nothing selected.')
-            this._graph.convertToSubgraph(this.selectedItems)
+            }
           }
         },
         {


### PR DESCRIPTION
## Summary
Added a right-click option to old Group Nodes to convert them to Subgraphs 

## Changes

- **What**: Added a right-click option to old Group Nodes to convert them to Subgraphs 
- **Breaking**: N/A
- **Dependencies**:  N/A

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->


https://github.com/user-attachments/assets/dfe9fa7e-7883-43a9-811b-a2730d440ab6

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4972-Convert-Group-Nodes-to-Subgraph-24e6d73d36508160837be93cbadbce0e) by [Unito](https://www.unito.io)
