### PR TITLE
[bugfix] Fix NodeHeader test workflow path

### DIFF
--- a/browser_tests/tests/vueNodes/NodeHeader.spec.ts
+++ b/browser_tests/tests/vueNodes/NodeHeader.spec.ts
@@ -11,7 +11,7 @@ test.describe('NodeHeader', () => {
     await comfyPage.setSetting('Comfy.EnableTooltips', true)
     await comfyPage.setup()
     // Load single SaveImage node workflow (positioned below menu bar)
-    await comfyPage.loadWorkflow('single_save_image_node')
+    await comfyPage.loadWorkflow('nodes/single_save_image_node')
   })
 
   test('displays node title', async ({ comfyPage }) => {


### PR DESCRIPTION
## Summary
Fixes test failure where NodeHeader.spec.ts was looking for workflow file at incorrect path. The test was authored before assets were reorganized but merged after, causing a path mismatch.

## Root Cause Timeline
- **287bd7ddd** (2024-09-04): Added `browser_tests/assets/single_save_image_node.json`
- **efd9b04a6** (2025-08-18): "[refactor] Organize all browser test assets into logical folders (#5058)" - Moved assets into subfolders, relocating file to `browser_tests/assets/nodes/single_save_image_node.json`
- **19084e279** (authored 2025-08-06, merged 2025-08-29): Added `browser_tests/tests/vueNodes/NodeHeader.spec.ts` with `loadWorkflow('single_save_image_node')` using the old path

The test was written targeting the original structure but merged after the refactor, resulting in ENOENT errors.

## Changes
- Updated workflow path in NodeHeader.spec.ts from `'single_save_image_node'` to `'nodes/single_save_image_node'`

## Test Plan
- [x] Browser tests now pass without ENOENT error
- [x] Verified file exists at `browser_tests/assets/nodes/single_save_image_node.json`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5359-bugfix-Fix-NodeHeader-test-workflow-path-2646d73d3650810dba6bc1cd0cca9da3) by [Unito](https://www.unito.io)
