### PR TITLE
feat: Add dropdown list for additional tabs

### DIFF
--- a/src/components/topbar/WorkflowOverflowMenu.vue
+++ b/src/components/topbar/WorkflowOverflowMenu.vue
@@ -9,7 +9,12 @@
       :aria-label="$t('g.moreWorkflows')"
       @click="menu?.toggle($event)"
     />
-    <Menu ref="menu" :model="menuItems" :popup="true" />
+    <Menu
+      ref="menu"
+      :model="menuItems"
+      :popup="true"
+      class="max-h-[40vh] overflow-auto"
+    />
   </div>
 </template>
 

--- a/src/components/topbar/WorkflowOverflowMenu.vue
+++ b/src/components/topbar/WorkflowOverflowMenu.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <Button
+      v-tooltip="{ value: $t('g.moreWorkflows'), showDelay: 300 }"
+      class="rounded-none"
+      icon="pi pi-ellipsis-h"
+      text
+      severity="secondary"
+      :aria-label="$t('g.moreWorkflows')"
+      @click="menu?.toggle($event)"
+    />
+    <Menu ref="menu" :model="menuItems" :popup="true" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import Menu from 'primevue/menu'
+import { computed, ref } from 'vue'
+
+import { useWorkflowService } from '@/services/workflowService'
+import type { ComfyWorkflow } from '@/stores/workflowStore'
+
+const props = defineProps<{
+  workflows: ComfyWorkflow[]
+  activeWorkflow: ComfyWorkflow | null
+}>()
+
+const menu = ref<InstanceType<typeof Menu> | null>(null)
+const workflowService = useWorkflowService()
+
+const menuItems = computed(() =>
+  props.workflows.map((workflow: ComfyWorkflow) => ({
+    label: workflow.filename,
+    icon:
+      props.activeWorkflow?.key === workflow.key ? 'pi pi-check' : undefined,
+    command: () => {
+      void workflowService.openWorkflow(workflow)
+    }
+  }))
+)
+</script>

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -3,11 +3,6 @@
     class="workflow-tabs-container flex flex-row max-w-full h-full flex-auto overflow-hidden"
     :class="{ 'workflow-tabs-container-desktop': isDesktop }"
   >
-    <WorkflowOverflowMenu
-      v-if="showOverflowArrows"
-      :workflows="workflowStore.openWorkflows"
-      :active-workflow="workflowStore.activeWorkflow"
-    />
     <Button
       v-if="showOverflowArrows"
       icon="pi pi-chevron-left"
@@ -52,6 +47,11 @@
       class="overflow-arrow overflow-arrow-right"
       :disabled="!rightArrowEnabled"
       @mousedown="whileMouseDown($event, () => scroll(1))"
+    />
+    <WorkflowOverflowMenu
+      v-if="showOverflowArrows"
+      :workflows="workflowStore.openWorkflows"
+      :active-workflow="workflowStore.activeWorkflow"
     />
     <Button
       v-tooltip="{ value: $t('sideToolbar.newBlankWorkflow'), showDelay: 300 }"

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -3,6 +3,11 @@
     class="workflow-tabs-container flex flex-row max-w-full h-full flex-auto overflow-hidden"
     :class="{ 'workflow-tabs-container-desktop': isDesktop }"
   >
+    <WorkflowOverflowMenu
+      v-if="showOverflowArrows"
+      :workflows="workflowStore.openWorkflows"
+      :active-workflow="workflowStore.activeWorkflow"
+    />
     <Button
       v-if="showOverflowArrows"
       icon="pi pi-chevron-left"
@@ -16,7 +21,7 @@
       ref="scrollPanelRef"
       class="overflow-hidden no-drag"
       :pt:content="{
-        class: 'p-0 w-full',
+        class: 'p-0 w-full flex',
         onwheel: handleWheel
       }"
       pt:bar-x="h-1"
@@ -84,6 +89,8 @@ import { useWorkflowStore } from '@/stores/workflowStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { isElectron } from '@/utils/envUtil'
 import { whileMouseDown } from '@/utils/mouseDownUtil'
+
+import WorkflowOverflowMenu from './WorkflowOverflowMenu.vue'
 
 interface WorkflowOption {
   value: string

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -148,7 +148,8 @@
     "micPermissionDenied": "Microphone permission denied",
     "noAudioRecorded": "No audio recorded",
     "nodesRunning": "nodes running",
-    "duplicate": "Duplicate"
+    "duplicate": "Duplicate",
+    "moreWorkflows": "More workflows"
   },
   "manager": {
     "title": "Custom Nodes Manager",


### PR DESCRIPTION
## Summary

Feature: #3870 

## Changes

So as mentioned in the ticket, I added a button that opens a menu listing all available workflows. The currently active workflow is displayed with a check icon.

## Review Focus

Will need to verify the design. Currently i have just added a check icon for active workflow.

## Screenshots (if applicable)
<img width="1903" height="606" alt="image" src="https://github.com/user-attachments/assets/bc210209-315f-4cd5-a475-4a2ffa65b306" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5046-feat-Add-dropdown-list-for-additional-tabs-2526d73d365081739d1ed1f3103004be) by [Unito](https://www.unito.io)
