### PR TITLE
Fix reference to .env_example in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Have another idea? Drop into Discord or open an issue, and let's chat!
    ```
 
 3. Configure environment (optional):
-   Create a `.env` file in the project root based on the provided [.env.example](.env.example) file.
+   Create a `.env` file in the project root based on the provided [.env_example](.env_example) file.
 
    **Note about ports**: By default, the dev server expects the ComfyUI backend at `localhost:8188`. If your ComfyUI instance runs on a different port, update this in your `.env` file.
 


### PR DESCRIPTION
## Summary

Found a broken link in the CONTRIBUTING.md, thought I'd quickly fix it.

// scoutsdeed

## Changes

- **What**: link in CONTRIBUTING.md
- **Breaking**: None
- **Dependencies**: None

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6255-Fix-reference-to-env_example-in-CONTRIBUTING-md-2966d73d365081a6bef2cc974a2ead9b) by [Unito](https://www.unito.io)
