### PR TITLE
Fix: Shift+Click+Drag from outputs with Subgraph outputs

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2585,9 +2585,21 @@ export class LGraphCanvas
               e.shiftKey &&
               (output.links?.length || output._floatingLinks?.size)
             ) {
-              linkConnector.moveOutputLink(graph, output)
-              this.#linkConnectorDrop()
-              return
+              const outputLinks = [
+                ...(output.links ?? []),
+                ...[...(output._floatingLinks ?? new Set())]
+              ]
+              if (
+                outputLinks.some(
+                  (linkId) =>
+                    typeof linkId === 'number' &&
+                    graph.getLink(linkId) !== undefined
+                )
+              ) {
+                linkConnector.moveOutputLink(graph, output)
+                this.#linkConnectorDrop()
+                return
+              }
             }
 
             // New output link

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -319,7 +319,7 @@ export class LinkConnector {
               console.warn(
                 'Subgraph output link found in non-subgraph network.'
               )
-              return
+              continue
             }
 
             const output = network.outputs.at(link.target_slot)
@@ -331,11 +331,8 @@ export class LinkConnector {
               output
             )
             renderLink.fromDirection = LinkDirection.NONE
-            this.renderLinks.push(renderLink)
+            renderLinks.push(renderLink)
 
-            this.state.connectingTo = 'output'
-
-            this.#setLegacyLinks(false)
             continue
           }
           const renderLink = new MovingOutputLink(

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -314,6 +314,30 @@ export class LinkConnector {
         this.outputLinks.push(link)
 
         try {
+          if (link.target_id === SUBGRAPH_OUTPUT_ID) {
+            if (!(network instanceof Subgraph)) {
+              console.warn(
+                'Subgraph output link found in non-subgraph network.'
+              )
+              return
+            }
+
+            const output = network.outputs.at(link.target_slot)
+            if (!output) throw new Error('No subgraph output found for link.')
+
+            const renderLink = new ToOutputFromIoNodeLink(
+              network,
+              network.outputNode,
+              output
+            )
+            renderLink.fromDirection = LinkDirection.NONE
+            this.renderLinks.push(renderLink)
+
+            this.state.connectingTo = 'output'
+
+            this.#setLegacyLinks(false)
+            continue
+          }
           const renderLink = new MovingOutputLink(
             network,
             link,


### PR DESCRIPTION
## Summary

A patch for now that addresses an issue in synchronizing the output slot's internal links and the Subgraph (as LinkNetwork)'s links map when connecting to or disconnecting from the Subgraph's outputs.

## Changes

- **What**: Node outputs that were connected to subgraph outputs before lost support for shift+click+drag. Now they behave as expected.

## Review Focus

Fixes #4877 

## Demonstration

https://github.com/user-attachments/assets/9bd1e719-4808-46a8-9de8-2ac16279efb3

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5115-Fix-Shift-Click-Drag-from-outputs-with-Subgraph-outputs-2556d73d3650817fb0bdefedd68cba75) by [Unito](https://www.unito.io)
