### PR TITLE
[refactor] Remove redundant module comment

### DIFF
--- a/src/renderer/extensions/vueNodes/layout/useNodeLayout.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeLayout.ts
@@ -1,10 +1,4 @@
 import { storeToRefs } from 'pinia'
-/**
- * Composable for individual Vue node components
- *
- * Uses customRef for shared write access with Canvas renderer.
- * Provides dragging functionality and reactive layout state.
- */
 import { type MaybeRefOrGetter, computed, inject, toValue } from 'vue'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'


### PR DESCRIPTION
Removes a comment added in initial Vue Nodes commit. The comment is interpolated between import statements which is stylistically awkward and it is almost totally redundant with the doc comment on the composable:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/c1d4709e96a642188751007e7b76f12d496a0163/src/renderer/extensions/vueNodes/layout/useNodeLayout.ts#L10-L14

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5711-refactor-Remove-redundant-module-comment-2756d73d365081ef9bffe0257b3670f1) by [Unito](https://www.unito.io)
