### PR TITLE
Fix incorrect id resolution in image preview store

### DIFF
--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -1,6 +1,10 @@
 import { defineStore } from 'pinia'
 
-import { LGraphNode, SubgraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  LGraphNode,
+  Subgraph,
+  SubgraphNode
+} from '@/lib/litegraph/src/litegraph'
 import {
   ExecutedWsMessage,
   ResultItem,
@@ -136,17 +140,22 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
   ) {
     if (!filenames || !node) return
 
+    const locatorId =
+      node.graph instanceof Subgraph
+        ? nodeIdToNodeLocatorId(node.id, node.graph ?? undefined)
+        : `${node.id}`
+    if (!locatorId) return
     if (typeof filenames === 'string') {
-      setNodeOutputsByNodeId(
-        node.id,
+      setOutputsByLocatorId(
+        locatorId,
         createOutputs([filenames], folder, isAnimated)
       )
     } else if (!Array.isArray(filenames)) {
-      setNodeOutputsByNodeId(node.id, filenames)
+      setOutputsByLocatorId(locatorId, filenames)
     } else {
       const resultItems = createOutputs(filenames, folder, isAnimated)
       if (!resultItems?.images?.length) return
-      setNodeOutputsByNodeId(node.id, resultItems)
+      setOutputsByLocatorId(locatorId, resultItems)
     }
   }
 
@@ -165,26 +174,6 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     options: SetOutputOptions = {}
   ) {
     const nodeLocatorId = executionIdToNodeLocatorId(executionId)
-    if (!nodeLocatorId) return
-
-    setOutputsByLocatorId(nodeLocatorId, outputs, options)
-  }
-
-  /**
-   * Set node outputs by node ID.
-   * Uses the current graph context to create the appropriate NodeLocatorId.
-   *
-   * @param nodeId - The node ID
-   * @param outputs - The outputs to store
-   * @param options - Options for setting outputs
-   * @param options.merge - If true, merge with existing outputs (arrays are concatenated)
-   */
-  function setNodeOutputsByNodeId(
-    nodeId: string | number,
-    outputs: ExecutedWsMessage['output'] | ResultItem,
-    options: SetOutputOptions = {}
-  ) {
-    const nodeLocatorId = nodeIdToNodeLocatorId(nodeId)
     if (!nodeLocatorId) return
 
     setOutputsByLocatorId(nodeLocatorId, outputs, options)
@@ -288,7 +277,6 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     getNodePreviews,
     setNodeOutputs,
     setNodeOutputsByExecutionId,
-    setNodeOutputsByNodeId,
     setNodePreviewsByExecutionId,
     setNodePreviewsByNodeId,
     revokePreviewsByExecutionId,


### PR DESCRIPTION
Resolves #5354 

The setNodeOutputsByNodeId would call nodeIdToNodeLocatorId without providing the optional subgraph argument. This causes the method to use the activeSubgraph . When a workflow is first loaded (and potentially when outputs are generated during execution) this method is called when the activeSubgraph does not represent the node a preview is being added for.

setNodeOutputsByNodeId lacks the required parameters to be made safe and is only used by the setNodeOutputs function. It has been removed and setNodeOutputs has been reworked to properly supply a node's graph when querying locator ids.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5357-Fix-incorrect-id-resolution-in-image-preview-store-2646d73d36508195b874f2fad3bec600) by [Unito](https://www.unito.io)
