### PR TITLE
Fix: Missing Node Title Editor bug

### DIFF
--- a/src/components/graph/TitleEditor.vue
+++ b/src/components/graph/TitleEditor.vue
@@ -47,7 +47,7 @@ const canvasStore = useCanvasStore()
 const previousCanvasDraggable = ref(true)
 
 const onEdit = (newValue: string) => {
-  if (titleEditorStore.titleEditorTarget && newValue.trim() !== '') {
+  if (titleEditorStore.titleEditorTarget && newValue?.trim()) {
     const trimmedTitle = newValue.trim()
     titleEditorStore.titleEditorTarget.title = trimmedTitle
 


### PR DESCRIPTION
Found by @marawan206

## Summary

Fixes the title editor glitching when the node doesn't have an initial value

## Screenshots (if applicable)

### Before
https://github.com/user-attachments/assets/4c4efbfd-73b9-4733-8227-fe2de59648d4

### After
https://github.com/user-attachments/assets/30f3279e-aa2b-451b-9bee-c134d3f8374c

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5963-Fix-Missing-Node-Title-Editor-bug-2856d73d365081389edbda546eca3bbb) by [Unito](https://www.unito.io)
