### PR TITLE
[perf] manually chunk vendored code

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -188,7 +188,36 @@ export default defineConfig({
     target: 'es2022',
     sourcemap: GENERATE_SOURCEMAP,
     rollupOptions: {
-      treeshake: true
+      treeshake: true,
+      output: {
+        manualChunks: (id) => {
+          if (!id.includes('node_modules')) {
+            return undefined
+          }
+
+          if (id.includes('primevue') || id.includes('@primeuix')) {
+            return 'vendor-primevue'
+          }
+
+          if (id.includes('@tiptap')) {
+            return 'vendor-tiptap'
+          }
+
+          if (id.includes('chart.js')) {
+            return 'vendor-chart'
+          }
+
+          if (id.includes('three') || id.includes('@xterm')) {
+            return 'vendor-visualization'
+          }
+
+          if (id.includes('/vue') || id.includes('pinia')) {
+            return 'vendor-vue'
+          }
+
+          return 'vendor-other'
+        }
+      }
     }
   },
 


### PR DESCRIPTION
## Summary

Added a `manualChunks` strategy in `vite.config.mts` that splits primevue, tiptap, chart.js, three/@xterm, core Vue/Pinia, and the remaining dependencies into dedicated vendor bundles. This reduces the main application chunk size and allows browsers to cache heavy third-party code across releases, improving load times when those libraries stay unchanged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6137-perf-manually-chunk-vendored-code-2916d73d36508140a44ec0de228ef9cc) by [Unito](https://www.unito.io)
