### PR TITLE
Show default node list after clearing search input

### DIFF
--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -35,6 +35,7 @@
     </Dialog>
 
     <AutoCompletePlus
+      ref="acpref"
       :model-value="filters"
       class="comfy-vue-node-search-box z-10 grow"
       scroll-height="40vh"
@@ -42,7 +43,6 @@
       :input-id="inputId"
       append-to="self"
       :suggestions="suggestions"
-      :min-length="0"
       :delay="100"
       :loading="!nodeFrequencyStore.isLoaded"
       complete-on-focus
@@ -50,6 +50,7 @@
       force-selection
       multiple
       :option-label="'display_name'"
+      @clear="search('')"
       @complete="search($event.query)"
       @option-select="emit('addNode', $event.value)"
       @focused-option-changed="setHoverSuggestion($event)"
@@ -105,6 +106,7 @@ const { filters, searchLimit = 64 } = defineProps<{
   filters: FuseFilterWithValue<ComfyNodeDefImpl, string>[]
   searchLimit?: number
 }>()
+const acpref = ref()
 
 const nodeSearchFilterVisible = ref(false)
 const inputId = `comfy-vue-node-search-box-input-${Math.random()}`
@@ -140,7 +142,11 @@ const reFocusInput = async () => {
   }
 }
 
-onMounted(reFocusInput)
+onMounted(() => {
+  acpref.value.hide = () => {}
+  search('')
+  acpref.value.show()
+})
 const onAddFilter = (
   filterAndValue: FuseFilterWithValue<ComfyNodeDefImpl, string>
 ) => {

--- a/src/components/searchbox/NodeSearchBox.vue
+++ b/src/components/searchbox/NodeSearchBox.vue
@@ -35,7 +35,7 @@
     </Dialog>
 
     <AutoCompletePlus
-      ref="acpref"
+      ref="autoCompletePlus"
       :model-value="filters"
       class="comfy-vue-node-search-box z-10 grow"
       scroll-height="40vh"
@@ -50,7 +50,6 @@
       force-selection
       multiple
       :option-label="'display_name'"
-      @clear="search('')"
       @complete="search($event.query)"
       @option-select="emit('addNode', $event.value)"
       @focused-option-changed="setHoverSuggestion($event)"
@@ -106,8 +105,8 @@ const { filters, searchLimit = 64 } = defineProps<{
   filters: FuseFilterWithValue<ComfyNodeDefImpl, string>[]
   searchLimit?: number
 }>()
-const acpref = ref()
 
+const autoCompletePlus = ref()
 const nodeSearchFilterVisible = ref(false)
 const inputId = `comfy-vue-node-search-box-input-${Math.random()}`
 const suggestions = ref<ComfyNodeDefImpl[]>([])
@@ -143,9 +142,11 @@ const reFocusInput = async () => {
 }
 
 onMounted(() => {
-  acpref.value.hide = () => {}
+  inputElement ??= document.getElementById(inputId) as HTMLInputElement
+  if (inputElement) inputElement.focus()
+  autoCompletePlus.value.hide = () => search('')
   search('')
-  acpref.value.show()
+  autoCompletePlus.value.show()
 })
 const onAddFilter = (
   filterAndValue: FuseFilterWithValue<ComfyNodeDefImpl, string>


### PR DESCRIPTION
![searchbox-clear](https://github.com/user-attachments/assets/94737766-bf96-4f03-86a0-70057b3b0e81)
Resolves #4887 

<details>
<summary>The dirty details</summary>
There's really not a cleaner workaround here. Prime vue is hardcoded to hide results when a query is received with length 0. With our search box, we never want completions not to be shown and the sanest, if not the only viable solution, is to simply block the hiding completely.

Future TODO:
- Completely remove the reFocusInput jank. If we can make the search box a frame more responsive, we should.

```ts
onInput(event) {
    if (this.typeahead) {
        if (this.searchTimeout) {
            clearTimeout(this.searchTimeout);
        }

        let query = event.target.value;

        if (!this.multiple) {
            this.updateModel(event, query);
        }

        if (query.length === 0) {
            this.hide();
            this.$emit('clear');
        } else {
            if (query.length >= this.minLength) {
                this.focusedOptionIndex = -1;

                this.searchTimeout = setTimeout(() => {
                    this.search(event, query, 'input');
                }, this.delay);
            } else {
                this.hide();
            }
        }
    }
}
hide(isFocus) {
    const _hide = () => {
        this.$emit('before-hide');
        this.dirty = isFocus;
        this.overlayVisible = false;
        this.clicked = false;
        this.focusedOptionIndex = -1;

        isFocus && focus(this.multiple ? this.$refs.focusInput : this.$refs.focusInput?.$el);
    };

    setTimeout(() => {
        _hide();
    }, 0); // For ScreenReaders
}
```
</details>

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6231-Show-default-node-list-after-clearing-search-input-2956d73d36508134960df537c7409646) by [Unito](https://www.unito.io)
