### PR TITLE
[Vue nodes] Remove overly noisy logging

### DIFF
--- a/src/renderer/core/layout/sync/useLayoutSync.ts
+++ b/src/renderer/core/layout/sync/useLayoutSync.ts
@@ -4,17 +4,9 @@
  * Implements one-way sync from Layout Store to LiteGraph.
  * The layout store is the single source of truth.
  */
-import log from 'loglevel'
 import { onUnmounted } from 'vue'
 
 import { layoutStore } from '@/renderer/core/layout/store/LayoutStore'
-
-// Create a logger for layout debugging
-const logger = log.getLogger('layout')
-// In dev mode, always show debug logs
-if (import.meta.env.DEV) {
-  logger.setLevel('debug')
-}
 
 /**
  * Composable for syncing LiteGraph with the Layout system
@@ -32,12 +24,6 @@ export function useLayoutSync() {
 
     // Subscribe to layout changes
     unsubscribe = layoutStore.onChange((change) => {
-      logger.debug('Layout sync received change:', {
-        source: change.source,
-        nodeIds: change.nodeIds,
-        type: change.type
-      })
-
       // Apply changes to LiteGraph regardless of source
       // The layout store is the single source of truth
       for (const nodeId of change.nodeIds) {
@@ -52,10 +38,6 @@ export function useLayoutSync() {
           liteNode.pos[0] !== layout.position.x ||
           liteNode.pos[1] !== layout.position.y
         ) {
-          logger.debug(`Updating LiteGraph node ${nodeId} position:`, {
-            from: { x: liteNode.pos[0], y: liteNode.pos[1] },
-            to: layout.position
-          })
           liteNode.pos[0] = layout.position.x
           liteNode.pos[1] = layout.position.y
         }

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -86,7 +86,6 @@
 </template>
 
 <script setup lang="ts">
-import log from 'loglevel'
 import { computed, onErrorCaptured, ref, toRef, watch } from 'vue'
 
 // Import the VueNodeData type
@@ -100,13 +99,6 @@ import NodeContent from './NodeContent.vue'
 import NodeHeader from './NodeHeader.vue'
 import NodeSlots from './NodeSlots.vue'
 import NodeWidgets from './NodeWidgets.vue'
-
-// Create logger for vue nodes
-const logger = log.getLogger('vue-nodes')
-// In dev mode, always show debug logs
-if (import.meta.env.DEV) {
-  logger.setLevel('debug')
-}
 
 // Extended props for main node component
 interface LGraphNodeProps {
@@ -165,25 +157,6 @@ const {
   handleDrag: handleLayoutDrag,
   endDrag
 } = useNodeLayout(props.nodeData.id)
-
-// Debug layout position
-watch(
-  layoutPosition,
-  (newPos, oldPos) => {
-    logger.debug(`Layout position changed for node ${props.nodeData.id}:`, {
-      newPos,
-      oldPos,
-      layoutPositionValue: layoutPosition.value
-    })
-  },
-  { immediate: true, deep: true }
-)
-
-logger.debug(`LGraphNode mounted for ${props.nodeData.id}`, {
-  layoutPosition: layoutPosition.value,
-  propsPosition: props.position,
-  nodeDataId: props.nodeData.id
-})
 
 // Drag state for styling
 const isDragging = ref(false)

--- a/src/renderer/extensions/vueNodes/layout/useNodeLayout.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeLayout.ts
@@ -4,19 +4,11 @@
  * Uses customRef for shared write access with Canvas renderer.
  * Provides dragging functionality and reactive layout state.
  */
-import log from 'loglevel'
 import { computed, inject } from 'vue'
 
 import { layoutMutations } from '@/renderer/core/layout/operations/LayoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/LayoutStore'
 import type { Point } from '@/renderer/core/layout/types'
-
-// Create a logger for layout debugging
-const logger = log.getLogger('layout')
-// In dev mode, always show debug logs
-if (import.meta.env.DEV) {
-  logger.setLevel('debug')
-}
 
 /**
  * Composable for individual Vue node components
@@ -37,20 +29,10 @@ export function useNodeLayout(nodeId: string) {
   // Get the customRef for this node (shared write access)
   const layoutRef = store.getNodeLayoutRef(nodeId)
 
-  logger.debug(`useNodeLayout initialized for node ${nodeId}`, {
-    hasLayout: !!layoutRef.value,
-    initialPosition: layoutRef.value?.position
-  })
-
   // Computed properties for easy access
   const position = computed(() => {
     const layout = layoutRef.value
     const pos = layout?.position ?? { x: 0, y: 0 }
-    logger.debug(`Node ${nodeId} position computed:`, {
-      pos,
-      hasLayout: !!layout,
-      layoutRefValue: layout
-    })
     return pos
   })
   const size = computed(
@@ -96,12 +78,6 @@ export function useNodeLayout(nodeId: string) {
    */
   const handleDrag = (event: PointerEvent) => {
     if (!isDragging || !dragStartPos || !dragStartMouse || !transformState) {
-      logger.debug(`Drag skipped for node ${nodeId}:`, {
-        isDragging,
-        hasDragStartPos: !!dragStartPos,
-        hasDragStartMouse: !!dragStartMouse,
-        hasTransformState: !!transformState
-      })
       return
     }
 
@@ -124,13 +100,6 @@ export function useNodeLayout(nodeId: string) {
       x: dragStartPos.x + canvasDelta.x,
       y: dragStartPos.y + canvasDelta.y
     }
-
-    logger.debug(`Dragging node ${nodeId}:`, {
-      mouseDelta,
-      canvasDelta,
-      newPosition,
-      currentLayoutPos: layoutRef.value?.position
-    })
 
     // Apply mutation through the layout system
     mutations.moveNode(nodeId, newPosition)


### PR DESCRIPTION
Continuation of https://github.com/Comfy-Org/ComfyUI_frontend/pull/5101: remove noisy logging that runs on render. Not necessary anymore now that layout system works.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5111-Vue-nodes-Remove-overly-noisy-logging-2546d73d365081c694cbef2d915a49e2) by [Unito](https://www.unito.io)
