### PR TITLE
fix invalid JSON (contains merge conflict markers) in 1.27 RC branch's locale json

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1912,8 +1912,6 @@
     "showGroups": "Show Frames/Groups",
     "renderBypassState": "Render Bypass State",
     "renderErrorState": "Render Error State"
-<<<<<<< Updated upstream
-=======
   },
   "assetBrowser": {
     "assets": "Assets",
@@ -1942,6 +1940,5 @@
         "Close": "Close"
       }
     }
->>>>>>> Stashed changes
   }
 }


### PR DESCRIPTION
## Summary

Merge markers were inadvertantly merged in https://github.com/comfy-org/ComfyuI_frontend/pull/5801, which [I thought was good to merge](https://github.com/Comfy-Org/ComfyUI_frontend/pull/5801#issuecomment-3340372578) but missed this due to difficulty reviewing the thousands of lines of translations that were in the backlog due to month+ long downtime on translation CI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5839-fix-invalid-JSON-contains-merge-conflict-markers-in-1-27-RC-branch-s-locale-json-27c6d73d365081439838ff4055714cf5) by [Unito](https://www.unito.io)
