### PR TITLE
Support watching changes on connections.

### DIFF
--- a/src/composables/node/useWatchWidget.ts
+++ b/src/composables/node/useWatchWidget.ts
@@ -75,6 +75,29 @@ export const useComputedWithWidgetWatch = (
         }
       })
     })
+    if (widgetNames && widgetNames.length > widgetsToObserve.length) {
+      //Inputs have been included
+      const indexesToObserve = widgetNames
+        .map((name) =>
+          widgetsToObserve.some((w) => w.name == name)
+            ? -1
+            : node.inputs.findIndex((i) => i.name == name)
+        )
+        .filter((i) => i >= 0)
+      node.onConnectionsChange = useChainCallback(
+        node.onConnectionsChange,
+        (_type: unknown, index: number, isConnected: boolean) => {
+          if (!indexesToObserve.includes(index)) return
+          widgetValues.value = {
+            ...widgetValues.value,
+            [indexesToObserve[index]]: isConnected
+          }
+          if (triggerCanvasRedraw) {
+            node.graph?.setDirtyCanvas(true, true)
+          }
+        }
+      )
+    }
   }
 
   // Returns a function that creates a computed that responds to widget changes.


### PR DESCRIPTION
This PR adds support for pricing indicators to watch for changes in input connections.

It slots into useWatchWidgets so that existing code path ways *just work*, but establishes a little bit of a misnomer.

See #5241

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5250-Support-watching-changes-on-connections-25d6d73d365081ae8834caef4cec8e52) by [Unito](https://www.unito.io)
