### PR TITLE
[refactor] Deduplicate download functionality in useImageMenuOptions

### DIFF
--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -1,5 +1,6 @@
 import { useI18n } from 'vue-i18n'
 
+import { downloadFile } from '@/base/common/downloadUtil'
 import { useCommandStore } from '@/stores/commandStore'
 
 import type { MenuOption } from './useMoreOptionsMenu'
@@ -69,22 +70,7 @@ export function useImageMenuOptions() {
     try {
       const url = new URL(img.src)
       url.searchParams.delete('preview')
-
-      const a = document.createElement('a')
-      a.href = url.toString()
-      a.setAttribute(
-        'download',
-        new URLSearchParams(url.search).get('filename') ?? 'image.png'
-      )
-      a.style.display = 'none'
-      document.body.appendChild(a)
-      a.click()
-
-      requestAnimationFrame(() => {
-        if (document.body.contains(a)) {
-          document.body.removeChild(a)
-        }
-      })
+      downloadFile(url.toString())
     } catch (error) {
       console.error('Failed to save image:', error)
     }


### PR DESCRIPTION
## Summary

Replace duplicated download implementation with existing downloadFile utility to reduce code duplication.

## Changes

- **What**: Import and use downloadFile from downloadUtil instead of duplicating anchor element logic
- **Dependencies**: None

## Review Focus

No breaking changes - identical functionality maintained with existing test coverage.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5569-refactor-Deduplicate-download-functionality-in-useImageMenuOptions-26f6d73d3650810a946ae372ceee9b4e) by [Unito](https://www.unito.io)
