### PR TITLE
fix: Remove lodash dependency from api.ts

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import get from 'lodash/get'
 
 import defaultClientFeatureFlags from '@/config/clientFeatureFlags.json'
 import type {
@@ -1087,7 +1086,7 @@ export class ComfyApi extends EventTarget {
    * @returns true if the feature is supported, false otherwise
    */
   serverSupportsFeature(featureName: string): boolean {
-    return get(this.serverFeatureFlags, featureName) === true
+    return this.serverFeatureFlags[featureName] === true
   }
 
   /**
@@ -1097,7 +1096,7 @@ export class ComfyApi extends EventTarget {
    * @returns The feature value or default
    */
   getServerFeature<T = unknown>(featureName: string, defaultValue?: T): T {
-    return get(this.serverFeatureFlags, featureName, defaultValue) as T
+    return (this.serverFeatureFlags[featureName] ?? defaultValue) as T
   }
 
   /**


### PR DESCRIPTION
## Summary
- Removed lodash dependency causing CI errors
- Replaced lodash `get` function with native JavaScript implementation

## Changes
- Removed `import get from 'lodash/get'` 
- Replaced `get(this.serverFeatureFlags, featureName)` with native property access `this.serverFeatureFlags[featureName]`
- Used nullish coalescing operator (`??`) for default value handling

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5147-fix-Remove-lodash-dependency-from-api-ts-2566d73d365081059214f17678724f09) by [Unito](https://www.unito.io)
