### PR TITLE
[feat] Redirect to login page after logout on cloud domains

### DIFF
--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -1,5 +1,6 @@
 import { FirebaseError } from 'firebase/app'
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
@@ -15,6 +16,7 @@ import { usdToMicros } from '@/utils/formatUtil'
 export const useFirebaseAuthActions = () => {
   const authStore = useFirebaseAuthStore()
   const toastStore = useToastStore()
+  const router = useRouter()
   const { wrapWithErrorHandlingAsync, toastErrorHandler } = useErrorHandling()
 
   const accessError = ref(false)
@@ -51,6 +53,12 @@ export const useFirebaseAuthActions = () => {
       detail: t('auth.signOut.successDetail'),
       life: 5000
     })
+
+    // Redirect to login page if we're on cloud domain
+    const hostname = window.location.hostname
+    if (hostname.includes('cloud.comfy.org')) {
+      await router.push({ name: 'cloud-login' })
+    }
   }, reportError)
 
   const sendPasswordReset = wrapWithErrorHandlingAsync(


### PR DESCRIPTION
Adds automatic redirect to cloud-login page after successful logout when on cloud domains.

Currently after logout, users stay on the current page in a logged-out state. This change ensures users are redirected to the login page after logout on cloud domains (cloud.comfy.org and stagingcloud.comfy.org).

Preserves existing toast notification and error handling behavior.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5570-feat-Redirect-to-login-page-after-logout-on-cloud-domains-26f6d73d3650816d8334c23098974b83) by [Unito](https://www.unito.io)
