### PR TITLE
pnpm catalog for centralized dependency management

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 ignore-workspace-root-check=true
+catalog-mode=prefer

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 
 catalog:
   # Core frameworks
-  typescript: ^5.8.3
+  typescript: ^5.9.2
   vue: ^3.5.13
 
   # Build tools

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,113 @@ packages:
   - apps/**
   - packages/**
 
+catalog:
+  # Core frameworks
+  typescript: ^5.8.3
+  vue: ^3.5.13
+
+  # Build tools
+  vite: ^5.4.19
+  '@vitejs/plugin-vue': ^5.1.4
+  vue-tsc: ^3.0.7
+  tsx: ^4.15.6
+  nx: 21.4.1
+  '@nx/vite': 21.4.1
+  '@nx/eslint': 21.4.1
+  '@nx/playwright': 21.4.1
+  '@nx/storybook': 21.4.1
+  'vite-plugin-dts': ^4.5.4
+
+  # Testing
+  vitest: ^3.2.4
+  '@vitest/ui': ^3.0.0
+  '@vitest/coverage-v8': ^3.2.4
+  '@vue/test-utils': ^2.4.6
+  '@pinia/testing': ^0.1.5
+  '@playwright/test': ^1.52.0
+  jsdom: ^26.1.0
+  'happy-dom': ^15.11.0
+
+  # Linting & Formatting
+  eslint: ^9.34.0
+  '@eslint/js': ^9.35.0
+  prettier: ^3.3.2
+  'eslint-config-prettier': ^10.1.8
+  'eslint-plugin-prettier': ^5.5.4
+  'eslint-plugin-vue': ^10.4.0
+  'eslint-plugin-unused-imports': ^4.2.0
+  'eslint-plugin-storybook': ^9.1.6
+  'vue-eslint-parser': ^10.2.0
+  'typescript-eslint': ^8.44.0
+  '@intlify/eslint-plugin-vue-i18n': ^4.1.0
+
+  # Vue ecosystem
+  'vue-router': ^4.4.3
+  pinia: ^2.1.7
+  'vue-i18n': ^9.14.3
+  vuefire: ^3.2.1
+  '@vueuse/core': ^11.0.0
+  '@vueuse/integrations': ^13.9.0
+  'vite-plugin-html': ^3.2.2
+  'vite-plugin-vue-devtools': ^7.7.6
+  '@sentry/vue': ^8.48.0
+
+  # PrimeVue UI framework
+  primevue: ^4.2.5
+  '@primevue/core': ^4.2.5
+  '@primevue/forms': ^4.2.5
+  '@primevue/icons': 4.2.5
+  '@primevue/themes': ^4.2.5
+  primeicons: ^7.0.0
+  '@primeuix/forms': 0.0.2
+  '@primeuix/styled': 0.3.2
+  '@primeuix/utils': ^0.3.2
+
+  # Tailwind CSS and design
+  tailwindcss: ^4.1.12
+  '@tailwindcss/vite': ^4.1.12
+  'tailwindcss-primeui': ^0.6.1
+  'tw-animate-css': ^1.3.8
+  '@iconify/json': ^2.2.380
+  '@iconify-json/lucide': ^1.1.178
+  '@iconify/tailwind': ^1.1.3
+  'unplugin-icons': ^0.22.0
+  'unplugin-vue-components': ^0.28.0
+
+  # Storybook
+  storybook: ^9.1.6
+  '@storybook/vue3': ^9.1.1
+  '@storybook/vue3-vite': ^9.1.1
+  '@storybook/addon-docs': ^9.1.1
+
+  # Data and validation
+  zod: ^3.23.8
+  'zod-validation-error': ^3.3.0
+  algoliasearch: ^5.21.0
+  firebase: ^11.6.0
+  yjs: ^13.6.27
+
+  # Dev tools
+  husky: ^9.0.11
+  'lint-staged': ^15.2.7
+  knip: ^5.62.0
+  dotenv: ^16.4.5
+  jiti: 2.4.2
+
+  # Type definitions
+  '@types/node': ^20.14.8
+  '@types/jsdom': ^21.1.7
+  '@types/fs-extra': ^11.0.4
+  '@types/semver': ^7.7.0
+  '@types/three': ^0.169.0
+  'vue-component-type-helpers': ^3.0.7
+  'zod-to-json-schema': ^3.24.1
+
+  # i18n
+  '@lobehub/i18n-cli': ^1.25.1
+  '@alloc/quick-lru': ^5.2.0
+  '@trivago/prettier-plugin-sort-imports': ^5.2.0
+
 ignoredBuiltDependencies:
   - '@firebase/util'
   - protobufjs

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,106 +8,106 @@ catalog:
   vue: ^3.5.13
 
   # Build tools
-  vite: ^5.4.19
-  '@vitejs/plugin-vue': ^5.1.4
-  vue-tsc: ^3.0.7
-  tsx: ^4.15.6
-  nx: 21.4.1
-  '@nx/vite': 21.4.1
   '@nx/eslint': 21.4.1
   '@nx/playwright': 21.4.1
   '@nx/storybook': 21.4.1
+  '@nx/vite': 21.4.1
+  nx: 21.4.1
+  tsx: ^4.15.6
+  vite: ^5.4.19
+  '@vitejs/plugin-vue': ^5.1.4
   'vite-plugin-dts': ^4.5.4
+  vue-tsc: ^3.0.7
 
   # Testing
-  vitest: ^3.2.4
-  '@vitest/ui': ^3.0.0
-  '@vitest/coverage-v8': ^3.2.4
-  '@vue/test-utils': ^2.4.6
+  'happy-dom': ^15.11.0
+  jsdom: ^26.1.0
   '@pinia/testing': ^0.1.5
   '@playwright/test': ^1.52.0
-  jsdom: ^26.1.0
-  'happy-dom': ^15.11.0
+  '@vitest/coverage-v8': ^3.2.4
+  '@vitest/ui': ^3.0.0
+  vitest: ^3.2.4
+  '@vue/test-utils': ^2.4.6
 
   # Linting & Formatting
-  eslint: ^9.34.0
   '@eslint/js': ^9.35.0
-  prettier: ^3.3.2
+  eslint: ^9.34.0
   'eslint-config-prettier': ^10.1.8
   'eslint-plugin-prettier': ^5.5.4
-  'eslint-plugin-vue': ^10.4.0
-  'eslint-plugin-unused-imports': ^4.2.0
   'eslint-plugin-storybook': ^9.1.6
-  'vue-eslint-parser': ^10.2.0
-  'typescript-eslint': ^8.44.0
-  '@intlify/eslint-plugin-vue-i18n': ^4.1.0
+  'eslint-plugin-unused-imports': ^4.2.0
+  'eslint-plugin-vue': ^10.4.0
   globals: ^15.9.0
+  '@intlify/eslint-plugin-vue-i18n': ^4.1.0
+  prettier: ^3.3.2
+  'typescript-eslint': ^8.44.0
+  'vue-eslint-parser': ^10.2.0
 
   # Vue ecosystem
-  'vue-router': ^4.4.3
-  pinia: ^2.1.7
-  'vue-i18n': ^9.14.3
-  vuefire: ^3.2.1
+  '@sentry/vue': ^8.48.0
   '@vueuse/core': ^11.0.0
   '@vueuse/integrations': ^13.9.0
   'vite-plugin-html': ^3.2.2
   'vite-plugin-vue-devtools': ^7.7.6
-  '@sentry/vue': ^8.48.0
+  pinia: ^2.1.7
+  'vue-i18n': ^9.14.3
+  'vue-router': ^4.4.3
+  vuefire: ^3.2.1
 
   # PrimeVue UI framework
-  primevue: ^4.2.5
+  '@primeuix/forms': 0.0.2
+  '@primeuix/styled': 0.3.2
+  '@primeuix/utils': ^0.3.2
   '@primevue/core': ^4.2.5
   '@primevue/forms': ^4.2.5
   '@primevue/icons': 4.2.5
   '@primevue/themes': ^4.2.5
   primeicons: ^7.0.0
-  '@primeuix/forms': 0.0.2
-  '@primeuix/styled': 0.3.2
-  '@primeuix/utils': ^0.3.2
+  primevue: ^4.2.5
 
   # Tailwind CSS and design
-  tailwindcss: ^4.1.12
-  '@tailwindcss/vite': ^4.1.12
-  'tailwindcss-primeui': ^0.6.1
-  'tw-animate-css': ^1.3.8
   '@iconify/json': ^2.2.380
   '@iconify-json/lucide': ^1.1.178
   '@iconify/tailwind': ^1.1.3
+  '@tailwindcss/vite': ^4.1.12
+  tailwindcss: ^4.1.12
+  'tailwindcss-primeui': ^0.6.1
+  'tw-animate-css': ^1.3.8
   'unplugin-icons': ^0.22.0
   'unplugin-vue-components': ^0.28.0
 
   # Storybook
+  '@storybook/addon-docs': ^9.1.1
   storybook: ^9.1.6
   '@storybook/vue3': ^9.1.1
   '@storybook/vue3-vite': ^9.1.1
-  '@storybook/addon-docs': ^9.1.1
 
   # Data and validation
-  zod: ^3.23.8
-  'zod-validation-error': ^3.3.0
   algoliasearch: ^5.21.0
   firebase: ^11.6.0
   yjs: ^13.6.27
+  zod: ^3.23.8
+  'zod-validation-error': ^3.3.0
 
   # Dev tools
-  husky: ^9.0.11
-  'lint-staged': ^15.2.7
-  knip: ^5.62.0
   dotenv: ^16.4.5
+  husky: ^9.0.11
   jiti: 2.4.2
+  knip: ^5.62.0
+  'lint-staged': ^15.2.7
 
   # Type definitions
-  '@types/node': ^20.14.8
-  '@types/jsdom': ^21.1.7
   '@types/fs-extra': ^11.0.4
+  '@types/jsdom': ^21.1.7
+  '@types/node': ^20.14.8
   '@types/semver': ^7.7.0
   '@types/three': ^0.169.0
   'vue-component-type-helpers': ^3.0.7
   'zod-to-json-schema': ^3.24.1
 
   # i18n
-  '@lobehub/i18n-cli': ^1.25.1
   '@alloc/quick-lru': ^5.2.0
+  '@lobehub/i18n-cli': ^1.25.1
   '@trivago/prettier-plugin-sort-imports': ^5.2.0
 
 ignoredBuiltDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ catalog:
   'vue-eslint-parser': ^10.2.0
   'typescript-eslint': ^8.44.0
   '@intlify/eslint-plugin-vue-i18n': ^4.1.0
+  globals: ^15.9.0
 
   # Vue ecosystem
   'vue-router': ^4.4.3


### PR DESCRIPTION
## Summary

Adds pnpm catalog to centralize dependency versions across the monorepo.

## Changes

- **What**: Consolidates dependencies into single default catalog with [`prefer` mode](https://pnpm.io/catalogs#catalog-mode)
- **Dependencies**: No new dependencies - reorganizes existing version management

## Review Focus

The catalog uses `prefer` mode which automatically uses catalog versions for packages already in the catalog, falling back to direct versions for packages not yet cataloged.

### Example Usage

When adding a dependency already in the catalog:
```bash
pnpm add vue
```

This automatically uses `"vue": "catalog:"` in `package.json` instead of a direct version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5871-pnpm-catalog-for-centralized-dependency-management-27e6d73d3650812da3fdf12a1a11ee12) by [Unito](https://www.unito.io)
