### PR TITLE
[backport] Remove unused Litegraph context menu options (cherry-pick #4867)

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -8061,18 +8061,6 @@ export class LGraphCanvas
     } else {
       options = [
         {
-          content: 'Inputs',
-          has_submenu: true,
-          disabled: true
-        },
-        {
-          content: 'Outputs',
-          has_submenu: true,
-          disabled: true,
-          callback: LGraphCanvas.showMenuNodeOptionalOutputs
-        },
-        null,
-        {
           content: 'Convert to Subgraph 🆕',
           callback: () => {
             if (!this.selectedItems.size)


### PR DESCRIPTION
## Summary
Backport of #4867 to core/1.25 branch

This removes unused Litegraph context menu options to clean up the right-click menu.

## Conflicts resolved
- Browser test screenshot files kept the core/1.25 baseline versions

Original PR: #4867

This PR should fix the failing tests from #4987 by bringing the menu changes that those screenshots expect.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-4998-backport-Remove-unused-Litegraph-context-menu-options-cherry-pick-4867-2506d73d365081e59fd6f5bdd7bf0248) by [Unito](https://www.unito.io)
