### PR TITLE
fix: Correct v2 prefix in manager API base URL

### DIFF
--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -36,7 +36,7 @@ enum ManagerRoute {
 }
 
 const managerApiClient = axios.create({
-  baseURL: api.apiURL('v2/'),
+  baseURL: api.apiURL('/v2/'),
   headers: {
     'Content-Type': 'application/json'
   }


### PR DESCRIPTION
## Summary
- Fixed incorrect v2 prefix in manager API client base URL from `v2/` to `/v2/`

## Details
The manager API client was incorrectly constructing the base URL with `v2/` instead of `/v2/`, which would result in malformed URLs when combined with the API base path. This fix ensures the v2 prefix is properly formatted with a leading slash.

## Test plan
- [ ] Verify manager API calls work correctly with the fixed URL prefix
- [ ] Check that all manager service endpoints are accessible

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5145-fix-Correct-v2-prefix-in-manager-API-base-URL-2566d73d365081ee9c69ecdfcf8c104c) by [Unito](https://www.unito.io)
