### PR TITLE
fix(links): remove drag-end offset in straight/linear modes

### DIFF
--- a/src/renderer/core/canvas/litegraph/litegraphLinkAdapter.ts
+++ b/src/renderer/core/canvas/litegraph/litegraphLinkAdapter.ts
@@ -208,6 +208,9 @@ export class LitegraphLinkAdapter {
         return 'up'
       case LinkDirection.DOWN:
         return 'down'
+      case LinkDirection.CENTER:
+      case LinkDirection.NONE:
+        return 'none'
       default:
         return 'right'
     }

--- a/src/renderer/core/canvas/pathRenderer.ts
+++ b/src/renderer/core/canvas/pathRenderer.ts
@@ -12,7 +12,7 @@ export interface Point {
   y: number
 }
 
-export type Direction = 'left' | 'right' | 'up' | 'down'
+export type Direction = 'left' | 'right' | 'up' | 'down' | 'none'
 export type RenderMode = 'spline' | 'straight' | 'linear'
 export type ArrowShape = 'triangle' | 'circle' | 'square'
 
@@ -255,6 +255,8 @@ export class CanvasPathRenderer {
       case 'down':
         innerA.y += l
         break
+      case 'none':
+        break
     }
 
     switch (endDir) {
@@ -269,6 +271,8 @@ export class CanvasPathRenderer {
         break
       case 'down':
         innerB.y += l
+        break
+      case 'none':
         break
     }
 
@@ -306,6 +310,8 @@ export class CanvasPathRenderer {
       case 'down':
         innerA.y += l
         break
+      case 'none':
+        break
     }
 
     switch (endDir) {
@@ -320,6 +326,8 @@ export class CanvasPathRenderer {
         break
       case 'down':
         innerB.y += l
+        break
+      case 'none':
         break
     }
 
@@ -399,6 +407,9 @@ export class CanvasPathRenderer {
         return { x: 0, y: -distance }
       case 'down':
         return { x: 0, y: distance }
+      case 'none':
+      default:
+        return { x: 0, y: 0 }
     }
   }
 
@@ -473,6 +484,8 @@ export class CanvasPathRenderer {
       case 'down':
         pa.y += dist * factor
         break
+      case 'none':
+        break
     }
 
     switch (endDirection) {
@@ -487,6 +500,8 @@ export class CanvasPathRenderer {
         break
       case 'down':
         pb.y += dist * factor
+        break
+      case 'none':
         break
     }
 
@@ -608,6 +623,9 @@ export class CanvasPathRenderer {
         return 'down'
       case 'down':
         return 'up'
+      case 'none':
+      default:
+        return 'none'
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the visual offset at the cursor end when dragging links in Straight and Linear modes by honoring CENTER/NONE as an explicit no-offset direction.

## Changes

- **What**: Renderers treat CENTER/NONE as no-offset for the moving end while dragging; start end keeps its small push-out. Added `'none'` direction to the pure path renderer and mapped `LinkDirection.CENTER`/`NONE` to it in the adapter.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

- Confirm dragging visuals in Straight and Linear modes: the moving end should remain directly under the cursor throughout the drag. The fixed start should still show the small offset (intended).
- Spline mode and non-drag rendering unchanged.
- Semantics: `CENTER` means "explicitly no offset" and `NONE` means "unset/placeholder" upstream; both map to no-offset at the renderer to avoid accidental end-offsets while dragging.

## Screenshots (if applicable)



https://github.com/user-attachments/assets/e0fa5b21-5c39-4e71-b8c1-929ca27077f1



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5520-fix-links-remove-drag-end-offset-in-straight-linear-modes-26c6d73d3650818ab774c1b1d3718761) by [Unito](https://www.unito.io)
