### PR TITLE
fix: Markdown widget `rows` prop should be number type

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -18,7 +18,7 @@
       :disabled="readonly"
       class="w-full text-xs"
       size="small"
-      rows="6"
+      :rows="6"
       :pt="{
         root: {
           onBlur: handleBlur


### PR DESCRIPTION
Per the [PrimeVue `TextArea` props API](https://primevue.org/textarea/), the type of the `rows` prop should be `number`. This PR changes the type to adhere to that.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5471-fix-Markdown-widget-rows-prop-should-be-number-type-26a6d73d36508106a820cb29d381e19b) by [Unito](https://www.unito.io)
