### PR TITLE
Add additional check when restoring widgets_values

### DIFF
--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -119,6 +119,7 @@ const onConfigure = function (
     this.properties.proxyWidgets = serialisedNode.properties.proxyWidgets
     const parsed = parseProxyWidgets(serialisedNode.properties.proxyWidgets)
     serialisedNode.widgets_values?.forEach((v, index) => {
+      if (parsed[index]?.[0] !== '-1') return
       const widget = this.widgets.find((w) => w.name == parsed[index][1])
       if (v !== null && widget) widget.value = v
     })


### PR DESCRIPTION
Prior to #6014, I had identified and started on #6015 to resolve what I believed to be a larger class of issues. While the issue I was solving produced the same error log on the same line, I misunderstood the circumstances in which the reported issue would occur. As proxyWidgets do not have their own value, only linked widgets should have their value restored from `widgets_values`. This PR adds an additional check both that the property entry is within bounds, and that the property entry is for a linked widget.

See #6014
A potential additional issue is still being investigated.
- Additional issue seems unrelated to fix here. Will leave issue open, but recommend merging this as is to not block v1.28.7

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6054-Add-additional-check-when-restoring-widgets_values-28c6d73d365081489d29fc9723132db0) by [Unito](https://www.unito.io)
