### PR TITLE
Fix SaveAs

### DIFF
--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -17,7 +17,7 @@ import { downloadBlob } from '@/scripts/utils'
 import { useDialogService } from '@/services/dialogService'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { appendJsonExt, generateUUID } from '@/utils/formatUtil'
+import { appendJsonExt } from '@/utils/formatUtil'
 
 export const useWorkflowService = () => {
   const settingStore = useSettingStore()
@@ -112,14 +112,7 @@ export const useWorkflowService = () => {
       await renameWorkflow(workflow, newPath)
       await workflowStore.saveWorkflow(workflow)
     } else {
-      // Generate new id when saving existing workflow as a new file
-      const id = generateUUID()
-      const state = JSON.parse(
-        JSON.stringify(workflow.activeState)
-      ) as ComfyWorkflowJSON
-      state.id = id
-
-      const tempWorkflow = workflowStore.saveAs(workflow, newPath, state)
+      const tempWorkflow = workflowStore.saveAs(workflow, newPath)
       await openWorkflow(tempWorkflow)
       await workflowStore.saveWorkflow(tempWorkflow)
     }

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -119,7 +119,7 @@ export const useWorkflowService = () => {
       ) as ComfyWorkflowJSON
       state.id = id
 
-      const tempWorkflow = workflowStore.saveAs(workflow, newPath)
+      const tempWorkflow = workflowStore.saveAs(workflow, newPath, state)
       await openWorkflow(tempWorkflow)
       await workflowStore.saveWorkflow(tempWorkflow)
     }

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -20,7 +20,7 @@ import {
   parseNodeExecutionId,
   parseNodeLocatorId
 } from '@/types/nodeIdentification'
-import { getPathDetails } from '@/utils/formatUtil'
+import { generateUUID, getPathDetails } from '@/utils/formatUtil'
 import { syncEntities } from '@/utils/syncUtil'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 
@@ -318,15 +318,21 @@ export const useWorkflowStore = defineStore('workflow', () => {
   }
   const saveAs = (
     existingWorkflow: ComfyWorkflow,
-    path: string,
-    workflowData: ComfyWorkflowJSON
+    path: string
   ): ComfyWorkflow => {
+    // Generate new id when saving existing workflow as a new file
+    const id = generateUUID()
+    const state = JSON.parse(
+      JSON.stringify(existingWorkflow.activeState)
+    ) as ComfyWorkflowJSON
+    state.id = id
+
     const workflow: ComfyWorkflow = new (existingWorkflow.constructor as any)({
       path,
       modified: Date.now(),
       size: -1
     })
-    workflow.originalContent = workflow.content = JSON.stringify(workflowData)
+    workflow.originalContent = workflow.content = JSON.stringify(state)
     workflowLookup.value[workflow.path] = workflow
     return workflow
   }

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -318,14 +318,15 @@ export const useWorkflowStore = defineStore('workflow', () => {
   }
   const saveAs = (
     existingWorkflow: ComfyWorkflow,
-    path: string
+    path: string,
+    workflowData: ComfyWorkflowJSON
   ): ComfyWorkflow => {
     const workflow: ComfyWorkflow = new (existingWorkflow.constructor as any)({
       path,
       modified: Date.now(),
       size: -1
     })
-    workflow.originalContent = workflow.content = existingWorkflow.content
+    workflow.originalContent = workflow.content = JSON.stringify(workflowData)
     workflowLookup.value[workflow.path] = workflow
     return workflow
   }


### PR DESCRIPTION
Implementing subgraph blueprints (#5139) included changes to saving to ensure that SaveAs generates a new workflow of the correct type. However this code failed to utilize the pre-prepared state when performing the actual save. This produced a couple of problems with both failing to detach the workflow and failing to apply the correct state 

This error is only encountered when using Save As from a non temporary workflow (one loaded from the workflows sidebar tab).

As this state calculation code is only used in this code path, it has been moved into the saveAs function of the workflowStore.

Resolves #5592

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5643-Fix-SaveAs-2726d73d3650818faa7af449d1f13c26) by [Unito](https://www.unito.io)
