### PR TITLE
When converting single group to subgraph, also convert children

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1465,6 +1465,7 @@ export class LGraph
     const { state, revision, config } = this
     const firstChild = [...items][0]
     if (items.size === 1 && firstChild instanceof LGraphGroup) {
+      items = new Set([firstChild])
       firstChild.recomputeInsideNodes()
       firstChild.children.forEach((n) => items.add(n))
     }

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1463,6 +1463,11 @@ export class LGraph
     if (items.size === 0)
       throw new Error('Cannot convert to subgraph: nothing to convert')
     const { state, revision, config } = this
+    const firstChild = [...items][0]
+    if (items.size === 1 && firstChild instanceof LGraphGroup) {
+      firstChild.recomputeInsideNodes()
+      firstChild.children.forEach((n) => items.add(n))
+    }
 
     const {
       boundaryLinks,

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "تم رفض إذن الميكروفون",
     "migrate": "ترحيل",
     "missing": "مفقود",
+    "moreWorkflows": "المزيد من سير العمل",
     "name": "الاسم",
     "newFolder": "مجلد جديد",
     "next": "التالي",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "Permiso de micrófono denegado",
     "migrate": "Migrar",
     "missing": "Faltante",
+    "moreWorkflows": "Más flujos de trabajo",
     "name": "Nombre",
     "newFolder": "Nueva carpeta",
     "next": "Siguiente",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "Permission du microphone refusée",
     "migrate": "Migrer",
     "missing": "Manquant",
+    "moreWorkflows": "Plus de workflows",
     "name": "Nom",
     "newFolder": "Nouveau dossier",
     "next": "Suivant",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "マイクの許可が拒否されました",
     "migrate": "移行する",
     "missing": "不足している",
+    "moreWorkflows": "さらに多くのワークフロー",
     "name": "名前",
     "newFolder": "新しいフォルダー",
     "next": "次へ",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "마이크 권한이 거부되었습니다",
     "migrate": "이전(migrate)",
     "missing": "누락됨",
+    "moreWorkflows": "더 많은 워크플로우",
     "name": "이름",
     "newFolder": "새 폴더",
     "next": "다음",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "Доступ к микрофону запрещён",
     "migrate": "Мигрировать",
     "missing": "Отсутствует",
+    "moreWorkflows": "Больше рабочих процессов",
     "name": "Имя",
     "newFolder": "Новая папка",
     "next": "Далее",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "麥克風權限被拒絕",
     "migrate": "遷移",
     "missing": "缺少",
+    "moreWorkflows": "更多工作流程",
     "name": "名稱",
     "newFolder": "新資料夾",
     "next": "下一步",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "麦克风权限被拒绝",
     "migrate": "迁移",
     "missing": "缺失",
+    "moreWorkflows": "更多工作流",
     "name": "名称",
     "newFolder": "新文件夹",
     "next": "下一个",


### PR DESCRIPTION
A small requested quality of life change.

If convert to subgraph is called on a selection consisting of a single group (the colored background rectangles), the items contained inside are also converted.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5217-When-converting-single-group-to-subgraph-also-convert-children-25b6d73d365081c396f0c2e9105b4311) by [Unito](https://www.unito.io)
