### PR TITLE
remove checkbox from sign up form

### DIFF
--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -27,28 +27,6 @@
 
     <PasswordFields />
 
-    <!-- Personal Data Consent Checkbox -->
-    <FormField
-      v-slot="$field"
-      name="personalDataConsent"
-      class="flex items-center gap-2"
-    >
-      <Checkbox
-        input-id="comfy-org-sign-up-personal-data-consent"
-        :binary="true"
-        :invalid="$field.invalid"
-      />
-      <label
-        for="comfy-org-sign-up-personal-data-consent"
-        class="text-base font-medium opacity-80"
-      >
-        {{ t('auth.signup.personalDataConsentLabel') }}
-      </label>
-      <small v-if="$field.error" class="-mt-4 text-red-500">{{
-        $field.error.message
-      }}</small>
-    </FormField>
-
     <!-- Submit Button -->
     <Button
       type="submit"
@@ -63,7 +41,6 @@ import type { FormSubmitEvent } from '@primevue/forms'
 import { Form, FormField } from '@primevue/forms'
 import { zodResolver } from '@primevue/forms/resolvers/zod'
 import Button from 'primevue/button'
-import Checkbox from 'primevue/checkbox'
 import InputText from 'primevue/inputtext'
 import { useI18n } from 'vue-i18n'
 

--- a/src/schemas/signInSchema.ts
+++ b/src/schemas/signInSchema.ts
@@ -45,16 +45,11 @@ export const signUpSchema = passwordSchema
     email: z
       .string()
       .email(t('validation.invalidEmail'))
-      .min(1, t('validation.required')),
-    personalDataConsent: z.boolean()
+      .min(1, t('validation.required'))
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: t('validation.password.match'),
     path: ['confirmPassword']
-  })
-  .refine((data) => data.personalDataConsent === true, {
-    message: t('validation.personalDataConsentRequired'),
-    path: ['personalDataConsent']
   })
 
 export type SignUpData = z.infer<typeof signUpSchema>


### PR DESCRIPTION
## Summary

Removes the checkbox from the sign up form to simplify the user experience. The "By clicking 'Next' or 'Sign Up'..." notice at the bottom already covers terms and privacy.

## Changes

- Removed checkbox field from sign up schema
- Updated `SignUpForm.vue` component
- Removed unused `Checkbox` import

## Before/After

**Before:**
Sign up form included a checkbox that users had to check before submitting

**After:**
Sign up form is cleaner without the checkbox. The existing notice text covers the same information:
> "By clicking 'Next' or 'Sign Up', you agree to our Terms of Use and Privacy Policy."

This notice appears on both sign in and sign up modals.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6269-remove-checkbox-from-sign-up-form-2976d73d3650819ab480e4db6685baee) by [Unito](https://www.unito.io)
