### PR TITLE
Fix broken links on bypass prior to reroute

### DIFF
--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -141,7 +141,8 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
    */
   resolveInput(
     slot: number,
-    visited = new Set<string>()
+    visited = new Set<string>(),
+    type?: ISlotType
   ): ResolvedInput | undefined {
     const uniqueId = `${this.subgraphNode?.subgraph.id}:${this.node.id}[I]${slot}`
     if (visited.has(uniqueId)) {
@@ -232,7 +233,11 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
         `No output node DTO found for id [${outputNodeExecutionId}]`
       )
 
-    return outputNodeDto.resolveOutput(link.origin_slot, input.type, visited)
+    return outputNodeDto.resolveOutput(
+      link.origin_slot,
+      type ?? input.type,
+      visited
+    )
   }
 
   /**
@@ -284,7 +289,7 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
 
     // Upstreamed: Other virtual nodes are bypassed using the same input/output index (slots must match)
     if (node.isVirtualNode) {
-      if (this.inputs.at(slot)) return this.resolveInput(slot, visited)
+      if (this.inputs.at(slot)) return this.resolveInput(slot, visited, type)
 
       // Fallback check for nodes performing link redirection
       const virtualLink = this.node.getInputLink(slot)


### PR DESCRIPTION
#4864 added more nuanced handling for links of bypassed nodes. Unfortunately, it introduced an edge case with a bypassed node prior to a legacy reroute. Legacy reroutes report their input type as `*`. This triggers a short circuit in `#getBypassSlotIndex`. When the determined bypassed connection does not match the actual type requirements on the other side of the reroute, this results in a type mismatch on execution.

While there is likely merit to further consideration upon the value of the short circuit,  this pull request is targeted to minimize unecessary changes in functionality by providing a route for virtual nodes, like reroutes, to pass their actual required input type.

Resolves comfyanonymous/ComfyUI#9567
Likely also related to 4839

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5237-Fix-broken-links-on-bypass-prior-to-reroute-25d6d73d3650819ea213cfbb1fba465e) by [Unito](https://www.unito.io)
