### PR TITLE
change some settings for cloud-specific behavior

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -18,7 +18,7 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Memory.AllowManualUnload',
     name: 'Allow manual unload of models and execution cache via user command',
-    type: isCloud ? 'hidden' : 'boolean',
+    type: 'hidden',
     defaultValue: isCloud ? false : true,
     versionAdded: '1.18.0'
   },

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1,4 +1,5 @@
 import { LinkMarkerShape, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingParams } from '@/platform/settings/types'
 import type { ColorPalettes } from '@/schemas/colorPaletteSchema'
@@ -17,15 +18,15 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Memory.AllowManualUnload',
     name: 'Allow manual unload of models and execution cache via user command',
-    type: 'hidden',
-    defaultValue: true,
+    type: isCloud ? 'hidden' : 'boolean',
+    defaultValue: isCloud ? false : true,
     versionAdded: '1.18.0'
   },
   {
     id: 'Comfy.Validation.Workflows',
     name: 'Validate workflows',
     type: 'boolean',
-    defaultValue: true
+    defaultValue: isCloud ? false : true
   },
   {
     id: 'Comfy.NodeSearchBoxImpl',
@@ -281,8 +282,8 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Workflow.ShowMissingModelsWarning',
     name: 'Show missing models warning',
-    type: 'boolean',
-    defaultValue: true,
+    type: isCloud ? 'hidden' : 'boolean',
+    defaultValue: isCloud ? false : true,
     experimental: true
   },
   {
@@ -388,7 +389,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Automatically load all model folders',
     tooltip:
       'If true, all folders will load as soon as you open the model library (this may cause delays while it loads). If false, root level model folders will only load once you click on them.',
-    type: 'boolean',
+    type: isCloud ? 'hidden' : 'boolean',
     defaultValue: false
   },
   {
@@ -597,7 +598,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'The maximum number of tasks added to the queue at one button click',
     type: 'number',
-    defaultValue: 100,
+    defaultValue: isCloud ? 4 : 100,
     versionAdded: '1.3.5'
   },
   {
@@ -807,7 +808,7 @@ export const CORE_SETTINGS: SettingParams[] = [
       max: 256,
       step: 2
     },
-    defaultValue: 64,
+    defaultValue: isCloud ? 256 : 64,
     versionAdded: '1.4.12'
   },
   {
@@ -943,7 +944,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Toast.DisableReconnectingToast',
     name: 'Disable toasts when reconnecting or reconnected',
     type: 'hidden',
-    defaultValue: false,
+    defaultValue: isCloud ? true : false,
     versionAdded: '1.15.12'
   },
   {
@@ -1069,7 +1070,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Use Asset API for model library',
     type: 'hidden',
     tooltip: 'Use new Asset API for model browsing',
-    defaultValue: false,
+    defaultValue: isCloud ? true : false,
     experimental: true
   }
 ]

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -808,7 +808,7 @@ export const CORE_SETTINGS: SettingParams[] = [
       max: 256,
       step: 2
     },
-    defaultValue: isCloud ? 256 : 64,
+    defaultValue: 64,
     versionAdded: '1.4.12'
   },
   {


### PR DESCRIPTION
## Summary

Make some settings dynamic based on whether in cloud or localhost

1. Comfy.Memory.AllowManualUnload (line 18-24)
   - Type: 'hidden' on cloud, 'boolean' on localhost
   - Default: false on cloud, true on localhost
2. Comfy.Validation.Workflows (line 25-30)
   - Default: false on cloud, true on localhost
3. Comfy.Workflow.ShowMissingModelsWarning (line 282-288)
   - Type: 'hidden' on cloud, 'boolean' on localhost
   - Default: false on cloud, true on localhost
4. Comfy.ModelLibrary.AutoLoadAll (line 387-394)
   - Type: 'hidden' on cloud, 'boolean' on localhost
5. Comfy.QueueButton.BatchCountLimit (line 595-603)
   - Default: 4 on cloud, 100 on localhost
6. Comfy.Toast.DisableReconnectingToast (line 943-949)
   - Default: true on cloud, false on localhost
7. Comfy.Assets.UseAssetAPI (line 1068-1075)
   - Default: true on cloud, false on localhost

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6302-change-some-settings-for-cloud-specific-behavior-2986d73d365081169be4ebd11823a7fa) by [Unito](https://www.unito.io)
