### PR TITLE
fix: Prevent pointer events on widgets from propagating

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { noop } from 'es-toolkit'
+
 import { COMFY_VUE_NODE_DIMENSIONS } from '@/lib/litegraph/src/litegraph'
 import { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -12,7 +14,7 @@ const widgetHeight = COMFY_VUE_NODE_DIMENSIONS.components.STANDARD_WIDGET_HEIGHT
 
 <template>
   <div
-    class="flex items-center justify-between gap-2"
+    class="flex items-center justify-between gap-2 overscroll-contain"
     :style="{ height: widgetHeight + 'px' }"
   >
     <p
@@ -21,7 +23,12 @@ const widgetHeight = COMFY_VUE_NODE_DIMENSIONS.components.STANDARD_WIDGET_HEIGHT
     >
       {{ widget.name }}
     </p>
-    <div class="w-75">
+    <div
+      class="w-75"
+      @pointerdown.stop="noop"
+      @pointermove.stop="noop"
+      @pointerup.stop="noop"
+    >
       <slot />
     </div>
   </div>


### PR DESCRIPTION
…to the containing node.

## Summary

`stopPropagation` on pointer events in the widget wrapper.

## Changes

- **What**: Keeps the nodes from moving when dragging the slider thumb.

## Review Focus

Try it out before and after.

## Demo

### Before

https://github.com/user-attachments/assets/75940435-5e97-459c-a359-371ffcaaf271

### After

https://github.com/user-attachments/assets/e5ffd79e-f119-4184-ad95-fe9814ae5b4c
