### PR TITLE
fix: save video preview

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -352,7 +352,6 @@ const nodeMedia = computed(() => {
   const newOutputs = nodeOutputs.nodeOutputs[nodeOutputLocatorId.value]
   const node = lgraphNode.value
 
-  // Early return if no outputs
   if (!node || !newOutputs?.images?.length) return undefined
 
   const urls = nodeOutputs.getNodeImageUrls(node)

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -352,17 +352,23 @@ const nodeMedia = computed(() => {
   const newOutputs = nodeOutputs.nodeOutputs[nodeOutputLocatorId.value]
   const node = lgraphNode.value
 
-  // Note: Despite the field name "images", videos are also included.
-  // The actual media type is determined by node.previewMediaType
-  // TODO: fix the backend to return videos using the vidoes key instead of the images key
-  if (node && newOutputs?.images?.length) {
-    const urls = nodeOutputs.getNodeImageUrls(node)
-    if (urls && urls.length > 0) {
-      const type = node.previewMediaType === 'video' ? 'video' : 'image'
-      return { type, urls } as const
-    }
-  }
-  return undefined
+  // Early return if no outputs
+  if (!node || !newOutputs?.images?.length) return undefined
+
+  const urls = nodeOutputs.getNodeImageUrls(node)
+  if (!urls?.length) return undefined
+
+  // Determine media type from previewMediaType or fallback to input slot types
+  // Note: Despite the field name "images", videos are also included in outputs
+  // TODO: fix the backend to return videos using the videos key instead of the images key
+  const hasVideoInput = node.inputs?.some((input) => input.type === 'VIDEO')
+  const type =
+    node.previewMediaType === 'video' ||
+    (!node.previewMediaType && hasVideoInput)
+      ? 'video'
+      : 'image'
+
+  return { type, urls } as const
 })
 
 const nodeContainerRef = ref()


### PR DESCRIPTION
## Summary

Fix the save video preview by checking for video inputs.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/26a1fbb1-f54c-4a17-a59d-ce89b4e0c389

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5897-fix-save-video-preview-2816d73d365081b79a47e0da29e1fed6) by [Unito](https://www.unito.io)
