### PR TITLE
[fix] remove unnecessary afterEach

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
@@ -69,10 +69,6 @@ const createMouseEvent = (
 describe('useNodePointerInteractions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
   })
 
   it('should only start drag on left-click', async () => {


### PR DESCRIPTION
## Summary

We didn't need the `afterEach` in this test.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5817-fix-remove-unnecessary-afterEach-27b6d73d3650814bb4f1c426c5b17a54) by [Unito](https://www.unito.io)
