### PR TITLE
[bugfix] Fix enable pack functionality to use proper API endpoint

### DIFF
--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -31,7 +31,7 @@ const mockNodePack = {
 }
 
 const mockIsPackEnabled = vi.fn()
-const mockEnablePack = { call: vi.fn().mockResolvedValue(undefined) }
+const mockEnablePack = vi.fn().mockResolvedValue(undefined)
 const mockDisablePack = vi.fn().mockResolvedValue(undefined)
 vi.mock('@/workbench/extensions/manager/stores/comfyManagerStore', () => ({
   useComfyManagerStore: vi.fn(() => ({
@@ -46,7 +46,7 @@ describe('PackEnableToggle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsPackEnabled.mockReset()
-    mockEnablePack.call.mockReset().mockResolvedValue(undefined)
+    mockEnablePack.mockReset().mockResolvedValue(undefined)
     mockDisablePack.mockReset().mockResolvedValue(undefined)
   })
 
@@ -116,7 +116,7 @@ describe('PackEnableToggle', () => {
     const toggleSwitch = wrapper.findComponent(ToggleSwitch)
     await toggleSwitch.vm.$emit('update:modelValue', true)
 
-    expect(mockEnablePack.call).toHaveBeenCalledWith(
+    expect(mockEnablePack).toHaveBeenCalledWith(
       expect.objectContaining({
         id: mockNodePack.id,
         version: mockNodePack.latest_version.version
@@ -143,7 +143,7 @@ describe('PackEnableToggle', () => {
     const pendingPromise = new Promise<void>((resolve) => {
       setTimeout(() => resolve(), 1000)
     })
-    mockEnablePack.call.mockReturnValue(pendingPromise)
+    mockEnablePack.mockReturnValue(pendingPromise)
 
     mockIsPackEnabled.mockReturnValue(false)
     const wrapper = mountComponent()

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.vue
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.vue
@@ -106,18 +106,11 @@ const handleEnable = () => {
   if (!nodePack.id) {
     throw new Error('Node ID is required for enabling')
   }
-  return enablePack.call({
+  return enablePack({
     id: nodePack.id,
     version:
       version.value ??
-      ('latest' as ManagerComponents['schemas']['SelectedVersion']),
-    selected_version:
-      version.value ??
-      ('latest' as ManagerComponents['schemas']['SelectedVersion']),
-    repository: nodePack.repository ?? '',
-    channel: 'default' as ManagerComponents['schemas']['ManagerChannel'],
-    mode: 'cache' as ManagerComponents['schemas']['ManagerDatabaseSource'],
-    skip_post_install: false
+      ('latest' as ManagerComponents['schemas']['SelectedVersion'])
   })
 }
 

--- a/src/workbench/extensions/manager/services/comfyManagerService.ts
+++ b/src/workbench/extensions/manager/services/comfyManagerService.ts
@@ -228,6 +228,14 @@ export const useComfyManagerService = () => {
     return queueTask('disable', params, ui_id, signal)
   }
 
+  const enablePack = async (
+    params: components['schemas']['EnablePackParams'],
+    ui_id?: string,
+    signal?: AbortSignal
+  ): Promise<null> => {
+    return queueTask('enable', params, ui_id, signal)
+  }
+
   const updatePack = async (
     params: components['schemas']['UpdatePackParams'],
     ui_id?: string,
@@ -321,7 +329,7 @@ export const useComfyManagerService = () => {
     getImportFailInfoBulk,
     installPack,
     uninstallPack,
-    enablePack: installPack, // enable is done via install
+    enablePack,
     disablePack,
     updatePack,
     updateAllPacks,

--- a/src/workbench/extensions/manager/stores/comfyManagerStore.ts
+++ b/src/workbench/extensions/manager/stores/comfyManagerStore.ts
@@ -317,6 +317,15 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     await enqueueTaskWithLogs(task, t('g.disabling', { id: params.id }))
   }
 
+  const enablePack = async (params: ManagerPackInfo, signal?: AbortSignal) => {
+    const enableParams: components['schemas']['EnablePackParams'] = {
+      cnr_id: params.id
+    }
+    const task = (taskId: string) =>
+      managerService.enablePack(enableParams, taskId, signal)
+    await enqueueTaskWithLogs(task, t('g.enabling', { id: params.id }))
+  }
+
   const getInstalledPackVersion = (packId: string) => {
     const pack = installedPacks.value[packId]
     return pack?.ver
@@ -380,7 +389,7 @@ export const useComfyManagerStore = defineStore('comfyManager', () => {
     updatePack,
     updateAllPacks,
     disablePack,
-    enablePack: installPack // Enable is done via install endpoint with a disabled pack
+    enablePack
   }
 })
 


### PR DESCRIPTION
## Summary
- Fixed issue where enabling a disabled pack incorrectly triggered installation instead of using the dedicated enable endpoint
- Added proper `enablePack` method in the manager service layer
- Updated store and component to use the correct API call

## Problem
When users toggled a disabled pack to enable it via `PackEnableToggle` component, the system was incorrectly calling the install endpoint with full installation parameters instead of the simpler enable endpoint that only requires the pack ID.

## Solution
1. **Added dedicated `enablePack` method in `comfyManagerService.ts`**:
   - Uses the `'enable'` task kind with `EnablePackParams`
   - Only requires `cnr_id` parameter (simpler than install)

2. **Updated `comfyManagerStore.ts`**:
   - Created proper `enablePack` function that queues an enable task
   - Removed the incorrect aliasing where `enablePack` was pointing to `installPack`

3. **Simplified `PackEnableToggle.vue`**:
   - Now calls `enablePack` with only required parameters (id, version)
   - Removed unnecessary installation-specific parameters

## Test plan
- [x] Enable a disabled pack and verify it uses the enable endpoint (not install)
- [x] Confirm the pack is properly enabled after the operation
- [x] Check that the task queue shows "Enabling" message (not "Installing")
- [x] Verify existing install/uninstall functionality still works

Fixes #6154

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6157-bugfix-Fix-enable-pack-functionality-to-use-proper-API-endpoint-2926d73d3650819fa4caf1b848f99735) by [Unito](https://www.unito.io)
