### PR TITLE
[bugfix] Fix link center dot hit detection when marker is disabled

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2421,7 +2421,10 @@ export class LGraphCanvas
             pointer.onDragEnd = (e) => this.#processDraggedItems(e)
             return
           }
-        } else if (isInRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
+        } else if (
+          this.linkMarkerShape !== LinkMarkerShape.None &&
+          isInRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)
+        ) {
           this.ctx.lineWidth = lineWidth
 
           pointer.onClick = () => this.showLinkMenu(linkSegment, e)
@@ -4641,6 +4644,11 @@ export class LGraphCanvas
 
   /** @returns If the pointer is over a link centre marker, the link segment it belongs to.  Otherwise, `undefined`.  */
   #getLinkCentreOnPos(e: CanvasPointerEvent): LinkSegment | undefined {
+    // Skip hit detection if center markers are disabled
+    if (this.linkMarkerShape === LinkMarkerShape.None) {
+      return undefined
+    }
+
     for (const linkSegment of this.renderedPaths) {
       const centre = linkSegment._pos
       if (!centre) continue


### PR DESCRIPTION
## Summary
- Fixed hit detection on link center dots when `linkMarkerShape` is set to `None`
- Clicks no longer register on invisible center dots

## Problem
When the link center marker is disabled (set to "None"), the center dot is not visible but clicks were still being detected on its position. This caused unexpected behavior where users could interact with an invisible element.

## Solution
Added checks in `LGraphCanvas.ts` to skip center dot hit detection when `linkMarkerShape === LinkMarkerShape.None`:
1. Modified `#getLinkCentreOnPos` method to return early when markers are disabled
2. Added condition to center click handler to check marker setting before processing clicks

## Test Plan
- [x] Set link marker shape to "None" in settings
- [x] Verify center dots are not visible on links
- [x] Click where center dots would normally be - no interaction should occur
- [x] Set link marker shape back to "Circle" - center dots should be visible and clickable again

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5135-bugfix-Fix-link-center-dot-hit-detection-when-marker-is-disabled-2556d73d3650815f9195fa8d46be499e) by [Unito](https://www.unito.io)
