### PR TITLE
[style] update Vue node tooltip style

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -93,10 +93,10 @@ export function useNodeTooltips(
       pt: {
         text: {
           class:
-            'bg-charcoal-100 border border-slate-300 rounded-md px-4 py-2 text-white text-sm font-normal leading-tight max-w-75 shadow-none'
+            'bg-charcoal-800 border border-slate-300 rounded-md px-4 py-2 text-white text-sm font-normal leading-tight max-w-75 shadow-none'
         },
         arrow: {
-          class: 'before:border-charcoal-100'
+          class: 'before:border-slate-300'
         }
       }
     }


### PR DESCRIPTION
## Summary

Change Vue node tooltips to align with [design](https://www.figma.com/design/31uH3r4x3xbIctuRWYW6NM/V3---Nodes?node-id=6267-16837&m=dev)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5717-style-update-Vue-node-tooltip-style-2766d73d365081bdb095faef17f6aeb6) by [Unito](https://www.unito.io)
