### PR TITLE
Fix/vue nodes markdown

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -16,7 +16,7 @@
       ref="textareaRef"
       v-model="localValue"
       :disabled="readonly"
-      class="w-full min-h-[60px] absolute inset-0"
+      class="w-full min-h-[60px] absolute inset-0 resize-none"
       :pt="{
         root: {
           class: 'text-sm w-full h-full',

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -5,7 +5,7 @@
   >
     <!-- Display mode: Rendered markdown -->
     <div
-      class="comfy-markdown-content text-sm min-h-[60px] w-full rounded-lg px-4 py-2 overflow-y-auto lod-toggle"
+      class="comfy-markdown-content hover:bg-[var(--p-content-hover-background)] text-sm min-h-[60px] w-full rounded-lg px-4 py-2 overflow-y-auto lod-toggle"
       :class="isEditing === false ? 'visible' : 'invisible'"
       v-html="renderedHtml"
     />
@@ -91,7 +91,7 @@ const handleBlur = () => {
   border-radius: var(--p-border-radius);
 }
 
-.widget-markdown:hover:not(:has(textarea)) {
+.comfy-markdown-content:hover {
   background-color: var(--p-content-hover-background);
 }
 </style>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -5,22 +5,21 @@
   >
     <!-- Display mode: Rendered markdown -->
     <div
-      v-if="!isEditing"
-      class="comfy-markdown-content text-xs min-h-[60px] rounded-lg px-4 py-2 overflow-y-auto lod-toggle"
+      class="comfy-markdown-content text-sm min-h-[60px] w-full rounded-lg px-4 py-2 overflow-y-auto lod-toggle"
+      :class="isEditing === false ? 'visible' : 'invisible'"
       v-html="renderedHtml"
     />
 
     <!-- Edit mode: Textarea -->
     <Textarea
-      v-else
+      v-show="isEditing"
       ref="textareaRef"
       v-model="localValue"
       :disabled="readonly"
-      class="w-full text-xs"
-      size="small"
-      :rows="6"
+      class="w-full min-h-[60px] absolute inset-0"
       :pt="{
         root: {
+          class: 'text-sm w-full h-full',
           onBlur: handleBlur
         }
       }"


### PR DESCRIPTION
## Summary

Improve markdown node by making the textarea match the rendered output width and height.

Fixes: https://www.notion.so/comfy-org/edit-markdown-changes-node-size-2786d73d36508093a417c72b044ba07d?source=copy_link

## Screenshots (if applicable)

https://github.com/user-attachments/assets/4701f947-0a4f-40f3-83c0-94e53cd10106


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5771-Fix-vue-nodes-markdown-2796d73d365081129428fe9c38178cc4) by [Unito](https://www.unito.io)
