### PR TITLE
feat(hostWhitelist): allow comfy.org hosts to authenticate

### DIFF
--- a/src/utils/hostWhitelist.ts
+++ b/src/utils/hostWhitelist.ts
@@ -42,6 +42,7 @@ export function isHostWhitelisted(rawHost: string): boolean {
   if (isLocalhostLabel(host)) return true
   if (isIPv4Loopback(host)) return true
   if (isIPv6Loopback(host)) return true
+  if (isComfyOrgHost(host)) return true
   const normalizedList = HOST_WHITELIST.map(normalizeHost)
   return normalizedList.includes(host)
 }
@@ -88,4 +89,10 @@ function isIPv6Loopback(h: string): boolean {
 
   // Require that at least one group was actually compressed: i.e., leftCount + rightCount ≤ 6.
   return leftCount + rightCount <= 6
+}
+
+const COMFY_ORG_HOST = /\.comfy\.org$/
+
+function isComfyOrgHost(h: string): boolean {
+  return COMFY_ORG_HOST.test(h)
 }

--- a/tests-ui/tests/utils/hostWhitelist.test.ts
+++ b/tests-ui/tests/utils/hostWhitelist.test.ts
@@ -119,5 +119,27 @@ describe('hostWhitelist utils', () => {
         expect(isHostWhitelisted('   ')).toBe(false)
       })
     })
+
+    describe('comfy.org hosts', () => {
+      it.each([
+        'staging.comfy.org',
+        'stagingcloud.comfy.org',
+        'pr-123.testingcloud.comfy.org',
+        'api.v2.staging.comfy.org'
+      ])('should allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(true)
+      })
+
+      it.each([
+        'comfy.org.evil.com',
+        'evil-comfy.org',
+        'comfy.organization',
+        'notcomfy.org',
+        'comfy.org.hacker.net',
+        'mycomfy.org.example.com'
+      ])('should NOT allow %o', (input) => {
+        expect(isHostWhitelisted(input)).toBe(false)
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary

Add `comfy.org` host names to the list of hosts that can authenticate via SSO.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5952-feat-hostWhitelist-allow-comfy-org-hosts-to-authenticate-2846d73d36508152a41af92ada2a698b) by [Unito](https://www.unito.io)
