### PR TITLE
[ci] add match-component-import-name eslint rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -98,6 +98,7 @@ export default defineConfig([
       'vue/no-restricted-class': ['error', '/^dark:/'],
       'vue/multi-word-component-names': 'off', // TODO: fix
       'vue/no-template-shadow': 'off', // TODO: fix
+      'vue/match-component-import-name': 'error',
       /* Toggle on to do additional until we can clean up existing violations.
       'vue/no-unused-emit-declarations': 'error',
       'vue/no-unused-properties': 'error',


### PR DESCRIPTION
## Summary

Added ESLint rule to enforce imported Vue component names match their file names.

Inspired by this PR which would have never been necessary in the first place had this rule been in place:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/5919

## Changes

- **What**: Enabled [`vue/match-component-import-name`](https://eslint.vuejs.org/rules/match-component-import-name.html) rule in ESLint configuration

## Review Focus

Impact on existing imports that use aliases (e.g., importing `MyComponent.vue` as `MyComp`). The rule enforces that import aliases match the component's name definition.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5971-ci-add-match-component-import-name-eslint-rule-2866d73d3650811bba97c1ddcc75df5d) by [Unito](https://www.unito.io)
