### PR TITLE
Add support for custom icons in menu

### DIFF
--- a/browser_tests/tests/menu.spec.ts
+++ b/browser_tests/tests/menu.spec.ts
@@ -178,6 +178,79 @@ test.describe('Menu', () => {
       await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
       expect(await comfyPage.getVisibleToastCount()).toBe(1)
     })
+
+    test('Browse Templates custom icon is visible and matches sidebar icon', async ({
+      comfyPage
+    }) => {
+      // Open the top menu
+      await comfyPage.menu.topbar.openTopbarMenu()
+      const menu = comfyPage.page.locator('.comfy-command-menu')
+
+      // Find the Browse Templates menu item
+      const browseTemplatesItem = menu.locator(
+        '.p-menubar-item-label:text-is("Browse Templates")'
+      )
+      await expect(browseTemplatesItem).toBeVisible()
+
+      // Check that the Browse Templates item has an icon
+      const menuIcon = browseTemplatesItem
+        .locator('..')
+        .locator('.p-menubar-item-icon')
+        .first()
+      await expect(menuIcon).toBeVisible()
+
+      // Get the icon's tag name and class to verify it's a component (not a string icon)
+      const menuIconType = await menuIcon.evaluate((el) => {
+        // If it's a Vue component, it will not have pi/mdi classes
+        // and should be an SVG or custom component
+        const tagName = el.tagName.toLowerCase()
+        const classes = el.className || ''
+        return {
+          tagName,
+          classes,
+          hasStringIcon:
+            typeof classes === 'string' &&
+            (classes.includes('pi ') || classes.includes('mdi '))
+        }
+      })
+
+      // Verify it's a component icon (not a string icon with pi/mdi classes)
+      expect(menuIconType.hasStringIcon).toBe(false)
+
+      // Close menu
+      await comfyPage.page.locator('body').click({ position: { x: 10, y: 10 } })
+
+      // Now check the sidebar templates button
+      const sidebarTemplatesButton = comfyPage.page.locator(
+        '.templates-tab-button'
+      )
+      await expect(sidebarTemplatesButton).toBeVisible()
+
+      // Get the sidebar icon info
+      const sidebarIcon = sidebarTemplatesButton.locator(
+        '.side-bar-button-icon'
+      )
+      await expect(sidebarIcon).toBeVisible()
+
+      const sidebarIconType = await sidebarIcon.evaluate((el) => {
+        const tagName = el.tagName.toLowerCase()
+        const classes = el.className || ''
+        return {
+          tagName,
+          classes,
+          hasStringIcon:
+            typeof classes === 'string' &&
+            (classes.includes('pi ') || classes.includes('mdi '))
+        }
+      })
+
+      // Verify sidebar also uses component icon (not string icon)
+      expect(sidebarIconType.hasStringIcon).toBe(false)
+
+      // Both should be using the same custom component (likely SVG elements)
+      expect(menuIconType.tagName).toBe('svg')
+      expect(sidebarIconType.tagName).toBe('svg')
+    })
   })
 
   // Only test 'Top' to reduce test time.

--- a/src/components/graph/selectionToolbox/ExtensionCommandButton.vue
+++ b/src/components/graph/selectionToolbox/ExtensionCommandButton.vue
@@ -7,7 +7,13 @@
     }"
     severity="secondary"
     text
-    :icon="typeof command.icon === 'function' ? command.icon() : command.icon"
+    :icon="
+      typeof command.icon === 'function'
+        ? command.icon()
+        : typeof command.icon === 'string'
+          ? command.icon
+          : undefined
+    "
     @click="() => commandStore.execute(command.id)"
   />
 </template>

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import type { Component } from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { ComfyExtension } from '@/types/comfy'
@@ -11,7 +12,7 @@ export interface ComfyCommand {
   function: () => void | Promise<void>
 
   label?: string | (() => string)
-  icon?: string | (() => string)
+  icon?: string | { component: Component } | (() => string)
   tooltip?: string | (() => string)
   menubarLabel?: string | (() => string) // Menubar item label, if different from command label
   versionAdded?: string
@@ -25,7 +26,7 @@ export class ComfyCommandImpl implements ComfyCommand {
   id: string
   function: () => void | Promise<void>
   _label?: string | (() => string)
-  _icon?: string | (() => string)
+  _icon?: string | { component: Component } | (() => string)
   _tooltip?: string | (() => string)
   _menubarLabel?: string | (() => string)
   versionAdded?: string

--- a/src/stores/workspace/sidebarTabStore.ts
+++ b/src/stores/workspace/sidebarTabStore.ts
@@ -57,7 +57,10 @@ export const useSidebarTabStore = defineStore('sidebarTab', () => {
 
     useCommandStore().registerCommand({
       id: `Workspace.ToggleSidebarTab.${tab.id}`,
-      icon: typeof tab.icon === 'string' ? tab.icon : undefined,
+      icon:
+        !tab.icon || typeof tab.icon === 'string'
+          ? tab.icon
+          : { component: tab.icon },
       label: labelFunction,
       menubarLabel: menubarLabelFunction,
       tooltip: tooltipFunction,


### PR DESCRIPTION
## Summary

Add support for Vue component icons in menu and change Browse Templates menu item to use the same custom icon as the sidebar tab icon as there was a mismatch

## Changes
- **What**:  Support custom icon components in command menu using  `<component :is>` to either render an `i` element or the component

<img width="296" height="342" alt="image" src="https://github.com/user-attachments/assets/1086e383-c681-449d-9dff-48b91e11110d" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5051-Add-support-for-custom-icons-in-menu-2526d73d36508113b020cf752a3c0e34) by [Unito](https://www.unito.io)
