### PR TITLE
[bugfix] Hide center dot when dragging links

### DIFF
--- a/src/renderer/core/canvas/litegraph/LitegraphLinkAdapter.ts
+++ b/src/renderer/core/canvas/litegraph/LitegraphLinkAdapter.ts
@@ -519,6 +519,9 @@ export class LitegraphLinkAdapter {
     // Convert context
     const pathContext = this.convertToPathRenderContext(context)
 
+    // Hide center marker when dragging links
+    pathContext.style.showCenterMarker = false
+
     // Render using pure renderer
     this.pathRenderer.drawDraggingLink(ctx, dragData, pathContext)
   }


### PR DESCRIPTION
## Summary
- Fixed an issue where the center dot on links was visible when dragging links to connect nodes
- The center marker is now properly hidden during link dragging operations

## Test plan
- [x] Drag a link from an output slot to an input slot - the center dot should not be visible
- [x] Drag a link from an input slot to an output slot - the center dot should not be visible  
- [x] Normal links should still show center dots based on the settings

🤖 Generated with Claude Code

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5133-bugfix-Hide-center-dot-when-dragging-links-2556d73d365081fa93a8e6cffd10b66b) by [Unito](https://www.unito.io)
