### PR TITLE
Allow connection to subgraphIOs in vue mode

### DIFF
--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -5,6 +5,7 @@ import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { app } from '@/scripts/app'
+import { isSubgraph } from '@/utils/typeGuardUtil'
 
 // Keep one adapter per graph so rendering and interaction share state.
 const adapterByGraph = new WeakMap<LGraph, LinkConnectorAdapter>()
@@ -130,6 +131,15 @@ export class LinkConnectorAdapter {
 
   /** Drops moving links onto the canvas (no target). */
   dropOnCanvas(event: CanvasPointerEvent): void {
+    //Add extra check for connection to subgraphInput/subgraphOutput
+    if (isSubgraph(this.network)) {
+      const { canvasX, canvasY } = event
+      const ioNode = this.network.getIoNodeOnPos?.(canvasX, canvasY)
+      if (ioNode) {
+        this.linkConnector.dropOnIoNode(ioNode, event)
+        return
+      }
+    }
     this.linkConnector.dropOnNothing(event)
   }
 


### PR DESCRIPTION
Adds support for link connections from nodes to subgraphInputs and subgraphOutputs when in vue mode.
![vue-subgraphio](https://github.com/user-attachments/assets/5b1ef66f-d45a-40c7-ace0-932aaf811e1d)

Resolves #5706

Known Issues
- Creating a connection from a widget does not trigger an update of the widget to the disabled state

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6016-Allow-connection-to-subgraphIOs-in-vue-mode-2896d73d3650816cbd88f645dced87df) by [Unito](https://www.unito.io)
