### PR TITLE
[Vue Nodes] Fix Node Header Tests

### DIFF
--- a/browser_tests/tests/vueNodes/NodeHeader.spec.ts
+++ b/browser_tests/tests/vueNodes/NodeHeader.spec.ts
@@ -9,6 +9,7 @@ test.describe('NodeHeader', () => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Enabled')
     await comfyPage.setSetting('Comfy.Graph.CanvasMenu', false)
     await comfyPage.setSetting('Comfy.EnableTooltips', true)
+    await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
     await comfyPage.setup()
     // Load single SaveImage node workflow (positioned below menu bar)
     await comfyPage.loadWorkflow('nodes/single_save_image_node')

--- a/browser_tests/tests/vueNodes/NodeHeader.spec.ts
+++ b/browser_tests/tests/vueNodes/NodeHeader.spec.ts
@@ -11,29 +11,26 @@ test.describe('NodeHeader', () => {
     await comfyPage.setSetting('Comfy.EnableTooltips', true)
     await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
     await comfyPage.setup()
-    // Load single SaveImage node workflow (positioned below menu bar)
-    await comfyPage.loadWorkflow('nodes/single_save_image_node')
   })
 
   test('displays node title', async ({ comfyPage }) => {
-    // Get the single SaveImage node from the workflow
-    const nodes = await comfyPage.getNodeRefsByType('SaveImage')
+    // Get the KSampler node from the default workflow
+    const nodes = await comfyPage.getNodeRefsByType('KSampler')
     expect(nodes.length).toBeGreaterThanOrEqual(1)
 
     const node = nodes[0]
     const vueNode = new VueNodeFixture(node, comfyPage.page)
 
     const title = await vueNode.getTitle()
-    expect(title).toBe('Save Image')
+    expect(title).toBe('KSampler')
 
     // Verify title is visible in the header
     const header = await vueNode.getHeader()
-    await expect(header).toContainText('Save Image')
+    await expect(header).toContainText('KSampler')
   })
 
   test('allows title renaming', async ({ comfyPage }) => {
-    // Get the single SaveImage node from the workflow
-    const nodes = await comfyPage.getNodeRefsByType('SaveImage')
+    const nodes = await comfyPage.getNodeRefsByType('KSampler')
     const node = nodes[0]
     const vueNode = new VueNodeFixture(node, comfyPage.page)
 
@@ -65,8 +62,8 @@ test.describe('NodeHeader', () => {
   })
 
   test('handles node collapsing', async ({ comfyPage }) => {
-    // Get the single SaveImage node from the workflow
-    const nodes = await comfyPage.getNodeRefsByType('SaveImage')
+    // Get the KSampler node from the default workflow
+    const nodes = await comfyPage.getNodeRefsByType('KSampler')
     const node = nodes[0]
     const vueNode = new VueNodeFixture(node, comfyPage.page)
 
@@ -94,8 +91,7 @@ test.describe('NodeHeader', () => {
   })
 
   test('shows collapse/expand icon state', async ({ comfyPage }) => {
-    // Get the single SaveImage node from the workflow
-    const nodes = await comfyPage.getNodeRefsByType('SaveImage')
+    const nodes = await comfyPage.getNodeRefsByType('KSampler')
     const node = nodes[0]
     const vueNode = new VueNodeFixture(node, comfyPage.page)
 
@@ -115,8 +111,7 @@ test.describe('NodeHeader', () => {
   })
 
   test('preserves title when collapsing/expanding', async ({ comfyPage }) => {
-    // Get the single SaveImage node from the workflow
-    const nodes = await comfyPage.getNodeRefsByType('SaveImage')
+    const nodes = await comfyPage.getNodeRefsByType('KSampler')
     const node = nodes[0]
     const vueNode = new VueNodeFixture(node, comfyPage.page)
 


### PR DESCRIPTION
Fixes tests in NodeHeader.spec.ts

- Enables Vue Nodes setting
- Switches from saveimage node to ksampler
  - saveimage for whatever reason on a single test case gets spawned/teleported underneath the workflow tabs, ksampler is just centered so it fixes it

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5360-Vue-Nodes-Fix-Node-Header-Tests-2646d73d36508141baa1ccc40d0f843a) by [Unito](https://www.unito.io)
