### PR TITLE
[bugfix] fix auth service worker to handle cross-origin redirects to GCS

### DIFF
--- a/public/auth-sw.js
+++ b/public/auth-sw.js
@@ -78,7 +78,6 @@ self.addEventListener('fetch', (event) => {
           if (location) {
             return fetch(location, {
               method: 'GET',
-              cache: 'no-store',
               redirect: 'follow'
             })
           }

--- a/public/auth-sw.js
+++ b/public/auth-sw.js
@@ -54,18 +54,37 @@ self.addEventListener('fetch', (event) => {
           headers.set(key, value)
         }
 
-        return fetch(
+        // Fetch with manual redirect to handle cross-origin redirects (e.g., GCS signed URLs)
+        const response = await fetch(
           new Request(event.request.url, {
             method: event.request.method,
             headers: headers,
-            mode: 'same-origin',
             credentials: event.request.credentials,
             cache: 'no-store',
-            redirect: event.request.redirect,
+            redirect: 'manual',
             referrer: event.request.referrer,
             integrity: event.request.integrity
           })
         )
+
+        // If redirected to external storage (GCS), follow without auth headers
+        // The signed URL contains its own authentication in query params
+        if (
+          response.type === 'opaqueredirect' ||
+          response.status === 302 ||
+          response.status === 301
+        ) {
+          const location = response.headers.get('location')
+          if (location) {
+            return fetch(location, {
+              method: 'GET',
+              cache: 'no-store',
+              redirect: 'follow'
+            })
+          }
+        }
+
+        return response
       } catch (error) {
         console.error('[Auth SW] Request failed:', error)
         return fetch(event.request)


### PR DESCRIPTION
## Summary

Fixes CORS errors in HTTPS environments where the auth service worker blocked cross-origin redirects to Google Cloud Storage.

## Problem

The service worker was using `mode: 'same-origin'` which prevented following redirects when `/api/view` returns a 302 redirect to GCS:

```
Unsafe attempt to load URL https://storage.googleapis.com/... 
from frame with URL https://testcloud.comfy.org/auth-sw.js. 
Domains, protocols and ports must match.
```

This only occurred in HTTPS/cloud environments where media is served from GCS. Localhost/HTTP test environments serve files directly without redirects, so the issue wasn't caught there.

## Solution

Changed redirect handling from automatic to manual:

1. **Initial request to `/api/view`**: Sends WITH auth headers (validates user access)
2. **Detect redirect response**: Checks for 301/302/opaqueredirect 
3. **Follow redirect to GCS**: Fetches WITHOUT auth headers (signed URL has built-in auth)

### Key Changes

- Removed `mode: 'same-origin'` (was blocking cross-origin redirects)
- Changed `redirect: event.request.redirect` to `redirect: 'manual'`
- Added manual redirect handling that follows to GCS without Firebase auth headers

## Why This Works

The two requests have different authentication mechanisms:
- **`/api/view` request**: Uses Firebase auth header (backend validates user access)
- **GCS request**: Uses signed URL with query params (`Signature=...`, `GoogleAccessId=...`, `Expires=...`)

The security check still happens on the initial `/api/view` request, but we allow the redirect to GCS to use its own authentication system.

## Testing

- Typecheck passed
- Should be tested in HTTPS cloud environment with media files stored in GCS

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6265-bugfix-fix-auth-service-worker-to-handle-cross-origin-redirects-to-GCS-2976d73d365081d0b124db4918f8194e) by [Unito](https://www.unito.io)
