### PR TITLE
feat: Add Playwright browser caching to CI workflows

### DIFF
--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -25,6 +25,13 @@ jobs:
         key: i18n-tools-cache-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/pnpm-lock.yaml') }}
         restore-keys: |
           i18n-tools-cache-${{ runner.os }}-
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-browsers-${{ runner.os }}-
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend

--- a/.github/workflows/test-browser-exp.yaml
+++ b/.github/workflows/test-browser-exp.yaml
@@ -11,6 +11,13 @@ jobs:
     if: github.event.label.name == 'New Browser Test Expectations'
     steps:
     - uses: Comfy-Org/ComfyUI_frontend_setup_action@v3
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ComfyUI_frontend/pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-browsers-${{ runner.os }}-
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
       working-directory: ComfyUI_frontend


### PR DESCRIPTION
## Summary

Adds Playwright browser caching to CI workflows to improve performance by avoiding repeated browser downloads.

## Changes

- **What**: Added GitHub Actions cache configuration for Playwright browsers in i18n.yaml and test-browser-exp.yaml workflows
- **Dependencies**: None - uses existing actions/cache@v4

## Review Focus

The cache keys use the pnpm-lock.yaml hash to ensure cache invalidation when dependencies change. This should significantly reduce CI execution time for workflows that use Playwright.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5272-feat-Add-Playwright-browser-caching-to-CI-workflows-25f6d73d365081d9b006cc9f0a62118a) by [Unito](https://www.unito.io)
