### PR TITLE
Enforce custom dark-theme: prefix instead of standard dark: prefix

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,8 @@ export default [
       '@typescript-eslint/prefer-as-const': 'off',
       'unused-imports/no-unused-imports': 'error',
       'vue/no-v-html': 'off',
+      // Enforce dark-theme: instead of dark: prefix
+      'vue/no-restricted-class': ['error', '/^dark:/'],
       // i18n rules
       '@intlify/vue-i18n/no-raw-text': [
         'error',

--- a/src/components/common/FormImageUpload.vue
+++ b/src/components/common/FormImageUpload.vue
@@ -3,7 +3,7 @@
     <div class="flex gap-2 items-center">
       <div
         class="preview-box border rounded p-2 w-16 h-16 flex items-center justify-center"
-        :class="{ 'bg-gray-100 dark:bg-gray-800': !modelValue }"
+        :class="{ 'bg-gray-100 dark-theme:bg-gray-800': !modelValue }"
       >
         <img
           v-if="modelValue"


### PR DESCRIPTION
## Summary
- Add `vue/no-restricted-class` ESLint rule to catch `dark:` prefix usage  
- Fix existing violation in `FormImageUpload.vue` (`dark:` → `dark-theme:`)
- Ensures consistent usage of project's custom [Tailwind variant](https://github.com/Comfy-Org/ComfyUI_frontend/blob/bd299b82103eac30685aeb1d2a7e492da680e807/tailwind.config.ts#L241-L243)

https://github.com/Comfy-Org/ComfyUI_frontend/blob/bd299b82103eac30685aeb1d2a7e492da680e807/tailwind.config.ts#L241-L243



## Why This Change?
The project uses a custom `dark-theme:` Tailwind variant instead of the standard `dark:` variant. This ESLint rule prevents accidental usage of the standard prefix and ensures consistency across the codebase.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5382-Enforce-custom-dark-theme-prefix-instead-of-standard-dark-prefix-2666d73d365081ccb624e767fca02355) by [Unito](https://www.unito.io)
