### PR TITLE
[devex] Fix .vue import failures silently discarded

### DIFF
--- a/src/types/vue-shim.d.ts
+++ b/src/types/vue-shim.d.ts
@@ -1,6 +1,0 @@
-// vue-shim.d.ts
-declare module '*.vue' {
-  import { DefineComponent } from 'vue'
-  const component: DefineComponent<{}, {}, any>
-  export default component
-}


### PR DESCRIPTION
## Summary

Removes the old Vue shim; this is not needed in modern Vue.  It actually appears to be detrimental, forcing `any` types and causing broken imports to be ignored by some tooling.

## Changes

- **What**: Deletes unnecessary TS decl.
- **Breaking**: Nein.
- **Dependencies**: Null.

## Review Focus

The **Approve** button.

## Screenshots (if applicable)

<img width="114" height="31" alt="image" src="https://github.com/user-attachments/assets/3bb3d895-8b4c-4540-8f9b-a110c338d666" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5852-devex-Fix-vue-import-failures-silently-discarded-27e6d73d3650819eb956f2aaf55420f2) by [Unito](https://www.unito.io)
