### PR TITLE
Fix untyped subgraph node outputs in vue mode

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeSlots.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.vue
@@ -14,9 +14,9 @@
       />
     </div>
 
-    <div v-if="filteredOutputs.length" class="flex flex-col gap-1 ml-auto">
+    <div v-if="nodeData?.outputs?.length" class="flex flex-col gap-1 ml-auto">
       <OutputSlot
-        v-for="(output, index) in filteredOutputs"
+        v-for="(output, index) in nodeData.outputs"
         :key="`output-${index}`"
         :slot-data="output"
         :node-type="nodeData?.type || ''"
@@ -66,20 +66,6 @@ const filteredInputs = computed(() => {
             boundingRect: [0, 0, 0, 0] as [number, number, number, number]
           } as INodeSlot)
     )
-})
-
-// Outputs don't have widgets, so we don't need to filter them
-const filteredOutputs = computed(() => {
-  const outputs = nodeData?.outputs || []
-  return outputs.map((output) =>
-    isSlotObject(output)
-      ? output
-      : ({
-          name: typeof output === 'string' ? output : '',
-          type: 'any',
-          boundingRect: [0, 0, 0, 0] as [number, number, number, number]
-        } as INodeSlot)
-  )
 })
 
 // Get the actual index of an input slot in the node's inputs array


### PR DESCRIPTION
Under some infrequent circumstances, the node outputs of subgraphNodes lack the boundingRect property. As this is a required property of `INodeSlot`s, it's presence is required to satisfy isSlotObject and the type information is discarded to instead display a placeholder output.

This boundingRect property is not used by vue nodes and the type of nodeData.outputs already satisfies INodeSlot, so this entire typeguard and computed can be removed.

<img width="405" height="209" alt="image" src="https://github.com/user-attachments/assets/8563abb7-b619-495e-b9ec-e3274e7668cf" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5930-Fix-untyped-subgraph-node-outputs-in-vue-mode-2836d73d3650814f993fc71590eca79b) by [Unito](https://www.unito.io)
