### PR TITLE
fix: `onNodeRemoved` not called when loading new graph (and tearing down previous)

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -184,8 +184,6 @@ export function useCoreCommands(): ComfyCommand[] {
             const subgraph = app.canvas.subgraph
             const nonIoNodes = getAllNonIoNodesInSubgraph(subgraph)
             nonIoNodes.forEach((node) => subgraph.remove(node))
-          } else {
-            app.graph.clear()
           }
           api.dispatchCustomEvent('graphCleared')
         }

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -314,6 +314,7 @@ export class LGraph
     if (this._nodes) {
       for (const _node of this._nodes) {
         _node.onRemoved?.()
+        this.onNodeRemoved?.(_node)
       }
     }
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1765,6 +1765,12 @@ export class ComfyApp {
     executionStore.lastExecutionError = null
 
     useDomWidgetStore().clear()
+
+    // Subgraph does not properly implement `clear` and the parent class's
+    // (`LGraph`) `clear` breaks the subgraph structure.
+    if (this.graph && !this.canvas.subgraph) {
+      this.graph.clear()
+    }
   }
 
   clientPosToCanvasPos(pos: Vector2): Vector2 {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1058,6 +1058,8 @@ export class ComfyApp {
       checkForRerouteMigration = false
     } = {}
   ) {
+    useWorkflowService().beforeLoadNewGraph()
+
     if (clean !== false) {
       this.clean()
     }
@@ -1093,7 +1095,6 @@ export class ComfyApp {
         severity: 'warn'
       })
     }
-    useWorkflowService().beforeLoadNewGraph()
     useSubgraphService().loadSubgraphs(graphData)
 
     const missingNodeTypes: MissingNodeType[] = []

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -634,7 +634,6 @@ export class ComfyUI {
               confirm('Clear workflow?')
             ) {
               app.clean()
-              app.graph.clear()
               useLitegraphService().resetView()
               api.dispatchCustomEvent('graphCleared')
             }

--- a/tests-ui/tests/composables/useCoreCommands.test.ts
+++ b/tests-ui/tests/composables/useCoreCommands.test.ts
@@ -8,7 +8,7 @@ import { useSettingStore } from '@/stores/settingStore'
 
 vi.mock('@/scripts/app', () => {
   const mockGraphClear = vi.fn()
-  const mockCanvas = { subgraph: null }
+  const mockCanvas = { subgraph: undefined }
 
   return {
     app: {
@@ -190,35 +190,6 @@ describe('useCoreCommands', () => {
       expect(app.clean).not.toHaveBeenCalled()
       expect(app.graph.clear).not.toHaveBeenCalled()
       expect(api.dispatchCustomEvent).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('Vue node cleanup regression test', () => {
-    it('should ensure app.clean() calls graph.clear() to trigger onNodeRemoved events', () => {
-      // This is a regression test for Vue node persistence bug
-      // Ensures that app.clean() properly triggers graph.clear() which
-      // calls onNodeRemoved callbacks for proper Vue node cleanup
-
-      const mockOnNodeRemoved = vi.fn()
-      const testApp = {
-        graph: {
-          clear: vi.fn(() => {
-            // Simulate LGraph.clear() behavior: call onNodeRemoved for each node
-            const mockNodes = [{ id: '1' }, { id: '2' }]
-            mockNodes.forEach((node) => mockOnNodeRemoved(node))
-          }),
-          onNodeRemoved: mockOnNodeRemoved
-        }
-      }
-
-      // Simulate app.clean() calling graph.clear()
-      testApp.graph.clear()
-
-      // Verify that onNodeRemoved would be called for each node
-      expect(testApp.graph.clear).toHaveBeenCalled()
-      expect(mockOnNodeRemoved).toHaveBeenCalledTimes(2)
-      expect(mockOnNodeRemoved).toHaveBeenCalledWith({ id: '1' })
-      expect(mockOnNodeRemoved).toHaveBeenCalledWith({ id: '2' })
     })
   })
 })

--- a/tests-ui/tests/litegraph/core/LGraph.test.ts
+++ b/tests-ui/tests/litegraph/core/LGraph.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'vitest'
 
-import { LGraph, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 
 import { test } from './fixtures/testExtensions'
 
@@ -125,6 +125,54 @@ describe('Floating Links / Reroutes', () => {
     expect(graph.links.size).toBe(0)
     expect(graph.floatingLinks.size).toBe(0)
     expect(graph.reroutes.size).toBe(0)
+  })
+})
+
+describe('Graph Clearing and Callbacks', () => {
+  test('clear() calls both node.onRemoved() and graph.onNodeRemoved()', ({
+    expect
+  }) => {
+    const graph = new LGraph()
+
+    // Create test nodes with onRemoved callbacks
+    const node1 = new LGraphNode('TestNode1')
+    const node2 = new LGraphNode('TestNode2')
+
+    // Add nodes to graph
+    graph.add(node1)
+    graph.add(node2)
+
+    // Track callback invocations
+    const nodeRemovedCallbacks = new Set<string>()
+    const graphRemovedCallbacks = new Set<string>()
+
+    // Set up node.onRemoved() callbacks
+    node1.onRemoved = () => {
+      nodeRemovedCallbacks.add(String(node1.id))
+    }
+    node2.onRemoved = () => {
+      nodeRemovedCallbacks.add(String(node2.id))
+    }
+
+    // Set up graph.onNodeRemoved() callback
+    graph.onNodeRemoved = (node) => {
+      graphRemovedCallbacks.add(String(node.id))
+    }
+
+    // Verify nodes are in graph before clearing
+    expect(graph.nodes.length).toBe(2)
+
+    // Clear the graph
+    graph.clear()
+
+    // Verify both types of callbacks were called
+    expect(nodeRemovedCallbacks).toContain(String(node1.id))
+    expect(nodeRemovedCallbacks).toContain(String(node2.id))
+    expect(graphRemovedCallbacks).toContain(String(node1.id))
+    expect(graphRemovedCallbacks).toContain(String(node2.id))
+
+    // Verify nodes were actually removed
+    expect(graph.nodes.length).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes issue where Vue nodes would persist after loading new workflows

The root cause was that LGraph.clear() only called individual node.onRemoved() callbacks but not the graph-level onNodeRemoved() callback that Vue node management relied on. This created a cleanup gap during workflow loading.
## Changes

- Add onNodeRemoved callback to LGraph.clear() to match behavior with individual node removal
- Modify app.clean() to call graph.clear() ensuring proper Vue node cleanup
- Remove redundant graph.clear() calls since app.clean() now handles it
- Also should fix any leaks associated with `onNodeRemoved` reliance (minimap, slot syncing, etc.)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5407-fix-onNodeRemoved-not-called-when-loading-new-graph-and-tearing-down-previous-2666d73d365081fd927cf7830482fbc4) by [Unito](https://www.unito.io)
