### PR TITLE
pass nodeId to widget component

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -45,6 +45,7 @@
         :widget="widget.simplified"
         :model-value="widget.value"
         :readonly="readonly"
+        :node-data="nodeData"
         class="flex-1"
         @update:model-value="widget.updateHandler"
       />

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -45,7 +45,7 @@
         :widget="widget.simplified"
         :model-value="widget.value"
         :readonly="readonly"
-        :node-data="nodeData"
+        :node-id="nodeData?.id != null ? String(nodeData.id) : ''"
         class="flex-1"
         @update:model-value="widget.updateHandler"
       />


### PR DESCRIPTION
## Summary

pass nodeId to widget component, which is a prerequirist for https://github.com/Comfy-Org/ComfyUI_frontend/pull/5765

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5853-pass-nodeData-to-widget-component-27e6d73d3650811e9e48ceb7c3a00545) by [Unito](https://www.unito.io)
