### PR TITLE
devex: Ignore playwright-report and coverage in the vite dev server

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -26,6 +26,9 @@ export default defineConfig({
   base: '',
   server: {
     host: VITE_REMOTE_DEV ? '0.0.0.0' : undefined,
+    watch: {
+      ignored: ['**/coverage/**', '**/playwright-report/**']
+    },
     proxy: {
       '/internal': {
         target: DEV_SERVER_COMFYUI_URL


### PR DESCRIPTION
## Summary

Very small change that helps when running playwright tests locally.

## Changes

- **What**: Dev server no longer detects playwright report updates 

## Review Focus

### If you run

- A local comfy instance (`comfy launch -- --disable-all-custom-nodes --whitelist-custom-nodes="ComfyUI_devtools" --multi-user`)
- The local dev server (`pnpm dev`)
- The Playwright tests (`pnpm test:browser`)

You should no longer have the dev server trying to regenerate s the playwright results are written.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5258-devex-Ignore-playwright-report-and-coverage-in-the-vite-dev-server-25e6d73d3650819f8433df30f3e88cdc) by [Unito](https://www.unito.io)
