### PR TITLE
feat: localization input slots for V3 UI

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -31,7 +31,7 @@
       v-if="!dotOnly"
       class="whitespace-nowrap text-sm font-normal dark-theme:text-[#9FA2BD] text-[#888682]"
     >
-      {{ slotData.name || `Input ${index}` }}
+      {{ slotData.localized_name || slotData.name || `Input ${index}` }}
     </span>
   </div>
 </template>


### PR DESCRIPTION

<img width="426" height="487" alt="CleanShot 2025-09-02 at 15 40 44" src="https://github.com/user-attachments/assets/e0ca276f-d00e-4c39-87fa-b96f0a45e96e" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5318-feat-localization-input-slots-for-V3-UI-2636d73d365081f6bf0bf09750a2560a) by [Unito](https://www.unito.io)
