### PR TITLE
fix: Initialize Vue node manager when first node is added to empty graph

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -754,6 +754,7 @@ onMounted(async () => {
 
   // Set up a one-time listener for when the first node is added
   // This handles the case where Vue nodes are enabled but the graph starts empty
+  // TODO: Replace this with a reactive graph mutations observer when available
   if (
     transformPaneEnabled.value &&
     comfyApp.graph &&

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -752,6 +752,31 @@ onMounted(async () => {
 
   comfyAppReady.value = true
 
+  // Set up a one-time listener for when the first node is added
+  // This handles the case where Vue nodes are enabled but the graph starts empty
+  if (
+    transformPaneEnabled.value &&
+    comfyApp.graph &&
+    !nodeManager &&
+    comfyApp.graph._nodes.length === 0
+  ) {
+    const originalOnNodeAdded = comfyApp.graph.onNodeAdded
+    comfyApp.graph.onNodeAdded = function (node: any) {
+      // Restore original handler
+      comfyApp.graph.onNodeAdded = originalOnNodeAdded
+
+      // Initialize node manager if needed
+      if (transformPaneEnabled.value && !nodeManager) {
+        initializeNodeManager()
+      }
+
+      // Call original handler
+      if (originalOnNodeAdded) {
+        originalOnNodeAdded.call(this, node)
+      }
+    }
+  }
+
   comfyApp.canvas.onSelectionChange = useChainCallback(
     comfyApp.canvas.onSelectionChange,
     () => canvasStore.updateSelectedItems()


### PR DESCRIPTION
## Summary

This PR fixes an issue where Vue nodes don't render on initial page load when the setting is enabled.

## Problem

When Vue nodes are enabled (`Comfy.VueNodes.Enabled = true`) and the graph starts empty (0 nodes), the node manager wasn't being initialized. This caused Vue nodes to not render until the setting was toggled off and on again.

The root cause was a timing issue:
- The graph is created during `comfyApp.setup()` but starts with 0 nodes
- Nodes are added later when a workflow is loaded
- The existing watchers weren't catching this transition

## Solution

The fix adds a one-time event handler that listens for the first node being added to an empty graph and initializes the node manager at that point.

This ensures Vue nodes start rendering immediately when:
- The Vue nodes setting is enabled
- The graph initially has no nodes
- Nodes are added later (e.g., when loading a workflow)

## Testing

1. Enable Vue nodes setting (via keybinding or manually setting `Comfy.VueNodes.Enabled = true`)
2. Refresh the page
3. Vue nodes should render immediately when a workflow is loaded

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes the issue where Vue nodes require manual toggling to start rendering.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5086-fix-Initialize-Vue-node-manager-when-first-node-is-added-to-empty-graph-2536d73d365081859b85c96de6a4cb9b) by [Unito](https://www.unito.io)
