### PR TITLE
set Sentry config based on distribution

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,11 +49,18 @@ Sentry.init({
   dsn: __SENTRY_DSN__,
   enabled: __SENTRY_ENABLED__,
   release: __COMFYUI_FRONTEND_VERSION__,
-  integrations: [],
-  autoSessionTracking: false,
-  defaultIntegrations: false,
   normalizeDepth: 8,
-  tracesSampleRate: 0
+  tracesSampleRate: isCloud ? 1.0 : 0,
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 0,
+  // Only set these for non-cloud builds
+  ...(isCloud
+    ? {}
+    : {
+        integrations: [],
+        autoSessionTracking: false,
+        defaultIntegrations: false
+      })
 })
 app.directive('tooltip', Tooltip)
 app


### PR DESCRIPTION
Set the config based on compile-time DISTRIBUTION env var.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6301-set-Sentry-config-based-on-distribution-2986d73d3650815f9b7ef821bbdd745f) by [Unito](https://www.unito.io)
