### PR TITLE
Bump to 1.26.11 (2/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.26.10",
+  "version": "1.26.11",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
So I forgot to add the Release label on my first release PR, then the second PR with the Release label didn't have any changes to package.json, so the plan is to lower the version in this PR, not triggering the update workflow because of the lack of a Release label, then merge another PR that with the bump AND Release label, triggering the release workflow.

