### PR TITLE
Version bump 1.27.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.27.7",
+  "version": "1.27.8",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Patch version increment to 1.27.8

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5944-Version-bump-1-27-8-2846d73d365081eaa942e5a2306fea86) by [Unito](https://www.unito.io)
