### PR TITLE
Fix: In standard mode, don't stop when you hit a Vue node.

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -36,6 +36,7 @@
     v-if="isVueNodesEnabled && comfyApp.canvas && comfyAppReady"
     :canvas="comfyApp.canvas"
     @transform-update="handleTransformUpdate"
+    @wheel.capture="forwardWheelEvent"
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <VueGraphNode
@@ -453,4 +454,20 @@ onMounted(async () => {
 onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
+
+function forwardWheelEvent(e: WheelEvent) {
+  // I don't love this, but it works.
+  const { clientX, clientY, deltaX, deltaY, ctrlKey, metaKey, shiftKey } = e
+  comfyApp.canvasEl.dispatchEvent(
+    new WheelEvent('wheel', {
+      clientX,
+      clientY,
+      deltaX,
+      deltaY,
+      ctrlKey,
+      metaKey,
+      shiftKey
+    })
+  )
+}
 </script>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -36,7 +36,7 @@
     v-if="isVueNodesEnabled && comfyApp.canvas && comfyAppReady"
     :canvas="comfyApp.canvas"
     @transform-update="handleTransformUpdate"
-    @wheel.capture="forwardWheelEvent"
+    @wheel.capture="canvasInteractions.forwardEventToCanvas"
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <VueGraphNode
@@ -97,6 +97,7 @@ import NodeSearchboxPopover from '@/components/searchbox/NodeSearchBoxPopover.vu
 import SideToolbar from '@/components/sidebar/SideToolbar.vue'
 import SecondRowWorkflowTabs from '@/components/topbar/SecondRowWorkflowTabs.vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { useCanvasInteractions } from '@/composables/graph/useCanvasInteractions'
 import { useViewportCulling } from '@/composables/graph/useViewportCulling'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
@@ -148,6 +149,8 @@ const workspaceStore = useWorkspaceStore()
 const canvasStore = useCanvasStore()
 const executionStore = useExecutionStore()
 const toastStore = useToastStore()
+const canvasInteractions = useCanvasInteractions()
+
 const betaMenuEnabled = computed(
   () => settingStore.get('Comfy.UseNewMenu') !== 'Disabled'
 )
@@ -454,20 +457,4 @@ onMounted(async () => {
 onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
-
-function forwardWheelEvent(e: WheelEvent) {
-  // I don't love this, but it works.
-  const { clientX, clientY, deltaX, deltaY, ctrlKey, metaKey, shiftKey } = e
-  comfyApp.canvasEl.dispatchEvent(
-    new WheelEvent('wheel', {
-      clientX,
-      clientY,
-      deltaX,
-      deltaY,
-      ctrlKey,
-      metaKey,
-      shiftKey
-    })
-  )
-}
 </script>

--- a/src/composables/graph/useCanvasInteractions.ts
+++ b/src/composables/graph/useCanvasInteractions.ts
@@ -24,14 +24,12 @@ export function useCanvasInteractions() {
   const handleWheel = (event: WheelEvent) => {
     // In standard mode, Ctrl+wheel should go to canvas for zoom
     if (isStandardNavMode.value && (event.ctrlKey || event.metaKey)) {
-      event.preventDefault() // Prevent browser zoom
       forwardEventToCanvas(event)
       return
     }
 
     // In legacy mode, all wheel events go to canvas for zoom
     if (!isStandardNavMode.value) {
-      event.preventDefault()
       forwardEventToCanvas(event)
       return
     }
@@ -68,9 +66,30 @@ export function useCanvasInteractions() {
   ) => {
     const canvasEl = app.canvas?.canvas
     if (!canvasEl) return
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (event instanceof WheelEvent) {
+      const { clientX, clientY, deltaX, deltaY, ctrlKey, metaKey, shiftKey } =
+        event
+      canvasEl.dispatchEvent(
+        new WheelEvent('wheel', {
+          clientX,
+          clientY,
+          deltaX,
+          deltaY,
+          ctrlKey,
+          metaKey,
+          shiftKey
+        })
+      )
+      return
+    }
 
     // Create new event with same properties
-    const EventConstructor = event.constructor as typeof WheelEvent
+    const EventConstructor = event.constructor as
+      | typeof MouseEvent
+      | typeof PointerEvent
     const newEvent = new EventConstructor(event.type, event)
     canvasEl.dispatchEvent(newEvent)
   }

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -6,8 +6,14 @@ import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
 
 // Mock stores
-vi.mock('@/stores/graphStore')
-vi.mock('@/stores/settingStore')
+vi.mock('@/stores/graphStore', () => {
+  const getCanvas = vi.fn()
+  return { useCanvasStore: vi.fn(() => ({ getCanvas })) }
+})
+vi.mock('@/stores/settingStore', () => {
+  const getFn = vi.fn()
+  return { useSettingStore: vi.fn(() => ({ get: getFn })) }
+})
 vi.mock('@/scripts/app', () => ({
   app: {
     canvas: {
@@ -21,12 +27,6 @@ vi.mock('@/scripts/app', () => ({
 describe('useCanvasInteractions', () => {
   beforeEach(() => {
     vi.resetAllMocks()
-    vi.mocked(useCanvasStore, { partial: true }).mockReturnValue({
-      getCanvas: vi.fn()
-    })
-    vi.mocked(useSettingStore, { partial: true }).mockReturnValue({
-      get: vi.fn()
-    })
   })
 
   describe('handlePointer', () => {

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCanvasInteractions } from '@/composables/graph/useCanvasInteractions'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/stores/graphStore'
 import { useSettingStore } from '@/stores/settingStore'
 
@@ -31,21 +32,21 @@ describe('useCanvasInteractions', () => {
   describe('handlePointer', () => {
     it('should forward space+drag events to canvas when read_only is true', () => {
       // Setup
-      const mockCanvas = { read_only: true }
+      const mockCanvas: Partial<LGraphCanvas> = { read_only: true }
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(mockCanvas as any)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
 
       const { handlePointer } = useCanvasInteractions()
 
       // Create mock pointer event
-      const mockEvent = {
+      const mockEvent: Partial<PointerEvent> = {
         buttons: 1, // Left mouse button
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<PointerEvent>
+      }
 
       // Test
-      handlePointer(mockEvent as unknown as PointerEvent)
+      handlePointer(mockEvent as PointerEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -54,21 +55,21 @@ describe('useCanvasInteractions', () => {
 
     it('should forward middle mouse button events to canvas', () => {
       // Setup
-      const mockCanvas = { read_only: false }
+      const mockCanvas: Partial<LGraphCanvas> = { read_only: false }
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(mockCanvas as any)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
 
       const { handlePointer } = useCanvasInteractions()
 
       // Create mock pointer event with middle button
-      const mockEvent = {
+      const mockEvent: Partial<PointerEvent> = {
         buttons: 4, // Middle mouse button
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<PointerEvent>
+      }
 
       // Test
-      handlePointer(mockEvent as unknown as PointerEvent)
+      handlePointer(mockEvent as PointerEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -77,21 +78,21 @@ describe('useCanvasInteractions', () => {
 
     it('should not prevent default when canvas is not in read_only mode and not middle button', () => {
       // Setup
-      const mockCanvas = { read_only: false }
+      const mockCanvas: Partial<LGraphCanvas> = { read_only: false }
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(mockCanvas as any)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
 
       const { handlePointer } = useCanvasInteractions()
 
       // Create mock pointer event
-      const mockEvent = {
+      const mockEvent: Partial<PointerEvent> = {
         buttons: 1, // Left mouse button
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<PointerEvent>
+      }
 
       // Test
-      handlePointer(mockEvent as unknown as PointerEvent)
+      handlePointer(mockEvent as PointerEvent)
 
       // Verify - should not prevent default (let media handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
@@ -101,19 +102,19 @@ describe('useCanvasInteractions', () => {
     it('should return early when canvas is null', () => {
       // Setup
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(null as any)
+      vi.mocked(getCanvas).mockReturnValue(null as unknown as LGraphCanvas) // TODO: Fix misaligned types
 
       const { handlePointer } = useCanvasInteractions()
 
       // Create mock pointer event that would normally trigger forwarding
-      const mockEvent = {
+      const mockEvent: Partial<PointerEvent> = {
         buttons: 1, // Left mouse button - would trigger space+drag if canvas had read_only=true
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<PointerEvent>
+      }
 
       // Test
-      handlePointer(mockEvent as unknown as PointerEvent)
+      handlePointer(mockEvent as PointerEvent)
 
       // Verify early return - no event methods should be called at all
       expect(getCanvas).toHaveBeenCalled()
@@ -131,15 +132,15 @@ describe('useCanvasInteractions', () => {
       const { handleWheel } = useCanvasInteractions()
 
       // Create mock wheel event with ctrl key
-      const mockEvent = {
+      const mockEvent: Partial<WheelEvent> = {
         ctrlKey: true,
         metaKey: false,
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<WheelEvent>
+      }
 
       // Test
-      handleWheel(mockEvent as unknown as WheelEvent)
+      handleWheel(mockEvent as WheelEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -153,15 +154,15 @@ describe('useCanvasInteractions', () => {
       const { handleWheel } = useCanvasInteractions()
 
       // Create mock wheel event without modifiers
-      const mockEvent = {
+      const mockEvent: Partial<WheelEvent> = {
         ctrlKey: false,
         metaKey: false,
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<WheelEvent>
+      }
 
       // Test
-      handleWheel(mockEvent as unknown as WheelEvent)
+      handleWheel(mockEvent as WheelEvent)
 
       // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -175,15 +176,15 @@ describe('useCanvasInteractions', () => {
       const { handleWheel } = useCanvasInteractions()
 
       // Create mock wheel event without modifiers
-      const mockEvent = {
+      const mockEvent: Partial<WheelEvent> = {
         ctrlKey: false,
         metaKey: false,
         preventDefault: vi.fn(),
         stopPropagation: vi.fn()
-      } satisfies Partial<WheelEvent>
+      }
 
       // Test
-      handleWheel(mockEvent as unknown as WheelEvent)
+      handleWheel(mockEvent as WheelEvent)
 
       // Verify - should not prevent default (let component handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -24,6 +24,17 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
+function createMockPointerEvent(
+  buttons: PointerEvent['buttons'] = 1
+): PointerEvent {
+  const mockEvent: Partial<PointerEvent> = {
+    buttons,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  }
+  return mockEvent as PointerEvent
+}
+
 describe('useCanvasInteractions', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -31,90 +42,54 @@ describe('useCanvasInteractions', () => {
 
   describe('handlePointer', () => {
     it('should forward space+drag events to canvas when read_only is true', () => {
-      // Setup
       const mockCanvas: Partial<LGraphCanvas> = { read_only: true }
       const { getCanvas } = useCanvasStore()
       vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
 
       const { handlePointer } = useCanvasInteractions()
 
-      // Create mock pointer event
-      const mockEvent: Partial<PointerEvent> = {
-        buttons: 1, // Left mouse button
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
+      const mockEvent = createMockPointerEvent(1) // Left Mouse Button
+      handlePointer(mockEvent)
 
-      // Test
-      handlePointer(mockEvent as PointerEvent)
-
-      // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
     })
 
     it('should forward middle mouse button events to canvas', () => {
-      // Setup
       const mockCanvas: Partial<LGraphCanvas> = { read_only: false }
       const { getCanvas } = useCanvasStore()
       vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
-
       const { handlePointer } = useCanvasInteractions()
 
-      // Create mock pointer event with middle button
-      const mockEvent: Partial<PointerEvent> = {
-        buttons: 4, // Middle mouse button
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
+      const mockEvent = createMockPointerEvent(4) // Middle mouse button
+      handlePointer(mockEvent)
 
-      // Test
-      handlePointer(mockEvent as PointerEvent)
-
-      // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
     })
 
     it('should not prevent default when canvas is not in read_only mode and not middle button', () => {
-      // Setup
       const mockCanvas: Partial<LGraphCanvas> = { read_only: false }
       const { getCanvas } = useCanvasStore()
       vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
-
       const { handlePointer } = useCanvasInteractions()
 
-      // Create mock pointer event
-      const mockEvent: Partial<PointerEvent> = {
-        buttons: 1, // Left mouse button
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
+      const mockEvent = createMockPointerEvent(1) // Left Mouse Button
+      handlePointer(mockEvent)
 
-      // Test
-      handlePointer(mockEvent as PointerEvent)
-
-      // Verify - should not prevent default (let media handle normally)
+      // Should not prevent default (let media handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })
 
     it('should return early when canvas is null', () => {
-      // Setup
       const { getCanvas } = useCanvasStore()
       vi.mocked(getCanvas).mockReturnValue(null as unknown as LGraphCanvas) // TODO: Fix misaligned types
-
       const { handlePointer } = useCanvasInteractions()
 
       // Create mock pointer event that would normally trigger forwarding
-      const mockEvent: Partial<PointerEvent> = {
-        buttons: 1, // Left mouse button - would trigger space+drag if canvas had read_only=true
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
-
-      // Test
-      handlePointer(mockEvent as PointerEvent)
+      const mockEvent = createMockPointerEvent(1) // Left mouse button - would trigger space+drag if canvas had read_only=true
+      handlePointer(mockEvent)
 
       // Verify early return - no event methods should be called at all
       expect(getCanvas).toHaveBeenCalled()
@@ -125,7 +100,6 @@ describe('useCanvasInteractions', () => {
 
   describe('handleWheel', () => {
     it('should forward ctrl+wheel events to canvas in standard nav mode', () => {
-      // Setup
       const { get } = useSettingStore()
       vi.mocked(get).mockReturnValue('standard')
 

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -126,6 +126,7 @@ describe('useCanvasInteractions', () => {
       handleWheel(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).toHaveBeenCalled()
     })
 
     it('should forward all wheel events to canvas in legacy nav mode', () => {
@@ -138,6 +139,7 @@ describe('useCanvasInteractions', () => {
       handleWheel(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).toHaveBeenCalled()
     })
 
     it('should not prevent default for regular wheel events in standard nav mode', () => {
@@ -151,6 +153,7 @@ describe('useCanvasInteractions', () => {
 
       // Verify - should not prevent default (let component handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/scripts/app', () => ({
 
 describe('useCanvasInteractions', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     vi.mocked(useCanvasStore, { partial: true }).mockReturnValue({
       getCanvas: vi.fn()
     })
@@ -134,7 +134,8 @@ describe('useCanvasInteractions', () => {
       const mockEvent = {
         ctrlKey: true,
         metaKey: false,
-        preventDefault: vi.fn()
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn()
       } satisfies Partial<WheelEvent>
 
       // Test
@@ -155,7 +156,8 @@ describe('useCanvasInteractions', () => {
       const mockEvent = {
         ctrlKey: false,
         metaKey: false,
-        preventDefault: vi.fn()
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn()
       } satisfies Partial<WheelEvent>
 
       // Test
@@ -176,7 +178,8 @@ describe('useCanvasInteractions', () => {
       const mockEvent = {
         ctrlKey: false,
         metaKey: false,
-        preventDefault: vi.fn()
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn()
       } satisfies Partial<WheelEvent>
 
       // Test

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -56,7 +56,7 @@ describe('useCanvasInteractions', () => {
   })
 
   describe('handlePointer', () => {
-    it('should forward space+drag events to canvas when read_only is true', () => {
+    it('should intercept left mouse events when canvas is read_only to enable space+drag navigation', () => {
       const { getCanvas } = useCanvasStore()
       const mockCanvas = createMockLGraphCanvas(true)
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
@@ -89,10 +89,9 @@ describe('useCanvasInteractions', () => {
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
       const { handlePointer } = useCanvasInteractions()
 
-      const mockEvent = createMockPointerEvent(1) // Left Mouse Button
+      const mockEvent = createMockPointerEvent(1)
       handlePointer(mockEvent)
 
-      // Should not prevent default (let media handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })
@@ -102,11 +101,9 @@ describe('useCanvasInteractions', () => {
       vi.mocked(getCanvas).mockReturnValue(null as unknown as LGraphCanvas) // TODO: Fix misaligned types
       const { handlePointer } = useCanvasInteractions()
 
-      // Create mock pointer event that would normally trigger forwarding
-      const mockEvent = createMockPointerEvent(1) // Left mouse button - would trigger space+drag if canvas had read_only=true
+      const mockEvent = createMockPointerEvent(1)
       handlePointer(mockEvent)
 
-      // Verify early return - no event methods should be called at all
       expect(getCanvas).toHaveBeenCalled()
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
@@ -120,8 +117,8 @@ describe('useCanvasInteractions', () => {
 
       const { handleWheel } = useCanvasInteractions()
 
-      // Create mock wheel event with ctrl key
-      const mockEvent = createMockWheelEvent(true, false)
+      // Ctrl key pressed
+      const mockEvent = createMockWheelEvent(true)
 
       handleWheel(mockEvent)
 
@@ -134,8 +131,7 @@ describe('useCanvasInteractions', () => {
       vi.mocked(get).mockReturnValue('legacy')
       const { handleWheel } = useCanvasInteractions()
 
-      // Create mock wheel event without modifiers
-      const mockEvent = createMockWheelEvent(false, false)
+      const mockEvent = createMockWheelEvent()
       handleWheel(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -147,11 +143,9 @@ describe('useCanvasInteractions', () => {
       vi.mocked(get).mockReturnValue('standard')
       const { handleWheel } = useCanvasInteractions()
 
-      // Create mock wheel event without modifiers
-      const mockEvent = createMockWheelEvent(false, false)
+      const mockEvent = createMockWheelEvent()
       handleWheel(mockEvent)
 
-      // Verify - should not prevent default (let component handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
     })

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -24,6 +24,11 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
+function createMockLGraphCanvas(read_only = true): LGraphCanvas {
+  const mockCanvas: Partial<LGraphCanvas> = { read_only }
+  return mockCanvas as LGraphCanvas
+}
+
 function createMockPointerEvent(
   buttons: PointerEvent['buttons'] = 1
 ): PointerEvent {
@@ -52,9 +57,9 @@ describe('useCanvasInteractions', () => {
 
   describe('handlePointer', () => {
     it('should forward space+drag events to canvas when read_only is true', () => {
-      const mockCanvas: Partial<LGraphCanvas> = { read_only: true }
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
+      const mockCanvas = createMockLGraphCanvas(true)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas)
 
       const { handlePointer } = useCanvasInteractions()
 
@@ -66,9 +71,9 @@ describe('useCanvasInteractions', () => {
     })
 
     it('should forward middle mouse button events to canvas', () => {
-      const mockCanvas: Partial<LGraphCanvas> = { read_only: false }
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
+      const mockCanvas = createMockLGraphCanvas(false)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas)
       const { handlePointer } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent(4) // Middle mouse button
@@ -79,9 +84,9 @@ describe('useCanvasInteractions', () => {
     })
 
     it('should not prevent default when canvas is not in read_only mode and not middle button', () => {
-      const mockCanvas: Partial<LGraphCanvas> = { read_only: false }
       const { getCanvas } = useCanvasStore()
-      vi.mocked(getCanvas).mockReturnValue(mockCanvas as LGraphCanvas)
+      const mockCanvas = createMockLGraphCanvas(false)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas)
       const { handlePointer } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent(1) // Left Mouse Button

--- a/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
+++ b/tests-ui/tests/composables/graph/useCanvasInteractions.test.ts
@@ -35,6 +35,16 @@ function createMockPointerEvent(
   return mockEvent as PointerEvent
 }
 
+function createMockWheelEvent(ctrlKey = false, metaKey = false): WheelEvent {
+  const mockEvent: Partial<WheelEvent> = {
+    ctrlKey,
+    metaKey,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  }
+  return mockEvent as WheelEvent
+}
+
 describe('useCanvasInteractions', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -106,59 +116,33 @@ describe('useCanvasInteractions', () => {
       const { handleWheel } = useCanvasInteractions()
 
       // Create mock wheel event with ctrl key
-      const mockEvent: Partial<WheelEvent> = {
-        ctrlKey: true,
-        metaKey: false,
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
+      const mockEvent = createMockWheelEvent(true, false)
 
-      // Test
-      handleWheel(mockEvent as WheelEvent)
+      handleWheel(mockEvent)
 
-      // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
     })
 
     it('should forward all wheel events to canvas in legacy nav mode', () => {
-      // Setup
       const { get } = useSettingStore()
       vi.mocked(get).mockReturnValue('legacy')
-
       const { handleWheel } = useCanvasInteractions()
 
       // Create mock wheel event without modifiers
-      const mockEvent: Partial<WheelEvent> = {
-        ctrlKey: false,
-        metaKey: false,
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
+      const mockEvent = createMockWheelEvent(false, false)
+      handleWheel(mockEvent)
 
-      // Test
-      handleWheel(mockEvent as WheelEvent)
-
-      // Verify
       expect(mockEvent.preventDefault).toHaveBeenCalled()
     })
 
     it('should not prevent default for regular wheel events in standard nav mode', () => {
-      // Setup
       const { get } = useSettingStore()
       vi.mocked(get).mockReturnValue('standard')
-
       const { handleWheel } = useCanvasInteractions()
 
       // Create mock wheel event without modifiers
-      const mockEvent: Partial<WheelEvent> = {
-        ctrlKey: false,
-        metaKey: false,
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn()
-      }
-
-      // Test
-      handleWheel(mockEvent as WheelEvent)
+      const mockEvent = createMockWheelEvent(false, false)
+      handleWheel(mockEvent)
 
       // Verify - should not prevent default (let component handle normally)
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

Forwards the scroll event to litegraph canvas.

Now using the existing `useCanvasInteractions`, thanks @benceruleanlu for pointing me in the right direction.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5445-Fix-In-standard-mode-don-t-stop-when-you-hit-a-Vue-node-2696d73d365081dfaa4dcc24e12e0951) by [Unito](https://www.unito.io)
