### PR TITLE
fix restoring outputs in Vue nodes (persisting node outputs when switching between workflow tabs)

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1778,9 +1778,8 @@ export class ComfyApp {
    * Clean current state
    */
   clean() {
-    this.nodeOutputs = {}
-    const { revokeAllPreviews } = useNodeOutputStore()
-    revokeAllPreviews()
+    const nodeOutputStore = useNodeOutputStore()
+    nodeOutputStore.resetAllOutputsAndPreviews()
     const executionStore = useExecutionStore()
     executionStore.lastNodeErrors = null
     executionStore.lastExecutionError = null

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -10,6 +10,7 @@ import {
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 import { useExecutionStore } from '@/stores/executionStore'
+import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
 import { api } from './api'
@@ -85,9 +86,7 @@ export class ChangeTracker {
       app.canvas.ds.scale = this.ds.scale
       app.canvas.ds.offset = this.ds.offset
     }
-    if (this.nodeOutputs) {
-      app.nodeOutputs = this.nodeOutputs
-    }
+    useNodeOutputStore().restoreOutputs(this.nodeOutputs ?? {})
     if (this.subgraphState) {
       const { navigation } = this.subgraphState
       useSubgraphNavigationStore().restoreState(navigation)

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -86,7 +86,9 @@ export class ChangeTracker {
       app.canvas.ds.scale = this.ds.scale
       app.canvas.ds.offset = this.ds.offset
     }
-    useNodeOutputStore().restoreOutputs(this.nodeOutputs ?? {})
+    if (this.nodeOutputs) {
+      useNodeOutputStore().restoreOutputs(this.nodeOutputs)
+    }
     if (this.subgraphState) {
       const { navigation } = this.subgraphState
       useSubgraphNavigationStore().restoreState(navigation)

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -328,6 +328,19 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     return hadOutputs
   }
 
+  function restoreOutputs(
+    outputs: Record<string, ExecutedWsMessage['output']>
+  ) {
+    app.nodeOutputs = outputs
+    nodeOutputs.value = outputs
+  }
+
+  function resetAllOutputsAndPreviews() {
+    app.nodeOutputs = {}
+    nodeOutputs.value = {}
+    revokeAllPreviews()
+  }
+
   return {
     // Getters
     getNodeOutputs,
@@ -346,6 +359,8 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     revokeAllPreviews,
     revokeSubgraphPreviews,
     removeNodeOutputs,
+    restoreOutputs,
+    resetAllOutputsAndPreviews,
 
     // State
     nodeOutputs,


### PR DESCRIPTION
## Summary

Fixed Vue node output restoration by consolidating state management through the node output store.

## Changes

- **What**: Refactored node output cleanup and restoration logic in `ChangeTracker` and `ComfyApp` to use centralized store methods
- **Breaking**: Removed direct manipulation of `app.nodeOutputs` in favor of store-managed state

## Review Focus

State synchronization between `app.nodeOutputs` and `nodeOutputs.value` during restore/reset operations, ensuring Vue reactivity is maintained.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5788-fix-restoring-outputs-in-Vue-nodes-persisting-node-outputs-when-switching-between-workfl-27a6d73d365081b39411fed7479d8ac5) by [Unito](https://www.unito.io)
