### PR TITLE
[cleanup] Remove debug logging from slot layout updates

### DIFF
--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -371,15 +371,6 @@ class LayoutStoreImpl implements LayoutStore {
   updateSlotLayout(key: string, layout: SlotLayout): void {
     const existing = this.slotLayouts.get(key)
 
-    if (!existing) {
-      logger.debug('Adding slot:', {
-        nodeId: layout.nodeId,
-        type: layout.type,
-        index: layout.index,
-        bounds: layout.bounds
-      })
-    }
-
     if (existing) {
       // Update spatial index
       this.slotSpatialIndex.update(key, layout.bounds)


### PR DESCRIPTION
## Summary

Remove debug logging from slot layout update method to reduce console noise in production.

## Changes

- **What**: Remove debug logging that was outputting slot details on every slot layout addition

## Review Focus

Simple cleanup - removing verbose debug logging that's no longer needed.

## Screenshots (if applicable)

N/A - Debug logging removal

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5384-cleanup-Remove-debug-logging-from-slot-layout-updates-2666d73d36508113a842f2db1dd3f640) by [Unito](https://www.unito.io)
