### PR TITLE
[test] add browser test to verify Vue node body double-click behavior 

### DIFF
--- a/browser_tests/tests/vueNodes/NodeHeader.spec.ts
+++ b/browser_tests/tests/vueNodes/NodeHeader.spec.ts
@@ -61,6 +61,19 @@ test.describe('NodeHeader', () => {
     expect(titleAfterCancel).toBe('My Custom Sampler')
   })
 
+  test('Double click node body does not trigger edit', async ({
+    comfyPage
+  }) => {
+    const loadCheckpointNode =
+      comfyPage.vueNodes.getNodeByTitle('Load Checkpoint')
+    const nodeBbox = await loadCheckpointNode.boundingBox()
+    if (!nodeBbox) throw new Error('Node not found')
+    await loadCheckpointNode.dblclick()
+
+    const editingTitleInput = comfyPage.page.getByTestId('node-title-input')
+    await expect(editingTitleInput).not.toBeVisible()
+  })
+
   test('handles node collapsing', async ({ comfyPage }) => {
     // Get the KSampler node from the default workflow
     const nodes = await comfyPage.getNodeRefsByType('KSampler')


### PR DESCRIPTION
## Summary

Added test coverage to verify double-clicking node body does not trigger title edit mode, mirroring test in Litegraph https://github.com/Comfy-Org/ComfyUI_frontend/blob/856eb446a5e65d501a2c9dd922e2ae305b9392ff/browser_tests/tests/interaction.spec.ts#L361

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5818-test-add-browser-test-to-verify-Vue-node-body-double-click-behavior-27b6d73d3650812f9efef1459d5d465f) by [Unito](https://www.unito.io)
