### PR TITLE
Add error border on missing nodes (vue nodes)

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -56,6 +56,7 @@ export interface VueNodeData {
   widgets?: SafeWidgetData[]
   inputs?: unknown[]
   outputs?: unknown[]
+  hasErrors?: boolean
   flags?: {
     collapsed?: boolean
   }
@@ -208,6 +209,7 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
       mode: node.mode || 0,
       selected: node.selected || false,
       executing: false, // Will be updated separately based on execution state
+      hasErrors: !!node.has_errors,
       widgets: safeWidgets,
       inputs: node.inputs ? [...node.inputs] : undefined,
       outputs: node.outputs ? [...node.outputs] : undefined,

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -13,7 +13,8 @@
         // border
         'border border-solid border-sand-100 dark-theme:border-charcoal-300',
         !!executing && 'border-blue-500 dark-theme:border-blue-500',
-        !!error && 'border-red-700 dark-theme:border-red-300',
+        !!(error || nodeData.hasErrors) &&
+          'border-error dark-theme:border-error',
         // hover
         'hover:ring-7 ring-gray-500/50 dark-theme:ring-gray-500/20',
         // Selected
@@ -21,7 +22,8 @@
         !!isSelected && 'outline-black dark-theme:outline-white',
         !!(isSelected && executing) &&
           'outline-blue-500 dark-theme:outline-blue-500',
-        !!(isSelected && error) && 'outline-red-500 dark-theme:outline-red-500',
+        !!(isSelected && (error || nodeData.hasErrors)) &&
+          'outline-error dark-theme:outline-error',
         {
           'animate-pulse': executing,
           'opacity-50': nodeData.mode === 4,

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -13,8 +13,7 @@
         // border
         'border border-solid border-sand-100 dark-theme:border-charcoal-300',
         !!executing && 'border-blue-500 dark-theme:border-blue-500',
-        !!(error || nodeData.hasErrors) &&
-          'border-error',
+        !!(error || nodeData.hasErrors) && 'border-error',
         // hover
         'hover:ring-7 ring-gray-500/50 dark-theme:ring-gray-500/20',
         // Selected
@@ -22,8 +21,7 @@
         !!isSelected && 'outline-black dark-theme:outline-white',
         !!(isSelected && executing) &&
           'outline-blue-500 dark-theme:outline-blue-500',
-        !!(isSelected && (error || nodeData.hasErrors)) &&
-          'outline-error',
+        !!(isSelected && (error || nodeData.hasErrors)) && 'outline-error',
         {
           'animate-pulse': executing,
           'opacity-50': nodeData.mode === 4,

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -14,7 +14,7 @@
         'border border-solid border-sand-100 dark-theme:border-charcoal-300',
         !!executing && 'border-blue-500 dark-theme:border-blue-500',
         !!(error || nodeData.hasErrors) &&
-          'border-error dark-theme:border-error',
+          'border-error',
         // hover
         'hover:ring-7 ring-gray-500/50 dark-theme:ring-gray-500/20',
         // Selected

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -23,7 +23,7 @@
         !!(isSelected && executing) &&
           'outline-blue-500 dark-theme:outline-blue-500',
         !!(isSelected && (error || nodeData.hasErrors)) &&
-          'outline-error dark-theme:outline-error',
+          'outline-error',
         {
           'animate-pulse': executing,
           'opacity-50': nodeData.mode === 4,


### PR DESCRIPTION
## Summary

Get the `has_errors` property and show a red border (per design). The `has_errors` is not dynamic so it can be consider final after loading graph data and doesn't need to be reactive or change based on events.

Todo in followup PRs:

- Create system to map execution errors -> node id -> add error border to vue node associated with the ID
- Create parallel system in Vue nodes that exists in canvas nodes whereby missing nodes are constructed as skeletons using the data available (inputs, outputs, type, and widgets are guessed based on `widgets_values`)

 
## Changes

- **What**: Add `hasError` property to initial node data used to construct vue nodes. Update error border to match Figma and use `hasError`


## Screenshots (if applicable)

<img width="1650" height="1138" alt="Selection_2161" src="https://github.com/user-attachments/assets/ffb1d8e8-8f61-46d9-b86d-c765ed86a091" />

<img width="826" height="372" alt="Selection_2162" src="https://github.com/user-attachments/assets/d8a3866f-f609-49ef-a730-999b6f828870" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5538-Add-error-border-on-missing-nodes-vue-nodes-26d6d73d36508177b2f1d33af1b8eafb) by [Unito](https://www.unito.io)
