### PR TITLE
Fix Connection of Primitive nodes to Subgraph node

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -369,10 +369,11 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       widget: promotedWidget,
       subgraphNode: this
     })
-
-    const backingInput =
-      (widget as { node?: LGraphNode }).node?.findInputSlot(widget.name, true)
-        ?.widget ?? {}
+    const hasNode = (w: any): w is { node: LGraphNode } =>
+      w && typeof w.node === 'object' && w.node.findInputSlot
+    const backingInput = hasNode(widget)
+      ? widget.node.findInputSlot(widget.name, true)?.widget ?? {}
+      : {}
     input.widget ??= { name: subgraphInput.name }
     input.widget.name = subgraphInput.name
     Object.setPrototypeOf(input.widget, backingInput)

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -313,9 +313,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     widget: Readonly<IBaseWidget>
   ) {
     // Use the first matching widget
-    const promotedWidget = toConcreteWidget(widget, this).createCopyForNode(
-      this
-    )
+    const targetWidget = toConcreteWidget(widget, this)
+    const promotedWidget = targetWidget.createCopyForNode(this)
 
     Object.assign(promotedWidget, {
       get name() {
@@ -369,11 +368,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       widget: promotedWidget,
       subgraphNode: this
     })
-    const hasNode = (w: any): w is { node: LGraphNode } =>
-      w && typeof w.node === 'object' && w.node.findInputSlot
-    const backingInput = hasNode(widget)
-      ? widget.node.findInputSlot(widget.name, true)?.widget ?? {}
-      : {}
+
+    const backingInput =
+      targetWidget.node.findInputSlot(widget.name, true)?.widget ?? {}
     input.widget ??= { name: subgraphInput.name }
     input.widget.name = subgraphInput.name
     Object.setPrototypeOf(input.widget, backingInput)

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -370,7 +370,10 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       subgraphNode: this
     })
 
-    input.widget = { name: subgraphInput.name }
+    const backingInput =
+      (widget as { node?: LGraphNode }).node?.findInputSlot(widget.name, true)
+        ?.widget ?? {}
+    input.widget = { ...backingInput, name: subgraphInput.name }
     input._widget = promotedWidget
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -373,7 +373,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     const backingInput =
       (widget as { node?: LGraphNode }).node?.findInputSlot(widget.name, true)
         ?.widget ?? {}
-    input.widget = { ...backingInput, name: subgraphInput.name }
+    input.widget ??= { name: subgraphInput.name }
+    input.widget.name = subgraphInput.name
+    Object.setPrototypeOf(input.widget, backingInput)
     input._widget = promotedWidget
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -369,11 +369,15 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       subgraphNode: this
     })
 
+    // NOTE: This code creates linked chains of prototypes for passing across
+    // multiple levels of subgraphs. As part of this, it intentionally avoids
+    // creating new objects. Have care when making changes.
     const backingInput =
       targetWidget.node.findInputSlot(widget.name, true)?.widget ?? {}
     input.widget ??= { name: subgraphInput.name }
     input.widget.name = subgraphInput.name
     Object.setPrototypeOf(input.widget, backingInput)
+
     input._widget = promotedWidget
   }
 


### PR DESCRIPTION
Had a clever idea which greatly simplifies the logic of nesting here. This patch is now entirely usable, and, in my opinion, worth releasing, but I've noticed a little spottyness with testing of swapped connections to partially matching types (FLOAT to FLOAT with different max/min)

![subgraph-primitives](https://github.com/user-attachments/assets/11206b9a-8956-44c0-849c-7e20d833b442)

Resolves #5000

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5024-Fix-Connection-of-Primitive-nodes-to-Subgraph-node-2506d73d365081afaf1cc58656aee460) by [Unito](https://www.unito.io)
