### PR TITLE
style: remove pulsing animation on executing Vue nodes

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -18,7 +18,6 @@
         borderClass,
         outlineClass,
         {
-          'animate-pulse': executing,
           'before:rounded-2xl before:pointer-events-none before:absolute before:bg-bypass/60 before:inset-0':
             bypassed,
           'before:rounded-2xl before:pointer-events-none before:absolute before:inset-0':

--- a/tests-ui/tests/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -197,11 +197,12 @@ describe('LGraphNode', () => {
     expect(wrapper.classes()).toContain('outline-node-component-outline')
   })
 
-  it('should apply executing animation when executing prop is true', () => {
+  it('should render progress indicator when executing prop is true', () => {
     mockData.mockExecuting = true
 
     const wrapper = mountLGraphNode({ nodeData: mockNodeData })
 
-    expect(wrapper.classes()).toContain('animate-pulse')
+    expect(wrapper.classes()).toContain('border-node-stroke-executing')
+    expect(wrapper.classes()).not.toContain('animate-pulse')
   })
 })

--- a/tests-ui/tests/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -203,6 +203,5 @@ describe('LGraphNode', () => {
     const wrapper = mountLGraphNode({ nodeData: mockNodeData })
 
     expect(wrapper.classes()).toContain('border-node-stroke-executing')
-    expect(wrapper.classes()).not.toContain('animate-pulse')
   })
 })


### PR DESCRIPTION
## Summary

Removes pulsing animation which wasn't part of the original design and has performance overhead.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6206-style-remove-pulsing-animation-on-executing-Vue-nodes-2946d73d3650816ab877da8120ab4085) by [Unito](https://www.unito.io)
