### PR TITLE
[bugfix] fix service worker registration timing to run after Pinia setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { VueFire, VueFireAuth } from 'vuefire'
 
 import { FIREBASE_CONFIG } from '@/config/firebase'
 import '@/lib/litegraph/public/css/litegraph.css'
-import '@/platform/auth/serviceWorker'
 import router from '@/router'
 
 import App from './App.vue'
@@ -82,4 +81,10 @@ app
     firebaseApp,
     modules: [VueFireAuth()]
   })
-  .mount('#vue-app')
+
+// Register auth service worker after Pinia is initialized (cloud-only)
+if (isCloud) {
+  void import('@/platform/auth/serviceWorker')
+}
+
+app.mount('#vue-app')


### PR DESCRIPTION
## Summary

Fixes Pinia initialization error that occurred when the auth service worker tried to access stores before Pinia was set up.

## Problem

The auth service worker was being imported at the top of `main.ts`, causing it to register immediately:

```typescript
import '@/platform/auth/serviceWorker'  // Runs immediately on import
```

This happened before Pinia was initialized, causing an error when the service worker setup tried to use stores:

```
Error: [🍍]: "getActivePinia()" was called but there was no active Pinia.
```

## Solution

Moved the service worker registration to after Pinia is set up but before mounting the app:

```typescript
  .use(pinia)
  .use(i18n)
  .use(VueFire, {
    firebaseApp,
    modules: [VueFireAuth()]
  })

// Register auth service worker after Pinia is initialized (cloud-only)
if (isCloud) {
  void import('@/platform/auth/serviceWorker')
}

app.mount('#vue-app')
```

## Benefits

- ✅ Pinia stores are available when service worker setup runs
- ✅ Still tree-shaken for non-cloud builds via dynamic import in `if (isCloud)` 
- ✅ Registers before mounting, so service worker is active from the start

## Testing

- Verified no Pinia errors in cloud builds
- Verified tree-shaking still works (service worker code not in localhost builds)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6272-bugfix-fix-service-worker-registration-timing-to-run-after-Pinia-setup-2976d73d365081b998dfd2eded782070) by [Unito](https://www.unito.io)
