### PR TITLE
[bugfix] Fix refresh node definitions for subgraph nodes

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -63,6 +63,7 @@ import { ExtensionManager } from '@/types/extensionTypes'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
 import { ColorAdjustOptions, adjustColor } from '@/utils/colorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
+import { forEachNode } from '@/utils/graphTraversalUtil'
 import {
   getNodeByExecutionId,
   triggerCallbackOnAllNodes
@@ -1700,12 +1701,13 @@ export class ComfyApp {
     for (const nodeId in defs) {
       this.registerNodeDef(nodeId, defs[nodeId])
     }
-    for (const node of this.graph.nodes) {
+    // Refresh combo widgets in all nodes including those in subgraphs
+    forEachNode(this.graph, (node) => {
       const def = defs[node.type]
       // Allow primitive nodes to handle refresh
       node.refreshComboInNode?.(defs)
 
-      if (!def?.input) continue
+      if (!def?.input) return
 
       if (node.widgets) {
         const nodeInputs = def.input
@@ -1732,7 +1734,7 @@ export class ComfyApp {
           }
         }
       }
-    }
+    })
 
     await useExtensionService().invokeExtensionsAsync(
       'refreshComboInNodes',


### PR DESCRIPTION
## Summary

Fixes issue where "Refresh Node Definitions" doesn't update combo widget options for nodes inside subgraphs.

- The `refreshComboInNodes()` function was only iterating over top-level nodes (`this.graph.nodes`)
- Nodes inside subgraphs were never being refreshed, so new model files wouldn't appear in their dropdown lists
- Users had to create completely new nodes to see refreshed values

## Changes

- Replace `for (const node of this.graph.nodes)` with `forEachNode(this.graph, (node) => {...})`
- Import `forEachNode` utility from `@/utils/graphTraversalUtil` 
- Change `continue` to `return` for callback function compatibility
- Add comment explaining the hierarchical traversal

## Technical Details

The `forEachNode` utility recursively traverses the graph hierarchy:
- Processes nodes at current level
- Recursively enters subgraphs via `node.subgraph` property
- Ensures all nodes receive the refresh treatment

## Test Plan

- [ ] Create a subgraph with nodes that have combo widgets (e.g., file selection)
- [ ] Add new model files to ComfyUI
- [ ] Run "Refresh Node Definitions" (Ctrl+R or button)
- [ ] Verify combo widgets in subgraph nodes now show new files
- [ ] Test with nested subgraphs (subgraphs inside subgraphs)

Fixes #5196

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5222-bugfix-Fix-refresh-node-definitions-for-subgraph-nodes-25c6d73d365081d5a427dec3855f2c86) by [Unito](https://www.unito.io)
