### PR TITLE
Fix slot position offset in Vue node rendering

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6,6 +6,7 @@ import {
   type LinkRenderContext,
   LitegraphLinkAdapter
 } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
+import { getSlotPosition } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 
 import { CanvasPointer } from './CanvasPointer'
@@ -5559,7 +5560,9 @@ export class LGraphCanvas
         const link = graph._links.get(link_id)
         if (!link) continue
 
-        const endPos = node.getInputPos(i)
+        const endPos: Point = LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
+          ? getSlotPosition(node, i, true)
+          : node.getInputPos(i)
 
         // find link info
         const start_node = graph.getNodeById(link.origin_id)
@@ -5569,7 +5572,9 @@ export class LGraphCanvas
         const startPos: Point =
           outputId === -1
             ? [start_node.pos[0] + 10, start_node.pos[1] + 10]
-            : start_node.getOutputPos(outputId)
+            : LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
+              ? getSlotPosition(start_node, outputId, false)
+              : start_node.getOutputPos(outputId)
 
         const output = start_node.outputs[outputId]
         if (!output) continue

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6,7 +6,6 @@ import {
   type LinkRenderContext,
   LitegraphLinkAdapter
 } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
-import { getSlotPosition } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 
 import { CanvasPointer } from './CanvasPointer'
@@ -5560,9 +5559,7 @@ export class LGraphCanvas
         const link = graph._links.get(link_id)
         if (!link) continue
 
-        const endPos: Point = LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
-          ? getSlotPosition(node, i, true)
-          : node.getInputPos(i)
+        const endPos = node.getInputPos(i)
 
         // find link info
         const start_node = graph.getNodeById(link.origin_id)
@@ -5572,9 +5569,7 @@ export class LGraphCanvas
         const startPos: Point =
           outputId === -1
             ? [start_node.pos[0] + 10, start_node.pos[1] + 10]
-            : LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
-              ? getSlotPosition(start_node, outputId, false)
-              : start_node.getOutputPos(outputId)
+            : start_node.getOutputPos(outputId)
 
         const output = start_node.outputs[outputId]
         if (!output) continue

--- a/src/renderer/core/layout/dom/canvasRectCache.ts
+++ b/src/renderer/core/layout/dom/canvasRectCache.ts
@@ -11,8 +11,6 @@
 import { useElementBounding } from '@vueuse/core'
 import { shallowRef, watch } from 'vue'
 
-type Rect = DOMRectReadOnly
-
 // Target container element (covers the canvas fully and shares its origin)
 const containerRef = shallowRef<HTMLElement | null>(null)
 
@@ -42,23 +40,10 @@ watch([x, y, width, height], () => {
   if (listeners.size) listeners.forEach((cb) => cb())
 })
 
-export function invalidate(notify = false) {
-  if (notify && listeners.size) listeners.forEach((cb) => cb())
-}
-
 export function onCanvasRectChange(cb: () => void): () => void {
   ensureContainer()
   listeners.add(cb)
   return () => listeners.delete(cb)
-}
-
-export function getCanvasRect(): Rect {
-  ensureContainer()
-  const lx = x.value || 0
-  const ly = y.value || 0
-  const w = width.value || 0
-  const h = height.value || 0
-  return new DOMRect(lx, ly, w, h)
 }
 
 export function getCanvasClientOrigin() {

--- a/src/renderer/core/layout/dom/canvasRectCache.ts
+++ b/src/renderer/core/layout/dom/canvasRectCache.ts
@@ -17,7 +17,7 @@ type Rect = DOMRectReadOnly
 const containerRef = shallowRef<HTMLElement | null>(null)
 
 // Bind bounding measurement once; element may be resolved later
-const { x, y, width, height } = useElementBounding(containerRef, {
+const { x, y, width, height, update } = useElementBounding(containerRef, {
   // Track layout changes from resize; scrolling is disabled globally
   windowResize: true,
   windowScroll: false,
@@ -32,6 +32,8 @@ function ensureContainer() {
     containerRef.value = document.getElementById(
       'graph-canvas-container'
     ) as HTMLElement | null
+    // Force an immediate measurement once the element is resolved
+    if (containerRef.value) update()
   }
 }
 
@@ -61,18 +63,5 @@ export function getCanvasRect(): Rect {
 
 export function getCanvasClientOrigin() {
   ensureContainer()
-  const el = containerRef.value
-  // VueUse refs can be 0 on first read right after binding
-  // if the element was assigned in the same tick. In that case,
-  // synchronously read from getBoundingClientRect as a fallback
-  // to avoid returning a zero offset during initialization.
-  const lx = x.value || 0
-  const ly = y.value || 0
-  // Also check width/height to distinguish a legitimate (0,0)
-  // from an unmeasured state (all zeros)
-  if (el && lx === 0 && ly === 0 && width.value === 0 && height.value === 0) {
-    const rect = el.getBoundingClientRect()
-    return { left: rect.left, top: rect.top }
-  }
-  return { left: lx, top: ly }
+  return { left: x.value || 0, top: y.value || 0 }
 }

--- a/src/renderer/core/layout/dom/canvasRectCache.ts
+++ b/src/renderer/core/layout/dom/canvasRectCache.ts
@@ -1,0 +1,65 @@
+/**
+ * Canvas Rect Cache (VueUse-based)
+ *
+ * Tracks the client-origin and size of the graph canvas container using
+ * useElementBounding, and exposes a small API to read the rect and
+ * subscribe to changes.
+ *
+ * We assume no document scrolling (body is overflow: hidden). Layout
+ * changes are driven by window resize and container/splitter changes.
+ */
+import { useElementBounding } from '@vueuse/core'
+import { shallowRef, watch } from 'vue'
+
+type Rect = DOMRectReadOnly
+
+// Target container element (covers the canvas fully and shares its origin)
+const containerRef = shallowRef<HTMLElement | null>(null)
+
+// Bind bounding measurement once; element may be resolved later
+const { x, y, width, height } = useElementBounding(containerRef, {
+  // Track layout changes from resize; scrolling is disabled globally
+  windowResize: true,
+  windowScroll: false,
+  immediate: true
+})
+
+// Listener registry for external subscribers
+const listeners = new Set<() => void>()
+
+function ensureContainer() {
+  if (!containerRef.value) {
+    containerRef.value = document.getElementById(
+      'graph-canvas-container'
+    ) as HTMLElement | null
+  }
+}
+
+// Notify subscribers when the bounding rect changes
+watch([x, y, width, height], () => {
+  if (listeners.size) listeners.forEach((cb) => cb())
+})
+
+export function invalidate(notify = false) {
+  if (notify && listeners.size) listeners.forEach((cb) => cb())
+}
+
+export function onCanvasRectChange(cb: () => void): () => void {
+  ensureContainer()
+  listeners.add(cb)
+  return () => listeners.delete(cb)
+}
+
+export function getCanvasRect(): Rect {
+  ensureContainer()
+  const lx = x.value || 0
+  const ly = y.value || 0
+  const w = width.value || 0
+  const h = height.value || 0
+  return new DOMRect(lx, ly, w, h)
+}
+
+export function getCanvasClientOrigin() {
+  ensureContainer()
+  return { left: x.value || 0, top: y.value || 0 }
+}

--- a/src/renderer/core/layout/dom/canvasRectCache.ts
+++ b/src/renderer/core/layout/dom/canvasRectCache.ts
@@ -61,5 +61,18 @@ export function getCanvasRect(): Rect {
 
 export function getCanvasClientOrigin() {
   ensureContainer()
-  return { left: x.value || 0, top: y.value || 0 }
+  const el = containerRef.value
+  // VueUse refs can be 0 on first read right after binding
+  // if the element was assigned in the same tick. In that case,
+  // synchronously read from getBoundingClientRect as a fallback
+  // to avoid returning a zero offset during initialization.
+  const lx = x.value || 0
+  const ly = y.value || 0
+  // Also check width/height to distinguish a legitimate (0,0)
+  // from an unmeasured state (all zeros)
+  if (el && lx === 0 && ly === 0 && width.value === 0 && height.value === 0) {
+    const rect = el.getBoundingClientRect()
+    return { left: rect.left, top: rect.top }
+  }
+  return { left: lx, top: ly }
 }


### PR DESCRIPTION
## Summary

Fix links being rendered offset from their slots by normalizing slot positions to canvas-relative coordinates before coordinate conversion.

## Problem

When measuring slot positions using `getBoundingClientRect()`, the coordinates were relative to the viewport. This caused misalignment when the canvas container wasn't positioned at (0,0) in the viewport (e.g., when sidebars or panels were present).

## Solution

- Add `canvasRectCache.ts` to track the canvas container's position using VueUse's `useElementBounding`
- Normalize slot coordinates to be relative to the canvas container before converting to canvas space
- Replace window resize listeners with a canvas rect change subscription that handles both resize and layout changes

## Changes

- **Added**: `canvasRectCache.ts` - Tracks canvas container position and notifies subscribers of changes
- **Modified**: `useDomSlotRegistration.ts` - Normalize slot positions relative to canvas container

## Review Focus

- Canvas-relative coordinate calculation in `useDomSlotRegistration.ts`
- Event subscription pattern for handling canvas rect changes

https://github.com/Comfy-Org/ComfyUI_frontend/pull/5400 ←https://github.com/Comfy-Org/ComfyUI_frontend/pull/5411

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5411-Fix-slot-position-offset-in-Vue-node-rendering-2676d73d36508145b7a3d4d9d1dbc60f) by [Unito](https://www.unito.io)