### PR TITLE
Use type check instead of cast

### DIFF
--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -178,8 +178,9 @@ app.registerExtension({
         audioUIWidget.options.canvasOnly = true
 
         const onAudioWidgetUpdate = () => {
+          if (typeof audioWidget.value !== 'string') return
           audioUIWidget.element.src = api.apiURL(
-            getResourceURL(...splitFilePath(audioWidget.value as string))
+            getResourceURL(...splitFilePath(audioWidget.value))
           )
         }
         // Initially load default audio file to audioUIWidget.


### PR DESCRIPTION
Under some infrequent circumstances, `audioWidget.value` is not a string. Presumably if a workflow is loaded with a saved file choice that does not exist and the value is set to undefined instead.

Instead of a cast, a proper type guard is used and the widget is not updated if the new value is not a string.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6041-Use-type-check-instead-of-cast-28b6d73d365081249353f4f905769f89) by [Unito](https://www.unito.io)
