### PR TITLE
Add explicit types for reroute and link IDs in layout system and don't change type of reroute IDs from LG

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1362,9 +1362,9 @@ export class LGraph
     // Register reroute in Layout Store for spatial tracking
     this.layoutMutations.setSource(LayoutSource.Canvas)
     this.layoutMutations.createReroute(
-      String(rerouteId),
+      rerouteId,
       { x: pos[0], y: pos[1] },
-      before.parentId ? String(before.parentId) : undefined,
+      before.parentId,
       Array.from(linkIds)
     )
 


### PR DESCRIPTION
- Don't convert reroute and link IDs to string (maintain original type `number`)
- Add explicit types for reroute and link IDs
- Use existing NodeId type for Node IDs
- Be more expressive about normalizing node IDs from `string | number` => `string`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5352-Add-explicit-types-for-reroute-and-link-IDs-in-layout-system-2646d73d365081ca96a0cf3242a8d1ed) by [Unito](https://www.unito.io)
