### PR TITLE
fix: issue #4121

### DIFF
--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -90,18 +90,16 @@ const closeDialog = () => {
 const canvasStore = useCanvasStore()
 
 const addNode = (nodeDef: ComfyNodeDefImpl) => {
-  if (!triggerEvent) {
-    console.warn('The trigger event was undefined when addNode was called.')
-    return
-  }
-
   const node = litegraphService.addNodeOnGraph(nodeDef, {
     pos: getNewNodeLocation()
   })
 
-  if (disconnectOnReset) {
+  if (disconnectOnReset && triggerEvent) {
     canvasStore.getCanvas().linkConnector.connectToNode(node, triggerEvent)
+  } else if (!triggerEvent) {
+    console.warn('The trigger event was undefined when addNode was called.')
   }
+
   disconnectOnReset = false
 
   // Notify changeTracker - new step should be added


### PR DESCRIPTION
## Summary

Search popover wasn't adding nodes. Now it adds the selected node.

## Changes

- **What**: We were early exiting in the absence of a canvas `triggerEvent`. We were just using that event to add the node where a users's mouse was if the added via right-click. Now instead we're using the fallback value which is the center of the canvas.

## Review Focus

Fixes #4121 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/8e8b65ec-08bd-4c06-a28f-e9a3b31961da

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5029-fix-issue-4121-2516d73d3650813eb666eb94a5be1d36) by [Unito](https://www.unito.io)
