### PR TITLE
Remove 'Desktop' suffix from desktop app title

### DIFF
--- a/apps/desktop-ui/index.html
+++ b/apps/desktop-ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>ComfyUI Desktop</title>
+    <title>ComfyUI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   </head>
   <body>


### PR DESCRIPTION
## Summary

Removes "Desktop" suffix from the desktop app window title.

## Changes

- **What**: Changes window title from "ComfyUI Desktop" to "ComfyUI"

## Review Focus

Fixes title regression introduced during desktop UI separation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6177-Remove-Desktop-suffix-from-desktop-app-title-2936d73d3650814abfa2db570f54e49e) by [Unito](https://www.unito.io)
