### PR TITLE
[fix] Correct checkout ref for fork PRs in lint-and-format workflow

### DIFF
--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
 
       - name: Install pnpm


### PR DESCRIPTION
## Summary
- Fixed the lint-and-format workflow to correctly checkout code from fork PRs
- Changed from using `head.ref` to `refs/pull/.../head` for proper PR reference

## Problem
The lint-and-format workflow was failing to checkout the correct code for PRs from forks. It was using:
```yaml
ref: ${{ github.event.pull_request.head.ref }}
```

This only contains the branch name (e.g., `mpe/typoFixes`). For fork PRs, this caused GitHub Actions to look for that branch in the main repository (`Comfy-Org/ComfyUI_frontend`) instead of the fork repository.

## Solution
Changed to use the proper PR reference:
```yaml
ref: refs/pull/${{ github.event.pull_request.number }}/head
```

This correctly references the PR's merge ref that GitHub creates, ensuring the workflow checks out the right code for both fork and non-fork PRs.

## Evidence
This issue was observed in PR #5880 where the workflow logs showed:
```
Fetching the repository
From https://github.com/Comfy-Org/ComfyUI_frontend
```
Instead of fetching from the contributor's fork.

## Note
This follows the same pattern already implemented in the `claude-pr-review.yml` workflow (fixed in #5874).

## Test Plan
- [ ] Verify workflow runs correctly on this PR (non-fork)
- [ ] Test with a fork PR to confirm it fetches from the correct repository

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5885-fix-Correct-checkout-ref-for-fork-PRs-in-lint-and-format-workflow-27f6d73d3650817a97f0f605fbe45c6f) by [Unito](https://www.unito.io)
