### PR TITLE
[ci] add Python syntax checking workflow on changes to devtools

### DIFF
--- a/.github/workflows/devtools-python.yaml
+++ b/.github/workflows/devtools-python.yaml
@@ -1,0 +1,26 @@
+name: Devtools Python Check
+
+on:
+  pull_request:
+    paths:
+      - 'tools/devtools/**'
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/devtools/**'
+
+jobs:
+  syntax:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate Python syntax
+        run: python3 -m compileall -q tools/devtools

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -20,6 +20,7 @@ const config: KnipConfig = {
       project: ['src/**/*.{js,ts}', '*.{js,ts,mts}']
     }
   },
+  ignoreBinaries: ['python3'],
   ignoreDependencies: [
     // Weird importmap things
     '@iconify/json',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "collect-i18n": "pnpm exec playwright test --config=playwright.i18n.config.ts",
     "json-schema": "tsx scripts/generate-json-schema.ts",
     "storybook": "nx storybook -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "devtools:pycheck": "python3 -m compileall -q tools/devtools"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",


### PR DESCRIPTION
## Summary

Added CI workflow and npm script for Python syntax validation in devtools directory.

## Changes

- **What**: Added GitHub Actions workflow for Python syntax checking with `python3 -m compileall`
- **Dependencies**: Added `python3` binary to knip ignore list

## Review Focus

Workflow triggers correctly on devtools path changes and Python syntax validation covers all relevant files.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5841-ci-add-Python-syntax-checking-workflow-on-changes-to-devtools-27c6d73d365081b8963dd4600a233852) by [Unito](https://www.unito.io)
