### PR TITLE
feat: remove the divider that between widgets and slots and content

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -104,11 +104,6 @@
           @slot-click="handleSlotClick"
         />
 
-        <div
-          v-if="shouldRenderSlots && shouldShowWidgets"
-          :class="separatorClasses"
-        />
-
         <!-- Widgets rendered at reduced+ detail -->
         <NodeWidgets
           v-if="shouldShowWidgets"
@@ -116,11 +111,6 @@
           :node-data="nodeData"
           :readonly="readonly"
           :lod-level="lodLevel"
-        />
-
-        <div
-          v-if="(shouldRenderSlots || shouldShowWidgets) && shouldShowContent"
-          :class="separatorClasses"
         />
 
         <!-- Custom content at reduced+ detail -->


### PR DESCRIPTION
Alex said : the separator was removed in Figma now

### Before 
<img width="505" height="329" alt="CleanShot 2025-09-12 at 18 00 22" src="https://github.com/user-attachments/assets/ff07ba4b-e6c7-4a7e-ab26-a3d556fd3b4a" />

### After
<img width="489" height="271" alt="CleanShot 2025-09-12 at 18 00 54" src="https://github.com/user-attachments/assets/c2ee90d6-d6cb-4722-9547-d44011969ce1" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5517-feat-remove-the-divider-that-between-widgets-and-slots-and-content-26c6d73d365081528227e6a6a4ca5e6e) by [Unito](https://www.unito.io)
