### PR TITLE
feat: style of progress bar in various scenarios

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -12,12 +12,15 @@
         'lg-node absolute rounded-2xl',
         // border
         'border border-solid border-sand-100 dark-theme:border-charcoal-300',
+        !!executing && 'border-blue-500 dark-theme:border-blue-500',
         !!error && 'border-red-700 dark-theme:border-red-300',
         // hover
         'hover:ring-7 ring-gray-500/50 dark-theme:ring-gray-500/20',
         // Selected
         'outline-transparent -outline-offset-2 outline-2',
         !!isSelected && 'outline-black dark-theme:outline-white',
+        !!(isSelected && executing) &&
+          'outline-blue-500 dark-theme:outline-blue-500',
         !!(isSelected && error) && 'outline-red-500 dark-theme:outline-red-500',
         {
           'animate-pulse': executing,
@@ -56,8 +59,35 @@
       />
     </div>
 
+    <div
+      v-if="
+        (isMinimalLOD || isCollapsed) && executing && progress !== undefined
+      "
+      :class="
+        cn(
+          'absolute inset-x-4 -bottom-[1px] translate-y-1/2 rounded-full',
+          progressClasses
+        )
+      "
+      :style="{ width: `${Math.min(progress * 100, 100)}%` }"
+    />
+
     <template v-if="!isMinimalLOD && !isCollapsed">
-      <div :class="cn(separatorClasses, 'mb-4')" />
+      <div class="mb-4 relative">
+        <div :class="separatorClasses" />
+        <!-- Progress bar for executing state -->
+        <div
+          v-if="executing && progress !== undefined"
+          :class="
+            cn(
+              'absolute inset-x-0 top-1/2 -translate-y-1/2',
+              !!(progress < 1) && 'rounded-r-full',
+              progressClasses
+            )
+          "
+          :style="{ width: `${Math.min(progress * 100, 100)}%` }"
+        />
+      </div>
 
       <!-- Node Body - rendered based on LOD level and collapsed state -->
       <div
@@ -102,13 +132,6 @@
         />
       </div>
     </template>
-
-    <!-- Progress bar for executing state -->
-    <div
-      v-if="executing && progress !== undefined"
-      class="absolute bottom-0 left-0 h-1 bg-primary-500 transition-all duration-300"
-      :style="{ width: `${progress * 100}%` }"
-    />
   </div>
 </template>
 
@@ -232,6 +255,7 @@ const hasCustomContent = computed(() => {
 // Computed classes and conditions for better reusability
 const separatorClasses =
   'bg-sand-100 dark-theme:bg-charcoal-300 h-[1px] mx-0 w-full'
+const progressClasses = 'h-2 bg-primary-500 transition-all duration-300'
 
 // Common condition computations to avoid repetition
 const shouldShowWidgets = computed(


### PR DESCRIPTION
- Progress bar effect for the node
  - Compare with the design draft to see the differences.
  - Fix the differences with the design draft.
    - Progress bar color, width, position, border radius
    - Hover and selected states
    - Collapsed and expanded states


<img width="300" alt="CleanShot 2025-09-11 at 19 00 59@2x" src="https://github.com/user-attachments/assets/586a3625-1b37-430a-b7c7-e02c2931e8fe" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5492-feat-style-of-progress-bar-in-various-scenarios-26b6d73d365081e8896ad9cc8876c73a) by [Unito](https://www.unito.io)
