### PR TITLE
Add Gemini Image node static pricing

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1332,6 +1332,9 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         return 'Token-based'
       }
     },
+    GeminiImageNode: {
+      displayPrice: '$0.03 per 1K tokens'
+    },
     // OpenAI nodes
     OpenAIChatNode: {
       displayPrice: (node: LGraphNode): string => {

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "تم رفض إذن الميكروفون",
     "migrate": "ترحيل",
     "missing": "مفقود",
+    "moreWorkflows": "المزيد من سير العمل",
     "name": "الاسم",
     "newFolder": "مجلد جديد",
     "next": "التالي",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "Permiso de micrófono denegado",
     "migrate": "Migrar",
     "missing": "Faltante",
+    "moreWorkflows": "Más flujos de trabajo",
     "name": "Nombre",
     "newFolder": "Nueva carpeta",
     "next": "Siguiente",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "Permission du microphone refusée",
     "migrate": "Migrer",
     "missing": "Manquant",
+    "moreWorkflows": "Plus de workflows",
     "name": "Nom",
     "newFolder": "Nouveau dossier",
     "next": "Suivant",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "マイクの許可が拒否されました",
     "migrate": "移行する",
     "missing": "不足している",
+    "moreWorkflows": "さらに多くのワークフロー",
     "name": "名前",
     "newFolder": "新しいフォルダー",
     "next": "次へ",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "마이크 권한이 거부되었습니다",
     "migrate": "이전(migrate)",
     "missing": "누락됨",
+    "moreWorkflows": "더 많은 워크플로우",
     "name": "이름",
     "newFolder": "새 폴더",
     "next": "다음",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "Доступ к микрофону запрещён",
     "migrate": "Мигрировать",
     "missing": "Отсутствует",
+    "moreWorkflows": "Больше рабочих процессов",
     "name": "Имя",
     "newFolder": "Новая папка",
     "next": "Далее",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "麥克風權限被拒絕",
     "migrate": "遷移",
     "missing": "缺少",
+    "moreWorkflows": "更多工作流程",
     "name": "名稱",
     "newFolder": "新資料夾",
     "next": "下一步",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -341,6 +341,7 @@
     "micPermissionDenied": "麦克风权限被拒绝",
     "migrate": "迁移",
     "missing": "缺失",
+    "moreWorkflows": "更多工作流",
     "name": "名称",
     "newFolder": "新文件夹",
     "next": "下一个",

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -1561,6 +1561,14 @@ describe('useNodePricing', () => {
         const price = getNodeDisplayPrice(node)
         expect(price).toBe('Token-based')
       })
+
+      it('should return static price for GeminiImageNode', () => {
+        const { getNodeDisplayPrice } = useNodePricing()
+        const node = createMockNode('GeminiImageNode')
+
+        const price = getNodeDisplayPrice(node)
+        expect(price).toBe('$0.03 per 1K tokens')
+      })
     })
 
     describe('Additional RunwayML edge cases', () => {


### PR DESCRIPTION
## Summary

Static pricing badge for new Google Gemini Image node was added. 

## Changes

- **What**: Added pricing badge for GeminiImageNode.

## Review Focus

The test for the badge should be working as intended, I'm unfamiliar with how to run it but looks legit.

## Screenshots (if applicable)

<img width="685" height="198" alt="image" src="https://github.com/user-attachments/assets/6cc1a425-faa0-4523-82ff-acb85ade65be" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5219-Add-Gemini-Image-node-static-pricing-25c6d73d3650816fa713e1de87341ad2) by [Unito](https://www.unito.io)
