### PR TITLE
Deep copy subgraphs to clipboard, update nested ids on paste

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3608,6 +3608,7 @@ export class LGraphCanvas
       subgraphs: []
     }
 
+    // NOTE: logic for traversing nested subgraphs depends on this being a set.
     const subgraphs = new Set<Subgraph>()
 
     // Create serialisable objects
@@ -3646,6 +3647,7 @@ export class LGraphCanvas
     }
 
     // Add unique subgraph entries
+    // NOTE: subgraphs is appended to mid iteration.
     for (const subgraph of subgraphs) {
       for (const node of subgraph.nodes) {
         if (node instanceof SubgraphNode) {


### PR DESCRIPTION
Resolves #5002

The copyToClipboard function wasn't walking subgraphs and leaving nested subgraphs unserialized. This has now been fixed. Note that this implementation involves adding subgraphs to the set mid iteration.

This requires that equivalent support be added to _pasteFromClipboard to update the ids of nested subgraphs which are pasted.

EDIT: Removed the now resolved TODO

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5003-Deep-copy-subgraphs-to-clipboard-update-nested-ids-on-paste-2506d73d36508141b6f9f1cf4a4ea3dc) by [Unito](https://www.unito.io)
