### PR TITLE
Extract AssetsSidebarTab template and improve UI structure

### DIFF
--- a/src/components/sidebar/tabs/AssetSidebarTemplate.vue
+++ b/src/components/sidebar/tabs/AssetSidebarTemplate.vue
@@ -1,0 +1,33 @@
+<template>
+  <div
+    class="flex h-full flex-col bg-white dark-theme:bg-zinc-900"
+    :class="props.class"
+  >
+    <div>
+      <div
+        v-if="slots.top"
+        class="flex min-h-12 items-center border-b border-zinc-200 px-4 py-2 dark-theme:border-zinc-700"
+      >
+        <slot name="top" />
+      </div>
+      <div v-if="slots.header" class="px-4">
+        <slot name="header" />
+      </div>
+    </div>
+    <!-- h-0 to force scrollpanel to grow -->
+    <ScrollPanel class="h-0 grow">
+      <slot name="body" />
+    </ScrollPanel>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ScrollPanel from 'primevue/scrollpanel'
+import { useSlots } from 'vue'
+
+const props = defineProps<{
+  class?: string
+}>()
+
+const slots = useSlots()
+</script>

--- a/src/components/sidebar/tabs/AssetSidebarTemplate.vue
+++ b/src/components/sidebar/tabs/AssetSidebarTemplate.vue
@@ -1,12 +1,12 @@
 <template>
   <div
-    class="flex h-full flex-col bg-white dark-theme:bg-zinc-900"
+    class="flex h-full flex-col bg-interface-panel-surface"
     :class="props.class"
   >
     <div>
       <div
         v-if="slots.top"
-        class="flex min-h-12 items-center border-b border-zinc-200 px-4 py-2 dark-theme:border-zinc-700"
+        class="flex min-h-12 items-center border-b border-interface-stroke px-4 py-2"
       >
         <slot name="top" />
       </div>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -8,7 +8,13 @@
         <div class="flex items-center gap-2">
           <span class="font-bold">{{ $t('Job ID') }}:</span>
           <span class="text-sm">{{ folderPromptId?.substring(0, 8) }}</span>
-          <i class="mb-1 icon-[lucide--copy] text-sm" @click="copyJobId"></i>
+          <button
+            class="m-0 cursor-pointer border-0 bg-transparent p-0 outline-0"
+            role="button"
+            @click="copyJobId"
+          >
+            <i class="mb-1 icon-[lucide--copy] text-sm"></i>
+          </button>
         </div>
         <div>
           <span>{{ formattedExecutionTime }}</span>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -1,45 +1,52 @@
 <template>
-  <SidebarTabTemplate
-    :title="isInFolderView ? '' : $t('sideToolbar.mediaAssets')"
-  >
-    <template v-if="isInFolderView" #tool-buttons>
-      <div class="flex w-full items-center gap-2">
-        <span class="font-medium"
-          >Job ID: {{ folderPromptId?.substring(0, 8) }}</span
-        >
-        <button
-          class="rounded p-1 transition-colors hover:bg-neutral-100 dark-theme:hover:bg-neutral-700"
-          :title="$t('g.copy')"
-          @click="copyJobId"
-        >
-          <i class="icon-[lucide--copy] size-4" />
-        </button>
-        <span class="ml-auto text-sm text-neutral-500">
-          {{ formattedExecutionTime }}
-        </span>
+  <AssetsSidebarTemplate>
+    <template #top>
+      <span v-if="!isInFolderView" class="font-bold">
+        {{ $t('sideToolbar.mediaAssets') }}
+      </span>
+      <div v-else class="flex w-full items-center justify-between gap-2">
+        <div class="flex items-center gap-2">
+          <span class="font-bold">{{ $t('Job ID') }}:</span>
+          <span class="text-sm">{{ folderPromptId?.substring(0, 8) }}</span>
+          <i class="mb-1 icon-[lucide--copy] text-sm" @click="copyJobId"></i>
+        </div>
+        <div>
+          <span>{{ formattedExecutionTime }}</span>
+        </div>
       </div>
     </template>
     <template #header>
       <!-- Job Detail View Header -->
-      <div
-        v-if="isInFolderView"
-        class="border-b border-neutral-300 px-4 pt-2 pb-3 dark-theme:border-neutral-700"
-      >
-        <button
-          class="flex items-center gap-2 rounded bg-neutral-100 px-3 py-1.5 text-sm transition-colors hover:bg-neutral-200 dark-theme:bg-neutral-700 dark-theme:hover:bg-neutral-600"
+      <div v-if="isInFolderView" class="pt-4 pb-1">
+        <IconTextButton
+          :label="$t('sideToolbar.backToAssets')"
+          type="secondary"
           @click="exitFolderView"
         >
-          <i class="icon-[lucide--arrow-left] size-4" />
-          <span>Back to all assets</span>
-        </button>
+          <template #icon>
+            <i class="icon-[lucide--arrow-left] size-4" />
+          </template>
+        </IconTextButton>
       </div>
       <!-- Normal Tab View -->
-      <Tabs v-model:value="activeTab" class="w-full">
+      <div v-else class="flex items-center gap-2 pt-4 pb-1">
+        <TextButton
+          :label="$t('sideToolbar.labels.imported')"
+          :type="activeTab === 'input' ? 'secondary' : 'transparent'"
+          @click.stop="activeTab = 'input'"
+        />
+        <TextButton
+          :label="$t('sideToolbar.labels.generated')"
+          :type="activeTab === 'output' ? 'secondary' : 'transparent'"
+          @click.stop="activeTab = 'output'"
+        />
+      </div>
+      <!-- <Tabs v-else v-model:value="activeTab" class="w-full">
         <TabList class="border-b border-neutral-300">
           <Tab value="input">{{ $t('sideToolbar.labels.imported') }}</Tab>
           <Tab value="output">{{ $t('sideToolbar.labels.generated') }}</Tab>
         </TabList>
-      </Tabs>
+      </Tabs> -->
     </template>
     <template #body>
       <VirtualGrid
@@ -85,7 +92,7 @@
         />
       </div>
     </template>
-  </SidebarTabTemplate>
+  </AssetsSidebarTemplate>
   <ResultGallery
     v-model:active-index="galleryActiveIndex"
     :all-gallery-items="galleryItems"
@@ -94,21 +101,21 @@
 
 <script setup lang="ts">
 import ProgressSpinner from 'primevue/progressspinner'
-import Tab from 'primevue/tab'
-import TabList from 'primevue/tablist'
-import Tabs from 'primevue/tabs'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 
+import IconTextButton from '@/components/button/IconTextButton.vue'
+import TextButton from '@/components/button/TextButton.vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
-import SidebarTabTemplate from '@/components/sidebar/tabs/SidebarTabTemplate.vue'
 import ResultGallery from '@/components/sidebar/tabs/queue/ResultGallery.vue'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
 import { useMediaAssets } from '@/platform/assets/composables/useMediaAssets'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { ResultItemImpl } from '@/stores/queueStore'
 import { formatDuration, getMediaTypeFromFilename } from '@/utils/formatUtil'
+
+import AssetsSidebarTemplate from './AssetSidebarTemplate.vue'
 
 const activeTab = ref<'input' | 'output'>('input')
 const selectedAsset = ref<AssetItem | null>(null)

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -15,7 +15,7 @@
           <i class="icon-[lucide--copy] size-4" />
         </button>
         <span class="ml-auto text-sm text-neutral-500">
-          {{ formatExecutionTime(folderExecutionTime) }}
+          {{ formattedExecutionTime }}
         </span>
       </div>
     </template>
@@ -108,13 +108,18 @@ import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
 import { useMediaAssets } from '@/platform/assets/composables/useMediaAssets'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { ResultItemImpl } from '@/stores/queueStore'
-import { getMediaTypeFromFilename } from '@/utils/formatUtil'
+import { formatDuration, getMediaTypeFromFilename } from '@/utils/formatUtil'
 
 const activeTab = ref<'input' | 'output'>('input')
 const selectedAsset = ref<AssetItem | null>(null)
 const folderPromptId = ref<string | null>(null)
 const folderExecutionTime = ref<number | undefined>(undefined)
 const isInFolderView = computed(() => folderPromptId.value !== null)
+
+const formattedExecutionTime = computed(() => {
+  if (!folderExecutionTime.value) return ''
+  return formatDuration(folderExecutionTime.value * 1000)
+})
 
 const toast = useToast()
 
@@ -282,17 +287,5 @@ const copyJobId = async () => {
       })
     }
   }
-}
-
-const formatExecutionTime = (seconds?: number): string => {
-  if (!seconds) return ''
-
-  const minutes = Math.floor(seconds / 60)
-  const remainingSeconds = Math.floor(seconds % 60)
-
-  if (minutes > 0) {
-    return `${minutes}m ${remainingSeconds}s`
-  }
-  return `${remainingSeconds}s`
 }
 </script>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -29,24 +29,10 @@
         </IconTextButton>
       </div>
       <!-- Normal Tab View -->
-      <div v-else class="flex items-center gap-2 pt-4 pb-1">
-        <TextButton
-          :label="$t('sideToolbar.labels.imported')"
-          :type="activeTab === 'input' ? 'secondary' : 'transparent'"
-          @click.stop="activeTab = 'input'"
-        />
-        <TextButton
-          :label="$t('sideToolbar.labels.generated')"
-          :type="activeTab === 'output' ? 'secondary' : 'transparent'"
-          @click.stop="activeTab = 'output'"
-        />
-      </div>
-      <!-- <Tabs v-else v-model:value="activeTab" class="w-full">
-        <TabList class="border-b border-neutral-300">
-          <Tab value="input">{{ $t('sideToolbar.labels.imported') }}</Tab>
-          <Tab value="output">{{ $t('sideToolbar.labels.generated') }}</Tab>
-        </TabList>
-      </Tabs> -->
+      <TabList v-else v-model="activeTab" class="pt-4 pb-1">
+        <Tab value="input">{{ $t('sideToolbar.labels.imported') }}</Tab>
+        <Tab value="output">{{ $t('sideToolbar.labels.generated') }}</Tab>
+      </TabList>
     </template>
     <template #body>
       <VirtualGrid
@@ -105,10 +91,11 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 
 import IconTextButton from '@/components/button/IconTextButton.vue'
-import TextButton from '@/components/button/TextButton.vue'
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import ResultGallery from '@/components/sidebar/tabs/queue/ResultGallery.vue'
+import Tab from '@/components/tab/Tab.vue'
+import TabList from '@/components/tab/TabList.vue'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
 import { useMediaAssets } from '@/platform/assets/composables/useMediaAssets'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'

--- a/src/components/tab/Tab.vue
+++ b/src/components/tab/Tab.vue
@@ -1,8 +1,11 @@
 <template>
   <button
+    :id="tabId"
     :class="tabClasses"
     role="tab"
     :aria-selected="isActive"
+    :aria-controls="panelId"
+    :tabindex="0"
     @click="handleClick"
   >
     <slot />
@@ -15,13 +18,15 @@ import { computed, inject } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-const { value } = defineProps<{
+const { value, panelId } = defineProps<{
   value: string
+  panelId?: string
 }>()
 
 const currentValue = inject<Ref<string>>('tabs-value')
 const updateValue = inject<(value: string) => void>('tabs-update')
 
+const tabId = computed(() => `tab-${value}`)
 const isActive = computed(() => currentValue?.value === value)
 
 const tabClasses = computed(() => {

--- a/src/components/tab/Tab.vue
+++ b/src/components/tab/Tab.vue
@@ -1,0 +1,43 @@
+<template>
+  <button
+    :class="tabClasses"
+    role="tab"
+    :aria-selected="isActive"
+    @click="handleClick"
+  >
+    <slot />
+  </button>
+</template>
+
+<script setup lang="ts">
+import type { Ref } from 'vue'
+import { computed, inject } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const { value } = defineProps<{
+  value: string
+}>()
+
+const currentValue = inject<Ref<string>>('tabs-value')
+const updateValue = inject<(value: string) => void>('tabs-update')
+
+const isActive = computed(() => currentValue?.value === value)
+
+const tabClasses = computed(() => {
+  return cn(
+    // Base styles from TextButton
+    'flex items-center justify-center shrink-0',
+    'px-2.5 py-2 text-sm rounded-lg cursor-pointer transition-all duration-200',
+    'outline-hidden border-none',
+    // State styles with semantic tokens
+    isActive.value
+      ? 'bg-interface-menu-component-surface-hovered text-text-primary text-bold'
+      : 'bg-transparent text-text-secondary hover:bg-button-hover-surface focus:bg-button-hover-surface'
+  )
+})
+
+const handleClick = () => {
+  updateValue?.(value)
+}
+</script>

--- a/src/components/tab/TabList.stories.ts
+++ b/src/components/tab/TabList.stories.ts
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
+
+import Tab from './Tab.vue'
+import TabList from './TabList.vue'
+
+const meta: Meta<typeof TabList> = {
+  title: 'Components/Tab/TabList',
+  component: TabList,
+  tags: ['autodocs'],
+  argTypes: {
+    modelValue: {
+      control: 'text',
+      description: 'The currently selected tab value'
+    },
+    'onUpdate:modelValue': { action: 'update:modelValue' }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { TabList, Tab },
+    setup() {
+      const activeTab = ref(args.modelValue || 'tab1')
+      return { activeTab }
+    },
+    template: `
+      <TabList v-model="activeTab">
+        <Tab value="tab1">Tab 1</Tab>
+        <Tab value="tab2">Tab 2</Tab>
+        <Tab value="tab3">Tab 3</Tab>
+      </TabList>
+      <div class="mt-4 p-4 border rounded">
+        Selected tab: {{ activeTab }}
+      </div>
+    `
+  }),
+  args: {
+    modelValue: 'tab1'
+  }
+}
+
+export const ManyTabs: Story = {
+  render: () => ({
+    components: { TabList, Tab },
+    setup() {
+      const activeTab = ref('tab1')
+      return { activeTab }
+    },
+    template: `
+      <TabList v-model="activeTab">
+        <Tab value="tab1">Dashboard</Tab>
+        <Tab value="tab2">Analytics</Tab>
+        <Tab value="tab3">Reports</Tab>
+        <Tab value="tab4">Settings</Tab>
+        <Tab value="tab5">Profile</Tab>
+      </TabList>
+      <div class="mt-4 p-4 border rounded">
+        Selected tab: {{ activeTab }}
+      </div>
+    `
+  })
+}
+
+export const WithIcons: Story = {
+  render: () => ({
+    components: { TabList, Tab },
+    setup() {
+      const activeTab = ref('home')
+      return { activeTab }
+    },
+    template: `
+      <TabList v-model="activeTab">
+        <Tab value="home">
+          <i class="pi pi-home mr-2"></i>
+          Home
+        </Tab>
+        <Tab value="users">
+          <i class="pi pi-users mr-2"></i>
+          Users
+        </Tab>
+        <Tab value="settings">
+          <i class="pi pi-cog mr-2"></i>
+          Settings
+        </Tab>
+      </TabList>
+      <div class="mt-4 p-4 border rounded">
+        Selected tab: {{ activeTab }}
+      </div>
+    `
+  })
+}
+
+export const LongLabels: Story = {
+  render: () => ({
+    components: { TabList, Tab },
+    setup() {
+      const activeTab = ref('overview')
+      return { activeTab }
+    },
+    template: `
+      <TabList v-model="activeTab">
+        <Tab value="overview">Project Overview</Tab>
+        <Tab value="documentation">Documentation & Guides</Tab>
+        <Tab value="deployment">Deployment Settings</Tab>
+        <Tab value="monitoring">Monitoring & Analytics</Tab>
+      </TabList>
+      <div class="mt-4 p-4 border rounded">
+        Selected tab: {{ activeTab }}
+      </div>
+    `
+  })
+}
+
+export const Interactive: Story = {
+  render: () => ({
+    components: { TabList, Tab },
+    setup() {
+      const activeTab = ref('input')
+      const handleTabChange = (value: string) => {
+        console.log('Tab changed to:', value)
+      }
+      return { activeTab, handleTabChange }
+    },
+    template: `
+      <div class="space-y-4">
+        <div>
+          <h3 class="text-sm font-semibold mb-2">Example: Media Assets</h3>
+          <TabList v-model="activeTab" @update:model-value="handleTabChange">
+            <Tab value="input">Imported</Tab>
+            <Tab value="output">Generated</Tab>
+          </TabList>
+        </div>
+        
+        <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded">
+          <div v-if="activeTab === 'input'">
+            <p>Showing imported assets...</p>
+          </div>
+          <div v-else-if="activeTab === 'output'">
+            <p>Showing generated assets...</p>
+          </div>
+        </div>
+        
+        <div class="text-sm text-gray-600">
+          Current tab value: <code>{{ activeTab }}</code>
+        </div>
+      </div>
+    `
+  })
+}

--- a/src/components/tab/TabList.vue
+++ b/src/components/tab/TabList.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="w-full">
-    <div class="flex items-center gap-2 pb-1">
-      <slot />
-    </div>
+  <div role="tablist" class="flex w-full items-center gap-2 pb-1">
+    <slot />
   </div>
 </template>
 

--- a/src/components/tab/TabList.vue
+++ b/src/components/tab/TabList.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="w-full">
+    <div class="flex items-center gap-2 pb-1">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { provide, toRef } from 'vue'
+
+const props = defineProps<{
+  modelValue: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+// Provide for child Tab components
+provide('tabs-value', toRef(props, 'modelValue'))
+provide('tabs-update', (value: string) => emit('update:modelValue', value))
+</script>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -597,6 +597,7 @@
     "templates": "Templates",
     "assets": "Assets",
     "mediaAssets": "Media Assets",
+    "backToAssets": "Back to all assets",
     "labels": {
       "queue": "Queue",
       "nodes": "Nodes",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2073,6 +2073,14 @@
       "loadingAsset": "Loading asset"
     }
   },
+  "mediaAsset": {
+    "jobIdToast": {
+      "jobIdCopied": "Job ID copied to clipboard",
+      "jobIdCopyFailed": "Failed to copy Job ID",
+      "copied": "Copied",
+      "error": "Error"
+    }
+  },
   "actionbar": {
     "dockToTop": "Dock to top"
   },

--- a/src/platform/assets/components/MediaAssetActions.vue
+++ b/src/platform/assets/components/MediaAssetActions.vue
@@ -3,7 +3,7 @@
     <IconButton size="sm" @click="handleDelete">
       <i class="icon-[lucide--trash-2] size-4" />
     </IconButton>
-    <IconButton size="sm" @click="handleDownload">
+    <IconButton v-if="assetType !== 'input'" size="sm" @click="handleDownload">
       <i class="icon-[lucide--download] size-4" />
     </IconButton>
     <MoreButton
@@ -12,14 +12,14 @@
       @menu-closed="emit('menuStateChanged', false)"
     >
       <template #default="{ close }">
-        <MediaAssetMoreMenu :close="close" />
+        <MediaAssetMoreMenu :close="close" @inspect="emit('inspect')" />
       </template>
     </MoreButton>
   </IconGroup>
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
+import { computed, inject } from 'vue'
 
 import IconButton from '@/components/button/IconButton.vue'
 import IconGroup from '@/components/button/IconGroup.vue'
@@ -31,10 +31,18 @@ import MediaAssetMoreMenu from './MediaAssetMoreMenu.vue'
 
 const emit = defineEmits<{
   menuStateChanged: [isOpen: boolean]
+  inspect: []
 }>()
 
-const { asset } = inject(MediaAssetKey)!
+const { asset, context } = inject(MediaAssetKey)!
 const actions = useMediaAssetActions()
+
+// Get asset type from context or tags
+const assetType = computed(() => {
+  // Check if asset has tags property (AssetItem type)
+  const assetWithTags = asset.value as any
+  return context?.value?.type || assetWithTags?.tags?.[0] || 'output'
+})
 
 const handleDelete = () => {
   if (asset.value) {
@@ -44,7 +52,7 @@ const handleDelete = () => {
 
 const handleDownload = () => {
   if (asset.value) {
-    actions.downloadAsset(asset.value.id)
+    actions.downloadAsset()
   }
 }
 </script>

--- a/src/platform/assets/components/MediaAssetActions.vue
+++ b/src/platform/assets/components/MediaAssetActions.vue
@@ -37,11 +37,8 @@ const emit = defineEmits<{
 const { asset, context } = inject(MediaAssetKey)!
 const actions = useMediaAssetActions()
 
-// Get asset type from context or tags
 const assetType = computed(() => {
-  // Check if asset has tags property (AssetItem type)
-  const assetWithTags = asset.value as any
-  return context?.value?.type || assetWithTags?.tags?.[0] || 'output'
+  return context?.value?.type || asset.value?.tags?.[0] || 'output'
 })
 
 const handleDelete = () => {

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -39,7 +39,7 @@
             :asset="adaptedAsset"
             :context="{ type: assetType }"
             @view="handleZoomClick"
-            @download="actions.downloadAsset(asset.id)"
+            @download="actions.downloadAsset()"
             @play="actions.playAsset(asset.id)"
             @video-playing-state-changed="isVideoPlaying = $event"
             @video-controls-changed="showVideoControls = $event"
@@ -51,6 +51,7 @@
         <template v-if="showActionsOverlay" #top-left>
           <MediaAssetActions
             @menu-state-changed="isMenuOpen = $event"
+            @inspect="handleZoomClick"
             @mouseenter="handleOverlayMouseEnter"
             @mouseleave="handleOverlayMouseLeave"
           />
@@ -85,12 +86,15 @@
         </template>
 
         <!-- Output count (bottom-right) - show on hover even when playing -->
-        <template v-if="showOutputCount" #bottom-right>
+        <template
+          v-if="showOutputCount && outputCount && outputCount > 1"
+          #bottom-right
+        >
           <IconTextButton
             type="secondary"
             size="sm"
-            label="0"
-            @click.stop="actions.openMoreOutputs(asset?.id || '')"
+            :label="String(outputCount || 0)"
+            @click.stop="handleOutputCountClick"
             @mouseenter="handleOverlayMouseEnter"
             @mouseleave="handleOverlayMouseLeave"
           >
@@ -172,14 +176,17 @@ function getBottomComponent(kind: MediaKind) {
   return mediaComponents.bottom[kind] || mediaComponents.bottom.image
 }
 
-const { asset, loading, selected } = defineProps<{
+const { asset, loading, selected, showOutputCount, outputCount } = defineProps<{
   asset?: AssetItem
   loading?: boolean
   selected?: boolean
+  showOutputCount?: boolean
+  outputCount?: number
 }>()
 
 const emit = defineEmits<{
   zoom: [asset: AssetItem]
+  'output-count-click': []
 }>()
 
 const cardContainerRef = ref<HTMLElement>()
@@ -277,7 +284,11 @@ const showHoverActions = computed(
   () => !loading && !!asset && isCardOrOverlayHovered.value
 )
 
-const showActionsOverlay = false
+const showActionsOverlay = computed(
+  () =>
+    showHoverActions.value &&
+    (!isVideoPlaying.value || isCardOrOverlayHovered.value)
+)
 
 const showZoomOverlay = computed(
   () =>
@@ -302,9 +313,7 @@ const showFileFormatChip = computed(
     (!isVideoPlaying.value || isCardOrOverlayHovered.value)
 )
 
-const showOutputCount = computed(
-  () => false // Remove output count for simplified version
-)
+// Remove the redundant showOutputCount computed since we're using prop directly
 
 const handleCardClick = () => {
   if (adaptedAsset.value) {
@@ -328,5 +337,9 @@ const handleZoomClick = () => {
 
 const handleImageLoaded = (width: number, height: number) => {
   imageDimensions.value = { width, height }
+}
+
+const handleOutputCountClick = () => {
+  emit('output-count-click')
 }
 </script>

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -86,14 +86,11 @@
         </template>
 
         <!-- Output count (bottom-right) - show on hover even when playing -->
-        <template
-          v-if="showOutputCount && outputCount && outputCount > 1"
-          #bottom-right
-        >
+        <template v-if="showOutputCount" #bottom-right>
           <IconTextButton
             type="secondary"
             size="sm"
-            :label="String(outputCount || 0)"
+            :label="String(outputCount)"
             @click.stop="handleOutputCountClick"
             @mouseenter="handleOverlayMouseEnter"
             @mouseleave="handleOverlayMouseLeave"
@@ -312,8 +309,6 @@ const showFileFormatChip = computed(
     !!fileFormat.value &&
     (!isVideoPlaying.value || isCardOrOverlayHovered.value)
 )
-
-// Remove the redundant showOutputCount computed since we're using prop directly
 
 const handleCardClick = () => {
   if (adaptedAsset.value) {

--- a/src/platform/assets/components/MediaAssetMoreMenu.vue
+++ b/src/platform/assets/components/MediaAssetMoreMenu.vue
@@ -113,7 +113,7 @@ const showWorkflowOptions = computed(() => context.value.type)
 
 // Only show Copy Job ID for output assets (not for imported/input assets)
 const showCopyJobId = computed(() => {
-  const assetType = (asset.value as any)?.tags?.[0] || context.value?.type
+  const assetType = asset.value?.tags?.[0] || context.value?.type
   return assetType !== 'input'
 })
 

--- a/src/platform/assets/components/MediaAssetMoreMenu.vue
+++ b/src/platform/assets/components/MediaAssetMoreMenu.vue
@@ -63,6 +63,7 @@
     <MediaAssetButtonDivider v-if="showWorkflowOptions" />
 
     <IconTextButton
+      v-if="showCopyJobId"
       type="transparent"
       class="dark-theme:text-white"
       label="Copy job ID"
@@ -73,7 +74,7 @@
       </template>
     </IconTextButton>
 
-    <MediaAssetButtonDivider />
+    <MediaAssetButtonDivider v-if="showCopyJobId" />
 
     <IconTextButton
       type="transparent"
@@ -94,7 +95,6 @@ import { computed, inject } from 'vue'
 import IconTextButton from '@/components/button/IconTextButton.vue'
 
 import { useMediaAssetActions } from '../composables/useMediaAssetActions'
-import { useMediaAssetGalleryStore } from '../composables/useMediaAssetGalleryStore'
 import { MediaAssetKey } from '../schemas/mediaAssetSchema'
 import MediaAssetButtonDivider from './MediaAssetButtonDivider.vue'
 
@@ -102,16 +102,23 @@ const { close } = defineProps<{
   close: () => void
 }>()
 
+const emit = defineEmits<{
+  inspect: []
+}>()
+
 const { asset, context } = inject(MediaAssetKey)!
 const actions = useMediaAssetActions()
-const galleryStore = useMediaAssetGalleryStore()
 
 const showWorkflowOptions = computed(() => context.value.type)
 
+// Only show Copy Job ID for output assets (not for imported/input assets)
+const showCopyJobId = computed(() => {
+  const assetType = (asset.value as any)?.tags?.[0] || context.value?.type
+  return assetType !== 'input'
+})
+
 const handleInspect = () => {
-  if (asset.value) {
-    galleryStore.openSingle(asset.value)
-  }
+  emit('inspect')
   close()
 }
 
@@ -124,7 +131,7 @@ const handleAddToWorkflow = () => {
 
 const handleDownload = () => {
   if (asset.value) {
-    actions.downloadAsset(asset.value.id)
+    actions.downloadAsset()
   }
   close()
 }
@@ -143,9 +150,9 @@ const handleExportWorkflow = () => {
   close()
 }
 
-const handleCopyJobId = () => {
+const handleCopyJobId = async () => {
   if (asset.value) {
-    actions.copyAssetUrl(asset.value.id)
+    await actions.copyJobId()
   }
   close()
 }

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -7,7 +7,6 @@ import { t } from '@/i18n'
 import { api } from '@/scripts/api'
 import { extractPromptIdFromAssetId } from '@/utils/uuidUtil'
 
-import type { AssetItem } from '../schemas/assetSchema'
 import type { AssetMeta } from '../schemas/mediaAssetSchema'
 import { MediaAssetKey } from '../schemas/mediaAssetSchema'
 
@@ -24,7 +23,7 @@ export function useMediaAssetActions() {
     if (!asset) return
 
     try {
-      const assetType = (asset as AssetItem).tags?.[0] || 'output'
+      const assetType = asset.tags?.[0] || 'output'
       const filename = asset.name
       const downloadUrl = api.apiURL(
         `/view?filename=${encodeURIComponent(filename)}&type=${assetType}`
@@ -77,14 +76,14 @@ export function useMediaAssetActions() {
       toast.add({
         severity: 'success',
         summary: t('g.success'),
-        detail: 'Job ID copied to clipboard',
+        detail: t('mediaAsset.jobIdToast.jobIdCopied'),
         life: 2000
       })
     } catch (error) {
       toast.add({
         severity: 'error',
         summary: t('g.error'),
-        detail: 'Failed to copy job ID',
+        detail: t('mediaAsset.jobIdToast.jobIdCopyFailed'),
         life: 3000
       })
     }

--- a/src/platform/assets/composables/useMediaAssets/assetMappers.ts
+++ b/src/platform/assets/composables/useMediaAssets/assetMappers.ts
@@ -1,4 +1,5 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import type { AssetContext } from '@/platform/assets/schemas/mediaAssetSchema'
 import { api } from '@/scripts/api'
 import type { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
@@ -25,25 +26,13 @@ export function mapTaskOutputToAssetItem(
   taskItem: TaskItemImpl,
   output: ResultItemImpl
 ): AssetItem {
-  const metadata: Record<string, any> = {
+  const metadata: OutputAssetMetadata = {
     promptId: taskItem.promptId,
     nodeId: output.nodeId,
-    subfolder: output.subfolder
-  }
-
-  // Add execution time if available
-  if (taskItem.executionTimeInSeconds) {
-    metadata.executionTimeInSeconds = taskItem.executionTimeInSeconds
-  }
-
-  // Add format if available
-  if (output.format) {
-    metadata.format = output.format
-  }
-
-  // Add workflow if available
-  if (taskItem.workflow) {
-    metadata.workflow = taskItem.workflow
+    subfolder: output.subfolder,
+    executionTimeInSeconds: taskItem.executionTimeInSeconds,
+    format: output.format,
+    workflow: taskItem.workflow
   }
 
   return {

--- a/src/platform/assets/composables/useMediaAssets/useAssetsApi.ts
+++ b/src/platform/assets/composables/useMediaAssets/useAssetsApi.ts
@@ -19,12 +19,24 @@ async function fetchInputAssets(directory: string): Promise<AssetItem[]> {
  */
 function fetchOutputAssets(): AssetItem[] {
   const queueStore = useQueueStore()
-  return queueStore.flatTasks
+
+  const assetItems: AssetItem[] = queueStore.tasks
     .filter((task) => task.previewOutput && task.displayStatus === 'Completed')
     .map((task) => {
       const output = task.previewOutput!
-      return mapTaskOutputToAssetItem(task, output)
+      const assetItem = mapTaskOutputToAssetItem(task, output)
+
+      // Add output count and all outputs for folder view
+      assetItem.user_metadata = {
+        ...assetItem.user_metadata,
+        outputCount: task.flatOutputs.filter((o) => o.supportsPreview).length,
+        allOutputs: task.flatOutputs.filter((o) => o.supportsPreview)
+      }
+
+      return assetItem
     })
+
+  return assetItems
 }
 
 /**

--- a/src/platform/assets/schemas/assetMetadataSchema.ts
+++ b/src/platform/assets/schemas/assetMetadataSchema.ts
@@ -1,0 +1,42 @@
+import type { ResultItemImpl } from '@/stores/queueStore'
+
+/**
+ * Metadata for output assets from queue store
+ * Extends Record<string, unknown> for compatibility with AssetItem schema
+ */
+export interface OutputAssetMetadata extends Record<string, unknown> {
+  promptId: string
+  nodeId: string | number
+  subfolder: string
+  executionTimeInSeconds?: number
+  format?: string
+  workflow?: unknown
+  outputCount?: number
+  allOutputs?: ResultItemImpl[]
+}
+
+/**
+ * Type guard to check if metadata is OutputAssetMetadata
+ */
+export function isOutputAssetMetadata(
+  metadata: any
+): metadata is OutputAssetMetadata {
+  return (
+    metadata &&
+    typeof metadata === 'object' &&
+    typeof metadata.promptId === 'string' &&
+    typeof metadata.nodeId === 'string'
+  )
+}
+
+/**
+ * Safely extract output asset metadata
+ */
+export function getOutputAssetMetadata(
+  userMetadata: any
+): OutputAssetMetadata | null {
+  if (isOutputAssetMetadata(userMetadata)) {
+    return userMetadata
+  }
+  return null
+}

--- a/src/platform/assets/schemas/assetMetadataSchema.ts
+++ b/src/platform/assets/schemas/assetMetadataSchema.ts
@@ -18,14 +18,13 @@ export interface OutputAssetMetadata extends Record<string, unknown> {
 /**
  * Type guard to check if metadata is OutputAssetMetadata
  */
-export function isOutputAssetMetadata(
-  metadata: any
+function isOutputAssetMetadata(
+  metadata: Record<string, unknown> | undefined
 ): metadata is OutputAssetMetadata {
+  if (!metadata) return false
   return (
-    metadata &&
-    typeof metadata === 'object' &&
     typeof metadata.promptId === 'string' &&
-    typeof metadata.nodeId === 'string'
+    (typeof metadata.nodeId === 'string' || typeof metadata.nodeId === 'number')
   )
 }
 
@@ -33,7 +32,7 @@ export function isOutputAssetMetadata(
  * Safely extract output asset metadata
  */
 export function getOutputAssetMetadata(
-  userMetadata: any
+  userMetadata: Record<string, unknown> | undefined
 ): OutputAssetMetadata | null {
   if (isOutputAssetMetadata(userMetadata)) {
     return userMetadata

--- a/src/platform/assets/schemas/mediaAssetSchema.ts
+++ b/src/platform/assets/schemas/mediaAssetSchema.ts
@@ -19,9 +19,7 @@ const zMediaAssetDisplayItemSchema = assetItemSchema.extend({
 
   // New optional fields
   duration: z.number().nonnegative().optional(),
-  dimensions: zDimensionsSchema.optional(),
-  jobId: z.string().optional(),
-  isMulti: z.boolean().optional()
+  dimensions: zDimensionsSchema.optional()
 })
 
 // Asset context schema

--- a/src/utils/uuidUtil.ts
+++ b/src/utils/uuidUtil.ts
@@ -1,9 +1,11 @@
+import { validate as uuidValidate, version as uuidVersion } from 'uuid'
+
 /**
  * UUID utility functions
  */
 
 /**
- * Regular expression for matching UUID v4 format
+ * Regular expression for matching UUID format at the beginning of a string
  * Format: 8-4-4-4-12 (e.g., 98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3)
  */
 const UUID_REGEX =
@@ -16,7 +18,20 @@ const UUID_REGEX =
  */
 export function extractUuidFromString(str: string): string | null {
   const match = str.match(UUID_REGEX)
-  return match ? match[1] : null
+  if (!match) return null
+
+  const uuid = match[1]
+  // Validate the extracted string is a valid UUID
+  return uuidValidate(uuid) ? uuid : null
+}
+
+/**
+ * Check if a string is a valid UUID (any version)
+ * @param str - The string to check
+ * @returns true if the string is a valid UUID
+ */
+export function isValidUuid(str: string): boolean {
+  return uuidValidate(str)
 }
 
 /**
@@ -24,10 +39,8 @@ export function extractUuidFromString(str: string): string | null {
  * @param str - The string to check
  * @returns true if the string is a valid UUID v4
  */
-export function isValidUuid(str: string): boolean {
-  const fullUuidRegex =
-    /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i
-  return fullUuidRegex.test(str)
+export function isValidUuidV4(str: string): boolean {
+  return uuidValidate(str) && uuidVersion(str) === 4
 }
 
 /**

--- a/src/utils/uuidUtil.ts
+++ b/src/utils/uuidUtil.ts
@@ -1,4 +1,4 @@
-import { validate as uuidValidate, version as uuidVersion } from 'uuid'
+import { validate as uuidValidate } from 'uuid'
 
 /**
  * UUID utility functions
@@ -32,15 +32,6 @@ export function extractUuidFromString(str: string): string | null {
  */
 export function isValidUuid(str: string): boolean {
   return uuidValidate(str)
-}
-
-/**
- * Check if a string is a valid UUID v4
- * @param str - The string to check
- * @returns true if the string is a valid UUID v4
- */
-export function isValidUuidV4(str: string): boolean {
-  return uuidValidate(str) && uuidVersion(str) === 4
 }
 
 /**

--- a/src/utils/uuidUtil.ts
+++ b/src/utils/uuidUtil.ts
@@ -1,0 +1,41 @@
+/**
+ * UUID utility functions
+ */
+
+/**
+ * Regular expression for matching UUID v4 format
+ * Format: 8-4-4-4-12 (e.g., 98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3)
+ */
+const UUID_REGEX =
+  /^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i
+
+/**
+ * Extract UUID from the beginning of a string
+ * @param str - The string to extract UUID from
+ * @returns The extracted UUID or null if not found
+ */
+export function extractUuidFromString(str: string): string | null {
+  const match = str.match(UUID_REGEX)
+  return match ? match[1] : null
+}
+
+/**
+ * Check if a string is a valid UUID v4
+ * @param str - The string to check
+ * @returns true if the string is a valid UUID v4
+ */
+export function isValidUuid(str: string): boolean {
+  const fullUuidRegex =
+    /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i
+  return fullUuidRegex.test(str)
+}
+
+/**
+ * Extract prompt ID from asset ID
+ * Asset ID format: "promptId-nodeId-filename"
+ * @param assetId - The asset ID string
+ * @returns The extracted prompt ID (UUID) or null
+ */
+export function extractPromptIdFromAssetId(assetId: string): string | null {
+  return extractUuidFromString(assetId)
+}

--- a/tests-ui/tests/utils/uuidUtil.test.ts
+++ b/tests-ui/tests/utils/uuidUtil.test.ts
@@ -26,10 +26,16 @@ describe('uuidUtil', () => {
       expect(result).toBeNull()
     })
 
-    it('should return null for invalid UUID format', () => {
-      const str = '12345678-1234-1234-1234-123456789abc-extra'
+    it('should extract valid UUID even with extra content', () => {
+      const str = '12345678-1234-5234-a234-123456789abc-extra'
       const result = extractUuidFromString(str)
-      expect(result).toBe('12345678-1234-1234-1234-123456789abc')
+      expect(result).toBe('12345678-1234-5234-a234-123456789abc')
+    })
+
+    it('should return null for invalid UUID format', () => {
+      const str = '12345678-1234-1234-1234-123456789xyz-extra' // xyz is not valid hex
+      const result = extractUuidFromString(str)
+      expect(result).toBeNull()
     })
 
     it('should handle UUID without trailing content', () => {

--- a/tests-ui/tests/utils/uuidUtil.test.ts
+++ b/tests-ui/tests/utils/uuidUtil.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractPromptIdFromAssetId,
+  extractUuidFromString,
+  isValidUuid
+} from '@/utils/uuidUtil'
+
+describe('uuidUtil', () => {
+  describe('extractUuidFromString', () => {
+    it('should extract UUID from the beginning of a string', () => {
+      const str = '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3-9-ComfyUI_00042_.png'
+      const result = extractUuidFromString(str)
+      expect(result).toBe('98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3')
+    })
+
+    it('should extract UUID with uppercase letters', () => {
+      const str = 'A8B0B007-7D78-4E3F-B7A8-0F483B9CF2D3-node-file.png'
+      const result = extractUuidFromString(str)
+      expect(result).toBe('A8B0B007-7D78-4E3F-B7A8-0F483B9CF2D3')
+    })
+
+    it('should return null if no UUID at the beginning', () => {
+      const str = 'not-a-uuid-98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3'
+      const result = extractUuidFromString(str)
+      expect(result).toBeNull()
+    })
+
+    it('should return null for invalid UUID format', () => {
+      const str = '12345678-1234-1234-1234-123456789abc-extra'
+      const result = extractUuidFromString(str)
+      expect(result).toBe('12345678-1234-1234-1234-123456789abc')
+    })
+
+    it('should handle UUID without trailing content', () => {
+      const str = '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3'
+      const result = extractUuidFromString(str)
+      expect(result).toBe('98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3')
+    })
+
+    it('should return null for empty string', () => {
+      const result = extractUuidFromString('')
+      expect(result).toBeNull()
+    })
+
+    it('should return null for malformed UUID', () => {
+      const str = '98b0b007-7d78-4e3f-b7a8'
+      const result = extractUuidFromString(str)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('isValidUuid', () => {
+    it('should return true for valid UUID v4', () => {
+      const uuid = '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3'
+      expect(isValidUuid(uuid)).toBe(true)
+    })
+
+    it('should return true for uppercase UUID', () => {
+      const uuid = 'A8B0B007-7D78-4E3F-B7A8-0F483B9CF2D3'
+      expect(isValidUuid(uuid)).toBe(true)
+    })
+
+    it('should return true for mixed case UUID', () => {
+      const uuid = 'a8B0b007-7D78-4e3F-B7a8-0F483b9CF2d3'
+      expect(isValidUuid(uuid)).toBe(true)
+    })
+
+    it('should return false for UUID with extra characters', () => {
+      const uuid = '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3-extra'
+      expect(isValidUuid(uuid)).toBe(false)
+    })
+
+    it('should return false for incomplete UUID', () => {
+      const uuid = '98b0b007-7d78-4e3f-b7a8'
+      expect(isValidUuid(uuid)).toBe(false)
+    })
+
+    it('should return false for UUID with wrong segment lengths', () => {
+      const uuid = '98b0b0007-7d78-4e3f-b7a8-0f483b9cf2d3'
+      expect(isValidUuid(uuid)).toBe(false)
+    })
+
+    it('should return false for UUID with invalid characters', () => {
+      const uuid = '98b0b007-7d78-4e3f-b7a8-0f483b9cfzd3'
+      expect(isValidUuid(uuid)).toBe(false)
+    })
+
+    it('should return false for empty string', () => {
+      expect(isValidUuid('')).toBe(false)
+    })
+
+    it('should return false for null-like values', () => {
+      expect(isValidUuid('null')).toBe(false)
+      expect(isValidUuid('undefined')).toBe(false)
+    })
+  })
+
+  describe('extractPromptIdFromAssetId', () => {
+    it('should extract promptId from typical asset ID', () => {
+      const assetId =
+        '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3-9-ComfyUI_00042_.png'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBe('98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3')
+    })
+
+    it('should extract promptId with multiple dashes in filename', () => {
+      const assetId =
+        '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3-15-my-image-file.png'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBe('98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3')
+    })
+
+    it('should handle asset ID with just UUID and node ID', () => {
+      const assetId = '98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3-42'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBe('98b0b007-7d78-4e3f-b7a8-0f483b9cf2d3')
+    })
+
+    it('should return null for input folder asset ID', () => {
+      const assetId = 'input-0-myimage.png'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBeNull()
+    })
+
+    it('should return null for malformed asset ID', () => {
+      const assetId = 'not-a-valid-asset-id'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBeNull()
+    })
+
+    it('should handle asset ID with special characters in filename', () => {
+      const assetId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890-1-image(1)[2].png'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    })
+
+    it('should return null for empty string', () => {
+      const result = extractPromptIdFromAssetId('')
+      expect(result).toBeNull()
+    })
+
+    it('should handle asset ID with underscores in UUID position', () => {
+      const assetId = 'output_1_image.png'
+      const result = extractPromptIdFromAssetId(assetId)
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Extract sidebar template into reusable AssetSidebarTemplate component
- Replace PrimeVue Tabs with TextButton for better visual consistency  
- Improve job detail view header layout with better spacing

## Changes
- Created `AssetSidebarTemplate.vue` as a reusable template component
- Replaced PrimeVue Tabs with TextButton components for tab navigation
- Added i18n translation key for "Back to all assets" button
- Improved spacing and layout in job detail view header
- Maintained all existing functionality while cleaning up template structure

## Test Plan
- [ ] Verify tab switching between Imported and Generated tabs works correctly
- [ ] Test job detail view displays properly with Job ID and execution time
- [ ] Confirm "Back to all assets" button returns to main view
- [ ] Check that all existing media asset features remain functional
- [ ] Verify UI consistency with other sidebar tabs

[screen-capture.webm](https://github.com/user-attachments/assets/4ed192e1-a9f7-4fc1-a41e-f732741dd55d)