### PR TITLE
[bugfix] Fix manager dialog warning banner close button visibility

### DIFF
--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -51,7 +51,7 @@
               type="transparent"
               @click="dismissWarningBanner"
             >
-              <i class="pi pi-times text-white text-xs"></i>
+              <i class="pi pi-times text-neutral text-xs"></i>
             </IconButton>
           </div>
           <RegistrySearchBar

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -29,7 +29,7 @@
           <!-- Conflict Warning Banner -->
           <div
             v-if="shouldShowManagerBanner"
-            class="bg-yellow-600 bg-opacity-20 border border-yellow-400 rounded-lg p-4 mt-3 mb-4 flex items-center gap-6 relative"
+            class="bg-yellow-500/20 rounded-lg p-4 mt-3 mb-4 flex items-center gap-6 relative"
           >
             <i class="pi pi-exclamation-triangle text-yellow-600 text-lg"></i>
             <div class="flex flex-col gap-2 flex-1">
@@ -46,14 +46,13 @@
                 {{ $t('manager.conflicts.warningBanner.button') }}
               </p>
             </div>
-            <button
-              type="button"
-              class="absolute top-2 right-2 w-6 h-6 border-none outline-none bg-transparent flex items-center justify-center text-yellow-600 rounded transition-colors"
-              :aria-label="$t('g.close')"
+            <IconButton
+              class="absolute top-0 right-0"
+              type="transparent"
               @click="dismissWarningBanner"
             >
-              <i class="pi pi-times text-sm"></i>
-            </button>
+              <i class="pi pi-times text-white text-xs"></i>
+            </IconButton>
           </div>
           <RegistrySearchBar
             v-model:searchQuery="searchQuery"
@@ -138,6 +137,7 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import IconButton from '@/components/button/IconButton.vue'
 import ContentDivider from '@/components/common/ContentDivider.vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import VirtualGrid from '@/components/common/VirtualGrid.vue'

--- a/src/components/dialog/content/manager/ManagerDialogContent.vue
+++ b/src/components/dialog/content/manager/ManagerDialogContent.vue
@@ -51,7 +51,9 @@
               type="transparent"
               @click="dismissWarningBanner"
             >
-              <i class="pi pi-times text-neutral text-xs"></i>
+              <i
+                class="pi pi-times text-neutral-900 dark-theme:text-white text-xs"
+              ></i>
             </IconButton>
           </div>
           <RegistrySearchBar


### PR DESCRIPTION
## Summary
- Fixed the close button visibility issue in the manager dialog warning banner
- Replaced custom button implementation with reusable IconButton component
- Simplified banner styling by removing unnecessary border styling

## Changes
- Replaced manual button element with `IconButton` component for better consistency
- Updated button positioning to use `top-0 right-0` for proper alignment
- Changed background opacity syntax from `bg-opacity-20` to modern Tailwind `bg-yellow-500/20`
- Removed yellow border that was making the UI too busy
- Ensured close icon is visible with white text color

## Test Plan
- [x] Open the manager dialog
- [x] Verify warning banner appears when there are conflicts
- [x] Confirm close button is visible and properly positioned
- [x] Test clicking close button dismisses the banner
- [x] Check dark mode compatibility

Fixes visibility issue where close button was hard to see against warning banner background.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5397-bugfix-Fix-manager-dialog-warning-banner-close-button-visibility-2666d73d36508135b4ddd918b38c333a) by [Unito](https://www.unito.io)
