### PR TITLE
[ux] clean up cloud login page: remove duplicate signup text and beta banner

### DIFF
--- a/src/platform/onboarding/cloud/CloudLoginView.vue
+++ b/src/platform/onboarding/cloud/CloudLoginView.vue
@@ -2,15 +2,6 @@
   <div class="flex h-full items-center justify-center p-8">
     <div class="max-w-[100vw] p-2 lg:w-96">
       <template v-if="!hasInviteCode">
-        <div class="rounded-lg bg-[#2d2e32] p-4">
-          <h4 class="m-0 pb-2 text-lg">
-            {{ t('cloudPrivateBeta_title') }}
-          </h4>
-          <p class="m-0 text-base leading-6">
-            {{ t('cloudPrivateBeta_desc') }}
-          </p>
-        </div>
-
         <!-- Header -->
         <div class="mt-6 mb-8 flex flex-col gap-4">
           <h1 class="my-0 text-xl leading-normal font-medium">
@@ -87,15 +78,6 @@
           >
             {{ t('cloudWaitlist_contactLink') }}</a
           >.
-        </p>
-        <p class="mt-5 text-sm text-gray-600">
-          {{ t('cloudStart_invited_signup_title') }}
-          <span
-            class="cursor-pointer text-blue-400 no-underline"
-            @click="navigateToSignup"
-          >
-            {{ t('cloudStart_invited_signup_description') }}</span
-          >
         </p>
       </template>
     </div>


### PR DESCRIPTION
## Summary

Cleans up the cloud login page by removing redundant UI elements.

## Changes

1. **Removed duplicate signup text**: "Don't have an account yet? Sign up instead" was appearing twice - once at the top and once at the bottom. Now it only appears once at the top where it's most visible.

2. **Removed beta banner**: The "Cloud is currently in private beta" banner at the top of the page has been removed.

## Before/After

**Before:**
- Beta banner at top
- "Don't have an account yet?" at top
- Form in middle
- "Don't have an account yet?" again at bottom (duplicate)

**After:**
- "Don't have an account yet?" at top only
- Form in middle
- Contact info at bottom

The page is now cleaner and less repetitive.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6270-ux-clean-up-cloud-login-page-remove-duplicate-signup-text-and-beta-banner-2976d73d365081c5a7a5c15dd426317d) by [Unito](https://www.unito.io)
