### PR TITLE
[refactor] Move pure functions from layout store to separate modules so they can be tested (and add tests)

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1421,7 +1421,7 @@ export class ComfyPage {
   }
 
   async closeDialog() {
-    await this.page.locator('.p-dialog-close-button').click()
+    await this.page.locator('.p-dialog-close-button').click({ force: true })
     await expect(this.page.locator('.p-dialog')).toBeHidden()
   }
 

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -100,7 +100,7 @@ class LayoutStoreImpl implements LayoutStore {
 
   // Yjs document and shared data structures
   private ydoc = new Y.Doc()
-  private ynodes: Y.Map<Y.Map<unknown>> // Maps nodeId -> Y.Map containing NodeLayout data
+  private ynodes: Y.Map<Y.Map<NodeLayout[keyof NodeLayout]>> // Maps nodeId -> Y.Map containing NodeLayout data
   private ylinks: Y.Map<Y.Map<unknown>> // Maps linkId -> Y.Map containing link data
   private yreroutes: Y.Map<Y.Map<unknown>> // Maps rerouteId -> Y.Map containing reroute data
   private yoperations: Y.Array<LayoutOperation> // Operation log
@@ -146,17 +146,19 @@ class LayoutStoreImpl implements LayoutStore {
     this.rerouteSpatialIndex = new SpatialIndexManager()
 
     // Listen for Yjs changes and trigger Vue reactivity
-    this.ynodes.observe((event: Y.YMapEvent<Y.Map<unknown>>) => {
-      this.version++
+    this.ynodes.observe(
+      (event: Y.YMapEvent<Y.Map<NodeLayout[keyof NodeLayout]>>) => {
+        this.version++
 
-      // Trigger all affected node refs
-      event.changes.keys.forEach((_change: YEventChange, key: string) => {
-        const trigger = this.nodeTriggers.get(key)
-        if (trigger) {
-          trigger()
-        }
-      })
-    })
+        // Trigger all affected node refs
+        event.changes.keys.forEach((_change: YEventChange, key: string) => {
+          const trigger = this.nodeTriggers.get(key)
+          if (trigger) {
+            trigger()
+          }
+        })
+      }
+    )
 
     // Listen for link changes and update spatial indexes
     this.ylinks.observe((event: Y.YMapEvent<Y.Map<unknown>>) => {
@@ -1163,7 +1165,7 @@ class LayoutStoreImpl implements LayoutStore {
    * Update node bounds helper
    */
   private updateNodeBounds(
-    ynode: Y.Map<unknown>,
+    ynode: Y.Map<NodeLayout[keyof NodeLayout]>,
     position: Point,
     size: { width: number; height: number }
   ): void {

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -56,8 +56,6 @@ type YEventChange = {
 
 const logger = log.getLogger('LayoutStore')
 
-// Constants moved to utils (REROUTE_RADIUS)
-
 // Utility functions
 function asRerouteId(id: string | number): RerouteId {
   return Number(id)
@@ -66,8 +64,6 @@ function asRerouteId(id: string | number): RerouteId {
 function asLinkId(id: string | number): LinkId {
   return Number(id)
 }
-
-// Node layout mapping moved to utils/mappers
 
 interface LinkData {
   id: LinkId

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -40,9 +40,9 @@ import {
 import {
   REROUTE_RADIUS,
   boundsIntersect as boundsIntersectUtil,
-  makeLinkSegmentKey,
   pointInBounds as pointInBoundsUtil
 } from '@/renderer/core/layout/utils/layoutMath'
+import { makeLinkSegmentKey } from '@/renderer/core/layout/utils/layoutUtils'
 import {
   layoutToYNode,
   yNodeToLayout
@@ -543,11 +543,6 @@ class LayoutStoreImpl implements LayoutStore {
   getRerouteLayout(rerouteId: RerouteId): RerouteLayout | null {
     return this.rerouteLayouts.get(rerouteId) || null
   }
-
-  /**
-   * Helper to create internal key for link segment
-   */
-  // makeLinkSegmentKey moved to utils/layoutMath
 
   /**
    * Update link segment layout data

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -35,9 +35,18 @@ import {
   type Point,
   type RerouteId,
   type RerouteLayout,
-  type Size,
   type SlotLayout
 } from '@/renderer/core/layout/types'
+import {
+  REROUTE_RADIUS,
+  boundsIntersect as boundsIntersectUtil,
+  makeLinkSegmentKey,
+  pointInBounds as pointInBoundsUtil
+} from '@/renderer/core/layout/utils/layoutMath'
+import {
+  layoutToYNode,
+  yNodeToLayout
+} from '@/renderer/core/layout/utils/mappers'
 import { SpatialIndexManager } from '@/renderer/core/spatial/SpatialIndex'
 
 type YEventChange = {
@@ -47,8 +56,7 @@ type YEventChange = {
 
 const logger = log.getLogger('LayoutStore')
 
-// Constants
-const REROUTE_RADIUS = 8
+// Constants moved to utils (REROUTE_RADIUS)
 
 // Utility functions
 function asRerouteId(id: string | number): RerouteId {
@@ -59,14 +67,7 @@ function asLinkId(id: string | number): LinkId {
   return Number(id)
 }
 
-interface NodeLayoutData {
-  id: NodeId
-  position: Point
-  size: Size
-  zIndex: number
-  visible: boolean
-  bounds: Bounds
-}
+// Node layout mapping moved to utils/mappers
 
 interface LinkData {
   id: LinkId
@@ -90,15 +91,6 @@ interface TypedYMap<T> {
 }
 
 class LayoutStoreImpl implements LayoutStore {
-  private static readonly NODE_DEFAULTS: NodeLayoutData = {
-    id: 'unknown-node',
-    position: { x: 0, y: 0 },
-    size: { width: 100, height: 50 },
-    zIndex: 0,
-    visible: true,
-    bounds: { x: 0, y: 0, width: 100, height: 50 }
-  }
-
   private static readonly REROUTE_DEFAULTS: RerouteData = {
     id: 0,
     position: { x: 0, y: 0 },
@@ -183,16 +175,6 @@ class LayoutStoreImpl implements LayoutStore {
     })
   }
 
-  private getNodeField<K extends keyof NodeLayoutData>(
-    ynode: Y.Map<unknown>,
-    field: K,
-    defaultValue: NodeLayoutData[K] = LayoutStoreImpl.NODE_DEFAULTS[field]
-  ): NodeLayoutData[K] {
-    const typedNode = ynode as TypedYMap<NodeLayoutData>
-    const value = typedNode.get(field)
-    return value ?? defaultValue
-  }
-
   private getLinkField<K extends keyof LinkData>(
     ylink: Y.Map<unknown>,
     field: K
@@ -226,7 +208,7 @@ class LayoutStoreImpl implements LayoutStore {
           get: () => {
             track()
             const ynode = this.ynodes.get(nodeId)
-            const layout = ynode ? this.yNodeToLayout(ynode) : null
+            const layout = ynode ? yNodeToLayout(ynode) : null
             return layout
           },
           set: (newLayout: NodeLayout | null) => {
@@ -241,7 +223,7 @@ class LayoutStoreImpl implements LayoutStore {
                   timestamp: Date.now(),
                   source: this.currentSource,
                   actor: this.currentActor,
-                  previousLayout: this.yNodeToLayout(existing)
+                  previousLayout: yNodeToLayout(existing)
                 })
               }
             } else {
@@ -259,7 +241,7 @@ class LayoutStoreImpl implements LayoutStore {
                   actor: this.currentActor
                 })
               } else {
-                const existingLayout = this.yNodeToLayout(existing)
+                const existingLayout = yNodeToLayout(existing)
 
                 // Check what properties changed
                 if (
@@ -329,8 +311,8 @@ class LayoutStoreImpl implements LayoutStore {
       for (const [nodeId] of this.ynodes) {
         const ynode = this.ynodes.get(nodeId)
         if (ynode) {
-          const layout = this.yNodeToLayout(ynode)
-          if (layout && this.boundsIntersect(layout.bounds, bounds)) {
+          const layout = yNodeToLayout(ynode)
+          if (layout && boundsIntersectUtil(layout.bounds, bounds)) {
             result.push(nodeId)
           }
         }
@@ -351,7 +333,7 @@ class LayoutStoreImpl implements LayoutStore {
       for (const [nodeId] of this.ynodes) {
         const ynode = this.ynodes.get(nodeId)
         if (ynode) {
-          const layout = this.yNodeToLayout(ynode)
+          const layout = yNodeToLayout(ynode)
           if (layout) {
             result.set(nodeId, layout)
           }
@@ -377,7 +359,7 @@ class LayoutStoreImpl implements LayoutStore {
     for (const [nodeId] of this.ynodes) {
       const ynode = this.ynodes.get(nodeId)
       if (ynode) {
-        const layout = this.yNodeToLayout(ynode)
+        const layout = yNodeToLayout(ynode)
         if (layout) {
           nodes.push([nodeId, layout])
         }
@@ -388,7 +370,7 @@ class LayoutStoreImpl implements LayoutStore {
     nodes.sort(([, a], [, b]) => b.zIndex - a.zIndex)
 
     for (const [nodeId, layout] of nodes) {
-      if (this.pointInBounds(point, layout.bounds)) {
+      if (pointInBoundsUtil(point, layout.bounds)) {
         return nodeId
       }
     }
@@ -563,12 +545,7 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Helper to create internal key for link segment
    */
-  private makeLinkSegmentKey(
-    linkId: LinkId,
-    rerouteId: RerouteId | null
-  ): string {
-    return `${linkId}:${rerouteId ?? 'final'}`
-  }
+  // makeLinkSegmentKey moved to utils/layoutMath
 
   /**
    * Update link segment layout data
@@ -578,7 +555,7 @@ class LayoutStoreImpl implements LayoutStore {
     rerouteId: RerouteId | null,
     layout: Omit<LinkSegmentLayout, 'linkId' | 'rerouteId'>
   ): void {
-    const key = this.makeLinkSegmentKey(linkId, rerouteId)
+    const key = makeLinkSegmentKey(linkId, rerouteId)
     const existing = this.linkSegmentLayouts.get(key)
 
     // Short-circuit if bounds and centerPos unchanged (prevents spatial index churn)
@@ -628,7 +605,7 @@ class LayoutStoreImpl implements LayoutStore {
    * Delete link segment layout data
    */
   deleteLinkSegmentLayout(linkId: LinkId, rerouteId: RerouteId | null): void {
-    const key = this.makeLinkSegmentKey(linkId, rerouteId)
+    const key = makeLinkSegmentKey(linkId, rerouteId)
     const deleted = this.linkSegmentLayouts.delete(key)
     if (deleted) {
       // Remove from spatial index
@@ -692,7 +669,7 @@ class LayoutStoreImpl implements LayoutStore {
             rerouteId: segmentLayout.rerouteId
           }
         }
-      } else if (this.pointInBounds(point, segmentLayout.bounds)) {
+      } else if (pointInBoundsUtil(point, segmentLayout.bounds)) {
         // Fallback to bounding box test
         return {
           linkId: segmentLayout.linkId,
@@ -732,7 +709,7 @@ class LayoutStoreImpl implements LayoutStore {
     // Check precise bounds for candidates
     for (const key of candidateSlotKeys) {
       const slotLayout = this.slotLayouts.get(key)
-      if (slotLayout && this.pointInBounds(point, slotLayout.bounds)) {
+      if (slotLayout && pointInBoundsUtil(point, slotLayout.bounds)) {
         return slotLayout
       }
     }
@@ -968,7 +945,7 @@ class LayoutStoreImpl implements LayoutStore {
           }
         }
 
-        this.ynodes.set(layout.id, this.layoutToYNode(layout))
+        this.ynodes.set(layout.id, layoutToYNode(layout))
 
         // Add to spatial index
         this.spatialIndex.insert(layout.id, layout.bounds)
@@ -986,7 +963,7 @@ class LayoutStoreImpl implements LayoutStore {
       return
     }
 
-    const size = this.getNodeField(ynode, 'size')
+    const size = yNodeToLayout(ynode).size
     const newBounds = {
       x: operation.position.x,
       y: operation.position.y,
@@ -1015,7 +992,7 @@ class LayoutStoreImpl implements LayoutStore {
     const ynode = this.ynodes.get(operation.nodeId)
     if (!ynode) return
 
-    const position = this.getNodeField(ynode, 'position')
+    const position = yNodeToLayout(ynode).position
     const newBounds = {
       x: position.x,
       y: position.y,
@@ -1052,7 +1029,7 @@ class LayoutStoreImpl implements LayoutStore {
     operation: CreateNodeOperation,
     change: LayoutChange
   ): void {
-    const ynode = this.layoutToYNode(operation.layout)
+    const ynode = layoutToYNode(operation.layout)
     this.ynodes.set(operation.nodeId, ynode)
 
     // Add to spatial index
@@ -1334,27 +1311,7 @@ class LayoutStoreImpl implements LayoutStore {
   }
 
   // Helper methods
-  private layoutToYNode(layout: NodeLayout): Y.Map<unknown> {
-    const ynode = new Y.Map<unknown>()
-    ynode.set('id', layout.id)
-    ynode.set('position', layout.position)
-    ynode.set('size', layout.size)
-    ynode.set('zIndex', layout.zIndex)
-    ynode.set('visible', layout.visible)
-    ynode.set('bounds', layout.bounds)
-    return ynode
-  }
-
-  private yNodeToLayout(ynode: Y.Map<unknown>): NodeLayout {
-    return {
-      id: this.getNodeField(ynode, 'id'),
-      position: this.getNodeField(ynode, 'position'),
-      size: this.getNodeField(ynode, 'size'),
-      zIndex: this.getNodeField(ynode, 'zIndex'),
-      visible: this.getNodeField(ynode, 'visible'),
-      bounds: this.getNodeField(ynode, 'bounds')
-    }
-  }
+  // Node layout mappers moved to utils/mappers
 
   private notifyChange(change: LayoutChange): void {
     this.changeListeners.forEach((listener) => {
@@ -1364,24 +1321,6 @@ class LayoutStoreImpl implements LayoutStore {
         console.error('Error in layout change listener:', error)
       }
     })
-  }
-
-  private pointInBounds(point: Point, bounds: Bounds): boolean {
-    return (
-      point.x >= bounds.x &&
-      point.x <= bounds.x + bounds.width &&
-      point.y >= bounds.y &&
-      point.y <= bounds.y + bounds.height
-    )
-  }
-
-  private boundsIntersect(a: Bounds, b: Bounds): boolean {
-    return !(
-      a.x + a.width < b.x ||
-      b.x + b.width < a.x ||
-      a.y + a.height < b.y ||
-      b.y + b.height < a.y
-    )
   }
 
   // CRDT-specific methods

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -39,8 +39,8 @@ import {
 } from '@/renderer/core/layout/types'
 import {
   REROUTE_RADIUS,
-  boundsIntersect as boundsIntersectUtil,
-  pointInBounds as pointInBoundsUtil
+  boundsIntersect,
+  pointInBounds
 } from '@/renderer/core/layout/utils/layoutMath'
 import { makeLinkSegmentKey } from '@/renderer/core/layout/utils/layoutUtils'
 import {
@@ -310,7 +310,7 @@ class LayoutStoreImpl implements LayoutStore {
         const ynode = this.ynodes.get(nodeId)
         if (ynode) {
           const layout = yNodeToLayout(ynode)
-          if (layout && boundsIntersectUtil(layout.bounds, bounds)) {
+          if (layout && boundsIntersect(layout.bounds, bounds)) {
             result.push(nodeId)
           }
         }
@@ -368,7 +368,7 @@ class LayoutStoreImpl implements LayoutStore {
     nodes.sort(([, a], [, b]) => b.zIndex - a.zIndex)
 
     for (const [nodeId, layout] of nodes) {
-      if (pointInBoundsUtil(point, layout.bounds)) {
+      if (pointInBounds(point, layout.bounds)) {
         return nodeId
       }
     }
@@ -662,7 +662,7 @@ class LayoutStoreImpl implements LayoutStore {
             rerouteId: segmentLayout.rerouteId
           }
         }
-      } else if (pointInBoundsUtil(point, segmentLayout.bounds)) {
+      } else if (pointInBounds(point, segmentLayout.bounds)) {
         // Fallback to bounding box test
         return {
           linkId: segmentLayout.linkId,
@@ -702,7 +702,7 @@ class LayoutStoreImpl implements LayoutStore {
     // Check precise bounds for candidates
     for (const key of candidateSlotKeys) {
       const slotLayout = this.slotLayouts.get(key)
-      if (slotLayout && pointInBoundsUtil(point, slotLayout.bounds)) {
+      if (slotLayout && pointInBounds(point, slotLayout.bounds)) {
         return slotLayout
       }
     }

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -1313,7 +1313,6 @@ class LayoutStoreImpl implements LayoutStore {
   }
 
   // Helper methods
-  // Node layout mappers moved to utils/mappers
 
   private notifyChange(change: LayoutChange): void {
     this.changeListeners.forEach((listener) => {

--- a/src/renderer/core/layout/utils/layoutMath.ts
+++ b/src/renderer/core/layout/utils/layoutMath.ts
@@ -1,0 +1,33 @@
+import type {
+  Bounds,
+  LinkId,
+  Point,
+  RerouteId
+} from '@/renderer/core/layout/types'
+
+export const REROUTE_RADIUS = 8
+
+export function pointInBounds(point: Point, bounds: Bounds): boolean {
+  return (
+    point.x >= bounds.x &&
+    point.x <= bounds.x + bounds.width &&
+    point.y >= bounds.y &&
+    point.y <= bounds.y + bounds.height
+  )
+}
+
+export function boundsIntersect(a: Bounds, b: Bounds): boolean {
+  return !(
+    a.x + a.width < b.x ||
+    b.x + b.width < a.x ||
+    a.y + a.height < b.y ||
+    b.y + b.height < a.y
+  )
+}
+
+export function makeLinkSegmentKey(
+  linkId: LinkId,
+  rerouteId: RerouteId | null
+): string {
+  return `${linkId}:${rerouteId ?? 'final'}`
+}

--- a/src/renderer/core/layout/utils/layoutMath.ts
+++ b/src/renderer/core/layout/utils/layoutMath.ts
@@ -1,9 +1,4 @@
-import type {
-  Bounds,
-  LinkId,
-  Point,
-  RerouteId
-} from '@/renderer/core/layout/types'
+import type { Bounds, Point } from '@/renderer/core/layout/types'
 
 export const REROUTE_RADIUS = 8
 
@@ -23,11 +18,4 @@ export function boundsIntersect(a: Bounds, b: Bounds): boolean {
     a.y + a.height < b.y ||
     b.y + b.height < a.y
   )
-}
-
-export function makeLinkSegmentKey(
-  linkId: LinkId,
-  rerouteId: RerouteId | null
-): string {
-  return `${linkId}:${rerouteId ?? 'final'}`
 }

--- a/src/renderer/core/layout/utils/layoutUtils.ts
+++ b/src/renderer/core/layout/utils/layoutUtils.ts
@@ -1,0 +1,11 @@
+import type { LinkId, RerouteId } from '@/renderer/core/layout/types'
+
+/**
+ * Creates a unique key for identifying link segments in spatial indexes
+ */
+export function makeLinkSegmentKey(
+  linkId: LinkId,
+  rerouteId: RerouteId | null
+): string {
+  return `${linkId}:${rerouteId ?? 'final'}`
+}

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -2,6 +2,9 @@ import * as Y from 'yjs'
 
 import type { NodeLayout } from '@/renderer/core/layout/types'
 
+// Named type for performance optimization (TypeScript wiki recommendation)
+export type NodeLayoutMap = Y.Map<NodeLayout[keyof NodeLayout]>
+
 export const NODE_LAYOUT_DEFAULTS: NodeLayout = {
   id: 'unknown-node',
   position: { x: 0, y: 0 },
@@ -11,10 +14,8 @@ export const NODE_LAYOUT_DEFAULTS: NodeLayout = {
   bounds: { x: 0, y: 0, width: 100, height: 50 }
 }
 
-export function layoutToYNode(
-  layout: NodeLayout
-): Y.Map<NodeLayout[keyof NodeLayout]> {
-  const ynode = new Y.Map<NodeLayout[keyof NodeLayout]>()
+export function layoutToYNode(layout: NodeLayout): NodeLayoutMap {
+  const ynode = new Y.Map<NodeLayout[keyof NodeLayout]>() as NodeLayoutMap
   ynode.set('id', layout.id)
   ynode.set('position', layout.position)
   ynode.set('size', layout.size)
@@ -24,40 +25,22 @@ export function layoutToYNode(
   return ynode
 }
 
-function getOr<T>(
-  map: Y.Map<NodeLayout[keyof NodeLayout]>,
-  key: string,
-  fallback: T
-): T {
+function getOr<K extends keyof NodeLayout>(
+  map: NodeLayoutMap,
+  key: K,
+  fallback: NodeLayout[K]
+): NodeLayout[K] {
   const v = map.get(key)
-  return (v ?? fallback) as T
+  return (v ?? fallback) as NodeLayout[K]
 }
 
-export function yNodeToLayout(
-  ynode: Y.Map<NodeLayout[keyof NodeLayout]>
-): NodeLayout {
+export function yNodeToLayout(ynode: NodeLayoutMap): NodeLayout {
   return {
-    id: getOr<NodeLayout['id']>(ynode, 'id', NODE_LAYOUT_DEFAULTS.id),
-    position: getOr<NodeLayout['position']>(
-      ynode,
-      'position',
-      NODE_LAYOUT_DEFAULTS.position
-    ),
-    size: getOr<NodeLayout['size']>(ynode, 'size', NODE_LAYOUT_DEFAULTS.size),
-    zIndex: getOr<NodeLayout['zIndex']>(
-      ynode,
-      'zIndex',
-      NODE_LAYOUT_DEFAULTS.zIndex
-    ),
-    visible: getOr<NodeLayout['visible']>(
-      ynode,
-      'visible',
-      NODE_LAYOUT_DEFAULTS.visible
-    ),
-    bounds: getOr<NodeLayout['bounds']>(
-      ynode,
-      'bounds',
-      NODE_LAYOUT_DEFAULTS.bounds
-    )
+    id: getOr(ynode, 'id', NODE_LAYOUT_DEFAULTS.id),
+    position: getOr(ynode, 'position', NODE_LAYOUT_DEFAULTS.position),
+    size: getOr(ynode, 'size', NODE_LAYOUT_DEFAULTS.size),
+    zIndex: getOr(ynode, 'zIndex', NODE_LAYOUT_DEFAULTS.zIndex),
+    visible: getOr(ynode, 'visible', NODE_LAYOUT_DEFAULTS.visible),
+    bounds: getOr(ynode, 'bounds', NODE_LAYOUT_DEFAULTS.bounds)
   }
 }

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -24,7 +24,7 @@ export function layoutToYNode(layout: NodeLayout): Y.Map<unknown> {
 
 function getOr<T>(map: Y.Map<unknown>, key: string, fallback: T): T {
   const v = map.get(key)
-  return v === undefined || v === null ? fallback : (v as T)
+  return (v ?? fallback) as T
 }
 
 export function yNodeToLayout(ynode: Y.Map<unknown>): NodeLayout {

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -2,7 +2,6 @@ import * as Y from 'yjs'
 
 import type { NodeLayout } from '@/renderer/core/layout/types'
 
-// Named type for performance optimization (TypeScript wiki recommendation)
 export type NodeLayoutMap = Y.Map<NodeLayout[keyof NodeLayout]>
 
 export const NODE_LAYOUT_DEFAULTS: NodeLayout = {

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -11,8 +11,10 @@ export const NODE_LAYOUT_DEFAULTS: NodeLayout = {
   bounds: { x: 0, y: 0, width: 100, height: 50 }
 }
 
-export function layoutToYNode(layout: NodeLayout): Y.Map<unknown> {
-  const ynode = new Y.Map<unknown>()
+export function layoutToYNode(
+  layout: NodeLayout
+): Y.Map<NodeLayout[keyof NodeLayout]> {
+  const ynode = new Y.Map<NodeLayout[keyof NodeLayout]>()
   ynode.set('id', layout.id)
   ynode.set('position', layout.position)
   ynode.set('size', layout.size)
@@ -22,12 +24,18 @@ export function layoutToYNode(layout: NodeLayout): Y.Map<unknown> {
   return ynode
 }
 
-function getOr<T>(map: Y.Map<unknown>, key: string, fallback: T): T {
+function getOr<T>(
+  map: Y.Map<NodeLayout[keyof NodeLayout]>,
+  key: string,
+  fallback: T
+): T {
   const v = map.get(key)
   return (v ?? fallback) as T
 }
 
-export function yNodeToLayout(ynode: Y.Map<unknown>): NodeLayout {
+export function yNodeToLayout(
+  ynode: Y.Map<NodeLayout[keyof NodeLayout]>
+): NodeLayout {
   return {
     id: getOr<NodeLayout['id']>(ynode, 'id', NODE_LAYOUT_DEFAULTS.id),
     position: getOr<NodeLayout['position']>(

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -1,0 +1,55 @@
+import * as Y from 'yjs'
+
+import type { NodeLayout } from '@/renderer/core/layout/types'
+
+export const NODE_LAYOUT_DEFAULTS: NodeLayout = {
+  id: 'unknown-node',
+  position: { x: 0, y: 0 },
+  size: { width: 100, height: 50 },
+  zIndex: 0,
+  visible: true,
+  bounds: { x: 0, y: 0, width: 100, height: 50 }
+}
+
+export function layoutToYNode(layout: NodeLayout): Y.Map<unknown> {
+  const ynode = new Y.Map<unknown>()
+  ynode.set('id', layout.id)
+  ynode.set('position', layout.position)
+  ynode.set('size', layout.size)
+  ynode.set('zIndex', layout.zIndex)
+  ynode.set('visible', layout.visible)
+  ynode.set('bounds', layout.bounds)
+  return ynode
+}
+
+function getOr<T>(map: Y.Map<unknown>, key: string, fallback: T): T {
+  const v = map.get(key)
+  return v === undefined || v === null ? fallback : (v as T)
+}
+
+export function yNodeToLayout(ynode: Y.Map<unknown>): NodeLayout {
+  return {
+    id: getOr<NodeLayout['id']>(ynode, 'id', NODE_LAYOUT_DEFAULTS.id),
+    position: getOr<NodeLayout['position']>(
+      ynode,
+      'position',
+      NODE_LAYOUT_DEFAULTS.position
+    ),
+    size: getOr<NodeLayout['size']>(ynode, 'size', NODE_LAYOUT_DEFAULTS.size),
+    zIndex: getOr<NodeLayout['zIndex']>(
+      ynode,
+      'zIndex',
+      NODE_LAYOUT_DEFAULTS.zIndex
+    ),
+    visible: getOr<NodeLayout['visible']>(
+      ynode,
+      'visible',
+      NODE_LAYOUT_DEFAULTS.visible
+    ),
+    bounds: getOr<NodeLayout['bounds']>(
+      ynode,
+      'bounds',
+      NODE_LAYOUT_DEFAULTS.bounds
+    )
+  }
+}

--- a/tests-ui/tests/renderer/core/layout/utils/layoutMath.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/layoutMath.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  REROUTE_RADIUS,
+  boundsIntersect,
+  makeLinkSegmentKey,
+  pointInBounds
+} from '@/renderer/core/layout/utils/layoutMath'
+
+describe('layoutMath utils', () => {
+  it('makeLinkSegmentKey creates stable keys', () => {
+    expect(makeLinkSegmentKey(10, null)).toBe('10:final')
+    expect(makeLinkSegmentKey(10, 3)).toBe('10:3')
+  })
+
+  it('pointInBounds detects inclusion correctly', () => {
+    const bounds = { x: 10, y: 10, width: 100, height: 50 }
+    expect(pointInBounds({ x: 10, y: 10 }, bounds)).toBe(true)
+    expect(pointInBounds({ x: 110, y: 60 }, bounds)).toBe(true)
+    expect(pointInBounds({ x: 9, y: 10 }, bounds)).toBe(false)
+    expect(pointInBounds({ x: 111, y: 10 }, bounds)).toBe(false)
+    expect(pointInBounds({ x: 10, y: 61 }, bounds)).toBe(false)
+  })
+
+  it('boundsIntersect detects intersection correctly', () => {
+    const a = { x: 0, y: 0, width: 10, height: 10 }
+    const b = { x: 5, y: 5, width: 10, height: 10 }
+    const c = { x: 11, y: 0, width: 5, height: 5 }
+    expect(boundsIntersect(a, b)).toBe(true)
+    expect(boundsIntersect(a, c)).toBe(false)
+  })
+
+  it('exports a sensible reroute radius', () => {
+    expect(REROUTE_RADIUS).toBeGreaterThan(0)
+  })
+
+  it('boundsIntersect treats touching edges as intersecting', () => {
+    const a = { x: 0, y: 0, width: 10, height: 10 }
+    const d = { x: 10, y: 0, width: 5, height: 5 } // touches at right edge
+    expect(boundsIntersect(a, d)).toBe(true)
+  })
+
+  it('pointInBounds works with zero-size bounds', () => {
+    const zero = { x: 10, y: 20, width: 0, height: 0 }
+    expect(pointInBounds({ x: 10, y: 20 }, zero)).toBe(true)
+    expect(pointInBounds({ x: 10, y: 21 }, zero)).toBe(false)
+    expect(pointInBounds({ x: 9, y: 20 }, zero)).toBe(false)
+  })
+
+  it('makeLinkSegmentKey handles null and numeric reroute ids', () => {
+    expect(makeLinkSegmentKey(42, null)).toBe('42:final')
+    expect(makeLinkSegmentKey(42, 0)).toBe('42:0')
+    expect(makeLinkSegmentKey(42, 7)).toBe('42:7')
+  })
+})

--- a/tests-ui/tests/renderer/core/layout/utils/layoutMath.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/layoutMath.test.ts
@@ -8,48 +8,56 @@ import {
 } from '@/renderer/core/layout/utils/layoutMath'
 
 describe('layoutMath utils', () => {
-  it('makeLinkSegmentKey creates stable keys', () => {
-    expect(makeLinkSegmentKey(10, null)).toBe('10:final')
-    expect(makeLinkSegmentKey(10, 3)).toBe('10:3')
+  describe('makeLinkSegmentKey', () => {
+    it('creates stable keys for null reroute', () => {
+      expect(makeLinkSegmentKey(10, null)).toBe('10:final')
+      expect(makeLinkSegmentKey(42, null)).toBe('42:final')
+    })
+
+    it('creates stable keys for numeric reroute ids', () => {
+      expect(makeLinkSegmentKey(10, 3)).toBe('10:3')
+      expect(makeLinkSegmentKey(42, 0)).toBe('42:0')
+      expect(makeLinkSegmentKey(42, 7)).toBe('42:7')
+    })
   })
 
-  it('pointInBounds detects inclusion correctly', () => {
-    const bounds = { x: 10, y: 10, width: 100, height: 50 }
-    expect(pointInBounds({ x: 10, y: 10 }, bounds)).toBe(true)
-    expect(pointInBounds({ x: 110, y: 60 }, bounds)).toBe(true)
-    expect(pointInBounds({ x: 9, y: 10 }, bounds)).toBe(false)
-    expect(pointInBounds({ x: 111, y: 10 }, bounds)).toBe(false)
-    expect(pointInBounds({ x: 10, y: 61 }, bounds)).toBe(false)
+  describe('pointInBounds', () => {
+    it('detects inclusion correctly', () => {
+      const bounds = { x: 10, y: 10, width: 100, height: 50 }
+      expect(pointInBounds({ x: 10, y: 10 }, bounds)).toBe(true)
+      expect(pointInBounds({ x: 110, y: 60 }, bounds)).toBe(true)
+      expect(pointInBounds({ x: 9, y: 10 }, bounds)).toBe(false)
+      expect(pointInBounds({ x: 111, y: 10 }, bounds)).toBe(false)
+      expect(pointInBounds({ x: 10, y: 61 }, bounds)).toBe(false)
+    })
+
+    it('works with zero-size bounds', () => {
+      const zero = { x: 10, y: 20, width: 0, height: 0 }
+      expect(pointInBounds({ x: 10, y: 20 }, zero)).toBe(true)
+      expect(pointInBounds({ x: 10, y: 21 }, zero)).toBe(false)
+      expect(pointInBounds({ x: 9, y: 20 }, zero)).toBe(false)
+    })
   })
 
-  it('boundsIntersect detects intersection correctly', () => {
-    const a = { x: 0, y: 0, width: 10, height: 10 }
-    const b = { x: 5, y: 5, width: 10, height: 10 }
-    const c = { x: 11, y: 0, width: 5, height: 5 }
-    expect(boundsIntersect(a, b)).toBe(true)
-    expect(boundsIntersect(a, c)).toBe(false)
+  describe('boundsIntersect', () => {
+    it('detects intersection correctly', () => {
+      const a = { x: 0, y: 0, width: 10, height: 10 }
+      const b = { x: 5, y: 5, width: 10, height: 10 }
+      const c = { x: 11, y: 0, width: 5, height: 5 }
+      expect(boundsIntersect(a, b)).toBe(true)
+      expect(boundsIntersect(a, c)).toBe(false)
+    })
+
+    it('treats touching edges as intersecting', () => {
+      const a = { x: 0, y: 0, width: 10, height: 10 }
+      const d = { x: 10, y: 0, width: 5, height: 5 } // touches at right edge
+      expect(boundsIntersect(a, d)).toBe(true)
+    })
   })
 
-  it('exports a sensible reroute radius', () => {
-    expect(REROUTE_RADIUS).toBeGreaterThan(0)
-  })
-
-  it('boundsIntersect treats touching edges as intersecting', () => {
-    const a = { x: 0, y: 0, width: 10, height: 10 }
-    const d = { x: 10, y: 0, width: 5, height: 5 } // touches at right edge
-    expect(boundsIntersect(a, d)).toBe(true)
-  })
-
-  it('pointInBounds works with zero-size bounds', () => {
-    const zero = { x: 10, y: 20, width: 0, height: 0 }
-    expect(pointInBounds({ x: 10, y: 20 }, zero)).toBe(true)
-    expect(pointInBounds({ x: 10, y: 21 }, zero)).toBe(false)
-    expect(pointInBounds({ x: 9, y: 20 }, zero)).toBe(false)
-  })
-
-  it('makeLinkSegmentKey handles null and numeric reroute ids', () => {
-    expect(makeLinkSegmentKey(42, null)).toBe('42:final')
-    expect(makeLinkSegmentKey(42, 0)).toBe('42:0')
-    expect(makeLinkSegmentKey(42, 7)).toBe('42:7')
+  describe('REROUTE_RADIUS', () => {
+    it('exports a sensible reroute radius', () => {
+      expect(REROUTE_RADIUS).toBeGreaterThan(0)
+    })
   })
 })

--- a/tests-ui/tests/renderer/core/layout/utils/layoutMath.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/layoutMath.test.ts
@@ -3,24 +3,10 @@ import { describe, expect, it } from 'vitest'
 import {
   REROUTE_RADIUS,
   boundsIntersect,
-  makeLinkSegmentKey,
   pointInBounds
 } from '@/renderer/core/layout/utils/layoutMath'
 
 describe('layoutMath utils', () => {
-  describe('makeLinkSegmentKey', () => {
-    it('creates stable keys for null reroute', () => {
-      expect(makeLinkSegmentKey(10, null)).toBe('10:final')
-      expect(makeLinkSegmentKey(42, null)).toBe('42:final')
-    })
-
-    it('creates stable keys for numeric reroute ids', () => {
-      expect(makeLinkSegmentKey(10, 3)).toBe('10:3')
-      expect(makeLinkSegmentKey(42, 0)).toBe('42:0')
-      expect(makeLinkSegmentKey(42, 7)).toBe('42:7')
-    })
-  })
-
   describe('pointInBounds', () => {
     it('detects inclusion correctly', () => {
       const bounds = { x: 10, y: 10, width: 100, height: 50 }

--- a/tests-ui/tests/renderer/core/layout/utils/layoutUtils.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/layoutUtils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { makeLinkSegmentKey } from '@/renderer/core/layout/utils/layoutUtils'
+
+describe('layoutUtils', () => {
+  describe('makeLinkSegmentKey', () => {
+    it('creates stable keys for null reroute', () => {
+      expect(makeLinkSegmentKey(10, null)).toBe('10:final')
+      expect(makeLinkSegmentKey(42, null)).toBe('42:final')
+    })
+
+    it('creates stable keys for numeric reroute ids', () => {
+      expect(makeLinkSegmentKey(10, 3)).toBe('10:3')
+      expect(makeLinkSegmentKey(42, 0)).toBe('42:0')
+      expect(makeLinkSegmentKey(42, 7)).toBe('42:7')
+    })
+  })
+})

--- a/tests-ui/tests/renderer/core/layout/utils/mappers.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/mappers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 
+import type { NodeLayout } from '@/renderer/core/layout/types'
 import {
   NODE_LAYOUT_DEFAULTS,
   yNodeToLayout
@@ -18,7 +19,7 @@ describe('mappers', () => {
     }
 
     const doc = new Y.Doc()
-    const ynode = doc.getMap<unknown>('node')
+    const ynode = doc.getMap('node') as Y.Map<NodeLayout[keyof NodeLayout]>
     ynode.set('id', layout.id)
     ynode.set('position', layout.position)
     ynode.set('size', layout.size)
@@ -30,15 +31,10 @@ describe('mappers', () => {
     expect(back).toEqual(layout)
   })
 
-  it('yNodeToLayout applies defaults for missing and null fields', () => {
+  it('yNodeToLayout applies defaults for missing fields', () => {
     const doc = new Y.Doc()
-    const ynode = doc.getMap<unknown>('node')
-    ynode.set('id', null)
-    ynode.set('position', null)
-    ynode.set('size', null)
-    ynode.set('zIndex', null)
-    ynode.set('visible', null)
-    ynode.set('bounds', null)
+    const ynode = doc.getMap('node') as Y.Map<NodeLayout[keyof NodeLayout]>
+    // Don't set any fields - they should all use defaults
 
     const back = yNodeToLayout(ynode)
     expect(back.id).toBe(NODE_LAYOUT_DEFAULTS.id)

--- a/tests-ui/tests/renderer/core/layout/utils/mappers.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/mappers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+
+import {
+  NODE_LAYOUT_DEFAULTS,
+  yNodeToLayout
+} from '@/renderer/core/layout/utils/mappers'
+
+describe('mappers', () => {
+  it('yNodeToLayout reads from Yjs-attached map', () => {
+    const layout = {
+      id: 'node-1',
+      position: { x: 12, y: 34 },
+      size: { width: 111, height: 222 },
+      zIndex: 5,
+      visible: true,
+      bounds: { x: 12, y: 34, width: 111, height: 222 }
+    }
+
+    const doc = new Y.Doc()
+    const ynode = doc.getMap<unknown>('node')
+    ynode.set('id', layout.id)
+    ynode.set('position', layout.position)
+    ynode.set('size', layout.size)
+    ynode.set('zIndex', layout.zIndex)
+    ynode.set('visible', layout.visible)
+    ynode.set('bounds', layout.bounds)
+
+    const back = yNodeToLayout(ynode)
+    expect(back).toEqual(layout)
+  })
+
+  it('yNodeToLayout applies defaults for missing and null fields', () => {
+    const doc = new Y.Doc()
+    const ynode = doc.getMap<unknown>('node')
+    ynode.set('id', null)
+    ynode.set('position', null)
+    ynode.set('size', null)
+    ynode.set('zIndex', null)
+    ynode.set('visible', null)
+    ynode.set('bounds', null)
+
+    const back = yNodeToLayout(ynode)
+    expect(back.id).toBe(NODE_LAYOUT_DEFAULTS.id)
+    expect(back.position).toEqual(NODE_LAYOUT_DEFAULTS.position)
+    expect(back.size).toEqual(NODE_LAYOUT_DEFAULTS.size)
+    expect(back.zIndex).toEqual(NODE_LAYOUT_DEFAULTS.zIndex)
+    expect(back.visible).toEqual(NODE_LAYOUT_DEFAULTS.visible)
+    expect(back.bounds).toEqual(NODE_LAYOUT_DEFAULTS.bounds)
+  })
+})

--- a/tests-ui/tests/renderer/core/layout/utils/mappers.test.ts
+++ b/tests-ui/tests/renderer/core/layout/utils/mappers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 
-import type { NodeLayout } from '@/renderer/core/layout/types'
 import {
   NODE_LAYOUT_DEFAULTS,
+  type NodeLayoutMap,
   yNodeToLayout
 } from '@/renderer/core/layout/utils/mappers'
 
@@ -19,7 +19,7 @@ describe('mappers', () => {
     }
 
     const doc = new Y.Doc()
-    const ynode = doc.getMap('node') as Y.Map<NodeLayout[keyof NodeLayout]>
+    const ynode = doc.getMap('node') as NodeLayoutMap
     ynode.set('id', layout.id)
     ynode.set('position', layout.position)
     ynode.set('size', layout.size)
@@ -33,7 +33,7 @@ describe('mappers', () => {
 
   it('yNodeToLayout applies defaults for missing fields', () => {
     const doc = new Y.Doc()
-    const ynode = doc.getMap('node') as Y.Map<NodeLayout[keyof NodeLayout]>
+    const ynode = doc.getMap('node') as NodeLayoutMap
     // Don't set any fields - they should all use defaults
 
     const back = yNodeToLayout(ynode)


### PR DESCRIPTION
Extracted pure layout utils (math + mappers) and rewired `layoutStore` to use them; added focused tests; no behavior changes.

## Changes

- **What**:
  - added `utils/layoutMath.ts` and `utils/mappers.ts`
  - updated `layoutStore.ts` to import these
  - added edge-case tests for math/mappers.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

- Verify no functional diffs in `layoutStore` (utils-only extraction).
- Confirm typed-getter defaults in `yNodeToLayout` match expectations.
- Ensure `makeLinkSegmentKey` compatibility with existing callers.
- Check tests reflect mapper naming and avoid duplicates.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5462-refactor-Move-pure-functions-from-layout-store-to-separate-modules-so-they-can-be-teste-26a6d73d3650818f98edd44a1eeea5d8) by [Unito](https://www.unito.io)
