### PR TITLE
[ci] drop console statements (except `warn` and `error`) when building app

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -195,7 +195,29 @@ export default defineConfig({
     minifyIdentifiers: SHOULD_MINIFY,
     keepNames: true,
     minifySyntax: SHOULD_MINIFY,
-    minifyWhitespace: SHOULD_MINIFY
+    minifyWhitespace: SHOULD_MINIFY,
+    pure: SHOULD_MINIFY
+      ? [
+          'console.log',
+          'console.debug',
+          'console.info',
+          'console.trace',
+          'console.dir',
+          'console.dirxml',
+          'console.group',
+          'console.groupCollapsed',
+          'console.groupEnd',
+          'console.table',
+          'console.time',
+          'console.timeEnd',
+          'console.timeLog',
+          'console.count',
+          'console.countReset',
+          'console.profile',
+          'console.profileEnd',
+          'console.clear'
+        ]
+      : []
   },
 
   test: {


### PR DESCRIPTION
## Summary

Marks all the console methods besides `warn` and `error` as pure functions so they can be dropped during DCE in build pipeline. It's simpler to use `drop` but that would remove errors/warnings.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6123-ci-drop-console-statements-except-warn-and-error-when-building-app-2906d73d365081f28303c0d784352b12) by [Unito](https://www.unito.io)
