### PR TITLE
Feat: Add menu item to refresh nodes

### DIFF
--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -13,6 +13,7 @@ export const CORE_MENU_COMMANDS = [
   ],
   [['Edit'], ['Comfy.Undo', 'Comfy.Redo']],
   [['Edit'], ['Comfy.OpenClipspace']],
+  [['Edit'], ['Comfy.RefreshNodeDefinitions']],
   [
     ['Help'],
     [


### PR DESCRIPTION
## Summary

Puts the refresh option back into the action menu.

## Changes

- **What**: Refresh controls through the menu.

## Screenshots (if applicable)

<img width="776" height="241" alt="image" src="https://github.com/user-attachments/assets/bef4bea6-389e-420a-90ef-4cd9d4f91eac" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5226-Feat-Add-menu-item-to-refresh-nodes-25c6d73d365081b9bb15e04cc21c5a1a) by [Unito](https://www.unito.io)
