### PR TITLE
[feat] Auto-remove New Browser Test Expectations label after workflow completes

### DIFF
--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -71,3 +71,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ComfyUI_frontend
+
+      - name: Remove New Browser Test Expectations label
+        if: always() && github.event_name == 'pull_request'
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "New Browser Test Expectations"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Automatically removes the `New Browser Test Expectations` label after the Playwright expectations update workflow completes.

## Changes
- Added a cleanup step to `.github/workflows/update-playwright-expectations.yaml` that removes the label using `gh pr edit --remove-label`
- Uses `if: always() && github.event_name == 'pull_request'` to ensure:
  - The label is removed even if the workflow fails
  - The label is only removed when triggered by the label event (not the `/update-playwright` comment trigger)

## Benefits
- Cleaner PR label management
- Labels can be re-applied to trigger additional expectations updates without manual cleanup
- Consistent with the claude-review workflow pattern
- Reduces noise in the PR interface

## Context
This is part of a broader effort to automatically clean up temporary action-triggering labels across all workflows. The first PR in this series (#5983) added the same functionality to the claude-review workflow.

## Test Plan
- Apply the `New Browser Test Expectations` label to a PR to verify the workflow removes it automatically after completion

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5998-feat-Auto-remove-New-Browser-Test-Expectations-label-after-workflow-completes-2876d73d365081e29fbbe6e3127ca973) by [Unito](https://www.unito.io)
