### PR TITLE
[ci] Restrict chromatic workflow to version-bump-* PRs and manual triggers

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -3,14 +3,15 @@ name: 'Chromatic'
 # - [Automate Chromatic with GitHub Actions • Chromatic docs]( https://www.chromatic.com/docs/github-actions/ )
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch: # Allow manual triggering
   pull_request:
     branches: [main]
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
+    # Only run for PRs from version-bump-* branches or manual triggers
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'version-bump-')
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary
- Restrict chromatic workflow to only run on PRs from `version-bump-*` branches or manual triggers
- Remove automatic trigger on push to main branch
- Add `workflow_dispatch` event for manual triggering
- Add conditional job execution using `github.head_ref` pattern matching

## Changes
- Modified `.github/workflows/chromatic.yaml` to add conditional execution
- This reduces unnecessary Chromatic builds on regular feature PRs
- Maintains functionality for release branches and allows manual runs when needed

## Test plan
- [x] Verify YAML syntax is valid
- [ ] Test that workflow does not run on regular PRs
- [ ] Test that workflow runs on version-bump-* PRs
- [ ] Test manual workflow dispatch functionality

Addresses request from PR #5148.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5167-ci-Restrict-chromatic-workflow-to-version-bump-PRs-and-manual-triggers-2576d73d365081b6bcd0d3469d8688a7) by [Unito](https://www.unito.io)
