### PR TITLE
Prepare desktop-ui 0.0.2 release

### DIFF
--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/desktop-ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "nx": {
     "tags": [


### PR DESCRIPTION
## Summary

Bumps desktop-ui version for release.

## Changes

- **What**: Version bump from 0.0.1 to 0.0.2

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6179-Prepare-desktop-ui-0-0-2-release-2936d73d365081af802cc0ce88e6ac25) by [Unito](https://www.unito.io)
