### PR TITLE
style: LOD color theme

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LODFallback.vue
+++ b/src/renderer/extensions/vueNodes/components/LODFallback.vue
@@ -1,3 +1,5 @@
 <template>
-  <div class="lod-fallback absolute inset-0 w-full h-full bg-zinc-800"></div>
+  <div
+    class="lod-fallback absolute inset-0 w-full h-full bg-zinc-300 dark-theme:bg-zinc-800"
+  ></div>
 </template>


### PR DESCRIPTION
## Summary

light mode styles for lod system

## Screenshots (if applicable)

<img width="1353" height="751" alt="image" src="https://github.com/user-attachments/assets/3caf2e7d-10c3-4ecb-bcd6-b605a643065b" />

<img width="1320" height="705" alt="image" src="https://github.com/user-attachments/assets/cb4a2675-f644-4564-af57-aa9f3920fb05" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5812-style-LOD-color-theme-27b6d73d365081fe8cd2c8c5a52b2493) by [Unito](https://www.unito.io)
