### PR TITLE
Fix light_theme changes default node background

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -649,8 +649,6 @@ export class ComfyApp {
       const opacity = useSettingStore().get('Comfy.Node.Opacity')
       if (opacity) adjustments.opacity = opacity
 
-      node.bgcolor = adjustColor(bgColor, adjustments)
-
       if (useColorPaletteStore().completedActivePalette.light_theme) {
         adjustments.lightness = 0.5
 
@@ -659,6 +657,8 @@ export class ComfyApp {
           node.color = adjustColor(old_color, { lightness: 0.5 })
         }
       }
+
+      node.bgcolor = adjustColor(bgColor, adjustments)
 
       // @ts-expect-error fixme ts strict error
       const res = origDrawNode.apply(this, arguments)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -636,10 +636,12 @@ export class ComfyApp {
         this.editor_alpha = 0.4
       }
 
-      let bgColor = old_bgcolor
+      let bgColor: string | undefined
       if (node.mode === LGraphEventMode.BYPASS) {
         bgColor = app.bypassBgColor
         this.editor_alpha = 0.2
+      } else {
+        bgColor = old_bgcolor
       }
 
       const adjustments: ColorAdjustOptions = {}

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -658,9 +658,7 @@ export class ComfyApp {
         }
       }
 
-      if (old_bgcolor) {
-        node.bgcolor = adjustColor(old_bgcolor, adjustments)
-      }
+      node.bgcolor = adjustColor(bgColor, adjustments)
 
       // @ts-expect-error fixme ts strict error
       const res = origDrawNode.apply(this, arguments)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -658,7 +658,9 @@ export class ComfyApp {
         }
       }
 
-      node.bgcolor = adjustColor(bgColor, adjustments)
+      if (old_bgcolor) {
+        node.bgcolor = adjustColor(old_bgcolor, adjustments)
+      }
 
       // @ts-expect-error fixme ts strict error
       const res = origDrawNode.apply(this, arguments)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -636,12 +636,12 @@ export class ComfyApp {
         this.editor_alpha = 0.4
       }
 
-      let bgColor: string | undefined
+      let bgColor: string
       if (node.mode === LGraphEventMode.BYPASS) {
         bgColor = app.bypassBgColor
         this.editor_alpha = 0.2
       } else {
-        bgColor = old_bgcolor
+        bgColor = old_bgcolor || LiteGraph.NODE_DEFAULT_BGCOLOR
       }
 
       const adjustments: ColorAdjustOptions = {}
@@ -658,8 +658,8 @@ export class ComfyApp {
         }
       }
 
-      if (bgColor) {
-        node.bgcolor = adjustColor(bgColor, adjustments)
+      if (old_bgcolor) {
+        node.bgcolor = adjustColor(old_bgcolor, adjustments)
       }
 
       // @ts-expect-error fixme ts strict error

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -649,6 +649,8 @@ export class ComfyApp {
       const opacity = useSettingStore().get('Comfy.Node.Opacity')
       if (opacity) adjustments.opacity = opacity
 
+      node.bgcolor = adjustColor(bgColor, adjustments)
+
       if (useColorPaletteStore().completedActivePalette.light_theme) {
         adjustments.lightness = 0.5
 
@@ -657,8 +659,6 @@ export class ComfyApp {
           node.color = adjustColor(old_color, { lightness: 0.5 })
         }
       }
-
-      node.bgcolor = adjustColor(bgColor, adjustments)
 
       // @ts-expect-error fixme ts strict error
       const res = origDrawNode.apply(this, arguments)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -636,12 +636,10 @@ export class ComfyApp {
         this.editor_alpha = 0.4
       }
 
-      let bgColor: string | undefined
+      let bgColor = old_bgcolor
       if (node.mode === LGraphEventMode.BYPASS) {
         bgColor = app.bypassBgColor
         this.editor_alpha = 0.2
-      } else {
-        bgColor = old_bgcolor
       }
 
       const adjustments: ColorAdjustOptions = {}

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -636,12 +636,12 @@ export class ComfyApp {
         this.editor_alpha = 0.4
       }
 
-      let bgColor: string
+      let bgColor: string | undefined
       if (node.mode === LGraphEventMode.BYPASS) {
         bgColor = app.bypassBgColor
         this.editor_alpha = 0.2
       } else {
-        bgColor = old_bgcolor || LiteGraph.NODE_DEFAULT_BGCOLOR
+        bgColor = old_bgcolor
       }
 
       const adjustments: ColorAdjustOptions = {}
@@ -658,8 +658,8 @@ export class ComfyApp {
         }
       }
 
-      if (old_bgcolor) {
-        node.bgcolor = adjustColor(old_bgcolor, adjustments)
+      if (bgColor) {
+        node.bgcolor = adjustColor(bgColor, adjustments)
       }
 
       // @ts-expect-error fixme ts strict error

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -650,7 +650,7 @@ export class ComfyApp {
       if (opacity) adjustments.opacity = opacity
 
       if (useColorPaletteStore().completedActivePalette.light_theme) {
-        adjustments.lightness = 0.5
+        if (old_bgcolor) adjustments.lightness = 0.5
 
         // Lighten title bar of colored nodes on light theme
         if (old_color) {


### PR DESCRIPTION
## Summary

Fixes an issue where the background of nodes which have no background explicitly configured were being lightened by the light_theme palette flag - when they should be skipped (default colour is explicitly set by the palette, therefore should already be light).

Went unnoticed because the only theme using this was the built-in light theme, which used white for node backgrounds anyway.

- Resolves a regression in "bypass", which in light mode, is currently an extremely transparent white (slightly _more_ transparent than muted nodes).

## Review Focus

- Resolves #5557

N.B. This will impact anyone who explicitly made their own light_theme: true theme, and _intentionally_ reduced lightness of their desired end colour by 50%.

I sincerely hope that the number of affected users very closely resembles "0".  Either way, I do not feel that the impact warrants gating this fix behind a new option.

## Screenshots (if applicable)

### Solarized (light_theme: undefined)

Two nodes with colours explicitly set (should change when light_theme: true).  Others default solarize.

<img width="1042" height="553" alt="image" src="https://github.com/user-attachments/assets/9727333b-33d7-4932-b118-3e6051435fae" />

### Current (light_theme: true)

<img width="1066" height="552" alt="image" src="https://github.com/user-attachments/assets/1449418e-3abb-4f0d-b6a7-4050817a5b74" />

### Original Proposed (light_theme: true)

<details>
<summary>
Old screenshot - caused issues with opacity
</summary>

This caused test failures due to theme opacity not being respected.

<img width="1045" height="549" alt="image" src="https://github.com/user-attachments/assets/a8f3da52-8227-45a1-838e-9a894fed8527" />

</details>

### Proposed (light_theme: true)

- First row: Purple node, blue node, muted node
- Second row: Bypassed node
- Third row: Normal node

<img width="1180" height="823" alt="image" src="https://github.com/user-attachments/assets/566441dc-20c1-435c-8d1b-560289adc5ca" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5562-Fix-light_theme-changes-default-node-background-26e6d73d3650814b90f3f7ad39d36057) by [Unito](https://www.unito.io)