### PR TITLE
Fix images missing during desktop install

### DIFF
--- a/src/components/install/GpuPicker.vue
+++ b/src/components/install/GpuPicker.vue
@@ -11,7 +11,7 @@
       <!-- Apple Metal / NVIDIA -->
       <HardwareOption
         v-if="platform === 'darwin'"
-        :image-path="'/assets/images/apple-mps-logo.png'"
+        :image-path="'assets/images/apple-mps-logo.png'"
         placeholder-text="Apple Metal"
         subtitle="Apple Metal"
         :value="'mps'"
@@ -21,7 +21,7 @@
       />
       <HardwareOption
         v-else
-        :image-path="'/assets/images/nvidia-logo-square.jpg'"
+        :image-path="'assets/images/nvidia-logo-square.jpg'"
         placeholder-text="NVIDIA"
         :subtitle="$t('install.gpuPicker.nvidiaSubtitle')"
         :value="'nvidia'"


### PR DESCRIPTION
## Summary

There's missing desktop GPU picker images caused by refactoring of desktop front-end installation code.  Was previously not an issue because the paths were automatically adjusted by Vue, vite, or some other tooling.  Now that these are set programmatically (component props), this "helpful" path adjustment is no longer occurring.

## Changes

- **What**: Takes away leading `/` from image paths.

## Screenshots (if applicable)

Current:
<img width="480" height="307" alt="image" src="https://github.com/user-attachments/assets/20c0dd29-26d1-41b8-a59d-d3b0e69d998a" />

Proposed:
<img width="480" height="299" alt="image" src="https://github.com/user-attachments/assets/aee87d1f-2060-4ec7-a8fc-43ebe2d650c2" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5941-Fix-images-missing-during-desktop-install-2846d73d365081c7b318c0ff31f70f2f) by [Unito](https://www.unito.io)
