### PR TITLE
[fix] Bypass Nx for i18n collection TypeScript compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "knip": "knip --cache",
     "knip:no-cache": "knip",
     "locale": "lobe-i18n locale",
-    "collect-i18n": "nx e2e --config=playwright.i18n.config.ts",
+    "collect-i18n": "npx playwright test --config=playwright.i18n.config.ts",
     "json-schema": "tsx scripts/generate-json-schema.ts",
     "storybook": "nx storybook -p 6006",
     "build-storybook": "nx build-storybook"


### PR DESCRIPTION
## Summary
Fix TypeScript compilation error in i18n collection by bypassing Nx compilation pipeline and using Playwright's native TypeScript handling.

## Problem
After the PNPM/Nx migration, the i18n workflow fails with:
```
SyntaxError: TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript
```

This occurs because:
- **Before:** `playwright test` used Playwright's native TypeScript compilation
- **After:** `nx e2e --config=playwright.i18n.config.ts` routes through Nx's compilation pipeline
- **Nx's pipeline** doesn't properly handle `declare` fields in LiteGraph source files

## Solution
Change the `collect-i18n` command from:
```json
"collect-i18n": "nx e2e --config=playwright.i18n.config.ts"
```

To:
```json
"collect-i18n": "npx playwright test --config=playwright.i18n.config.ts"
```

This bypasses Nx and uses Playwright's native TypeScript compilation, which handles `declare` fields correctly.


This is the third and hopefully final fix for the i18n workflow after PRs #5266 and #5270.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5278-fix-Bypass-Nx-for-i18n-collection-TypeScript-compilation-2606d73d3650815ca35bda5914163d6e) by [Unito](https://www.unito.io)
