### PR TITLE
fix: Allow for leading/trailing spaces when searching settings

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -120,7 +120,7 @@ const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {
 }
 
 const handleSearch = (query: string) => {
-  handleSearchBase(query)
+  handleSearchBase(query.trim())
   activeCategory.value = query ? null : defaultCategory.value
 }
 


### PR DESCRIPTION
## Summary

Makes the search in the Settings dialog more robust. Ignores leading/trailing whitespace.


## Screenshots

### Before

https://github.com/user-attachments/assets/02215e3e-9151-4c11-9613-8196b9ec601e

### After

https://github.com/user-attachments/assets/657a7489-e82b-4f44-bbf0-a3bcaa70e3c5


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5193-fix-Allow-for-leading-trailing-spaces-when-searching-settings-25a6d73d3650817c82c5d57b698ca2d1) by [Unito](https://www.unito.io)
