### PR TITLE
[refactor] Improve type narrowing syntax in graph node manager

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -235,11 +235,15 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
     }
     if (typeof value === 'object') {
       // Check if it's a File array
-      if (Array.isArray(value) && value.every((item) => item instanceof File)) {
-        return value as File[]
+      if (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((item): item is File => item instanceof File)
+      ) {
+        return value
       }
       // Otherwise it's a generic object
-      return value as object
+      return value
     }
     // If none of the above, return undefined
     console.warn(`Invalid widget value type: ${typeof value}`, value)


### PR DESCRIPTION
Changes type narrowing to use type guard instead of assertion. Remove unecessary assertion `as object`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5380-refactor-Improve-type-narrowing-syntax-in-graph-node-manager-2666d73d3650811f9a68d817cd66e2dc) by [Unito](https://www.unito.io)
