### PR TITLE
Expand drop zone for docking run button

### DIFF
--- a/browser_tests/helpers/actionbar.ts
+++ b/browser_tests/helpers/actionbar.ts
@@ -13,7 +13,7 @@ export class ComfyActionbar {
 
   async isDocked() {
     const className = await this.root.getAttribute('class')
-    return className?.includes('is-docked') ?? false
+    return className?.includes('static') ?? false
   }
 }
 

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -9,6 +9,7 @@
       @mouseenter="onMouseEnterDropZone"
       @mouseleave="onMouseLeaveDropZone"
     >
+      <div class="-ml-[200px] h-full w-[200px]" />
       {{ t('actionbar.dockToTop') }}
     </div>
 

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -2,25 +2,18 @@
   <div class="flex h-full items-center">
     <div
       v-if="isDragging && !isDocked"
-      class="actionbar-drop-zone m-1.5 flex items-center justify-center self-stretch rounded-md"
-      :class="{
-        'drop-zone-active': isMouseOverDropZone
-      }"
+      :class="actionbarClass"
       @mouseenter="onMouseEnterDropZone"
       @mouseleave="onMouseLeaveDropZone"
     >
-      <div class="-ml-[200px] h-full w-[200px]" />
       {{ t('actionbar.dockToTop') }}
     </div>
 
     <Panel
-      class="actionbar"
+      class="pointer-events-auto z-1000"
       :style="style"
-      :class="{
-        fixed: !isDocked,
-        'is-dragging': isDragging,
-        'is-docked static mr-2 border-none bg-transparent p-0': isDocked
-      }"
+      :class="panelClass"
+      :pt="{ header: { class: 'hidden' }, content: { class: 'p-1' } }"
     >
       <div
         ref="panelRef"
@@ -252,45 +245,21 @@ watch(isDragging, (dragging) => {
     isMouseOverDropZone.value = false
   }
 })
+const actionbarClass = computed(() =>
+  cn(
+    'w-[265px] border-dashed border-blue-500 opacity-80',
+    'actionbar-drop-zone m-1.5 flex items-center justify-center self-stretch',
+    'rounded-md before:content-[] before:w-50 before:-ml-50 before:h-full',
+    isMouseOverDropZone.value &&
+      'border-[3px] opacity-100 scale-105 shadow-[0_0_20px] shadow-blue-500'
+  )
+)
+const panelClass = computed(() =>
+  cn(
+    'pointer-events-auto z1000',
+    !isDocked.value && 'fixed',
+    isDragging.value && 'select-none pointer-events-none',
+    isDocked.value && 'p-0 static mr-2 border-none bg-transparent'
+  )
+)
 </script>
-
-<style scoped>
-@reference '../../assets/css/style.css';
-
-.actionbar {
-  pointer-events: all;
-  z-index: 1000;
-}
-
-.actionbar-drop-zone {
-  width: 265px;
-  border: 2px dashed var(--p-primary-color);
-  opacity: 0.8;
-}
-
-.actionbar-drop-zone.drop-zone-active {
-  background: var(--p-highlight-background-focus);
-  border-color: var(--p-primary-color);
-  border-width: 3px;
-  box-shadow: 0 0 20px var(--p-primary-color);
-  opacity: 1;
-  transform: scale(1.05);
-}
-
-.actionbar.is-dragging {
-  user-select: none;
-  pointer-events: none;
-}
-
-:deep(.p-panel-content) {
-  @apply p-1;
-}
-
-.is-docked :deep(.p-panel-content) {
-  @apply p-0;
-}
-
-:deep(.p-panel-header) {
-  display: none;
-}
-</style>

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -251,8 +251,8 @@ watch(isDragging, (dragging) => {
 const actionbarClass = computed(() =>
   cn(
     'w-[265px] border-dashed border-blue-500 opacity-80',
-    'actionbar-drop-zone m-1.5 flex items-center justify-center self-stretch',
-    'rounded-md before:content-[] before:w-50 before:-ml-50 before:h-full',
+    'm-1.5 flex items-center justify-center self-stretch',
+    'rounded-md before:w-50 before:-ml-50 before:h-full',
     isMouseOverDropZone.value &&
       'border-[3px] opacity-100 scale-105 shadow-[0_0_20px] shadow-blue-500'
   )
@@ -260,9 +260,8 @@ const actionbarClass = computed(() =>
 const panelClass = computed(() =>
   cn(
     'pointer-events-auto z1000',
-    !isDocked.value && 'fixed',
     isDragging.value && 'select-none pointer-events-none',
-    isDocked.value && 'p-0 static mr-2 border-none bg-transparent'
+    isDocked.value ? 'p-0 static mr-2 border-none bg-transparent' : 'fixed'
   )
 )
 </script>

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -18,10 +18,7 @@
         content: { class: isDocked ? 'p-0' : 'p-1' }
       }"
     >
-      <div
-        ref="panelRef"
-        class="actionbar-content flex items-center select-none"
-      >
+      <div ref="panelRef" class="flex items-center select-none">
         <span
           ref="dragHandleRef"
           :class="
@@ -259,7 +256,7 @@ const actionbarClass = computed(() =>
 )
 const panelClass = computed(() =>
   cn(
-    'pointer-events-auto z1000',
+    'actionbar pointer-events-auto z1000',
     isDragging.value && 'select-none pointer-events-none',
     isDocked.value ? 'p-0 static mr-2 border-none bg-transparent' : 'fixed'
   )

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -13,7 +13,10 @@
       class="pointer-events-auto z-1000"
       :style="style"
       :class="panelClass"
-      :pt="{ header: { class: 'hidden' }, content: { class: 'p-1' } }"
+      :pt="{
+        header: { class: 'hidden' },
+        content: { class: isDocked ? 'p-0' : 'p-1' }
+      }"
     >
       <div
         ref="panelRef"


### PR DESCRIPTION
Expand the drop zone for docking the run button to be a bit more forgiving.
<img width="494" height="99" alt="image" src="https://github.com/user-attachments/assets/97eb6948-211d-4ed6-b06c-d6fb57b45f0b" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6193-Expand-drop-zone-for-docking-run-button-2946d73d3650816d996fdc57022161db) by [Unito](https://www.unito.io)
