### PR TITLE
Remove duplicate semantic labeling from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: 'Report something that is not working correctly'
-title: '[Bug]: '
+title: ''
 labels: ['Potential Bug']
 type: Bug
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Report a problem or limitation you're experiencing
-title: '[Feature]: '
-labels: ['enhancement']
+title: ''
+labels: []
 type: Feature
 
 body:


### PR DESCRIPTION
Removes redundant prefixes and labels from issue templates since they duplicate the `type` field.

Fixes #5100

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5114-Remove-duplicate-semantic-labeling-from-issue-templates-2546d73d3650816c948ce999b167bc1a) by [Unito](https://www.unito.io)
