### PR TITLE
[ci] Fix detached HEAD state in Playwright update workflow

### DIFF
--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -23,11 +23,16 @@ jobs:
     steps:
       - name: Initial Checkout
         uses: actions/checkout@v5
-      - name: Pull Request Checkout
+      - name: Pull Request Checkout (from comment)
         run: gh pr checkout ${{ github.event.issue.number }}
-        if: github.event.issue.pull_request && github.event_name == 'issue_comment'
+        if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull Request Checkout (from label)
+        run: |
+          git fetch origin ${{ github.head_ref }}
+          git checkout ${{ github.head_ref }}
+        if: github.event_name == 'pull_request'
       - name: Setup Frontend
         uses: ./.github/actions/setup-frontend
       - name: Setup Playwright
@@ -53,8 +58,16 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git add browser_tests
-          git diff --cached --quiet || git commit -m "[automated] Update test expectations"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "[automated] Update test expectations"
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              git push origin HEAD:${{ github.head_ref }}
+            else
+              git push
+            fi
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ComfyUI_frontend


### PR DESCRIPTION
## Summary

Fixes the Playwright update workflow broken by #5960. When triggered by adding the "New Browser Test Expectations" label, the workflow was left in a detached HEAD state, causing `git push` to fail.

## Changes

- **Restores branch checkout for label triggers**: Uses `github.head_ref` to fetch and checkout the branch when triggered by `pull_request` events
- **Preserves comment trigger functionality**: Keeps `gh pr checkout` for `issue_comment` events using `github.event.issue.number`
- **Event-specific push logic**: Uses explicit `git push origin HEAD:${{ github.head_ref }}` for label triggers, plain `git push` for comment triggers

## Root Cause

PR #5960 removed the original branch checkout logic:
```yaml
git fetch origin ${{ github.head_ref }}
git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
git push origin HEAD:${{ github.head_ref }}
```

This left the label-triggered workflow in detached HEAD after `actions/checkout@v5`, breaking the push step.

## Testing

This fix properly uses `github.head_ref` only when it's available (`pull_request` events) and `github.event.issue.number` only for `issue_comment` events where `head_ref` isn't available.

Fixes #5960

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5985-ci-Fix-detached-HEAD-state-in-Playwright-update-workflow-2866d73d36508183b63bca03a40da4a8) by [Unito](https://www.unito.io)
