### PR TITLE
fix: resolve breadcrumb and workflow tabs layout conflict

### DIFF
--- a/src/components/breadcrumb/SubgraphBreadcrumb.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="subgraph-breadcrumb w-auto"
+    class="subgraph-breadcrumb w-auto relative z-10"
     :class="{
       'subgraph-breadcrumb-collapse': collapseTabs,
       'subgraph-breadcrumb-overflow': overflowingTabs
@@ -157,8 +157,7 @@ onUpdated(() => {
 
 <style scoped>
 .subgraph-breadcrumb:not(:empty) {
-  flex: auto;
-  flex-shrink: 10000;
+  flex: 1 1 auto;
   min-width: 120px;
 }
 


### PR DESCRIPTION
## Problem
Workflow tabs appeared underneath the breadcrumb component on initial page load, but positioned correctly after a page refresh.

## Root Cause
The breadcrumb component had extreme `flex-shrink: 10000` value, causing it to shrink excessively when competing for space with other elements. This created layout instability during initial render.

## Solution
- Changed `flex: auto` to explicit `flex: 1 1 auto` for clarity and predictability
- Removed `flex-shrink: 10000` override that caused extreme shrinking behavior
- Added `z-10` class for proper layer ordering
- Maintained `min-width: 120px` for minimum visibility

### Why `flex: 1 1 auto`?
- **flex-grow: 1** - Takes fair share of available space
- **flex-shrink: 1** - Shrinks proportionally with other elements (not 10000x faster!)
- **flex-basis: auto** - Starts from content size

## Testing
- [x] Verified breadcrumb displays correctly on initial load
- [x] Confirmed workflow tabs don't appear under breadcrumb
- [x] Tested with long subgraph paths (no artificial width limit)
- [x] Validated layout stability after page refresh
- [x] Ensured breadcrumb can use full available width when needed

## Visual Impact
**Before:** Breadcrumb would shrink to almost nothing, allowing tabs to overlap
**After:** Breadcrumb maintains proper size and layers correctly with tabs

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5096-fix-resolve-breadcrumb-and-workflow-tabs-layout-conflict-2546d73d36508169a881d580b1c00f28) by [Unito](https://www.unito.io)
