### PR TITLE
Remove redundant npm pack step from desktop-ui publish workflow

### DIFF
--- a/.github/workflows/publish-desktop-ui.yaml
+++ b/.github/workflows/publish-desktop-ui.yaml
@@ -161,20 +161,6 @@ jobs:
           echo "publish_dir=$PUBLISH_DIR" >> "$GITHUB_OUTPUT"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Pack (preview only)
-        shell: bash
-        working-directory: ${{ steps.pkg.outputs.publish_dir }}
-        run: |
-          set -euo pipefail
-          npm pack --json | tee pack-result.json
-
-      - name: Upload package tarball artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: desktop-ui-npm-tarball-${{ inputs.version }}
-          path: ${{ steps.pkg.outputs.publish_dir }}/*.tgz
-          if-no-files-found: error
-
       - name: Check if version already on npm
         id: check_npm
         env:


### PR DESCRIPTION
## Summary

Removes duplicate tarball creation from desktop-ui publish workflow - `pnpm publish` handles this internally.

## Changes

- **What**: Removes `npm pack` step and GitHub Actions artifact upload
- **Breaking**: None - workflow behavior unchanged, publish still works identically

## Review Focus

The `npm pack` + artifact upload was creating a duplicate of what `pnpm publish` generates and uploads to npm anyway. Verified `publish-frontend-types.yaml` follows this same pattern (no pack step, direct publish).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6176-Remove-redundant-npm-pack-step-from-desktop-ui-publish-workflow-2936d73d3650814eaaa8c648023498b7) by [Unito](https://www.unito.io)
