### PR TITLE
add bypassLOD

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -39,7 +39,7 @@
     @pointerdown="handlePointerDown"
     @pointermove="handlePointerMove"
     @pointerup="handlePointerUp"
-    @wheel="handleWheel"
+    @wheel="handleNodeWheel"
   >
     <div class="flex items-center">
       <template v-if="isCollapsed">
@@ -292,9 +292,17 @@ const { latestPreviewUrl, shouldShowPreviewImg } = useNodePreviewState(
   }
 )
 
+// Check if any widget bypasses LOD restrictions
+const hasLODBypassWidgets = computed(() => {
+  if (!nodeData.widgets?.length) return false
+  return nodeData.widgets.some((w: any) => w.options?.bypassLOD === true)
+})
+
 // Common condition computations to avoid repetition
 const shouldShowWidgets = computed(
-  () => shouldRenderWidgets.value && nodeData.widgets?.length
+  () =>
+    (shouldRenderWidgets.value || hasLODBypassWidgets.value) &&
+    nodeData.widgets?.length
 )
 
 const shouldShowContent = computed(
@@ -331,6 +339,18 @@ const handleCollapse = () => {
 
 const handleHeaderTitleUpdate = (newTitle: string) => {
   handleNodeTitleUpdate(nodeData.id, newTitle)
+}
+
+const handleNodeWheel = (event: WheelEvent) => {
+  const target = event.target as HTMLElement
+  const isInLoad3D = target?.closest('.comfy-load-3d')
+
+  // Don't handle wheel events from Load3D components
+  if (isInLoad3D) {
+    return
+  }
+
+  handleWheel(event)
 }
 
 const handleEnterSubgraph = () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -39,7 +39,7 @@
     @pointerdown="handlePointerDown"
     @pointermove="handlePointerMove"
     @pointerup="handlePointerUp"
-    @wheel="handleNodeWheel"
+    @wheel="handleWheel"
   >
     <div class="flex items-center">
       <template v-if="isCollapsed">
@@ -339,18 +339,6 @@ const handleCollapse = () => {
 
 const handleHeaderTitleUpdate = (newTitle: string) => {
   handleNodeTitleUpdate(nodeData.id, newTitle)
-}
-
-const handleNodeWheel = (event: WheelEvent) => {
-  const target = event.target as HTMLElement
-  const isInLoad3D = target?.closest('.comfy-load-3d')
-
-  // Don't handle wheel events from Load3D components
-  if (isInLoad3D) {
-    return
-  }
-
-  handleWheel(event)
 }
 
 const handleEnterSubgraph = () => {

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -125,17 +125,22 @@ const processedWidgets = computed((): ProcessedWidget[] => {
   const widgets = nodeData.widgets as SafeWidgetData[]
   const result: ProcessedWidget[] = []
 
-  if (lodLevel === LODLevel.MINIMAL) {
-    return []
-  }
-
   for (const widget of widgets) {
     if (widget.options?.hidden) continue
     if (widget.options?.canvasOnly) continue
     if (!widget.type) continue
     if (!shouldRenderAsVue(widget)) continue
 
-    if (lodLevel === LODLevel.REDUCED && !isEssential(widget.type)) continue
+    const bypassLOD = widget.options?.bypassLOD === true
+
+    if (!bypassLOD) {
+      if (
+        lodLevel === LODLevel.MINIMAL ||
+        (lodLevel === LODLevel.REDUCED && !isEssential(widget.type))
+      ) {
+        continue
+      }
+    }
 
     const vueComponent = getComponent(widget.type) || WidgetInputText
 


### PR DESCRIPTION
## Summary

Add bypassLOD Option for Critical Widgets in vueNodes System

## Changes

Certain widgets like Load3D contain critical WebGL contexts that must remain active regardless of zoom level:

  1. WebGL Context Destruction: When Load3D widgets are hidden by LOD, their Three.js WebGL contexts are destroyed, losing all scene data, camera positions, and loaded models
  2. Workflow Execution Failure: Users cannot execute workflows at reduced zoom levels because the 3D scene no longer exists when needed for rendering
  3. State Loss: Even when zooming back in, the 3D scene must be completely reconstructed, losing user configurations

  **Why hideOnZoom Doesn't Work for Load3D**

  The existing hideOnZoom option only affects canvas 2D rendering - it draws a placeholder rectangle instead of the widget content when zoomed out. However, Load3D is a Vue component widget that renders in the DOM, not on the canvas 2D context. The Three.js scene exists as DOM elements with WebGL contexts, which are completely destroyed when the Vue component is unmounted due to LOD restrictions. Therefore, hideOnZoom has no effect on preventing the destruction of Load3D widgets.

  Solution

  This PR introduces a bypassLOD option that allows specific widgets to opt out of LOD restrictions at the Vue component level:

  // Widget configuration
  options: {
    bypassLOD: true  // Widget will render at all zoom levels
  }

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5726-add-bypassLOD-2766d73d365081a7977be7f1f6053dc7) by [Unito](https://www.unito.io)
