### PR TITLE
Allow reordering of linked subgraph widgets

### DIFF
--- a/src/core/graph/subgraph/SubgraphNode.vue
+++ b/src/core/graph/subgraph/SubgraphNode.vue
@@ -169,10 +169,10 @@ function showAll() {
 function hideAll() {
   const node = activeNode.value
   if (!node) return //Not reachable
-  //Not great from a nesting perspective, but path is cold
-  //and it cleans up potential error states
   proxyWidgets.value = proxyWidgets.value.filter(
-    (widgetItem) => !filteredActive.value.some(matchesWidgetItem(widgetItem))
+    (propertyItem) =>
+      !filteredActive.value.some(matchesWidgetItem(propertyItem)) ||
+      propertyItem[0] === '-1'
   )
 }
 function showRecommended() {

--- a/src/core/graph/subgraph/SubgraphNode.vue
+++ b/src/core/graph/subgraph/SubgraphNode.vue
@@ -262,21 +262,16 @@ onBeforeUnmount(() => {
       >
     </div>
     <div ref="draggableItems">
-      <div
+      <SubgraphNodeWidget
         v-for="[node, widget] in filteredActive"
         :key="toKey([node, widget])"
-        class="draggable-item w-full"
-        style=""
-      >
-        <SubgraphNodeWidget
-          :node-title="node.title"
-          :widget-name="widget.name"
-          :is-shown="true"
-          :is-draggable="!debouncedQuery"
-          :is-physical="node.id === -1"
-          @toggle-visibility="demote([node, widget])"
-        />
-      </div>
+        :node-title="node.title"
+        :widget-name="widget.name"
+        :is-shown="true"
+        :is-draggable="!debouncedQuery"
+        :is-physical="node.id === -1"
+        @toggle-visibility="demote([node, widget])"
+      />
     </div>
   </div>
   <div v-if="filteredCandidates.length" class="pt-1 pb-4">
@@ -291,17 +286,13 @@ onBeforeUnmount(() => {
         {{ $t('subgraphStore.showAll') }}</a
       >
     </div>
-    <div
+    <SubgraphNodeWidget
       v-for="[node, widget] in filteredCandidates"
       :key="toKey([node, widget])"
-      class="w-full"
-    >
-      <SubgraphNodeWidget
-        :node-title="node.title"
-        :widget-name="widget.name"
-        @toggle-visibility="promote([node, widget])"
-      />
-    </div>
+      :node-title="node.title"
+      :widget-name="widget.name"
+      @toggle-visibility="promote([node, widget])"
+    />
   </div>
   <div
     v-if="recommendedWidgets.length"

--- a/src/core/graph/subgraph/SubgraphNodeWidget.vue
+++ b/src/core/graph/subgraph/SubgraphNodeWidget.vue
@@ -18,9 +18,7 @@ function classes() {
   return cn(
     'flex py-1 pr-4 pl-0 break-all rounded items-center gap-1',
     'bg-node-component-surface',
-    props.isDraggable
-      ? 'drag-handle cursor-grab [.is-draggable]:cursor-grabbing'
-      : ''
+    props.isDraggable ? 'drag-handle cursor-grab' : ''
   )
 }
 function getIcon() {

--- a/src/core/graph/subgraph/SubgraphNodeWidget.vue
+++ b/src/core/graph/subgraph/SubgraphNodeWidget.vue
@@ -18,12 +18,15 @@ function classes() {
   return cn(
     'flex py-1 pr-4 pl-0 break-all rounded items-center gap-1',
     'bg-node-component-surface',
-    props.isDraggable ? 'drag-handle cursor-grab' : ''
+    props.isDraggable && 'drag-handle cursor-grab'
   )
 }
 function getIcon() {
-  if (props.isPhysical) return 'icon-[lucide--link]'
-  return props.isDraggable ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off]'
+  return props.isPhysical
+    ? 'icon-[lucide--link]'
+    : props.isDraggable
+      ? 'icon-[lucide--eye]'
+      : 'icon-[lucide--eye-off]'
 }
 </script>
 <template>

--- a/src/core/graph/subgraph/SubgraphNodeWidget.vue
+++ b/src/core/graph/subgraph/SubgraphNodeWidget.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   widgetName: string
   isShown?: boolean
   isDraggable?: boolean
+  isPhysical?: boolean
 }>()
 defineEmits<{
   (e: 'toggleVisibility'): void
@@ -21,6 +22,10 @@ function classes() {
       ? 'drag-handle cursor-grab [.is-draggable]:cursor-grabbing'
       : ''
   )
+}
+function getIcon() {
+  if (props.isPhysical) return 'icon-[lucide--link]'
+  return props.isDraggable ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off]'
 }
 </script>
 <template>
@@ -40,7 +45,8 @@ function classes() {
     <Button
       size="small"
       text
-      :icon="isDraggable ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off]'"
+      :icon="getIcon()"
+      :disabled="isPhysical"
       severity="secondary"
       @click.stop="$emit('toggleVisibility')"
     />

--- a/src/core/graph/subgraph/SubgraphNodeWidget.vue
+++ b/src/core/graph/subgraph/SubgraphNodeWidget.vue
@@ -18,7 +18,8 @@ function classes() {
   return cn(
     'flex py-1 pr-4 pl-0 break-all rounded items-center gap-1',
     'bg-node-component-surface',
-    props.isDraggable && 'drag-handle cursor-grab'
+    props.isDraggable &&
+      'draggable-item drag-handle cursor-grab [&.is-draggable]:cursor-grabbing'
   )
 }
 function getIcon() {

--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -79,12 +79,12 @@ const onConfigure = function (
   originalOnConfigure?.call(this, serialisedNode)
 
   Object.defineProperty(this.properties, 'proxyWidgets', {
-    get: () => {
-      return this.widgets.map((w) => {
-        if (!isProxyWidget(w)) return ['-1', w.name]
-        return [w._overlay.nodeId, w._overlay.widgetName]
-      })
-    },
+    get: () =>
+      this.widgets.map((w) =>
+        isProxyWidget(w)
+          ? [w._overlay.nodeId, w._overlay.widgetName]
+          : ['-1', w.name]
+      ),
     set: (property: string) => {
       const parsed = parseProxyWidgets(property)
       const { deactivateWidget, setWidget } = useDomWidgetStore()
@@ -104,7 +104,7 @@ const onConfigure = function (
           realIndexes.push([i, widget])
         } else proxyItems.push(parsed[i])
       }
-      this.widgets.length = 0
+      this.widgets.length -= Math.min(this.widgets.length, parsed.length)
       for (const [nodeId, widgetName] of proxyItems) {
         const w = addProxyWidget(this, `${nodeId}`, widgetName)
         if (isActiveGraph && w instanceof DOMWidgetImpl) setWidget(w)

--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -44,7 +44,7 @@ type Overlay = Partial<IBaseWidget> & {
  * on the linked widget
  */
 type ProxyWidget = IBaseWidget & { _overlay: Overlay }
-export function isProxyWidget(w: IBaseWidget): w is ProxyWidget {
+function isProxyWidget(w: IBaseWidget): w is ProxyWidget {
   return (w as { _overlay?: Overlay })?._overlay?.isProxyWidget ?? false
 }
 
@@ -145,7 +145,7 @@ function addProxyWidget(
   }
   return addProxyFromOverlay(subgraphNode, overlay)
 }
-export function resolveLinkedWidget(
+function resolveLinkedWidget(
   overlay: Overlay
 ): [LGraphNode | undefined, IBaseWidget | undefined] {
   const { graph, nodeId, widgetName } = overlay

--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -109,7 +109,10 @@ const onConfigure = function (
         const w = addProxyWidget(this, `${nodeId}`, widgetName)
         if (isActiveGraph && w instanceof DOMWidgetImpl) setWidget(w)
       }
-      for (const [i, w] of realIndexes) this.widgets.splice(i, 0, w)
+      for (const [i, w] of realIndexes) {
+        w.value = serialisedNode.widgets_values?.[i] ?? w.value
+        this.widgets.splice(i, 0, w)
+      }
       canvasStore.canvas?.setDirty(true, true)
       this._setConcreteSlots()
       this.arrange()

--- a/src/core/graph/subgraph/proxyWidgetUtils.ts
+++ b/src/core/graph/subgraph/proxyWidgetUtils.ts
@@ -1,6 +1,5 @@
 import { parseProxyWidgets } from '@/core/schemas/proxyWidget'
 import type { ProxyWidgetsProperty } from '@/core/schemas/proxyWidget'
-import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type {
   IContextMenuValue,
   LGraphNode
@@ -10,7 +9,7 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets.ts'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
-type PartialNode = { id: NodeId; title: string; type: string }
+type PartialNode = Pick<LGraphNode, 'title' | 'id' | 'type'>
 
 export type WidgetItem = [PartialNode, IBaseWidget]
 

--- a/src/core/graph/subgraph/proxyWidgetUtils.ts
+++ b/src/core/graph/subgraph/proxyWidgetUtils.ts
@@ -1,5 +1,6 @@
 import { parseProxyWidgets } from '@/core/schemas/proxyWidget'
 import type { ProxyWidgetsProperty } from '@/core/schemas/proxyWidget'
+import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type {
   IContextMenuValue,
   LGraphNode
@@ -9,13 +10,15 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets.ts'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
-export type WidgetItem = [LGraphNode, IBaseWidget]
+type PartialNode = { id: NodeId; title: string; type: string }
+
+export type WidgetItem = [PartialNode, IBaseWidget]
 
 function getProxyWidgets(node: SubgraphNode) {
   return parseProxyWidgets(node.properties.proxyWidgets)
 }
 export function promoteWidget(
-  node: LGraphNode,
+  node: PartialNode,
   widget: IBaseWidget,
   parents: SubgraphNode[]
 ) {
@@ -30,7 +33,7 @@ export function promoteWidget(
 }
 
 export function demoteWidget(
-  node: LGraphNode,
+  node: PartialNode,
   widget: IBaseWidget,
   parents: SubgraphNode[]
 ) {

--- a/tests-ui/tests/widgets/proxyWidget.test.ts
+++ b/tests-ui/tests/widgets/proxyWidget.test.ts
@@ -2,11 +2,8 @@ import { describe, expect, test, vi } from 'vitest'
 
 import { registerProxyWidgets } from '@/core/graph/subgraph/proxyWidget'
 import { parseProxyWidgets } from '@/core/schemas/proxyWidget'
-import {
-  type LGraphCanvas,
-  LGraphNode,
-  type SubgraphNode
-} from '@/lib/litegraph/src/litegraph'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas, SubgraphNode } from '@/lib/litegraph/src/litegraph'
 
 import {
   createTestSubgraph,
@@ -71,9 +68,11 @@ describe('Subgraph proxyWidgets', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)
     innerNodes[0].addWidget('text', 'istringWidget', 'value', () => {})
     subgraphNode.addWidget('text', 'stringWidget', 'value', () => {})
+
     const proxyWidgets = parseProxyWidgets(subgraphNode.properties.proxyWidgets)
     proxyWidgets.push(['1', 'istringWidget'])
     subgraphNode.properties.proxyWidgets = proxyWidgets
+
     expect(subgraphNode.widgets.length).toBe(2)
     expect(subgraphNode.widgets[0].name).toBe('stringWidget')
     subgraphNode.properties.proxyWidgets = [proxyWidgets[1], proxyWidgets[0]]

--- a/tests-ui/tests/widgets/proxyWidget.test.ts
+++ b/tests-ui/tests/widgets/proxyWidget.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 
 import { registerProxyWidgets } from '@/core/graph/subgraph/proxyWidget'
+import { parseProxyWidgets } from '@/core/schemas/proxyWidget'
 import {
   type LGraphCanvas,
   LGraphNode,
@@ -66,14 +67,17 @@ describe('Subgraph proxyWidgets', () => {
       subgraphNode.widgets[1].name
     )
   })
-  test('Will not modify existing widgets', () => {
+  test('Will serialize existing widgets', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)
-    innerNodes[0].addWidget('text', 'stringWidget', 'value', () => {})
+    innerNodes[0].addWidget('text', 'istringWidget', 'value', () => {})
     subgraphNode.addWidget('text', 'stringWidget', 'value', () => {})
-    subgraphNode.properties.proxyWidgets = [['1', 'stringWidget']]
+    const proxyWidgets = parseProxyWidgets(subgraphNode.properties.proxyWidgets)
+    proxyWidgets.push(['1', 'istringWidget'])
+    subgraphNode.properties.proxyWidgets = proxyWidgets
     expect(subgraphNode.widgets.length).toBe(2)
-    subgraphNode.properties.proxyWidgets = []
-    expect(subgraphNode.widgets.length).toBe(1)
+    expect(subgraphNode.widgets[0].name).toBe('stringWidget')
+    subgraphNode.properties.proxyWidgets = [proxyWidgets[1], proxyWidgets[0]]
+    expect(subgraphNode.widgets[0].name).toBe('1: istringWidget')
   })
   test('Will mirror changes to value', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)


### PR DESCRIPTION
Widgets which are promoted by linking to a subgraphInput node are now also displayed in the subgraph configuration window. They can now be reordered by drag and drop along with proxyWidgets

![linked-reorder](https://github.com/user-attachments/assets/e1b8d590-211a-4d84-9f84-3a5fd5a7aa6c)

Known Issues:
- "Hide All" will incorrectly remove physically linked widgets

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5981-Allow-reordering-of-linked-subgraph-widgets-2866d73d365081d9b27cf4a9c3078007) by [Unito](https://www.unito.io)
