### PR TITLE
[refactor] simplify redundant check in cloud badge extension

### DIFF
--- a/src/extensions/core/cloudBadge.ts
+++ b/src/extensions/core/cloudBadge.ts
@@ -1,16 +1,12 @@
 import { t } from '@/i18n'
-import { isCloud } from '@/platform/distribution/types'
 import { useExtensionService } from '@/services/extensionService'
 
 useExtensionService().registerExtension({
   name: 'Comfy.CloudBadge',
-  // Only show badge when running in cloud environment
-  topbarBadges: isCloud
-    ? [
-        {
-          label: t('g.beta'),
-          text: 'Comfy Cloud'
-        }
-      ]
-    : undefined
+  topbarBadges: [
+    {
+      label: t('g.beta'),
+      text: 'Comfy Cloud'
+    }
+  ]
 })

--- a/src/platform/distribution/types.ts
+++ b/src/platform/distribution/types.ts
@@ -17,4 +17,4 @@ const DISTRIBUTION: Distribution = __DISTRIBUTION__
 /** Distribution type checks */
 export const isDesktop = DISTRIBUTION === 'desktop' || isElectron() // TODO: replace with build var
 export const isCloud = DISTRIBUTION === 'cloud'
-// export const isLocalhost = !isDesktop && !isCloud
+// export const isLocalhost = DISTRIBUTION === 'localhost' || (!isDesktop && !isCloud)


### PR DESCRIPTION
Simplifies code with tautological condition. The extension is only loaded when `isCloud` is true due to https://github.com/Comfy-Org/ComfyUI_frontend/blob/38f188759dac8d3d8923156dd238c26594421f20/src/extensions/core/index.ts#L27-L29

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6106-refactor-simplify-redundant-check-in-cloud-badge-extension-28f6d73d365081d69903f5a985fdc8be) by [Unito](https://www.unito.io)
