### PR TITLE
[bugfix] Allow removeInput/removeOutput on nodes without graph reference

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1574,7 +1574,10 @@ export class LGraphNode
    * remove an existing output slot
    */
   removeOutput(slot: number): void {
-    this.disconnectOutput(slot)
+    // Only disconnect if node is part of a graph
+    if (this.graph) {
+      this.disconnectOutput(slot)
+    }
     const { outputs } = this
     outputs.splice(slot, 1)
 
@@ -1582,11 +1585,12 @@ export class LGraphNode
       const output = outputs[i]
       if (!output || !output.links) continue
 
-      for (const linkId of output.links) {
-        if (!this.graph) throw new NullGraphError()
-
-        const link = this.graph._links.get(linkId)
-        if (link) link.origin_slot--
+      // Only update link indices if node is part of a graph
+      if (this.graph) {
+        for (const linkId of output.links) {
+          const link = this.graph._links.get(linkId)
+          if (link) link.origin_slot--
+        }
       }
     }
 
@@ -1626,7 +1630,10 @@ export class LGraphNode
    * remove an existing input slot
    */
   removeInput(slot: number): void {
-    this.disconnectInput(slot, true)
+    // Only disconnect if node is part of a graph
+    if (this.graph) {
+      this.disconnectInput(slot, true)
+    }
     const { inputs } = this
     const slot_info = inputs.splice(slot, 1)
 
@@ -1634,9 +1641,11 @@ export class LGraphNode
       const input = inputs[i]
       if (!input?.link) continue
 
-      if (!this.graph) throw new NullGraphError()
-      const link = this.graph._links.get(input.link)
-      if (link) link.target_slot--
+      // Only update link indices if node is part of a graph
+      if (this.graph) {
+        const link = this.graph._links.get(input.link)
+        if (link) link.target_slot--
+      }
     }
     this.onInputRemoved?.(slot, slot_info[0])
     this.setDirtyCanvas(true, true)


### PR DESCRIPTION
This PR fixes issue #5037 where calling removeInput or removeOutput on a copied/cloned node throws a NullGraphError because the node doesn't have a graph reference.

The issue affects extension developers who have nodes with dynamic inputs/outputs that need to update their interface during copy operations. When a node is copied to the clipboard, it's cloned without a graph reference, but it still retains its inputs and outputs. Extensions may need to remove or modify these slots as part of their configuration logic, particularly when the copied node no longer has connections that would justify keeping certain dynamic slots.

The fix modifies removeInput and removeOutput to only call their respective disconnect methods when the node has a graph reference. The methods still perform their other essential functions: removing the slot from the node's structure, calling lifecycle callbacks like onInputRemoved/onOutputRemoved, and marking the canvas as dirty for redraw. This allows nodes to be fully configured in their desired state before being added to a graph.

This change is semantically correct because the disconnect operations are only meaningful when a node is part of a graph with actual link connections to manage. The ability to modify a node's interface structure should not depend on graph membership, as nodes often need to be configured during creation, cloning, or other operations that happen outside of a graph context. Examples include the RerouteNode's clone method which needs to rename outputs, widget input synchronization during graph configuration, and SubgraphNode event handling.

Tests have been added to verify the new behavior works correctly both for nodes without graphs and for nodes that are subsequently added to graphs. The fix maintains backward compatibility while enabling the legitimate use cases that were previously throwing errors.

Fixes #5037

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5053-bugfix-Allow-removeInput-removeOutput-on-nodes-without-graph-reference-2526d73d365081c0b328f6061e526053) by [Unito](https://www.unito.io)
