### PR TITLE
use PrimeVue tooltip for "enter subgraph" button on Vue node headers

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -45,11 +45,11 @@
       <div class="flex items-center lod-toggle shrink-0">
         <IconButton
           v-if="isSubgraphNode"
+          v-tooltip.top="enterSubgraphTooltipConfig"
           size="sm"
           type="transparent"
           class="text-stone-200 dark-theme:text-slate-300"
           data-testid="subgraph-enter-button"
-          title="Enter Subgraph"
           @click.stop="handleEnterSubgraph"
           @dblclick.stop
         >
@@ -121,6 +121,10 @@ const tooltipConfig = computed(() => {
   }
   const description = getNodeDescription.value
   return createTooltipConfig(description)
+})
+
+const enterSubgraphTooltipConfig = computed(() => {
+  return createTooltipConfig(st('enterSubgraph', 'Enter Subgraph'))
 })
 
 const headerStyle = computed(() => {


### PR DESCRIPTION
## Summary

Replaced HTML `title` attribute with PrimeVue tooltip component for the "Enter Subgraph" button in Vue node headers.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5920-use-PrimeVue-tooltip-for-enter-subgraph-button-on-Vue-node-headers-2826d73d365081bdb0b9dcc7b4509d39) by [Unito](https://www.unito.io)
