### PR TITLE
Fix double click primitive widgets with subgraphs

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -593,7 +593,7 @@ app.registerExtension({
       const node = LiteGraph.createNode('PrimitiveNode')
       if (!node) return r
 
-      app.graph.add(node)
+      this.graph?.add(node)
 
       // Calculate a position that wont directly overlap another node
       const pos: [number, number] = [


### PR DESCRIPTION
Double clicking the input slot of a node creates and connects a primitive widget. However, this code would always add the created primitive to the root graph. This is fixed to use the graph containing the double clicked node, or to silently fail if the node is somehow not contained in a graph.

Proposed big future task: There's lots of ambiguous uses of `app.graph` in the codebase.
- Setting the type of `app.graph` to `unknown` produces type warnings without breaking existing extensions
  - There's currently 178 (+10 test) uses of  `app.graph`
- Introduce a new app.rootGraph property and migrate all `app.graph` uses as appropriate.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5372-Fix-double-click-primitive-widgets-with-subgraphs-2656d73d365081b1857dff8571c56509) by [Unito](https://www.unito.io)
