### PR TITLE
Fix Vue node selection detection in browser tests

### DIFF
--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -17,7 +17,9 @@ export class VueNodeHelpers {
    * Get locator for selected Vue node components (using visual selection indicators)
    */
   get selectedNodes(): Locator {
-    return this.page.locator('[data-node-id].border-blue-500')
+    return this.page.locator(
+      '[data-node-id].outline-black, [data-node-id].outline-white'
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes failing Vue node delete key interaction tests by correcting the CSS selector used to detect selected nodes.

## Changes
- Updated `VueNodeHelpers.selectedNodes` selector from `.border-blue-500` to `.outline-black, .outline-white` 
- This matches the actual selection styling used in `LGraphNode.vue` component

## Fixes
The following browser tests were failing because they couldn't detect selected nodes:
- "Can select all and delete Vue nodes with Delete key" 
- "Can select specific Vue node and delete it"
- "Can multi-select with Ctrl+click and delete multiple Vue nodes"


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5555-Fix-Vue-node-selection-detection-in-browser-tests-26e6d73d365081e7a2a1f7022fb2a7ae) by [Unito](https://www.unito.io)
