### PR TITLE
Fix Electron update GitHub Action PR title/body

### DIFF
--- a/.github/workflows/update-electron-types.yaml
+++ b/.github/workflows/update-electron-types.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Get new version
         id: get-version
         run: |
-          NEW_VERSION=$(pnpm list @comfyorg/comfyui-electron-types --json --depth=0 | jq -r '.[0].version')
+          NEW_VERSION=$(pnpm list @comfyorg/comfyui-electron-types --json --depth=0 | jq -r '.[0].dependencies."@comfyorg/comfyui-electron-types".version')
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request


### PR DESCRIPTION
Was pulling frontend version for PR title/body.  Now uses updated package version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5527-Fix-Electron-update-GitHub-Action-PR-title-body-26d6d73d36508143ad87d0602744d533) by [Unito](https://www.unito.io)
