### PR TITLE
[style] remove hover effect on Vue node socket labels

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -118,9 +118,7 @@ const slotWrapperClass = computed(() =>
   cn(
     'lg-slot lg-slot--input flex items-center group rounded-r-lg h-6',
     'cursor-crosshair',
-    props.dotOnly
-      ? 'lg-slot--dot-only'
-      : 'pr-6 hover:bg-black/5 hover:dark:bg-white/5',
+    props.dotOnly ? 'lg-slot--dot-only' : 'pr-6',
     {
       'lg-slot--connected': props.connected,
       'lg-slot--compatible': props.compatible,

--- a/src/renderer/extensions/vueNodes/components/OutputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.vue
@@ -88,9 +88,7 @@ const slotWrapperClass = computed(() =>
   cn(
     'lg-slot lg-slot--output flex items-center justify-end group rounded-l-lg h-6',
     'cursor-crosshair',
-    props.dotOnly
-      ? 'lg-slot--dot-only justify-center'
-      : 'pl-6 hover:bg-black/5 hover:dark:bg-white/5',
+    props.dotOnly ? 'lg-slot--dot-only justify-center' : 'pl-6',
     {
       'lg-slot--connected': props.connected,
       'lg-slot--compatible': props.compatible,


### PR DESCRIPTION
## Summary

Align with the design by removing hover state. Hover state should not be applied if clicking doesn't actually do anything.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6150-style-remove-hover-effect-on-Vue-node-socket-labels-2916d73d365081158edef8065edc42e8) by [Unito](https://www.unito.io)
