### PR TITLE
fix: correct Vue ref auto-unwrapping in slot components

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -32,7 +32,14 @@
 </template>
 
 <script setup lang="ts">
-import { type Ref, computed, inject, onErrorCaptured, ref, watch } from 'vue'
+import {
+  type ComponentPublicInstance,
+  computed,
+  inject,
+  onErrorCaptured,
+  ref,
+  watchEffect
+} from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { getSlotColor } from '@/constants/slotColors'
@@ -83,19 +90,17 @@ const transformState = inject<TransformState | undefined>(
   undefined
 )
 
-const connectionDotRef = ref<{ slotElRef: Ref<HTMLElement> }>()
+const connectionDotRef = ref<ComponentPublicInstance<{
+  slotElRef: HTMLElement | undefined
+}> | null>(null)
 const slotElRef = ref<HTMLElement | null>(null)
 
-// Watch for connection dot ref changes and sync the element ref
-watch(
-  connectionDotRef,
-  (newValue) => {
-    if (newValue?.slotElRef) {
-      slotElRef.value = newValue.slotElRef.value
-    }
-  },
-  { immediate: true }
-)
+// Watch for when the child component's ref becomes available
+// Vue automatically unwraps the Ref when exposing it
+watchEffect(() => {
+  const el = connectionDotRef.value?.slotElRef
+  slotElRef.value = el || null
+})
 
 useDomSlotRegistration({
   nodeId: props.nodeId ?? '',

--- a/src/renderer/extensions/vueNodes/components/OutputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.vue
@@ -33,7 +33,14 @@
 </template>
 
 <script setup lang="ts">
-import { type Ref, computed, inject, onErrorCaptured, ref, watch } from 'vue'
+import {
+  type ComponentPublicInstance,
+  computed,
+  inject,
+  onErrorCaptured,
+  ref,
+  watchEffect
+} from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { getSlotColor } from '@/constants/slotColors'
@@ -82,19 +89,17 @@ const transformState = inject<TransformState | undefined>(
   undefined
 )
 
-const connectionDotRef = ref<{ slotElRef: Ref<HTMLElement> }>()
+const connectionDotRef = ref<ComponentPublicInstance<{
+  slotElRef: HTMLElement | undefined
+}> | null>(null)
 const slotElRef = ref<HTMLElement | null>(null)
 
-// Watch for connection dot ref changes and sync the element ref
-watch(
-  connectionDotRef,
-  (newValue) => {
-    if (newValue?.slotElRef) {
-      slotElRef.value = newValue.slotElRef.value
-    }
-  },
-  { immediate: true }
-)
+// Watch for when the child component's ref becomes available
+// Vue automatically unwraps the Ref when exposing it
+watchEffect(() => {
+  const el = connectionDotRef.value?.slotElRef
+  slotElRef.value = el || null
+})
 
 useDomSlotRegistration({
   nodeId: props.nodeId ?? '',


### PR DESCRIPTION
## Summary

Fixed Vue's auto-unwrapping behavior for exposed template refs in slot components, resolving slot registration failures.

## Changes

- **What**: Corrected type and access pattern for component refs exposed via `defineExpose` in InputSlot.vue and OutputSlot.vue
- **Breaking**: None
- **Dependencies**: None

## Review Focus

The key fix addresses Vue's automatic ref unwrapping when a child component exposes a ref through `defineExpose`. The parent was incorrectly treating the exposed value as a `Ref<HTMLElement>` and calling `.value`, but Vue already unwraps it to `HTMLElement`.

## Technical Details

### Exact Issue
- Child component `SlotConnectionDot.vue` exposes a template ref with `defineExpose({ slotElRef })`, where `slotElRef` comes from `useTemplateRef('slot-el')`
- When a child exposes a Ref via `defineExpose`, Vue auto-unwraps it on the parent component instance proxy
- Previously, the parent treated it as `Ref` and read `.value` (double-unwrapping), which produced `undefined` at runtime
- Result: `slotElRef` stayed null and `useDomSlotRegistration` had no element to measure/register, breaking slot hit-testing/linking

### What Changed
**Before:**
- `connectionDotRef: ref<{ slotElRef: Ref<HTMLElement> }>()`
- Used `watch(connectionDotRef, ...)` and accessed `newValue.slotElRef.value`

**After:**
- `connectionDotRef: ref<ComponentPublicInstance<{ slotElRef: HTMLElement | undefined }> | null>()`
- Used `watchEffect(() => { slotElRef.value = connectionDotRef.value?.slotElRef || null })`

### Why It Works
1. **Auto-unwrapping**: Stopped calling `.value` on an already unwrapped HTMLElement
2. **Timing**: `watchEffect` reruns when the child's exposed `slotElRef` appears (after mount), whereas the old `watch` only reacted to component ref assignment

With these fixes, `slotElRef` is reliably populated, `useDomSlotRegistration` can measure and register slot positions, and slot hit-testing/connection logic works as intended.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5378-fix-correct-Vue-ref-auto-unwrapping-in-slot-components-2666d73d3650818c8908f7c88e5a530d) by [Unito](https://www.unito.io)
