### PR TITLE
[test] add browser test for control+a selection of Vue nodes

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
@@ -54,7 +54,7 @@ test.describe('Vue Node Selection', () => {
     const initialCount = await comfyPage.vueNodes.getNodeCount()
     expect(initialCount).toBeGreaterThan(0)
 
-    await comfyPage.page.keyboard.press('Control+a')
+    await comfyPage.canvas.press('Control+a')
 
     const selectedCount = await comfyPage.vueNodes.getSelectedNodeCount()
     expect(selectedCount).toBe(initialCount)

--- a/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
@@ -50,15 +50,23 @@ test.describe('Vue Node Selection', () => {
     })
   }
 
+  test('should select all nodes with ctrl+a', async ({ comfyPage }) => {
+    const initialCount = await comfyPage.vueNodes.getNodeCount()
+    expect(initialCount).toBeGreaterThan(0)
+
+    await comfyPage.page.keyboard.press('Control+a')
+
+    const selectedCount = await comfyPage.vueNodes.getSelectedNodeCount()
+    expect(selectedCount).toBe(initialCount)
+  })
+
   test('should select pinned node without dragging', async ({ comfyPage }) => {
     const PIN_HOTKEY = 'p'
     const PIN_INDICATOR = '[data-testid="node-pin-indicator"]'
 
-    // Select a node by clicking its title
     const checkpointNodeHeader = comfyPage.page.getByText('Load Checkpoint')
     await checkpointNodeHeader.click()
 
-    // Pin it using the hotkey (as a user would)
     await comfyPage.page.keyboard.press(PIN_HOTKEY)
 
     const checkpointNode = comfyPage.vueNodes.getNodeByTitle('Load Checkpoint')


### PR DESCRIPTION
## Summary

Adds test case ensuring you can select all Vue nodes with `Ctrl`+`a`, mirroring coverage of similar behavior when using Litegraph nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6031-test-add-browser-test-for-control-a-selection-of-Vue-nodes-28a6d73d365081079860c3a083a946ef) by [Unito](https://www.unito.io)
