### PR TITLE
fix: Set Vue node initial size in layout store instead of CSS

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -961,9 +961,7 @@ audio.comfy-audio.empty-audio-widget {
   /* Uses default styling - no overrides needed */
 }
 
-/* Smooth transitions between LOD levels */
 .lg-node {
-  transition: min-height 0.2s ease;
   /* Disable text selection on all nodes */
   user-select: none;
   -webkit-user-select: none;

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -8,7 +8,6 @@
     :class="
       cn(
         'bg-white dark-theme:bg-charcoal-100',
-        'min-w-[445px]',
         'lg-node absolute rounded-2xl',
         // border
         'border border-solid border-sand-100 dark-theme:border-charcoal-300',
@@ -131,6 +130,7 @@ import {
   computed,
   inject,
   onErrorCaptured,
+  onMounted,
   provide,
   ref,
   toRef,
@@ -196,6 +196,21 @@ if (!selectedNodeIds) {
   )
 }
 
+// Inject transform state for coordinate conversion
+const transformState = inject('transformState') as
+  | {
+      camera: { z: number }
+      canvasToScreen: (point: { x: number; y: number }) => {
+        x: number
+        y: number
+      }
+      screenToCanvas: (point: { x: number; y: number }) => {
+        x: number
+        y: number
+      }
+    }
+  | undefined
+
 // Computed selection state - only this node re-evaluates when its selection changes
 const isSelected = computed(() => {
   return selectedNodeIds.value.has(props.nodeData.id)
@@ -213,6 +228,17 @@ const {
   shouldRenderContent,
   lodCssClass
 } = useLOD(zoomRef)
+
+onMounted(() => {
+  if (props.size && transformState) {
+    const scale = transformState.camera.z
+    const screenSize = {
+      width: props.size.width * scale,
+      height: props.size.height * scale
+    }
+    resize(screenSize)
+  }
+})
 
 // Computed properties for template usage
 const isMinimalLOD = computed(() => lodLevel.value === LODLevel.MINIMAL)
@@ -233,7 +259,8 @@ const {
   zIndex,
   startDrag,
   handleDrag: handleLayoutDrag,
-  endDrag
+  endDrag,
+  resize
 } = useNodeLayout(props.nodeData.id)
 
 // Drag state for styling
@@ -379,3 +406,5 @@ watch(
 // Provide nodeImageUrls to child components
 provide('nodeImageUrls', nodeImageUrls)
 </script>
+
+<style scoped></style>

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -406,5 +406,3 @@ watch(
 // Provide nodeImageUrls to child components
 provide('nodeImageUrls', nodeImageUrls)
 </script>
-
-<style scoped></style>

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -248,17 +248,6 @@ const {
   lodCssClass
 } = useLOD(zoomRef)
 
-onMounted(() => {
-  if (size && transformState) {
-    const scale = transformState.camera.z
-    const screenSize = {
-      width: size.width * scale,
-      height: size.height * scale
-    }
-    resize(screenSize)
-  }
-})
-
 // Computed properties for template usage
 const isMinimalLOD = computed(() => lodLevel.value === LODLevel.MINIMAL)
 


### PR DESCRIPTION
## Summary
- Vue nodes now properly set their initial size in the layout store using the `resize()` function from `useNodeLayout` on component mount
- Ensures the layout store is the single source of truth for sizing, preventing conflicts with the ResizeObserver
- Removes CSS-based initial sizing approach that was causing feedback loops

## Problem
Vue nodes were experiencing sizing issues where they would shrink to minimal size after user interaction. This was caused by:

1. Initial size set via CSS custom properties
2. ResizeObserver detecting actual DOM size and updating layout store
3. Layout store overriding the CSS sizing, creating a feedback loop
4. After interaction, nodes would shrink because ResizeObserver measurements took precedence over initial sizing

## Solution
Set the initial size directly in the layout store on component mount using the existing `resize()` function from `useNodeLayout`. This approach:

- Makes the layout store the authoritative source for sizing
- Eliminates conflicts between CSS sizing and ResizeObserver updates  
- Allows ResizeObserver to properly track content-driven size changes
- Maintains consistent sizing behavior after user interactions

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5571-fix-Set-Vue-node-initial-size-in-layout-store-instead-of-CSS-26f6d73d365081979548c0527bda6adf) by [Unito](https://www.unito.io)
