### PR TITLE
feat(api-nodes): add pricing for new Kling 2.5 Turbo model

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -355,7 +355,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         const modelValue = String(modelWidget.value)
 
         // Same pricing matrix as KlingTextToVideoNode
-        if (
+        if (modelValue.includes('v2-5-turbo')) {
+          if (durationValue.includes('10')) {
+            return '$0.70/Run'
+          }
+          return '$0.35/Run' // 5s default
+        } else if (
           modelValue.includes('v2-1-master') ||
           modelValue.includes('v2-master')
         ) {
@@ -505,7 +510,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         const modeValue = String(modeWidget.value)
 
         // Pricing matrix from CSV data based on mode string content
-        if (modeValue.includes('v2-1-master')) {
+        if (modeValue.includes('v2-5-turbo')) {
+          if (modeValue.includes('10')) {
+            return '$0.70/Run'
+          }
+          return '$0.35/Run' // 5s default
+        } else if (modeValue.includes('v2-1-master')) {
           if (modeValue.includes('10s')) {
             return '$2.80/Run' // price is the same as for v2-master model
           }

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -115,6 +115,26 @@ describe('useNodePricing', () => {
       expect(price).toBe('$1.40/Run')
     })
 
+    it('should return low price for kling-v2-turbo model', () => {
+      const { getNodeDisplayPrice } = useNodePricing()
+      const node = createMockNode('KlingTextToVideoNode', [
+        { name: 'mode', value: 'pro / 5s / v2-5-turbo' }
+      ])
+
+      const price = getNodeDisplayPrice(node)
+      expect(price).toBe('$0.35/Run')
+    })
+
+    it('should return high price for kling-v2-turbo model', () => {
+      const { getNodeDisplayPrice } = useNodePricing()
+      const node = createMockNode('KlingTextToVideoNode', [
+        { name: 'mode', value: 'pro / 10s / v2-5-turbo' }
+      ])
+
+      const price = getNodeDisplayPrice(node)
+      expect(price).toBe('$0.70/Run')
+    })
+
     it('should return standard price for kling-v1-6 model', () => {
       const { getNodeDisplayPrice } = useNodePricing()
       const node = createMockNode('KlingTextToVideoNode', [
@@ -153,6 +173,18 @@ describe('useNodePricing', () => {
 
       const price = getNodeDisplayPrice(node)
       expect(price).toBe('$1.40/Run')
+    })
+
+    it('should return high price for kling-v2-5-turbo model', () => {
+      const { getNodeDisplayPrice } = useNodePricing()
+      const node = createMockNode('KlingImage2VideoNode', [
+        { name: 'model_name', value: 'v2-5-turbo' },
+        { name: 'mode', value: 'pro mode / 10s duration / kling-v2-5-turbo' },
+        { name: 'duration', value: '10' }
+      ])
+
+      const price = getNodeDisplayPrice(node)
+      expect(price).toBe('$0.70/Run')
     })
 
     it('should return standard price for kling-v1-6 model', () => {


### PR DESCRIPTION
## Summary

Added prices for new model to the `KlingTextToVideoNode` and `KlingImage2VideoNode` nodes

## Screenshots (if applicable)

<img width="2150" height="991" alt="Screenshot From 2025-10-02 10-51-04" src="https://github.com/user-attachments/assets/489d2aeb-9c8b-4123-91ab-4e17df460862" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5892-feat-api-nodes-add-pricing-for-new-Kling-2-5-Turbo-model-2806d73d3650810eb33cf794dca23266) by [Unito](https://www.unito.io)
