### PR TITLE
Translated Keyboard Shortcuts

### DIFF
--- a/src/components/bottomPanel/tabs/shortcuts/ShortcutsList.vue
+++ b/src/components/bottomPanel/tabs/shortcuts/ShortcutsList.vue
@@ -20,7 +20,7 @@
           >
             <div class="shortcut-info flex-grow pr-4">
               <div class="shortcut-name text-sm font-medium">
-                {{ command.label || command.id }}
+                {{ $t(`commands.${normalizeI18nKey(command.id)}.label`) }}
               </div>
             </div>
 
@@ -50,6 +50,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { ComfyCommandImpl } from '@/stores/commandStore'
+import { normalizeI18nKey } from '@/utils/formatUtil'
 
 const { t } = useI18n()
 

--- a/src/components/bottomPanel/tabs/shortcuts/ShortcutsList.vue
+++ b/src/components/bottomPanel/tabs/shortcuts/ShortcutsList.vue
@@ -20,7 +20,7 @@
           >
             <div class="shortcut-info flex-grow pr-4">
               <div class="shortcut-name text-sm font-medium">
-                {{ $t(`commands.${normalizeI18nKey(command.id)}.label`) }}
+                {{ t(`commands.${normalizeI18nKey(command.id)}.label`) }}
               </div>
             </div>
 

--- a/tests-ui/tests/components/bottomPanel/ShortcutsList.spec.ts
+++ b/tests-ui/tests/components/bottomPanel/ShortcutsList.spec.ts
@@ -76,9 +76,7 @@ describe('ShortcutsList', () => {
     expect(wrapper.text()).toContain('Queue')
 
     // Check that commands are rendered
-    expect(wrapper.text()).toContain('New Workflow')
-    expect(wrapper.text()).toContain('Add Node')
-    expect(wrapper.text()).toContain('Clear Queue')
+    expect(wrapper.text()).toBeTruthy()
   })
 
   it('should format keyboard shortcuts correctly', () => {

--- a/tests-ui/tests/components/bottomPanel/ShortcutsList.spec.ts
+++ b/tests-ui/tests/components/bottomPanel/ShortcutsList.spec.ts
@@ -11,7 +11,8 @@ const mockT = vi.fn((key: string) => {
     'shortcuts.subcategories.node': 'Node',
     'shortcuts.subcategories.queue': 'Queue',
     'shortcuts.subcategories.view': 'View',
-    'shortcuts.subcategories.panelControls': 'Panel Controls'
+    'shortcuts.subcategories.panelControls': 'Panel Controls',
+    'commands.Workflow_New.label': 'New Blank Workflow'
   }
   return translations[key] || key
 })
@@ -76,7 +77,7 @@ describe('ShortcutsList', () => {
     expect(wrapper.text()).toContain('Queue')
 
     // Check that commands are rendered
-    expect(wrapper.text()).toBeTruthy()
+    expect(wrapper.text()).toContain('New Blank Workflow')
   })
 
   it('should format keyboard shortcuts correctly', () => {


### PR DESCRIPTION
## Summary

<!-- One sentence describing what changed and why. -->

## Changes

- **What**:  Added translations for keyboard shortcut panel
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<img width="1458" height="904" alt="Screenshot 2025-08-15 at 18 14 16" src="https://github.com/user-attachments/assets/5b86c49c-1625-414d-9c7d-19bf8dc7df9b" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5007-Translated-Keyboard-Shortcuts-2506d73d3650813faa02c7c5af39b52c) by [Unito](https://www.unito.io)
