### PR TITLE
[bugfix] Fix cloud invite code route authentication issue

### DIFF
--- a/src/onboardingCloudRoutes.ts
+++ b/src/onboardingCloudRoutes.ts
@@ -7,6 +7,12 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
       import('@/platform/onboarding/cloud/components/CloudLayoutView.vue'),
     children: [
       {
+        path: 'code/:code',
+        name: 'cloud-invite-code',
+        component: () =>
+          import('@/platform/onboarding/cloud/CloudInviteEntryView.vue')
+      },
+      {
         path: 'login',
         name: 'cloud-login',
         component: () =>
@@ -43,13 +49,6 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         name: 'cloud-user-check',
         component: () =>
           import('@/platform/onboarding/cloud/UserCheckView.vue'),
-        meta: { requiresAuth: true }
-      },
-      {
-        path: 'code/:code',
-        name: 'cloud-invite-code',
-        component: () =>
-          import('@/platform/onboarding/cloud/CloudInviteEntryView.vue'),
         meta: { requiresAuth: true }
       },
       {


### PR DESCRIPTION
## Summary
- Remove `requiresAuth: true` from cloud-invite-code route to fix redirect issues in production

## Problem
The `/cloud/code/:code` route had conflicting configurations:
- Route was marked as `requiresAuth: true` in route definition
- But was treated as a public route in the router guard logic
- This caused authentication redirect issues when unauthenticated users tried to access invite links

## Solution
Removed the `requiresAuth: true` meta property from the cloud-invite-code route, allowing it to properly function as a public route that redirects to login with the invite code.

## Test plan
- [x] Access `/cloud/code/TESTCODE` while logged out - should redirect to login with `inviteCode` query param
- [x] Verify no authentication errors in console
- [x] Confirm invite code is preserved through the redirect flow

Fixes authentication redirect issue for cloud invite links

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5730-bugfix-Fix-cloud-invite-code-route-authentication-issue-2776d73d36508149b512d7f735b1a231) by [Unito](https://www.unito.io)
