### PR TITLE
In update-locales workflow, don't skip ci

### DIFF
--- a/.github/workflows/update-locales.yaml
+++ b/.github/workflows/update-locales.yaml
@@ -54,5 +54,5 @@ jobs:
         # Apply the stashed changes if any
         git stash pop || true
         git add src/locales/
-        git diff --staged --quiet || git commit -m "Update locales [skip ci]"
+        git diff --staged --quiet || git commit -m "Update locales"
         git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
Adding `[skip ci]` causes release workflows to break and the added safety of rerunning tests is beneficial for releases.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6081-In-update-locales-workflow-don-t-skip-ci-28e6d73d365081208332ef7b11ebbb52) by [Unito](https://www.unito.io)
