### PR TITLE
[fix] unignore Claude project settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ dist-ssr
 *.local
 # Claude configuration
 .claude/*.local.json
-.claude/settings.json
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary

Fix improper .gitignore change from #5110

## Changes

- **What**: I mistakenly added `.claude/settings.json` to the project ignore.

## Review Focus

Fixes #5110

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5171-fix-unignore-Claud-project-settings-json-2576d73d365081f999d2df32c42e80cd) by [Unito](https://www.unito.io)
