### PR TITLE
fix: update to standardized mobile web app meta tag syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <link rel="stylesheet" type="text/css" href="user.css" />
     <link rel="stylesheet" type="text/css" href="api/userdata/user.css" />
     
-    <!-- Fullscreen mode on iOS -->
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <!-- Fullscreen mode on mobile browsers -->
+    <meta name="mobile-web-app-capable" content="yes">
     <!-- Status bar style (eg. black or transparent) -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     


### PR DESCRIPTION
## Summary

Fixed WebKit deprecation warning by updating to standardized mobile web app meta tag syntax.

## Changes

- **What**: Replaced deprecated `apple-mobile-web-app-capable` with cross-platform [`mobile-web-app-capable`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name#mobile-web-app-capable) meta tag to align with WebKit's move toward vendor-neutral standards

## Review Focus

Verify "Add to Home Screen" functionality still works on iOS/iPadOS and that the WebKit console warning is resolved in production builds.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5672-fix-update-to-standardized-mobile-web-app-meta-tag-syntax-2736d73d3650811cb2a1f0b14ce0a0e7) by [Unito](https://www.unito.io)
