### PR TITLE
fix: don't immediately close missing nodes dialog if manager is disabled

### DIFF
--- a/src/components/dialog/content/LoadWorkflowWarning.vue
+++ b/src/components/dialog/content/LoadWorkflowWarning.vue
@@ -138,7 +138,7 @@ const allMissingNodesInstalled = computed(() => {
 })
 // Watch for completion and close dialog
 watch(allMissingNodesInstalled, async (allInstalled) => {
-  if (allInstalled) {
+  if (allInstalled && showInstallAllButton.value) {
     // Use nextTick to ensure state updates are complete
     await nextTick()
 


### PR DESCRIPTION
If manager is disabled, it assumed all missing nodes are installed and immediately closes the missing nodes warning when loading a workflow with missing nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5647-fix-don-t-immediately-close-missing-nodes-dialog-if-manager-is-disabled-2736d73d36508199a50bca2026528ab6) by [Unito](https://www.unito.io)
