### PR TITLE
[refactor] Use public nodes getter instead of private _nodes property

### DIFF
--- a/src/renderer/core/layout/sync/useSlotLayoutSync.ts
+++ b/src/renderer/core/layout/sync/useSlotLayoutSync.ts
@@ -70,7 +70,7 @@ export function useSlotLayoutSync() {
     if (!graph) return
 
     // Initial registration for all nodes in the current graph
-    for (const node of graph._nodes) {
+    for (const node of graph.nodes) {
       computeAndRegisterSlots(node)
     }
 


### PR DESCRIPTION
## Summary

Replace direct access to graph._nodes with the public graph.nodes getter to follow proper encapsulation.

## Changes

- **What**: Use public `graph.nodes` getter instead of accessing private `graph._nodes` property in useSlotLayoutSync

## Review Focus

Simple refactor to use the proper public API instead of accessing private properties.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5369-refactor-Use-public-nodes-getter-instead-of-private-_nodes-property-2656d73d365081bbb3fbdac3a9a725e5) by [Unito](https://www.unito.io)
