### PR TITLE
[fix] Update .gitignore to properly ignore Linux core dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ templates_repo/
 vite.config.mts.timestamp-*.mjs
 
 # Linux core dumps
-./core
+/core
 
 *storybook.log
 storybook-static


### PR DESCRIPTION
## Summary
Fixes the .gitignore pattern for Linux core dump files from `./core` to `/core`.

## Problem
The pattern `./core` in .gitignore doesn't work as expected. Git interprets the `./` prefix literally, looking for a path named `./core` rather than matching `core` at the repository root.

## Solution
Change to `/core` which is the correct gitignore syntax to ignore files/directories named `core` at the repository root only.

## Why This Matters
- Linux systems can generate core dump files named `core` when programs crash
- These files shouldn't be tracked in version control
- The previous pattern wasn't actually ignoring these files

## Testing
The new pattern will properly ignore `core` files at the root while not affecting subdirectories (e.g., `src/core/` would still be tracked).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6201-fix-Update-gitignore-to-properly-ignore-Linux-core-dumps-2946d73d365081059e57d9919d03a501) by [Unito](https://www.unito.io)
