### PR TITLE
fix: unignore stylelint

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,7 +23,7 @@ const config: KnipConfig = {
       project: ['src/**/*.{js,ts}']
     }
   },
-  ignoreBinaries: ['python3', 'stylelint'],
+  ignoreBinaries: ['python3'],
   ignoreDependencies: [
     // Weird importmap things
     '@iconify/json',
@@ -32,8 +32,7 @@ const config: KnipConfig = {
     '@primeuix/utils',
     '@primevue/icons',
     // Dev
-    '@trivago/prettier-plugin-sort-imports',
-    'stylelint'
+    '@trivago/prettier-plugin-sort-imports'
   ],
   ignore: [
     // Auto generated manager types


### PR DESCRIPTION
## Summary

Minimal fix to let Knip succeed but also use its built-in [stylelint plugin](https://knip.dev/reference/plugins/stylelint).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5935-fix-unignore-stylelint-2846d73d3650816d9949faf405012416) by [Unito](https://www.unito.io)
