### PR TITLE
[refactor] Refactor reroute change handlers

### DIFF
--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -1178,31 +1178,25 @@ class LayoutStoreImpl implements LayoutStore {
     const rerouteId = Number(rerouteIdStr) as RerouteId
 
     if (change.action === 'delete') {
-      this.handleRerouteDelete(rerouteId, rerouteIdStr)
-    } else if (change.action === 'update' || change.action === 'add') {
-      this.handleRerouteAddOrUpdate(rerouteId, rerouteIdStr)
+      this.handleRerouteDelete(rerouteId)
+    } else {
+      this.handleRerouteUpsert(rerouteId)
     }
   }
 
   /**
    * Handle reroute deletion
    */
-  private handleRerouteDelete(
-    rerouteId: RerouteId,
-    rerouteIdStr: string
-  ): void {
+  private handleRerouteDelete(rerouteId: RerouteId): void {
     this.rerouteLayouts.delete(rerouteId)
-    this.rerouteSpatialIndex.remove(rerouteIdStr)
+    this.rerouteSpatialIndex.remove(String(rerouteId))
   }
 
   /**
-   * Handle reroute add or update
+   * Handle reroute upsert (update if exists, create if not)
    */
-  private handleRerouteAddOrUpdate(
-    rerouteId: RerouteId,
-    rerouteIdStr: string
-  ): void {
-    const rerouteData = this.yreroutes.get(rerouteIdStr)
+  private handleRerouteUpsert(rerouteId: RerouteId): void {
+    const rerouteData = this.yreroutes.get(String(rerouteId))
     if (!rerouteData) return
 
     const position = rerouteData.get('position') as Point
@@ -1351,6 +1345,3 @@ class LayoutStoreImpl implements LayoutStore {
 
 // Create singleton instance
 export const layoutStore = new LayoutStoreImpl()
-
-// Export types for convenience
-export type { LayoutStore } from '@/renderer/core/layout/types'


### PR DESCRIPTION
## Summary

Refactors reroute change handlers. 

## Changes

- Replace handleRerouteAdd + handleRerouteUpdate with single handleRerouteUpsert
- Both operations performed identical logic (full layout replacement)
- Remove redundant parameter passing (rerouteIdStr + rerouteId)
- Remove 'export type { LayoutStore } from types' pattern that obscures dependencies

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5379-refactor-Refactor-reroute-change-handlers-2666d73d36508121b35df4e88cdb3f54) by [Unito](https://www.unito.io)
