### PR TITLE
CI: Use main version number instead of pinning

### DIFF
--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -89,7 +89,7 @@ jobs:
         run: sleep 10
 
       - name: Restore cached setup
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
           path: |
@@ -155,7 +155,7 @@ jobs:
         run: sleep 10
 
       - name: Restore cached setup
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
           path: |


### PR DESCRIPTION
## Summary

Minimal change to use the versioned cache action instead of pinning to a specific commit.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5951-CI-Use-main-version-number-instead-of-pinning-2846d73d36508130821ffb659cb52464) by [Unito](https://www.unito.io)
