### PR TITLE
Fix Chromatic build failure by updating build-storybook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "collect-i18n": "nx e2e --config=playwright.i18n.config.ts",
     "json-schema": "tsx scripts/generate-json-schema.ts",
     "storybook": "nx storybook -p 6006",
-    "build-storybook": "nx build-storybook"
+    "build-storybook": "storybook build"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.26.8",
+  "version": "0.7",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "0.7",
+  "version": "1.26.7",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.26.7",
+  "version": "1.26.8",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
## Summary
- Fix Chromatic deployment failure in GitHub Actions by updating build-storybook script
- Replace `nx build-storybook` with direct `storybook build` command to properly forward --output-dir argument

## Problem
The Chromatic deployment was failing because the Nx wrapper for `build-storybook` wasn't forwarding the `--output-dir` argument that Chromatic passes. This caused static files (HTML, CSS, fonts) to be empty (0 bytes), making Chromatic reject the build as invalid.

## Solution
Changed package.json script from `nx build-storybook` to `storybook build` to allow proper argument forwarding.

## Test plan
- [x] Verified local build works with custom output directory
- [x] Tested that static files are properly generated
- [ ] Verify Chromatic deployment passes in CI

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5276-Fix-Chromatic-build-failure-by-updating-build-storybook-script-2606d73d36508185aa4bcc83d1b970b7) by [Unito](https://www.unito.io)
