### PR TITLE
add prices for StabilityAudio API nodes

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1031,6 +1031,15 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
     StabilityUpscaleFastNode: {
       displayPrice: '$0.01/Run'
     },
+    StabilityTextToAudio: {
+      displayPrice: '$0.20/Run'
+    },
+    StabilityAudioToAudio: {
+      displayPrice: '$0.20/Run'
+    },
+    StabilityAudioInpaint: {
+      displayPrice: '$0.20/Run'
+    },
     VeoVideoGenerationNode: {
       displayPrice: (node: LGraphNode): string => {
         const durationWidget = node.widgets?.find(


### PR DESCRIPTION
## Summary

Currently we support only one latest model, prices for it are fixed and do not depend on any parameters.

_note: this should be included in the next week's release_

## Screenshots (if applicable)

<img width="1208" height="767" alt="Screenshot from 2025-09-06 11-26-56" src="https://github.com/user-attachments/assets/495b9e5b-9b96-4071-82e7-6670d4e240fc" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5387-add-prices-for-StabilityAudio-API-nodes-2666d73d365081a38d1ede30c6e78858) by [Unito](https://www.unito.io)
