### PR TITLE
fix: resolve circular dependency to enable verbatimModuleSyntax

### DIFF
--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -17,8 +17,8 @@ import type {
   INodeInputSlot,
   INodeOutputSlot
 } from '@/lib/litegraph/src/interfaces'
-import { EmptySubgraphInput } from '@/lib/litegraph/src/subgraph/EmptySubgraphInput'
-import { EmptySubgraphOutput } from '@/lib/litegraph/src/subgraph/EmptySubgraphOutput'
+import type { EmptySubgraphInput } from '@/lib/litegraph/src/subgraph/EmptySubgraphInput'
+import type { EmptySubgraphOutput } from '@/lib/litegraph/src/subgraph/EmptySubgraphOutput'
 import { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import { SubgraphInputNode } from '@/lib/litegraph/src/subgraph/SubgraphInputNode'
@@ -673,7 +673,7 @@ export class LinkConnector {
         link.connectToSubgraphOutput(targetSlot, this.events)
 
         // If we just connected to an EmptySubgraphOutput, check if we should reuse the slot
-        if (output instanceof EmptySubgraphOutput && ioNode.slots.length > 0) {
+        if (output === ioNode.emptySlot && ioNode.slots.length > 0) {
           // Get the last created slot (newest one)
           const createdSlot = ioNode.slots[ioNode.slots.length - 1]
 
@@ -719,7 +719,7 @@ export class LinkConnector {
         link.connectToSubgraphInput(targetSlot, this.events)
 
         // If we just connected to an EmptySubgraphInput, check if we should reuse the slot
-        if (input instanceof EmptySubgraphInput && ioNode.slots.length > 0) {
+        if (input === ioNode.emptySlot && ioNode.slots.length > 0) {
           // Get the last created slot (newest one)
           const createdSlot = ioNode.slots[ioNode.slots.length - 1]
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,
     "noImplicitOverride": true,
+    "verbatimModuleSyntax": true,
     "allowJs": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- Resolves circular dependency issues that prevented enabling TypeScript's `verbatimModuleSyntax`
- Uses lazy initialization pattern to break the circular dependency chain
- Enables `verbatimModuleSyntax` in TypeScript configuration

## Problem
The codebase had a blocking circular dependency:
```
EmptySubgraphInput → SubgraphInput → SubgraphInputNode → EmptySubgraphInput
```

This prevented enabling `verbatimModuleSyntax` which would improve TypeScript's module resolution and type checking.

## Solution
1. **Lazy Initialization**: Changed `EmptySubgraphInput` and `EmptySubgraphOutput` from being instantiated at module load time to being created lazily on first access
2. **Factory Functions**: Used factory functions with `require()` to defer module loading until after initialization phase
3. **Type-only Imports**: Converted direct imports to type-only imports where possible
4. **Identity Checks**: Replaced `instanceof` checks with identity checks in LinkConnector

## Changes
- Modified `SubgraphInputNode` and `SubgraphOutputNode` to use lazy getters for empty slots
- Updated `LinkConnector` to use identity checks instead of `instanceof`
- Enabled `verbatimModuleSyntax` in `tsconfig.json`
- Added factory functions to handle deferred module loading

## Testing
- ✅ Tests pass without runtime errors
- ✅ Circular dependency is resolved
- ✅ Module initialization works correctly

## Notes
The use of `require()` is necessary here to break the circular dependency at module initialization time. ESLint disable comments have been added for these specific cases.

Fixes #5545

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5546-fix-resolve-circular-dependency-to-enable-verbatimModuleSyntax-26e6d73d365081278d1ce7b33ec8a49c) by [Unito](https://www.unito.io)
