### PR TITLE
[CI] Fix desktop API types update action

### DIFF
--- a/.github/workflows/update-electron-types.yaml
+++ b/.github/workflows/update-electron-types.yaml
@@ -35,7 +35,7 @@ jobs:
             electron-types-tools-cache-${{ runner.os }}-
 
       - name: Update electron types
-        run: pnpm install @comfyorg/comfyui-electron-types@latest
+        run: pnpm install --workspace-root @comfyorg/comfyui-electron-types@latest
 
       - name: Get new version
         id: get-version


### PR DESCRIPTION
Use --workspace-root flag to install at workspace level.  The GH Action requires this due to pnpm workspace changes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5337-CI-Fix-desktop-API-types-update-action-2646d73d3650811c9e67daf1be2de36f) by [Unito](https://www.unito.io)
