### PR TITLE
[don't backport to main] fix queue history reconciliation to use prompt_id instead of priority

### DIFF
--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -481,8 +481,8 @@ export const useQueueStore = defineStore('queue', () => {
       runningTasks.value = toClassAll(queue.Running)
       pendingTasks.value = toClassAll(queue.Pending)
 
-      const allIndex = new Set<number>(
-        history.History.map((item: TaskItem) => item.prompt.priority)
+      const allIndex = new Set<string>(
+        history.History.map((item: TaskItem) => item.prompt.prompt_id)
       )
       const newHistoryItems = toClassAll(
         history.History.filter(
@@ -492,7 +492,7 @@ export const useQueueStore = defineStore('queue', () => {
         )
       )
       const existingHistoryItems = historyTasks.value.filter((item) =>
-        allIndex.has(item.queueIndex)
+        allIndex.has(item.promptId)
       )
       const sortedTasks = [...newHistoryItems, ...existingHistoryItems]
         .slice(0, maxHistoryItems.value)


### PR DESCRIPTION
## Summary

Fixes queue history reconciliation broken by cloud distribution removing the `priority` field from task items.

## Problem

The reconciliation logic in `queueStore.ts` was using the `priority` field to determine which existing history items to keep:
- Created a Set of all `priority` values from server history
- Filtered local history items to keep only those whose `queueIndex` (priority) exists in server

Since cloud does not have unique `priority` fields, reconciliation was failing completely - which could be reproduced with the steps:

* Clear all tasks
* Run 2 jobs and let complete
* Delete one
* Check the refresh (GET history) triggered by queueStore.update
* response will only have 1 item
* Queue panel will still show 2, since it's checking which of the previous (existing state) priorrity (queue_index) are in the new (new state)  

## Solution

Changed reconciliation to use `prompt_id` instead of `priority`:
- `allIndex` now uses `prompt_id` (string) instead of `priority` (number)
- `existingHistoryItems` filter now checks `item.promptId` instead of `item.queueIndex`

## Notes

- This fix is separate from deduplication (already uses `prompt_id`) and sorting (uses timestamps)
- `prompt_id` is a stable, unique identifier that always exists
- Typecheck passed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6263-bugfix-fix-queue-history-reconciliation-to-use-prompt_id-instead-of-priority-2966d73d365081709480d2132905116a) by [Unito](https://www.unito.io)
