### PR TITLE
fix: feature flags and manager state handling

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -272,12 +272,10 @@ export class ComfyPage {
 
   async setup({
     clearStorage = true,
-    mockReleases = true,
-    mockManagerDisabled = true
+    mockReleases = true
   }: {
     clearStorage?: boolean
     mockReleases?: boolean
-    mockManagerDisabled?: boolean
   } = {}) {
     await this.goto()
 
@@ -329,25 +327,6 @@ export class ComfyPage {
         // window['app'].extensionManager => GraphView ready
         window['app'] && window['app'].extensionManager
     )
-
-    // Mock manager feature flag AFTER app is ready
-    if (mockManagerDisabled) {
-      await this.page.evaluate(() => {
-        // Store original getServerFeature function
-        const api = window['app']?.api
-        if (api && api.getServerFeature) {
-          const originalGetServerFeature = api.getServerFeature.bind(api)
-
-          // Override to disable manager by default
-          api.getServerFeature = function (feature: string) {
-            if (feature === 'extension.manager.supports_v4') {
-              return false // Disable manager in tests
-            }
-            return originalGetServerFeature(feature)
-          }
-        }
-      })
-    }
     await this.page.waitForSelector('.p-blockui-mask', { state: 'hidden' })
     await this.nextFrame()
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,14 +15,12 @@ import ProgressSpinner from 'primevue/progressspinner'
 import { computed, onMounted } from 'vue'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
-import { useConflictDetection } from '@/composables/useConflictDetection'
 import config from '@/config'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 import { electronAPI, isElectron } from './utils/envUtil'
 
 const workspaceStore = useWorkspaceStore()
-const conflictDetection = useConflictDetection()
 const isLoading = computed<boolean>(() => workspaceStore.spinner)
 const handleKey = (e: KeyboardEvent) => {
   workspaceStore.shiftDown = e.shiftKey
@@ -49,9 +47,5 @@ onMounted(() => {
   if (isElectron()) {
     document.addEventListener('contextmenu', showContextMenu)
   }
-
-  // Initialize conflict detection in background
-  // This runs async and doesn't block UI setup
-  void conflictDetection.initializeConflictDetection()
 })
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,9 +18,11 @@ import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
+import { useConflictDetection } from './composables/useConflictDetection'
 import { electronAPI, isElectron } from './utils/envUtil'
 
 const workspaceStore = useWorkspaceStore()
+const conflictDetection = useConflictDetection()
 const isLoading = computed<boolean>(() => workspaceStore.spinner)
 const handleKey = (e: KeyboardEvent) => {
   workspaceStore.shiftDown = e.shiftKey
@@ -47,5 +49,9 @@ onMounted(() => {
   if (isElectron()) {
     document.addEventListener('contextmenu', showContextMenu)
   }
+
+  // Initialize conflict detection in background
+  // This runs async and doesn't block UI setup
+  void conflictDetection.initializeConflictDetection()
 })
 </script>

--- a/src/components/dialog/content/ErrorDialogContent.vue
+++ b/src/components/dialog/content/ErrorDialogContent.vue
@@ -105,7 +105,7 @@ const showContactSupport = async () => {
 
 onMounted(async () => {
   if (!systemStatsStore.systemStats) {
-    await systemStatsStore.fetchSystemStats()
+    await systemStatsStore.refetchSystemStats()
   }
 
   try {

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -107,12 +107,12 @@ const uniqueNodes = computed(() => {
 
 // Show manager buttons unless manager is disabled
 const showManagerButtons = computed(() => {
-  return managerState.shouldShowManagerButtons.value
+  return managerState.shouldShowManagerButtons
 })
 
 // Only show Install All button for NEW_UI (new manager with v4 support)
 const showInstallAllButton = computed(() => {
-  return managerState.shouldShowInstallButton.value
+  return managerState.shouldShowInstallButton
 })
 
 const openManager = async () => {

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -107,12 +107,12 @@ const uniqueNodes = computed(() => {
 
 // Show manager buttons unless manager is disabled
 const showManagerButtons = computed(() => {
-  return managerState.shouldShowManagerButtons
+  return managerState.shouldShowManagerButtons.value
 })
 
 // Only show Install All button for NEW_UI (new manager with v4 support)
 const showInstallAllButton = computed(() => {
-  return managerState.shouldShowInstallButton
+  return managerState.shouldShowInstallButton.value
 })
 
 const openManager = async () => {

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -115,12 +115,12 @@ const managerStateStore = useManagerStateStore()
 
 // Show manager buttons unless manager is disabled
 const showManagerButtons = computed(() => {
-  return managerStateStore.getManagerUIState() !== ManagerUIState.DISABLED
+  return managerStateStore.shouldShowManagerButtons()
 })
 
 // Only show Install All button for NEW_UI (new manager with v4 support)
 const showInstallAllButton = computed(() => {
-  return managerStateStore.getManagerUIState() === ManagerUIState.NEW_UI
+  return managerStateStore.shouldShowInstallButton()
 })
 
 const openManager = async () => {

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -58,8 +58,8 @@ import { computed } from 'vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import MissingCoreNodesMessage from '@/components/dialog/content/MissingCoreNodesMessage.vue'
 import { useMissingNodes } from '@/composables/nodePack/useMissingNodes'
+import { useManagerState } from '@/composables/useManagerState'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
-import { useManagerStateStore } from '@/stores/managerStateStore'
 import type { MissingNodeType } from '@/types/comfy'
 import { ManagerTab } from '@/types/comfyManagerTypes'
 
@@ -74,6 +74,7 @@ const { missingNodePacks, isLoading, error, missingCoreNodes } =
   useMissingNodes()
 
 const comfyManagerStore = useComfyManagerStore()
+const managerState = useManagerState()
 
 // Check if any of the missing packs are currently being installed
 const isInstalling = computed(() => {
@@ -104,20 +105,18 @@ const uniqueNodes = computed(() => {
     })
 })
 
-const managerStateStore = useManagerStateStore()
-
 // Show manager buttons unless manager is disabled
 const showManagerButtons = computed(() => {
-  return managerStateStore.shouldShowManagerButtons()
+  return managerState.shouldShowManagerButtons()
 })
 
 // Only show Install All button for NEW_UI (new manager with v4 support)
 const showInstallAllButton = computed(() => {
-  return managerStateStore.shouldShowInstallButton()
+  return managerState.shouldShowInstallButton()
 })
 
 const openManager = async () => {
-  await managerStateStore.openManager({
+  await managerState.openManager({
     initialTab: ManagerTab.Missing,
     showToastOnLegacyError: true
   })

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -54,19 +54,12 @@
 import Button from 'primevue/button'
 import ListBox from 'primevue/listbox'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import MissingCoreNodesMessage from '@/components/dialog/content/MissingCoreNodesMessage.vue'
 import { useMissingNodes } from '@/composables/nodePack/useMissingNodes'
-import { useDialogService } from '@/services/dialogService'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
-import { useCommandStore } from '@/stores/commandStore'
-import {
-  ManagerUIState,
-  useManagerStateStore
-} from '@/stores/managerStateStore'
-import { useToastStore } from '@/stores/toastStore'
+import { useManagerStateStore } from '@/stores/managerStateStore'
 import type { MissingNodeType } from '@/types/comfy'
 import { ManagerTab } from '@/types/comfyManagerTypes'
 
@@ -124,34 +117,10 @@ const showInstallAllButton = computed(() => {
 })
 
 const openManager = async () => {
-  const state = managerStateStore.getManagerUIState()
-
-  switch (state) {
-    case ManagerUIState.DISABLED:
-      useDialogService().showSettingsDialog('extension')
-      break
-
-    case ManagerUIState.LEGACY_UI:
-      try {
-        await useCommandStore().execute('Comfy.Manager.Menu.ToggleVisibility')
-      } catch {
-        // If legacy command doesn't exist, show toast
-        const { t } = useI18n()
-        useToastStore().add({
-          severity: 'error',
-          summary: t('g.error'),
-          detail: t('manager.legacyMenuNotAvailable'),
-          life: 3000
-        })
-      }
-      break
-
-    case ManagerUIState.NEW_UI:
-      useDialogService().showManagerDialog({
-        initialTab: ManagerTab.Missing
-      })
-      break
-  }
+  await managerStateStore.openManager({
+    initialTab: ManagerTab.Missing,
+    showToastOnLegacyError: true
+  })
 }
 </script>
 

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -107,12 +107,12 @@ const uniqueNodes = computed(() => {
 
 // Show manager buttons unless manager is disabled
 const showManagerButtons = computed(() => {
-  return managerState.shouldShowManagerButtons()
+  return managerState.shouldShowManagerButtons.value
 })
 
 // Only show Install All button for NEW_UI (new manager with v4 support)
 const showInstallAllButton = computed(() => {
-  return managerState.shouldShowInstallButton()
+  return managerState.shouldShowInstallButton.value
 })
 
 const openManager = async () => {

--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -115,16 +115,16 @@ const managerStateStore = useManagerStateStore()
 
 // Show manager buttons unless manager is disabled
 const showManagerButtons = computed(() => {
-  return managerStateStore.managerUIState !== ManagerUIState.DISABLED
+  return managerStateStore.getManagerUIState() !== ManagerUIState.DISABLED
 })
 
 // Only show Install All button for NEW_UI (new manager with v4 support)
 const showInstallAllButton = computed(() => {
-  return managerStateStore.managerUIState === ManagerUIState.NEW_UI
+  return managerStateStore.getManagerUIState() === ManagerUIState.NEW_UI
 })
 
 const openManager = async () => {
-  const state = managerStateStore.managerUIState
+  const state = managerStateStore.getManagerUIState()
 
   switch (state) {
     case ManagerUIState.DISABLED:

--- a/src/components/dialog/content/MissingCoreNodesMessage.vue
+++ b/src/components/dialog/content/MissingCoreNodesMessage.vue
@@ -42,9 +42,8 @@
 </template>
 
 <script setup lang="ts">
-import { whenever } from '@vueuse/core'
 import Message from 'primevue/message'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
@@ -60,20 +59,11 @@ const hasMissingCoreNodes = computed(() => {
   return Object.keys(props.missingCoreNodes).length > 0
 })
 
-const currentComfyUIVersion = ref<string | null>(null)
-whenever(
-  hasMissingCoreNodes,
-  async () => {
-    if (!systemStatsStore.systemStats) {
-      await systemStatsStore.fetchSystemStats()
-    }
-    currentComfyUIVersion.value =
-      systemStatsStore.systemStats?.system?.comfyui_version ?? null
-  },
-  {
-    immediate: true
-  }
-)
+// Use computed for reactive version tracking
+const currentComfyUIVersion = computed<string | null>(() => {
+  if (!hasMissingCoreNodes.value) return null
+  return systemStatsStore.systemStats?.system?.comfyui_version ?? null
+})
 
 const sortedMissingCoreNodes = computed(() => {
   return Object.entries(props.missingCoreNodes).sort(([a], [b]) => {

--- a/src/components/dialog/content/setting/AboutPanel.vue
+++ b/src/components/dialog/content/setting/AboutPanel.vue
@@ -34,7 +34,6 @@
 <script setup lang="ts">
 import Divider from 'primevue/divider'
 import Tag from 'primevue/tag'
-import { onMounted } from 'vue'
 
 import SystemStatsPanel from '@/components/common/SystemStatsPanel.vue'
 import { useAboutPanelStore } from '@/stores/aboutPanelStore'
@@ -44,10 +43,4 @@ import PanelTemplate from './PanelTemplate.vue'
 
 const systemStatsStore = useSystemStatsStore()
 const aboutPanelStore = useAboutPanelStore()
-
-onMounted(async () => {
-  if (!systemStatsStore.systemStats) {
-    await systemStatsStore.fetchSystemStats()
-  }
-})
 </script>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -106,6 +106,7 @@ import { useContextMenuTranslation } from '@/composables/useContextMenuTranslati
 import { useCopy } from '@/composables/useCopy'
 import { useGlobalLitegraph } from '@/composables/useGlobalLitegraph'
 import { useLitegraphSettings } from '@/composables/useLitegraphSettings'
+import { useManagerState } from '@/composables/useManagerState'
 import { usePaste } from '@/composables/usePaste'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import { useWorkflowAutoSave } from '@/composables/useWorkflowAutoSave'
@@ -420,7 +421,9 @@ onMounted(async () => {
   // Initialize conflict detection after GraphCanvas is ready
   // This ensures SystemStats and Manager state are properly loaded
   const conflictDetection = useConflictDetection()
-  void conflictDetection.initializeConflictDetection()
+  const managerState = useManagerState()
+  if (managerState.isManagerEnabled.value)
+    void conflictDetection.initializeConflictDetection()
 
   // Start watching for locale change after the initial value is loaded.
   watch(

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -420,10 +420,10 @@ onMounted(async () => {
 
   // Initialize conflict detection after GraphCanvas is ready
   // This ensures SystemStats and Manager state are properly loaded
-  const conflictDetection = useConflictDetection()
+  // Also This ensures ComfyApp is initialized which implies ComfyApi.init was called and feature flags were negotiated
   const managerState = useManagerState()
   if (managerState.isManagerEnabled.value)
-    void conflictDetection.initializeConflictDetection()
+    void useConflictDetection().initializeConflictDetection()
 
   // Start watching for locale change after the initial value is loaded.
   watch(

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -101,12 +101,10 @@ import { useViewportCulling } from '@/composables/graph/useViewportCulling'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
-import { useConflictDetection } from '@/composables/useConflictDetection'
 import { useContextMenuTranslation } from '@/composables/useContextMenuTranslation'
 import { useCopy } from '@/composables/useCopy'
 import { useGlobalLitegraph } from '@/composables/useGlobalLitegraph'
 import { useLitegraphSettings } from '@/composables/useLitegraphSettings'
-import { useManagerState } from '@/composables/useManagerState'
 import { usePaste } from '@/composables/usePaste'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import { useWorkflowAutoSave } from '@/composables/useWorkflowAutoSave'
@@ -417,13 +415,6 @@ onMounted(async () => {
   const { useReleaseStore } = await import('@/stores/releaseStore')
   const releaseStore = useReleaseStore()
   void releaseStore.initialize()
-
-  // Initialize conflict detection after GraphCanvas is ready
-  // This ensures SystemStats and Manager state are properly loaded
-  // Also This ensures ComfyApp is initialized which implies ComfyApi.init was called and feature flags were negotiated
-  const managerState = useManagerState()
-  if (managerState.isManagerEnabled.value)
-    void useConflictDetection().initializeConflictDetection()
 
   // Start watching for locale change after the initial value is loaded.
   watch(

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -101,6 +101,7 @@ import { useViewportCulling } from '@/composables/graph/useViewportCulling'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
+import { useConflictDetection } from '@/composables/useConflictDetection'
 import { useContextMenuTranslation } from '@/composables/useContextMenuTranslation'
 import { useCopy } from '@/composables/useCopy'
 import { useGlobalLitegraph } from '@/composables/useGlobalLitegraph'
@@ -415,6 +416,11 @@ onMounted(async () => {
   const { useReleaseStore } = await import('@/stores/releaseStore')
   const releaseStore = useReleaseStore()
   void releaseStore.initialize()
+
+  // Initialize conflict detection after GraphCanvas is ready
+  // This ensures SystemStats and Manager state are properly loaded
+  const conflictDetection = useConflictDetection()
+  void conflictDetection.initializeConflictDetection()
 
   // Start watching for locale change after the initial value is loaded.
   watch(

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -142,9 +142,9 @@ import { useI18n } from 'vue-i18n'
 
 import PuzzleIcon from '@/components/icons/PuzzleIcon.vue'
 import { useConflictAcknowledgment } from '@/composables/useConflictAcknowledgment'
+import { useManagerState } from '@/composables/useManagerState'
 import { type ReleaseNote } from '@/services/releaseService'
 import { useCommandStore } from '@/stores/commandStore'
-import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useReleaseStore } from '@/stores/releaseStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { ManagerTab } from '@/types/comfyManagerTypes'
@@ -314,7 +314,7 @@ const menuItems = computed<MenuItem[]>(() => {
       label: t('helpCenter.managerExtension'),
       showRedDot: shouldShowManagerRedDot.value,
       action: async () => {
-        await useManagerStateStore().openManager({
+        await useManagerState().openManager({
           initialTab: ManagerTab.All,
           showToastOnLegacyError: false
         })

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -147,6 +147,7 @@ import { useCommandStore } from '@/stores/commandStore'
 import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useReleaseStore } from '@/stores/releaseStore'
 import { useSettingStore } from '@/stores/settingStore'
+import { ManagerTab } from '@/types/comfyManagerTypes'
 import { electronAPI, isElectron } from '@/utils/envUtil'
 import { formatVersionAnchor } from '@/utils/formatUtil'
 
@@ -314,6 +315,7 @@ const menuItems = computed<MenuItem[]>(() => {
       showRedDot: shouldShowManagerRedDot.value,
       action: async () => {
         await useManagerStateStore().openManager({
+          initialTab: ManagerTab.All,
           showToastOnLegacyError: false
         })
         emit('close')

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -142,13 +142,9 @@ import { useI18n } from 'vue-i18n'
 
 import PuzzleIcon from '@/components/icons/PuzzleIcon.vue'
 import { useConflictAcknowledgment } from '@/composables/useConflictAcknowledgment'
-import { useDialogService } from '@/services/dialogService'
 import { type ReleaseNote } from '@/services/releaseService'
 import { useCommandStore } from '@/stores/commandStore'
-import {
-  ManagerUIState,
-  useManagerStateStore
-} from '@/stores/managerStateStore'
+import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useReleaseStore } from '@/stores/releaseStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { electronAPI, isElectron } from '@/utils/envUtil'
@@ -195,7 +191,6 @@ const { t, locale } = useI18n()
 const releaseStore = useReleaseStore()
 const commandStore = useCommandStore()
 const settingStore = useSettingStore()
-const dialogService = useDialogService()
 
 // Emits
 const emit = defineEmits<{
@@ -318,28 +313,9 @@ const menuItems = computed<MenuItem[]>(() => {
       label: t('helpCenter.managerExtension'),
       showRedDot: shouldShowManagerRedDot.value,
       action: async () => {
-        const managerState = useManagerStateStore().getManagerUIState()
-
-        switch (managerState) {
-          case ManagerUIState.DISABLED:
-            dialogService.showSettingsDialog('extension')
-            break
-
-          case ManagerUIState.LEGACY_UI:
-            try {
-              await useCommandStore().execute(
-                'Comfy.Manager.Menu.ToggleVisibility'
-              )
-            } catch {
-              // If legacy command doesn't exist, fall back to extensions panel
-              dialogService.showSettingsDialog('extension')
-            }
-            break
-
-          case ManagerUIState.NEW_UI:
-            dialogService.showManagerDialog()
-            break
-        }
+        await useManagerStateStore().openManager({
+          showToastOnLegacyError: false
+        })
         emit('close')
       }
     },

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -84,13 +84,9 @@ import SubgraphBreadcrumb from '@/components/breadcrumb/SubgraphBreadcrumb.vue'
 import SettingDialogContent from '@/components/dialog/content/SettingDialogContent.vue'
 import SettingDialogHeader from '@/components/dialog/header/SettingDialogHeader.vue'
 import { useColorPaletteService } from '@/services/colorPaletteService'
-import { useDialogService } from '@/services/dialogService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
-import {
-  ManagerUIState,
-  useManagerStateStore
-} from '@/stores/managerStateStore'
+import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
@@ -141,26 +137,7 @@ const showSettings = (defaultPanel?: string) => {
 const managerStateStore = useManagerStateStore()
 
 const showManageExtensions = async () => {
-  const state = managerStateStore.getManagerUIState()
-
-  switch (state) {
-    case ManagerUIState.DISABLED:
-      showSettings('extension')
-      break
-
-    case ManagerUIState.LEGACY_UI:
-      try {
-        await commandStore.execute('Comfy.Manager.Menu.ToggleVisibility')
-      } catch {
-        // If legacy command doesn't exist, fall back to extensions panel
-        showSettings('extension')
-      }
-      break
-
-    case ManagerUIState.NEW_UI:
-      useDialogService().showManagerDialog()
-      break
-  }
+  await managerStateStore.openManager({ showToastOnLegacyError: false })
 }
 
 const themeMenuItems = computed(() => {

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -83,10 +83,10 @@ import { useI18n } from 'vue-i18n'
 import SubgraphBreadcrumb from '@/components/breadcrumb/SubgraphBreadcrumb.vue'
 import SettingDialogContent from '@/components/dialog/content/SettingDialogContent.vue'
 import SettingDialogHeader from '@/components/dialog/header/SettingDialogHeader.vue'
+import { useManagerState } from '@/composables/useManagerState'
 import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
-import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
@@ -102,6 +102,8 @@ const commandStore = useCommandStore()
 const dialogStore = useDialogStore()
 const settingStore = useSettingStore()
 const { t } = useI18n()
+
+const managerState = useManagerState()
 
 const menuRef = ref<
   ({ dirty: boolean } & TieredMenuMethods & TieredMenuState) | null
@@ -135,10 +137,8 @@ const showSettings = (defaultPanel?: string) => {
   })
 }
 
-const managerStateStore = useManagerStateStore()
-
 const showManageExtensions = async () => {
-  await managerStateStore.openManager({
+  await managerState.openManager({
     initialTab: ManagerTab.All,
     showToastOnLegacyError: false
   })

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -90,6 +90,7 @@ import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+import { ManagerTab } from '@/types/comfyManagerTypes'
 import { showNativeSystemMenu } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 import { whileMouseDown } from '@/utils/mouseDownUtil'
@@ -137,7 +138,10 @@ const showSettings = (defaultPanel?: string) => {
 const managerStateStore = useManagerStateStore()
 
 const showManageExtensions = async () => {
-  await managerStateStore.openManager({ showToastOnLegacyError: false })
+  await managerStateStore.openManager({
+    initialTab: ManagerTab.All,
+    showToastOnLegacyError: false
+  })
 }
 
 const themeMenuItems = computed(() => {

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -141,7 +141,7 @@ const showSettings = (defaultPanel?: string) => {
 const managerStateStore = useManagerStateStore()
 
 const showManageExtensions = async () => {
-  const state = managerStateStore.managerUIState
+  const state = managerStateStore.getManagerUIState()
 
   switch (state) {
     case ManagerUIState.DISABLED:

--- a/src/composables/nodePack/useWorkflowPacks.ts
+++ b/src/composables/nodePack/useWorkflowPacks.ts
@@ -61,7 +61,7 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
     const nodeDef = nodeDefStore.nodeDefsByName[nodeName]
     if (nodeDef?.nodeSource.type === 'core') {
       if (!systemStatsStore.systemStats) {
-        await systemStatsStore.fetchSystemStats()
+        await systemStatsStore.refetchSystemStats()
       }
       return {
         id: CORE_NODES_PACK_NAME,

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -80,7 +80,7 @@ export function useConflictDetection() {
       const systemStatsStore = useSystemStatsStore()
       // Wait for systemStats to be initialized if not already
       if (!systemStatsStore.isInitialized) {
-        await systemStatsStore.fetchSystemStats()
+        await systemStatsStore.refetchSystemStats()
       }
 
       // Fetch version information from backend (with error resilience)

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -640,18 +640,18 @@ export function useConflictDetection() {
    */
   async function initializeConflictDetection(): Promise<void> {
     try {
-      // Check if manager is enabled before proceeding
+      // Check if manager is new Manager before proceeding
       const { useManagerState } = await import('@/composables/useManagerState')
       const managerState = useManagerState()
 
-      if (!managerState.isManagerEnabled.value) {
+      if (!managerState.isNewManagerUI.value) {
         console.debug(
-          '[ConflictDetection] Manager is disabled, skipping conflict detection'
+          '[ConflictDetection] Manager is not new Manager, skipping conflict detection'
         )
         return
       }
 
-      // Manager is enabled, perform conflict detection
+      // Manager is new Manager, perform conflict detection
       // The useInstalledPacks will handle fetching installed list if needed
       await performConflictDetection()
     } catch (error) {

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -3,7 +3,6 @@ import { computed, getCurrentInstance, onUnmounted, readonly, ref } from 'vue'
 
 import { useInstalledPacks } from '@/composables/nodePack/useInstalledPacks'
 import { useConflictAcknowledgment } from '@/composables/useConflictAcknowledgment'
-import { useManagerState } from '@/composables/useManagerState'
 import config from '@/config'
 import { useComfyManagerService } from '@/services/comfyManagerService'
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
@@ -637,15 +636,6 @@ export function useConflictDetection() {
    */
   async function initializeConflictDetection(): Promise<void> {
     try {
-      // Check if manager is disabled before running conflict detection
-      const managerState = useManagerState()
-      if (!managerState.isManagerEnabled.value) {
-        console.log(
-          '[ConflictDetection] Manager is disabled, skipping conflict detection'
-        )
-        return
-      }
-
       // Simply perform conflict detection
       // The useInstalledPacks will handle fetching installed list if needed
       await performConflictDetection()

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -636,7 +636,7 @@ export function useConflictDetection() {
   /**
    * Error-resilient initialization (called on app mount).
    * Async function that doesn't block UI setup.
-   * Ensures proper order: installed -> system_stats -> versions bulk -> import_fail_info_bulk
+   * Ensures proper order: system_stats -> manager state -> installed -> versions bulk -> import_fail_info_bulk
    */
   async function initializeConflictDetection(): Promise<void> {
     try {

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -8,6 +8,7 @@ import { useComfyManagerService } from '@/services/comfyManagerService'
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import { useConflictDetectionStore } from '@/stores/conflictDetectionStore'
+import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { SystemStats } from '@/types'
 import type { components } from '@/types/comfyRegistryTypes'
@@ -636,6 +637,15 @@ export function useConflictDetection() {
    */
   async function initializeConflictDetection(): Promise<void> {
     try {
+      // Check if manager is disabled before running conflict detection
+      const managerStore = useManagerStateStore()
+      if (!managerStore.isManagerEnabled()) {
+        console.log(
+          '[ConflictDetection] Manager is disabled, skipping conflict detection'
+        )
+        return
+      }
+
       // Simply perform conflict detection
       // The useInstalledPacks will handle fetching installed list if needed
       await performConflictDetection()

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -1,3 +1,4 @@
+import { until } from '@vueuse/core'
 import { uniqBy } from 'es-toolkit/compat'
 import { computed, getCurrentInstance, onUnmounted, readonly, ref } from 'vue'
 
@@ -79,9 +80,7 @@ export function useConflictDetection() {
       // Get system stats from store (primary source of system information)
       const systemStatsStore = useSystemStatsStore()
       // Wait for systemStats to be initialized if not already
-      if (!systemStatsStore.isInitialized) {
-        await systemStatsStore.refetchSystemStats()
-      }
+      await until(systemStatsStore.isInitialized)
 
       // Fetch version information from backend (with error resilience)
       const [frontendVersion] = await Promise.allSettled([

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -3,12 +3,12 @@ import { computed, getCurrentInstance, onUnmounted, readonly, ref } from 'vue'
 
 import { useInstalledPacks } from '@/composables/nodePack/useInstalledPacks'
 import { useConflictAcknowledgment } from '@/composables/useConflictAcknowledgment'
+import { useManagerState } from '@/composables/useManagerState'
 import config from '@/config'
 import { useComfyManagerService } from '@/services/comfyManagerService'
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
 import { useComfyManagerStore } from '@/stores/comfyManagerStore'
 import { useConflictDetectionStore } from '@/stores/conflictDetectionStore'
-import { useManagerStateStore } from '@/stores/managerStateStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { SystemStats } from '@/types'
 import type { components } from '@/types/comfyRegistryTypes'
@@ -638,8 +638,8 @@ export function useConflictDetection() {
   async function initializeConflictDetection(): Promise<void> {
     try {
       // Check if manager is disabled before running conflict detection
-      const managerStore = useManagerStateStore()
-      if (!managerStore.isManagerEnabled()) {
+      const managerState = useManagerState()
+      if (!managerState.isManagerEnabled()) {
         console.log(
           '[ConflictDetection] Manager is disabled, skipping conflict detection'
         )

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -127,7 +127,7 @@ export function useConflictDetection() {
       }
 
       systemEnvironment.value = environment
-      console.log(
+      console.debug(
         '[ConflictDetection] System environment detection completed:',
         environment
       )
@@ -427,7 +427,7 @@ export function useConflictDetection() {
         Object.entries(bulkResult).forEach(([packageId, failInfo]) => {
           if (failInfo !== null) {
             importFailures[packageId] = failInfo
-            console.log(
+            console.debug(
               `[ConflictDetection] Import failure found for ${packageId}:`,
               failInfo
             )
@@ -500,7 +500,7 @@ export function useConflictDetection() {
    */
   async function performConflictDetection(): Promise<ConflictDetectionResponse> {
     if (isDetecting.value) {
-      console.log('[ConflictDetection] Already detecting, skipping')
+      console.debug('[ConflictDetection] Already detecting, skipping')
       return {
         success: false,
         error_message: 'Already detecting conflicts',
@@ -556,7 +556,10 @@ export function useConflictDetection() {
       detectionSummary.value = summary
       lastDetectionTime.value = new Date().toISOString()
 
-      console.log('[ConflictDetection] Conflict detection completed:', summary)
+      console.debug(
+        '[ConflictDetection] Conflict detection completed:',
+        summary
+      )
 
       // Store conflict results for later UI display
       // Dialog will be shown based on specific events, not on app mount
@@ -568,7 +571,7 @@ export function useConflictDetection() {
         // Merge conflicts for packages with the same name
         const mergedConflicts = mergeConflictsByPackageName(conflictedResults)
 
-        console.log(
+        console.debug(
           '[ConflictDetection] Conflicts detected (stored for UI):',
           mergedConflicts
         )
@@ -671,13 +674,13 @@ export function useConflictDetection() {
    * Check if conflicts should trigger modal display after "What's New" dismissal
    */
   async function shouldShowConflictModalAfterUpdate(): Promise<boolean> {
-    console.log(
+    console.debug(
       '[ConflictDetection] Checking if conflict modal should show after update...'
     )
 
     // Ensure conflict detection has run
     if (detectionResults.value.length === 0) {
-      console.log(
+      console.debug(
         '[ConflictDetection] No detection results, running conflict detection...'
       )
       await performConflictDetection()
@@ -689,7 +692,7 @@ export function useConflictDetection() {
     const hasActualConflicts = hasConflicts.value
     const canShowModal = acknowledgment.shouldShowConflictModal.value
 
-    console.log('[ConflictDetection] Modal check:', {
+    console.debug('[ConflictDetection] Modal check:', {
       hasConflicts: hasActualConflicts,
       canShowModal: canShowModal,
       conflictedPackagesCount: conflictedPackages.value.length

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -639,7 +639,7 @@ export function useConflictDetection() {
     try {
       // Check if manager is disabled before running conflict detection
       const managerState = useManagerState()
-      if (!managerState.isManagerEnabled()) {
+      if (!managerState.isManagerEnabled.value) {
         console.log(
           '[ConflictDetection] Manager is disabled, skipping conflict detection'
         )

--- a/src/composables/useConflictDetection.ts
+++ b/src/composables/useConflictDetection.ts
@@ -78,7 +78,8 @@ export function useConflictDetection() {
     try {
       // Get system stats from store (primary source of system information)
       const systemStatsStore = useSystemStatsStore()
-      if (!systemStatsStore.systemStats) {
+      // Wait for systemStats to be initialized if not already
+      if (!systemStatsStore.isInitialized) {
         await systemStatsStore.fetchSystemStats()
       }
 
@@ -639,7 +640,18 @@ export function useConflictDetection() {
    */
   async function initializeConflictDetection(): Promise<void> {
     try {
-      // Simply perform conflict detection
+      // Check if manager is enabled before proceeding
+      const { useManagerState } = await import('@/composables/useManagerState')
+      const managerState = useManagerState()
+
+      if (!managerState.isManagerEnabled.value) {
+        console.debug(
+          '[ConflictDetection] Manager is disabled, skipping conflict detection'
+        )
+        return
+      }
+
+      // Manager is enabled, perform conflict detection
       // The useInstalledPacks will handle fetching installed list if needed
       await performConflictDetection()
     } catch (error) {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1,5 +1,6 @@
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
+import { ManagerUIState, useManagerState } from '@/composables/useManagerState'
 import { useModelSelectorDialog } from '@/composables/useModelSelectorDialog'
 import {
   DEFAULT_DARK_COLOR_PALETTE,
@@ -24,10 +25,6 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { useCanvasStore, useTitleEditorStore } from '@/stores/graphStore'
 import { useHelpCenterStore } from '@/stores/helpCenterStore'
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
-import {
-  ManagerUIState,
-  useManagerStateStore
-} from '@/stores/managerStateStore'
 import { useQueueSettingsStore, useQueueStore } from '@/stores/queueStore'
 import { useSettingStore } from '@/stores/settingStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
@@ -731,7 +728,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Custom Nodes Manager',
       versionAdded: '1.12.10',
       function: async () => {
-        await useManagerStateStore().openManager({
+        await useManagerState().openManager({
           showToastOnLegacyError: true
         })
       }
@@ -742,8 +739,8 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Check for Custom Node Updates',
       versionAdded: '1.17.0',
       function: async () => {
-        const managerStore = useManagerStateStore()
-        const state = managerStore.getManagerUIState()
+        const managerState = useManagerState()
+        const state = managerState.getManagerUIState()
 
         // For DISABLED state, show error toast instead of opening settings
         if (state === ManagerUIState.DISABLED) {
@@ -756,7 +753,7 @@ export function useCoreCommands(): ComfyCommand[] {
           return
         }
 
-        await managerStore.openManager({
+        await managerState.openManager({
           initialTab: ManagerTab.UpdateAvailable,
           showToastOnLegacyError: false
         })
@@ -768,7 +765,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Install Missing Custom Nodes',
       versionAdded: '1.17.0',
       function: async () => {
-        await useManagerStateStore().openManager({
+        await useManagerState().openManager({
           initialTab: ManagerTab.Missing,
           showToastOnLegacyError: false
         })
@@ -878,7 +875,7 @@ export function useCoreCommands(): ComfyCommand[] {
       icon: 'mdi mdi-puzzle-outline',
       label: 'Manager',
       function: async () => {
-        await useManagerStateStore().openManager({
+        await useManagerState().openManager({
           initialTab: ManagerTab.All,
           showToastOnLegacyError: false
         })
@@ -946,7 +943,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Custom Nodes (Legacy)',
       versionAdded: '1.16.4',
       function: async () => {
-        await useManagerStateStore().openManager({
+        await useManagerState().openManager({
           legacyCommand: 'Comfy.Manager.CustomNodesManager.ToggleVisibility',
           showToastOnLegacyError: true,
           isLegacyOnly: true
@@ -959,7 +956,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Manager Menu (Legacy)',
       versionAdded: '1.16.4',
       function: async () => {
-        await useManagerStateStore().openManager({
+        await useManagerState().openManager({
           showToastOnLegacyError: true,
           isLegacyOnly: true
         })

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -933,8 +933,29 @@ export function useCoreCommands(): ComfyCommand[] {
       id: 'Comfy.OpenManagerDialog',
       icon: 'mdi mdi-puzzle-outline',
       label: 'Manager',
-      function: () => {
-        dialogService.showManagerDialog()
+      function: async () => {
+        const managerState = useManagerStateStore().getManagerUIState()
+
+        switch (managerState) {
+          case ManagerUIState.DISABLED:
+            dialogService.showSettingsDialog('extension')
+            break
+
+          case ManagerUIState.LEGACY_UI:
+            try {
+              await useCommandStore().execute(
+                'Comfy.Manager.Menu.ToggleVisibility'
+              )
+            } catch {
+              // If legacy command doesn't exist, fall back to extensions panel
+              dialogService.showSettingsDialog('extension')
+            }
+            break
+
+          case ManagerUIState.NEW_UI:
+            dialogService.showManagerDialog()
+            break
+        }
       }
     },
     {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -756,7 +756,10 @@ export function useCoreCommands(): ComfyCommand[] {
           return
         }
 
-        await managerStore.openManager({ showToastOnLegacyError: false })
+        await managerStore.openManager({
+          initialTab: ManagerTab.UpdateAvailable,
+          showToastOnLegacyError: false
+        })
       }
     },
     {
@@ -876,6 +879,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Manager',
       function: async () => {
         await useManagerStateStore().openManager({
+          initialTab: ManagerTab.All,
           showToastOnLegacyError: false
         })
       }

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1020,17 +1020,37 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Custom Nodes (Legacy)',
       versionAdded: '1.16.4',
       function: async () => {
-        try {
-          await useCommandStore().execute(
-            'Comfy.Manager.CustomNodesManager.ToggleVisibility'
-          )
-        } catch (error) {
-          useToastStore().add({
-            severity: 'error',
-            summary: t('g.error'),
-            detail: t('manager.legacyMenuNotAvailable'),
-            life: 3000
-          })
+        const managerState = useManagerStateStore().getManagerUIState()
+
+        switch (managerState) {
+          case ManagerUIState.DISABLED:
+            dialogService.showSettingsDialog('extension')
+            break
+
+          case ManagerUIState.LEGACY_UI:
+            try {
+              await useCommandStore().execute(
+                'Comfy.Manager.CustomNodesManager.ToggleVisibility'
+              )
+            } catch (error) {
+              useToastStore().add({
+                severity: 'error',
+                summary: t('g.error'),
+                detail: t('manager.legacyMenuNotAvailable'),
+                life: 3000
+              })
+            }
+            break
+
+          case ManagerUIState.NEW_UI:
+            // Legacy command is not available in NEW_UI mode
+            useToastStore().add({
+              severity: 'error',
+              summary: t('g.error'),
+              detail: t('manager.legacyMenuNotAvailable'),
+              life: 3000
+            })
+            break
         }
       }
     },
@@ -1040,15 +1060,37 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Manager Menu (Legacy)',
       versionAdded: '1.16.4',
       function: async () => {
-        try {
-          await useCommandStore().execute('Comfy.Manager.Menu.ToggleVisibility')
-        } catch (error) {
-          useToastStore().add({
-            severity: 'error',
-            summary: t('g.error'),
-            detail: t('manager.legacyMenuNotAvailable'),
-            life: 3000
-          })
+        const managerState = useManagerStateStore().getManagerUIState()
+
+        switch (managerState) {
+          case ManagerUIState.DISABLED:
+            dialogService.showSettingsDialog('extension')
+            break
+
+          case ManagerUIState.LEGACY_UI:
+            try {
+              await useCommandStore().execute(
+                'Comfy.Manager.Menu.ToggleVisibility'
+              )
+            } catch (error) {
+              useToastStore().add({
+                severity: 'error',
+                summary: t('g.error'),
+                detail: t('manager.legacyMenuNotAvailable'),
+                life: 3000
+              })
+            }
+            break
+
+          case ManagerUIState.NEW_UI:
+            // Legacy command is not available in NEW_UI mode
+            useToastStore().add({
+              severity: 'error',
+              summary: t('g.error'),
+              detail: t('manager.legacyMenuNotAvailable'),
+              life: 3000
+            })
+            break
         }
       }
     },

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -732,7 +732,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Custom Nodes Manager',
       versionAdded: '1.12.10',
       function: async () => {
-        const managerState = useManagerStateStore().managerUIState
+        const managerState = useManagerStateStore().getManagerUIState()
 
         switch (managerState) {
           case ManagerUIState.DISABLED:
@@ -769,7 +769,7 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.17.0',
       function: () => {
         const managerStore = useManagerStateStore()
-        const state = managerStore.managerUIState
+        const state = managerStore.getManagerUIState()
 
         switch (state) {
           case ManagerUIState.DISABLED:
@@ -803,7 +803,7 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.17.0',
       function: async () => {
         const managerStore = useManagerStateStore()
-        const state = managerStore.managerUIState
+        const state = managerStore.getManagerUIState()
 
         switch (state) {
           case ManagerUIState.DISABLED:

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -740,7 +740,7 @@ export function useCoreCommands(): ComfyCommand[] {
       versionAdded: '1.17.0',
       function: async () => {
         const managerState = useManagerState()
-        const state = managerState.getManagerUIState()
+        const state = managerState.managerUIState.value
 
         // For DISABLED state, show error toast instead of opening settings
         if (state === ManagerUIState.DISABLED) {

--- a/src/composables/useManagerState.ts
+++ b/src/composables/useManagerState.ts
@@ -1,5 +1,3 @@
-import { defineStore } from 'pinia'
-
 import { t } from '@/i18n'
 import { api } from '@/scripts/api'
 import { useDialogService } from '@/services/dialogService'
@@ -14,7 +12,7 @@ export enum ManagerUIState {
   NEW_UI = 'new'
 }
 
-export const useManagerStateStore = defineStore('managerState', () => {
+export function useManagerState() {
   const systemStatsStore = useSystemStatsStore()
 
   /**
@@ -179,4 +177,4 @@ export const useManagerStateStore = defineStore('managerState', () => {
     shouldShowManagerButtons,
     openManager
   }
-})
+}

--- a/src/composables/useManagerState.ts
+++ b/src/composables/useManagerState.ts
@@ -26,7 +26,7 @@ export function useManagerState() {
     computed((): ManagerUIState => {
       // Wait for systemStats to be initialized
       if (!systemStatsStore.isInitialized) {
-        // Default to NEW_UI while loading
+        // Default to DISABLED while loading
         return ManagerUIState.DISABLED
       }
 

--- a/src/composables/useManagerState.ts
+++ b/src/composables/useManagerState.ts
@@ -28,7 +28,7 @@ export function useManagerState() {
   const managerUIState = readonly(
     computed((): ManagerUIState => {
       // Wait for systemStats to be initialized
-      if (!systemInitialized) {
+      if (!systemInitialized.value) {
         // Default to DISABLED while loading
         return ManagerUIState.DISABLED
       }

--- a/src/composables/useManagerState.ts
+++ b/src/composables/useManagerState.ts
@@ -1,3 +1,5 @@
+import { computed, readonly } from 'vue'
+
 import { t } from '@/i18n'
 import { api } from '@/scripts/api'
 import { useDialogService } from '@/services/dialogService'
@@ -16,92 +18,102 @@ export function useManagerState() {
   const systemStatsStore = useSystemStatsStore()
 
   /**
-   * Get the current manager UI state.
-   * This is NOT reactive - it computes the value fresh each time it's called.
-   * This ensures we always get the latest state without timing issues.
+   * The current manager UI state.
+   * Computed once and cached until dependencies change (which they don't during runtime).
+   * This follows Vue's conventions and provides better performance through caching.
    */
-  const getManagerUIState = (): ManagerUIState => {
-    // Get current values at the time of function call
-    const systemStats = systemStatsStore.systemStats
-    const clientSupportsV4 =
-      api.getClientFeatureFlags().supports_manager_v4_ui ?? false
+  const managerUIState = readonly(
+    computed((): ManagerUIState => {
+      // Get current values
+      const systemStats = systemStatsStore.systemStats
+      const clientSupportsV4 =
+        api.getClientFeatureFlags().supports_manager_v4_ui ?? false
 
-    const serverSupportsV4 = api.getServerFeature(
-      'extension.manager.supports_v4'
-    )
+      const serverSupportsV4 = api.getServerFeature(
+        'extension.manager.supports_v4'
+      )
 
-    // Check command line args first (highest priority)
-    if (systemStats?.system?.argv?.includes('--disable-manager')) {
+      // Check command line args first (highest priority)
+      if (systemStats?.system?.argv?.includes('--disable-manager')) {
+        return ManagerUIState.DISABLED
+      }
+
+      if (systemStats?.system?.argv?.includes('--enable-manager-legacy-ui')) {
+        return ManagerUIState.LEGACY_UI
+      }
+
+      // Both client and server support v4 = NEW_UI
+      if (clientSupportsV4 && serverSupportsV4 === true) {
+        return ManagerUIState.NEW_UI
+      }
+
+      // Server supports v4 but client doesn't = LEGACY_UI
+      if (serverSupportsV4 === true && !clientSupportsV4) {
+        return ManagerUIState.LEGACY_UI
+      }
+
+      // Server explicitly doesn't support v4 = LEGACY_UI
+      if (serverSupportsV4 === false) {
+        return ManagerUIState.LEGACY_UI
+      }
+
+      // If server feature flags haven't loaded yet, default to NEW_UI
+      // This is a temporary state - feature flags are exchanged immediately on WebSocket connection
+      // NEW_UI is the safest default since v2 API is the current standard
+      // If the server doesn't support v2, API calls will fail with 404 and be handled gracefully
+      if (serverSupportsV4 === undefined) {
+        return ManagerUIState.NEW_UI
+      }
+
+      // Should never reach here, but if we do, disable manager
       return ManagerUIState.DISABLED
-    }
-
-    if (systemStats?.system?.argv?.includes('--enable-manager-legacy-ui')) {
-      return ManagerUIState.LEGACY_UI
-    }
-
-    // Both client and server support v4 = NEW_UI
-    if (clientSupportsV4 && serverSupportsV4 === true) {
-      return ManagerUIState.NEW_UI
-    }
-
-    // Server supports v4 but client doesn't = LEGACY_UI
-    if (serverSupportsV4 === true && !clientSupportsV4) {
-      return ManagerUIState.LEGACY_UI
-    }
-
-    // Server explicitly doesn't support v4 = LEGACY_UI
-    if (serverSupportsV4 === false) {
-      return ManagerUIState.LEGACY_UI
-    }
-
-    // If server feature flags haven't loaded yet, default to NEW_UI
-    // This is a temporary state - feature flags are exchanged immediately on WebSocket connection
-    // NEW_UI is the safest default since v2 API is the current standard
-    // If the server doesn't support v2, API calls will fail with 404 and be handled gracefully
-    if (serverSupportsV4 === undefined) {
-      return ManagerUIState.NEW_UI
-    }
-
-    // Should never reach here, but if we do, disable manager
-    return ManagerUIState.DISABLED
-  }
+    })
+  )
 
   /**
-   * Helper function to check if manager is enabled (not DISABLED)
+   * Check if manager is enabled (not DISABLED)
    */
-  const isManagerEnabled = (): boolean => {
-    return getManagerUIState() !== ManagerUIState.DISABLED
-  }
+  const isManagerEnabled = readonly(
+    computed((): boolean => {
+      return managerUIState.value !== ManagerUIState.DISABLED
+    })
+  )
 
   /**
-   * Helper function to check if manager UI is in NEW_UI mode
+   * Check if manager UI is in NEW_UI mode
    */
-  const isNewManagerUI = (): boolean => {
-    return getManagerUIState() === ManagerUIState.NEW_UI
-  }
+  const isNewManagerUI = readonly(
+    computed((): boolean => {
+      return managerUIState.value === ManagerUIState.NEW_UI
+    })
+  )
 
   /**
-   * Helper function to check if manager UI is in LEGACY_UI mode
+   * Check if manager UI is in LEGACY_UI mode
    */
-  const isLegacyManagerUI = (): boolean => {
-    return getManagerUIState() === ManagerUIState.LEGACY_UI
-  }
+  const isLegacyManagerUI = readonly(
+    computed((): boolean => {
+      return managerUIState.value === ManagerUIState.LEGACY_UI
+    })
+  )
 
   /**
-   * Helper function to check if install button should be shown
-   * (only in NEW_UI mode)
+   * Check if install button should be shown (only in NEW_UI mode)
    */
-  const shouldShowInstallButton = (): boolean => {
-    return isNewManagerUI()
-  }
+  const shouldShowInstallButton = readonly(
+    computed((): boolean => {
+      return isNewManagerUI.value
+    })
+  )
 
   /**
-   * Helper function to check if manager buttons should be shown
-   * (when manager is not disabled)
+   * Check if manager buttons should be shown (when manager is not disabled)
    */
-  const shouldShowManagerButtons = (): boolean => {
-    return isManagerEnabled()
-  }
+  const shouldShowManagerButtons = readonly(
+    computed((): boolean => {
+      return isManagerEnabled.value
+    })
+  )
 
   /**
    * Opens the manager UI based on current state
@@ -118,7 +130,7 @@ export function useManagerState() {
     showToastOnLegacyError?: boolean
     isLegacyOnly?: boolean
   }): Promise<void> => {
-    const state = getManagerUIState()
+    const state = managerUIState.value
     const dialogService = useDialogService()
     const commandStore = useCommandStore()
 
@@ -169,7 +181,7 @@ export function useManagerState() {
   }
 
   return {
-    getManagerUIState,
+    managerUIState,
     isManagerEnabled,
     isNewManagerUI,
     isLegacyManagerUI,

--- a/src/composables/useManagerState.ts
+++ b/src/composables/useManagerState.ts
@@ -24,6 +24,12 @@ export function useManagerState() {
    */
   const managerUIState = readonly(
     computed((): ManagerUIState => {
+      // Wait for systemStats to be initialized
+      if (!systemStatsStore.isInitialized) {
+        // Default to NEW_UI while loading
+        return ManagerUIState.DISABLED
+      }
+
       // Get current values
       const systemStats = systemStatsStore.systemStats
       const clientSupportsV4 =

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -2,8 +2,8 @@ import axios, { AxiosError, AxiosResponse } from 'axios'
 import { v4 as uuidv4 } from 'uuid'
 import { ref } from 'vue'
 
+import { useManagerState } from '@/composables/useManagerState'
 import { api } from '@/scripts/api'
-import { useManagerStateStore } from '@/stores/managerStateStore'
 import { components } from '@/types/generatedManagerTypes'
 import { isAbortError } from '@/utils/typeGuardUtil'
 
@@ -54,8 +54,8 @@ export const useComfyManagerService = () => {
 
   // Check if manager service should be available
   const isManagerServiceAvailable = () => {
-    const managerStore = useManagerStateStore()
-    return managerStore.isNewManagerUI()
+    const managerState = useManagerState()
+    return managerState.isNewManagerUI()
   }
 
   const handleRequestError = (

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -171,6 +171,10 @@ export const useComfyManagerService = () => {
   ) => {
     const errorContext = 'Fetching bulk import failure information'
 
+    if (!params.cnr_ids?.length && !params.urls?.length) {
+      return {}
+    }
+
     return executeRequest<components['schemas']['ImportFailInfoBulkResponse']>(
       () =>
         managerApiClient.post(ManagerRoute.IMPORT_FAIL_INFO_BULK, params, {

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -35,7 +35,6 @@ enum ManagerRoute {
   QUEUE_TASK = 'manager/queue/task'
 }
 
-// Always use v2 API for New Manager (no dynamic switching needed)
 const managerApiClient = axios.create({
   baseURL: api.apiURL('/v2/'),
   headers: {

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -55,7 +55,7 @@ export const useComfyManagerService = () => {
   // Check if manager service should be available
   const isManagerServiceAvailable = () => {
     const managerState = useManagerState()
-    return managerState.isNewManagerUI()
+    return managerState.isNewManagerUI.value
   }
 
   const handleRequestError = (

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -3,10 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { ref } from 'vue'
 
 import { api } from '@/scripts/api'
-import {
-  ManagerUIState,
-  useManagerStateStore
-} from '@/stores/managerStateStore'
+import { useManagerStateStore } from '@/stores/managerStateStore'
 import { components } from '@/types/generatedManagerTypes'
 import { isAbortError } from '@/utils/typeGuardUtil'
 
@@ -58,7 +55,7 @@ export const useComfyManagerService = () => {
   // Check if manager service should be available
   const isManagerServiceAvailable = () => {
     const managerStore = useManagerStateStore()
-    return managerStore.getManagerUIState() === ManagerUIState.NEW_UI
+    return managerStore.isNewManagerUI()
   }
 
   const handleRequestError = (

--- a/src/services/comfyManagerService.ts
+++ b/src/services/comfyManagerService.ts
@@ -45,7 +45,6 @@ const getApiBaseURL = () => {
 
   // Use v2 API only for NEW_UI state
   const apiPrefix = state === ManagerUIState.NEW_UI ? '/v2/' : '/'
-  console.log('[Manager API] State:', state, 'Using prefix:', apiPrefix)
   return api.apiURL(apiPrefix)
 }
 

--- a/src/stores/managerStateStore.ts
+++ b/src/stores/managerStateStore.ts
@@ -32,44 +32,62 @@ export const useManagerStateStore = defineStore('managerState', () => {
       'extension.manager.supports_v4'
     )
 
-    console.log('[Manager State Debug]', {
+    const result = {
       systemStats: systemStats?.system?.argv,
       clientSupportsV4,
       serverSupportsV4,
       hasLegacyManager,
       extensions: extensionStore.extensions.map((e) => e.name)
-    })
+    }
+    console.log('[Manager State Debug]', result)
 
     // Check command line args first (highest priority)
     if (systemStats?.system?.argv?.includes('--disable-manager')) {
+      console.log(
+        '[Manager State] Returning DISABLED due to --disable-manager flag'
+      )
       return ManagerUIState.DISABLED
     }
 
     if (systemStats?.system?.argv?.includes('--enable-manager-legacy-ui')) {
+      console.log(
+        '[Manager State] Returning LEGACY_UI due to --enable-manager-legacy-ui flag'
+      )
       return ManagerUIState.LEGACY_UI
     }
 
     // Both client and server support v4 = NEW_UI
     if (clientSupportsV4 && serverSupportsV4 === true) {
+      console.log('[Manager State] Returning NEW_UI (both support v4)')
       return ManagerUIState.NEW_UI
     }
 
     // Server supports v4 but client doesn't = LEGACY_UI
     if (serverSupportsV4 === true) {
+      console.log(
+        '[Manager State] Returning LEGACY_UI (server supports v4, client does not)'
+      )
       return ManagerUIState.LEGACY_UI
     }
 
     // No server v4 support but legacy manager extension exists = LEGACY_UI
     if (hasLegacyManager) {
+      console.log(
+        '[Manager State] Returning LEGACY_UI (has legacy manager extension)'
+      )
       return ManagerUIState.LEGACY_UI
     }
 
     // If server feature flags haven't loaded yet, return DISABLED for now
     if (serverSupportsV4 === undefined) {
+      console.log(
+        '[Manager State] Returning DISABLED (server feature flags not loaded)'
+      )
       return ManagerUIState.DISABLED
     }
 
     // No manager at all = DISABLED
+    console.log('[Manager State] Returning DISABLED (no manager support)')
     return ManagerUIState.DISABLED
   }
 

--- a/src/stores/managerStateStore.ts
+++ b/src/stores/managerStateStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { useI18n } from 'vue-i18n'
 
+import { t } from '@/i18n'
 import { api } from '@/scripts/api'
 import { useDialogService } from '@/services/dialogService'
 import { useCommandStore } from '@/stores/commandStore'
@@ -137,7 +137,6 @@ export const useManagerStateStore = defineStore('managerState', () => {
         } catch {
           // If legacy command doesn't exist
           if (options?.showToastOnLegacyError !== false) {
-            const { t } = useI18n()
             useToastStore().add({
               severity: 'error',
               summary: t('g.error'),
@@ -156,7 +155,6 @@ export const useManagerStateStore = defineStore('managerState', () => {
       case ManagerUIState.NEW_UI:
         if (options?.isLegacyOnly) {
           // Legacy command is not available in NEW_UI mode
-          const { t } = useI18n()
           useToastStore().add({
             severity: 'error',
             summary: t('g.error'),

--- a/src/stores/managerStateStore.ts
+++ b/src/stores/managerStateStore.ts
@@ -27,61 +27,37 @@ export const useManagerStateStore = defineStore('managerState', () => {
       'extension.manager.supports_v4'
     )
 
-    const result = {
-      systemStats: systemStats?.system?.argv,
-      clientSupportsV4,
-      serverSupportsV4
-    }
-    console.log('[Manager State Debug]', result)
-
     // Check command line args first (highest priority)
     if (systemStats?.system?.argv?.includes('--disable-manager')) {
-      console.log(
-        '[Manager State] Returning DISABLED due to --disable-manager flag'
-      )
       return ManagerUIState.DISABLED
     }
 
     if (systemStats?.system?.argv?.includes('--enable-manager-legacy-ui')) {
-      console.log(
-        '[Manager State] Returning LEGACY_UI due to --enable-manager-legacy-ui flag'
-      )
       return ManagerUIState.LEGACY_UI
     }
 
     // Both client and server support v4 = NEW_UI
     if (clientSupportsV4 && serverSupportsV4 === true) {
-      console.log('[Manager State] Returning NEW_UI (both support v4)')
       return ManagerUIState.NEW_UI
     }
 
     // Server supports v4 but client doesn't = LEGACY_UI
     if (serverSupportsV4 === true && !clientSupportsV4) {
-      console.log(
-        '[Manager State] Returning LEGACY_UI (server supports v4, client does not)'
-      )
       return ManagerUIState.LEGACY_UI
     }
 
     // Server explicitly doesn't support v4 = LEGACY_UI
     if (serverSupportsV4 === false) {
-      console.log(
-        '[Manager State] Returning LEGACY_UI (server does not support v4)'
-      )
       return ManagerUIState.LEGACY_UI
     }
 
     // If server feature flags haven't loaded yet, default to NEW_UI
     // This is the safest default since v2 API is the current standard
     if (serverSupportsV4 === undefined) {
-      console.log(
-        '[Manager State] Returning NEW_UI (server feature flags not loaded, using default)'
-      )
       return ManagerUIState.NEW_UI
     }
 
     // Should never reach here, but if we do, disable manager
-    console.log('[Manager State] Returning DISABLED (unexpected state)')
     return ManagerUIState.DISABLED
   }
 

--- a/src/stores/managerStateStore.ts
+++ b/src/stores/managerStateStore.ts
@@ -52,7 +52,9 @@ export const useManagerStateStore = defineStore('managerState', () => {
     }
 
     // If server feature flags haven't loaded yet, default to NEW_UI
-    // This is the safest default since v2 API is the current standard
+    // This is a temporary state - feature flags are exchanged immediately on WebSocket connection
+    // NEW_UI is the safest default since v2 API is the current standard
+    // If the server doesn't support v2, API calls will fail with 404 and be handled gracefully
     if (serverSupportsV4 === undefined) {
       return ManagerUIState.NEW_UI
     }

--- a/src/stores/managerStateStore.ts
+++ b/src/stores/managerStateStore.ts
@@ -61,7 +61,49 @@ export const useManagerStateStore = defineStore('managerState', () => {
     return ManagerUIState.DISABLED
   }
 
+  /**
+   * Helper function to check if manager is enabled (not DISABLED)
+   */
+  const isManagerEnabled = (): boolean => {
+    return getManagerUIState() !== ManagerUIState.DISABLED
+  }
+
+  /**
+   * Helper function to check if manager UI is in NEW_UI mode
+   */
+  const isNewManagerUI = (): boolean => {
+    return getManagerUIState() === ManagerUIState.NEW_UI
+  }
+
+  /**
+   * Helper function to check if manager UI is in LEGACY_UI mode
+   */
+  const isLegacyManagerUI = (): boolean => {
+    return getManagerUIState() === ManagerUIState.LEGACY_UI
+  }
+
+  /**
+   * Helper function to check if install button should be shown
+   * (only in NEW_UI mode)
+   */
+  const shouldShowInstallButton = (): boolean => {
+    return isNewManagerUI()
+  }
+
+  /**
+   * Helper function to check if manager buttons should be shown
+   * (when manager is not disabled)
+   */
+  const shouldShowManagerButtons = (): boolean => {
+    return isManagerEnabled()
+  }
+
   return {
-    getManagerUIState
+    getManagerUIState,
+    isManagerEnabled,
+    isNewManagerUI,
+    isLegacyManagerUI,
+    shouldShowInstallButton,
+    shouldShowManagerButtons
   }
 })

--- a/src/stores/managerStateStore.ts
+++ b/src/stores/managerStateStore.ts
@@ -56,9 +56,17 @@ export const useManagerStateStore = defineStore('managerState', () => {
     }
 
     // Server supports v4 but client doesn't = LEGACY_UI
-    if (serverSupportsV4 === true) {
+    if (serverSupportsV4 === true && !clientSupportsV4) {
       console.log(
         '[Manager State] Returning LEGACY_UI (server supports v4, client does not)'
+      )
+      return ManagerUIState.LEGACY_UI
+    }
+
+    // Server explicitly doesn't support v4 = LEGACY_UI
+    if (serverSupportsV4 === false) {
+      console.log(
+        '[Manager State] Returning LEGACY_UI (server does not support v4)'
       )
       return ManagerUIState.LEGACY_UI
     }
@@ -72,8 +80,8 @@ export const useManagerStateStore = defineStore('managerState', () => {
       return ManagerUIState.NEW_UI
     }
 
-    // No manager at all = DISABLED
-    console.log('[Manager State] Returning DISABLED (no manager support)')
+    // Should never reach here, but if we do, disable manager
+    console.log('[Manager State] Returning DISABLED (unexpected state)')
     return ManagerUIState.DISABLED
   }
 

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -240,7 +240,7 @@ export const useReleaseStore = defineStore('release', () => {
     try {
       // Ensure system stats are loaded
       if (!systemStatsStore.systemStats) {
-        await systemStatsStore.fetchSystemStats()
+        await systemStatsStore.refetchSystemStats()
       }
 
       const fetchedReleases = await releaseService.getReleases({

--- a/src/stores/releaseStore.ts
+++ b/src/stores/releaseStore.ts
@@ -1,3 +1,4 @@
+import { until } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
@@ -240,7 +241,7 @@ export const useReleaseStore = defineStore('release', () => {
     try {
       // Ensure system stats are loaded
       if (!systemStatsStore.systemStats) {
-        await systemStatsStore.refetchSystemStats()
+        await until(systemStatsStore.isInitialized)
       }
 
       const fetchedReleases = await releaseService.getReleases({

--- a/src/stores/systemStatsStore.ts
+++ b/src/stores/systemStatsStore.ts
@@ -20,7 +20,7 @@ export const useSystemStatsStore = defineStore('systemStats', () => {
     isLoading,
     error,
     isReady: isInitialized,
-    execute: fetchSystemStats
+    execute: refetchSystemStats
   } = useAsyncState<SystemStats | null>(
     fetchSystemStatsData,
     null, // initial value
@@ -65,7 +65,7 @@ export const useSystemStatsStore = defineStore('systemStats', () => {
     isLoading,
     error,
     isInitialized,
-    fetchSystemStats,
+    refetchSystemStats,
     getFormFactor
   }
 })

--- a/src/stores/systemStatsStore.ts
+++ b/src/stores/systemStatsStore.ts
@@ -1,31 +1,33 @@
+import { useAsyncState } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
 
 import type { SystemStats } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { isElectron } from '@/utils/envUtil'
 
 export const useSystemStatsStore = defineStore('systemStats', () => {
-  const systemStats = ref<SystemStats | null>(null)
-  const isLoading = ref(false)
-  const error = ref<string | null>(null)
-
-  async function fetchSystemStats() {
-    isLoading.value = true
-    error.value = null
-
+  const fetchSystemStatsData = async () => {
     try {
-      systemStats.value = await api.getSystemStats()
+      return await api.getSystemStats()
     } catch (err) {
-      error.value =
-        err instanceof Error
-          ? err.message
-          : 'An error occurred while fetching system stats'
       console.error('Error fetching system stats:', err)
-    } finally {
-      isLoading.value = false
+      throw err
     }
   }
+
+  const {
+    state: systemStats,
+    isLoading,
+    error,
+    isReady: isInitialized,
+    execute: fetchSystemStats
+  } = useAsyncState<SystemStats | null>(
+    fetchSystemStatsData,
+    null, // initial value
+    {
+      immediate: true
+    }
+  )
 
   function getFormFactor(): string {
     if (!systemStats.value?.system?.os) {
@@ -62,6 +64,7 @@ export const useSystemStatsStore = defineStore('systemStats', () => {
     systemStats,
     isLoading,
     error,
+    isInitialized,
     fetchSystemStats,
     getFormFactor
   }

--- a/src/stores/versionCompatibilityStore.ts
+++ b/src/stores/versionCompatibilityStore.ts
@@ -103,7 +103,7 @@ export const useVersionCompatibilityStore = defineStore(
 
     async function checkVersionCompatibility() {
       if (!systemStatsStore.systemStats) {
-        await systemStatsStore.fetchSystemStats()
+        await systemStatsStore.refetchSystemStats()
       }
     }
 

--- a/src/stores/versionCompatibilityStore.ts
+++ b/src/stores/versionCompatibilityStore.ts
@@ -1,4 +1,4 @@
-import { useStorage } from '@vueuse/core'
+import { until, useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import * as semver from 'semver'
 import { computed } from 'vue'
@@ -103,7 +103,7 @@ export const useVersionCompatibilityStore = defineStore(
 
     async function checkVersionCompatibility() {
       if (!systemStatsStore.systemStats) {
-        await systemStatsStore.refetchSystemStats()
+        await until(systemStatsStore.isInitialized)
       }
     }
 

--- a/tests-ui/tests/components/dialog/content/MissingCoreNodesMessage.spec.ts
+++ b/tests-ui/tests/components/dialog/content/MissingCoreNodesMessage.spec.ts
@@ -86,15 +86,11 @@ describe('MissingCoreNodesMessage', () => {
     expect(wrapper.findComponent(Message).exists()).toBe(true)
   })
 
-  it('fetches and displays current ComfyUI version', async () => {
-    // Start with no systemStats to trigger fetch
-    mockSystemStatsStore.fetchSystemStats.mockImplementation(() => {
-      // Simulate the fetch setting the systemStats
-      mockSystemStatsStore.systemStats = {
-        system: { comfyui_version: '1.0.0' }
-      }
-      return Promise.resolve()
-    })
+  it('displays current ComfyUI version when available', async () => {
+    // Set systemStats directly (store auto-fetches with useAsyncState)
+    mockSystemStatsStore.systemStats = {
+      system: { comfyui_version: '1.0.0' }
+    }
 
     const missingCoreNodes = {
       '1.2.0': [createMockNode('TestNode', '1.2.0')]
@@ -102,20 +98,18 @@ describe('MissingCoreNodesMessage', () => {
 
     const wrapper = mountComponent({ missingCoreNodes })
 
-    // Wait for all async operations
-    await nextTick()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Wait for component to render
     await nextTick()
 
-    expect(mockSystemStatsStore.fetchSystemStats).toHaveBeenCalled()
+    // No need to check if fetchSystemStats was called since useAsyncState auto-fetches
     expect(wrapper.text()).toContain(
       'Some nodes require a newer version of ComfyUI (current: 1.0.0)'
     )
   })
 
   it('displays generic message when version is unavailable', async () => {
-    // Mock fetchSystemStats to resolve without setting systemStats
-    mockSystemStatsStore.fetchSystemStats.mockResolvedValue(undefined)
+    // No systemStats set - version unavailable
+    mockSystemStatsStore.systemStats = null
 
     const missingCoreNodes = {
       '1.2.0': [createMockNode('TestNode', '1.2.0')]

--- a/tests-ui/tests/components/dialog/content/MissingCoreNodesMessage.spec.ts
+++ b/tests-ui/tests/components/dialog/content/MissingCoreNodesMessage.spec.ts
@@ -33,14 +33,14 @@ const createMockNode = (type: string, version?: string): LGraphNode =>
 describe('MissingCoreNodesMessage', () => {
   const mockSystemStatsStore = {
     systemStats: null as { system?: { comfyui_version?: string } } | null,
-    fetchSystemStats: vi.fn()
+    refetchSystemStats: vi.fn()
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset the mock store state
     mockSystemStatsStore.systemStats = null
-    mockSystemStatsStore.fetchSystemStats = vi.fn()
+    mockSystemStatsStore.refetchSystemStats = vi.fn()
     // @ts-expect-error - Mocking the return value of useSystemStatsStore for testing.
     // The actual store has more properties, but we only need these for our tests.
     useSystemStatsStore.mockReturnValue(mockSystemStatsStore)

--- a/tests-ui/tests/composables/useConflictDetection.test.ts
+++ b/tests-ui/tests/composables/useConflictDetection.test.ts
@@ -96,7 +96,7 @@ describe.skip('useConflictDetection with Registry Store', () => {
   }
 
   const mockSystemStatsStore = {
-    fetchSystemStats: vi.fn(),
+    refetchSystemStats: vi.fn(),
     systemStats: {
       system: {
         comfyui_version: '0.3.41',
@@ -133,7 +133,7 @@ describe.skip('useConflictDetection with Registry Store', () => {
     } as any
 
     // Reset mock functions
-    mockSystemStatsStore.fetchSystemStats.mockResolvedValue(undefined)
+    mockSystemStatsStore.refetchSystemStats.mockResolvedValue(undefined)
     mockComfyManagerService.listInstalledPacks.mockReset()
     mockComfyManagerService.getImportFailInfo.mockReset()
     mockRegistryService.getPackByVersion.mockReset()
@@ -185,7 +185,7 @@ describe.skip('useConflictDetection with Registry Store', () => {
 
     it('should return fallback environment information when systemStatsStore fails', async () => {
       // Mock systemStatsStore failure
-      mockSystemStatsStore.fetchSystemStats.mockRejectedValue(
+      mockSystemStatsStore.refetchSystemStats.mockRejectedValue(
         new Error('Store failure')
       )
       mockSystemStatsStore.systemStats = null
@@ -754,7 +754,7 @@ describe.skip('useConflictDetection with Registry Store', () => {
   describe('error resilience with Registry Store', () => {
     it('should continue execution even when system environment detection fails', async () => {
       // Mock system stats store failure
-      mockSystemStatsStore.fetchSystemStats.mockRejectedValue(
+      mockSystemStatsStore.refetchSystemStats.mockRejectedValue(
         new Error('Store error')
       )
       mockSystemStatsStore.systemStats = null
@@ -851,7 +851,7 @@ describe.skip('useConflictDetection with Registry Store', () => {
 
     it('should handle complete system failure gracefully', async () => {
       // Mock all stores/services failing
-      mockSystemStatsStore.fetchSystemStats.mockRejectedValue(
+      mockSystemStatsStore.refetchSystemStats.mockRejectedValue(
         new Error('Critical error')
       )
       mockSystemStatsStore.systemStats = null

--- a/tests-ui/tests/composables/useManagerState.test.ts
+++ b/tests-ui/tests/composables/useManagerState.test.ts
@@ -296,7 +296,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.shouldShowInstallButton.value).toBe(true)
+      expect(managerState.shouldShowInstallButton).toBe(true)
     })
 
     it('shouldShowManagerButtons should return true when not DISABLED', () => {
@@ -313,7 +313,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.shouldShowManagerButtons.value).toBe(true)
+      expect(managerState.shouldShowManagerButtons).toBe(true)
     })
   })
 })

--- a/tests-ui/tests/composables/useManagerState.test.ts
+++ b/tests-ui/tests/composables/useManagerState.test.ts
@@ -54,7 +54,7 @@ describe('useManagerState', () => {
     vi.clearAllMocks()
   })
 
-  describe('getManagerUIState function', () => {
+  describe('managerUIState property', () => {
     it('should return DISABLED state when --disable-manager is present', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: {
@@ -68,7 +68,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.DISABLED)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.DISABLED)
     })
 
     it('should return LEGACY_UI state when --enable-manager-legacy-ui is present', () => {
@@ -84,7 +84,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return NEW_UI state when client and server both support v4', () => {
@@ -105,7 +105,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should return LEGACY_UI state when server supports v4 but client does not', () => {
@@ -126,7 +126,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return LEGACY_UI state when legacy manager extension exists', () => {
@@ -144,7 +144,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return NEW_UI state when server feature flags are undefined', () => {
@@ -163,7 +163,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should return LEGACY_UI state when server does not support v4', () => {
@@ -182,7 +182,7 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should handle null systemStats gracefully', () => {
@@ -203,11 +203,11 @@ describe('useManagerState', () => {
 
       const managerState = useManagerState()
 
-      expect(managerState.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
+      expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
   })
 
-  describe('helper functions', () => {
+  describe('helper properties', () => {
     it('isManagerEnabled should return true when state is not DISABLED', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: { system: { argv: ['python', 'main.py'] } }
@@ -221,7 +221,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.isManagerEnabled()).toBe(true)
+      expect(managerState.isManagerEnabled.value).toBe(true)
     })
 
     it('isManagerEnabled should return false when state is DISABLED', () => {
@@ -236,7 +236,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.isManagerEnabled()).toBe(false)
+      expect(managerState.isManagerEnabled.value).toBe(false)
     })
 
     it('isNewManagerUI should return true when state is NEW_UI', () => {
@@ -252,7 +252,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.isNewManagerUI()).toBe(true)
+      expect(managerState.isNewManagerUI.value).toBe(true)
     })
 
     it('isLegacyManagerUI should return true when state is LEGACY_UI', () => {
@@ -267,7 +267,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.isLegacyManagerUI()).toBe(true)
+      expect(managerState.isLegacyManagerUI.value).toBe(true)
     })
 
     it('shouldShowInstallButton should return true only for NEW_UI', () => {
@@ -283,7 +283,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.shouldShowInstallButton()).toBe(true)
+      expect(managerState.shouldShowInstallButton.value).toBe(true)
     })
 
     it('shouldShowManagerButtons should return true when not DISABLED', () => {
@@ -299,7 +299,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.shouldShowManagerButtons()).toBe(true)
+      expect(managerState.shouldShowManagerButtons.value).toBe(true)
     })
   })
 })

--- a/tests-ui/tests/composables/useManagerState.test.ts
+++ b/tests-ui/tests/composables/useManagerState.test.ts
@@ -1,13 +1,9 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { ManagerUIState, useManagerState } from '@/composables/useManagerState'
 import { api } from '@/scripts/api'
 import { useExtensionStore } from '@/stores/extensionStore'
-import {
-  ManagerUIState,
-  useManagerStateStore
-} from '@/stores/managerStateStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 
 // Mock dependencies
@@ -53,9 +49,8 @@ vi.mock('@/stores/toastStore', () => ({
   }))
 }))
 
-describe('useManagerStateStore', () => {
+describe('useManagerState', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     vi.clearAllMocks()
   })
 
@@ -71,9 +66,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.DISABLED)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.DISABLED)
     })
 
     it('should return LEGACY_UI state when --enable-manager-legacy-ui is present', () => {
@@ -87,9 +82,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return NEW_UI state when client and server both support v4', () => {
@@ -108,9 +103,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should return LEGACY_UI state when server supports v4 but client does not', () => {
@@ -129,9 +124,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return LEGACY_UI state when legacy manager extension exists', () => {
@@ -147,9 +142,9 @@ describe('useManagerStateStore', () => {
         extensions: [{ name: 'Comfy.CustomNodesManager' }]
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return NEW_UI state when server feature flags are undefined', () => {
@@ -166,9 +161,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should return LEGACY_UI state when server does not support v4', () => {
@@ -185,9 +180,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should handle null systemStats gracefully', () => {
@@ -206,9 +201,9 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
+      const managerState = useManagerState()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
+      expect(managerState.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
   })
 
@@ -225,8 +220,8 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
-      expect(store.isManagerEnabled()).toBe(true)
+      const managerState = useManagerState()
+      expect(managerState.isManagerEnabled()).toBe(true)
     })
 
     it('isManagerEnabled should return false when state is DISABLED', () => {
@@ -240,8 +235,8 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
-      expect(store.isManagerEnabled()).toBe(false)
+      const managerState = useManagerState()
+      expect(managerState.isManagerEnabled()).toBe(false)
     })
 
     it('isNewManagerUI should return true when state is NEW_UI', () => {
@@ -256,8 +251,8 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
-      expect(store.isNewManagerUI()).toBe(true)
+      const managerState = useManagerState()
+      expect(managerState.isNewManagerUI()).toBe(true)
     })
 
     it('isLegacyManagerUI should return true when state is LEGACY_UI', () => {
@@ -271,8 +266,8 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
-      expect(store.isLegacyManagerUI()).toBe(true)
+      const managerState = useManagerState()
+      expect(managerState.isLegacyManagerUI()).toBe(true)
     })
 
     it('shouldShowInstallButton should return true only for NEW_UI', () => {
@@ -287,8 +282,8 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
-      expect(store.shouldShowInstallButton()).toBe(true)
+      const managerState = useManagerState()
+      expect(managerState.shouldShowInstallButton()).toBe(true)
     })
 
     it('shouldShowManagerButtons should return true when not DISABLED', () => {
@@ -303,8 +298,8 @@ describe('useManagerStateStore', () => {
         extensions: []
       } as any)
 
-      const store = useManagerStateStore()
-      expect(store.shouldShowManagerButtons()).toBe(true)
+      const managerState = useManagerState()
+      expect(managerState.shouldShowManagerButtons()).toBe(true)
     })
   })
 })

--- a/tests-ui/tests/composables/useManagerState.test.ts
+++ b/tests-ui/tests/composables/useManagerState.test.ts
@@ -296,7 +296,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.shouldShowInstallButton).toBe(true)
+      expect(managerState.shouldShowInstallButton.value).toBe(true)
     })
 
     it('shouldShowManagerButtons should return true when not DISABLED', () => {
@@ -313,7 +313,7 @@ describe('useManagerState', () => {
       } as any)
 
       const managerState = useManagerState()
-      expect(managerState.shouldShowManagerButtons).toBe(true)
+      expect(managerState.shouldShowManagerButtons.value).toBe(true)
     })
   })
 })

--- a/tests-ui/tests/composables/useManagerState.test.ts
+++ b/tests-ui/tests/composables/useManagerState.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { ManagerUIState, useManagerState } from '@/composables/useManagerState'
@@ -57,10 +58,10 @@ describe('useManagerState', () => {
   describe('managerUIState property', () => {
     it('should return DISABLED state when --disable-manager is present', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: {
+        systemStats: ref({
           system: { argv: ['python', 'main.py', '--disable-manager'] }
-        },
-        isInitialized: true
+        }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -74,10 +75,10 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when --enable-manager-legacy-ui is present', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: {
+        systemStats: ref({
           system: { argv: ['python', 'main.py', '--enable-manager-legacy-ui'] }
-        },
-        isInitialized: true
+        }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -91,8 +92,8 @@ describe('useManagerState', () => {
 
     it('should return NEW_UI state when client and server both support v4', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -113,8 +114,8 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when server supports v4 but client does not', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: false
@@ -135,8 +136,8 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when legacy manager extension exists', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useFeatureFlags).mockReturnValue({
@@ -154,8 +155,8 @@ describe('useManagerState', () => {
 
     it('should return NEW_UI state when server feature flags are undefined', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(api.getServerFeature).mockReturnValue(undefined)
@@ -174,8 +175,8 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when server does not support v4', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(api.getServerFeature).mockReturnValue(false)
@@ -194,8 +195,8 @@ describe('useManagerState', () => {
 
     it('should handle null systemStats gracefully', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: null,
-        isInitialized: true
+        systemStats: ref(null),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -218,8 +219,8 @@ describe('useManagerState', () => {
   describe('helper properties', () => {
     it('isManagerEnabled should return true when state is not DISABLED', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -235,10 +236,10 @@ describe('useManagerState', () => {
 
     it('isManagerEnabled should return false when state is DISABLED', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: {
+        systemStats: ref({
           system: { argv: ['python', 'main.py', '--disable-manager'] }
-        },
-        isInitialized: true
+        }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -251,8 +252,8 @@ describe('useManagerState', () => {
 
     it('isNewManagerUI should return true when state is NEW_UI', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -268,10 +269,10 @@ describe('useManagerState', () => {
 
     it('isLegacyManagerUI should return true when state is LEGACY_UI', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: {
+        systemStats: ref({
           system: { argv: ['python', 'main.py', '--enable-manager-legacy-ui'] }
-        },
-        isInitialized: true
+        }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -284,8 +285,8 @@ describe('useManagerState', () => {
 
     it('shouldShowInstallButton should return true only for NEW_UI', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -301,8 +302,8 @@ describe('useManagerState', () => {
 
     it('shouldShowManagerButtons should return true when not DISABLED', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } },
-        isInitialized: true
+        systemStats: ref({ system: { argv: ['python', 'main.py'] } }),
+        isInitialized: ref(true)
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true

--- a/tests-ui/tests/composables/useManagerState.test.ts
+++ b/tests-ui/tests/composables/useManagerState.test.ts
@@ -59,7 +59,8 @@ describe('useManagerState', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: {
           system: { argv: ['python', 'main.py', '--disable-manager'] }
-        }
+        },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -75,7 +76,8 @@ describe('useManagerState', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: {
           system: { argv: ['python', 'main.py', '--enable-manager-legacy-ui'] }
-        }
+        },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -89,7 +91,8 @@ describe('useManagerState', () => {
 
     it('should return NEW_UI state when client and server both support v4', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -110,7 +113,8 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when server supports v4 but client does not', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: false
@@ -131,7 +135,8 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when legacy manager extension exists', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useFeatureFlags).mockReturnValue({
@@ -149,7 +154,8 @@ describe('useManagerState', () => {
 
     it('should return NEW_UI state when server feature flags are undefined', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(api.getServerFeature).mockReturnValue(undefined)
@@ -168,7 +174,8 @@ describe('useManagerState', () => {
 
     it('should return LEGACY_UI state when server does not support v4', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(api.getServerFeature).mockReturnValue(false)
@@ -187,7 +194,8 @@ describe('useManagerState', () => {
 
     it('should handle null systemStats gracefully', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: null
+        systemStats: null,
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -210,7 +218,8 @@ describe('useManagerState', () => {
   describe('helper properties', () => {
     it('isManagerEnabled should return true when state is not DISABLED', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -228,7 +237,8 @@ describe('useManagerState', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: {
           system: { argv: ['python', 'main.py', '--disable-manager'] }
-        }
+        },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -241,7 +251,8 @@ describe('useManagerState', () => {
 
     it('isNewManagerUI should return true when state is NEW_UI', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -259,7 +270,8 @@ describe('useManagerState', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: {
           system: { argv: ['python', 'main.py', '--enable-manager-legacy-ui'] }
-        }
+        },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
       vi.mocked(useExtensionStore).mockReturnValue({
@@ -272,7 +284,8 @@ describe('useManagerState', () => {
 
     it('shouldShowInstallButton should return true only for NEW_UI', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
@@ -288,7 +301,8 @@ describe('useManagerState', () => {
 
     it('shouldShowManagerButtons should return true when not DISABLED', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
-        systemStats: { system: { argv: ['python', 'main.py'] } }
+        systemStats: { system: { argv: ['python', 'main.py'] } },
+        isInitialized: true
       } as any)
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true

--- a/tests-ui/tests/store/releaseStore.test.ts
+++ b/tests-ui/tests/store/releaseStore.test.ts
@@ -49,7 +49,7 @@ describe('useReleaseStore', () => {
           comfyui_version: '1.0.0'
         }
       },
-      fetchSystemStats: vi.fn(),
+      refetchSystemStats: vi.fn(),
       getFormFactor: vi.fn(() => 'git-windows')
     }
 
@@ -339,7 +339,7 @@ describe('useReleaseStore', () => {
 
       await store.initialize()
 
-      expect(mockSystemStatsStore.fetchSystemStats).toHaveBeenCalled()
+      expect(mockSystemStatsStore.refetchSystemStats).toHaveBeenCalled()
     })
 
     it('should not set loading state when notifications disabled', async () => {
@@ -406,7 +406,7 @@ describe('useReleaseStore', () => {
 
       await store.fetchReleases()
 
-      expect(mockSystemStatsStore.fetchSystemStats).toHaveBeenCalled()
+      expect(mockSystemStatsStore.refetchSystemStats).toHaveBeenCalled()
       expect(mockReleaseService.getReleases).toHaveBeenCalled()
     })
   })
@@ -530,7 +530,7 @@ describe('useReleaseStore', () => {
       await store.initialize()
 
       // Should not fetch system stats when notifications disabled
-      expect(mockSystemStatsStore.fetchSystemStats).not.toHaveBeenCalled()
+      expect(mockSystemStatsStore.refetchSystemStats).not.toHaveBeenCalled()
     })
 
     it('should handle concurrent fetchReleases calls', async () => {

--- a/tests-ui/tests/store/systemStatsStore.test.ts
+++ b/tests-ui/tests/store/systemStatsStore.test.ts
@@ -39,7 +39,7 @@ describe('useSystemStatsStore', () => {
     expect(store.isInitialized).toBe(true) // Should be initialized after fetch
   })
 
-  describe('fetchSystemStats', () => {
+  describe('refetchSystemStats', () => {
     it('should fetch system stats successfully', async () => {
       const mockStats = {
         system: {
@@ -58,7 +58,7 @@ describe('useSystemStatsStore', () => {
 
       vi.mocked(api.getSystemStats).mockResolvedValue(mockStats)
 
-      await store.fetchSystemStats()
+      await store.refetchSystemStats()
 
       expect(store.systemStats).toEqual(mockStats)
       expect(store.isLoading).toBe(false)
@@ -71,7 +71,7 @@ describe('useSystemStatsStore', () => {
       const error = new Error('API Error')
       vi.mocked(api.getSystemStats).mockRejectedValue(error)
 
-      await store.fetchSystemStats()
+      await store.refetchSystemStats()
 
       expect(store.systemStats).toBeNull() // Initial value stays null on error
       expect(store.isLoading).toBe(false)
@@ -81,7 +81,7 @@ describe('useSystemStatsStore', () => {
     it('should handle non-Error objects', async () => {
       vi.mocked(api.getSystemStats).mockRejectedValue('String error')
 
-      await store.fetchSystemStats()
+      await store.refetchSystemStats()
 
       expect(store.error).toBe('String error') // useAsyncState stores the actual error
     })
@@ -93,7 +93,7 @@ describe('useSystemStatsStore', () => {
       })
       vi.mocked(api.getSystemStats).mockReturnValue(promise)
 
-      const fetchPromise = store.fetchSystemStats()
+      const fetchPromise = store.refetchSystemStats()
       expect(store.isLoading).toBe(true)
 
       resolvePromise({})
@@ -120,7 +120,7 @@ describe('useSystemStatsStore', () => {
 
       vi.mocked(api.getSystemStats).mockResolvedValue(updatedStats)
 
-      await store.fetchSystemStats()
+      await store.refetchSystemStats()
 
       expect(store.systemStats).toEqual(updatedStats)
       expect(store.isLoading).toBe(false)

--- a/tests-ui/tests/store/systemStatsStore.test.ts
+++ b/tests-ui/tests/store/systemStatsStore.test.ts
@@ -21,15 +21,22 @@ describe('useSystemStatsStore', () => {
   let store: ReturnType<typeof useSystemStatsStore>
 
   beforeEach(() => {
+    // Mock API to prevent automatic fetch on store creation
+    vi.mocked(api.getSystemStats).mockResolvedValue(null as any)
     setActivePinia(createPinia())
     store = useSystemStatsStore()
     vi.clearAllMocks()
   })
 
-  it('should initialize with null systemStats', () => {
-    expect(store.systemStats).toBeNull()
-    expect(store.isLoading).toBe(false)
-    expect(store.error).toBeNull()
+  it('should initialize and start fetching immediately', async () => {
+    // useAsyncState with immediate: true starts loading right away
+    // In test environment, the mock resolves immediately so loading might be false already
+    expect(store.systemStats).toBeNull() // Initial value is null
+    expect(store.error).toBeUndefined()
+
+    // Wait for initial fetch to complete
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(store.isInitialized).toBe(true) // Should be initialized after fetch
   })
 
   describe('fetchSystemStats', () => {
@@ -55,7 +62,8 @@ describe('useSystemStatsStore', () => {
 
       expect(store.systemStats).toEqual(mockStats)
       expect(store.isLoading).toBe(false)
-      expect(store.error).toBeNull()
+      expect(store.error).toBeUndefined() // useAsyncState uses undefined for no error
+      expect(store.isInitialized).toBe(true)
       expect(api.getSystemStats).toHaveBeenCalled()
     })
 
@@ -65,9 +73,9 @@ describe('useSystemStatsStore', () => {
 
       await store.fetchSystemStats()
 
-      expect(store.systemStats).toBeNull()
+      expect(store.systemStats).toBeNull() // Initial value stays null on error
       expect(store.isLoading).toBe(false)
-      expect(store.error).toBe('API Error')
+      expect(store.error).toEqual(error) // useAsyncState stores the actual error object
     })
 
     it('should handle non-Error objects', async () => {
@@ -75,7 +83,7 @@ describe('useSystemStatsStore', () => {
 
       await store.fetchSystemStats()
 
-      expect(store.error).toBe('An error occurred while fetching system stats')
+      expect(store.error).toBe('String error') // useAsyncState stores the actual error
     })
 
     it('should set loading state correctly', async () => {
@@ -116,7 +124,8 @@ describe('useSystemStatsStore', () => {
 
       expect(store.systemStats).toEqual(updatedStats)
       expect(store.isLoading).toBe(false)
-      expect(store.error).toBeNull()
+      expect(store.error).toBeUndefined()
+      expect(store.isInitialized).toBe(true)
       expect(api.getSystemStats).toHaveBeenCalled()
     })
   })

--- a/tests-ui/tests/store/versionCompatibilityStore.test.ts
+++ b/tests-ui/tests/store/versionCompatibilityStore.test.ts
@@ -13,10 +13,11 @@ vi.mock('@/config', () => ({
 
 vi.mock('@/stores/systemStatsStore')
 
-// Mock useStorage from VueUse
+// Mock useStorage and until from VueUse
 const mockDismissalStorage = ref({} as Record<string, number>)
 vi.mock('@vueuse/core', () => ({
-  useStorage: vi.fn(() => mockDismissalStorage)
+  useStorage: vi.fn(() => mockDismissalStorage),
+  until: vi.fn(() => Promise.resolve())
 }))
 
 describe('useVersionCompatibilityStore', () => {
@@ -31,6 +32,7 @@ describe('useVersionCompatibilityStore', () => {
 
     mockSystemStatsStore = {
       systemStats: null,
+      isInitialized: false,
       refetchSystemStats: vi.fn()
     }
 
@@ -51,6 +53,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -68,6 +71,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.23.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -83,6 +87,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.24.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -98,6 +103,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: ''
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -113,6 +119,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: 'not-a-version' // invalid semver format
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -129,6 +136,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.23.0' // Required is 1.23.0, frontend 1.24.0 meets this
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -148,6 +156,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -167,6 +176,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -180,6 +190,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.24.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -195,6 +206,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -212,6 +224,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.24.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
 
@@ -230,6 +243,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
       store.dismissWarning()
@@ -252,6 +266,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
 
@@ -270,6 +285,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.25.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
 
@@ -289,6 +305,7 @@ describe('useVersionCompatibilityStore', () => {
           required_frontend_version: '1.26.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
 
@@ -298,24 +315,28 @@ describe('useVersionCompatibilityStore', () => {
 
   describe('initialization', () => {
     it('should fetch system stats if not available', async () => {
+      const { until } = await import('@vueuse/core')
       mockSystemStatsStore.systemStats = null
+      mockSystemStatsStore.isInitialized = false
 
       await store.initialize()
 
-      expect(mockSystemStatsStore.refetchSystemStats).toHaveBeenCalled()
+      expect(until).toHaveBeenCalled()
     })
 
     it('should not fetch system stats if already available', async () => {
+      const { until } = await import('@vueuse/core')
       mockSystemStatsStore.systemStats = {
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
       }
+      mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
 
-      expect(mockSystemStatsStore.refetchSystemStats).not.toHaveBeenCalled()
+      expect(until).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests-ui/tests/store/versionCompatibilityStore.test.ts
+++ b/tests-ui/tests/store/versionCompatibilityStore.test.ts
@@ -31,7 +31,7 @@ describe('useVersionCompatibilityStore', () => {
 
     mockSystemStatsStore = {
       systemStats: null,
-      fetchSystemStats: vi.fn()
+      refetchSystemStats: vi.fn()
     }
 
     vi.mocked(useSystemStatsStore).mockReturnValue(mockSystemStatsStore)
@@ -302,7 +302,7 @@ describe('useVersionCompatibilityStore', () => {
 
       await store.initialize()
 
-      expect(mockSystemStatsStore.fetchSystemStats).toHaveBeenCalled()
+      expect(mockSystemStatsStore.refetchSystemStats).toHaveBeenCalled()
     })
 
     it('should not fetch system stats if already available', async () => {
@@ -315,7 +315,7 @@ describe('useVersionCompatibilityStore', () => {
 
       await store.initialize()
 
-      expect(mockSystemStatsStore.fetchSystemStats).not.toHaveBeenCalled()
+      expect(mockSystemStatsStore.refetchSystemStats).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests-ui/tests/stores/managerStateStore.test.ts
+++ b/tests-ui/tests/stores/managerStateStore.test.ts
@@ -191,4 +191,100 @@ describe('useManagerStateStore', () => {
       expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
   })
+
+  describe('helper functions', () => {
+    it('isManagerEnabled should return true when state is not DISABLED', () => {
+      vi.mocked(useSystemStatsStore).mockReturnValue({
+        systemStats: { system: { argv: ['python', 'main.py'] } }
+      } as any)
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      vi.mocked(useExtensionStore).mockReturnValue({
+        extensions: []
+      } as any)
+
+      const store = useManagerStateStore()
+      expect(store.isManagerEnabled()).toBe(true)
+    })
+
+    it('isManagerEnabled should return false when state is DISABLED', () => {
+      vi.mocked(useSystemStatsStore).mockReturnValue({
+        systemStats: {
+          system: { argv: ['python', 'main.py', '--disable-manager'] }
+        }
+      } as any)
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
+      vi.mocked(useExtensionStore).mockReturnValue({
+        extensions: []
+      } as any)
+
+      const store = useManagerStateStore()
+      expect(store.isManagerEnabled()).toBe(false)
+    })
+
+    it('isNewManagerUI should return true when state is NEW_UI', () => {
+      vi.mocked(useSystemStatsStore).mockReturnValue({
+        systemStats: { system: { argv: ['python', 'main.py'] } }
+      } as any)
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      vi.mocked(useExtensionStore).mockReturnValue({
+        extensions: []
+      } as any)
+
+      const store = useManagerStateStore()
+      expect(store.isNewManagerUI()).toBe(true)
+    })
+
+    it('isLegacyManagerUI should return true when state is LEGACY_UI', () => {
+      vi.mocked(useSystemStatsStore).mockReturnValue({
+        systemStats: {
+          system: { argv: ['python', 'main.py', '--enable-manager-legacy-ui'] }
+        }
+      } as any)
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
+      vi.mocked(useExtensionStore).mockReturnValue({
+        extensions: []
+      } as any)
+
+      const store = useManagerStateStore()
+      expect(store.isLegacyManagerUI()).toBe(true)
+    })
+
+    it('shouldShowInstallButton should return true only for NEW_UI', () => {
+      vi.mocked(useSystemStatsStore).mockReturnValue({
+        systemStats: { system: { argv: ['python', 'main.py'] } }
+      } as any)
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      vi.mocked(useExtensionStore).mockReturnValue({
+        extensions: []
+      } as any)
+
+      const store = useManagerStateStore()
+      expect(store.shouldShowInstallButton()).toBe(true)
+    })
+
+    it('shouldShowManagerButtons should return true when not DISABLED', () => {
+      vi.mocked(useSystemStatsStore).mockReturnValue({
+        systemStats: { system: { argv: ['python', 'main.py'] } }
+      } as any)
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      vi.mocked(useExtensionStore).mockReturnValue({
+        extensions: []
+      } as any)
+
+      const store = useManagerStateStore()
+      expect(store.shouldShowManagerButtons()).toBe(true)
+    })
+  })
 })

--- a/tests-ui/tests/stores/managerStateStore.test.ts
+++ b/tests-ui/tests/stores/managerStateStore.test.ts
@@ -39,7 +39,7 @@ describe('useManagerStateStore', () => {
     vi.clearAllMocks()
   })
 
-  describe('managerUIState computed', () => {
+  describe('getManagerUIState function', () => {
     it('should return DISABLED state when --disable-manager is present', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: {
@@ -53,7 +53,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.DISABLED)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.DISABLED)
     })
 
     it('should return LEGACY_UI state when --enable-manager-legacy-ui is present', () => {
@@ -69,7 +69,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.LEGACY_UI)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return NEW_UI state when client and server both support v4', () => {
@@ -90,7 +90,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.NEW_UI)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should return LEGACY_UI state when server supports v4 but client does not', () => {
@@ -111,7 +111,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.LEGACY_UI)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return LEGACY_UI state when legacy manager extension exists', () => {
@@ -129,7 +129,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.LEGACY_UI)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return DISABLED state when feature flags are undefined', () => {
@@ -148,7 +148,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.DISABLED)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.DISABLED)
     })
 
     it('should return DISABLED state when no manager is available', () => {
@@ -167,7 +167,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.DISABLED)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.DISABLED)
     })
 
     it('should handle null systemStats gracefully', () => {
@@ -188,7 +188,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.managerUIState).toBe(ManagerUIState.NEW_UI)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
   })
 })

--- a/tests-ui/tests/stores/managerStateStore.test.ts
+++ b/tests-ui/tests/stores/managerStateStore.test.ts
@@ -33,6 +33,26 @@ vi.mock('@/stores/systemStatsStore', () => ({
   useSystemStatsStore: vi.fn()
 }))
 
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: vi.fn(() => ({
+    showManagerPopup: vi.fn(),
+    showLegacyManagerPopup: vi.fn(),
+    showSettingsDialog: vi.fn()
+  }))
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: vi.fn(() => ({
+    execute: vi.fn()
+  }))
+}))
+
+vi.mock('@/stores/toastStore', () => ({
+  useToastStore: vi.fn(() => ({
+    add: vi.fn()
+  }))
+}))
+
 describe('useManagerStateStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())

--- a/tests-ui/tests/stores/managerStateStore.test.ts
+++ b/tests-ui/tests/stores/managerStateStore.test.ts
@@ -132,7 +132,7 @@ describe('useManagerStateStore', () => {
       expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
-    it('should return DISABLED state when feature flags are undefined', () => {
+    it('should return NEW_UI state when server feature flags are undefined', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: { system: { argv: ['python', 'main.py'] } }
       } as any)
@@ -148,10 +148,10 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.DISABLED)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.NEW_UI)
     })
 
-    it('should return DISABLED state when no manager is available', () => {
+    it('should return LEGACY_UI state when server does not support v4', () => {
       vi.mocked(useSystemStatsStore).mockReturnValue({
         systemStats: { system: { argv: ['python', 'main.py'] } }
       } as any)
@@ -167,7 +167,7 @@ describe('useManagerStateStore', () => {
 
       const store = useManagerStateStore()
 
-      expect(store.getManagerUIState()).toBe(ManagerUIState.DISABLED)
+      expect(store.getManagerUIState()).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should handle null systemStats gracefully', () => {


### PR DESCRIPTION
## Summary

Fix ComfyUI Manager feature flag reactivity issues and improve manager state determination logic.

## Changes

### 1. Replace reactive feature flags with non-reactive approach (72cb4d268)
- Changed `managerUIState` from computed property to `getManagerUIState()` function
- Ensures fresh computation on each call to avoid Vue reactivity timing issues
- Updates all consumers to use the new function-based approach

### 2. Add HelpCenter manager state handling and API version switching (0cc07bd16)
- Fixed HelpCenter manager extension to check manager state
- Fixed 'Manager' command to respect manager state
- Added dynamic API prefix switching based on manager state (`/api/` for legacy, `/api/v2/` for new)

### 3. Simplify manager state determination and fix API timing issues (45de89eab)
- Remove unnecessary extension check from manager state store
- Use only feature flags (client and server) for state determination
- Default to NEW_UI when server flags not loaded (safer default)
- Fix ImportFailInfoBulk to not send empty requests
- Resolves initial 404 errors on installed API calls

### 4. Correct manager state for non-v4 servers (f00eff204)
- Fix servers without v4 support returning DISABLED instead of LEGACY_UI
- Servers without v4 support should use legacy manager, not disable it
- Clarify condition for server v4 + client non-v4 case

## Testing

- [x] Unit tests updated and passing
- [x] Tested with v4 enabled server
- [x] Tested with v4 disabled server
- [x] Tested manager UI state transitions
- [x] Verified no 404 errors on initial load

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Fixes #5316