### PR TITLE
[bugfix] Fix invalid ManagerChannel enum value in nodepack installation

### DIFF
--- a/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
+++ b/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
@@ -110,7 +110,7 @@ const SelectedVersionValues = {
 }
 
 const ManagerChannelValues = {
-  STABLE: 'stable' as ManagerChannel,
+  DEFAULT: 'default' as ManagerChannel,
   DEV: 'dev' as ManagerChannel
 }
 
@@ -242,7 +242,7 @@ const handleSubmit = async () => {
   await managerStore.installPack.call({
     id: nodePack.id,
     repository: nodePack.repository ?? '',
-    channel: ManagerChannelValues.STABLE,
+    channel: ManagerChannelValues.DEFAULT,
     mode: ManagerDatabaseSourceValues.CACHE,
     version: actualVersion,
     selected_version: selectedVersion.value

--- a/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
+++ b/src/components/dialog/content/manager/PackVersionSelectorPopover.vue
@@ -109,15 +109,15 @@ const SelectedVersionValues = {
   NIGHTLY: 'nightly' as SelectedVersion
 }
 
-const ManagerChannelValues = {
-  DEFAULT: 'default' as ManagerChannel,
-  DEV: 'dev' as ManagerChannel
+const ManagerChannelValues: Record<string, ManagerChannel> = {
+  DEFAULT: 'default', // ✅ Valid - will compile
+  DEV: 'dev' // ✅ Valid - will compile
 }
 
-const ManagerDatabaseSourceValues = {
-  CACHE: 'cache' as ManagerDatabaseSource,
-  REMOTE: 'remote' as ManagerDatabaseSource,
-  LOCAL: 'local' as ManagerDatabaseSource
+const ManagerDatabaseSourceValues: Record<string, ManagerDatabaseSource> = {
+  CACHE: 'cache',
+  REMOTE: 'remote',
+  LOCAL: 'local'
 }
 
 const { nodePack } = defineProps<{


### PR DESCRIPTION
## Summary
- Fix nodepack installation failure caused by using invalid 'stable' channel value
- Replace 'stable' with 'default' which is a valid ManagerChannel enum value
- Update ManagerChannelValues constant to use correct enum mapping

## Problem
Nodepack installations were failing validation at the `/v2/manager/queue/task` endpoint because the frontend was sending `channel: 'stable'` but the backend ManagerChannel enum only accepts: `'default'  |  'recent' | 'legacy' | 'forked' | 'dev' | 'tutorial'`.

After, switching versions works again from the version selection popover

<img width="1032" height="368" alt="Selection_2081" src="https://github.com/user-attachments/assets/b194034a-b0fb-489a-b636-3ef5e65ee634" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5312-bugfix-Fix-invalid-ManagerChannel-enum-value-in-nodepack-installation-2636d73d3650819fbe21e290350cf03f) by [Unito](https://www.unito.io)
