### PR TITLE
Fix widgets added after previews on subgraph nodes

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -361,7 +361,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       }
     })
 
-    this.widgets.push(promotedWidget)
+    const widgetCount = this.inputs.filter((i) => i.widget).length
+    this.widgets.splice(widgetCount, 0, promotedWidget)
 
     // Dispatch widget-promoted event
     this.subgraph.events.dispatch('widget-promoted', {


### PR DESCRIPTION
Image previews are displayed on nodes as a widget. If a new input is added to a subgraph that already has an image preview, that widget is incorrectly placed after the preview. This is fixed by instead counting the number of existing inputs that are already linked to widgets.  

Resolves #5083

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5084-Fix-widgets-added-after-previews-on-subgraph-nodes-2536d73d36508183a3f5e58b2ae89bf5) by [Unito](https://www.unito.io)
