### PR TITLE
Implement selection state management in Vue Nodes

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -44,7 +44,6 @@
       :node-data="nodeData"
       :position="nodePositions.get(nodeData.id)"
       :size="nodeSizes.get(nodeData.id)"
-      :selected="nodeData.selected"
       :readonly="false"
       :executing="executionStore.executingNodeId === nodeData.id"
       :error="
@@ -79,6 +78,7 @@ import {
   computed,
   onMounted,
   onUnmounted,
+  provide,
   ref,
   shallowRef,
   watch,
@@ -112,6 +112,7 @@ import { useWorkflowPersistence } from '@/composables/useWorkflowPersistence'
 import { CORE_SETTINGS } from '@/constants/coreSettings'
 import { i18n, t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { SelectedNodeIdsKey } from '@/renderer/core/canvas/injectionKeys'
 import TransformPane from '@/renderer/core/layout/TransformPane.vue'
 import MiniMap from '@/renderer/extensions/minimap/MiniMap.vue'
 import VueGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
@@ -188,6 +189,21 @@ const handleTransformUpdate = () => {
 const handleNodeSelect = nodeEventHandlers.handleNodeSelect
 const handleNodeCollapse = nodeEventHandlers.handleNodeCollapse
 const handleNodeTitleUpdate = nodeEventHandlers.handleNodeTitleUpdate
+
+// Provide selection state to all Vue nodes
+const selectedNodeIds = ref(new Set<string>())
+provide(SelectedNodeIdsKey, selectedNodeIds)
+watch(
+  () => canvasStore.selectedItems,
+  (newSelectedItems) => {
+    selectedNodeIds.value = new Set(
+      newSelectedItems
+        .filter((item) => item.id !== undefined)
+        .map((item) => String(item.id))
+    )
+  },
+  { immediate: true }
+)
 
 watchEffect(() => {
   nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -191,19 +191,15 @@ const handleNodeCollapse = nodeEventHandlers.handleNodeCollapse
 const handleNodeTitleUpdate = nodeEventHandlers.handleNodeTitleUpdate
 
 // Provide selection state to all Vue nodes
-const selectedNodeIds = ref(new Set<string>())
-provide(SelectedNodeIdsKey, selectedNodeIds)
-watch(
-  () => canvasStore.selectedItems,
-  (newSelectedItems) => {
-    selectedNodeIds.value = new Set(
-      newSelectedItems
+const selectedNodeIds = computed(
+  () =>
+    new Set(
+      canvasStore.selectedItems
         .filter((item) => item.id !== undefined)
         .map((item) => String(item.id))
     )
-  },
-  { immediate: true }
 )
+provide(SelectedNodeIdsKey, selectedNodeIds)
 
 watchEffect(() => {
   nodeDefStore.showDeprecated = settingStore.get('Comfy.Node.ShowDeprecated')

--- a/src/composables/graph/useNodeEventHandlers.ts
+++ b/src/composables/graph/useNodeEventHandlers.ts
@@ -33,12 +33,20 @@ export function useNodeEventHandlers(nodeManager: Ref<NodeManager | null>) {
     const node = nodeManager.value.getNode(nodeData.id)
     if (!node) return
 
-    // Handle multi-select with Ctrl/Cmd key
-    if (!event.ctrlKey && !event.metaKey) {
-      canvasStore.canvas.deselectAllNodes()
-    }
+    const isMultiSelect = event.ctrlKey || event.metaKey
 
-    canvasStore.canvas.selectNode(node)
+    if (isMultiSelect) {
+      // Ctrl/Cmd+click -> toggle selection
+      if (node.selected) {
+        canvasStore.canvas.deselect(node)
+      } else {
+        canvasStore.canvas.select(node)
+      }
+    } else {
+      // Regular click -> single select
+      canvasStore.canvas.deselectAll()
+      canvasStore.canvas.select(node)
+    }
 
     // Bring node to front when clicked (similar to LiteGraph behavior)
     // Skip if node is pinned to avoid unwanted movement
@@ -46,9 +54,6 @@ export function useNodeEventHandlers(nodeManager: Ref<NodeManager | null>) {
       layoutMutations.setSource(LayoutSource.Vue)
       layoutMutations.bringNodeToFront(nodeData.id)
     }
-
-    // Ensure node selection state is set
-    node.selected = true
 
     // Update canvas selection tracking
     canvasStore.updateSelectedItems()

--- a/src/renderer/core/canvas/injectionKeys.ts
+++ b/src/renderer/core/canvas/injectionKeys.ts
@@ -1,0 +1,8 @@
+import type { InjectionKey, Ref } from 'vue'
+
+/**
+ * Injection key for providing selected node IDs to Vue node components.
+ * Contains a reactive Set of selected node IDs (as strings).
+ */
+export const SelectedNodeIdsKey: InjectionKey<Ref<Set<string>>> =
+  Symbol('selectedNodeIds')

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -154,7 +154,12 @@ const emit = defineEmits<{
 }>()
 
 // Inject selection state from parent
-const selectedNodeIds = inject(SelectedNodeIdsKey, ref(new Set<string>()))
+const selectedNodeIds = inject(SelectedNodeIdsKey)
+if (!selectedNodeIds) {
+  throw new Error(
+    'SelectedNodeIds not provided - LGraphNode must be used within a component that provides selection state'
+  )
+}
 
 // Computed selection state - only this node re-evaluates when its selection changes
 const isSelected = computed(() => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -10,10 +10,13 @@
         'bg-white dark-theme:bg-[#15161A]',
         'min-w-[445px]',
         'lg-node absolute border border-solid rounded-2xl',
-        'outline outline-transparent outline-2 hover:outline-black dark-theme:hover:outline-white',
+        'outline outline-transparent outline-2',
         {
-          'border-blue-500 ring-2 ring-blue-300': selected,
-          'border-[#e1ded5] dark-theme:border-[#292A30]': !selected,
+          'outline-black dark-theme:outline-white': isSelected
+        },
+        {
+          'border-blue-500 ring-2 ring-blue-300': isSelected,
+          'border-[#e1ded5] dark-theme:border-[#292A30]': !isSelected,
           'animate-pulse': executing,
           'opacity-50': nodeData.mode === 4,
           'border-red-500 bg-red-50': error,
@@ -107,12 +110,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onErrorCaptured, ref, toRef, watch } from 'vue'
+import { computed, inject, onErrorCaptured, ref, toRef, watch } from 'vue'
 
 // Import the VueNodeData type
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { SelectedNodeIdsKey } from '@/renderer/core/canvas/injectionKeys'
 import { useNodeLayout } from '@/renderer/extensions/vueNodes/layout/useNodeLayout'
 import { LODLevel, useLOD } from '@/renderer/extensions/vueNodes/lod/useLOD'
 import { cn } from '@/utils/tailwindUtil'
@@ -129,7 +133,6 @@ interface LGraphNodeProps {
   position?: { x: number; y: number }
   size?: { width: number; height: number }
   readonly?: boolean
-  selected?: boolean
   executing?: boolean
   progress?: number
   error?: string | null
@@ -149,6 +152,14 @@ const emit = defineEmits<{
   'update:collapsed': [nodeId: string, collapsed: boolean]
   'update:title': [nodeId: string, newTitle: string]
 }>()
+
+// Inject selection state from parent
+const selectedNodeIds = inject(SelectedNodeIdsKey, ref(new Set<string>()))
+
+// Computed selection state - only this node re-evaluates when its selection changes
+const isSelected = computed(() => {
+  return selectedNodeIds.value.has(props.nodeData.id)
+})
 
 // LOD (Level of Detail) system based on zoom level
 const zoomRef = toRef(() => props.zoomLevel ?? 1)
@@ -193,7 +204,7 @@ const isCollapsed = ref(props.nodeData.flags?.collapsed ?? false)
 // Watch for external changes to the collapsed state
 watch(
   () => props.nodeData.flags?.collapsed,
-  (newCollapsed) => {
+  (newCollapsed: boolean | undefined) => {
     if (newCollapsed !== undefined && newCollapsed !== isCollapsed.value) {
       isCollapsed.value = newCollapsed
     }

--- a/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
+++ b/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
@@ -14,6 +14,15 @@ describe('useNodeEventHandlers', () => {
   let mockCanvasStore: any
   let mockLayoutMutations: any
 
+  const testNodeData: VueNodeData = {
+    id: 'node-1',
+    title: 'Test Node',
+    type: 'test',
+    mode: 0,
+    selected: false,
+    executing: false
+  }
+
   beforeEach(async () => {
     // Create mocked objects using vi.mockObject
     mockNode = {
@@ -66,16 +75,7 @@ describe('useNodeEventHandlers', () => {
         metaKey: false
       })
 
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
-      handleNodeSelect(event, nodeData)
+      handleNodeSelect(event, testNodeData)
 
       expect(mockCanvas.deselectAll).toHaveBeenCalledOnce()
       expect(mockCanvas.select).toHaveBeenCalledWith(mockNode)
@@ -95,16 +95,7 @@ describe('useNodeEventHandlers', () => {
         metaKey: false
       })
 
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
-      handleNodeSelect(ctrlClickEvent, nodeData)
+      handleNodeSelect(ctrlClickEvent, testNodeData)
 
       expect(mockCanvas.deselectAll).not.toHaveBeenCalled()
       expect(mockCanvas.select).toHaveBeenCalledWith(mockNode)
@@ -123,16 +114,7 @@ describe('useNodeEventHandlers', () => {
         metaKey: false
       })
 
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
-      handleNodeSelect(ctrlClickEvent, nodeData)
+      handleNodeSelect(ctrlClickEvent, testNodeData)
 
       expect(mockCanvas.deselect).toHaveBeenCalledWith(mockNode)
       expect(mockCanvas.select).not.toHaveBeenCalled()
@@ -150,16 +132,7 @@ describe('useNodeEventHandlers', () => {
         metaKey: true
       })
 
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
-      handleNodeSelect(metaClickEvent, nodeData)
+      handleNodeSelect(metaClickEvent, testNodeData)
 
       expect(mockCanvas.select).toHaveBeenCalledWith(mockNode)
       expect(mockCanvas.deselectAll).not.toHaveBeenCalled()
@@ -172,16 +145,7 @@ describe('useNodeEventHandlers', () => {
       mockNode.flags.pinned = false
 
       const event = new PointerEvent('pointerdown')
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
-      handleNodeSelect(event, nodeData)
+      handleNodeSelect(event, testNodeData)
 
       expect(mockLayoutMutations.bringNodeToFront).toHaveBeenCalledWith(
         'node-1'
@@ -195,16 +159,7 @@ describe('useNodeEventHandlers', () => {
       mockNode.flags.pinned = true
 
       const event = new PointerEvent('pointerdown')
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
-      handleNodeSelect(event, nodeData)
+      handleNodeSelect(event, testNodeData)
 
       expect(mockLayoutMutations.bringNodeToFront).not.toHaveBeenCalled()
     })
@@ -216,17 +171,8 @@ describe('useNodeEventHandlers', () => {
       mockCanvasStore.canvas = null
 
       const event = new PointerEvent('pointerdown')
-      const nodeData: VueNodeData = {
-        id: 'node-1',
-        title: 'Test Node',
-        type: 'test',
-        mode: 0,
-        selected: false,
-        executing: false
-      }
-
       expect(() => {
-        handleNodeSelect(event, nodeData)
+        handleNodeSelect(event, testNodeData)
       }).not.toThrow()
 
       expect(mockCanvas.select).not.toHaveBeenCalled()

--- a/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
+++ b/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
@@ -4,7 +4,6 @@ import { ref } from 'vue'
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import { useNodeEventHandlers } from '@/composables/graph/useNodeEventHandlers'
 import type { Positionable } from '@/lib/litegraph/src/interfaces'
-import type { LayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 
 vi.mock('@/stores/graphStore')
 vi.mock('@/renderer/core/layout/operations/layoutMutations')
@@ -34,8 +33,7 @@ interface MockCanvasStore {
   updateSelectedItems: ReturnType<typeof vi.fn>
 }
 
-interface MockLayoutMutations
-  extends Pick<LayoutMutations, 'setSource' | 'bringNodeToFront'> {
+interface MockLayoutMutations {
   setSource: ReturnType<typeof vi.fn>
   bringNodeToFront: ReturnType<typeof vi.fn>
 }

--- a/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
+++ b/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { useNodeEventHandlers } from '@/composables/graph/useNodeEventHandlers'
+import type { Positionable } from '@/lib/litegraph/src/interfaces'
+import type { LayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
+
+vi.mock('@/stores/graphStore')
+vi.mock('@/renderer/core/layout/operations/layoutMutations')
+
+interface MockCanvas {
+  select: ReturnType<typeof vi.fn>
+  deselect: ReturnType<typeof vi.fn>
+  deselectAll: ReturnType<typeof vi.fn>
+  updateSelectedItems: ReturnType<typeof vi.fn>
+}
+
+interface MockLGraphNode {
+  id: string
+  selected: boolean
+  flags: {
+    pinned: boolean
+  }
+}
+
+interface MockNodeManager {
+  getNode: ReturnType<typeof vi.fn>
+}
+
+interface MockCanvasStore {
+  canvas: MockCanvas | null
+  selectedItems: Positionable[]
+  updateSelectedItems: ReturnType<typeof vi.fn>
+}
+
+interface MockLayoutMutations
+  extends Pick<LayoutMutations, 'setSource' | 'bringNodeToFront'> {
+  setSource: ReturnType<typeof vi.fn>
+  bringNodeToFront: ReturnType<typeof vi.fn>
+}
+
+describe('useNodeEventHandlers', () => {
+  let mockCanvas: MockCanvas
+  let mockNode: MockLGraphNode
+  let mockNodeManager: MockNodeManager
+  let mockCanvasStore: MockCanvasStore
+  let mockLayoutMutations: MockLayoutMutations
+
+  beforeEach(async () => {
+    // Mock LiteGraph node
+    mockNode = {
+      id: 'node-1',
+      selected: false,
+      flags: { pinned: false }
+    }
+
+    // Mock canvas with select/deselect methods
+    mockCanvas = {
+      select: vi.fn(),
+      deselect: vi.fn(),
+      deselectAll: vi.fn(),
+      updateSelectedItems: vi.fn()
+    }
+
+    // Mock node manager
+    mockNodeManager = {
+      getNode: vi.fn().mockReturnValue(mockNode)
+    }
+
+    // Mock canvas store
+    mockCanvasStore = {
+      canvas: mockCanvas,
+      selectedItems: [],
+      updateSelectedItems: vi.fn()
+    }
+
+    // Mock layout mutations
+    mockLayoutMutations = {
+      setSource: vi.fn(),
+      bringNodeToFront: vi.fn()
+    }
+
+    // Setup module mocks
+    const { useCanvasStore } = await import('@/stores/graphStore')
+    const { useLayoutMutations } = await import(
+      '@/renderer/core/layout/operations/layoutMutations'
+    )
+
+    // @ts-expect-error - Test mocks only need minimal interface, full Pinia store type too complex
+    vi.mocked(useCanvasStore).mockImplementation(() => mockCanvasStore)
+
+    // @ts-expect-error - Test mocks only need minimal interface, full LayoutMutations type too complex
+    vi.mocked(useLayoutMutations).mockImplementation(() => mockLayoutMutations)
+  })
+
+  describe('handleNodeSelect', () => {
+    it('should select single node on regular click', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      const event = new PointerEvent('pointerdown', {
+        bubbles: true,
+        ctrlKey: false,
+        metaKey: false
+      })
+
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      handleNodeSelect(event, nodeData)
+
+      expect(mockCanvas.deselectAll).toHaveBeenCalledOnce()
+      expect(mockCanvas.select).toHaveBeenCalledWith(mockNode)
+      expect(mockCanvasStore.updateSelectedItems).toHaveBeenCalledOnce()
+    })
+
+    it('should toggle selection on ctrl+click', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      // Test selecting unselected node with ctrl
+      mockNode.selected = false
+
+      const ctrlClickEvent = new PointerEvent('pointerdown', {
+        bubbles: true,
+        ctrlKey: true,
+        metaKey: false
+      })
+
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      handleNodeSelect(ctrlClickEvent, nodeData)
+
+      expect(mockCanvas.deselectAll).not.toHaveBeenCalled()
+      expect(mockCanvas.select).toHaveBeenCalledWith(mockNode)
+    })
+
+    it('should deselect on ctrl+click of selected node', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      // Test deselecting selected node with ctrl
+      mockNode.selected = true
+
+      const ctrlClickEvent = new PointerEvent('pointerdown', {
+        bubbles: true,
+        ctrlKey: true,
+        metaKey: false
+      })
+
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      handleNodeSelect(ctrlClickEvent, nodeData)
+
+      expect(mockCanvas.deselect).toHaveBeenCalledWith(mockNode)
+      expect(mockCanvas.select).not.toHaveBeenCalled()
+    })
+
+    it('should handle meta key (Cmd) on Mac', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      mockNode.selected = false
+
+      const metaClickEvent = new PointerEvent('pointerdown', {
+        bubbles: true,
+        ctrlKey: false,
+        metaKey: true
+      })
+
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      handleNodeSelect(metaClickEvent, nodeData)
+
+      expect(mockCanvas.select).toHaveBeenCalledWith(mockNode)
+      expect(mockCanvas.deselectAll).not.toHaveBeenCalled()
+    })
+
+    it('should bring node to front when not pinned', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      mockNode.flags.pinned = false
+
+      const event = new PointerEvent('pointerdown')
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      handleNodeSelect(event, nodeData)
+
+      expect(mockLayoutMutations.bringNodeToFront).toHaveBeenCalledWith(
+        'node-1'
+      )
+    })
+
+    it('should not bring pinned node to front', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      mockNode.flags.pinned = true
+
+      const event = new PointerEvent('pointerdown')
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      handleNodeSelect(event, nodeData)
+
+      expect(mockLayoutMutations.bringNodeToFront).not.toHaveBeenCalled()
+    })
+
+    it('should handle missing canvas gracefully', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      mockCanvasStore.canvas = null
+
+      const event = new PointerEvent('pointerdown')
+      const nodeData: VueNodeData = {
+        id: 'node-1',
+        title: 'Test Node',
+        type: 'test',
+        mode: 0,
+        selected: false,
+        executing: false
+      }
+
+      expect(() => {
+        handleNodeSelect(event, nodeData)
+      }).not.toThrow()
+
+      expect(mockCanvas.select).not.toHaveBeenCalled()
+    })
+
+    it('should handle missing node gracefully', () => {
+      const nodeManager = ref(mockNodeManager)
+      const { handleNodeSelect } = useNodeEventHandlers(nodeManager)
+
+      mockNodeManager.getNode.mockReturnValue(null)
+
+      const event = new PointerEvent('pointerdown')
+      const nodeData = {
+        id: 'missing-node',
+        title: 'Missing Node',
+        type: 'test'
+      } as any
+
+      expect(() => {
+        handleNodeSelect(event, nodeData)
+      }).not.toThrow()
+
+      expect(mockCanvas.select).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
+++ b/tests-ui/tests/composables/graph/useNodeEventHandlers.test.ts
@@ -3,81 +3,47 @@ import { ref } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import { useNodeEventHandlers } from '@/composables/graph/useNodeEventHandlers'
-import type { Positionable } from '@/lib/litegraph/src/interfaces'
 
 vi.mock('@/stores/graphStore')
 vi.mock('@/renderer/core/layout/operations/layoutMutations')
 
-interface MockCanvas {
-  select: ReturnType<typeof vi.fn>
-  deselect: ReturnType<typeof vi.fn>
-  deselectAll: ReturnType<typeof vi.fn>
-  updateSelectedItems: ReturnType<typeof vi.fn>
-}
-
-interface MockLGraphNode {
-  id: string
-  selected: boolean
-  flags: {
-    pinned: boolean
-  }
-}
-
-interface MockNodeManager {
-  getNode: ReturnType<typeof vi.fn>
-}
-
-interface MockCanvasStore {
-  canvas: MockCanvas | null
-  selectedItems: Positionable[]
-  updateSelectedItems: ReturnType<typeof vi.fn>
-}
-
-interface MockLayoutMutations {
-  setSource: ReturnType<typeof vi.fn>
-  bringNodeToFront: ReturnType<typeof vi.fn>
-}
-
 describe('useNodeEventHandlers', () => {
-  let mockCanvas: MockCanvas
-  let mockNode: MockLGraphNode
-  let mockNodeManager: MockNodeManager
-  let mockCanvasStore: MockCanvasStore
-  let mockLayoutMutations: MockLayoutMutations
+  let mockCanvas: any
+  let mockNode: any
+  let mockNodeManager: any
+  let mockCanvasStore: any
+  let mockLayoutMutations: any
 
   beforeEach(async () => {
-    // Mock LiteGraph node
+    // Create mocked objects using vi.mockObject
     mockNode = {
       id: 'node-1',
       selected: false,
       flags: { pinned: false }
     }
 
-    // Mock canvas with select/deselect methods
-    mockCanvas = {
-      select: vi.fn(),
-      deselect: vi.fn(),
-      deselectAll: vi.fn(),
-      updateSelectedItems: vi.fn()
-    }
+    mockCanvas = vi.mockObject({
+      select: () => {},
+      deselect: () => {},
+      deselectAll: () => {},
+      updateSelectedItems: () => {}
+    })
 
-    // Mock node manager
-    mockNodeManager = {
-      getNode: vi.fn().mockReturnValue(mockNode)
-    }
+    mockNodeManager = vi.mockObject({
+      getNode: () => mockNode
+    })
+    mockNodeManager.getNode.mockReturnValue(mockNode)
 
-    // Mock canvas store
-    mockCanvasStore = {
+    mockCanvasStore = vi.mockObject({
       canvas: mockCanvas,
       selectedItems: [],
-      updateSelectedItems: vi.fn()
-    }
+      updateSelectedItems: () => {}
+    })
 
-    // Mock layout mutations
-    mockLayoutMutations = {
-      setSource: vi.fn(),
-      bringNodeToFront: vi.fn()
-    }
+    mockLayoutMutations = vi.mockObject({
+      setSource: () => {},
+      bringNodeToFront: () => {}
+    })
 
     // Setup module mocks
     const { useCanvasStore } = await import('@/stores/graphStore')
@@ -85,10 +51,7 @@ describe('useNodeEventHandlers', () => {
       '@/renderer/core/layout/operations/layoutMutations'
     )
 
-    // @ts-expect-error - Test mocks only need minimal interface, full Pinia store type too complex
     vi.mocked(useCanvasStore).mockImplementation(() => mockCanvasStore)
-
-    // @ts-expect-error - Test mocks only need minimal interface, full LayoutMutations type too complex
     vi.mocked(useLayoutMutations).mockImplementation(() => mockLayoutMutations)
   })
 


### PR DESCRIPTION
## Summary

Lets LGraphCanvas maintain ownership over selection state. Fixes selection state in Vue Nodes to match existing behavior/UX.

## Changes

- **What**: Watch changes to selected items in canvas state, provide a set of selected nodes to children. In LGraphNode.vue, watch the selected items and update selection state of UI.

Key choices:

* `LGraphCanvas` already exposes a reactive state of selected items. It’s one of the few parts of litegraph that transitioned to reactivity before this project, and it’s very ergonomic—showing why we should extend reactivity across the codebase
* Centralized Vue Node event handler needs to update `LGraphCanvas`'s selection state instead of maintaining internally
* `LGraphNode.vue` needs to watch selection state → updates UI (border)
* Instead of having each node component watch and filter the `selected` list by ID, make watcher live in the parent (`GraphCanvas.vue`).
* Use `provide`/`inject` instead of a prop → avoid full node list re-renders
* Store selected IDs in `Set` rather than `Array` → only need O(1) membership check in each node component when selection changes
* Future: no need to store selection state in layout tree now; later can attach actor + and use CRDT but selection/focus/hover is more of an ephemeral client-bound state

## Screenshots (if applicable)


https://github.com/user-attachments/assets/1d37a2b1-c829-4962-aa28-4cb78c3e082d

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5421-Implement-selection-state-management-in-Vue-Nodes-2676d73d365081529d04d40c8b75be37) by [Unito](https://www.unito.io)
