### PR TITLE
feat: add error handling and timeout recovery to cloud onboarding

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1806,6 +1806,14 @@
       "learnAboutButton": "Learn about Cloud",
       "wantToRun": "Want to run comfyUI locally instead?",
       "download": "Download ComfyUI"
+    },
+    "checkingStatus": "Checking your account status...",
+    "retrying": "Retrying...",
+    "retry": "Try Again",
+    "authTimeout": {
+      "title": "Connection Taking Too Long",
+      "message": "We're having trouble connecting to ComfyUI Cloud. This could be due to a slow connection or temporary service issue.",
+      "restart": "Sign Out & Try Again"
     }
   }
 }

--- a/src/onboardingCloudRoutes.ts
+++ b/src/onboardingCloudRoutes.ts
@@ -70,6 +70,12 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         name: 'cloud-sorry-contact-support',
         component: () =>
           import('@/platform/onboarding/cloud/CloudSorryContactSupportView.vue')
+      },
+      {
+        path: 'auth-timeout',
+        name: 'cloud-auth-timeout',
+        component: () =>
+          import('@/platform/onboarding/cloud/CloudAuthTimeoutView.vue')
       }
     ]
   }

--- a/src/platform/onboarding/cloud/CloudAuthTimeoutView.vue
+++ b/src/platform/onboarding/cloud/CloudAuthTimeoutView.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="h-full flex items-center justify-center p-8">
+    <div class="w-96 text-center">
+      <h2 class="text-xl mb-4">
+        {{ $t('cloudOnboarding.authTimeout.title') }}
+      </h2>
+      <p class="mb-6 text-gray-600">
+        {{ $t('cloudOnboarding.authTimeout.message') }}
+      </p>
+
+      <div class="flex flex-col gap-3">
+        <Button
+          :label="$t('cloudOnboarding.authTimeout.restart')"
+          class="w-full"
+          @click="handleRestart"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { useRouter } from 'vue-router'
+
+import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
+
+const router = useRouter()
+const { logout } = useFirebaseAuthActions()
+
+const handleRestart = async () => {
+  await logout()
+  await router.replace({ name: 'cloud-login' })
+}
+</script>


### PR DESCRIPTION
Implements robust error handling and authentication timeout recovery for the cloud onboarding flow.

Prevents users from getting stuck on loading screens during network issues or API failures by adding comprehensive error handling with retry mechanisms and user-friendly recovery options.

## Changes
- Enhanced UserCheckView with VueUse useAsyncState for declarative error handling
- Added parallel API calls for better performance using Promise.all  
- Implemented loading states with ProgressSpinner and user-friendly error messages
- Added authentication timeout handling (16s) with recovery options
- Created CloudAuthTimeoutView with "Sign Out & Try Again" functionality
- Added comprehensive i18n support for error states

<img width="3806" height="2017" alt="Selection_2182" src="https://github.com/user-attachments/assets/bfacc517-150e-4009-a4c0-f3c049d04b9e" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5573-feat-add-error-handling-and-timeout-recovery-to-cloud-onboarding-26f6d73d3650816faf9ec63dcf436b8f) by [Unito](https://www.unito.io)
