### PR TITLE
chore(eslint): allow default project for Playwright configs to fix pre-commit linting

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -37,7 +37,9 @@ export default defineConfig([
           allowDefaultProject: [
             'vite.config.mts',
             'vite.electron.config.mts',
-            'vite.types.config.mts'
+            'vite.types.config.mts',
+            'playwright.config.ts',
+            'playwright.i18n.config.ts'
           ]
         },
         tsConfigRootDir: import.meta.dirname,


### PR DESCRIPTION
Summary
- Adds playwright.config.ts and playwright.i18n.config.ts to typescript-eslint projectService.allowDefaultProject in eslint.config.ts.

Why
- Pre-commit runs lint-staged, which lints staged TypeScript files including Playwright config files.
- These configs are not included in any tsconfig, so typescript-eslint’s project service can’t find a project and fails with:
  "Parsing error: .../playwright.config.ts was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject".

What this changes
- Whitelists the two Playwright config files to use the default project (isolated file parsing) so ESLint can parse and lint them without being part of a tsconfig.
- Does not affect application code linting, which remains fully type-aware via existing tsconfigs.

Alternatives considered
- Include these configs in a dedicated ESLint tsconfig (e.g., tsconfig.eslint.json) and point ESLint to it.
- Exclude Playwright config files from lint-staged (would reduce lint coverage for them).
- Keep as TypeScript but non-type-aware: current approach is minimal and avoids touching tsconfig scopes.

Verification
- Reproduced pre-commit failure when changing playwright.config.ts.
- After this change, `pnpm exec eslint --cache --fix playwright.config.ts` succeeds.
- `pnpm typecheck` passes.

Notes
- No changes to Playwright runtime behavior. This only affects linting.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5901-chore-eslint-allow-default-project-for-Playwright-configs-to-fix-pre-commit-linting-2816d73d36508156b94dfeff79a91c7f) by [Unito](https://www.unito.io)
