### PR TITLE
Update & clarify Node.js version requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Have another idea? Drop into Discord or open an issue, and let's chat!
 ### Prerequisites & Technology Stack
 
 - **Required Software**:
-  - Node.js (v16 or later; v24 strongly recommended) and pnpm
+  - Node.js (v18 or later to build; v24 for vite dev server) and pnpm
   - Git for version control
   - A running ComfyUI backend instance
   


### PR DESCRIPTION
Specifies v18+ for building, v24 for dev server.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5280-Update-clarify-Node-js-version-requirements-2606d73d365081cea022da323eb39d3d) by [Unito](https://www.unito.io)
