### PR TITLE
[feat] carve out path to call asset browser in combo widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tests-ui/workflows/examples
 /blob-report/
 /playwright/.cache/
 browser_tests/**/*-win32.png
+browser-tests/local/
 
 .env
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1757,6 +1757,9 @@
     "copiedTooltip": "Copied",
     "copyTooltip": "Copy message to clipboard"
   },
+  "widgets": {
+    "selectModel": "Select model"
+  },
   "nodeHelpPage": {
     "inputs": "Inputs",
     "outputs": "Outputs",

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -1,8 +1,12 @@
 import { ref } from 'vue'
 
 import MultiSelectWidget from '@/components/graph/widgets/MultiSelectWidget.vue'
+import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import type { IComboWidget } from '@/lib/litegraph/src/types/widgets'
+import type {
+  IBaseWidget,
+  IComboWidget
+} from '@/lib/litegraph/src/types/widgets'
 import { transformInputSpecV2ToV1 } from '@/schemas/nodeDef/migration'
 import {
   ComboInputSpec,
@@ -18,6 +22,8 @@ import {
   type ComfyWidgetConstructorV2,
   addValueControlWidgets
 } from '@/scripts/widgets'
+import { assetService } from '@/services/assetService'
+import { useSettingStore } from '@/stores/settingStore'
 
 import { useRemoteWidget } from './useRemoteWidget'
 
@@ -28,7 +34,10 @@ const getDefaultValue = (inputSpec: ComboInputSpec) => {
   return undefined
 }
 
-const addMultiSelectWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
+const addMultiSelectWidget = (
+  node: LGraphNode,
+  inputSpec: ComboInputSpec
+): IBaseWidget => {
   const widgetValue = ref<string[]>([])
   const widget = new ComponentWidgetImpl({
     node,
@@ -48,7 +57,37 @@ const addMultiSelectWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
   return widget
 }
 
-const addComboWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
+const addComboWidget = (
+  node: LGraphNode,
+  inputSpec: ComboInputSpec
+): IComboWidget => {
+  const settingStore = useSettingStore()
+  const isUsingAssetAPI = settingStore.get('Comfy.Assets.UseAssetAPI')
+  const isAssetBrowserEligible = assetService.isAssetBrowserEligible(
+    inputSpec.name
+  )
+
+  if (isUsingAssetAPI && isAssetBrowserEligible) {
+    // Get the default value for the button text (currently selected model)
+    const currentValue = getDefaultValue(inputSpec)
+
+    const widget = node.addWidget(
+      'combo',
+      inputSpec.name,
+      currentValue,
+      () => {
+        console.log(
+          `Asset Browser would open here for:\nNode: ${node.type}\nWidget: ${inputSpec.name}\nCurrent Value:${currentValue}`
+        )
+      },
+      {
+        values: [t('widgets.selectModel')]
+      }
+    )
+
+    return widget as IComboWidget
+  }
+
   const defaultValue = getDefaultValue(inputSpec)
   const comboOptions = inputSpec.options ?? []
   const widget = node.addWidget(
@@ -59,14 +98,14 @@ const addComboWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
     {
       values: comboOptions
     }
-  ) as IComboWidget
+  )
 
   if (inputSpec.remote) {
     const remoteWidget = useRemoteWidget({
       remoteConfig: inputSpec.remote,
       defaultValue,
       node,
-      widget
+      widget: widget as IComboWidget
     })
     if (inputSpec.remote.refresh_button) remoteWidget.addRefreshButton()
 
@@ -91,7 +130,7 @@ const addComboWidget = (node: LGraphNode, inputSpec: ComboInputSpec) => {
     )
   }
 
-  return widget
+  return widget as IComboWidget
 }
 
 export const useComboWidget = () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -60,34 +60,33 @@ const addMultiSelectWidget = (
 const addComboWidget = (
   node: LGraphNode,
   inputSpec: ComboInputSpec
-): IComboWidget => {
+): IBaseWidget => {
   const settingStore = useSettingStore()
   const isUsingAssetAPI = settingStore.get('Comfy.Assets.UseAssetAPI')
-  const isAssetBrowserEligible = assetService.isAssetBrowserEligible(
-    inputSpec.name
+  const isEligible = assetService.isAssetBrowserEligible(
+    inputSpec.name,
+    node.comfyClass || ''
   )
 
-  if (isUsingAssetAPI && isAssetBrowserEligible) {
-    // Get the default value for the button text (currently selected model)
+  if (isUsingAssetAPI && isEligible) {
+    // Create button widget for Asset Browser
     const currentValue = getDefaultValue(inputSpec)
 
     const widget = node.addWidget(
-      'combo',
+      'button',
       inputSpec.name,
-      currentValue,
+      t('widgets.selectModel'),
       () => {
         console.log(
           `Asset Browser would open here for:\nNode: ${node.type}\nWidget: ${inputSpec.name}\nCurrent Value:${currentValue}`
         )
-      },
-      {
-        values: [t('widgets.selectModel')]
       }
     )
 
-    return widget as IComboWidget
+    return widget
   }
 
+  // Create normal combo widget
   const defaultValue = getDefaultValue(inputSpec)
   const comboOptions = inputSpec.options ?? []
   const widget = node.addWidget(
@@ -123,14 +122,14 @@ const addComboWidget = (
   if (inputSpec.control_after_generate) {
     widget.linkedWidgets = addValueControlWidgets(
       node,
-      widget,
+      widget as IComboWidget,
       undefined,
       undefined,
       transformInputSpecV2ToV1(inputSpec)
     )
   }
 
-  return widget as IComboWidget
+  return widget
 }
 
 export const useComboWidget = () => {

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -102,9 +102,31 @@ function createAssetService() {
     )
   }
 
+  /**
+   * Widget spec names that are eligible for asset browser
+   */
+  type AssetBrowserEligibleSpec = 'ckpt_name' | 'lora_name' | 'vae_name'
+
+  /**
+   * Checks if a widget input spec should use the asset browser
+   *
+   * @param specName - The input spec name (e.g., 'ckpt_name', 'lora_name')
+   * @returns true if this spec should use asset browser
+   */
+  function isAssetBrowserEligible(
+    specName: string
+  ): specName is AssetBrowserEligibleSpec {
+    return (
+      specName === 'ckpt_name' ||
+      specName === 'lora_name' ||
+      specName === 'vae_name'
+    )
+  }
+
   return {
     getAssetModelFolders,
-    getAssetModels
+    getAssetModels,
+    isAssetBrowserEligible
   }
 }
 

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -7,10 +7,16 @@ import {
   assetResponseSchema
 } from '@/schemas/assetSchema'
 import { api } from '@/scripts/api'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 
 const ASSETS_ENDPOINT = '/assets'
 const MODELS_TAG = 'models'
 const MISSING_TAG = 'missing'
+
+/**
+ * Input names that are eligible for asset browser
+ */
+const WHITELISTED_INPUTS = new Set(['ckpt_name', 'lora_name', 'vae_name'])
 
 /**
  * Validates asset response data using Zod schema
@@ -103,23 +109,21 @@ function createAssetService() {
   }
 
   /**
-   * Widget spec names that are eligible for asset browser
-   */
-  type AssetBrowserEligibleSpec = 'ckpt_name' | 'lora_name' | 'vae_name'
-
-  /**
-   * Checks if a widget input spec should use the asset browser
+   * Checks if a widget input should use the asset browser based on both input name and node comfyClass
    *
-   * @param specName - The input spec name (e.g., 'ckpt_name', 'lora_name')
-   * @returns true if this spec should use asset browser
+   * @param inputName - The input name (e.g., 'ckpt_name', 'lora_name')
+   * @param nodeType - The ComfyUI node comfyClass (e.g., 'CheckpointLoaderSimple', 'LoraLoader')
+   * @returns true if this input should use asset browser
    */
   function isAssetBrowserEligible(
-    specName: string
-  ): specName is AssetBrowserEligibleSpec {
+    inputName: string,
+    nodeType: string
+  ): boolean {
     return (
-      specName === 'ckpt_name' ||
-      specName === 'lora_name' ||
-      specName === 'vae_name'
+      // Must be an approved input name
+      WHITELISTED_INPUTS.has(inputName) &&
+      // Must be a registered node type
+      useModelToNodeStore().getRegisteredNodeTypes().has(nodeType)
     )
   }
 

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -484,7 +484,18 @@ export const useLitegraphService = () => {
         ) ?? {}
 
         if (widget) {
-          widget.label = st(nameKey, widget.label ?? inputName)
+          // Check if this is an Asset Browser button widget
+          const isAssetBrowserButton =
+            widget.type === 'button' && widget.value === 'Select model'
+
+          if (isAssetBrowserButton) {
+            // Preserve Asset Browser button label (don't translate)
+            widget.label = String(widget.value)
+          } else {
+            // Apply normal translation for other widgets
+            widget.label = st(nameKey, widget.label ?? inputName)
+          }
+
           widget.options ??= {}
           Object.assign(widget.options, {
             advanced: inputSpec.advanced,

--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 
@@ -22,6 +22,22 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
   const modelToNodeMap = ref<Record<string, ModelNodeProvider[]>>({})
   const nodeDefStore = useNodeDefStore()
   const haveDefaultsLoaded = ref(false)
+
+  /** Internal computed for reactive caching of registered node types */
+  const registeredNodeTypes = computed(() => {
+    return new Set(
+      Object.values(modelToNodeMap.value)
+        .flat()
+        .map((provider) => provider.nodeDef.name)
+    )
+  })
+
+  /** Get set of all registered node types for efficient lookup */
+  function getRegisteredNodeTypes(): Set<string> {
+    registerDefaults()
+    return registeredNodeTypes.value
+  }
+
   /**
    * Get the node provider for the given model type name.
    * @param modelType The name of the model type to get the node provider for.
@@ -91,6 +107,7 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
 
   return {
     modelToNodeMap,
+    getRegisteredNodeTypes,
     getNodeProvider,
     getAllNodeProviders,
     registerNodeProvider,

--- a/tests-ui/tests/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -2,20 +2,43 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useComboWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useComboWidget'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { assetService } from '@/services/assetService'
 
 vi.mock('@/scripts/widgets', () => ({
   addValueControlWidgets: vi.fn()
 }))
 
+const mockSettingStoreGet = vi.fn(() => false) // Default: asset API disabled
+vi.mock('@/stores/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: mockSettingStoreGet
+  }))
+}))
+
+vi.mock('@/i18n', () => ({
+  t: vi.fn((key: string) =>
+    key === 'widgets.selectModel' ? 'Select model' : key
+  )
+}))
+
+vi.mock('@/services/assetService', () => ({
+  assetService: {
+    isAssetBrowserEligible: vi.fn(() => false) // Default: not eligible
+  }
+}))
+
 describe('useComboWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset to defaults
+    mockSettingStoreGet.mockReturnValue(false)
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false)
   })
 
   it('should handle undefined spec', () => {
     const constructor = useComboWidget()
     const mockNode = {
-      addWidget: vi.fn().mockReturnValue({ options: {} } as any)
+      addWidget: vi.fn().mockReturnValue({ type: 'combo', options: {} } as any)
     }
 
     const inputSpec: InputSpec = {
@@ -34,6 +57,142 @@ describe('useComboWidget', () => {
         values: []
       })
     )
-    expect(widget).toEqual({ options: {} })
+    expect(widget).toEqual({ type: 'combo', options: {} })
+  })
+
+  it('should create normal combo widget when asset API is disabled', () => {
+    mockSettingStoreGet.mockReturnValue(false) // Asset API disabled
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true) // Widget is eligible
+
+    const constructor = useComboWidget()
+    const mockNode = {
+      addWidget: vi.fn().mockReturnValue({ type: 'combo', options: {} })
+    }
+
+    const inputSpec = {
+      type: 'COMBO' as const,
+      name: 'ckpt_name',
+      options: ['model1.safetensors', 'model2.safetensors']
+    }
+
+    const widget = constructor(mockNode as any, inputSpec)
+
+    expect(mockNode.addWidget).toHaveBeenCalledWith(
+      'combo',
+      'ckpt_name',
+      'model1.safetensors',
+      expect.any(Function),
+      { values: ['model1.safetensors', 'model2.safetensors'] }
+    )
+    expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
+    expect(widget).toEqual({ type: 'combo', options: {} })
+  })
+
+  it('should create normal combo widget when widget is not eligible for asset browser', () => {
+    mockSettingStoreGet.mockReturnValue(true) // Asset API enabled
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false) // Widget not eligible
+
+    const constructor = useComboWidget()
+    const mockNode = {
+      addWidget: vi.fn().mockReturnValue({ type: 'combo', options: {} })
+    }
+
+    const inputSpec = {
+      type: 'COMBO' as const,
+      name: 'not_eligible_widget',
+      options: ['option1', 'option2']
+    }
+
+    const widget = constructor(mockNode as any, inputSpec)
+
+    expect(mockNode.addWidget).toHaveBeenCalledWith(
+      'combo',
+      'not_eligible_widget',
+      'option1',
+      expect.any(Function),
+      { values: ['option1', 'option2'] }
+    )
+    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
+      'not_eligible_widget'
+    )
+    expect(widget).toEqual({ type: 'combo', options: {} })
+  })
+
+  it('should create asset browser combo widget when API enabled and widget eligible', () => {
+    mockSettingStoreGet.mockReturnValue(true) // Asset API enabled
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true) // Widget eligible
+
+    const constructor = useComboWidget()
+    const mockWidget = {
+      type: 'combo',
+      options: {},
+      name: 'ckpt_name',
+      value: 'model1.safetensors'
+    }
+    const mockNode = {
+      addWidget: vi.fn().mockReturnValue(mockWidget)
+    }
+
+    const inputSpec = {
+      type: 'COMBO' as const,
+      name: 'ckpt_name',
+      options: ['model1.safetensors', 'model2.safetensors']
+    }
+
+    const widget = constructor(mockNode as any, inputSpec)
+
+    // Should create combo widget with asset browser configuration, not normal path
+    expect(mockNode.addWidget).toHaveBeenCalledWith(
+      'combo',
+      'ckpt_name',
+      'model1.safetensors',
+      expect.any(Function),
+      { values: ['Select model'] } // Key difference - asset browser path
+    )
+
+    expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
+    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
+      'ckpt_name'
+    )
+    expect(widget).toBe(mockWidget)
+  })
+
+  it('should use asset browser values even when inputSpec has a default value but no options', () => {
+    mockSettingStoreGet.mockReturnValue(true) // Asset API enabled
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true) // Widget eligible
+
+    const constructor = useComboWidget()
+    const mockWidget = {
+      type: 'combo',
+      options: {},
+      name: 'ckpt_name',
+      value: 'fallback.safetensors'
+    }
+    const mockNode = {
+      addWidget: vi.fn().mockReturnValue(mockWidget)
+    }
+
+    const inputSpec = {
+      type: 'COMBO' as const,
+      name: 'ckpt_name',
+      default: 'fallback.safetensors'
+      // Note: no options array provided
+    }
+
+    const widget = constructor(mockNode as any, inputSpec)
+
+    expect(mockNode.addWidget).toHaveBeenCalledWith(
+      'combo',
+      'ckpt_name',
+      'fallback.safetensors',
+      expect.any(Function),
+      { values: ['Select model'] } // Should still use asset browser path
+    )
+
+    expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
+    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
+      'ckpt_name'
+    )
+    expect(widget).toBe(mockWidget)
   })
 })

--- a/tests-ui/tests/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useComboWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useComboWidget'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { assetService } from '@/services/assetService'
@@ -8,7 +10,7 @@ vi.mock('@/scripts/widgets', () => ({
   addValueControlWidgets: vi.fn()
 }))
 
-const mockSettingStoreGet = vi.fn(() => false) // Default: asset API disabled
+const mockSettingStoreGet = vi.fn(() => false)
 vi.mock('@/stores/settingStore', () => ({
   useSettingStore: vi.fn(() => ({
     get: mockSettingStoreGet
@@ -23,9 +25,38 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/services/assetService', () => ({
   assetService: {
-    isAssetBrowserEligible: vi.fn(() => false) // Default: not eligible
+    isAssetBrowserEligible: vi.fn(() => false)
   }
 }))
+
+// Test factory functions
+function createMockWidget(overrides: Partial<IBaseWidget> = {}): IBaseWidget {
+  return {
+    type: 'combo',
+    options: {},
+    name: 'testWidget',
+    value: undefined,
+    ...overrides
+  } as IBaseWidget
+}
+
+function createMockNode(comfyClass = 'TestNode'): LGraphNode {
+  const node = new LGraphNode('TestNode')
+  node.comfyClass = comfyClass
+
+  // Spy on the addWidget method
+  vi.spyOn(node, 'addWidget').mockReturnValue(createMockWidget())
+
+  return node
+}
+
+function createMockInputSpec(overrides: Partial<InputSpec> = {}): InputSpec {
+  return {
+    type: 'COMBO',
+    name: 'testInput',
+    ...overrides
+  } as InputSpec
+}
 
 describe('useComboWidget', () => {
   beforeEach(() => {
@@ -37,45 +68,39 @@ describe('useComboWidget', () => {
 
   it('should handle undefined spec', () => {
     const constructor = useComboWidget()
-    const mockNode = {
-      addWidget: vi.fn().mockReturnValue({ type: 'combo', options: {} } as any)
-    }
+    const mockWidget = createMockWidget()
+    const mockNode = createMockNode()
+    vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
+    const inputSpec = createMockInputSpec({ name: 'inputName' })
 
-    const inputSpec: InputSpec = {
-      type: 'COMBO',
-      name: 'inputName'
-    }
-
-    const widget = constructor(mockNode as any, inputSpec)
+    const widget = constructor(mockNode, inputSpec)
 
     expect(mockNode.addWidget).toHaveBeenCalledWith(
       'combo',
       'inputName',
-      undefined, // default value
-      expect.any(Function), // callback
+      undefined,
+      expect.any(Function),
       expect.objectContaining({
         values: []
       })
     )
-    expect(widget).toEqual({ type: 'combo', options: {} })
+    expect(widget).toBe(mockWidget)
   })
 
   it('should create normal combo widget when asset API is disabled', () => {
-    mockSettingStoreGet.mockReturnValue(false) // Asset API disabled
-    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true) // Widget is eligible
+    mockSettingStoreGet.mockReturnValue(false)
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true)
 
     const constructor = useComboWidget()
-    const mockNode = {
-      addWidget: vi.fn().mockReturnValue({ type: 'combo', options: {} })
-    }
-
-    const inputSpec = {
-      type: 'COMBO' as const,
+    const mockWidget = createMockWidget()
+    const mockNode = createMockNode('CheckpointLoaderSimple')
+    vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
+    const inputSpec = createMockInputSpec({
       name: 'ckpt_name',
       options: ['model1.safetensors', 'model2.safetensors']
-    }
+    })
 
-    const widget = constructor(mockNode as any, inputSpec)
+    const widget = constructor(mockNode, inputSpec)
 
     expect(mockNode.addWidget).toHaveBeenCalledWith(
       'combo',
@@ -85,25 +110,23 @@ describe('useComboWidget', () => {
       { values: ['model1.safetensors', 'model2.safetensors'] }
     )
     expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
-    expect(widget).toEqual({ type: 'combo', options: {} })
+    expect(widget).toBe(mockWidget)
   })
 
   it('should create normal combo widget when widget is not eligible for asset browser', () => {
-    mockSettingStoreGet.mockReturnValue(true) // Asset API enabled
-    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false) // Widget not eligible
+    mockSettingStoreGet.mockReturnValue(true)
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false)
 
     const constructor = useComboWidget()
-    const mockNode = {
-      addWidget: vi.fn().mockReturnValue({ type: 'combo', options: {} })
-    }
-
-    const inputSpec = {
-      type: 'COMBO' as const,
+    const mockWidget = createMockWidget()
+    const mockNode = createMockNode()
+    vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
+    const inputSpec = createMockInputSpec({
       name: 'not_eligible_widget',
       options: ['option1', 'option2']
-    }
+    })
 
-    const widget = constructor(mockNode as any, inputSpec)
+    const widget = constructor(mockNode, inputSpec)
 
     expect(mockNode.addWidget).toHaveBeenCalledWith(
       'combo',
@@ -113,85 +136,75 @@ describe('useComboWidget', () => {
       { values: ['option1', 'option2'] }
     )
     expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'not_eligible_widget'
-    )
-    expect(widget).toEqual({ type: 'combo', options: {} })
-  })
-
-  it('should create asset browser combo widget when API enabled and widget eligible', () => {
-    mockSettingStoreGet.mockReturnValue(true) // Asset API enabled
-    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true) // Widget eligible
-
-    const constructor = useComboWidget()
-    const mockWidget = {
-      type: 'combo',
-      options: {},
-      name: 'ckpt_name',
-      value: 'model1.safetensors'
-    }
-    const mockNode = {
-      addWidget: vi.fn().mockReturnValue(mockWidget)
-    }
-
-    const inputSpec = {
-      type: 'COMBO' as const,
-      name: 'ckpt_name',
-      options: ['model1.safetensors', 'model2.safetensors']
-    }
-
-    const widget = constructor(mockNode as any, inputSpec)
-
-    // Should create combo widget with asset browser configuration, not normal path
-    expect(mockNode.addWidget).toHaveBeenCalledWith(
-      'combo',
-      'ckpt_name',
-      'model1.safetensors',
-      expect.any(Function),
-      { values: ['Select model'] } // Key difference - asset browser path
-    )
-
-    expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
-    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'ckpt_name'
+      'not_eligible_widget',
+      'TestNode'
     )
     expect(widget).toBe(mockWidget)
   })
 
-  it('should use asset browser values even when inputSpec has a default value but no options', () => {
-    mockSettingStoreGet.mockReturnValue(true) // Asset API enabled
-    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true) // Widget eligible
+  it('should create asset browser button widget when API enabled and widget eligible', () => {
+    mockSettingStoreGet.mockReturnValue(true)
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true)
 
     const constructor = useComboWidget()
-    const mockWidget = {
-      type: 'combo',
-      options: {},
+    const mockWidget = createMockWidget({
+      type: 'button',
       name: 'ckpt_name',
-      value: 'fallback.safetensors'
-    }
-    const mockNode = {
-      addWidget: vi.fn().mockReturnValue(mockWidget)
-    }
+      value: 'Select model'
+    })
+    const mockNode = createMockNode('CheckpointLoaderSimple')
+    vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
+    const inputSpec = createMockInputSpec({
+      name: 'ckpt_name',
+      options: ['model1.safetensors', 'model2.safetensors']
+    })
 
-    const inputSpec = {
-      type: 'COMBO' as const,
+    const widget = constructor(mockNode, inputSpec)
+
+    expect(mockNode.addWidget).toHaveBeenCalledWith(
+      'button',
+      'ckpt_name',
+      'Select model',
+      expect.any(Function)
+    )
+    expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
+    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
+      'ckpt_name',
+      'CheckpointLoaderSimple'
+    )
+    expect(widget).toBe(mockWidget)
+  })
+
+  it('should use asset browser button even when inputSpec has a default value but no options', () => {
+    mockSettingStoreGet.mockReturnValue(true)
+    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true)
+
+    const constructor = useComboWidget()
+    const mockWidget = createMockWidget({
+      type: 'button',
+      name: 'ckpt_name',
+      value: 'Select model'
+    })
+    const mockNode = createMockNode('CheckpointLoaderSimple')
+    vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
+    const inputSpec = createMockInputSpec({
       name: 'ckpt_name',
       default: 'fallback.safetensors'
       // Note: no options array provided
-    }
+    })
 
-    const widget = constructor(mockNode as any, inputSpec)
+    const widget = constructor(mockNode, inputSpec)
 
     expect(mockNode.addWidget).toHaveBeenCalledWith(
-      'combo',
+      'button',
       'ckpt_name',
-      'fallback.safetensors',
-      expect.any(Function),
-      { values: ['Select model'] } // Should still use asset browser path
+      'Select model',
+      expect.any(Function)
     )
-
     expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
     expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'ckpt_name'
+      'ckpt_name',
+      'CheckpointLoaderSimple'
     )
     expect(widget).toBe(mockWidget)
   })

--- a/tests-ui/tests/services/assetService.test.ts
+++ b/tests-ui/tests/services/assetService.test.ts
@@ -147,4 +147,19 @@ describe('assetService', () => {
       )
     })
   })
+
+  describe('isAssetBrowserEligible', () => {
+    it('should return true for eligible widget names', () => {
+      expect(assetService.isAssetBrowserEligible('ckpt_name')).toBe(true)
+      expect(assetService.isAssetBrowserEligible('lora_name')).toBe(true)
+      expect(assetService.isAssetBrowserEligible('vae_name')).toBe(true)
+    })
+
+    it('should return false for non-eligible widget names', () => {
+      expect(assetService.isAssetBrowserEligible('seed')).toBe(false)
+      expect(assetService.isAssetBrowserEligible('steps')).toBe(false)
+      expect(assetService.isAssetBrowserEligible('sampler_name')).toBe(false)
+      expect(assetService.isAssetBrowserEligible('')).toBe(false)
+    })
+  })
 })

--- a/tests-ui/tests/services/assetService.test.ts
+++ b/tests-ui/tests/services/assetService.test.ts
@@ -3,6 +3,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '@/scripts/api'
 import { assetService } from '@/services/assetService'
 
+vi.mock('@/stores/modelToNodeStore', () => ({
+  useModelToNodeStore: vi.fn(() => ({
+    getRegisteredNodeTypes: vi.fn(
+      () =>
+        new Set([
+          'CheckpointLoaderSimple',
+          'LoraLoader',
+          'VAELoader',
+          'TestNode'
+        ])
+    )
+  }))
+}))
+
 // Test data constants
 const MOCK_ASSETS = {
   checkpoints: {
@@ -149,17 +163,41 @@ describe('assetService', () => {
   })
 
   describe('isAssetBrowserEligible', () => {
-    it('should return true for eligible widget names', () => {
-      expect(assetService.isAssetBrowserEligible('ckpt_name')).toBe(true)
-      expect(assetService.isAssetBrowserEligible('lora_name')).toBe(true)
-      expect(assetService.isAssetBrowserEligible('vae_name')).toBe(true)
+    it('should return true for eligible widget names with registered node types', () => {
+      expect(
+        assetService.isAssetBrowserEligible(
+          'ckpt_name',
+          'CheckpointLoaderSimple'
+        )
+      ).toBe(true)
+      expect(
+        assetService.isAssetBrowserEligible('lora_name', 'LoraLoader')
+      ).toBe(true)
+      expect(assetService.isAssetBrowserEligible('vae_name', 'VAELoader')).toBe(
+        true
+      )
     })
 
     it('should return false for non-eligible widget names', () => {
-      expect(assetService.isAssetBrowserEligible('seed')).toBe(false)
-      expect(assetService.isAssetBrowserEligible('steps')).toBe(false)
-      expect(assetService.isAssetBrowserEligible('sampler_name')).toBe(false)
-      expect(assetService.isAssetBrowserEligible('')).toBe(false)
+      expect(assetService.isAssetBrowserEligible('seed', 'TestNode')).toBe(
+        false
+      )
+      expect(assetService.isAssetBrowserEligible('steps', 'TestNode')).toBe(
+        false
+      )
+      expect(
+        assetService.isAssetBrowserEligible('sampler_name', 'TestNode')
+      ).toBe(false)
+      expect(assetService.isAssetBrowserEligible('', 'TestNode')).toBe(false)
+    })
+
+    it('should return false for eligible widget names with unregistered node types', () => {
+      expect(
+        assetService.isAssetBrowserEligible('ckpt_name', 'UnknownNode')
+      ).toBe(false)
+      expect(
+        assetService.isAssetBrowserEligible('lora_name', 'UnknownNode')
+      ).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary

Add the forking logic to allow us to start hooking up the Asset Browsing experience.

## Changes

1. Add switching logic to allow the combo widget to have forked behavior for model nodes 
2. Create whitelist of eligible nodes that can get the forked experince.
3. The general logic is `AssetsAPI == enabled && Node in EligibilityList`

## Review Focus

Logic and tests.

## Screenshots (if applicable)

With AssetsAPI setting enabled:
<img width="542" height="271" alt="Screenshot 2025-09-10 at 7 51 32 PM" src="https://github.com/user-attachments/assets/25e555fc-91c0-4d31-9836-4eeb9171fd2d" />
<img width="1027" height="871" alt="Screenshot 2025-09-10 at 7 49 59 PM" src="https://github.com/user-attachments/assets/10ed2344-0514-4894-8ccb-02ad79fb8898" />

