### PR TITLE
When toggling selected nodes, align state

### DIFF
--- a/src/composables/canvas/useSelectedLiteGraphItems.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.ts
@@ -123,12 +123,14 @@ export function useSelectedLiteGraphItems() {
     for (const i in selectedNodes) {
       selectedNodeArray.push(selectedNodes[i])
     }
+    const allNodesMatch = !selectedNodeArray.some(
+      (selectedNode) => selectedNode.mode !== mode
+    )
+    const newModeForSelectedNode = allNodesMatch ? LGraphEventMode.ALWAYS : mode
 
     // Process each selected node independently to determine its target state and apply to children
     selectedNodeArray.forEach((selectedNode) => {
       // Apply standard toggle logic to the selected node itself
-      const newModeForSelectedNode =
-        selectedNode.mode === mode ? LGraphEventMode.ALWAYS : mode
 
       selectedNode.mode = newModeForSelectedNode
 

--- a/tests-ui/tests/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/tests-ui/tests/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -237,9 +237,9 @@ describe('useSelectedLiteGraphItems', () => {
       toggleSelectedNodesMode(LGraphEventMode.NEVER)
 
       // node1 should change from ALWAYS to NEVER
-      // node2 should change from NEVER to ALWAYS (since it was already NEVER)
+      // node2 should stay NEVER (since a selected node exists which is not NEVER)
       expect(node1.mode).toBe(LGraphEventMode.NEVER)
-      expect(node2.mode).toBe(LGraphEventMode.ALWAYS)
+      expect(node2.mode).toBe(LGraphEventMode.NEVER)
     })
 
     it('toggleSelectedNodesMode should set mode to ALWAYS when already in target mode', () => {


### PR DESCRIPTION
Previously, when toggling the mode of multiple nodes, each node would have its state individually toggled. Now it sets the target mode if any node does not already match that mode and only disables if all already match.

![BypassToggle](https://github.com/user-attachments/assets/dfa029c7-fcc1-4bfa-85d3-c409aee0d967)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5482-When-toggling-selected-nodes-align-state-26a6d73d3650818cab41c76f81d8505b) by [Unito](https://www.unito.io)
