### PR TITLE
Devex: Add additional trigger for Playwright updates

### DIFF
--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -21,8 +21,13 @@ jobs:
         ) &&
         startsWith(github.event.comment.body, '/update-playwright') )
     steps:
-      - name: Checkout workflow repo
+      - name: Initial Checkout
         uses: actions/checkout@v5
+      - name: Pull Request Checkout
+        run: gh pr checkout ${{ github.event.issue.number }}
+        if: github.event.issue.pull_request && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Frontend
         uses: ./.github/actions/setup-frontend
       - name: Setup Playwright
@@ -47,7 +52,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
-          gh pr checkout ${{ github.event.issue.number }}
           git add browser_tests
           git commit -m "[automated] Update test expectations"
           git push

--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       ( github.event_name == 'pull_request' && github.event.label.name == 'New Browser Test Expectations' ) ||
-      ( github.event.issue.pull_request && github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/update-playwright') ) }}
+      ( github.event.issue.pull_request && github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/update-playwright') )
     steps:
     - name: Checkout workflow repo
       uses: actions/checkout@v5

--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -53,7 +53,7 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git add browser_tests
-          git commit -m "[automated] Update test expectations"
+          git diff --cached --quiet || git commit -m "[automated] Update test expectations"
           git push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -4,11 +4,15 @@ name: Update Playwright Expectations
 on:
   pull_request:
     types: [ labeled ]
+  issue_comment:
+    types: [ created ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'New Browser Test Expectations'
+    if: >
+      ( github.event_name == 'pull_request' && github.event.label.name == 'New Browser Test Expectations' ) ||
+      ( github.event.issue.pull_request && github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/update-playwright') ) }}
     steps:
     - name: Checkout workflow repo
       uses: actions/checkout@v5

--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -40,16 +40,17 @@ jobs:
           retention-days: 30
       - name: Debugging info
         run: |
-          echo "Branch: ${{ github.head_ref }}"
+          echo "PR: ${{ github.event.issue.number }}"
           git status
         working-directory: ComfyUI_frontend
       - name: Commit updated expectations
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
-          git fetch origin ${{ github.head_ref }}
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
+          gh pr checkout ${{ github.event.issue.number }}
           git add browser_tests
           git commit -m "[automated] Update test expectations"
-          git push origin HEAD:${{ github.head_ref }}
+          git push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ComfyUI_frontend

--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -3,46 +3,53 @@ name: Update Playwright Expectations
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: [labeled]
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     if: >
       ( github.event_name == 'pull_request' && github.event.label.name == 'New Browser Test Expectations' ) ||
-      ( github.event.issue.pull_request && github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/update-playwright') )
+      ( github.event.issue.pull_request && 
+        github.event_name == 'issue_comment' &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        startsWith(github.event.comment.body, '/update-playwright') )
     steps:
-    - name: Checkout workflow repo
-      uses: actions/checkout@v5
-    - name: Setup Frontend
-      uses: ./.github/actions/setup-frontend
-    - name: Setup Playwright
-      uses: ./.github/actions/setup-playwright
-    - name: Run Playwright tests and update snapshots
-      id: playwright-tests
-      run: pnpm exec playwright test --update-snapshots
-      continue-on-error: true
-      working-directory: ComfyUI_frontend
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: ComfyUI_frontend/playwright-report/
-        retention-days: 30
-    - name: Debugging info
-      run: |
-        echo "Branch: ${{ github.head_ref }}"
-        git status
-      working-directory: ComfyUI_frontend
-    - name: Commit updated expectations
-      run: |
-        git config --global user.name 'github-actions'
-        git config --global user.email 'github-actions@github.com'
-        git fetch origin ${{ github.head_ref }}
-        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
-        git add browser_tests
-        git commit -m "[automated] Update test expectations"
-        git push origin HEAD:${{ github.head_ref }}
-      working-directory: ComfyUI_frontend
+      - name: Checkout workflow repo
+        uses: actions/checkout@v5
+      - name: Setup Frontend
+        uses: ./.github/actions/setup-frontend
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+      - name: Run Playwright tests and update snapshots
+        id: playwright-tests
+        run: pnpm exec playwright test --update-snapshots
+        continue-on-error: true
+        working-directory: ComfyUI_frontend
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: ComfyUI_frontend/playwright-report/
+          retention-days: 30
+      - name: Debugging info
+        run: |
+          echo "Branch: ${{ github.head_ref }}"
+          git status
+        working-directory: ComfyUI_frontend
+      - name: Commit updated expectations
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+          git fetch origin ${{ github.head_ref }}
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
+          git add browser_tests
+          git commit -m "[automated] Update test expectations"
+          git push origin HEAD:${{ github.head_ref }}
+        working-directory: ComfyUI_frontend


### PR DESCRIPTION
## Summary

Allow for secondary trigger for updating screenshots:
> Adding a comment starting with `/update-playwright`

## Review Focus

- Is this the command you'd expect?
- Should I also add `/playwright-update`?

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5960-Devex-Add-additional-trigger-for-Playwright-updates-2856d73d365081768f70d0a8aafa9c11) by [Unito](https://www.unito.io)
