### PR TITLE
Add design system color variables to tailwind config and use in Vue Nodes

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -7,7 +7,7 @@
     :data-node-id="nodeData.id"
     :class="
       cn(
-        'bg-white dark-theme:bg-[#15161A]',
+        'bg-white dark-theme:bg-charcoal-primary',
         'min-w-[445px]',
         'lg-node absolute border border-solid rounded-2xl',
         'outline outline-transparent outline-2',
@@ -16,7 +16,8 @@
         },
         {
           'border-blue-500 ring-2 ring-blue-300': isSelected,
-          'border-[#e1ded5] dark-theme:border-[#292A30]': !isSelected,
+          'border-sand-primary dark-theme:border-charcoal-tertiary':
+            !isSelected,
           'animate-pulse': executing,
           'opacity-50': nodeData.mode === 4,
           'border-red-500 bg-red-50': error,
@@ -224,7 +225,8 @@ const hasCustomContent = computed(() => {
 })
 
 // Computed classes and conditions for better reusability
-const separatorClasses = 'bg-[#e1ded5] dark-theme:bg-[#292A30] h-[1px] mx-0'
+const separatorClasses =
+  'bg-sand-primary dark-theme:bg-charcoal-tertiary h-[1px] mx-0'
 
 // Common condition computations to avoid repetition
 const shouldShowWidgets = computed(

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -188,7 +188,60 @@ export default {
           800: '#b38400',
           900: '#997200',
           950: '#664d00'
-        }
+        },
+
+        // Neutrals
+        'pure-black': '#000000',
+        'pure-white': '#FFFFFF',
+
+        // Charcoal palette
+        'charcoal-primary': '#171718',
+        'charcoal-secondary': '#202121',
+        'charcoal-tertiary': '#262729',
+        'charcoal-400': '#302F32',
+        'charcoal-500': '#313235',
+
+        // Stone palette
+        'stone-primary': '#444444',
+        'stone-secondary': '#828282',
+        'stone-tertiary': '#BBBBBB',
+
+        // Ivory palette
+        'ivory-primary': '#FDFBFA',
+        'ivory-secondary': '#FAF9F5',
+        'ivory-tertiary': '#F0EEE6',
+
+        // Gray palette
+        'gray-primary': '#EEEEEE',
+        'gray-secondary': '#F3F3F3',
+        'gray-tertiary': '#D9D9D9',
+        'gray-quaternary': '#E7E6E6',
+
+        // Sand palette
+        'sand-primary': '#E1DED5',
+        'sand-secondary': '#D6CFC2',
+        'sand-tertiary': '#888682',
+
+        // Slate palette
+        'slate-primary': '#9C9EAB',
+        'slate-secondary': '#9FA2BD',
+        'slate-tertiary': '#5B5E7D',
+
+        // Brand colors
+        'brand-yellow': '#F0FF41',
+        'brand-blue': '#172DD7',
+
+        // Accent colors
+        'blue-primary': '#0B8CE9',
+        'blue-secondary': '#31B9F4',
+        'blue-selection': 'rgba(11, 140, 233, 0.3)',
+        'success-primary': '#00CD72',
+        'success-secondary': '#47E469',
+        'warning-primary': '#FD9903',
+        'warning-secondary': '#FCBF64',
+        'danger-primary': '#C02323',
+        'danger-secondary': '#C83A27',
+        error: '#962A2A'
       },
 
       textColor: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -190,58 +190,70 @@ export default {
           950: '#664d00'
         },
 
-        // Neutrals
+        // Base colors
         'pure-black': '#000000',
         'pure-white': '#FFFFFF',
 
         // Charcoal palette
-        'charcoal-primary': '#171718',
-        'charcoal-secondary': '#202121',
-        'charcoal-tertiary': '#262729',
-        'charcoal-400': '#302F32',
+        'charcoal-100': '#171718',
+        'charcoal-200': '#202121',
+        'charcoal-300': '#262729',
+        'charcoal-400': '#2D2E32',
         'charcoal-500': '#313235',
+        'charcoal-600': '#3C3D42',
+        'charcoal-700': '#494A50',
+        'charcoal-800': '#55565E',
 
         // Stone palette
-        'stone-primary': '#444444',
-        'stone-secondary': '#828282',
-        'stone-tertiary': '#BBBBBB',
+        'stone-100': '#444444',
+        'stone-200': '#828282',
+        'stone-300': '#BBBBBB',
 
         // Ivory palette
-        'ivory-primary': '#FDFBFA',
-        'ivory-secondary': '#FAF9F5',
-        'ivory-tertiary': '#F0EEE6',
+        'ivory-100': '#FDFBFA',
+        'ivory-200': '#FAF9F5',
+        'ivory-300': '#F0EEE6',
 
         // Gray palette
-        'gray-primary': '#EEEEEE',
-        'gray-secondary': '#F3F3F3',
-        'gray-tertiary': '#D9D9D9',
-        'gray-quaternary': '#E7E6E6',
+        'gray-100': '#F3F3F3',
+        'gray-200': '#E9E9E9',
+        'gray-300': '#E1E1E1',
+        'gray-400': '#D9D9D9',
+        'gray-500': '#C5C5C5',
+        'gray-600': '#B4B4B4',
+        'gray-700': '#A0A0A0',
+        'gray-800': '#8A8A8A',
 
         // Sand palette
-        'sand-primary': '#E1DED5',
-        'sand-secondary': '#D6CFC2',
-        'sand-tertiary': '#888682',
+        'sand-100': '#E1DED5',
+        'sand-200': '#D6CFC2',
+        'sand-300': '#888682',
 
         // Slate palette
-        'slate-primary': '#9C9EAB',
-        'slate-secondary': '#9FA2BD',
-        'slate-tertiary': '#5B5E7D',
+        'slate-100': '#9C9EAB',
+        'slate-200': '#9FA2BD',
+        'slate-300': '#5B5E7D',
 
         // Brand colors
         'brand-yellow': '#F0FF41',
         'brand-blue': '#172DD7',
 
-        // Accent colors
-        'blue-primary': '#0B8CE9',
-        'blue-secondary': '#31B9F4',
+        // Functional colors
+        'blue-100': '#0B8CE9',
+        'blue-200': '#31B9F4',
+        'success-100': '#00CD72',
+        'success-200': '#47E469',
+        'warning-100': '#FD9903',
+        'warning-200': '#FCBF64',
+        'danger-100': '#C02323',
+        'danger-200': '#D62952',
+        error: '#962A2A',
+
+        // Alpha variants
         'blue-selection': 'rgba(11, 140, 233, 0.3)',
-        'success-primary': '#00CD72',
-        'success-secondary': '#47E469',
-        'warning-primary': '#FD9903',
-        'warning-secondary': '#FCBF64',
-        'danger-primary': '#C02323',
-        'danger-secondary': '#C83A27',
-        error: '#962A2A'
+        'node-hover-100': 'rgba(85, 86, 94, 0.15)',
+        'node-hover-200': 'rgba(85, 86, 94, 0.1)',
+        'modal-tag': 'rgba(217, 217, 217, 0.4)'
       },
 
       textColor: {


### PR DESCRIPTION
## Summary

Adds color variables from [Figma variable table](https://www.figma.com/design/vALUV83vIdBzEsTJAhQgXq/Comfy_PrimeVue_Design_System?node-id=0-1&p=f&t=8zROn7pJ7G7sVB5w-0)

---

Note: These colors exist outside of PrimeVue design system and PrimeVue's design system cannot use our tailwind variables. But switching to unstyled and unifying everything would be hard. Using variables for now will make refactoring later easier either way.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5430-Add-design-system-tokens-to-tailwind-config-and-use-in-Vue-Node-2686d73d365081a3b448cd4a7c4e4c7b) by [Unito](https://www.unito.io)
