### PR TITLE
fix Vue node being dragged when interacting with widgets (e.g., resizing textarea)

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -12,9 +12,9 @@
           : 'pointer-events-none'
       )
     "
-    @pointerdown="handleWidgetPointerEvent"
-    @pointermove="handleWidgetPointerEvent"
-    @pointerup="handleWidgetPointerEvent"
+    @pointerdown.stop="handleWidgetPointerEvent"
+    @pointermove.stop="handleWidgetPointerEvent"
+    @pointerup.stop="handleWidgetPointerEvent"
   >
     <div
       v-for="(widget, index) in processedWidgets"


### PR DESCRIPTION
## Summary

Applying changes in https://github.com/Comfy-Org/ComfyUI_frontend/pull/5424 to entire widget wrapper.


https://github.com/user-attachments/assets/a2168ac8-0741-4d6b-8418-e93cb332a747


 
## Changes

- **What**: Added `.stop` modifier to pointer events in NodeWidgets component to prevent [event propagation](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation)

## Review Focus

Verify widget interactions remain functional while ensuring parent node drag/selection behavior is properly isolated.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5719-fix-Vue-node-being-dragged-when-interacting-with-widgets-e-g-resizing-textarea-2766d73d3650815091adcd1d65197c7b) by [Unito](https://www.unito.io)
