### PR TITLE
[fix] Fix `step` prop scaling issue on numeric Vue widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSlider.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSlider.vue
@@ -74,13 +74,9 @@ const precision = computed(() => {
 
 // Calculate the step value based on precision or widget options
 const stepValue = computed(() => {
-  // Use step2 (correct value) instead of step (legacy 10x value)
+  // Use step2 (correct input spec value) instead of step (legacy 10x value)
   if (props.widget.options?.step2 !== undefined) {
     return String(props.widget.options.step2)
-  }
-  // Fallback to legacy step if step2 not available
-  if (props.widget.options?.step !== undefined) {
-    return String(props.widget.options.step)
   }
   // Otherwise, derive from precision
   if (precision.value !== undefined) {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSlider.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSlider.vue
@@ -74,7 +74,11 @@ const precision = computed(() => {
 
 // Calculate the step value based on precision or widget options
 const stepValue = computed(() => {
-  // If step is explicitly defined in options, use it
+  // Use step2 (correct value) instead of step (legacy 10x value)
+  if (props.widget.options?.step2 !== undefined) {
+    return String(props.widget.options.step2)
+  }
+  // Fallback to legacy step if step2 not available
   if (props.widget.options?.step !== undefined) {
     return String(props.widget.options.step)
   }


### PR DESCRIPTION
Account for a hacky workaround on the `step` prop of numeric widgets that was introduced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/2759 to account for scaling issues.

The InputNumber widget is not implemented yet, but this will have to be mirrored there when it is.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5386-fix-Fix-step-prop-scaling-issue-on-numeric-Vue-widgets-2666d73d3650813bb5c3c7275d3c78f1) by [Unito](https://www.unito.io)
