### PR TITLE
disable transform settling reflow when panning the graph

### DIFF
--- a/src/renderer/core/layout/__tests__/TransformPane.test.ts
+++ b/src/renderer/core/layout/__tests__/TransformPane.test.ts
@@ -155,17 +155,17 @@ describe('TransformPane', () => {
         expect.any(Function),
         expect.any(Object)
       )
-      expect(mockCanvas.canvas.addEventListener).toHaveBeenCalledWith(
+      expect(mockCanvas.canvas.addEventListener).not.toHaveBeenCalledWith(
         'pointerdown',
         expect.any(Function),
         expect.any(Object)
       )
-      expect(mockCanvas.canvas.addEventListener).toHaveBeenCalledWith(
+      expect(mockCanvas.canvas.addEventListener).not.toHaveBeenCalledWith(
         'pointerup',
         expect.any(Function),
         expect.any(Object)
       )
-      expect(mockCanvas.canvas.addEventListener).toHaveBeenCalledWith(
+      expect(mockCanvas.canvas.addEventListener).not.toHaveBeenCalledWith(
         'pointercancel',
         expect.any(Function),
         expect.any(Object)
@@ -188,17 +188,17 @@ describe('TransformPane', () => {
         expect.any(Function),
         expect.any(Object)
       )
-      expect(mockCanvas.canvas.removeEventListener).toHaveBeenCalledWith(
+      expect(mockCanvas.canvas.removeEventListener).not.toHaveBeenCalledWith(
         'pointerdown',
         expect.any(Function),
         expect.any(Object)
       )
-      expect(mockCanvas.canvas.removeEventListener).toHaveBeenCalledWith(
+      expect(mockCanvas.canvas.removeEventListener).not.toHaveBeenCalledWith(
         'pointerup',
         expect.any(Function),
         expect.any(Object)
       )
-      expect(mockCanvas.canvas.removeEventListener).toHaveBeenCalledWith(
+      expect(mockCanvas.canvas.removeEventListener).not.toHaveBeenCalledWith(
         'pointercancel',
         expect.any(Function),
         expect.any(Object)

--- a/src/renderer/core/layout/transform/TransformPane.vue
+++ b/src/renderer/core/layout/transform/TransformPane.vue
@@ -45,8 +45,8 @@ const { isLOD } = useLOD(camera)
 
 const canvasElement = computed(() => props.canvas?.canvas)
 const { isTransforming: isInteracting } = useTransformSettling(canvasElement, {
-  settleDelay: 200,
-  trackPan: true
+  settleDelay: 512,
+  trackPan: false // panning doesn't require a reflow because there's no pixel-stretching
 })
 
 provide(TransformStateKey, {

--- a/src/renderer/core/layout/transform/TransformPane.vue
+++ b/src/renderer/core/layout/transform/TransformPane.vue
@@ -45,8 +45,7 @@ const { isLOD } = useLOD(camera)
 
 const canvasElement = computed(() => props.canvas?.canvas)
 const { isTransforming: isInteracting } = useTransformSettling(canvasElement, {
-  settleDelay: 512,
-  trackPan: false // panning doesn't require a reflow because there's no pixel-stretching
+  settleDelay: 512
 })
 
 provide(TransformStateKey, {

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -1,3 +1,4 @@
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -71,11 +72,17 @@ const createMouseEvent = (
 describe('useNodePointerInteractions', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
+    setActivePinia(createPinia())
     // Reset layout store state between tests
     const { layoutStore } = await import(
       '@/renderer/core/layout/store/layoutStore'
     )
     layoutStore.isDraggingVueNodes.value = false
+    const { useCanvasStore } = await import(
+      '@/renderer/core/canvas/canvasStore'
+    )
+    const canvasStore = useCanvasStore()
+    canvasStore.setVueNodePointerInteractionsDisabled(false)
   })
 
   it('should only start drag on left-click', async () => {

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -78,11 +78,6 @@ describe('useNodePointerInteractions', () => {
       '@/renderer/core/layout/store/layoutStore'
     )
     layoutStore.isDraggingVueNodes.value = false
-    const { useCanvasStore } = await import(
-      '@/renderer/core/canvas/canvasStore'
-    )
-    const canvasStore = useCanvasStore()
-    canvasStore.setVueNodePointerInteractionsDisabled(false)
   })
 
   it('should only start drag on left-click', async () => {


### PR DESCRIPTION
## Summary

- disable pan tracking in `useTransformSettling` so we stop wiring high-frequency pointer listeners during canvas drags
- the post-navigation-interaction forced reflow is only necessary when zooming since it is for fixing pixel stretch that results from `scale` (which doesn't happen during panning/`translate`)
- extend settle delay to 512ms to reduce unnecessary reflow while preserving post-zoom pixel fix

After this PR, there should be 0 reflows when panning the graph.

First PR in series to address:

- https://github.com/Comfy-Org/ComfyUI_frontend/issues/6151

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6186-disable-transform-settling-reflow-when-panning-the-graph-2936d73d365081c2b357e3c72d711439) by [Unito](https://www.unito.io)
