### PR TITLE
add widget-expands on Markdown widget

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="widget-markdown relative w-full cursor-text"
+    class="widget-expands widget-markdown relative w-full cursor-text"
     @click="startEditing"
   >
     <!-- Display mode: Rendered markdown -->

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -5,7 +5,7 @@
   >
     <!-- Display mode: Rendered markdown -->
     <div
-      class="comfy-markdown-content lod-toggle min-h-[60px] w-full overflow-y-auto rounded-lg px-4 py-2 text-sm hover:bg-[var(--p-content-hover-background)]"
+      class="comfy-markdown-content lod-toggle h-full min-h-[60px] w-full overflow-y-auto rounded-lg px-4 py-2 text-sm hover:bg-[var(--p-content-hover-background)]"
       :class="isEditing === false ? 'visible' : 'invisible'"
       v-html="renderedHtml"
     />


### PR DESCRIPTION
## Summary
Markdown widget also needs widget-expands class

before adding  widget-expands
<img width="545" height="503" alt="image" src="https://github.com/user-attachments/assets/db8fbf0b-5371-4d2b-9e81-0a37b5e07086" />

after added widget-expands
<img width="578" height="513" alt="image" src="https://github.com/user-attachments/assets/9aa94807-167d-4ee1-bcc3-ee23d2673dfe" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6245-add-widget-expands-on-Markdown-widget-2966d73d365081c29ae4c4c82fdf4372) by [Unito](https://www.unito.io)
