### PR TITLE
Revert "fix dragging video/image components on Vue nodes triggers node drag (#5922)"

### DIFF
--- a/src/renderer/extensions/vueNodes/VideoPreview.vue
+++ b/src/renderer/extensions/vueNodes/VideoPreview.vue
@@ -5,7 +5,6 @@
     tabindex="0"
     role="region"
     :aria-label="$t('g.videoPreview')"
-    data-capture-node="true"
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
     @keydown="handleKeyDown"

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -2,7 +2,6 @@
   <div
     v-if="imageUrls.length > 0"
     class="image-preview group relative flex size-full min-h-16 min-w-16 flex-col px-2"
-    data-capture-node="true"
     tabindex="0"
     role="region"
     :aria-label="$t('g.imagePreview')"

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -55,17 +55,6 @@ export function useNodePointerInteractions(
 
     if (forwardMiddlePointerIfNeeded(event)) return
 
-    const stopNodeDragTarget =
-      event.target instanceof HTMLElement
-        ? event.target.closest('[data-capture-node="true"]')
-        : null
-    if (stopNodeDragTarget) {
-      if (!shouldHandleNodePointerEvents.value) {
-        forwardEventToCanvas(event)
-      }
-      return
-    }
-
     // Only start drag on left-click (button 0)
     if (event.button !== 0) {
       return


### PR DESCRIPTION
## Summary

This PR reverts #5922 which fixed pointer capture behavior on video and image preview components to prevent unintended node dragging.

## Changes

- Removes `data-capture-node="true"` attribute from `VideoPreview.vue` and `ImagePreview.vue` components
- Removes pointer event delegation logic from `useNodePointerInteractions.ts` composable
- Restores previous drag behavior where dragging on preview components triggers node drag

## Reason for Revert

This changes the behavior from original Litegraph and is generally annoying. Users would rather be able to drag the node than be able to drag an image/video out from a node.

Reverts #5922

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6148-Revert-fix-dragging-video-image-components-on-Vue-nodes-triggers-node-drag-5922-2916d73d365081398bb5c20384e26bb8) by [Unito](https://www.unito.io)
