### PR TITLE
[feat] Improve low quality rendering zoom threshold tooltip

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -773,7 +773,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'LiteGraph.Canvas.LowQualityRenderingZoomThreshold',
     name: 'Low quality rendering zoom threshold',
     tooltip:
-      'Controls when simplified rendering activates based on zoom level. Lower values (closer to 0.1) keep high quality rendering even when zoomed far out. Higher values (closer to 1.0) switch to simplified rendering even at normal zoom levels, improving performance but reducing visual quality. Simplified rendering removes shadows, rounded corners, and connection borders.',
+      'Zoom level threshold for performance mode. Lower values (0.1) = quality at all zoom levels. Higher values (1.0) = performance mode even when zoomed in. Performance mode simplifies rendering by hiding text labels, shadows, and details.',
     type: 'slider',
     attrs: {
       min: 0.1,

--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -772,7 +772,8 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'LiteGraph.Canvas.LowQualityRenderingZoomThreshold',
     name: 'Low quality rendering zoom threshold',
-    tooltip: 'Render low quality shapes when zoomed out',
+    tooltip:
+      'Controls when simplified rendering activates based on zoom level. Lower values (closer to 0.1) keep high quality rendering even when zoomed far out. Higher values (closer to 1.0) switch to simplified rendering even at normal zoom levels, improving performance but reducing visual quality. Simplified rendering removes shadows, rounded corners, and connection borders.',
     type: 'slider',
     attrs: {
       min: 0.1,

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -390,7 +390,7 @@
   },
   "LiteGraph_Canvas_LowQualityRenderingZoomThreshold": {
     "name": "Low quality rendering zoom threshold",
-    "tooltip": "Render low quality shapes when zoomed out"
+    "tooltip": "Controls when simplified rendering activates based on zoom level. Lower values (closer to 0.1) keep high quality rendering even when zoomed far out. Higher values (closer to 1.0) switch to simplified rendering even at normal zoom levels, improving performance but reducing visual quality. Simplified rendering removes shadows, rounded corners, and connection borders."
   },
   "LiteGraph_Canvas_MaximumFps": {
     "name": "Maximum FPS",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -390,7 +390,7 @@
   },
   "LiteGraph_Canvas_LowQualityRenderingZoomThreshold": {
     "name": "Low quality rendering zoom threshold",
-    "tooltip": "Controls when simplified rendering activates based on zoom level. Lower values (closer to 0.1) keep high quality rendering even when zoomed far out. Higher values (closer to 1.0) switch to simplified rendering even at normal zoom levels, improving performance but reducing visual quality. Simplified rendering removes shadows, rounded corners, and connection borders."
+    "tooltip": "Zoom level threshold for performance mode. Lower values (0.1) = quality at all zoom levels. Higher values (1.0) = performance mode even when zoomed in. Performance mode simplifies rendering by hiding text labels, shadows, and details."
   },
   "LiteGraph_Canvas_MaximumFps": {
     "name": "Maximum FPS",


### PR DESCRIPTION
## Summary
- Improved the tooltip for the "Low quality rendering zoom threshold" setting to clearly explain how the threshold values affect rendering behavior

## Details
The previous tooltip "Render low quality shapes when zoomed out" was confusing and didn't explain what the threshold values actually do. The new tooltip clarifies:
- Lower values (0.1) = maintain high quality even when zoomed far out
- Higher values (1.0) = use simplified rendering even at normal zoom levels
- What visual features are affected (shadows, rounded corners, connection borders)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5009-feat-Improve-low-quality-rendering-zoom-threshold-tooltip-2506d73d3650815b95abf0700d0a8a30) by [Unito](https://www.unito.io)
