### PR TITLE
Allow Macs to zoom with Cmd + wheel

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3498,8 +3498,9 @@ export class LGraphCanvas
 
     // Detect if this is a trackpad gesture or mouse wheel
     const isTrackpad = this.pointer.isTrackpadGesture(e)
-    const isZoomModifier =
+    const isCtrlOrMacMeta =
       e.ctrlKey || (e.metaKey && navigator.platform.includes('Mac'))
+    const isZoomModifier = isCtrlOrMacMeta && !e.altKey && !e.shiftKey
 
     if (isZoomModifier || LiteGraph.canvasNavigationMode === 'legacy') {
       // Legacy mode or standard mode with ctrl - use wheel for zoom

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3498,8 +3498,10 @@ export class LGraphCanvas
 
     // Detect if this is a trackpad gesture or mouse wheel
     const isTrackpad = this.pointer.isTrackpadGesture(e)
+    const isZoomModifier =
+      e.ctrlKey || (e.metaKey && navigator.platform.includes('Mac'))
 
-    if (e.ctrlKey || LiteGraph.canvasNavigationMode === 'legacy') {
+    if (isZoomModifier || LiteGraph.canvasNavigationMode === 'legacy') {
       // Legacy mode or standard mode with ctrl - use wheel for zoom
       if (isTrackpad) {
         // Trackpad gesture - use smooth scaling


### PR DESCRIPTION
## Summary

- Allow Mac to zoom with combo: Cmd + wheel
- Only zoom when exact modifier pressed
- Does not trigger zoom on Windows/Linux when using Win + wheel

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5143-Allow-Macs-to-zoom-with-Cmd-wheel-2566d73d365081c186a8ddad61ae5809) by [Unito](https://www.unito.io)
