### PR TITLE
Restrict Vite entry point to index.html

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -198,6 +198,7 @@ export default defineConfig({
   },
 
   optimizeDeps: {
-    exclude: ['@comfyorg/comfyui-electron-types']
+    exclude: ['@comfyorg/comfyui-electron-types'],
+    entries: ['index.html']
   }
 }) satisfies UserConfig as UserConfig


### PR DESCRIPTION
## Summary

Restricts Vite's dependency optimization scanning entry points to the root `index.html`, preventing excessive error messages from scanning unintended files in other packages.

## Changes

- **What**: Adds `entries: ['index.html']` to `optimizeDeps` in vite.config.mts
- **Breaking**: None

## Review Focus

May require additional entries or inversion - exclude-based approach instead of include-based - if possible.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5934-Restrict-Vite-entry-point-to-index-html-2846d73d3650816fbf45fa29493891ae) by [Unito](https://www.unito.io)
