### PR TITLE
api_nodes: add prices for Kling 2.1 model for KlingStartEndFrame node

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -395,7 +395,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         const modeValue = String(modeWidget.value)
 
         // Same pricing matrix as KlingTextToVideoNode
-        if (modeValue.includes('v2-master')) {
+        if (modeValue.includes('v2-1')) {
+          if (modeValue.includes('10s')) {
+            return '$0.98/Run' // pro, 10s
+          }
+          return '$0.49/Run' // pro, 5s default
+        } else if (modeValue.includes('v2-master')) {
           if (modeValue.includes('10s')) {
             return '$2.80/Run'
           }


### PR DESCRIPTION
PR to ComfyUI repo: https://github.com/comfyanonymous/ComfyUI/pull/9630

## Summary

Added prices for the new model.

## Screenshots (if applicable)

<img width="595" height="883" alt="Screenshot from 2025-08-30 10-08-02" src="https://github.com/user-attachments/assets/fe644331-88ba-4b80-b88f-6a19b247fba0" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5264-api_nodes-add-prices-for-Kling-2-1-model-for-KlingStartEndFrame-node-25f6d73d3650811ea360c750b9fe19f4) by [Unito](https://www.unito.io)
