### PR TITLE
Tailwind: Reduce the number of `@apply`s in our components

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -543,13 +543,10 @@ button.comfy-close-menu-btn {
 }
 
 span.drag-handle {
-  width: 10px;
-  height: 20px;
   display: inline-block;
   overflow: hidden;
   line-height: 5px;
   padding: 3px 4px;
-  cursor: move;
   vertical-align: middle;
   margin-top: -0.4em;
   margin-left: -0.2em;

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -79,8 +79,6 @@ const sidebarStateKey = computed(() => {
 </script>
 
 <style scoped>
-@reference '../assets/css/style.css';
-
 :deep(.p-splitter-gutter) {
   pointer-events: auto;
 }
@@ -102,11 +100,16 @@ const sidebarStateKey = computed(() => {
 }
 
 .splitter-overlay {
-  @apply bg-transparent pointer-events-none border-none;
+  background: transparent;
+  border-style: none;
+  pointer-events: none;
 }
 
 .splitter-overlay-root {
-  @apply w-full h-full absolute top-0 left-0;
+  height: 100%;
+  inset: 0;
+  position: absolute;
+  width: 100%;
 
   /* Set it the same as the ComfyUI menu */
   /* Note: Lite-graph DOM widgets have the same z-index as the node id, so

--- a/src/components/MenuHamburger.vue
+++ b/src/components/MenuHamburger.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-show="workspaceState.focusMode"
-    class="comfy-menu-hamburger no-drag"
+    class="fixed z-9999 flex flex-row no-drag"
     :style="positionCSS"
   >
     <Button
@@ -54,11 +54,3 @@ const positionCSS = computed<CSSProperties>(() =>
     : { top: '0px', right: '0px' }
 )
 </script>
-
-<style scoped>
-@reference '../assets/css/style.css';
-
-.comfy-menu-hamburger {
-  @apply fixed z-9999 flex flex-row;
-}
-</style>

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -2,7 +2,12 @@
   <Panel
     class="actionbar w-fit"
     :style="style"
-    :class="cn({ 'is-dragging': isDragging, 'is-docked': isDocked })"
+    :class="
+      cn({
+        'is-dragging': isDragging,
+        'is-docked bg-transparent border-none p-0': isDocked
+      })
+    "
   >
     <div ref="panelRef" class="actionbar-content flex items-center select-none">
       <span

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -2,10 +2,13 @@
   <Panel
     class="actionbar w-fit"
     :style="style"
-    :class="{ 'is-dragging': isDragging, 'is-docked': isDocked }"
+    :class="cn({ 'is-dragging': isDragging, 'is-docked': isDocked })"
   >
     <div ref="panelRef" class="actionbar-content flex items-center select-none">
-      <span ref="dragHandleRef" class="drag-handle cursor-move mr-2" />
+      <span
+        ref="dragHandleRef"
+        class="drag-handle w-3 h-max cursor-move mr-2"
+      />
       <ComfyQueueButton />
     </div>
   </Panel>
@@ -25,6 +28,7 @@ import Panel from 'primevue/panel'
 import { Ref, computed, inject, nextTick, onMounted, ref, watch } from 'vue'
 
 import { useSettingStore } from '@/stores/settingStore'
+import { cn } from '@/utils/tailwindUtil'
 
 import ComfyQueueButton from './ComfyQueueButton.vue'
 
@@ -228,8 +232,6 @@ watch([isDragging, isOverlappingWithTopMenu], ([dragging, overlapping]) => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 .actionbar {
   pointer-events: all;
   position: fixed;
@@ -238,7 +240,6 @@ watch([isDragging, isOverlappingWithTopMenu], ([dragging, overlapping]) => {
 
 .actionbar.is-docked {
   position: static;
-  @apply bg-transparent border-none p-0;
 }
 
 .actionbar.is-dragging {
@@ -246,18 +247,14 @@ watch([isDragging, isOverlappingWithTopMenu], ([dragging, overlapping]) => {
 }
 
 :deep(.p-panel-content) {
-  @apply p-1;
+  padding: calc(var(--spacing) * 1);
 }
 
 .is-docked :deep(.p-panel-content) {
-  @apply p-0;
+  padding: calc(var(--spacing) * 0);
 }
 
 :deep(.p-panel-header) {
   display: none;
-}
-
-.drag-handle {
-  @apply w-3 h-max;
 }
 </style>

--- a/src/components/breadcrumb/SubgraphBreadcrumb.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="subgraph-breadcrumb w-auto"
+    class="subgraph-breadcrumb overflow-hidden w-auto"
     :class="{
       'subgraph-breadcrumb-collapse': collapseTabs,
       'subgraph-breadcrumb-overflow': overflowingTabs
@@ -14,7 +14,7 @@
   >
     <Breadcrumb
       ref="breadcrumbRef"
-      class="bg-transparent p-0"
+      class="bg-transparent p-0 overflow-clip"
       :model="items"
       aria-label="Graph navigation"
     >
@@ -161,21 +161,17 @@ onUpdated(() => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 .subgraph-breadcrumb:not(:empty) {
   flex: auto;
   flex-shrink: 10000;
   min-width: 120px;
 }
 
-.subgraph-breadcrumb,
-:deep(.p-breadcrumb) {
-  @apply overflow-hidden;
-}
-
 :deep(.p-breadcrumb-item) {
-  @apply flex items-center rounded-lg overflow-hidden;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-lg);
+  overflow: clip;
   min-width: calc(var(--p-breadcrumb-item-min-width) + 1rem);
   /* Collapse middle items first */
   flex-shrink: 10000;
@@ -203,18 +199,16 @@ onUpdated(() => {
 </style>
 
 <style>
-@reference '../../assets/css/style.css';
-
 .subgraph-breadcrumb-collapse .p-breadcrumb-list {
   .p-breadcrumb-item,
   .p-breadcrumb-separator {
-    @apply hidden;
+    display: none;
   }
 
   .p-breadcrumb-item:nth-last-child(3),
   .p-breadcrumb-separator:nth-last-child(2),
   .p-breadcrumb-item:nth-last-child(1) {
-    @apply block;
+    display: block;
   }
 }
 </style>

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -6,7 +6,7 @@
       showDelay: 512
     }"
     href="#"
-    class="cursor-pointer p-breadcrumb-item-link"
+    class="cursor-pointer select-none overflow-hidden p-(--p-breadcrumb-item-padding) p-breadcrumb-item-link"
     :class="{
       'flex items-center gap-1': isActive,
       'p-breadcrumb-item-link-menu-visible': menu?.overlayVisible,
@@ -227,20 +227,10 @@ const inputBlur = async (doRename: boolean) => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
-.p-breadcrumb-item-link,
-.p-breadcrumb-item-icon {
-  @apply select-none;
-}
-
-.p-breadcrumb-item-link {
-  @apply overflow-hidden;
-  padding: var(--p-breadcrumb-item-padding);
-}
-
 .p-breadcrumb-item-label {
-  @apply whitespace-nowrap text-ellipsis overflow-hidden;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .active-breadcrumb-item {

--- a/src/components/common/SearchBox.vue
+++ b/src/components/common/SearchBox.vue
@@ -3,7 +3,7 @@
     <IconField>
       <Button
         v-if="filterIcon"
-        class="p-inputicon filter-button"
+        class="p-inputicon overflow-visible p-0 w-auto border-none filter-button"
         :icon="filterIcon"
         text
         severity="contrast"
@@ -18,7 +18,7 @@
       <InputIcon v-if="!modelValue" :class="icon" />
       <Button
         v-if="modelValue"
-        class="p-inputicon clear-button"
+        class="p-inputicon overflow-visible p-0 w-auto border-none clear-button"
         icon="pi pi-times"
         text
         severity="contrast"
@@ -91,13 +91,7 @@ const clearSearch = () => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 :deep(.p-inputtext) {
   --p-form-field-padding-x: 0.625rem;
-}
-
-.p-button.p-inputicon {
-  @apply p-0 w-auto border-none;
 }
 </style>

--- a/src/components/common/SearchFilterChip.vue
+++ b/src/components/common/SearchFilterChip.vue
@@ -1,6 +1,6 @@
 <template>
   <Chip removable @remove="$emit('remove', $event)">
-    <Badge size="small" :class="badgeClass">
+    <Badge size="small" :class="cn(badgeClass, badgeClasses[badgeClass])">
       {{ badge }}
     </Badge>
     {{ text }}
@@ -11,6 +11,8 @@
 import Badge from 'primevue/badge'
 import Chip from 'primevue/chip'
 
+import { cn } from '@/utils/tailwindUtil'
+
 export interface SearchFilter {
   text: string
   badge: string
@@ -18,26 +20,13 @@ export interface SearchFilter {
   id: string | number
 }
 
+const badgeClasses: Record<string, string> = {
+  'i-badge': 'bg-green-500 text-white',
+  'o-badge': 'bg-red-500 text-white',
+  'c-badge': 'bg-blue-500 text-white',
+  's-badge': 'bg-yellow-500'
+}
+
 defineProps<Omit<SearchFilter, 'id'>>()
 defineEmits(['remove'])
 </script>
-
-<style scoped>
-@reference '../../assets/css/style.css';
-
-:deep(.i-badge) {
-  @apply bg-green-500 text-white;
-}
-
-:deep(.o-badge) {
-  @apply bg-red-500 text-white;
-}
-
-:deep(.c-badge) {
-  @apply bg-blue-500 text-white;
-}
-
-:deep(.s-badge) {
-  @apply bg-yellow-500;
-}
-</style>

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -10,7 +10,10 @@
     :aria-labelledby="item.key"
   >
     <template #header>
-      <div v-if="!item.dialogComponentProps?.headless">
+      <div
+        v-if="!item.dialogComponentProps?.headless"
+        class="p-2 2xl:p-(--p-dialog-header-padding) pb-0"
+      >
         <component
           :is="item.headerComponent"
           v-if="item.headerComponent"
@@ -26,6 +29,7 @@
       :is="item.component"
       v-bind="item.contentProps"
       :maximized="item.dialogComponentProps.maximized"
+      class="p-2 2xl:p-(--p-dialog-content-padding) pt-0"
     />
 
     <template v-if="item.footerComponent" #footer>
@@ -42,19 +46,7 @@ import { useDialogStore } from '@/stores/dialogStore'
 const dialogStore = useDialogStore()
 </script>
 
-<style>
-@reference '../../assets/css/style.css';
-
-.global-dialog .p-dialog-header {
-  @apply p-2 2xl:p-[var(--p-dialog-header-padding)];
-  @apply pb-0;
-}
-
-.global-dialog .p-dialog-content {
-  @apply p-2 2xl:p-[var(--p-dialog-content-padding)];
-  @apply pt-0;
-}
-
+<style scoped>
 .manager-dialog {
   height: 80vh;
   max-width: 1724px;

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -295,15 +295,13 @@ async function resetAllKeybindings() {
 </script>
 
 <style scoped>
-@reference '../../../../assets/css/style.css';
-
 :deep(.p-datatable-tbody) > tr > td {
-  @apply p-1;
+  padding: calc(var(--spacing) * 1);
   min-height: 2rem;
 }
 
 :deep(.p-datatable-row-selected) .actions,
 :deep(.p-datatable-selectable-row:hover) .actions {
-  @apply visible;
+  visibility: visible;
 }
 </style>

--- a/src/components/dialog/content/signin/SignInForm.vue
+++ b/src/components/dialog/content/signin/SignInForm.vue
@@ -34,10 +34,12 @@
           {{ t('auth.login.passwordLabel') }}
         </label>
         <span
-          class="text-muted text-base font-medium cursor-pointer select-none"
-          :class="{
-            'text-link-disabled': !$form.email?.value || $form.email?.invalid
-          }"
+          :class="
+            cn('text-muted text-base font-medium cursor-pointer select-none', {
+              'opacity-50 cursor-not-allowed':
+                !$form.email?.value || $form.email?.invalid
+            })
+          "
           @click="handleForgotPassword($form.email?.value, $form.email?.valid)"
         >
           {{ t('auth.login.forgotPassword') }}
@@ -84,6 +86,7 @@ import { useI18n } from 'vue-i18n'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { type SignInData, signInSchema } from '@/schemas/signInSchema'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
+import { cn } from '@/utils/tailwindUtil'
 
 const authStore = useFirebaseAuthStore()
 const firebaseAuthActions = useFirebaseAuthActions()
@@ -121,11 +124,3 @@ const handleForgotPassword = async (
   await firebaseAuthActions.sendPasswordReset(email)
 }
 </script>
-
-<style scoped>
-@reference '../../../../assets/css/style.css';
-
-.text-link-disabled {
-  @apply opacity-50 cursor-not-allowed;
-}
-</style>

--- a/src/components/graph/selectionToolbox/ColorPickerButton.vue
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.vue
@@ -153,13 +153,12 @@ watch(
 </script>
 
 <style scoped>
-@reference '../../../assets/css/style.css';
-
 .color-picker-container {
   transform: translateX(-50%);
 }
 
 :deep(.p-togglebutton) {
-  @apply py-2 px-1;
+  padding-block: calc(var(--spacing) * 2);
+  padding-inline: calc(var(--spacing) * 1);
 }
 </style>

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -189,9 +189,8 @@ watch(
 </script>
 
 <style scoped>
-@reference '../../../assets/css/style.css';
-
 .dom-widget > * {
-  @apply h-full w-full;
+  height: 100%;
+  width: 100%;
 }
 </style>

--- a/src/components/maintenance/TaskCard.vue
+++ b/src/components/maintenance/TaskCard.vue
@@ -4,7 +4,7 @@
     :class="{ 'opacity-75': isLoading }"
   >
     <Card
-      class="max-w-48 relative h-full overflow-hidden"
+      class="max-w-48 relative h-full overflow-hidden transition-opacity"
       :class="{ 'opacity-65': runner.state !== 'error' }"
       v-bind="(({ onClick, ...rest }) => rest)($attrs)"
     >
@@ -43,7 +43,7 @@
 
     <i
       v-if="!isLoading && runner.state === 'OK'"
-      class="task-card-ok pi pi-check"
+      class="task-card-ok pi pi-check text-green-500 absolute -right-4 -bottom-4 opacity-100 row-span-full col-span-full transition-opacity"
     />
   </div>
 </template>
@@ -86,19 +86,13 @@ const isExecuting = useMinLoadingDurationRef(reactiveExecuting, 250)
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 .task-card-ok {
-  @apply text-green-500 absolute -right-4 -bottom-4 opacity-100 row-span-full col-span-full transition-opacity;
-
   font-size: 4rem;
   text-shadow: 0.25rem 0 0.5rem black;
   z-index: 10;
 }
 
 .p-card {
-  @apply transition-opacity;
-
   --p-card-background: var(--p-button-secondary-background);
   opacity: 0.9;
 

--- a/src/components/searchbox/NodeSearchFilter.vue
+++ b/src/components/searchbox/NodeSearchFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="_content">
+  <div class="flex flex-col space-y-2">
     <SelectButton
       v-model="selectedFilter"
       class="filter-type-select"
@@ -16,7 +16,7 @@
       auto-filter-focus
     />
   </div>
-  <div class="_footer">
+  <div class="flex flex-col pt-4 items-end">
     <Button type="button" :label="$t('g.add')" @click="submit" />
   </div>
 </template>
@@ -66,15 +66,3 @@ const submit = () => {
   })
 }
 </script>
-
-<style scoped>
-@reference '../../assets/css/style.css';
-
-._content {
-  @apply flex flex-col space-y-2;
-}
-
-._footer {
-  @apply flex flex-col pt-4 items-end;
-}
-</style>

--- a/src/components/sidebar/SidebarIcon.vue
+++ b/src/components/sidebar/SidebarIcon.vue
@@ -19,7 +19,7 @@
     @click="emit('click', $event)"
   >
     <template #icon>
-      <div class="side-bar-button-content">
+      <div class="flex flex-col items-center gap-2">
         <slot name="icon">
           <OverlayBadge v-if="shouldShowBadge" :value="overlayValue">
             <i
@@ -38,9 +38,11 @@
             class="side-bar-button-icon"
           />
         </slot>
-        <span v-if="label && !isSmall" class="side-bar-button-label">{{
-          t(label)
-        }}</span>
+        <span
+          v-if="label && !isSmall"
+          class="leading-[1] text-xxs text-center"
+          >{{ t(label) }}</span
+        >
       </div>
     </template>
   </Button>
@@ -94,8 +96,6 @@ const computedTooltip = computed(() => t(tooltip) + tooltipSuffix)
 </style>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 .side-bar-button {
   width: var(--sidebar-width);
   height: calc(var(--sidebar-width) + 0.5rem);
@@ -104,15 +104,6 @@ const computedTooltip = computed(() => t(tooltip) + tooltipSuffix)
 
 .side-tool-bar-end .side-bar-button {
   height: var(--sidebar-width);
-}
-
-.side-bar-button-content {
-  @apply flex flex-col items-center gap-2;
-}
-
-.side-bar-button-label {
-  @apply text-[10px] text-center;
-  line-height: 1;
 }
 
 .comfyui-body-left .side-bar-button.side-bar-button-selected,

--- a/src/components/sidebar/tabs/SidebarTabTemplate.vue
+++ b/src/components/sidebar/tabs/SidebarTabTemplate.vue
@@ -12,7 +12,12 @@
         </template>
         <template #end>
           <div
-            class="flex flex-row motion-safe:w-0 motion-safe:opacity-0 motion-safe:group-hover/sidebar-tab:w-auto motion-safe:group-hover/sidebar-tab:opacity-100 motion-safe:group-focus-within/sidebar-tab:w-auto motion-safe:group-focus-within/sidebar-tab:opacity-100 touch:w-auto touch:opacity-100 transition-all duration-200"
+            :class="
+              cn(
+                'flex flex-row motion-safe:w-0 motion-safe:opacity-0 motion-safe:group-hover/sidebar-tab:w-auto motion-safe:group-hover/sidebar-tab:opacity-100 motion-safe:group-focus-within/sidebar-tab:w-auto motion-safe:group-focus-within/sidebar-tab:opacity-100 touch:w-auto touch:opacity-100 transition-all duration-200',
+                '[&_.p-button]:py-1 [&_.p-button]:2xl:py-2'
+              )
+            "
           >
             <slot name="tool-buttons" />
           </div>
@@ -31,6 +36,8 @@
 import ScrollPanel from 'primevue/scrollpanel'
 import Toolbar from 'primevue/toolbar'
 
+import { cn } from '@/utils/tailwindUtil'
+
 const props = defineProps<{
   title: string
   class?: string
@@ -38,13 +45,9 @@ const props = defineProps<{
 </script>
 
 <style scoped>
-@reference '../../../assets/css/style.css';
-
-:deep(.p-toolbar-end) .p-button {
-  @apply py-1 2xl:py-2;
-}
-
 :deep(.p-toolbar-start) {
-  @apply min-w-0 flex-1 overflow-hidden;
+  min-width: 0;
+  flex: 1;
+  overflow: clip;
 }
 </style>

--- a/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="container" class="node-lib-node-container">
+  <div ref="container" class="size-full">
     <TreeExplorerTreeNode :node="node" @contextmenu="handleContextMenu">
       <template #before-label>
         <Tag
@@ -188,11 +188,3 @@ onUnmounted(() => {
   nodeContentElement.value?.removeEventListener('mouseleave', handleMouseLeave)
 })
 </script>
-
-<style scoped>
-@reference '../../../../assets/css/style.css';
-
-.node-lib-node-container {
-  @apply h-full w-full;
-}
-</style>

--- a/src/components/topbar/CommandMenubar.vue
+++ b/src/components/topbar/CommandMenubar.vue
@@ -280,10 +280,10 @@ const hasActiveStateSiblings = (item: MenuItem): boolean => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 :deep(.p-menubar-submenu.dropdown-direction-up) {
-  @apply top-auto bottom-full flex-col-reverse;
+  bottom: 100%;
+  flex-direction: column-reverse;
+  top: auto;
 }
 
 .keybinding-tag {

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -11,7 +11,9 @@
       {{ workflowOption.workflow.filename }}
     </span>
     <div class="relative">
-      <span v-if="shouldShowStatusIndicator" class="status-indicator">•</span>
+      <span v-if="shouldShowStatusIndicator" class="status-indicator font-bold"
+        >•</span
+      >
       <Button
         class="close-button p-0 w-auto"
         icon="pi pi-times"
@@ -175,10 +177,8 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 .status-indicator {
-  @apply absolute font-bold;
+  position: absolute;
   font-size: 1.5rem;
   top: 50%;
   left: 50%;

--- a/src/components/topbar/WorkflowTabPopover.vue
+++ b/src/components/topbar/WorkflowTabPopover.vue
@@ -9,7 +9,12 @@
     append-to="body"
     :pt="{
       root: {
-        class: 'workflow-popover-fade fit-content ' + positions.root,
+        class: cn(
+          'workflow-popover-fade fit-content',
+          'bg-transparent rounded-xl ',
+          'shadow-lg dark-theme:shadow-2xl ',
+          positions.root
+        ),
         'data-popover-id': id,
         style: {
           transform: positions.active
@@ -19,19 +24,25 @@
     @mouseenter="cancelHidePopover"
     @mouseleave="hidePopover"
   >
-    <div class="workflow-preview-content">
+    <div
+      class="text-(--fg-color) max-w-(--popover-width) bg-(--comfy-menu-secondary-bg) flex flex-col rounded-xl overflow-hidden"
+    >
       <div
         v-if="thumbnailUrl && !isActiveTab"
-        class="workflow-preview-thumbnail relative"
+        class="workflow-preview-thumbnail relative p-2"
       >
         <img
           :src="thumbnailUrl"
-          class="block h-[200px] object-cover rounded-lg p-2"
+          class="block h-[200px] object-cover rounded-lg p-2 shadow-md dark-theme:shadow-lg"
           :style="{ width: `${POPOVER_WIDTH}px` }"
+          :alt="`Preview Thumbnail for ${workflowFilename}`"
         />
       </div>
-      <div class="workflow-preview-footer">
-        <span class="workflow-preview-name">{{ workflowFilename }}</span>
+      <div class="pt-1 pb-2 px-3">
+        <span
+          class="block text-sm font-medium overflow-hidden text-ellipsis whitespace-nowrap text-(--fg-color)"
+          >{{ workflowFilename }}</span
+        >
       </div>
     </div>
   </Popover>
@@ -42,6 +53,7 @@ import Popover from 'primevue/popover'
 import { computed, nextTick, ref, toRefs, useId } from 'vue'
 
 import { useSettingStore } from '@/stores/settingStore'
+import { cn } from '@/utils/tailwindUtil'
 
 const POPOVER_WIDTH = 250
 
@@ -169,58 +181,25 @@ defineExpose({
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
-.workflow-preview-content {
-  @apply flex flex-col rounded-xl overflow-hidden;
-  max-width: var(--popover-width);
-  background-color: var(--comfy-menu-secondary-bg);
-  color: var(--fg-color);
-}
-
-.workflow-preview-thumbnail {
-  @apply relative p-2;
-}
-
 .workflow-preview-thumbnail img {
-  @apply shadow-md;
   background-color: color-mix(
     in srgb,
     var(--comfy-menu-secondary-bg) 70%,
     black
   );
 }
-
-.dark-theme .workflow-preview-thumbnail img {
-  @apply shadow-lg;
-}
-
-.workflow-preview-footer {
-  @apply pt-1 pb-2 px-3;
-}
-
-.workflow-preview-name {
-  @apply block text-sm font-medium overflow-hidden text-ellipsis whitespace-nowrap;
-  color: var(--fg-color);
-}
 </style>
 
 <style>
-@reference '../../assets/css/style.css';
-
 .workflow-popover-fade {
   --p-popover-background: transparent;
   --p-popover-content-padding: 0;
-  @apply bg-transparent rounded-xl shadow-lg;
   transition: opacity 0.15s ease-out !important;
 }
 
 .workflow-popover-fade.p-popover-flipped {
-  @apply -translate-y-full;
-}
-
-.dark-theme .workflow-popover-fade {
-  @apply shadow-2xl;
+  --tw-translate-y: -100%;
+  translate: var(--tw-translate-x) var(--tw-translate-y);
 }
 
 .workflow-popover-fade.p-popover:after,

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -8,7 +8,7 @@
       icon="pi pi-chevron-left"
       text
       severity="secondary"
-      class="overflow-arrow overflow-arrow-left"
+      class="overflow-arrow-left px-2 rounded-none disabled:opacity-25"
       :disabled="!leftArrowEnabled"
       @mousedown="whileMouseDown($event, () => scroll(-1))"
     />
@@ -22,12 +22,18 @@
       pt:bar-x="h-1"
     >
       <SelectButton
-        class="workflow-tabs bg-transparent"
+        class="workflow-tabs bg-transparent min-w-"
         :class="props.class"
         :model-value="selectedWorkflow"
         :options="options"
         option-label="label"
         data-key="value"
+        :pt:pc-toggle-button="{
+          root: `p-0 bg-transparent rounded-none shrink relative border-0 border-r border-solid
+            border-r-(--border-color) min-w-[90px]
+            before:hidden`,
+          content: `max-w-full`
+        }"
         @update:model-value="onWorkflowChange"
       >
         <template #option="{ option }">
@@ -44,7 +50,7 @@
       icon="pi pi-chevron-right"
       text
       severity="secondary"
-      class="overflow-arrow overflow-arrow-right"
+      class="overflow-arrow-right px-2 rounded-none disabled:opacity-25"
       :disabled="!rightArrowEnabled"
       @mousedown="whileMouseDown($event, () => scroll(1))"
     />
@@ -302,71 +308,50 @@ onUpdated(() => {
 </script>
 
 <style scoped>
-@reference '../../assets/css/style.css';
-
 .workflow-tabs-container {
   background-color: var(--comfy-menu-secondary-bg);
 }
 
-:deep(.p-togglebutton) {
-  @apply p-0 bg-transparent rounded-none shrink relative border-0 border-r border-solid;
-  border-right-color: var(--border-color);
-  min-width: 90px;
-}
-
-.overflow-arrow {
-  @apply px-2 rounded-none;
-}
-
-.overflow-arrow[disabled] {
-  @apply opacity-25;
-}
-
-:deep(.p-togglebutton > .p-togglebutton-content) {
-  @apply max-w-full;
-}
-
 :deep(.workflow-tab) {
-  @apply max-w-full;
-}
-
-:deep(.p-togglebutton::before) {
-  @apply hidden;
+  max-width: 100%;
 }
 
 :deep(.p-togglebutton:first-child) {
-  @apply border-l border-solid;
   border-left-color: var(--border-color);
+  border-left-style: solid;
+  border-left-width: 1px;
 }
 
 :deep(.p-togglebutton:not(:first-child)) {
-  @apply border-l-0;
+  border-left: 0;
 }
 
 :deep(.p-togglebutton.p-togglebutton-checked) {
-  @apply border-b border-solid h-full;
   border-bottom-color: var(--p-button-text-primary-color);
+  border-bottom-style: solid;
+  border-bottom: 1px;
+  height: 100%;
 }
 
 :deep(.p-togglebutton:not(.p-togglebutton-checked)) {
-  @apply opacity-75;
+  opacity: 75%;
 }
 
 :deep(.p-togglebutton-checked) .close-button,
 :deep(.p-togglebutton:hover) .close-button {
-  @apply visible;
+  visibility: visible;
 }
 
 :deep(.p-togglebutton:hover) .status-indicator {
-  @apply hidden;
+  display: none;
 }
 
 :deep(.p-togglebutton) .close-button {
-  @apply invisible;
+  visibility: hidden;
 }
 
 :deep(.p-scrollpanel-content) {
-  @apply h-full;
+  height: 100%;
 }
 
 :deep(.workflow-tabs) {
@@ -376,11 +361,12 @@ onUpdated(() => {
 /* Scrollbar half opacity to avoid blocking the active tab bottom border */
 :deep(.p-scrollpanel:hover .p-scrollpanel-bar),
 :deep(.p-scrollpanel:active .p-scrollpanel-bar) {
-  @apply opacity-50;
+  opacity: 50%;
 }
 
 :deep(.p-selectbutton) {
-  @apply rounded-none h-full;
+  border-radius: 0;
+  height: 100%;
 }
 
 .workflow-tabs-container-desktop {
@@ -388,7 +374,7 @@ onUpdated(() => {
 }
 
 .window-actions-spacer {
-  @apply flex-auto;
+  flex: auto;
   /* If we are using custom titlebar, then we need to add a gap for the user to drag the window */
   --window-actions-spacer-width: min(75px, env(titlebar-area-width, 0) * 9999);
   min-width: var(--window-actions-spacer-width);

--- a/src/views/DesktopUpdateView.vue
+++ b/src/views/DesktopUpdateView.vue
@@ -61,10 +61,10 @@ onUnmounted(() => electron.Validation.dispose())
 </script>
 
 <style scoped>
-@reference '../assets/css/style.css';
-
 .download-bg::before {
-  @apply m-0 absolute text-muted;
+  margin: 0;
+  position: absolute;
+  color: var(--color-muted);
   font-family: 'primeicons';
   top: -2rem;
   right: 2rem;

--- a/src/views/InstallView.vue
+++ b/src/views/InstallView.vue
@@ -202,9 +202,7 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-@reference '../assets/css/style.css';
-
 :deep(.p-steppanel) {
-  @apply bg-transparent;
+  background: transparent;
 }
 </style>

--- a/src/views/MaintenanceView.vue
+++ b/src/views/MaintenanceView.vue
@@ -178,14 +178,14 @@ onUnmounted(() => electron.Validation.dispose())
 </script>
 
 <style scoped>
-@reference '../assets/css/style.css';
-
 :deep(.p-tag) {
   --p-tag-gap: 0.375rem;
 }
 
 .backspan::before {
-  @apply m-0 absolute text-muted;
+  margin: 0;
+  position: absolute;
+  color: var(--color-muted);
   font-family: 'primeicons';
   top: -2rem;
   right: -2rem;

--- a/src/views/NotSupportedView.vue
+++ b/src/views/NotSupportedView.vue
@@ -1,6 +1,6 @@
 <template>
   <BaseViewTemplate>
-    <div class="sad-container">
+    <div class="sad-container grid items-center justify-evenly">
       <!-- Right side image -->
       <img
         class="sad-girl"
@@ -79,10 +79,7 @@ const continueToInstall = async () => {
 </script>
 
 <style scoped>
-@reference '../assets/css/style.css';
-
 .sad-container {
-  @apply grid items-center justify-evenly;
   grid-template-columns: 25rem 1fr;
 
   & > * {

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -2,7 +2,7 @@
   <BaseViewTemplate dark>
     <div class="flex flex-col items-center justify-center gap-8 p-8">
       <!-- Header -->
-      <h1 class="animated-gradient-text text-glow select-none">
+      <h1 class="animated-gradient-text font-bold text-glow select-none">
         {{ $t('welcome.title') }}
       </h1>
 
@@ -33,10 +33,7 @@ const navigateTo = async (path: string) => {
 </script>
 
 <style scoped>
-@reference '../assets/css/style.css';
-
 .animated-gradient-text {
-  @apply font-bold;
   font-size: clamp(2rem, 8vw, 4rem);
   background: linear-gradient(to right, #12c2e9, #c471ed, #f64f59, #12c2e9);
   background-size: 300% auto;


### PR DESCRIPTION
## Summary

Cleaning up existing use of `@apply` in favor of directly using the utilities where possible.

## Changes

- **What**: With Tailwind v4, `@apply` [requires context](https://tailwindcss.com/docs/compatibility#explicit-context-sharing) to work properly. But it also is kind of a violation of the design and intent of Tailwind, more of an escape-hatch than a feature. Removing it to help keep consistency and reduce complexity in the codebase for future style changes.

## Review Focus

I checked to see if some of the classes were also used as selectors in tests, but please double-check my work if you can.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5498-Tailwind-Reduce-the-number-of-apply-s-in-our-components-26b6d73d365081638a09fa33f1e4f4fc) by [Unito](https://www.unito.io)
