### PR TITLE
[bugfix] Fix Chinese locale detection for traditional Chinese sidebar display

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -58,10 +58,26 @@ const messages = {
   ar: buildLocale(ar, arNodes, arCommands, arSettings)
 }
 
+function getDefaultLocale(): string {
+  const lang = navigator.language
+
+  // Handle Chinese variants specifically to distinguish between simplified and traditional
+  if (lang.startsWith('zh-')) {
+    return lang.startsWith('zh-TW') ||
+      lang.startsWith('zh-HK') ||
+      lang.startsWith('zh-Hant')
+      ? 'zh-TW'
+      : 'zh'
+  }
+
+  // For other languages, use the existing logic
+  return lang.split('-')[0] || 'en'
+}
+
 export const i18n = createI18n({
   // Must set `false`, as Vue I18n Legacy API is for Vue 2
   legacy: false,
-  locale: navigator.language.split('-')[0] || 'en',
+  locale: getDefaultLocale(),
   fallbackLocale: 'en',
   messages,
   // Ignore warnings for locale options as each option is in its own language.


### PR DESCRIPTION
## Summary
- Fixes issue #5151 where Chinese language sidebar displays traditional characters incorrectly
- Updates locale detection logic to properly differentiate between simplified (zh-CN) and traditional (zh-TW) Chinese
- Browsers set to traditional Chinese variants now correctly load traditional Chinese translations

## Problem Analysis
The root cause was in `src/i18n.ts:64` where `navigator.language.split('-')[0]` was stripping region codes, causing both `zh-CN` and `zh-TW` browser settings to default to simplified Chinese (`zh`) translations.

## Solution
- Added `getDefaultLocale()` function that properly handles Chinese language variants
- `zh-TW`, `zh-HK`, `zh-Hant` → maps to `zh-TW` (traditional Chinese)
- `zh-CN`, `zh`, `zh-Hans` → maps to `zh` (simplified Chinese)
- Preserves existing behavior for all other languages

## Test Plan
- [ ] Test with browser language set to `zh-CN` → should show simplified Chinese
- [ ] Test with browser language set to `zh-TW` → should show traditional Chinese  
- [ ] Test with browser language set to `zh-HK` → should show traditional Chinese
- [ ] Test manual language selection in settings still works correctly
- [ ] Verify no regression in other language detections

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5165-bugfix-Fix-Chinese-locale-detection-for-traditional-Chinese-sidebar-display-2576d73d36508126b907cf30a5ea3588) by [Unito](https://www.unito.io)
