### PR TITLE
Fix copying from multi-outputs with clipspace

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -379,8 +379,8 @@ export class ComfyApp {
       selectedIndex = node.imageIndex
     }
 
-    const paintedIndex = selectedIndex + 1
-    const combinedIndex = selectedIndex + 2
+    const paintedIndex = imgs ? imgs.length + 1 : 1
+    const combinedIndex = imgs ? imgs.length + 2 : 2
 
     // for vueNodes mode
     const images =


### PR DESCRIPTION
`copyToClipspace` sets the `paintedIndex` and `combinedIndex` regardless of if any editing was actually performed on the image. Previously, they  were set to be simple increments above the currently selected image. 

When attempting to copy from a node previewing multiple images, these indexes may refer to images that already exist.
This is resolved by instead setting the indexes to be used for paintedIndex and combinedIndex to always be beyond the range of current images.
<img width="998" height="761" alt="image" src="https://github.com/user-attachments/assets/dacd46b3-9029-45e3-a6b3-07e971125a14" />


Resolves #6202

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6210-Fix-copying-from-multi-outputs-with-clipspace-2956d73d365081c5a07be4ddb0b352a3) by [Unito](https://www.unito.io)
