### PR TITLE
Add .git-blame-ignore-revs for cleaner git blame history

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# .git-blame-ignore-revs
+# List of commits to ignore in git blame
+# Format: <commit hash> # <description>
+
+# npm run format on litegraph merge (10,672 insertions, 7,327 deletions across 129 files)
+c53f197de2a3e0fa66b16dedc65c131235c1c4b6

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:browser": "npx playwright test",
     "test:unit": "vitest run tests-ui/tests",
     "test:component": "vitest run src/components/",
-    "prepare": "husky || true",
+    "prepare": "husky || true && git config blame.ignoreRevsFile .git-blame-ignore-revs || true",
     "preview": "vite preview",
     "lint": "eslint src --cache",
     "lint:fix": "eslint src --cache --fix",


### PR DESCRIPTION
## Summary
- Added `.git-blame-ignore-revs` file to exclude mass formatting commits from git blame
- Configured automatic setup in package.json prepare script

## Details
When merging litegraph.js into ComfyUI_frontend, a mass formatting commit (c53f197de) changed 10,672 insertions and 7,327 deletions across 129 files. This commit now gets ignored in git blame, making it easier to track meaningful code changes.

The prepare script automatically configures git to use this file when developers run `npm install`.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5078-Add-git-blame-ignore-revs-for-cleaner-git-blame-history-2536d73d36508112a039ff48c681cf5f) by [Unito](https://www.unito.io)
