### PR TITLE
Fix FE types publishing workflow

### DIFF
--- a/.github/workflows/publish-frontend-types.yaml
+++ b/.github/workflows/publish-frontend-types.yaml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Build types
         run: pnpm build:types
@@ -131,7 +133,7 @@ jobs:
 
       - name: Publish package
         if: steps.check_npm.outputs.exists == 'false'
-        run: pnpm publish --access public --tag "${{ inputs.dist_tag }}"
+        run: pnpm publish --access public --tag "${{ inputs.dist_tag }}" --no-git-checks
         working-directory: dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes FE types publishing workflow because it wanted to publish from master/main default but we allowed postmortem publishing, RC branch publishing, and just generally whatever hash publishing

Also stops from automatically downloading playwright browsers since they're not needed.

## Changes

- **What**:  Adds --no-git-checks and PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5602-Fix-FE-types-publishing-workflow-26f6d73d3650815cba39e3142072f294) by [Unito](https://www.unito.io)
