### PR TITLE
Manually Backport #5500

### DIFF
--- a/src/components/sidebar/SidebarHelpCenterIcon.vue
+++ b/src/components/sidebar/SidebarHelpCenterIcon.vue
@@ -88,8 +88,8 @@ const { shouldShowRedDot: shouldShowConflictRedDot, markConflictsAsSeen } =
   useConflictAcknowledgment()
 
 // Use either release red dot or conflict red dot
-const shouldShowRedDot = computed(() => {
-  const releaseRedDot = showReleaseRedDot
+const shouldShowRedDot = computed((): boolean => {
+  const releaseRedDot = showReleaseRedDot.value
   return releaseRedDot || shouldShowConflictRedDot.value
 })
 


### PR DESCRIPTION
## Summary

Red dot on the help center was always visible.

## Changes

- **What**: Missing ref dereference


*Original: https://github.com/Comfy-Org/ComfyUI_frontend/pull/5500*

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5502-Manually-Backport-5500-26c6d73d365081eb8695dcff4b2c5337) by [Unito](https://www.unito.io)
