### PR TITLE
make support URL dynamic based on distribution

### DIFF
--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -310,9 +310,11 @@ test.describe('Support', () => {
     const newPage = await pagePromise
 
     await newPage.waitForLoadState('networkidle')
-    await expect(newPage).toHaveURL(
-      /.*support\.comfy\.org\/hc\/en-us\/requests\/new\?tf_42243568391700=oss.*/
-    )
+    await expect(newPage).toHaveURL(/.*support\.comfy\.org.*/)
+
+    const url = new URL(newPage.url())
+    expect(url.searchParams.get('tf_42243568391700')).toBe('oss')
+
     await newPage.close()
   })
 })

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -1,7 +1,6 @@
 import type { Locator } from '@playwright/test'
 import { expect } from '@playwright/test'
 
-import { DISTRIBUTION_FIELD_ID } from '../../src/platform/support/config'
 import type { Keybinding } from '../../src/schemas/keyBindingSchema'
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 
@@ -314,7 +313,7 @@ test.describe('Support', () => {
     await expect(newPage).toHaveURL(/.*support\.comfy\.org.*/)
 
     const url = new URL(newPage.url())
-    expect(url.searchParams.get(DISTRIBUTION_FIELD_ID)).toBe('oss')
+    expect(url.searchParams.get('tf_42243568391700')).toBe('oss')
 
     await newPage.close()
   })

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -301,14 +301,18 @@ test.describe('Settings', () => {
 })
 
 test.describe('Support', () => {
-  test('Should open external zendesk link', async ({ comfyPage }) => {
+  test('Should open external zendesk link with OSS tag', async ({
+    comfyPage
+  }) => {
     await comfyPage.setSetting('Comfy.UseNewMenu', 'Top')
     const pagePromise = comfyPage.page.context().waitForEvent('page')
     await comfyPage.menu.topbar.triggerTopbarCommand(['Help', 'Support'])
     const newPage = await pagePromise
 
     await newPage.waitForLoadState('networkidle')
-    await expect(newPage).toHaveURL(/.*support\.comfy\.org.*/)
+    await expect(newPage).toHaveURL(
+      /.*support\.comfy\.org\/hc\/en-us\/requests\/new\?tf_42243568391700=oss.*/
+    )
     await newPage.close()
   })
 })

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator } from '@playwright/test'
 import { expect } from '@playwright/test'
 
+import { DISTRIBUTION_FIELD_ID } from '../../src/platform/support/config'
 import type { Keybinding } from '../../src/schemas/keyBindingSchema'
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 
@@ -313,7 +314,7 @@ test.describe('Support', () => {
     await expect(newPage).toHaveURL(/.*support\.comfy\.org.*/)
 
     const url = new URL(newPage.url())
-    expect(url.searchParams.get('tf_42243568391700')).toBe('oss')
+    expect(url.searchParams.get(DISTRIBUTION_FIELD_ID)).toBe('oss')
 
     await newPage.close()
   })

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -200,7 +200,7 @@
   --node-stroke-executing: var(--color-blue-100);
   --text-secondary: var(--color-stone-100);
   --text-primary: var(--color-charcoal-700);
-  --input-surface: rgba(0, 0, 0, 0.15);
+  --input-surface: rgb(0 0 0 / 0.15);
 }
 
 .dark-theme {
@@ -247,7 +247,7 @@
   --node-stroke-executing: var(--color-blue-100);
   --text-secondary: var(--color-slate-100);
   --text-primary: var(--color-pure-white);
-  --input-surface: rgba(130, 130, 130, 0.1);
+  --input-surface: rgb(130 130 130 / 0.1);
 }
 
 @theme inline {
@@ -1174,7 +1174,7 @@ audio.comfy-audio.empty-audio-widget {
 }
 
 .isLOD .lg-node-header {
-  border-radius: 0px;
+  border-radius: 0;
   pointer-events: none;
 }
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -23,6 +23,7 @@ import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBro
 import { createModelNodeFromAsset } from '@/platform/assets/utils/createModelNodeFromAsset'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { SUPPORT_URL } from '@/platform/support/config'
 import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
@@ -775,7 +776,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Contact Support',
       versionAdded: '1.17.8',
       function: () => {
-        window.open('https://support.comfy.org/', '_blank')
+        window.open(SUPPORT_URL, '_blank')
       }
     },
     {

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -4,7 +4,7 @@ import { isCloud } from '@/platform/distribution/types'
  * Zendesk ticket form field ID for the distribution tag.
  * This field is used to categorize support requests by their source (cloud vs OSS).
  */
-export const DISTRIBUTION_FIELD_ID = 'tf_42243568391700'
+const DISTRIBUTION_FIELD_ID = 'tf_42243568391700'
 
 /**
  * Support URLs for the ComfyUI platform.

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -4,7 +4,7 @@ import { isCloud } from '@/platform/distribution/types'
  * Zendesk ticket form field ID for the distribution tag.
  * This field is used to categorize support requests by their source (cloud vs OSS).
  */
-const DISTRIBUTION_FIELD_ID = 'tf_42243568391700'
+export const DISTRIBUTION_FIELD_ID = 'tf_42243568391700'
 
 /**
  * Support URLs for the ComfyUI platform.

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -1,6 +1,12 @@
 import { isCloud } from '@/platform/distribution/types'
 
 /**
+ * Zendesk ticket form field ID for the distribution tag.
+ * This field is used to categorize support requests by their source (cloud vs OSS).
+ */
+const DISTRIBUTION_FIELD_ID = 'tf_42243568391700'
+
+/**
  * Support URLs for the ComfyUI platform.
  * The URL varies based on whether the application is running in Cloud or OSS distribution.
  *
@@ -8,4 +14,4 @@ import { isCloud } from '@/platform/distribution/types'
  * - OSS: Includes 'oss' tag for identifying open-source support requests
  */
 const TAG = isCloud ? 'ccloud' : 'oss'
-export const SUPPORT_URL = `https://support.comfy.org/hc/en-us/requests/new?tf_42243568391700=${TAG}`
+export const SUPPORT_URL = `https://support.comfy.org/hc/en-us/requests/new?${DISTRIBUTION_FIELD_ID}=${TAG}`

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -7,6 +7,5 @@ import { isCloud } from '@/platform/distribution/types'
  * - Cloud: Includes 'ccloud' tag for identifying cloud-based support requests
  * - OSS: Includes 'oss' tag for identifying open-source support requests
  */
-export const SUPPORT_URL = isCloud
-  ? 'https://support.comfy.org/hc/en-us/requests/new?tf_42243568391700=ccloud'
-  : 'https://support.comfy.org/hc/en-us/requests/new?tf_42243568391700=oss'
+const TAG = isCloud ? 'ccloud' : 'oss'
+export const SUPPORT_URL = `https://support.comfy.org/hc/en-us/requests/new?tf_42243568391700=${TAG}`

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -1,0 +1,12 @@
+import { isCloud } from '@/platform/distribution/types'
+
+/**
+ * Support URLs for the ComfyUI platform.
+ * The URL varies based on whether the application is running in Cloud or OSS distribution.
+ *
+ * - Cloud: Includes 'ccloud' tag for identifying cloud-based support requests
+ * - OSS: Includes 'oss' tag for identifying open-source support requests
+ */
+export const SUPPORT_URL = isCloud
+  ? 'https://support.comfy.org/hc/en-us/requests/new?tf_42243568391700=ccloud'
+  : 'https://support.comfy.org/hc/en-us/requests/new?tf_42243568391700=oss'

--- a/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.vue
@@ -388,7 +388,7 @@ onUnmounted(() => {
 
 <style scoped>
 .audio-player-menu {
-  --p-tieredmenu-item-focus-background: rgba(255, 255, 255, 0.1);
-  --p-tieredmenu-item-active-background: rgba(255, 255, 255, 0.1);
+  --p-tieredmenu-item-focus-background: rgb(255 255 255 / 0.1);
+  --p-tieredmenu-item-active-background: rgb(255 255 255 / 0.1);
 }
 </style>


### PR DESCRIPTION
## Summary

Add query param to indicate whether support ticket is from cloud or OSS.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6205-make-support-URL-dynamic-based-on-distribution-2946d73d365081868093c52981021189) by [Unito](https://www.unito.io)
