### PR TITLE
Fix handle minimap cleanup called before map set

### DIFF
--- a/src/composables/useMinimap.ts
+++ b/src/composables/useMinimap.ts
@@ -685,9 +685,10 @@ export function useMinimap() {
 
     const originalCallbacks = originalCallbacksMap.get(g.id)
     if (!originalCallbacks) {
-      throw new Error(
+      console.error(
         'Attempted to cleanup event listeners for graph that was never set up'
       )
+      return
     }
 
     g.onNodeAdded = originalCallbacks.onNodeAdded


### PR DESCRIPTION
This change fixes the missing sidebar elements, canvas menu and widget components caused by recent FE changes.

## Before

<img width="3454" height="1902" alt="image" src="https://github.com/user-attachments/assets/bd937b31-4ede-4b61-9c1c-e84515f149f2" />
<img width="2828" height="1600" alt="image" src="https://github.com/user-attachments/assets/8b2ff51e-83d7-448a-a3e1-a8f367a8a0d3" />

## After

<img width="1727" height="955" alt="image" src="https://github.com/user-attachments/assets/23855bf3-aa34-4e73-afd2-6e5e93c007d6" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5038-Fix-handle-minimap-cleanup-called-before-map-set-2516d73d365081fb947bf6e7d67241a8) by [Unito](https://www.unito.io)
