### PR TITLE
fix: add LODFallback to markdown widget

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -6,7 +6,7 @@
     <!-- Display mode: Rendered markdown -->
     <div
       v-if="!isEditing"
-      class="comfy-markdown-content text-xs min-h-[60px] rounded-lg px-4 py-2 overflow-y-auto"
+      class="comfy-markdown-content text-xs min-h-[60px] rounded-lg px-4 py-2 overflow-y-auto lod-toggle"
       v-html="renderedHtml"
     />
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -28,6 +28,7 @@
       @click.stop
       @keydown.stop
     />
+    <LODFallback />
   </div>
 </template>
 
@@ -38,6 +39,8 @@ import { computed, nextTick, ref } from 'vue'
 import { useStringWidgetValue } from '@/composables/graph/useWidgetValue'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { renderMarkdownToHtml } from '@/utils/markdownRendererUtil'
+
+import LODFallback from '../../components/LODFallback.vue'
 
 const props = defineProps<{
   widget: SimplifiedWidget<string>


### PR DESCRIPTION
## Summary

Add LOD fallback to markdown widget

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5734-fix-add-LODFallback-to-markdown-widget-2776d73d36508128b923d45beab50f03) by [Unito](https://www.unito.io)
