### PR TITLE
[CI] Fix desktop release update throws due to format issue

### DIFF
--- a/.github/workflows/update-electron-types.yaml
+++ b/.github/workflows/update-electron-types.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Get new version
         id: get-version
         run: |
-          NEW_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('./pnpm-lock.yaml')).packages['node_modules/@comfyorg/comfyui-electron-types'].version)")
+          NEW_VERSION=$(pnpm list @comfyorg/comfyui-electron-types --json --depth=0 | jq -r '.[0].version')
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request


### PR DESCRIPTION
### Issue

The CI was updated to use `pnpm`, and the package lock file name was changed. However, the action was using JSON parsing instead of YAML.

### Proposed

- Query `pnpm` for the version properly instead of parsing the lock file
- Replace the node script with a much simpler `jq`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5342-CI-Fix-desktop-release-update-throws-due-to-format-issue-2646d73d365081ad99dbe914f27899ba) by [Unito](https://www.unito.io)
