### PR TITLE
Version bump 1.27.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.27.9",
+  "version": "1.27.10",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
Patch version increment to 1.27.10

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5969-Version-bump-1-27-10-2866d73d365081b78ae2dbbb26f1d113) by [Unito](https://www.unito.io)
