### PR TITLE
Skip rename operation on focus lost.

### DIFF
--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -38,7 +38,7 @@
     ref="itemInputRef"
     v-model="itemLabel"
     class="fixed z-10000 px-2 py-2 text-[.8rem]"
-    @blur="inputBlur(true)"
+    @blur="inputBlur(false)"
     @click.stop
     @keydown.enter="inputBlur(true)"
     @keydown.esc="inputBlur(false)"


### PR DESCRIPTION
When renaming a workflow through the breadcrumb bar. It is intended to complete the rename operation if the user clicks away from the text input. However, completing the text input by pressing enter can cause the rename operation to occur twice: On pressing enter and on loss of focus. When this occurs, the second rename causes, an error to be raised because renaming a workflow to the same name is not allowed.

Worse, a user should be able to cancel a rename by pressing escape, but this still causes the "loss of focus" event to fire and rename the workflow anyways.

As a simple fix to both of these, this PR disables rename on loss of focus. A rename only occurs when the user completes a rename operation with the enter key.

Resolves #6051

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6052-Skip-rename-operation-on-focus-lost-28c6d73d3650815d9a5fecd8567d4299) by [Unito](https://www.unito.io)
