### PR TITLE
feat: implement asset deletion functionality

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -60,6 +60,7 @@
             @click="handleAssetSelect(item)"
             @zoom="handleZoomClick(item)"
             @output-count-click="enterFolderView(item)"
+            @asset-deleted="refreshAssets"
           />
         </template>
       </VirtualGrid>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1774,6 +1774,8 @@
     }
   },
   "mediaAsset": {
+    "deleteAssetTitle": "Delete this asset?",
+    "deleteAssetDescription": "This asset will be permanently removed.",
     "jobIdToast": {
       "jobIdCopied": "Job ID copied to clipboard",
       "jobIdCopyFailed": "Failed to copy Job ID",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1776,6 +1776,9 @@
   "mediaAsset": {
     "deleteAssetTitle": "Delete this asset?",
     "deleteAssetDescription": "This asset will be permanently removed.",
+    "assetDeletedSuccessfully": "Asset deleted successfully",
+    "deletingImportedFilesCloudOnly": "Deleting imported files is only supported in cloud version",
+    "failedToDeleteAsset": "Failed to delete asset",
     "jobIdToast": {
       "jobIdCopied": "Job ID copied to clipboard",
       "jobIdCopyFailed": "Failed to copy Job ID",

--- a/src/platform/assets/components/MediaAssetActions.vue
+++ b/src/platform/assets/components/MediaAssetActions.vue
@@ -24,20 +24,15 @@
 
 <script setup lang="ts">
 import { computed, inject } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import IconButton from '@/components/button/IconButton.vue'
 import IconGroup from '@/components/button/IconGroup.vue'
 import MoreButton from '@/components/button/MoreButton.vue'
-import ConfirmationDialogContent from '@/components/dialog/content/ConfirmationDialogContent.vue'
 import { isCloud } from '@/platform/distribution/types'
-import { useDialogStore } from '@/stores/dialogStore'
 
 import { useMediaAssetActions } from '../composables/useMediaAssetActions'
 import { MediaAssetKey } from '../schemas/mediaAssetSchema'
 import MediaAssetMoreMenu from './MediaAssetMoreMenu.vue'
-
-const { t } = useI18n()
 
 const emit = defineEmits<{
   menuStateChanged: [isOpen: boolean]
@@ -47,7 +42,6 @@ const emit = defineEmits<{
 
 const { asset, context } = inject(MediaAssetKey)!
 const actions = useMediaAssetActions()
-const dialogStore = useDialogStore()
 
 const assetType = computed(() => {
   return context?.value?.type || asset.value?.tags?.[0] || 'output'
@@ -59,25 +53,13 @@ const showDeleteButton = computed(() => {
   )
 })
 
-const handleDelete = () => {
-  if (!asset.value?.id || !assetType.value) return
+const handleDelete = async () => {
+  if (!asset.value) return
 
-  dialogStore.showDialog({
-    key: 'delete-asset-confirmation',
-    title: t('mediaAsset.deleteAssetTitle'),
-    component: ConfirmationDialogContent,
-    props: {
-      message: t('mediaAsset.deleteAssetDescription'),
-      type: 'delete',
-      itemList: [asset.value.name],
-      onConfirm: async () => {
-        const success = await actions.deleteAsset(asset.value!, assetType.value)
-        if (success) {
-          emit('asset-deleted')
-        }
-      }
-    }
-  })
+  const success = await actions.confirmDelete(asset.value)
+  if (success) {
+    emit('asset-deleted')
+  }
 }
 
 const handleDownload = () => {

--- a/src/platform/assets/components/MediaAssetActions.vue
+++ b/src/platform/assets/components/MediaAssetActions.vue
@@ -1,9 +1,9 @@
 <template>
   <IconGroup>
-    <IconButton size="sm" @click="handleDelete">
+    <IconButton v-if="showDeleteButton" size="sm" @click="handleDelete">
       <i class="icon-[lucide--trash-2] size-4" />
     </IconButton>
-    <IconButton v-if="assetType !== 'input'" size="sm" @click="handleDownload">
+    <IconButton size="sm" @click="handleDownload">
       <i class="icon-[lucide--download] size-4" />
     </IconButton>
     <MoreButton
@@ -12,7 +12,11 @@
       @menu-closed="emit('menuStateChanged', false)"
     >
       <template #default="{ close }">
-        <MediaAssetMoreMenu :close="close" @inspect="emit('inspect')" />
+        <MediaAssetMoreMenu
+          :close="close"
+          @inspect="emit('inspect')"
+          @asset-deleted="emit('asset-deleted')"
+        />
       </template>
     </MoreButton>
   </IconGroup>
@@ -20,31 +24,60 @@
 
 <script setup lang="ts">
 import { computed, inject } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import IconButton from '@/components/button/IconButton.vue'
 import IconGroup from '@/components/button/IconGroup.vue'
 import MoreButton from '@/components/button/MoreButton.vue'
+import ConfirmationDialogContent from '@/components/dialog/content/ConfirmationDialogContent.vue'
+import { isCloud } from '@/platform/distribution/types'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import { useMediaAssetActions } from '../composables/useMediaAssetActions'
 import { MediaAssetKey } from '../schemas/mediaAssetSchema'
 import MediaAssetMoreMenu from './MediaAssetMoreMenu.vue'
 
+const { t } = useI18n()
+
 const emit = defineEmits<{
   menuStateChanged: [isOpen: boolean]
   inspect: []
+  'asset-deleted': []
 }>()
 
 const { asset, context } = inject(MediaAssetKey)!
 const actions = useMediaAssetActions()
+const dialogStore = useDialogStore()
 
 const assetType = computed(() => {
   return context?.value?.type || asset.value?.tags?.[0] || 'output'
 })
 
+const showDeleteButton = computed(() => {
+  return (
+    assetType.value === 'output' || (assetType.value === 'input' && isCloud)
+  )
+})
+
 const handleDelete = () => {
-  if (asset.value) {
-    actions.deleteAsset(asset.value.id)
-  }
+  if (!asset.value?.id || !assetType.value) return
+
+  dialogStore.showDialog({
+    key: 'delete-asset-confirmation',
+    title: t('mediaAsset.deleteAssetTitle'),
+    component: ConfirmationDialogContent,
+    props: {
+      message: t('mediaAsset.deleteAssetDescription'),
+      type: 'delete',
+      itemList: [asset.value.name],
+      onConfirm: async () => {
+        const success = await actions.deleteAsset(asset.value!, assetType.value)
+        if (success) {
+          emit('asset-deleted')
+        }
+      }
+    }
+  })
 }
 
 const handleDownload = () => {

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -52,6 +52,7 @@
           <MediaAssetActions
             @menu-state-changed="isMenuOpen = $event"
             @inspect="handleZoomClick"
+            @asset-deleted="handleAssetDelete"
             @mouseenter="handleOverlayMouseEnter"
             @mouseleave="handleOverlayMouseLeave"
           />
@@ -184,6 +185,7 @@ const { asset, loading, selected, showOutputCount, outputCount } = defineProps<{
 const emit = defineEmits<{
   zoom: [asset: AssetItem]
   'output-count-click': []
+  'asset-deleted': []
 }>()
 
 const cardContainerRef = ref<HTMLElement>()
@@ -336,5 +338,9 @@ const handleImageLoaded = (width: number, height: number) => {
 
 const handleOutputCountClick = () => {
   emit('output-count-click')
+}
+
+const handleAssetDelete = () => {
+  emit('asset-deleted')
 }
 </script>

--- a/src/platform/assets/components/MediaAssetMoreMenu.vue
+++ b/src/platform/assets/components/MediaAssetMoreMenu.vue
@@ -93,12 +93,9 @@
 
 <script setup lang="ts">
 import { computed, inject } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import IconTextButton from '@/components/button/IconTextButton.vue'
-import ConfirmationDialogContent from '@/components/dialog/content/ConfirmationDialogContent.vue'
 import { isCloud } from '@/platform/distribution/types'
-import { useDialogStore } from '@/stores/dialogStore'
 
 import { useMediaAssetActions } from '../composables/useMediaAssetActions'
 import { MediaAssetKey } from '../schemas/mediaAssetSchema'
@@ -115,8 +112,6 @@ const emit = defineEmits<{
 
 const { asset, context } = inject(MediaAssetKey)!
 const actions = useMediaAssetActions()
-const dialogStore = useDialogStore()
-const { t } = useI18n()
 
 const assetType = computed(() => {
   return asset.value?.tags?.[0] || context.value?.type || 'output'
@@ -178,25 +173,14 @@ const handleCopyJobId = async () => {
   close()
 }
 
-const handleDelete = () => {
-  if (!asset.value?.id || !assetType.value) return
+const handleDelete = async () => {
+  if (!asset.value) return
 
   close() // Close the menu first
 
-  // Show confirmation dialog
-  dialogStore.showDialog({
-    key: 'delete-asset-confirmation',
-    title: t('assetBrowser.deleteAssetTitle'),
-    component: ConfirmationDialogContent,
-    props: {
-      message: t('assetBrowser.deleteAssetDescription'),
-      type: 'delete',
-      itemList: [asset.value.name],
-      onConfirm: async () => {
-        await actions.deleteAsset(asset.value!, assetType.value)
-        emit('asset-deleted')
-      }
-    }
-  })
+  const success = await actions.confirmDelete(asset.value)
+  if (success) {
+    emit('asset-deleted')
+  }
 }
 </script>

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -218,13 +218,34 @@ function createAssetService() {
     )
   }
 
+  /**
+   * Deletes an asset by ID
+   * Only available in cloud environment
+   *
+   * @param id - The asset ID (UUID)
+   * @returns Promise<void>
+   * @throws Error if deletion fails
+   */
+  async function deleteAsset(id: string): Promise<void> {
+    const res = await api.fetchApi(`${ASSETS_ENDPOINT}/${id}`, {
+      method: 'DELETE'
+    })
+
+    if (!res.ok) {
+      throw new Error(
+        `Unable to delete asset ${id}: Server returned ${res.status}`
+      )
+    }
+  }
+
   return {
     getAssetModelFolders,
     getAssetModels,
     isAssetBrowserEligible,
     getAssetsForNodeType,
     getAssetDetails,
-    getAssetsByTag
+    getAssetsByTag,
+    deleteAsset
   }
 }
 


### PR DESCRIPTION
## Summary
- Implement asset deletion for media assets
- Add delete confirmation dialog  
- Support both cloud and internal asset deletion
- Refresh assets list after successful deletion

## Changes
- Add delete button to MediaAssetActions component
- Implement deleteAsset method in useMediaAssetActions
- Add confirmation dialog before deletion
- Handle asset-deleted event to refresh the list
- Refactor to use QueueStore.tasks for proper grouping

## Test plan
- [x] Delete output assets in internal mode
- [x] Delete input/output assets in cloud mode
- [x] Verify confirmation dialog appears
- [x] Check assets list refreshes after deletion
- [x] Test folder view functionality

[screen-capture (3).webm](https://github.com/user-attachments/assets/3306262e-627a-4db0-90c1-fd59ba3abf7c)