### PR TITLE
fix: stabilize flaky load audio widget test

### DIFF
--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -318,6 +318,7 @@ test.describe('Animated image widget', () => {
 test.describe('Load audio widget', () => {
   test('Can load audio', async ({ comfyPage }) => {
     await comfyPage.loadWorkflow('widgets/load_audio_widget')
+    await comfyPage.page.waitForTimeout(300)
     await expect(comfyPage.canvas).toHaveScreenshot('load_audio_widget.png')
   })
 })


### PR DESCRIPTION
## Summary
- Add explicit wait time after loading audio widget workflow to ensure proper rendering before screenshot
- Follows same pattern as other widget tests that require rendering time

## Problem
The "Can load audio" test was intermittently failing in CI due to timing issues where the audio widget hadn't fully rendered before the screenshot was taken.

## Solution
Added `waitForTimeout(300)` after loading the workflow, consistent with how other widget tests (slider, number) handle rendering delays.

## Test plan
- [x] Fix applied to the flaky test
- [ ] CI tests should pass consistently

Fixes flaky test seen in: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/17969177702/job/51107754992

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5752-fix-stabilize-flaky-load-audio-widget-test-2786d73d3650815398c7cb7aeb49d44d) by [Unito](https://www.unito.io)
