### PR TITLE
Fix: Allow uncoloring Vue Nodes

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -344,8 +344,8 @@ export class LGraphNode
   /** @inheritdoc {@link IColorable.setColorOption} */
   setColorOption(colorOption: ColorOption | null): void {
     if (colorOption == null) {
-      delete this.color
-      delete this.bgcolor
+      this.color = undefined
+      this.bgcolor = undefined
     } else {
       this.color = colorOption.color
       this.bgcolor = colorOption.bgcolor
@@ -495,7 +495,7 @@ export class LGraphNode
   set shape(v: RenderShape | 'default' | 'box' | 'round' | 'circle' | 'card') {
     switch (v) {
       case 'default':
-        delete this._shape
+        this._shape = undefined
         break
       case 'box':
         this._shape = RenderShape.BOX
@@ -943,7 +943,7 @@ export class LGraphNode
     }
 
     // @ts-expect-error Exceptional case: id is removed so that the graph can assign a new one on add.
-    delete data.id
+    data.id = undefined
 
     if (LiteGraph.use_uuids) data.id = LiteGraph.uuidv4()
 
@@ -1948,7 +1948,7 @@ export class LGraphNode
       for (const input of this.inputs) {
         if (input._widget === widget) {
           input._widget = undefined
-          delete input.widget
+          input.widget = undefined
         }
       }
     }
@@ -2857,7 +2857,7 @@ export class LGraphNode
     const reroutes = LLink.getReroutes(graph, link)
     for (const reroute of reroutes) {
       reroute.linkIds.add(link.id)
-      if (reroute.floating) delete reroute.floating
+      if (reroute.floating) reroute.floating = undefined
       reroute._dragging = undefined
     }
 
@@ -2947,7 +2947,7 @@ export class LGraphNode
 
     reroute.floatingLinkIds.add(link.id)
     link.parentId = reroute.id
-    delete parentReroute.floating
+    parentReroute.floating = undefined
     return reroute
   }
 

--- a/src/lib/litegraph/src/LGraphNodeProperties.ts
+++ b/src/lib/litegraph/src/LGraphNodeProperties.ts
@@ -132,14 +132,14 @@ export class LGraphNodeProperties {
     oldValue: any,
     newValue: any
   ): void {
-    if (oldValue !== newValue && this.node.graph) {
-      this.node.graph.trigger('node:property:changed', {
-        nodeId: this.node.id,
-        property: propertyPath,
-        oldValue,
-        newValue
-      })
-    }
+    // if (oldValue !== newValue && this.node.graph) {
+    this.node.graph?.trigger('node:property:changed', {
+      nodeId: this.node.id,
+      property: propertyPath,
+      oldValue,
+      newValue
+    })
+    // }
   }
 
   /**

--- a/src/lib/litegraph/src/LGraphNodeProperties.ts
+++ b/src/lib/litegraph/src/LGraphNodeProperties.ts
@@ -132,14 +132,12 @@ export class LGraphNodeProperties {
     oldValue: any,
     newValue: any
   ): void {
-    // if (oldValue !== newValue && this.node.graph) {
     this.node.graph?.trigger('node:property:changed', {
       nodeId: this.node.id,
       property: propertyPath,
       oldValue,
       newValue
     })
-    // }
   }
 
   /**

--- a/tests-ui/tests/litegraph/core/LGraphNodeProperties.test.ts
+++ b/tests-ui/tests/litegraph/core/LGraphNodeProperties.test.ts
@@ -46,12 +46,12 @@ describe('LGraphNodeProperties', () => {
       })
     })
 
-    it("should not emit events when value doesn't change", () => {
+    it('should emit event when value is set to the same value', () => {
       new LGraphNodeProperties(mockNode)
 
       mockNode.title = 'Test Node' // Same value as original
 
-      expect(mockGraph.trigger).toHaveBeenCalledTimes(0)
+      expect(mockGraph.trigger).toHaveBeenCalledTimes(1)
     })
 
     it('should not emit events when node has no graph', () => {


### PR DESCRIPTION
## Summary

Fixes an issue where trying to uncolor a node broke the vue color syncing.

## Changes

- **What**: Changes litegraph property removal from `delete` to `= undefined`

## Screenshots

### Before 

https://github.com/user-attachments/assets/81a1ad40-ba5d-4dec-8f90-5b61eb804a16

### After

https://github.com/user-attachments/assets/459d2d15-c728-49d2-abd9-6e255e5383e5

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5991-Fix-Allow-uncoloring-Vue-Nodes-2876d73d365081f4a74fc9fa423aae1c) by [Unito](https://www.unito.io)
