### PR TITLE
[ci] enable minification in build workflows

### DIFF
--- a/.github/workflows/publish-desktop-ui.yaml
+++ b/.github/workflows/publish-desktop-ui.yaml
@@ -44,6 +44,7 @@ jobs:
       contents: read
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+      ENABLE_MINIFY: 'true'
     steps:
       - name: Validate inputs
         env:

--- a/.github/workflows/release-draft-create.yaml
+++ b/.github/workflows/release-draft-create.yaml
@@ -55,6 +55,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ENABLE_MINIFY: 'true'
           USE_PROD_CONFIG: 'true'
         run: |
           pnpm install --frozen-lockfile

--- a/.github/workflows/release-pypi-dev.yaml
+++ b/.github/workflows/release-pypi-dev.yaml
@@ -44,6 +44,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ENABLE_MINIFY: 'true'
           USE_PROD_CONFIG: 'true'
         run: |
           pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Continuation of https://github.com/Comfy-Org/ComfyUI_frontend/pull/6068: set `SHOULD_MINIFY` in build workflows to enable minification.

Our build plugin dictates what files are available for extensions to import at runtime: https://github.com/Comfy-Org/ComfyUI_frontend/blob/bfe083dcbad61965b0ef04cf91d06a9cddaca361/build/plugins/comfyAPIPlugin.ts#L52

The shimming marks these files and their named exports and named memebrs as side-effectful, so names should be preserved from the perspective of 3rd party extensions, making this safe in theory.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6116-ci-enable-minification-in-build-workflows-2906d73d36508141be57f63b619f9f16) by [Unito](https://www.unito.io)
