### PR TITLE
[backport rh-test] fix service worker registration timing to run after Pinia setup (#6272)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { VueFire, VueFireAuth } from 'vuefire'
 
 import { FIREBASE_CONFIG } from '@/config/firebase'
 import '@/lib/litegraph/public/css/litegraph.css'
-import '@/platform/auth/serviceWorker'
 import { isCloud } from '@/platform/distribution/types'
 import router from '@/router'
 
@@ -85,4 +84,10 @@ app
     firebaseApp,
     modules: [VueFireAuth()]
   })
-  .mount('#vue-app')
+
+// Register auth service worker after Pinia is initialized (cloud-only)
+if (isCloud) {
+  void import('@/platform/auth/serviceWorker')
+}
+
+app.mount('#vue-app')


### PR DESCRIPTION
Backport of #6272 to rh-test

## Summary

Fixes the Pinia initialization error by moving service worker registration to after Pinia is initialized in the app setup flow.

## Problem

The service worker was being registered before Pinia was initialized, causing:
```
Error: [🍍]: "getActivePinia()" was called but there was no active Pinia.
```

## Solution

Moved the dynamic import of the service worker to execute after Pinia setup but before app mounting, while preserving the tree-shaking pattern for cloud-only builds.

## Test Plan

- [x] Typecheck passes
- [x] Verify service worker registers correctly in cloud build
- [x] Verify no Pinia initialization errors

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6273-backport-rh-test-fix-service-worker-registration-timing-to-run-after-Pinia-setup-6272-2976d73d365081d6bd19fa0f77f66254) by [Unito](https://www.unito.io)
