### PR TITLE
Don't remove labels if initial jobs were skipped

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -141,7 +141,6 @@ jobs:
   merge-and-commit:
     needs: [setup, update-snapshots-sharded]
     runs-on: ubuntu-latest
-    if: always()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/pr-update-playwright-expectations.yaml` file, removing the unconditional `if: always()` condition from the `merge-and-commit` job. This means the job will now only run if its dependencies succeed, rather than always running regardless of previous job outcomes.