### PR TITLE
fix Vue node widgets should be in disabled state if their slots are connected with a link

### DIFF
--- a/browser_tests/assets/vueNodes/linked-int-widget.json
+++ b/browser_tests/assets/vueNodes/linked-int-widget.json
@@ -1,0 +1,90 @@
+{
+  "id": "95ea19ba-456c-46e8-aa40-dc3ff135b746",
+  "revision": 0,
+  "last_node_id": 11,
+  "last_link_id": 10,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "KSampler",
+      "pos": [494.3333740234375, 142.3333282470703],
+      "size": [444, 399],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": null
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": null
+        },
+        {
+          "name": "seed",
+          "type": "INT",
+          "widget": {
+            "name": "seed"
+          },
+          "link": 10
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [67, "randomize", 20, 8, "euler", "simple", 1]
+    },
+    {
+      "id": 11,
+      "type": "PrimitiveInt",
+      "pos": [24.333343505859375, 149.6666717529297],
+      "size": [444, 125],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [10]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PrimitiveInt"
+      },
+      "widgets_values": [67, "randomize"]
+    }
+  ],
+  "links": [[10, 11, 0, 10, 4, "INT"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [0, 0]
+    },
+    "frontendVersion": "1.28.6"
+  },
+  "version": 0.4
+}

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -121,4 +121,24 @@ export class VueNodeHelpers {
       await this.page.waitForSelector('[data-node-id]')
     }
   }
+
+  /**
+   * Get a specific widget by node title and widget name
+   */
+  getWidgetByName(nodeTitle: string, widgetName: string): Locator {
+    return this.getNodeByTitle(nodeTitle).locator(
+      `_vue=[widget.name="${widgetName}"]`
+    )
+  }
+
+  /**
+   * Get controls for input number widgets (increment/decrement buttons and input)
+   */
+  getInputNumberControls(widget: Locator) {
+    return {
+      input: widget.locator('input'),
+      incrementButton: widget.locator('button').first(),
+      decrementButton: widget.locator('button').last()
+    }
+  }
 }

--- a/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
@@ -1,0 +1,42 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '../../../../fixtures/ComfyPage'
+
+test.describe('Vue Integer Widget', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.setup()
+  })
+
+  test('should be disabled and not allow changing value when link connected to slot', async ({
+    comfyPage
+  }) => {
+    await comfyPage.loadWorkflow('vueNodes/linked-int-widget')
+    await comfyPage.vueNodes.waitForNodes()
+
+    const seedWidget = comfyPage.vueNodes.getWidgetByName('KSampler', 'seed')
+    const controls = comfyPage.vueNodes.getInputNumberControls(seedWidget)
+    const initialValue = Number(await controls.input.inputValue())
+
+    // Verify widget is disabled when linked
+    await controls.incrementButton.click({ force: true })
+    await expect(controls.input).toHaveValue(initialValue.toString())
+
+    await controls.decrementButton.click({ force: true })
+    await expect(controls.input).toHaveValue(initialValue.toString())
+
+    await expect(seedWidget).toBeVisible()
+
+    // Delete the node that is linked to the slot (freeing up the widget)
+    await comfyPage.vueNodes.getNodeByTitle('Int').click()
+    await comfyPage.vueNodes.deleteSelected()
+
+    // Test widget works when unlinked
+    await controls.incrementButton.click()
+    await expect(controls.input).toHaveValue((initialValue + 1).toString())
+
+    await controls.decrementButton.click()
+    await expect(controls.input).toHaveValue(initialValue.toString())
+  })
+})

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -56,6 +56,7 @@ import {
 import { Alignment, LGraphEventMode } from './types/globalEnums'
 import type {
   LGraphTriggerAction,
+  LGraphTriggerEvent,
   LGraphTriggerHandler,
   LGraphTriggerParam
 } from './types/graphTriggers'
@@ -1196,7 +1197,27 @@ export class LGraph
   ): void
   trigger(action: string, param: unknown): void
   trigger(action: string, param: unknown) {
-    this.onTrigger?.(action, param)
+    // Convert to discriminated union format for typed handlers
+    if (
+      action === 'node:slot-links:changed' &&
+      param &&
+      typeof param === 'object'
+    ) {
+      this.onTrigger?.({ type: action, ...param } as LGraphTriggerEvent)
+    } else if (
+      action === 'node:slot-errors:changed' &&
+      param &&
+      typeof param === 'object'
+    ) {
+      this.onTrigger?.({ type: action, ...param } as LGraphTriggerEvent)
+    } else if (
+      action === 'node:property:changed' &&
+      param &&
+      typeof param === 'object'
+    ) {
+      this.onTrigger?.({ type: action, ...param } as LGraphTriggerEvent)
+    }
+    // Don't handle unknown events - just ignore them
   }
 
   /** @todo Clean up - never implemented. */

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1198,23 +1198,13 @@ export class LGraph
   trigger(action: string, param: unknown): void
   trigger(action: string, param: unknown) {
     // Convert to discriminated union format for typed handlers
-    if (
-      action === 'node:slot-links:changed' &&
-      param &&
-      typeof param === 'object'
-    ) {
-      this.onTrigger?.({ type: action, ...param } as LGraphTriggerEvent)
-    } else if (
-      action === 'node:slot-errors:changed' &&
-      param &&
-      typeof param === 'object'
-    ) {
-      this.onTrigger?.({ type: action, ...param } as LGraphTriggerEvent)
-    } else if (
-      action === 'node:property:changed' &&
-      param &&
-      typeof param === 'object'
-    ) {
+    const validEventTypes = new Set([
+      'node:slot-links:changed',
+      'node:slot-errors:changed',
+      'node:property:changed'
+    ])
+
+    if (validEventTypes.has(action) && param && typeof param === 'object') {
       this.onTrigger?.({ type: action, ...param } as LGraphTriggerEvent)
     }
     // Don't handle unknown events - just ignore them

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -55,6 +55,11 @@ import {
 } from './subgraph/subgraphUtils'
 import { Alignment, LGraphEventMode } from './types/globalEnums'
 import type {
+  LGraphTriggerAction,
+  LGraphTriggerHandler,
+  LGraphTriggerParam
+} from './types/graphTriggers'
+import type {
   ExportedSubgraph,
   ExposedWidget,
   ISerialisedGraph,
@@ -64,6 +69,11 @@ import type {
   SerialisableReroute
 } from './types/serialisation'
 import { getAllNestedItems } from './utils/collections'
+
+export type {
+  LGraphTriggerAction,
+  LGraphTriggerParam
+} from './types/graphTriggers'
 
 export interface LGraphState {
   lastGroupId: number
@@ -254,7 +264,7 @@ export class LGraph
   onExecuteStep?(): void
   onNodeAdded?(node: LGraphNode): void
   onNodeRemoved?(node: LGraphNode): void
-  onTrigger?(action: string, param: unknown): void
+  onTrigger?: LGraphTriggerHandler
   onBeforeChange?(graph: LGraph, info?: LGraphNode): void
   onAfterChange?(graph: LGraph, info?: LGraphNode | null): void
   onConnectionChange?(node: LGraphNode): void
@@ -1180,6 +1190,11 @@ export class LGraph
   }
 
   // ********** GLOBALS *****************
+  trigger<A extends LGraphTriggerAction>(
+    action: A,
+    param: LGraphTriggerParam<A>
+  ): void
+  trigger(action: string, param: unknown): void
   trigger(action: string, param: unknown) {
     this.onTrigger?.(action, param)
   }

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -2852,7 +2852,17 @@ export class LGraphNode
     output.links ??= []
     output.links.push(link.id)
     // connect in input
-    inputNode.inputs[inputIndex].link = link.id
+    const targetInput = inputNode.inputs[inputIndex]
+    targetInput.link = link.id
+    if (targetInput.widget) {
+      graph.trigger('node:slot-links:changed', {
+        nodeId: inputNode.id,
+        slotType: NodeSlotType.INPUT,
+        slotIndex: inputIndex,
+        connected: true,
+        linkId: link.id
+      })
+    }
 
     // Reroutes
     const reroutes = LLink.getReroutes(graph, link)
@@ -3009,6 +3019,15 @@ export class LGraphNode
         const input = target.inputs[link_info.target_slot]
         // remove there
         input.link = null
+        if (input.widget) {
+          graph.trigger('node:slot-links:changed', {
+            nodeId: target.id,
+            slotType: NodeSlotType.INPUT,
+            slotIndex: link_info.target_slot,
+            connected: false,
+            linkId: link_info.id
+          })
+        }
 
         // remove the link from the links pool
         link_info.disconnect(graph, 'input')
@@ -3045,6 +3064,15 @@ export class LGraphNode
           const input = target.inputs[link_info.target_slot]
           // remove other side link
           input.link = null
+          if (input.widget) {
+            graph.trigger('node:slot-links:changed', {
+              nodeId: target.id,
+              slotType: NodeSlotType.INPUT,
+              slotIndex: link_info.target_slot,
+              connected: false,
+              linkId: link_info.id
+            })
+          }
 
           // link_info hasn't been modified so its ok
           target.onConnectionsChange?.(
@@ -3114,6 +3142,15 @@ export class LGraphNode
     const link_id = this.inputs[slot].link
     if (link_id != null) {
       this.inputs[slot].link = null
+      if (input.widget) {
+        graph.trigger('node:slot-links:changed', {
+          nodeId: this.id,
+          slotType: NodeSlotType.INPUT,
+          slotIndex: slot,
+          connected: false,
+          linkId: link_id
+        })
+      }
 
       // remove other side
       const link_info = graph._links.get(link_id)

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -98,7 +98,11 @@ export type {
   Positionable,
   Size
 } from './interfaces'
-export { LGraph } from './LGraph'
+export {
+  LGraph,
+  type LGraphTriggerAction,
+  type LGraphTriggerParam
+} from './LGraph'
 export { BadgePosition, LGraphBadge } from './LGraphBadge'
 export { LGraphCanvas } from './LGraphCanvas'
 export { LGraphGroup } from './LGraphGroup'

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -103,10 +103,7 @@ export {
   type LGraphTriggerAction,
   type LGraphTriggerParam
 } from './LGraph'
-export type {
-  LGraphTriggerHandler,
-  LGraphTriggerEvent
-} from './types/graphTriggers'
+export type { LGraphTriggerEvent } from './types/graphTriggers'
 export { BadgePosition, LGraphBadge } from './LGraphBadge'
 export { LGraphCanvas } from './LGraphCanvas'
 export { LGraphGroup } from './LGraphGroup'

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -103,6 +103,10 @@ export {
   type LGraphTriggerAction,
   type LGraphTriggerParam
 } from './LGraph'
+export type {
+  LGraphTriggerHandler,
+  LGraphTriggerEvent
+} from './types/graphTriggers'
 export { BadgePosition, LGraphBadge } from './LGraphBadge'
 export { LGraphCanvas } from './LGraphCanvas'
 export { LGraphGroup } from './LGraphGroup'

--- a/src/lib/litegraph/src/types/graphTriggers.ts
+++ b/src/lib/litegraph/src/types/graphTriggers.ts
@@ -1,0 +1,36 @@
+import type { NodeSlotType } from './globalEnums'
+
+interface NodePropertyChangedEvent {
+  nodeId: string | number
+  property: string
+  oldValue: unknown
+  newValue: unknown
+}
+
+interface NodeSlotErrorsChangedEvent {
+  nodeId: string | number
+}
+
+interface NodeSlotLinksChangedEvent {
+  nodeId: string | number
+  slotType: NodeSlotType
+  slotIndex: number
+  connected: boolean
+  linkId: number
+}
+
+type LGraphTriggerEventMap = {
+  'node:property:changed': NodePropertyChangedEvent
+  'node:slot-errors:changed': NodeSlotErrorsChangedEvent
+  'node:slot-links:changed': NodeSlotLinksChangedEvent
+}
+
+export type LGraphTriggerAction = keyof LGraphTriggerEventMap
+
+export type LGraphTriggerParam<A extends LGraphTriggerAction> =
+  A extends keyof LGraphTriggerEventMap ? LGraphTriggerEventMap[A] : unknown
+
+export type LGraphTriggerHandler = {
+  <A extends LGraphTriggerAction>(action: A, param: LGraphTriggerParam<A>): void
+  (action: string, param: unknown): void
+}

--- a/src/lib/litegraph/src/types/graphTriggers.ts
+++ b/src/lib/litegraph/src/types/graphTriggers.ts
@@ -1,6 +1,7 @@
 import type { NodeSlotType } from './globalEnums'
 
 interface NodePropertyChangedEvent {
+  type: 'node:property:changed'
   nodeId: string | number
   property: string
   oldValue: unknown
@@ -8,10 +9,12 @@ interface NodePropertyChangedEvent {
 }
 
 interface NodeSlotErrorsChangedEvent {
+  type: 'node:slot-errors:changed'
   nodeId: string | number
 }
 
 interface NodeSlotLinksChangedEvent {
+  type: 'node:slot-links:changed'
   nodeId: string | number
   slotType: NodeSlotType
   slotIndex: number
@@ -19,18 +22,16 @@ interface NodeSlotLinksChangedEvent {
   linkId: number
 }
 
-type LGraphTriggerEventMap = {
-  'node:property:changed': NodePropertyChangedEvent
-  'node:slot-errors:changed': NodeSlotErrorsChangedEvent
-  'node:slot-links:changed': NodeSlotLinksChangedEvent
-}
+export type LGraphTriggerEvent =
+  | NodePropertyChangedEvent
+  | NodeSlotErrorsChangedEvent
+  | NodeSlotLinksChangedEvent
 
-export type LGraphTriggerAction = keyof LGraphTriggerEventMap
+export type LGraphTriggerAction = LGraphTriggerEvent['type']
 
-export type LGraphTriggerParam<A extends LGraphTriggerAction> =
-  A extends keyof LGraphTriggerEventMap ? LGraphTriggerEventMap[A] : unknown
+export type LGraphTriggerParam<A extends LGraphTriggerAction> = Extract<
+  LGraphTriggerEvent,
+  { type: A }
+>
 
-export type LGraphTriggerHandler = {
-  <A extends LGraphTriggerAction>(action: A, param: LGraphTriggerParam<A>): void
-  (action: string, param: unknown): void
-}
+export type LGraphTriggerHandler = (event: LGraphTriggerEvent) => void

--- a/src/lib/litegraph/src/types/graphTriggers.ts
+++ b/src/lib/litegraph/src/types/graphTriggers.ts
@@ -1,8 +1,9 @@
+import type { NodeId } from '../LGraphNode'
 import type { NodeSlotType } from './globalEnums'
 
 interface NodePropertyChangedEvent {
   type: 'node:property:changed'
-  nodeId: string | number
+  nodeId: NodeId
   property: string
   oldValue: unknown
   newValue: unknown
@@ -10,12 +11,12 @@ interface NodePropertyChangedEvent {
 
 interface NodeSlotErrorsChangedEvent {
   type: 'node:slot-errors:changed'
-  nodeId: string | number
+  nodeId: NodeId
 }
 
 interface NodeSlotLinksChangedEvent {
   type: 'node:slot-links:changed'
-  nodeId: string | number
+  nodeId: NodeId
   slotType: NodeSlotType
   slotIndex: number
   connected: boolean

--- a/src/renderer/core/layout/sync/useSlotLayoutSync.ts
+++ b/src/renderer/core/layout/sync/useSlotLayoutSync.ts
@@ -95,19 +95,19 @@ export function useSlotLayoutSync() {
       }
     }
 
-    graph.onTrigger = (action: string, param: any) => {
+    graph.onTrigger = (event) => {
       if (
-        action === 'node:property:changed' &&
-        param?.property === 'flags.collapsed'
+        event.type === 'node:property:changed' &&
+        event.property === 'flags.collapsed'
       ) {
-        const node = graph.getNodeById(parseInt(String(param.nodeId)))
+        const node = graph.getNodeById(parseInt(String(event.nodeId)))
         if (node) {
           computeAndRegisterSlots(node)
         }
       }
-      if (origTrigger) {
-        origTrigger.call(graph, action, param)
-      }
+
+      // Chain to original handler
+      origTrigger?.(event)
     }
 
     graph.onAfterChange = (graph: any, node?: any) => {

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -133,6 +133,9 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     const slotMetadata = widget.slotMetadata
 
     let widgetOptions = widget.options
+    // Core feature: Disable Vue widgets when their input slots are connected
+    // This prevents conflicting input sources - when a slot is linked to another
+    // node's output, the widget should be read-only to avoid data conflicts
     if (slotMetadata?.linked) {
       widgetOptions = widget.options
         ? { ...widget.options, disabled: true }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
@@ -90,6 +90,7 @@ const buttonTooltip = computed(() => {
         :step="stepValue"
         :use-grouping="useGrouping"
         :class="cn(WidgetInputBaseClass, 'w-full text-xs')"
+        :aria-label="widget.name"
         :pt="{
           incrementButton:
             '!rounded-r-lg bg-transparent border-none hover:bg-zinc-500/30 active:bg-zinc-500/40',

--- a/tests-ui/tests/litegraph/core/__snapshots__/LGraph.test.ts.snap
+++ b/tests-ui/tests/litegraph/core/__snapshots__/LGraph.test.ts.snap
@@ -283,6 +283,7 @@ LGraph {
   "nodes_actioning": [],
   "nodes_executedAction": [],
   "nodes_executing": [],
+  "onTrigger": undefined,
   "revision": 0,
   "runningtime": 0,
   "starttime": 0,


### PR DESCRIPTION
## Summary

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/5692 by making widget link connection status trigger on change so Vue widgets with connected links could properly switch to the `disabled` state when they are implicitly converted to inputs. 

## Changes

- **What**: Added `node:slot-links:changed` event tracking and reactive slot data synchronization for Vue widgets

```mermaid
graph TD
    A[Widget Link Change] --> B[NodeInputSlot.link setter]
    B --> C{Is Widget Input?}
    C -->|Yes| D[Trigger slot-links:changed]
    C -->|No| E[End]
    D --> F[Graph Event Handler]
    F --> G[syncNodeSlotData]
    G --> H[Update Vue Reactive Data]
    H --> I[Widget Re-render]
    
    style A fill:#f9f9f9,stroke:#333,color:#000
    style I fill:#f9f9f9,stroke:#333,color:#000
```

## Review Focus

Widget reactivity performance with frequent link changes and event handler memory management in graph operations.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5834-fix-Vue-node-widgets-should-be-in-disabled-state-if-their-slots-are-connected-with-a-link-27c6d73d365081f6a6c3c1ddc3905c5e) by [Unito](https://www.unito.io)
