### PR TITLE
fix "what's changed" release toast attention level logic

### DIFF
--- a/src/platform/updates/common/releaseStore.ts
+++ b/src/platform/updates/common/releaseStore.ts
@@ -72,14 +72,10 @@ export const useReleaseStore = defineStore('release', () => {
       ) === 0
   )
 
-  const hasMediumOrHighAttention = computed(() =>
-    recentReleases.value
-      .slice(0, -1)
-      .some(
-        (release) =>
-          release.attention === 'medium' || release.attention === 'high'
-      )
-  )
+  const hasMediumOrHighAttention = computed(() => {
+    const attention = recentRelease.value?.attention
+    return attention === 'medium' || attention === 'high'
+  })
 
   // Show toast if needed
   const shouldShowToast = computed(() => {

--- a/tests-ui/tests/store/releaseStore.test.ts
+++ b/tests-ui/tests/store/releaseStore.test.ts
@@ -145,16 +145,22 @@ describe('useReleaseStore', () => {
 
       it('should show toast for medium/high attention releases', () => {
         vi.mocked(semverCompare).mockReturnValue(1)
-
-        // Need multiple releases for hasMediumOrHighAttention to work
-        const mediumRelease = {
-          ...mockRelease,
-          id: 2,
-          attention: 'medium' as const
-        }
-        store.releases = [mockRelease, mediumRelease]
+        store.releases = [mockRelease]
 
         expect(store.shouldShowToast).toBe(true)
+      })
+
+      it('should not show toast for low attention releases', () => {
+        vi.mocked(semverCompare).mockReturnValue(1)
+
+        const lowAttentionRelease = {
+          ...mockRelease,
+          attention: 'low' as const
+        }
+
+        store.releases = [lowAttentionRelease]
+
+        expect(store.shouldShowToast).toBe(false)
       })
 
       it('should show red dot for new versions', () => {
@@ -490,12 +496,7 @@ describe('useReleaseStore', () => {
 
       vi.mocked(semverCompare).mockReturnValue(1)
 
-      const mediumRelease = { ...mockRelease, attention: 'medium' as const }
-      store.releases = [
-        mockRelease,
-        mediumRelease,
-        { ...mockRelease, attention: 'low' as const }
-      ]
+      store.releases = [mockRelease]
 
       expect(store.shouldShowToast).toBe(true)
     })
@@ -578,14 +579,7 @@ describe('useReleaseStore', () => {
 
       it('should show toast when conditions are met', () => {
         vi.mocked(semverCompare).mockReturnValue(1)
-
-        // Need multiple releases for hasMediumOrHighAttention
-        const mediumRelease = {
-          ...mockRelease,
-          id: 2,
-          attention: 'medium' as const
-        }
-        store.releases = [mockRelease, mediumRelease]
+        store.releases = [mockRelease]
 
         expect(store.shouldShowToast).toBe(true)
       })
@@ -615,12 +609,7 @@ describe('useReleaseStore', () => {
         vi.mocked(semverCompare).mockReturnValue(1)
 
         // Set up all conditions that would normally show toast
-        const mediumRelease = {
-          ...mockRelease,
-          id: 2,
-          attention: 'medium' as const
-        }
-        store.releases = [mockRelease, mediumRelease]
+        store.releases = [mockRelease]
 
         expect(store.shouldShowToast).toBe(false)
       })


### PR DESCRIPTION
## Summary

Currently, the "What's Changed" popup toast in bottom left appears after updating if three conditions are true:

1. Using Desktop app
2. Don't have notifications disabled in settings
3. Have not seen/dismissed the notification before

Then the fourth condition is

4. At least 1 of the last 2 notifications is medium or high priority

However, we only ever show the most recent notification, so this logic is flawed. In addition, it presents issues:

- When the changelog is first generated by AI, it is marked as "low" priority until human review. But if the changelog _prior_ to that is "medium" or "high", the AI-generated one might get shown anyway - which frustrates the intended process.

There's also a bug fixed here concidentally where if the server only returns a single entry, it is never shown (due to `slice(0, -1)` syntax when checking priorities). 

## Changes

- **What**: Updated Pinia release store to read `attention` from the newest release only and expanded unit coverage for toast visibility

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5959-fix-what-s-changed-release-toast-attention-level-logic-2856d73d36508141b9b2d8d3b11153b2) by [Unito](https://www.unito.io)
