### PR TITLE
[style] adjust appearance of "delete account" component to be text rather than button

### DIFF
--- a/src/components/dialog/content/setting/UserPanel.vue
+++ b/src/components/dialog/content/setting/UserPanel.vue
@@ -67,10 +67,10 @@
           />
           <Button
             v-if="!isApiKeyLogin"
-            class="w-32"
+            class="w-fit"
+            variant="text"
             severity="danger"
             :label="$t('auth.deleteAccount.deleteAccount')"
-            icon="pi pi-trash"
             @click="handleDeleteAccount"
           />
         </div>


### PR DESCRIPTION
Adjusts style of "Delete Account" button.

**Before**:

<img width="731" height="925" alt="Screenshot from 2025-10-18 04-22-24" src="https://github.com/user-attachments/assets/497de4ca-9359-41d8-b944-0d69835f43b1" />

**After**:

<img width="731" height="925" alt="Screenshot from 2025-10-18 04-22-14" src="https://github.com/user-attachments/assets/f42a21fb-7d4d-43f5-b27b-1f85e4470dbd" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6126-style-adjust-appearance-of-delete-account-component-to-be-text-rather-than-button-2906d73d365081eab48ece171fa4fd8a) by [Unito](https://www.unito.io)
