### PR TITLE
[test] extend Vue node selection browser test to cover Mac (Meta) key

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
@@ -15,7 +15,8 @@ test.describe('Vue Node Selection', () => {
 
   const modifiers = [
     { key: 'Control', name: 'ctrl' },
-    { key: 'Shift', name: 'shift' }
+    { key: 'Shift', name: 'shift' },
+    { key: 'Meta', name: 'meta' }
   ] as const
 
   for (const { key: modifier, name } of modifiers) {


### PR DESCRIPTION
## Summary

Extend Vue node selection tests to also cover Meta key (Mac).

## Changes

- **What**: Extended node selection test modifiers to include [Meta key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey) alongside existing Ctrl and Shift keys

## Review Focus

Cross-platform keyboard modifier testing coverage and Mac-specific interaction patterns.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5824-test-extend-Vue-node-selection-browser-test-to-cover-Mac-Meta-key-27b6d73d365081778833cefb8592f158) by [Unito](https://www.unito.io)
