### PR TITLE
fix: Add hasConflict prop to PackEnableToggle component

### DIFF
--- a/src/components/dialog/content/manager/packCard/PackCardFooter.vue
+++ b/src/components/dialog/content/manager/packCard/PackCardFooter.vue
@@ -13,7 +13,11 @@
       :has-conflict="hasConflicts"
       :conflict-info="conflictInfo"
     />
-    <PackEnableToggle v-else :node-pack="nodePack" />
+    <PackEnableToggle
+      v-else
+      :has-conflict="hasConflicts"
+      :node-pack="nodePack"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- Added missing `hasConflict` prop to `PackEnableToggle` component in `PackCardFooter.vue`
- This ensures the enable toggle button receives conflict state information consistently

## Changes
- Pass `hasConflicts` prop to `PackEnableToggle` component to maintain consistent conflict state handling

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5392-fix-Add-hasConflict-prop-to-PackEnableToggle-component-2666d73d365081549c01df0ca73a19d9) by [Unito](https://www.unito.io)
