### PR TITLE
[fix] Update i18n workflow for PNPM/Nx compatibility

### DIFF
--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -34,7 +34,7 @@ jobs:
       run: pnpm dev:electron &
       working-directory: ComfyUI_frontend
     - name: Update en.json
-      run: pnpm collect-i18n -- scripts/collect-i18n-general.ts
+      run: pnpm collect-i18n
       env:
         PLAYWRIGHT_TEST_URL: http://localhost:5173
       working-directory: ComfyUI_frontend


### PR DESCRIPTION
## Summary
Fix i18n workflow failing due to incompatible command arguments after PNPM/Nx migration.

## Changes
- Remove explicit file arguments from `pnpm collect-i18n` command
- The playwright config already uses `testMatch: /collect-i18n-.*\.ts/` to automatically find test files

## Problem
The command `pnpm collect-i18n -- scripts/collect-i18n-general.ts` was failing because the new Nx e2e setup doesn't accept file arguments in the same way as the previous setup.

## Solution
Use `pnpm collect-i18n` without arguments, letting the playwright config handle test discovery.

Fixes workflow failure in release PR #5263

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5266-fix-Update-i18n-workflow-for-PNPM-Nx-compatibility-25f6d73d36508157a971cb964bffdf3c) by [Unito](https://www.unito.io)
