### PR TITLE
Devex: Improve dev server

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -30,10 +30,17 @@ export default defineConfig({
     host: VITE_REMOTE_DEV ? '0.0.0.0' : undefined,
     watch: {
       ignored: [
-        '**/coverage/**',
-        '**/playwright-report/**',
+        '.eslintcache',
+        '*.config.{ts,mts}',
+        '**/.git/**',
+        '**/.github/**',
+        '**/.nx/**',
         '**/*.{test,spec}.ts',
-        '*.config.{ts,mts}'
+        '**/coverage/**',
+        '**/dist/**',
+        '**/playwright-report/**',
+        '**/test-results/**',
+        'node_modules/**'
       ]
     },
     proxy: {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -30,6 +30,9 @@ export default defineConfig({
     host: VITE_REMOTE_DEV ? '0.0.0.0' : undefined,
     watch: {
       ignored: [
+        './browser_tests/**',
+        './node_modules/**',
+        './tests-ui/**',
         '.eslintcache',
         '*.config.{ts,mts}',
         '**/.git/**',
@@ -39,8 +42,7 @@ export default defineConfig({
         '**/coverage/**',
         '**/dist/**',
         '**/playwright-report/**',
-        '**/test-results/**',
-        'node_modules/**'
+        '**/test-results/**'
       ]
     },
     proxy: {


### PR DESCRIPTION
## Summary

Keep Vite from watching extra files, should cut down on the amount of times it tries to reload and hopefully fix a file contention issue with git.
https://vite.dev/config/server-options.html#server-watch

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6002-Devex-Improve-dev-server-2876d73d365081a09417c2bf17da659f) by [Unito](https://www.unito.io)
