### PR TITLE
[refactor] remove import alias on LGraphNode.vue

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -39,7 +39,7 @@
     @wheel.capture="canvasInteractions.forwardEventToCanvas"
   >
     <!-- Vue nodes rendered based on graph nodes -->
-    <VueGraphNode
+    <LGraphNode
       v-for="nodeData in allNodes"
       :key="nodeData.id"
       :node-data="nodeData"
@@ -117,7 +117,7 @@ import { attachSlotLinkPreviewRenderer } from '@/renderer/core/canvas/links/slot
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import TransformPane from '@/renderer/core/layout/transform/TransformPane.vue'
 import MiniMap from '@/renderer/extensions/minimap/MiniMap.vue'
-import VueGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
+import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
 import { UnauthorizedError, api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { ChangeTracker } from '@/scripts/changeTracker'


### PR DESCRIPTION
## Summary

Changes import name such that it matches the SFC filename.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5919-refactor-remove-import-alias-on-LGraphNode-vue-2826d73d365081fc80d8f277a40f7d81) by [Unito](https://www.unito.io)
