### PR TITLE
[ci] Enhance CI/CD caching across all workflows

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -51,6 +51,16 @@ jobs:
             ---
             *This comment will be updated when the build completes*
 
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: storybook-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            storybook-tools-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -58,8 +58,11 @@ jobs:
             node_modules/.cache
             .cache
             storybook-static
-          key: storybook-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+            tsconfig.tsbuildinfo
+          key: storybook-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js}', '*.config.*', '.storybook/**/*') }}
           restore-keys: |
+            storybook-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-
+            storybook-cache-${{ runner.os }}-
             storybook-tools-cache-${{ runner.os }}-
 
       - name: Install dependencies

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -57,6 +57,7 @@ jobs:
           path: |
             node_modules/.cache
             .cache
+            storybook-static
           key: storybook-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             storybook-tools-cache-${{ runner.os }}-

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -55,8 +55,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
             .cache
+            node_modules/.cache
             storybook-static
             tsconfig.tsbuildinfo
           key: storybook-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js}', '*.config.*', '.storybook/**/*') }}

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -56,7 +56,6 @@ jobs:
         with:
           path: |
             .cache
-            node_modules/.cache
             storybook-static
             tsconfig.tsbuildinfo
           key: storybook-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js}', '*.config.*', '.storybook/**/*') }}

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -25,7 +25,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .cache
+            dist
             node_modules/.cache
+            tsconfig.tsbuildinfo
             .cache
             tsconfig.tsbuildinfo
             dist

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -19,6 +19,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: dev-release-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            dev-release-tools-cache-${{ runner.os }}-
+
       - name: Get current version
         id: current_version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -27,6 +27,8 @@ jobs:
           path: |
             node_modules/.cache
             .cache
+            tsconfig.tsbuildinfo
+            dist
           key: dev-release-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             dev-release-tools-cache-${{ runner.os }}-

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -27,11 +27,7 @@ jobs:
           path: |
             .cache
             dist
-            node_modules/.cache
             tsconfig.tsbuildinfo
-            .cache
-            tsconfig.tsbuildinfo
-            dist
           key: dev-release-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             dev-release-tools-cache-${{ runner.os }}-

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -23,7 +23,6 @@ jobs:
       with:
         path: |
           ComfyUI_frontend/.cache
-          ComfyUI_frontend/node_modules/.cache
           ComfyUI_frontend/.cache
         key: i18n-tools-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}
         restore-keys: |

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -17,6 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v2.3
+    
+    - name: Cache tool outputs
+      uses: actions/cache@v4
+      with:
+        path: |
+          ComfyUI_frontend/node_modules/.cache
+          ComfyUI_frontend/.cache
+        key: i18n-tools-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}
+        restore-keys: |
+          i18n-tools-cache-${{ runner.os }}-
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
+          ComfyUI_frontend/.cache
           ComfyUI_frontend/node_modules/.cache
           ComfyUI_frontend/.cache
         key: i18n-tools-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -33,9 +33,12 @@ jobs:
             .eslintcache
             .cache
             tsconfig.tsbuildinfo
-          key: ci-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.vue', '*.config.*') }}
+            .prettierCache
+            .knip-cache
+          key: lint-format-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js,mts}', '*.config.*', '.eslintrc.*', '.prettierrc.*', 'tsconfig.json') }}
           restore-keys: |
-            ci-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-
+            lint-format-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-
+            lint-format-cache-${{ runner.os }}-
             ci-tools-cache-${{ runner.os }}-
 
       - name: Install dependencies

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -25,6 +25,17 @@ jobs:
           node-version: 'lts/*'
           cache: 'npm'
 
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .eslintcache
+            .cache
+          key: ci-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ci-tools-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -32,8 +32,10 @@ jobs:
             node_modules/.cache
             .eslintcache
             .cache
-          key: ci-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+            tsconfig.tsbuildinfo
+          key: ci-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.vue', '*.config.*') }}
           restore-keys: |
+            ci-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-
             ci-tools-cache-${{ runner.os }}-
 
       - name: Install dependencies

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
-            .eslintcache
             .cache
+            .eslintcache
+            node_modules/.cache
             tsconfig.tsbuildinfo
             .prettierCache
             .knip-cache

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -31,7 +31,6 @@ jobs:
           path: |
             .cache
             .eslintcache
-            node_modules/.cache
             tsconfig.tsbuildinfo
             .prettierCache
             .knip-cache

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
             .cache
             tsconfig.tsbuildinfo
           key: release-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -136,7 +135,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
             .cache
             tsconfig.tsbuildinfo
             dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: release-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            release-tools-cache-${{ runner.os }}-
+
       - name: Get current version
         id: current_version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
@@ -116,7 +128,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+          cache: 'npm'
           registry-url: https://registry.npmjs.org
+
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: types-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            types-tools-cache-${{ runner.os }}-
+
       - run: npm ci
       - run: npm run build:types
       - name: Publish package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
           path: |
             node_modules/.cache
             .cache
+            tsconfig.tsbuildinfo
           key: release-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             release-tools-cache-${{ runner.os }}-
@@ -137,6 +138,8 @@ jobs:
           path: |
             node_modules/.cache
             .cache
+            tsconfig.tsbuildinfo
+            dist
           key: types-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             types-tools-cache-${{ runner.os }}-

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -41,6 +41,7 @@ jobs:
         with:
           node-version: lts/*
           cache: 'npm'
+          cache-dependency-path: 'ComfyUI_frontend/package-lock.json'
 
       - name: Get current time
         id: current-time

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: 'npm'
 
       - name: Get current time
         id: current-time
@@ -64,6 +65,16 @@ jobs:
 
             ---
             *This comment will be updated when tests complete*
+
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ComfyUI_frontend/node_modules/.cache
+            ComfyUI_frontend/.cache
+          key: playwright-tools-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}
+          restore-keys: |
+            playwright-tools-cache-${{ runner.os }}-
 
       - name: Build ComfyUI_frontend
         run: |

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -71,7 +71,6 @@ jobs:
         with:
           path: |
             ComfyUI_frontend/.cache
-            ComfyUI_frontend/node_modules/.cache
             ComfyUI_frontend/tsconfig.tsbuildinfo
           key: playwright-setup-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}-${{ hashFiles('ComfyUI_frontend/src/**/*.{ts,vue,js}', 'ComfyUI_frontend/*.config.*') }}
           restore-keys: |

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -129,6 +129,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pip'
 
       - name: Get current time
         id: current-time
@@ -170,6 +171,14 @@ jobs:
           python main.py --cpu --multi-user --front-end-root ../ComfyUI_frontend/dist &
           wait-for-it --service 127.0.0.1:8188 -t 600
         working-directory: ComfyUI
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}
+          restore-keys: |
+            playwright-browsers-${{ runner.os }}-
 
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -72,8 +72,11 @@ jobs:
           path: |
             ComfyUI_frontend/node_modules/.cache
             ComfyUI_frontend/.cache
-          key: playwright-tools-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}
+            ComfyUI_frontend/tsconfig.tsbuildinfo
+          key: playwright-setup-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}-${{ hashFiles('ComfyUI_frontend/src/**/*.{ts,vue,js}', 'ComfyUI_frontend/*.config.*') }}
           restore-keys: |
+            playwright-setup-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}-
+            playwright-setup-cache-${{ runner.os }}-
             playwright-tools-cache-${{ runner.os }}-
 
       - name: Build ComfyUI_frontend
@@ -176,8 +179,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}-${{ matrix.browser }}
           restore-keys: |
+            playwright-browsers-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}-
             playwright-browsers-${{ runner.os }}-
 
       - name: Install Playwright Browsers

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -70,8 +70,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ComfyUI_frontend/node_modules/.cache
             ComfyUI_frontend/.cache
+            ComfyUI_frontend/node_modules/.cache
             ComfyUI_frontend/tsconfig.tsbuildinfo
           key: playwright-setup-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/package-lock.json') }}-${{ hashFiles('ComfyUI_frontend/src/**/*.{ts,vue,js}', 'ComfyUI_frontend/*.config.*') }}
           restore-keys: |

--- a/.github/workflows/update-electron-types.yaml
+++ b/.github/workflows/update-electron-types.yaml
@@ -25,7 +25,6 @@ jobs:
         with:
           path: |
             .cache
-            node_modules/.cache
           key: electron-types-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             electron-types-tools-cache-${{ runner.os }}-

--- a/.github/workflows/update-electron-types.yaml
+++ b/.github/workflows/update-electron-types.yaml
@@ -20,6 +20,16 @@ jobs:
           node-version: lts/*
           cache: 'npm'
 
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: electron-types-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            electron-types-tools-cache-${{ runner.os }}-
+
       - name: Update electron types
         run: npm install @comfyorg/comfyui-electron-types@latest
 

--- a/.github/workflows/update-electron-types.yaml
+++ b/.github/workflows/update-electron-types.yaml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
             .cache
+            node_modules/.cache
           key: electron-types-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             electron-types-tools-cache-${{ runner.os }}-

--- a/.github/workflows/update-manager-types.yaml
+++ b/.github/workflows/update-manager-types.yaml
@@ -38,6 +38,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache ComfyUI-Manager repository
+        uses: actions/cache@v4
+        with:
+          path: ComfyUI-Manager
+          key: comfyui-manager-repo-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            comfyui-manager-repo-${{ runner.os }}-
+
       - name: Checkout ComfyUI-Manager repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-manager-types.yaml
+++ b/.github/workflows/update-manager-types.yaml
@@ -25,6 +25,16 @@ jobs:
           node-version: lts/*
           cache: 'npm'
 
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: update-manager-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            update-manager-tools-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/update-manager-types.yaml
+++ b/.github/workflows/update-manager-types.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
             .cache
           key: update-manager-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |

--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -29,7 +29,6 @@ jobs:
         with:
           path: |
             .cache
-            node_modules/.cache
           key: update-registry-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             update-registry-tools-cache-${{ runner.os }}-

--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -24,6 +24,16 @@ jobs:
           node-version: lts/*
           cache: 'npm'
 
+      - name: Cache tool outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .cache
+          key: update-registry-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            update-registry-tools-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -37,6 +37,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache comfy-api repository
+        uses: actions/cache@v4
+        with:
+          path: comfy-api
+          key: comfy-api-repo-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            comfy-api-repo-${{ runner.os }}-
+
       - name: Checkout comfy-api repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-registry-types.yaml
+++ b/.github/workflows/update-registry-types.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules/.cache
             .cache
+            node_modules/.cache
           key: update-registry-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             update-registry-tools-cache-${{ runner.os }}-

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -25,6 +25,7 @@ jobs:
         path: |
           node_modules/.cache
           .cache
+          coverage
         key: test-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           test-tools-cache-${{ runner.os }}-

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -25,7 +25,6 @@ jobs:
         path: |
           .cache
           coverage
-          node_modules/.cache
           .vitest-cache
         key: vitest-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js}', 'vitest.config.*', 'tsconfig.json') }}
         restore-keys: |

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -17,6 +17,17 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
+        cache: 'npm'
+
+    - name: Cache tool outputs
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules/.cache
+          .cache
+        key: test-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          test-tools-cache-${{ runner.os }}-
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -26,8 +26,11 @@ jobs:
           node_modules/.cache
           .cache
           coverage
-        key: test-tools-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          .vitest-cache
+        key: vitest-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js}', 'vitest.config.*', 'tsconfig.json') }}
         restore-keys: |
+          vitest-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-
+          vitest-cache-${{ runner.os }}-
           test-tools-cache-${{ runner.os }}-
 
     - name: Install dependencies

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -23,9 +23,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          node_modules/.cache
           .cache
           coverage
+          node_modules/.cache
           .vitest-cache
         key: vitest-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.{ts,vue,js}', 'vitest.config.*', 'tsconfig.json') }}
         restore-keys: |


### PR DESCRIPTION
- Add tool cache steps for node_modules/.cache, .cache, and .eslintcache
- Enable npm caching for Node.js setup actions where missing
- Add cache configurations for ESLint, Prettier, Knip, and other build tools
- Improve build performance by caching tool outputs between runs
- Use unique cache keys per workflow to avoid conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

<!-- One sentence describing what changed and why. -->

## Changes

- **What**: <!-- Core functionality added/modified -->
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5117-ci-Enhance-CI-CD-caching-across-all-workflows-2556d73d365081e18161cf14dd522841) by [Unito](https://www.unito.io)
