### PR TITLE
Feat/vue nodes preview

### DIFF
--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -1,9 +1,9 @@
 <!-- Reference:
 https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c683087a3e168db/app/js/functions/sb_fn.js#L149
 -->
-
 <template>
-  <div class="_sb_node_preview">
+  <LGraphNodePreview v-if="shouldRenderVueNodes" :node-def="nodeDef" />
+  <div v-else class="_sb_node_preview">
     <div class="_sb_table">
       <div
         class="node_header text-ellipsis mr-4"
@@ -85,6 +85,8 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 import _ from 'es-toolkit/compat'
 import { computed } from 'vue'
 
+import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
+import LGraphNodePreview from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { useWidgetStore } from '@/stores/widgetStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
@@ -93,6 +95,8 @@ import { renderMarkdownToHtml } from '@/utils/markdownRendererUtil'
 const { nodeDef } = defineProps<{
   nodeDef: ComfyNodeDefV2
 }>()
+
+const { shouldRenderVueNodes } = useVueFeatureFlags()
 
 const colorPaletteStore = useColorPaletteStore()
 const litegraphColors = computed(

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="scale-75">
+    <div
+      class="bg-white dark-theme:bg-charcoal-800 lg-node absolute rounded-2xl border border-solid border-sand-100 dark-theme:border-charcoal-600 outline-transparent -outline-offset-2 outline-2 pointer-events-none"
+    >
+      <div class="flex items-center">
+        <NodeHeader :node-data="nodeData" :readonly="readonly" />
+      </div>
+
+      <div class="mb-4 relative">
+        <div class="bg-sand-100 dark-theme:bg-charcoal-600 h-px mx-0 w-full" />
+      </div>
+
+      <div class="flex flex-col gap-4 pb-4">
+        <NodeSlots
+          v-memo="[nodeData.inputs?.length, nodeData.outputs?.length]"
+          :node-data="nodeData"
+          :readonly="readonly"
+        />
+
+        <NodeWidgets
+          v-if="nodeData.widgets?.length"
+          v-memo="[nodeData.widgets?.length]"
+          :node-data="nodeData"
+          :readonly="readonly"
+        />
+
+        <NodeContent
+          v-if="hasCustomContent"
+          :node-data="nodeData"
+          :readonly="readonly"
+          :image-urls="nodeImageUrls"
+        />
+        <!-- Live preview image -->
+        <!-- <div v-if="shouldShowPreviewImg" class="px-4">
+          <img
+            :src="latestPreviewUrl"
+            alt="preview"
+            class="w-full max-h-64 object-contain"
+          />
+        </div> -->
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import NodeContent from '@/renderer/extensions/vueNodes/components/NodeContent.vue'
+import NodeHeader from '@/renderer/extensions/vueNodes/components/NodeHeader.vue'
+import NodeSlots from '@/renderer/extensions/vueNodes/components/NodeSlots.vue'
+import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
+import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { useWidgetStore } from '@/stores/widgetStore'
+
+const { nodeDef } = defineProps<{
+  nodeDef: ComfyNodeDefV2
+}>()
+
+const widgetStore = useWidgetStore()
+
+// Convert nodeDef into VueNodeData
+const nodeData = computed<VueNodeData>(() => {
+  // Convert inputs to widgets (those that have widget constructors)
+  const widgets = Object.entries(nodeDef.inputs || {})
+    .filter(([_, input]) => widgetStore.inputIsWidget(input))
+    .map(([name, input]) => ({
+      name,
+      type: input.widgetType || input.type,
+      value:
+        input.default !== undefined
+          ? input.default
+          : input.type === 'COMBO' &&
+              Array.isArray(input.options) &&
+              input.options.length > 0
+            ? input.options[0]
+            : undefined,
+      options: {
+        ...input,
+        hidden: input.hidden,
+        advanced: input.advanced,
+        values: input.type === 'COMBO' ? input.options : undefined // For combo widgets
+      }
+    }))
+
+  // Filter non-widget inputs for slots
+  const inputs = Object.entries(nodeDef.inputs || {})
+    .filter(([_, input]) => !widgetStore.inputIsWidget(input))
+    .map(([name, input]) => ({
+      name,
+      type: input.type,
+      shape: input.isOptional ? 'HollowCircle' : undefined
+    }))
+
+  return {
+    id: `preview-${nodeDef.name}`,
+    title: nodeDef.display_name || nodeDef.name,
+    type: nodeDef.name,
+    mode: 0, // Normal mode
+    selected: false,
+    executing: false,
+    widgets,
+    inputs,
+    outputs: nodeDef.outputs || [],
+    flags: {
+      collapsed: false
+    }
+  }
+})
+
+const readonly = true
+
+const hasCustomContent = computed(() => {
+  return false
+})
+
+const nodeImageUrls = computed(() => {
+  return []
+})
+</script>

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
@@ -80,22 +80,20 @@ const nodeData = computed<VueNodeData>(() => {
       name,
       type: input.type,
       shape: input.isOptional ? 'HollowCircle' : undefined,
-      boundingRect: [0, 0, 0, 0] as [number, number, number, number]
+      boundingRect: [0, 0, 0, 0]
     }))
 
   const outputs = (nodeDef.outputs || []).map((output) => {
-    // Handle both string and object formats for outputs
     if (typeof output === 'string') {
       return {
         name: output,
         type: output,
-        boundingRect: [0, 0, 0, 0] as [number, number, number, number]
+        boundingRect: [0, 0, 0, 0]
       }
     }
-    // If it's already an object, add boundingRect
     return {
       ...output,
-      boundingRect: [0, 0, 0, 0] as [number, number, number, number]
+      boundingRect: [0, 0, 0, 0]
     }
   })
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
@@ -3,13 +3,11 @@
     <div
       class="bg-white dark-theme:bg-charcoal-800 lg-node absolute rounded-2xl border border-solid border-sand-100 dark-theme:border-charcoal-600 outline-transparent -outline-offset-2 outline-2 pointer-events-none"
     >
-      <div class="flex items-center">
-        <NodeHeader :node-data="nodeData" :readonly="readonly" />
-      </div>
+      <NodeHeader :node-data="nodeData" :readonly="readonly" />
 
-      <div class="mb-4 relative">
-        <div class="bg-sand-100 dark-theme:bg-charcoal-600 h-px mx-0 w-full" />
-      </div>
+      <div
+        class="bg-sand-100 dark-theme:bg-charcoal-600 h-px mx-0 w-full mb-4"
+      />
 
       <div class="flex flex-col gap-4 pb-4">
         <NodeSlots

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
@@ -79,8 +79,25 @@ const nodeData = computed<VueNodeData>(() => {
     .map(([name, input]) => ({
       name,
       type: input.type,
-      shape: input.isOptional ? 'HollowCircle' : undefined
+      shape: input.isOptional ? 'HollowCircle' : undefined,
+      boundingRect: [0, 0, 0, 0] as [number, number, number, number]
     }))
+
+  const outputs = (nodeDef.outputs || []).map((output) => {
+    // Handle both string and object formats for outputs
+    if (typeof output === 'string') {
+      return {
+        name: output,
+        type: output,
+        boundingRect: [0, 0, 0, 0] as [number, number, number, number]
+      }
+    }
+    // If it's already an object, add boundingRect
+    return {
+      ...output,
+      boundingRect: [0, 0, 0, 0] as [number, number, number, number]
+    }
+  })
 
   return {
     id: `preview-${nodeDef.name}`,
@@ -91,7 +108,7 @@ const nodeData = computed<VueNodeData>(() => {
     executing: false,
     widgets,
     inputs,
-    outputs: nodeDef.outputs || [],
+    outputs,
     flags: {
       collapsed: false
     }

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
@@ -31,14 +31,6 @@
           :readonly="readonly"
           :image-urls="nodeImageUrls"
         />
-        <!-- Live preview image -->
-        <!-- <div v-if="shouldShowPreviewImg" class="px-4">
-          <img
-            :src="latestPreviewUrl"
-            alt="preview"
-            class="w-full max-h-64 object-contain"
-          />
-        </div> -->
       </div>
     </div>
   </div>
@@ -63,7 +55,6 @@ const widgetStore = useWidgetStore()
 
 // Convert nodeDef into VueNodeData
 const nodeData = computed<VueNodeData>(() => {
-  // Convert inputs to widgets (those that have widget constructors)
   const widgets = Object.entries(nodeDef.inputs || {})
     .filter(([_, input]) => widgetStore.inputIsWidget(input))
     .map(([name, input]) => ({
@@ -85,7 +76,6 @@ const nodeData = computed<VueNodeData>(() => {
       }
     }))
 
-  // Filter non-widget inputs for slots
   const inputs = Object.entries(nodeDef.inputs || {})
     .filter(([_, input]) => !widgetStore.inputIsWidget(input))
     .map(([name, input]) => ({
@@ -111,12 +101,6 @@ const nodeData = computed<VueNodeData>(() => {
 })
 
 const readonly = true
-
-const hasCustomContent = computed(() => {
-  return false
-})
-
-const nodeImageUrls = computed(() => {
-  return []
-})
+const hasCustomContent = false
+const nodeImageUrls = ['']
 </script>

--- a/tests-ui/tests/components/dialog/content/manager/packCard/PackCard.test.ts
+++ b/tests-ui/tests/components/dialog/content/manager/packCard/PackCard.test.ts
@@ -45,7 +45,8 @@ vi.mock('@vueuse/core', async () => {
     whenever: vi.fn(),
     useStorage: vi.fn((_key, defaultValue) => {
       return ref(defaultValue)
-    })
+    }),
+    createSharedComposable: vi.fn((fn) => fn)
   }
 })
 

--- a/tests-ui/tests/store/releaseStore.test.ts
+++ b/tests-ui/tests/store/releaseStore.test.ts
@@ -12,7 +12,8 @@ vi.mock('@/platform/settings/settingStore')
 vi.mock('@/stores/systemStatsStore')
 vi.mock('@vueuse/core', () => ({
   until: vi.fn(() => Promise.resolve()),
-  useStorage: vi.fn(() => ({ value: {} }))
+  useStorage: vi.fn(() => ({ value: {} })),
+  createSharedComposable: vi.fn((fn) => fn)
 }))
 
 describe('useReleaseStore', () => {


### PR DESCRIPTION
## Summary

Create a LGraphNodePreview.vue component to use Vue Nodes for preview when hovering over search results / sidebar tree list.

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<img width="3024" height="1642" alt="image" src="https://github.com/user-attachments/assets/d102b08e-2970-407b-aff8-3fa6333d5e38" />
<img width="3024" height="1646" alt="image (1)" src="https://github.com/user-attachments/assets/b5d378d5-3cf6-4cca-9fa1-741647e8d72c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5747-Feat-vue-nodes-preview-2786d73d3650817dbf9af458bd5dda8c) by [Unito](https://www.unito.io)
