### PR TITLE
Respect minimum node size on subgraph conversion

### DIFF
--- a/src/core/graph/subgraph/proxyWidgetUtils.ts
+++ b/src/core/graph/subgraph/proxyWidgetUtils.ts
@@ -161,4 +161,5 @@ export function promoteRecommendedWidgets(subgraphNode: SubgraphNode) {
   const proxyWidgets: ProxyWidgetsProperty =
     filteredWidgets.map(widgetItemToProperty)
   subgraphNode.properties.proxyWidgets = proxyWidgets
+  subgraphNode.computeSize(subgraphNode.size)
 }

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -3680,7 +3680,7 @@ export class LGraphNode
         }
         ctx.font = savedFont // Restore font after button measurements
         if (buttonsWidth > 0) {
-          buttonsWidth += 10 // Extra margin before buttons
+          buttonsWidth -= 20 // Reduce by empty padding
           availableWidth -= buttonsWidth
         }
       }


### PR DESCRIPTION
Two small changes to improve sizing on subgraphs
- On conversion, automatically promoted widgets can increase the minimum width of a node. When this occurs, the node is now automatically resized to respect this new minimum. <img width="434" height="274" alt="image" src="https://github.com/user-attachments/assets/8b642f12-24bf-439a-a07d-b392b1f406df" />

- On nodes with title_badges,  titles now have greatly reduced empty padding before being abbreviated. <img width="314" height="123" alt="image" src="https://github.com/user-attachments/assets/4d8fd899-a159-4c0d-b309-04844b6203fc" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6241-Respect-minimum-node-size-on-subgraph-conversion-2956d73d3650817c867fe42d60afa28b) by [Unito](https://www.unito.io)
