### PR TITLE
feat: add default keybindings for changing the mask brush size

### DIFF
--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -82,6 +82,18 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
     },
     commandId: 'Comfy.ShowSettingsDialog'
   },
+  {
+    combo: {
+      key: '['
+    },
+    commandId: 'Comfy.MaskEditor.BrushSize.Decrease'
+  },
+  {
+    combo: {
+      key: ']'
+    },
+    commandId: 'Comfy.MaskEditor.BrushSize.Increase'
+  },
   // For '=' both holding shift and not holding shift
   {
     combo: {


### PR DESCRIPTION
## Summary

Make it easier to change the mask brush size. These keybindings are familiar to users of other image editors.

## Changes

- **What**: Added `[` to decrease and `]` to increase the brush size.

## Review Focus

Is this generically useful enough to include the default keybindings?

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6003-feat-add-default-keybindings-for-changing-the-mask-brush-size-2876d73d365081de8832fcd4d94729f6) by [Unito](https://www.unito.io)

## References

- [GIMP brush size shortcuts](https://docs.gimp.org/3.0/en/gimp-using-variable-size-brush.html)
- [Photoshop brush size shortcuts](https://helpx.adobe.com/photoshop/using/default-keyboard-shortcuts.html)
- [Krita brush size shortcuts](https://imagy.app/shortcuts-for-krita-on-windows/#Shortcuts_for_Painting)
