### PR TITLE
fix: surface knip hook output in vscode

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Run Knip with cache via package script
-pnpm knip
+pnpm knip 1>&2
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # Run Knip with cache via package script
 pnpm knip 1>&2


### PR DESCRIPTION
## Summary
- redirect pnpm knip output to stderr so VS Code surfaces failures

## Testing
<img width="1585" height="483" alt="image" src="https://github.com/user-attachments/assets/d65af783-d168-45cf-b01e-2b727e429a91" />

before it would literally just say it failed and you'd have to manually rerun pnpm knip in ur own terminal

------
https://chatgpt.com/codex/tasks/task_e_68f7d2f2f2548330a23ae74554f1a54a