### PR TITLE
add pricing for WanImageToImageApi node

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1613,6 +1613,9 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
     },
     WanTextToImageApi: {
       displayPrice: '$0.03/Run'
+    },
+    WanImageToImageApi: {
+      displayPrice: '$0.03/Run'
     }
   }
 


### PR DESCRIPTION
## Summary

Currently the price is constant.

## Screenshots (if applicable)

<img width="452" height="380" alt="Screenshot From 2025-09-28 18-01-47" src="https://github.com/user-attachments/assets/b9026be9-ef88-417f-aaca-b5a29eb23c55" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5829-add-pricing-for-WanImageToImageApi-node-27c6d73d36508137b1baf75c0031f172) by [Unito](https://www.unito.io)
