### PR TITLE
api_nodes: added prices for Vidu Video nodes

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1371,6 +1371,18 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         }
         return 'Token-based'
       }
+    },
+    ViduTextToVideoNode: {
+      displayPrice: '$0.4/Run'
+    },
+    ViduImageToVideoNode: {
+      displayPrice: '$0.4/Run'
+    },
+    ViduReferenceVideoNode: {
+      displayPrice: '$0.4/Run'
+    },
+    ViduStartEndToVideoNode: {
+      displayPrice: '$0.4/Run'
     }
   }
 


### PR DESCRIPTION
## Summary

Added pricing for the nodes added in this PR: https://github.com/comfyanonymous/ComfyUI/pull/9368

Prices are the same for all four nodes as we currently only support one flagship model.

## Screenshots (if applicable)

<img width="1281" height="913" alt="Screenshot from 2025-08-16 13-56-44" src="https://github.com/user-attachments/assets/bc706818-7fe2-4ba7-a9f4-5e0bdff8fe36" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5035-api_nodes-added-prices-for-Vidu-Video-nodes-2516d73d365081fb9090d48c4c6216b8) by [Unito](https://www.unito.io)
