### PR TITLE
Fix Claude review workflow checkout ref

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
By default, in this case the checkout action will checkout to github's temporary merge base ref, which may include changes from the base branch when the base branch moves.

This happened in this review: https://github.com/Comfy-Org/ComfyUI_frontend/pull/5866#pullrequestreview-3287366541

To prevent this, the PR's HEAD SHA was specified to be used specifically, keeping claude's reviews only looking at that PR's branch.