### PR TITLE
Fix nodeDef resolution for virtual nodes.

### DIFF
--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -342,7 +342,6 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     nodeDefsByDisplayName.value[nodeDef.display_name] = nodeDefImpl
   }
   function fromLGraphNode(node: LGraphNode): ComfyNodeDefImpl | null {
-    // Frontend-only nodes don't have nodeDef
     const nodeTypeName = node.constructor?.nodeData?.name ?? node.type
     if (!nodeTypeName) return null
     const nodeDef = nodeDefsByName.value[nodeTypeName] ?? null

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -343,7 +343,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   }
   function fromLGraphNode(node: LGraphNode): ComfyNodeDefImpl | null {
     // Frontend-only nodes don't have nodeDef
-    const nodeTypeName = node.constructor?.nodeData?.name
+    const nodeTypeName = node.constructor?.nodeData?.name ?? node.type
     if (!nodeTypeName) return null
     const nodeDef = nodeDefsByName.value[nodeTypeName] ?? null
     return nodeDef


### PR DESCRIPTION
<img width="697" height="250" alt="image" src="https://github.com/user-attachments/assets/71fe7d9b-0cd6-43c6-b0d5-7dcb64d385a6" />

Virtual nodes (like primitives) don't have a nodeData. As a result, the existing call to attempt lookup from a node instance fails. This is fixed by adding `node.type` as a fallback

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6175-Fix-nodeDef-resolution-for-virtual-nodes-2936d73d365081b0abfcfe8532a50f8e) by [Unito](https://www.unito.io)
