### PR TITLE
[refactor] Solve circular dependency in LiteGraph module

### DIFF
--- a/src/lib/litegraph/src/ContextMenu.ts
+++ b/src/lib/litegraph/src/ContextMenu.ts
@@ -1,9 +1,9 @@
+import { LiteGraphInternal } from './LiteGraphInternal'
 import type {
   ContextMenuDivElement,
   IContextMenuOptions,
   IContextMenuValue
 } from './interfaces'
-import { LiteGraph } from './litegraph'
 
 // TODO: Replace this pattern with something more modern.
 export interface ContextMenu<TValue = unknown> {
@@ -182,7 +182,7 @@ export class ContextMenu<TValue = unknown> {
     root.style.left = `${left}px`
     root.style.top = `${top}px`
 
-    if (LiteGraph.context_menu_scaling && options.scale) {
+    if (LiteGraphInternal.context_menu_scaling && options.scale) {
       root.style.transform = `scale(${Math.round(options.scale * 4) * 0.25})`
     }
   }
@@ -355,7 +355,7 @@ export class ContextMenu<TValue = unknown> {
       ) {
         ContextMenu.trigger(
           this.parentMenu.root,
-          `${LiteGraph.pointerevents_method}leave`,
+          `${LiteGraphInternal.pointerevents_method}leave`,
           e
         )
       }

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -14,6 +14,7 @@ import { LGraphCanvas } from './LGraphCanvas'
 import { LGraphGroup } from './LGraphGroup'
 import { LGraphNode, type NodeId } from './LGraphNode'
 import { LLink, type LinkId } from './LLink'
+import { LiteGraphInternal } from './LiteGraphInternal'
 import { MapProxyHandler } from './MapProxyHandler'
 import { Reroute, type RerouteId } from './Reroute'
 import { CustomEventTarget } from './infrastructure/CustomEventTarget'
@@ -34,7 +35,7 @@ import type {
   Positionable,
   Size
 } from './interfaces'
-import { LiteGraph, SubgraphNode } from './litegraph'
+import { SubgraphNode } from './litegraph'
 import {
   alignOutsideContainer,
   alignToContainer,
@@ -274,7 +275,7 @@ export class LGraph
    * @param o data from previous serialization [optional]
    */
   constructor(o?: ISerialisedGraph | SerialisableGraph) {
-    if (LiteGraph.debug) console.log('Graph created')
+    if (LiteGraphInternal.debug) console.log('Graph created')
 
     /** @see MapProxyHandler */
     const links = this._links
@@ -424,7 +425,7 @@ export class LGraph
     this.sendEventToAllNodes('onStart')
 
     // launch
-    this.starttime = LiteGraph.getTime()
+    this.starttime = LiteGraphInternal.getTime()
     this.last_update_time = this.starttime
     interval ||= 0
 
@@ -486,7 +487,7 @@ export class LGraph
   runStep(num: number, do_not_catch_errors: boolean, limit?: number): void {
     num = num || 1
 
-    const start = LiteGraph.getTime()
+    const start = LiteGraphInternal.getTime()
     this.globaltime = 0.001 * (start - this.starttime)
 
     const nodes = this._nodes_executable || this._nodes
@@ -530,14 +531,15 @@ export class LGraph
         this.errors_in_execution = false
       } catch (error) {
         this.errors_in_execution = true
-        if (LiteGraph.throw_errors) throw error
+        if (LiteGraphInternal.throw_errors) throw error
 
-        if (LiteGraph.debug) console.log('Error during execution:', error)
+        if (LiteGraphInternal.debug)
+          console.log('Error during execution:', error)
         this.stop()
       }
     }
 
-    const now = LiteGraph.getTime()
+    const now = LiteGraphInternal.getTime()
     let elapsed = now - start
     if (elapsed == 0) elapsed = 1
 
@@ -662,7 +664,7 @@ export class LGraph
       L.push(M[i])
     }
 
-    if (L.length != this._nodes.length && LiteGraph.debug)
+    if (L.length != this._nodes.length && LiteGraphInternal.debug)
       console.warn('something went wrong, nodes missing')
 
     /** Ensure type is set */
@@ -718,16 +720,21 @@ export class LGraph
       if (!column) continue
 
       let max_size = 100
-      let y = margin + LiteGraph.NODE_TITLE_HEIGHT
+      let y = margin + LiteGraphInternal.NODE_TITLE_HEIGHT
       for (const node of column) {
-        node.pos[0] = layout == LiteGraph.VERTICAL_LAYOUT ? y : x
-        node.pos[1] = layout == LiteGraph.VERTICAL_LAYOUT ? x : y
-        const max_size_index = layout == LiteGraph.VERTICAL_LAYOUT ? 1 : 0
+        node.pos[0] = layout == LiteGraphInternal.VERTICAL_LAYOUT ? y : x
+        node.pos[1] = layout == LiteGraphInternal.VERTICAL_LAYOUT ? x : y
+        const max_size_index =
+          layout == LiteGraphInternal.VERTICAL_LAYOUT ? 1 : 0
         if (node.size[max_size_index] > max_size) {
           max_size = node.size[max_size_index]
         }
-        const node_size_index = layout == LiteGraph.VERTICAL_LAYOUT ? 0 : 1
-        y += node.size[node_size_index] + margin + LiteGraph.NODE_TITLE_HEIGHT
+        const node_size_index =
+          layout == LiteGraphInternal.VERTICAL_LAYOUT ? 0 : 1
+        y +=
+          node.size[node_size_index] +
+          margin +
+          LiteGraphInternal.NODE_TITLE_HEIGHT
       }
       x += max_size + margin
     }
@@ -831,7 +838,7 @@ export class LGraph
     const { state } = this
 
     // Ensure created items are snapped
-    if (LiteGraph.alwaysSnapToGrid) {
+    if (LiteGraphInternal.alwaysSnapToGrid) {
       const snapTo = this.getSnapToGridSize()
       if (snapTo) node.snapToGrid(snapTo)
     }
@@ -856,16 +863,18 @@ export class LGraph
       console.warn(
         'LiteGraph: there is already a node with this ID, changing it'
       )
-      node.id = LiteGraph.use_uuids ? LiteGraph.uuidv4() : ++state.lastNodeId
+      node.id = LiteGraphInternal.use_uuids
+        ? LiteGraphInternal.uuidv4()
+        : ++state.lastNodeId
     }
 
-    if (this._nodes.length >= LiteGraph.MAX_NUMBER_OF_NODES) {
+    if (this._nodes.length >= LiteGraphInternal.MAX_NUMBER_OF_NODES) {
       throw 'LiteGraph: max number of nodes in a graph reached'
     }
 
     // give him an id
-    if (LiteGraph.use_uuids) {
-      if (node.id == null || node.id == -1) node.id = LiteGraph.uuidv4()
+    if (LiteGraphInternal.use_uuids) {
+      if (node.id == null || node.id == -1) node.id = LiteGraphInternal.uuidv4()
     } else {
       if (node.id == null || node.id == -1) {
         node.id = ++state.lastNodeId
@@ -1128,9 +1137,9 @@ export class LGraph
   /**
    * Snaps the provided items to a grid.
    *
-   * Item positions are reounded to the nearest multiple of {@link LiteGraph.CANVAS_GRID_SIZE}.
+   * Item positions are reounded to the nearest multiple of {@link LiteGraphInternal.CANVAS_GRID_SIZE}.
    *
-   * When {@link LiteGraph.alwaysSnapToGrid} is enabled
+   * When {@link LiteGraphInternal.alwaysSnapToGrid} is enabled
    * and the grid size is falsy, a default of 1 is used.
    * @param items The items to be snapped to the grid
    * @todo Currently only snaps nodes.
@@ -1150,9 +1159,9 @@ export class LGraph
    */
   getSnapToGridSize(): number {
     // Default to 1 when always snapping
-    return LiteGraph.alwaysSnapToGrid
-      ? LiteGraph.CANVAS_GRID_SIZE || 1
-      : LiteGraph.CANVAS_GRID_SIZE
+    return LiteGraphInternal.alwaysSnapToGrid
+      ? LiteGraphInternal.CANVAS_GRID_SIZE || 1
+      : LiteGraphInternal.CANVAS_GRID_SIZE
   }
 
   /**
@@ -1164,11 +1173,11 @@ export class LGraph
   checkNodeTypes() {
     const { _nodes } = this
     for (const [i, node] of _nodes.entries()) {
-      const ctor = LiteGraph.registered_node_types[node.type]
+      const ctor = LiteGraphInternal.registered_node_types[node.type]
       if (node.constructor == ctor) continue
 
       console.log('node being replaced by newer version:', node.type)
-      const newnode = LiteGraph.createNode(node.type)
+      const newnode = LiteGraphInternal.createNode(node.type)
       if (!newnode) continue
       _nodes[i] = newnode
       newnode.configure(node.serialize())
@@ -1229,7 +1238,7 @@ export class LGraph
 
   /* Called when something visually changed (not the graph!) */
   change(): void {
-    if (LiteGraph.debug) {
+    if (LiteGraphInternal.debug) {
       console.log('Graph changed')
     }
     this.canvasAction((c) => c.setDirty(true, true))
@@ -1579,9 +1588,13 @@ export class LGraph
     })
 
     // Create subgraph node object
-    const subgraphNode = LiteGraph.createNode(subgraph.id, subgraph.name, {
-      outputs: structuredClone(outputs)
-    })
+    const subgraphNode = LiteGraphInternal.createNode(
+      subgraph.id,
+      subgraph.name,
+      {
+        outputs: structuredClone(outputs)
+      }
+    )
     if (!subgraphNode) throw new Error('Failed to create subgraph node')
     for (let i = 0; i < inputs.length; i++) {
       Object.assign(subgraphNode.inputs[i], inputs[i])
@@ -1598,7 +1611,7 @@ export class LGraph
     )
 
     //Correct for title height. It's included in bounding box, but not _posSize
-    subgraphNode.pos[1] += LiteGraph.NODE_TITLE_HEIGHT / 2
+    subgraphNode.pos[1] += LiteGraphInternal.NODE_TITLE_HEIGHT / 2
 
     // Add the subgraph node to the graph
     this.add(subgraphNode)
@@ -1719,7 +1732,10 @@ export class LGraph
     const movedNodes = multiClone(subgraphNode.subgraph.nodes)
     const nodeIdMap = new Map<NodeId, NodeId>()
     for (const n_info of movedNodes) {
-      const node = LiteGraph.createNode(String(n_info.type), n_info.title)
+      const node = LiteGraphInternal.createNode(
+        String(n_info.type),
+        n_info.title
+      )
       if (!node) {
         throw new Error('Node not found')
       }
@@ -2027,7 +2043,7 @@ export class LGraph
       definitions,
       config,
       extra,
-      version: LiteGraph.VERSION
+      version: LiteGraphInternal.VERSION
     }
   }
 
@@ -2052,7 +2068,7 @@ export class LGraph
     const { id, revision, config, state } = this
 
     const nodeList =
-      !LiteGraph.use_uuids && options?.sortNodes
+      !LiteGraphInternal.use_uuids && options?.sortNodes
         ? // @ts-expect-error If LiteGraph.use_uuids is false, ids are numbers.
           [...this._nodes].sort((a, b) => a.id - b.id)
         : this._nodes
@@ -2072,7 +2088,8 @@ export class LGraph
 
     // Save scale and offset
     const extra = { ...this.extra }
-    if (LiteGraph.saveViewportWithGraph) extra.ds = this.#getDragAndScale()
+    if (LiteGraphInternal.saveViewportWithGraph)
+      extra.ds = this.#getDragAndScale()
     if (!extra.ds) delete extra.ds
 
     const data: ReturnType<typeof this.asSerialisable> = {
@@ -2230,9 +2247,12 @@ export class LGraph
       if (nodesData) {
         for (const n_info of nodesData) {
           // stored info
-          let node = LiteGraph.createNode(String(n_info.type), n_info.title)
+          let node = LiteGraphInternal.createNode(
+            String(n_info.type),
+            n_info.title
+          )
           if (!node) {
-            if (LiteGraph.debug)
+            if (LiteGraphInternal.debug)
               console.log('Node not found or has errors:', n_info.type)
 
             // in case of error we create a replacement node to avoid losing info
@@ -2284,7 +2304,7 @@ export class LGraph
       if (groupData) {
         for (const data of groupData) {
           // TODO: Search/remove these global object refs
-          const group = new LiteGraph.LGraphGroup()
+          const group = new LiteGraphInternal.LGraphGroup()
           group.configure(data)
           this.add(group)
         }

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -16,6 +16,7 @@ import type { LGraph } from './LGraph'
 import { LGraphGroup } from './LGraphGroup'
 import { LGraphNode, type NodeId, type NodeProperty } from './LGraphNode'
 import { LLink, type LinkId } from './LLink'
+import { LiteGraphInternal } from './LiteGraphInternal'
 import { Reroute, type RerouteId } from './Reroute'
 import { isOverNodeInput, isOverNodeOutput } from './canvas/measureSlots'
 import { strokeShape } from './draw'
@@ -52,7 +53,7 @@ import type {
   Rect,
   Size
 } from './interfaces'
-import { LiteGraph, Rectangle, SubgraphNode, createUuidv4 } from './litegraph'
+import { Rectangle, SubgraphNode, createUuidv4 } from './litegraph'
 import {
   containsRect,
   createBounds,
@@ -410,12 +411,12 @@ export class LGraphCanvas
    * @deprecated Use {@link LGraphNode.titleFontStyle} instead.
    */
   get title_text_font(): string {
-    return `${LiteGraph.NODE_TEXT_SIZE}px ${LiteGraph.NODE_FONT}`
+    return `${LiteGraphInternal.NODE_TEXT_SIZE}px ${LiteGraphInternal.NODE_FONT}`
   }
   // #endregion Legacy accessors
 
   get inner_text_font(): string {
-    return `normal ${LiteGraph.NODE_SUBTEXT_SIZE}px ${LiteGraph.NODE_FONT}`
+    return `normal ${LiteGraphInternal.NODE_SUBTEXT_SIZE}px ${LiteGraphInternal.NODE_FONT}`
   }
 
   #maximumFrameGap = 0
@@ -434,14 +435,14 @@ export class LGraphCanvas
    * @deprecated Use {@link LiteGraphGlobal.ROUND_RADIUS} instead.
    */
   get round_radius() {
-    return LiteGraph.ROUND_RADIUS
+    return LiteGraphInternal.ROUND_RADIUS
   }
 
   /**
    * @deprecated Use {@link LiteGraphGlobal.ROUND_RADIUS} instead.
    */
   set round_radius(value: number) {
-    LiteGraph.ROUND_RADIUS = value
+    LiteGraphInternal.ROUND_RADIUS = value
   }
 
   // Cached LOD threshold values for performance
@@ -460,7 +461,7 @@ export class LGraphCanvas
       return
     }
 
-    const baseFontSize = LiteGraph.NODE_TEXT_SIZE // 14px
+    const baseFontSize = LiteGraphInternal.NODE_TEXT_SIZE // 14px
     const dprAdjustment = Math.sqrt(window.devicePixelRatio || 1) //Using sqrt here because higher DPR monitors do not linearily scale the readability of the font, instead they increase the font by some heurisitc, and to approximate we use sqrt to say bascially a DPR of 2 increases the readibility by 40%, 3 by 70%
 
     // Calculate the zoom level where text becomes unreadable
@@ -789,7 +790,7 @@ export class LGraphCanvas
 
         // No longer in use
         // add menu when releasing link in empty space
-        if (LiteGraph.release_link_on_empty_shows_menu) {
+        if (LiteGraphInternal.release_link_on_empty_shows_menu) {
           const linkReleaseContext =
             this.linkConnector.state.connectingTo === 'input'
               ? {
@@ -836,8 +837,8 @@ export class LGraphCanvas
     // in range (1.01, 2.5). Less than 1 will invert the zoom direction
     this.zoom_speed = 1.1
 
-    this.node_title_color = LiteGraph.NODE_TITLE_COLOR
-    this.default_link_color = LiteGraph.LINK_COLOR
+    this.node_title_color = LiteGraphInternal.NODE_TITLE_COLOR
+    this.default_link_color = LiteGraphInternal.LINK_COLOR
     this.default_connection_color = {
       input_off: '#778',
       input_on: '#7F7',
@@ -960,7 +961,7 @@ export class LGraphCanvas
   ): void {
     const canvas = LGraphCanvas.active_canvas
 
-    const group = new LiteGraph.LGraphGroup()
+    const group = new LiteGraphInternal.LGraphGroup()
     group.pos = canvas.convertEventToCanvasOffset(mouse_event)
     if (!canvas.graph) throw new NullGraphError()
     canvas.graph.add(group)
@@ -1010,7 +1011,7 @@ export class LGraphCanvas
     prev_menu: ContextMenu<string>,
     node: LGraphNode
   ): void {
-    new LiteGraph.ContextMenu(['Top', 'Bottom', 'Left', 'Right'], {
+    new LiteGraphInternal.ContextMenu(['Top', 'Bottom', 'Left', 'Right'], {
       event,
       callback: inner_clicked,
       parentMenu: prev_menu
@@ -1034,7 +1035,7 @@ export class LGraphCanvas
     event: MouseEvent,
     prev_menu: ContextMenu<string>
   ): void {
-    new LiteGraph.ContextMenu(['Top', 'Bottom', 'Left', 'Right'], {
+    new LiteGraphInternal.ContextMenu(['Top', 'Bottom', 'Left', 'Right'], {
       event,
       callback: inner_clicked,
       parentMenu: prev_menu
@@ -1057,7 +1058,7 @@ export class LGraphCanvas
     event: MouseEvent,
     prev_menu: ContextMenu<string>
   ): void {
-    new LiteGraph.ContextMenu(['Vertically', 'Horizontally'], {
+    new LiteGraphInternal.ContextMenu(['Vertically', 'Horizontally'], {
       event,
       callback: inner_clicked,
       parentMenu: prev_menu
@@ -1105,7 +1106,7 @@ export class LGraphCanvas
     ): void {
       if (!graph) return
 
-      const categories = LiteGraph.getNodeTypesCategories(
+      const categories = LiteGraphInternal.getNodeTypesCategories(
         canvas.filter || graph.filter
       ).filter((category) => category.startsWith(base_category))
       const entries: AddNodeMenu[] = []
@@ -1148,7 +1149,7 @@ export class LGraphCanvas
         }
       }
 
-      const nodes = LiteGraph.getNodeTypesInCategory(
+      const nodes = LiteGraphInternal.getNodeTypesInCategory(
         base_category.slice(0, -1),
         canvas.filter || graph.filter
       )
@@ -1172,7 +1173,7 @@ export class LGraphCanvas
 
             const first_event = contextMenu.getFirstEvent()
             canvas.graph.beforeChange()
-            const node = LiteGraph.createNode(value.value)
+            const node = LiteGraphInternal.createNode(value.value)
             if (node) {
               if (!first_event)
                 throw new TypeError(
@@ -1192,7 +1193,7 @@ export class LGraphCanvas
         entries.push(entry)
       }
 
-      new LiteGraph.ContextMenu(
+      new LiteGraphInternal.ContextMenu(
         entries,
         { event: e, parentMenu: prev_menu },
         // @ts-expect-error - extra parameter
@@ -1221,12 +1222,12 @@ export class LGraphCanvas
     let entries: (IContextMenuValue<INodeSlotContextItem> | null)[] = []
 
     if (
-      LiteGraph.do_add_triggers_slots &&
+      LiteGraphInternal.do_add_triggers_slots &&
       node.findOutputSlot('onExecuted') == -1
     ) {
       entries.push({
         content: 'On Executed',
-        value: ['onExecuted', LiteGraph.EVENT, { nameLocked: true }],
+        value: ['onExecuted', LiteGraphInternal.EVENT, { nameLocked: true }],
         className: 'event'
       })
     }
@@ -1236,7 +1237,7 @@ export class LGraphCanvas
 
     if (!entries.length) return
 
-    new LiteGraph.ContextMenu<INodeSlotContextItem>(entries, {
+    new LiteGraphInternal.ContextMenu<INodeSlotContextItem>(entries, {
       event: e,
       callback: inner_clicked,
       parentMenu: prev_menu,
@@ -1264,7 +1265,7 @@ export class LGraphCanvas
         for (const i in value) {
           entries.push({ content: i, value: value[i] })
         }
-        new LiteGraph.ContextMenu(entries, {
+        new LiteGraphInternal.ContextMenu(entries, {
           event: e,
           callback: inner_clicked,
           parentMenu: prev_menu,
@@ -1323,7 +1324,7 @@ export class LGraphCanvas
       return
     }
 
-    new LiteGraph.ContextMenu<string>(
+    new LiteGraphInternal.ContextMenu<string>(
       entries,
       {
         event: e,
@@ -1466,18 +1467,21 @@ export class LGraphCanvas
 
     let dialogCloseTimer: number
     dialog.addEventListener('mouseleave', function () {
-      if (LiteGraph.dialog_close_on_mouse_leave) {
-        if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave) {
+      if (LiteGraphInternal.dialog_close_on_mouse_leave) {
+        if (
+          !dialog.is_modified &&
+          LiteGraphInternal.dialog_close_on_mouse_leave
+        ) {
           // @ts-expect-error - setTimeout type
           dialogCloseTimer = setTimeout(
             dialog.close,
-            LiteGraph.dialog_close_on_mouse_leave_delay
+            LiteGraphInternal.dialog_close_on_mouse_leave_delay
           )
         }
       }
     })
     dialog.addEventListener('mouseenter', function () {
-      if (LiteGraph.dialog_close_on_mouse_leave) {
+      if (LiteGraphInternal.dialog_close_on_mouse_leave) {
         if (dialogCloseTimer) clearTimeout(dialogCloseTimer)
       }
     })
@@ -1597,7 +1601,7 @@ export class LGraphCanvas
     menu: ContextMenu,
     node: LGraphNode
   ): boolean {
-    new LiteGraph.ContextMenu(LiteGraph.NODE_MODES, {
+    new LiteGraphInternal.ContextMenu(LiteGraphInternal.NODE_MODES, {
       event: e,
       callback: inner_clicked,
       parentMenu: menu,
@@ -1607,9 +1611,9 @@ export class LGraphCanvas
     function inner_clicked(v: string) {
       if (!node) return
 
-      const kV = Object.values(LiteGraph.NODE_MODES).indexOf(v)
+      const kV = Object.values(LiteGraphInternal.NODE_MODES).indexOf(v)
       const fApplyMultiNode = function (node: LGraphNode) {
-        if (kV !== -1 && LiteGraph.NODE_MODES[kV]) {
+        if (kV !== -1 && LiteGraphInternal.NODE_MODES[kV]) {
           node.changeMode(kV)
         } else {
           console.warn(`unexpected mode: ${v}`)
@@ -1665,7 +1669,7 @@ export class LGraphCanvas
       }
       values.push(value)
     }
-    new LiteGraph.ContextMenu<string | null>(values, {
+    new LiteGraphInternal.ContextMenu<string | null>(values, {
       event: e,
       callback: inner_clicked,
       parentMenu: menu,
@@ -1699,26 +1703,27 @@ export class LGraphCanvas
 
   static onMenuNodeShapes(
     // @ts-expect-error - unused parameter
-    value: IContextMenuValue<(typeof LiteGraph.VALID_SHAPES)[number]>,
+    value: IContextMenuValue<(typeof LiteGraphInternal.VALID_SHAPES)[number]>,
     // @ts-expect-error - unused parameter
-    options: IContextMenuOptions<(typeof LiteGraph.VALID_SHAPES)[number]>,
+    options: IContextMenuOptions<
+      (typeof LiteGraphInternal.VALID_SHAPES)[number]
+    >,
     e: MouseEvent,
-    menu?: ContextMenu<(typeof LiteGraph.VALID_SHAPES)[number]>,
+    menu?: ContextMenu<(typeof LiteGraphInternal.VALID_SHAPES)[number]>,
     node?: LGraphNode
   ): boolean {
     if (!node) throw 'no node passed'
 
-    new LiteGraph.ContextMenu<(typeof LiteGraph.VALID_SHAPES)[number]>(
-      LiteGraph.VALID_SHAPES,
-      {
-        event: e,
-        callback: inner_clicked,
-        parentMenu: menu,
-        node
-      }
-    )
+    new LiteGraphInternal.ContextMenu<
+      (typeof LiteGraphInternal.VALID_SHAPES)[number]
+    >(LiteGraphInternal.VALID_SHAPES, {
+      event: e,
+      callback: inner_clicked,
+      parentMenu: menu,
+      node
+    })
 
-    function inner_clicked(v: (typeof LiteGraph.VALID_SHAPES)[number]) {
+    function inner_clicked(v: (typeof LiteGraphInternal.VALID_SHAPES)[number]) {
       if (!node) return
       if (!node.graph) throw new NullGraphError()
 
@@ -2100,7 +2105,8 @@ export class LGraphCanvas
         if (this.#maximumFrameGap > 0) {
           // Manual FPS limit
           const gap =
-            this.#maximumFrameGap - (LiteGraph.getTime() - this.last_draw_time)
+            this.#maximumFrameGap -
+            (LiteGraphInternal.getTime() - this.last_draw_time)
           setTimeout(renderFrame.bind(this), Math.max(1, gap))
         } else {
           // FPS limited by refresh rate
@@ -2171,7 +2177,7 @@ export class LGraphCanvas
         // Hover transitions
         // TODO: Implement single lerp ease factor for current progress on hover in/out.
         // In drawNode, multiply by ease factor and differential value (e.g. bg alpha +0.5).
-        otherNode.lostFocusAt = LiteGraph.getTime()
+        otherNode.lostFocusAt = LiteGraphInternal.getTime()
 
         this.node_over?.onMouseLeave?.(e)
         this.node_over = undefined
@@ -2224,7 +2230,7 @@ export class LGraphCanvas
 
     this.canvas.focus()
 
-    LiteGraph.closeAllContextMenus(ref_window)
+    LiteGraphInternal.closeAllContextMenus(ref_window)
 
     if (this.onMouse?.(e) == true) return
 
@@ -2295,7 +2301,7 @@ export class LGraphCanvas
     }
 
     this.last_mouse = [x, y]
-    this.last_mouseclick = LiteGraph.getTime()
+    this.last_mouseclick = LiteGraphInternal.getTime()
     this.last_mouse_dragging = true
 
     graph.change()
@@ -2349,7 +2355,7 @@ export class LGraphCanvas
     if (
       ctrlOrMeta &&
       !e.altKey &&
-      LiteGraph.leftMouseClickBehavior === 'panning'
+      LiteGraphInternal.leftMouseClickBehavior === 'panning'
     ) {
       this.#setupNodeSelectionDrag(e, pointer, node)
 
@@ -2364,7 +2370,7 @@ export class LGraphCanvas
 
     // clone node ALT dragging
     if (
-      LiteGraph.alt_drag_do_clone_nodes &&
+      LiteGraphInternal.alt_drag_do_clone_nodes &&
       e.altKey &&
       !e.ctrlKey &&
       node &&
@@ -2384,7 +2390,7 @@ export class LGraphCanvas
       if (node_data?.type != null) {
         // Ensure the cloned node is configured against the correct type (especially for SubgraphNodes)
         node_data.type = newType
-        const cloned = LiteGraph.createNode(newType)
+        const cloned = LiteGraphInternal.createNode(newType)
         if (cloned) {
           cloned.configure(node_data)
           cloned.pos[0] += 5
@@ -2567,7 +2573,7 @@ export class LGraphCanvas
           }
           pointer.finally = () => (this.resizingGroup = null)
         } else {
-          const f = group.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE
+          const f = group.font_size || LiteGraphInternal.DEFAULT_GROUP_FONT_SIZE
           const headerHeight = f * 1.4
           if (
             isInRectangle(
@@ -2618,7 +2624,10 @@ export class LGraphCanvas
       this.allow_dragcanvas
     ) {
       // allow dragging canvas based on leftMouseClickBehavior or read-only mode
-      if (LiteGraph.leftMouseClickBehavior === 'panning' || this.read_only) {
+      if (
+        LiteGraphInternal.leftMouseClickBehavior === 'panning' ||
+        this.read_only
+      ) {
         pointer.onClick = () => this.processSelect(null, e)
         pointer.finally = () => (this.dragging_canvas = false)
         this.dragging_canvas = true
@@ -2715,11 +2724,11 @@ export class LGraphCanvas
             linkConnector.dragNewFromOutput(graph, node, output)
             this.#linkConnectorDrop()
 
-            if (LiteGraph.shift_click_do_break_link_from) {
+            if (LiteGraphInternal.shift_click_do_break_link_from) {
               if (e.shiftKey) {
                 node.disconnectOutput(i)
               }
-            } else if (LiteGraph.ctrl_alt_click_do_break_link) {
+            } else if (LiteGraphInternal.ctrl_alt_click_do_break_link) {
               if (ctrlOrMeta && e.altKey && !e.shiftKey) {
                 node.disconnectOutput(i)
               }
@@ -2748,13 +2757,13 @@ export class LGraphCanvas
             pointer.onClick = () => node.onInputClick?.(i, e)
 
             const shouldBreakLink =
-              LiteGraph.ctrl_alt_click_do_break_link &&
+              LiteGraphInternal.ctrl_alt_click_do_break_link &&
               ctrlOrMeta &&
               e.altKey &&
               !e.shiftKey
             if (input.link !== null || input._floatingLinks?.size) {
               // Existing link
-              if (shouldBreakLink || LiteGraph.click_do_break_link_to) {
+              if (shouldBreakLink || LiteGraphInternal.click_do_break_link_to) {
                 node.disconnectInput(i, true)
               } else if (e.shiftKey || this.allow_reconnect_links) {
                 linkConnector.moveInputLink(graph, input)
@@ -3029,7 +3038,7 @@ export class LGraphCanvas
     const { pointer } = this
 
     if (
-      LiteGraph.middle_click_slot_add_default_node &&
+      LiteGraphInternal.middle_click_slot_add_default_node &&
       node &&
       this.allow_interaction &&
       !this.read_only &&
@@ -3324,7 +3333,7 @@ export class LGraphCanvas
                 } else if (
                   inputId != -1 &&
                   node.inputs[inputId] &&
-                  LiteGraph.isValidConnection(
+                  LiteGraphInternal.isValidConnection(
                     firstLink.fromSlot.type,
                     node.inputs[inputId].type
                   )
@@ -3351,7 +3360,7 @@ export class LGraphCanvas
                 if (
                   outputId != -1 &&
                   node.outputs[outputId] &&
-                  LiteGraph.isValidConnection(
+                  LiteGraphInternal.isValidConnection(
                     firstLink.fromSlot.type,
                     node.outputs[outputId].type
                   )
@@ -3504,7 +3513,7 @@ export class LGraphCanvas
    */
   #processDraggedItems(e: CanvasPointerEvent): void {
     const { graph } = this
-    if (e.shiftKey || LiteGraph.alwaysSnapToGrid)
+    if (e.shiftKey || LiteGraphInternal.alwaysSnapToGrid)
       graph?.snapToGrid(this.selectedItems)
 
     this.dirty_canvas = true
@@ -3528,7 +3537,7 @@ export class LGraphCanvas
 
     this.adjustMouseEvent(e)
 
-    const now = LiteGraph.getTime()
+    const now = LiteGraphInternal.getTime()
     e.click_time = now - this.last_mouseclick
 
     /** The mouseup event occurred near the mousedown event. */
@@ -3630,7 +3639,7 @@ export class LGraphCanvas
       e.ctrlKey || (e.metaKey && navigator.platform.includes('Mac'))
     const isZoomModifier = isCtrlOrMacMeta && !e.altKey && !e.shiftKey
 
-    if (isZoomModifier || LiteGraph.mouseWheelScroll === 'zoom') {
+    if (isZoomModifier || LiteGraphInternal.mouseWheelScroll === 'zoom') {
       // Zoom mode or modifier key pressed - use wheel for zoom
       if (isTrackpad) {
         // Trackpad gesture - use smooth scaling
@@ -3870,7 +3879,7 @@ export class LGraphCanvas
 
     // if ctrl + shift + v is off, return when isConnectUnselected is true (shift is pressed) to maintain old behavior
     if (
-      !LiteGraph.ctrl_shift_v_paste_connect_unselected_outputs &&
+      !LiteGraphInternal.ctrl_shift_v_paste_connect_unselected_outputs &&
       connectInputs
     )
       return
@@ -3952,7 +3961,8 @@ export class LGraphCanvas
 
     // Nodes
     for (const info of parsed.nodes) {
-      const node = info.type == null ? null : LiteGraph.createNode(info.type)
+      const node =
+        info.type == null ? null : LiteGraphInternal.createNode(info.type)
       if (!node) {
         // failedNodes.push(info)
         continue
@@ -3995,7 +4005,7 @@ export class LGraphCanvas
       // If it wasn't copied, use the original graph value
       if (
         connectInputs &&
-        LiteGraph.ctrl_shift_v_paste_connect_unselected_outputs
+        LiteGraphInternal.ctrl_shift_v_paste_connect_unselected_outputs
       ) {
         outNode ??= graph.getNodeById(info.origin_id)
         afterRerouteId ??= info.parentId
@@ -4572,7 +4582,7 @@ export class LGraphCanvas
       return
 
     // fps counting
-    const now = LiteGraph.getTime()
+    const now = LiteGraphInternal.getTime()
     this.render_time = (now - this.last_draw_time) * 0.001
     this.last_draw_time = now
 
@@ -4637,7 +4647,7 @@ export class LGraphCanvas
 
     // TODO: Set snapping value when changed instead of once per frame
     this.#snapToGrid =
-      this.#shiftDown || LiteGraph.alwaysSnapToGrid
+      this.#shiftDown || LiteGraphInternal.alwaysSnapToGrid
         ? this.graph?.getSnapToGridSize()
         : undefined
 
@@ -4749,7 +4759,10 @@ export class LGraphCanvas
 
           ctx.fillStyle = colour
           ctx.beginPath()
-          if (connType === LiteGraph.EVENT || connShape === RenderShape.BOX) {
+          if (
+            connType === LiteGraphInternal.EVENT ||
+            connShape === RenderShape.BOX
+          ) {
             ctx.rect(pos[0] - 6 + 0.5, pos[1] - 5 + 0.5, 14, 10)
             ctx.rect(
               highlightPos[0] - 6 + 0.5,
@@ -4839,7 +4852,7 @@ export class LGraphCanvas
 
   /** Get the target snap / highlight point in graph space */
   #getHighlightPosition(): ReadOnlyPoint {
-    return LiteGraph.snaps_for_comfy
+    return LiteGraphInternal.snaps_for_comfy
       ? this.linkConnector.state.snapLinksPos ??
           this._highlight_pos ??
           this.graph_mouse
@@ -4875,7 +4888,7 @@ export class LGraphCanvas
     const { linkConnector } = this
     const { overReroute, overWidget } = linkConnector
     if (
-      !LiteGraph.snap_highlights_node ||
+      !LiteGraphInternal.snap_highlights_node ||
       !linkConnector.isConnecting ||
       linkConnectorSnap
     )
@@ -4892,7 +4905,7 @@ export class LGraphCanvas
 
     const area = node.boundingRect
     const gap = 3
-    const radius = LiteGraph.ROUND_RADIUS + gap
+    const radius = LiteGraphInternal.ROUND_RADIUS + gap
 
     const x = area[0] - gap
     const y = area[1] - gap
@@ -4940,7 +4953,7 @@ export class LGraphCanvas
       const {
         pos: [nodeX, nodeY]
       } = node
-      const height = LiteGraph.NODE_WIDGET_HEIGHT
+      const height = LiteGraphInternal.NODE_WIDGET_HEIGHT
       if (
         overWidget.type.startsWith('custom') &&
         computedHeight != null &&
@@ -4984,7 +4997,7 @@ export class LGraphCanvas
     ctx.save()
     ctx.translate(x, y)
 
-    ctx.font = `10px ${LiteGraph.DEFAULT_FONT}`
+    ctx.font = `10px ${LiteGraphInternal.DEFAULT_FONT}`
     ctx.fillStyle = '#888'
     ctx.textAlign = 'left'
     if (this.graph) {
@@ -5163,7 +5176,7 @@ export class LGraphCanvas
     // When Vue nodes mode is enabled, LiteGraph should not draw node chrome or widgets.
     // We still need to keep slot metrics and layout in sync for hit-testing and links.
     // Interaction system changes coming later, chances are vue nodes mode will be mostly broken on land
-    if (LiteGraph.vueNodesMode) {
+    if (LiteGraphInternal.vueNodesMode) {
       // Prepare concrete slots and compute layout measures without rendering visuals.
       node._setConcreteSlots()
       if (!node.collapsed) {
@@ -5180,7 +5193,7 @@ export class LGraphCanvas
     ctx.globalAlpha = editor_alpha
 
     if (this.render_shadows && !low_quality) {
-      ctx.shadowColor = LiteGraph.DEFAULT_SHADOW_COLOR
+      ctx.shadowColor = LiteGraphInternal.DEFAULT_SHADOW_COLOR
       ctx.shadowOffsetX = 2 * this.ds.scale
       ctx.shadowOffsetY = 2 * this.ds.scale
       ctx.shadowBlur = 3 * this.ds.scale
@@ -5220,7 +5233,7 @@ export class LGraphCanvas
 
     // Render title buttons (if not collapsed)
     if (node.title_buttons && !node.flags.collapsed) {
-      const title_height = LiteGraph.NODE_TITLE_HEIGHT
+      const title_height = LiteGraphInternal.NODE_TITLE_HEIGHT
       let current_x = size[0] // Start flush with right edge
 
       for (let i = 0; i < node.title_buttons.length; i++) {
@@ -5247,7 +5260,7 @@ export class LGraphCanvas
     ctx.shadowColor = 'transparent'
 
     // TODO: Legacy behaviour: onDrawForeground received ctx in this state
-    ctx.strokeStyle = LiteGraph.NODE_BOX_OUTLINE_COLOR
+    ctx.strokeStyle = LiteGraphInternal.NODE_BOX_OUTLINE_COLOR
 
     // Draw Foreground
     node.onDrawForeground?.(ctx, this, this.canvas)
@@ -5375,7 +5388,7 @@ export class LGraphCanvas
     ctx.strokeStyle = fgcolor
     ctx.fillStyle = bgcolor
 
-    const title_height = LiteGraph.NODE_TITLE_HEIGHT
+    const title_height = LiteGraphInternal.NODE_TITLE_HEIGHT
     const { low_quality } = this
 
     const { collapsed } = node.flags
@@ -5407,8 +5420,13 @@ export class LGraphCanvas
         area[2],
         area[3],
         shape == RenderShape.CARD
-          ? [LiteGraph.ROUND_RADIUS, LiteGraph.ROUND_RADIUS, 0, 0]
-          : [LiteGraph.ROUND_RADIUS]
+          ? [
+              LiteGraphInternal.ROUND_RADIUS,
+              LiteGraphInternal.ROUND_RADIUS,
+              0,
+              0
+            ]
+          : [LiteGraphInternal.ROUND_RADIUS]
       )
     } else if (shape == RenderShape.CIRCLE) {
       ctx.arc(size[0] * 0.5, size[1] * 0.5, size[0] * 0.5, 0, Math.PI * 2)
@@ -5536,7 +5554,7 @@ export class LGraphCanvas
 
     const visibleReroutes: Reroute[] = []
 
-    const now = LiteGraph.getTime()
+    const now = LiteGraphInternal.getTime()
     const { visible_area } = this
     LGraphCanvas.#margin_area[0] = visible_area[0] - 20
     LGraphCanvas.#margin_area[1] = visible_area[1] - 20
@@ -5563,7 +5581,7 @@ export class LGraphCanvas
         const link = graph._links.get(link_id)
         if (!link) continue
 
-        const endPos: Point = LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
+        const endPos: Point = LiteGraphInternal.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
           ? getSlotPosition(node, i, true)
           : node.getInputPos(i)
 
@@ -5575,7 +5593,7 @@ export class LGraphCanvas
         const startPos: Point =
           outputId === -1
             ? [start_node.pos[0] + 10, start_node.pos[1] + 10]
-            : LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
+            : LiteGraphInternal.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
               ? getSlotPosition(start_node, outputId, false)
               : start_node.getOutputPos(outputId)
 
@@ -5995,23 +6013,23 @@ export class LGraphCanvas
     for (const node of visible_nodes) {
       ctx.fillStyle = 'black'
       ctx.fillRect(
-        node.pos[0] - LiteGraph.NODE_TITLE_HEIGHT,
-        node.pos[1] - LiteGraph.NODE_TITLE_HEIGHT,
-        LiteGraph.NODE_TITLE_HEIGHT,
-        LiteGraph.NODE_TITLE_HEIGHT
+        node.pos[0] - LiteGraphInternal.NODE_TITLE_HEIGHT,
+        node.pos[1] - LiteGraphInternal.NODE_TITLE_HEIGHT,
+        LiteGraphInternal.NODE_TITLE_HEIGHT,
+        LiteGraphInternal.NODE_TITLE_HEIGHT
       )
       if (node.order == 0) {
         ctx.strokeRect(
-          node.pos[0] - LiteGraph.NODE_TITLE_HEIGHT + 0.5,
-          node.pos[1] - LiteGraph.NODE_TITLE_HEIGHT + 0.5,
-          LiteGraph.NODE_TITLE_HEIGHT,
-          LiteGraph.NODE_TITLE_HEIGHT
+          node.pos[0] - LiteGraphInternal.NODE_TITLE_HEIGHT + 0.5,
+          node.pos[1] - LiteGraphInternal.NODE_TITLE_HEIGHT + 0.5,
+          LiteGraphInternal.NODE_TITLE_HEIGHT,
+          LiteGraphInternal.NODE_TITLE_HEIGHT
         )
       }
       ctx.fillStyle = '#FFF'
       ctx.fillText(
         toString(node.order),
-        node.pos[0] + LiteGraph.NODE_TITLE_HEIGHT * -0.5,
+        node.pos[0] + LiteGraphInternal.NODE_TITLE_HEIGHT * -0.5,
         node.pos[1] - 6
       )
     }
@@ -6110,7 +6128,7 @@ export class LGraphCanvas
 
     const { origin_id, origin_slot } = segment
     if (origin_id == null || origin_slot == null) {
-      new LiteGraph.ContextMenu<string>(['Link has no origin'], {
+      new LiteGraphInternal.ContextMenu<string>(['Link has no origin'], {
         event: e,
         title
       })
@@ -6122,7 +6140,7 @@ export class LGraphCanvas
 
     const options = ['Add Node', 'Add Reroute', null, 'Delete', null]
 
-    const menu = new LiteGraph.ContextMenu<string>(options, {
+    const menu = new LiteGraphInternal.ContextMenu<string>(options, {
       event: e,
       title,
       callback: inner_clicked.bind(this)
@@ -6285,10 +6303,11 @@ export class LGraphCanvas
     }
 
     // check for defaults nodes for this slottype
-    const fromSlotType = slotX.type == LiteGraph.EVENT ? '_event_' : slotX.type
+    const fromSlotType =
+      slotX.type == LiteGraphInternal.EVENT ? '_event_' : slotX.type
     const slotTypesDefault = isFrom
-      ? LiteGraph.slot_types_default_out
-      : LiteGraph.slot_types_default_in
+      ? LiteGraphInternal.slot_types_default_out
+      : LiteGraphInternal.slot_types_default_in
     if (slotTypesDefault?.[fromSlotType]) {
       // TODO: Remove "any" kludge
       let nodeNewType: any = false
@@ -6317,14 +6336,18 @@ export class LGraphCanvas
         }
 
         // that.graph.beforeChange();
-        const xSizeFix = opts.posSizeFix[0] * LiteGraph.NODE_WIDTH
-        const ySizeFix = opts.posSizeFix[1] * LiteGraph.NODE_SLOT_HEIGHT
+        const xSizeFix = opts.posSizeFix[0] * LiteGraphInternal.NODE_WIDTH
+        const ySizeFix = opts.posSizeFix[1] * LiteGraphInternal.NODE_SLOT_HEIGHT
         const nodeX = opts.position[0] + opts.posAdd[0] + xSizeFix
         const nodeY = opts.position[1] + opts.posAdd[1] + ySizeFix
         const pos = [nodeX, nodeY]
-        const newNode = LiteGraph.createNode(nodeNewType, nodeNewOpts.title, {
-          pos
-        })
+        const newNode = LiteGraphInternal.createNode(
+          nodeNewType,
+          nodeNewOpts.title,
+          {
+            pos
+          }
+        )
         if (newNode) {
           // if is object pass options
           if (nodeNewOpts) {
@@ -6492,10 +6515,11 @@ export class LGraphCanvas
     }
 
     // get defaults nodes for this slottype
-    const fromSlotType = slotX.type == LiteGraph.EVENT ? '_event_' : slotX.type
+    const fromSlotType =
+      slotX.type == LiteGraphInternal.EVENT ? '_event_' : slotX.type
     const slotTypesDefault = isFrom
-      ? LiteGraph.slot_types_default_out
-      : LiteGraph.slot_types_default_in
+      ? LiteGraphInternal.slot_types_default_out
+      : LiteGraphInternal.slot_types_default_in
     if (slotTypesDefault?.[fromSlotType]) {
       if (typeof slotTypesDefault[fromSlotType] == 'object') {
         for (const typeX in slotTypesDefault[fromSlotType]) {
@@ -6507,7 +6531,7 @@ export class LGraphCanvas
     }
 
     // build menu
-    const menu = new LiteGraph.ContextMenu<string>(options, {
+    const menu = new LiteGraphInternal.ContextMenu<string>(options, {
       event: opts.e,
       extra: slotX,
       title:
@@ -6656,20 +6680,23 @@ export class LGraphCanvas
 
     let dialogCloseTimer: number
     let prevent_timeout = 0
-    LiteGraph.pointerListenerAdd(dialog, 'leave', function () {
+    LiteGraphInternal.pointerListenerAdd(dialog, 'leave', function () {
       if (prevent_timeout) return
-      if (LiteGraph.dialog_close_on_mouse_leave) {
-        if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave) {
+      if (LiteGraphInternal.dialog_close_on_mouse_leave) {
+        if (
+          !dialog.is_modified &&
+          LiteGraphInternal.dialog_close_on_mouse_leave
+        ) {
           // @ts-expect-error - setTimeout type
           dialogCloseTimer = setTimeout(
             dialog.close,
-            LiteGraph.dialog_close_on_mouse_leave_delay
+            LiteGraphInternal.dialog_close_on_mouse_leave_delay
           )
         }
       }
     })
-    LiteGraph.pointerListenerAdd(dialog, 'enter', function () {
-      if (LiteGraph.dialog_close_on_mouse_leave && dialogCloseTimer)
+    LiteGraphInternal.pointerListenerAdd(dialog, 'enter', function () {
+      if (LiteGraphInternal.dialog_close_on_mouse_leave && dialogCloseTimer)
         clearTimeout(dialogCloseTimer)
     })
     const selInDia = dialog.querySelectorAll('select')
@@ -6778,7 +6805,7 @@ export class LGraphCanvas
       node_to: null,
       // TODO check for registered_slot_[in/out]_types not empty
       // this will be checked for functionality enabled : filter on slot type, in and out
-      do_type_filter: LiteGraph.search_filter_enabled,
+      do_type_filter: LiteGraphInternal.search_filter_enabled,
 
       // these are default: pass to set initially set values
       // @ts-expect-error Property missing from interface definition
@@ -6787,9 +6814,9 @@ export class LGraphCanvas
       type_filter_out: false,
       show_general_if_none_on_typefilter: true,
       show_general_after_typefiltered: true,
-      hide_on_mouse_leave: LiteGraph.search_hide_on_mouse_leave,
+      hide_on_mouse_leave: LiteGraphInternal.search_hide_on_mouse_leave,
       show_all_if_empty: true,
-      show_all_on_open: LiteGraph.search_show_all_on_open
+      show_all_on_open: LiteGraphInternal.search_show_all_on_open
     }
     Object.assign(options, searchOptions)
 
@@ -6850,7 +6877,7 @@ export class LGraphCanvas
       // FIXME: Remove "any" kludge
       let prevent_timeout: any = false
       let timeout_close: number | null = null
-      LiteGraph.pointerListenerAdd(dialog, 'enter', function () {
+      LiteGraphInternal.pointerListenerAdd(dialog, 'enter', function () {
         if (timeout_close) {
           clearTimeout(timeout_close)
           timeout_close = null
@@ -6945,12 +6972,12 @@ export class LGraphCanvas
     // if should filter on type, load and fill selected and choose elements if passed
     if (options.do_type_filter) {
       if (selIn) {
-        const aSlots = LiteGraph.slot_types_in
+        const aSlots = LiteGraphInternal.slot_types_in
         const nSlots = aSlots.length
 
         if (
-          options.type_filter_in == LiteGraph.EVENT ||
-          options.type_filter_in == LiteGraph.ACTION
+          options.type_filter_in == LiteGraphInternal.EVENT ||
+          options.type_filter_in == LiteGraphInternal.ACTION
         ) {
           options.type_filter_in = '_event_'
         }
@@ -6973,11 +7000,11 @@ export class LGraphCanvas
         })
       }
       if (selOut) {
-        const aSlots = LiteGraph.slot_types_out
+        const aSlots = LiteGraphInternal.slot_types_out
 
         if (
-          options.type_filter_out == LiteGraph.EVENT ||
-          options.type_filter_out == LiteGraph.ACTION
+          options.type_filter_out == LiteGraphInternal.EVENT ||
+          options.type_filter_out == LiteGraphInternal.ACTION
         ) {
           options.type_filter_out = '_event_'
         }
@@ -7036,7 +7063,7 @@ export class LGraphCanvas
           if (!graphcanvas.graph) throw new NullGraphError()
 
           graphcanvas.graph.beforeChange()
-          const node = LiteGraph.createNode(name)
+          const node = LiteGraphInternal.createNode(name)
           if (node) {
             node.pos = graphcanvas.convertEventToCanvasOffset(safeEvent)
             graphcanvas.graph.add(node, false)
@@ -7189,7 +7216,7 @@ export class LGraphCanvas
           sOut = that.search_box.querySelector('.slot_out_type_filter')
         }
 
-        const keys = Object.keys(LiteGraph.registered_node_types)
+        const keys = Object.keys(LiteGraphInternal.registered_node_types)
         const filtered = keys.filter((x) => inner_test_filter(x))
 
         for (const item of filtered) {
@@ -7209,7 +7236,7 @@ export class LGraphCanvas
           // FIXME: Undeclared variable again
           // @ts-expect-error Variable declared without type annotation
           filtered_extra = []
-          for (const i in LiteGraph.registered_node_types) {
+          for (const i in LiteGraphInternal.registered_node_types) {
             if (
               inner_test_filter(i, {
                 inTypeOverride: sIn && sIn.value ? '*' : false,
@@ -7239,7 +7266,7 @@ export class LGraphCanvas
         ) {
           // @ts-expect-error Variable declared without type annotation
           filtered_extra = []
-          for (const i in LiteGraph.registered_node_types) {
+          for (const i in LiteGraphInternal.registered_node_types) {
             if (inner_test_filter(i, { skipFilter: true }))
               // @ts-expect-error Variable declared without type annotation
               filtered_extra.push(i)
@@ -7270,7 +7297,7 @@ export class LGraphCanvas
             outTypeOverride: false
           }
           const opts = Object.assign(optsDef, optsIn)
-          const ctor = LiteGraph.registered_node_types[type]
+          const ctor = LiteGraphInternal.registered_node_types[type]
           if (filter && ctor.filter != filter) return false
           if (
             (!options.show_all_if_empty || str) &&
@@ -7287,18 +7314,30 @@ export class LGraphCanvas
             let sV =
               opts.inTypeOverride !== false ? opts.inTypeOverride : sIn.value
             // type is stored
-            if (sIn && sV && LiteGraph.registered_slot_in_types[sV]?.nodes) {
+            if (
+              sIn &&
+              sV &&
+              LiteGraphInternal.registered_slot_in_types[sV]?.nodes
+            ) {
               const doesInc =
-                LiteGraph.registered_slot_in_types[sV].nodes.includes(sType)
+                LiteGraphInternal.registered_slot_in_types[sV].nodes.includes(
+                  sType
+                )
               if (doesInc === false) return false
             }
 
             sV = sOut.value
             if (opts.outTypeOverride !== false) sV = opts.outTypeOverride
             // type is stored
-            if (sOut && sV && LiteGraph.registered_slot_out_types[sV]?.nodes) {
+            if (
+              sOut &&
+              sV &&
+              LiteGraphInternal.registered_slot_out_types[sV]?.nodes
+            ) {
               const doesInc =
-                LiteGraph.registered_slot_out_types[sV].nodes.includes(sType)
+                LiteGraphInternal.registered_slot_out_types[sV].nodes.includes(
+                  sType
+                )
               if (doesInc === false) return false
             }
           }
@@ -7310,7 +7349,7 @@ export class LGraphCanvas
         const help = document.createElement('div')
         first ||= type
 
-        const nodeType = LiteGraph.registered_node_types[type]
+        const nodeType = LiteGraphInternal.registered_node_types[type]
         if (nodeType?.title) {
           help.textContent = nodeType?.title
           const typeEl = document.createElement('span')
@@ -7544,16 +7583,22 @@ export class LGraphCanvas
     dialog.addEventListener('mouseleave', function () {
       if (prevent_timeout) return
 
-      if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave) {
+      if (
+        !dialog.is_modified &&
+        LiteGraphInternal.dialog_close_on_mouse_leave
+      ) {
         // @ts-expect-error - setTimeout type
         dialogCloseTimer = setTimeout(
           dialog.close,
-          LiteGraph.dialog_close_on_mouse_leave_delay
+          LiteGraphInternal.dialog_close_on_mouse_leave_delay
         )
       }
     })
     dialog.addEventListener('mouseenter', function () {
-      if (options.closeOnLeave || LiteGraph.dialog_close_on_mouse_leave) {
+      if (
+        options.closeOnLeave ||
+        LiteGraphInternal.dialog_close_on_mouse_leave
+      ) {
         if (dialogCloseTimer) clearTimeout(dialogCloseTimer)
       }
     })
@@ -7756,7 +7801,7 @@ export class LGraphCanvas
             innerChange(propname, v)
             return false
           }
-          new LiteGraph.ContextMenu(
+          new LiteGraphInternal.ContextMenu(
             values,
             {
               event,
@@ -7839,8 +7884,10 @@ export class LGraphCanvas
             if (typeof value !== 'string')
               throw new TypeError('Attempting to set mode to non-string value.')
 
-            const kV = Object.values(LiteGraph.NODE_MODES).indexOf(value)
-            if (kV !== -1 && LiteGraph.NODE_MODES[kV]) {
+            const kV = Object.values(LiteGraphInternal.NODE_MODES).indexOf(
+              value
+            )
+            if (kV !== -1 && LiteGraphInternal.NODE_MODES[kV]) {
               node.changeMode(kV)
             } else {
               console.warn(`unexpected mode: ${value}`)
@@ -7871,12 +7918,12 @@ export class LGraphCanvas
       panel.addWidget('string', 'Title', node.title, {}, fUpdate)
 
       const mode =
-        node.mode == null ? undefined : LiteGraph.NODE_MODES[node.mode]
+        node.mode == null ? undefined : LiteGraphInternal.NODE_MODES[node.mode]
       panel.addWidget(
         'combo',
         'Mode',
         mode,
-        { values: LiteGraph.NODE_MODES },
+        { values: LiteGraphInternal.NODE_MODES },
         fUpdate
       )
 
@@ -8024,7 +8071,7 @@ export class LGraphCanvas
       | IContextMenuValue<string | null>
       | IContextMenuValue<INodeSlotContextItem>
       | IContextMenuValue<unknown, LGraphNode>
-      | IContextMenuValue<(typeof LiteGraph.VALID_SHAPES)[number]>
+      | IContextMenuValue<(typeof LiteGraphInternal.VALID_SHAPES)[number]>
       | null
     )[]
     if (node.getMenuOptions) {
@@ -8246,10 +8293,10 @@ export class LGraphCanvas
         }
         // @ts-expect-error Slot type can be number and has number checks
         options.title = (slot.input ? slot.input.type : slot.output.type) || '*'
-        if (slot.input && slot.input.type == LiteGraph.ACTION)
+        if (slot.input && slot.input.type == LiteGraphInternal.ACTION)
           options.title = 'Action'
 
-        if (slot.output && slot.output.type == LiteGraph.EVENT)
+        if (slot.output && slot.output.type == LiteGraphInternal.EVENT)
           options.title = 'Event'
       } else {
         // on node
@@ -8311,7 +8358,7 @@ export class LGraphCanvas
     if (!menu_info) return
 
     // @ts-expect-error Remove param ref_window - unused
-    new LiteGraph.ContextMenu(menu_info, options, ref_window)
+    new LiteGraphInternal.ContextMenu(menu_info, options, ref_window)
 
     const createDialog = (options: IDialogOptions) =>
       this.createDialog(

--- a/src/lib/litegraph/src/LGraphGroup.ts
+++ b/src/lib/litegraph/src/LGraphGroup.ts
@@ -3,6 +3,7 @@ import { NullGraphError } from '@/lib/litegraph/src/infrastructure/NullGraphErro
 import type { LGraph } from './LGraph'
 import { LGraphCanvas } from './LGraphCanvas'
 import { LGraphNode } from './LGraphNode'
+import { LiteGraphInternal } from './LiteGraphInternal'
 import { strokeShape } from './draw'
 import type {
   ColorOption,
@@ -13,7 +14,6 @@ import type {
   Positionable,
   Size
 } from './interfaces'
-import { LiteGraph } from './litegraph'
 import {
   containsCentre,
   containsRect,
@@ -39,7 +39,7 @@ export class LGraphGroup implements Positionable, IPinnable, IColorable {
   color?: string
   title: string
   font?: string
-  font_size: number = LiteGraph.DEFAULT_GROUP_FONT || 24
+  font_size: number = LiteGraphInternal.DEFAULT_GROUP_FONT || 24
   _bounding: Float32Array = new Float32Array([
     10,
     10,
@@ -170,7 +170,8 @@ export class LGraphGroup implements Positionable, IPinnable, IColorable {
    */
   draw(graphCanvas: LGraphCanvas, ctx: CanvasRenderingContext2D): void {
     const { padding, resizeLength, defaultColour } = LGraphGroup
-    const font_size = this.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE
+    const font_size =
+      this.font_size || LiteGraphInternal.DEFAULT_GROUP_FONT_SIZE
 
     const [x, y] = this._pos
     const [width, height] = this._size
@@ -201,7 +202,7 @@ export class LGraphGroup implements Positionable, IPinnable, IColorable {
     ctx.fill()
 
     // Title
-    ctx.font = `${font_size}px ${LiteGraph.GROUP_FONT}`
+    ctx.font = `${font_size}px ${LiteGraphInternal.GROUP_FONT}`
     ctx.textAlign = 'left'
     ctx.fillText(
       this.title + (this.pinned ? '📌' : ''),
@@ -209,7 +210,7 @@ export class LGraphGroup implements Positionable, IPinnable, IColorable {
       y + font_size
     )
 
-    if (LiteGraph.highlight_selected_group && this.selected) {
+    if (LiteGraphInternal.highlight_selected_group && this.selected) {
       strokeShape(ctx, this._bounding, {
         title_height: this.titleHeight,
         padding

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -14,6 +14,7 @@ import { BadgePosition, LGraphBadge } from './LGraphBadge'
 import { LGraphButton, type LGraphButtonOptions } from './LGraphButton'
 import { LGraphCanvas } from './LGraphCanvas'
 import { LLink } from './LLink'
+import { LiteGraphInternal } from './LiteGraphInternal'
 import type { Reroute, RerouteId } from './Reroute'
 import { getNodeInputOnPos, getNodeOutputOnPos } from './canvas/measureSlots'
 import type { IDrawBoundingOptions } from './draw'
@@ -42,12 +43,7 @@ import type {
   Rect,
   Size
 } from './interfaces'
-import {
-  type LGraphNodeConstructor,
-  LiteGraph,
-  type Subgraph,
-  type SubgraphNode
-} from './litegraph'
+import type { LGraphNodeConstructor, Subgraph, SubgraphNode } from './litegraph'
 import {
   createBounds,
   isInRect,
@@ -244,11 +240,11 @@ export class LGraphNode
    * The font style used to render the node's title text.
    */
   get titleFontStyle(): string {
-    return `${LiteGraph.NODE_TEXT_SIZE}px ${LiteGraph.NODE_FONT}`
+    return `${LiteGraphInternal.NODE_TEXT_SIZE}px ${LiteGraphInternal.NODE_FONT}`
   }
 
   get innerFontStyle(): string {
-    return `normal ${LiteGraph.NODE_SUBTEXT_SIZE}px ${LiteGraph.NODE_FONT}`
+    return `normal ${LiteGraphInternal.NODE_SUBTEXT_SIZE}px ${LiteGraphInternal.NODE_FONT}`
   }
 
   get displayType(): string {
@@ -303,13 +299,19 @@ export class LGraphNode
 
   /** The fg color used to render the node. */
   get renderingColor(): string {
-    return this.color || this.constructor.color || LiteGraph.NODE_DEFAULT_COLOR
+    return (
+      this.color ||
+      this.constructor.color ||
+      LiteGraphInternal.NODE_DEFAULT_COLOR
+    )
   }
 
   /** The bg color used to render the node. */
   get renderingBgColor(): string {
     return (
-      this.bgcolor || this.constructor.bgcolor || LiteGraph.NODE_DEFAULT_BGCOLOR
+      this.bgcolor ||
+      this.constructor.bgcolor ||
+      LiteGraphInternal.NODE_DEFAULT_BGCOLOR
     )
   }
 
@@ -317,17 +319,17 @@ export class LGraphNode
   get renderingBoxColor(): string {
     if (this.boxcolor) return this.boxcolor
 
-    if (LiteGraph.node_box_coloured_when_on) {
+    if (LiteGraphInternal.node_box_coloured_when_on) {
       if (this.action_triggered) return '#FFF'
       if (this.execute_triggered) return '#AAA'
     }
 
-    if (LiteGraph.node_box_coloured_by_mode) {
+    if (LiteGraphInternal.node_box_coloured_by_mode) {
       const modeColour =
-        LiteGraph.NODE_MODES_COLORS[this.mode ?? LGraphEventMode.ALWAYS]
+        LiteGraphInternal.NODE_MODES_COLORS[this.mode ?? LGraphEventMode.ALWAYS]
       if (modeColour) return modeColour
     }
-    return LiteGraph.NODE_DEFAULT_BOXCOLOR
+    return LiteGraphInternal.NODE_DEFAULT_BOXCOLOR
   }
 
   /** @inheritdoc {@link IColorable.setColorOption} */
@@ -507,7 +509,11 @@ export class LGraphNode
    * The shape of the node used for rendering. @see {@link RenderShape}
    */
   get renderingShape(): RenderShape {
-    return this._shape || this.constructor.shape || LiteGraph.NODE_DEFAULT_SHAPE
+    return (
+      this._shape ||
+      this.constructor.shape ||
+      LiteGraphInternal.NODE_DEFAULT_SHAPE
+    )
   }
 
   public get is_selected(): boolean | undefined {
@@ -720,7 +726,7 @@ export class LGraphNode
       return {
         padding: 12,
         lineWidth: 10,
-        color: LiteGraph.NODE_ERROR_COLOUR
+        color: LiteGraphInternal.NODE_ERROR_COLOUR
       }
     }
   }
@@ -734,10 +740,10 @@ export class LGraphNode
   }
 
   constructor(title: string, type?: string) {
-    this.id = LiteGraph.use_uuids ? LiteGraph.uuidv4() : -1
+    this.id = LiteGraphInternal.use_uuids ? LiteGraphInternal.uuidv4() : -1
     this.title = title || 'Unnamed'
     this.type = type ?? ''
-    this.size = [LiteGraph.NODE_WIDTH, 60]
+    this.size = [LiteGraphInternal.NODE_WIDTH, 60]
     this.pos = [10, 10]
     this.strokeStyles = {
       error: this.#getErrorStrokeStyle,
@@ -778,7 +784,7 @@ export class LGraphNode
           this[j]?.configure(info[j])
         } else {
           // @ts-expect-error #594
-          this[j] = LiteGraph.cloneObject(info[j], this[j])
+          this[j] = LiteGraphInternal.cloneObject(info[j], this[j])
         }
       } else {
         // value
@@ -863,7 +869,7 @@ export class LGraphNode
       type: this.type,
       pos: [this.pos[0], this.pos[1]],
       size: [this.size[0], this.size[1]],
-      flags: LiteGraph.cloneObject(this.flags),
+      flags: LiteGraphInternal.cloneObject(this.flags),
       order: this.order,
       mode: this.mode,
       showAdvanced: this.showAdvanced
@@ -881,7 +887,8 @@ export class LGraphNode
 
     if (this.title && this.title != this.constructor.title) o.title = this.title
 
-    if (this.properties) o.properties = LiteGraph.cloneObject(this.properties)
+    if (this.properties)
+      o.properties = LiteGraphInternal.cloneObject(this.properties)
 
     const { widgets } = this
     if (widgets && this.serialize_widgets) {
@@ -911,11 +918,11 @@ export class LGraphNode
   /* Creates a clone of this node */
   clone(): LGraphNode | null {
     if (this.type == null) return null
-    const node = LiteGraph.createNode(this.type)
+    const node = LiteGraphInternal.createNode(this.type)
     if (!node) return null
 
     // we clone it because serialize returns shared containers
-    const data = LiteGraph.cloneObject(this.serialize())
+    const data = LiteGraphInternal.cloneObject(this.serialize())
     const { inputs, outputs } = data
 
     // remove links
@@ -934,7 +941,7 @@ export class LGraphNode
     // @ts-expect-error Exceptional case: id is removed so that the graph can assign a new one on add.
     delete data.id
 
-    if (LiteGraph.use_uuids) data.id = LiteGraph.uuidv4()
+    if (LiteGraphInternal.use_uuids) data.id = LiteGraphInternal.uuidv4()
 
     node.configure(data)
 
@@ -1255,7 +1262,7 @@ export class LGraphNode
   addOnTriggerInput(): number {
     const trigS = this.findInputSlot('onTrigger')
     if (trigS == -1) {
-      this.addInput('onTrigger', LiteGraph.EVENT, {
+      this.addInput('onTrigger', LiteGraphInternal.EVENT, {
         nameLocked: true
       })
       return this.findInputSlot('onTrigger')
@@ -1266,7 +1273,7 @@ export class LGraphNode
   addOnExecutedOutput(): number {
     const trigS = this.findOutputSlot('onExecuted')
     if (trigS == -1) {
-      this.addOutput('onExecuted', LiteGraph.ACTION, {
+      this.addOutput('onExecuted', LiteGraphInternal.ACTION, {
         nameLocked: true
       })
       return this.findOutputSlot('onExecuted')
@@ -1298,7 +1305,7 @@ export class LGraphNode
         break
 
       // @ts-expect-error Not impl.
-      case LiteGraph.ON_REQUEST:
+      case LiteGraphInternal.ON_REQUEST:
         break
 
       default:
@@ -1385,12 +1392,12 @@ export class LGraphNode
       return
     }
 
-    if (this.graph) this.graph._last_trigger_time = LiteGraph.getTime()
+    if (this.graph) this.graph._last_trigger_time = LiteGraphInternal.getTime()
 
     for (const [i, output] of outputs.entries()) {
       if (
         !output ||
-        output.type !== LiteGraph.EVENT ||
+        output.type !== LiteGraphInternal.EVENT ||
         (action && output.name != action)
       ) {
         continue
@@ -1430,7 +1437,7 @@ export class LGraphNode
     if (!links || !links.length) return
 
     if (!this.graph) throw new NullGraphError()
-    this.graph._last_trigger_time = LiteGraph.getTime()
+    this.graph._last_trigger_time = LiteGraphInternal.getTime()
 
     // for every link attached here
     for (const id of links) {
@@ -1441,7 +1448,7 @@ export class LGraphNode
       // not connected
       if (!link_info) continue
 
-      link_info._last_time = LiteGraph.getTime()
+      link_info._last_time = LiteGraphInternal.getTime()
       const node = this.graph.getNodeById(link_info.target_id)
       // node not found?
       if (!node) continue
@@ -1551,8 +1558,8 @@ export class LGraphNode
     this.outputs.push(output)
     this.onOutputAdded?.(output)
 
-    if (LiteGraph.auto_load_slot_types)
-      LiteGraph.registerNodeAndSlotType(this, type, true)
+    if (LiteGraphInternal.auto_load_slot_types)
+      LiteGraphInternal.registerNodeAndSlotType(this, type, true)
 
     this.expandToFitContent()
     this.setDirtyCanvas(true, true)
@@ -1609,7 +1616,7 @@ export class LGraphNode
     this.expandToFitContent()
 
     this.onInputAdded?.(input)
-    LiteGraph.registerNodeAndSlotType(this, type)
+    LiteGraphInternal.registerNodeAndSlotType(this, type)
 
     this.setDirtyCanvas(true, true)
     return input
@@ -1656,9 +1663,9 @@ export class LGraphNode
     const size = out || new Float32Array([0, 0])
     rows = Math.max(rows, 1)
     // although it should be graphcanvas.inner_text_font size
-    const font_size = LiteGraph.NODE_TEXT_SIZE
+    const font_size = LiteGraphInternal.NODE_TEXT_SIZE
 
-    const padLeft = LiteGraph.NODE_TITLE_HEIGHT
+    const padLeft = LiteGraphInternal.NODE_TITLE_HEIGHT
     const padRight = padLeft * 0.33
     const title_width =
       padLeft + compute_text_size(this.title, this.titleFontStyle) + padRight
@@ -1689,13 +1696,13 @@ export class LGraphNode
       }
     }
 
-    const minWidth = LiteGraph.NODE_WIDTH * (widgets?.length ? 1.5 : 1)
+    const minWidth = LiteGraphInternal.NODE_WIDTH * (widgets?.length ? 1.5 : 1)
     // Text + slot width + centre padding
     const centrePadding = input_width && output_width ? 5 : 0
     const slotsWidth =
       input_width +
       output_width +
-      2 * LiteGraph.NODE_SLOT_HEIGHT +
+      2 * LiteGraphInternal.NODE_SLOT_HEIGHT +
       centrePadding
 
     // Total distance from edge of node to the inner edge of the widget 'previous' arrow button
@@ -1706,7 +1713,8 @@ export class LGraphNode
 
     size[0] = Math.max(slotsWidth, widgetWidth, title_width, minWidth)
     size[1] =
-      (this.constructor.slot_start_y || 0) + rows * LiteGraph.NODE_SLOT_HEIGHT
+      (this.constructor.slot_start_y || 0) +
+      rows * LiteGraphInternal.NODE_SLOT_HEIGHT
 
     // Get widget height & expand size if necessary
     let widgets_height = 0
@@ -1725,7 +1733,7 @@ export class LGraphNode
 
           widget_height += minHeight
         } else {
-          widget_height += LiteGraph.NODE_WIDGET_HEIGHT
+          widget_height += LiteGraphInternal.NODE_WIDGET_HEIGHT
         }
         widgets_height += widget_height + 4
       }
@@ -1758,7 +1766,8 @@ export class LGraphNode
   inResizeCorner(canvasX: number, canvasY: number): boolean {
     const rows = this.outputs ? this.outputs.length : 1
     const outputs_offset =
-      (this.constructor.slot_start_y || 0) + rows * LiteGraph.NODE_SLOT_HEIGHT
+      (this.constructor.slot_start_y || 0) +
+      rows * LiteGraphInternal.NODE_SLOT_HEIGHT
     return isInRectangle(
       canvasX,
       canvasY,
@@ -1959,7 +1968,7 @@ export class LGraphNode
 
     // If Vue nodes mode is enabled, skip LiteGraph's direct position update
     // The layout store will handle the movement and sync back to LiteGraph
-    if (LiteGraph.vueNodesMode) {
+    if (LiteGraphInternal.vueNodesMode) {
       // Vue nodes handle their own dragging through the layout store
       // This prevents the snap-back issue from conflicting position updates
       return
@@ -1983,7 +1992,7 @@ export class LGraphNode
     const renderTitle =
       titleMode != TitleMode.TRANSPARENT_TITLE &&
       titleMode != TitleMode.NO_TITLE
-    const titleHeight = renderTitle ? LiteGraph.NODE_TITLE_HEIGHT : 0
+    const titleHeight = renderTitle ? LiteGraphInternal.NODE_TITLE_HEIGHT : 0
 
     out[0] = this.pos[0]
     out[1] = this.pos[1] + -titleHeight
@@ -1995,10 +2004,10 @@ export class LGraphNode
       this._collapsed_width = Math.min(
         this.size[0],
         ctx.measureText(this.getTitle() ?? '').width +
-          LiteGraph.NODE_TITLE_HEIGHT * 2
+          LiteGraphInternal.NODE_TITLE_HEIGHT * 2
       )
-      out[2] = this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH
-      out[3] = LiteGraph.NODE_TITLE_HEIGHT
+      out[2] = this._collapsed_width || LiteGraphInternal.NODE_COLLAPSED_WIDTH
+      out[3] = LiteGraphInternal.NODE_TITLE_HEIGHT
     }
   }
 
@@ -2055,7 +2064,7 @@ export class LGraphNode
    * @returns true if the x,y point is in the collapse button area, otherwise false
    */
   isPointInCollapse(x: number, y: number): boolean {
-    const squareLength = LiteGraph.NODE_TITLE_HEIGHT
+    const squareLength = LiteGraphInternal.NODE_TITLE_HEIGHT
     return isInRectangle(
       x,
       y,
@@ -2158,7 +2167,7 @@ export class LGraphNode
       const h =
         widget.computedHeight ??
         widget.computeSize?.(nodeWidth)[1] ??
-        LiteGraph.NODE_WIDGET_HEIGHT
+        LiteGraphInternal.NODE_WIDGET_HEIGHT
 
       const maybeDOMWidget = widget as { margin?: number }
       const mtop = maybeDOMWidget.margin ?? -2
@@ -2439,10 +2448,12 @@ export class LGraphNode
 
       for (const sourceType of sourceTypes) {
         // TODO: Remove _event_ entirely.
-        const source = sourceType == '_event_' ? LiteGraph.EVENT : sourceType
+        const source =
+          sourceType == '_event_' ? LiteGraphInternal.EVENT : sourceType
 
         for (const destType of destTypes) {
-          const dest = destType == '_event_' ? LiteGraph.EVENT : destType
+          const dest =
+            destType == '_event_' ? LiteGraphInternal.EVENT : destType
 
           if (source == dest || source === '*' || dest === '*') {
             if (preferFreeSlot && (slot.links?.length || slot.link != null)) {
@@ -2502,9 +2513,10 @@ export class LGraphNode
     if (slot >= 0 && slot !== null) return slot
 
     // TODO: Remove or reimpl. events.  WILL CREATE THE onTrigger IN SLOT
-    if (opts.createEventInCase && slotType == LiteGraph.EVENT) {
+    if (opts.createEventInCase && slotType == LiteGraphInternal.EVENT) {
       if (findInputs) return -1
-      if (LiteGraph.do_add_triggers_slots) return node.addOnExecutedOutput()
+      if (LiteGraphInternal.do_add_triggers_slots)
+        return node.addOnExecutedOutput()
     }
 
     // connect to the first general output slot if not found a specific type and
@@ -2517,7 +2529,7 @@ export class LGraphNode
       opts.wildcardToTyped &&
       (slotType == 0 || slotType == '*' || slotType == '')
     ) {
-      const opt = { typesNotAccepted: [LiteGraph.EVENT] }
+      const opt = { typesNotAccepted: [LiteGraphInternal.EVENT] }
       const nonEventSlot = findInputs
         ? node.findInputSlotFree(opt)
         : node.findOutputSlotFree(opt)
@@ -2637,7 +2649,7 @@ export class LGraphNode
   ) {
     return (
       this.id !== node.id &&
-      LiteGraph.isValidConnection(fromSlot.type, toSlot.type)
+      LiteGraphInternal.isValidConnection(fromSlot.type, toSlot.type)
     )
   }
 
@@ -2671,12 +2683,13 @@ export class LGraphNode
     if (typeof slot === 'string') {
       slot = this.findOutputSlot(slot)
       if (slot == -1) {
-        if (LiteGraph.debug)
+        if (LiteGraphInternal.debug)
           console.log(`Connect: Error, no slot of name ${slot}`)
         return null
       }
     } else if (!outputs || slot >= outputs.length) {
-      if (LiteGraph.debug) console.log('Connect: Error, slot number not found')
+      if (LiteGraphInternal.debug)
+        console.log('Connect: Error, slot number not found')
       return null
     }
 
@@ -2695,13 +2708,13 @@ export class LGraphNode
     if (typeof target_slot === 'string') {
       targetIndex = target_node.findInputSlot(target_slot)
       if (targetIndex == -1) {
-        if (LiteGraph.debug)
+        if (LiteGraphInternal.debug)
           console.log(`Connect: Error, no slot of name ${targetIndex}`)
         return null
       }
-    } else if (target_slot === LiteGraph.EVENT) {
+    } else if (target_slot === LiteGraphInternal.EVENT) {
       // TODO: Events
-      if (LiteGraph.do_add_triggers_slots) {
+      if (LiteGraphInternal.do_add_triggers_slots) {
         target_node.changeMode(LGraphEventMode.ON_TRIGGER)
         targetIndex = target_node.findInputSlot('onTrigger')
       } else {
@@ -2728,7 +2741,8 @@ export class LGraphNode
       !target_node.inputs ||
       targetIndex >= target_node.inputs.length
     ) {
-      if (LiteGraph.debug) console.log('Connect: Error, slot number not found')
+      if (LiteGraphInternal.debug)
+        console.log('Connect: Error, slot number not found')
       return null
     }
 
@@ -2739,8 +2753,8 @@ export class LGraphNode
 
     if (output.links?.length) {
       if (
-        output.type === LiteGraph.EVENT &&
-        !LiteGraph.allow_multi_output_for_events
+        output.type === LiteGraphInternal.EVENT &&
+        !LiteGraphInternal.allow_multi_output_for_events
       ) {
         graph.beforeChange()
         // @ts-expect-error Unused param
@@ -2783,7 +2797,7 @@ export class LGraphNode
     }
 
     // check targetSlot and check connection types
-    if (!LiteGraph.isValidConnection(output.type, input.type)) {
+    if (!LiteGraphInternal.isValidConnection(output.type, input.type)) {
       this.setDirtyCanvas(false, true)
       return null
     }
@@ -2954,12 +2968,13 @@ export class LGraphNode
     if (typeof slot === 'string') {
       slot = this.findOutputSlot(slot)
       if (slot == -1) {
-        if (LiteGraph.debug)
+        if (LiteGraphInternal.debug)
           console.log(`Connect: Error, no slot of name ${slot}`)
         return false
       }
     } else if (!this.outputs || slot >= this.outputs.length) {
-      if (LiteGraph.debug) console.log('Connect: Error, slot number not found')
+      if (LiteGraphInternal.debug)
+        console.log('Connect: Error, slot number not found')
       return false
     }
 
@@ -3074,12 +3089,12 @@ export class LGraphNode
     if (typeof slot === 'string') {
       slot = this.findInputSlot(slot)
       if (slot == -1) {
-        if (LiteGraph.debug)
+        if (LiteGraphInternal.debug)
           console.log(`Connect: Error, no slot of name ${slot}`)
         return false
       }
     } else if (!this.inputs || slot >= this.inputs.length) {
-      if (LiteGraph.debug) {
+      if (LiteGraphInternal.debug) {
         console.log('Connect: Error, slot number not found')
       }
       return false
@@ -3183,16 +3198,16 @@ export class LGraphNode
     } = this
 
     if (this.flags.collapsed) {
-      const w = this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH
+      const w = this._collapsed_width || LiteGraphInternal.NODE_COLLAPSED_WIDTH
       out[0] = is_input ? nodeX : nodeX + w
-      out[1] = nodeY - LiteGraph.NODE_TITLE_HEIGHT * 0.5
+      out[1] = nodeY - LiteGraphInternal.NODE_TITLE_HEIGHT * 0.5
       return out
     }
 
     // weird feature that never got finished
     if (is_input && slot_number == -1) {
-      out[0] = nodeX + LiteGraph.NODE_TITLE_HEIGHT * 0.5
-      out[1] = nodeY + LiteGraph.NODE_TITLE_HEIGHT * 0.5
+      out[0] = nodeX + LiteGraphInternal.NODE_TITLE_HEIGHT * 0.5
+      out[1] = nodeY + LiteGraphInternal.NODE_TITLE_HEIGHT * 0.5
       return out
     }
 
@@ -3211,7 +3226,7 @@ export class LGraphNode
     }
 
     // default vertical slots
-    const offset = LiteGraph.NODE_SLOT_HEIGHT * 0.5
+    const offset = LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
     const slotIndex = is_input
       ? this.#defaultVerticalInputs.indexOf(this.inputs[slot_number])
       : this.#defaultVerticalOutputs.indexOf(this.outputs[slot_number])
@@ -3219,7 +3234,7 @@ export class LGraphNode
     out[0] = is_input ? nodeX + offset : nodeX + this.size[0] + 1 - offset
     out[1] =
       nodeY +
-      (slotIndex + 0.7) * LiteGraph.NODE_SLOT_HEIGHT +
+      (slotIndex + 0.7) * LiteGraphInternal.NODE_SLOT_HEIGHT +
       (this.constructor.slot_start_y || 0)
     return out
   }
@@ -3297,7 +3312,7 @@ export class LGraphNode
 
   /** @see {@link snapToGrid} */
   alignToGrid(): void {
-    this.snapToGrid(LiteGraph.CANVAS_GRID_SIZE)
+    this.snapToGrid(LiteGraphInternal.CANVAS_GRID_SIZE)
   }
 
   /* Console output */
@@ -3321,7 +3336,7 @@ export class LGraphNode
     }
 
     const img: AsyncImageElement = new Image()
-    img.src = LiteGraph.node_images_path + url
+    img.src = LiteGraphInternal.node_images_path + url
     img.ready = false
 
     const dirty = () => this.setDirtyCanvas(true)
@@ -3416,7 +3431,7 @@ export class LGraphNode
 
   get width() {
     return this.collapsed
-      ? this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH
+      ? this._collapsed_width || LiteGraphInternal.NODE_COLLAPSED_WIDTH
       : this.size[0]
   }
 
@@ -3424,7 +3439,7 @@ export class LGraphNode
    * Returns the height of the node, including the title bar.
    */
   get height() {
-    return LiteGraph.NODE_TITLE_HEIGHT + this.bodyHeight
+    return LiteGraphInternal.NODE_TITLE_HEIGHT + this.bodyHeight
   }
 
   /**
@@ -3447,7 +3462,7 @@ export class LGraphNode
           (acc, badge) => acc + badge.getWidth(ctx) + gap,
           0
         )
-    const y = -(LiteGraph.NODE_TITLE_HEIGHT + gap)
+    const y = -(LiteGraphInternal.NODE_TITLE_HEIGHT + gap)
 
     for (const badge of badgeInstances) {
       badge.draw(ctx, currentX, y - badge.height)
@@ -3462,7 +3477,7 @@ export class LGraphNode
     ctx: CanvasRenderingContext2D,
     {
       scale,
-      title_height = LiteGraph.NODE_TITLE_HEIGHT,
+      title_height = LiteGraphInternal.NODE_TITLE_HEIGHT,
       low_quality = false
     }: DrawTitleOptions
   ): void {
@@ -3480,7 +3495,7 @@ export class LGraphNode
     }
 
     if (this.collapsed) {
-      ctx.shadowColor = LiteGraph.DEFAULT_SHADOW_COLOR
+      ctx.shadowColor = LiteGraphInternal.DEFAULT_SHADOW_COLOR
     }
 
     ctx.fillStyle = this.constructor.title_color || fgcolor
@@ -3495,8 +3510,13 @@ export class LGraphNode
         size[0],
         title_height,
         this.collapsed
-          ? [LiteGraph.ROUND_RADIUS]
-          : [LiteGraph.ROUND_RADIUS, LiteGraph.ROUND_RADIUS, 0, 0]
+          ? [LiteGraphInternal.ROUND_RADIUS]
+          : [
+              LiteGraphInternal.ROUND_RADIUS,
+              LiteGraphInternal.ROUND_RADIUS,
+              0,
+              0
+            ]
       )
     }
     ctx.fill()
@@ -3513,7 +3533,7 @@ export class LGraphNode
     {
       scale,
       low_quality = false,
-      title_height = LiteGraph.NODE_TITLE_HEIGHT,
+      title_height = LiteGraphInternal.NODE_TITLE_HEIGHT,
       box_size = 10
     }: DrawTitleBoxOptions
   ): void {
@@ -3589,7 +3609,7 @@ export class LGraphNode
       scale,
       default_title_color,
       low_quality = false,
-      title_height = LiteGraph.NODE_TITLE_HEIGHT
+      title_height = LiteGraphInternal.NODE_TITLE_HEIGHT
     }: DrawTitleTextOptions
   ): void {
     const size = this.renderingSize
@@ -3617,7 +3637,7 @@ export class LGraphNode
     const title = String(rawTitle) + (this.pinned ? '📌' : '')
     if (title) {
       if (selected) {
-        ctx.fillStyle = LiteGraph.NODE_SELECTED_TITLE_COLOR
+        ctx.fillStyle = LiteGraphInternal.NODE_SELECTED_TITLE_COLOR
       } else {
         ctx.fillStyle = this.constructor.title_text_color || default_title_color
       }
@@ -3656,7 +3676,7 @@ export class LGraphNode
       ctx.fillText(
         displayTitle,
         title_height,
-        LiteGraph.NODE_TITLE_TEXT_Y - title_height
+        LiteGraphInternal.NODE_TITLE_TEXT_Y - title_height
       )
     }
   }
@@ -3689,7 +3709,10 @@ export class LGraphNode
       if (input.link == null) continue
 
       const output = outputs[index]
-      if (!output || !LiteGraph.isValidConnection(input.type, output.type))
+      if (
+        !output ||
+        !LiteGraphInternal.isValidConnection(input.type, output.type)
+      )
         continue
 
       const inLink = _links.get(input.link)
@@ -3713,7 +3736,8 @@ export class LGraphNode
       if (!inNode) continue
 
       for (const output of outputs) {
-        if (!LiteGraph.isValidConnection(input.type, output.type)) continue
+        if (!LiteGraphInternal.isValidConnection(input.type, output.type))
+          continue
 
         bypassAllLinks(output, inNode, inLink, graph)
         break
@@ -3764,7 +3788,7 @@ export class LGraphNode
 
     const nodeWidth = this.size[0]
     const { widgets } = this
-    const H = LiteGraph.NODE_WIDGET_HEIGHT
+    const H = LiteGraphInternal.NODE_WIDGET_HEIGHT
     const showText = !lowQuality
     ctx.save()
     ctx.globalAlpha = editorAlpha
@@ -3774,8 +3798,8 @@ export class LGraphNode
 
       const { y } = widget
       const outlineColour = widget.advanced
-        ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR
-        : LiteGraph.WIDGET_OUTLINE_COLOR
+        ? LiteGraphInternal.WIDGET_ADVANCED_OUTLINE_COLOR
+        : LiteGraphInternal.WIDGET_OUTLINE_COLOR
 
       widget.last_y = y
       // Disable widget if it is disabled or if the value is passed from socket connection.
@@ -3833,12 +3857,12 @@ export class LGraphNode
       ? this.getInputPos(slotIndex)
       : this.getOutputPos(slotIndex)
 
-    slot.boundingRect[0] = pos[0] - LiteGraph.NODE_SLOT_HEIGHT * 0.5
-    slot.boundingRect[1] = pos[1] - LiteGraph.NODE_SLOT_HEIGHT * 0.5
+    slot.boundingRect[0] = pos[0] - LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
+    slot.boundingRect[1] = pos[1] - LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
     slot.boundingRect[2] = slot.isWidgetInputSlot
       ? BaseWidget.margin
-      : LiteGraph.NODE_SLOT_HEIGHT
-    slot.boundingRect[3] = LiteGraph.NODE_SLOT_HEIGHT
+      : LiteGraphInternal.NODE_SLOT_HEIGHT
+    slot.boundingRect[3] = LiteGraphInternal.NODE_SLOT_HEIGHT
   }
 
   #measureSlots(): ReadOnlyRect | null {
@@ -3973,7 +3997,7 @@ export class LGraphNode
           w
         })
       } else {
-        const height = LiteGraph.NODE_WIDGET_HEIGHT + 4
+        const height = LiteGraphInternal.NODE_WIDGET_HEIGHT + 4
         w.computedHeight = height
         fixedWidgetHeight += height
       }
@@ -4036,13 +4060,13 @@ export class LGraphNode
 
     // Only set custom pos if not using Vue positioning
     // Vue positioning calculates widget slot positions dynamically
-    if (!LiteGraph.vueNodesMode) {
+    if (!LiteGraphInternal.vueNodesMode) {
       for (const widget of this.widgets) {
         const slot = slotByWidgetName.get(widget.name)
         if (!slot) continue
 
         const actualSlot = this.#concreteInputs[slot.index]
-        const offset = LiteGraph.NODE_SLOT_HEIGHT * 0.5
+        const offset = LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
         actualSlot.pos = [offset, widget.y + offset]
         this.#measureSlot(actualSlot, slot.index, true)
       }

--- a/src/lib/litegraph/src/LiteGraphInternal.ts
+++ b/src/lib/litegraph/src/LiteGraphInternal.ts
@@ -1,0 +1,7 @@
+import { LiteGraphGlobal } from './LiteGraphGlobal'
+
+// To prevent circular dependency in litegraph/itself.ts -> litegraph.ts -> litegraph/itself.ts
+// For all src/lib/litegraph/**/*.ts files, We should import litegraph instance from here
+// And for imports outside from litegraph, We can import it directly from 'src/lib/litegraph/src/litegraph' for simplicity
+
+export const LiteGraphInternal = new LiteGraphGlobal()

--- a/src/lib/litegraph/src/draw.ts
+++ b/src/lib/litegraph/src/draw.ts
@@ -1,6 +1,6 @@
+import { LiteGraphInternal } from './LiteGraphInternal'
 import type { Rectangle } from './infrastructure/Rectangle'
 import type { CanvasColour, Rect } from './interfaces'
-import { LiteGraph } from './litegraph'
 import { RenderShape, TitleMode } from './types/globalEnums'
 
 const ELLIPSIS = '\u2026'
@@ -80,12 +80,12 @@ export function strokeShape(
   }: IDrawBoundingOptions = {}
 ): void {
   // These param defaults are not compile-time static, and must be re-evaluated at runtime
-  round_radius ??= LiteGraph.ROUND_RADIUS
-  color ??= LiteGraph.NODE_BOX_OUTLINE_COLOR
+  round_radius ??= LiteGraphInternal.ROUND_RADIUS
+  color ??= LiteGraphInternal.NODE_BOX_OUTLINE_COLOR
 
   // Adjust area if title is transparent
   if (title_mode === TitleMode.TRANSPARENT_TITLE) {
-    const height = title_height ?? LiteGraph.NODE_TITLE_HEIGHT
+    const height = title_height ?? LiteGraphInternal.NODE_TITLE_HEIGHT
     area[1] -= height
     area[3] += height
   }

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -1,6 +1,6 @@
 import type { ContextMenu } from './ContextMenu'
 import type { LGraphNode } from './LGraphNode'
-import { LiteGraphGlobal } from './LiteGraphGlobal'
+import { LiteGraphInternal } from './LiteGraphInternal'
 import type { ConnectingLink, Point } from './interfaces'
 import type { IContextMenuOptions, Size } from './interfaces'
 import { loadPolyfills } from './polyfills'
@@ -10,7 +10,10 @@ import type { RenderShape, TitleMode } from './types/globalEnums'
 // Must remain above LiteGraphGlobal (circular dependency due to abstract factory behaviour in `configure`)
 export { Subgraph } from './subgraph/Subgraph'
 
-export const LiteGraph = new LiteGraphGlobal()
+// Note: To prevent circular dependency in litegraph/itself.ts -> litegraph.ts -> litegraph/itself.ts
+// For all src/lib/litegraph/**/*.ts files, We should import litegraph instance from LiteGraphInternal
+// And for imports outside from litegraph, We can import it directly from here for simplicity
+export const LiteGraph = LiteGraphInternal
 
 // Load legacy polyfills
 loadPolyfills()

--- a/src/lib/litegraph/src/node/NodeInputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.ts
@@ -7,12 +7,13 @@ import type {
   OptionalProps,
   ReadOnlyPoint
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { type IDrawOptions, NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
 import { isSubgraphInput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { LiteGraphInternal } from '../LiteGraphInternal'
 
 export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
   link: LinkId | null
@@ -33,7 +34,7 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
   }
 
   get collapsedPos(): ReadOnlyPoint {
-    return [0, LiteGraph.NODE_TITLE_HEIGHT * -0.5]
+    return [0, LiteGraphInternal.NODE_TITLE_HEIGHT * -0.5]
   }
 
   constructor(
@@ -52,11 +53,11 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
     fromSlot: INodeInputSlot | INodeOutputSlot | SubgraphInput | SubgraphOutput
   ): boolean {
     if ('links' in fromSlot) {
-      return LiteGraph.isValidConnection(fromSlot.type, this.type)
+      return LiteGraphInternal.isValidConnection(fromSlot.type, this.type)
     }
 
     if (isSubgraphInput(fromSlot)) {
-      return LiteGraph.isValidConnection(fromSlot.type, this.type)
+      return LiteGraphInternal.isValidConnection(fromSlot.type, this.type)
     }
 
     return false

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -7,11 +7,12 @@ import type {
   OptionalProps,
   ReadOnlyPoint
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { type IDrawOptions, NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
 import { isSubgraphOutput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
+
+import { LiteGraphInternal } from '../LiteGraphInternal'
 
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   #node: LGraphNode
@@ -26,8 +27,8 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
 
   get collapsedPos(): ReadOnlyPoint {
     return [
-      this.#node._collapsed_width ?? LiteGraph.NODE_COLLAPSED_WIDTH,
-      LiteGraph.NODE_TITLE_HEIGHT * -0.5
+      this.#node._collapsed_width ?? LiteGraphInternal.NODE_COLLAPSED_WIDTH,
+      LiteGraphInternal.NODE_TITLE_HEIGHT * -0.5
     ]
   }
 
@@ -46,11 +47,11 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     fromSlot: INodeInputSlot | INodeOutputSlot | SubgraphInput | SubgraphOutput
   ): boolean {
     if ('link' in fromSlot) {
-      return LiteGraph.isValidConnection(this.type, fromSlot.type)
+      return LiteGraphInternal.isValidConnection(this.type, fromSlot.type)
     }
 
     if (isSubgraphOutput(fromSlot)) {
-      return LiteGraph.isValidConnection(this.type, fromSlot.type)
+      return LiteGraphInternal.isValidConnection(this.type, fromSlot.type)
     }
 
     return false

--- a/src/lib/litegraph/src/node/NodeSlot.ts
+++ b/src/lib/litegraph/src/node/NodeSlot.ts
@@ -11,7 +11,7 @@ import type {
   Point,
   ReadOnlyPoint
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph, Rectangle } from '@/lib/litegraph/src/litegraph'
+import { Rectangle } from '@/lib/litegraph/src/litegraph'
 import { getCentre } from '@/lib/litegraph/src/measure'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
@@ -20,6 +20,7 @@ import {
   RenderShape
 } from '@/lib/litegraph/src/types/globalEnums'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import { NodeInputSlot } from './NodeInputSlot'
 import { SlotBase } from './SlotBase'
 
@@ -61,9 +62,9 @@ export abstract class NodeSlot extends SlotBase implements INodeSlot {
 
   get highlightColor(): CanvasColour {
     return (
-      LiteGraph.NODE_TEXT_HIGHLIGHT_COLOR ??
-      LiteGraph.NODE_SELECTED_TITLE_COLOR ??
-      LiteGraph.NODE_TEXT_COLOR
+      LiteGraphInternal.NODE_TEXT_HIGHLIGHT_COLOR ??
+      LiteGraphInternal.NODE_SELECTED_TITLE_COLOR ??
+      LiteGraphInternal.NODE_TEXT_COLOR
     )
   }
 
@@ -123,7 +124,7 @@ export abstract class NodeSlot extends SlotBase implements INodeSlot {
 
     const labelColor = highlight
       ? this.highlightColor
-      : LiteGraph.NODE_TEXT_COLOR
+      : LiteGraphInternal.NODE_TEXT_COLOR
 
     const pos = this.#centreOffset
     const slot_type = this.type

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -9,8 +9,9 @@ import type {
   CallbackReturn,
   ISlotType
 } from '@/lib/litegraph/src/interfaces'
-import { LGraphEventMode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import type { Subgraph } from './Subgraph'
 import type { SubgraphNode } from './SubgraphNode'
 
@@ -346,8 +347,8 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
     // Prefer input with the same slot ID
     if (
       oppositeInput &&
-      LiteGraph.isValidConnection(oppositeInput.type, outputType) &&
-      LiteGraph.isValidConnection(oppositeInput.type, type)
+      LiteGraphInternal.isValidConnection(oppositeInput.type, outputType) &&
+      LiteGraphInternal.isValidConnection(oppositeInput.type, type)
     ) {
       return slot
     }
@@ -359,8 +360,8 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
     // Find first matching slot - prefer exact type
     return inputs.findIndex(
       (input) =>
-        LiteGraph.isValidConnection(input.type, outputType) &&
-        LiteGraph.isValidConnection(input.type, type)
+        LiteGraphInternal.isValidConnection(input.type, outputType) &&
+        LiteGraphInternal.isValidConnection(input.type, type)
     )
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -9,12 +9,11 @@ import type {
   Point,
   Positionable
 } from '@/lib/litegraph/src/interfaces'
-import {
-  type CanvasColour,
-  type CanvasPointer,
-  type CanvasPointerEvent,
-  type IContextMenuValue,
-  LiteGraph
+import type {
+  CanvasColour,
+  CanvasPointer,
+  CanvasPointerEvent,
+  IContextMenuValue
 } from '@/lib/litegraph/src/litegraph'
 import { snapPoint } from '@/lib/litegraph/src/measure'
 import { CanvasItem } from '@/lib/litegraph/src/types/globalEnums'
@@ -23,6 +22,7 @@ import type {
   Serialisable
 } from '@/lib/litegraph/src/types/serialisation'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import type { EmptySubgraphInput } from './EmptySubgraphInput'
 import type { EmptySubgraphOutput } from './EmptySubgraphOutput'
 import type { Subgraph } from './Subgraph'
@@ -194,7 +194,7 @@ export abstract class SubgraphIONodeBase<
     const options: (IContextMenuValue | null)[] = this.#getSlotMenuOptions(slot)
     if (!(options.length > 0)) return
 
-    new LiteGraph.ContextMenu(options, {
+    new LiteGraphInternal.ContextMenu(options, {
       event: event as any,
       title: slot.name || 'Subgraph Output',
       callback: (item: IContextMenuValue) => {

--- a/src/lib/litegraph/src/subgraph/SubgraphInput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInput.ts
@@ -9,10 +9,10 @@ import type {
   Point,
   ReadOnlyRect
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import type { SubgraphInputNode } from './SubgraphInputNode'
 import type { SubgraphOutput } from './SubgraphOutput'
 import { SubgraphSlot } from './SubgraphSlotBase'
@@ -237,12 +237,12 @@ export class SubgraphInput extends SubgraphSlot {
     if (isNodeSlot(fromSlot)) {
       return (
         'link' in fromSlot &&
-        LiteGraph.isValidConnection(this.type, fromSlot.type)
+        LiteGraphInternal.isValidConnection(this.type, fromSlot.type)
       )
     }
 
     if (isSubgraphOutput(fromSlot)) {
-      return LiteGraph.isValidConnection(this.type, fromSlot.type)
+      return LiteGraphInternal.isValidConnection(this.type, fromSlot.type)
     }
 
     return false

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -9,9 +9,9 @@ import type {
   Point,
   ReadOnlyRect
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import type { SubgraphInput } from './SubgraphInput'
 import type { SubgraphOutputNode } from './SubgraphOutputNode'
 import { SubgraphSlot } from './SubgraphSlotBase'
@@ -39,7 +39,7 @@ export class SubgraphOutput extends SubgraphSlot {
     const { subgraph } = this.parent
 
     // Validate type compatibility
-    if (!LiteGraph.isValidConnection(slot.type, this.type)) return
+    if (!LiteGraphInternal.isValidConnection(slot.type, this.type)) return
 
     // Allow nodes to block connection
     const outputIndex = node.outputs.indexOf(slot)
@@ -143,12 +143,12 @@ export class SubgraphOutput extends SubgraphSlot {
     if (isNodeSlot(fromSlot)) {
       return (
         'links' in fromSlot &&
-        LiteGraph.isValidConnection(fromSlot.type, this.type)
+        LiteGraphInternal.isValidConnection(fromSlot.type, this.type)
       )
     }
 
     if (isSubgraphInput(fromSlot)) {
-      return LiteGraph.isValidConnection(fromSlot.type, this.type)
+      return LiteGraphInternal.isValidConnection(fromSlot.type, this.type)
     }
 
     return false

--- a/src/lib/litegraph/src/subgraph/SubgraphSlotBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphSlotBase.ts
@@ -14,7 +14,6 @@ import type {
   ReadOnlyRect,
   ReadOnlySize
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { SlotBase } from '@/lib/litegraph/src/node/SlotBase'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type {
@@ -23,6 +22,7 @@ import type {
 } from '@/lib/litegraph/src/types/serialisation'
 import { type UUID, createUuidv4 } from '@/lib/litegraph/src/utils/uuid'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import type { SubgraphInput } from './SubgraphInput'
 import type { SubgraphInputNode } from './SubgraphInputNode'
 import type { SubgraphOutput } from './SubgraphOutput'
@@ -42,7 +42,7 @@ export abstract class SubgraphSlot
   implements SubgraphIO, Hoverable, Serialisable<SubgraphIO>
 {
   static get defaultHeight() {
-    return LiteGraph.NODE_SLOT_HEIGHT
+    return LiteGraphInternal.NODE_SLOT_HEIGHT
   }
 
   readonly #pos: Point = new Float32Array(2)
@@ -228,7 +228,9 @@ export abstract class SubgraphSlot
     if (this.displayName) {
       const [labelX, labelY] = this.labelPos
       // Also apply highlight logic to text color
-      ctx.fillStyle = highlight ? 'white' : LiteGraph.NODE_TEXT_COLOR || '#AAA'
+      ctx.fillStyle = highlight
+        ? 'white'
+        : LiteGraphInternal.NODE_TEXT_COLOR || '#AAA'
       ctx.fillText(this.displayName, labelX, labelY)
     }
 

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -12,7 +12,7 @@ import type {
   INodeOutputSlot,
   Positionable
 } from '@/lib/litegraph/src/interfaces'
-import { LiteGraph, createUuidv4 } from '@/lib/litegraph/src/litegraph'
+import { createUuidv4 } from '@/lib/litegraph/src/litegraph'
 import { nextUniqueName } from '@/lib/litegraph/src/strings'
 import type {
   ISerialisedNode,
@@ -21,6 +21,7 @@ import type {
 } from '@/lib/litegraph/src/types/serialisation'
 import type { UUID } from '@/lib/litegraph/src/utils/uuid'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import type { GraphOrSubgraph } from './Subgraph'
 import type { SubgraphInput } from './SubgraphInput'
 import { SubgraphInputNode } from './SubgraphInputNode'
@@ -217,14 +218,14 @@ export function multiClone(nodes: Iterable<LGraphNode>): ISerialisedNode[] {
 
   // Selectively clone - keep IDs & links
   for (const node of nodes) {
-    const newNode = LiteGraph.createNode(node.type)
+    const newNode = LiteGraphInternal.createNode(node.type)
     if (!newNode) {
       console.warn('Failed to create node', node.type)
       continue
     }
 
     // Must be cloned; litegraph "serialize" is mostly shallow clone
-    const data = LiteGraph.cloneObject(node.serialize())
+    const data = LiteGraphInternal.cloneObject(node.serialize())
     newNode.configure(data)
 
     clonedNodes.push(newNode.serialize())

--- a/src/lib/litegraph/src/types/serialisation.ts
+++ b/src/lib/litegraph/src/types/serialisation.ts
@@ -4,6 +4,7 @@ import type { LGraphConfig, LGraphExtra, LGraphState } from '../LGraph'
 import type { IGraphGroupFlags } from '../LGraphGroup'
 import type { NodeId, NodeProperty } from '../LGraphNode'
 import type { LinkId, SerialisedLLinkArray } from '../LLink'
+import type { LiteGraphInternal } from '../LiteGraphInternal'
 import type { FloatingRerouteSlot, RerouteId } from '../Reroute'
 import type {
   Dictionary,
@@ -15,7 +16,6 @@ import type {
   Point,
   Size
 } from '../interfaces'
-import type { LiteGraph } from '../litegraph'
 import type { TWidgetValue } from '../types/widgets'
 import type { RenderShape } from './globalEnums'
 
@@ -124,7 +124,7 @@ export interface ISerialisedGraph extends BaseExportedGraph {
   links: SerialisedLLinkArray[]
   floatingLinks?: SerialisableLLink[]
   groups: ISerialisedGroup[]
-  version: typeof LiteGraph.VERSION
+  version: typeof LiteGraphInternal.VERSION
   extra?: LGraphExtra
 }
 

--- a/src/lib/litegraph/src/utils/feedback.ts
+++ b/src/lib/litegraph/src/utils/feedback.ts
@@ -1,4 +1,4 @@
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LiteGraphInternal } from '../LiteGraphInternal'
 
 /** Guard against unbound allocation. */
 const UNIQUE_MESSAGE_LIMIT = 10_000
@@ -11,7 +11,7 @@ const sentWarnings: Set<string> = new Set()
  * @param source A reference object to include alongside the message, e.g. `this`.
  */
 export function warnDeprecated(message: string, source?: object): void {
-  if (!LiteGraph.alwaysRepeatWarnings) {
+  if (!LiteGraphInternal.alwaysRepeatWarnings) {
     // Do not repeat
     if (sentWarnings.has(message)) return
 
@@ -21,7 +21,7 @@ export function warnDeprecated(message: string, source?: object): void {
     sentWarnings.add(message)
   }
 
-  for (const callback of LiteGraph.onDeprecationWarning) {
+  for (const callback of LiteGraphInternal.onDeprecationWarning) {
     callback(message, source)
   }
 }

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -7,9 +7,10 @@ import type {
   LGraphNode,
   Size
 } from '@/lib/litegraph/src/litegraph'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { LiteGraphInternal } from '../LiteGraphInternal'
 
 export interface DrawWidgetOptions {
   /** The width of the node where this widget will be displayed. */
@@ -147,28 +148,28 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
 
   get outline_color() {
     return this.advanced
-      ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR
-      : LiteGraph.WIDGET_OUTLINE_COLOR
+      ? LiteGraphInternal.WIDGET_ADVANCED_OUTLINE_COLOR
+      : LiteGraphInternal.WIDGET_OUTLINE_COLOR
   }
 
   get background_color() {
-    return LiteGraph.WIDGET_BGCOLOR
+    return LiteGraphInternal.WIDGET_BGCOLOR
   }
 
   get height() {
-    return LiteGraph.NODE_WIDGET_HEIGHT
+    return LiteGraphInternal.NODE_WIDGET_HEIGHT
   }
 
   get text_color() {
-    return LiteGraph.WIDGET_TEXT_COLOR
+    return LiteGraphInternal.WIDGET_TEXT_COLOR
   }
 
   get secondary_text_color() {
-    return LiteGraph.WIDGET_SECONDARY_TEXT_COLOR
+    return LiteGraphInternal.WIDGET_SECONDARY_TEXT_COLOR
   }
 
   get disabledTextColor() {
-    return LiteGraph.WIDGET_DISABLED_TEXT_COLOR
+    return LiteGraphInternal.WIDGET_DISABLED_TEXT_COLOR
   }
 
   get displayName() {
@@ -255,7 +256,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     if (requiredWidth <= totalWidth) {
       // Draw label & value normally
       drawTextInArea({ ctx, text: displayName, area, align: 'left' })
-    } else if (LiteGraph.truncateWidgetTextEvenly) {
+    } else if (LiteGraphInternal.truncateWidgetTextEvenly) {
       // Label + value will not fit - scale evenly to fit
       const scale = (totalWidth - gap) / (requiredWidth - gap)
       area.width = labelWidth * scale
@@ -265,7 +266,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       // Move the area to the right to render the value
       area.right = x + totalWidth
       area.setWidthRightAnchored(valueWidth * scale)
-    } else if (LiteGraph.truncateWidgetValuesFirst) {
+    } else if (LiteGraphInternal.truncateWidgetValuesFirst) {
       // Label + value will not fit - use legacy scaling of value first
       const cappedLabelWidth = Math.min(labelWidth, totalWidth)
 

--- a/src/lib/litegraph/src/widgets/ComboWidget.ts
+++ b/src/lib/litegraph/src/widgets/ComboWidget.ts
@@ -1,13 +1,13 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   IComboWidget,
   IStringComboWidget
 } from '@/lib/litegraph/src/types/widgets'
 import { warnDeprecated } from '@/lib/litegraph/src/utils/feedback'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import { BaseSteppedWidget } from './BaseSteppedWidget'
 import type { WidgetEventOptions } from './BaseWidget'
 
@@ -133,7 +133,7 @@ export class ComboWidget
 
     // Handle center click - show dropdown menu
     const text_values = values != values_list ? Object.values(values) : values
-    new LiteGraph.ContextMenu(text_values, {
+    new LiteGraphInternal.ContextMenu(text_values, {
       scale: Math.max(1, canvas.ds.scale),
       event: e,
       className: 'dark',

--- a/src/lib/litegraph/src/widgets/LegacyWidget.ts
+++ b/src/lib/litegraph/src/widgets/LegacyWidget.ts
@@ -1,7 +1,7 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
+import { LiteGraphInternal } from '../LiteGraphInternal'
 import { BaseWidget, type DrawWidgetOptions } from './BaseWidget'
 
 /**
@@ -27,7 +27,7 @@ export class LegacyWidget<TWidget extends IBaseWidget = IBaseWidget>
     ctx: CanvasRenderingContext2D,
     options: DrawWidgetOptions
   ) {
-    const H = LiteGraph.NODE_WIDGET_HEIGHT
+    const H = LiteGraphInternal.NODE_WIDGET_HEIGHT
     this.draw?.(ctx, this.node, options.width, this.y, H, !!options.showText)
   }
 

--- a/src/lib/litegraph/test/LGraph.test.ts
+++ b/src/lib/litegraph/test/LGraph.test.ts
@@ -1,7 +1,8 @@
 import { describe } from 'vitest'
 
-import { LGraph, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraph } from '@/lib/litegraph/src/litegraph'
 
+import { LiteGraphInternal } from '../src/LiteGraphInternal'
 import { test } from './testExtensions'
 
 describe('LGraph', () => {
@@ -17,8 +18,8 @@ describe('LGraph', () => {
     const directImport = await import('@/lib/litegraph/src/LGraph')
     const entryPointImport = await import('@/lib/litegraph/src/litegraph')
 
-    expect(LiteGraph.LGraph).toBe(directImport.LGraph)
-    expect(LiteGraph.LGraph).toBe(entryPointImport.LGraph)
+    expect(LiteGraphInternal.LGraph).toBe(directImport.LGraph)
+    expect(LiteGraphInternal.LGraph).toBe(entryPointImport.LGraph)
   })
 
   test('populates optional values', ({ expect, minimalSerialisableGraph }) => {
@@ -139,6 +140,6 @@ describe('Legacy LGraph Compatibility Layer', () => {
   })
 
   test('is correctly assigned to LiteGraph', ({ expect }) => {
-    expect(LiteGraph.LGraph).toBe(LGraph)
+    expect(LiteGraphInternal.LGraph).toBe(LGraph)
   })
 })

--- a/src/lib/litegraph/test/LGraphCanvas.titleButtons.test.ts
+++ b/src/lib/litegraph/test/LGraphCanvas.titleButtons.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
-import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { LiteGraphInternal } from '../src/LiteGraphInternal'
 
 describe('LGraphCanvas Title Button Rendering', () => {
   let canvas: LGraphCanvas
@@ -115,7 +117,7 @@ describe('LGraphCanvas Title Button Rendering', () => {
       // Check draw positions (right-aligned from node width)
       // First button (rightmost): 200 - 5 = 195, then subtract width
       // Second button: first button position - 5 - button width
-      const titleHeight = LiteGraph.NODE_TITLE_HEIGHT
+      const titleHeight = LiteGraphInternal.NODE_TITLE_HEIGHT
       const buttonY = -titleHeight + (titleHeight - 20) / 2 // Centered
       expect(draw1).toHaveBeenCalledWith(ctx, 180, buttonY) // 200 - 20
       expect(draw2).toHaveBeenCalledWith(ctx, 153, buttonY) // 180 - 2 - 25
@@ -180,7 +182,7 @@ describe('LGraphCanvas Title Button Rendering', () => {
 
       canvas.drawNode(node, ctx)
 
-      const titleHeight = LiteGraph.NODE_TITLE_HEIGHT
+      const titleHeight = LiteGraphInternal.NODE_TITLE_HEIGHT
 
       // Check positions are correctly spaced (right to left)
       // Starting position: 200
@@ -209,7 +211,8 @@ describe('LGraphCanvas Title Button Rendering', () => {
 
       // Buttons should still be rendered in low quality mode
       const buttonY =
-        -LiteGraph.NODE_TITLE_HEIGHT + (LiteGraph.NODE_TITLE_HEIGHT - 20) / 2
+        -LiteGraphInternal.NODE_TITLE_HEIGHT +
+        (LiteGraphInternal.NODE_TITLE_HEIGHT - 20) / 2
       expect(drawSpy).toHaveBeenCalledWith(ctx, 180, buttonY)
     })
 
@@ -236,7 +239,7 @@ describe('LGraphCanvas Title Button Rendering', () => {
 
       canvas.drawNode(node, ctx)
 
-      const titleHeight = LiteGraph.NODE_TITLE_HEIGHT
+      const titleHeight = LiteGraphInternal.NODE_TITLE_HEIGHT
 
       // Small button (rightmost): 200 - 15 = 185
       const buttonY = -titleHeight + (titleHeight - 20) / 2
@@ -263,7 +266,7 @@ describe('LGraphCanvas Title Button Rendering', () => {
 
       canvas.drawNode(node, ctx)
 
-      const titleHeight = LiteGraph.NODE_TITLE_HEIGHT
+      const titleHeight = LiteGraphInternal.NODE_TITLE_HEIGHT
       // Should use new width: 300 - 20 = 280
       const buttonY = -titleHeight + (titleHeight - 20) / 2
       expect(drawSpy).toHaveBeenCalledWith(ctx, 280, buttonY)

--- a/src/lib/litegraph/test/LGraphNode.resize.test.ts
+++ b/src/lib/litegraph/test/LGraphNode.resize.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect } from 'vitest'
 
-import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
+import { LiteGraphInternal } from '../src/LiteGraphInternal'
 import { test } from './testExtensions'
 
 describe('LGraphNode resize functionality', () => {
@@ -9,7 +10,7 @@ describe('LGraphNode resize functionality', () => {
 
   beforeEach(() => {
     // Set up LiteGraph constants needed for measure
-    LiteGraph.NODE_TITLE_HEIGHT = 20
+    LiteGraphInternal.NODE_TITLE_HEIGHT = 20
 
     node = new LGraphNode('Test Node')
     node.pos = [100, 100]

--- a/src/lib/litegraph/test/LGraphNode.test.ts
+++ b/src/lib/litegraph/test/LGraphNode.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest'
 
 import type { INodeInputSlot, Point } from '@/lib/litegraph/src/interfaces'
-import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
 import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 
+import { LiteGraphInternal } from '../src/LiteGraphInternal'
 import { test } from './testExtensions'
 
 function getMockISerialisedNode(
@@ -28,14 +29,14 @@ function getMockISerialisedNode(
 
 describe('LGraphNode', () => {
   let node: LGraphNode
-  let origLiteGraph: typeof LiteGraph
+  let origLiteGraph: typeof LiteGraphInternal
 
   beforeEach(() => {
-    origLiteGraph = Object.assign({}, LiteGraph)
+    origLiteGraph = Object.assign({}, LiteGraphInternal)
     // @ts-expect-error TODO: Fix after merge - Classes property not in type
     delete origLiteGraph.Classes
 
-    Object.assign(LiteGraph, {
+    Object.assign(LiteGraphInternal, {
       NODE_TITLE_HEIGHT: 20,
       NODE_SLOT_HEIGHT: 15,
       NODE_TEXT_SIZE: 14,
@@ -52,7 +53,7 @@ describe('LGraphNode', () => {
   })
 
   afterEach(() => {
-    Object.assign(LiteGraph, origLiteGraph)
+    Object.assign(LiteGraphInternal, origLiteGraph)
   })
 
   test('should serialize position/size correctly', () => {
@@ -460,8 +461,8 @@ describe('LGraphNode', () => {
       node.addOutput('output2', 'number')
 
       // Calculate expected positions
-      const slotOffset = LiteGraph.NODE_SLOT_HEIGHT * 0.5
-      const slotSpacing = LiteGraph.NODE_SLOT_HEIGHT
+      const slotOffset = LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
+      const slotSpacing = LiteGraphInternal.NODE_SLOT_HEIGHT
       const nodeWidth = node.size[0]
 
       // Test input positions
@@ -496,8 +497,8 @@ describe('LGraphNode', () => {
       node.addInput('default-input1', 'number')
       node.addInput('default-input2', 'number')
 
-      const slotOffset = LiteGraph.NODE_SLOT_HEIGHT * 0.5
-      const slotSpacing = LiteGraph.NODE_SLOT_HEIGHT
+      const slotOffset = LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
+      const slotSpacing = LiteGraphInternal.NODE_SLOT_HEIGHT
 
       // Test: default positioned slots should be consecutive, ignoring absolute positioned ones
       expect(node.getInputPos(1)).toEqual([
@@ -576,7 +577,10 @@ describe('LGraphNode', () => {
     })
     test('should return position based on title height when collapsed', () => {
       node.flags.collapsed = true
-      const expectedPos: Point = [100, 200 - LiteGraph.NODE_TITLE_HEIGHT * 0.5]
+      const expectedPos: Point = [
+        100,
+        200 - LiteGraphInternal.NODE_TITLE_HEIGHT * 0.5
+      ]
       expect(node.getInputSlotPos(inputSlot)).toEqual(expectedPos)
     })
 
@@ -600,12 +604,16 @@ describe('LGraphNode', () => {
       const slotIndex = 0
       const nodeOffsetY = (node.constructor as any).slot_start_y || 0
       const expectedY =
-        200 + (slotIndex + 0.7) * LiteGraph.NODE_SLOT_HEIGHT + nodeOffsetY
-      const expectedX = 100 + LiteGraph.NODE_SLOT_HEIGHT * 0.5
+        200 +
+        (slotIndex + 0.7) * LiteGraphInternal.NODE_SLOT_HEIGHT +
+        nodeOffsetY
+      const expectedX = 100 + LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
       expect(node.getInputSlotPos(inputSlot)).toEqual([expectedX, expectedY])
       const slotIndex2 = 1
       const expectedY2 =
-        200 + (slotIndex2 + 0.7) * LiteGraph.NODE_SLOT_HEIGHT + nodeOffsetY
+        200 +
+        (slotIndex2 + 0.7) * LiteGraphInternal.NODE_SLOT_HEIGHT +
+        nodeOffsetY
       expect(node.getInputSlotPos(inputSlot2)).toEqual([expectedX, expectedY2])
     })
 
@@ -616,8 +624,10 @@ describe('LGraphNode', () => {
       const slotIndex = 0
       const nodeOffsetY = 25
       const expectedY =
-        200 + (slotIndex + 0.7) * LiteGraph.NODE_SLOT_HEIGHT + nodeOffsetY
-      const expectedX = 100 + LiteGraph.NODE_SLOT_HEIGHT * 0.5
+        200 +
+        (slotIndex + 0.7) * LiteGraphInternal.NODE_SLOT_HEIGHT +
+        nodeOffsetY
+      const expectedX = 100 + LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
       expect(node.getInputSlotPos(inputSlot)).toEqual([expectedX, expectedY])
       delete (node.constructor as any).slot_start_y
     })
@@ -650,8 +660,10 @@ describe('LGraphNode', () => {
       const slotIndex = 0
       const nodeOffsetY = (node.constructor as any).slot_start_y || 0
       const expectedDefaultY =
-        200 + (slotIndex + 0.7) * LiteGraph.NODE_SLOT_HEIGHT + nodeOffsetY
-      const expectedDefaultX = 100 + LiteGraph.NODE_SLOT_HEIGHT * 0.5
+        200 +
+        (slotIndex + 0.7) * LiteGraphInternal.NODE_SLOT_HEIGHT +
+        nodeOffsetY
+      const expectedDefaultX = 100 + LiteGraphInternal.NODE_SLOT_HEIGHT * 0.5
       expect(node.getInputPos(0)).toEqual([expectedDefaultX, expectedDefaultY])
       spy.mockRestore()
     })
@@ -660,7 +672,7 @@ describe('LGraphNode', () => {
   describe('removeInput/removeOutput on copied nodes', () => {
     beforeEach(() => {
       // Register a test node type so clone() can work
-      LiteGraph.registerNodeType('TestNode', LGraphNode)
+      LiteGraphInternal.registerNodeType('TestNode', LGraphNode)
     })
 
     test('should NOT throw error when calling removeInput on a copied node without graph', () => {

--- a/src/lib/litegraph/test/litegraph.test.ts
+++ b/src/lib/litegraph/test/litegraph.test.ts
@@ -2,14 +2,15 @@ import { clamp } from 'es-toolkit/compat'
 import { beforeEach, describe, expect, vi } from 'vitest'
 
 import { LiteGraphGlobal } from '@/lib/litegraph/src/LiteGraphGlobal'
-import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 
+import { LiteGraphInternal } from '../src/LiteGraphInternal'
 import { test } from './testExtensions'
 
 describe('Litegraph module', () => {
   test('contains a global export', ({ expect }) => {
-    expect(LiteGraph).toBeInstanceOf(LiteGraphGlobal)
-    expect(LiteGraph.LGraphCanvas).toBe(LGraphCanvas)
+    expect(LiteGraphInternal).toBeInstanceOf(LiteGraphGlobal)
+    expect(LiteGraphInternal.LGraphCanvas).toBe(LGraphCanvas)
   })
 
   test('has the same structure', ({ expect }) => {
@@ -36,8 +37,12 @@ describe('Import order dependency', () => {
       const directImport = await import('@/lib/litegraph/src/LGraph')
 
       // Sanity check that imports were cleared.
-      expect(Object.is(LiteGraph, entryPointImport.LiteGraph)).toBe(false)
-      expect(Object.is(LiteGraph.LGraph, directImport.LGraph)).toBe(false)
+      expect(Object.is(LiteGraphInternal, entryPointImport.LiteGraph)).toBe(
+        false
+      )
+      expect(Object.is(LiteGraphInternal.LGraph, directImport.LGraph)).toBe(
+        false
+      )
     }
 
     await expect(importNormally()).resolves.toBeUndefined()

--- a/src/lib/litegraph/test/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/test/subgraph/SubgraphConversion.test.ts
@@ -1,12 +1,9 @@
 import { assert, describe, expect, it } from 'vitest'
 
 import type { ISlotType, LGraph } from '@/lib/litegraph/src/litegraph'
-import {
-  LGraphGroup,
-  LGraphNode,
-  LiteGraph
-} from '@/lib/litegraph/src/litegraph'
+import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
 
+import { LiteGraphInternal } from '../../src/LiteGraphInternal'
 import {
   createTestSubgraph,
   createTestSubgraphNode
@@ -19,7 +16,7 @@ function createNode(
   title?: string
 ) {
   const type = JSON.stringify({ inputs, outputs })
-  if (!LiteGraph.registered_node_types[type]) {
+  if (!LiteGraphInternal.registered_node_types[type]) {
     class testnode extends LGraphNode {
       constructor(title: string) {
         super(title)
@@ -30,9 +27,9 @@ function createNode(
           this.addOutput('output_' + o_count++, output)
       }
     }
-    LiteGraph.registered_node_types[type] = testnode
+    LiteGraphInternal.registered_node_types[type] = testnode
   }
-  const node = LiteGraph.createNode(type, title)
+  const node = LiteGraphInternal.createNode(type, title)
   if (!node) {
     throw new Error('Failed to create node')
   }

--- a/src/lib/litegraph/test/testExtensions.ts
+++ b/src/lib/litegraph/test/testExtensions.ts
@@ -1,8 +1,8 @@
 import { test as baseTest } from 'vitest'
 
 import { LGraph } from '@/lib/litegraph/src/LGraph'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 
+import { LiteGraphInternal } from '../src/LiteGraphInternal'
 import type {
   ISerialisedGraph,
   SerialisableGraph
@@ -74,7 +74,10 @@ export const dirtyTest = test.extend<DirtyFixtures>({
 
     // Register node types
     for (const node of basicSerialisableGraph.nodes) {
-      LiteGraph.registerNodeType(node.type!, LiteGraph.LGraphNode)
+      LiteGraphInternal.registerNodeType(
+        node.type!,
+        LiteGraphInternal.LGraphNode
+      )
     }
 
     await use(structuredClone(basicSerialisableGraph))


### PR DESCRIPTION
## Summary
- Extracted LiteGraph singleton instance into a separate module to break circular dependency chains
- Improves module loading order and prevents initialization issues
- Maintains the same API and functionality

## Context
This PR addresses the **second circular dependency issue** mentioned in #5533:
- The circular import chain: `SubgraphNode → LGraphNode → litegraph.ts → SubgraphNode`
- When `litegraph.ts` exports modules, it triggers loading of `SubgraphNode` which tries to extend `LGraphNode`, but `LGraphNode` imports from `litegraph.ts` causing circular initialization

## Solution
By extracting the LiteGraph singleton into a separate `LiteGraphSingleton.ts` module, we break the circular dependency chain and ensure proper module initialization order.

## Changes
- Created new `LiteGraphSingleton.ts` module to hold the singleton instance
- Updated all imports across the codebase to reference the singleton from the new module
- No functional changes, purely a refactoring to improve module structure

## Test Plan
- [x] All existing tests pass
- [x] No runtime errors from circular dependencies
- [x] Module loading order is now deterministic

🤖 Generated with [Claude Code](https://claude.ai/code)