### PR TITLE
[bugfix] Fix flaky test 'Does not report warning on undo/redo'

### DIFF
--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -36,6 +36,10 @@ test('Does not report warning on undo/redo', async ({ comfyPage }) => {
   await comfyPage.loadWorkflow('missing/missing_nodes')
   await comfyPage.closeDialog()
 
+  // Wait for any async operations to complete after dialog closes
+  await comfyPage.nextFrame()
+  await comfyPage.page.waitForTimeout(100)
+
   // Make a change to the graph
   await comfyPage.doubleClickCanvas()
   await comfyPage.searchBox.fillAndSelectFirstNode('KSampler')


### PR DESCRIPTION
## Summary
- Fixed flaky test in `browser_tests/tests/dialog.spec.ts:33`
- Added additional wait after closing dialog to prevent race conditions

## Problem
The test `Does not report warning on undo/redo` was failing intermittently on CI. The issue occurred because `closeDialog()` waits for the dialog to be hidden, but there may be additional async state updates that need to complete after the dialog closes.

## Solution
Added `nextFrame()` and a small timeout after closing the dialog to ensure all async operations complete before the test continues. This gives the application time to fully process the dialog closure before proceeding with undo/redo operations.

## Test plan
- [ ] Run the test multiple times locally to verify stability
- [ ] CI should pass consistently without flaky failures

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5488-bugfix-Fix-flaky-test-Does-not-report-warning-on-undo-redo-26b6d73d3650813eacfcc0f85b16333a) by [Unito](https://www.unito.io)
