### PR TITLE
add support for cmd + wheel to zoom in/out on Mac

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3499,8 +3499,8 @@ export class LGraphCanvas
     // Detect if this is a trackpad gesture or mouse wheel
     const isTrackpad = this.pointer.isTrackpadGesture(e)
 
-    if (e.ctrlKey || LiteGraph.canvasNavigationMode === 'legacy') {
-      // Legacy mode or standard mode with ctrl - use wheel for zoom
+    if (e.ctrlKey || e.metaKey || LiteGraph.canvasNavigationMode === 'legacy') {
+      // Legacy mode or standard mode with ctrl/cmd - use wheel for zoom
       if (isTrackpad) {
         // Trackpad gesture - use smooth scaling
         scale *= 1 + e.deltaY * (1 - this.zoom_speed) * 0.18


### PR DESCRIPTION
## Summary
add support for cmd + wheel to zoom in/out on Mac (same to figma)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5141-add-support-for-cmd-wheel-to-zoom-in-out-on-Mac-2566d73d3650810686f4e8e5b96c55a0) by [Unito](https://www.unito.io)
