### PR TITLE
[fix] #4468 gracefully handle Firebase auth failure 

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1303,8 +1303,16 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     executionStore.lastNodeErrors = null
 
-    let comfyOrgAuthToken =
-      (await useFirebaseAuthStore().getIdToken()) ?? undefined
+    let comfyOrgAuthToken = await useFirebaseAuthStore()
+      .getIdToken()
+      .catch((error: unknown) => {
+        useDialogService().showErrorDialog(error, {
+          title: t('errorDialog.defaultTitle'),
+          reportType: 'authenticationError'
+        })
+        console.error(error)
+      })
+
     let comfyOrgApiKey = useApiKeyAuthStore().getApiKey()
 
     try {
@@ -1321,7 +1329,7 @@ export class ComfyApp {
 
           const p = await this.graphToPrompt(this.graph)
           try {
-            api.authToken = comfyOrgAuthToken
+            api.authToken = comfyOrgAuthToken ?? undefined
             api.apiKey = comfyOrgApiKey ?? undefined
             const res = await api.queuePrompt(number, p, {
               partialExecutionTargets: queueNodeIds

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1303,16 +1303,7 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     executionStore.lastNodeErrors = null
 
-    let comfyOrgAuthToken = await useFirebaseAuthStore()
-      .getIdToken()
-      .catch((error: unknown) => {
-        useDialogService().showErrorDialog(error, {
-          title: t('errorDialog.defaultTitle'),
-          reportType: 'authenticationError'
-        })
-        console.error(error)
-      })
-
+    let comfyOrgAuthToken = await useFirebaseAuthStore().getIdToken()
     let comfyOrgApiKey = useApiKeyAuthStore().getApiKey()
 
     try {
@@ -1329,7 +1320,7 @@ export class ComfyApp {
 
           const p = await this.graphToPrompt(this.graph)
           try {
-            api.authToken = comfyOrgAuthToken ?? undefined
+            api.authToken = comfyOrgAuthToken
             api.apiKey = comfyOrgApiKey ?? undefined
             const res = await api.queuePrompt(number, p, {
               partialExecutionTargets: queueNodeIds

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -1,5 +1,7 @@
+import { FirebaseError } from 'firebase/app'
 import {
   type Auth,
+  AuthErrorCodes,
   GithubAuthProvider,
   GoogleAuthProvider,
   type User,
@@ -20,6 +22,7 @@ import { useFirebaseAuth } from 'vuefire'
 
 import { COMFY_API_BASE_URL } from '@/config/comfyApi'
 import { t } from '@/i18n'
+import { useDialogService } from '@/services/dialogService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { type AuthHeader } from '@/types/authTypes'
 import { operations } from '@/types/comfyRegistryTypes'
@@ -88,21 +91,28 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     lastBalanceUpdateTime.value = null
   })
 
-  const getIdToken = async (): Promise<string | null> => {
+  const getIdToken = async (): Promise<string | undefined> => {
     if (currentUser.value) {
       try {
         return await currentUser.value.getIdToken()
-      } catch (error: any) {
-        if (error?.code === 'auth/network-request-failed') {
+      } catch (error: unknown) {
+        if (
+          error instanceof FirebaseError &&
+          error.code === AuthErrorCodes.NETWORK_REQUEST_FAILED
+        ) {
           console.warn(
             'Could not authenticate with Firebase. Features requiring authentication might not work.'
           )
-          return null // handle gracefully
+          return
         }
-        throw error
+
+        useDialogService().showErrorDialog(error, {
+          title: t('errorDialog.defaultTitle'),
+          reportType: 'authenticationError'
+        })
+        console.error(error)
       }
     }
-    return null
   }
 
   /**

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -92,26 +92,25 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   })
 
   const getIdToken = async (): Promise<string | undefined> => {
-    if (currentUser.value) {
-      try {
-        return await currentUser.value.getIdToken()
-      } catch (error: unknown) {
-        if (
-          error instanceof FirebaseError &&
-          error.code === AuthErrorCodes.NETWORK_REQUEST_FAILED
-        ) {
-          console.warn(
-            'Could not authenticate with Firebase. Features requiring authentication might not work.'
-          )
-          return
-        }
-
-        useDialogService().showErrorDialog(error, {
-          title: t('errorDialog.defaultTitle'),
-          reportType: 'authenticationError'
-        })
-        console.error(error)
+    if (!currentUser.value) return
+    try {
+      return await currentUser.value.getIdToken()
+    } catch (error: unknown) {
+      if (
+        error instanceof FirebaseError &&
+        error.code === AuthErrorCodes.NETWORK_REQUEST_FAILED
+      ) {
+        console.warn(
+          'Could not authenticate with Firebase. Features requiring authentication might not work.'
+        )
+        return
       }
+
+      useDialogService().showErrorDialog(error, {
+        title: t('errorDialog.defaultTitle'),
+        reportType: 'authenticationError'
+      })
+      console.error(error)
     }
   }
 

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -90,7 +90,17 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
 
   const getIdToken = async (): Promise<string | null> => {
     if (currentUser.value) {
-      return currentUser.value.getIdToken()
+      try {
+        return await currentUser.value.getIdToken()
+      } catch (error: any) {
+        if (error?.code === 'auth/network-request-failed') {
+          console.warn(
+            'Could not authenticate with Firebase. Features requiring authentication might not work.'
+          )
+          return null // handle gracefully
+        }
+        throw error
+      }
     }
     return null
   }

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -363,9 +363,10 @@ describe('useFirebaseAuthStore', () => {
       mockUser.getIdToken.mockReset()
 
       // Mock a non-network error using actual Firebase Auth error code
-      const authError = new Error('User account is disabled.')
-      authError.name = 'FirebaseError'
-      ;(authError as any).code = 'auth/user-disabled'
+      const authError = new FirebaseError(
+        /** whichever one is 'auth/user-disabled' */,
+        'User account is disabled.'
+      )
 
       mockUser.getIdToken.mockRejectedValue(authError)
 

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -348,13 +348,6 @@ describe('useFirebaseAuthStore', () => {
 
       mockUser.getIdToken.mockRejectedValue(networkError)
 
-      // This should fail until the fix is implemented
-      // The expected behavior is to return null gracefully instead of throwing
-      await expect(store.getIdToken()).rejects.toThrow(
-        'auth/network-request-failed'
-      )
-
-      // TODO: After implementing the fix, this test should pass:
       const token = await store.getIdToken()
       expect(token).toBeNull() // Should return null instead of throwing
     })
@@ -382,16 +375,8 @@ describe('useFirebaseAuthStore', () => {
       ;(networkError as any).code = 'auth/network-request-failed'
       mockUser.getIdToken.mockRejectedValue(networkError)
 
-      // This should fail until the fix is implemented
-      // The expected behavior is to fallback to API key or return null gracefully
-      await expect(store.getAuthHeader()).rejects.toThrow(
-        'auth/network-request-failed'
-      )
-
-      // TODO: After implementing the fix, this should pass:
-      // const authHeader = await store.getAuthHeader()
-      // expect(authHeader).toBeNull() // Should fallback gracefully
-      // expect(mockApiKeyStore.getAuthHeader).toHaveBeenCalled() // Should try API key fallback
+      const authHeader = await store.getAuthHeader()
+      expect(authHeader).toBeNull() // Should fallback gracefully
     })
   })
 

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -364,7 +364,7 @@ describe('useFirebaseAuthStore', () => {
 
       // Mock a non-network error using actual Firebase Auth error code
       const authError = new FirebaseError(
-        /** whichever one is 'auth/user-disabled' */,
+        firebaseAuth.AuthErrorCodes.USER_DISABLED,
         'User account is disabled.'
       )
 
@@ -372,10 +372,9 @@ describe('useFirebaseAuthStore', () => {
 
       // Should call the error dialog instead of throwing
       const token = await store.getIdToken()
+      const dialogService = useDialogService()
 
-      expect(
-        vi.mocked(useDialogService)().showErrorDialog
-      ).toHaveBeenCalledWith(authError, {
+      expect(dialogService.showErrorDialog).toHaveBeenCalledWith(authError, {
         title: 'errorDialog.defaultTitle',
         reportType: 'authenticationError'
       })

--- a/tests-ui/tests/store/firebaseAuthStore.test.ts
+++ b/tests-ui/tests/store/firebaseAuthStore.test.ts
@@ -351,6 +351,23 @@ describe('useFirebaseAuthStore', () => {
       const token = await store.getIdToken()
       expect(token).toBeNull() // Should return null instead of throwing
     })
+
+    it('should throw error when getIdToken fails with non-network error', async () => {
+      // This test verifies that non-network errors are thrown instead of handled gracefully
+      mockUser.getIdToken.mockReset()
+
+      // Mock a non-network error using actual Firebase Auth error code
+      const authError = new Error('User account is disabled.')
+      authError.name = 'FirebaseError'
+      ;(authError as any).code = 'auth/user-disabled'
+
+      mockUser.getIdToken.mockRejectedValue(authError)
+
+      // Should throw the error instead of returning null
+      await expect(store.getIdToken()).rejects.toThrow(
+        'User account is disabled.'
+      )
+    })
   })
 
   describe('getAuthHeader', () => {


### PR DESCRIPTION
## Summary
Fixes #4468 

Firebase network failures are now gracefully handled.

The error is no longer fatal.

The user is still able to use ComfyUI for workflows that don't require authentication.

For workflows that require authentication, they are prompted to log in when the core server rejects their request for improper credentials. (This was an existing fall back workflow).

See attached video for a visual demo.

## Changes

- **What**: 
If Firebase became unavailable during a long lived (> 1 hour) user session, the user would get a fatal error when Firebase tried to refresh their expired token and the network request failed.

We now will gracefully handle this error and pass all others up the chain for handling. See [Firebase Errors](https://github.com/lamodots/error-codes-and-messages-for-firebase-authentication-API) for a comprehensive list.

## Review Focus

`src/stores/firebaseAuthStore.ts` - handles the error triage and propagation logic.
`src/scripts/app.ts` - handles UI concerns by showing an error dialog for any unhandled errors from `getIdToken`
`tests-ui/tests/store/firebaseAuthStore.test.ts` - incorporates the test cases from #4685 that @snomiao generated. I had to modify some of these test cases (and add an additional one) to match the behavior of the actual solution. Sno, i'd love your review here to make sure I didn't accidentally remove an important assertion.

Fixes #4468 

## Screenshots

https://github.com/user-attachments/assets/330a1c6c-a698-4fcd-9a31-00c681aaada0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5144-fix-4468-gracefully-handle-Firebase-auth-failure-2566d73d3650817a941de7e161df6f36) by [Unito](https://www.unito.io)
