### PR TITLE
Support cross domain/application copy/paste

### DIFF
--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -2,6 +2,11 @@ import { useEventListener } from '@vueuse/core'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
+const clipboardHTMLWrapper = [
+  '<meta charset="utf-8"><div><span data-metadata="',
+  '"></span></div><span style="white-space:pre-wrap;">Text</span>'
+]
+
 /**
  * Adds a handler on copy that serializes selected nodes to JSON
  */
@@ -23,9 +28,7 @@ export const useCopy = () => {
       // clearData doesn't remove images from clipboard
       e.clipboardData?.setData(
         'text/html',
-        '<meta charset="utf-8"><div><span data-metadata="' +
-          btoa(serializedData) +
-          '"></span></div><span style="white-space:pre-wrap;">Text</span>'
+        clipboardHTMLWrapper.join(btoa(serializedData))
       )
       e.preventDefault()
       e.stopImmediatePropagation()

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -1,6 +1,7 @@
 import { useEventListener } from '@vueuse/core'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
 
 const clipboardHTMLWrapper = [
   '<meta charset="utf-8"><div><span data-metadata="',
@@ -14,10 +15,7 @@ export const useCopy = () => {
   const canvasStore = useCanvasStore()
 
   useEventListener(document, 'copy', (e) => {
-    if (
-      e.target instanceof HTMLTextAreaElement ||
-      e.target instanceof HTMLInputElement
-    ) {
+    if (shouldIgnoreCopyPaste(e.target)) {
       // Default system copy
       return
     }

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -9,9 +9,6 @@ export const useCopy = () => {
   const canvasStore = useCanvasStore()
 
   useEventListener(document, 'copy', (e) => {
-    if (!(e.target instanceof Element)) {
-      return
-    }
     if (
       (e.target instanceof HTMLTextAreaElement &&
         e.target.type === 'textarea') ||
@@ -20,14 +17,9 @@ export const useCopy = () => {
       // Default system copy
       return
     }
-    const isTargetInGraph =
-      e.target.classList.contains('litegraph') ||
-      e.target.classList.contains('graph-canvas-container') ||
-      e.target.id === 'graph-canvas'
-
     // copy nodes and clear clipboard
     const canvas = canvasStore.canvas
-    if (isTargetInGraph && canvas?.selectedItems) {
+    if (canvas?.selectedItems) {
       const serializedData = canvas.copyToClipboard()
       // clearData doesn't remove images from clipboard
       e.clipboardData?.setData(

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -10,9 +10,8 @@ export const useCopy = () => {
 
   useEventListener(document, 'copy', (e) => {
     if (
-      (e.target instanceof HTMLTextAreaElement &&
-        e.target.type === 'textarea') ||
-      (e.target instanceof HTMLInputElement && e.target.type === 'text')
+      e.target instanceof HTMLTextAreaElement ||
+      e.target instanceof HTMLInputElement
     ) {
       // Default system copy
       return

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -28,9 +28,14 @@ export const useCopy = () => {
     // copy nodes and clear clipboard
     const canvas = canvasStore.canvas
     if (isTargetInGraph && canvas?.selectedItems) {
-      canvas.copyToClipboard()
+      const serializedData = canvas.copyToClipboard()
       // clearData doesn't remove images from clipboard
-      e.clipboardData?.setData('text', ' ')
+      e.clipboardData?.setData(
+        'text/html',
+        '<meta charset="utf-8"><div><span data-metadata="' +
+          btoa(serializedData) +
+          '"></span></div><span style="white-space:pre-wrap;">Text</span>'
+      )
       e.preventDefault()
       e.stopImmediatePropagation()
       return false

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -7,6 +7,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { isAudioNode, isImageNode, isVideoNode } from '@/utils/litegraphUtil'
+import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
 
 function pasteClipboardItems(data: DataTransfer): boolean {
   const rawData = data.getData('text/html')
@@ -53,10 +54,7 @@ export const usePaste = () => {
   }
 
   useEventListener(document, 'paste', async (e) => {
-    if (
-      e.target instanceof HTMLTextAreaElement ||
-      e.target instanceof HTMLInputElement
-    ) {
+    if (shouldIgnoreCopyPaste(e.target)) {
       // Default system copy
       return
     }

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -9,17 +9,13 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { isAudioNode, isImageNode, isVideoNode } from '@/utils/litegraphUtil'
 
 function pasteClipboardItems(data: DataTransfer): boolean {
+  const rawData = data.getData('text/html')
+  const match = rawData.match(/data-metadata="([A-Za-z0-9+/=]+)"/)?.[1]
+  if (!match) return false
   try {
-    const tempElement = document.createElement('div')
-    tempElement.innerHTML = data.getData('text/html')
-    const dataElement = tempElement.querySelector('div span')
-    if (!dataElement) return false
-    const encodedData =
-      dataElement.attributes?.getNamedItem('data-metadata')?.value
-    if (!encodedData) return false
     useCanvasStore()
       .getCanvas()
-      ._deserializeItems(JSON.parse(atob(encodedData)), {})
+      ._deserializeItems(JSON.parse(atob(match)), {})
     return true
   } catch (err) {
     console.error(err)

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -39,9 +39,8 @@ export const usePaste = () => {
 
   useEventListener(document, 'paste', async (e) => {
     if (
-      (e.target instanceof HTMLTextAreaElement &&
-        e.target.type === 'textarea') ||
-      (e.target instanceof HTMLInputElement && e.target.type === 'text')
+      e.target instanceof HTMLTextAreaElement ||
+      e.target instanceof HTMLInputElement
     ) {
       // Default system copy
       return

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -110,12 +110,11 @@ export const usePaste = () => {
     try {
       const tempElement = document.createElement('div')
       tempElement.innerHTML = data.getData('text/html')
-      const nodeData = atob(
-        // @ts-expect-error Unused param
-        tempElement?.children?.[1]?.children?.[0]?.attributes?.['data-metadata']
+      const encodedData =
+        // @ts-expect-error no type checking
+        tempElement.querySelector('div span').attributes?.['data-metadata']
           .value
-      )
-      canvas._deserializeItems(JSON.parse(nodeData), {})
+      canvas._deserializeItems(JSON.parse(atob(encodedData)), {})
       return
     } catch (err) {
       console.error(err)

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -38,15 +38,14 @@ export const usePaste = () => {
   }
 
   useEventListener(document, 'paste', async (e) => {
-    const isTargetInGraph =
-      e.target instanceof Element &&
-      (e.target.classList.contains('litegraph') ||
-        e.target.classList.contains('graph-canvas-container') ||
-        e.target.id === 'graph-canvas')
-
-    // If the target is not in the graph, we don't want to handle the paste event
-    if (!isTargetInGraph) return
-
+    if (
+      (e.target instanceof HTMLTextAreaElement &&
+        e.target.type === 'textarea') ||
+      (e.target instanceof HTMLInputElement && e.target.type === 'text')
+    ) {
+      // Default system copy
+      return
+    }
     // ctrl+shift+v is used to paste nodes with connections
     // this is handled by litegraph
     if (workspaceStore.shiftDown) return

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -109,6 +109,19 @@ export const usePaste = () => {
         return
       }
     }
+    try {
+      const tempElement = document.createElement('div')
+      tempElement.innerHTML = data.getData('text/html')
+      const nodeData = atob(
+        // @ts-expect-error Unused param
+        tempElement?.children?.[1]?.children?.[0]?.attributes?.['data-metadata']
+          .value
+      )
+      canvas._deserializeItems(JSON.parse(nodeData), {})
+      return
+    } catch (err) {
+      console.error(err)
+    }
 
     // No image found. Look for node data
     data = data.getData('text/plain')

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3853,11 +3853,10 @@ export class LGraphCanvas
    * When called without parameters, it copies {@link selectedItems}.
    * @param items The items to copy.  If nullish, all selected items are copied.
    */
-  copyToClipboard(items?: Iterable<Positionable>): void {
-    localStorage.setItem(
-      'litegrapheditor_clipboard',
-      JSON.stringify(this._serializeItems(items))
-    )
+  copyToClipboard(items?: Iterable<Positionable>): string {
+    const serializedData = JSON.stringify(this._serializeItems(items))
+    localStorage.setItem('litegrapheditor_clipboard', serializedData)
+    return serializedData
   }
 
   emitEvent(detail: LGraphCanvasEventMap['litegraph:canvas']): void {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3892,6 +3892,7 @@ export class LGraphCanvas
     if (!data) return
     return this._deserializeItems(JSON.parse(data), options)
   }
+
   _deserializeItems(
     parsed: ClipboardItems,
     options: IPasteFromClipboardOptions
@@ -3908,6 +3909,7 @@ export class LGraphCanvas
     const { graph } = this
     if (!graph) throw new NullGraphError()
     graph.beforeChange()
+    this.emitBeforeChange()
 
     // Parse & initialise
     parsed.nodes ??= []
@@ -4077,6 +4079,7 @@ export class LGraphCanvas
     this.selectItems(created)
 
     graph.afterChange()
+    this.emitAfterChange()
 
     return results
   }

--- a/src/workbench/eventHelpers.ts
+++ b/src/workbench/eventHelpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Utility functions for handling workbench events
+ */
+
+/**
+ * Used by clipboard handlers to determine if copy/paste events should be
+ * intercepted for graph operations vs. allowing default browser behavior
+ * for text inputs and other UI elements.
+ *
+ * @param target - The event target to check
+ * @returns true if copy paste events will be handled by target
+ */
+export function shouldIgnoreCopyPaste(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLInputElement &&
+      ![
+        'button',
+        'checkbox',
+        'file',
+        'hidden',
+        'image',
+        'radio',
+        'range',
+        'reset',
+        'search',
+        'submit'
+      ].includes(target.type))
+  )
+}


### PR DESCRIPTION
![AnimateDiff_00001](https://github.com/user-attachments/assets/8ae88dc5-bba8-40c0-9cc2-5e81f579761d)


Browsers place very heavy restrictions on what can be copied and pasted. See:
- https://alexharri.com/blog/clipboard
- https://www.w3.org/TR/clipboard-apis/#mandatory-data-types-x

Further thoughts and TODO
- Should the local storage of copied nodes be removed entirely?
  - It's unlikely a person would want to paste nodes from several days back, but having multiple items in the clipboard may be desirable. Should "copy node -> copy text -> paste text -> paste node" be possible?
- Need to add extra safety to the checks instead of a try/catch block

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6087-Experimental-cross-domain-application-copy-paste-28e6d73d36508154a0a8deeb392f43a4) by [Unito](https://www.unito.io)
