### PR TITLE
fix: prevent toolbar animation when clicking textarea DOM widgets

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2661,6 +2661,9 @@ export class LGraphCanvas
     if (widget) {
       this.#processWidgetClick(e, node, widget)
       this.node_widget = [node, widget]
+      // Override the onClick handler to prevent selection update for DOM widgets
+      // This fixes issue #4953: clicking textarea shouldn't trigger toolbar remount animation
+      pointer.onClick = () => {} // No-op to prevent processSelect from being called
     } else {
       // Node background
       pointer.onDoubleClick = () => {


### PR DESCRIPTION
Fixes issue #4953 where clicking on textarea DOM widgets would trigger unwanted toolbar remount animations.

The problem was that clicking a textarea would trigger both widget click handling AND node selection logic, causing the selection state to update and the toolbar to remount with its slide-up animation.

Implemented soln: Override the onClick handler with a no-op function when a widget is clicked, preventing processSelect() from being called and thus avoiding the unwanted selection state change.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4974-fix-prevent-toolbar-animation-when-clicking-textarea-DOM-widgets-24e6d73d365081db8a77c3697b5f5d47) by [Unito](https://www.unito.io)
