### PR TITLE
[refactor] remove downlevelIteration from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "downlevelIteration": true,
     "noImplicitOverride": true,
     "allowJs": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
Remove downlevelIteration compiler option as it's no longer needed with ES2023 target.

picked from - [\[Cleanup\] Remove TS migration lines from tsconfig by webfiltered · Pull Request #5330 · Comfy-Org/ComfyUI_frontend]( https://github.com/Comfy-Org/ComfyUI_frontend/pull/5330 )

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6279-refactor-remove-downlevelIteration-from-tsconfig-2976d73d3650819a9d4be716006e8b85) by [Unito](https://www.unito.io)
