### PR TITLE
fix: Remove npm warnings in collect-i18n script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "knip": "knip --cache",
     "knip:no-cache": "knip",
     "locale": "lobe-i18n locale",
-    "collect-i18n": "npx playwright test --config=playwright.i18n.config.ts",
+    "collect-i18n": "node_modules/.bin/playwright test --config=playwright.i18n.config.ts",
     "json-schema": "tsx scripts/generate-json-schema.ts",
     "storybook": "nx storybook -p 6006",
     "build-storybook": "storybook build"


### PR DESCRIPTION
## Summary
- Fixes npm v11 warnings when running `pnpm collect-i18n`
- Replaces `npx` with direct playwright binary call to avoid passing unrecognized environment configs

## Problem
When running `pnpm collect-i18n`, npm v11 shows warnings:
```
npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
```

These configs are passed from pnpm's environment but are not recognized by npm v11.

## Solution
Changed the script from using `npx playwright` to directly calling `node_modules/.bin/playwright`, which avoids the npm wrapper and its environment variable warnings.

## Test plan
- [x] Run `pnpm collect-i18n` and verify no npm warnings appear
- [x] Verify the script still attempts to run playwright tests (though there's a separate babel config issue to address)

🤖 Generated with Claude Code

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5513-fix-Remove-npm-warnings-in-collect-i18n-script-26c6d73d365081faa731dbf79a0839e7) by [Unito](https://www.unito.io)
