### PR TITLE
[feat] Add skeleton loading states to cloud onboarding flow

### DIFF
--- a/src/platform/onboarding/cloud/InviteCheckView.vue
+++ b/src/platform/onboarding/cloud/InviteCheckView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div />
+  <CloudClaimInviteViewSkeleton />
 </template>
 
 <script setup lang="ts">
@@ -7,6 +7,8 @@ import { nextTick, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { getInviteCodeStatus } from '@/api/auth'
+
+import CloudClaimInviteViewSkeleton from './skeletons/CloudClaimInviteViewSkeleton.vue'
 
 const router = useRouter()
 const route = useRoute()

--- a/src/platform/onboarding/cloud/skeletons/CloudClaimInviteViewSkeleton.vue
+++ b/src/platform/onboarding/cloud/skeletons/CloudClaimInviteViewSkeleton.vue
@@ -1,0 +1,12 @@
+<template>
+  <div
+    class="flex flex-col justify-center items-center h-screen font-mono text-black gap-4"
+  >
+    <Skeleton width="60%" height="2rem" />
+    <Skeleton width="30%" height="2.5rem" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import Skeleton from 'primevue/skeleton'
+</script>

--- a/src/platform/onboarding/cloud/skeletons/CloudLoginViewSkeleton.vue
+++ b/src/platform/onboarding/cloud/skeletons/CloudLoginViewSkeleton.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="h-full flex items-center justify-center p-8">
+    <div class="w-96 p-2">
+      <div class="bg-[#2d2e32] p-4 rounded-lg">
+        <Skeleton width="60%" height="1.125rem" class="mb-2" />
+        <Skeleton width="90%" height="1rem" class="mb-2" />
+        <Skeleton width="80%" height="1rem" />
+      </div>
+
+      <div class="flex flex-col gap-4 mt-6 mb-8">
+        <Skeleton width="45%" height="1.5rem" class="my-0" />
+        <div class="flex items-center">
+          <Skeleton width="25%" height="1rem" class="mr-1" />
+          <Skeleton width="20%" height="1rem" />
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <Skeleton width="20%" height="1rem" class="mb-2" />
+        <Skeleton width="100%" height="2.5rem" class="mb-4" />
+        <Skeleton width="25%" height="1rem" class="mb-4" />
+        <Skeleton width="100%" height="2.5rem" class="mb-6" />
+        <Skeleton width="80%" height="1rem" class="mb-4" />
+        <Skeleton width="100%" height="2.5rem" />
+      </div>
+
+      <div class="flex items-center my-8">
+        <div class="flex-1 border-t border-gray-300"></div>
+        <Skeleton width="30%" height="1rem" class="mx-4" />
+        <div class="flex-1 border-t border-gray-300"></div>
+      </div>
+
+      <div class="flex flex-col gap-6">
+        <Skeleton width="100%" height="2.5rem" />
+        <Skeleton width="100%" height="2.5rem" />
+      </div>
+
+      <div class="mt-5">
+        <Skeleton width="70%" height="0.875rem" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Skeleton from 'primevue/skeleton'
+</script>

--- a/src/platform/onboarding/cloud/skeletons/CloudSurveyViewSkeleton.vue
+++ b/src/platform/onboarding/cloud/skeletons/CloudSurveyViewSkeleton.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <div class="flex flex-col min-h-[638px] min-w-[320px]">
+      <Skeleton width="100%" height="0.5rem" class="mb-8" />
+
+      <div class="p-0 flex-1 flex flex-col">
+        <div class="flex-1 min-h-full flex flex-col justify-between">
+          <div>
+            <Skeleton width="70%" height="1.75rem" class="mb-8" />
+            <div class="flex flex-col gap-6">
+              <div v-for="i in 5" :key="i" class="flex items-center gap-3">
+                <Skeleton width="1.25rem" height="1.25rem" shape="circle" />
+                <Skeleton width="85%" height="0.875rem" />
+              </div>
+            </div>
+          </div>
+
+          <div class="flex justify-between pt-4">
+            <span />
+            <Skeleton width="100%" height="2.5rem" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Skeleton from 'primevue/skeleton'
+</script>

--- a/src/platform/onboarding/cloud/skeletons/CloudWaitlistViewSkeleton.vue
+++ b/src/platform/onboarding/cloud/skeletons/CloudWaitlistViewSkeleton.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="flex flex-col items-center justify-center p-8">
+    <div class="w-full max-w-md text-center">
+      <div class="mb-8">
+        <Skeleton width="80%" height="3rem" class="mb-2 mx-auto" />
+        <Skeleton width="60%" height="3rem" class="mx-auto" />
+      </div>
+      <div class="max-w-[320px] mx-auto">
+        <div class="mb-4">
+          <Skeleton width="90%" height="1.5rem" class="mb-2 mx-auto" />
+          <Skeleton width="70%" height="1.5rem" class="mx-auto" />
+        </div>
+        <div>
+          <Skeleton width="80%" height="1.5rem" class="mb-2 mx-auto" />
+          <div class="flex justify-center items-center gap-2">
+            <Skeleton width="20%" height="1.5rem" />
+            <Skeleton width="15%" height="1.5rem" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Skeleton from 'primevue/skeleton'
+</script>


### PR DESCRIPTION
Added progressive skeleton loading states throughout cloud onboarding flow with dedicated skeleton components that match exact layouts of destination views.

Progressive flow: simple loading → survey skeleton while checking survey status → waitlist skeleton while checking user activation → redirect to appropriate destination.

Created CloudLoginViewSkeleton, CloudSurveyViewSkeleton, CloudClaimInviteViewSkeleton, and CloudWaitlistViewSkeleton components. Updated UserCheckView and InviteCheckView to show contextual skeletons based on API response flow.

Uses PrimeVue Skeleton components and preserves all original code structure from upstream authors.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5568-feat-Add-skeleton-loading-states-to-cloud-onboarding-flow-26f6d73d3650813e8c79ca74404cfbde) by [Unito](https://www.unito.io)
