### PR TITLE
[chore] make experiment asset api setting hidden

### DIFF
--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -13,6 +13,7 @@ import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 const ASSETS_ENDPOINT = '/assets'
 const MODELS_TAG = 'models'
 const MISSING_TAG = 'missing'
+const EXPERIMENTAL_WARNING = `EXPERIMENTAL: If you are seeing this please make sure "Comfy.Assets.UseAssetAPI" is set to "false" in your ComfyUI Settings.\n`
 
 /**
  * Input names that are eligible for asset browser
@@ -27,7 +28,9 @@ function validateAssetResponse(data: unknown): AssetResponse {
   if (result.success) return result.data
 
   const error = fromZodError(result.error)
-  throw new Error(`Invalid asset response against zod schema:\n${error}`)
+  throw new Error(
+    `${EXPERIMENTAL_WARNING}Invalid asset response against zod schema:\n${error}`
+  )
 }
 
 /**
@@ -45,7 +48,7 @@ function createAssetService() {
     const res = await api.fetchApi(url)
     if (!res.ok) {
       throw new Error(
-        `Unable to load ${context}: Server returned ${res.status}. Please try again.`
+        `${EXPERIMENTAL_WARNING}Unable to load ${context}: Server returned ${res.status}. Please try again.`
       )
     }
     const data = await res.json()
@@ -174,7 +177,7 @@ function createAssetService() {
     const res = await api.fetchApi(`${ASSETS_ENDPOINT}/${id}`)
     if (!res.ok) {
       throw new Error(
-        `Unable to load asset details for ${id}: Server returned ${res.status}. Please try again.`
+        `${EXPERIMENTAL_WARNING}Unable to load asset details for ${id}: Server returned ${res.status}. Please try again.`
       )
     }
     const data = await res.json()
@@ -188,7 +191,9 @@ function createAssetService() {
     const error = result.error
       ? fromZodError(result.error)
       : 'Unknown validation error'
-    throw new Error(`Invalid asset response against zod schema:\n${error}`)
+    throw new Error(
+      `${EXPERIMENTAL_WARNING}Invalid asset response against zod schema:\n${error}`
+    )
   }
 
   return {

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1052,7 +1052,7 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Assets.UseAssetAPI',
     name: 'Use Asset API for model library',
-    type: 'boolean',
+    type: 'hidden',
     tooltip: 'Use new Asset API for model browsing',
     defaultValue: false,
     experimental: true


### PR DESCRIPTION
## Summary

This way no one can accidentally enable it when they are messing around.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5851-chore-make-experiment-asset-api-setting-hidden-27d6d73d36508113a6c1e41a764325f3) by [Unito](https://www.unito.io)
