### PR TITLE
[fix] Disable link markers on dragged connections

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4716,7 +4716,6 @@ export class LGraphCanvas
 
           // the connection being dragged by the mouse
           if (this.linkRenderer) {
-            const context = this.buildLinkRenderContext()
             this.linkRenderer.renderLinkDirect(
               ctx,
               pos,
@@ -4727,7 +4726,10 @@ export class LGraphCanvas
               colour,
               fromDirection,
               dragDirection,
-              context,
+              {
+                ...this.buildLinkRenderContext(),
+                linkMarkerShape: LinkMarkerShape.None
+              },
               {
                 disabled: false
               }


### PR DESCRIPTION
Removes link markers (arrows) from connections that are being actively dragged by the mouse to prevent visual artifacts during link creation.

## Changes
- Set `linkMarkerShape: LinkMarkerShape.None` when rendering links being dragged
- Prevents arrows from appearing on temporary dragged connections

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5358-fix-Disable-link-markers-on-dragged-connections-2646d73d3650819eb613f5157f6469f7) by [Unito](https://www.unito.io)
