### PR TITLE
[feat] Auto-remove claude-review label after CI review completes

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -73,10 +73,10 @@ jobs:
         with:
           label_trigger: "claude-review"
           prompt: |
-            Read the file .claude/commands/comprehensive-pr-review.md and follow ALL the instructions exactly. 
-            
-            CRITICAL: You must post individual inline comments using the gh api commands shown in the file. 
-            DO NOT create a summary comment. 
+            Read the file .claude/commands/comprehensive-pr-review.md and follow ALL the instructions exactly.
+
+            CRITICAL: You must post individual inline comments using the gh api commands shown in the file.
+            DO NOT create a summary comment.
             Each issue must be posted as a separate inline comment on the specific line of code.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 256 --allowedTools 'Bash(git:*),Bash(gh api:*),Bash(gh pr:*),Bash(gh repo:*),Bash(jq:*),Bash(echo:*),Read,Write,Edit,Glob,Grep,WebFetch'"
@@ -86,3 +86,9 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPOSITORY: ${{ github.repository }}
+
+      - name: Remove claude-review label
+        if: always()
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "claude-review"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Automatically removes the `claude-review` label after the Claude PR review workflow completes, regardless of success or failure.

## Changes
- Added a cleanup step to `.github/workflows/claude-pr-review.yml` that removes the label using `gh pr edit --remove-label`
- Uses `if: always()` to ensure the label is removed even if the review fails
- This prevents label accumulation and allows the label to be re-applied for additional reviews

## Benefits
- Cleaner PR label management
- Labels can be re-applied to trigger additional reviews without manual cleanup
- Reduces noise in the PR interface

## Test Plan
- Apply the `claude-review` label to this PR to verify the workflow removes it automatically after completion

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5983-feat-Auto-remove-claude-review-label-after-CI-review-completes-2866d73d365081da929cd393996010e1) by [Unito](https://www.unito.io)
