### PR TITLE
[refactor] adjust Vue node fixtures to not be coupled to Litegraph

### DIFF
--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -110,9 +110,20 @@ export class VueNodeHelpers {
 
   /**
    * Return a DOM-focused VueNodeFixture for the first node matching the title.
+   * Resolves the node id up front so subsequent interactions survive title changes.
    */
-  getFixtureByTitle(title: string): VueNodeFixture {
-    return new VueNodeFixture(this.getNodeByTitle(title).first())
+  async getFixtureByTitle(title: string): Promise<VueNodeFixture> {
+    const node = this.getNodeByTitle(title).first()
+    await node.waitFor({ state: 'visible' })
+
+    const nodeId = await node.evaluate((el) => el.getAttribute('data-node-id'))
+    if (!nodeId) {
+      throw new Error(
+        `Vue node titled "${title}" is missing its data-node-id attribute`
+      )
+    }
+
+    return new VueNodeFixture(this.getNodeLocator(nodeId))
   }
 
   /**

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -3,6 +3,8 @@
  */
 import type { Locator, Page } from '@playwright/test'
 
+import { VueNodeFixture } from './utils/vueNodeFixtures'
+
 export class VueNodeHelpers {
   constructor(private page: Page) {}
 
@@ -104,6 +106,13 @@ export class VueNodeHelpers {
   async deleteSelectedWithBackspace(): Promise<void> {
     await this.page.locator('#graph-canvas').focus()
     await this.page.keyboard.press('Backspace')
+  }
+
+  /**
+   * Return a DOM-focused VueNodeFixture for the first node matching the title.
+   */
+  getFixtureByTitle(title: string): VueNodeFixture {
+    return new VueNodeFixture(this.getNodeByTitle(title).first())
   }
 
   /**

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -29,12 +29,16 @@ export class VueNodeFixture {
     return this.collapseButton.locator('i')
   }
 
+  get root(): Locator {
+    return this.locator
+  }
+
   async getTitle(): Promise<string> {
     return (await this.title.textContent()) ?? ''
   }
 
   async setTitle(value: string): Promise<void> {
-    await this.title.dblclick()
+    await this.header.dblclick()
     const input = this.titleInput
     await expect(input).toBeVisible()
     await input.fill(value)
@@ -42,7 +46,7 @@ export class VueNodeFixture {
   }
 
   async cancelTitleEdit(): Promise<void> {
-    await this.title.dblclick()
+    await this.header.dblclick()
     const input = this.titleInput
     await expect(input).toBeVisible()
     await input.press('Escape')
@@ -58,9 +62,5 @@ export class VueNodeFixture {
 
   boundingBox(): ReturnType<Locator['boundingBox']> {
     return this.locator.boundingBox()
-  }
-
-  get element(): Locator {
-    return this.locator
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 
 /** DOM-centric helper for a single Vue-rendered node on the canvas. */
@@ -35,13 +36,16 @@ export class VueNodeFixture {
   async setTitle(value: string): Promise<void> {
     await this.title.dblclick()
     const input = this.titleInput
+    await expect(input).toBeVisible()
     await input.fill(value)
     await input.press('Enter')
   }
 
   async cancelTitleEdit(): Promise<void> {
     await this.title.dblclick()
-    await this.titleInput.press('Escape')
+    const input = this.titleInput
+    await expect(input).toBeVisible()
+    await input.press('Escape')
   }
 
   async toggleCollapse(): Promise<void> {

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,131 +1,62 @@
-import type { Locator, Page } from '@playwright/test'
+import type { Locator } from '@playwright/test'
 
-import type { NodeReference } from './litegraphUtils'
-
-/**
- * VueNodeFixture provides Vue-specific testing utilities for interacting with
- * Vue node components. It bridges the gap between litegraph node references
- * and Vue UI components.
- */
+/** DOM-centric helper for a single Vue-rendered node on the canvas. */
 export class VueNodeFixture {
-  constructor(
-    private readonly nodeRef: NodeReference,
-    private readonly page: Page
-  ) {}
+  constructor(private readonly locator: Locator) {}
 
-  /**
-   * Get the node's header element using data-testid
-   */
-  async getHeader(): Promise<Locator> {
-    const nodeId = this.nodeRef.id
-    return this.page.locator(`[data-testid="node-header-${nodeId}"]`)
+  get header(): Locator {
+    return this.locator.locator('[data-testid^="node-header-"]')
   }
 
-  /**
-   * Get the node's title element
-   */
-  async getTitleElement(): Promise<Locator> {
-    const header = await this.getHeader()
-    return header.locator('[data-testid="node-title"]')
+  get title(): Locator {
+    return this.locator.locator('[data-testid="node-title"]')
   }
 
-  /**
-   * Get the current title text
-   */
+  get titleInput(): Locator {
+    return this.locator.locator('[data-testid="node-title-input"]')
+  }
+
+  get body(): Locator {
+    return this.locator.locator('[data-testid^="node-body-"]')
+  }
+
+  get collapseButton(): Locator {
+    return this.locator.locator('[data-testid="node-collapse-button"]')
+  }
+
+  get collapseIcon(): Locator {
+    return this.collapseButton.locator('i')
+  }
+
   async getTitle(): Promise<string> {
-    const titleElement = await this.getTitleElement()
-    return (await titleElement.textContent()) || ''
+    return (await this.title.textContent()) ?? ''
   }
 
-  /**
-   * Set a new title by double-clicking and entering text
-   */
-  async setTitle(newTitle: string): Promise<void> {
-    const titleElement = await this.getTitleElement()
-    await titleElement.dblclick()
-
-    const input = (await this.getHeader()).locator(
-      '[data-testid="node-title-input"]'
-    )
-    await input.fill(newTitle)
+  async setTitle(value: string): Promise<void> {
+    await this.title.dblclick()
+    const input = this.titleInput
+    await input.fill(value)
     await input.press('Enter')
   }
 
-  /**
-   * Cancel title editing
-   */
   async cancelTitleEdit(): Promise<void> {
-    const titleElement = await this.getTitleElement()
-    await titleElement.dblclick()
-
-    const input = (await this.getHeader()).locator(
-      '[data-testid="node-title-input"]'
-    )
-    await input.press('Escape')
+    await this.title.dblclick()
+    await this.titleInput.press('Escape')
   }
 
-  /**
-   * Check if the title is currently being edited
-   */
-  async isEditingTitle(): Promise<boolean> {
-    const header = await this.getHeader()
-    const input = header.locator('[data-testid="node-title-input"]')
-    return await input.isVisible()
-  }
-
-  /**
-   * Get the collapse/expand button
-   */
-  async getCollapseButton(): Promise<Locator> {
-    const header = await this.getHeader()
-    return header.locator('[data-testid="node-collapse-button"]')
-  }
-
-  /**
-   * Toggle the node's collapsed state
-   */
   async toggleCollapse(): Promise<void> {
-    const button = await this.getCollapseButton()
-    await button.click()
+    await this.collapseButton.click()
   }
 
-  /**
-   * Get the collapse icon element
-   */
-  async getCollapseIcon(): Promise<Locator> {
-    const button = await this.getCollapseButton()
-    return button.locator('i')
-  }
-
-  /**
-   * Get the collapse icon's CSS classes
-   */
   async getCollapseIconClass(): Promise<string> {
-    const icon = await this.getCollapseIcon()
-    return (await icon.getAttribute('class')) || ''
+    return (await this.collapseIcon.getAttribute('class')) ?? ''
   }
 
-  /**
-   * Check if the collapse button is visible
-   */
-  async isCollapseButtonVisible(): Promise<boolean> {
-    const button = await this.getCollapseButton()
-    return await button.isVisible()
+  boundingBox(): ReturnType<Locator['boundingBox']> {
+    return this.locator.boundingBox()
   }
 
-  /**
-   * Get the node's body/content element
-   */
-  async getBody(): Promise<Locator> {
-    const nodeId = this.nodeRef.id
-    return this.page.locator(`[data-testid="node-body-${nodeId}"]`)
-  }
-
-  /**
-   * Check if the node body is visible (not collapsed)
-   */
-  async isBodyVisible(): Promise<boolean> {
-    const body = await this.getBody()
-    return await body.isVisible()
+  get element(): Locator {
+    return this.locator
   }
 }

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -2,70 +2,62 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '../../../../fixtures/ComfyPage'
-import { VueNodeFixture } from '../../../../fixtures/utils/vueNodeFixtures'
 
 test.describe('Vue Nodes Renaming', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.setSetting('Comfy.Graph.CanvasMenu', false)
     await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
     await comfyPage.setup()
+    await comfyPage.vueNodes.waitForNodes()
   })
 
   test('should display node title', async ({ comfyPage }) => {
-    // Get the KSampler node from the default workflow
-    const nodes = await comfyPage.getNodeRefsByType('KSampler')
-    expect(nodes.length).toBeGreaterThanOrEqual(1)
+    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
+    await expect(node).toBeVisible()
 
-    const node = nodes[0]
-    const vueNode = new VueNodeFixture(node, comfyPage.page)
-
-    const title = await vueNode.getTitle()
-    expect(title).toBe('KSampler')
-
-    // Verify title is visible in the header
-    const header = await vueNode.getHeader()
-    await expect(header).toContainText('KSampler')
+    const title = node.locator('[data-testid="node-title"]')
+    await expect(title).toHaveText('KSampler')
   })
 
   test('should allow title renaming by double clicking on the node header', async ({
     comfyPage
   }) => {
-    const nodes = await comfyPage.getNodeRefsByType('KSampler')
-    const node = nodes[0]
-    const vueNode = new VueNodeFixture(node, comfyPage.page)
+    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
+    await expect(node).toBeVisible()
+
+    const title = node.locator('[data-testid="node-title"]')
+    const titleInput = node.locator('[data-testid="node-title-input"]')
 
     // Test renaming with Enter
-    await vueNode.setTitle('My Custom Sampler')
-    const newTitle = await vueNode.getTitle()
-    expect(newTitle).toBe('My Custom Sampler')
+    await title.dblclick()
+    await titleInput.fill('My Custom Sampler')
+    await titleInput.press('Enter')
+    await expect(title).toHaveText('My Custom Sampler')
 
     // Verify the title is displayed
-    const header = await vueNode.getHeader()
-    await expect(header).toContainText('My Custom Sampler')
+    await expect(node.locator('[data-testid^="node-header-"]')).toContainText(
+      'My Custom Sampler'
+    )
 
     // Test cancel with Escape
-    const titleElement = await vueNode.getTitleElement()
-    await titleElement.dblclick()
+    await title.dblclick()
     await comfyPage.nextFrame()
 
     // Type a different value but cancel
-    const input = (await vueNode.getHeader()).locator(
-      '[data-testid="node-title-input"]'
-    )
-    await input.fill('This Should Be Cancelled')
-    await input.press('Escape')
+    await titleInput.fill('This Should Be Cancelled')
+    await titleInput.press('Escape')
     await comfyPage.nextFrame()
 
     // Title should remain as the previously saved value
-    const titleAfterCancel = await vueNode.getTitle()
-    expect(titleAfterCancel).toBe('My Custom Sampler')
+    await expect(title).toHaveText('My Custom Sampler')
   })
 
   test('Double click node body does not trigger edit', async ({
     comfyPage
   }) => {
-    const loadCheckpointNode =
-      comfyPage.vueNodes.getNodeByTitle('Load Checkpoint')
+    const loadCheckpointNode = comfyPage.vueNodes
+      .getNodeByTitle('Load Checkpoint')
+      .first()
     const nodeBbox = await loadCheckpointNode.boundingBox()
     if (!nodeBbox) throw new Error('Node not found')
     await loadCheckpointNode.dblclick()

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -12,37 +12,28 @@ test.describe('Vue Nodes Renaming', () => {
   })
 
   test('should display node title', async ({ comfyPage }) => {
-    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
     await expect(vueNode.header).toContainText('KSampler')
   })
 
   test('should allow title renaming by double clicking on the node header', async ({
     comfyPage
   }) => {
-    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
-    const title = vueNode.title
-    const titleInput = vueNode.titleInput
-
+    const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
     // Test renaming with Enter
-    await title.dblclick()
-    await titleInput.fill('My Custom Sampler')
-    await titleInput.press('Enter')
-    await expect(title).toHaveText('My Custom Sampler')
-
-    // Verify the title is displayed
+    await vueNode.setTitle('My Custom Sampler')
+    await expect(await vueNode.getTitle()).toBe('My Custom Sampler')
     await expect(vueNode.header).toContainText('My Custom Sampler')
 
     // Test cancel with Escape
-    await title.dblclick()
+    await vueNode.title.dblclick()
     await comfyPage.nextFrame()
-
-    // Type a different value but cancel
-    await titleInput.fill('This Should Be Cancelled')
-    await titleInput.press('Escape')
+    await vueNode.titleInput.fill('This Should Be Cancelled')
+    await vueNode.titleInput.press('Escape')
     await comfyPage.nextFrame()
 
     // Title should remain as the previously saved value
-    await expect(title).toHaveText('My Custom Sampler')
+    await expect(await vueNode.getTitle()).toBe('My Custom Sampler')
   })
 
   test('Double click node body does not trigger edit', async ({

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -12,21 +12,16 @@ test.describe('Vue Nodes Renaming', () => {
   })
 
   test('should display node title', async ({ comfyPage }) => {
-    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
-    await expect(node).toBeVisible()
-
-    const title = node.locator('[data-testid="node-title"]')
-    await expect(title).toHaveText('KSampler')
+    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.header).toContainText('KSampler')
   })
 
   test('should allow title renaming by double clicking on the node header', async ({
     comfyPage
   }) => {
-    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
-    await expect(node).toBeVisible()
-
-    const title = node.locator('[data-testid="node-title"]')
-    const titleInput = node.locator('[data-testid="node-title-input"]')
+    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    const title = vueNode.title
+    const titleInput = vueNode.titleInput
 
     // Test renaming with Enter
     await title.dblclick()
@@ -35,9 +30,7 @@ test.describe('Vue Nodes Renaming', () => {
     await expect(title).toHaveText('My Custom Sampler')
 
     // Verify the title is displayed
-    await expect(node.locator('[data-testid^="node-header-"]')).toContainText(
-      'My Custom Sampler'
-    )
+    await expect(vueNode.header).toContainText('My Custom Sampler')
 
     // Test cancel with Escape
     await title.dblclick()

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '../../../fixtures/ComfyPage'
-import { VueNodeFixture } from '../../../fixtures/utils/vueNodeFixtures'
 
 test.describe('Vue Node Collapse', () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -10,80 +9,94 @@ test.describe('Vue Node Collapse', () => {
     await comfyPage.setSetting('Comfy.EnableTooltips', true)
     await comfyPage.setSetting('Comfy.VueNodes.Enabled', true)
     await comfyPage.setup()
+    await comfyPage.vueNodes.waitForNodes()
   })
 
   test('should allow collapsing node with collapse icon', async ({
     comfyPage
   }) => {
-    // Get the KSampler node from the default workflow
-    const nodes = await comfyPage.getNodeRefsByType('KSampler')
-    const node = nodes[0]
-    const vueNode = new VueNodeFixture(node, comfyPage.page)
+    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
+    await expect(node).toBeVisible()
 
     // Initially should not be collapsed
-    expect(await node.isCollapsed()).toBe(false)
-    const body = await vueNode.getBody()
+    const body = node.locator('[data-testid^="node-body-"]')
     await expect(body).toBeVisible()
+    const expandedBoundingBox = await node.boundingBox()
+    if (!expandedBoundingBox)
+      throw new Error('Failed to get node bounding box before collapse')
 
     // Collapse the node
-    await vueNode.toggleCollapse()
-    expect(await node.isCollapsed()).toBe(true)
+    await node.locator('[data-testid="node-collapse-button"]').click()
+    await comfyPage.nextFrame()
 
     // Verify node content is hidden
-    const collapsedSize = await node.getSize()
     await expect(body).not.toBeVisible()
+    const collapsedBoundingBox = await node.boundingBox()
+    if (!collapsedBoundingBox)
+      throw new Error('Failed to get node bounding box after collapse')
+    expect(collapsedBoundingBox.height).toBeLessThan(expandedBoundingBox.height)
 
     // Expand again
-    await vueNode.toggleCollapse()
-    expect(await node.isCollapsed()).toBe(false)
+    await node.locator('[data-testid="node-collapse-button"]').click()
+    await comfyPage.nextFrame()
     await expect(body).toBeVisible()
 
     // Size should be restored
-    const expandedSize = await node.getSize()
-    expect(expandedSize.height).toBeGreaterThanOrEqual(collapsedSize.height)
+    const expandedBoundingBoxAfter = await node.boundingBox()
+    if (!expandedBoundingBoxAfter)
+      throw new Error('Failed to get node bounding box after expand')
+    expect(expandedBoundingBoxAfter.height).toBeGreaterThanOrEqual(
+      collapsedBoundingBox.height
+    )
   })
 
   test('should show collapse/expand icon state', async ({ comfyPage }) => {
-    const nodes = await comfyPage.getNodeRefsByType('KSampler')
-    const node = nodes[0]
-    const vueNode = new VueNodeFixture(node, comfyPage.page)
+    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
+    await expect(node).toBeVisible()
+    const collapseButton = node.locator('[data-testid="node-collapse-button"]')
+    const collapseIcon = collapseButton.locator('i')
 
     // Check initial expanded state icon
-    let iconClass = await vueNode.getCollapseIconClass()
+    let iconClass = await collapseIcon.getAttribute('class')
     expect(iconClass).not.toContain('-rotate-90')
 
     // Collapse and check icon
-    await vueNode.toggleCollapse()
-    iconClass = await vueNode.getCollapseIconClass()
+    await collapseButton.click()
+    iconClass = (await collapseIcon.getAttribute('class')) || ''
     expect(iconClass).toContain('-rotate-90')
 
     // Expand and check icon
-    await vueNode.toggleCollapse()
-    iconClass = await vueNode.getCollapseIconClass()
+    await collapseButton.click()
+    iconClass = (await collapseIcon.getAttribute('class')) || ''
     expect(iconClass).not.toContain('-rotate-90')
   })
 
   test('should preserve title when collapsing/expanding', async ({
     comfyPage
   }) => {
-    const nodes = await comfyPage.getNodeRefsByType('KSampler')
-    const node = nodes[0]
-    const vueNode = new VueNodeFixture(node, comfyPage.page)
+    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
+    await expect(node).toBeVisible()
+    const title = node.locator('[data-testid="node-title"]')
+    const collapseButton = node.locator('[data-testid="node-collapse-button"]')
 
     // Set custom title
-    await vueNode.setTitle('Test Sampler')
-    expect(await vueNode.getTitle()).toBe('Test Sampler')
+    await title.dblclick()
+    const input = node.locator('[data-testid="node-title-input"]')
+    await input.fill('Test Sampler')
+    await input.press('Enter')
+    await expect(title).toHaveText('Test Sampler')
 
     // Collapse
-    await vueNode.toggleCollapse()
-    expect(await vueNode.getTitle()).toBe('Test Sampler')
+    await collapseButton.click()
+    await expect(title).toHaveText('Test Sampler')
 
     // Expand
-    await vueNode.toggleCollapse()
-    expect(await vueNode.getTitle()).toBe('Test Sampler')
+    await collapseButton.click()
+    await expect(title).toHaveText('Test Sampler')
 
     // Verify title is still displayed
-    const header = await vueNode.getHeader()
-    await expect(header).toContainText('Test Sampler')
+    await expect(node.locator('[data-testid^="node-header-"]')).toContainText(
+      'Test Sampler'
+    )
   })
 })

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -15,8 +15,8 @@ test.describe('Vue Node Collapse', () => {
   test('should allow collapsing node with collapse icon', async ({
     comfyPage
   }) => {
-    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
-    await expect(vueNode.element).toBeVisible()
+    const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.root).toBeVisible()
 
     // Initially should not be collapsed
     const body = vueNode.body
@@ -51,8 +51,8 @@ test.describe('Vue Node Collapse', () => {
   })
 
   test('should show collapse/expand icon state', async ({ comfyPage }) => {
-    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
-    await expect(vueNode.element).toBeVisible()
+    const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.root).toBeVisible()
 
     // Check initial expanded state icon
     let iconClass = await vueNode.getCollapseIconClass()
@@ -72,8 +72,8 @@ test.describe('Vue Node Collapse', () => {
   test('should preserve title when collapsing/expanding', async ({
     comfyPage
   }) => {
-    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
-    await expect(vueNode.element).toBeVisible()
+    const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.root).toBeVisible()
 
     // Set custom title
     await vueNode.setTitle('Test Sampler')

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -15,34 +15,34 @@ test.describe('Vue Node Collapse', () => {
   test('should allow collapsing node with collapse icon', async ({
     comfyPage
   }) => {
-    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
-    await expect(node).toBeVisible()
+    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.element).toBeVisible()
 
     // Initially should not be collapsed
-    const body = node.locator('[data-testid^="node-body-"]')
+    const body = vueNode.body
     await expect(body).toBeVisible()
-    const expandedBoundingBox = await node.boundingBox()
+    const expandedBoundingBox = await vueNode.boundingBox()
     if (!expandedBoundingBox)
       throw new Error('Failed to get node bounding box before collapse')
 
     // Collapse the node
-    await node.locator('[data-testid="node-collapse-button"]').click()
+    await vueNode.toggleCollapse()
     await comfyPage.nextFrame()
 
     // Verify node content is hidden
     await expect(body).not.toBeVisible()
-    const collapsedBoundingBox = await node.boundingBox()
+    const collapsedBoundingBox = await vueNode.boundingBox()
     if (!collapsedBoundingBox)
       throw new Error('Failed to get node bounding box after collapse')
     expect(collapsedBoundingBox.height).toBeLessThan(expandedBoundingBox.height)
 
     // Expand again
-    await node.locator('[data-testid="node-collapse-button"]').click()
+    await vueNode.toggleCollapse()
     await comfyPage.nextFrame()
     await expect(body).toBeVisible()
 
     // Size should be restored
-    const expandedBoundingBoxAfter = await node.boundingBox()
+    const expandedBoundingBoxAfter = await vueNode.boundingBox()
     if (!expandedBoundingBoxAfter)
       throw new Error('Failed to get node bounding box after expand')
     expect(expandedBoundingBoxAfter.height).toBeGreaterThanOrEqual(
@@ -51,52 +51,43 @@ test.describe('Vue Node Collapse', () => {
   })
 
   test('should show collapse/expand icon state', async ({ comfyPage }) => {
-    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
-    await expect(node).toBeVisible()
-    const collapseButton = node.locator('[data-testid="node-collapse-button"]')
-    const collapseIcon = collapseButton.locator('i')
+    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.element).toBeVisible()
 
     // Check initial expanded state icon
-    let iconClass = await collapseIcon.getAttribute('class')
+    let iconClass = await vueNode.getCollapseIconClass()
     expect(iconClass).not.toContain('-rotate-90')
 
     // Collapse and check icon
-    await collapseButton.click()
-    iconClass = (await collapseIcon.getAttribute('class')) || ''
+    await vueNode.toggleCollapse()
+    iconClass = await vueNode.getCollapseIconClass()
     expect(iconClass).toContain('-rotate-90')
 
     // Expand and check icon
-    await collapseButton.click()
-    iconClass = (await collapseIcon.getAttribute('class')) || ''
+    await vueNode.toggleCollapse()
+    iconClass = await vueNode.getCollapseIconClass()
     expect(iconClass).not.toContain('-rotate-90')
   })
 
   test('should preserve title when collapsing/expanding', async ({
     comfyPage
   }) => {
-    const node = comfyPage.vueNodes.getNodeByTitle('KSampler').first()
-    await expect(node).toBeVisible()
-    const title = node.locator('[data-testid="node-title"]')
-    const collapseButton = node.locator('[data-testid="node-collapse-button"]')
+    const vueNode = comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await expect(vueNode.element).toBeVisible()
 
     // Set custom title
-    await title.dblclick()
-    const input = node.locator('[data-testid="node-title-input"]')
-    await input.fill('Test Sampler')
-    await input.press('Enter')
-    await expect(title).toHaveText('Test Sampler')
+    await vueNode.setTitle('Test Sampler')
+    expect(await vueNode.getTitle()).toBe('Test Sampler')
 
     // Collapse
-    await collapseButton.click()
-    await expect(title).toHaveText('Test Sampler')
+    await vueNode.toggleCollapse()
+    expect(await vueNode.getTitle()).toBe('Test Sampler')
 
     // Expand
-    await collapseButton.click()
-    await expect(title).toHaveText('Test Sampler')
+    await vueNode.toggleCollapse()
+    expect(await vueNode.getTitle()).toBe('Test Sampler')
 
     // Verify title is still displayed
-    await expect(node.locator('[data-testid^="node-header-"]')).toContainText(
-      'Test Sampler'
-    )
+    await expect(vueNode.header).toContainText('Test Sampler')
   })
 })


### PR DESCRIPTION
## Summary

Changes the Vue node test fixture to not rely on Litegraph internal objects (which should eventually be fully decoupled from Vue nodes) and instead interact with nodes using black-box approach that emulates user actions (preferred appraoch for e2e tests).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6033-refactor-adjust-Vue-node-fixtures-to-not-be-coupled-to-Litegraph-28a6d73d3650817b8152d27dc4fe0017) by [Unito](https://www.unito.io)
