### PR TITLE
[perf] disable cache-busting param on cloud

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/utils/audioUtils.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/audioUtils.ts
@@ -1,5 +1,6 @@
 import type { ResultItemType } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
+import { app } from '@/scripts/app'
 
 /**
  * Format time in MM:SS format
@@ -23,10 +24,6 @@ export function getAudioUrlFromPath(
   return api.apiURL(getResourceURL(subfolder, filename, type))
 }
 
-function getRandParam() {
-  return '&rand=' + Math.random()
-}
-
 export function getResourceURL(
   subfolder: string,
   filename: string,
@@ -36,7 +33,7 @@ export function getResourceURL(
     'filename=' + encodeURIComponent(filename),
     'type=' + type,
     'subfolder=' + subfolder,
-    getRandParam().substring(1)
+    app.getRandParam().substring(1)
   ].join('&')
 
   return `/view?${params}`

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/litegraph/src/litegraph'
 import type { Vector2 } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
@@ -336,6 +337,7 @@ export class ComfyApp {
   }
 
   getRandParam() {
+    if (isCloud) return ''
     return '&rand=' + Math.random()
   }
 


### PR DESCRIPTION
## Summary

Updates `ComfyApp.getRandParam()` to return an empty string on cloud builds (detected via `isCloud`), letting hosted deployments rely on HTTP caching for `/view` assets while local hosts retain the legacy cache busting. The audio widget helpers now defer to the same method instead of generating their own random suffix, so every frontend consumer shares this logic.

This keeps the original overwrite protection for localhost workflows but removes needless cache misses in the cloud stack, where GCS already serve strong ETags and there is not really a concern about stale filenames. Once the backend exposes a deterministic file-version field, we can delete the remaining local-only randomness entirely.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6105-perf-disable-cache-busting-param-on-cloud-28f6d73d36508181b34afad406fabc59) by [Unito](https://www.unito.io)
