### PR TITLE
Refactor: Further state management cleanup

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -11,11 +11,6 @@ import type { WidgetValue } from '@/types/simplifiedWidget'
 
 import type { LGraph, LGraphNode } from '../../lib/litegraph/src/litegraph'
 
-interface NodeMetadata {
-  lastRenderTime: number
-  cachedBounds: DOMRect | null
-  lodLevel: 'high' | 'medium' | 'low'
-}
 export interface SafeWidgetData {
   name: string
   type: string
@@ -60,17 +55,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
   // Non-reactive storage for original LiteGraph nodes
   const nodeRefs = new Map<string, LGraphNode>()
-
-  // WeakMap for heavy data that auto-GCs when nodes are removed
-  const nodeMetadata = new WeakMap<LGraphNode, NodeMetadata>()
-
-  const attachMetadata = (node: LGraphNode) => {
-    nodeMetadata.set(node, {
-      lastRenderTime: performance.now(),
-      cachedBounds: null,
-      lodLevel: 'high'
-    })
-  }
 
   // Extract safe data from LiteGraph node for Vue consumption
   const extractVueNodeData = (node: LGraphNode): VueNodeData => {
@@ -286,10 +270,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
       // Extract and store safe data for Vue
       vueNodeData.set(id, extractVueNodeData(node))
-
-      if (!nodeMetadata.has(node)) {
-        attachMetadata(node)
-      }
     })
   }
 
@@ -316,8 +296,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
       // Extract actual positions after configure() has potentially updated them
       const nodePosition = { x: node.pos[0], y: node.pos[1] }
       const nodeSize = { width: node.size[0], height: node.size[1] }
-
-      attachMetadata(node)
 
       // Add node to layout store with final positions
       setSource(LayoutSource.Canvas)

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -18,18 +18,6 @@ interface NodeMetadata {
   lodLevel: 'high' | 'medium' | 'low'
   spatialIndex?: QuadTree<string>
 }
-
-interface PerformanceMetrics {
-  fps: number
-  frameTime: number
-  updateTime: number
-  nodeCount: number
-  culledCount: number
-  callbackUpdateCount: number
-  rafUpdateCount: number
-  adaptiveQuality: boolean
-}
-
 export interface SafeWidgetData {
   name: string
   type: string
@@ -70,7 +58,6 @@ export interface GraphNodeManager {
     nodeId?: string,
     priority?: 'critical' | 'normal' | 'low'
   ): void
-  forceSync(): void
 }
 
 export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
@@ -84,18 +71,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
   // WeakMap for heavy data that auto-GCs when nodes are removed
   const nodeMetadata = new WeakMap<LGraphNode, NodeMetadata>()
-
-  // Performance tracking
-  const performanceMetrics = reactive<PerformanceMetrics>({
-    fps: 0,
-    frameTime: 0,
-    updateTime: 0,
-    nodeCount: 0,
-    culledCount: 0,
-    callbackUpdateCount: 0,
-    rafUpdateCount: 0,
-    adaptiveQuality: false
-  })
 
   // Spatial indexing using QuadTree
   const spatialIndex = new QuadTree<string>(
@@ -245,7 +220,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
         ...currentData,
         widgets: updatedWidgets
       })
-      performanceMetrics.callbackUpdateCount++
     } catch (error) {
       // Ignore widget update errors to prevent cascade failures
     }
@@ -347,8 +321,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
   }
 
   const flush = () => {
-    const startTime = performance.now()
-
     if (batchTimeoutId !== null) {
       clearTimeout(batchTimeoutId)
       batchTimeoutId = null
@@ -362,9 +334,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
     // Sync with graph state
     syncWithGraph()
-
-    const endTime = performance.now()
-    performanceMetrics.updateTime = endTime - startTime
   }
 
   const syncWithGraph = () => {
@@ -408,9 +377,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
         spatialIndex.insert(id, bounds, id)
       }
     })
-
-    // Update performance metrics
-    performanceMetrics.nodeCount = vueNodeData.size
   }
 
   /**
@@ -634,7 +600,6 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
     vueNodeData,
     getNode,
     cleanup,
-    scheduleUpdate,
-    forceSync: syncWithGraph
+    scheduleUpdate
   }
 }

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -1,15 +1,5 @@
-/**
- * Vue Node Lifecycle Management Composable
- *
- * Handles the complete lifecycle of Vue node rendering system including:
- * - Node manager initialization and cleanup
- * - Layout store synchronization
- * - Slot and link sync management
- * - Reactive state management for node data, positions, and sizes
- * - Memory management and proper cleanup
- */
 import { createSharedComposable } from '@vueuse/core'
-import { computed, readonly, ref, shallowRef, watch } from 'vue'
+import { readonly, ref, shallowRef, watch } from 'vue'
 
 import { useGraphNodeManager } from '@/composables/graph/useGraphNodeManager'
 import type {
@@ -46,8 +36,6 @@ function useVueNodeLifecycleIndividual() {
 
   // Trigger for forcing computed re-evaluation
   const nodeDataTrigger = ref(0)
-
-  const isNodeManagerReady = computed(() => nodeManager.value !== null)
 
   const initializeNodeManager = () => {
     // Use canvas graph if available (handles subgraph contexts), fallback to app graph
@@ -218,10 +206,7 @@ function useVueNodeLifecycleIndividual() {
 
   return {
     vueNodeData,
-    nodeState,
-    nodeDataTrigger: readonly(nodeDataTrigger),
     nodeManager: readonly(nodeManager),
-    isNodeManagerReady,
 
     // Lifecycle methods
     initializeNodeManager,

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -4,7 +4,6 @@ import { readonly, ref, shallowRef, watch } from 'vue'
 import { useGraphNodeManager } from '@/composables/graph/useGraphNodeManager'
 import type {
   GraphNodeManager,
-  NodeState,
   VueNodeData
 } from '@/composables/graph/useGraphNodeManager'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
@@ -32,7 +31,6 @@ function useVueNodeLifecycleIndividual() {
 
   // Vue node data state
   const vueNodeData = ref<ReadonlyMap<string, VueNodeData>>(new Map())
-  const nodeState = ref<ReadonlyMap<string, NodeState>>(new Map())
 
   // Trigger for forcing computed re-evaluation
   const nodeDataTrigger = ref(0)
@@ -49,7 +47,6 @@ function useVueNodeLifecycleIndividual() {
 
     // Use the manager's data maps
     vueNodeData.value = manager.vueNodeData
-    nodeState.value = manager.nodeState
 
     // Initialize layout system with existing nodes from active graph
     const nodes = activeGraph._nodes.map((node: LGraphNode) => ({
@@ -112,7 +109,6 @@ function useVueNodeLifecycleIndividual() {
 
     // Reset reactive maps to clean state
     vueNodeData.value = new Map()
-    nodeState.value = new Map()
   }
 
   // Watch for Vue nodes enabled state changes

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4032,6 +4032,18 @@ export class LGraphCanvas
 
     // TODO: Report failures, i.e. `failedNodes`
 
+    const newPositions = created.map((node) => ({
+      nodeId: String(node.id),
+      bounds: {
+        x: node.pos[0],
+        y: node.pos[1],
+        width: node.size?.[0] ?? 100,
+        height: node.size?.[1] ?? 200
+      }
+    }))
+
+    layoutStore.batchUpdateNodeBounds(newPositions)
+
     this.selectItems(created)
 
     graph.afterChange()

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -82,6 +82,7 @@ export interface Positionable extends Parent<Positionable>, HasBoundingRect {
    * @default 0,0
    */
   readonly pos: Point
+  readonly size?: Size
   /** true if this object is part of the selection, otherwise false. */
   selected?: boolean
 

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -1379,6 +1379,7 @@ class LayoutStoreImpl implements LayoutStore {
 
         this.spatialIndex.update(nodeId, bounds)
         ynode.set('bounds', bounds)
+        ynode.set('position', { x: bounds.x, y: bounds.y })
         ynode.set('size', { width: bounds.width, height: bounds.height })
       }
     }, this.currentActor)

--- a/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.ts
@@ -82,7 +82,6 @@ function useNodeEventHandlersIndividual() {
     const currentCollapsed = node.flags?.collapsed ?? false
     if (currentCollapsed !== collapsed) {
       node.collapse()
-      nodeManager.value.scheduleUpdate(nodeId, 'critical')
     }
   }
 


### PR DESCRIPTION
## Summary

Going through the GraphNodeManager and VueNodeLifecycle one property at a time and removing the pieces that are not currently wired up or used by the rest of the application

Fixes paste location by updating the layoutStore in LGraphCanvas (which already mutates layoutStore elsewhere)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5727-WIP-Refactor-Further-state-management-cleanup-2766d73d36508173b379c6009c194a5a) by [Unito](https://www.unito.io)
