### PR TITLE
Fix Vue slot label colors for light theme

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -21,7 +21,7 @@
     <!-- Slot Name -->
     <span
       v-if="!dotOnly"
-      class="whitespace-nowrap text-sm font-normal dark-theme:text-[#9FA2BD] text-[#888682]"
+      class="whitespace-nowrap text-sm font-normal dark-theme:text-slate-200 text-stone-200"
     >
       {{ slotData.localized_name || slotData.name || `Input ${index}` }}
     </span>

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -18,7 +18,7 @@
     >
       <i
         :class="collapsed ? 'pi pi-chevron-right' : 'pi pi-chevron-down'"
-        class="text-xs leading-none relative top-[1px] text-[#888682] dark-theme:text-[#5B5E7D]"
+        class="text-xs leading-none relative top-[1px] text-stone-200 dark-theme:text-[#5B5E7D]"
       ></i>
     </button>
 

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -18,7 +18,7 @@
     >
       <i
         :class="collapsed ? 'pi pi-chevron-right' : 'pi pi-chevron-down'"
-        class="text-xs leading-none relative top-[1px] text-stone-200 dark-theme:text-[#5B5E7D]"
+        class="text-xs leading-none relative top-px text-stone-200 dark-theme:text-slate-300"
       ></i>
     </button>
 

--- a/src/renderer/extensions/vueNodes/components/OutputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.vue
@@ -15,7 +15,7 @@
     <!-- Slot Name -->
     <span
       v-if="!dotOnly"
-      class="whitespace-nowrap text-sm font-normal dark-theme:text-[#9FA2BD] text-[#888682]"
+      class="whitespace-nowrap text-sm font-normal dark-theme:text-slate-200 text-stone-200"
     >
       {{ slotData.name || `Output ${index}` }}
     </span>

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
@@ -14,7 +14,7 @@ defineProps<{
   >
     <p
       v-if="widget.name"
-      class="text-sm text-[#888682] dark-theme:text-[#9FA2BD] font-normal flex-1 truncate w-20"
+      class="text-sm text-stone-200 dark-theme:text-slate-200 font-normal flex-1 truncate w-20"
     >
       {{ widget.name }}
     </p>


### PR DESCRIPTION
## Summary

Updated Vue node slot label components to use stone-200 color for improved theme consistency in light mode (use Figma variables).

## Changes

- **What**: Replaced hardcoded hex color `#888682` with [Tailwind CSS](https://tailwindcss.com/docs/customizing-colors) `stone-200` token for light theme slot labels

## Review Focus

Color token consistency across Vue nodes system and visual contrast in light theme.

Fixes slot label readability issue in light theme by using the correct design system color token.

## Screenshots

**Before**

<img width="898" height="964" alt="Selection_2157" src="https://github.com/user-attachments/assets/b99dfbc8-83ad-48e2-83b0-a5663b3cacb1" />

**After**

<img width="1434" height="1456" alt="Selection_2156" src="https://github.com/user-attachments/assets/aed46c62-13d6-4dcb-94fc-3e4d2a1dc1f6" />
