### PR TITLE
Fix inconsistency on bypass from context menu

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -1,5 +1,6 @@
 import _ from 'es-toolkit/compat'
 
+import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
 import { useNodeAnimatedImage } from '@/composables/node/useNodeAnimatedImage'
 import { useNodeCanvasImagePreview } from '@/composables/node/useNodeCanvasImagePreview'
 import { useNodeImage, useNodeVideo } from '@/composables/node/useNodeImage'
@@ -63,6 +64,7 @@ export const useLitegraphService = () => {
   const toastStore = useToastStore()
   const widgetStore = useWidgetStore()
   const canvasStore = useCanvasStore()
+  const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
 
   // TODO: Dedupe `registerNodeDef`; this should remain synchronous.
   function registerSubgraphNodeDef(
@@ -762,15 +764,8 @@ export const useLitegraphService = () => {
       options.push({
         content: 'Bypass',
         callback: () => {
-          const mode =
-            this.mode === LGraphEventMode.BYPASS
-              ? LGraphEventMode.ALWAYS
-              : LGraphEventMode.BYPASS
-          for (const item of app.canvas.selectedItems) {
-            if (item instanceof LGraphNode) item.mode = mode
-          }
-          // @ts-expect-error fixme ts strict error
-          this.graph.change()
+          toggleSelectedNodesMode(LGraphEventMode.BYPASS)
+          app.canvas.setDirty(true, true)
         }
       })
 


### PR DESCRIPTION
When a node is bypassed from the selection toolbox or by pressing a keybind for bypass, it will also recursively bypass the contents of a subgraph. This effect was not applied when clicking the bypass button from the context menu. The context menu option has been updated to perform the same action as the others so that behaviour is consistent.

See comfyanonymous/ComfyUI#9282

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4988-Fix-inconsistency-on-bypass-from-context-menu-24f6d73d3650818195afcb0c49378ff8) by [Unito](https://www.unito.io)
