### PR TITLE
Safer restoration of widgets_values on subgraph nodes

### DIFF
--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -115,11 +115,14 @@ const onConfigure = function (
       this.arrange()
     }
   })
-  if (serialisedNode.properties?.proxyWidgets)
+  if (serialisedNode.properties?.proxyWidgets) {
     this.properties.proxyWidgets = serialisedNode.properties.proxyWidgets
-  serialisedNode.widgets_values?.forEach((v, index) => {
-    if (v !== null) this.widgets[index].value = v
-  })
+    const parsed = parseProxyWidgets(serialisedNode.properties.proxyWidgets)
+    serialisedNode.widgets_values?.forEach((v, index) => {
+      const widget = this.widgets.find((w) => w.name == parsed[index][1])
+      if (v !== null && widget) widget.value = v
+    })
+  }
 }
 
 function newProxyWidget(


### PR DESCRIPTION
Reordering linked widgets requires special attention on load to restore widgets_values. The method which was merged was optimistic and insufficient for some rarer edge cases.

Resolves #6014 

Fix was already included in #6009. Backport is not required.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6015-Safer-restoration-of-widgets_values-on-subgraph-nodes-2896d73d3650813a9162e8459e686981) by [Unito](https://www.unito.io)
