### PR TITLE
[refactor] Add DDD refactor commits to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,21 @@ c53f197de2a3e0fa66b16dedc65c131235c1c4b6
 
 # Reorganize renderer components into domain-driven folder structure
 c8a83a9caede7bdb5f8598c5492b07d08c339d49
+
+# Domain-driven design (DDD) refactors - September 2025
+# These commits reorganized the codebase into domain-driven architecture
+
+# [refactor] Improve renderer domain organization (#5552)
+6349ceee6
+
+# [refactor] Improve settings domain organization (#5550)  
+4c8c4a1ad
+
+# [refactor] Improve workflow domain organization (#5584)
+ca312fd1e
+
+# [refactor] Move thumbnail functionality to renderer/core domain (#5586)
+e3bb29ceb
+
+# [refactor] Improve updates/notifications domain organization (#5590)
+27ab355f9

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,16 +12,16 @@ c8a83a9caede7bdb5f8598c5492b07d08c339d49
 # These commits reorganized the codebase into domain-driven architecture
 
 # [refactor] Improve renderer domain organization (#5552)
-6349ceee6
+6349ceee6c0a57fc7992e85635def9b6e22eaeb2
 
 # [refactor] Improve settings domain organization (#5550)  
-4c8c4a1ad
+4c8c4a1ad4f53354f700a33ea1b95262aeda2719
 
 # [refactor] Improve workflow domain organization (#5584)
-ca312fd1e
+ca312fd1eab540cc4ddc0e3d244d38b3858574f0
 
 # [refactor] Move thumbnail functionality to renderer/core domain (#5586)
-e3bb29ceb
+e3bb29ceb8174b8bbca9e48ec7d42cd540f40efa
 
 # [refactor] Improve updates/notifications domain organization (#5590)
-27ab355f9
+27ab355f9c73415dc39f4d3f512b02308f847801


### PR DESCRIPTION
## Summary

Add recent domain-driven design refactor commits to `.git-blame-ignore-revs` to improve git blame output by excluding large structural reorganizations.

## What this does

When running `git blame`, these commits will be automatically ignored, allowing blame to show the actual logic changes rather than when files were moved during DDD refactoring.

## Added commits

- **6349ceee6** [refactor] Improve renderer domain organization (#5552)
- **4c8c4a1ad** [refactor] Improve settings domain organization (#5550)  
- **ca312fd1e** [refactor] Improve workflow domain organization (#5584)
- **e3bb29ceb** [refactor] Move thumbnail functionality to renderer/core domain (#5586)
- **27ab355f9** [refactor] Improve updates/notifications domain organization (#5590)


After merge, developers can use `git blame --ignore-revs-file=.git-blame-ignore-revs` or configure git to use this file automatically.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5591-refactor-Add-DDD-refactor-commits-to-git-blame-ignore-revs-26f6d73d365081b58922eee87b7286fb) by [Unito](https://www.unito.io)
