### PR TITLE
Remove empty title field from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: 'Report something that is not working correctly'
-title: ''
 labels: ['Potential Bug']
 type: Bug
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Report a problem or limitation you're experiencing
-title: ''
 labels: []
 type: Feature
 


### PR DESCRIPTION
Removed `title: ` from the bug report and feature issue templates, fixes #5131

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5136-Remove-empty-title-field-from-issue-templates-2556d73d36508135be52f5c0165b56ec) by [Unito](https://www.unito.io)
