### PR TITLE
[fix] Use defineConfig for i18n Playwright config TypeScript compilation

### DIFF
--- a/playwright.i18n.config.ts
+++ b/playwright.i18n.config.ts
@@ -1,6 +1,6 @@
-import { PlaywrightTestConfig } from '@playwright/test'
+import { defineConfig } from '@playwright/test'
 
-const config: PlaywrightTestConfig = {
+export default defineConfig({
   testDir: './scripts',
   use: {
     baseURL: 'http://localhost:5173',
@@ -9,6 +9,4 @@ const config: PlaywrightTestConfig = {
   reporter: 'list',
   timeout: 60000,
   testMatch: /collect-i18n-.*\.ts/
-}
-
-export default config
+})


### PR DESCRIPTION
## Summary
Fix TypeScript compilation error in i18n collection workflow by updating `playwright.i18n.config.ts` to use modern `defineConfig` API.

## Problem
The i18n workflow was failing with:
```
SyntaxError: TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript
```

This occurred because `playwright.i18n.config.ts` was using the older `PlaywrightTestConfig` interface instead of `defineConfig()` which provides proper Vite integration for TypeScript compilation.

## Solution
- Replace `PlaywrightTestConfig` interface with `defineConfig()` API
- Maintains all existing i18n collection functionality
- Aligns with main `playwright.config.ts` which already uses `defineConfig`


Fixes the remaining issue after PR #5266

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5270-fix-Use-defineConfig-for-i18n-Playwright-config-TypeScript-compilation-25f6d73d36508151badcd6d94935f0ce) by [Unito](https://www.unito.io)
