### PR TITLE
Add desktop dialogs framework

### DIFF
--- a/scripts/collect-i18n-general.ts
+++ b/scripts/collect-i18n-general.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 
 import { comfyPageFixture as test } from '../browser_tests/fixtures/ComfyPage'
 import { CORE_MENU_COMMANDS } from '../src/constants/coreMenuCommands'
+import { DESKTOP_DIALOGS } from '../src/constants/desktopDialogs'
 import { SERVER_CONFIG_ITEMS } from '../src/constants/serverConfig'
 import type { FormItem, SettingParams } from '../src/platform/settings/types'
 import type { ComfyCommandImpl } from '../src/stores/commandStore'
@@ -131,6 +132,23 @@ test('collect-i18n-general', async ({ comfyPage }) => {
     ])
   )
 
+  // Desktop Dialogs
+  const allDesktopDialogsLocale = Object.fromEntries(
+    Object.values(DESKTOP_DIALOGS).map((dialog) => [
+      normalizeI18nKey(dialog.id),
+      {
+        title: dialog.title,
+        message: dialog.message,
+        buttons: Object.fromEntries(
+          dialog.buttons.map((button) => [
+            normalizeI18nKey(button.label),
+            button.label
+          ])
+        )
+      }
+    ])
+  )
+
   fs.writeFileSync(
     localePath,
     JSON.stringify(
@@ -144,7 +162,8 @@ test('collect-i18n-general', async ({ comfyPage }) => {
           ...allSettingCategoriesLocale
         },
         serverConfigItems: allServerConfigsLocale,
-        serverConfigCategories: allServerConfigCategoriesLocale
+        serverConfigCategories: allServerConfigCategoriesLocale,
+        desktopDialogs: allDesktopDialogsLocale
       },
       null,
       2

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -65,7 +65,6 @@
   --color-charcoal-600: #262729;
   --color-charcoal-700: #202121;
   --color-charcoal-800: #171718;
-  --color-charcoal-900: #61626C;
 
   --color-neutral-550: #636363;
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -67,6 +67,8 @@
   --color-charcoal-800: #171718;
   --color-charcoal-900: #61626C;
 
+  --color-neutral-550: #636363;
+
   --color-stone-100: #444444;
   --color-stone-200: #828282;
   --color-stone-300: #bbbbbb;

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -104,9 +104,9 @@
   --color-danger-200: #d62952;
   --color-coral-red: #f14352;
 
-  --color-coral-red-50: rgb(from var(--color-coral-red) r g b / 0.5);
-  --color-coral-red-75: rgb(from var(--color-coral-red) r g b / 0.75);
-  --color-coral-red-88: rgb(from var(--color-coral-red) r g b / 0.88);
+  --color-coral-red-600: #973a40;
+  --color-coral-red-500: #c53f49;
+  --color-coral-red-400: #dd424e;
 
   --color-bypass: #6a246a;
   --color-error: #962a2a;

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -65,6 +65,7 @@
   --color-charcoal-600: #262729;
   --color-charcoal-700: #202121;
   --color-charcoal-800: #171718;
+  --color-charcoal-900: #61626C;
 
   --color-stone-100: #444444;
   --color-stone-200: #828282;

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -102,11 +102,11 @@
   --color-warning-200: #fcbf64;
   --color-danger-100: #c02323;
   --color-danger-200: #d62952;
-  --color-danger-button: #f14352;
+  --color-coral-red: #f14352;
 
-  --color-danger-button-default: rgb(from var(--color-danger-button) r g b / 0.5);
-  --color-danger-button-hover: rgb(from var(--color-danger-button) r g b / 0.75);
-  --color-danger-button-active: rgb(from var(--color-danger-button) r g b / 0.88);
+  --color-coral-red-50: rgb(from var(--color-coral-red) r g b / 0.5);
+  --color-coral-red-75: rgb(from var(--color-coral-red) r g b / 0.75);
+  --color-coral-red-88: rgb(from var(--color-coral-red) r g b / 0.88);
 
   --color-bypass: #6a246a;
   --color-error: #962a2a;

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -102,6 +102,11 @@
   --color-warning-200: #fcbf64;
   --color-danger-100: #c02323;
   --color-danger-200: #d62952;
+  --color-danger-button: #f14352;
+
+  --color-danger-button-default: rgb(from var(--color-danger-button) r g b / 0.5);
+  --color-danger-button-hover: rgb(from var(--color-danger-button) r g b / 0.75);
+  --color-danger-button-active: rgb(from var(--color-danger-button) r g b / 0.88);
 
   --color-bypass: #6a246a;
   --color-error: #962a2a;

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -104,7 +104,6 @@
   --color-warning-200: #fcbf64;
   --color-danger-100: #c02323;
   --color-danger-200: #d62952;
-  --color-coral-red: #f14352;
 
   --color-coral-red-600: #973a40;
   --color-coral-red-500: #c53f49;

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -63,10 +63,14 @@ function isDialogId(id: unknown): id is keyof typeof DESKTOP_DIALOGS {
  * @param id The ID of the dialog to get
  * @returns The dialog with the given ID
  */
-export function getDialog(id: string | string[]): DesktopDialog {
-  if (isDialogId(id)) {
-    return DESKTOP_DIALOGS[id]
-  }
-
-  return DESKTOP_DIALOGS.reinstallFreshStart
+export function getDialog(id: string | string[]): {
+  id: keyof typeof DESKTOP_DIALOGS
+  dialog: DesktopDialog
+} {
+  return isDialogId(id)
+    ? { id, dialog: DESKTOP_DIALOGS[id] }
+    : {
+        id: 'invalidDialog',
+        dialog: DESKTOP_DIALOGS.invalidDialog
+      }
 }

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -13,6 +13,7 @@ export interface DesktopDialog {
 }
 
 export const DESKTOP_DIALOGS = {
+  /** Shown when a corrupt venv is detected. */
   reinstallFreshStart: {
     title: 'Reinstall ComfyUI (Fresh Start)?',
     message: `Sorry, we can't launch ComfyUI because some installed packages aren't compatible.

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -1,38 +1,40 @@
-interface DialogAction {
+export interface DialogAction {
   label: string
   action: 'openUrl' | 'close'
   url?: string
-  severity?: 'danger'
+  severity?: 'danger' | 'primary' | 'secondary' | 'warn'
   returnValue: string
 }
 
-interface DialogData {
+export interface DesktopDialog {
   id: string
   title: string
   message: string
   buttons: DialogAction[]
 }
 
-export const reinstallDialog: DialogData = {
-  id: 'reinstallFreshStart',
-  title: 'Reinstall ComfyUI (Fresh Start)?',
-  message: `Sorry, we can't launch ComfyUI because some installed packages aren't compatible.
+export const DESKTOP_DIALOGS: Record<string, DesktopDialog> = {
+  reinstallFreshStart: {
+    id: 'reinstallFreshStart',
+    title: 'Reinstall ComfyUI (Fresh Start)?',
+    message: `Sorry, we can't launch ComfyUI because some installed packages aren't compatible.
 
 Click Reinstall to restore ComfyUI and get back up and running.
 
 Please note: if you've added custom nodes, you'll need to reinstall them after this process.`,
-  buttons: [
-    {
-      label: 'Learn More',
-      action: 'openUrl',
-      url: 'https://docs.comfy.org',
-      returnValue: 'openDocs'
-    },
-    {
-      label: 'Reinstall',
-      action: 'close',
-      severity: 'danger',
-      returnValue: 'resetVenv'
-    }
-  ]
+    buttons: [
+      {
+        label: 'Learn More',
+        action: 'openUrl',
+        url: 'https://docs.comfy.org',
+        returnValue: 'openDocs'
+      },
+      {
+        label: 'Reinstall',
+        action: 'close',
+        severity: 'danger',
+        returnValue: 'resetVenv'
+      }
+    ]
+  }
 }

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -1,6 +1,6 @@
 export interface DialogAction {
   label: string
-  action: 'openUrl' | 'close'
+  action: 'openUrl' | 'close' | 'cancel'
   url?: string
   severity?: 'danger' | 'primary' | 'secondary' | 'warn'
   returnValue: string

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -39,10 +39,20 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
   }
 } as const satisfies { [K: string]: DesktopDialog }
 
+/**
+ * Checks if {@link id} is a valid dialog ID.
+ * @param id The string to check
+ * @returns `true` if the ID is a valid dialog ID, otherwise `false`
+ */
 function isDialogId(id: unknown): id is keyof typeof DESKTOP_DIALOGS {
   return typeof id === 'string' && id in DESKTOP_DIALOGS
 }
 
+/**
+ * Gets the dialog with the given ID.
+ * @param id The ID of the dialog to get
+ * @returns The dialog with the given ID
+ */
 export function getDialog(id: string | string[]): DesktopDialog {
   if (isDialogId(id)) {
     return DESKTOP_DIALOGS[id]

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -64,16 +64,12 @@ function isDialogId(id: unknown): id is DesktopDialogId {
 
 /**
  * Gets the dialog with the given ID.
- * @param id The ID of the dialog to get
+ * @param dialogId The ID of the dialog to get
  * @returns The dialog with the given ID
  */
 export function getDialog(
-  id: string | string[]
+  dialogId: string | string[]
 ): DesktopDialog & { id: DesktopDialogId } {
-  return isDialogId(id)
-    ? { id, ...DESKTOP_DIALOGS[id] }
-    : {
-        id: 'invalidDialog',
-        ...DESKTOP_DIALOGS.invalidDialog
-      }
+  const id = isDialogId(dialogId) ? dialogId : 'invalidDialog'
+  return { id, ...DESKTOP_DIALOGS[id] }
 }

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -14,7 +14,7 @@ export interface DesktopDialog {
 
 export const DESKTOP_DIALOGS = {
   /** Shown when a corrupt venv is detected. */
-  reinstallFreshStart: {
+  reinstallVenv: {
     title: 'Reinstall ComfyUI (Fresh Start)?',
     message: `Sorry, we can't launch ComfyUI because some installed packages aren't compatible.
 

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -7,7 +7,6 @@ export interface DialogAction {
 }
 
 export interface DesktopDialog {
-  id: string
   title: string
   message: string
   buttons: DialogAction[]
@@ -15,7 +14,6 @@ export interface DesktopDialog {
 
 export const DESKTOP_DIALOGS = {
   reinstallFreshStart: {
-    id: 'reinstallFreshStart',
     title: 'Reinstall ComfyUI (Fresh Start)?',
     message: `Sorry, we can't launch ComfyUI because some installed packages aren't compatible.
 

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -71,5 +71,5 @@ export function getDialog(
   dialogId: string | string[]
 ): DesktopDialog & { id: DesktopDialogId } {
   const id = isDialogId(dialogId) ? dialogId : 'invalidDialog'
-  return { id, ...DESKTOP_DIALOGS[id] }
+  return { id, ...structuredClone(DESKTOP_DIALOGS[id]) }
 }

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -13,7 +13,7 @@ export interface DesktopDialog {
   buttons: DialogAction[]
 }
 
-export const DESKTOP_DIALOGS: Record<string, DesktopDialog> = {
+export const DESKTOP_DIALOGS = {
   reinstallFreshStart: {
     id: 'reinstallFreshStart',
     title: 'Reinstall ComfyUI (Fresh Start)?',
@@ -35,6 +35,8 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
         severity: 'danger',
         returnValue: 'resetVenv'
       }
-    ]
+    ] as DialogAction[]
   }
-}
+} satisfies Record<string, DesktopDialog>
+
+export type DesktopDialogId = keyof typeof DESKTOP_DIALOGS

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -36,6 +36,18 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
         returnValue: 'resetVenv'
       }
     ]
+  },
+  /** A dialog that is shown when an invalid dialog ID is provided. */
+  invalidDialog: {
+    title: 'Invalid Dialog',
+    message: `Invalid dialog ID was provided.`,
+    buttons: [
+      {
+        label: 'Close',
+        action: 'cancel',
+        returnValue: 'cancel'
+      }
+    ]
   }
 } as const satisfies { [K: string]: DesktopDialog }
 

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -13,7 +13,7 @@ export interface DesktopDialog {
   buttons: DialogAction[]
 }
 
-const dialogsConfig = {
+export const DESKTOP_DIALOGS = {
   reinstallFreshStart: {
     id: 'reinstallFreshStart',
     title: 'Reinstall ComfyUI (Fresh Start)?',
@@ -35,14 +35,23 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
         severity: 'danger',
         returnValue: 'resetVenv'
       }
-    ] as DialogAction[]
+    ]
   }
-} as const
+} satisfies { [K: string]: DesktopDialog }
 
-export const DESKTOP_DIALOGS: Record<string, DesktopDialog> = dialogsConfig
-export type DesktopDialogId = keyof typeof dialogsConfig
+export type DesktopDialogId = keyof typeof DESKTOP_DIALOGS
+export type DesktopDialogsMap = typeof DESKTOP_DIALOGS
+
+function isDialogId(id: unknown): id is DesktopDialogId {
+  return typeof id === 'string' && id in DESKTOP_DIALOGS
+}
 
 export function getDialog(id: string | string[]): DesktopDialog {
   const dialogId = Array.isArray(id) ? id[0] : id
-  return DESKTOP_DIALOGS[dialogId] ?? DESKTOP_DIALOGS.reinstallFreshStart
+
+  if (isDialogId(dialogId)) {
+    return DESKTOP_DIALOGS[dialogId]
+  }
+
+  return DESKTOP_DIALOGS.reinstallFreshStart
 }

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -16,10 +16,11 @@ interface DialogData {
 export const reinstallDialog: DialogData = {
   id: 'reinstallFreshStart',
   title: 'Reinstall ComfyUI (Fresh Start)?',
-  message:
-    "Sorry, we can't launch ComfyUI because some installed packages aren't compatible.\n\n" +
-    'Click Reinstall to restore ComfyUI and get back up and running.\n\n' +
-    "Please note: if you've added custom nodes, you'll need to reinstall them after this process.",
+  message: `Sorry, we can't launch ComfyUI because some installed packages aren't compatible.
+
+Click Reinstall to restore ComfyUI and get back up and running.
+
+Please note: if you've added custom nodes, you'll need to reinstall them after this process.`,
   buttons: [
     {
       label: 'Learn More',

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -49,12 +49,15 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
   }
 } as const satisfies { [K: string]: DesktopDialog }
 
+/** The ID of a desktop dialog. */
+type DesktopDialogId = keyof typeof DESKTOP_DIALOGS
+
 /**
  * Checks if {@link id} is a valid dialog ID.
  * @param id The string to check
  * @returns `true` if the ID is a valid dialog ID, otherwise `false`
  */
-function isDialogId(id: unknown): id is keyof typeof DESKTOP_DIALOGS {
+function isDialogId(id: unknown): id is DesktopDialogId {
   return typeof id === 'string' && id in DESKTOP_DIALOGS
 }
 
@@ -63,14 +66,13 @@ function isDialogId(id: unknown): id is keyof typeof DESKTOP_DIALOGS {
  * @param id The ID of the dialog to get
  * @returns The dialog with the given ID
  */
-export function getDialog(id: string | string[]): {
-  id: keyof typeof DESKTOP_DIALOGS
-  dialog: DesktopDialog
-} {
+export function getDialog(
+  id: string | string[]
+): DesktopDialog & { id: DesktopDialogId } {
   return isDialogId(id)
-    ? { id, dialog: DESKTOP_DIALOGS[id] }
+    ? { id, ...DESKTOP_DIALOGS[id] }
     : {
         id: 'invalidDialog',
-        dialog: DESKTOP_DIALOGS.invalidDialog
+        ...DESKTOP_DIALOGS.invalidDialog
       }
 }

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -1,15 +1,15 @@
 export interface DialogAction {
-  label: string
-  action: 'openUrl' | 'close' | 'cancel'
-  url?: string
-  severity?: 'danger' | 'primary' | 'secondary' | 'warn'
-  returnValue: string
+  readonly label: string
+  readonly action: 'openUrl' | 'close' | 'cancel'
+  readonly url?: string
+  readonly severity?: 'danger' | 'primary' | 'secondary' | 'warn'
+  readonly returnValue: string
 }
 
 export interface DesktopDialog {
-  title: string
-  message: string
-  buttons: DialogAction[]
+  readonly title: string
+  readonly message: string
+  readonly buttons: DialogAction[]
 }
 
 export const DESKTOP_DIALOGS = {

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -6,7 +6,7 @@ export interface DialogAction {
   readonly returnValue: string
 }
 
-export interface DesktopDialog {
+interface DesktopDialog {
   readonly title: string
   readonly message: string
   readonly buttons: DialogAction[]

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -13,7 +13,7 @@ export interface DesktopDialog {
   buttons: DialogAction[]
 }
 
-export const DESKTOP_DIALOGS = {
+const dialogsConfig = {
   reinstallFreshStart: {
     id: 'reinstallFreshStart',
     title: 'Reinstall ComfyUI (Fresh Start)?',
@@ -37,6 +37,12 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
       }
     ] as DialogAction[]
   }
-} satisfies Record<string, DesktopDialog>
+} as const
 
-export type DesktopDialogId = keyof typeof DESKTOP_DIALOGS
+export const DESKTOP_DIALOGS: Record<string, DesktopDialog> = dialogsConfig
+export type DesktopDialogId = keyof typeof dialogsConfig
+
+export function getDialog(id: string | string[]): DesktopDialog {
+  const dialogId = Array.isArray(id) ? id[0] : id
+  return DESKTOP_DIALOGS[dialogId] ?? DESKTOP_DIALOGS.reinstallFreshStart
+}

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -1,0 +1,37 @@
+interface DialogAction {
+  label: string
+  action: 'openUrl' | 'close'
+  url?: string
+  severity?: 'danger'
+  returnValue: string
+}
+
+interface DialogData {
+  id: string
+  title: string
+  message: string
+  buttons: DialogAction[]
+}
+
+export const reinstallDialog: DialogData = {
+  id: 'reinstallFreshStart',
+  title: 'Reinstall ComfyUI (Fresh Start)?',
+  message:
+    "Sorry, we can't launch ComfyUI because some installed packages aren't compatible.\n\n" +
+    'Click Reinstall to restore ComfyUI and get back up and running.\n\n' +
+    "Please note: if you've added custom nodes, you'll need to reinstall them after this process.",
+  buttons: [
+    {
+      label: 'Learn More',
+      action: 'openUrl',
+      url: 'https://docs.comfy.org',
+      returnValue: 'openDocs'
+    },
+    {
+      label: 'Reinstall',
+      action: 'close',
+      severity: 'danger',
+      returnValue: 'resetVenv'
+    }
+  ]
+}

--- a/src/constants/desktopDialogs.ts
+++ b/src/constants/desktopDialogs.ts
@@ -37,20 +37,15 @@ Please note: if you've added custom nodes, you'll need to reinstall them after t
       }
     ]
   }
-} satisfies { [K: string]: DesktopDialog }
+} as const satisfies { [K: string]: DesktopDialog }
 
-export type DesktopDialogId = keyof typeof DESKTOP_DIALOGS
-export type DesktopDialogsMap = typeof DESKTOP_DIALOGS
-
-function isDialogId(id: unknown): id is DesktopDialogId {
+function isDialogId(id: unknown): id is keyof typeof DESKTOP_DIALOGS {
   return typeof id === 'string' && id in DESKTOP_DIALOGS
 }
 
 export function getDialog(id: string | string[]): DesktopDialog {
-  const dialogId = Array.isArray(id) ? id[0] : id
-
-  if (isDialogId(dialogId)) {
-    return DESKTOP_DIALOGS[dialogId]
+  if (isDialogId(id)) {
+    return DESKTOP_DIALOGS[id]
   }
 
   return DESKTOP_DIALOGS.reinstallFreshStart

--- a/src/router.ts
+++ b/src/router.ts
@@ -115,6 +115,12 @@ const router = createRouter({
           name: 'DesktopUpdateView',
           component: () => import('@/views/DesktopUpdateView.vue'),
           beforeEnter: guardElectronAccess
+        },
+        {
+          path: 'desktop-dialog/:dialogId',
+          name: 'DesktopDialogView',
+          component: () => import('@/views/DesktopDialogView.vue'),
+          beforeEnter: guardElectronAccess
         }
       ]
     }

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -38,11 +38,8 @@ import { normalizeI18nKey } from '@/utils/formatUtil'
 const route = useRoute()
 const { id, title, message, buttons } = getDialog(route.params.dialogId)
 
-const handleButtonClick = (button: DialogAction) => {
-  if (button.action === 'openUrl' && button.url) {
-    window.open(button.url, '_blank')
-  }
-  void electronAPI().Dialog.clickButton(button.returnValue)
+const handleButtonClick = async (button: DialogAction) => {
+  await electronAPI().Dialog.clickButton(button.returnValue)
 }
 </script>
 

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -3,10 +3,10 @@
     class="w-full h-full flex flex-col rounded-lg p-6 bg-[#2d2d2d] justify-between"
   >
     <h1 class="dialog-title font-semibold text-xl m-0 italic">
-      {{ t(`desktopDialogs.${dialogI18nKey}.title`, title) }}
+      {{ t(`desktopDialogs.${id}.title`, title) }}
     </h1>
     <p class="whitespace-pre-wrap">
-      {{ t(`desktopDialogs.${dialogI18nKey}.message`, message) }}
+      {{ t(`desktopDialogs.${id}.message`, message) }}
     </p>
     <div class="flex w-full gap-2">
       <Button
@@ -15,7 +15,7 @@
         class="first:mr-auto"
         :label="
           t(
-            `desktopDialogs.${dialogI18nKey}.buttons.${normalizeI18nKey(button.label)}`,
+            `desktopDialogs.${id}.buttons.${normalizeI18nKey(button.label)}`,
             button.label
           )
         "
@@ -37,7 +37,6 @@ import { normalizeI18nKey } from '@/utils/formatUtil'
 
 const route = useRoute()
 const { id, title, message, buttons } = getDialog(route.params.dialogId)
-const dialogI18nKey = normalizeI18nKey(id)
 
 const handleButtonClick = (button: DialogAction) => {
   if (button.action === 'openUrl' && button.url) {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -43,10 +43,8 @@ import { normalizeI18nKey } from '@/utils/formatUtil'
 const route = useRoute()
 const { dialogId } = route.params
 
-// Get dialog with fallback - using Object.hasOwn for cleaner type narrowing
 let dialog: DesktopDialog
 if (typeof dialogId === 'string' && Object.hasOwn(DESKTOP_DIALOGS, dialogId)) {
-  // TypeScript now knows dialogId is a valid key
   dialog = DESKTOP_DIALOGS[dialogId as keyof typeof DESKTOP_DIALOGS]
 } else {
   dialog = DESKTOP_DIALOGS.reinstallFreshStart

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -3,14 +3,14 @@
     class="w-full h-full flex flex-col rounded-lg p-6 bg-[#2d2d2d] justify-between"
   >
     <h1 class="dialog-title font-semibold text-xl m-0 italic">
-      {{ t(`desktopDialogs.${dialogI18nKey}.title`, dialog.title) }}
+      {{ t(`desktopDialogs.${dialogI18nKey}.title`, title) }}
     </h1>
     <p class="whitespace-pre-wrap">
-      {{ t(`desktopDialogs.${dialogI18nKey}.message`, dialog.message) }}
+      {{ t(`desktopDialogs.${dialogI18nKey}.message`, message) }}
     </p>
     <div class="flex w-full gap-2">
       <Button
-        v-for="button in dialog.buttons"
+        v-for="button in buttons"
         :key="button.label"
         class="first:mr-auto"
         :label="
@@ -36,7 +36,7 @@ import { electronAPI } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
 const route = useRoute()
-const { id, dialog } = getDialog(route.params.dialogId)
+const { id, title, message, buttons } = getDialog(route.params.dialogId)
 const dialogI18nKey = normalizeI18nKey(id)
 
 const handleButtonClick = (button: DialogAction) => {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -45,7 +45,7 @@ const handleButtonClick = async (button: DialogAction) => {
 @reference '../assets/css/style.css';
 
 .p-button-secondary {
-  @apply text-white rounded-lg border-none bg-neutral-600;
+  @apply text-white border-none bg-neutral-600;
 }
 
 .p-button-secondary:hover {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -57,7 +57,7 @@ const handleButtonClick = async (button: DialogAction) => {
 }
 
 .p-button-danger {
-  @apply bg-coral-red-600 border-0;
+  @apply bg-coral-red-600;
 }
 
 .p-button-danger:hover {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -30,26 +30,13 @@
 import Button from 'primevue/button'
 import { useRoute } from 'vue-router'
 
-import {
-  DESKTOP_DIALOGS,
-  type DesktopDialog,
-  type DialogAction
-} from '@/constants/desktopDialogs'
+import { type DialogAction, getDialog } from '@/constants/desktopDialogs'
 import { t } from '@/i18n'
 import { electronAPI } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
-// Get dialog ID from route parameter
 const route = useRoute()
-const { dialogId } = route.params
-
-let dialog: DesktopDialog
-if (typeof dialogId === 'string' && Object.hasOwn(DESKTOP_DIALOGS, dialogId)) {
-  dialog = DESKTOP_DIALOGS[dialogId as keyof typeof DESKTOP_DIALOGS]
-} else {
-  dialog = DESKTOP_DIALOGS.reinstallFreshStart
-}
-
+const dialog = getDialog(route.params.dialogId)
 const dialogI18nKey = normalizeI18nKey(dialog.id)
 
 const handleButtonClick = (button: DialogAction) => {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="w-full h-full flex flex-col rounded-lg p-6 bg-[#2d2d2d] justify-between"
-  >
+  <div class="w-full h-full flex flex-col rounded-lg p-6 justify-between">
     <h1 class="font-inter font-semibold text-xl m-0 italic">
       {{ t(`desktopDialogs.${id}.title`, title) }}
     </h1>

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -64,16 +64,15 @@ const handleButtonClick = (button: DialogAction) => {
 }
 
 .p-button-danger {
-  background: var(--color-danger-button-default);
-  border: 0;
+  @apply bg-danger-button-default border-0;
 }
 
 .p-button-danger:hover {
-  background: var(--color-danger-button-hover);
+  @apply bg-danger-button-hover;
 }
 
 .p-button-danger:active {
-  background: var(--color-danger-button-active);
+  @apply bg-danger-button-active;
 }
 
 .p-button-warn {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -28,14 +28,17 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button'
+import { useRoute } from 'vue-router'
 
 import { DESKTOP_DIALOGS, type DialogAction } from '@/constants/desktopDialogs'
 import { t } from '@/i18n'
 import { electronAPI } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
-// Use the const data directly
-const dialog = DESKTOP_DIALOGS.reinstallFreshStart
+// Get dialog ID from route parameter
+const route = useRoute()
+const dialogId = route.params.dialogId as string
+const dialog = DESKTOP_DIALOGS[dialogId] || DESKTOP_DIALOGS.reinstallFreshStart
 const dialogI18nKey = normalizeI18nKey(dialog.id)
 
 const handleButtonClick = (button: DialogAction) => {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -50,17 +50,15 @@ const handleButtonClick = (button: DialogAction) => {
 @reference '../assets/css/style.css';
 
 .p-button-secondary {
-  @apply text-white rounded-lg border-none;
-
-  background: var(--color-button-background, rgba(255, 255, 255, 0.15));
+  @apply text-white rounded-lg border-none bg-charcoal-600;
 }
 
 .p-button-secondary:hover {
-  background: rgba(255, 255, 255, 0.25);
+  @apply bg-charcoal-700;
 }
 
 .p-button-secondary:active {
-  background: rgba(255, 255, 255, 0.35);
+  @apply bg-charcoal-800;
 }
 
 .p-button-danger {
@@ -76,20 +74,14 @@ const handleButtonClick = (button: DialogAction) => {
 }
 
 .p-button-warn {
-  background: rgba(23, 45, 215, 0.66);
-  color: #f0ff41;
-  border: 0;
+  @apply bg-brand-blue/65 text-brand-yellow border-0;
 }
 
 .p-button-warn:hover {
-  background: rgba(23, 45, 215, 0.88);
-  color: #f0ff41;
-  border: 0;
+  @apply bg-brand-blue/90 text-brand-yellow border-0;
 }
 
 .p-button-warn:active {
-  background: rgba(23, 45, 215, 1);
-  color: #f0ff41;
-  border: 0;
+  @apply bg-brand-blue text-brand-yellow border-0;
 }
 </style>

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -41,8 +41,9 @@ const { dialogId } = route.params
 
 // Fallback to reinstallFreshStart if dialog not found
 const dialog =
-  (typeof dialogId === 'string' && DESKTOP_DIALOGS[dialogId]) ||
-  DESKTOP_DIALOGS.reinstallFreshStart
+  typeof dialogId === 'string' && dialogId in DESKTOP_DIALOGS
+    ? DESKTOP_DIALOGS[dialogId as keyof typeof DESKTOP_DIALOGS]
+    : DESKTOP_DIALOGS.reinstallFreshStart
 const dialogI18nKey = normalizeI18nKey(dialog.id)
 
 const handleButtonClick = (button: DialogAction) => {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -30,7 +30,11 @@
 import Button from 'primevue/button'
 import { useRoute } from 'vue-router'
 
-import { DESKTOP_DIALOGS, type DialogAction } from '@/constants/desktopDialogs'
+import {
+  DESKTOP_DIALOGS,
+  type DesktopDialog,
+  type DialogAction
+} from '@/constants/desktopDialogs'
 import { t } from '@/i18n'
 import { electronAPI } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
@@ -39,11 +43,15 @@ import { normalizeI18nKey } from '@/utils/formatUtil'
 const route = useRoute()
 const { dialogId } = route.params
 
-// Fallback to reinstallFreshStart if dialog not found
-const dialog =
-  typeof dialogId === 'string' && dialogId in DESKTOP_DIALOGS
-    ? DESKTOP_DIALOGS[dialogId as keyof typeof DESKTOP_DIALOGS]
-    : DESKTOP_DIALOGS.reinstallFreshStart
+// Get dialog with fallback - using Object.hasOwn for cleaner type narrowing
+let dialog: DesktopDialog
+if (typeof dialogId === 'string' && Object.hasOwn(DESKTOP_DIALOGS, dialogId)) {
+  // TypeScript now knows dialogId is a valid key
+  dialog = DESKTOP_DIALOGS[dialogId as keyof typeof DESKTOP_DIALOGS]
+} else {
+  dialog = DESKTOP_DIALOGS.reinstallFreshStart
+}
+
 const dialogI18nKey = normalizeI18nKey(dialog.id)
 
 const handleButtonClick = (button: DialogAction) => {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -37,7 +37,7 @@ import { normalizeI18nKey } from '@/utils/formatUtil'
 
 // Get dialog ID from route parameter
 const route = useRoute()
-const dialogId = route.params.dialogId
+const { dialogId } = route.params
 
 // Fallback to reinstallFreshStart if dialog not found
 const dialog =

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -64,15 +64,15 @@ const handleButtonClick = (button: DialogAction) => {
 }
 
 .p-button-danger {
-  @apply bg-danger-button-default border-0;
+  @apply bg-coral-red-50 border-0;
 }
 
 .p-button-danger:hover {
-  @apply bg-danger-button-hover;
+  @apply bg-coral-red-75;
 }
 
 .p-button-danger:active {
-  @apply bg-danger-button-active;
+  @apply bg-coral-red-88;
 }
 
 .p-button-warn {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -22,13 +22,13 @@
 <script setup lang="ts">
 import Button from 'primevue/button'
 
-import { reinstallDialog } from '@/constants/desktopDialogs'
+import { DESKTOP_DIALOGS, type DialogAction } from '@/constants/desktopDialogs'
 import { electronAPI } from '@/utils/envUtil'
 
 // Use the const data directly
-const dialog = reinstallDialog
+const dialog = DESKTOP_DIALOGS.reinstallFreshStart
 
-const handleButtonClick = (button: (typeof dialog.buttons)[0]) => {
+const handleButtonClick = (button: DialogAction) => {
   if (button.action === 'openUrl' && button.url) {
     window.open(button.url, '_blank')
   }

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -1,0 +1,94 @@
+<template>
+  <div
+    class="w-full h-full flex flex-col rounded-lg p-6 bg-[#2d2d2d] justify-between"
+  >
+    <h1 class="dialog-title font-semibold text-xl m-0 italic">
+      {{ dialog.title }}
+    </h1>
+    <p class="whitespace-pre-wrap">{{ dialog.message }}</p>
+    <div class="flex w-full gap-2">
+      <Button
+        v-for="button in dialog.buttons"
+        :key="button.label"
+        class="first:mr-auto"
+        :label="button.label"
+        :severity="button.severity ?? 'secondary'"
+        @click="handleButtonClick(button)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+
+import { reinstallDialog } from '@/constants/desktopDialogs'
+import { electronAPI } from '@/utils/envUtil'
+
+// Use the const data directly
+const dialog = reinstallDialog
+
+const handleButtonClick = (button: (typeof dialog.buttons)[0]) => {
+  if (button.action === 'openUrl' && button.url) {
+    window.open(button.url, '_blank')
+  }
+  void electronAPI().Dialog.clickButton(button.returnValue)
+}
+</script>
+
+<style scoped>
+@reference '../assets/css/style.css';
+
+.dialog-title {
+  font-family: 'ABC ROM';
+}
+
+.p-button {
+  @apply rounded-lg;
+}
+
+.p-button-secondary {
+  @apply text-white rounded-lg border-none;
+
+  background: var(--color-button-background, rgba(255, 255, 255, 0.15));
+}
+
+.p-button-secondary:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.p-button-secondary:active {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.p-button-danger {
+  background: rgba(241, 67, 82, 0.5);
+  border: 0;
+}
+
+.p-button-danger:hover {
+  background: rgba(241, 67, 82, 0.75);
+}
+
+.p-button-danger:active {
+  background: rgba(241, 67, 82, 0.88);
+}
+
+.p-button-warn {
+  background: rgba(23, 45, 215, 0.66);
+  color: #f0ff41;
+  border: 0;
+}
+
+.p-button-warn:hover {
+  background: rgba(23, 45, 215, 0.88);
+  color: #f0ff41;
+  border: 0;
+}
+
+.p-button-warn:active {
+  background: rgba(23, 45, 215, 1);
+  color: #f0ff41;
+  border: 0;
+}
+</style>

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -36,8 +36,8 @@ import { electronAPI } from '@/utils/envUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
 const route = useRoute()
-const dialog = getDialog(route.params.dialogId)
-const dialogI18nKey = normalizeI18nKey(dialog.id)
+const { id, dialog } = getDialog(route.params.dialogId)
+const dialogI18nKey = normalizeI18nKey(id)
 
 const handleButtonClick = (button: DialogAction) => {
   if (button.action === 'openUrl' && button.url) {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -50,15 +50,15 @@ const handleButtonClick = (button: DialogAction) => {
 @reference '../assets/css/style.css';
 
 .p-button-secondary {
-  @apply text-white rounded-lg border-none bg-charcoal-600;
+  @apply text-white rounded-lg border-none bg-charcoal-700;
 }
 
 .p-button-secondary:hover {
-  @apply bg-charcoal-700;
+  @apply bg-charcoal-800;
 }
 
 .p-button-secondary:active {
-  @apply bg-charcoal-800;
+  @apply bg-charcoal-900;
 }
 
 .p-button-danger {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -37,8 +37,12 @@ import { normalizeI18nKey } from '@/utils/formatUtil'
 
 // Get dialog ID from route parameter
 const route = useRoute()
-const dialogId = route.params.dialogId as string
-const dialog = DESKTOP_DIALOGS[dialogId] || DESKTOP_DIALOGS.reinstallFreshStart
+const dialogId = route.params.dialogId
+
+// Fallback to reinstallFreshStart if dialog not found
+const dialog =
+  (typeof dialogId === 'string' && DESKTOP_DIALOGS[dialogId]) ||
+  DESKTOP_DIALOGS.reinstallFreshStart
 const dialogI18nKey = normalizeI18nKey(dialog.id)
 
 const handleButtonClick = (button: DialogAction) => {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -50,15 +50,15 @@ const handleButtonClick = (button: DialogAction) => {
 @reference '../assets/css/style.css';
 
 .p-button-secondary {
-  @apply text-white rounded-lg border-none bg-charcoal-700;
+  @apply text-white rounded-lg border-none bg-neutral-600;
 }
 
 .p-button-secondary:hover {
-  @apply bg-charcoal-800;
+  @apply bg-neutral-550;
 }
 
 .p-button-secondary:active {
-  @apply bg-charcoal-900;
+  @apply bg-neutral-500;
 }
 
 .p-button-danger {
@@ -71,17 +71,5 @@ const handleButtonClick = (button: DialogAction) => {
 
 .p-button-danger:active {
   @apply bg-coral-red-400;
-}
-
-.p-button-warn {
-  @apply bg-brand-blue/65 text-brand-yellow border-0;
-}
-
-.p-button-warn:hover {
-  @apply bg-brand-blue/90 text-brand-yellow border-0;
-}
-
-.p-button-warn:active {
-  @apply bg-brand-blue text-brand-yellow border-0;
 }
 </style>

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -2,7 +2,7 @@
   <div
     class="w-full h-full flex flex-col rounded-lg p-6 bg-[#2d2d2d] justify-between"
   >
-    <h1 class="dialog-title font-semibold text-xl m-0 italic">
+    <h1 class="font-inter font-semibold text-xl m-0 italic">
       {{ t(`desktopDialogs.${id}.title`, title) }}
     </h1>
     <p class="whitespace-pre-wrap">
@@ -12,7 +12,7 @@
       <Button
         v-for="button in buttons"
         :key="button.label"
-        class="first:mr-auto"
+        class="rounded-lg first:mr-auto"
         :label="
           t(
             `desktopDialogs.${id}.buttons.${normalizeI18nKey(button.label)}`,
@@ -48,14 +48,6 @@ const handleButtonClick = (button: DialogAction) => {
 
 <style scoped>
 @reference '../assets/css/style.css';
-
-.dialog-title {
-  font-family: 'ABC ROM';
-}
-
-.p-button {
-  @apply rounded-lg;
-}
 
 .p-button-secondary {
   @apply text-white rounded-lg border-none;

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -3,15 +3,22 @@
     class="w-full h-full flex flex-col rounded-lg p-6 bg-[#2d2d2d] justify-between"
   >
     <h1 class="dialog-title font-semibold text-xl m-0 italic">
-      {{ dialog.title }}
+      {{ t(`desktopDialogs.${dialogI18nKey}.title`, dialog.title) }}
     </h1>
-    <p class="whitespace-pre-wrap">{{ dialog.message }}</p>
+    <p class="whitespace-pre-wrap">
+      {{ t(`desktopDialogs.${dialogI18nKey}.message`, dialog.message) }}
+    </p>
     <div class="flex w-full gap-2">
       <Button
         v-for="button in dialog.buttons"
         :key="button.label"
         class="first:mr-auto"
-        :label="button.label"
+        :label="
+          t(
+            `desktopDialogs.${dialogI18nKey}.buttons.${normalizeI18nKey(button.label)}`,
+            button.label
+          )
+        "
         :severity="button.severity ?? 'secondary'"
         @click="handleButtonClick(button)"
       />
@@ -23,10 +30,13 @@
 import Button from 'primevue/button'
 
 import { DESKTOP_DIALOGS, type DialogAction } from '@/constants/desktopDialogs'
+import { t } from '@/i18n'
 import { electronAPI } from '@/utils/envUtil'
+import { normalizeI18nKey } from '@/utils/formatUtil'
 
 // Use the const data directly
 const dialog = DESKTOP_DIALOGS.reinstallFreshStart
+const dialogI18nKey = normalizeI18nKey(dialog.id)
 
 const handleButtonClick = (button: DialogAction) => {
   if (button.action === 'openUrl' && button.url) {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -64,15 +64,15 @@ const handleButtonClick = (button: DialogAction) => {
 }
 
 .p-button-danger {
-  @apply bg-coral-red-50 border-0;
+  @apply bg-coral-red-600 border-0;
 }
 
 .p-button-danger:hover {
-  @apply bg-coral-red-75;
+  @apply bg-coral-red-500;
 }
 
 .p-button-danger:active {
-  @apply bg-coral-red-88;
+  @apply bg-coral-red-400;
 }
 
 .p-button-warn {

--- a/src/views/DesktopDialogView.vue
+++ b/src/views/DesktopDialogView.vue
@@ -64,16 +64,16 @@ const handleButtonClick = (button: DialogAction) => {
 }
 
 .p-button-danger {
-  background: rgba(241, 67, 82, 0.5);
+  background: var(--color-danger-button-default);
   border: 0;
 }
 
 .p-button-danger:hover {
-  background: rgba(241, 67, 82, 0.75);
+  background: var(--color-danger-button-hover);
 }
 
 .p-button-danger:active {
-  background: rgba(241, 67, 82, 0.88);
+  background: var(--color-danger-button-active);
 }
 
 .p-button-warn {


### PR DESCRIPTION
### Summary

Adds desktop dialog framework with data-driven dialog definitions.

### Changes

- Data-driven dialog structure in `desktopDialogs.ts`
- Dynamic dialog view component with i18n support
- Button action types: openUrl, close, cancel
- Button severity levels for styling (primary, secondary, danger, warn)
- Fallback invalid dialog for error handling
- i18n collection script updated for dialog strings

### Review focus

- Colors added to match Figma design specs (coral-red, neutral-550)

### Screenshots

When a corrupt environment is detected during server start:
<img width="637" height="504" alt="image" src="https://github.com/user-attachments/assets/e5b11a15-c3ed-4bf9-a8dc-31dd4b7d4db7" />

If we make mistakes during dev (should NEVER be seen in prod):
<img width="638" height="501" alt="image" src="https://github.com/user-attachments/assets/6472c911-592a-434b-8365-3ca45583b9aa" />