### PR TITLE
Remove layout logging noise from console

### DIFF
--- a/src/renderer/core/layout/constants.ts
+++ b/src/renderer/core/layout/constants.ts
@@ -49,18 +49,6 @@ export const NODE_DEFAULTS = {
 } as const
 
 /**
- * Debug and development settings
- */
-export const DEBUG_CONFIG = {
-  /** LocalStorage key for enabling layout debug mode */
-  LAYOUT_DEBUG_KEY: 'layout-debug',
-  /** Logger name for layout system */
-  LOGGER_NAME: 'layout',
-  /** Logger name for layout store */
-  STORE_LOGGER_NAME: 'layout-store'
-} as const
-
-/**
  * Actor and source identifiers
  */
 export const ACTOR_CONFIG = {


### PR DESCRIPTION
## Summary
- Remove excessive logging from layout system that was adding noise to console
- Clean up unused debug configuration constants
- Preserve error handling while removing debug logging

## Changes
- Removed loglevel import and logger setup from LayoutStore
- Removed all logger.debug() calls throughout LayoutStore 
- Removed localStorage debug check for layout operations
- Removed unused DEBUG_CONFIG from layout constants

## Test plan
- [x] Run typecheck - passes
- [x] Run lint - passes  
- [x] Verify console is cleaner without debug noise
- [ ] Test layout functionality still works correctly

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5101-Remove-layout-logging-noise-from-console-2546d73d3650814696fec06aa9049a01) by [Unito](https://www.unito.io)
