### PR TITLE
[test] add browser tests for Vue node multiline string widgets

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -37,7 +37,7 @@ test.describe('Vue Multiline String Widget', () => {
     const textarea = getFirstMultilineStringWidget(comfyPage)
 
     await textarea.fill('Keep me around')
-    await comfyPage.canvas.click()
+    await comfyPage.clickEmptySpace()
     await getFirstClipNode(comfyPage).click()
 
     await expect(textarea).toHaveValue('Keep me around')

--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -37,7 +37,11 @@ test.describe('Vue Multiline String Widget', () => {
     const textarea = getFirstMultilineStringWidget(comfyPage)
 
     await textarea.fill('Keep me around')
-    await comfyPage.clickEmptySpace()
+
+    // Click another node
+    const loadCheckpointNode =
+      comfyPage.vueNodes.getNodeByTitle('Load Checkpoint')
+    await loadCheckpointNode.click()
     await getFirstClipNode(comfyPage).click()
 
     await expect(textarea).toHaveValue('Keep me around')

--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -1,0 +1,45 @@
+import {
+  type ComfyPage,
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '../../../../fixtures/ComfyPage'
+
+test.describe('Vue Multiline String Widget', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.vueNodes.waitForNodes()
+  })
+
+  const getMultilineStringWidget = (comfyPage: ComfyPage) =>
+    comfyPage.vueNodes.getNodeByTitle('CLIP Text Encode (Prompt)').first()
+
+  const getFirstMultilineStringWidget = (comfyPage: ComfyPage) =>
+    getMultilineStringWidget(comfyPage).getByRole('textbox', { name: 'text' })
+
+  test('should allow entering text', async ({ comfyPage }) => {
+    const textarea = getFirstMultilineStringWidget(comfyPage)
+    await textarea.fill('Hello World')
+    await expect(textarea).toHaveValue('Hello World')
+    await textarea.fill('Hello World 2')
+    await expect(textarea).toHaveValue('Hello World 2')
+  })
+
+  test('should support entering multiline content', async ({ comfyPage }) => {
+    const textarea = getFirstMultilineStringWidget(comfyPage)
+
+    const multilineValue = ['Line 1', 'Line 2', 'Line 3'].join('\n')
+
+    await textarea.fill(multilineValue)
+    await expect(textarea).toHaveValue(multilineValue)
+  })
+
+  test('should retain value after focus changes', async ({ comfyPage }) => {
+    const textarea = getFirstMultilineStringWidget(comfyPage)
+
+    await textarea.fill('Keep me around')
+    await comfyPage.canvas.click()
+    await getMultilineStringWidget(comfyPage).click()
+
+    await expect(textarea).toHaveValue('Keep me around')
+  })
+})

--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -10,11 +10,11 @@ test.describe('Vue Multiline String Widget', () => {
     await comfyPage.vueNodes.waitForNodes()
   })
 
-  const getMultilineStringWidget = (comfyPage: ComfyPage) =>
+  const getFirstClipNode = (comfyPage: ComfyPage) =>
     comfyPage.vueNodes.getNodeByTitle('CLIP Text Encode (Prompt)').first()
 
   const getFirstMultilineStringWidget = (comfyPage: ComfyPage) =>
-    getMultilineStringWidget(comfyPage).getByRole('textbox', { name: 'text' })
+    getFirstClipNode(comfyPage).getByRole('textbox', { name: 'text' })
 
   test('should allow entering text', async ({ comfyPage }) => {
     const textarea = getFirstMultilineStringWidget(comfyPage)
@@ -38,7 +38,7 @@ test.describe('Vue Multiline String Widget', () => {
 
     await textarea.fill('Keep me around')
     await comfyPage.canvas.click()
-    await getMultilineStringWidget(comfyPage).click()
+    await getFirstClipNode(comfyPage).click()
 
     await expect(textarea).toHaveValue('Keep me around')
   })


### PR DESCRIPTION
## Summary

Added Playwright E2E tests for Vue multiline string widget functionality to ensure text input and persistence work correctly.

## Changes

- **What**: Created browser tests for multiline string widget in Vue nodes implementation, covering text input, multiline text input, and focus change behavior.

## Review Focus

Test coverage for text input persistence across focus changes and multiline content handling in the CLIP Text Encode widget.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5819-test-add-browser-tests-for-Vue-node-multiline-string-widgets-27b6d73d365081e2916ae663e2d44899) by [Unito](https://www.unito.io)
