### PR TITLE
fix Vue node header width

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -4,7 +4,7 @@
   </div>
   <div
     v-else
-    class="lg-node-header p-4 rounded-t-2xl cursor-move"
+    class="lg-node-header p-4 rounded-t-2xl cursor-move w-full"
     :style="headerStyle"
     :data-testid="`node-header-${nodeData?.id || ''}`"
     @dblclick="handleDoubleClick"


### PR DESCRIPTION
## Summary

Added `w-full` class to Vue node header to ensure full width layout consistency.

## Changes

- **What**: Applied [Tailwind CSS w-full utility](https://tailwindcss.com/docs/width#full-width) to NodeHeader component for consistent width behavior

## Review Focus

If this is best place to set the class

## Screenshots (if applicable)

*Before*

<img width="931" height="919" alt="image" src="https://github.com/user-attachments/assets/fe94ddad-f43b-4441-a924-60aeaff94041" />

*After*

<img width="931" height="919" alt="Screenshot from 2025-10-02 10-38-53" src="https://github.com/user-attachments/assets/596681ad-309a-4fab-a343-bfbb73d72f6c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5895-fix-Vue-node-header-width-2806d73d365081bb82ddf6abe8665f8b) by [Unito](https://www.unito.io)
