### PR TITLE
feat: ✨ support frontend node description (originally @melMass)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -218,6 +218,7 @@ export class LGraphNode
   static MAX_CONSOLE?: number
   static type?: string
   static category?: string
+  static description?: string
   static filter?: string
   static skip_list?: boolean
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -918,7 +918,7 @@ export class ComfyApp {
         output_is_list: [],
         output_node: false,
         python_module: 'custom_nodes.frontend_only',
-        description: `Frontend only node for ${name}`
+        description: node.description ?? `Frontend only node for ${name}`
       } as ComfyNodeDefV1
     }
 


### PR DESCRIPTION
See https://github.com/Comfy-Org/ComfyUI_frontend/pull/4109

Credit to @melMass. Just made this new one since the code reorganization would make the merge more painful. Also put the description typing on the LGraphNode instead of in the augments since we have that power now.

## Summary

Allows Frontend only nodes to declare a `description` on the Node class to display to a user.

## Changes

- **What**: If a node creator has a Frontend only (JS) node and sets a description string, that's displayed instead of the default `Frontend only node for ${name}`

## Review Focus

## Screenshots (if applicable)

Did a local tweak using an rgthree node.

<img width="439" height="84" alt="image" src="https://github.com/user-attachments/assets/e6e96ee8-9c31-4ef8-8930-116acd887fca" />

<img width="322" height="93" alt="image" src="https://github.com/user-attachments/assets/6352335c-88af-4b20-b47c-645c5e94b176" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5187-feat-support-frontend-node-description-originally-melMass-2596d73d365081518900d7d856aa5021) by [Unito](https://www.unito.io)
