### PR TITLE
Use input spec to determine asset type in upload widgets

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -207,10 +207,7 @@ export const useGraphNodeManager = (graph: LGraph): GraphNodeManager => {
         return {
           name: widget.name || 'unknown',
           type: widget.type || 'text',
-          value: undefined, // Already a valid WidgetValue
-          options: undefined,
-          callback: undefined,
-          spec: undefined
+          value: undefined
         }
       }
     })

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -8,7 +8,7 @@ import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { type Bounds, QuadTree } from '@/renderer/core/spatial/QuadTree'
-import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { SpatialIndexDebugInfo } from '@/types/spatialIndex'
@@ -46,7 +46,7 @@ export interface SafeWidgetData {
   value: WidgetValue
   options?: Record<string, unknown>
   callback?: ((value: unknown) => void) | undefined
-  spec?: InputSpecV2
+  spec?: InputSpec
 }
 
 export interface VueNodeData {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1821,7 +1821,10 @@
     "copyTooltip": "Copy message to clipboard"
   },
   "widgets": {
-    "selectModel": "Select model"
+    "selectModel": "Select model",
+    "uploadSelect": {
+      "placeholder": "Select..."
+    }
   },
   "nodeHelpPage": {
     "inputs": "Inputs",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1823,7 +1823,12 @@
   "widgets": {
     "selectModel": "Select model",
     "uploadSelect": {
-      "placeholder": "Select..."
+      "placeholder": "Select...",
+      "placeholderImage": "Select image...",
+      "placeholderAudio": "Select audio...",
+      "placeholderVideo": "Select video...",
+      "placeholderModel": "Select model...",
+      "placeholderUnknown": "Select media..."
     }
   },
   "nodeHelpPage": {

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -116,7 +116,8 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       type: widget.type,
       value: widget.value,
       options: widget.options,
-      callback: widget.callback
+      callback: widget.callback,
+      spec: widget.spec
     }
 
     const updateHandler = (value: unknown) => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.test.ts
@@ -215,7 +215,7 @@ describe('WidgetSelect Value Binding', () => {
       const dropdown = wrapper.findComponent(WidgetSelectDropdown)
 
       expect(dropdown.exists()).toBe(true)
-      expect(dropdown.props('mediaKind')).toBe('audio')
+      expect(dropdown.props('assetKind')).toBe('audio')
       expect(dropdown.props('allowUpload')).toBe(false)
     })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -2,7 +2,7 @@
   <WidgetSelectDropdown
     v-if="isDropdownUIWidget"
     v-bind="props"
-    :media-kind="mediaKind"
+    :asset-kind="assetKind"
     :allow-upload="allowUpload"
     :upload-folder="uploadFolder"
     @update:model-value="handleUpdateModelValue"
@@ -23,7 +23,7 @@ import {
   isComboInputSpec
 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
-import type { MediaKind } from '@/types/widgetTypes'
+import type { AssetKind } from '@/types/widgetTypes'
 
 import WidgetSelectDefault from './WidgetSelectDefault.vue'
 import WidgetSelectDropdown from './WidgetSelectDropdown.vue'
@@ -51,7 +51,7 @@ const specDescriptor = computed(() => {
   const spec = comboSpec.value
   if (!spec) {
     return {
-      kind: 'unknown' as MediaKind,
+      kind: 'unknown' as AssetKind,
       allowUpload: false,
       folder: undefined as ResultItemType | undefined
     }
@@ -68,7 +68,7 @@ const specDescriptor = computed(() => {
     (spec as Partial<Record<'audio_upload', boolean>>).audio_upload
   )
 
-  let kind: MediaKind = 'unknown'
+  let kind: AssetKind = 'unknown'
   if (video_upload) {
     kind = 'video'
   } else if (image_upload || animated_image_upload) {
@@ -95,8 +95,8 @@ const specDescriptor = computed(() => {
   }
 })
 
-const mediaKind = computed(() => specDescriptor.value.kind)
-const isDropdownUIWidget = computed(() => mediaKind.value !== 'unknown')
+const assetKind = computed(() => specDescriptor.value.kind)
+const isDropdownUIWidget = computed(() => assetKind.value !== 'unknown')
 const allowUpload = computed(() => specDescriptor.value.allowUpload)
 const uploadFolder = computed<ResultItemType>(() => {
   return specDescriptor.value.folder ?? 'input'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -81,12 +81,13 @@ const specDescriptor = computed<{
   }
   // TODO: add support for models (checkpoints, VAE, LoRAs, etc.) -- get widgetType from spec
 
+  const allowUpload =
+    image_upload === true ||
+    animated_image_upload === true ||
+    audio_upload === true
   return {
     kind,
-    allowUpload:
-      image_upload === true ||
-      animated_image_upload === true ||
-      audio_upload === true,
+    allowUpload,
     folder: image_folder
   }
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -49,13 +49,17 @@ const comboSpec = computed<ComboInputSpec | undefined>(() => {
   return undefined
 })
 
-const specDescriptor = computed(() => {
+const specDescriptor = computed<{
+  kind: AssetKind
+  allowUpload: boolean
+  folder: ResultItemType | undefined
+}>(() => {
   const spec = comboSpec.value
   if (!spec) {
     return {
-      kind: 'unknown' as AssetKind,
+      kind: 'unknown',
       allowUpload: false,
-      folder: undefined as ResultItemType | undefined
+      folder: undefined
     }
   }
 
@@ -63,36 +67,26 @@ const specDescriptor = computed(() => {
     image_upload,
     animated_image_upload,
     video_upload,
-    widgetType,
-    image_folder
+    image_folder,
+    audio_upload
   } = spec
-  const audioUpload = Boolean(
-    (spec as Partial<Record<'audio_upload', boolean>>).audio_upload
-  )
 
   let kind: AssetKind = 'unknown'
   if (video_upload) {
     kind = 'video'
   } else if (image_upload || animated_image_upload) {
     kind = 'image'
-  } else if (audioUpload) {
+  } else if (audio_upload) {
     kind = 'audio'
-  } else if (widgetType) {
-    const normalized = widgetType.toLowerCase()
-    if (normalized.includes('model')) {
-      kind = 'model'
-    } else if (normalized.includes('audio')) {
-      kind = 'audio'
-    } else if (normalized.includes('image')) {
-      kind = 'image'
-    } else if (normalized.includes('video')) {
-      kind = 'video'
-    }
   }
+  // TODO: add support for models (checkpoints, VAE, LoRAs, etc.) -- get widgetType from spec
 
   return {
     kind,
-    allowUpload: image_upload === true || animated_image_upload === true,
+    allowUpload:
+      image_upload === true ||
+      animated_image_upload === true ||
+      audio_upload === true,
     folder: image_folder
   }
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -43,8 +43,10 @@ function handleUpdateModelValue(value: string | number | undefined) {
 }
 
 const comboSpec = computed<ComboInputSpec | undefined>(() => {
-  if (!props.widget.spec) return undefined
-  return isComboInputSpec(props.widget.spec) ? props.widget.spec : undefined
+  if (props.widget.spec && isComboInputSpec(props.widget.spec)) {
+    return props.widget.spec
+  }
+  return undefined
 })
 
 const specDescriptor = computed(() => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -7,6 +7,7 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ResultItemType } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import type { MediaKind } from '@/types/widgetTypes'
 import {
   PANEL_EXCLUDED_PROPS,
   filterWidgetProps
@@ -24,7 +25,9 @@ const props = defineProps<{
   widget: SimplifiedWidget<string | number | undefined>
   modelValue: string | number | undefined
   readonly?: boolean
-  fileType?: 'image' | 'video' | 'audio' | 'model' | 'unknown'
+  mediaKind?: MediaKind
+  allowUpload?: boolean
+  uploadFolder?: ResultItemType
 }>()
 
 const emit = defineEmits<{
@@ -70,7 +73,7 @@ const mediaPlaceholder = computed(() => {
     return options.placeholder
   }
 
-  switch (props.fileType) {
+  switch (props.mediaKind) {
     case 'image':
       return 'Select image...'
     case 'video':
@@ -86,9 +89,7 @@ const mediaPlaceholder = computed(() => {
   return 'Select media...'
 })
 
-const uploadable = computed(() => {
-  return props.fileType === 'image'
-})
+const uploadable = computed(() => props.allowUpload === true)
 
 watch(
   localValue,
@@ -152,8 +153,9 @@ const uploadFile = async (
 
 // Handle multiple file uploads
 const uploadFiles = async (files: File[]): Promise<string[]> => {
+  const folder = props.uploadFolder ?? 'input'
   const uploadPromises = files.map((file) =>
-    uploadFile(file, false, { type: 'input' })
+    uploadFile(file, false, { type: folder })
   )
   const results = await Promise.all(uploadPromises)
   return results.filter((path): path is string => path !== null)
@@ -196,7 +198,7 @@ async function handleFilesUpdate(files: File[]) {
 }
 
 function getMediaUrl(filename: string): string {
-  if (props.fileType !== 'image') return ''
+  if (props.mediaKind !== 'image') return ''
   // TODO: This needs to be adapted based on actual ComfyUI API structure
   return `/api/view?filename=${encodeURIComponent(filename)}&type=input`
 }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -3,11 +3,12 @@ import { computed, ref, watch } from 'vue'
 
 import { useWidgetValue } from '@/composables/graph/useWidgetValue'
 import { useTransformCompatOverlayProps } from '@/composables/useTransformCompatOverlayProps'
+import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ResultItemType } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
-import type { MediaKind } from '@/types/widgetTypes'
+import type { AssetKind } from '@/types/widgetTypes'
 import {
   PANEL_EXCLUDED_PROPS,
   filterWidgetProps
@@ -25,7 +26,7 @@ const props = defineProps<{
   widget: SimplifiedWidget<string | number | undefined>
   modelValue: string | number | undefined
   readonly?: boolean
-  mediaKind?: MediaKind
+  assetKind?: AssetKind
   allowUpload?: boolean
   uploadFolder?: ResultItemType
 }>()
@@ -73,20 +74,20 @@ const mediaPlaceholder = computed(() => {
     return options.placeholder
   }
 
-  switch (props.mediaKind) {
+  switch (props.assetKind) {
     case 'image':
-      return 'Select image...'
+      return t('widgets.uploadSelect.placeholderImage')
     case 'video':
-      return 'Select video...'
+      return t('widgets.uploadSelect.placeholderVideo')
     case 'audio':
-      return 'Select audio...'
+      return t('widgets.uploadSelect.placeholderAudio')
     case 'model':
-      return 'Select model...'
+      return t('widgets.uploadSelect.placeholderModel')
     case 'unknown':
-      return 'Select media...'
+      return t('widgets.uploadSelect.placeholderUnknown')
   }
 
-  return 'Select media...'
+  return t('widgets.uploadSelect.placeholder')
 })
 
 const uploadable = computed(() => props.allowUpload === true)
@@ -198,7 +199,7 @@ async function handleFilesUpdate(files: File[]) {
 }
 
 function getMediaUrl(filename: string): string {
-  if (props.mediaKind !== 'image') return ''
+  if (props.assetKind !== 'image') return ''
   // TODO: This needs to be adapted based on actual ComfyUI API structure
   return `/api/view?filename=${encodeURIComponent(filename)}&type=input`
 }

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -3,6 +3,7 @@ import { refDebounced } from '@vueuse/core'
 import Popover from 'primevue/popover'
 import { computed, ref, useTemplateRef, watch } from 'vue'
 
+import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import FormDropdownInput from './FormDropdownInput.vue'
@@ -43,7 +44,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  placeholder: 'Select...',
+  placeholder: t('widgets.uploadSelect.placeholder'),
   multiple: false,
   uploadable: false,
   disabled: false,
@@ -119,7 +120,7 @@ const defaultSorter = computed<SortOption['sorter']>(() => {
   )?.sorter
   return sorter || (({ items }) => items.slice())
 })
-const SelectedSorter = computed<SortOption['sorter']>(() => {
+const selectedSorter = computed<SortOption['sorter']>(() => {
   if (sortSelected.value === 'default') return defaultSorter.value
   const sorter = props.sortOptions.find(
     (option) => option.id === sortSelected.value
@@ -127,7 +128,7 @@ const SelectedSorter = computed<SortOption['sorter']>(() => {
   return sorter || defaultSorter.value
 })
 const sortedItems = computed(() => {
-  return SelectedSorter.value({ items: filteredItems.value }) || []
+  return selectedSorter.value({ items: filteredItems.value }) || []
 })
 
 function internalIsSelected(item: DropdownItem, index: number): boolean {

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -77,6 +77,7 @@ export const zComboInputOptions = zBaseInputOptions.extend({
   image_folder: resultItemType.optional(),
   allow_batch: z.boolean().optional(),
   video_upload: z.boolean().optional(),
+  audio_upload: z.boolean().optional(),
   animated_image_upload: z.boolean().optional(),
   options: z.array(zComboOption).optional(),
   remote: zRemoteWidgetConfig.optional(),

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -352,6 +352,16 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     return nodeDef
   }
 
+  function getInputSpecForWidget(
+    node: LGraphNode,
+    widgetName: string
+  ): InputSpecV2 | undefined {
+    const nodeDef = fromLGraphNode(node)
+    if (!nodeDef) return undefined
+
+    return nodeDef.inputs[widgetName]
+  }
+
   /**
    * Registers a node definition filter.
    * @param filter - The filter to register
@@ -424,6 +434,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     updateNodeDefs,
     addNodeDef,
     fromLGraphNode,
+    getInputSpecForWidget,
     registerNodeDefFilter,
     unregisterNodeDefFilter
   }

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -2,6 +2,7 @@
  * Simplified widget interface for Vue-based node rendering
  * Removes all DOM manipulation and positioning concerns
  */
+import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 
 /** Valid types for widget values */
 export type WidgetValue =
@@ -32,6 +33,9 @@ export interface SimplifiedWidget<
 
   /** Callback fired when value changes */
   callback?: (value: T) => void
+
+  /** Optional input specification backing this widget */
+  spec?: InputSpecV2
 
   /** Optional serialization method for custom value handling */
   serializeValue?: () => any

--- a/src/types/widgetTypes.ts
+++ b/src/types/widgetTypes.ts
@@ -1,3 +1,5 @@
 import type { InjectionKey } from 'vue'
 
+export type MediaKind = 'image' | 'video' | 'audio' | 'model' | 'unknown'
+
 export const OnCloseKey: InjectionKey<() => void> = Symbol()

--- a/src/types/widgetTypes.ts
+++ b/src/types/widgetTypes.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey } from 'vue'
 
-export type MediaKind = 'image' | 'video' | 'audio' | 'model' | 'unknown'
+export type AssetKind = 'image' | 'video' | 'audio' | 'model' | 'unknown'
 
 export const OnCloseKey: InjectionKey<() => void> = Symbol()


### PR DESCRIPTION
Refactored widget rendering to use input specification metadata for determining asset kinds instead of file extension heuristics.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5798-Use-input-spec-to-determine-asset-type-in-upload-widgets-27a6d73d365081f39cfaf45bbc377e49) by [Unito](https://www.unito.io)
