### PR TITLE
[fix] use object-contain for image preview

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -35,7 +35,7 @@
         v-else
         :src="currentImageUrl"
         :alt="imageAltText"
-        class="w-full h-[352px] object-cover block"
+        class="w-full h-[352px] object-contain block"
         @load="handleImageLoad"
         @error="handleImageError"
       />


### PR DESCRIPTION
## Summary

Change css so preview images are fully contained within the image preview component

## Screenshots (if applicable)

### Before

<img width="453" height="640" alt="Screenshot 2025-09-23 at 2 55 56 PM" src="https://github.com/user-attachments/assets/892c7fd4-b9d9-4fdd-9846-d480c5aeb6be" />

### After

<img width="523" height="673" alt="Screenshot 2025-09-23 at 2 55 26 PM" src="https://github.com/user-attachments/assets/ca3f4823-9d57-4bf4-93cc-492652ee9631" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5739-fix-use-object-contain-for-image-preview-2776d73d365081f3b77ce498bd8799ec) by [Unito](https://www.unito.io)
