### PR TITLE
fix Vue node number widget inc/dec buttons hover state style

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useNumberWidgetButtonPt.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useNumberWidgetButtonPt.ts
@@ -1,7 +1,7 @@
 const sharedButtonClasses =
   '!inline-flex !items-center !justify-center !border-0 bg-transparent text-inherit transition-colors duration-150 ease-in-out ' +
   'hover:bg-node-component-surface-hovered active:bg-node-component-surface-selected' +
-  'disabled:!bg-[var(--node-component-disabled)] disabled:!text-[var(--node-icon-disabled)] disabled:cursor-not-allowed'
+  'disabled:bg-node-component-disabled disabled:text-node-icon-disabled disabled:cursor-not-allowed'
 
 export function useNumberWidgetButtonPt(options?: {
   roundedLeft?: boolean

--- a/src/renderer/extensions/vueNodes/widgets/composables/useNumberWidgetButtonPt.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useNumberWidgetButtonPt.ts
@@ -1,6 +1,6 @@
 const sharedButtonClasses =
-  '!inline-flex !items-center !justify-center !border-0 !bg-transparent text-inherit transition-colors duration-150 ease-in-out ' +
-  'hover:!bg-[var(--node-component-surface-hovered)] active:!bg-[var(--node-component-surface-selected)] ' +
+  '!inline-flex !items-center !justify-center !border-0 bg-transparent text-inherit transition-colors duration-150 ease-in-out ' +
+  'hover:bg-node-component-surface-hovered active:bg-node-component-surface-selected' +
   'disabled:!bg-[var(--node-component-disabled)] disabled:!text-[var(--node-icon-disabled)] disabled:cursor-not-allowed'
 
 export function useNumberWidgetButtonPt(options?: {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useNumberWidgetButtonPt.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useNumberWidgetButtonPt.ts
@@ -1,7 +1,7 @@
 const sharedButtonClasses =
   '!inline-flex !items-center !justify-center !border-0 !bg-transparent text-inherit transition-colors duration-150 ease-in-out ' +
-  'hover:!bg-[var(--color-node-component-surface-hovered)] active:!bg-[var(--color-node-component-surface-selected)] ' +
-  'disabled:!bg-[var(--color-node-component-disabled)] disabled:!text-[var(--color-node-icon-disabled)] disabled:cursor-not-allowed'
+  'hover:!bg-[var(--node-component-surface-hovered)] active:!bg-[var(--node-component-surface-selected)] ' +
+  'disabled:!bg-[var(--node-component-disabled)] disabled:!text-[var(--node-icon-disabled)] disabled:cursor-not-allowed'
 
 export function useNumberWidgetButtonPt(options?: {
   roundedLeft?: boolean


### PR DESCRIPTION
## Summary

Fix hover state on Vue node number widget incremenet/decrement buttons. The problem was in `useNumberWidgetButtonPt.ts`, the button hover styles were using `var(--color-node-component-surface-hovered)` which references a Tailwind theme color created by the `@theme` inline directive. This theme color doesn't properly inherit the `.dark-theme` class overrides, so it was showing the light mode color (white) even in dark mode.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6121-fix-Vue-node-number-widget-inc-dec-buttons-hover-state-style-2906d73d36508144b91aec3490e32d28) by [Unito](https://www.unito.io)
