### PR TITLE
fix: Replace lodash with es-toolkit in useFloatWidget

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useFloatWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useFloatWidget.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import { clamp } from 'es-toolkit/compat'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { INumericWidget } from '@/lib/litegraph/src/types/widgets'
@@ -15,7 +15,7 @@ function onFloatValueChange(this: INumericWidget, v: number) {
     const precision =
       this.options.precision ?? Math.max(0, -Math.floor(Math.log10(round)))
     const rounded = Math.round(v / round) * round
-    this.value = _.clamp(
+    this.value = clamp(
       Number(rounded.toFixed(precision)),
       this.options.min ?? -Infinity,
       this.options.max ?? Infinity


### PR DESCRIPTION
## Summary
- Replaced lodash import with es-toolkit/compat in useFloatWidget
- Fixed missing clamp import that was causing build issues

## Test plan
- [x] Type checking passes
- [x] Build completes successfully
- [x] Float widgets continue to work correctly with clamping behavior

🤖 Generated with [Claude Code](https://claude.ai/code)