### PR TITLE
Test: Multiple flaky Playwright tests

### DIFF
--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -210,28 +210,6 @@ test.describe('Templates', () => {
     await expect(nav).toBeVisible() // Nav should be visible at tablet size
   })
 
-  test('hover effects work on template cards', async ({ comfyPage }) => {
-    // Open templates dialog
-    await comfyPage.executeCommand('Comfy.BrowseTemplates')
-    await expect(comfyPage.templates.content).toBeVisible()
-
-    // Get a template card using data-testid
-    const firstCard = comfyPage.page
-      .locator('[data-testid^="template-workflow-"]')
-      .first()
-    await expect(firstCard).toBeVisible({ timeout: 5000 })
-
-    // Check initial state - card should have transition classes
-    // Take snapshot before hover
-    await expect(firstCard).toHaveScreenshot('template-card-before-hover.png')
-
-    // Hover over the card
-    await firstCard.hover()
-
-    // Take snapshot after hover to verify hover effect
-    await expect(firstCard).toHaveScreenshot('template-card-after-hover.png')
-  })
-
   test('template cards descriptions adjust height dynamically', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/versionMismatchWarnings.spec.ts
+++ b/browser_tests/tests/versionMismatchWarnings.spec.ts
@@ -85,6 +85,7 @@ test.describe('Version Mismatch Warnings', () => {
   test('should persist dismissed state across sessions', async ({
     comfyPage
   }) => {
+    test.setTimeout(30_000)
     // Mock system_stats route to indicate that the installed version is always ahead of the required version
     await comfyPage.page.route('**/system_stats**', async (route) => {
       await route.fulfill({


### PR DESCRIPTION
## Summary

Double timeout for Version Mismatch Warnings in `should persist dismissed state across sessions`

Remove Template card hover test.

https://ccfbaff5.comfyui-playwright-chromium.pages.dev/#?testId=b07187838e41a32597d7-951ff47f196f7f22f516

https://7bf44be0.comfyui-playwright-chromium.pages.dev/#?testId=b07187838e41a32597d7-951ff47f196f7f22f516

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5814-Test-Double-timeout-for-Version-Mismatch-Warnings-27b6d73d365081be8c73c9a12759f83e) by [Unito](https://www.unito.io)
