### PR TITLE
Add knip check to lint-staged pre-commit hook

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -4,7 +4,10 @@ export default {
   './**/*.{ts,tsx,vue,mts}': (stagedFiles) => [
     ...formatAndEslint(stagedFiles),
     'vue-tsc --noEmit'
-  ]
+  ],
+
+  // Run knip on any staged files to check for unused dependencies and exports
+  '*': () => 'npm run knip'
 }
 
 function formatAndEslint(fileNames) {

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -7,7 +7,7 @@ export default {
   ],
 
   // Run knip on any staged files to check for unused dependencies and exports
-  '*': () => 'npm run knip'
+  '*': () => 'pnpm run knip'
 }
 
 function formatAndEslint(fileNames) {


### PR DESCRIPTION
Fixes #5160 by adding the missing knip CI check to lint-staged configuration


## Changes


1. Added knip check: Modified lint-staged.config.js to include npm run knip as a check that runs on all staged files ('*': () => 'npm run knip')
2. Verified intlify coverage: Confirmed that intlify checks are already covered through the existing ESLint configuration, as the @intlify/vue-i18n plugin is properly configured in eslint.config.js with the @intlify/vue-i18n/no-raw-text rule.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5172-Add-knip-check-to-lint-staged-pre-commit-hook-2586d73d365081308ca9d017957687f1) by [Unito](https://www.unito.io)
