### PR TITLE
[backport 1.25] [feat] update navigation mode default to legacy and improve display name

### DIFF
--- a/src/constants/coreSettings.ts
+++ b/src/constants/coreSettings.ts
@@ -790,11 +790,11 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'combo',
     options: [
       { value: 'standard', text: 'Standard (New)' },
-      { value: 'legacy', text: 'Left-Click Pan (Legacy)' }
+      { value: 'legacy', text: 'Drag Navigation' }
     ],
     versionAdded: '1.25.0',
     defaultsByInstallVersion: {
-      '1.25.0': 'standard'
+      '1.25.0': 'legacy'
     }
   },
   {


### PR DESCRIPTION
Backport of #5181 to core/1.25

This change updates the navigation mode settings:
- Change defaultsByInstallVersion from 'standard' to 'legacy' 
- Change display text from 'Left-Click Pan (Legacy)' to 'Drag Navigation'

The changes ensure consistent navigation behavior across versions and improve the user-facing display text.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5183-backport-1-25-feat-update-navigation-mode-default-to-legacy-and-improve-display-name-2586d73d3650818f96e6edab9b2101a3) by [Unito](https://www.unito.io)
