### PR TITLE
feat: Let mode changes trigger a re-render for Vue nodes

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -806,7 +806,6 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
               })
               break
             case 'mode':
-              console.log('Do the thing')
               vueNodeData.set(nodeId, {
                 ...currentData,
                 mode: typeof event.newValue === 'number' ? event.newValue : 0

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -789,19 +789,28 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
         const currentData = vueNodeData.get(nodeId)
 
         if (currentData) {
-          if (event.property === 'title') {
-            vueNodeData.set(nodeId, {
-              ...currentData,
-              title: String(event.newValue)
-            })
-          } else if (event.property === 'flags.collapsed') {
-            vueNodeData.set(nodeId, {
-              ...currentData,
-              flags: {
-                ...currentData.flags,
-                collapsed: Boolean(event.newValue)
-              }
-            })
+          switch (event.property) {
+            case 'title':
+              vueNodeData.set(nodeId, {
+                ...currentData,
+                title: String(event.newValue)
+              })
+              break
+            case 'flags.collapsed':
+              vueNodeData.set(nodeId, {
+                ...currentData,
+                flags: {
+                  ...currentData.flags,
+                  collapsed: Boolean(event.newValue)
+                }
+              })
+              break
+            case 'mode':
+              console.log('Do the thing')
+              vueNodeData.set(nodeId, {
+                ...currentData,
+                mode: typeof event.newValue === 'number' ? event.newValue : 0
+              })
           }
         }
       }

--- a/src/lib/litegraph/src/LGraphNodeProperties.ts
+++ b/src/lib/litegraph/src/LGraphNodeProperties.ts
@@ -3,7 +3,11 @@ import type { LGraphNode } from './LGraphNode'
 /**
  * Default properties to track
  */
-const DEFAULT_TRACKED_PROPERTIES: string[] = ['title', 'flags.collapsed']
+const DEFAULT_TRACKED_PROPERTIES: string[] = [
+  'title',
+  'flags.collapsed',
+  'mode'
+]
 
 /**
  * Manages node properties with optional change tracking and instrumentation.


### PR DESCRIPTION
## Summary

Instrument mode to trigger node data updates.

## Changes

- **What**: Makes bypass/mute work immediately on the Vue nodes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5599-feat-Let-mode-changes-trigger-a-re-render-for-Vue-nodes-26f6d73d365081dca306dd4a1523dbb3) by [Unito](https://www.unito.io)
