### PR TITLE
Fix: Reset size when collapsing

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -124,6 +124,7 @@
 </template>
 
 <script setup lang="ts">
+import { whenever } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, inject, onErrorCaptured, onMounted, ref } from 'vue'
 
@@ -211,6 +212,7 @@ const hasAnyError = computed((): boolean => {
   )
 })
 
+const isCollapsed = computed(() => nodeData.flags?.collapsed ?? false)
 const bypassed = computed((): boolean => nodeData.mode === 4)
 const muted = computed((): boolean => nodeData.mode === 2) // NEVER mode
 
@@ -290,8 +292,12 @@ const { startResize } = useNodeResize(
   }
 )
 
-// Track collapsed state
-const isCollapsed = computed(() => nodeData.flags?.collapsed ?? false)
+whenever(isCollapsed, () => {
+  const element = nodeContainerRef.value
+  if (!element) return
+  element.style.width = ''
+  element.style.height = ''
+})
 
 // Check if node has custom content (like image/video outputs)
 const hasCustomContent = computed(() => {
@@ -395,5 +401,5 @@ const nodeMedia = computed(() => {
   return { type, urls } as const
 })
 
-const nodeContainerRef = ref()
+const nodeContainerRef = ref<HTMLDivElement>()
 </script>


### PR DESCRIPTION
## Summary

Minimal initial fix to allow resized nodes to collapse.
Does not retain the size across collapse/expand.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/bd6bf496-eb58-4f48-b5dc-b388f20ed0d9


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6004-Fix-Reset-size-when-collapsing-2876d73d365081d7886cc4b708adddd6) by [Unito](https://www.unito.io)
