### PR TITLE
When restoring workflow tabs from previous session, don't skip workflows that were modified

### DIFF
--- a/src/platform/workflow/persistence/composables/useWorkflowPersistence.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistence.ts
@@ -104,7 +104,7 @@ export function useWorkflowPersistence() {
       }
 
       const paths = openWorkflows.value
-        .filter((workflow) => workflow?.isPersisted && !workflow.isModified)
+        .filter((workflow) => workflow?.isPersisted)
         .map((workflow) => workflow.path)
       const activeIndex = openWorkflows.value.findIndex(
         (workflow) => workflow.path === activeWorkflow.value?.path


### PR DESCRIPTION
## Summary

In https://github.com/Comfy-Org/ComfyUI_frontend/pull/2238, we added feature to restore open tabs from previous session. At that time, it was decided to not restore the tabs if they had a modified worklow - the reason being that we would not be able to restore the actual state. However, MANY users have expressed frustration with this - so, for now, restore the tabs even if they were modified in the previous session (and unsaved).

There are already e2e test cases for this feature here: https://github.com/Comfy-Org/ComfyUI_frontend/blob/26cf45ed3659d58543720310705ca0f09f3610e3/browser_tests/tests/interaction.spec.ts#L679

And unit tests for the relevant workflow store methods here: https://github.com/Comfy-Org/ComfyUI_frontend/blob/26cf45ed3659d58543720310705ca0f09f3610e3/tests-ui/tests/store/workflowStore.test.ts#L184

Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/5848

## Changes

- **What**: Modified filter in `restoreState` computed property to persist both saved and modified workflows

## Review Focus

Impact on browser storage when users have many modified workflows open simultaneously.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5857-When-restoring-workflow-tabs-from-previous-session-don-t-skip-workflows-that-were-modifi-27e6d73d36508182a900d2918d0fb163) by [Unito](https://www.unito.io)
