### PR TITLE
[bugfix] add mode: no-cors to fix CORS error when following GCS redirects

### DIFF
--- a/public/auth-sw.js
+++ b/public/auth-sw.js
@@ -70,16 +70,17 @@ self.addEventListener('fetch', (event) => {
         // Handle redirects to external storage (e.g., GCS signed URLs)
         if (response.type === 'opaqueredirect') {
           // Opaqueredirect: redirect occurred but response is opaque (headers not accessible)
-          // Re-fetch the original /api/view URL with redirect: 'follow'
-          // Browser will:
-          // 1. Send auth headers to /api/view (same-origin)
-          // 2. Receive 302 redirect to GCS
-          // 3. Automatically strip auth headers when following cross-origin redirect
-          // 4. Use GCS signed URL authentication instead
+          // Re-fetch the original /api/view URL with redirect: 'follow' and mode: 'no-cors'
+          // - mode: 'no-cors' allows cross-origin fetches without CORS headers (GCS doesn't have CORS)
+          // - Returns opaque response, which works fine for images/videos/audio
+          // - Browser will send auth headers to /api/view (same-origin)
+          // - Browser will receive 302 redirect to GCS
+          // - Browser will follow redirect using GCS signed URL authentication
           return fetch(event.request.url, {
             method: 'GET',
             headers: headers,
-            redirect: 'follow'
+            redirect: 'follow',
+            mode: 'no-cors'
           })
         }
 


### PR DESCRIPTION
Fixes CORS error when service worker follows redirects to GCS by using mode: 'no-cors' to allow cross-origin fetches without CORS headers.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6277-bugfix-add-mode-no-cors-to-fix-CORS-error-when-following-GCS-redirects-2976d73d36508101a4cbd7b59106dfc3) by [Unito](https://www.unito.io)
