### PR TITLE
Feat: Bypass styling for Vue nodes

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -99,6 +99,7 @@
   --color-danger-100: #c02323;
   --color-danger-200: #d62952;
 
+  --color-bypass: #6A246A;
   --color-error: #962a2a;
 
   --color-blue-selection: rgb( from var(--color-blue-100) r g b / 0.3); 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -9,18 +9,11 @@
       cn(
         'bg-white dark-theme:bg-charcoal-100',
         'lg-node absolute rounded-2xl',
-        // border
         'border border-solid border-sand-100 dark-theme:border-charcoal-300',
-        !!executing && 'border-blue-100 dark-theme:border-blue-100',
-        hasAnyError && 'border-error',
-        // hover
         'hover:ring-7 ring-gray-500/50 dark-theme:ring-gray-500/20',
-        // Selected
         'outline-transparent -outline-offset-2 outline-2',
-        !!isSelected && 'outline-black dark-theme:outline-white',
-        !!(isSelected && executing) &&
-          'outline-blue-100 dark-theme:outline-blue-100',
-        isSelected && hasAnyError && 'outline-error',
+        borderClass,
+        outlineClass,
         {
           'animate-pulse': executing,
           'opacity-50': nodeData.mode === 4,
@@ -324,6 +317,29 @@ const shouldShowWidgets = computed(
 const shouldShowContent = computed(
   () => shouldRenderContent.value && hasCustomContent.value
 )
+
+const borderClass = computed(() => {
+  if (hasAnyError.value) {
+    return 'border-error'
+  }
+  if (executing.value) {
+    return 'border-blue-500'
+  }
+  return undefined
+})
+
+const outlineClass = computed(() => {
+  if (!isSelected.value) {
+    return undefined
+  }
+  if (hasAnyError.value) {
+    return 'outline-error'
+  }
+  if (executing.value) {
+    return 'outline-blue-500'
+  }
+  return 'outline-black dark-theme:outline-white'
+})
 
 // Event handlers
 const handlePointerDown = (event: PointerEvent) => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -16,7 +16,8 @@
         outlineClass,
         {
           'animate-pulse': executing,
-          'opacity-50': nodeData.mode === 4,
+          'opacity-50 before:rounded-2xl before:pointer-events-none before:absolute before:bg-bypass/60 before:inset-0':
+            bypassed,
           'will-change-transform': isDragging
         },
         lodCssClass,
@@ -230,6 +231,8 @@ const hasExecutionError = computed(
 const hasAnyError = computed(
   (): boolean => !!(hasExecutionError.value || nodeData.hasErrors || error)
 )
+
+const bypassed = computed((): boolean => nodeData.mode === 4)
 
 // LOD (Level of Detail) system based on zoom level
 const zoomRef = toRef(() => zoomLevel)


### PR DESCRIPTION
## Summary

Add the lovely magenta coloring to bypassed nodes.

## Review Focus

How does it look?

## Screenshots (if applicable)

<img width="1401" height="820" alt="image" src="https://github.com/user-attachments/assets/ee0f2ce7-2745-46a0-b14d-2df8529b00b2" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5593-Feat-Bypass-styling-for-Vue-nodes-26f6d73d365081febeeed80bdad466c2) by [Unito](https://www.unito.io)
