### PR TITLE
[type] properly type Vue node tooltip config pt object

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -1,3 +1,4 @@
+import type { TooltipDirectivePassThroughOptions } from 'primevue'
 import { type MaybeRef, type Ref, computed, unref } from 'vue'
 
 import type { SafeWidgetData } from '@/composables/graph/useGraphNodeManager'
@@ -85,7 +86,7 @@ export function useNodeTooltips(
       showDelay: number
       disabled: boolean
       appendTo?: HTMLElement
-      pt?: any
+      pt?: TooltipDirectivePassThroughOptions
     } = {
       value: tooltipText,
       showDelay: tooltipDelay as number,


### PR DESCRIPTION
## Summary

Changes `any` type to proper type per the documentation here https://primevue.org/tooltip/#api.tooltip.interfaces.TooltipOptions.pt

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5832-type-properly-type-Vue-node-tooltip-config-pt-object-27c6d73d365081ea99c2c719d9ee6586) by [Unito](https://www.unito.io)
