### PR TITLE
[chore] fix LOD test regressed by 4-way resize drag PR

### DIFF
--- a/browser_tests/tests/vueNodes/nodeStates/lod.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/lod.spec.ts
@@ -23,7 +23,10 @@ test.describe('Vue Nodes - LOD', () => {
 
     const vueNodesContainer = comfyPage.vueNodes.nodes
     const textboxesInNodes = vueNodesContainer.getByRole('textbox')
-    const buttonsInNodes = vueNodesContainer.getByRole('button')
+    // Select buttons within node body (excludes resize handles)
+    const buttonsInNodes = vueNodesContainer
+      .locator('[data-testid^="node-body-"]')
+      .getByRole('button')
 
     await expect(textboxesInNodes.first()).toBeVisible()
     await expect(buttonsInNodes.first()).toBeVisible()

--- a/browser_tests/tests/vueNodes/nodeStates/lod.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/lod.spec.ts
@@ -23,13 +23,10 @@ test.describe('Vue Nodes - LOD', () => {
 
     const vueNodesContainer = comfyPage.vueNodes.nodes
     const textboxesInNodes = vueNodesContainer.getByRole('textbox')
-    // Select buttons within node body (excludes resize handles)
-    const buttonsInNodes = vueNodesContainer
-      .locator('[data-testid^="node-body-"]')
-      .getByRole('button')
+    const comboboxesInNodes = vueNodesContainer.getByRole('combobox')
 
     await expect(textboxesInNodes.first()).toBeVisible()
-    await expect(buttonsInNodes.first()).toBeVisible()
+    await expect(comboboxesInNodes.first()).toBeVisible()
 
     await comfyPage.zoom(120, 10)
     await comfyPage.nextFrame()
@@ -37,7 +34,7 @@ test.describe('Vue Nodes - LOD', () => {
     await expect(comfyPage.canvas).toHaveScreenshot('vue-nodes-lod-active.png')
 
     await expect(textboxesInNodes.first()).toBeHidden()
-    await expect(buttonsInNodes.first()).toBeHidden()
+    await expect(comboboxesInNodes.first()).toBeHidden()
 
     await comfyPage.zoom(-120, 10)
     await comfyPage.nextFrame()
@@ -46,6 +43,6 @@ test.describe('Vue Nodes - LOD', () => {
       'vue-nodes-lod-inactive.png'
     )
     await expect(textboxesInNodes.first()).toBeVisible()
-    await expect(buttonsInNodes.first()).toBeVisible()
+    await expect(comboboxesInNodes.first()).toBeVisible()
   })
 })


### PR DESCRIPTION
Button locator is shadowed by resize handler

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6238-chore-update-Playwright-snapshots-2956d73d36508159b1f7e6e0e4d16d9f) by [Unito](https://www.unito.io)
