### PR TITLE
[release] Bump version to 1.25.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.25.6",
+  "version": "1.25.7",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
## Release 1.25.7

This patch release includes backported fixes and features that improve stability and user experience.

### 🎯 Backported Changes Since v1.25.6

#### Subgraph Improvements
- **Deep copy subgraphs to clipboard** (#5003) - Properly handles nested IDs when pasting subgraphs
- **Fix minimap subgraph navigation** (#5018) - Improves navigation with graph UUID callback tracking
- **Fix widget disconnection in subgraphs** (#5015) - Resolves issue #4922 where widgets were getting disconnected

#### Pricing & API
- **Added GPT-5 series model pricing** (#4958) - Updates api_nodes with pricing for new GPT-5 models

#### Internationalization
- **Translated Keyboard Shortcuts** (#5007) - Adds keyboard shortcut translations
- **Traditional to Simplified Chinese fixes** (#5005) - Corrects character translations in Chinese locale

#### Testing
- **Release fetch skip tests** (#4799) - Adds tests for `--disable-api-nodes` functionality

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5026-release-Bump-version-to-1-25-7-2506d73d3650819b9579da7b177b30cc) by [Unito](https://www.unito.io)
