### PR TITLE
Remove the non-wrap nature of text labels for longer labels so they can wrap

### DIFF
--- a/src/components/sidebar/SidebarIcon.vue
+++ b/src/components/sidebar/SidebarIcon.vue
@@ -109,7 +109,7 @@ const computedTooltip = computed(() => t(tooltip) + tooltipSuffix)
 }
 
 .side-bar-button-label {
-  @apply text-[10px] text-center whitespace-nowrap;
+  @apply text-[10px] text-center;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary

When labels are longer than the sidebar, they overflow under the main canvas area.

## Changes

**What Changes**: 

Literally just remove the whitespace-nowrap tag from the css for the sidebar button labels.

## Screenshots

<img width="267" height="923" alt="image" src="https://github.com/user-attachments/assets/6f88a90d-98e4-493c-afe1-8b8004d736d2" />

<img width="265" height="1088" alt="image" src="https://github.com/user-attachments/assets/c6d402ef-71a6-474c-9105-873b691cfadb" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5105-Remove-the-non-wrap-nature-of-text-labels-for-longer-labels-so-they-can-wrap-2546d73d365081d5b8e1cf6cc03f1540) by [Unito](https://www.unito.io)
