### PR TITLE
Add save/save as to breadcrumb root item

### DIFF
--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -107,6 +107,7 @@ const rename = async (
   }
 }
 
+const isRoot = props.item.key === 'root'
 const menuItems = computed<MenuItem[]>(() => {
   return [
     {
@@ -120,7 +121,27 @@ const menuItems = computed<MenuItem[]>(() => {
       command: async () => {
         await workflowService.duplicateWorkflow(workflowStore.activeWorkflow!)
       },
-      visible: props.item.key === 'root'
+      visible: isRoot
+    },
+    {
+      separator: true,
+      visible: isRoot
+    },
+    {
+      label: t('menuLabels.Save'),
+      icon: 'pi pi-save',
+      command: async () => {
+        await useCommandStore().execute('Comfy.SaveWorkflow')
+      },
+      visible: isRoot
+    },
+    {
+      label: t('menuLabels.Save As'),
+      icon: 'pi pi-save',
+      command: async () => {
+        await useCommandStore().execute('Comfy.SaveWorkflowAs')
+      },
+      visible: isRoot
     },
     {
       separator: true
@@ -134,7 +155,7 @@ const menuItems = computed<MenuItem[]>(() => {
     },
     {
       separator: true,
-      visible: props.item.key === 'root'
+      visible: isRoot
     },
     {
       label: t('breadcrumbsMenu.deleteWorkflow'),
@@ -142,7 +163,7 @@ const menuItems = computed<MenuItem[]>(() => {
       command: async () => {
         await workflowService.deleteWorkflow(workflowStore.activeWorkflow!)
       },
-      visible: props.item.key === 'root'
+      visible: isRoot
     }
   ]
 })


### PR DESCRIPTION
## Summary

Users frequently want to access the Save/Save as menu items so putting them in this menu decreases the friction in both finding and number of clicks required

## Changes

- **What**: Add menu items to breadcrumb root item

## Screenshots (if applicable)

<img width="296" height="322" alt="image" src="https://github.com/user-attachments/assets/7c722e38-c0b4-4272-8552-f9815b0019a0" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5213-Add-save-save-as-to-breadcrumb-root-item-25b6d73d365081b1a158c4a0e0769628) by [Unito](https://www.unito.io)
