### PR TITLE
feat(auth): Allow SSO login only for whitelisted addresses (localhost)

### DIFF
--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -145,7 +145,7 @@
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
 import Message from 'primevue/message'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
@@ -167,9 +167,7 @@ const authActions = useFirebaseAuthActions()
 const isSecureContext = window.isSecureContext
 const isSignIn = ref(true)
 const showApiKeyForm = ref(false)
-const ssoAllowed = computed(() =>
-  isHostWhitelisted(normalizeHost(window.location.hostname))
-)
+const ssoAllowed = isHostWhitelisted(normalizeHost(window.location.hostname))
 
 const toggleState = () => {
   isSignIn.value = !isSignIn.value

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -45,37 +45,39 @@
         <span class="text-muted">{{ t('auth.login.orContinueWith') }}</span>
       </Divider>
 
-      <!-- Social Login Buttons -->
+      <!-- Social Login Buttons (hidden if host not whitelisted) -->
       <div class="flex flex-col gap-6">
-        <Button
-          type="button"
-          class="h-10"
-          severity="secondary"
-          outlined
-          @click="signInWithGoogle"
-        >
-          <i class="pi pi-google mr-2"></i>
-          {{
-            isSignIn
-              ? t('auth.login.loginWithGoogle')
-              : t('auth.signup.signUpWithGoogle')
-          }}
-        </Button>
+        <template v-if="ssoAllowed">
+          <Button
+            type="button"
+            class="h-10"
+            severity="secondary"
+            outlined
+            @click="signInWithGoogle"
+          >
+            <i class="pi pi-google mr-2"></i>
+            {{
+              isSignIn
+                ? t('auth.login.loginWithGoogle')
+                : t('auth.signup.signUpWithGoogle')
+            }}
+          </Button>
 
-        <Button
-          type="button"
-          class="h-10"
-          severity="secondary"
-          outlined
-          @click="signInWithGithub"
-        >
-          <i class="pi pi-github mr-2"></i>
-          {{
-            isSignIn
-              ? t('auth.login.loginWithGithub')
-              : t('auth.signup.signUpWithGithub')
-          }}
-        </Button>
+          <Button
+            type="button"
+            class="h-10"
+            severity="secondary"
+            outlined
+            @click="signInWithGithub"
+          >
+            <i class="pi pi-github mr-2"></i>
+            {{
+              isSignIn
+                ? t('auth.login.loginWithGithub')
+                : t('auth.signup.signUpWithGithub')
+            }}
+          </Button>
+        </template>
 
         <Button
           type="button"
@@ -143,12 +145,13 @@
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
 import Message from 'primevue/message'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { COMFY_PLATFORM_BASE_URL } from '@/config/comfyApi'
 import type { SignInData, SignUpData } from '@/schemas/signInSchema'
+import { isHostWhitelisted, normalizeHost } from '@/utils/hostWhitelist'
 import { isInChina } from '@/utils/networkUtil'
 
 import ApiKeyForm from './signin/ApiKeyForm.vue'
@@ -164,6 +167,9 @@ const authActions = useFirebaseAuthActions()
 const isSecureContext = window.isSecureContext
 const isSignIn = ref(true)
 const showApiKeyForm = ref(false)
+const ssoAllowed = computed(() =>
+  isHostWhitelisted(normalizeHost(window.location.hostname))
+)
 
 const toggleState = () => {
   isSignIn.value = !isSignIn.value

--- a/src/utils/hostWhitelist.ts
+++ b/src/utils/hostWhitelist.ts
@@ -1,0 +1,99 @@
+/**
+ * Whitelisting helper for enabling SSO on safe, local-only hosts.
+ *
+ * Built-ins (always allowed):
+ *   • 'localhost' and any subdomain of '.localhost' (e.g., app.localhost)
+ *   • IPv4 loopback 127.0.0.0/8 (e.g., 127.0.0.1, 127.1.2.3)
+ *   • IPv6 loopback ::1 (supports compressed/expanded textual forms)
+ *   • IPv6-mapped IPv4 loopback ::ffff:127.x.y.z
+ *
+ * No environment variables are used. To add more exact hostnames,
+ * edit HOST_WHITELIST below.
+ */
+
+const HOST_WHITELIST: string[] = ['localhost']
+
+/** Normalize for comparison: lowercase, strip port/brackets, trim trailing dot. */
+export function normalizeHost(input: string): string {
+  let h = (input || '').trim().toLowerCase()
+
+  // Trim a trailing dot: 'localhost.' -> 'localhost'
+  h = h.replace(/\.$/, '')
+
+  // Remove ':port' safely.
+  // Case 1: [IPv6]:port
+  const mBracket = h.match(/^\[([^\]]+)\]:(\d+)$/)
+  if (mBracket) {
+    h = mBracket[1] // keep only the host inside the brackets
+  } else {
+    // Case 2: hostname/IPv4:port (exactly one ':')
+    const mPort = h.match(/^([^:]+):(\d+)$/)
+    if (mPort) h = mPort[1]
+  }
+
+  // Strip any remaining brackets (e.g., '[::1]' -> '::1')
+  h = h.replace(/^\[|\]$/g, '')
+
+  return h
+}
+
+/** Public check used by the UI. */
+export function isHostWhitelisted(rawHost: string): boolean {
+  const host = normalizeHost(rawHost)
+  if (isLocalhostLabel(host)) return true
+  if (isIPv4Loopback(host)) return true
+  if (isIPv6Loopback(host)) return true
+  const normalizedList = HOST_WHITELIST.map(normalizeHost)
+  return normalizedList.includes(host)
+}
+
+/* -------------------- Helpers -------------------- */
+
+function isLocalhostLabel(h: string): boolean {
+  // 'localhost' and any subdomain (e.g., 'app.localhost')
+  return h === 'localhost' || h.endsWith('.localhost')
+}
+
+function isIPv4Loopback(h: string): boolean {
+  // 127/8: 127.x.y.z
+  const parts = h.split('.')
+  if (parts.length !== 4) return false
+  if (!parts.every((p) => /^\d{1,3}$/.test(p))) return false
+  const nums = parts.map((n) => parseInt(n, 10))
+  if (nums.some((n) => n < 0 || n > 255)) return false
+  return nums[0] === 127
+}
+
+function isIPv6Loopback(h: string): boolean {
+  if (h === '::1') return true
+
+  // Fully expanded form: 0:0:0:0:0:0:0:1 (allow leading zeros)
+  const segs = h.split(':')
+  if (segs.length === 8 && segs.every(validHexSeg)) {
+    return segs.slice(0, 7).every(zeroSeg) && isOne(segs[7])
+  }
+
+  // Compressed (::) forms still equal to ::1 (e.g., ::0001, 0:0::1, etc.)
+  if (h.includes('::')) {
+    const [lhs, rhs] = h.split('::')
+    const leftSegs = lhs ? lhs.split(':').filter(Boolean) : []
+    const rightSegs = rhs ? rhs.split(':').filter(Boolean) : []
+    if (![...leftSegs, ...rightSegs].every(validHexSeg)) return false
+    const missing = 8 - (leftSegs.length + rightSegs.length)
+    if (missing < 1) return false // '::' must compress at least one zero group
+    const expanded = [...leftSegs, ...Array(missing).fill('0'), ...rightSegs]
+    return expanded.slice(0, 7).every(zeroSeg) && isOne(expanded[7])
+  }
+
+  return false
+}
+
+function validHexSeg(s: string): boolean {
+  return s.length > 0 && s.length <= 4 && /^[0-9a-f]+$/i.test(s)
+}
+function zeroSeg(s: string): boolean {
+  return parseInt(s || '0', 16) === 0
+}
+function isOne(s: string): boolean {
+  return parseInt(s || '0', 16) === 1
+}

--- a/src/utils/hostWhitelist.ts
+++ b/src/utils/hostWhitelist.ts
@@ -5,7 +5,6 @@
  *   • 'localhost' and any subdomain of '.localhost' (e.g., app.localhost)
  *   • IPv4 loopback 127.0.0.0/8 (e.g., 127.0.0.1, 127.1.2.3)
  *   • IPv6 loopback ::1 (supports compressed/expanded textual forms)
- *   • IPv6-mapped IPv4 loopback ::ffff:127.x.y.z
  *
  * No environment variables are used. To add more exact hostnames,
  * edit HOST_WHITELIST below.

--- a/tests-ui/tests/utils/hostWhitelist.test.ts
+++ b/tests-ui/tests/utils/hostWhitelist.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import { isHostWhitelisted, normalizeHost } from '@/utils/hostWhitelist'
+
+describe('hostWhitelist utils', () => {
+  describe('normalizeHost', () => {
+    it.each([
+      ['LOCALHOST', 'localhost'],
+      ['localhost.', 'localhost'], // trims trailing dot
+      ['localhost:5173', 'localhost'], // strips :port
+      ['127.0.0.1:5173', '127.0.0.1'], // strips :port
+      ['[::1]:5173', '::1'], // strips brackets + :port
+      ['[::1]', '::1'], // strips brackets
+      ['::1', '::1'], // leaves plain IPv6
+      ['  [::1]  ', '::1'], // trims whitespace
+      ['APP.LOCALHOST', 'app.localhost'], // lowercases
+      ['example.com.', 'example.com'], // trims trailing dot
+      ['[2001:db8::1]:8443', '2001:db8::1'], // IPv6 with brackets+port
+      ['2001:db8::1', '2001:db8::1'] // plain IPv6 stays
+    ])('normalizeHost(%o) -> %o', (input, expected) => {
+      expect(normalizeHost(input)).toBe(expected)
+    })
+
+    it('does not strip non-numeric suffixes (not a port pattern)', () => {
+      // Only `:digits` is treated as a port; this input is preserved.
+      expect(normalizeHost('example.com:abc')).toBe('example.com:abc')
+    })
+  })
+
+  describe('isHostWhitelisted', () => {
+    describe('localhost label', () => {
+      it.each([
+        'localhost',
+        'LOCALHOST',
+        'localhost.',
+        'localhost:5173',
+        'foo.localhost',
+        'Foo.Localhost',
+        'sub.foo.localhost',
+        'foo.localhost:5173'
+      ])('should allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(true)
+      })
+
+      it.each([
+        'localhost.com',
+        'evil-localhost',
+        'notlocalhost',
+        'foo.localhost.evil'
+      ])('should NOT allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(false)
+      })
+    })
+
+    describe('IPv4 127/8 loopback', () => {
+      it.each([
+        '127.0.0.1',
+        '127.1.2.3',
+        '127.255.255.255',
+        '127.0.0.1:3000',
+        '127.000.000.001' // leading zeros are still digits 0-255
+      ])('should allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(true)
+      })
+
+      it.each([
+        '126.0.0.1',
+        '127.256.0.1',
+        '127.-1.0.1',
+        '127.0.0.1:abc',
+        '128.0.0.1',
+        '192.168.1.10',
+        '10.0.0.2',
+        '0.0.0.0',
+        '255.255.255.255',
+        '127.0.0', // malformed
+        '127.0.0.1.5' // malformed
+      ])('should NOT allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(false)
+      })
+    })
+
+    describe('IPv6 loopback ::1 (all textual forms)', () => {
+      it.each([
+        '::1',
+        '[::1]',
+        '[::1]:5173',
+        '::0001',
+        '0:0:0:0:0:0:0:1',
+        '0000:0000:0000:0000:0000:0000:0000:0001',
+        // Compressed equivalents of ::1 (with zeros compressed)
+        '0:0:0:0:0:0::1',
+        '::0:1' // compressing the initial zeros (still ::1 when expanded)
+      ])('should allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(true)
+      })
+
+      it.each([
+        '::2',
+        '::',
+        '::0',
+        '0:0:0:0:0:0:0:2',
+        'fe80::1', // link-local, not loopback
+        '2001:db8::1',
+        '[::1%25lo0]',
+        '[::1%25lo0]:5173',
+        '::1%25lo0'
+      ])('should NOT allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Hide Google/GitHub SSO login options when the UI is accessed from **non‑local** addresses.
This PR also adds a **static whitelist** (editable in code) so we can allow additional hosts if needed.

Default whitelisted addresses:

1. `localhost` and any subdomain: `*.localhost`
2. IPv4 loopback `127.0.0.0/8` (e.g., `127.x.y.z`)
4. IPv6 loopback `::1` (including equivalent textual forms such as `::0001`)

## Changes

- **What**: 
  * Add `src/utils/hostWhitelist.ts` with `normalizeHost` and `isHostWhitelisted` helpers.
  * Update `SignInContent.vue` to **hide** SSO options when
    `isHostWhitelisted(normalizeHost(window.location.hostname))` returns `false`.
- **Breaking**:
  * Users accessing from Runpod or other previously allowed **non‑local** hosts will **lose** SSO login options.
    If we need to keep SSO there, we should add those hosts to the whitelist in `hostWhitelist.ts`.

## Review Focus

1. Verify that logging in from local addresses (`localhost`, `*.localhost`, `127.0.0.1`, `::1`) **does not change** the current behavior: SSO is visible.
2. Verify that from a **non‑local** address, SSO options are **not** displayed.

## Screenshots (if applicable)

UI opened from `192.168.2.109` address:

<img width="500" height="990" alt="Screenshot From 2025-09-27 13-22-15" src="https://github.com/user-attachments/assets/c97b10a1-b069-43e4-a26b-a71eeb228a51" />

UI opened from default `127.0.0.1` address(nothing changed):

<img width="462" height="955" alt="Screenshot From 2025-09-27 13-35-27" src="https://github.com/user-attachments/assets/bb2bf21c-dc8d-49cb-b48e-8fc6e408023c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5815-feat-auth-Allow-SSO-login-only-for-whitelisted-addresses-localhost-27b6d73d365081ccbe84c034cf8e416d) by [Unito](https://www.unito.io)
