### PR TITLE
add sortOrder for setting item

### DIFF
--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -114,7 +114,6 @@ const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {
     .map((group) => ({
       label: group.label,
       settings: flattenTree<SettingParams>(group).sort((a, b) => {
-        // Sort by priority first, higher priority comes first
         const sortOrderA = a.sortOrder ?? 0
         const sortOrderB = b.sortOrder ?? 0
 

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -113,7 +113,18 @@ const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {
     .sort((a, b) => a.label.localeCompare(b.label))
     .map((group) => ({
       label: group.label,
-      settings: flattenTree<SettingParams>(group)
+      settings: flattenTree<SettingParams>(group).sort((a, b) => {
+        // Sort by priority first, higher priority comes first
+        const priorityA = a.priority ?? 0
+        const priorityB = b.priority ?? 0
+
+        if (priorityA !== priorityB) {
+          return priorityB - priorityA
+        }
+
+        // If priorities are equal, sort alphabetically by name
+        return a.name.localeCompare(b.name)
+      })
     }))
 }
 

--- a/src/components/dialog/content/SettingDialogContent.vue
+++ b/src/components/dialog/content/SettingDialogContent.vue
@@ -115,15 +115,10 @@ const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {
       label: group.label,
       settings: flattenTree<SettingParams>(group).sort((a, b) => {
         // Sort by priority first, higher priority comes first
-        const priorityA = a.priority ?? 0
-        const priorityB = b.priority ?? 0
+        const sortOrderA = a.sortOrder ?? 0
+        const sortOrderB = b.sortOrder ?? 0
 
-        if (priorityA !== priorityB) {
-          return priorityB - priorityA
-        }
-
-        // If priorities are equal, sort alphabetically by name
-        return a.name.localeCompare(b.name)
+        return sortOrderB - sortOrderA
       })
     }))
 }

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -43,6 +43,9 @@ export interface SettingParams<TValue = unknown> extends FormItem {
   versionAdded?: string
   // Version of the setting when it was last modified
   versionModified?: string
+  // Priority for sorting settings within a group. Higher values appear first.
+  // Default is 0 if not specified.
+  priority?: number
 }
 
 /**

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -43,9 +43,9 @@ export interface SettingParams<TValue = unknown> extends FormItem {
   versionAdded?: string
   // Version of the setting when it was last modified
   versionModified?: string
-  // Priority for sorting settings within a group. Higher values appear first.
+  // sortOrder for sorting settings within a group. Higher values appear first.
   // Default is 0 if not specified.
-  priority?: number
+  sortOrder?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

in some desgin requirement, some settings should display on top of others

## Changes

- **What**: add sortOrder for setting item

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

https://github.com/user-attachments/assets/6953810c-6a9a-4a50-b966-5e07965d954c

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5534-add-priority-for-setting-item-26d6d73d36508120af77e3c7e1095daa) by [Unito](https://www.unito.io)
