### PR TITLE
[test] fix flaky Vue group/frame test (minimap flakiness)

### DIFF
--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -8,6 +8,7 @@ const CREATE_GROUP_HOTKEY = 'Control+g'
 test.describe('Vue Node Groups', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.setSetting('Comfy.Minimap.ShowGroups', true)
     await comfyPage.vueNodes.waitForNodes()
   })
 
@@ -15,6 +16,7 @@ test.describe('Vue Node Groups', () => {
     await comfyPage.page.getByText('Load Checkpoint').click()
     await comfyPage.page.getByText('KSampler').click({ modifiers: ['Control'] })
     await comfyPage.page.keyboard.press(CREATE_GROUP_HOTKEY)
+    await comfyPage.nextFrame()
     await expect(comfyPage.canvas).toHaveScreenshot(
       'vue-groups-create-group.png'
     )


### PR DESCRIPTION
Attempts to fix flakiness when groups are enabled on the minimap and the screenshot is taken too early, before the render completes. See [comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/5942#issuecomment-3374615335) for more context.

May or may not solve the flakiness.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5962-wait-for-frame-on-group-creation-test-2856d73d365081f6a059ebfc5a03857c) by [Unito](https://www.unito.io)
