### PR TITLE
fix: Missing `.value` led to the release dot always showing

### DIFF
--- a/src/components/sidebar/SidebarHelpCenterIcon.vue
+++ b/src/components/sidebar/SidebarHelpCenterIcon.vue
@@ -88,8 +88,8 @@ const { shouldShowRedDot: shouldShowConflictRedDot, markConflictsAsSeen } =
   useConflictAcknowledgment()
 
 // Use either release red dot or conflict red dot
-const shouldShowRedDot = computed(() => {
-  const releaseRedDot = showReleaseRedDot
+const shouldShowRedDot = computed((): boolean => {
+  const releaseRedDot = showReleaseRedDot.value
   return releaseRedDot || shouldShowConflictRedDot.value
 })
 


### PR DESCRIPTION
## Summary

Red dot on the help center was always visible.

## Changes

- **What**: Missing ref dereference

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5500-fix-Missing-value-led-to-the-release-dot-always-showing-26c6d73d365081ec8740e8f824d93aae) by [Unito](https://www.unito.io)
