### PR TITLE
[bugfix] Fix update-playwright-expectations workflow missing frontend build

### DIFF
--- a/.github/workflows/update-playwright-expectations.yaml
+++ b/.github/workflows/update-playwright-expectations.yaml
@@ -55,6 +55,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.get-branch.outputs.branch }}
+      - name: Setup Frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: true
       - name: Setup ComfyUI Server
         uses: ./.github/actions/setup-comfyui-server
         with:


### PR DESCRIPTION
## Problem

The `update-playwright-expectations.yaml` workflow was failing with:
```
error: argument --front-end-root: The path '../dist' does not exist.
```

This was happening because the workflow was trying to launch the ComfyUI server with `--front-end-root ../dist` before building the frontend.

## Root Cause

The workflow was missing the frontend build step entirely. It went directly from checkout → setup server with `launch_server: true` → run tests, skipping the crucial frontend build.

## Solution

1. Remove `launch_server: true` from `setup-comfyui-server` action call
2. Add `setup-frontend` action with `include_build_step: true` to build the frontend
3. Add separate "Launch ComfyUI Server" step that runs AFTER frontend is built

This ensures the `dist/` directory exists before the server tries to use it.

## Testing

This fixes errors seen on PR #5863 and any PR using the `/update-playwright` comment trigger.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6005-bugfix-Fix-update-playwright-expectations-workflow-missing-frontend-build-2876d73d36508182bb1af1123f3b2a87) by [Unito](https://www.unito.io)
