### PR TITLE
[fix] Improve Storybook comment workflow status handling

### DIFF
--- a/.github/workflows/pr-storybook-comment.yaml
+++ b/.github/workflows/pr-storybook-comment.yaml
@@ -8,7 +8,10 @@ on:
 jobs:
   comment-storybook:
     runs-on: ubuntu-latest
-    if: github.repository == 'Comfy-Org/ComfyUI_frontend' && github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.repository == 'Comfy-Org/ComfyUI_frontend'
+      && github.event.workflow_run.event == 'pull_request'
+      && startsWith(github.event.workflow_run.head_branch, 'version-bump-')
     permissions:
       pull-requests: write
       actions: read
@@ -97,7 +100,17 @@ jobs:
             <!-- STORYBOOK_BUILD_STATUS -->
             ## 🎨 Storybook Build Status
 
-            ${{ fromJSON(steps.workflow-run.outputs.result).conclusion == 'success' && '✅' || '❌' }} **${{ fromJSON(steps.workflow-run.outputs.result).conclusion == 'success' && 'Build completed successfully!' || 'Build failed!' }}**
+            ${{
+              fromJSON(steps.workflow-run.outputs.result).conclusion == 'success' && '✅'
+              || fromJSON(steps.workflow-run.outputs.result).conclusion == 'skipped' && '⏭️'
+              || fromJSON(steps.workflow-run.outputs.result).conclusion == 'cancelled' && '🚫'
+              || '❌'
+            }} **${{
+              fromJSON(steps.workflow-run.outputs.result).conclusion == 'success' && 'Build completed successfully!'
+              || fromJSON(steps.workflow-run.outputs.result).conclusion == 'skipped' && 'Build skipped.'
+              || fromJSON(steps.workflow-run.outputs.result).conclusion == 'cancelled' && 'Build cancelled.'
+              || 'Build failed!'
+            }}**
 
             ⏰ Completed at: ${{ steps.completion-time.outputs.time }} UTC
 
@@ -105,4 +118,9 @@ jobs:
             - [📊 View Workflow Run](${{ fromJSON(steps.workflow-run.outputs.result).html_url }})
 
             ---
-            ${{ fromJSON(steps.workflow-run.outputs.result).conclusion == 'success' && '🎉 Your Storybook is ready for review!' || '⚠️ Please check the workflow logs for error details.' }}
+            ${{
+              fromJSON(steps.workflow-run.outputs.result).conclusion == 'success' && '🎉 Your Storybook is ready for review!'
+              || fromJSON(steps.workflow-run.outputs.result).conclusion == 'skipped' && 'ℹ️ Chromatic was skipped for this PR.'
+              || fromJSON(steps.workflow-run.outputs.result).conclusion == 'cancelled' && 'ℹ️ The Chromatic run was cancelled.'
+              || '⚠️ Please check the workflow logs for error details.'
+            }}


### PR DESCRIPTION
## Summary

Enhanced the Storybook comment workflow to restrict execution to version-bump branches and properly handle different build statuses.

## Changes

- **What**: Updated pr-storybook-comment workflow to handle skipped and cancelled build statuses with appropriate messaging and icons
- **Breaking**: None
- **Dependencies**: None

## Review Focus

The workflow now:
1. Only runs on branches starting with `version-bump-` to avoid unnecessary comments on regular PRs
2. Properly handles 4 different build conclusions: success (✅), skipped (⏭️), cancelled (🚫), and failed (❌)
3. Provides clear, status-specific messages for each conclusion type

This improves the user experience by providing clearer feedback about the Chromatic/Storybook build status and reduces noise on non-version-bump PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5273-fix-Improve-Storybook-comment-workflow-status-handling-25f6d73d365081cd8455ff7517e0e825) by [Unito](https://www.unito.io)
