### PR TITLE
Use workspace in knip config

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,15 +1,25 @@
 import type { KnipConfig } from 'knip'
 
 const config: KnipConfig = {
-  entry: [
-    '{build,scripts}/**/*.{js,ts}',
-    'src/assets/css/style.css',
-    'src/main.ts',
-    'src/scripts/ui/menu/index.ts',
-    'src/types/index.ts'
-  ],
-  project: ['**/*.{js,ts,vue}', '*.{js,ts,mts}'],
-  ignoreBinaries: ['only-allow', 'openapi-typescript'],
+  workspaces: {
+    '.': {
+      entry: [
+        '{build,scripts}/**/*.{js,ts}',
+        'src/assets/css/style.css',
+        'src/main.ts',
+        'src/scripts/ui/menu/index.ts',
+        'src/types/index.ts'
+      ],
+      project: ['**/*.{js,ts,vue}', '*.{js,ts,mts}']
+    },
+    'packages/tailwind-utils': {
+      project: ['src/**/*.{js,ts}']
+    },
+    'packages/design-system': {
+      entry: ['src/**/*.ts'],
+      project: ['src/**/*.{js,ts}', '*.{js,ts,mts}']
+    }
+  },
   ignoreDependencies: [
     // Weird importmap things
     '@iconify/json',


### PR DESCRIPTION
## Summary

After the `pnpm`/`Nx` monorepo migration, `knip` emitted configuration hints like “Remove or move unused top-level entry…/project…” because it discovered multiple workspaces but our config still declared global `entry`/`project` patterns:

```
  > knip --cache

  Configuration hints (4)
  Remove or move unused top-level entry to one of workspaces: [{build,scripts}/**/*.{js,ts}, …]
  Remove or move unused top-level project to one of workspaces: [**/*.{js,ts,vue}, …]
  Remove from ignoreBinaries: only-allow
  Remove from ignoreBinaries: openapi-typescript
```

Rewriting `knip.config.ts` to define those patterns inside the `workspaces` map for `'.'`, `packages/tailwind-utils`, and `packages/design-system` matches Knip’s documented workspace schema (root key `'.'` plus per-package overrides) and aligns each package’s source with the files it actually exposes.

Follow-up: trim `packages/design-system` entries to the real public surface, add a wildcard workspace default for future packages, and capture this expectation somewhere in the repo's docs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5809-Use-workspace-in-knip-config-27b6d73d365081b8ace9c82aee78b1db) by [Unito](https://www.unito.io)
