### PR TITLE
Skip login step for authenticated users in invite flow

### DIFF
--- a/src/platform/onboarding/cloud/CloudInviteEntryView.vue
+++ b/src/platform/onboarding/cloud/CloudInviteEntryView.vue
@@ -6,18 +6,43 @@
 import { onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import BaseViewTemplate from '@/views/templates/BaseViewTemplate.vue'
 
 const route = useRoute()
 const router = useRouter()
+const firebaseAuthStore = useFirebaseAuthStore()
 
 onMounted(async () => {
-  const inviteCode = route.params.code
-  await router.push({
-    name: 'cloud-login',
-    query: {
-      inviteCode
+  const inviteCode = route.params.code as string | undefined
+
+  if (firebaseAuthStore.isAuthenticated) {
+    const { isEmailVerified } = firebaseAuthStore
+
+    if (!isEmailVerified) {
+      // User is logged in but email not verified
+      await router.push({ name: 'cloud-verify-email', query: { inviteCode } })
+    } else {
+      // User is logged in and verified
+      if (inviteCode) {
+        // Handle invite code flow - go to invite check
+        await router.push({
+          name: 'cloud-invite-check',
+          query: { inviteCode }
+        })
+      } else {
+        // Normal login flow - go to user check
+        await router.push({ name: 'cloud-user-check' })
+      }
     }
-  })
+  } else {
+    // User is not logged in - proceed to login page
+    await router.push({
+      name: 'cloud-login',
+      query: {
+        inviteCode
+      }
+    })
+  }
 })
 </script>


### PR DESCRIPTION
## 🎯 Summary

Improves the user experience for already authenticated users when accessing invite links by skipping the unnecessary login step.

## 📋 Changes

### Modified CloudInviteEntryView.vue
- Added authentication check on component mount
- Implemented conditional routing based on authentication status:
  - **Not authenticated**: Routes to login page (original behavior)
  - **Authenticated but email not verified**: Routes to email verification
  - **Authenticated and verified with invite code**: Routes to invite check page
  - **Authenticated and verified without invite code**: Routes to user check page

## 🔍 Impact

- **Before**: All users were redirected to login page, even if already logged in
- **After**: Authenticated users skip login and go directly to the appropriate next step

[invite-code-entry.webm](https://github.com/user-attachments/assets/79ea13cd-c7ba-4ff7-b755-cd62ecef91eb)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6113-Skip-login-step-for-authenticated-users-in-invite-flow-28f6d73d3650813ba635fc74c7fe445b) by [Unito](https://www.unito.io)
