### PR TITLE
[fix] Remove pnpm cache from release-version-bump workflow

### DIFF
--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -59,7 +59,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: 'pnpm'
 
       - name: Bump version
         id: bump-version


### PR DESCRIPTION
## Summary
- Fixed the "Post Setup Node.js" failure in the release-version-bump workflow
- Removed unnecessary pnpm cache configuration that was causing validation errors

fixes this JOB
- [Release: Version Bump · Comfy-Org/ComfyUI_frontend@2e8e136]( https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/18695441150/job/53311521564 )
<img width="1361" height="229" alt="image" src="https://github.com/user-attachments/assets/22f780f0-59b8-4e57-ad9b-540683289a10" />


## Problem
The workflow was failing with error: "Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved."

This occurred because `setup-node@v4` with `cache: 'pnpm'` expects the pnpm store directory to exist, but the workflow never runs `pnpm install`. The workflow only executes `pnpm version`, which doesn't require dependencies to be installed.

## Solution
Removed the `cache: 'pnpm'` configuration from the Setup Node.js step since:
1. The workflow doesn't install dependencies
2. The cache provides no benefit for this workflow
3. It was causing the post-setup cleanup step to fail

## Test Plan
- [ ] Verify workflow runs successfully without cache errors
- [ ] Confirm version bump functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6199-fix-Remove-pnpm-cache-from-release-version-bump-workflow-2946d73d3650813dae7cf987a800e28b) by [Unito](https://www.unito.io)
