### PR TITLE
fix: Include extensions and renderer in knip entry points

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,7 +8,11 @@ const config: KnipConfig = {
         'src/assets/css/style.css',
         'src/main.ts',
         'src/scripts/ui/menu/index.ts',
-        'src/types/index.ts'
+        'src/types/index.ts',
+        // Include extension entry points to detect dependencies like 'three'
+        'src/extensions/**/*.ts',
+        // Include core renderer components to detect dependencies like 'yjs'
+        'src/renderer/**/*.ts'
       ],
       project: ['**/*.{js,ts,vue}', '*.{js,ts,mts}']
     },


### PR DESCRIPTION
## Summary
Fixes knip incorrectly flagging `three` and `yjs` as unused dependencies by including extension and renderer entry points in the configuration.

## Changes
- Add `src/extensions/**/*.ts` to knip entry points to detect `three` usage in load3d extension (19 files)
- Add `src/renderer/**/*.ts` to knip entry points to detect `yjs` usage in layout components (3 files)

## Test plan
- [x] Verified `three` and `yjs` are no longer flagged as unused dependencies
- [x] Ran `pnpm knip --workspace . --dependencies` to confirm fix
- [x] Pre-commit hooks passed (lint, prettier, typecheck)

## Fixes
Resolves CI/CD validation failures from - [\[chore\] Add Oxc linter to project · Comfy-Org/ComfyUI_frontend@3736dde]( https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/18706522255/job/53345542419 )

Related to: [chore] Add Oxc linter to project · Comfy-Org/ComfyUI_frontend@3736dde

🤖 Generated with [Claude Code](https://claude.ai/code)