### PR TITLE
Fix asset browser on subgraph nodes

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -371,7 +371,7 @@ const addComboWidget = (
       'asset',
       inputSpec.name,
       displayLabel,
-      async () => {
+      async function () {
         if (!isAssetWidget(widget)) {
           throw new Error(`Expected asset widget but received ${widget.type}`)
         }
@@ -406,7 +406,7 @@ const addComboWidget = (
             }
 
             const oldValue = widget.value
-            widget.value = validatedFilename.data
+            this.value = validatedFilename.data
             node.onWidgetChanged?.(
               widget.name,
               validatedFilename.data,


### PR DESCRIPTION
When a widget is linked to a subgraph, the subgraph creates a copy of the widget. The callback used by the asset browser to update the widget still refers to the widget that lives inside the subgraph, but at time of execution, this is overwritten by the unchanged value of the copy.

This is fixed by instead updating the value of the caller. It's a little hacky, and may need future review.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6237-Fix-asset-browser-on-subgraph-ndoes-2956d73d365081e8a52fff0da5205403) by [Unito](https://www.unito.io)
