### PR TITLE
Fix copy & paste is not possible from desktop app start

### DIFF
--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -100,10 +100,3 @@ onMounted(async () => {
   electronVersion.value = await electron.getElectronVersion()
 })
 </script>
-
-<style scoped>
-:deep(.xterm-helper-textarea) {
-  /* Hide this as it moves all over when uv is running */
-  display: none;
-}
-</style>


### PR DESCRIPTION
### Summary

- Fixes the inability to copy & paste from server start terminal
- Allows users to copy & paste error messages into e.g. google, support issues

### Notes

After trying several hacky workarounds, it appears that the original issue described in the removed comment is just no longer relevant.

It could have been an update or removal of a conflicting style.  In any case, UX is now intuitive and fully functional for ctrl/cmd + C.

### Screenshot

<img width="636" height="224" alt="image" src="https://github.com/user-attachments/assets/b1c497f2-bf1c-40a9-8a2d-abad11137c74" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5559-Fix-copy-paste-is-not-possible-from-desktop-app-start-26e6d73d3650812d84a2c79342e59403) by [Unito](https://www.unito.io)

### Refs

- Resolves https://github.com/Comfy-Org/desktop/issues/355
- Resolves https://github.com/Comfy-Org/desktop/issues/894