### PR TITLE
Fix/vue nodes viewport culling

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -186,9 +186,9 @@ const nodeSizes = vueNodeLifecycle.nodeSizes
 const allNodes = viewportCulling.allNodes
 
 const handleTransformUpdate = () => {
-  viewportCulling.handleTransformUpdate(
-    vueNodeLifecycle.detectChangesInRAF.value
-  )
+  viewportCulling.handleTransformUpdate()
+  // TODO: Fix paste position sync in separate PR
+  vueNodeLifecycle.detectChangesInRAF.value()
 }
 const handleNodeSelect = nodeEventHandlers.handleNodeSelect
 const handleNodeCollapse = nodeEventHandlers.handleNodeCollapse
@@ -458,10 +458,3 @@ onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
 </script>
-
-<style>
-/* Simple CSS-based visibility control */
-.node-hidden {
-  display: none !important;
-}
-</style>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -40,7 +40,7 @@
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <VueGraphNode
-      v-for="nodeData in nodesToRender"
+      v-for="nodeData in allNodes"
       :key="nodeData.id"
       :node-data="nodeData"
       :position="nodePositions.get(nodeData.id)"
@@ -183,7 +183,7 @@ const nodeEventHandlers = useNodeEventHandlers(vueNodeLifecycle.nodeManager)
 
 const nodePositions = vueNodeLifecycle.nodePositions
 const nodeSizes = vueNodeLifecycle.nodeSizes
-const nodesToRender = viewportCulling.nodesToRender
+const allNodes = viewportCulling.allNodes
 
 const handleTransformUpdate = () => {
   viewportCulling.handleTransformUpdate(
@@ -458,3 +458,10 @@ onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
 </script>
+
+<style>
+/* Simple CSS-based visibility control */
+.node-hidden {
+  display: none !important;
+}
+</style>

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -1,15 +1,14 @@
 /**
- * Viewport Culling - Direct DOM manipulation without caching
+ * Vue Nodes Viewport Culling
  *
  * Principles:
  * 1. Query DOM directly using data attributes (no cache to maintain)
- * 2. Use most efficient CSS update method (display: none)
+ * 2. Set display none on element to avoid cascade resolution overheead
  * 3. Only run when transform changes (event driven)
  */
 import { type Ref, computed } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
-import { app as comfyApp } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 
 interface NodeManager {
@@ -35,7 +34,7 @@ export function useViewportCulling(
    * Queries DOM directly - no cache maintenance needed
    */
   const updateVisibility = () => {
-    if (!nodeManager.value || !canvasStore.canvas || !comfyApp.canvas) return
+    if (!nodeManager.value || !canvasStore.canvas) return
 
     const canvas = canvasStore.canvas
     const manager = nodeManager.value
@@ -63,15 +62,16 @@ export function useViewportCulling(
       const screen_width = node.size[0] * ds.scale
       const screen_height = node.size[1] * ds.scale
 
-      const isVisible = !(
+      const isVisible =
         screen_x + screen_width < -margin ||
         screen_x > viewport_width + margin ||
         screen_y + screen_height < -margin ||
         screen_y > viewport_height + margin
-      )
 
-      // Setting diplay directly SHOULD avoid cascade resolution
-      ;(element as HTMLElement).style.display = isVisible ? '' : 'none'
+      // Setting hidden directly avoid cascade resolution
+      if (element instanceof HTMLElement) {
+        element.style.display = !isVisible ? '' : 'none'
+      }
     }
   }
 

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -3,7 +3,7 @@
  *
  * Principles:
  * 1. Query DOM directly using data attributes (no cache to maintain)
- * 2. Set display none on element to avoid cascade resolution overheead
+ * 2. Set display none on element to avoid cascade resolution overhead
  * 3. Only run when transform changes (event driven)
  */
 import { type Ref, computed } from 'vue'
@@ -51,18 +51,18 @@ export function useViewportCulling(
     // Update each element's visibility
     for (const element of nodeElements) {
       const nodeId = element.getAttribute('data-node-id')
-      if (!nodeId) return
+      if (!nodeId) continue
 
       const node = manager.getNode(nodeId)
-      if (!node) return
+      if (!node) continue
 
-      // Calculate if in viewport
+      // Calculate if node is outside viewport
       const screen_x = (node.pos[0] + ds.offset[0]) * ds.scale
       const screen_y = (node.pos[1] + ds.offset[1]) * ds.scale
       const screen_width = node.size[0] * ds.scale
       const screen_height = node.size[1] * ds.scale
 
-      const isVisible =
+      const isNodeOutsideiewport =
         screen_x + screen_width < -margin ||
         screen_x > viewport_width + margin ||
         screen_y + screen_height < -margin ||
@@ -70,7 +70,7 @@ export function useViewportCulling(
 
       // Setting display none directly avoid potential cascade resolution
       if (element instanceof HTMLElement) {
-        element.style.display = !isVisible ? '' : 'none'
+        element.style.display = isNodeOutsideiewport ? 'none' : ''
       }
     }
   }

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -68,7 +68,7 @@ export function useViewportCulling(
         screen_y + screen_height < -margin ||
         screen_y > viewport_height + margin
 
-      // Setting hidden directly avoid cascade resolution
+      // Setting display none directly avoid potential cascade resolution
       if (element instanceof HTMLElement) {
         element.style.display = !isVisible ? '' : 'none'
       }

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -7,7 +7,7 @@
  * - Adaptive margin computation based on zoom level
  * - Performance optimizations for large graphs
  */
-import { type Ref, computed, readonly, ref } from 'vue'
+import { type Ref, computed, onUnmounted, readonly, ref } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import { useTransformState } from '@/renderer/core/layout/useTransformState'
@@ -28,9 +28,34 @@ export function useViewportCulling(
   const { syncWithCanvas } = useTransformState()
 
   // Transform tracking for performance optimization
-  const lastScale = ref(1)
-  const lastOffsetX = ref(0)
-  const lastOffsetY = ref(0)
+  // Initialize with canvas values if available
+  const lastScale = ref(comfyApp.canvas?.ds?.scale ?? 1)
+  const lastOffsetX = ref(comfyApp.canvas?.ds?.offset?.[0] ?? 0)
+  const lastOffsetY = ref(comfyApp.canvas?.ds?.offset?.[1] ?? 0)
+
+  // Viewport tracking for efficient culling updates
+  // Only update culling when viewport changes significantly
+  const viewportScale = ref(lastScale.value)
+  const viewportOffsetX = ref(lastOffsetX.value)
+  const viewportOffsetY = ref(lastOffsetY.value)
+
+  // Threshold for viewport changes (in canvas units)
+  const VIEWPORT_UPDATE_THRESHOLD = 50 // Update culling when moved 50+ canvas units
+  const SCALE_UPDATE_THRESHOLD = 0.1 // Update culling when scale changes by 10%+
+
+  // Debounced update for final viewport position
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  const updateViewportDebounced = () => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      // Force viewport update after panning stops
+      if (comfyApp.canvas?.ds) {
+        viewportScale.value = comfyApp.canvas.ds.scale
+        viewportOffsetX.value = comfyApp.canvas.ds.offset[0]
+        viewportOffsetY.value = comfyApp.canvas.ds.offset[1]
+      }
+    }, 150) // Update 150ms after panning stops
+  }
 
   // Current transform state
   const currentTransformState = computed(() => ({
@@ -43,20 +68,18 @@ export function useViewportCulling(
    * Computed property that returns nodes visible in the current viewport
    * Implements sophisticated culling algorithm with adaptive margins
    */
-
-  const DISABLE_CULLING = true
-
   const nodesToRender = computed(() => {
     if (!isVueNodesEnabled.value) {
       return []
     }
-
-    if (DISABLE_CULLING) {
-      return Array.from(vueNodeData.value.values())
-    }
-
     // Access trigger to force re-evaluation after nodeManager initialization
     void nodeDataTrigger.value
+
+    // IMPORTANT: Use viewport refs for culling, not the constantly updating transform refs
+    // This prevents re-evaluation on every frame during panning
+    const currentScale = viewportScale.value
+    const currentOffsetX = viewportOffsetX.value
+    const currentOffsetY = viewportOffsetY.value
 
     if (!comfyApp.graph) {
       return []
@@ -70,10 +93,11 @@ export function useViewportCulling(
       const canvas = canvasStore.canvas
       const manager = nodeManager.value
 
-      // Ensure transform is synced before checking visibility
-      syncWithCanvas(comfyApp.canvas)
-
-      const ds = canvas.ds
+      // Use the reactive transform values instead of directly reading from canvas.ds
+      // This ensures Vue tracks these as dependencies
+      const scale = currentScale
+      const offsetX = currentOffsetX
+      const offsetY = currentOffsetY
 
       // Work in screen space - viewport is simply the canvas element size
       const viewport_width = canvas.canvas.width
@@ -82,18 +106,18 @@ export function useViewportCulling(
       // Add margin that represents a constant distance in canvas space
       // Convert canvas units to screen pixels by multiplying by scale
       const canvasMarginDistance = 200 // Fixed margin in canvas units
-      const margin_x = canvasMarginDistance * ds.scale
-      const margin_y = canvasMarginDistance * ds.scale
+      const margin_x = canvasMarginDistance * scale
+      const margin_y = canvasMarginDistance * scale
 
       const filtered = allNodes.filter((nodeData) => {
         const node = manager.getNode(nodeData.id)
         if (!node) return false
 
         // Transform node position to screen space (same as DOM widgets)
-        const screen_x = (node.pos[0] + ds.offset[0]) * ds.scale
-        const screen_y = (node.pos[1] + ds.offset[1]) * ds.scale
-        const screen_width = node.size[0] * ds.scale
-        const screen_height = node.size[1] * ds.scale
+        const screen_x = (node.pos[0] + offsetX) * scale
+        const screen_y = (node.pos[1] + offsetY) * scale
+        const screen_width = node.size[0] * scale
+        const screen_height = node.size[1] * scale
 
         // Check if node bounds intersect with expanded viewport (in screen space)
         const isVisible = !(
@@ -134,17 +158,35 @@ export function useViewportCulling(
         currentOffsetY !== lastOffsetY.value
       ) {
         syncWithCanvas(comfyApp.canvas)
+        // Update transform tracking refs
         lastScale.value = currentScale
         lastOffsetX.value = currentOffsetX
         lastOffsetY.value = currentOffsetY
+
+        // Only update viewport refs (triggering culling recalc) if change is significant
+        const scaleDiff =
+          Math.abs(currentScale - viewportScale.value) / viewportScale.value
+        const offsetDiffX = Math.abs(currentOffsetX - viewportOffsetX.value)
+        const offsetDiffY = Math.abs(currentOffsetY - viewportOffsetY.value)
+
+        if (
+          scaleDiff > SCALE_UPDATE_THRESHOLD ||
+          offsetDiffX > VIEWPORT_UPDATE_THRESHOLD ||
+          offsetDiffY > VIEWPORT_UPDATE_THRESHOLD
+        ) {
+          // Significant viewport change - update culling
+          viewportScale.value = currentScale
+          viewportOffsetX.value = currentOffsetX
+          viewportOffsetY.value = currentOffsetY
+        } else {
+          // Small change - schedule debounced update for when panning stops
+          updateViewportDebounced()
+        }
       }
     }
 
     // Detect node changes during transform updates
     detectChangesInRAF()
-
-    // Trigger reactivity for nodesToRender
-    void nodesToRender.value.length
   }
 
   /**
@@ -203,6 +245,13 @@ export function useViewportCulling(
       margin_y: 200 * ds.scale
     }
   }
+
+  // Cleanup on unmount
+  onUnmounted(() => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+    }
+  })
 
   return {
     nodesToRender,

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -1,16 +1,14 @@
 /**
- * Viewport Culling Composable
+ * Viewport Culling - Direct DOM manipulation with element caching
  *
- * Handles viewport culling optimization for Vue nodes including:
- * - Transform state synchronization
- * - Visible node calculation with screen space transforms
- * - Adaptive margin computation based on zoom level
- * - Performance optimizations for large graphs
+ * Principles:
+ * 1. Cache DOM elements ONCE when mounted
+ * 2. No timeouts - event driven
+ * 3. No reactivity - pure DOM manipulation
  */
-import { type Ref, computed, onUnmounted, readonly, ref } from 'vue'
+import { type Ref, computed } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
-import { useTransformState } from '@/renderer/core/layout/useTransformState'
 import { app as comfyApp } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 
@@ -25,244 +23,102 @@ export function useViewportCulling(
   nodeManager: Ref<NodeManager | null>
 ) {
   const canvasStore = useCanvasStore()
-  const { syncWithCanvas } = useTransformState()
 
-  // Transform tracking for performance optimization
-  // Initialize with canvas values if available
-  const lastScale = ref(comfyApp.canvas?.ds?.scale ?? 1)
-  const lastOffsetX = ref(comfyApp.canvas?.ds?.offset?.[0] ?? 0)
-  const lastOffsetY = ref(comfyApp.canvas?.ds?.offset?.[1] ?? 0)
-
-  // Viewport tracking for efficient culling updates
-  // Only update culling when viewport changes significantly
-  const viewportScale = ref(lastScale.value)
-  const viewportOffsetX = ref(lastOffsetX.value)
-  const viewportOffsetY = ref(lastOffsetY.value)
-
-  // Threshold for viewport changes (in canvas units)
-  const VIEWPORT_UPDATE_THRESHOLD = 50 // Update culling when moved 50+ canvas units
-  const SCALE_UPDATE_THRESHOLD = 0.1 // Update culling when scale changes by 10%+
-
-  // Debounced update for final viewport position
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null
-  const updateViewportDebounced = () => {
-    if (debounceTimer) clearTimeout(debounceTimer)
-    debounceTimer = setTimeout(() => {
-      // Force viewport update after panning stops
-      if (comfyApp.canvas?.ds) {
-        viewportScale.value = comfyApp.canvas.ds.scale
-        viewportOffsetX.value = comfyApp.canvas.ds.offset[0]
-        viewportOffsetY.value = comfyApp.canvas.ds.offset[1]
-      }
-    }, 150) // Update 150ms after panning stops
-  }
-
-  // Current transform state
-  const currentTransformState = computed(() => ({
-    scale: lastScale.value,
-    offsetX: lastOffsetX.value,
-    offsetY: lastOffsetY.value
-  }))
-
-  /**
-   * Computed property that returns nodes visible in the current viewport
-   * Implements sophisticated culling algorithm with adaptive margins
-   */
-  const nodesToRender = computed(() => {
-    if (!isVueNodesEnabled.value) {
-      return []
-    }
-    // Access trigger to force re-evaluation after nodeManager initialization
-    void nodeDataTrigger.value
-
-    // IMPORTANT: Use viewport refs for culling, not the constantly updating transform refs
-    // This prevents re-evaluation on every frame during panning
-    const currentScale = viewportScale.value
-    const currentOffsetX = viewportOffsetX.value
-    const currentOffsetY = viewportOffsetY.value
-
-    if (!comfyApp.graph) {
-      return []
-    }
-
-    const allNodes = Array.from(vueNodeData.value.values())
-
-    // Apply viewport culling - check if node bounds intersect with viewport
-    // TODO: use quadtree
-    if (nodeManager.value && canvasStore.canvas && comfyApp.canvas) {
-      const canvas = canvasStore.canvas
-      const manager = nodeManager.value
-
-      // Use the reactive transform values instead of directly reading from canvas.ds
-      // This ensures Vue tracks these as dependencies
-      const scale = currentScale
-      const offsetX = currentOffsetX
-      const offsetY = currentOffsetY
-
-      // Work in screen space - viewport is simply the canvas element size
-      const viewport_width = canvas.canvas.width
-      const viewport_height = canvas.canvas.height
-
-      // Add margin that represents a constant distance in canvas space
-      // Convert canvas units to screen pixels by multiplying by scale
-      const canvasMarginDistance = 200 // Fixed margin in canvas units
-      const margin_x = canvasMarginDistance * scale
-      const margin_y = canvasMarginDistance * scale
-
-      const filtered = allNodes.filter((nodeData) => {
-        const node = manager.getNode(nodeData.id)
-        if (!node) return false
-
-        // Transform node position to screen space (same as DOM widgets)
-        const screen_x = (node.pos[0] + offsetX) * scale
-        const screen_y = (node.pos[1] + offsetY) * scale
-        const screen_width = node.size[0] * scale
-        const screen_height = node.size[1] * scale
-
-        // Check if node bounds intersect with expanded viewport (in screen space)
-        const isVisible = !(
-          screen_x + screen_width < -margin_x ||
-          screen_x > viewport_width + margin_x ||
-          screen_y + screen_height < -margin_y ||
-          screen_y > viewport_height + margin_y
-        )
-
-        return isVisible
-      })
-
-      return filtered
-    }
-
-    return allNodes
+  const allNodes = computed(() => {
+    if (!isVueNodesEnabled.value) return []
+    void nodeDataTrigger.value // Force re-evaluation when nodeManager initializes
+    return Array.from(vueNodeData.value.values())
   })
 
-  /**
-   * Handle transform updates with performance optimization
-   * Only syncs when transform actually changes to avoid unnecessary reflows
-   */
-  const handleTransformUpdate = (detectChangesInRAF: () => void) => {
-    // Skip all work if Vue nodes are disabled
-    if (!isVueNodesEnabled.value) {
-      return
+  const elementCache = new Map<string, Element>()
+
+  const refreshElementCache = () => {
+    // Clear cache for removed nodes
+    for (const [id] of elementCache) {
+      if (!vueNodeData.value.has(id)) {
+        elementCache.delete(id)
+      }
     }
 
-    // Sync transform state only when it changes (avoids reflows)
-    if (comfyApp.canvas?.ds) {
-      const currentScale = comfyApp.canvas.ds.scale
-      const currentOffsetX = comfyApp.canvas.ds.offset[0]
-      const currentOffsetY = comfyApp.canvas.ds.offset[1]
-
-      if (
-        currentScale !== lastScale.value ||
-        currentOffsetX !== lastOffsetX.value ||
-        currentOffsetY !== lastOffsetY.value
-      ) {
-        syncWithCanvas(comfyApp.canvas)
-        // Update transform tracking refs
-        lastScale.value = currentScale
-        lastOffsetX.value = currentOffsetX
-        lastOffsetY.value = currentOffsetY
-
-        // Only update viewport refs (triggering culling recalc) if change is significant
-        const scaleDiff =
-          Math.abs(currentScale - viewportScale.value) / viewportScale.value
-        const offsetDiffX = Math.abs(currentOffsetX - viewportOffsetX.value)
-        const offsetDiffY = Math.abs(currentOffsetY - viewportOffsetY.value)
-
-        if (
-          scaleDiff > SCALE_UPDATE_THRESHOLD ||
-          offsetDiffX > VIEWPORT_UPDATE_THRESHOLD ||
-          offsetDiffY > VIEWPORT_UPDATE_THRESHOLD
-        ) {
-          // Significant viewport change - update culling
-          viewportScale.value = currentScale
-          viewportOffsetX.value = currentOffsetX
-          viewportOffsetY.value = currentOffsetY
-        } else {
-          // Small change - schedule debounced update for when panning stops
-          updateViewportDebounced()
+    // Add new nodes to cache
+    for (const [id] of vueNodeData.value) {
+      if (!elementCache.has(id)) {
+        const element = document.querySelector(`[data-node-id="${id}"]`)
+        if (element) {
+          elementCache.set(id, element)
         }
       }
     }
-
-    // Detect node changes during transform updates
-    detectChangesInRAF()
   }
 
   /**
-   * Calculate if a specific node is visible in viewport
-   * Useful for individual node visibility checks
+   * Update visibility - uses cached elements
    */
-  const isNodeVisible = (nodeData: VueNodeData): boolean => {
-    if (!nodeManager.value || !canvasStore.canvas || !comfyApp.canvas) {
-      return true // Default to visible if culling not available
-    }
+  const updateVisibility = () => {
+    if (!nodeManager.value || !canvasStore.canvas || !comfyApp.canvas) return
 
     const canvas = canvasStore.canvas
-    const node = nodeManager.value.getNode(nodeData.id)
-    if (!node) return false
-
-    syncWithCanvas(comfyApp.canvas)
+    const manager = nodeManager.value
     const ds = canvas.ds
 
+    // Viewport bounds
     const viewport_width = canvas.canvas.width
     const viewport_height = canvas.canvas.height
-    const canvasMarginDistance = 200
-    const margin_x = canvasMarginDistance * ds.scale
-    const margin_y = canvasMarginDistance * ds.scale
+    const margin = 200 * ds.scale
 
-    const screen_x = (node.pos[0] + ds.offset[0]) * ds.scale
-    const screen_y = (node.pos[1] + ds.offset[1]) * ds.scale
-    const screen_width = node.size[0] * ds.scale
-    const screen_height = node.size[1] * ds.scale
+    // Update visibility using cached elements
+    elementCache.forEach((element, nodeId) => {
+      const node = manager.getNode(nodeId)
+      if (!node) {
+        // Node deleted, remove from cache
+        elementCache.delete(nodeId)
+        return
+      }
 
-    return !(
-      screen_x + screen_width < -margin_x ||
-      screen_x > viewport_width + margin_x ||
-      screen_y + screen_height < -margin_y ||
-      screen_y > viewport_height + margin_y
-    )
+      // Calculate if in viewport
+      const screen_x = (node.pos[0] + ds.offset[0]) * ds.scale
+      const screen_y = (node.pos[1] + ds.offset[1]) * ds.scale
+      const screen_width = node.size[0] * ds.scale
+      const screen_height = node.size[1] * ds.scale
+
+      const isVisible = !(
+        screen_x + screen_width < -margin ||
+        screen_x > viewport_width + margin ||
+        screen_y + screen_height < -margin ||
+        screen_y > viewport_height + margin
+      )
+
+      // Toggle visibility class
+      if (isVisible) {
+        element.classList.remove('node-hidden')
+      } else {
+        element.classList.add('node-hidden')
+      }
+    })
   }
 
   /**
-   * Get viewport bounds information for debugging
+   * Handle transform update - called by TransformPane event
+   * @param detectChangesInRAF - Function to detect node position/size changes
    */
-  const getViewportInfo = () => {
-    if (!canvasStore.canvas || !comfyApp.canvas) {
-      return null
+  const handleTransformUpdate = (detectChangesInRAF?: () => void) => {
+    if (!isVueNodesEnabled.value) return
+
+    // Detect node position/size changes if function provided
+    if (detectChangesInRAF) {
+      detectChangesInRAF()
     }
 
-    const canvas = canvasStore.canvas
-    const ds = canvas.ds
+    // Refresh cache for any new/removed nodes
+    refreshElementCache()
 
-    return {
-      viewport_width: canvas.canvas.width,
-      viewport_height: canvas.canvas.height,
-      scale: ds.scale,
-      offset: [ds.offset[0], ds.offset[1]],
-      margin_distance: 200,
-      margin_x: 200 * ds.scale,
-      margin_y: 200 * ds.scale
-    }
+    // Update visibility culling
+    updateVisibility()
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    if (debounceTimer) {
-      clearTimeout(debounceTimer)
-    }
-  })
-
   return {
-    nodesToRender,
+    allNodes,
     handleTransformUpdate,
-    isNodeVisible,
-    getViewportInfo,
-
-    // Transform state
-    currentTransformState: readonly(currentTransformState),
-    lastScale: readonly(lastScale),
-    lastOffsetX: readonly(lastOffsetX),
-    lastOffsetY: readonly(lastOffsetY)
+    updateVisibility
   }
 }

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -9,6 +9,7 @@
 import { type Ref, computed } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { app as comfyApp } from '@/scripts/app'
 import { useCanvasStore } from '@/stores/graphStore'
 
 interface NodeManager {
@@ -34,7 +35,7 @@ export function useViewportCulling(
    * Queries DOM directly - no cache maintenance needed
    */
   const updateVisibility = () => {
-    if (!nodeManager.value || !canvasStore.canvas) return
+    if (!nodeManager.value || !canvasStore.canvas || !comfyApp.canvas) return
 
     const canvas = canvasStore.canvas
     const manager = nodeManager.value
@@ -62,7 +63,7 @@ export function useViewportCulling(
       const screen_width = node.size[0] * ds.scale
       const screen_height = node.size[1] * ds.scale
 
-      const isNodeOutsideiewport =
+      const isNodeOutsideViewport =
         screen_x + screen_width < -margin ||
         screen_x > viewport_width + margin ||
         screen_y + screen_height < -margin ||
@@ -70,7 +71,7 @@ export function useViewportCulling(
 
       // Setting display none directly avoid potential cascade resolution
       if (element instanceof HTMLElement) {
-        element.style.display = isNodeOutsideiewport ? 'none' : ''
+        element.style.display = isNodeOutsideViewport ? 'none' : ''
       }
     }
   }

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -43,9 +43,16 @@ export function useViewportCulling(
    * Computed property that returns nodes visible in the current viewport
    * Implements sophisticated culling algorithm with adaptive margins
    */
+
+  const DISABLE_CULLING = true
+
   const nodesToRender = computed(() => {
     if (!isVueNodesEnabled.value) {
       return []
+    }
+
+    if (DISABLE_CULLING) {
+      return Array.from(vueNodeData.value.values())
     }
 
     // Access trigger to force re-evaluation after nodeManager initialization

--- a/src/composables/graph/useViewportCulling.ts
+++ b/src/composables/graph/useViewportCulling.ts
@@ -50,7 +50,7 @@ export function useViewportCulling(
     const nodeElements = document.querySelectorAll('[data-node-id]')
 
     // Update each element's visibility
-    nodeElements.forEach((element) => {
+    for (const element of nodeElements) {
       const nodeId = element.getAttribute('data-node-id')
       if (!nodeId) return
 
@@ -72,7 +72,7 @@ export function useViewportCulling(
 
       // Setting diplay directly SHOULD avoid cascade resolution
       ;(element as HTMLElement).style.display = isVisible ? '' : 'none'
-    })
+    }
   }
 
   // RAF throttling for smooth updates during continuous panning


### PR DESCRIPTION
## Summary

- Fix viewport culling bug
- Improve performance of culling by keeping all nodes in the DOM and then using display: none instead of removing and adding nodes nodesToRender array.


Note: This approach to culling is a performance trade off (Rendering performance > Memory usage). In the future the high memory usage could be addressed via a client hydration system.

## Changes

- **What**: Viewport culling (fix and improved)
- **Breaking**: N/A
- **Dependencies**: N/A

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

https://github.com/user-attachments/assets/79c3ab5d-7e8f-46fd-9697-65b1b3b9172f

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5510-Fix-vue-nodes-viewport-culling-26c6d73d365081929475f44e80634983) by [Unito](https://www.unito.io)
