### PR TITLE
Desktop: Add terminal context menu (text)

### DIFF
--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
@@ -30,9 +30,7 @@ if (isElectron()) {
   useEventListener(terminalEl, 'contextmenu', showContextMenu)
 }
 
-onUnmounted(() => {
-  emit('unmounted')
-})
+onUnmounted(() => emit('unmounted'))
 </script>
 
 <style scoped>

--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
@@ -7,9 +7,10 @@
 </template>
 
 <script setup lang="ts">
-import { Ref, onUnmounted, ref } from 'vue'
+import { Ref, onMounted, onUnmounted, ref } from 'vue'
 
 import { useTerminal } from '@/composables/bottomPanelTabs/useTerminal'
+import { electronAPI, isElectron } from '@/utils/envUtil'
 
 const emit = defineEmits<{
   created: [ReturnType<typeof useTerminal>, Ref<HTMLElement | undefined>]
@@ -19,7 +20,23 @@ const terminalEl = ref<HTMLElement | undefined>()
 const rootEl = ref<HTMLElement | undefined>()
 emit('created', useTerminal(terminalEl), rootEl)
 
-onUnmounted(() => emit('unmounted'))
+const showContextMenu = (event: MouseEvent) => {
+  event.preventDefault()
+  electronAPI()?.showContextMenu({ type: 'text' })
+}
+
+onMounted(() => {
+  if (isElectron() && terminalEl.value) {
+    terminalEl.value.addEventListener('contextmenu', showContextMenu)
+  }
+})
+
+onUnmounted(() => {
+  if (isElectron() && terminalEl.value) {
+    terminalEl.value.removeEventListener('contextmenu', showContextMenu)
+  }
+  emit('unmounted')
+})
 </script>
 
 <style scoped>

--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
@@ -8,7 +8,7 @@
 
 <script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
-import { Ref, ref } from 'vue'
+import { Ref, onUnmounted, ref } from 'vue'
 
 import { useTerminal } from '@/composables/bottomPanelTabs/useTerminal'
 import { electronAPI, isElectron } from '@/utils/envUtil'
@@ -30,7 +30,9 @@ if (isElectron()) {
   useEventListener(terminalEl, 'contextmenu', showContextMenu)
 }
 
-emit('unmounted')
+onUnmounted(() => {
+  emit('unmounted')
+})
 </script>
 
 <style scoped>

--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.vue
@@ -7,7 +7,8 @@
 </template>
 
 <script setup lang="ts">
-import { Ref, onMounted, onUnmounted, ref } from 'vue'
+import { useEventListener } from '@vueuse/core'
+import { Ref, ref } from 'vue'
 
 import { useTerminal } from '@/composables/bottomPanelTabs/useTerminal'
 import { electronAPI, isElectron } from '@/utils/envUtil'
@@ -25,18 +26,11 @@ const showContextMenu = (event: MouseEvent) => {
   electronAPI()?.showContextMenu({ type: 'text' })
 }
 
-onMounted(() => {
-  if (isElectron() && terminalEl.value) {
-    terminalEl.value.addEventListener('contextmenu', showContextMenu)
-  }
-})
+if (isElectron()) {
+  useEventListener(terminalEl, 'contextmenu', showContextMenu)
+}
 
-onUnmounted(() => {
-  if (isElectron() && terminalEl.value) {
-    terminalEl.value.removeEventListener('contextmenu', showContextMenu)
-  }
-  emit('unmounted')
-})
+emit('unmounted')
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Enable single right-click context menu in BaseTerminal for desktop app users.  Previously required two _consecutive_ right clicks - moving the pointer would reset the count.

## Screenshots (if applicable)

<img width="437" height="272" alt="image" src="https://github.com/user-attachments/assets/3c886f32-6938-4dee-a9b1-877372e4cd7c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5563-Desktop-Add-terminal-context-menu-text-26f6d73d365081cd9455d027cd78f406) by [Unito](https://www.unito.io)
