### PR TITLE
fix(collect-i18n-node-defs): backport ComfyNodeDefImpl browser context fix to core/1.27

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -33,7 +33,16 @@ export default defineConfig([
       },
       parserOptions: {
         parser: tseslint.parser,
-        projectService: true,
+        projectService: {
+          allowDefaultProject: [
+            'vite.config.mts',
+            'vite.electron.config.mts',
+            'vite.types.config.mts',
+            'playwright.config.ts',
+            'playwright.i18n.config.ts',
+            'scripts/collect-i18n-node-defs.ts'
+          ]
+        },
         tsConfigRootDir: import.meta.dirname,
         ecmaVersion: 2020,
         sourceType: 'module',

--- a/playwright.i18n.config.ts
+++ b/playwright.i18n.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     headless: true
   },
   reporter: 'list',
+  workers: 1,
   timeout: 60000,
   testMatch: /collect-i18n-.*\.ts/
 })

--- a/scripts/collect-i18n-node-defs.ts
+++ b/scripts/collect-i18n-node-defs.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs'
 
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
 import { comfyPageFixture as test } from '../browser_tests/fixtures/ComfyPage'
-import type { ComfyNodeDef } from '../src/schemas/nodeDefSchema'
-import type { ComfyApi } from '../src/scripts/api'
-import { ComfyNodeDefImpl } from '../src/stores/nodeDefStore'
+import type { ComfyNodeDefImpl } from '../src/stores/nodeDefStore'
 import { normalizeI18nKey } from '../src/utils/formatUtil'
 
 const localePath = './src/locales/en/main.json'
@@ -11,23 +11,28 @@ const nodeDefsPath = './src/locales/en/nodeDefs.json'
 
 test('collect-i18n-node-defs', async ({ comfyPage }) => {
   // Mock view route
-  comfyPage.page.route('**/view**', async (route) => {
+  await comfyPage.page.route('**/view**', async (route) => {
     await route.fulfill({
       body: JSON.stringify({})
     })
   })
 
-  const nodeDefs: ComfyNodeDefImpl[] = (
-    Object.values(
-      await comfyPage.page.evaluate(async () => {
-        const api = window['app'].api as ComfyApi
-        return await api.getNodeDefs()
-      })
-    ) as ComfyNodeDef[]
+  // Note: Don't mock the object_info API endpoint - let it hit the actual backend
+
+  const nodeDefs: ComfyNodeDefImpl[] = await comfyPage.page.evaluate(
+    async () => {
+      const api = window['app'].api
+      const rawNodeDefs = await api.getNodeDefs()
+      const { ComfyNodeDefImpl } = await import('../src/stores/nodeDefStore')
+
+      return (
+        Object.values(rawNodeDefs)
+          // Ignore DevTools nodes (used for internal testing)
+          .filter((def: ComfyNodeDef) => !def.name.startsWith('DevTools'))
+          .map((def: ComfyNodeDef) => new ComfyNodeDefImpl(def))
+      )
+    }
   )
-    // Ignore DevTools nodes (used for internal testing)
-    .filter((def) => !def.name.startsWith('DevTools'))
-    .map((def) => new ComfyNodeDefImpl(def))
 
   console.log(`Collected ${nodeDefs.length} node definitions`)
 


### PR DESCRIPTION
## Summary
Backports the ComfyNodeDefImpl browser context fix from #5775 to the core/1.27 branch.

## Changes
- Move ComfyNodeDefImpl instantiation to browser context to avoid Node.js compatibility issues
- Add workers: 1 to playwright i18n config for consistent execution 
- Fix floating promise by awaiting page.route() call
- Add allowDefaultProject config for playwright and script files to resolve ESLint parsing

## Original Issue
The `collect-i18n-node-defs.ts` script was failing due to Vue components being imported into Node.js context, causing Babel compilation errors with TypeScript 'declare' fields.

## Solution
Uses dynamic imports to defer module loading until runtime in the browser context, avoiding Babel compilation of problematic TypeScript/Vue files.

Cherry-picked from 3a9365af1


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5796-fix-collect-i18n-node-defs-backport-ComfyNodeDefImpl-browser-context-fix-to-core-1-27-27a6d73d365081639625f25ecf9553fd) by [Unito](https://www.unito.io)
