### PR TITLE
[refactor] Remove legacy manager UI support and tag from header

### DIFF
--- a/src/workbench/extensions/manager/components/manager/ManagerHeader.test.ts
+++ b/src/workbench/extensions/manager/components/manager/ManagerHeader.test.ts
@@ -1,8 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
-import Tag from 'primevue/tag'
-import Tooltip from 'primevue/tooltip'
 import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -22,13 +20,7 @@ describe('ManagerHeader', () => {
   const createWrapper = () => {
     return mount(ManagerHeader, {
       global: {
-        plugins: [createPinia(), PrimeVue, i18n],
-        directives: {
-          tooltip: Tooltip
-        },
-        components: {
-          Tag
-        }
+        plugins: [createPinia(), PrimeVue, i18n]
       }
     })
   }
@@ -41,42 +33,13 @@ describe('ManagerHeader', () => {
     )
   })
 
-  it('displays the legacy manager UI tag', () => {
-    const wrapper = createWrapper()
-
-    const tag = wrapper.find('[data-pc-name="tag"]')
-    expect(tag.exists()).toBe(true)
-    expect(tag.text()).toContain(enMessages.manager.legacyManagerUI)
-  })
-
-  it('applies info severity to the tag', () => {
-    const wrapper = createWrapper()
-
-    const tag = wrapper.find('[data-pc-name="tag"]')
-    expect(tag.classes()).toContain('p-tag-info')
-  })
-
-  it('displays info icon in the tag', () => {
-    const wrapper = createWrapper()
-
-    const icon = wrapper.find('.pi-info-circle')
-    expect(icon.exists()).toBe(true)
-  })
-
-  it('has cursor-help class on the tag', () => {
-    const wrapper = createWrapper()
-
-    const tag = wrapper.find('[data-pc-name="tag"]')
-    expect(tag.classes()).toContain('cursor-help')
-  })
-
   it('has proper structure with flex container', () => {
     const wrapper = createWrapper()
 
-    const flexContainer = wrapper.find('.flex.justify-end.ml-auto.pr-4')
+    const flexContainer = wrapper.find('.flex.items-center')
     expect(flexContainer.exists()).toBe(true)
 
-    const tag = flexContainer.find('[data-pc-name="tag"]')
-    expect(tag.exists()).toBe(true)
+    const title = flexContainer.find('h2')
+    expect(title.exists()).toBe(true)
   })
 })

--- a/src/workbench/extensions/manager/components/manager/ManagerHeader.vue
+++ b/src/workbench/extensions/manager/components/manager/ManagerHeader.vue
@@ -4,22 +4,8 @@
       <h2 class="text-lg font-normal text-left">
         {{ $t('manager.discoverCommunityContent') }}
       </h2>
-      <div class="flex justify-end ml-auto pr-4 pl-2">
-        <Tag
-          v-tooltip.left="$t('manager.legacyManagerUIDescription')"
-          severity="info"
-          icon="pi pi-info-circle"
-          :value="$t('manager.legacyManagerUI')"
-          class="cursor-help ml-2"
-          :pt="{
-            root: { class: 'text-xs' }
-          }"
-        />
-      </div>
     </div>
   </div>
 </template>
 
-<script setup lang="ts">
-import Tag from 'primevue/tag'
-</script>
+<script setup lang="ts"></script>


### PR DESCRIPTION
## Summary

Removed the informational "Use Legacy UI" tag from the ManagerHeader component while preserving all underlying legacy manager functionality.

## Changes

- **What**: Removed Tag component displaying legacy UI information from ManagerHeader
- **Breaking**: None - all legacy manager functionality remains intact
- **Dependencies**: None

## Review Focus

Visual cleanup only - the `--enable-manager-legacy-ui` CLI flag and all related functionality continues to work normally. Only the informational UI tag has been removed from the header.