### PR TITLE
Remove optional ref: master from setup-frontend action

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -13,7 +13,6 @@ runs:
       with:
         repository: 'comfyanonymous/ComfyUI'
         path: 'ComfyUI'
-        ref: 'master'
 
     - name: Checkout ComfyUI_frontend
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Removed the optional `ref: master` parameter from the ComfyUI checkout step in the setup-frontend action
- The ref parameter defaults to the repository's default branch when omitted

## Details
The `ref: master` specification in `.github/actions/setup-frontend/action.yml` is unnecessary since GitHub Actions will automatically use the repository's default branch when the ref parameter is not provided.

This simplifies the configuration and makes it more maintainable, as the action will automatically follow any future changes to the default branch name.

## Test plan
- [ ] Verify that GitHub Actions workflows using this composite action still work correctly
- [ ] Confirm ComfyUI is checked out properly in CI/CD pipelines

Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5858-Remove-optional-ref-master-from-setup-frontend-action-27e6d73d365081aeb632f2d0e76f267d) by [Unito](https://www.unito.io)
