### PR TITLE
feat: handle empty link drop in Vue

### DIFF
--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -262,17 +262,26 @@ function cancelNextReset(e: CustomEvent<CanvasPointerEvent>) {
 }
 
 function handleDroppedOnCanvas(e: CustomEvent<CanvasPointerEvent>) {
-  disconnectOnReset = true
-  const action = e.detail.shiftKey
+  const pendingAction = searchBoxStore.pendingLinkDropAction
+  searchBoxStore.setPendingLinkDropAction(null)
+
+  const fallbackAction = e.detail.shiftKey
     ? linkReleaseActionShift.value
     : linkReleaseAction.value
+
+  const action =
+    pendingAction ?? fallbackAction ?? LinkReleaseTriggerAction.NO_ACTION
+
+  disconnectOnReset = action !== LinkReleaseTriggerAction.NO_ACTION
+  if (!disconnectOnReset) return
+
+  cancelNextReset(e)
+
   switch (action) {
     case LinkReleaseTriggerAction.SEARCH_BOX:
-      cancelNextReset(e)
       showSearchBox(e.detail)
       break
     case LinkReleaseTriggerAction.CONTEXT_MENU:
-      cancelNextReset(e)
       showContextMenu(e.detail)
       break
     case LinkReleaseTriggerAction.NO_ACTION:

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -903,6 +903,9 @@ export class ComfyApp {
       this.canvasContainer,
       this.canvas
     )
+
+    // Provide high-performance position converter to LGraphCanvas
+    this.canvas.positionConverter = this.#positionConversion
   }
 
   resizeCanvas() {

--- a/src/stores/workspace/searchBoxStore.ts
+++ b/src/stores/workspace/searchBoxStore.ts
@@ -5,6 +5,7 @@ import { computed, ref, shallowRef } from 'vue'
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import type { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 
 export const useSearchBoxStore = defineStore('searchBox', () => {
   const settingStore = useSettingStore()
@@ -41,10 +42,17 @@ export const useSearchBoxStore = defineStore('searchBox', () => {
     )
   }
 
+  const pendingLinkDropAction = ref<LinkReleaseTriggerAction | null>(null)
+  function setPendingLinkDropAction(action: LinkReleaseTriggerAction | null) {
+    pendingLinkDropAction.value = action
+  }
+
   return {
     newSearchBoxEnabled,
     setPopoverRef,
     toggleVisible,
-    visible
+    visible,
+    pendingLinkDropAction,
+    setPendingLinkDropAction
   }
 })


### PR DESCRIPTION
## Summary

Add support for dropping links on the canvas to mirror litegraph functionality. Injects our cached canvas position into litegraph.

## Changes

- **What**: inject a PositionConverter into LGraphCanvas, normalize pointer events without DOM reads, and drive search/context-menu actions via the search box store
- **Breaking**: None
- **Dependencies**: None

## Review Focus

Best reviewed starting from useSlotLinkInteraction.ts

## Screenshots (if applicable)

n/a

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5850-feat-handle-empty-link-drop-in-Vue-27d6d73d36508105844cd75030fb867b) by [Unito](https://www.unito.io)
