### PR TITLE
ci: fork-safe checkout for lint workflow

### DIFF
--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Use conditional ref to support forks and avoid checkout failures.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5887-ci-fork-safe-checkout-for-lint-workflow-2806d73d36508139b9effa6d18e1cadb) by [Unito](https://www.unito.io)
