### PR TITLE
Fix/vue nodes snap to grid

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3700,7 +3700,8 @@ export class LGraphCanvas
 
     let block_default = false
     // @ts-expect-error EventTarget.localName is not in standard types
-    if (e.target.localName == 'input') return
+    if (e.target.localName == 'input' || e.target.localName === 'textarea')
+      return
 
     if (e.type == 'keydown') {
       // TODO: Switch

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1997,8 +1997,8 @@ export class LGraphCanvas
     // Keyboard
     this._key_callback = this.processKey.bind(this)
 
-    canvas.addEventListener('keydown', this._key_callback, true)
-    // keyup event must be bound on the document
+    // Both keydown and keyup on document to capture events even when Vue nodes have focus
+    document.addEventListener('keydown', this._key_callback, true)
     document.addEventListener('keyup', this._key_callback, true)
 
     canvas.addEventListener('dragover', this._doNothing, false)
@@ -2028,7 +2028,7 @@ export class LGraphCanvas
     canvas.removeEventListener('pointerup', this._mouseup_callback!)
     canvas.removeEventListener('pointerdown', this._mousedown_callback!)
     canvas.removeEventListener('wheel', this._mousewheel_callback!)
-    canvas.removeEventListener('keydown', this._key_callback!)
+    document.removeEventListener('keydown', this._key_callback!)
     document.removeEventListener('keyup', this._key_callback!)
     canvas.removeEventListener('contextmenu', this._doNothing)
     canvas.removeEventListener('dragenter', this._doReturnTrue)
@@ -4696,7 +4696,9 @@ export class LGraphCanvas
 
       // draw nodes
       const { visible_nodes } = this
-      const drawSnapGuides = this.#snapToGrid && this.isDragging
+      const drawSnapGuides =
+        this.#snapToGrid &&
+        (this.isDragging || layoutStore.isDraggingVueNodes.value)
 
       for (const node of visible_nodes) {
         ctx.save()
@@ -6074,7 +6076,9 @@ export class LGraphCanvas
 
     ctx.save()
     ctx.globalAlpha = 0.5 * this.editor_alpha
-    const drawSnapGuides = this.#snapToGrid && this.isDragging
+    const drawSnapGuides =
+      this.#snapToGrid &&
+      (this.isDragging || layoutStore.isDraggingVueNodes.value)
 
     for (const group of groups) {
       // out of the visible area

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1997,8 +1997,8 @@ export class LGraphCanvas
     // Keyboard
     this._key_callback = this.processKey.bind(this)
 
-    // Both keydown and keyup on document to capture events even when Vue nodes have focus
-    document.addEventListener('keydown', this._key_callback, true)
+    canvas.addEventListener('keydown', this._key_callback, true)
+    // keyup event must be bound on the document
     document.addEventListener('keyup', this._key_callback, true)
 
     canvas.addEventListener('dragover', this._doNothing, false)
@@ -2028,7 +2028,7 @@ export class LGraphCanvas
     canvas.removeEventListener('pointerup', this._mouseup_callback!)
     canvas.removeEventListener('pointerdown', this._mousedown_callback!)
     canvas.removeEventListener('wheel', this._mousewheel_callback!)
-    document.removeEventListener('keydown', this._key_callback!)
+    canvas.removeEventListener('keydown', this._key_callback!)
     document.removeEventListener('keyup', this._key_callback!)
     canvas.removeEventListener('contextmenu', this._doNothing)
     canvas.removeEventListener('dragenter', this._doReturnTrue)
@@ -3700,8 +3700,7 @@ export class LGraphCanvas
 
     let block_default = false
     // @ts-expect-error EventTarget.localName is not in standard types
-    if (e.target.localName == 'input' || e.target.localName === 'textarea')
-      return
+    if (e.target.localName == 'input') return
 
     if (e.type == 'keydown') {
       // TODO: Switch

--- a/src/renderer/extensions/vueNodes/composables/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeResize.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 
 import type { TransformState } from '@/renderer/core/layout/injectionKeys'
 import { useNodeSnap } from '@/renderer/extensions/vueNodes/composables/useNodeSnap'
+import { useShiftKeySync } from '@/renderer/extensions/vueNodes/composables/useShiftKeySync'
 
 interface Size {
   width: number
@@ -39,12 +40,18 @@ export function useNodeResize(
   // Snap-to-grid functionality
   const { shouldSnap, applySnapToSize } = useNodeSnap()
 
+  // Shift key sync for LiteGraph canvas preview
+  const { syncShiftKeyToCanvas } = useShiftKeySync()
+
   const startResize = (event: PointerEvent) => {
     event.preventDefault()
     event.stopPropagation()
 
     const target = event.currentTarget
     if (!(target instanceof HTMLElement)) return
+
+    // Sync shift key state to canvas for snap preview
+    syncShiftKeyToCanvas(event)
 
     // Capture pointer to ensure we get all move/up events
     target.setPointerCapture(event.pointerId)
@@ -90,6 +97,9 @@ export function useNodeResize(
       )
         return
 
+      // Sync shift key state to canvas for snap preview
+      syncShiftKeyToCanvas(moveEvent)
+
       const dx = moveEvent.clientX - resizeStartPos.value.x
       const dy = moveEvent.clientY - resizeStartPos.value.y
 
@@ -124,6 +134,9 @@ export function useNodeResize(
 
     const handlePointerUp = (upEvent: PointerEvent) => {
       if (isResizing.value) {
+        // Sync shift key state to canvas for snap preview
+        syncShiftKeyToCanvas(upEvent)
+
         isResizing.value = false
         resizeStartPos.value = null
         resizeStartSize.value = null

--- a/src/renderer/extensions/vueNodes/composables/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeResize.ts
@@ -2,6 +2,7 @@ import { useEventListener } from '@vueuse/core'
 import { ref } from 'vue'
 
 import type { TransformState } from '@/renderer/core/layout/injectionKeys'
+import { useNodeSnap } from '@/renderer/extensions/vueNodes/composables/useNodeSnap'
 
 interface Size {
   width: number
@@ -34,6 +35,9 @@ export function useNodeResize(
   const resizeStartPos = ref<Position | null>(null)
   const resizeStartSize = ref<Size | null>(null)
   const intrinsicMinSize = ref<Size | null>(null)
+
+  // Snap-to-grid functionality
+  const { shouldSnap, applySnapToSize } = useNodeSnap()
 
   const startResize = (event: PointerEvent) => {
     event.preventDefault()
@@ -95,19 +99,26 @@ export function useNodeResize(
       const scaledDy = dy / scale
 
       // Apply constraints: only minimum size based on content, no maximum
-      const newWidth = Math.max(
-        intrinsicMinSize.value.width,
-        resizeStartSize.value.width + scaledDx
-      )
-      const newHeight = Math.max(
-        intrinsicMinSize.value.height,
-        resizeStartSize.value.height + scaledDy
-      )
+      const constrainedSize = {
+        width: Math.max(
+          intrinsicMinSize.value.width,
+          resizeStartSize.value.width + scaledDx
+        ),
+        height: Math.max(
+          intrinsicMinSize.value.height,
+          resizeStartSize.value.height + scaledDy
+        )
+      }
+
+      // Apply snap-to-grid if shift is held or always snap is enabled
+      const finalSize = shouldSnap(moveEvent)
+        ? applySnapToSize(constrainedSize)
+        : constrainedSize
 
       // Get the node element to apply size directly
       const nodeElement = target.closest('[data-node-id]')
       if (nodeElement instanceof HTMLElement) {
-        resizeCallback({ width: newWidth, height: newHeight }, nodeElement)
+        resizeCallback(finalSize, nodeElement)
       }
     }
 

--- a/src/renderer/extensions/vueNodes/composables/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeResize.ts
@@ -41,7 +41,7 @@ export function useNodeResize(
   const { shouldSnap, applySnapToSize } = useNodeSnap()
 
   // Shift key sync for LiteGraph canvas preview
-  const { syncShiftKeyToCanvas } = useShiftKeySync()
+  const { trackShiftKey } = useShiftKeySync()
 
   const startResize = (event: PointerEvent) => {
     event.preventDefault()
@@ -50,8 +50,8 @@ export function useNodeResize(
     const target = event.currentTarget
     if (!(target instanceof HTMLElement)) return
 
-    // Sync shift key state to canvas for snap preview
-    syncShiftKeyToCanvas(event)
+    // Track shift key state and sync to canvas for snap preview
+    const stopShiftSync = trackShiftKey(event)
 
     // Capture pointer to ensure we get all move/up events
     target.setPointerCapture(event.pointerId)
@@ -97,9 +97,6 @@ export function useNodeResize(
       )
         return
 
-      // Sync shift key state to canvas for snap preview
-      syncShiftKeyToCanvas(moveEvent)
-
       const dx = moveEvent.clientX - resizeStartPos.value.x
       const dy = moveEvent.clientY - resizeStartPos.value.y
 
@@ -134,13 +131,13 @@ export function useNodeResize(
 
     const handlePointerUp = (upEvent: PointerEvent) => {
       if (isResizing.value) {
-        // Sync shift key state to canvas for snap preview
-        syncShiftKeyToCanvas(upEvent)
-
         isResizing.value = false
         resizeStartPos.value = null
         resizeStartSize.value = null
         intrinsicMinSize.value = null
+
+        // Stop tracking shift key state
+        stopShiftSync()
 
         target.releasePointerCapture(upEvent.pointerId)
         stopMoveListen()

--- a/src/renderer/extensions/vueNodes/composables/useNodeSnap.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeSnap.ts
@@ -1,0 +1,75 @@
+import { computed } from 'vue'
+
+import { snapPoint } from '@/lib/litegraph/src/measure'
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+/**
+ * Composable for node snap-to-grid functionality
+ *
+ * Provides reactive access to snap settings and utilities for applying
+ * snap-to-grid behavior to Vue nodes during drag and resize operations.
+ */
+export function useNodeSnap() {
+  const settingStore = useSettingStore()
+
+  // Reactive snap settings
+  const gridSize = computed(() => settingStore.get('Comfy.SnapToGrid.GridSize'))
+  const alwaysSnap = computed(() => settingStore.get('pysssss.SnapToGrid'))
+
+  /**
+   * Determines if snap-to-grid should be applied based on shift key and settings
+   * @param event - The pointer event to check for shift key
+   * @returns true if snapping should be applied
+   */
+  function shouldSnap(event: PointerEvent): boolean {
+    return event.shiftKey || alwaysSnap.value
+  }
+
+  /**
+   * Applies snap-to-grid to a position
+   * @param position - Position object with x, y coordinates
+   * @returns The snapped position (mutates input and returns it)
+   */
+  function applySnapToPosition(position: { x: number; y: number }): {
+    x: number
+    y: number
+  } {
+    const size = gridSize.value
+    if (!size) return position
+
+    const posArray: [number, number] = [position.x, position.y]
+    if (snapPoint(posArray, size)) {
+      position.x = posArray[0]
+      position.y = posArray[1]
+    }
+    return position
+  }
+
+  /**
+   * Applies snap-to-grid to a size (width/height)
+   * @param size - Size object with width, height
+   * @returns The snapped size (mutates input and returns it)
+   */
+  function applySnapToSize(size: { width: number; height: number }): {
+    width: number
+    height: number
+  } {
+    const gridSizeValue = gridSize.value
+    if (!gridSizeValue) return size
+
+    const sizeArray: [number, number] = [size.width, size.height]
+    if (snapPoint(sizeArray, gridSizeValue)) {
+      size.width = sizeArray[0]
+      size.height = sizeArray[1]
+    }
+    return size
+  }
+
+  return {
+    gridSize,
+    alwaysSnap,
+    shouldSnap,
+    applySnapToPosition,
+    applySnapToSize
+  }
+}

--- a/src/renderer/extensions/vueNodes/composables/useNodeSnap.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeSnap.ts
@@ -28,41 +28,39 @@ export function useNodeSnap() {
   /**
    * Applies snap-to-grid to a position
    * @param position - Position object with x, y coordinates
-   * @returns The snapped position (mutates input and returns it)
+   * @returns The snapped position as a new object
    */
   function applySnapToPosition(position: { x: number; y: number }): {
     x: number
     y: number
   } {
     const size = gridSize.value
-    if (!size) return position
+    if (!size) return { ...position }
 
     const posArray: [number, number] = [position.x, position.y]
     if (snapPoint(posArray, size)) {
-      position.x = posArray[0]
-      position.y = posArray[1]
+      return { x: posArray[0], y: posArray[1] }
     }
-    return position
+    return { ...position }
   }
 
   /**
    * Applies snap-to-grid to a size (width/height)
    * @param size - Size object with width, height
-   * @returns The snapped size (mutates input and returns it)
+   * @returns The snapped size as a new object
    */
   function applySnapToSize(size: { width: number; height: number }): {
     width: number
     height: number
   } {
     const gridSizeValue = gridSize.value
-    if (!gridSizeValue) return size
+    if (!gridSizeValue) return { ...size }
 
     const sizeArray: [number, number] = [size.width, size.height]
     if (snapPoint(sizeArray, gridSizeValue)) {
-      size.width = sizeArray[0]
-      size.height = sizeArray[1]
+      return { width: sizeArray[0], height: sizeArray[1] }
     }
-    return size
+    return { ...size }
   }
 
   return {

--- a/src/renderer/extensions/vueNodes/composables/useShiftKeySync.ts
+++ b/src/renderer/extensions/vueNodes/composables/useShiftKeySync.ts
@@ -1,0 +1,45 @@
+import { onScopeDispose, shallowRef } from 'vue'
+
+import { app } from '@/scripts/app'
+
+/**
+ * Composable for syncing shift key state from Vue pointer events to LiteGraph canvas.
+ * This enables snap-to-grid preview rendering in LiteGraph when dragging/resizing Vue nodes.
+ *
+ * @returns Object containing the syncShiftKeyToCanvas function
+ */
+export function useShiftKeySync() {
+  const shiftKeyState = shallowRef(false)
+  let canvasEl: HTMLCanvasElement | null = null
+
+  /**
+   * Syncs shift key state from Vue pointer events to LiteGraph canvas
+   * for snap-to-grid preview rendering
+   */
+  function syncShiftKeyToCanvas(event: PointerEvent) {
+    if (event.shiftKey === shiftKeyState.value) return
+
+    // Lazy-initialize canvas reference on first use
+    if (!canvasEl) {
+      canvasEl = app.canvas?.canvas ?? null
+      if (!canvasEl) return // Canvas not ready yet
+    }
+
+    shiftKeyState.value = event.shiftKey
+    canvasEl.dispatchEvent(
+      new KeyboardEvent(event.shiftKey ? 'keydown' : 'keyup', {
+        key: 'Shift',
+        shiftKey: event.shiftKey,
+        bubbles: true
+      })
+    )
+  }
+
+  // Cleanup on component unmount
+  onScopeDispose(() => {
+    shiftKeyState.value = false
+    canvasEl = null
+  })
+
+  return { syncShiftKeyToCanvas }
+}

--- a/src/renderer/extensions/vueNodes/composables/useShiftKeySync.ts
+++ b/src/renderer/extensions/vueNodes/composables/useShiftKeySync.ts
@@ -1,4 +1,5 @@
-import { onScopeDispose, shallowRef } from 'vue'
+import { tryOnScopeDispose } from '@vueuse/core'
+import { shallowRef } from 'vue'
 
 import { app } from '@/scripts/app'
 
@@ -6,18 +7,17 @@ import { app } from '@/scripts/app'
  * Composable for syncing shift key state from Vue pointer events to LiteGraph canvas.
  * This enables snap-to-grid preview rendering in LiteGraph when dragging/resizing Vue nodes.
  *
- * @returns Object containing the syncShiftKeyToCanvas function
+ * @returns Object containing trackShiftKey for automatic shift state synchronization
  */
 export function useShiftKeySync() {
   const shiftKeyState = shallowRef(false)
   let canvasEl: HTMLCanvasElement | null = null
 
   /**
-   * Syncs shift key state from Vue pointer events to LiteGraph canvas
-   * for snap-to-grid preview rendering
+   * Syncs shift key state to LiteGraph canvas for snap-to-grid preview rendering
    */
-  function syncShiftKeyToCanvas(event: PointerEvent) {
-    if (event.shiftKey === shiftKeyState.value) return
+  function syncShiftState(isShiftPressed: boolean) {
+    if (isShiftPressed === shiftKeyState.value) return
 
     // Lazy-initialize canvas reference on first use
     if (!canvasEl) {
@@ -25,21 +25,55 @@ export function useShiftKeySync() {
       if (!canvasEl) return // Canvas not ready yet
     }
 
-    shiftKeyState.value = event.shiftKey
+    shiftKeyState.value = isShiftPressed
     canvasEl.dispatchEvent(
-      new KeyboardEvent(event.shiftKey ? 'keydown' : 'keyup', {
+      new KeyboardEvent(isShiftPressed ? 'keydown' : 'keyup', {
         key: 'Shift',
-        shiftKey: event.shiftKey,
+        shiftKey: isShiftPressed,
         bubbles: true
       })
     )
   }
 
+  /**
+   * Track shift key state during drag/resize operations and sync to canvas.
+   * Call at the start of pointer operations to enable continuous synchronization.
+   *
+   * @param initialEvent - The initial pointer event (pointerdown)
+   * @returns Cleanup function to stop tracking - must be called when operation ends
+   *
+   * @example
+   * ```ts
+   * const stopTracking = trackShiftKey(event)
+   * // ... drag/resize happens, shift state syncs automatically ...
+   * stopTracking() // Call on pointerup
+   * ```
+   */
+  function trackShiftKey(initialEvent: PointerEvent): () => void {
+    // Sync initial shift state
+    syncShiftState(initialEvent.shiftKey)
+
+    // Listen for shift key press/release during the operation
+    const handleKeyEvent = (e: KeyboardEvent) => {
+      if (e.key !== 'Shift') return
+      syncShiftState(e.shiftKey)
+    }
+
+    window.addEventListener('keydown', handleKeyEvent, { passive: true })
+    window.addEventListener('keyup', handleKeyEvent, { passive: true })
+
+    // Return cleanup function
+    return () => {
+      window.removeEventListener('keydown', handleKeyEvent)
+      window.removeEventListener('keyup', handleKeyEvent)
+    }
+  }
+
   // Cleanup on component unmount
-  onScopeDispose(() => {
+  tryOnScopeDispose(() => {
     shiftKeyState.value = false
     canvasEl = null
   })
 
-  return { syncShiftKeyToCanvas }
+  return { trackShiftKey }
 }


### PR DESCRIPTION
## Summary

Enable node snap to grid in vue nodes mirroring the same behavior as litegraph.

- Show node snap preview (semi transparent white box target behind node)
- Resize snap to grid
- Shift + drag / Auto snap 
- Multi select + group snap

## Changes

- **What**: useNodeSnap.ts useShifyKeySync.ts setups the core hooks into both the vue node positioning/resizing system and the event forwarding technique for communicating to litegraph.

## Review Focus

Both new composables and specifically the useNodeLayout modifications to batch the mutations when snapping.
A key tradeoff/note is why we are using the useShifyKeySync.ts which dispatches a new shift event to the canvas layer. This approach is the cleaner / more declaritive method mimicking how other vue node -> litegraph realtime events are passed.

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

https://github.com/user-attachments/assets/5a04dd0a-8cc2-45db-aa19-eb72e3cc416a


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5973-Fix-vue-nodes-snap-to-grid-2866d73d365081c1a058d223c8c52576) by [Unito](https://www.unito.io)
