### PR TITLE
[desktop] Removes broken installer terminal button

### DIFF
--- a/src/views/ServerStartView.vue
+++ b/src/views/ServerStartView.vue
@@ -66,17 +66,6 @@
               @click="troubleshoot"
             />
           </div>
-
-          <div class="text-center">
-            <button
-              v-if="!terminalVisible"
-              class="text-sm text-neutral-500 hover:text-neutral-300 transition-colors flex items-center gap-2 mx-auto"
-              @click="terminalVisible = true"
-            >
-              <i class="pi pi-search"></i>
-              {{ $t('serverStart.showTerminal') }}
-            </button>
-          </div>
         </div>
 
         <!-- Terminal Output (positioned at bottom when manually toggled in error state) -->


### PR DESCRIPTION
## Summary

Removes the terminal toggle button from the desktop installer that causes broken UX when clicked during desktop install.

The button itself is merely a means to show the version of logs stored in memory, using the in-app interface, as opposed to reading the files from disk.  The `Show Logs` button (working) takes the user directly into the log directory.

## Changes

- **What**: Removes "Show Terminal" button from ServerStartView during install flow
- **Breaking**: Removes show terminal button functionality

## Review Focus

The button is removed and is to be re-added at a later date (if Design agree).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5946-desktop-Removes-broken-installer-terminal-button-2846d73d365081ac88d6c541a5d9c592) by [Unito](https://www.unito.io)
