### PR TITLE
[ci] allow setting `GENERATE_SOURCEMAP` as env var

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -22,6 +22,7 @@ const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE === 'true'
 const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const DISABLE_VUE_PLUGINS = process.env.DISABLE_VUE_PLUGINS === 'true'
+const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
 
 const DEV_SERVER_COMFYUI_URL =
   process.env.DEV_SERVER_COMFYUI_URL || 'http://127.0.0.1:8188'
@@ -185,7 +186,7 @@ export default defineConfig({
   build: {
     minify: SHOULD_MINIFY ? 'esbuild' : false,
     target: 'es2022',
-    sourcemap: true,
+    sourcemap: GENERATE_SOURCEMAP,
     rollupOptions: {
       treeshake: true
     }


### PR DESCRIPTION
## Summary

Introduces a `GENERATE_SOURCEMAP` environment flag in `vite.config.mts` that defaults to enabled (`true` unless set to `'false'`). This keeps source maps on by default, while allowing opt-out for lean production artifacts.

Allows the choice to be made as part of the distribution pipeline and changed for different targets.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6134-ci-allow-setting-GENERATE_SOURCEMAP-as-env-var-2916d73d3650815d91b9eff12b6e55fd) by [Unito](https://www.unito.io)
