### PR TITLE
Fix overlapping elements in desktop installer

### DIFF
--- a/src/components/install/GpuPicker.vue
+++ b/src/components/install/GpuPicker.vue
@@ -112,16 +112,12 @@
     </div>
 
     <div
-      class="transition-opacity flex gap-3 h-0"
+      class="transition-opacity flex gap-3 h-0 items-center"
       :class="{
         'opacity-40': selected && selected !== 'cpu'
       }"
     >
-      <ToggleSwitch
-        v-model="cpuMode"
-        input-id="cpu-mode"
-        class="-translate-y-40"
-      />
+      <ToggleSwitch v-model="cpuMode" input-id="cpu-mode" />
       <label for="cpu-mode" class="select-none">
         {{ $t('install.gpuSelection.enableCpuMode') }}
       </label>


### PR DESCRIPTION
Fixes regression from Tailwind v4 upgrade where CPU toggle overlaps content.

Removed unnecessary translate transform causing element positioning issues.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5735-Fix-overlapping-elements-in-desktop-installer-2776d73d365081299affc7894bc88faa) by [Unito](https://www.unito.io)
