### PR TITLE
fix: remove clipping by removing unnecessary css contain

### DIFF
--- a/src/components/graph/TransformPane.vue
+++ b/src/components/graph/TransformPane.vue
@@ -117,7 +117,6 @@ useCanvasTransformSync(props.canvas, syncWithCanvas, {
 .transform-pane {
   position: absolute;
   inset: 0;
-  contain: layout style paint;
   transform-origin: 0 0;
   pointer-events: none;
   top: 0;


### PR DESCRIPTION
## Summary

### Problem:
When zooming, dragging or panning, the vue nodes get clipped/cut off to the size of the initial viewport.

<img width="1533" height="1267" alt="image" src="https://github.com/user-attachments/assets/f4b71d22-bf5f-4fa6-b997-c330eba4db7b" />

This is because the TransformPane parent element's CSS pixel width and height is set only once during the first layout to be the size of the viewport. And using the css property contain: paint clips anything beyond that size.

### Solution:
Remove the contain property because we are already culling/remove nodes outside the viewport and we are relying of the fact that with transform elements skip layout.

<img width="1531" height="1269" alt="image" src="https://github.com/user-attachments/assets/dee2654f-250b-43f1-a33f-00dc4a78f579" />

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
Fixes https://www.notion.so/comfy-org/Transform-pane-becomes-misaligned-with-the-canvas-viewport-2626d73d365080bda9a9f2bfe31e3fb5?source=copy_link

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->
