### PR TITLE
add telemetry provider for cloud distribution

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -4,6 +4,7 @@ declare const __SENTRY_DSN__: string
 declare const __ALGOLIA_APP_ID__: string
 declare const __ALGOLIA_API_KEY__: string
 declare const __USE_PROD_CONFIG__: boolean
+declare const __MIXPANEL_TOKEN__: string
 
 type BuildFeatureFlags = {
   REQUIRE_SUBSCRIPTION: boolean

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "knip": "catalog:",
     "lint-staged": "catalog:",
     "markdown-table": "catalog:",
+    "mixpanel-browser": "catalog:",
     "nx": "catalog:",
     "picocolors": "catalog:",
     "postcss-html": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ catalogs:
     markdown-table:
       specifier: ^3.0.4
       version: 3.0.4
+    mixpanel-browser:
+      specifier: ^2.71.0
+      version: 2.71.0
     nx:
       specifier: 21.4.1
       version: 21.4.1
@@ -597,6 +600,9 @@ importers:
       markdown-table:
         specifier: 'catalog:'
         version: 3.0.4
+      mixpanel-browser:
+        specifier: 'catalog:'
+        version: 2.71.0
       nx:
         specifier: 'catalog:'
         version: 21.4.1
@@ -2201,6 +2207,21 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-vX/tbnS14ZzzatC7vOyvAm9tOLU8tof0BuppBlphzEx1YHTSw8DQiAmyAc0AmXidchLV0W+cUHV/WsehPLh2hQ==}
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-2kSnjZZ3QZ9zOz/isOt8s54mXUUDgXk/u0eEi/rE0xBWDeuA0NHrBcqiMc+w4F/yWWUpo5F5zcuPeYpc6ufAsw==}
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-ucIYe1mfJ2UksvXW+d3bOySTB2/0yUSqQJlUydvbBz6OO2Bhq3nJHyLXV9ExkgUMZm1ZyDcvvmNUd1+5tAXlpA==}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-OomKIB6GTx5xvCLJ7iic2khT/t/tnCJUex13aEqsbSqIT/UzUUsqf+LTrgUK5ex+f6odmkCNjre2y5jvpNqn+g==}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-J3dVTEu6Z4p8di7y9KKvUooNuBjX97DdG6XGWoPEPi07A9512h9M8MEtvlY3mK0PGfuC0Mz5Pv/Ws6gjGYfKQg==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -3020,6 +3041,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -3518,6 +3542,9 @@ packages:
   '@webgpu/types@0.1.51':
     resolution: {integrity: sha512-ktR3u64NPjwIViNCck+z9QeyN0iPkQCUOQ07ZCV1RzlkfP+olLTeEZ95O1QHS+v4w9vJeY9xj/uJuSphsHy5rQ==}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
@@ -3799,6 +3826,10 @@ packages:
 
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5986,6 +6017,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mixpanel-browser@2.71.0:
+    resolution: {integrity: sha512-jKmDXe68/oQFgk/9ns9Z36bA0CJ31PH8Y77XTLLGfJvhsUPbvu+7Se9e281NejZF6+OMqx7cE+zFxToozYyNrA==}
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -9499,6 +9533,29 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.2':
+    dependencies:
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.2
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.2':
+    dependencies:
+      postcss: 8.5.6
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.2': {}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.2': {}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.2':
+    dependencies:
+      '@mixpanel/rrdom': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-types': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.2
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -10387,6 +10444,8 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -10980,6 +11039,8 @@ snapshots:
 
   '@webgpu/types@0.1.51': {}
 
+  '@xstate/fsm@1.6.5': {}
+
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
@@ -11295,6 +11356,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@2.0.0: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -13863,6 +13926,10 @@ snapshots:
       minipass: 7.1.2
 
   mitt@3.0.1: {}
+
+  mixpanel-browser@2.71.0:
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.2
 
   mkdirp@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,6 +98,7 @@ catalog:
   zod: ^3.23.8
   zod-to-json-schema: ^3.24.1
   zod-validation-error: ^3.3.0
+  mixpanel-browser: ^2.71.0
 
 cleanupUnusedCatalogs: true
 

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -86,6 +86,7 @@ import SplitButton from 'primevue/splitbutton'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import {
@@ -147,7 +148,9 @@ const queuePrompt = async (e: Event) => {
     ? 'Comfy.QueuePromptFront'
     : 'Comfy.QueuePrompt'
 
-  useTelemetry()?.trackRunButton({ subscribe_to_run: false })
+  if (isCloud) {
+    useTelemetry()?.trackRunButton({ subscribe_to_run: false })
+  }
 
   await commandStore.execute(commandId)
 }

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -86,6 +86,7 @@ import SplitButton from 'primevue/splitbutton'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import {
   useQueuePendingTaskCountStore,
@@ -141,10 +142,13 @@ const hasPendingTasks = computed(
 
 const commandStore = useCommandStore()
 const queuePrompt = async (e: Event) => {
-  const commandId =
-    'shiftKey' in e && e.shiftKey
-      ? 'Comfy.QueuePromptFront'
-      : 'Comfy.QueuePrompt'
+  const isShiftPressed = 'shiftKey' in e && e.shiftKey
+  const commandId = isShiftPressed
+    ? 'Comfy.QueuePromptFront'
+    : 'Comfy.QueuePrompt'
+
+  useTelemetry()?.trackRunButton({ subscribe_to_run: false })
+
   await commandStore.execute(commandId)
 }
 </script>

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -21,7 +21,9 @@ import {
 import type { Point } from '@/lib/litegraph/src/litegraph'
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
 import { createModelNodeFromAsset } from '@/platform/assets/utils/createModelNodeFromAsset'
+import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -451,6 +453,11 @@ export function useCoreCommands(): ComfyCommand[] {
       category: 'essentials' as const,
       function: async () => {
         const batchCount = useQueueSettingsStore().batchCount
+
+        if (isCloud) {
+          useTelemetry()?.trackWorkflowExecution()
+        }
+
         await app.queuePrompt(0, batchCount)
       }
     },
@@ -462,6 +469,11 @@ export function useCoreCommands(): ComfyCommand[] {
       category: 'essentials' as const,
       function: async () => {
         const batchCount = useQueueSettingsStore().batchCount
+
+        if (isCloud) {
+          useTelemetry()?.trackWorkflowExecution()
+        }
+
         await app.queuePrompt(-1, batchCount)
       }
     },

--- a/src/platform/cloud/subscription/components/SubscribeButton.vue
+++ b/src/platform/cloud/subscription/components/SubscribeButton.vue
@@ -15,6 +15,8 @@ import Button from 'primevue/button'
 import { onBeforeUnmount, ref } from 'vue'
 
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
 
 withDefaults(
   defineProps<{
@@ -82,6 +84,10 @@ const stopPolling = () => {
 }
 
 const handleSubscribe = async () => {
+  if (isCloud) {
+    useTelemetry()?.trackSubscription('subscribe_clicked')
+  }
+
   isLoading.value = true
   try {
     await subscribe()

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -10,7 +10,7 @@
     severity="primary"
     size="small"
     data-testid="subscribe-to-run-button"
-    @click="showSubscriptionDialog"
+    @click="handleSubscribeToRun"
   />
 </template>
 
@@ -18,6 +18,16 @@
 import Button from 'primevue/button'
 
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
 
 const { showSubscriptionDialog } = useSubscription()
+
+const handleSubscribeToRun = () => {
+  if (isCloud) {
+    useTelemetry()?.trackRunButton({ subscribe_to_run: true })
+  }
+
+  showSubscriptionDialog()
+}
 </script>

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -7,6 +7,7 @@ import { COMFY_API_BASE_URL } from '@/config/comfyApi'
 import { MONTHLY_SUBSCRIPTION_PRICE } from '@/config/subscriptionPricesConfig'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import {
   FirebaseAuthStoreError,
@@ -78,6 +79,10 @@ export function useSubscription() {
   }, reportError)
 
   const showSubscriptionDialog = () => {
+    if (isCloud) {
+      useTelemetry()?.trackSubscription('modal_opened')
+    }
+
     dialogService.showSubscriptionRequiredDialog()
   }
 

--- a/src/platform/telemetry/index.ts
+++ b/src/platform/telemetry/index.ts
@@ -1,14 +1,14 @@
 /**
  * Telemetry Provider - OSS Build Safety
  *
- * ⚠️ CRITICAL: OSS Build Safety ⚠️
+ * CRITICAL: OSS Build Safety
  * This module is conditionally compiled based on distribution. When building
  * the open source version (DISTRIBUTION unset), this entire module and its dependencies
- * are excluded through Vite's tree-shaking optimization.
+ * are excluded through via tree-shaking.
  *
  * To verify OSS builds exclude this code:
  * 1. `DISTRIBUTION= pnpm build` (OSS build)
- * 2. `rg -r dist "telemetry|mixpanel"` (should find nothing)
+ * 2. `grep -RinE --include='*.js' 'trackWorkflow|trackEvent|mixpanel' dist/` (should find nothing)
  * 3. Check dist/assets/*.js files contain no tracking code
  *
  * This approach maintains complete separation between cloud and OSS builds
@@ -24,7 +24,10 @@ let _telemetryProvider: TelemetryProvider | null = null
 
 /**
  * Telemetry factory - conditionally creates provider based on distribution
- * Returns singleton instance
+ * Returns singleton instance.
+ *
+ * CRITICAL: This returns undefined in OSS builds. There is no telemetry provider
+ * for OSS builds and all tracking calls are no-ops.
  */
 export function useTelemetry(): TelemetryProvider | null {
   if (_telemetryProvider === null) {

--- a/src/platform/telemetry/index.ts
+++ b/src/platform/telemetry/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Telemetry Provider - OSS Build Safety
+ *
+ * ⚠️ CRITICAL: OSS Build Safety ⚠️
+ * This module is conditionally compiled based on distribution. When building
+ * the open source version (DISTRIBUTION unset), this entire module and its dependencies
+ * are excluded through Vite's tree-shaking optimization.
+ *
+ * To verify OSS builds exclude this code:
+ * 1. `DISTRIBUTION= pnpm build` (OSS build)
+ * 2. `rg -r dist "telemetry|mixpanel"` (should find nothing)
+ * 3. Check dist/assets/*.js files contain no tracking code
+ *
+ * This approach maintains complete separation between cloud and OSS builds
+ * while ensuring the open source version contains no telemetry dependencies.
+ */
+import { isCloud } from '@/platform/distribution/types'
+
+import { MixpanelTelemetryProvider } from './providers/cloud/MixpanelTelemetryProvider'
+import type { TelemetryProvider } from './types'
+
+// Singleton instance
+let _telemetryProvider: TelemetryProvider | null = null
+
+/**
+ * Telemetry factory - conditionally creates provider based on distribution
+ * Returns singleton instance
+ */
+export function useTelemetry(): TelemetryProvider | null {
+  if (_telemetryProvider === null) {
+    // Use distribution check for tree-shaking
+    if (isCloud) {
+      _telemetryProvider = new MixpanelTelemetryProvider()
+    }
+    // For OSS builds, _telemetryProvider stays null
+  }
+
+  return _telemetryProvider
+}

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -15,6 +15,11 @@ import type {
 } from '../../types'
 import { TelemetryEvents } from '../../types'
 
+interface QueuedEvent {
+  eventName: TelemetryEventName
+  properties?: TelemetryEventProperties
+}
+
 /**
  * Mixpanel Telemetry Provider - Cloud Build Implementation
  *
@@ -27,11 +32,6 @@ import { TelemetryEvents } from '../../types'
  * 2. `grep -RinE --include='*.js' 'trackWorkflow|trackEvent|mixpanel' dist/` (should find nothing)
  * 3. Check dist/assets/*.js files contain no tracking code
  */
-interface QueuedEvent {
-  eventName: TelemetryEventName
-  properties?: TelemetryEventProperties
-}
-
 export class MixpanelTelemetryProvider implements TelemetryProvider {
   private isEnabled = true
   private mixpanel: OverridedMixpanel | null = null
@@ -55,7 +55,7 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
               persistence: 'cookie',
               loaded: () => {
                 this.isInitialized = true
-                this.flushEventQueue() // flush events queued while initializing
+                this.flushEventQueue() // flush events that were queued while initializing
                 useCurrentUser().onUserResolved((user) => {
                   if (this.mixpanel && user.id) {
                     this.mixpanel.identify(user.id)

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -1,0 +1,139 @@
+import mixpanel from 'mixpanel-browser'
+
+import type {
+  AuthMetadata,
+  RunContext,
+  SurveyResponses,
+  TelemetryEventName,
+  TelemetryProvider,
+  TemplateMetadata
+} from '../../types'
+import { TelemetryEvents } from '../../types'
+
+/**
+ * Mixpanel Telemetry Provider - Cloud Build Implementation
+ *
+ * ⚠️ CRITICAL: OSS Build Safety ⚠️
+ * This provider integrates with Mixpanel for cloud telemetry tracking.
+ * Entire file is tree-shaken away in OSS builds (DISTRIBUTION unset).
+ *
+ * To verify OSS builds exclude this code:
+ * 1. `DISTRIBUTION= pnpm build` (OSS build)
+ * 2. `rg -r dist "telemetry|mixpanel"` (should find nothing)
+ * 3. Check dist/assets/*.js files contain no tracking code
+ */
+export class MixpanelTelemetryProvider implements TelemetryProvider {
+  private isEnabled: boolean
+
+  constructor() {
+    const token = __MIXPANEL_TOKEN__
+
+    if (token) {
+      try {
+        mixpanel.init(token, {
+          debug: import.meta.env.DEV,
+          track_pageview: true,
+          persistence: 'localStorage'
+        })
+        this.isEnabled = true
+      } catch (error) {
+        console.error('Failed to initialize Mixpanel:', error)
+        this.isEnabled = false
+      }
+    } else {
+      console.warn('Mixpanel token not provided')
+      this.isEnabled = false
+    }
+  }
+
+  /**
+   * Track event with Mixpanel
+   */
+  private trackEvent(
+    eventName: TelemetryEventName,
+    properties: Record<string, unknown> = {}
+  ): void {
+    if (!this.isEnabled) {
+      return
+    }
+
+    try {
+      mixpanel.track(eventName, properties)
+    } catch (error) {
+      console.error('Failed to track event:', error)
+    }
+  }
+
+  trackSignUp(stage: 'opened' | 'completed', metadata?: AuthMetadata): void {
+    const eventName =
+      stage === 'opened'
+        ? TelemetryEvents.USER_SIGN_UP_OPENED
+        : TelemetryEvents.USER_SIGN_UP_COMPLETED
+
+    this.trackEvent(eventName, {
+      ...metadata,
+      timestamp: Date.now()
+    })
+  }
+
+  trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void {
+    const eventName =
+      event === 'modal_opened'
+        ? TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED
+        : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED
+
+    this.trackEvent(eventName, {
+      timestamp: Date.now()
+    })
+  }
+
+  trackRunButton(subscribeToRun: boolean, context?: Partial<RunContext>): void {
+    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, {
+      subscribe_to_run: subscribeToRun,
+      ...context,
+      timestamp: Date.now()
+    })
+  }
+
+  trackSurvey(
+    stage: 'opened' | 'submitted',
+    responses?: SurveyResponses
+  ): void {
+    const eventName =
+      stage === 'opened'
+        ? TelemetryEvents.USER_SURVEY_OPENED
+        : TelemetryEvents.USER_SURVEY_SUBMITTED
+
+    this.trackEvent(eventName, {
+      ...responses,
+      timestamp: Date.now()
+    })
+  }
+
+  trackEmailVerification(stage: 'opened' | 'requested' | 'completed'): void {
+    let eventName: TelemetryEventName
+
+    switch (stage) {
+      case 'opened':
+        eventName = TelemetryEvents.USER_EMAIL_VERIFY_OPENED
+        break
+      case 'requested':
+        eventName = TelemetryEvents.USER_EMAIL_VERIFY_REQUESTED
+        break
+      case 'completed':
+        eventName = TelemetryEvents.USER_EMAIL_VERIFY_COMPLETED
+        break
+    }
+
+    this.trackEvent(eventName, {
+      timestamp: Date.now()
+    })
+  }
+
+  trackTemplate(metadata: TemplateMetadata): void {
+    this.trackEvent(TelemetryEvents.TEMPLATE_WORKFLOW_OPENED, {
+      ...metadata,
+      timestamp: Date.now()
+    })
+  }
+}

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -7,6 +7,7 @@ import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/reposit
 import type {
   AuthMetadata,
   ExecutionContext,
+  RunButtonProperties,
   SurveyResponses,
   TelemetryEventName,
   TelemetryEventProperties,
@@ -78,9 +79,6 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     }
   }
 
-  /**
-   * Track event with Mixpanel
-   */
   private flushEventQueue(): void {
     if (!this.isInitialized || !this.mixpanel) {
       return
@@ -135,11 +133,13 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
   trackRunButton(options?: { subscribe_to_run?: boolean }): void {
     const executionContext = this.getExecutionContext()
 
-    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, {
+    const runButtonProperties: RunButtonProperties = {
       subscribe_to_run: options?.subscribe_to_run || false,
       workflow_type: executionContext.is_template ? 'template' : 'custom',
-      workflow_name: executionContext.workflow_name
-    })
+      workflow_name: executionContext.workflow_name ?? 'untitled'
+    }
+
+    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
   }
 
   trackSurvey(

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Telemetry Provider Interface
+ *
+ * ⚠️ CRITICAL: OSS Build Safety ⚠️
+ * This module is excluded from OSS builds via conditional compilation.
+ * When DISTRIBUTION is unset (OSS builds), Vite's tree-shaking removes this code entirely,
+ * ensuring the open source build contains no telemetry dependencies.
+ *
+ * To verify OSS builds are clean:
+ * 1. `DISTRIBUTION= pnpm build` (OSS build)
+ * 2. `rg -r dist "telemetry|mixpanel"` (should find nothing)
+ * 3. Check dist/assets/*.js files contain no tracking code
+ */
+
+/**
+ * Authentication metadata for sign-up tracking
+ */
+export interface AuthMetadata {
+  signup_method?: 'email' | 'google' | 'github'
+  referrer_url?: string
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+}
+
+/**
+ * Survey response data for user profiling
+ */
+export interface SurveyResponses {
+  industry?: string
+  team_size?: string
+  use_case?: string
+  familiarity?: string
+  intended_use?: 'personal' | 'client' | 'inhouse'
+}
+
+/**
+ * Run context for subscription tracking
+ */
+export interface RunContext {
+  subscribe_to_run: boolean
+  workflow_type?: 'template' | 'custom'
+  workflow_name?: string
+  is_first_run?: boolean
+}
+
+/**
+ * Template metadata for workflow tracking
+ */
+export interface TemplateMetadata {
+  workflow_id?: string
+  workflow_name: string
+  category?: string
+  source?: string
+}
+
+/**
+ * Core telemetry provider interface
+ */
+export interface TelemetryProvider {
+  // Authentication flow events
+  trackSignUp(stage: 'opened' | 'completed', metadata?: AuthMetadata): void
+
+  // Subscription flow events
+  trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void
+  trackRunButton(subscribeToRun: boolean, context?: Partial<RunContext>): void
+
+  // Survey flow events
+  trackSurvey(stage: 'opened' | 'submitted', responses?: SurveyResponses): void
+
+  // Email verification events
+  trackEmailVerification(stage: 'opened' | 'requested' | 'completed'): void
+
+  // Template workflow events
+  trackTemplate(metadata: TemplateMetadata): void
+}
+
+/**
+ * Telemetry event constants
+ */
+export const TelemetryEvents = {
+  // Authentication Flow
+  USER_SIGN_UP_OPENED: 'user_sign_up_opened',
+  USER_SIGN_UP_COMPLETED: 'user_sign_up_completed',
+
+  // Subscription Flow
+  RUN_BUTTON_CLICKED: 'run_button_clicked',
+  SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'subscription_required_modal_opened',
+  SUBSCRIBE_NOW_BUTTON_CLICKED: 'subscribe_now_button_clicked',
+
+  // Onboarding Survey
+  USER_SURVEY_OPENED: 'user_survey_opened',
+  USER_SURVEY_SUBMITTED: 'user_survey_submitted',
+
+  // Email Verification
+  USER_EMAIL_VERIFY_OPENED: 'user_email_verify_opened',
+  USER_EMAIL_VERIFY_REQUESTED: 'user_email_verify_requested',
+  USER_EMAIL_VERIFY_COMPLETED: 'user_email_verify_completed',
+
+  // Enhanced Template Tracking
+  TEMPLATE_WORKFLOW_OPENED: 'template_workflow_opened'
+} as const
+
+export type TelemetryEventName =
+  (typeof TelemetryEvents)[keyof typeof TelemetryEvents]

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -36,6 +36,15 @@ export interface SurveyResponses {
 }
 
 /**
+ * Run button tracking properties
+ */
+export interface RunButtonProperties {
+  subscribe_to_run: boolean
+  workflow_type: 'template' | 'custom'
+  workflow_name: string
+}
+
+/**
  * Execution context for workflow tracking
  */
 export interface ExecutionContext {
@@ -108,7 +117,7 @@ export const TelemetryEvents = {
   USER_EMAIL_VERIFY_REQUESTED: 'user_email_verify_requested',
   USER_EMAIL_VERIFY_COMPLETED: 'user_email_verify_completed',
 
-  // Enhanced Template Tracking
+  // Template Tracking
   TEMPLATE_WORKFLOW_OPENED: 'template_workflow_opened',
 
   // Workflow Execution Tracking
@@ -122,8 +131,8 @@ export type TelemetryEventName =
  * Union type for all possible telemetry event properties
  */
 export type TelemetryEventProperties =
-  | Record<string, unknown>
   | AuthMetadata
   | SurveyResponses
   | TemplateMetadata
   | ExecutionContext
+  | RunButtonProperties

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -1,6 +1,8 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
 import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
 import type {
   TemplateGroup,
@@ -128,6 +130,13 @@ export function useTemplateWorkflows() {
             ? t(`templateWorkflows.template.${id}`, id)
             : id
 
+        if (isCloud) {
+          useTelemetry()?.trackTemplate({
+            workflow_name: workflowName,
+            template_source: actualSourceModule
+          })
+        }
+
         dialogStore.closeDialog()
         await app.loadGraphData(json, true, true, workflowName)
 
@@ -141,6 +150,13 @@ export function useTemplateWorkflows() {
         sourceModule === 'default'
           ? t(`templateWorkflows.template.${id}`, id)
           : id
+
+      if (isCloud) {
+        useTelemetry()?.trackTemplate({
+          workflow_name: workflowName,
+          template_source: sourceModule
+        })
+      }
 
       dialogStore.closeDialog()
       await app.loadGraphData(json, true, true, workflowName)

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -30,6 +30,11 @@ export const useWorkflowTemplatesStore = defineStore(
     const customTemplates = shallowRef<{ [moduleName: string]: string[] }>({})
     const coreTemplates = shallowRef<WorkflowTemplates[]>([])
     const isLoaded = ref(false)
+    const knownTemplateNames = ref(new Set<string>())
+
+    const getTemplateByName = (name: string): EnhancedTemplate | undefined => {
+      return enhancedTemplates.value.find((template) => template.name === name)
+    }
 
     // Store filter mappings for dynamic categories
     type FilterData = {
@@ -432,6 +437,13 @@ export const useWorkflowTemplatesStore = defineStore(
           customTemplates.value = await api.getWorkflowTemplates()
           const locale = i18n.global.locale.value
           coreTemplates.value = await api.getCoreWorkflowTemplates(locale)
+
+          const coreNames = coreTemplates.value.flatMap((category) =>
+            category.templates.map((template) => template.name)
+          )
+          const customNames = Object.values(customTemplates.value).flat()
+          knownTemplateNames.value = new Set([...coreNames, ...customNames])
+
           isLoaded.value = true
         }
       } catch (error) {
@@ -446,7 +458,9 @@ export const useWorkflowTemplatesStore = defineStore(
       templateFuse,
       filterTemplatesByCategory,
       isLoaded,
-      loadWorkflowTemplates
+      loadWorkflowTemplates,
+      knownTemplateNames,
+      getTemplateByName
     }
   }
 )

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -252,7 +252,6 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track all auth events (login)
     if (isCloud) {
       useTelemetry()?.trackAuth({
         method: 'email',
@@ -273,7 +272,6 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track all auth events (signup)
     if (isCloud) {
       useTelemetry()?.trackAuth({
         method: 'email',
@@ -290,7 +288,6 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track all auth events (Google SSO)
     if (isCloud) {
       const additionalUserInfo = getAdditionalUserInfo(result)
       const isNewUser = additionalUserInfo?.isNewUser ?? false
@@ -309,7 +306,6 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track all auth events (GitHub SSO)
     if (isCloud) {
       const additionalUserInfo = getAdditionalUserInfo(result)
       const isNewUser = additionalUserInfo?.isNewUser ?? false

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -6,6 +6,7 @@ import {
   browserLocalPersistence,
   createUserWithEmailAndPassword,
   deleteUser,
+  getAdditionalUserInfo,
   onAuthStateChanged,
   sendPasswordResetEmail,
   setPersistence,
@@ -21,6 +22,7 @@ import { useFirebaseAuth } from 'vuefire'
 
 import { COMFY_API_BASE_URL } from '@/config/comfyApi'
 import { t } from '@/i18n'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
@@ -250,8 +252,13 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track successful sign-in completion
-    useTelemetry()?.trackSignUp('completed', { signup_method: 'email' })
+    // Track all auth events (login)
+    if (isCloud) {
+      useTelemetry()?.trackAuth({
+        method: 'email',
+        is_new_user: false
+      })
+    }
 
     return result
   }
@@ -266,8 +273,13 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track successful sign-up completion
-    useTelemetry()?.trackSignUp('completed', { signup_method: 'email' })
+    // Track all auth events (signup)
+    if (isCloud) {
+      useTelemetry()?.trackAuth({
+        method: 'email',
+        is_new_user: true
+      })
+    }
 
     return result
   }
@@ -278,8 +290,15 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track successful Google sign-in completion
-    useTelemetry()?.trackSignUp('completed', { signup_method: 'google' })
+    // Track all auth events (Google SSO)
+    if (isCloud) {
+      const additionalUserInfo = getAdditionalUserInfo(result)
+      const isNewUser = additionalUserInfo?.isNewUser ?? false
+      useTelemetry()?.trackAuth({
+        method: 'google',
+        is_new_user: isNewUser
+      })
+    }
 
     return result
   }
@@ -290,8 +309,15 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
       { createCustomer: true }
     )
 
-    // Track successful GitHub sign-in completion
-    useTelemetry()?.trackSignUp('completed', { signup_method: 'github' })
+    // Track all auth events (GitHub SSO)
+    if (isCloud) {
+      const additionalUserInfo = getAdditionalUserInfo(result)
+      const isNewUser = additionalUserInfo?.isNewUser ?? false
+      useTelemetry()?.trackAuth({
+        method: 'github',
+        is_new_user: isNewUser
+      })
+    }
 
     return result
   }

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -21,6 +21,7 @@ import { useFirebaseAuth } from 'vuefire'
 
 import { COMFY_API_BASE_URL } from '@/config/comfyApi'
 import { t } from '@/i18n'
+import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import type { AuthHeader } from '@/types/authTypes'
@@ -242,35 +243,58 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   const login = async (
     email: string,
     password: string
-  ): Promise<UserCredential> =>
-    executeAuthAction(
+  ): Promise<UserCredential> => {
+    const result = await executeAuthAction(
       (authInstance) =>
         signInWithEmailAndPassword(authInstance, email, password),
       { createCustomer: true }
     )
 
+    // Track successful sign-in completion
+    useTelemetry()?.trackSignUp('completed', { signup_method: 'email' })
+
+    return result
+  }
+
   const register = async (
     email: string,
     password: string
   ): Promise<UserCredential> => {
-    return executeAuthAction(
+    const result = await executeAuthAction(
       (authInstance) =>
         createUserWithEmailAndPassword(authInstance, email, password),
       { createCustomer: true }
     )
+
+    // Track successful sign-up completion
+    useTelemetry()?.trackSignUp('completed', { signup_method: 'email' })
+
+    return result
   }
 
-  const loginWithGoogle = async (): Promise<UserCredential> =>
-    executeAuthAction(
+  const loginWithGoogle = async (): Promise<UserCredential> => {
+    const result = await executeAuthAction(
       (authInstance) => signInWithPopup(authInstance, googleProvider),
       { createCustomer: true }
     )
 
-  const loginWithGithub = async (): Promise<UserCredential> =>
-    executeAuthAction(
+    // Track successful Google sign-in completion
+    useTelemetry()?.trackSignUp('completed', { signup_method: 'google' })
+
+    return result
+  }
+
+  const loginWithGithub = async (): Promise<UserCredential> => {
+    const result = await executeAuthAction(
       (authInstance) => signInWithPopup(authInstance, githubProvider),
       { createCustomer: true }
     )
+
+    // Track successful GitHub sign-in completion
+    useTelemetry()?.trackSignUp('completed', { signup_method: 'github' })
+
+    return result
+  }
 
   const logout = async (): Promise<void> =>
     executeAuthAction((authInstance) => signOut(authInstance))

--- a/tests-ui/tests/composables/useTemplateWorkflows.test.ts
+++ b/tests-ui/tests/composables/useTemplateWorkflows.test.ts
@@ -31,6 +31,11 @@ vi.mock('@/scripts/app', () => ({
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: vi.fn((key, fallback) => fallback || key)
+  }),
+  createI18n: () => ({
+    global: {
+      t: (key: string) => key
+    }
   })
 }))
 

--- a/tests-ui/tests/platform/cloud/subscription/useSubscription.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/useSubscription.test.ts
@@ -19,6 +19,10 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
   }))
 }))
 
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: vi.fn(() => null)
+}))
+
 vi.mock('@/composables/auth/useFirebaseAuthActions', () => ({
   useFirebaseAuthActions: vi.fn(() => ({
     reportError: mockReportError,

--- a/tests-ui/tests/platform/telemetry/useTelemetry.test.ts
+++ b/tests-ui/tests/platform/telemetry/useTelemetry.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the distribution check
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false
+}))
+
+describe('useTelemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return null when not in cloud distribution', async () => {
+    const { useTelemetry } = await import('@/platform/telemetry')
+    const provider = useTelemetry()
+
+    // Should return null for OSS builds
+    expect(provider).toBeNull()
+  })
+
+  it('should return null consistently for OSS builds', async () => {
+    const { useTelemetry } = await import('@/platform/telemetry')
+
+    const provider1 = useTelemetry()
+    const provider2 = useTelemetry()
+
+    // Both should be null for OSS builds
+    expect(provider1).toBeNull()
+    expect(provider2).toBeNull()
+  })
+
+  it('should have correct TelemetryEvents constants', async () => {
+    const { TelemetryEvents } = await import('@/platform/telemetry/types')
+
+    expect(TelemetryEvents.USER_SIGN_UP_OPENED).toBe('user_sign_up_opened')
+    expect(TelemetryEvents.USER_SIGN_UP_COMPLETED).toBe(
+      'user_sign_up_completed'
+    )
+    expect(TelemetryEvents.RUN_BUTTON_CLICKED).toBe('run_button_clicked')
+    expect(TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED).toBe(
+      'subscription_required_modal_opened'
+    )
+    expect(TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED).toBe(
+      'subscribe_now_button_clicked'
+    )
+    expect(TelemetryEvents.USER_SURVEY_OPENED).toBe('user_survey_opened')
+    expect(TelemetryEvents.USER_SURVEY_SUBMITTED).toBe('user_survey_submitted')
+    expect(TelemetryEvents.USER_EMAIL_VERIFY_OPENED).toBe(
+      'user_email_verify_opened'
+    )
+    expect(TelemetryEvents.USER_EMAIL_VERIFY_REQUESTED).toBe(
+      'user_email_verify_requested'
+    )
+    expect(TelemetryEvents.USER_EMAIL_VERIFY_COMPLETED).toBe(
+      'user_email_verify_completed'
+    )
+    expect(TelemetryEvents.TEMPLATE_WORKFLOW_OPENED).toBe(
+      'template_workflow_opened'
+    )
+  })
+})

--- a/tests-ui/tests/platform/telemetry/useTelemetry.test.ts
+++ b/tests-ui/tests/platform/telemetry/useTelemetry.test.ts
@@ -32,10 +32,7 @@ describe('useTelemetry', () => {
   it('should have correct TelemetryEvents constants', async () => {
     const { TelemetryEvents } = await import('@/platform/telemetry/types')
 
-    expect(TelemetryEvents.USER_SIGN_UP_OPENED).toBe('user_sign_up_opened')
-    expect(TelemetryEvents.USER_SIGN_UP_COMPLETED).toBe(
-      'user_sign_up_completed'
-    )
+    expect(TelemetryEvents.USER_AUTH_COMPLETED).toBe('user_auth_completed')
     expect(TelemetryEvents.RUN_BUTTON_CLICKED).toBe('run_button_clicked')
     expect(TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED).toBe(
       'subscription_required_modal_opened'

--- a/tests-ui/tests/platform/telemetry/useTelemetry.test.ts
+++ b/tests-ui/tests/platform/telemetry/useTelemetry.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock the distribution check
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: false
 }))
@@ -27,32 +26,5 @@ describe('useTelemetry', () => {
     // Both should be null for OSS builds
     expect(provider1).toBeNull()
     expect(provider2).toBeNull()
-  })
-
-  it('should have correct TelemetryEvents constants', async () => {
-    const { TelemetryEvents } = await import('@/platform/telemetry/types')
-
-    expect(TelemetryEvents.USER_AUTH_COMPLETED).toBe('user_auth_completed')
-    expect(TelemetryEvents.RUN_BUTTON_CLICKED).toBe('run_button_clicked')
-    expect(TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED).toBe(
-      'subscription_required_modal_opened'
-    )
-    expect(TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED).toBe(
-      'subscribe_now_button_clicked'
-    )
-    expect(TelemetryEvents.USER_SURVEY_OPENED).toBe('user_survey_opened')
-    expect(TelemetryEvents.USER_SURVEY_SUBMITTED).toBe('user_survey_submitted')
-    expect(TelemetryEvents.USER_EMAIL_VERIFY_OPENED).toBe(
-      'user_email_verify_opened'
-    )
-    expect(TelemetryEvents.USER_EMAIL_VERIFY_REQUESTED).toBe(
-      'user_email_verify_requested'
-    )
-    expect(TelemetryEvents.USER_EMAIL_VERIFY_COMPLETED).toBe(
-      'user_email_verify_completed'
-    )
-    expect(TelemetryEvents.TEMPLATE_WORKFLOW_OPENED).toBe(
-      'template_workflow_opened'
-    )
   })
 })

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -272,7 +272,8 @@ export default defineConfig({
     __ALGOLIA_API_KEY__: JSON.stringify(process.env.ALGOLIA_API_KEY || ''),
     __USE_PROD_CONFIG__: process.env.USE_PROD_CONFIG === 'true',
     __DISTRIBUTION__: JSON.stringify(DISTRIBUTION),
-    __BUILD_FLAGS__: JSON.stringify(BUILD_FLAGS)
+    __BUILD_FLAGS__: JSON.stringify(BUILD_FLAGS),
+    __MIXPANEL_TOKEN__: JSON.stringify(process.env.MIXPANEL_TOKEN || '')
   },
 
   resolve: {


### PR DESCRIPTION
## Summary

This code is entirely excluded from open-source, local, and desktop builds. During minification and dead-code elimination, the Mixpanel library is fully tree-shaken -- meaning no telemetry code is ever included or downloaded in those builds. Even the inline callsites are removed during the build (because `isCloud` becomes false and the entire block becomes dead code and is removed). The code not only has no effect, is not even distributed in the first place. We’ve gone to great lengths to ensure this behavior.

Verification proof:

https://github.com/user-attachments/assets/b66c35f7-e233-447f-93da-4d70c433908d

Telemetry is *enabled only in the ComfyUI Cloud environment*. Its goal is to help us understand and improve onboarding and new-user adoption. ComfyUI aims to be accessible to everyone, but we know the learning curve can be steep. Anonymous usage insights will help us identify where users struggle and guide us toward making the experience more intuitive and welcoming.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6154-add-telemetry-provider-for-cloud-distribution-2926d73d3650813cb9ccfb3a2733848b) by [Unito](https://www.unito.io)
