### PR TITLE
fix flaky version mismatch warning browser test

### DIFF
--- a/browser_tests/tests/versionMismatchWarnings.spec.ts
+++ b/browser_tests/tests/versionMismatchWarnings.spec.ts
@@ -105,8 +105,13 @@ test.describe('Version Mismatch Warnings', () => {
     await warningToast.waitFor({ state: 'visible' })
     const dismissButton = warningToast.getByRole('button', { name: 'Close' })
     await dismissButton.click()
-    // Wait for the setting to be written
-    await comfyPage.page.waitForTimeout(256)
+
+    // Wait for the dismissed state to be persisted
+    await comfyPage.page.waitForFunction(
+      () =>
+        localStorage.getItem('comfyui_version_mismatch_warning_dismissed') ===
+        'true'
+    )
 
     // Reload the page, keeping local storage
     await comfyPage.setup({ clearStorage: false })

--- a/browser_tests/tests/versionMismatchWarnings.spec.ts
+++ b/browser_tests/tests/versionMismatchWarnings.spec.ts
@@ -108,9 +108,7 @@ test.describe('Version Mismatch Warnings', () => {
 
     // Wait for the dismissed state to be persisted
     await comfyPage.page.waitForFunction(
-      () =>
-        localStorage.getItem('comfyui_version_mismatch_warning_dismissed') ===
-        'true'
+      () => !!localStorage.getItem('comfy.versionMismatch.dismissals')
     )
 
     // Reload the page, keeping local storage

--- a/browser_tests/tests/versionMismatchWarnings.spec.ts
+++ b/browser_tests/tests/versionMismatchWarnings.spec.ts
@@ -105,6 +105,8 @@ test.describe('Version Mismatch Warnings', () => {
     await warningToast.waitFor({ state: 'visible' })
     const dismissButton = warningToast.getByRole('button', { name: 'Close' })
     await dismissButton.click()
+    // Wait for the setting to be written
+    await comfyPage.page.waitForTimeout(256)
 
     // Reload the page, keeping local storage
     await comfyPage.setup({ clearStorage: false })


### PR DESCRIPTION
Adds a wait to ensure the dismissed state is saved to localstorage properly before `setup` (page reload).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5792-fix-broken-test-27a6d73d365081e69c1febbc246448fa) by [Unito](https://www.unito.io)
