### PR TITLE
ci(tests-ui): unpin ComfyUI_devtools in test-ui

### DIFF
--- a/.github/workflows/i18n-custom-nodes.yaml
+++ b/.github/workflows/i18n-custom-nodes.yaml
@@ -37,6 +37,7 @@ jobs:
       with:
         repository: Comfy-Org/ComfyUI_devtools
         path: ComfyUI/custom_nodes/ComfyUI_devtools
+        ref: a92e8ae968830671846eb1da2ae43130eebbee3c
     - name: Checkout custom node repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/i18n-custom-nodes.yaml
+++ b/.github/workflows/i18n-custom-nodes.yaml
@@ -37,7 +37,6 @@ jobs:
       with:
         repository: Comfy-Org/ComfyUI_devtools
         path: ComfyUI/custom_nodes/ComfyUI_devtools
-        ref: a92e8ae968830671846eb1da2ae43130eebbee3c
     - name: Checkout custom node repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: 'Comfy-Org/ComfyUI_devtools'
           path: 'ComfyUI/custom_nodes/ComfyUI_devtools'
-          ref: 'd05fd48dd787a4192e16802d4244cfcc0e2f9684'
+          ref: 'a92e8ae968830671846eb1da2ae43130eebbee3c'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -32,7 +32,6 @@ jobs:
         with:
           repository: 'Comfy-Org/ComfyUI_devtools'
           path: 'ComfyUI/custom_nodes/ComfyUI_devtools'
-          ref: 'a92e8ae968830671846eb1da2ae43130eebbee3c'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Pins ComfyUI_devtools to $SHA so Playwright runs against the latest devtools test nodes.
Updates all workflow locations that checkout devtools.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5600-ci-tests-ui-pin-ComfyUI_devtools-to-a92e-26f6d73d3650816780e5e5d09ebea116) by [Unito](https://www.unito.io)
