### PR TITLE
Lint: Ignore browser_tests for now

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -20,6 +20,7 @@ export default defineConfig([
       'src/types/vue-shim.d.ts',
       'src/types/comfyRegistryTypes.ts',
       'src/types/generatedManagerTypes.ts',
+      'browser_tests/**/*',
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*'
     ]


### PR DESCRIPTION
Until we can properly configure a tsconfig for them.

## Summary

Tells eslint to ignore the browser_tests

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5632-Lint-Ignore-browser_tests-for-now-2726d73d365081ea9c11d14792301d33) by [Unito](https://www.unito.io)
