### PR TITLE
fix: Handle missing subgraph inputs gracefully during workflow import

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -266,10 +266,14 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       const subgraphInput = this.subgraph.inputNode.slots.find(
         (slot) => slot.name === input.name
       )
-      if (!subgraphInput)
-        throw new Error(
-          `[SubgraphNode.configure] No subgraph input found for input ${input.name}`
+      if (!subgraphInput) {
+        // Skip inputs that don't exist in the subgraph definition
+        // This can happen when loading workflows with dynamically added inputs
+        console.warn(
+          `[SubgraphNode.configure] No subgraph input found for input ${input.name}, skipping`
         )
+        continue
+      }
 
       this.#addSubgraphInputListeners(subgraphInput, input)
 


### PR DESCRIPTION
## Summary

This PR fixes issue #4905 where workflows fail to load with the error `[SubgraphNode.configure] No subgraph input found for input image`.

The throw was added during initial widget promotion commit https://github.com/Comfy-Org/ComfyUI_frontend/commit/8b8f38f4dede07e97825a83d1f603257b7dc16ff

## Problem

When loading workflows, SubgraphNode throws an error if an input exists in the serialized data that doesn't exist in the current subgraph definition. This prevents workflows from loading entirely.

## Root Cause

The issue occurs in `SubgraphNode._internalConfigureAfterSlots()` when:
1. A workflow is saved with a SubgraphNode that has certain inputs
2. The subgraph definition changes (inputs removed/renamed) after the workflow was saved
3. When loading, the code tries to match each serialized input with the subgraph definition
4. If no match is found, it throws an error, preventing the workflow from loading

This can happen when:
- Subgraph definitions change after workflows are saved
- Workflows are shared between users with different subgraph versions  
- Dynamic inputs were added that don't exist in the base definition

## Solution

Changed the error to a warning and continue processing:
- Instead of throwing an error, log a warning to the console
- Skip the problematic input and continue with the rest
- This allows workflows to load even with mismatched configurations


Fixes #4905

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4985-fix-Handle-missing-subgraph-inputs-gracefully-during-workflow-import-24f6d73d365081d8a123f09cf770195e) by [Unito](https://www.unito.io)
