### PR TITLE
Fix context menu creating nodes in wrong position

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6316,10 +6316,9 @@ export class LGraphCanvas
         // that.graph.beforeChange();
         const xSizeFix = opts.posSizeFix[0] * LiteGraph.NODE_WIDTH
         const ySizeFix = opts.posSizeFix[1] * LiteGraph.NODE_SLOT_HEIGHT
-        const pos = [
-          opts.position[0] + opts.posAdd[0] + xSizeFix,
-          opts.position[1] + opts.posAdd[1] + ySizeFix
-        ]
+        const nodeX = opts.position[0] + opts.posAdd[0] + xSizeFix
+        const nodeY = opts.position[1] + opts.posAdd[1] + ySizeFix
+        const pos = [nodeX, nodeY]
         const newNode = LiteGraph.createNode(nodeNewType, nodeNewOpts.title, {
           pos
         })

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6314,7 +6314,21 @@ export class LGraphCanvas
         }
 
         // that.graph.beforeChange();
-        const newNode = LiteGraph.createNode(nodeNewType)
+        const pos = [
+          opts.position[0] +
+            opts.posAdd[0] +
+            (opts.posSizeFix[0]
+              ? opts.posSizeFix[0] * LiteGraph.NODE_WIDTH
+              : 0),
+          opts.position[1] +
+            opts.posAdd[1] +
+            (opts.posSizeFix[1]
+              ? opts.posSizeFix[1] * LiteGraph.NODE_SLOT_HEIGHT
+              : 0)
+        ]
+        const newNode = LiteGraph.createNode(nodeNewType, nodeNewOpts.title, {
+          pos
+        })
         if (newNode) {
           // if is object pass options
           if (nodeNewOpts) {
@@ -6341,9 +6355,6 @@ export class LGraphCanvas
                 )
               }
             }
-            if (nodeNewOpts.title) {
-              newNode.title = nodeNewOpts.title
-            }
             if (nodeNewOpts.json) {
               newNode.configure(nodeNewOpts.json)
             }
@@ -6353,14 +6364,6 @@ export class LGraphCanvas
           if (!this.graph) throw new NullGraphError()
 
           this.graph.add(newNode)
-          newNode.pos = [
-            opts.position[0] +
-              opts.posAdd[0] +
-              (opts.posSizeFix[0] ? opts.posSizeFix[0] * newNode.size[0] : 0),
-            opts.position[1] +
-              opts.posAdd[1] +
-              (opts.posSizeFix[1] ? opts.posSizeFix[1] * newNode.size[1] : 0)
-          ]
 
           // Interim API - allow the link connection to be canceled.
           // TODO: https://github.com/Comfy-Org/litegraph.js/issues/946

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6314,17 +6314,11 @@ export class LGraphCanvas
         }
 
         // that.graph.beforeChange();
+        const xSizeFix = opts.posSizeFix[0] * LiteGraph.NODE_WIDTH
+        const ySizeFix = opts.posSizeFix[1] * LiteGraph.NODE_SLOT_HEIGHT
         const pos = [
-          opts.position[0] +
-            opts.posAdd[0] +
-            (opts.posSizeFix[0]
-              ? opts.posSizeFix[0] * LiteGraph.NODE_WIDTH
-              : 0),
-          opts.position[1] +
-            opts.posAdd[1] +
-            (opts.posSizeFix[1]
-              ? opts.posSizeFix[1] * LiteGraph.NODE_SLOT_HEIGHT
-              : 0)
+          opts.position[0] + opts.posAdd[0] + xSizeFix,
+          opts.position[1] + opts.posAdd[1] + ySizeFix
         ]
         const newNode = LiteGraph.createNode(nodeNewType, nodeNewOpts.title, {
           pos


### PR DESCRIPTION
When nodes are created from the context menu, they previously had there position set immediately after the node itself was created. Under some circumstances, this new position would be overwritten by the layout store.

This is solved by setting the position before node initialization. As an unfortunate caveat, it means the functionality for positioning nodes created by middle-clicking a slot can no longer use the actual size of the node after it's been created. Because this is always a reroute node, these values are easily determined in advance.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5595-Fix-context-menu-creating-nodes-in-wrong-position-26f6d73d36508158b633df3bebda0373) by [Unito](https://www.unito.io)
