### PR TITLE
Full Asset Selection Experience (Assets API)

### DIFF
--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -67,14 +67,10 @@ const isSmall = computed(
 const tabs = computed(() => workspaceStore.getSidebarTabs())
 const selectedTab = computed(() => workspaceStore.sidebarTab.activeSidebarTab)
 
-const onTabClick = async (item: SidebarTabExtension) => {
-  const command = commandStore.commands.find(
-    (cmd) => cmd.id === `Workspace.ToggleSidebarTab.${item.id}`
-  )
-  if (command) {
-    await command.function()
-  }
-}
+const onTabClick = async (item: SidebarTabExtension) =>
+  await commandStore.commands
+    .find((cmd) => cmd.id === `Workspace.ToggleSidebarTab.${item.id}`)
+    ?.function?.()
 
 const keybindingStore = useKeybindingStore()
 const getTabTooltipSuffix = (tab: SidebarTabExtension) => {

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -33,14 +33,12 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
 import SidebarBottomPanelToggleButton from '@/components/sidebar/SidebarBottomPanelToggleButton.vue'
 import SidebarShortcutsToggleButton from '@/components/sidebar/SidebarShortcutsToggleButton.vue'
-import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
-import { createModelNodeFromAsset } from '@/platform/assets/utils/createModelNodeFromAsset'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { useKeybindingStore } from '@/stores/keybindingStore'
 import { useUserStore } from '@/stores/userStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
@@ -54,11 +52,7 @@ import SidebarTemplatesButton from './SidebarTemplatesButton.vue'
 const workspaceStore = useWorkspaceStore()
 const settingStore = useSettingStore()
 const userStore = useUserStore()
-const { t } = useI18n()
-
-const isUsingAssetAPI = computed(() =>
-  settingStore.get('Comfy.Assets.UseAssetAPI')
-)
+const commandStore = useCommandStore()
 
 const teleportTarget = computed(() =>
   settingStore.get('Comfy.Sidebar.Location') === 'left'
@@ -74,19 +68,12 @@ const tabs = computed(() => workspaceStore.getSidebarTabs())
 const selectedTab = computed(() => workspaceStore.sidebarTab.activeSidebarTab)
 
 const onTabClick = async (item: SidebarTabExtension) => {
-  if (isUsingAssetAPI.value && item.id === 'model-library') {
-    const assetBrowserDialog = useAssetBrowserDialog()
-    await assetBrowserDialog.browse({
-      assetType: 'models',
-      title: t('sideToolbar.modelLibrary'),
-      onAssetSelected: (asset) => {
-        createModelNodeFromAsset(asset)
-      }
-    })
-    return
+  const command = commandStore.commands.find(
+    (cmd) => cmd.id === `Workspace.ToggleSidebarTab.${item.id}`
+  )
+  if (command) {
+    await command.function()
   }
-
-  workspaceStore.sidebarTab.toggleSidebarTab(item.id)
 }
 
 const keybindingStore = useKeybindingStore()

--- a/src/components/widget/layout/BaseModalLayout.vue
+++ b/src/components/widget/layout/BaseModalLayout.vue
@@ -48,7 +48,10 @@
           <main class="flex flex-col flex-1 min-h-0">
             <!-- Fallback title bar when no leftPanel is provided -->
             <slot name="contentFilter"></slot>
-            <h2 v-if="!$slots.leftPanel" class="text-xxl px-6 pt-2 pb-6 m-0">
+            <h2
+              v-if="!$slots.leftPanel"
+              class="text-xxl px-6 pt-2 pb-6 m-0 capitalize"
+            >
               {{ contentTitle }}
             </h2>
             <div :class="contentContainerClasses">

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1076,7 +1076,15 @@ export function useCoreCommands(): ComfyCommand[] {
           assetType: 'models',
           title: t('sideToolbar.modelLibrary'),
           onAssetSelected: (asset) => {
-            createModelNodeFromAsset(asset)
+            const result = createModelNodeFromAsset(asset)
+            if (!result.success) {
+              toastStore.add({
+                severity: 'error',
+                summary: t('g.error'),
+                detail: t('assetBrowser.failedToCreateNode')
+              })
+              console.error('Node creation failed:', result.error)
+            }
           }
         })
       }

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -15,6 +15,8 @@ import {
   SubgraphNode
 } from '@/lib/litegraph/src/litegraph'
 import type { Point } from '@/lib/litegraph/src/litegraph'
+import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import { createModelNodeFromAsset } from '@/platform/assets/utils/createModelNodeFromAsset'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
@@ -1061,6 +1063,22 @@ export function useCoreCommands(): ComfyCommand[] {
           return
         }
         await api.freeMemory({ freeExecutionCache: true })
+      }
+    },
+    {
+      id: 'Comfy.BrowseModelAssets',
+      icon: 'pi pi-folder-open',
+      label: 'Browse Model Assets',
+      versionAdded: '1.28.3',
+      function: async () => {
+        const assetBrowserDialog = useAssetBrowserDialog()
+        await assetBrowserDialog.browse({
+          assetType: 'models',
+          title: t('sideToolbar.modelLibrary'),
+          onAssetSelected: (asset) => {
+            createModelNodeFromAsset(asset)
+          }
+        })
       }
     }
   ]

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1942,6 +1942,7 @@
     "tryAdjustingFilters": "Try adjusting your search or filters",
     "loadingModels": "Loading {type}...",
     "connectionError": "Please check your connection and try again",
+    "failedToCreateNode": "Failed to create node. Please try again or check console for details.",
     "noModelsInFolder": "No {type} available in this folder",
     "searchAssetsPlaceholder": "Search assets...",
     "allModels": "All Models",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1945,6 +1945,7 @@
     "noModelsInFolder": "No {type} available in this folder",
     "searchAssetsPlaceholder": "Search assets...",
     "allModels": "All Models",
+    "allCategory": "All {category}",
     "unknown": "Unknown",
     "fileFormats": "File formats",
     "baseModels": "Base models",

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -2,7 +2,7 @@
   <BaseModalLayout
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
-    :content-title="contentTitle"
+    :content-title="displayTitle"
     @close="handleClose"
   >
     <template v-if="shouldShowLeftPanel" #leftPanel>
@@ -14,7 +14,9 @@
         <template #header-icon>
           <div class="icon-[lucide--folder] size-4" />
         </template>
-        <template #header-title>{{ $t('assetBrowser.browseAssets') }}</template>
+        <template #header-title>
+          <span class="capitalize">{{ displayTitle }}</span>
+        </template>
       </LeftSidePanel>
     </template>
 
@@ -63,6 +65,7 @@ const props = defineProps<{
   onClose?: () => void
   showLeftPanel?: boolean
   assets?: AssetItem[]
+  title?: string
 }>()
 
 const emit = defineEmits<{
@@ -81,6 +84,10 @@ const {
   filteredAssets,
   updateFilters
 } = useAssetBrowser(props.assets)
+
+const displayTitle = computed(() => {
+  return props.title ?? contentTitle.value
+})
 
 const shouldShowLeftPanel = computed(() => {
   return props.showLeftPanel ?? true

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -28,7 +28,10 @@
     </template>
 
     <template #contentFilter>
-      <AssetFilterBar :assets="assets" @filter-change="updateFilters" />
+      <AssetFilterBar
+        :assets="categoryFilteredAssets"
+        @filter-change="updateFilters"
+      />
     </template>
 
     <template #content>
@@ -74,8 +77,8 @@ const {
   selectedCategory,
   availableCategories,
   contentTitle,
+  categoryFilteredAssets,
   filteredAssets,
-  selectAssetWithCallback,
   updateFilters
 } = useAssetBrowser(props.assets)
 
@@ -88,8 +91,10 @@ function handleClose() {
   emit('close')
 }
 
-async function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
+function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
   emit('asset-select', asset)
-  await selectAssetWithCallback(asset.id, props.onSelect)
+  // onSelect callback is provided by dialog composable layer
+  // It handles the appropriate transformation (filename extraction or full asset)
+  props.onSelect?.(asset)
 }
 </script>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -56,7 +56,7 @@ import { OnCloseKey } from '@/types/widgetTypes'
 const props = defineProps<{
   nodeType?: string
   inputName?: string
-  onSelect?: (assetPath: string) => void
+  onSelect?: (asset: AssetItem) => void
   onClose?: () => void
   showLeftPanel?: boolean
   assets?: AssetItem[]

--- a/src/platform/assets/components/AssetFilterBar.stories.ts
+++ b/src/platform/assets/components/AssetFilterBar.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
 
 import {
   createAssetWithSpecificBaseModel,
@@ -6,6 +7,7 @@ import {
   createAssetWithoutBaseModel,
   createAssetWithoutExtension
 } from '@/platform/assets/fixtures/ui-mock-assets'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
 import AssetFilterBar from './AssetFilterBar.vue'
 
@@ -46,14 +48,19 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const BothFiltersVisible: Story = {
-  args: {
-    assets: [
-      createAssetWithSpecificExtension('safetensors'),
-      createAssetWithSpecificExtension('ckpt'),
-      createAssetWithSpecificBaseModel('sd15'),
-      createAssetWithSpecificBaseModel('sdxl')
-    ]
-  },
+  render: () => ({
+    components: { AssetFilterBar },
+    setup() {
+      const assets = ref<AssetItem[]>([
+        createAssetWithSpecificExtension('safetensors'),
+        createAssetWithSpecificExtension('ckpt'),
+        createAssetWithSpecificBaseModel('sd15'),
+        createAssetWithSpecificBaseModel('sdxl')
+      ])
+      return { assets }
+    },
+    template: '<AssetFilterBar :assets="assets" />'
+  }),
   parameters: {
     docs: {
       description: {
@@ -65,16 +72,23 @@ export const BothFiltersVisible: Story = {
 }
 
 export const OnlyFileFormatFilter: Story = {
-  args: {
-    assets: [
-      // Assets with extensions but explicitly NO base models
-      {
-        ...createAssetWithSpecificExtension('safetensors'),
-        user_metadata: undefined
-      },
-      { ...createAssetWithSpecificExtension('ckpt'), user_metadata: undefined }
-    ]
-  },
+  render: () => ({
+    components: { AssetFilterBar },
+    setup() {
+      const assets = ref<AssetItem[]>([
+        {
+          ...createAssetWithSpecificExtension('safetensors'),
+          user_metadata: undefined
+        },
+        {
+          ...createAssetWithSpecificExtension('ckpt'),
+          user_metadata: undefined
+        }
+      ])
+      return { assets }
+    },
+    template: '<AssetFilterBar :assets="assets" />'
+  }),
   parameters: {
     docs: {
       description: {
@@ -86,16 +100,20 @@ export const OnlyFileFormatFilter: Story = {
 }
 
 export const OnlyBaseModelFilter: Story = {
-  args: {
-    assets: [
-      // Assets with base models but no recognizable extensions
-      {
-        ...createAssetWithSpecificBaseModel('sd15'),
-        name: 'model_without_extension'
-      },
-      { ...createAssetWithSpecificBaseModel('sdxl'), name: 'another_model' }
-    ]
-  },
+  render: () => ({
+    components: { AssetFilterBar },
+    setup() {
+      const assets = ref<AssetItem[]>([
+        {
+          ...createAssetWithSpecificBaseModel('sd15'),
+          name: 'model_without_extension'
+        },
+        { ...createAssetWithSpecificBaseModel('sdxl'), name: 'another_model' }
+      ])
+      return { assets }
+    },
+    template: '<AssetFilterBar :assets="assets" />'
+  }),
   parameters: {
     docs: {
       description: {
@@ -107,9 +125,14 @@ export const OnlyBaseModelFilter: Story = {
 }
 
 export const NoFiltersVisible: Story = {
-  args: {
-    assets: []
-  },
+  render: () => ({
+    components: { AssetFilterBar },
+    setup() {
+      const assets = ref<AssetItem[]>([])
+      return { assets }
+    },
+    template: '<AssetFilterBar :assets="assets" />'
+  }),
   parameters: {
     docs: {
       description: {
@@ -121,14 +144,121 @@ export const NoFiltersVisible: Story = {
 }
 
 export const NoFiltersFromAssetsWithoutOptions: Story = {
-  args: {
-    assets: [createAssetWithoutExtension(), createAssetWithoutBaseModel()]
-  },
+  render: () => ({
+    components: { AssetFilterBar },
+    setup() {
+      const assets = ref<AssetItem[]>([
+        createAssetWithoutExtension(),
+        createAssetWithoutBaseModel()
+      ])
+      return { assets }
+    },
+    template: '<AssetFilterBar :assets="assets" />'
+  }),
   parameters: {
     docs: {
       description: {
         story:
           'Shows no filters when assets are provided but contain no filterable options (no extensions or base models).'
+      }
+    }
+  }
+}
+
+export const CategorySwitchingReactivity: Story = {
+  render: () => ({
+    components: { AssetFilterBar },
+    setup() {
+      const selectedCategory = ref('all')
+
+      const checkpointAssets: AssetItem[] = [
+        {
+          ...createAssetWithSpecificExtension('safetensors'),
+          tags: ['models', 'checkpoints'],
+          user_metadata: { base_model: 'sd15' }
+        },
+        {
+          ...createAssetWithSpecificExtension('safetensors'),
+          tags: ['models', 'checkpoints'],
+          user_metadata: { base_model: 'sdxl' }
+        }
+      ]
+
+      const loraAssets: AssetItem[] = [
+        {
+          ...createAssetWithSpecificExtension('pt'),
+          tags: ['models', 'loras'],
+          user_metadata: { base_model: 'sd15' }
+        },
+        {
+          ...createAssetWithSpecificExtension('pt'),
+          tags: ['models', 'loras'],
+          user_metadata: undefined
+        }
+      ]
+
+      const allAssets = [...checkpointAssets, ...loraAssets]
+
+      const categoryFilteredAssets = ref<AssetItem[]>(allAssets)
+
+      const switchCategory = (category: string) => {
+        selectedCategory.value = category
+        categoryFilteredAssets.value =
+          category === 'all'
+            ? allAssets
+            : category === 'checkpoints'
+              ? checkpointAssets
+              : loraAssets
+      }
+
+      return { categoryFilteredAssets, selectedCategory, switchCategory }
+    },
+    template: `
+      <div class="space-y-4 p-4">
+        <div class="flex gap-2">
+          <button
+            @click="switchCategory('all')"
+            :class="[
+              'px-4 py-2 rounded border',
+              selectedCategory === 'all'
+                ? 'bg-blue-500 text-white border-blue-600'
+                : 'bg-white dark-theme:bg-charcoal-700 border-gray-300 dark-theme:border-charcoal-600'
+            ]"
+          >
+            All (.safetensors + .pt, sd15 + sdxl)
+          </button>
+          <button
+            @click="switchCategory('checkpoints')"
+            :class="[
+              'px-4 py-2 rounded border',
+              selectedCategory === 'checkpoints'
+                ? 'bg-blue-500 text-white border-blue-600'
+                : 'bg-white dark-theme:bg-charcoal-700 border-gray-300 dark-theme:border-charcoal-600'
+            ]"
+          >
+            Checkpoints (.safetensors, sd15 + sdxl)
+          </button>
+          <button
+            @click="switchCategory('loras')"
+            :class="[
+              'px-4 py-2 rounded border',
+              selectedCategory === 'loras'
+                ? 'bg-blue-500 text-white border-blue-600'
+                : 'bg-white dark-theme:bg-charcoal-700 border-gray-300 dark-theme:border-charcoal-600'
+            ]"
+          >
+            LoRAs (.pt, sd15 only)
+          </button>
+        </div>
+        <AssetFilterBar :assets="categoryFilteredAssets" />
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive demo showing filter options updating reactively when category changes. Click buttons to see filters adapt to the selected category.'
       }
     }
   }

--- a/src/platform/assets/components/AssetFilterBar.vue
+++ b/src/platform/assets/components/AssetFilterBar.vue
@@ -64,9 +64,8 @@ const fileFormats = ref<SelectOption[]>([])
 const baseModels = ref<SelectOption[]>([])
 const sortBy = ref('name-asc')
 
-const { availableFileFormats, availableBaseModels } = useAssetFilterOptions(
-  () => assets
-)
+const { availableFileFormats, availableBaseModels } =
+  useAssetFilterOptions(assets)
 
 // TODO: Make sortOptions configurable via props
 // Different asset types might need different sorting options

--- a/src/platform/assets/components/AssetFilterBar.vue
+++ b/src/platform/assets/components/AssetFilterBar.vue
@@ -64,16 +64,16 @@ const fileFormats = ref<SelectOption[]>([])
 const baseModels = ref<SelectOption[]>([])
 const sortBy = ref('name-asc')
 
-const { availableFileFormats, availableBaseModels } =
-  useAssetFilterOptions(assets)
+const { availableFileFormats, availableBaseModels } = useAssetFilterOptions(
+  () => assets
+)
 
 // TODO: Make sortOptions configurable via props
 // Different asset types might need different sorting options
 const sortOptions = [
   { name: t('assetBrowser.sortAZ'), value: 'name-asc' },
   { name: t('assetBrowser.sortZA'), value: 'name-desc' },
-  { name: t('assetBrowser.sortRecent'), value: 'recent' },
-  { name: t('assetBrowser.sortPopular'), value: 'popular' }
+  { name: t('assetBrowser.sortRecent'), value: 'recent' }
 ]
 
 const emit = defineEmits<{

--- a/src/platform/assets/components/AssetFilterBar.vue
+++ b/src/platform/assets/components/AssetFilterBar.vue
@@ -67,8 +67,6 @@ const sortBy = ref('name-asc')
 const { availableFileFormats, availableBaseModels } =
   useAssetFilterOptions(assets)
 
-// TODO: Make sortOptions configurable via props
-// Different asset types might need different sorting options
 const sortOptions = [
   { name: t('assetBrowser.sortAZ'), value: 'name-asc' },
   { name: t('assetBrowser.sortZA'), value: 'name-desc' },

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -3,8 +3,6 @@ import { computed, ref } from 'vue'
 import { d, t } from '@/i18n'
 import type { FilterState } from '@/platform/assets/components/AssetFilterBar.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { assetFilenameSchema } from '@/platform/assets/schemas/assetSchema'
-import { assetService } from '@/platform/assets/services/assetService'
 import {
   getAssetBaseModel,
   getAssetDescription
@@ -161,9 +159,13 @@ export function useAssetBrowser(assets: AssetItem[] = []) {
     return category?.label || t('assetBrowser.assets')
   })
 
+  // Category-filtered assets for filter options (before search/format/base model filters)
+  const categoryFilteredAssets = computed(() => {
+    return assets.filter(filterByCategory(selectedCategory.value))
+  })
+
   const filteredAssets = computed(() => {
-    const filtered = assets
-      .filter(filterByCategory(selectedCategory.value))
+    const filtered = categoryFilteredAssets.value
       .filter(filterByQuery(searchQuery.value))
       .filter(filterByFileFormats(filters.value.fileFormats))
       .filter(filterByBaseModels(filters.value.baseModels))
@@ -189,39 +191,6 @@ export function useAssetBrowser(assets: AssetItem[] = []) {
     return filtered.map(transformAssetForDisplay)
   })
 
-  /**
-   * Asset selection that fetches full details and executes callback with AssetItem
-   * @param assetId - The asset ID to select and fetch details for
-   * @param onSelect - Optional callback to execute with the full AssetItem
-   */
-  async function selectAssetWithCallback(
-    assetId: string,
-    onSelect?: (asset: AssetItem) => void
-  ): Promise<void> {
-    if (!onSelect) {
-      return
-    }
-
-    try {
-      const assetDetails = await assetService.getAssetDetails(assetId)
-      const filename = assetDetails.user_metadata?.filename
-      const validatedFilename = assetFilenameSchema.safeParse(filename)
-      if (!validatedFilename.success) {
-        console.error(
-          'Invalid asset filename:',
-          validatedFilename.error.errors,
-          'for asset:',
-          assetId
-        )
-        return
-      }
-
-      onSelect(assetDetails)
-    } catch (error) {
-      console.error(`Failed to fetch asset details for ${assetId}:`, error)
-    }
-  }
-
   function updateFilters(newFilters: FilterState) {
     filters.value = { ...newFilters }
   }
@@ -231,8 +200,8 @@ export function useAssetBrowser(assets: AssetItem[] = []) {
     selectedCategory,
     availableCategories,
     contentTitle,
+    categoryFilteredAssets,
     filteredAssets,
-    selectAssetWithCallback,
     updateFilters
   }
 }

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -190,21 +190,21 @@ export function useAssetBrowser(assets: AssetItem[] = []) {
   })
 
   /**
-   * Asset selection that fetches full details and executes callback with filename
+   * Asset selection that fetches full details and executes callback with AssetItem
    * @param assetId - The asset ID to select and fetch details for
-   * @param onSelect - Optional callback to execute with the asset filename
+   * @param onSelect - Optional callback to execute with the full AssetItem
    */
   async function selectAssetWithCallback(
     assetId: string,
-    onSelect?: (filename: string) => void
+    onSelect?: (asset: AssetItem) => void
   ): Promise<void> {
     if (!onSelect) {
       return
     }
 
     try {
-      const detailAsset = await assetService.getAssetDetails(assetId)
-      const filename = detailAsset.user_metadata?.filename
+      const assetDetails = await assetService.getAssetDetails(assetId)
+      const filename = assetDetails.user_metadata?.filename
       const validatedFilename = assetFilenameSchema.safeParse(filename)
       if (!validatedFilename.success) {
         console.error(
@@ -216,7 +216,7 @@ export function useAssetBrowser(assets: AssetItem[] = []) {
         return
       }
 
-      onSelect(validatedFilename.data)
+      onSelect(assetDetails)
     } catch (error) {
       console.error(`Failed to fetch asset details for ${assetId}:`, error)
     }

--- a/src/platform/assets/composables/useAssetBrowserDialog.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.ts
@@ -1,5 +1,6 @@
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { assetFilenameSchema } from '@/platform/assets/schemas/assetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
 import { type DialogComponentProps, useDialogStore } from '@/stores/dialogStore'
 
@@ -48,8 +49,22 @@ export const useAssetBrowserDialog = () => {
   const dialogKey = 'global-asset-browser'
 
   async function show(props: ShowOptions) {
-    const handleAssetSelected = (filename: string) => {
-      props.onAssetSelected?.(filename)
+    const handleAssetSelected = (asset: AssetItem) => {
+      const filename = asset.user_metadata?.filename
+      const validatedFilename = assetFilenameSchema.safeParse(filename)
+
+      if (!validatedFilename.success) {
+        console.error(
+          'Invalid asset filename:',
+          validatedFilename.error.errors,
+          'for asset:',
+          asset.id
+        )
+        dialogStore.closeDialog({ key: dialogKey })
+        return
+      }
+
+      props.onAssetSelected?.(validatedFilename.data)
       dialogStore.closeDialog({ key: dialogKey })
     }
 

--- a/src/platform/assets/composables/useAssetBrowserDialog.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.ts
@@ -3,7 +3,7 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
 import { type DialogComponentProps, useDialogStore } from '@/stores/dialogStore'
 
-interface AssetBrowserDialogProps {
+interface ShowOptions {
   /** ComfyUI node type for context (e.g., 'CheckpointLoaderSimple') */
   nodeType: string
   /** Widget input name (e.g., 'ckpt_name') */
@@ -17,30 +17,40 @@ interface AssetBrowserDialogProps {
   onAssetSelected?: (filename: string) => void
 }
 
+interface BrowseOptions {
+  /** Asset type tag to filter by (e.g., 'models') */
+  assetType: string
+  /** Custom modal title (optional) */
+  title?: string
+  /** Called when asset selected */
+  onAssetSelected?: (asset: AssetItem) => void
+}
+
+const PROPS: DialogComponentProps = {
+  headless: true,
+  modal: true,
+  closable: true,
+  pt: {
+    root: {
+      class: 'rounded-2xl overflow-hidden asset-browser-dialog'
+    },
+    header: {
+      class: '!p-0 hidden'
+    },
+    content: {
+      class: '!p-0 !m-0 h-full w-full'
+    }
+  }
+}
+
 export const useAssetBrowserDialog = () => {
   const dialogStore = useDialogStore()
   const dialogKey = 'global-asset-browser'
 
-  async function show(props: AssetBrowserDialogProps) {
+  async function show(props: ShowOptions) {
     const handleAssetSelected = (filename: string) => {
       props.onAssetSelected?.(filename)
       dialogStore.closeDialog({ key: dialogKey })
-    }
-    const dialogComponentProps: DialogComponentProps = {
-      headless: true,
-      modal: true,
-      closable: true,
-      pt: {
-        root: {
-          class: 'rounded-2xl overflow-hidden asset-browser-dialog'
-        },
-        header: {
-          class: '!p-0 hidden'
-        },
-        content: {
-          class: '!p-0 !m-0 h-full w-full'
-        }
-      }
     }
 
     const assets: AssetItem[] = await assetService
@@ -65,9 +75,42 @@ export const useAssetBrowserDialog = () => {
         onSelect: handleAssetSelected,
         onClose: () => dialogStore.closeDialog({ key: dialogKey })
       },
-      dialogComponentProps
+      dialogComponentProps: PROPS
     })
   }
 
-  return { show }
+  async function browse(options: BrowseOptions): Promise<void> {
+    const handleAssetSelected = (asset: AssetItem) => {
+      options.onAssetSelected?.(asset)
+      dialogStore.closeDialog({ key: dialogKey })
+    }
+
+    const assets = await assetService
+      .getAssetsByTag(options.assetType)
+      .catch((error) => {
+        console.error(
+          'Failed to fetch assets for tag:',
+          options.assetType,
+          error
+        )
+        return []
+      })
+
+    dialogStore.showDialog({
+      key: dialogKey,
+      component: AssetBrowserModal,
+      props: {
+        nodeType: undefined,
+        inputName: undefined,
+        assets,
+        showLeftPanel: true,
+        title: options.title,
+        onSelect: handleAssetSelected,
+        onClose: () => dialogStore.closeDialog({ key: dialogKey })
+      },
+      dialogComponentProps: PROPS
+    })
+  }
+
+  return { show, browse }
 }

--- a/src/platform/assets/composables/useAssetBrowserDialog.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.ts
@@ -1,3 +1,4 @@
+import { t } from '@/i18n'
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { assetFilenameSchema } from '@/platform/assets/schemas/assetSchema'
@@ -79,6 +80,22 @@ export const useAssetBrowserDialog = () => {
         return []
       })
 
+    // Extract node type category from first asset's tags (e.g., "loras", "checkpoints")
+    // Tags are ordered: ["models", "loras"] so take the second tag
+    const nodeTypeCategory =
+      assets[0]?.tags?.find((tag) => tag !== 'models') ?? 'models'
+
+    // Format category label: replace underscores, handle special acronyms
+    const acronyms = new Set(['vae', 'clip', 'gligen'])
+    const categoryLabel = nodeTypeCategory
+      .split('_')
+      .map((word) =>
+        acronyms.has(word.toLowerCase()) ? word.toUpperCase() : word
+      )
+      .join(' ')
+
+    const title = t('assetBrowser.allCategory', { category: categoryLabel })
+
     dialogStore.showDialog({
       key: dialogKey,
       component: AssetBrowserModal,
@@ -87,6 +104,7 @@ export const useAssetBrowserDialog = () => {
         inputName: props.inputName,
         currentValue: props.currentValue,
         assets,
+        title,
         onSelect: handleAssetSelected,
         onClose: () => dialogStore.closeDialog({ key: dialogKey })
       },

--- a/src/platform/assets/composables/useAssetBrowserDialog.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.ts
@@ -66,13 +66,13 @@ export const useAssetBrowserDialog = () => {
     const nodeTypeCategory =
       assets[0]?.tags?.find((tag) => tag !== 'models') ?? 'models'
 
-    // Format category label: replace underscores, handle special acronyms
-    const acronyms = new Set(['vae', 'clip', 'gligen'])
+    const acronyms = new Set(['VAE', 'CLIP', 'GLIGEN'])
     const categoryLabel = nodeTypeCategory
       .split('_')
-      .map((word) =>
-        acronyms.has(word.toLowerCase()) ? word.toUpperCase() : word
-      )
+      .map((word) => {
+        const uc = word.toUpperCase()
+        return acronyms.has(uc) ? uc : word
+      })
       .join(' ')
 
     const title = t('assetBrowser.allCategory', { category: categoryLabel })

--- a/src/platform/assets/composables/useAssetBrowserDialog.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.ts
@@ -1,7 +1,6 @@
 import { t } from '@/i18n'
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { assetFilenameSchema } from '@/platform/assets/schemas/assetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
 import { type DialogComponentProps, useDialogStore } from '@/stores/dialogStore'
 
@@ -12,11 +11,7 @@ interface ShowOptions {
   inputName: string
   /** Current selected asset value */
   currentValue?: string
-  /**
-   * Callback for when an asset is selected
-   * @param {string} filename - The validated filename from user_metadata.filename
-   */
-  onAssetSelected?: (filename: string) => void
+  onAssetSelected?: (asset: AssetItem) => void
 }
 
 interface BrowseOptions {
@@ -28,7 +23,7 @@ interface BrowseOptions {
   onAssetSelected?: (asset: AssetItem) => void
 }
 
-const PROPS: DialogComponentProps = {
+const dialogComponentProps: DialogComponentProps = {
   headless: true,
   modal: true,
   closable: true,
@@ -43,7 +38,7 @@ const PROPS: DialogComponentProps = {
       class: '!p-0 !m-0 h-full w-full'
     }
   }
-}
+} as const
 
 export const useAssetBrowserDialog = () => {
   const dialogStore = useDialogStore()
@@ -51,21 +46,7 @@ export const useAssetBrowserDialog = () => {
 
   async function show(props: ShowOptions) {
     const handleAssetSelected = (asset: AssetItem) => {
-      const filename = asset.user_metadata?.filename
-      const validatedFilename = assetFilenameSchema.safeParse(filename)
-
-      if (!validatedFilename.success) {
-        console.error(
-          'Invalid asset filename:',
-          validatedFilename.error.errors,
-          'for asset:',
-          asset.id
-        )
-        dialogStore.closeDialog({ key: dialogKey })
-        return
-      }
-
-      props.onAssetSelected?.(validatedFilename.data)
+      props.onAssetSelected?.(asset)
       dialogStore.closeDialog({ key: dialogKey })
     }
 
@@ -108,7 +89,7 @@ export const useAssetBrowserDialog = () => {
         onSelect: handleAssetSelected,
         onClose: () => dialogStore.closeDialog({ key: dialogKey })
       },
-      dialogComponentProps: PROPS
+      dialogComponentProps
     })
   }
 
@@ -141,7 +122,7 @@ export const useAssetBrowserDialog = () => {
         onSelect: handleAssetSelected,
         onClose: () => dialogStore.closeDialog({ key: dialogKey })
       },
-      dialogComponentProps: PROPS
+      dialogComponentProps
     })
   }
 

--- a/src/platform/assets/composables/useAssetFilterOptions.ts
+++ b/src/platform/assets/composables/useAssetFilterOptions.ts
@@ -1,5 +1,5 @@
 import { uniqWith } from 'es-toolkit'
-import { computed } from 'vue'
+import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
 import type { SelectOption } from '@/components/input/types'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
@@ -8,14 +8,14 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
  * Composable that extracts available filter options from asset data
  * Provides reactive computed properties for file formats and base models
  */
-export function useAssetFilterOptions(assetsGetter: () => AssetItem[]) {
+export function useAssetFilterOptions(assets: MaybeRefOrGetter<AssetItem[]>) {
   /**
    * Extract unique file formats from asset names
    * Returns sorted SelectOption array with extensions
    */
   const availableFileFormats = computed<SelectOption[]>(() => {
-    const assets = assetsGetter()
-    const extensions = assets
+    const assetList = toValue(assets)
+    const extensions = assetList
       .map((asset) => {
         const extension = asset.name.split('.').pop()
         return extension && extension !== asset.name ? extension : null
@@ -35,8 +35,8 @@ export function useAssetFilterOptions(assetsGetter: () => AssetItem[]) {
    * Returns sorted SelectOption array with base model names
    */
   const availableBaseModels = computed<SelectOption[]>(() => {
-    const assets = assetsGetter()
-    const models = assets
+    const assetList = toValue(assets)
+    const models = assetList
       .map((asset) => asset.user_metadata?.base_model)
       .filter(
         (baseModel): baseModel is string =>

--- a/src/platform/assets/composables/useAssetFilterOptions.ts
+++ b/src/platform/assets/composables/useAssetFilterOptions.ts
@@ -8,12 +8,13 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
  * Composable that extracts available filter options from asset data
  * Provides reactive computed properties for file formats and base models
  */
-export function useAssetFilterOptions(assets: AssetItem[] = []) {
+export function useAssetFilterOptions(assetsGetter: () => AssetItem[]) {
   /**
    * Extract unique file formats from asset names
    * Returns sorted SelectOption array with extensions
    */
   const availableFileFormats = computed<SelectOption[]>(() => {
+    const assets = assetsGetter()
     const extensions = assets
       .map((asset) => {
         const extension = asset.name.split('.').pop()
@@ -34,6 +35,7 @@ export function useAssetFilterOptions(assets: AssetItem[] = []) {
    * Returns sorted SelectOption array with base model names
    */
   const availableBaseModels = computed<SelectOption[]>(() => {
+    const assets = assetsGetter()
     const models = assets
       .map((asset) => asset.user_metadata?.base_model)
       .filter(

--- a/src/platform/assets/constants.ts
+++ b/src/platform/assets/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Tag applied by cloud API to all model assets
+ */
+export const MODELS_TAG = 'models'
+
+/**
+ * Tag applied by cloud API to assets that are referenced but don't exist on server
+ */
+export const MISSING_TAG = 'missing'

--- a/src/platform/assets/constants.ts
+++ b/src/platform/assets/constants.ts
@@ -1,9 +1,0 @@
-/**
- * Tag applied by cloud API to all model assets
- */
-export const MODELS_TAG = 'models'
-
-/**
- * Tag applied by cloud API to assets that are referenced but don't exist on server
- */
-export const MISSING_TAG = 'missing'

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -42,6 +42,7 @@ export const assetFilenameSchema = z
   .trim()
 
 // Export schemas following repository patterns
+export const assetItemSchema = zAsset
 export const assetResponseSchema = zAssetResponse
 
 // Export types derived from Zod schemas

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -14,11 +14,7 @@ const ASSETS_ENDPOINT = '/assets'
 const MODELS_TAG = 'models'
 const MISSING_TAG = 'missing'
 const EXPERIMENTAL_WARNING = `EXPERIMENTAL: If you are seeing this please make sure "Comfy.Assets.UseAssetAPI" is set to "false" in your ComfyUI Settings.\n`
-
-/**
- * Input names that are eligible for asset browser
- */
-const WHITELISTED_INPUTS = new Set(['ckpt_name', 'lora_name', 'vae_name'])
+const DEFAULT_LIMIT = 300
 
 /**
  * Validates asset response data using Zod schema
@@ -66,7 +62,7 @@ function createAssetService() {
    */
   async function getAssetModelFolders(): Promise<ModelFolder[]> {
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG}`,
+      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG}&limit=${DEFAULT_LIMIT}`,
       'model folders'
     )
 
@@ -95,7 +91,7 @@ function createAssetService() {
    */
   async function getAssetModels(folder: string): Promise<ModelFile[]> {
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG},${folder}`,
+      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG},${folder}&limit=${DEFAULT_LIMIT}`,
       `models for ${folder}`
     )
 
@@ -115,20 +111,11 @@ function createAssetService() {
   /**
    * Checks if a widget input should use the asset browser based on both input name and node comfyClass
    *
-   * @param inputName - The input name (e.g., 'ckpt_name', 'lora_name')
    * @param nodeType - The ComfyUI node comfyClass (e.g., 'CheckpointLoaderSimple', 'LoraLoader')
    * @returns true if this input should use asset browser
    */
-  function isAssetBrowserEligible(
-    inputName: string,
-    nodeType: string
-  ): boolean {
-    return (
-      // Must be an approved input name
-      WHITELISTED_INPUTS.has(inputName) &&
-      // Must be a registered node type
-      useModelToNodeStore().getRegisteredNodeTypes().has(nodeType)
-    )
+  function isAssetBrowserEligible(nodeType: string): boolean {
+    return useModelToNodeStore().getRegisteredNodeTypes().has(nodeType)
   }
 
   /**
@@ -153,7 +140,7 @@ function createAssetService() {
 
     // Fetch assets for this category using same API pattern as getAssetModels
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG},${category}`,
+      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG},${category}&limit=${DEFAULT_LIMIT}`,
       `assets for ${nodeType}`
     )
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -1,6 +1,5 @@
 import { fromZodError } from 'zod-validation-error'
 
-import { MISSING_TAG, MODELS_TAG } from '@/platform/assets/constants'
 import {
   type AssetItem,
   type AssetResponse,
@@ -14,6 +13,9 @@ import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 const ASSETS_ENDPOINT = '/assets'
 const EXPERIMENTAL_WARNING = `EXPERIMENTAL: If you are seeing this please make sure "Comfy.Assets.UseAssetAPI" is set to "false" in your ComfyUI Settings.\n`
 const DEFAULT_LIMIT = 300
+
+export const MODELS_TAG = 'models'
+export const MISSING_TAG = 'missing'
 
 /**
  * Validates asset response data using Zod schema
@@ -113,8 +115,10 @@ function createAssetService() {
    * @param nodeType - The ComfyUI node comfyClass (e.g., 'CheckpointLoaderSimple', 'LoraLoader')
    * @returns true if this input should use asset browser
    */
-  function isAssetBrowserEligible(nodeType: string): boolean {
-    return useModelToNodeStore().getRegisteredNodeTypes().has(nodeType)
+  function isAssetBrowserEligible(nodeType: string = ''): boolean {
+    return (
+      !!nodeType && useModelToNodeStore().getRegisteredNodeTypes().has(nodeType)
+    )
   }
 
   /**

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -1,5 +1,6 @@
 import { fromZodError } from 'zod-validation-error'
 
+import { MISSING_TAG, MODELS_TAG } from '@/platform/assets/constants'
 import {
   type AssetItem,
   type AssetResponse,
@@ -11,8 +12,6 @@ import { api } from '@/scripts/api'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 
 const ASSETS_ENDPOINT = '/assets'
-const MODELS_TAG = 'models'
-const MISSING_TAG = 'missing'
 const EXPERIMENTAL_WARNING = `EXPERIMENTAL: If you are seeing this please make sure "Comfy.Assets.UseAssetAPI" is set to "false" in your ComfyUI Settings.\n`
 const DEFAULT_LIMIT = 300
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -182,12 +182,30 @@ function createAssetService() {
     )
   }
 
+  /**
+   * Gets assets filtered by a specific tag
+   *
+   * @param tag - The tag to filter by (e.g., 'models')
+   * @returns Promise<AssetItem[]> - Full asset objects filtered by tag, excluding missing assets
+   */
+  async function getAssetsByTag(tag: string): Promise<AssetItem[]> {
+    const data = await handleAssetRequest(
+      `${ASSETS_ENDPOINT}?include_tags=${tag}&limit=${DEFAULT_LIMIT}`,
+      `assets for tag ${tag}`
+    )
+
+    return (
+      data?.assets?.filter((asset) => !asset.tags.includes(MISSING_TAG)) ?? []
+    )
+  }
+
   return {
     getAssetModelFolders,
     getAssetModels,
     isAssetBrowserEligible,
     getAssetsForNodeType,
-    getAssetDetails
+    getAssetDetails,
+    getAssetsByTag
   }
 }
 

--- a/src/platform/assets/utils/createModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/createModelNodeFromAsset.ts
@@ -3,8 +3,11 @@ import {
   LiteGraph,
   type Point
 } from '@/lib/litegraph/src/litegraph'
-import { MISSING_TAG, MODELS_TAG } from '@/platform/assets/constants'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import {
+  MISSING_TAG,
+  MODELS_TAG
+} from '@/platform/assets/services/assetService'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'

--- a/src/platform/assets/utils/createModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/createModelNodeFromAsset.ts
@@ -20,59 +20,138 @@ interface CreateNodeOptions {
   position?: Point
 }
 
+type NodeCreationErrorCode =
+  | 'INVALID_ASSET'
+  | 'NO_PROVIDER'
+  | 'NODE_CREATION_FAILED'
+  | 'MISSING_WIDGET'
+  | 'NO_GRAPH'
+
+interface NodeCreationError {
+  code: NodeCreationErrorCode
+  message: string
+  assetId: string
+  details?: Record<string, unknown>
+}
+
+type Result<T, E> = { success: true; value: T } | { success: false; error: E }
+
+/**
+ * Creates a LiteGraph node from an asset item.
+ *
+ * **Boundary Function**: Bridges Vue reactive domain with LiteGraph canvas domain.
+ *
+ * @param asset - Asset item to create node from (Vue domain)
+ * @param options - Optional position and configuration
+ * @returns Result with LiteGraph node (Canvas domain) or error details
+ *
+ * @remarks
+ * This function performs side effects on the canvas graph. Validation failures
+ * return error results rather than throwing to allow graceful degradation in UI contexts.
+ * Widget validation occurs before graph mutation to prevent orphaned nodes.
+ */
 export function createModelNodeFromAsset(
   asset: AssetItem,
   options?: CreateNodeOptions
-): LGraphNode {
+): Result<LGraphNode, NodeCreationError> {
   const validatedAsset = assetItemSchema.safeParse(asset)
 
   if (!validatedAsset.success) {
-    throw new Error(
-      `Invalid asset item: ${validatedAsset.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ')}`
-    )
+    const errorMessage = validatedAsset.error.errors
+      .map((e) => `${e.path.join('.')}: ${e.message}`)
+      .join(', ')
+    console.error('Invalid asset item:', errorMessage)
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ASSET',
+        message: 'Asset schema validation failed',
+        assetId: asset.id,
+        details: { validationErrors: errorMessage }
+      }
+    }
   }
 
   const validAsset = validatedAsset.data
 
   const userMetadata = validAsset.user_metadata
   if (!userMetadata) {
-    throw new Error(`Asset ${validAsset.id} missing required user_metadata`)
+    console.error(`Asset ${validAsset.id} missing required user_metadata`)
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ASSET',
+        message: 'Asset missing required user_metadata',
+        assetId: validAsset.id
+      }
+    }
   }
 
   const filename = userMetadata.filename
   if (typeof filename !== 'string' || filename.length === 0) {
-    throw new Error(
+    console.error(
       `Asset ${validAsset.id} has invalid user_metadata.filename (expected non-empty string, got ${typeof filename})`
     )
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ASSET',
+        message: `Invalid filename (expected non-empty string, got ${typeof filename})`,
+        assetId: validAsset.id
+      }
+    }
   }
 
   if (validAsset.tags.length === 0) {
-    throw new Error(
+    console.error(
       `Asset ${validAsset.id} has no tags defined (expected at least one category tag)`
     )
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ASSET',
+        message: 'Asset has no tags defined',
+        assetId: validAsset.id
+      }
+    }
   }
 
   const category = validAsset.tags.find(
     (tag) => tag !== MODELS_TAG && tag !== MISSING_TAG
   )
   if (!category) {
-    throw new Error(
+    console.error(
       `Asset ${validAsset.id} has no valid category tag. Available tags: ${validAsset.tags.join(', ')} (expected tag other than '${MODELS_TAG}' or '${MISSING_TAG}')`
     )
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ASSET',
+        message: 'Asset has no valid category tag',
+        assetId: validAsset.id,
+        details: { availableTags: validAsset.tags }
+      }
+    }
   }
 
-  // 3. Get node provider for category
   const modelToNodeStore = useModelToNodeStore()
   const provider = modelToNodeStore.getNodeProvider(category)
   if (!provider) {
-    throw new Error(`No node provider registered for category: ${category}`)
+    console.error(`No node provider registered for category: ${category}`)
+    return {
+      success: false,
+      error: {
+        code: 'NO_PROVIDER',
+        message: `No node provider registered for category: ${category}`,
+        assetId: validAsset.id,
+        details: { category }
+      }
+    }
   }
 
-  // 4. Get position (default to canvas center)
   const litegraphService = useLitegraphService()
   const pos = options?.position ?? litegraphService.getCanvasCenter()
 
-  // 5. Create node
   const node = LiteGraph.createNode(
     provider.nodeDef.name,
     provider.nodeDef.display_name,
@@ -80,30 +159,53 @@ export function createModelNodeFromAsset(
   )
 
   if (!node) {
-    throw new Error(`Failed to create node for type: ${provider.nodeDef.name}`)
+    console.error(`Failed to create node for type: ${provider.nodeDef.name}`)
+    return {
+      success: false,
+      error: {
+        code: 'NODE_CREATION_FAILED',
+        message: `Failed to create node for type: ${provider.nodeDef.name}`,
+        assetId: validAsset.id,
+        details: { nodeType: provider.nodeDef.name }
+      }
+    }
   }
 
-  // 6. Add node to appropriate graph
   const workflowStore = useWorkflowStore()
   const targetGraph = workflowStore.isSubgraphActive
     ? workflowStore.activeSubgraph
     : app.canvas.graph
 
   if (!targetGraph) {
-    throw new Error('No active graph available')
+    console.error('No active graph available')
+    return {
+      success: false,
+      error: {
+        code: 'NO_GRAPH',
+        message: 'No active graph available',
+        assetId: validAsset.id
+      }
+    }
+  }
+
+  const widget = node.widgets?.find((w) => w.name === provider.key)
+  if (!widget) {
+    console.error(
+      `Widget ${provider.key} not found on node ${provider.nodeDef.name}`
+    )
+    return {
+      success: false,
+      error: {
+        code: 'MISSING_WIDGET',
+        message: `Widget ${provider.key} not found on node ${provider.nodeDef.name}`,
+        assetId: validAsset.id,
+        details: { widgetName: provider.key, nodeType: provider.nodeDef.name }
+      }
+    }
   }
 
   targetGraph.add(node)
+  widget.value = filename
 
-  // 7. Set widget value
-  const widget = node.widgets?.find((w) => w.name === provider.key)
-  if (!widget) {
-    console.warn(
-      `Widget ${provider.key} not found on node ${provider.nodeDef.name}`
-    )
-  } else {
-    widget.value = filename
-  }
-
-  return node
+  return { success: true, value: node }
 }

--- a/src/platform/assets/utils/createModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/createModelNodeFromAsset.ts
@@ -1,0 +1,94 @@
+import {
+  type LGraphNode,
+  LiteGraph,
+  type Point
+} from '@/lib/litegraph/src/litegraph'
+import { MISSING_TAG, MODELS_TAG } from '@/platform/assets/constants'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
+import { useLitegraphService } from '@/services/litegraphService'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+
+interface CreateNodeOptions {
+  position?: Point
+}
+
+export function createModelNodeFromAsset(
+  asset: AssetItem,
+  options?: CreateNodeOptions
+): LGraphNode {
+  // 1. Validate filename exists
+  const userMetadata: Record<string, unknown> | undefined = asset.user_metadata
+  if (!userMetadata) {
+    throw new Error(`Asset ${asset.id} missing required user_metadata`)
+  }
+
+  const filename = userMetadata.filename
+  if (typeof filename !== 'string' || filename.length === 0) {
+    throw new Error(
+      `Asset ${asset.id} has invalid user_metadata.filename (expected non-empty string, got ${typeof filename})`
+    )
+  }
+
+  // 2. Extract category from tags
+  const tags = asset.tags
+  if (!tags || tags.length === 0) {
+    throw new Error(
+      `Asset ${asset.id} has no tags defined (expected at least one category tag)`
+    )
+  }
+
+  const category = tags.find((tag) => tag !== MODELS_TAG && tag !== MISSING_TAG)
+  if (!category) {
+    throw new Error(
+      `Asset ${asset.id} has no valid category tag. Available tags: ${tags.join(', ')} (expected tag other than '${MODELS_TAG}' or '${MISSING_TAG}')`
+    )
+  }
+
+  // 3. Get node provider for category
+  const modelToNodeStore = useModelToNodeStore()
+  const provider = modelToNodeStore.getNodeProvider(category)
+  if (!provider) {
+    throw new Error(`No node provider registered for category: ${category}`)
+  }
+
+  // 4. Get position (default to canvas center)
+  const litegraphService = useLitegraphService()
+  const pos = options?.position ?? litegraphService.getCanvasCenter()
+
+  // 5. Create node
+  const node = LiteGraph.createNode(
+    provider.nodeDef.name,
+    provider.nodeDef.display_name,
+    { pos }
+  )
+
+  if (!node) {
+    throw new Error(`Failed to create node for type: ${provider.nodeDef.name}`)
+  }
+
+  // 6. Add node to appropriate graph
+  const workflowStore = useWorkflowStore()
+  const targetGraph = workflowStore.isSubgraphActive
+    ? workflowStore.activeSubgraph
+    : app.canvas.graph
+
+  if (!targetGraph) {
+    throw new Error('No active graph available')
+  }
+
+  targetGraph.add(node)
+
+  // 7. Set widget value
+  const widget = node.widgets?.find((w) => w.name === provider.key)
+  if (!widget) {
+    console.warn(
+      `Widget ${provider.key} not found on node ${provider.nodeDef.name}`
+    )
+  } else {
+    widget.value = filename
+  }
+
+  return node
+}

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -62,10 +62,7 @@ const addComboWidget = (
 ): IBaseWidget => {
   const settingStore = useSettingStore()
   const isUsingAssetAPI = settingStore.get('Comfy.Assets.UseAssetAPI')
-  const isEligible = assetService.isAssetBrowserEligible(
-    inputSpec.name,
-    node.comfyClass || ''
-  )
+  const isEligible = assetService.isAssetBrowserEligible(node.comfyClass ?? '')
 
   if (isUsingAssetAPI && isEligible) {
     // Get the default value for the button text (currently selected model)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -63,7 +63,7 @@ const addComboWidget = (
 ): IBaseWidget => {
   const settingStore = useSettingStore()
   const isUsingAssetAPI = settingStore.get('Comfy.Assets.UseAssetAPI')
-  const isEligible = assetService.isAssetBrowserEligible(node.comfyClass ?? '')
+  const isEligible = assetService.isAssetBrowserEligible(node.comfyClass)
 
   if (isUsingAssetAPI && isEligible) {
     const currentValue = getDefaultValue(inputSpec)

--- a/src/stores/workspace/sidebarTabStore.ts
+++ b/src/stores/workspace/sidebarTabStore.ts
@@ -72,10 +72,9 @@ export const useSidebarTabStore = defineStore('sidebarTab', () => {
           tab.id === 'model-library' &&
           settingStore.get('Comfy.Assets.UseAssetAPI')
         ) {
-          const browseCommand = commandStore.commands.find(
-            (cmd) => cmd.id === 'Comfy.BrowseModelAssets'
-          )
-          await browseCommand?.function()
+          await commandStore.commands
+            .find((cmd) => cmd.id === 'Comfy.BrowseModelAssets')
+            ?.function?.()
           return
         }
 

--- a/src/stores/workspace/sidebarTabStore.ts
+++ b/src/stores/workspace/sidebarTabStore.ts
@@ -5,6 +5,7 @@ import { useModelLibrarySidebarTab } from '@/composables/sidebarTabs/useModelLib
 import { useNodeLibrarySidebarTab } from '@/composables/sidebarTabs/useNodeLibrarySidebarTab'
 import { useQueueSidebarTab } from '@/composables/sidebarTabs/useQueueSidebarTab'
 import { t, te } from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useWorkflowsSidebarTab } from '@/platform/workflow/management/composables/useWorkflowsSidebarTab'
 import { useCommandStore } from '@/stores/commandStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
@@ -63,7 +64,21 @@ export const useSidebarTabStore = defineStore('sidebarTab', () => {
       tooltip: tooltipFunction,
       versionAdded: '1.3.9',
       category: 'view-controls' as const,
-      function: () => {
+      function: async () => {
+        const settingStore = useSettingStore()
+        const commandStore = useCommandStore()
+
+        if (
+          tab.id === 'model-library' &&
+          settingStore.get('Comfy.Assets.UseAssetAPI')
+        ) {
+          const browseCommand = commandStore.commands.find(
+            (cmd) => cmd.id === 'Comfy.BrowseModelAssets'
+          )
+          await browseCommand?.function()
+          return
+        }
+
         toggleSidebarTab(tab.id)
       },
       active: () => activeSidebarTab.value?.id === tab.id,

--- a/tests-ui/platform/assets/components/AssetBrowserModal.test.ts
+++ b/tests-ui/platform/assets/components/AssetBrowserModal.test.ts
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
 
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
@@ -75,6 +74,9 @@ vi.mock('@/components/widget/panel/LeftSidePanel.vue', () => ({
     emits: ['update:modelValue'],
     template: `
       <div data-testid="left-side-panel">
+        <div v-if="$slots['header-title']" data-testid="header-title">
+          <slot name="header-title" />
+        </div>
         <button
           v-for="item in navItems"
           :key="item.id"
@@ -185,99 +187,33 @@ describe('AssetBrowserModal', () => {
     })
   }
 
-  describe('Search Functionality', () => {
-    it('filters assets when search query changes', async () => {
+  describe('Integration with useAssetBrowser', () => {
+    it('passes filteredAssets from composable to AssetGrid', () => {
       const assets = [
-        createTestAsset('asset1', 'Checkpoint Model A', 'checkpoints'),
-        createTestAsset('asset2', 'Checkpoint Model B', 'checkpoints'),
-        createTestAsset('asset3', 'LoRA Model C', 'loras')
+        createTestAsset('asset1', 'Model A', 'checkpoints'),
+        createTestAsset('asset2', 'Model B', 'loras')
       ]
       const wrapper = createWrapper(assets)
-
-      const searchBox = wrapper.find('[data-testid="search-box"]')
-
-      // Search for "Checkpoint"
-      await searchBox.setValue('Checkpoint')
-      await nextTick()
-
-      // Should filter to only checkpoint assets
-      const assetGrid = wrapper.findComponent({ name: 'AssetGrid' })
-      const filteredAssets = assetGrid.props('assets') as AssetDisplayItem[]
-
-      expect(filteredAssets.length).toBe(2)
-      expect(
-        filteredAssets.every((asset: AssetDisplayItem) =>
-          asset.name.includes('Checkpoint')
-        )
-      ).toBe(true)
-    })
-
-    it('search is case insensitive', async () => {
-      const assets = [
-        createTestAsset('asset1', 'LoRA Model C', 'loras'),
-        createTestAsset('asset2', 'Checkpoint Model', 'checkpoints')
-      ]
-      const wrapper = createWrapper(assets)
-
-      const searchBox = wrapper.find('[data-testid="search-box"]')
-
-      // Search with different case
-      await searchBox.setValue('lora')
-      await nextTick()
 
       const assetGrid = wrapper.findComponent({ name: 'AssetGrid' })
-      const filteredAssets = assetGrid.props('assets') as AssetDisplayItem[]
+      const gridAssets = assetGrid.props('assets') as AssetDisplayItem[]
 
-      expect(filteredAssets.length).toBe(1)
-      expect(filteredAssets[0].name).toContain('LoRA')
+      expect(gridAssets).toHaveLength(2)
+      expect(gridAssets[0].id).toBe('asset1')
     })
 
-    it('shows empty state when search has no results', async () => {
+    it('passes categoryFilteredAssets to AssetFilterBar', () => {
       const assets = [
-        createTestAsset('asset1', 'Checkpoint Model', 'checkpoints')
-      ]
-      const wrapper = createWrapper(assets)
-
-      const searchBox = wrapper.find('[data-testid="search-box"]')
-
-      // Search for something that doesn't exist
-      await searchBox.setValue('nonexistent')
-      await nextTick()
-
-      expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true)
-    })
-  })
-
-  describe('Category Navigation', () => {
-    it('filters assets by selected category', async () => {
-      const assets = [
-        createTestAsset('asset1', 'Checkpoint Model A', 'checkpoints'),
-        createTestAsset('asset2', 'LoRA Model C', 'loras'),
-        createTestAsset('asset3', 'VAE Model D', 'vae')
+        createTestAsset('c1', 'model.safetensors', 'checkpoints'),
+        createTestAsset('l1', 'lora.pt', 'loras')
       ]
       const wrapper = createWrapper(assets, { showLeftPanel: true })
 
-      // Wait for Vue reactivity and component mounting
-      await nextTick()
+      const filterBar = wrapper.findComponent({ name: 'AssetFilterBar' })
+      const filterBarAssets = filterBar.props('assets')
 
-      // Check if left panel exists first (since we have multiple categories)
-      const leftPanel = wrapper.find('[data-testid="left-panel"]')
-      expect(leftPanel.exists()).toBe(true)
-
-      // Check if the nav item exists before clicking
-      const lorasNavItem = wrapper.find('[data-testid="nav-item-loras"]')
-      expect(lorasNavItem.exists()).toBe(true)
-
-      // Click the loras category
-      await lorasNavItem.trigger('click')
-      await nextTick()
-
-      // Should filter to only LoRA assets
-      const assetGrid = wrapper.findComponent({ name: 'AssetGrid' })
-      const filteredAssets = assetGrid.props('assets') as AssetDisplayItem[]
-
-      expect(filteredAssets.length).toBe(1)
-      expect(filteredAssets[0].name).toContain('LoRA')
+      // Should initially show all assets
+      expect(filterBarAssets).toHaveLength(2)
     })
   })
 
@@ -378,6 +314,27 @@ describe('AssetBrowserModal', () => {
       expect(
         filterBarAssets.every((a: AssetItem) => a.tags.includes('checkpoints'))
       ).toBe(true)
+    })
+  })
+
+  describe('Title Management', () => {
+    it('passes custom title to BaseModalLayout when title prop provided', () => {
+      const assets = [createTestAsset('asset1', 'Test Model', 'checkpoints')]
+      const customTitle = 'Model Library'
+      const wrapper = createWrapper(assets, { title: customTitle })
+
+      const baseModal = wrapper.findComponent({ name: 'BaseModalLayout' })
+      expect(baseModal.props('contentTitle')).toBe(customTitle)
+    })
+
+    it('passes computed contentTitle to BaseModalLayout when no title prop', () => {
+      const assets = [createTestAsset('asset1', 'Test Model', 'checkpoints')]
+      const wrapper = createWrapper(assets)
+
+      const baseModal = wrapper.findComponent({ name: 'BaseModalLayout' })
+      // Should use contentTitle from useAssetBrowser (e.g., "All Models")
+      expect(baseModal.props('contentTitle')).toBeTruthy()
+      expect(baseModal.props('contentTitle')).not.toBe('')
     })
   })
 })

--- a/tests-ui/platform/assets/components/AssetBrowserModal.test.ts
+++ b/tests-ui/platform/assets/components/AssetBrowserModal.test.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
-import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
 // Mock @/i18n for useAssetBrowser and AssetFilterBar
@@ -98,7 +97,7 @@ vi.mock('@/platform/assets/components/AssetFilterBar.vue', () => ({
     emits: ['filter-change'],
     template: `
       <div data-testid="asset-filter-bar">
-        Filter bar with {{ assets ? assets.length : 0 }} assets
+        Filter bar with {{ assets?.length ?? 0 }} assets
       </div>
     `
   }
@@ -196,7 +195,7 @@ describe('AssetBrowserModal', () => {
       const wrapper = createWrapper(assets)
 
       const assetGrid = wrapper.findComponent({ name: 'AssetGrid' })
-      const gridAssets = assetGrid.props('assets') as AssetDisplayItem[]
+      const gridAssets = assetGrid.props('assets')
 
       expect(gridAssets).toHaveLength(2)
       expect(gridAssets[0].id).toBe('asset1')
@@ -229,7 +228,7 @@ describe('AssetBrowserModal', () => {
       expect(emitted).toBeDefined()
       expect(emitted).toHaveLength(1)
 
-      const emittedAsset = emitted![0][0] as AssetDisplayItem
+      const emittedAsset = emitted![0][0] as AssetItem
       expect(emittedAsset.id).toBe('asset1')
     })
 
@@ -309,7 +308,6 @@ describe('AssetBrowserModal', () => {
       const updatedFilterBar = wrapper.findComponent({ name: 'AssetFilterBar' })
       const filterBarAssets = updatedFilterBar.props('assets')
 
-      // Should only have checkpoints (both .safetensors)
       expect(filterBarAssets).toHaveLength(2)
       expect(
         filterBarAssets.every((a: AssetItem) => a.tags.includes('checkpoints'))

--- a/tests-ui/platform/assets/composables/useAssetBrowser.test.ts
+++ b/tests-ui/platform/assets/composables/useAssetBrowser.test.ts
@@ -259,28 +259,26 @@ describe('useAssetBrowser', () => {
   })
 
   describe('Async Asset Selection with Detail Fetching', () => {
-    it('should fetch asset details and call onSelect with filename when provided', async () => {
+    it('should fetch asset details and call onSelect with full AssetItem', async () => {
       const onSelectSpy = vi.fn()
       const asset = createApiAsset({
         id: 'asset-123',
         name: 'test-model.safetensors'
       })
 
-      const detailAsset = createApiAsset({
+      const assetDetails = createApiAsset({
         id: 'asset-123',
         name: 'test-model.safetensors',
         user_metadata: { filename: 'checkpoints/test-model.safetensors' }
       })
-      vi.mocked(assetService.getAssetDetails).mockResolvedValue(detailAsset)
+      vi.mocked(assetService.getAssetDetails).mockResolvedValue(assetDetails)
 
       const { selectAssetWithCallback } = useAssetBrowser([asset])
 
       await selectAssetWithCallback(asset.id, onSelectSpy)
 
       expect(assetService.getAssetDetails).toHaveBeenCalledWith('asset-123')
-      expect(onSelectSpy).toHaveBeenCalledWith(
-        'checkpoints/test-model.safetensors'
-      )
+      expect(onSelectSpy).toHaveBeenCalledWith(assetDetails)
     })
 
     it('should handle missing user_metadata.filename as error', async () => {
@@ -290,11 +288,11 @@ describe('useAssetBrowser', () => {
       const onSelectSpy = vi.fn()
       const asset = createApiAsset({ id: 'asset-456' })
 
-      const detailAsset = createApiAsset({
+      const assetDetails = createApiAsset({
         id: 'asset-456',
         user_metadata: { filename: '' } // Invalid empty filename
       })
-      vi.mocked(assetService.getAssetDetails).mockResolvedValue(detailAsset)
+      vi.mocked(assetService.getAssetDetails).mockResolvedValue(assetDetails)
 
       const { selectAssetWithCallback } = useAssetBrowser([asset])
 
@@ -367,9 +365,7 @@ describe('useAssetBrowser', () => {
       const { selectAssetWithCallback } = useAssetBrowser([testAsset])
       await selectAssetWithCallback(testAsset.id, onSelectSpy)
 
-      expect(onSelectSpy).toHaveBeenCalledWith(
-        'models/checkpoints/v1/test-model.safetensors'
-      )
+      expect(onSelectSpy).toHaveBeenCalledWith(detailAsset)
     })
 
     it('rejects directory traversal attacks', async () => {

--- a/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -43,28 +43,18 @@ function createMockAsset(overrides: Partial<AssetItem> = {}): AssetItem {
 function setupDialogMocks() {
   const mockShowDialog = vi.fn()
   const mockCloseDialog = vi.fn()
-  vi.mocked(useDialogStore).mockReturnValue({
+  vi.mocked(useDialogStore, { partial: true }).mockReturnValue({
     showDialog: mockShowDialog,
     closeDialog: mockCloseDialog
-  } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-    typeof useDialogStore
-  >)
+  })
+
   return { mockShowDialog, mockCloseDialog }
 }
 
 describe('useAssetBrowserDialog', () => {
   describe('Asset Selection Flow', () => {
     it('auto-closes dialog when asset is selected', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
+      const { mockShowDialog, mockCloseDialog } = setupDialogMocks()
       const assetBrowserDialog = useAssetBrowserDialog()
       const onAssetSelected = vi.fn()
 
@@ -94,16 +84,7 @@ describe('useAssetBrowserDialog', () => {
     })
 
     it('closes dialog when close handler is called', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
+      const { mockShowDialog, mockCloseDialog } = setupDialogMocks()
       const assetBrowserDialog = useAssetBrowserDialog()
 
       await assetBrowserDialog.show({
@@ -124,16 +105,7 @@ describe('useAssetBrowserDialog', () => {
 
   describe('.browse() method', () => {
     it('opens asset browser dialog with tag-based filtering', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
+      const { mockShowDialog } = setupDialogMocks()
       const assetBrowserDialog = useAssetBrowserDialog()
       await assetBrowserDialog.browse({
         assetType: 'models',
@@ -151,76 +123,43 @@ describe('useAssetBrowserDialog', () => {
     })
 
     it('calls onAssetSelected callback when asset is selected', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
+      const { mockShowDialog } = setupDialogMocks()
+      const assetBrowserDialog = useAssetBrowserDialog()
       const mockAsset = createMockAsset()
       const onAssetSelected = vi.fn()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
-      const assetBrowserDialog = useAssetBrowserDialog()
       await assetBrowserDialog.browse({
         assetType: 'models',
         onAssetSelected
       })
 
-      // Get the onSelect handler that was passed to the dialog
       const dialogCall = mockShowDialog.mock.calls[0][0]
       const onSelectHandler = dialogCall.props.onSelect
 
-      // Simulate asset selection by passing the asset object
       onSelectHandler(mockAsset)
 
-      // Should call the callback with the full AssetItem
       expect(onAssetSelected).toHaveBeenCalledWith(mockAsset)
     })
 
     it('closes dialog after asset selection', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
-      const mockAsset = createMockAsset()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
+      const { mockShowDialog, mockCloseDialog } = setupDialogMocks()
       const assetBrowserDialog = useAssetBrowserDialog()
+      const mockAsset = createMockAsset()
       await assetBrowserDialog.browse({
         assetType: 'models'
       })
 
-      // Get the onSelect handler
       const dialogCall = mockShowDialog.mock.calls[0][0]
       const onSelectHandler = dialogCall.props.onSelect
 
-      // Simulate asset selection
       onSelectHandler(mockAsset)
 
-      // Should close dialog
       expect(mockCloseDialog).toHaveBeenCalledWith({
         key: 'global-asset-browser'
       })
     })
 
     it('uses custom title when provided', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
+      const { mockShowDialog } = setupDialogMocks()
       const assetBrowserDialog = useAssetBrowserDialog()
       await assetBrowserDialog.browse({
         assetType: 'models',
@@ -232,18 +171,7 @@ describe('useAssetBrowserDialog', () => {
     })
 
     it('calls getAssetsByTag with correct assetType parameter', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
-
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
-      mockGetAssetsByTag.mockClear()
-
+      setupDialogMocks()
       const assetBrowserDialog = useAssetBrowserDialog()
       await assetBrowserDialog.browse({
         assetType: 'models'
@@ -253,23 +181,14 @@ describe('useAssetBrowserDialog', () => {
     })
 
     it('passes fetched assets to dialog props', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
+      const { mockShowDialog } = setupDialogMocks()
+      const assetBrowserDialog = useAssetBrowserDialog()
       const mockAssets = [
         createMockAsset({ id: 'asset-1', name: 'model1.safetensors' }),
         createMockAsset({ id: 'asset-2', name: 'model2.safetensors' })
       ]
 
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
       mockGetAssetsByTag.mockResolvedValueOnce(mockAssets)
-
-      const assetBrowserDialog = useAssetBrowserDialog()
       await assetBrowserDialog.browse({
         assetType: 'models'
       })
@@ -279,32 +198,21 @@ describe('useAssetBrowserDialog', () => {
     })
 
     it('handles asset fetch errors gracefully', async () => {
-      const mockShowDialog = vi.fn()
-      const mockCloseDialog = vi.fn()
+      const { mockShowDialog } = setupDialogMocks()
+      const assetBrowserDialog = useAssetBrowserDialog()
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {})
 
-      vi.mocked(useDialogStore).mockReturnValue({
-        showDialog: mockShowDialog,
-        closeDialog: mockCloseDialog
-      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-        typeof useDialogStore
-      >)
-
       mockGetAssetsByTag.mockRejectedValueOnce(new Error('Network error'))
-
-      const assetBrowserDialog = useAssetBrowserDialog()
       await assetBrowserDialog.browse({
         assetType: 'models'
       })
 
-      // Should still open dialog with empty assets
       expect(mockShowDialog).toHaveBeenCalled()
       const dialogCall = mockShowDialog.mock.calls[0][0]
       expect(dialogCall.props.assets).toEqual([])
 
-      // Should log error
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Failed to fetch assets for tag:',
         'models',

--- a/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -55,7 +55,6 @@ function setupDialogMocks() {
 describe('useAssetBrowserDialog', () => {
   describe('Asset Selection Flow', () => {
     it('auto-closes dialog when asset is selected', async () => {
-      // Create fresh mocks for this test
       const mockShowDialog = vi.fn()
       const mockCloseDialog = vi.fn()
 
@@ -75,11 +74,9 @@ describe('useAssetBrowserDialog', () => {
         onAssetSelected
       })
 
-      // Get the onSelect handler that was passed to the dialog
       const dialogCall = mockShowDialog.mock.calls[0][0]
       const onSelectHandler = dialogCall.props.onSelect
 
-      // Simulate asset selection with AssetItem
       const mockAsset = {
         id: 'test-asset-id',
         name: 'test.safetensors',
@@ -90,15 +87,13 @@ describe('useAssetBrowserDialog', () => {
       }
       onSelectHandler(mockAsset)
 
-      // Should call the original callback with extracted filename
-      expect(onAssetSelected).toHaveBeenCalledWith('selected-asset-path')
+      expect(onAssetSelected).toHaveBeenCalledWith(mockAsset)
       expect(mockCloseDialog).toHaveBeenCalledWith({
         key: 'global-asset-browser'
       })
     })
 
     it('closes dialog when close handler is called', async () => {
-      // Create fresh mocks for this test
       const mockShowDialog = vi.fn()
       const mockCloseDialog = vi.fn()
 
@@ -116,11 +111,9 @@ describe('useAssetBrowserDialog', () => {
         inputName: 'ckpt_name'
       })
 
-      // Get the onClose handler that was passed to the dialog
       const dialogCall = mockShowDialog.mock.calls[0][0]
       const onCloseHandler = dialogCall.props.onClose
 
-      // Simulate dialog close
       onCloseHandler()
 
       expect(mockCloseDialog).toHaveBeenCalledWith({

--- a/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -43,10 +43,18 @@ describe('useAssetBrowserDialog', () => {
       const dialogCall = mockShowDialog.mock.calls[0][0]
       const onSelectHandler = dialogCall.props.onSelect
 
-      // Simulate asset selection
-      onSelectHandler('selected-asset-path')
+      // Simulate asset selection with AssetItem
+      const mockAsset = {
+        id: 'test-asset-id',
+        name: 'test.safetensors',
+        size: 1024,
+        created_at: '2025-10-01T00:00:00Z',
+        tags: ['models', 'checkpoints'],
+        user_metadata: { filename: 'selected-asset-path' }
+      }
+      onSelectHandler(mockAsset)
 
-      // Should call the original callback and trigger hide animation
+      // Should call the original callback with extracted filename
       expect(onAssetSelected).toHaveBeenCalledWith('selected-asset-path')
       expect(mockCloseDialog).toHaveBeenCalledWith({
         key: 'global-asset-browser'
@@ -258,7 +266,9 @@ describe('useAssetBrowserDialog', () => {
     it('handles asset fetch errors gracefully', async () => {
       const mockShowDialog = vi.fn()
       const mockCloseDialog = vi.fn()
-      const consoleErrorSpy = vi.spyOn(console, 'error')
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
 
       vi.mocked(useDialogStore).mockReturnValue({
         showDialog: mockShowDialog,

--- a/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/tests-ui/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -1,34 +1,20 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
-// Mock the dialog store
 vi.mock('@/stores/dialogStore')
 
-// Mock the asset service
 vi.mock('@/platform/assets/services/assetService', () => ({
   assetService: {
-    getAssetsForNodeType: vi.fn().mockResolvedValue([])
+    getAssetsForNodeType: vi.fn().mockResolvedValue([]),
+    getAssetsByTag: vi.fn().mockResolvedValue([])
   }
 }))
 
-// Test factory functions
-interface AssetBrowserProps {
-  nodeType: string
-  inputName: string
-  onAssetSelected?: (filename: string) => void
-}
-
-function createAssetBrowserProps(
-  overrides: Partial<AssetBrowserProps> = {}
-): AssetBrowserProps {
-  return {
-    nodeType: 'CheckpointLoaderSimple',
-    inputName: 'ckpt_name',
-    ...overrides
-  }
-}
+const { assetService } = await import('@/platform/assets/services/assetService')
+const mockGetAssetsByTag = vi.mocked(assetService.getAssetsByTag)
 
 describe('useAssetBrowserDialog', () => {
   describe('Asset Selection Flow', () => {
@@ -46,9 +32,12 @@ describe('useAssetBrowserDialog', () => {
 
       const assetBrowserDialog = useAssetBrowserDialog()
       const onAssetSelected = vi.fn()
-      const props = createAssetBrowserProps({ onAssetSelected })
 
-      await assetBrowserDialog.show(props)
+      await assetBrowserDialog.show({
+        nodeType: 'CheckpointLoaderSimple',
+        inputName: 'ckpt_name',
+        onAssetSelected
+      })
 
       // Get the onSelect handler that was passed to the dialog
       const dialogCall = mockShowDialog.mock.calls[0][0]
@@ -77,9 +66,11 @@ describe('useAssetBrowserDialog', () => {
       >)
 
       const assetBrowserDialog = useAssetBrowserDialog()
-      const props = createAssetBrowserProps()
 
-      await assetBrowserDialog.show(props)
+      await assetBrowserDialog.show({
+        nodeType: 'CheckpointLoaderSimple',
+        inputName: 'ckpt_name'
+      })
 
       // Get the onClose handler that was passed to the dialog
       const dialogCall = mockShowDialog.mock.calls[0][0]
@@ -91,6 +82,211 @@ describe('useAssetBrowserDialog', () => {
       expect(mockCloseDialog).toHaveBeenCalledWith({
         key: 'global-asset-browser'
       })
+    })
+  })
+
+  describe('.browse() method', () => {
+    function createMockAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+      return {
+        id: 'asset-123',
+        name: 'test-model.safetensors',
+        size: 1024,
+        created_at: '2025-10-01T00:00:00Z',
+        tags: ['models', 'checkpoints'],
+        user_metadata: {
+          filename: 'models/checkpoints/test-model.safetensors'
+        },
+        ...overrides
+      }
+    }
+
+    it('opens asset browser dialog with tag-based filtering', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models',
+        title: 'Model Library'
+      })
+
+      expect(mockShowDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'global-asset-browser',
+          props: expect.objectContaining({
+            showLeftPanel: true
+          })
+        })
+      )
+    })
+
+    it('calls onAssetSelected callback when asset is selected', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+      const mockAsset = createMockAsset()
+      const onAssetSelected = vi.fn()
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models',
+        onAssetSelected
+      })
+
+      // Get the onSelect handler that was passed to the dialog
+      const dialogCall = mockShowDialog.mock.calls[0][0]
+      const onSelectHandler = dialogCall.props.onSelect
+
+      // Simulate asset selection by passing the asset object
+      onSelectHandler(mockAsset)
+
+      // Should call the callback with the full AssetItem
+      expect(onAssetSelected).toHaveBeenCalledWith(mockAsset)
+    })
+
+    it('closes dialog after asset selection', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+      const mockAsset = createMockAsset()
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models'
+      })
+
+      // Get the onSelect handler
+      const dialogCall = mockShowDialog.mock.calls[0][0]
+      const onSelectHandler = dialogCall.props.onSelect
+
+      // Simulate asset selection
+      onSelectHandler(mockAsset)
+
+      // Should close dialog
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'global-asset-browser'
+      })
+    })
+
+    it('uses custom title when provided', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models',
+        title: 'Custom Model Browser'
+      })
+
+      const dialogCall = mockShowDialog.mock.calls[0][0]
+      expect(dialogCall.props.title).toBe('Custom Model Browser')
+    })
+
+    it('calls getAssetsByTag with correct assetType parameter', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      mockGetAssetsByTag.mockClear()
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models'
+      })
+
+      expect(mockGetAssetsByTag).toHaveBeenCalledWith('models')
+    })
+
+    it('passes fetched assets to dialog props', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+      const mockAssets = [
+        createMockAsset({ id: 'asset-1', name: 'model1.safetensors' }),
+        createMockAsset({ id: 'asset-2', name: 'model2.safetensors' })
+      ]
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      mockGetAssetsByTag.mockResolvedValueOnce(mockAssets)
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models'
+      })
+
+      const dialogCall = mockShowDialog.mock.calls[0][0]
+      expect(dialogCall.props.assets).toEqual(mockAssets)
+    })
+
+    it('handles asset fetch errors gracefully', async () => {
+      const mockShowDialog = vi.fn()
+      const mockCloseDialog = vi.fn()
+      const consoleErrorSpy = vi.spyOn(console, 'error')
+
+      vi.mocked(useDialogStore).mockReturnValue({
+        showDialog: mockShowDialog,
+        closeDialog: mockCloseDialog
+      } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
+        typeof useDialogStore
+      >)
+
+      mockGetAssetsByTag.mockRejectedValueOnce(new Error('Network error'))
+
+      const assetBrowserDialog = useAssetBrowserDialog()
+      await assetBrowserDialog.browse({
+        assetType: 'models'
+      })
+
+      // Should still open dialog with empty assets
+      expect(mockShowDialog).toHaveBeenCalled()
+      const dialogCall = mockShowDialog.mock.calls[0][0]
+      expect(dialogCall.props.assets).toEqual([])
+
+      // Should log error
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to fetch assets for tag:',
+        'models',
+        expect.any(Error)
+      )
+
+      consoleErrorSpy.mockRestore()
     })
   })
 })

--- a/tests-ui/platform/assets/composables/useAssetFilterOptions.test.ts
+++ b/tests-ui/platform/assets/composables/useAssetFilterOptions.test.ts
@@ -18,7 +18,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificExtension('pt')
       ]
 
-      const { availableFileFormats } = useAssetFilterOptions(assets)
+      const { availableFileFormats } = useAssetFilterOptions(() => assets)
 
       expect(availableFileFormats.value).toEqual([
         { name: '.ckpt', value: 'ckpt' },
@@ -34,7 +34,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificExtension('ckpt')
       ]
 
-      const { availableFileFormats } = useAssetFilterOptions(assets)
+      const { availableFileFormats } = useAssetFilterOptions(() => assets)
 
       expect(availableFileFormats.value).toEqual([
         { name: '.ckpt', value: 'ckpt' },
@@ -48,7 +48,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificExtension('safetensors')
       ]
 
-      const { availableFileFormats } = useAssetFilterOptions(assets)
+      const { availableFileFormats } = useAssetFilterOptions(() => assets)
 
       expect(availableFileFormats.value).toEqual([
         { name: '.safetensors', value: 'safetensors' }
@@ -56,7 +56,7 @@ describe('useAssetFilterOptions', () => {
     })
 
     it('handles empty asset list', () => {
-      const { availableFileFormats } = useAssetFilterOptions([])
+      const { availableFileFormats } = useAssetFilterOptions(() => [])
 
       expect(availableFileFormats.value).toEqual([])
     })
@@ -70,7 +70,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificBaseModel('sd35')
       ]
 
-      const { availableBaseModels } = useAssetFilterOptions(assets)
+      const { availableBaseModels } = useAssetFilterOptions(() => assets)
 
       expect(availableBaseModels.value).toEqual([
         { name: 'sd15', value: 'sd15' },
@@ -86,7 +86,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificBaseModel('sdxl')
       ]
 
-      const { availableBaseModels } = useAssetFilterOptions(assets)
+      const { availableBaseModels } = useAssetFilterOptions(() => assets)
 
       expect(availableBaseModels.value).toEqual([
         { name: 'sd15', value: 'sd15' },
@@ -100,7 +100,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificBaseModel('sd15')
       ]
 
-      const { availableBaseModels } = useAssetFilterOptions(assets)
+      const { availableBaseModels } = useAssetFilterOptions(() => assets)
 
       expect(availableBaseModels.value).toEqual([
         { name: 'sd15', value: 'sd15' }
@@ -113,7 +113,7 @@ describe('useAssetFilterOptions', () => {
         createAssetWithSpecificBaseModel('sdxl')
       ]
 
-      const { availableBaseModels } = useAssetFilterOptions(assets)
+      const { availableBaseModels } = useAssetFilterOptions(() => assets)
 
       expect(availableBaseModels.value).toEqual([
         { name: 'sdxl', value: 'sdxl' }
@@ -121,7 +121,7 @@ describe('useAssetFilterOptions', () => {
     })
 
     it('handles empty asset list', () => {
-      const { availableBaseModels } = useAssetFilterOptions([])
+      const { availableBaseModels } = useAssetFilterOptions(() => [])
 
       expect(availableBaseModels.value).toEqual([])
     })
@@ -132,9 +132,8 @@ describe('useAssetFilterOptions', () => {
       const assets = [createAssetWithSpecificExtension('safetensors')]
 
       const { availableFileFormats, availableBaseModels } =
-        useAssetFilterOptions(assets)
+        useAssetFilterOptions(() => assets)
 
-      // These should be computed refs
       expect(availableFileFormats.value).toBeDefined()
       expect(availableBaseModels.value).toBeDefined()
       expect(typeof availableFileFormats.value).toBe('object')

--- a/tests-ui/platform/assets/utils/createModelNodeFromAsset.test.ts
+++ b/tests-ui/platform/assets/utils/createModelNodeFromAsset.test.ts
@@ -1,0 +1,428 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { createModelNodeFromAsset } from '@/platform/assets/utils/createModelNodeFromAsset'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
+import { useLitegraphService } from '@/services/litegraphService'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+
+// Type definitions for type-safe mocks
+type ModelToNodeStoreMock = Pick<
+  ReturnType<typeof useModelToNodeStore>,
+  'getNodeProvider'
+>
+
+type LitegraphServiceMock = Pick<
+  ReturnType<typeof useLitegraphService>,
+  'getCanvasCenter'
+>
+
+type WorkflowStoreMock = Pick<
+  ReturnType<typeof useWorkflowStore>,
+  'activeSubgraph' | 'isSubgraphActive'
+>
+
+// Mock dependencies
+vi.mock('@/scripts/api', () => ({
+  api: {
+    apiURL: vi.fn((path: string) => `http://localhost:8188${path}`)
+  }
+}))
+vi.mock('@/stores/modelToNodeStore')
+vi.mock('@/platform/workflow/management/stores/workflowStore')
+vi.mock('@/services/litegraphService')
+vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/litegraph/src/litegraph')>()
+  return {
+    ...actual,
+    LiteGraph: {
+      ...actual.LiteGraph,
+      createNode: vi.fn()
+    }
+  }
+})
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: {
+      graph: {
+        add: vi.fn()
+      }
+    }
+  }
+}))
+
+function createMockAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'asset-123',
+    name: 'test-model.safetensors',
+    size: 1024,
+    created_at: '2025-10-01T00:00:00Z',
+    tags: ['models', 'checkpoints'],
+    user_metadata: {
+      filename: 'models/checkpoints/test-model.safetensors'
+    },
+    ...overrides
+  }
+}
+
+function createMockNode(overrides?: {
+  widgetName?: string
+  widgetValue?: string
+  hasWidgets?: boolean
+}) {
+  const {
+    widgetName = 'ckpt_name',
+    widgetValue = '',
+    hasWidgets = true
+  } = overrides || {}
+
+  if (!hasWidgets) {
+    return {}
+  }
+
+  type Widget = NonNullable<LGraphNode['widgets']>[number]
+
+  const widget: Pick<Widget, 'name' | 'value' | 'type' | 'options' | 'y'> = {
+    name: widgetName,
+    value: widgetValue,
+    type: 'string',
+    options: {},
+    y: 0
+  }
+
+  return {
+    widgets: [widget]
+  }
+}
+
+function createMockNodeProvider() {
+  return {
+    nodeDef: {
+      name: 'CheckpointLoaderSimple',
+      display_name: 'Load Checkpoint'
+    },
+    key: 'ckpt_name'
+  }
+}
+
+function getMockApp() {
+  return app as unknown as {
+    canvas: { graph: { add: ReturnType<typeof vi.fn> } }
+  }
+}
+
+function getMockRootGraph() {
+  return getMockApp().canvas.graph
+}
+
+/**
+ * Configures all mocked dependencies with sensible defaults.
+ * Returns mock references for spying on method calls in assertions.
+ * For error paths or edge cases, set up mocks explicitly instead of using this helper.
+ */
+function setupMocks(
+  overrides: {
+    node?: ReturnType<typeof createMockNode>
+    position?: [number, number]
+    activeSubgraph?: { add: ReturnType<typeof vi.fn> }
+  } = {}
+) {
+  const {
+    node = createMockNode(),
+    position = [100, 200],
+    activeSubgraph = undefined
+  } = overrides
+
+  const mockModelToNodeStore: ModelToNodeStoreMock = {
+    getNodeProvider: vi.fn().mockReturnValue(createMockNodeProvider())
+  }
+  const mockLitegraphService: LitegraphServiceMock = {
+    getCanvasCenter: vi.fn().mockReturnValue(position)
+  }
+  const mockWorkflowStore: WorkflowStoreMock = {
+    activeSubgraph: activeSubgraph as ReturnType<
+      typeof useWorkflowStore
+    >['activeSubgraph'],
+    isSubgraphActive: !!activeSubgraph
+  }
+
+  vi.mocked(useModelToNodeStore).mockReturnValue(
+    mockModelToNodeStore as ReturnType<typeof useModelToNodeStore>
+  )
+  vi.mocked(useLitegraphService).mockReturnValue(
+    mockLitegraphService as ReturnType<typeof useLitegraphService>
+  )
+  vi.mocked(useWorkflowStore).mockReturnValue(
+    mockWorkflowStore as ReturnType<typeof useWorkflowStore>
+  )
+  vi.mocked(LiteGraph.createNode).mockReturnValue(node as LGraphNode)
+
+  return { mockModelToNodeStore, mockLitegraphService, mockWorkflowStore }
+}
+
+describe('createModelNodeFromAsset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  describe('input validation', () => {
+    describe('when asset metadata is invalid', () => {
+      it.each([
+        {
+          case: 'missing user_metadata',
+          overrides: { user_metadata: undefined },
+          errorPattern: 'Asset asset-123 missing required user_metadata'
+        },
+        {
+          case: 'missing filename property',
+          overrides: { user_metadata: {} },
+          errorPattern:
+            /Asset asset-123 has invalid user_metadata\.filename.*expected non-empty string, got undefined/
+        },
+        {
+          case: 'non-string filename',
+          overrides: { user_metadata: { filename: 123 } },
+          errorPattern:
+            /Asset asset-123 has invalid user_metadata\.filename.*expected non-empty string, got number/
+        },
+        {
+          case: 'empty filename',
+          overrides: { user_metadata: { filename: '' } },
+          errorPattern:
+            /Asset asset-123 has invalid user_metadata\.filename.*expected non-empty string/
+        }
+      ])('rejects assets with $case', ({ overrides, errorPattern }) => {
+        const asset = createMockAsset(overrides)
+        expect(() => createModelNodeFromAsset(asset)).toThrow(errorPattern)
+      })
+    })
+
+    describe('when asset tags are invalid', () => {
+      it.each([
+        {
+          case: 'without tags',
+          overrides: { tags: undefined },
+          errorPattern:
+            'Asset asset-123 has no tags defined (expected at least one category tag)'
+        },
+        {
+          case: 'with only excluded tags',
+          overrides: { tags: ['models', 'missing'] },
+          errorPattern:
+            /Asset asset-123 has no valid category tag.*Available tags: models, missing/
+        },
+        {
+          case: 'with only the models tag',
+          overrides: { tags: ['models'] },
+          errorPattern:
+            /Asset asset-123 has no valid category tag.*Available tags: models/
+        }
+      ])('rejects assets $case', ({ overrides, errorPattern }) => {
+        const asset = createMockAsset(overrides)
+        expect(() => createModelNodeFromAsset(asset)).toThrow(errorPattern)
+      })
+    })
+
+    describe('when node provider is unavailable', () => {
+      it('throws error when no provider registered for category', () => {
+        const asset = createMockAsset()
+        const mockModelToNodeStore: ModelToNodeStoreMock = {
+          getNodeProvider: vi.fn().mockReturnValue(null)
+        }
+
+        vi.mocked(useModelToNodeStore).mockReturnValue(
+          mockModelToNodeStore as ReturnType<typeof useModelToNodeStore>
+        )
+
+        expect(() => createModelNodeFromAsset(asset)).toThrow(
+          'No node provider registered for category: checkpoints'
+        )
+      })
+    })
+  })
+
+  describe('node creation', () => {
+    describe('when LiteGraph fails to create node', () => {
+      it('throws error identifying the failed node type', () => {
+        const asset = createMockAsset()
+        const mockModelToNodeStore: ModelToNodeStoreMock = {
+          getNodeProvider: vi.fn().mockReturnValue(createMockNodeProvider())
+        }
+        const mockLitegraphService: LitegraphServiceMock = {
+          getCanvasCenter: vi.fn().mockReturnValue([100, 200])
+        }
+
+        vi.mocked(useModelToNodeStore).mockReturnValue(
+          mockModelToNodeStore as ReturnType<typeof useModelToNodeStore>
+        )
+        vi.mocked(useLitegraphService).mockReturnValue(
+          mockLitegraphService as ReturnType<typeof useLitegraphService>
+        )
+        vi.mocked(LiteGraph.createNode).mockReturnValue(null)
+
+        expect(() => createModelNodeFromAsset(asset)).toThrow(
+          'Failed to create node for type: CheckpointLoaderSimple'
+        )
+      })
+    })
+
+    describe('node type selection', () => {
+      it('selects loader node by querying provider for asset category', () => {
+        const asset = createMockAsset()
+        const { mockModelToNodeStore } = setupMocks()
+
+        createModelNodeFromAsset(asset)
+
+        expect(mockModelToNodeStore.getNodeProvider).toHaveBeenCalledWith(
+          'checkpoints'
+        )
+        expect(LiteGraph.createNode).toHaveBeenCalledWith(
+          'CheckpointLoaderSimple',
+          'Load Checkpoint',
+          { pos: [100, 200] }
+        )
+      })
+    })
+
+    describe('node positioning', () => {
+      it('positions node at canvas center by default', () => {
+        const asset = createMockAsset()
+        const { mockLitegraphService } = setupMocks({
+          position: [150, 250]
+        })
+
+        createModelNodeFromAsset(asset)
+
+        expect(mockLitegraphService.getCanvasCenter).toHaveBeenCalled()
+        expect(LiteGraph.createNode).toHaveBeenCalledWith(
+          'CheckpointLoaderSimple',
+          'Load Checkpoint',
+          { pos: [150, 250] }
+        )
+      })
+
+      it('uses custom position when explicitly provided', () => {
+        const asset = createMockAsset()
+        const { mockLitegraphService } = setupMocks()
+
+        createModelNodeFromAsset(asset, { position: [300, 400] })
+
+        expect(mockLitegraphService.getCanvasCenter).not.toHaveBeenCalled()
+        expect(LiteGraph.createNode).toHaveBeenCalledWith(
+          'CheckpointLoaderSimple',
+          'Load Checkpoint',
+          { pos: [300, 400] }
+        )
+      })
+    })
+  })
+
+  describe('widget configuration', () => {
+    it('configures widget with asset file path', () => {
+      const asset = createMockAsset()
+      const mockNode = createMockNode()
+      setupMocks({ node: mockNode })
+
+      createModelNodeFromAsset(asset)
+
+      expect(mockNode.widgets?.[0].value).toBe(
+        'models/checkpoints/test-model.safetensors'
+      )
+    })
+
+    it('warns when expected widget is missing from node', () => {
+      const asset = createMockAsset()
+      const mockNode = createMockNode({ widgetName: 'wrong_widget' })
+      setupMocks({ node: mockNode })
+
+      createModelNodeFromAsset(asset)
+
+      expect(console.warn).toHaveBeenCalledWith(
+        'Widget ckpt_name not found on node CheckpointLoaderSimple'
+      )
+    })
+
+    it('warns when node has no widgets array', () => {
+      const asset = createMockAsset()
+      const mockNode = createMockNode({ hasWidgets: false })
+      setupMocks({ node: mockNode })
+
+      createModelNodeFromAsset(asset)
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Widget ckpt_name not found')
+      )
+    })
+  })
+
+  describe('graph placement', () => {
+    it('adds node to root graph when no subgraph is active', () => {
+      const asset = createMockAsset()
+      const mockNode = createMockNode()
+      setupMocks({ node: mockNode })
+
+      createModelNodeFromAsset(asset)
+
+      expect(getMockRootGraph().add).toHaveBeenCalledWith(mockNode)
+    })
+
+    it('adds node to active subgraph when present', () => {
+      const asset = createMockAsset()
+      const mockNode = createMockNode()
+      const mockSubgraph = { add: vi.fn() }
+      setupMocks({
+        node: mockNode,
+        activeSubgraph: mockSubgraph
+      })
+
+      createModelNodeFromAsset(asset)
+
+      expect(mockSubgraph.add).toHaveBeenCalledWith(mockNode)
+      expect(getMockRootGraph().add).not.toHaveBeenCalled()
+    })
+
+    it('throws error when neither root graph nor subgraph is available', () => {
+      const asset = createMockAsset()
+      const mockNode = createMockNode()
+      const mockModelToNodeStore: ModelToNodeStoreMock = {
+        getNodeProvider: vi.fn().mockReturnValue(createMockNodeProvider())
+      }
+      const mockLitegraphService: LitegraphServiceMock = {
+        getCanvasCenter: vi.fn().mockReturnValue([100, 200])
+      }
+      const mockWorkflowStore: WorkflowStoreMock = {
+        activeSubgraph: null as unknown as ReturnType<
+          typeof useWorkflowStore
+        >['activeSubgraph'],
+        isSubgraphActive: false
+      }
+
+      vi.mocked(useModelToNodeStore).mockReturnValue(
+        mockModelToNodeStore as ReturnType<typeof useModelToNodeStore>
+      )
+      vi.mocked(useLitegraphService).mockReturnValue(
+        mockLitegraphService as ReturnType<typeof useLitegraphService>
+      )
+      vi.mocked(useWorkflowStore).mockReturnValue(
+        mockWorkflowStore as ReturnType<typeof useWorkflowStore>
+      )
+      vi.mocked(LiteGraph.createNode).mockReturnValue(mockNode as LGraphNode)
+
+      const mockApp = getMockApp()
+      const originalGraph = mockApp.canvas.graph
+      mockApp.canvas.graph = null as unknown as {
+        add: ReturnType<typeof vi.fn>
+      }
+
+      expect(() => createModelNodeFromAsset(asset)).toThrow(
+        'No active graph available'
+      )
+
+      mockApp.canvas.graph = originalGraph
+    })
+  })
+})

--- a/tests-ui/tests/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -136,36 +136,7 @@ describe('useComboWidget', () => {
     expect(widget).toBe(mockWidget)
   })
 
-  it('should create normal combo widget when widget is not eligible for asset browser', () => {
-    mockSettingStoreGet.mockReturnValue(true)
-    vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false)
-
-    const constructor = useComboWidget()
-    const mockWidget = createMockWidget()
-    const mockNode = createMockNode()
-    vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
-    const inputSpec = createMockInputSpec({
-      name: 'not_eligible_widget',
-      options: ['option1', 'option2']
-    })
-
-    const widget = constructor(mockNode, inputSpec)
-
-    expect(mockNode.addWidget).toHaveBeenCalledWith(
-      'combo',
-      'not_eligible_widget',
-      'option1',
-      expect.any(Function),
-      { values: ['option1', 'option2'] }
-    )
-    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'not_eligible_widget',
-      'TestNode'
-    )
-    expect(widget).toBe(mockWidget)
-  })
-
-  it('should create asset browser widget when API enabled and widget eligible', () => {
+  it('should create asset browser widget when API enabled', () => {
     mockSettingStoreGet.mockReturnValue(true)
     vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true)
 
@@ -192,13 +163,12 @@ describe('useComboWidget', () => {
     )
     expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
     expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'ckpt_name',
       'CheckpointLoaderSimple'
     )
     expect(widget).toBe(mockWidget)
   })
 
-  it('should create asset browser widget with options when API enabled and widget eligible', () => {
+  it('should create asset browser widget with options when API enabled', () => {
     mockSettingStoreGet.mockReturnValue(true)
     vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(true)
 
@@ -224,10 +194,6 @@ describe('useComboWidget', () => {
       expect.any(Function)
     )
     expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
-    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'ckpt_name',
-      'CheckpointLoaderSimple'
-    )
     expect(widget).toBe(mockWidget)
   })
 
@@ -258,10 +224,6 @@ describe('useComboWidget', () => {
       expect.any(Function)
     )
     expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
-    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'ckpt_name',
-      'CheckpointLoaderSimple'
-    )
     expect(widget).toBe(mockWidget)
   })
 
@@ -291,10 +253,6 @@ describe('useComboWidget', () => {
       expect.any(Function)
     )
     expect(mockSettingStoreGet).toHaveBeenCalledWith('Comfy.Assets.UseAssetAPI')
-    expect(vi.mocked(assetService.isAssetBrowserEligible)).toHaveBeenCalledWith(
-      'ckpt_name',
-      'CheckpointLoaderSimple'
-    )
     expect(widget).toBe(mockWidget)
   })
 })

--- a/tests-ui/tests/services/assetService.test.ts
+++ b/tests-ui/tests/services/assetService.test.ts
@@ -108,7 +108,9 @@ describe('assetService', () => {
 
       const result = await assetService.getAssetModelFolders()
 
-      expect(api.fetchApi).toHaveBeenCalledWith('/assets?include_tags=models')
+      expect(api.fetchApi).toHaveBeenCalledWith(
+        '/assets?include_tags=models&limit=300'
+      )
       expect(result).toHaveLength(2)
 
       const folderNames = result.map((f) => f.name)
@@ -153,7 +155,7 @@ describe('assetService', () => {
       const result = await assetService.getAssetModels('checkpoints')
 
       expect(api.fetchApi).toHaveBeenCalledWith(
-        '/assets?include_tags=models,checkpoints'
+        '/assets?include_tags=models,checkpoints&limit=300'
       )
       expect(result).toEqual([
         expect.objectContaining({ name: 'valid.safetensors', pathIndex: 0 })
@@ -181,41 +183,17 @@ describe('assetService', () => {
   })
 
   describe('isAssetBrowserEligible', () => {
-    it('should return true for eligible widget names with registered node types', () => {
+    it('should return true for registered node types', () => {
       expect(
-        assetService.isAssetBrowserEligible(
-          'ckpt_name',
-          'CheckpointLoaderSimple'
-        )
+        assetService.isAssetBrowserEligible('CheckpointLoaderSimple')
       ).toBe(true)
-      expect(
-        assetService.isAssetBrowserEligible('lora_name', 'LoraLoader')
-      ).toBe(true)
-      expect(assetService.isAssetBrowserEligible('vae_name', 'VAELoader')).toBe(
-        true
-      )
+      expect(assetService.isAssetBrowserEligible('LoraLoader')).toBe(true)
+      expect(assetService.isAssetBrowserEligible('VAELoader')).toBe(true)
     })
 
-    it('should return false for non-eligible widget names', () => {
-      expect(assetService.isAssetBrowserEligible('seed', 'TestNode')).toBe(
-        false
-      )
-      expect(assetService.isAssetBrowserEligible('steps', 'TestNode')).toBe(
-        false
-      )
-      expect(
-        assetService.isAssetBrowserEligible('sampler_name', 'TestNode')
-      ).toBe(false)
-      expect(assetService.isAssetBrowserEligible('', 'TestNode')).toBe(false)
-    })
-
-    it('should return false for eligible widget names with unregistered node types', () => {
-      expect(
-        assetService.isAssetBrowserEligible('ckpt_name', 'UnknownNode')
-      ).toBe(false)
-      expect(
-        assetService.isAssetBrowserEligible('lora_name', 'UnknownNode')
-      ).toBe(false)
+    it('should return false for unregistered node types', () => {
+      expect(assetService.isAssetBrowserEligible('UnknownNode')).toBe(false)
+      expect(assetService.isAssetBrowserEligible('UnknownNode')).toBe(false)
     })
   })
 
@@ -249,7 +227,7 @@ describe('assetService', () => {
 
       // Verify API call includes correct category
       expect(api.fetchApi).toHaveBeenCalledWith(
-        '/assets?include_tags=models,checkpoints'
+        '/assets?include_tags=models,checkpoints&limit=300'
       )
     })
 


### PR DESCRIPTION
## Summary

Full Integration of Asset Browsing and Selection when Assets API is enabled.

## Changes

1. Replace Model Left Side Tab with experience
2. Configurable titles for the Asset Browser Modal
3. Refactors to simplify callback code
4. Refactor to make modal filters reactive (they change their values based on assets displayed)
5. Add `browse()` mode with ability to create node directly from the Asset Browser Modal (in `browse()` mode)

## Screenshots

Demo of many different types of Nodes getting configured by the Modal


https://github.com/user-attachments/assets/34f9c964-cdf2-4c5d-86a9-a8e7126a7de9

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5900-Feat-asset-selection-cloud-integration-2816d73d365081ccb4aeecdc14b0e5d3) by [Unito](https://www.unito.io)
