### PR TITLE
Consolidate network calls to use consistent HTTP clients (1/6)

### DIFF
--- a/src/composables/useTemplateWorkflows.ts
+++ b/src/composables/useTemplateWorkflows.ts
@@ -162,13 +162,13 @@ export function useTemplateWorkflows() {
     if (sourceModule === 'default') {
       // Default templates provided by frontend are served as static files
       const response = await fetch(api.fileURL(`/templates/${id}.json`))
-      return response.json()
+      return await response.json()
     } else {
       // Custom node templates served via API
       const response = await api.fetchApi(
         `/workflow_templates/${sourceModule}/${id}.json`
       )
-      return response.json()
+      return await response.json()
     }
   }
 

--- a/src/composables/useTemplateWorkflows.ts
+++ b/src/composables/useTemplateWorkflows.ts
@@ -160,12 +160,15 @@ export function useTemplateWorkflows() {
    */
   const fetchTemplateJson = async (id: string, sourceModule: string) => {
     if (sourceModule === 'default') {
-      // Default templates provided by frontend are served on this separate endpoint
-      return fetch(api.fileURL(`/templates/${id}.json`)).then((r) => r.json())
+      // Default templates provided by frontend are served as static files
+      const response = await fetch(api.fileURL(`/templates/${id}.json`))
+      return response.json()
     } else {
-      return fetch(
-        api.apiURL(`/workflow_templates/${sourceModule}/${id}.json`)
-      ).then((r) => r.json())
+      // Custom node templates served via API
+      const response = await api.fetchApi(
+        `/workflow_templates/${sourceModule}/${id}.json`
+      )
+      return response.json()
     }
   }
 

--- a/src/extensions/core/load3d/ModelExporter.ts
+++ b/src/extensions/core/load3d/ModelExporter.ts
@@ -4,6 +4,7 @@ import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter'
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter'
 
 import { t } from '@/i18n'
+import { api } from '@/scripts/api'
 import { useToastStore } from '@/stores/toastStore'
 
 export class ModelExporter {
@@ -36,7 +37,18 @@ export class ModelExporter {
     desiredFilename: string
   ): Promise<void> {
     try {
-      const response = await fetch(url)
+      // Check if this is a ComfyUI relative URL
+      const isComfyUrl = url.startsWith('/') || url.includes('/view?')
+
+      let response: Response
+      if (isComfyUrl) {
+        // Use ComfyUI API client for internal URLs
+        response = await fetch(api.apiURL(url))
+      } else {
+        // Use direct fetch for external URLs
+        response = await fetch(url)
+      }
+
       const blob = await response.blob()
 
       const link = document.createElement('a')

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -7,23 +7,28 @@ import * as vuefire from 'vuefire'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 
 // Mock axios before any imports that use it
-vi.mock('axios')
+vi.mock('axios', () => {
+  const mockAxiosInstance = {
+    get: vi.fn().mockResolvedValue({
+      data: { balance: { credits: 0 } },
+      status: 200
+    }),
+    post: vi.fn().mockResolvedValue({
+      data: { id: 'test-customer-id' },
+      status: 201
+    })
+  }
+
+  return {
+    default: {
+      create: vi.fn().mockReturnValue(mockAxiosInstance),
+      isAxiosError: vi.fn().mockImplementation(() => false)
+    }
+  }
+})
+
 const mockedAxios = vi.mocked(axios)
-
-// Set up axios mock with default instance
-const mockAxiosInstance = {
-  get: vi.fn().mockResolvedValue({
-    data: { balance: { credits: 0 } },
-    status: 200
-  }),
-  post: vi.fn().mockResolvedValue({
-    data: { id: 'test-customer-id' },
-    status: 201
-  })
-}
-
-mockedAxios.create = vi.fn().mockReturnValue(mockAxiosInstance)
-mockedAxios.isAxiosError = vi.fn().mockImplementation(() => false) as any
+const mockAxiosInstance = mockedAxios.create() as any
 
 // Mock fetch
 const mockFetch = vi.fn()
@@ -122,7 +127,7 @@ describe('useFirebaseAuthStore', () => {
       data: { id: 'test-customer-id' },
       status: 201
     })
-    mockedAxios.isAxiosError = vi.fn().mockImplementation(() => false) as any
+    ;(mockedAxios.isAxiosError as any).mockReturnValue(false)
 
     // Mock useFirebaseAuth to return our mock auth object
     vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(mockAuth as any)

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -1,9 +1,29 @@
+import axios from 'axios'
 import * as firebaseAuth from 'firebase/auth'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
+
+// Mock axios before any imports that use it
+vi.mock('axios')
+const mockedAxios = vi.mocked(axios)
+
+// Set up axios mock with default instance
+const mockAxiosInstance = {
+  get: vi.fn().mockResolvedValue({
+    data: { balance: { credits: 0 } },
+    status: 200
+  }),
+  post: vi.fn().mockResolvedValue({
+    data: { id: 'test-customer-id' },
+    status: 201
+  })
+}
+
+mockedAxios.create = vi.fn().mockReturnValue(mockAxiosInstance)
+mockedAxios.isAxiosError = vi.fn().mockImplementation(() => false) as any
 
 // Mock fetch
 const mockFetch = vi.fn()
@@ -91,7 +111,18 @@ describe('useFirebaseAuthStore', () => {
   }
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
+
+    // Reset axios mock responses to defaults
+    mockAxiosInstance.get.mockResolvedValue({
+      data: { balance: { credits: 0 } },
+      status: 200
+    })
+    mockAxiosInstance.post.mockResolvedValue({
+      data: { id: 'test-customer-id' },
+      status: 201
+    })
+    mockedAxios.isAxiosError = vi.fn().mockImplementation(() => false) as any
 
     // Mock useFirebaseAuth to return our mock auth object
     vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(mockAuth as any)


### PR DESCRIPTION
## Summary

Consolidates network calls across the codebase to use consistent HTTP client patterns, preparing the foundation for future header registration and middleware capabilities.

## Changes

### Firebase Auth Store
- Replaced 4 direct `fetch()` calls with axios client instance
- Maintained exact error handling behavior and logic flow
- Follows same pattern as other service classes

### Template Workflows
- Updated to use `api.fetchApi()` for API endpoints
- Kept direct fetch for static files (already using `api.fileURL()`)

### Model Exporter (3D)
- Added logic to distinguish ComfyUI URLs from external URLs
- Uses `api.apiURL()` for internal URLs, direct fetch for external URLs
- Preserves existing download functionality

### Files Already Following Correct Patterns
- **Upload Audio**: Already using `api.fetchApi()`
- **3D Loading Utils**: Already using `api.fetchApi()` (fetch call is for blob conversion)
- **Download Utility**: Correctly uses direct fetch for external URLs

## Benefits

- ✅ Consistent error handling across all network operations
- ✅ Centralized request configuration
- ✅ Foundation for future header registration system
- ✅ Better testing with centralized mocking points
- ✅ No breaking changes - all existing functionality preserved

## Testing

- All TypeScript compilation checks pass
- Existing unit tests continue to pass
- Manual testing of affected features confirmed working

Related to #5017

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5021-Consolidate-network-calls-to-use-consistent-HTTP-clients-2506d73d3650819f99d2f22fd817b9fa) by [Unito](https://www.unito.io)
