### PR TITLE
Fix circular dependency in setting registration

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -420,9 +420,7 @@ onMounted(async () => {
       throw error
     }
   }
-  CORE_SETTINGS.forEach((setting) => {
-    settingStore.addSetting(setting)
-  })
+  CORE_SETTINGS.forEach(settingStore.addSetting)
 
   await newUserService().initializeIfNewUser(settingStore)
 

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -163,7 +163,8 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultsByInstallVersion: {
       '1.25.0': 'legacy'
     },
-    onChange: async (newValue: string) => {
+    onChange: async (newValue: string, oldValue?: string) => {
+      if (!oldValue) return
       const settingStore = useSettingStore()
 
       if (newValue === 'standard') {


### PR DESCRIPTION
`Comfy.Canvas.NavigationMode` and `Comfy.Canvas.LeftMouseClickBehavior` introduce a circular dependency where setting the value of one will set the value of the other.

This is solved by having `NavigationMode`  skip changing other settings when `oldValue` is undefined.
- Note that `oldValue` is only undefined during initial load. When a user changes the value for the first time, oldValue will be the default value.

In the unlikely event desync occurs (a user manually editing the backing json?), the registration of the subsequent `LeftMouseClickBehavior` will still correct `NavigationMode` back to custom

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6184-Fix-circular-dependency-in-setting-registration-2936d73d365081809aa5d8bff0bf2333) by [Unito](https://www.unito.io)
