### PR TITLE
Add theme-aware styling for Vue node tooltips

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -89,6 +89,8 @@
   --color-sand-200: #d6cfc2;
   --color-sand-300: #888682;
 
+  --color-pure-white: #ffffff;
+
   --color-slate-100: #9c9eab;
   --color-slate-200: #9fa2bd;
   --color-slate-300: #5b5e7d;

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -93,7 +93,7 @@ export function useNodeTooltips(
       pt: {
         text: {
           class:
-            'bg-charcoal-800 border border-slate-300 rounded-md px-4 py-2 text-white text-sm font-normal leading-tight max-w-75 shadow-none'
+            'bg-pure-white dark-theme:bg-charcoal-800 border dark-theme:border-slate-300 rounded-md px-4 py-2 text-charcoal-700 dark-theme:text-pure-white text-sm font-normal leading-tight max-w-75 shadow-none'
         },
         arrow: {
           class: 'before:border-slate-300'


### PR DESCRIPTION
Adds light theme colors from the [designs](https://www.figma.com/design/31uH3r4x3xbIctuRWYW6NM/V3---Nodes?node-id=6267-16837&m=dev).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5786-Add-theme-aware-styling-for-Vue-node-tooltips-27a6d73d36508167979fe797efcbe3c0) by [Unito](https://www.unito.io)
