### PR TITLE
[bugfix] Fix slot layout sync timing and cleanup on rendering mode switch

### DIFF
--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -420,6 +420,15 @@ class LayoutStoreImpl implements LayoutStore {
   }
 
   /**
+   * Clear all slot layouts and their spatial index (O(1) operations)
+   * Used when switching rendering modes (Vue ↔ LiteGraph)
+   */
+  clearAllSlotLayouts(): void {
+    this.slotLayouts.clear()
+    this.slotSpatialIndex.clear()
+  }
+
+  /**
    * Update reroute layout data
    */
   updateRerouteLayout(rerouteId: RerouteId, layout: RerouteLayout): void {

--- a/src/renderer/core/layout/sync/useSlotLayoutSync.ts
+++ b/src/renderer/core/layout/sync/useSlotLayoutSync.ts
@@ -16,7 +16,7 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
  * Compute and register slot layouts for a node
  * @param node LiteGraph node to process
  */
-function computeAndRegisterSlots(node: LGraphNode): void {
+export function computeAndRegisterSlots(node: LGraphNode): void {
   const nodeId = String(node.id)
   const nodeLayout = layoutStore.getNodeLayoutRef(nodeId).value
 
@@ -57,17 +57,18 @@ export function useSlotLayoutSync() {
   let restoreHandlers: (() => void) | null = null
 
   /**
-   * Start slot layout sync with full event-driven functionality
+   * Attempt to start slot layout sync with full event-driven functionality
    * @param canvas LiteGraph canvas instance
+   * @returns true if sync was actually started, false if early-returned
    */
-  function start(canvas: LGraphCanvas): void {
+  function attemptStart(canvas: LGraphCanvas): boolean {
     // When Vue nodes are enabled, slot DOM registers exact positions.
     // Skip calculated registration to avoid conflicts.
     if (LiteGraph.vueNodesMode) {
-      return
+      return false
     }
     const graph = canvas?.graph
-    if (!graph) return
+    if (!graph) return false
 
     // Initial registration for all nodes in the current graph
     for (const node of graph.nodes) {
@@ -135,6 +136,8 @@ export function useSlotLayoutSync() {
       graph.onTrigger = origTrigger || undefined
       graph.onAfterChange = origAfterChange || undefined
     }
+
+    return true
   }
 
   /**
@@ -157,7 +160,7 @@ export function useSlotLayoutSync() {
   })
 
   return {
-    start,
+    attemptStart,
     stop
   }
 }

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -297,6 +297,7 @@ export interface LayoutStore {
   deleteSlotLayout(key: string): void
   deleteNodeSlotLayouts(nodeId: NodeId): void
   deleteRerouteLayout(rerouteId: RerouteId): void
+  clearAllSlotLayouts(): void
 
   // Get layout data
   getLinkLayout(linkId: LinkId): LinkLayout | null


### PR DESCRIPTION
## Summary

Fix slot layout sync initialization timing and properly clear slot layouts when switching between Vue and LiteGraph rendering modes.

## Changes

- **What**: 
  - Add proper lifecycle management for slot layout sync initialization
  - Clear all slot layouts when switching between Vue and LiteGraph rendering modes
  - Fix timing issues where slot sync could start before canvas is ready
  - Prevent duplicate slot registrations from conflicting sync mechanisms

## Review Focus

- The consolidated watch in GraphCanvas.vue that manages slot sync lifecycle based on rendering mode
- The new `clearAllSlotLayouts()` method that ensures clean state transitions between modes
- The `attemptStart()` pattern that returns success status to prevent invalid state tracking

Fixes #5363