### PR TITLE
[devex] Generalize AGENTS.md for all contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 
 ## Commit & Pull Request Guidelines
 - Commits: Use `[skip ci]` for locale-only updates when appropriate.
-- PRs: Include clear description, linked issues (`Fixes #123`), and screenshots/GIFs for UI changes.
+- PRs: Include clear description, linked issues (`- Fixes #123`), and screenshots/GIFs for UI changes.
 - Quality gates: `pnpm lint`, `pnpm typecheck`, and relevant tests must pass. Keep PRs focused and small.
 
 ## Security & Configuration Tips

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,3 @@
 
 ## Security & Configuration Tips
 - Secrets: Use `.env` (see `.env_example`); do not commit secrets.
-- Backend: Dev server expects ComfyUI backend at `localhost:8188` by default; configure via `.env`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Playwright: place tests in `browser_tests/`; optional tags like `@mobile`, `@2x` are respected by config.
 
 ## Commit & Pull Request Guidelines
-- Commits: Prefer Conventional Commits (e.g., `feat(ui): add sidebar`), `refactor(litegraph): …`. Use `[skip ci]` for locale-only updates when appropriate.
+- Commits: Use `[skip ci]` for locale-only updates when appropriate.
 - PRs: Include clear description, linked issues (`Fixes #123`), and screenshots/GIFs for UI changes. Add/adjust tests and i18n strings when applicable.
 - Quality gates: `pnpm lint`, `pnpm typecheck`, and relevant tests must pass. Keep PRs focused and small.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 
 ## Commit & Pull Request Guidelines
 - Commits: Use `[skip ci]` for locale-only updates when appropriate.
-- PRs: Include clear description, linked issues (`Fixes #123`), and screenshots/GIFs for UI changes. Add/adjust tests and i18n strings when applicable.
+- PRs: Include clear description, linked issues (`Fixes #123`), and screenshots/GIFs for UI changes.
 - Quality gates: `pnpm lint`, `pnpm typecheck`, and relevant tests must pass. Keep PRs focused and small.
 
 ## Security & Configuration Tips


### PR DESCRIPTION
## Summary

Updates AGENTS.md to be more universal and contributor-friendly by removing user-specific preferences.

## Changes

- **What**: Refined AGENTS.md to remove individual preferences, one-time setup tasks, and conflicting i18n instructions

## Review Focus

These updates make agent instructions work better for all contributors by:
- Removing individual coding preferences in favor of project-wide standards
- Eliminating one-time environment setup that clutters agent context
- Removing i18n instructions that caused agents to make unwanted changes
- Improving PR link formatting for better GitHub rendering

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5836-Generalize-AGENTS-md-for-all-contributors-27c6d73d365081e7acf6f37d9f8ceeaf) by [Unito](https://www.unito.io)
