### PR TITLE
Align links to slots in subgraphs

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5617,7 +5617,9 @@ export class LGraphCanvas
           const { link, inputNode, input } = resolved
           if (!inputNode || !input) continue
 
-          const endPos = inputNode.getInputPos(link.target_slot)
+          const endPos = LiteGraph.vueNodesMode
+            ? getSlotPosition(inputNode, link.target_slot, true)
+            : inputNode.getInputPos(link.target_slot)
 
           this.#renderAllLinkSegments(
             ctx,
@@ -5642,7 +5644,9 @@ export class LGraphCanvas
         const { link, outputNode, output } = resolved
         if (!outputNode || !output) continue
 
-        const startPos = outputNode.getOutputPos(link.origin_slot)
+        const startPos = LiteGraph.vueNodesMode
+          ? getSlotPosition(outputNode, link.origin_slot, false)
+          : outputNode.getOutputPos(link.origin_slot)
 
         this.#renderAllLinkSegments(
           ctx,


### PR DESCRIPTION
When vue nodes is enabled, switch to the new getSlotPosition for subgraph nodes as well.

This aligns links to slots in subgraphs.

Do note, getSlotPosition is actually the new standard, but we fallback to inputNode.getInputPos since it's so core, idea is to switch over fully to getSlotPosition without the vue flag once things are more stable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5876-Align-links-to-slots-in-subgraphs-27f6d73d365081148b92f312a0af84a0) by [Unito](https://www.unito.io)
