### PR TITLE
chore: Remove signup option on invite page when using invite code

### DIFF
--- a/src/platform/onboarding/cloud/CloudLoginView.vue
+++ b/src/platform/onboarding/cloud/CloudLoginView.vue
@@ -76,26 +76,28 @@
       </div>
 
       <!-- Terms & Contact -->
-      <p v-if="!hasInviteCode" class="mt-5 text-sm text-gray-600">
-        {{ t('cloudWaitlist_questionsText') }}
-        <a
-          href="https://support.comfy.org"
-          class="cursor-pointer text-blue-400 no-underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {{ t('cloudWaitlist_contactLink') }}</a
-        >.
-      </p>
-      <p v-else class="mt-5 text-sm text-gray-600">
-        {{ t('cloudStart_invited_signup_title') }}
-        <span
-          class="cursor-pointer text-blue-400 no-underline"
-          @click="navigateToSignup"
-        >
-          {{ t('cloudStart_invited_signup_description') }}</span
-        >
-      </p>
+      <template v-if="!hasInviteCode">
+        <p class="mt-5 text-sm text-gray-600">
+          {{ t('cloudWaitlist_questionsText') }}
+          <a
+            href="https://support.comfy.org"
+            class="cursor-pointer text-blue-400 no-underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ t('cloudWaitlist_contactLink') }}</a
+          >.
+        </p>
+        <p class="mt-5 text-sm text-gray-600">
+          {{ t('cloudStart_invited_signup_title') }}
+          <span
+            class="cursor-pointer text-blue-400 no-underline"
+            @click="navigateToSignup"
+          >
+            {{ t('cloudStart_invited_signup_description') }}</span
+          >
+        </p>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Removed the "Don't have an account? Sign up" link from the CloudLoginView when users access the page with an invite code (from invite link in email)
- The signup option now only shows when there's no invite code present

## Changes
- Modified `CloudLoginView.vue` to conditionally show the signup text only when `!hasInviteCode`
- Used `<template>` wrapper for better conditional rendering

## Why this change?
Users coming from an invite email link should focus on logging in with their existing account rather than being presented with a signup option, as they've already been invited to join.

Fixes the UX issue where invited users might get confused by seeing a signup option when they should be logging in with their invited account.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6070-chore-Remove-signup-option-on-invite-page-when-using-invite-code-28d6d73d365081e29ac7d58140b2079f) by [Unito](https://www.unito.io)
