### PR TITLE
fix: prevent pointer events on widgets when in LOD

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -970,10 +970,10 @@ audio.comfy-audio.empty-audio-widget {
   border-radius: 0;
   contain: layout style;
   transition: none;
- 
+
 }
 
-.isLOD .lg-node > * {
+.isLOD .lg-node-widgets {
   pointer-events: none;
 }
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -970,7 +970,6 @@ audio.comfy-audio.empty-audio-widget {
   border-radius: 0;
   contain: layout style;
   transition: none;
-
 }
 
 .isLOD .lg-node-widgets {


### PR DESCRIPTION
## Summary

Prevent pointer events on widgets themselves when isLOD.

Fixes: https://www.notion.so/comfy-org/LOD-state-allows-pointer-events-on-widgets-2786d73d3650800da600d7b52c66475a?source=copy_link

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5762-fix-prevent-pointer-events-on-widgets-when-in-LOD-2796d73d365081ac95d4ec27eda5027c) by [Unito](https://www.unito.io)
