### PR TITLE
Fix HoverDissolveThumbnail layering issue preventing dissolve effect

### DIFF
--- a/src/components/templates/thumbnails/HoverDissolveThumbnail.spec.ts
+++ b/src/components/templates/thumbnails/HoverDissolveThumbnail.spec.ts
@@ -94,18 +94,16 @@ describe('HoverDissolveThumbnail', () => {
 
     // Check base image
     const baseImageClass = lazyImages[0].props('imageClass')
-    const baseClassString = Array.isArray(baseImageClass)
-      ? baseImageClass.join(' ')
-      : baseImageClass
-    expect(baseClassString).toContain('w-full')
-    expect(baseClassString).toContain('h-full')
+    const baseClassList = Array.isArray(baseImageClass)
+      ? baseImageClass
+      : baseImageClass.split(' ')
+    expect(baseClassList).toContain('size-full')
 
     // Check overlay image
     const overlayImageClass = lazyImages[1].props('imageClass')
-    const overlayClassString = Array.isArray(overlayImageClass)
-      ? overlayImageClass.join(' ')
-      : overlayImageClass
-    expect(overlayClassString).toContain('w-full')
-    expect(overlayClassString).toContain('h-full')
+    const overlayClassList = Array.isArray(overlayImageClass)
+      ? overlayImageClass
+      : overlayImageClass.split(' ')
+    expect(overlayClassList).toContain('size-full')
   })
 })

--- a/src/components/templates/thumbnails/HoverDissolveThumbnail.spec.ts
+++ b/src/components/templates/thumbnails/HoverDissolveThumbnail.spec.ts
@@ -97,15 +97,15 @@ describe('HoverDissolveThumbnail', () => {
     const baseClassString = Array.isArray(baseImageClass)
       ? baseImageClass.join(' ')
       : baseImageClass
-    expect(baseClassString).toContain('absolute')
-    expect(baseClassString).toContain('inset-0')
+    expect(baseClassString).toContain('w-full')
+    expect(baseClassString).toContain('h-full')
 
     // Check overlay image
     const overlayImageClass = lazyImages[1].props('imageClass')
     const overlayClassString = Array.isArray(overlayImageClass)
       ? overlayImageClass.join(' ')
       : overlayImageClass
-    expect(overlayClassString).toContain('absolute')
-    expect(overlayClassString).toContain('inset-0')
+    expect(overlayClassString).toContain('w-full')
+    expect(overlayClassString).toContain('h-full')
   })
 })

--- a/src/components/templates/thumbnails/HoverDissolveThumbnail.vue
+++ b/src/components/templates/thumbnails/HoverDissolveThumbnail.vue
@@ -41,13 +41,13 @@ const isVideoType =
 
 const baseImageClass = computed(() => {
   const sizeClasses = isVideoType
-    ? 'w-full h-full object-cover'
-    : 'w-full h-full object-contain'
+    ? 'size-full object-cover'
+    : 'size-full object-contain'
   return sizeClasses
 })
 
 const overlayImageClass = computed(() => {
-  const baseClasses = 'w-full h-full transition-opacity duration-300'
+  const baseClasses = 'size-full transition-opacity duration-300'
   const sizeClasses = isVideoType ? 'object-cover' : 'object-contain'
   const opacityClasses = isHovered ? 'opacity-100' : 'opacity-0'
   return `${baseClasses} ${sizeClasses} ${opacityClasses}`

--- a/src/components/templates/thumbnails/HoverDissolveThumbnail.vue
+++ b/src/components/templates/thumbnails/HoverDissolveThumbnail.vue
@@ -1,12 +1,20 @@
 <template>
   <BaseThumbnail :is-hovered="isHovered">
     <div class="relative w-full h-full">
-      <LazyImage :src="baseImageSrc" :alt="alt" :image-class="baseImageClass" />
-      <LazyImage
-        :src="overlayImageSrc"
-        :alt="alt"
-        :image-class="overlayImageClass"
-      />
+      <div class="absolute inset-0">
+        <LazyImage
+          :src="baseImageSrc"
+          :alt="alt"
+          :image-class="baseImageClass"
+        />
+      </div>
+      <div class="absolute inset-0 z-10">
+        <LazyImage
+          :src="overlayImageSrc"
+          :alt="alt"
+          :image-class="overlayImageClass"
+        />
+      </div>
     </div>
   </BaseThumbnail>
 </template>
@@ -32,14 +40,15 @@ const isVideoType =
   false
 
 const baseImageClass = computed(() => {
-  return `absolute inset-0 ${isVideoType ? 'w-full h-full object-cover' : 'max-w-full max-h-64 object-contain'}`
+  const sizeClasses = isVideoType
+    ? 'w-full h-full object-cover'
+    : 'w-full h-full object-contain'
+  return sizeClasses
 })
 
 const overlayImageClass = computed(() => {
-  const baseClasses = 'absolute inset-0 transition-opacity duration-300'
-  const sizeClasses = isVideoType
-    ? 'w-full h-full object-cover'
-    : 'max-w-full max-h-64 object-contain'
+  const baseClasses = 'w-full h-full transition-opacity duration-300'
+  const sizeClasses = isVideoType ? 'object-cover' : 'object-contain'
   const opacityClasses = isHovered ? 'opacity-100' : 'opacity-0'
   return `${baseClasses} ${sizeClasses} ${opacityClasses}`
 })


### PR DESCRIPTION
## Summary
- Fixes hover dissolve effect not working in template workflow cards
- Resolves layering issue where LazyImage containers blocked overlay visibility  
- Restructures component template with proper z-index layering

### Before (Current issue)

https://github.com/user-attachments/assets/fd9518c4-1a39-4e30-9835-1c20966a672c

### After

https://github.com/user-attachments/assets/51f08a74-9f2d-4fae-a1e7-4860b171dc85


## Changes Made
- Added separate positioning containers for base and overlay images
- Used `z-10` to ensure overlay image appears above base image  
- Updated CSS classes from absolute positioning on images to container-based positioning
- Modified test assertions to match new class structure

## Test Plan  
- [x] Unit tests pass with updated assertions
- [x] Hover dissolve transition works correctly from opacity-0 to opacity-100
- [x] Template workflow cards display dissolve effect on hover

## Technical Details
The issue was caused by `LazyImage` components creating container divs that interfered with the layering. The fix wraps each `LazyImage` in its own positioned container with proper z-index values.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5191-Fix-HoverDissolveThumbnail-layering-issue-preventing-dissolve-effect-2596d73d365081f5b63ff25817457325) by [Unito](https://www.unito.io)
