### PR TITLE
[refactor] Refactor minimap initialization logic

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -21,7 +21,6 @@
 
       <MiniMap
         v-if="comfyAppReady && minimapEnabled"
-        ref="minimapRef"
         class="pointer-events-auto"
       />
     </template>
@@ -71,7 +70,6 @@ import { useContextMenuTranslation } from '@/composables/useContextMenuTranslati
 import { useCopy } from '@/composables/useCopy'
 import { useGlobalLitegraph } from '@/composables/useGlobalLitegraph'
 import { useLitegraphSettings } from '@/composables/useLitegraphSettings'
-import { useMinimap } from '@/composables/useMinimap'
 import { usePaste } from '@/composables/usePaste'
 import { useWorkflowAutoSave } from '@/composables/useWorkflowAutoSave'
 import { useWorkflowPersistence } from '@/composables/useWorkflowPersistence'
@@ -119,9 +117,7 @@ const selectionToolboxEnabled = computed(() =>
   settingStore.get('Comfy.Canvas.SelectionToolbox')
 )
 
-const minimapRef = ref<InstanceType<typeof MiniMap>>()
 const minimapEnabled = computed(() => settingStore.get('Comfy.Minimap.Visible'))
-const minimap = useMinimap()
 
 watchEffect(() => {
   nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')
@@ -355,13 +351,6 @@ onMounted(async () => {
     async () => {
       await useCommandStore().execute('Comfy.RefreshNodeDefinitions')
       await useWorkflowService().reloadCurrentWorkflow()
-    }
-  )
-
-  whenever(
-    () => minimapRef.value,
-    (ref) => {
-      minimap.setMinimapRef(ref)
     }
   )
 

--- a/src/components/graph/MiniMap.vue
+++ b/src/components/graph/MiniMap.vue
@@ -55,14 +55,11 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 
 import { useMinimap } from '@/composables/useMinimap'
-import { useCanvasStore } from '@/stores/graphStore'
 
 import MiniMapPanel from './MiniMapPanel.vue'
-
-const canvasStore = useCanvasStore()
 
 const minimapRef = ref<HTMLDivElement>()
 
@@ -82,7 +79,6 @@ const {
   renderBypass,
   renderError,
   updateOption,
-  init,
   destroy,
   handlePointerDown,
   handlePointerMove,
@@ -96,16 +92,6 @@ const showOptionsPanel = ref(false)
 const toggleOptionsPanel = () => {
   showOptionsPanel.value = !showOptionsPanel.value
 }
-
-watch(
-  () => canvasStore.canvas,
-  async (canvas) => {
-    if (canvas && !initialized.value) {
-      await init()
-    }
-  },
-  { immediate: true }
-)
 
 onMounted(() => {
   setMinimapRef(minimapRef.value)

--- a/src/components/graph/MiniMap.vue
+++ b/src/components/graph/MiniMap.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="visible && initialized"
+    ref="minimapRef"
     class="minimap-main-container flex absolute bottom-[20px] right-[90px] z-[1000]"
   >
     <MiniMapPanel
@@ -61,8 +62,9 @@ import { useCanvasStore } from '@/stores/graphStore'
 
 import MiniMapPanel from './MiniMapPanel.vue'
 
-const minimap = useMinimap()
 const canvasStore = useCanvasStore()
+
+const minimapRef = ref<HTMLDivElement>()
 
 const {
   initialized,
@@ -85,8 +87,9 @@ const {
   handlePointerDown,
   handlePointerMove,
   handlePointerUp,
-  handleWheel
-} = minimap
+  handleWheel,
+  setMinimapRef
+} = useMinimap()
 
 const showOptionsPanel = ref(false)
 
@@ -104,10 +107,8 @@ watch(
   { immediate: true }
 )
 
-onMounted(async () => {
-  if (canvasStore.canvas) {
-    await init()
-  }
+onMounted(() => {
+  setMinimapRef(minimapRef.value)
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
Refactors minimap.

- Previously, the minimap ref was being initialized in the parent component, requiring the parent to watch for render before passing the ref. The parent component should not pass the ref to a composable being used in the child, as it can easily cause timing issues with rendering order and generally breaks encapsulation.
- Previously, the minimap composable's `init` was being called in three places: (1) Minimap component's `onMounted`, (2) Minimap component's canvas watcher, (3) useMinimap composable's canvas watcher. It only needs to happen in one place, so just keep it in (3) for now.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5052-refactor-Refactor-minimap-initialization-logic-2526d73d3650812ab38cc4b757289f4a) by [Unito](https://www.unito.io)
