### PR TITLE
[fix] Resolve group node execution error when connecting to external nodes

### DIFF
--- a/src/utils/executableGroupNodeChildDTO.ts
+++ b/src/utils/executableGroupNodeChildDTO.ts
@@ -27,6 +27,13 @@ export class ExecutableGroupNodeChildDTO extends ExecutableNodeDTO {
   }
 
   override resolveInput(slot: number) {
+    // Check if this group node is inside a subgraph (unsupported)
+    if (this.id.split(':').length > 2) {
+      throw new Error(
+        'Group nodes inside subgraphs are not supported. Please convert the group node to a subgraph instead.'
+      )
+    }
+
     const inputNode = this.node.getInputNode(slot)
     if (!inputNode) return
 

--- a/src/utils/executableGroupNodeChildDTO.ts
+++ b/src/utils/executableGroupNodeChildDTO.ts
@@ -33,19 +33,28 @@ export class ExecutableGroupNodeChildDTO extends ExecutableNodeDTO {
     const link = this.node.getInputLink(slot)
     if (!link) throw new Error('Failed to get input link')
 
-    const id = String(inputNode.id).split(':').at(-1)
-    if (id === undefined) throw new Error('Invalid input node id')
+    const inputNodeId = String(inputNode.id)
 
-    const inputNodeDto = this.nodesByExecutionId?.get(id)
+    // Try to find the node using the full ID first (for nodes outside the group)
+    let inputNodeDto = this.nodesByExecutionId?.get(inputNodeId)
+
+    // If not found, try with just the last part of the ID (for nodes inside the group)
+    if (!inputNodeDto) {
+      const id = inputNodeId.split(':').at(-1)
+      if (id !== undefined) {
+        inputNodeDto = this.nodesByExecutionId?.get(id)
+      }
+    }
+
     if (!inputNodeDto) {
       throw new Error(
-        `Failed to get input node ${id} for group node child ${this.id} with slot ${slot}`
+        `Failed to get input node ${inputNodeId} for group node child ${this.id} with slot ${slot}`
       )
     }
 
     return {
       node: inputNodeDto,
-      origin_id: String(inputNode.id),
+      origin_id: inputNodeId,
       origin_slot: link.origin_slot
     }
   }

--- a/tests-ui/tests/utils/executableGroupNodeChildDTO.test.ts
+++ b/tests-ui/tests/utils/executableGroupNodeChildDTO.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GroupNodeHandler } from '@/extensions/core/groupNode'
+import type {
+  ExecutableLGraphNode,
+  ExecutionId,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import { ExecutableGroupNodeChildDTO } from '@/utils/executableGroupNodeChildDTO'
+
+describe('ExecutableGroupNodeChildDTO', () => {
+  let mockNode: LGraphNode
+  let mockInputNode: LGraphNode
+  let mockNodesByExecutionId: Map<ExecutionId, ExecutableLGraphNode>
+  let mockGroupNodeHandler: GroupNodeHandler
+
+  beforeEach(() => {
+    // Create mock nodes
+    mockNode = {
+      id: '10:3',
+      graph: {},
+      getInputNode: vi.fn(),
+      getInputLink: vi.fn(),
+      inputs: []
+    } as any
+
+    mockInputNode = {
+      id: '1',
+      graph: {}
+    } as any
+
+    // Create the nodesByExecutionId map
+    mockNodesByExecutionId = new Map()
+
+    mockGroupNodeHandler = {} as GroupNodeHandler
+  })
+
+  describe('resolveInput', () => {
+    it('should resolve input from external node (node outside the group)', () => {
+      // Setup: External node with ID '1'
+      const externalNodeDto = {
+        id: '1',
+        type: 'TestNode'
+      } as ExecutableLGraphNode
+
+      mockNodesByExecutionId.set('1', externalNodeDto)
+
+      mockNode.getInputNode = vi.fn().mockReturnValue(mockInputNode)
+      mockNode.getInputLink = vi.fn().mockReturnValue({
+        origin_slot: 0
+      })
+
+      const dto = new ExecutableGroupNodeChildDTO(
+        mockNode,
+        ['10'], // Group node ID is 10
+        mockNodesByExecutionId,
+        undefined,
+        mockGroupNodeHandler
+      )
+
+      const result = dto.resolveInput(0)
+
+      expect(result).toEqual({
+        node: externalNodeDto,
+        origin_id: '1',
+        origin_slot: 0
+      })
+    })
+
+    it('should resolve input from internal node (node inside the same group)', () => {
+      // Setup: Internal node with ID '10:2'
+      const internalInputNode = {
+        id: '10:2',
+        graph: {}
+      } as LGraphNode
+
+      const internalNodeDto = {
+        id: '2',
+        type: 'InternalNode'
+      } as ExecutableLGraphNode
+
+      // Internal nodes are stored with just their index
+      mockNodesByExecutionId.set('2', internalNodeDto)
+
+      mockNode.getInputNode = vi.fn().mockReturnValue(internalInputNode)
+      mockNode.getInputLink = vi.fn().mockReturnValue({
+        origin_slot: 1
+      })
+
+      const dto = new ExecutableGroupNodeChildDTO(
+        mockNode,
+        ['10'],
+        mockNodesByExecutionId,
+        undefined,
+        mockGroupNodeHandler
+      )
+
+      const result = dto.resolveInput(0)
+
+      expect(result).toEqual({
+        node: internalNodeDto,
+        origin_id: '10:2',
+        origin_slot: 1
+      })
+    })
+
+    it('should return undefined if no input node exists', () => {
+      mockNode.getInputNode = vi.fn().mockReturnValue(null)
+
+      const dto = new ExecutableGroupNodeChildDTO(
+        mockNode,
+        ['10'],
+        mockNodesByExecutionId,
+        undefined,
+        mockGroupNodeHandler
+      )
+
+      const result = dto.resolveInput(0)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should throw error if input link is missing', () => {
+      mockNode.getInputNode = vi.fn().mockReturnValue(mockInputNode)
+      mockNode.getInputLink = vi.fn().mockReturnValue(null)
+
+      const dto = new ExecutableGroupNodeChildDTO(
+        mockNode,
+        ['10'],
+        mockNodesByExecutionId,
+        undefined,
+        mockGroupNodeHandler
+      )
+
+      expect(() => dto.resolveInput(0)).toThrow('Failed to get input link')
+    })
+
+    it('should throw error if input node cannot be found in nodesByExecutionId', () => {
+      // Node exists but is not in the map
+      mockNode.getInputNode = vi.fn().mockReturnValue(mockInputNode)
+      mockNode.getInputLink = vi.fn().mockReturnValue({
+        origin_slot: 0
+      })
+
+      const dto = new ExecutableGroupNodeChildDTO(
+        mockNode,
+        ['10'],
+        mockNodesByExecutionId, // Empty map
+        undefined,
+        mockGroupNodeHandler
+      )
+
+      expect(() => dto.resolveInput(0)).toThrow(
+        'Failed to get input node 1 for group node child 10:10:3 with slot 0'
+      )
+    })
+
+    it('should handle nested group nodes correctly', () => {
+      // Setup: Node in a nested group with ID '10:5:2'
+      const nestedInputNode = {
+        id: '10:5:2',
+        graph: {}
+      } as LGraphNode
+
+      const nestedNodeDto = {
+        id: '2',
+        type: 'NestedNode'
+      } as ExecutableLGraphNode
+
+      mockNodesByExecutionId.set('2', nestedNodeDto)
+
+      mockNode.getInputNode = vi.fn().mockReturnValue(nestedInputNode)
+      mockNode.getInputLink = vi.fn().mockReturnValue({
+        origin_slot: 2
+      })
+
+      const dto = new ExecutableGroupNodeChildDTO(
+        mockNode,
+        ['10', '5'], // Nested in group 10, then group 5
+        mockNodesByExecutionId,
+        undefined,
+        mockGroupNodeHandler
+      )
+
+      const result = dto.resolveInput(0)
+
+      expect(result).toEqual({
+        node: nestedNodeDto,
+        origin_id: '10:5:2',
+        origin_slot: 2
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes a bug where group node children would fail to execute when connected to nodes outside the group, throwing 'Failed to get input node' errors.

The issue was in ExecutableGroupNodeChildDTO.resolveInput which assumed all node IDs follow a colon-separated format, but external nodes have simple IDs. Now properly handles both external connections (trying full ID first) and internal group node connections (falling back to shortened ID).

Includes comprehensive unit tests to prevent regression.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5054-fix-Resolve-group-node-execution-error-when-connecting-to-external-nodes-2526d73d3650816db779fbc080c10579) by [Unito](https://www.unito.io)
