### PR TITLE
Bump to 1.26.11 (1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.26.11",
+  "version": "1.26.10",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
So I forgot to add the Release label on my first release PR, then the second PR with the Release label didn't have any changes to package.json, so the plan is to lower the version in this PR, not triggering the update workflow because of the lack of a Release label, then merge another PR that with the bump AND Release label, triggering the release workflow.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5508-Bump-to-1-26-11-1-2-26c6d73d365081e79a2bc5dedd70c2d2) by [Unito](https://www.unito.io)
