### PR TITLE
Fix link resolution of virtual nodes

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1665,7 +1665,7 @@ export class LGraph
         continue
       }
 
-      const input = subgraphNode.findInputSlotByType(link.type, true, true)
+      const input = subgraphNode.inputs[i - 1]
       outputNode.connectSlots(output, subgraphNode, input, link.parentId)
     }
 

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -294,25 +294,21 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
       // Fallback check for nodes performing link redirection
       const virtualLink = this.node.getInputLink(slot)
       if (virtualLink) {
-        const outputNode = this.graph.getNodeById(virtualLink.origin_id)
-        if (!outputNode)
+        const { inputNode } = virtualLink.resolve(this.graph)
+        if (!inputNode)
           throw new InvalidLinkError(
             `Virtual node failed to resolve parent [${this.id}] slot [${slot}]`
           )
 
-        const outputNodeExecutionId = [
+        const inputNodeExecutionId = [
           ...this.subgraphNodePath,
-          outputNode.id
+          inputNode.id
         ].join(':')
-        const outputNodeDto = this.nodesByExecutionId.get(outputNodeExecutionId)
-        if (!outputNodeDto)
-          throw new Error(`No output node DTO found for id [${outputNode.id}]`)
+        const inputNodeDto = this.nodesByExecutionId.get(inputNodeExecutionId)
+        if (!inputNodeDto)
+          throw new Error(`No input node DTO found for id [${inputNode.id}]`)
 
-        return outputNodeDto.resolveOutput(
-          virtualLink.origin_slot,
-          type,
-          visited
-        )
+        return inputNodeDto.resolveInput(virtualLink.target_slot, visited, type)
       }
 
       // Virtual nodes without a matching input should be discarded.


### PR DESCRIPTION
Some virtual nodes (like get/set nodes) perform link redirection at prompt resolution. The prior implementation incorrectly tried to return the source of the virtual link after resolution, but this causes things to break when the source of the virtual link is a subgraph IO.

Instead, this PR changes the code section to restart resolution from the destination of the virtual link so that the existing subgraph boundary resolution code is applied.

Edit: Also fix a bug with reconnection of complex/any types on conversion to subgraph.
- This second change gives me pause. The level of complexity suggests that there was an intentional reason to handle things in the prior (broken) way, but the adjacent subgraphInput code does already uses this new indexing methodology.
  - Traced down original commit. I'm now confident fix is correct.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6135-Fix-link-resolution-of-virtual-nodes-2916d73d36508183b891ef6eb39bad4c) by [Unito](https://www.unito.io)
