### PR TITLE
[feat] Improve template modal UI layout and spacing

### DIFF
--- a/src/components/templates/TemplateSearchBar.vue
+++ b/src/components/templates/TemplateSearchBar.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="relative w-full p-4">
+  <div class="relative w-full">
     <div class="h-12 flex items-center gap-4 justify-between">
-      <div class="flex-1 max-w-md">
+      <div class="flex-1 max-w-xs">
         <AutoComplete
           v-model.lazy="searchQuery"
           :placeholder="$t('templateWorkflows.searchPlaceholder')"

--- a/src/components/templates/TemplateWorkflowCard.vue
+++ b/src/components/templates/TemplateWorkflowCard.vue
@@ -67,7 +67,7 @@
           <h3 class="line-clamp-2 text-lg font-normal mb-0" :title="title">
             {{ title }}
           </h3>
-          <p class="line-clamp-2 text-sm text-muted grow" :title="description">
+          <p class="line-clamp-4 text-sm text-muted grow" :title="description">
             {{ description }}
           </p>
         </div>

--- a/src/components/templates/TemplateWorkflowView.vue
+++ b/src/components/templates/TemplateWorkflowView.vue
@@ -5,11 +5,12 @@
     data-key="name"
     :lazy="true"
     pt:root="h-full grid grid-rows-[auto_1fr_auto]"
+    pt:header="p-0"
     pt:content="p-2 overflow-auto"
   >
     <template #header>
-      <div class="flex flex-col">
-        <div class="flex justify-between items-center mb-4">
+      <div class="flex flex-col mb-4">
+        <div class="flex justify-between items-center">
           <h2 class="text-lg">{{ title }}</h2>
           <SelectButton
             v-model="layout"


### PR DESCRIPTION
## Description
Improve template modal UI layout and spacing for better user experience and visual balance.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- **Increase card description display**: Changed from 2 to 4 lines in `TemplateWorkflowCard.vue` for more content visibility
- **Remove header padding**: Cleaned up layout in `TemplateWorkflowView.vue` by removing header padding for better spacing
- **Optimize search bar proportions**: Reduced search bar width in `TemplateSearchBar.vue` for improved visual balance

## Testing
- [x] Manual testing completed
- [x] UI changes verified in development environment
- [x] Responsive design maintained

## Screenshots

### Before
* Template descriptions cut off at 2 lines
* Extra spacing in header reduces area for viewing templates

<img width="3413" height="1882" alt="before" src="https://github.com/user-attachments/assets/d44029fd-6bdc-4409-8431-6564adbeedf8" />

### After
* Template descriptions have 4 lines
* Reduced spacing in header gives more area for viewing templates 

<img width="3413" height="1882" alt="after" src="https://github.com/user-attachments/assets/95482879-9e22-47d9-91f6-de3a0bdc6750" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5671-feat-Improve-template-modal-UI-layout-and-spacing-2736d73d365081268b2feac84b2f638f) by [Unito](https://www.unito.io)
