### PR TITLE
fix: resolve flaky combo menu test by waiting for visibility

### DIFF
--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -188,7 +188,7 @@ test.describe('Image widget', () => {
     // Click the combo widget used to select the image filename
     const fileComboWidget = await loadImageNode.getWidget(0)
     await fileComboWidget.click()
-    
+
     // Wait a moment for the menu to render
     await comfyPage.nextFrame()
 

--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -188,6 +188,9 @@ test.describe('Image widget', () => {
     // Click the combo widget used to select the image filename
     const fileComboWidget = await loadImageNode.getWidget(0)
     await fileComboWidget.click()
+    
+    // Wait a moment for the menu to render
+    await comfyPage.nextFrame()
 
     // Wait for menu to be visible and select a new image filename value
     const comboEntry = comfyPage.page.getByRole('menuitem', {

--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -189,11 +189,12 @@ test.describe('Image widget', () => {
     const fileComboWidget = await loadImageNode.getWidget(0)
     await fileComboWidget.click()
 
-    // Select a new image filename value from the combo context menu
+    // Wait for menu to be visible and select a new image filename value
     const comboEntry = comfyPage.page.getByRole('menuitem', {
       name: 'image32x32.webp'
     })
-    await comboEntry.click({ noWaitAfter: true })
+    await comboEntry.waitFor({ state: 'visible' })
+    await comboEntry.click()
 
     // Expect the image preview to change automatically
     await expect(comfyPage.canvas).toHaveScreenshot(


### PR DESCRIPTION
## Summary
- Fixes flaky test "Can change image by changing the filename combo value" in `browser_tests/tests/widget.spec.ts:181`
- The test was timing out on `comboEntry.click` due to a race condition

## Changes
- Removed `noWaitAfter: true` option that prevented proper waiting
- Added explicit `waitFor` visibility check before clicking menu item  
- Added `nextFrame()` call to ensure menu is fully rendered

## Test plan
- [x] Modified the flaky test to properly wait for menu visibility
- [ ] Run browser tests to confirm the fix resolves the timeout issue
- [ ] Verify test passes consistently across multiple runs

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5450-fix-resolve-flaky-combo-menu-test-by-waiting-for-visibility-2696d73d365081f49504c84760411bfd) by [Unito](https://www.unito.io)
