### PR TITLE
CI: Add concurrency checks to PR workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   wait-for-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -7,6 +7,10 @@ on:
     branches-ignore:
       [wip/*, draft/*, temp/*, vue-nodes-migration, sno-playwright-*]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
         with:
-          include_build_step: 'true'
+          include_build_step: "true"
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright # Setup Playwright and cache browsers
 

--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
         with:
-          include_build_step: "true"
+          include_build_step: true
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright # Setup Playwright and cache browsers
 

--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -8,7 +8,8 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.event.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/vitest-tests.yaml
+++ b/.github/workflows/vitest-tests.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Summary

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

## Changes

- **What**:  Will cancel ongoing checks when new commits are pushed to the PR branch

## Review Focus

What other optimizations could we make?

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6000-CI-Add-concurrency-checks-to-PR-workflows-2876d73d3650813cbb65eb8c397ac748) by [Unito](https://www.unito.io)
