### PR TITLE
[feat] Replace Claude loading GIF with ComfyUI logo in test workflow

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -66,7 +66,7 @@ jobs:
 
             ---
 
-            <img alt='claude-loading-gif' src="https://github.com/user-attachments/assets/5ac382c7-e004-429b-8e35-7feb3e8f9c6f" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />
+            <img alt='comfy-loading-gif' src="https://github.com/user-attachments/assets/755c86ee-e445-4ea8-bc2c-cca85df48686" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />
             <bold>[${{ steps.current-time.outputs.time }} UTC] Preparing browser tests across multiple browsers...</bold>
 
             ---
@@ -168,7 +168,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           edit-mode: append
           body: |
-            <img alt='claude-loading-gif' src="https://github.com/user-attachments/assets/5ac382c7-e004-429b-8e35-7feb3e8f9c6f" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />
+            <img alt='comfy-loading-gif' src="https://github.com/user-attachments/assets/755c86ee-e445-4ea8-bc2c-cca85df48686" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />
             <bold>${{ matrix.browser }}</bold>: Running tests...
 
       - name: Install requirements


### PR DESCRIPTION
- Replace the Claude loading GIF in the test workflow PR comments with ComfyUI's animated favicon progress frames
- Updates both the initial test preparation comment and per-browser test status comments
- Uses the same 10-frame progress animation that's already used for the browser favicon

<img alt='comfy-loading-gif' src="https://github.com/user-attachments/assets/755c86ee-e445-4ea8-bc2c-cca85df48686" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />
<bold>[08/27/2025, 04:16:33 PM UTC] Preparing browser tests across multiple browsers...</bold>

preview above

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5229-feat-Replace-Claude-loading-GIF-with-ComfyUI-logo-in-test-workflow-25c6d73d365081729980ff2f814346f3) by [Unito](https://www.unito.io)
