### PR TITLE
Subgraph widget promotion - Part 1

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -25,7 +25,9 @@ const config: KnipConfig = {
     'src/types/generatedManagerTypes.ts',
     'src/types/comfyRegistryTypes.ts',
     // Used by a custom node (that should move off of this)
-    'src/scripts/ui/components/splitButton.ts'
+    'src/scripts/ui/components/splitButton.ts',
+    // Staged for for use with subgraph widget promotion
+    'src/lib/litegraph/src/widgets/DisconnectedWidget.ts'
   ],
   compilers: {
     // https://github.com/webpro-nl/knip/issues/1008#issuecomment-3207756199

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -34,7 +34,7 @@ const updateWidgets = () => {
     const widget = widgetState.widget
 
     // Early exit for non-visible widgets
-    if (!widget.isVisible()) {
+    if (!widget.isVisible() || !widgetState.active) {
       widgetState.visible = false
       continue
     }

--- a/src/lib/litegraph/src/widgets/ComboWidget.ts
+++ b/src/lib/litegraph/src/widgets/ComboWidget.ts
@@ -45,7 +45,7 @@ export class ComboWidget
     return typeof this.value === 'number' ? String(this.value) : this.value
   }
 
-  getValues(node: LGraphNode): Values {
+  private getValues(node: LGraphNode): Values {
     const { values } = this.options
     if (values == null) throw new Error('[ComboWidget]: values is required')
 
@@ -57,7 +57,7 @@ export class ComboWidget
    * @param increment `true` if checking the use of the increment button, `false` for decrement
    * @returns `true` if the value is at the given index, otherwise `false`.
    */
-  canUseButton(increment: boolean): boolean {
+  private canUseButton(increment: boolean): boolean {
     const { values } = this.options
     // If using legacy duck-typed method, false is the most permissive return value
     if (typeof values === 'function') return false
@@ -93,7 +93,7 @@ export class ComboWidget
     this.tryChangeValue(-1, options)
   }
 
-  tryChangeValue(delta: number, options: WidgetEventOptions): void {
+  private tryChangeValue(delta: number, options: WidgetEventOptions): void {
     const values = this.getValues(options.node)
     const indexedValues = toArray(values)
 

--- a/src/lib/litegraph/src/widgets/ComboWidget.ts
+++ b/src/lib/litegraph/src/widgets/ComboWidget.ts
@@ -45,7 +45,7 @@ export class ComboWidget
     return typeof this.value === 'number' ? String(this.value) : this.value
   }
 
-  #getValues(node: LGraphNode): Values {
+  getValues(node: LGraphNode): Values {
     const { values } = this.options
     if (values == null) throw new Error('[ComboWidget]: values is required')
 
@@ -57,7 +57,7 @@ export class ComboWidget
    * @param increment `true` if checking the use of the increment button, `false` for decrement
    * @returns `true` if the value is at the given index, otherwise `false`.
    */
-  #canUseButton(increment: boolean): boolean {
+  canUseButton(increment: boolean): boolean {
     const { values } = this.options
     // If using legacy duck-typed method, false is the most permissive return value
     if (typeof values === 'function') return false
@@ -78,23 +78,23 @@ export class ComboWidget
    * Handles edge case where the value is both the first and last item in the list.
    */
   override canIncrement(): boolean {
-    return this.#canUseButton(true)
+    return this.canUseButton(true)
   }
 
   override canDecrement(): boolean {
-    return this.#canUseButton(false)
+    return this.canUseButton(false)
   }
 
   override incrementValue(options: WidgetEventOptions): void {
-    this.#tryChangeValue(1, options)
+    this.tryChangeValue(1, options)
   }
 
   override decrementValue(options: WidgetEventOptions): void {
-    this.#tryChangeValue(-1, options)
+    this.tryChangeValue(-1, options)
   }
 
-  #tryChangeValue(delta: number, options: WidgetEventOptions): void {
-    const values = this.#getValues(options.node)
+  tryChangeValue(delta: number, options: WidgetEventOptions): void {
+    const values = this.getValues(options.node)
     const indexedValues = toArray(values)
 
     // avoids double click event
@@ -128,7 +128,7 @@ export class ComboWidget
     if (x > width - 40) return this.incrementValue({ e, node, canvas })
 
     // Otherwise, show dropdown menu
-    const values = this.#getValues(node)
+    const values = this.getValues(node)
     const values_list = toArray(values)
 
     // Handle center click - show dropdown menu

--- a/src/lib/litegraph/src/widgets/DisconnectedWidget.ts
+++ b/src/lib/litegraph/src/widgets/DisconnectedWidget.ts
@@ -1,0 +1,38 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IButtonWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { BaseWidget, type DrawWidgetOptions } from './BaseWidget'
+
+class DisconnectedWidget extends BaseWidget<IButtonWidget> {
+  constructor(widget: IButtonWidget, node: LGraphNode) {
+    super(widget, node)
+    this.disabled = true
+  }
+
+  override drawWidget(
+    ctx: CanvasRenderingContext2D,
+    { width, showText = true }: DrawWidgetOptions
+  ) {
+    ctx.save()
+    this.drawWidgetShape(ctx, { width, showText })
+    if (showText) {
+      this.drawTruncatingText({ ctx, width, leftPadding: 0, rightPadding: 0 })
+    }
+    ctx.restore()
+  }
+
+  override onClick() {}
+
+  override get _displayValue() {
+    return 'Disconnected'
+  }
+}
+const conf: IButtonWidget = {
+  type: 'button',
+  value: undefined,
+  name: 'Disconnected',
+  options: {},
+  y: 0,
+  clicked: false
+}
+export const disconnectedWidget = new DisconnectedWidget(conf, {} as LGraphNode)

--- a/src/lib/litegraph/src/widgets/DisconnectedWidget.ts
+++ b/src/lib/litegraph/src/widgets/DisconnectedWidget.ts
@@ -1,11 +1,11 @@
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IButtonWidget } from '@/lib/litegraph/src/types/widgets'
 
 import { BaseWidget, type DrawWidgetOptions } from './BaseWidget'
 
 class DisconnectedWidget extends BaseWidget<IButtonWidget> {
-  constructor(widget: IButtonWidget, node: LGraphNode) {
-    super(widget, node)
+  constructor(widget: IButtonWidget) {
+    super(widget, new LGraphNode('DisconnectedPlaceholder'))
     this.disabled = true
   }
 
@@ -35,4 +35,4 @@ const conf: IButtonWidget = {
   y: 0,
   clicked: false
 }
-export const disconnectedWidget = new DisconnectedWidget(conf, {} as LGraphNode)
+export const disconnectedWidget = new DisconnectedWidget(conf)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -838,24 +838,27 @@ export class ComfyApp {
     this.canvas.canvas.addEventListener<'litegraph:set-graph'>(
       'litegraph:set-graph',
       (e) => {
-        // Assertion: Not yet defined in litegraph.
         const { newGraph } = e.detail
 
-        const widgetIds: Record<string, BaseDOMWidget<object | string>> = {}
         const widgetStore = useDomWidgetStore()
 
-        for (const node of newGraph.nodes)
-          for (const w of node.widgets ?? [])
-            if (w instanceof DOMWidgetImpl && w.id) widgetIds[w.id] = w
+        const activeWidgets: Record<
+          string,
+          BaseDOMWidget<object | string>
+        > = Object.fromEntries(
+          newGraph.nodes
+            .flatMap((node) => node.widgets ?? [])
+            .filter((w) => w instanceof DOMWidgetImpl)
+            .map((w) => [w.id, w])
+        )
 
-        // Assertions: UnwrapRef
-        for (const widgetId of widgetStore.widgetStates.keys()) {
-          const widgetState = widgetStore.widgetStates.get(widgetId)
-          //Unreachable, but required for type safety
-          if (!widgetState) continue
-          if (widgetId in widgetIds) {
+        for (const [
+          widgetId,
+          widgetState
+        ] of widgetStore.widgetStates.entries()) {
+          if (widgetId in activeWidgets) {
             widgetState.active = true
-            widgetState.widget = widgetIds[widgetId]
+            widgetState.widget = activeWidgets[widgetId]
           } else {
             widgetState.active = false
           }


### PR DESCRIPTION
Small minimally objectionable prerequisite changes required for the widget promotion implementation.
- DOMWidgets ignored their active state and display solely based off if they are calculated as visible
- ComboWidgets used lots of private methods that were particularly thorny to proxy.
- Update the graph swap bookkeeping for DOMWidgets. Since a single DOMWidget element can now be owned by (up to) one widget per graph, slightly more robust logic is required to determine if a widget is active when swapping between subgraphs.
- Add a new Disconnected Widget
  - Not currently used anywhere (which necessitates a temporary knip ignore).
  - To be used as a placeholder if a user deletes a node with a promoted widget inside a subgraph.
  - Will not be added to widget registry or exposed for external use.
<img width="532" height="573" alt="image" src="https://github.com/user-attachments/assets/4169f340-a229-4ed1-a947-0393a293498c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5537-Subgraph-widget-promotion-Part-1-26d6d73d36508105a7dad8a83696dea4) by [Unito](https://www.unito.io)
