### PR TITLE
Re-add ComfyUI loading GIF to PR comments

### DIFF
--- a/.github/workflows/pr-playwright-comment.yaml
+++ b/.github/workflows/pr-playwright-comment.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "<!-- PLAYWRIGHT_TEST_STATUS -->" > comment.md
           echo "## 🎭 Playwright Test Results" >> comment.md
           echo "" >> comment.md
-          echo "⏳ **Tests are starting...** " >> comment.md
+          echo "<img alt='comfy-loading-gif' src='https://github.com/user-attachments/assets/755c86ee-e445-4ea8-bc2c-cca85df48686' width='14px' height='14px' style='vertical-align: middle; margin-right: 4px;' /> **Tests are starting...** " >> comment.md
           echo "" >> comment.md
           echo "⏰ Started at: ${{ steps.completion-time.outputs.time }} UTC" >> comment.md
           echo "" >> comment.md

--- a/.github/workflows/pr-storybook-comment.yaml
+++ b/.github/workflows/pr-storybook-comment.yaml
@@ -73,7 +73,7 @@ jobs:
             <!-- STORYBOOK_BUILD_STATUS -->
             ## 🎨 Storybook Build Status
 
-            ⏳ **Build is starting...** 
+            <img alt='comfy-loading-gif' src='https://github.com/user-attachments/assets/755c86ee-e445-4ea8-bc2c-cca85df48686' width='14px' height='14px' style='vertical-align: middle; margin-right: 4px;' /> **Build is starting...** 
 
             ⏰ Started at: ${{ steps.completion-time.outputs.time }} UTC
 


### PR DESCRIPTION
Restores the ComfyUI loading GIF to workflow status comments that was removed in PR #5209.

The loading GIF now appears in Playwright and Storybook status comments during CI runs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5277-Re-add-ComfyUI-loading-GIF-to-PR-comments-2606d73d36508190a63ecc91f43de8b0) by [Unito](https://www.unito.io)
