### PR TITLE
Remove broken installer terminal button

### DIFF
--- a/apps/desktop-ui/src/views/ServerStartView.vue
+++ b/apps/desktop-ui/src/views/ServerStartView.vue
@@ -66,17 +66,6 @@
               @click="troubleshoot"
             />
           </div>
-
-          <div class="text-center">
-            <button
-              v-if="!terminalVisible"
-              class="text-sm text-neutral-500 hover:text-neutral-300 transition-colors flex items-center gap-2 mx-auto"
-              @click="terminalVisible = true"
-            >
-              <i class="pi pi-search"></i>
-              {{ $t('serverStart.showTerminal') }}
-            </button>
-          </div>
         </div>
 
         <!-- Terminal Output (positioned at bottom when manually toggled in error state) -->


### PR DESCRIPTION
## Summary

Removes broken terminal toggle button that causes UX issues during desktop installation.

## Changes

- **What**: Removes "Show Terminal" button from ServerStartView during install flow
- **Breaking**: None (removes broken functionality)

## Review Focus

Cherry-picked from feb3c078f (v1.27.9). The button causes broken UX when clicked during install. The working "Show Logs" button remains and takes users directly to the log directory.  This patch was written directly for the release, in a rush to fix issues.  The fix was not PR'd into main as well (due to timing), so the original issue has now resurfaced.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6180-Remove-broken-installer-terminal-button-2936d73d365081559d76fb0f137e7396) by [Unito](https://www.unito.io)
