### PR TITLE
Cleanup: Potpourri PR of small changes that reduce the warning noise

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,13 @@
 * text=auto
 
 # Force TS to LF to make the unixy scripts not break on Windows
+*.cjs text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.mjs text eol=lf
+*.mts text eol=lf
 *.ts text eol=lf
 *.vue text eol=lf
-*.js text eol=lf
 
 # Generated files
 src/types/comfyRegistryTypes.ts linguist-generated=true

--- a/src/components/input/SearchBox.vue
+++ b/src/components/input/SearchBox.vue
@@ -13,7 +13,7 @@
 
 <script setup lang="ts">
 import InputText from 'primevue/inputtext'
-import { computed, defineModel } from 'vue'
+import { computed } from 'vue'
 
 const { placeHolder, hasBorder = false } = defineProps<{
   placeHolder?: string

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -136,7 +136,8 @@ export default defineConfig({
       ],
       dirs: ['src/components', 'src/layout', 'src/views'],
       deep: true,
-      extensions: ['vue']
+      extensions: ['vue'],
+      directoryAsNamespace: true
     })
   ],
 


### PR DESCRIPTION
## Summary

Potpourri PR of small changes that reduce the warning noise

## Changes

- **What**:
  - A compiler macro that doesn't need to be imported
  - Two components with the same name that need to be differentiated for Vite
  - LF (\n) EOL sequences for the qualified versions of JS/TS files.

## Review Focus

Let me know what other warnings you are too used to seeing that could be addressed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5128-Cleanup-Potpourri-PR-of-small-changes-that-reduce-the-warning-noise-2556d73d365081b1a984ee7f89e5defd) by [Unito](https://www.unito.io)
