### PR TITLE
fix: replace invalid return with exit 0 in backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -36,7 +36,7 @@ jobs:
           
           if [ -z "$EXISTING_BACKPORTS" ]; then
             echo "skip=false" >> $GITHUB_OUTPUT
-            return
+            exit 0
           fi
           
           echo "Found existing backport PRs:"


### PR DESCRIPTION
## Summary
- Fixes shell script error in backport.yaml workflow where `return` was used outside of a function
- Replaces `return` with `exit 0` on line 39 to properly exit the script with success status


```
/home/runner/work/_temp/037b1923-a435-4635-b01c-efb3e963e1e4.sh: line 6: return: can only `return' from a function or sourced script
```


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5401-fix-replace-invalid-return-with-exit-0-in-backport-workflow-2666d73d36508186ab7ddfb6ffe7bd14) by [Unito](https://www.unito.io)
