### PR TITLE
Fix clicks near DOMWidgets being swallowed

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -2136,10 +2136,22 @@ export class LGraphNode
         widget.computeSize?.(nodeWidth)[1] ??
         LiteGraph.NODE_WIDGET_HEIGHT
 
+      const maybeDOMWidget = widget as { margin?: number }
+      const mtop = maybeDOMWidget.margin ?? -2
+      const mbot = maybeDOMWidget.margin ?? 2
+      const mx = maybeDOMWidget.margin ?? 6
+
       const w = widget.width || nodeWidth
       if (
         widget.last_y !== undefined &&
-        isInRectangle(x, y, 6, widget.last_y, w - 12, h)
+        isInRectangle(
+          x,
+          y,
+          mx,
+          widget.last_y + mtop,
+          w - 2 * mx,
+          h - mtop - mbot
+        )
       ) {
         return widget
       }


### PR DESCRIPTION
DOMWidgets do not perfectly align with their allocated space on a node.
Clicks on the element proper are never seen by litegraph, but there's a small border region where the LegacyWidget onClick method is called (See LGraphNode.getWidgetOnPos). To end users who will not see the console warning, it appears the click just gets swallowed.

~~This PR addresses the issue in two parts:~~
- ~~It provides a method on canvas to set a pointer event to be handled as a passthrough~~
- ~~It sets DOMWidgets to use this method for clicks that are not handled by the element itself~~

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5253-Fix-clicks-near-DOMWidgets-being-swallowed-25e6d73d36508165adf5c144ecd95024) by [Unito](https://www.unito.io)
