### PR TITLE
devex: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -54,3 +54,10 @@
 
 # Translations
 /src/locales/                                     @Yorha4D @KarryCharon @shinshin86 @Comfy-Org/comfy_maintainer
+
+# LLM Instructions (blank on purpose)
+.claude/
+.cursor/
+.cursorrules
+**/AGENTS.md
+**/CLAUDE.md


### PR DESCRIPTION
## Summary

Exempts the instructions files from CODEOWNERS

## Review Focus

Should we have specific owners for these files?

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-5999-devex-Update-CODEOWNERS-2876d73d365081dc8ed1e7cdd350cd36) by [Unito](https://www.unito.io)
