### PR TITLE
Backports for 1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comfyorg/comfyui-frontend",
   "private": true,
-  "version": "1.28.6",
+  "version": "1.28.7",
   "type": "module",
   "repository": "https://github.com/Comfy-Org/ComfyUI_frontend",
   "homepage": "https://comfy.org",


### PR DESCRIPTION
## Summary

Create version `1.28.7`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6084-Backports-for-1-28-28e6d73d3650819fa902d38a22a04736) by [Unito](https://www.unito.io)
