### PR TITLE
[fix] fix #4438 do not repeatedly try to load 404'ed images

### DIFF
--- a/src/components/common/TreeExplorer.vue
+++ b/src/components/common/TreeExplorer.vue
@@ -36,20 +36,13 @@
       <!-- Always show icon initially, hide it when image loads successfully -->
       <i
         v-show="
-          !imageLoadStatus[node.key] ||
-          imageLoadStatus[node.key] === 'new' ||
-          imageLoadStatus[node.key] === 'failed'
+          !imageLoadStatus[node.key] || imageLoadStatus[node.key] === 'failed'
         "
         :class="node.icon"
       />
       <!-- Load image in background if preview exists and hasn't failed -->
       <img
-        v-if="
-          node.previewImageUrl &&
-          (!imageLoadStatus[node.key] ||
-            imageLoadStatus[node.key] === 'new' ||
-            imageLoadStatus[node.key] === 'loaded')
-        "
+        v-if="node.previewImageUrl && imageLoadStatus[node.key] !== 'failed'"
         v-show="imageLoadStatus[node.key] === 'loaded'"
         :src="node.previewImageUrl"
         class="tree-node-preview-image"
@@ -132,7 +125,7 @@ const getTreeNodeIcon = (node: TreeExplorerNode) => {
   return isExpanded ? 'pi pi-folder-open' : 'pi pi-folder'
 }
 // Track image loading states using a single record with status
-type ImageLoadStatus = 'new' | 'loaded' | 'failed'
+type ImageLoadStatus = 'loaded' | 'failed'
 const imageLoadStatus = ref<Record<string, ImageLoadStatus>>({})
 
 const handleImageLoad = (_e: Event, key: string) => {

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -124,14 +124,35 @@ const renderedRoot = computed<TreeExplorerNode<ModelOrFolder>>(() => {
       data: node.data,
       getIcon() {
         if (model) {
-          return model.image ? 'pi pi-image' : 'pi pi-file'
+          return 'pi pi-image'
         }
         if (folder) {
           return folder.state === ResourceState.Loading
             ? 'pi pi-spin pi-spinner'
             : 'pi pi-folder'
         }
-        return 'pi pi-folder'
+        return 'pi pi-file'
+      },
+      getPreviewImageUrl() {
+        if (!model) {
+          return undefined
+        }
+
+        // Check for explicit model image first
+        if (model.image) {
+          return model.image
+        }
+
+        // Construct preview URL
+        const folder = model.directory
+        const path_index = model.path_index
+        const extension = model.file_name.split('.').pop()
+        const filename = model.file_name.replace(`.${extension}`, '.webp')
+        const encodedFilename = encodeURIComponent(filename).replace(
+          /%2F/g,
+          '/'
+        )
+        return `/api/experiment/models/preview/${folder}/${path_index}/${encodedFilename}`
       },
       getBadgeText() {
         // Return undefined to apply default badge text

--- a/src/components/sidebar/tabs/modelLibrary/ModelTreeLeaf.vue
+++ b/src/components/sidebar/tabs/modelLibrary/ModelTreeLeaf.vue
@@ -1,15 +1,6 @@
 <template>
   <div ref="container" class="model-lib-node-container h-full w-full">
-    <TreeExplorerTreeNode :node="node">
-      <template #before-label>
-        <span v-if="modelPreviewUrl" class="model-lib-model-icon-container">
-          <span
-            class="model-lib-model-icon"
-            :style="{ backgroundImage: `url(${modelPreviewUrl})` }"
-          />
-        </span>
-      </template>
-    </TreeExplorerTreeNode>
+    <TreeExplorerTreeNode :node="node" />
 
     <teleport v-if="showPreview" to="#model-library-model-preview-container">
       <div class="model-lib-model-preview" :style="modelPreviewStyle">
@@ -42,18 +33,6 @@ const props = defineProps<{
 
 // Note: The leaf node should always have a model definition on node.data.
 const modelDef = computed<ComfyModelDef>(() => props.node.data!)
-
-const modelPreviewUrl = computed(() => {
-  if (modelDef.value.image) {
-    return modelDef.value.image
-  }
-  const folder = modelDef.value.directory
-  const path_index = modelDef.value.path_index
-  const extension = modelDef.value.file_name.split('.').pop()
-  const filename = modelDef.value.file_name.replace(`.${extension}`, '.webp')
-  const encodedFilename = encodeURIComponent(filename).replace(/%2F/g, '/')
-  return `/api/experiment/models/preview/${folder}/${path_index}/${encodedFilename}`
-})
 
 const previewRef = ref<InstanceType<typeof ModelPreview> | null>(null)
 const modelPreviewStyle = ref<CSSProperties>({
@@ -128,25 +107,3 @@ onUnmounted(() => {
   modelContentElement.value?.removeEventListener('mouseleave', handleMouseLeave)
 })
 </script>
-
-<style scoped>
-.model-lib-model-icon-container {
-  display: inline-block;
-  position: relative;
-  left: 0;
-  height: 1.5rem;
-  vertical-align: top;
-  width: 0;
-}
-.model-lib-model-icon {
-  background-size: cover;
-  background-position: center;
-  display: inline-block;
-  position: relative;
-  left: -2.2rem;
-  top: -0.1rem;
-  height: 1.7rem;
-  width: 1.7rem;
-  vertical-align: top;
-}
-</style>

--- a/src/types/treeExplorerTypes.ts
+++ b/src/types/treeExplorerTypes.ts
@@ -17,6 +17,11 @@ export interface TreeExplorerNode<T = any> extends TreeNode {
    */
   getIcon?: (this: TreeExplorerNode<T>) => string | undefined
   /**
+   * Function to get preview image URL for the node.
+   * Returns undefined if no preview is available.
+   */
+  getPreviewImageUrl?: (this: TreeExplorerNode<T>) => string | undefined
+  /**
    * Function to override what text to use for the leaf-count badge on a folder node.
    * Return undefined to fallback to default badge text, which is the subtree's leaf count.
    * Return empty string to hide the badge.
@@ -64,6 +69,8 @@ export interface TreeExplorerNode<T = any> extends TreeNode {
 export interface RenderedTreeExplorerNode<T = any> extends TreeExplorerNode<T> {
   children?: this[]
   icon: string
+  /** Preview image URL computed from getPreviewImageUrl if available */
+  previewImageUrl?: string
   type: 'folder' | 'node'
   /** Total number of leaves in the subtree */
   totalLeaves: number


### PR DESCRIPTION
1. Move rendering of images to TreeExplorer
2. Cache attempts to load so we only do one request for the image src

## Summary

We used to repeatedly make API request to load the image preview of models if the images weren't available (i.e., the server returned a 404). Now we cache errors and successful loads. The 404's do not repeatedly load. See video.

## Changes

- **What**: Cache failures and success of preview images. Do not attempt to load the preview images after one failed attempt to load them.

## Review Focus

1. Anything with idiomatic Vue. I think I avoided horrible stuff.
2. I tried to keep this bug's fix scope tight. I am pretty sure we could refactor this code and LazyImage to use [useImage](https://vueuse.org/core/useImage/), but I am not sure if that's in scope for this PR. Let me know otherwise.

Fixes #4438

## Screenshots (if applicable)

### Before

https://github.com/user-attachments/assets/547a3726-f638-4a01-93ab-8b0736179ee7

### After

https://github.com/user-attachments/assets/697d8fe2-6bff-4967-a6b1-d8f66614d93d

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5174-fix-fix-4438-do-not-repeatedly-try-to-load-404-ed-images-2586d73d3650819a8294d05f5e6b6d85) by [Unito](https://www.unito.io)
