### PR TITLE
[fix] Enable mouse gestures over video previews

### DIFF
--- a/src/composables/graph/useCanvasInteractions.ts
+++ b/src/composables/graph/useCanvasInteractions.ts
@@ -58,8 +58,6 @@ export function useCanvasInteractions() {
       forwardEventToCanvas(event)
       return
     }
-
-    // Otherwise, let the media element handle normally (preserves drag behavior)
   }
 
   /**

--- a/src/composables/graph/useCanvasInteractions.ts
+++ b/src/composables/graph/useCanvasInteractions.ts
@@ -48,17 +48,11 @@ export function useCanvasInteractions() {
     const canvas = getCanvas()
     if (!canvas) return
 
-    // Forward space+drag (panning) events to canvas
-    // The canvas already handles space key state via read_only property
-    if (canvas.read_only && event.buttons === 1) {
-      event.preventDefault()
-      event.stopPropagation()
-      forwardEventToCanvas(event)
-      return
-    }
+    // Check conditions for forwarding events to canvas
+    const isSpacePanningDrag = canvas.read_only && event.buttons === 1 // Space key pressed + left mouse drag
+    const isMiddleMousePanning = event.buttons === 4 // Middle mouse button for panning
 
-    // Forward middle mouse button events for panning
-    if (event.buttons === 4) {
+    if (isSpacePanningDrag || isMiddleMousePanning) {
       event.preventDefault()
       event.stopPropagation()
       forwardEventToCanvas(event)

--- a/src/composables/node/useNodeImage.ts
+++ b/src/composables/node/useNodeImage.ts
@@ -1,3 +1,4 @@
+import { useCanvasInteractions } from '@/composables/graph/useCanvasInteractions'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 import { fitDimensionsToNodeWidth } from '@/utils/imageUtil'
@@ -130,6 +131,8 @@ export const useNodeVideo = (node: LGraphNode) => {
   let minHeight = DEFAULT_VIDEO_SIZE
   let minWidth = DEFAULT_VIDEO_SIZE
 
+  const { handleWheel, handlePointer } = useCanvasInteractions()
+
   const setMinDimensions = (video: HTMLVideoElement) => {
     const { minHeight: calculatedHeight, minWidth: calculatedWidth } =
       fitDimensionsToNodeWidth(
@@ -146,6 +149,12 @@ export const useNodeVideo = (node: LGraphNode) => {
     new Promise((resolve) => {
       const video = document.createElement('video')
       Object.assign(video, VIDEO_DEFAULT_OPTIONS)
+
+      // Add event listeners for canvas interactions
+      video.addEventListener('wheel', handleWheel)
+      video.addEventListener('pointermove', handlePointer)
+      video.addEventListener('pointerdown', handlePointer)
+
       video.onloadeddata = () => {
         setMinDimensions(video)
         resolve(video)

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -18,16 +18,13 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 describe('useCanvasInteractions', () => {
-  const mockGetCanvas = vi.fn()
-  const mockGet = vi.fn()
-
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(useCanvasStore, { partial: true }).mockReturnValue({
-      getCanvas: mockGetCanvas
+      getCanvas: vi.fn()
     })
     vi.mocked(useSettingStore, { partial: true }).mockReturnValue({
-      get: mockGet
+      get: vi.fn()
     })
   })
 
@@ -35,7 +32,8 @@ describe('useCanvasInteractions', () => {
     it('should forward space+drag events to canvas when read_only is true', () => {
       // Setup
       const mockCanvas = { read_only: true }
-      mockGetCanvas.mockReturnValue(mockCanvas)
+      const { getCanvas } = useCanvasStore()
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas as any)
 
       const { handlePointer } = useCanvasInteractions()
 
@@ -57,7 +55,8 @@ describe('useCanvasInteractions', () => {
     it('should forward middle mouse button events to canvas', () => {
       // Setup
       const mockCanvas = { read_only: false }
-      mockGetCanvas.mockReturnValue(mockCanvas)
+      const { getCanvas } = useCanvasStore()
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas as any)
 
       const { handlePointer } = useCanvasInteractions()
 
@@ -79,7 +78,8 @@ describe('useCanvasInteractions', () => {
     it('should not prevent default when canvas is not in read_only mode and not middle button', () => {
       // Setup
       const mockCanvas = { read_only: false }
-      mockGetCanvas.mockReturnValue(mockCanvas)
+      const { getCanvas } = useCanvasStore()
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas as any)
 
       const { handlePointer } = useCanvasInteractions()
 
@@ -100,7 +100,8 @@ describe('useCanvasInteractions', () => {
 
     it('should return early when canvas is null', () => {
       // Setup
-      mockGetCanvas.mockReturnValue(null)
+      const { getCanvas } = useCanvasStore()
+      vi.mocked(getCanvas).mockReturnValue(null as any)
 
       const { handlePointer } = useCanvasInteractions()
 
@@ -115,7 +116,7 @@ describe('useCanvasInteractions', () => {
       handlePointer(mockEvent as unknown as PointerEvent)
 
       // Verify early return - no event methods should be called at all
-      expect(mockGetCanvas).toHaveBeenCalled()
+      expect(getCanvas).toHaveBeenCalled()
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })
@@ -124,7 +125,8 @@ describe('useCanvasInteractions', () => {
   describe('handleWheel', () => {
     it('should forward ctrl+wheel events to canvas in standard nav mode', () => {
       // Setup
-      mockGet.mockReturnValue('standard')
+      const { get } = useSettingStore()
+      vi.mocked(get).mockReturnValue('standard')
 
       const { handleWheel } = useCanvasInteractions()
 
@@ -144,7 +146,8 @@ describe('useCanvasInteractions', () => {
 
     it('should forward all wheel events to canvas in legacy nav mode', () => {
       // Setup
-      mockGet.mockReturnValue('legacy')
+      const { get } = useSettingStore()
+      vi.mocked(get).mockReturnValue('legacy')
 
       const { handleWheel } = useCanvasInteractions()
 
@@ -164,7 +167,8 @@ describe('useCanvasInteractions', () => {
 
     it('should not prevent default for regular wheel events in standard nav mode', () => {
       // Setup
-      mockGet.mockReturnValue('standard')
+      const { get } = useSettingStore()
+      vi.mocked(get).mockReturnValue('standard')
 
       const { handleWheel } = useCanvasInteractions()
 

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -23,12 +23,12 @@ describe('useCanvasInteractions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(useCanvasStore).mockReturnValue({
+    vi.mocked(useCanvasStore, { partial: true }).mockReturnValue({
       getCanvas: mockGetCanvas
-    } as any)
-    vi.mocked(useSettingStore).mockReturnValue({
+    })
+    vi.mocked(useSettingStore, { partial: true }).mockReturnValue({
       get: mockGet
-    } as any)
+    })
   })
 
   describe('handlePointer', () => {
@@ -44,10 +44,10 @@ describe('useCanvasInteractions', () => {
         buttons: 1, // Left mouse button
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } as unknown as PointerEvent
+      } satisfies Partial<PointerEvent>
 
       // Test
-      handlePointer(mockEvent)
+      handlePointer(mockEvent as unknown as PointerEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -66,10 +66,10 @@ describe('useCanvasInteractions', () => {
         buttons: 4, // Middle mouse button
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } as unknown as PointerEvent
+      } satisfies Partial<PointerEvent>
 
       // Test
-      handlePointer(mockEvent)
+      handlePointer(mockEvent as unknown as PointerEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -88,10 +88,10 @@ describe('useCanvasInteractions', () => {
         buttons: 1, // Left mouse button
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } as unknown as PointerEvent
+      } satisfies Partial<PointerEvent>
 
       // Test
-      handlePointer(mockEvent)
+      handlePointer(mockEvent as unknown as PointerEvent)
 
       // Verify - should not prevent default (let media handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
@@ -109,12 +109,12 @@ describe('useCanvasInteractions', () => {
         buttons: 1,
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } as unknown as PointerEvent
+      } satisfies Partial<PointerEvent>
 
-      // Test - should not throw
-      expect(() => handlePointer(mockEvent)).not.toThrow()
+      // Test
+      handlePointer(mockEvent as unknown as PointerEvent)
 
-      // Verify
+      // Verify - should not prevent default when no canvas
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
     })
   })
@@ -131,10 +131,10 @@ describe('useCanvasInteractions', () => {
         ctrlKey: true,
         metaKey: false,
         preventDefault: vi.fn()
-      } as unknown as WheelEvent
+      } satisfies Partial<WheelEvent>
 
       // Test
-      handleWheel(mockEvent)
+      handleWheel(mockEvent as unknown as WheelEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -151,10 +151,10 @@ describe('useCanvasInteractions', () => {
         ctrlKey: false,
         metaKey: false,
         preventDefault: vi.fn()
-      } as unknown as WheelEvent
+      } satisfies Partial<WheelEvent>
 
       // Test
-      handleWheel(mockEvent)
+      handleWheel(mockEvent as unknown as WheelEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -171,10 +171,10 @@ describe('useCanvasInteractions', () => {
         ctrlKey: false,
         metaKey: false,
         preventDefault: vi.fn()
-      } as unknown as WheelEvent
+      } satisfies Partial<WheelEvent>
 
       // Test
-      handleWheel(mockEvent)
+      handleWheel(mockEvent as unknown as WheelEvent)
 
       // Verify - should not prevent default (let component handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -98,15 +98,15 @@ describe('useCanvasInteractions', () => {
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })
 
-    it('should handle missing canvas gracefully', () => {
+    it('should return early when canvas is null', () => {
       // Setup
       mockGetCanvas.mockReturnValue(null)
 
       const { handlePointer } = useCanvasInteractions()
 
-      // Create mock pointer event
+      // Create mock pointer event that would normally trigger forwarding
       const mockEvent = {
-        buttons: 1,
+        buttons: 1, // Left mouse button - would trigger space+drag if canvas had read_only=true
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
       } satisfies Partial<PointerEvent>
@@ -114,8 +114,10 @@ describe('useCanvasInteractions', () => {
       // Test
       handlePointer(mockEvent as unknown as PointerEvent)
 
-      // Verify - should not prevent default when no canvas
+      // Verify early return - no event methods should be called at all
+      expect(mockGetCanvas).toHaveBeenCalled()
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Summary
- Fixes ctrl+scroll zoom when cursor is over video/image previews  
- Fixes space+drag panning when cursor is over video/image previews
- Preserves existing drag behavior for node manipulation

## Technical Details
- Extended `useCanvasInteractions` composable with `handlePointer` method
- Added event listeners to video elements in `useNodeVideo` 
- Uses existing canvas space key detection (`read_only` property)
- Follows established canvas store patterns



https://github.com/user-attachments/assets/0c9427ac-78d5-4b3c-ab81-e98981640327

Related:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/4574
- https://github.com/Comfy-Org/ComfyUI_frontend/issues/2986

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5279-fix-Enable-mouse-gestures-over-video-previews-2606d73d3650812fb378d4c72eedae8b) by [Unito](https://www.unito.io)
