### PR TITLE
fix: Ensure logout clears both Firebase auth and API key

### DIFF
--- a/src/components/topbar/CurrentUserPopover.spec.ts
+++ b/src/components/topbar/CurrentUserPopover.spec.ts
@@ -41,11 +41,13 @@ afterAll(() => {
 })
 
 // Mock the useCurrentUser composable
+const mockHandleSignOut = vi.fn()
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: vi.fn(() => ({
     userPhotoUrl: 'https://example.com/avatar.jpg',
     userDisplayName: 'Test User',
-    userEmail: 'test@example.com'
+    userEmail: 'test@example.com',
+    handleSignOut: mockHandleSignOut
   }))
 }))
 
@@ -155,8 +157,8 @@ describe('CurrentUserPopover', () => {
     // Click the logout button
     await logoutButton.trigger('click')
 
-    // Verify logout was called
-    expect(mockLogout).toHaveBeenCalled()
+    // Verify handleSignOut was called
+    expect(mockHandleSignOut).toHaveBeenCalled()
 
     // Verify close event was emitted
     expect(wrapper.emitted('close')).toBeTruthy()

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -88,7 +88,8 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { userDisplayName, userEmail, userPhotoUrl } = useCurrentUser()
+const { userDisplayName, userEmail, userPhotoUrl, handleSignOut } =
+  useCurrentUser()
 const authActions = useFirebaseAuthActions()
 const dialogService = useDialogService()
 
@@ -103,7 +104,7 @@ const handleTopUp = () => {
 }
 
 const handleLogout = async () => {
-  await authActions.logout()
+  await handleSignOut()
   emit('close')
 }
 


### PR DESCRIPTION
## Summary
- Fixed logout functionality to properly clear both Firebase authentication and API key
- Updated `CurrentUserPopover` component to use the correct logout handler

## Problem
When logging out via the avatar dropdown in the top right, the logout function was only clearing Firebase authentication but not the stored API key. This could leave users partially authenticated with their API key still active after appearing to log out.

## Solution
Updated `CurrentUserPopover.vue` to use `handleSignOut` from the `useCurrentUser` composable instead of directly calling `authActions.logout()`. The `handleSignOut` method properly handles both authentication methods:
- Clears API key if logged in with API key
- Signs out Firebase if logged in with Firebase

This ensures complete logout regardless of authentication method.

### Console commands to verify auth state:
```javascript
// Check Firebase auth
const firebaseStore = (await import('./src/stores/firebaseAuthStore.ts')).useFirebaseAuthStore()
console.log('Firebase authenticated:', firebaseStore.isAuthenticated)

// Check API key
const apiKeyStore = (await import('./src/stores/apiKeyAuthStore.ts')).useApiKeyAuthStore()
console.log('Has API key:', !!apiKeyStore.getApiKey())
```

Fixes #5261

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5274-fix-Ensure-logout-clears-both-Firebase-auth-and-API-key-2606d73d365081df8daec95ee707a859) by [Unito](https://www.unito.io)
