### PR TITLE
fix: replace `any` type in unit test with real type

### DIFF
--- a/tests-ui/tests/renderer/core/layout/layoutStore.test.ts
+++ b/tests-ui/tests/renderer/core/layout/layoutStore.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
-import { LayoutSource, type NodeLayout } from '@/renderer/core/layout/types'
+import {
+  type LayoutChange,
+  LayoutSource,
+  type NodeLayout
+} from '@/renderer/core/layout/types'
 
 describe('layoutStore CRDT operations', () => {
   beforeEach(() => {
@@ -145,7 +149,7 @@ describe('layoutStore CRDT operations', () => {
     layoutStore.setActor('user-123')
 
     // Track change notifications AFTER setting source/actor
-    const changes: any[] = []
+    const changes: LayoutChange[] = []
     const unsubscribe = layoutStore.onChange((change) => {
       changes.push(change)
     })


### PR DESCRIPTION
Fixes an `any` type that was used in a unit test file. The actual type is readily available.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5428-fix-replace-any-type-in-unit-test-with-real-type-2686d73d36508158a6f8d40436ecacd8) by [Unito](https://www.unito.io)
