### PR TITLE
[refactor] Remove unused legacy mutation types from layout system

### DIFF
--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -92,68 +92,6 @@ export interface ConnectionLayout {
   controlPoints?: Point[]
 }
 
-// Mutation types (legacy - for compatibility)
-export type LayoutMutationType =
-  | 'moveNode'
-  | 'resizeNode'
-  | 'setNodeZIndex'
-  | 'createNode'
-  | 'deleteNode'
-  | 'batch'
-
-export interface LayoutMutation {
-  type: LayoutMutationType
-  timestamp: number
-  source: LayoutSource
-}
-
-export interface MoveNodeMutation extends LayoutMutation {
-  type: 'moveNode'
-  nodeId: NodeId
-  position: Point
-  previousPosition?: Point
-}
-
-export interface ResizeNodeMutation extends LayoutMutation {
-  type: 'resizeNode'
-  nodeId: NodeId
-  size: Size
-  previousSize?: Size
-}
-
-export interface SetNodeZIndexMutation extends LayoutMutation {
-  type: 'setNodeZIndex'
-  nodeId: NodeId
-  zIndex: number
-  previousZIndex?: number
-}
-
-export interface CreateNodeMutation extends LayoutMutation {
-  type: 'createNode'
-  nodeId: NodeId
-  layout: NodeLayout
-}
-
-export interface DeleteNodeMutation extends LayoutMutation {
-  type: 'deleteNode'
-  nodeId: NodeId
-  previousLayout?: NodeLayout
-}
-
-export interface BatchMutation extends LayoutMutation {
-  type: 'batch'
-  mutations: AnyLayoutMutation[]
-}
-
-// Union type for all mutations
-export type AnyLayoutMutation =
-  | MoveNodeMutation
-  | ResizeNodeMutation
-  | SetNodeZIndexMutation
-  | CreateNodeMutation
-  | DeleteNodeMutation
-  | BatchMutation
-
 // CRDT Operation Types
 
 /**


### PR DESCRIPTION
Clean up the layout system by removing unused legacy mutation types that were designed for backward compatibility but have never been used since this code hasn't been merged to main.

- Remove `LayoutMutationType`, `LayoutMutation`, and related interfaces from both type files
- Remove `AnyLayoutMutation` union type and specific mutation interfaces  
- Clean up duplicate legacy types from both `layoutTypes.ts` and `layout/types.ts`
- Fix JSON syntax error in Chinese locale file (missing comma)
- Replace `lodash` with `es-toolkit` in `useFloatWidget` (per project standards)



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5262-refactor-Remove-unused-legacy-mutation-types-from-layout-system-25f6d73d36508176b034c90375b9d946) by [Unito](https://www.unito.io)
