### PR TITLE
[feat] update navigation mode default to legacy and improve display name

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -791,11 +791,11 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'combo',
     options: [
       { value: 'standard', text: 'Standard (New)' },
-      { value: 'legacy', text: 'Left-Click Pan (Legacy)' }
+      { value: 'legacy', text: 'Drag Navigation' }
     ],
     versionAdded: '1.25.0',
     defaultsByInstallVersion: {
-      '1.25.0': 'standard'
+      '1.25.0': 'legacy'
     }
   },
   {

--- a/src/locales/ar/settings.json
+++ b/src/locales/ar/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "وضع تنقل اللوحة",
     "options": {
-      "Left-Click Pan (Legacy)": "سحب بالنقر الأيسر (قديم)",
+      "Drag Navigation": "سحب للتنقل",
       "Standard (New)": "قياسي (جديد)"
     }
   },

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -33,7 +33,7 @@
     "name": "Canvas Navigation Mode",
     "options": {
       "Standard (New)": "Standard (New)",
-      "Left-Click Pan (Legacy)": "Left-Click Pan (Legacy)"
+      "Drag Navigation": "Drag Navigation"
     }
   },
   "Comfy_Canvas_SelectionToolbox": {

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "Modo de navegación del lienzo",
     "options": {
-      "Left-Click Pan (Legacy)": "Desplazamiento con clic izquierdo (Legado)",
+      "Drag Navigation": "Navegación por arrastre",
       "Standard (New)": "Estándar (Nuevo)"
     }
   },

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "Mode de navigation sur le canvas",
     "options": {
-      "Left-Click Pan (Legacy)": "Panoramique clic gauche (Hérité)",
+      "Drag Navigation": "Navigation par glisser-déposer",
       "Standard (New)": "Standard (Nouveau)"
     }
   },

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "キャンバスナビゲーションモード",
     "options": {
-      "Left-Click Pan (Legacy)": "左クリックパン（レガシー）",
+      "Drag Navigation": "ドラッグナビゲーション",
       "Standard (New)": "標準（新）"
     }
   },

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "캔버스 내비게이션 모드",
     "options": {
-      "Left-Click Pan (Legacy)": "왼쪽 클릭 이동(레거시)",
+      "Drag Navigation": "드래그 내비게이션",
       "Standard (New)": "표준(신규)"
     }
   },

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "Режим навигации по холсту",
     "options": {
-      "Left-Click Pan (Legacy)": "Перемещение левой кнопкой (устаревший)",
+      "Drag Navigation": "Перетаскивание",
       "Standard (New)": "Стандартный (новый)"
     }
   },

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "畫布導航模式",
     "options": {
-      "Left-Click Pan (Legacy)": "左鍵拖曳平移（舊版）",
+      "Drag Navigation": "拖曳導覽",
       "Standard (New)": "標準（新）"
     }
   },

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -32,7 +32,7 @@
   "Comfy_Canvas_NavigationMode": {
     "name": "画布导航模式",
     "options": {
-      "Left-Click Pan (Legacy)": "左键拖曳（旧版）",
+      "Drag Navigation": "拖动画布",
       "Standard (New)": "标准（新）"
     }
   },


### PR DESCRIPTION
Updates the Canvas Navigation Mode setting to improve user experience and clarify naming:

## Changes Made

1. **Changed default for new installs**: `defaultsByInstallVersion` now sets version 1.25.0+ to use `legacy` instead of `standard`
2. **Improved display name**: Updated legacy navigation from "Left-Click Pan (Legacy)" to "Drag Navigation" for better clarity

## Rationale

- Maintains both navigation systems over the long term as intended
- Provides clearer, more descriptive naming that focuses on the behavior rather than legacy status
- Sets more stable default for new users while preserving existing user preferences

The setting now offers:
- **Standard (New)**: Modern navigation mode
- **Drag Navigation**: Classic drag-based navigation (default for new installs)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5181-feat-update-navigation-mode-default-to-legacy-and-improve-display-name-2586d73d365081b38d67d18f5258e2aa) by [Unito](https://www.unito.io)
