### PR TITLE
Fix: Make breadcrumbs non-draggable.

### DIFF
--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -5,6 +5,7 @@
       value: item.label,
       showDelay: 512
     }"
+    draggable="false"
     href="#"
     class="p-breadcrumb-item-link h-12 cursor-pointer px-2"
     :class="{


### PR DESCRIPTION
## Summary

Prevents accidentally trying to load the current site as if it were a workflow.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6191-Fix-Make-breadcrumbs-non-draggable-2946d73d365081bda833c7a413903e97) by [Unito](https://www.unito.io)
