### PR TITLE
[docs] Change "Monorepo Conversion" ADR status to accepted

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [0001](0001-merge-litegraph-into-frontend.md) | Merge LiteGraph.js into ComfyUI Frontend | Accepted | 2025-08-05 |
-| [0002](0002-monorepo-conversion.md) | Restructure as a Monorepo | Proposed | 2025-08-25 |
+| [0002](0002-monorepo-conversion.md) | Restructure as a Monorepo | Accepted | 2025-08-25 |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
Changes the status of the [monorepo conversation ADR](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/adr/0002-monorepo-conversion.md?plain=1) to _accepted_.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5364-docs-Change-Monorepo-Conversion-ADR-status-to-accepted-2656d73d365081879811e113a4cbb230) by [Unito](https://www.unito.io)
