### PR TITLE
Fix getSlotPosition readonly return value

### DIFF
--- a/src/renderer/core/canvas/litegraph/slotCalculations.ts
+++ b/src/renderer/core/canvas/litegraph/slotCalculations.ts
@@ -9,8 +9,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type {
   INodeInputSlot,
   INodeOutputSlot,
-  Point,
-  ReadOnlyPoint
+  Point
 } from '@/lib/litegraph/src/interfaces'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { isWidgetInputSlot } from '@/lib/litegraph/src/node/slotUtils'
@@ -138,7 +137,7 @@ export function getSlotPosition(
   node: LGraphNode,
   slotIndex: number,
   isInput: boolean
-): ReadOnlyPoint {
+): Point {
   // Try to get precise position from slot layout (DOM-registered)
   const slotKey = getSlotKey(String(node.id), slotIndex, isInput)
   const slotLayout = layoutStore.getSlotLayout(slotKey)


### PR DESCRIPTION
Fixes root cause of type issue in #5400, removing need for workaround.  `getSlotPosition` is _creating_ `Point`s; there is no need to constrain the return type to readonly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5433-Fix-getSlotPosition-readonly-return-value-2686d73d365081ea940ad00ee5a81d6f) by [Unito](https://www.unito.io)
