### PR TITLE
[refactor] Extract Vue node entry point logic into focused composables

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -162,11 +162,11 @@ const selectionToolboxEnabled = computed(() =>
 
 const minimapEnabled = computed(() => settingStore.get('Comfy.Minimap.Visible'))
 
-// Feature flags (Vue-related)
+// Feature flags
 const { shouldRenderVueNodes } = useVueFeatureFlags()
 const isVueNodesEnabled = computed(() => shouldRenderVueNodes.value)
 
-// Vue node system - using focused composables with proper reactivity
+// Vue node system
 const vueNodeLifecycle = useVueNodeLifecycle(isVueNodesEnabled)
 const viewportCulling = useViewportCulling(
   isVueNodesEnabled,
@@ -176,12 +176,10 @@ const viewportCulling = useViewportCulling(
 )
 const nodeEventHandlers = useNodeEventHandlers(vueNodeLifecycle.nodeManager)
 
-// Reactive refs from composables - no need for extraction
 const nodePositions = vueNodeLifecycle.nodePositions
 const nodeSizes = vueNodeLifecycle.nodeSizes
 const nodesToRender = viewportCulling.nodesToRender
 
-// Handlers - now using reactive detectChangesInRAF
 const handleTransformUpdate = () => {
   viewportCulling.handleTransformUpdate(
     vueNodeLifecycle.detectChangesInRAF.value
@@ -397,7 +395,6 @@ onMounted(async () => {
 
   comfyAppReady.value = true
 
-  // Set up Vue node initialization only when enabled
   vueNodeLifecycle.setupEmptyGraphListener()
 
   comfyApp.canvas.onSelectionChange = useChainCallback(

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -604,7 +604,7 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
     // Set up widget callbacks BEFORE extracting data (critical order)
     setupNodeWidgetCallbacks(node)
 
-    // Extract safe data for Vue (now with proper callbacks)
+    // Extract safe data for Vue
     vueNodeData.set(id, extractVueNodeData(node))
 
     // Set up reactive tracking state

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -2,7 +2,7 @@
  * Vue node lifecycle management for LiteGraph integration
  * Provides event-driven reactivity with performance optimizations
  */
-import { nextTick, reactive, readonly } from 'vue'
+import { nextTick, reactive } from 'vue'
 
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
@@ -789,16 +789,10 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
   }
 
   return {
-    vueNodeData: readonly(vueNodeData) as ReadonlyMap<string, VueNodeData>,
-    nodeState: readonly(nodeState) as ReadonlyMap<string, NodeState>,
-    nodePositions: readonly(nodePositions) as ReadonlyMap<
-      string,
-      { x: number; y: number }
-    >,
-    nodeSizes: readonly(nodeSizes) as ReadonlyMap<
-      string,
-      { width: number; height: number }
-    >,
+    vueNodeData,
+    nodeState,
+    nodePositions,
+    nodeSizes,
     getNode,
     setupEventListeners,
     cleanup,
@@ -807,7 +801,7 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
     detectChangesInRAF,
     getVisibleNodeIds,
     performanceMetrics,
-    spatialMetrics: readonly(spatialMetrics),
+    spatialMetrics,
     getSpatialIndexDebugInfo: () => spatialIndex.getDebugInfo()
   }
 }

--- a/src/composables/graph/useNodeEventHandlers.ts
+++ b/src/composables/graph/useNodeEventHandlers.ts
@@ -1,0 +1,212 @@
+/**
+ * Node Event Handlers Composable
+ *
+ * Handles all Vue node interaction events including:
+ * - Node selection with multi-select support
+ * - Node collapse/expand state management
+ * - Node title editing and updates
+ * - Layout mutations for visual feedback
+ * - Integration with LiteGraph canvas selection system
+ */
+import type { Ref } from 'vue'
+
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
+import { LayoutSource } from '@/renderer/core/layout/types'
+import { useCanvasStore } from '@/stores/graphStore'
+
+interface NodeManager {
+  getNode: (id: string) => any
+}
+
+export function useNodeEventHandlers(nodeManager: Ref<NodeManager | null>) {
+  const canvasStore = useCanvasStore()
+  const layoutMutations = useLayoutMutations()
+
+  /**
+   * Handle node selection events
+   * Supports single selection and multi-select with Ctrl/Cmd
+   */
+  const handleNodeSelect = (event: PointerEvent, nodeData: VueNodeData) => {
+    if (!canvasStore.canvas || !nodeManager.value) return
+
+    const node = nodeManager.value.getNode(nodeData.id)
+    if (!node) return
+
+    // Handle multi-select with Ctrl/Cmd key
+    if (!event.ctrlKey && !event.metaKey) {
+      canvasStore.canvas.deselectAllNodes()
+    }
+
+    canvasStore.canvas.selectNode(node)
+
+    // Bring node to front when clicked (similar to LiteGraph behavior)
+    // Skip if node is pinned to avoid unwanted movement
+    if (!node.flags?.pinned) {
+      layoutMutations.setSource(LayoutSource.Vue)
+      layoutMutations.bringNodeToFront(nodeData.id)
+    }
+
+    // Ensure node selection state is set
+    node.selected = true
+
+    // Update canvas selection tracking
+    canvasStore.updateSelectedItems()
+  }
+
+  /**
+   * Handle node collapse/expand state changes
+   * Uses LiteGraph's native collapse method for proper state management
+   */
+  const handleNodeCollapse = (nodeId: string, collapsed: boolean) => {
+    if (!nodeManager.value) return
+
+    const node = nodeManager.value.getNode(nodeId)
+    if (!node) return
+
+    // Use LiteGraph's collapse method if the state needs to change
+    const currentCollapsed = node.flags?.collapsed ?? false
+    if (currentCollapsed !== collapsed) {
+      node.collapse()
+    }
+  }
+
+  /**
+   * Handle node title updates
+   * Updates the title in LiteGraph for persistence across sessions
+   */
+  const handleNodeTitleUpdate = (nodeId: string, newTitle: string) => {
+    if (!nodeManager.value) return
+
+    const node = nodeManager.value.getNode(nodeId)
+    if (!node) return
+
+    // Update the node title in LiteGraph for persistence
+    node.title = newTitle
+  }
+
+  /**
+   * Handle node double-click events
+   * Can be used for custom actions like opening node editor
+   */
+  const handleNodeDoubleClick = (
+    event: PointerEvent,
+    nodeData: VueNodeData
+  ) => {
+    if (!canvasStore.canvas || !nodeManager.value) return
+
+    const node = nodeManager.value.getNode(nodeData.id)
+    if (!node) return
+
+    // Prevent default browser behavior
+    event.preventDefault()
+
+    // TODO: add custom double-click behavior here
+    // For now, ensure node is selected
+    if (!node.selected) {
+      handleNodeSelect(event, nodeData)
+    }
+  }
+
+  /**
+   * Handle node right-click context menu events
+   * Integrates with LiteGraph's context menu system
+   */
+  const handleNodeRightClick = (event: PointerEvent, nodeData: VueNodeData) => {
+    if (!canvasStore.canvas || !nodeManager.value) return
+
+    const node = nodeManager.value.getNode(nodeData.id)
+    if (!node) return
+
+    // Prevent default context menu
+    event.preventDefault()
+
+    // Select the node if not already selected
+    if (!node.selected) {
+      handleNodeSelect(event, nodeData)
+    }
+
+    // Let LiteGraph handle the context menu
+    // The canvas will handle showing the appropriate context menu
+  }
+
+  /**
+   * Handle node drag start events
+   * Prepares node for dragging and sets appropriate visual state
+   */
+  const handleNodeDragStart = (event: DragEvent, nodeData: VueNodeData) => {
+    if (!canvasStore.canvas || !nodeManager.value) return
+
+    const node = nodeManager.value.getNode(nodeData.id)
+    if (!node) return
+
+    // Ensure node is selected before dragging
+    if (!node.selected) {
+      // Create a synthetic pointer event for selection
+      const syntheticEvent = new PointerEvent('pointerdown', {
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        bubbles: true
+      })
+      handleNodeSelect(syntheticEvent, nodeData)
+    }
+
+    // Set drag data for potential drop operations
+    if (event.dataTransfer) {
+      event.dataTransfer.setData('application/comfy-node-id', nodeData.id)
+      event.dataTransfer.effectAllowed = 'move'
+    }
+  }
+
+  /**
+   * Batch select multiple nodes
+   * Useful for selection toolbox or area selection
+   */
+  const selectNodes = (nodeIds: string[], addToSelection = false) => {
+    if (!canvasStore.canvas || !nodeManager.value) return
+
+    if (!addToSelection) {
+      canvasStore.canvas.deselectAllNodes()
+    }
+
+    nodeIds.forEach((nodeId) => {
+      const node = nodeManager.value?.getNode(nodeId)
+      if (node && canvasStore.canvas) {
+        canvasStore.canvas.selectNode(node)
+        node.selected = true
+      }
+    })
+
+    canvasStore.updateSelectedItems()
+  }
+
+  /**
+   * Deselect specific nodes
+   */
+  const deselectNodes = (nodeIds: string[]) => {
+    if (!canvasStore.canvas || !nodeManager.value) return
+
+    nodeIds.forEach((nodeId) => {
+      const node = nodeManager.value?.getNode(nodeId)
+      if (node) {
+        node.selected = false
+      }
+    })
+
+    canvasStore.updateSelectedItems()
+  }
+
+  return {
+    // Core event handlers
+    handleNodeSelect,
+    handleNodeCollapse,
+    handleNodeTitleUpdate,
+    handleNodeDoubleClick,
+    handleNodeRightClick,
+    handleNodeDragStart,
+
+    // Batch operations
+    selectNodes,
+    deselectNodes
+  }
+}

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -9,8 +9,8 @@
  */
 import { type Ref, computed, readonly, ref } from 'vue'
 
-import { useTransformState } from '@/renderer/core/layout/useTransformState'
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { useTransformState } from '@/renderer/core/layout/useTransformState'
 import { app as comfyApp } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -1,0 +1,212 @@
+/**
+ * Viewport Culling Composable
+ *
+ * Handles viewport culling optimization for Vue nodes including:
+ * - Transform state synchronization
+ * - Visible node calculation with screen space transforms
+ * - Adaptive margin computation based on zoom level
+ * - Performance optimizations for large graphs
+ */
+import { type Ref, computed, readonly, ref } from 'vue'
+
+import { useTransformState } from '@/renderer/core/layout/useTransformState'
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { app as comfyApp } from '@/scripts/app'
+import { useCanvasStore } from '@/stores/graphStore'
+
+interface NodeManager {
+  getNode: (id: string) => any
+}
+
+export function useViewportCulling(
+  isVueNodesEnabled: Ref<boolean>,
+  vueNodeData: Ref<ReadonlyMap<string, VueNodeData>>,
+  nodeDataTrigger: Ref<number>,
+  nodeManager: Ref<NodeManager | null>
+) {
+  const canvasStore = useCanvasStore()
+  const { syncWithCanvas } = useTransformState()
+
+  // Transform tracking for performance optimization - reactive
+  const lastScale = ref(1)
+  const lastOffsetX = ref(0)
+  const lastOffsetY = ref(0)
+
+  // Computed properties for transform state
+  const currentTransformState = computed(() => ({
+    scale: lastScale.value,
+    offsetX: lastOffsetX.value,
+    offsetY: lastOffsetY.value
+  }))
+
+  /**
+   * Computed property that returns nodes visible in the current viewport
+   * Implements sophisticated culling algorithm with adaptive margins
+   */
+  const nodesToRender = computed(() => {
+    if (!isVueNodesEnabled.value) {
+      return []
+    }
+
+    // Access trigger to force re-evaluation after nodeManager initialization
+    void nodeDataTrigger.value
+
+    if (!comfyApp.graph) {
+      return []
+    }
+
+    const allNodes = Array.from(vueNodeData.value.values())
+
+    // Apply viewport culling - check if node bounds intersect with viewport
+    // TODO: use quadtree
+    if (nodeManager.value && canvasStore.canvas && comfyApp.canvas) {
+      const canvas = canvasStore.canvas
+      const manager = nodeManager.value
+
+      // Ensure transform is synced before checking visibility
+      syncWithCanvas(comfyApp.canvas)
+
+      const ds = canvas.ds
+
+      // Work in screen space - viewport is simply the canvas element size
+      const viewport_width = canvas.canvas.width
+      const viewport_height = canvas.canvas.height
+
+      // Add margin that represents a constant distance in canvas space
+      // Convert canvas units to screen pixels by multiplying by scale
+      const canvasMarginDistance = 200 // Fixed margin in canvas units
+      const margin_x = canvasMarginDistance * ds.scale
+      const margin_y = canvasMarginDistance * ds.scale
+
+      const filtered = allNodes.filter((nodeData) => {
+        const node = manager.getNode(nodeData.id)
+        if (!node) return false
+
+        // Transform node position to screen space (same as DOM widgets)
+        const screen_x = (node.pos[0] + ds.offset[0]) * ds.scale
+        const screen_y = (node.pos[1] + ds.offset[1]) * ds.scale
+        const screen_width = node.size[0] * ds.scale
+        const screen_height = node.size[1] * ds.scale
+
+        // Check if node bounds intersect with expanded viewport (in screen space)
+        const isVisible = !(
+          screen_x + screen_width < -margin_x ||
+          screen_x > viewport_width + margin_x ||
+          screen_y + screen_height < -margin_y ||
+          screen_y > viewport_height + margin_y
+        )
+
+        return isVisible
+      })
+
+      return filtered
+    }
+
+    return allNodes
+  })
+
+  /**
+   * Handle transform updates with performance optimization
+   * Only syncs when transform actually changes to avoid unnecessary reflows
+   */
+  const handleTransformUpdate = (detectChangesInRAF: () => void) => {
+    // Skip all work if Vue nodes are disabled
+    if (!isVueNodesEnabled.value) {
+      return
+    }
+
+    // Sync transform state only when it changes (avoids reflows)
+    if (comfyApp.canvas?.ds) {
+      const currentScale = comfyApp.canvas.ds.scale
+      const currentOffsetX = comfyApp.canvas.ds.offset[0]
+      const currentOffsetY = comfyApp.canvas.ds.offset[1]
+
+      if (
+        currentScale !== lastScale.value ||
+        currentOffsetX !== lastOffsetX.value ||
+        currentOffsetY !== lastOffsetY.value
+      ) {
+        syncWithCanvas(comfyApp.canvas)
+        lastScale.value = currentScale
+        lastOffsetX.value = currentOffsetX
+        lastOffsetY.value = currentOffsetY
+      }
+    }
+
+    // Detect node changes during transform updates
+    detectChangesInRAF()
+
+    // Trigger reactivity for nodesToRender
+    void nodesToRender.value.length
+  }
+
+  /**
+   * Calculate if a specific node is visible in viewport
+   * Useful for individual node visibility checks
+   */
+  const isNodeVisible = (nodeData: VueNodeData): boolean => {
+    if (!nodeManager.value || !canvasStore.canvas || !comfyApp.canvas) {
+      return true // Default to visible if culling not available
+    }
+
+    const canvas = canvasStore.canvas
+    const node = nodeManager.value.getNode(nodeData.id)
+    if (!node) return false
+
+    syncWithCanvas(comfyApp.canvas)
+    const ds = canvas.ds
+
+    const viewport_width = canvas.canvas.width
+    const viewport_height = canvas.canvas.height
+    const canvasMarginDistance = 200
+    const margin_x = canvasMarginDistance * ds.scale
+    const margin_y = canvasMarginDistance * ds.scale
+
+    const screen_x = (node.pos[0] + ds.offset[0]) * ds.scale
+    const screen_y = (node.pos[1] + ds.offset[1]) * ds.scale
+    const screen_width = node.size[0] * ds.scale
+    const screen_height = node.size[1] * ds.scale
+
+    return !(
+      screen_x + screen_width < -margin_x ||
+      screen_x > viewport_width + margin_x ||
+      screen_y + screen_height < -margin_y ||
+      screen_y > viewport_height + margin_y
+    )
+  }
+
+  /**
+   * Get viewport bounds information for debugging
+   */
+  const getViewportInfo = () => {
+    if (!canvasStore.canvas || !comfyApp.canvas) {
+      return null
+    }
+
+    const canvas = canvasStore.canvas
+    const ds = canvas.ds
+
+    return {
+      viewport_width: canvas.canvas.width,
+      viewport_height: canvas.canvas.height,
+      scale: ds.scale,
+      offset: [ds.offset[0], ds.offset[1]],
+      margin_distance: 200,
+      margin_x: 200 * ds.scale,
+      margin_y: 200 * ds.scale
+    }
+  }
+
+  return {
+    nodesToRender,
+    handleTransformUpdate,
+    isNodeVisible,
+    getViewportInfo,
+
+    // Reactive transform state
+    currentTransformState: readonly(currentTransformState),
+    lastScale: readonly(lastScale),
+    lastOffsetX: readonly(lastOffsetX),
+    lastOffsetY: readonly(lastOffsetY)
+  }
+}

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -27,12 +27,12 @@ export function useViewportCulling(
   const canvasStore = useCanvasStore()
   const { syncWithCanvas } = useTransformState()
 
-  // Transform tracking for performance optimization - reactive
+  // Transform tracking for performance optimization
   const lastScale = ref(1)
   const lastOffsetX = ref(0)
   const lastOffsetY = ref(0)
 
-  // Computed properties for transform state
+  // Current transform state
   const currentTransformState = computed(() => ({
     scale: lastScale.value,
     offsetX: lastOffsetX.value,
@@ -203,7 +203,7 @@ export function useViewportCulling(
     isNodeVisible,
     getViewportInfo,
 
-    // Reactive transform state
+    // Transform state
     currentTransformState: readonly(currentTransformState),
     lastScale: readonly(lastScale),
     lastOffsetX: readonly(lastOffsetX),

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -1,0 +1,252 @@
+/**
+ * Vue Node Lifecycle Management Composable
+ *
+ * Handles the complete lifecycle of Vue node rendering system including:
+ * - Node manager initialization and cleanup
+ * - Layout store synchronization
+ * - Slot and link sync management
+ * - Reactive state management for node data, positions, and sizes
+ * - Memory management and proper cleanup
+ */
+import { type Ref, computed, readonly, ref, shallowRef, watch } from 'vue'
+
+import { useGraphNodeManager } from '@/composables/graph/useGraphNodeManager'
+import type {
+  NodeState,
+  VueNodeData
+} from '@/composables/graph/useGraphNodeManager'
+import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { useLayoutSync } from '@/renderer/core/layout/sync/useLayoutSync'
+import { useLinkLayoutSync } from '@/renderer/core/layout/sync/useLinkLayoutSync'
+import { useSlotLayoutSync } from '@/renderer/core/layout/sync/useSlotLayoutSync'
+import { app as comfyApp } from '@/scripts/app'
+import { useCanvasStore } from '@/stores/graphStore'
+
+export function useVueNodeLifecycle(isVueNodesEnabled: Ref<boolean>) {
+  const canvasStore = useCanvasStore()
+  const layoutMutations = useLayoutMutations()
+
+  const nodeManager = shallowRef<ReturnType<typeof useGraphNodeManager> | null>(
+    null
+  )
+  const cleanupNodeManager = shallowRef<(() => void) | null>(null)
+
+  // Reactive sync management
+  const slotSync = shallowRef<ReturnType<typeof useSlotLayoutSync> | null>(null)
+  const slotSyncStarted = ref(false)
+  const linkSync = shallowRef<ReturnType<typeof useLinkLayoutSync> | null>(null)
+
+  // Reactive state for Vue node data
+  const vueNodeData = ref<ReadonlyMap<string, VueNodeData>>(new Map())
+  const nodeState = ref<ReadonlyMap<string, NodeState>>(new Map())
+  const nodePositions = ref<ReadonlyMap<string, { x: number; y: number }>>(
+    new Map()
+  )
+  const nodeSizes = ref<ReadonlyMap<string, { width: number; height: number }>>(
+    new Map()
+  )
+
+  // RAF change detection function - reactive
+  const detectChangesInRAF = ref<() => void>(() => {})
+
+  // Reactivity trigger for forcing computed re-evaluation
+  const nodeDataTrigger = ref(0)
+
+  const isNodeManagerReady = computed(() => nodeManager.value !== null)
+
+  const initializeNodeManager = () => {
+    if (!comfyApp.graph || nodeManager.value) return
+
+    // Initialize the core node manager
+    const manager = useGraphNodeManager(comfyApp.graph)
+    nodeManager.value = manager
+    cleanupNodeManager.value = manager.cleanup
+
+    // Use the manager's reactive maps directly
+    vueNodeData.value = manager.vueNodeData
+    nodeState.value = manager.nodeState
+    nodePositions.value = manager.nodePositions
+    nodeSizes.value = manager.nodeSizes
+    detectChangesInRAF.value = manager.detectChangesInRAF
+
+    // Initialize layout system with existing nodes
+    const nodes = comfyApp.graph._nodes.map((node: LGraphNode) => ({
+      id: node.id.toString(),
+      pos: [node.pos[0], node.pos[1]] as [number, number],
+      size: [node.size[0], node.size[1]] as [number, number]
+    }))
+    layoutStore.initializeFromLiteGraph(nodes)
+
+    // Seed reroutes into the Layout Store so hit-testing uses the new path
+    for (const reroute of comfyApp.graph.reroutes.values()) {
+      const [x, y] = reroute.pos
+      const parent = reroute.parentId ?? undefined
+      const linkIds = Array.from(reroute.linkIds)
+      layoutMutations.createReroute(reroute.id, { x, y }, parent, linkIds)
+    }
+
+    // Seed existing links into the Layout Store (topology only)
+    for (const link of comfyApp.graph._links.values()) {
+      layoutMutations.createLink(
+        link.id,
+        link.origin_id,
+        link.origin_slot,
+        link.target_id,
+        link.target_slot
+      )
+    }
+
+    // Initialize layout sync (one-way: Layout Store → LiteGraph)
+    const { startSync } = useLayoutSync()
+    startSync(canvasStore.canvas)
+
+    // Initialize link layout sync for event-driven updates
+    const linkSyncManager = useLinkLayoutSync()
+    linkSync.value = linkSyncManager
+    if (comfyApp.canvas) {
+      linkSyncManager.start(comfyApp.canvas)
+    }
+
+    // Force computed properties to re-evaluate
+    nodeDataTrigger.value++
+  }
+
+  const disposeNodeManagerAndSyncs = () => {
+    if (!nodeManager.value) return
+
+    try {
+      cleanupNodeManager.value?.()
+    } catch {
+      /* empty */
+    }
+    nodeManager.value = null
+    cleanupNodeManager.value = null
+
+    // Clean up link layout sync
+    if (linkSync.value) {
+      linkSync.value.stop()
+      linkSync.value = null
+    }
+
+    // Reset reactive maps to clean state
+    vueNodeData.value = new Map()
+    nodeState.value = new Map()
+    nodePositions.value = new Map()
+    nodeSizes.value = new Map()
+
+    // Reset change detection function
+    detectChangesInRAF.value = () => {}
+  }
+
+  // Watch for Vue nodes enabled state changes
+  watch(
+    () => isVueNodesEnabled.value && Boolean(comfyApp.graph),
+    (enabled) => {
+      if (enabled) {
+        initializeNodeManager()
+      } else {
+        disposeNodeManagerAndSyncs()
+      }
+    },
+    { immediate: true }
+  )
+
+  // Consolidated watch for slot layout sync management
+  watch(
+    [() => canvasStore.canvas, () => isVueNodesEnabled.value],
+    ([canvas, vueMode], [, oldVueMode]) => {
+      const modeChanged = vueMode !== oldVueMode
+
+      // Clear stale slot layouts when switching modes
+      if (modeChanged) {
+        layoutStore.clearAllSlotLayouts()
+      }
+
+      // Switching to Vue
+      if (vueMode && slotSyncStarted.value) {
+        slotSync.value?.stop()
+        slotSyncStarted.value = false
+      }
+
+      // Switching to LG
+      const shouldRun = Boolean(canvas?.graph) && !vueMode
+      if (shouldRun && !slotSyncStarted.value && canvas) {
+        // Initialize slot sync if not already created
+        if (!slotSync.value) {
+          slotSync.value = useSlotLayoutSync()
+        }
+        const started = slotSync.value.attemptStart(canvas as LGraphCanvas)
+        slotSyncStarted.value = started
+      }
+    },
+    { immediate: true }
+  )
+
+  // Handle case where Vue nodes are enabled but graph starts empty
+  const setupEmptyGraphListener = () => {
+    if (
+      isVueNodesEnabled.value &&
+      comfyApp.graph &&
+      !nodeManager.value &&
+      comfyApp.graph._nodes.length === 0
+    ) {
+      const originalOnNodeAdded = comfyApp.graph.onNodeAdded
+      comfyApp.graph.onNodeAdded = function (node: LGraphNode) {
+        // Restore original handler
+        comfyApp.graph.onNodeAdded = originalOnNodeAdded
+
+        // Initialize node manager if needed
+        if (isVueNodesEnabled.value && !nodeManager.value) {
+          initializeNodeManager()
+        }
+
+        // Call original handler
+        if (originalOnNodeAdded) {
+          originalOnNodeAdded.call(this, node)
+        }
+      }
+    }
+  }
+
+  // Cleanup function for component unmounting
+  const cleanup = () => {
+    if (nodeManager.value) {
+      nodeManager.value.cleanup()
+      nodeManager.value = null
+    }
+    if (slotSyncStarted.value) {
+      slotSync.value?.stop()
+      slotSyncStarted.value = false
+    }
+    slotSync.value = null
+    if (linkSync.value) {
+      linkSync.value.stop()
+      linkSync.value = null
+    }
+  }
+
+  // Vue-idiomatic public API with proper reactivity
+  return {
+    // Reactive state - already readonly maps from manager
+    vueNodeData,
+    nodeState,
+    nodePositions,
+    nodeSizes,
+    nodeDataTrigger: readonly(nodeDataTrigger),
+
+    // Reactive manager access - no more getter anti-pattern
+    nodeManager: readonly(nodeManager),
+    detectChangesInRAF: readonly(detectChangesInRAF),
+
+    // Computed derived state
+    isNodeManagerReady,
+
+    // Lifecycle methods
+    initializeNodeManager,
+    disposeNodeManagerAndSyncs,
+    setupEmptyGraphListener,
+    cleanup
+  }
+}

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -33,12 +33,12 @@ export function useVueNodeLifecycle(isVueNodesEnabled: Ref<boolean>) {
   )
   const cleanupNodeManager = shallowRef<(() => void) | null>(null)
 
-  // Reactive sync management
+  // Sync management
   const slotSync = shallowRef<ReturnType<typeof useSlotLayoutSync> | null>(null)
   const slotSyncStarted = ref(false)
   const linkSync = shallowRef<ReturnType<typeof useLinkLayoutSync> | null>(null)
 
-  // Reactive state for Vue node data
+  // Vue node data state
   const vueNodeData = ref<ReadonlyMap<string, VueNodeData>>(new Map())
   const nodeState = ref<ReadonlyMap<string, NodeState>>(new Map())
   const nodePositions = ref<ReadonlyMap<string, { x: number; y: number }>>(
@@ -48,10 +48,10 @@ export function useVueNodeLifecycle(isVueNodesEnabled: Ref<boolean>) {
     new Map()
   )
 
-  // RAF change detection function - reactive
+  // Change detection function
   const detectChangesInRAF = ref<() => void>(() => {})
 
-  // Reactivity trigger for forcing computed re-evaluation
+  // Trigger for forcing computed re-evaluation
   const nodeDataTrigger = ref(0)
 
   const isNodeManagerReady = computed(() => nodeManager.value !== null)
@@ -64,7 +64,7 @@ export function useVueNodeLifecycle(isVueNodesEnabled: Ref<boolean>) {
     nodeManager.value = manager
     cleanupNodeManager.value = manager.cleanup
 
-    // Use the manager's reactive maps directly
+    // Use the manager's data maps
     vueNodeData.value = manager.vueNodeData
     nodeState.value = manager.nodeState
     nodePositions.value = manager.nodePositions

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -227,20 +227,14 @@ export function useVueNodeLifecycle(isVueNodesEnabled: Ref<boolean>) {
     }
   }
 
-  // Vue-idiomatic public API with proper reactivity
   return {
-    // Reactive state - already readonly maps from manager
     vueNodeData,
     nodeState,
     nodePositions,
     nodeSizes,
     nodeDataTrigger: readonly(nodeDataTrigger),
-
-    // Reactive manager access - no more getter anti-pattern
     nodeManager: readonly(nodeManager),
     detectChangesInRAF: readonly(detectChangesInRAF),
-
-    // Computed derived state
     isNodeManagerReady,
 
     // Lifecycle methods


### PR DESCRIPTION
- Extract logic from GraphCanvas.vue (735→200 lines) into 3 composables:
  - useVueNodeLifecycle: Node manager initialization and cleanup
  - useViewportCulling: Viewport culling with transform sync
  - useNodeEventHandlers: Node selection, collapse, title handlers

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5390-refactor-Extract-Vue-node-entry-point-logic-into-focused-composables-2666d73d3650814c86ddeec2c32c978c) by [Unito](https://www.unito.io)
