### PR TITLE
Add base url to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,21 @@
   <head>
     <meta charset="UTF-8">
     <title>ComfyUI</title>
+    <!-- All assets should be loaded from the root no matter the initial path -->
+    <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel="stylesheet" type="text/css" href="materialdesignicons.min.css" />
     <link rel="stylesheet" type="text/css" href="user.css" />
     <link rel="stylesheet" type="text/css" href="api/userdata/user.css" />
-    
+
     <!-- Fullscreen mode on iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <!-- Status bar style (eg. black or transparent) -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    
+
     <link rel="manifest" href="manifest.json">
   </head>
-  
+
   <body class="litegraph grid">
     <div id="vue-app"></div>
     <script type="module" src="src/main.ts"></script>


### PR DESCRIPTION
cloud.comfy.org/cloud/code/XXXX-XXXX-XXXX was returning a white page. The problem is our assets are using relative path, and so we were requesting assets from cloud.comfy.org/cloud/code/assets/...

We have an SPA fallback handler on the ingest handler which resolves /cloud/ to /, so paths like cloud.comfy.org/cloud/part1 still worked. But it broke down when we have cloud.comfy.org/cloud/part1/part2. 

This PR adds a base url to the html so assets are loaded relative to "/". 

## Tests
Built frontend and copied to ingest server, and checked on local ingest server that it works (it was failing before). 

[Slack thread](https://comfy-organization.slack.com/archives/C08V9NDB3B4/p1758642698302389?thread_ts=1758593690.577669&cid=C08V9NDB3B4)