### PR TITLE
[ci] fix update locales workflow

### DIFF
--- a/.github/workflows/update-locales.yaml
+++ b/.github/workflows/update-locales.yaml
@@ -18,14 +18,14 @@ jobs:
       uses: actions/checkout@v5
 
     # Setup playwright environment
-    - name: Setup ComfyUI Server
-      uses: ./.github/actions/setup-comfyui-server
-      with:
-        launch_server: true
     - name: Setup ComfyUI Frontend
       uses: ./.github/actions/setup-frontend
       with:
         include_build_step: true
+    - name: Setup ComfyUI Server
+      uses: ./.github/actions/setup-comfyui-server
+      with:
+        launch_server: true
     - name: Setup Playwright
       uses: ./.github/actions/setup-playwright
 


### PR DESCRIPTION
Similar to https://github.com/Comfy-Org/ComfyUI_frontend/pull/6005, fixing the update-locales workflow by setting up the frontend before launching ComfyUI server.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6017-ci-fix-update-locales-workflow-2896d73d36508173aaf9e0eefe4f7660) by [Unito](https://www.unito.io)
