### PR TITLE
[backport rh-test] remove checkbox from sign up form

### DIFF
--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -27,28 +27,6 @@
 
     <PasswordFields />
 
-    <!-- Personal Data Consent Checkbox -->
-    <FormField
-      v-slot="$field"
-      name="personalDataConsent"
-      class="flex items-center gap-2"
-    >
-      <Checkbox
-        input-id="comfy-org-sign-up-personal-data-consent"
-        :binary="true"
-        :invalid="$field.invalid"
-      />
-      <label
-        for="comfy-org-sign-up-personal-data-consent"
-        class="text-base font-medium opacity-80"
-      >
-        {{ t('auth.signup.personalDataConsentLabel') }}
-      </label>
-      <small v-if="$field.error" class="-mt-4 text-red-500">{{
-        $field.error.message
-      }}</small>
-    </FormField>
-
     <!-- Auth Error Message -->
     <Message v-if="authError" severity="error">
       {{ authError }}
@@ -68,7 +46,6 @@ import type { FormSubmitEvent } from '@primevue/forms'
 import { Form, FormField } from '@primevue/forms'
 import { zodResolver } from '@primevue/forms/resolvers/zod'
 import Button from 'primevue/button'
-import Checkbox from 'primevue/checkbox'
 import InputText from 'primevue/inputtext'
 import Message from 'primevue/message'
 import { useI18n } from 'vue-i18n'

--- a/src/schemas/signInSchema.ts
+++ b/src/schemas/signInSchema.ts
@@ -45,16 +45,11 @@ export const signUpSchema = passwordSchema
     email: z
       .string()
       .email(t('validation.invalidEmail'))
-      .min(1, t('validation.required')),
-    personalDataConsent: z.boolean()
+      .min(1, t('validation.required'))
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: t('validation.password.match'),
     path: ['confirmPassword']
-  })
-  .refine((data) => data.personalDataConsent === true, {
-    message: t('validation.personalDataConsentRequired'),
-    path: ['personalDataConsent']
   })
 
 export type SignUpData = z.infer<typeof signUpSchema>


### PR DESCRIPTION
## Summary

Backport of #6269 to rh-test.

Removes the checkbox from the sign up form to simplify the user experience.

## Changes

- Removed checkbox field from sign up schema
- Updated `SignUpForm.vue` component
- Kept rh-test-specific auth error display

## Conflict Resolution

Manually resolved merge conflict in `SignUpForm.vue`:
- Removed the checkbox as in main
- Preserved the auth error message section that exists on rh-test

The "By clicking 'Next' or 'Sign Up'..." notice already covers the same information.

Original commit: b1439be7f0198e4d2c39a7c25658f56a2969ba21

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6271-backport-rh-test-remove-checkbox-from-sign-up-form-2976d73d36508109ba52eab1c80e787f) by [Unito](https://www.unito.io)
