### PR TITLE
Close zoom menu when toggling minimap visibility

### DIFF
--- a/browser_tests/tests/minimap.spec.ts
+++ b/browser_tests/tests/minimap.spec.ts
@@ -77,6 +77,11 @@ test.describe('Minimap', () => {
     await comfyPage.nextFrame()
 
     await expect(minimapContainer).toBeVisible()
+
+    // Open zoom controls dropdown again to verify button text
+    await zoomControlsButton.click()
+    await comfyPage.nextFrame()
+
     await expect(toggleButton).toContainText('Hide Minimap')
   })
 

--- a/browser_tests/tests/minimap.spec.ts
+++ b/browser_tests/tests/minimap.spec.ts
@@ -68,11 +68,11 @@ test.describe('Minimap', () => {
     await expect(minimapContainer).not.toBeVisible()
     await expect(toggleButton).toContainText('Show Minimap')
 
-    await toggleButton.click()
-    await comfyPage.nextFrame()
-
     // Open zoom controls dropdown first
     await zoomControlsButton.click()
+    await comfyPage.nextFrame()
+
+    await toggleButton.click()
     await comfyPage.nextFrame()
 
     await expect(minimapContainer).toBeVisible()

--- a/browser_tests/tests/minimap.spec.ts
+++ b/browser_tests/tests/minimap.spec.ts
@@ -71,6 +71,10 @@ test.describe('Minimap', () => {
     await toggleButton.click()
     await comfyPage.nextFrame()
 
+    // Open zoom controls dropdown first
+    await zoomControlsButton.click()
+    await comfyPage.nextFrame()
+
     await expect(minimapContainer).toBeVisible()
     await expect(toggleButton).toContainText('Hide Minimap')
   })

--- a/browser_tests/tests/minimap.spec.ts
+++ b/browser_tests/tests/minimap.spec.ts
@@ -66,11 +66,12 @@ test.describe('Minimap', () => {
     await comfyPage.nextFrame()
 
     await expect(minimapContainer).not.toBeVisible()
-    await expect(toggleButton).toContainText('Show Minimap')
 
-    // Open zoom controls dropdown first
+    // Open zoom controls dropdown again
     await zoomControlsButton.click()
     await comfyPage.nextFrame()
+
+    await expect(toggleButton).toContainText('Show Minimap')
 
     await toggleButton.click()
     await comfyPage.nextFrame()

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <ZoomControlsModal :visible="isModalVisible" />
+    <ZoomControlsModal :visible="isModalVisible" @close="hideModal" />
 
     <!-- Backdrop -->
     <div

--- a/src/components/graph/modals/ZoomControlsModal.vue
+++ b/src/components/graph/modals/ZoomControlsModal.vue
@@ -158,6 +158,10 @@ interface Props {
 
 const props = defineProps<Props>()
 
+const emit = defineEmits<{
+  close: []
+}>()
+
 const interval = ref<number | null>(null)
 
 // Computed properties for reactive states
@@ -177,6 +181,9 @@ const applyZoom = (val: InputNumberInputEvent) => {
 
 const executeCommand = (command: string) => {
   void commandStore.execute(command)
+  if (command === 'Comfy.Canvas.ToggleMinimap') {
+    emit('close')
+  }
 }
 
 const startRepeat = (command: string) => {

--- a/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
+++ b/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
@@ -69,8 +69,11 @@ const createWrapper = (props = {}) => {
 }
 
 describe('ZoomControlsModal', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('should execute zoom in command when zoom in button is clicked', async () => {
-    mockExecute.mockClear()
     const wrapper = createWrapper()
 
     const buttons = wrapper.findAll('button')
@@ -85,7 +88,6 @@ describe('ZoomControlsModal', () => {
   })
 
   it('should execute zoom out command when zoom out button is clicked', async () => {
-    mockExecute.mockClear()
     const wrapper = createWrapper()
 
     const buttons = wrapper.findAll('button')
@@ -100,7 +102,6 @@ describe('ZoomControlsModal', () => {
   })
 
   it('should execute fit view command when fit view button is clicked', async () => {
-    mockExecute.mockClear()
     const wrapper = createWrapper()
 
     const buttons = wrapper.findAll('button')
@@ -115,7 +116,6 @@ describe('ZoomControlsModal', () => {
   })
 
   it('should emit close when minimap toggle button is clicked', async () => {
-    mockExecute.mockClear()
     const wrapper = createWrapper()
 
     const minimapButton = wrapper.find('[data-testid="toggle-minimap-button"]')
@@ -129,7 +129,6 @@ describe('ZoomControlsModal', () => {
   })
 
   it('should not emit close when other command buttons are clicked', async () => {
-    mockExecute.mockClear()
     const wrapper = createWrapper()
 
     const buttons = wrapper.findAll('button')
@@ -145,7 +144,6 @@ describe('ZoomControlsModal', () => {
   })
 
   it('should call setAppZoomFromPercentage with valid zoom input values', async () => {
-    mockSetAppZoom.mockClear()
     const wrapper = createWrapper()
 
     const inputNumber = wrapper.findComponent({ name: 'InputNumber' })
@@ -158,7 +156,6 @@ describe('ZoomControlsModal', () => {
   })
 
   it('should not call setAppZoomFromPercentage with invalid zoom input values', async () => {
-    mockSetAppZoom.mockClear()
     const wrapper = createWrapper()
 
     const inputNumber = wrapper.findComponent({ name: 'InputNumber' })
@@ -202,16 +199,5 @@ describe('ZoomControlsModal', () => {
     const wrapper = createWrapper({ visible: false })
 
     expect(wrapper.find('.absolute').exists()).toBe(false)
-  })
-
-  it('should apply minimap container styles', () => {
-    const wrapper = createWrapper()
-
-    const container = wrapper.find('.bg-white')
-    expect(container.exists()).toBe(true)
-
-    // The component should apply the filtered minimap styles
-    const style = container.attributes('style')
-    expect(style).toContain('background-color')
   })
 })

--- a/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
+++ b/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
@@ -63,6 +63,40 @@ describe('ZoomControlsModal', () => {
     expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.FitView')
   })
 
+  it('should emit close when minimap toggle command is executed', () => {
+    mockExecute.mockClear()
+    const mockEmit = vi.fn()
+
+    // Simulate the executeCommand function behavior with emit
+    const executeCommand = (command: string) => {
+      mockExecute(command)
+      if (command === 'Comfy.Canvas.ToggleMinimap') {
+        mockEmit('close')
+      }
+    }
+
+    executeCommand('Comfy.Canvas.ToggleMinimap')
+    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ToggleMinimap')
+    expect(mockEmit).toHaveBeenCalledWith('close')
+  })
+
+  it('should not emit close for other commands', () => {
+    mockExecute.mockClear()
+    const mockEmit = vi.fn()
+
+    // Simulate the executeCommand function behavior with emit
+    const executeCommand = (command: string) => {
+      mockExecute(command)
+      if (command === 'Comfy.Canvas.ToggleMinimap') {
+        mockEmit('close')
+      }
+    }
+
+    executeCommand('Comfy.Canvas.FitView')
+    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.FitView')
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
   it('should validate zoom input ranges correctly', () => {
     mockSetAppZoom.mockClear()
 

--- a/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
+++ b/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
@@ -66,24 +66,48 @@ const createWrapper = (props = {}) => {
 }
 
 describe('ZoomControlsModal', () => {
-  it('should have proper props interface', () => {
-    // Test that the component file structure and basic exports work
-    expect(mockExecute).toBeDefined()
-    expect(mockGetCommand).toBeDefined()
-    expect(mockFormatKeySequence).toBeDefined()
-    expect(mockSetAppZoom).toBeDefined()
-    expect(mockSettingGet).toBeDefined()
+  it('should execute zoom in command when zoom in button is clicked', async () => {
+    mockExecute.mockClear()
+    const wrapper = createWrapper()
+
+    const buttons = wrapper.findAll('button')
+    const zoomInButton = buttons.find((btn) =>
+      btn.text().includes('graphCanvasMenu.zoomIn')
+    )
+
+    expect(zoomInButton).toBeDefined()
+    await zoomInButton!.trigger('mousedown')
+
+    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ZoomIn')
   })
 
-  it('should call command store execute when executeCommand is invoked', () => {
+  it('should execute zoom out command when zoom out button is clicked', async () => {
     mockExecute.mockClear()
+    const wrapper = createWrapper()
 
-    // Simulate the executeCommand function behavior
-    const executeCommand = (command: string) => {
-      mockExecute(command)
-    }
+    const buttons = wrapper.findAll('button')
+    const zoomOutButton = buttons.find((btn) =>
+      btn.text().includes('graphCanvasMenu.zoomOut')
+    )
 
-    executeCommand('Comfy.Canvas.FitView')
+    expect(zoomOutButton).toBeDefined()
+    await zoomOutButton!.trigger('mousedown')
+
+    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ZoomOut')
+  })
+
+  it('should execute fit view command when fit view button is clicked', async () => {
+    mockExecute.mockClear()
+    const wrapper = createWrapper()
+
+    const buttons = wrapper.findAll('button')
+    const fitViewButton = buttons.find((btn) =>
+      btn.text().includes('zoomControls.zoomToFit')
+    )
+
+    expect(fitViewButton).toBeDefined()
+    await fitViewButton!.trigger('click')
+
     expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.FitView')
   })
 
@@ -117,106 +141,76 @@ describe('ZoomControlsModal', () => {
     expect(wrapper.emitted('close')).toBeFalsy()
   })
 
-  it('should validate zoom input ranges correctly', () => {
+  it('should call setAppZoomFromPercentage with valid zoom input values', async () => {
     mockSetAppZoom.mockClear()
+    const wrapper = createWrapper()
 
-    // Simulate the applyZoom function behavior
-    const applyZoom = (val: { value: number }) => {
-      const inputValue = val.value as number
-      if (isNaN(inputValue) || inputValue < 1 || inputValue > 1000) {
-        return
-      }
-      mockSetAppZoom(inputValue)
-    }
+    const input = wrapper.find('input[type="text"]')
+    expect(input.exists()).toBe(true)
 
-    // Test invalid values
-    applyZoom({ value: 0 })
-    applyZoom({ value: 1010 })
-    applyZoom({ value: NaN })
+    await input.setValue('150')
+    await input.trigger('input')
+
+    expect(mockSetAppZoom).toHaveBeenCalledWith(150)
+  })
+
+  it('should not call setAppZoomFromPercentage with invalid zoom input values', async () => {
+    mockSetAppZoom.mockClear()
+    const wrapper = createWrapper()
+
+    const input = wrapper.find('input[type="text"]')
+    expect(input.exists()).toBe(true)
+
+    // Test out of range values
+    await input.setValue('0')
+    await input.trigger('input')
     expect(mockSetAppZoom).not.toHaveBeenCalled()
 
-    // Test valid value
-    applyZoom({ value: 50 })
-    expect(mockSetAppZoom).toHaveBeenCalledWith(50)
+    await input.setValue('1001')
+    await input.trigger('input')
+    expect(mockSetAppZoom).not.toHaveBeenCalled()
   })
 
-  it('should return correct minimap toggle text based on setting', () => {
-    const t = (key: string) => {
-      const translations: Record<string, string> = {
-        'zoomControls.showMinimap': 'Show Minimap',
-        'zoomControls.hideMinimap': 'Hide Minimap'
-      }
-      return translations[key] || key
-    }
-
-    // Simulate the minimapToggleText computed property
-    const minimapToggleText = () =>
-      mockSettingGet('Comfy.Minimap.Visible')
-        ? t('zoomControls.hideMinimap')
-        : t('zoomControls.showMinimap')
-
-    // Test when minimap is visible
+  it('should display "Hide Minimap" when minimap is visible', () => {
     mockSettingGet.mockReturnValue(true)
-    expect(minimapToggleText()).toBe('Hide Minimap')
+    const wrapper = createWrapper()
 
-    // Test when minimap is hidden
+    const minimapButton = wrapper.find('[data-testid="toggle-minimap-button"]')
+    expect(minimapButton.text()).toContain('zoomControls.hideMinimap')
+  })
+
+  it('should display "Show Minimap" when minimap is hidden', () => {
     mockSettingGet.mockReturnValue(false)
-    expect(minimapToggleText()).toBe('Show Minimap')
+    const wrapper = createWrapper()
+
+    const minimapButton = wrapper.find('[data-testid="toggle-minimap-button"]')
+    expect(minimapButton.text()).toContain('zoomControls.showMinimap')
   })
 
-  it('should format keyboard shortcuts correctly', () => {
-    mockFormatKeySequence.mockReturnValue('Ctrl+')
+  it('should display keyboard shortcuts for commands', () => {
+    const wrapper = createWrapper()
 
-    expect(mockFormatKeySequence()).toBe('Ctrl+')
-    expect(mockGetCommand).toBeDefined()
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toBeGreaterThan(0)
+
+    // Each command button should show the keyboard shortcut
+    expect(mockFormatKeySequence).toHaveBeenCalled()
   })
 
-  it('should handle repeat command functionality', () => {
-    mockExecute.mockClear()
-    let interval: number | null = null
+  it('should not be visible when visible prop is false', () => {
+    const wrapper = createWrapper({ visible: false })
 
-    // Simulate the repeat functionality
-    const startRepeat = (command: string) => {
-      if (interval) return
-      const cmd = () => mockExecute(command)
-      cmd() // Execute immediately
-      interval = 1 // Mock interval ID
-    }
-
-    const stopRepeat = () => {
-      if (interval) {
-        interval = null
-      }
-    }
-
-    startRepeat('Comfy.Canvas.ZoomIn')
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ZoomIn')
-
-    stopRepeat()
-    expect(interval).toBeNull()
+    expect(wrapper.find('.absolute').exists()).toBe(false)
   })
 
-  it('should have proper filteredMinimapStyles computed property', () => {
-    const mockContainerStyles = {
-      backgroundColor: '#fff',
-      borderRadius: '8px',
-      height: '100px',
-      width: '200px'
-    }
+  it('should apply minimap container styles', () => {
+    const wrapper = createWrapper()
 
-    // Simulate the filteredMinimapStyles computed property
-    const filteredMinimapStyles = () => {
-      return {
-        ...mockContainerStyles,
-        height: undefined,
-        width: undefined
-      }
-    }
+    const container = wrapper.find('.bg-white')
+    expect(container.exists()).toBe(true)
 
-    const result = filteredMinimapStyles()
-    expect(result.backgroundColor).toBe('#fff')
-    expect(result.borderRadius).toBe('8px')
-    expect(result.height).toBeUndefined()
-    expect(result.width).toBeUndefined()
+    // The component should apply the filtered minimap styles
+    const style = container.attributes('style')
+    expect(style).toContain('background-color')
   })
 })

--- a/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
+++ b/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
@@ -63,40 +63,6 @@ describe('ZoomControlsModal', () => {
     expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.FitView')
   })
 
-  it('should emit close when minimap toggle command is executed', () => {
-    mockExecute.mockClear()
-    const mockEmit = vi.fn()
-
-    // Simulate the executeCommand function behavior with emit
-    const executeCommand = (command: string) => {
-      mockExecute(command)
-      if (command === 'Comfy.Canvas.ToggleMinimap') {
-        mockEmit('close')
-      }
-    }
-
-    executeCommand('Comfy.Canvas.ToggleMinimap')
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ToggleMinimap')
-    expect(mockEmit).toHaveBeenCalledWith('close')
-  })
-
-  it('should not emit close for other commands', () => {
-    mockExecute.mockClear()
-    const mockEmit = vi.fn()
-
-    // Simulate the executeCommand function behavior with emit
-    const executeCommand = (command: string) => {
-      mockExecute(command)
-      if (command === 'Comfy.Canvas.ToggleMinimap') {
-        mockEmit('close')
-      }
-    }
-
-    executeCommand('Comfy.Canvas.FitView')
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.FitView')
-    expect(mockEmit).not.toHaveBeenCalled()
-  })
-
   it('should validate zoom input ranges correctly', () => {
     mockSetAppZoom.mockClear()
 

--- a/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
+++ b/tests-ui/tests/components/graph/ZoomControlsModal.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
 
 import ZoomControlsModal from '@/components/graph/modals/ZoomControlsModal.vue'
 
@@ -16,12 +17,13 @@ const mockFormatKeySequence = vi.fn().mockReturnValue('Ctrl+')
 const mockSetAppZoom = vi.fn()
 const mockSettingGet = vi.fn().mockReturnValue(true)
 
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
 // Mock dependencies
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => key
-  })
-}))
 
 vi.mock('@/renderer/extensions/minimap/composables/useMinimap', () => ({
   useMinimap: () => ({
@@ -57,6 +59,7 @@ const createWrapper = (props = {}) => {
       ...props
     },
     global: {
+      plugins: [i18n],
       stubs: {
         Button: false,
         InputNumber: false
@@ -145,11 +148,11 @@ describe('ZoomControlsModal', () => {
     mockSetAppZoom.mockClear()
     const wrapper = createWrapper()
 
-    const input = wrapper.find('input[type="text"]')
-    expect(input.exists()).toBe(true)
+    const inputNumber = wrapper.findComponent({ name: 'InputNumber' })
+    expect(inputNumber.exists()).toBe(true)
 
-    await input.setValue('150')
-    await input.trigger('input')
+    // Emit the input event with PrimeVue's InputNumberInputEvent structure
+    await inputNumber.vm.$emit('input', { value: 150 })
 
     expect(mockSetAppZoom).toHaveBeenCalledWith(150)
   })
@@ -158,16 +161,14 @@ describe('ZoomControlsModal', () => {
     mockSetAppZoom.mockClear()
     const wrapper = createWrapper()
 
-    const input = wrapper.find('input[type="text"]')
-    expect(input.exists()).toBe(true)
+    const inputNumber = wrapper.findComponent({ name: 'InputNumber' })
+    expect(inputNumber.exists()).toBe(true)
 
     // Test out of range values
-    await input.setValue('0')
-    await input.trigger('input')
+    await inputNumber.vm.$emit('input', { value: 0 })
     expect(mockSetAppZoom).not.toHaveBeenCalled()
 
-    await input.setValue('1001')
-    await input.trigger('input')
+    await inputNumber.vm.$emit('input', { value: 1001 })
     expect(mockSetAppZoom).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary

Closes the zoom menu popup when clicking show/hide minimap to prevent the menu from remaining open after toggling.

## Changes

- **What**: Adds `close` event emission from `ZoomControlsModal` when minimap toggle is clicked, wired to `hideModal` in parent `GraphCanvasMenu`
- **Tests**: Adds unit tests verifying close behavior for minimap toggle vs other commands

## Review Focus

This fixes the immediate UX issue where the zoom popup remained open after toggling minimap visibility. However, the minimap toggle's placement within the zoom menu is **not** ideal—it's not intuitive to look for minimap controls within zoom controls. This PR addresses the current UX friction without tackling the broader discoverability issue.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5974-Close-zoom-menu-when-toggling-minimap-visibility-2866d73d365081bdbb0bfeb0da4b8c2b) by [Unito](https://www.unito.io)
