### PR TITLE
add pricing for new Veo3.1 model

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1141,9 +1141,15 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         const generateAudio =
           String(generateAudioWidget.value).toLowerCase() === 'true'
 
-        if (model.includes('veo-3.0-fast-generate-001')) {
+        if (
+          model.includes('veo-3.0-fast-generate-001') ||
+          model.includes('veo-3.1-fast-generate')
+        ) {
           return generateAudio ? '$1.20/Run' : '$0.80/Run'
-        } else if (model.includes('veo-3.0-generate-001')) {
+        } else if (
+          model.includes('veo-3.0-generate-001') ||
+          model.includes('veo-3.1-generate')
+        ) {
           return generateAudio ? '$3.20/Run' : '$1.60/Run'
         }
 


### PR DESCRIPTION
## Summary

The prices for Veo3.1 are the same as the existing Veo3, just added a new model via `||`

## Screenshots (if applicable)

<img width="1125" height="1077" alt="Screenshot From 2025-10-15 20-39-37" src="https://github.com/user-attachments/assets/441cba83-cdd7-4bae-af0a-259c2dd38a59" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6074-add-pricing-for-new-Veo3-1-model-28d6d73d3650817b8bb8ea7442ff3e1a) by [Unito](https://www.unito.io)
