### PR TITLE
fix flaky templates browser test

### DIFF
--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -181,6 +181,7 @@ test.describe('Templates', () => {
   }) => {
     // Open templates dialog
     await comfyPage.executeCommand('Comfy.BrowseTemplates')
+    await comfyPage.templates.content.waitFor({ state: 'visible' })
 
     const templateGrid = comfyPage.page.locator(
       '[data-testid="template-workflows-content"]'


### PR DESCRIPTION
Fixes flaky templates modal test introduced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/5802 by ensuring the templates modal is visible before querying the visible card count and asserting that it is greater than 0.

If we immediately count the number of cards after executing the "load templates" command, it's possible that there are 0 visible due to them loading (rather than being caused by a legitimate bug).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5808-fix-flaky-templates-browser-test-27b6d73d365081e58c65f608944976a0) by [Unito](https://www.unito.io)
