### PR TITLE
Enhanced auto-retry configuration for flaky tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Retry on CI only - increased for better flaky test handling */
+  retries: process.env.CI ? 3 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
+    retry: process.env.CI ? 2 : 0,
     include: [
       'tests-ui/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'src/components/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',


### PR DESCRIPTION
## Summary

This PR enhances the test retry configuration to better handle flaky tests that have been causing CI instability.

## Changes

- **Playwright Tests**: Increased retry count from 2 to 3 in CI environment
- **Vitest Unit Tests**: Added retry configuration (2 retries) for CI environment
- Both configurations remain at 0 retries for local development

## Problem Addressed

Addresses the consistently flaky tests identified in:
- Issue #4658: Flaky playwright tests in CI
- Issue #4416: Consistently flaky tests

The following tests have been identified as flaky:
- Feature flags negotiation test
- Remote COMBO widget refresh behavior test  
- Workflows sidebar save functionality test
- Animated image widget drag-and-drop test
- Combo text widget refresh test

## Benefits

- **Improved CI Reliability**: Additional retry reduces false negatives from flaky tests
- **Better Developer Experience**: Fewer spurious CI failures requiring manual re-runs
- **Consistent Test Environment**: Both browser and unit tests now have retry protection
- **No Local Impact**: Retries only apply in CI environment

## Test Plan

- [x] Type checking passes
- [x] Pre-commit hooks pass (eslint, prettier, vue-tsc)
- [ ] CI pipeline validates retry behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5089-Enhanced-auto-retry-configuration-for-flaky-tests-2546d73d3650811cb36dc3dc8398ba57) by [Unito](https://www.unito.io)
