### PR TITLE
[backport rh-test] track analytics in English for template metadata

### DIFF
--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -434,15 +434,20 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
           const template = this._templatesStore.getTemplateByName(
             activeWorkflow.filename
           )
+
+          const englishMetadata = this._templatesStore.getEnglishMetadata(
+            activeWorkflow.filename
+          )
+
           return {
             is_template: true,
             workflow_name: activeWorkflow.filename,
             template_source: template?.sourceModule,
-            template_category: template?.category,
-            template_tags: template?.tags,
-            template_models: template?.models,
-            template_use_case: template?.useCase,
-            template_license: template?.license
+            template_category: englishMetadata?.category ?? template?.category,
+            template_tags: englishMetadata?.tags ?? template?.tags,
+            template_models: englishMetadata?.models ?? template?.models,
+            template_use_case: englishMetadata?.useCase ?? template?.useCase,
+            template_license: englishMetadata?.license ?? template?.license
           }
         }
 

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
 import { i18n, st } from '@/i18n'
+import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import type { NavGroupData, NavItemData } from '@/types/navTypes'
 import { getCategoryIcon } from '@/utils/categoryIcons'
@@ -29,6 +30,7 @@ export const useWorkflowTemplatesStore = defineStore(
   () => {
     const customTemplates = shallowRef<{ [moduleName: string]: string[] }>({})
     const coreTemplates = shallowRef<WorkflowTemplates[]>([])
+    const englishTemplates = shallowRef<WorkflowTemplates[]>([])
     const isLoaded = ref(false)
     const knownTemplateNames = ref(new Set<string>())
 
@@ -436,7 +438,16 @@ export const useWorkflowTemplatesStore = defineStore(
         if (!isLoaded.value) {
           customTemplates.value = await api.getWorkflowTemplates()
           const locale = i18n.global.locale.value
-          coreTemplates.value = await api.getCoreWorkflowTemplates(locale)
+
+          const [coreResult, englishResult] = await Promise.all([
+            api.getCoreWorkflowTemplates(locale),
+            isCloud && locale !== 'en'
+              ? api.getCoreWorkflowTemplates('en')
+              : Promise.resolve([])
+          ])
+
+          coreTemplates.value = coreResult
+          englishTemplates.value = englishResult
 
           const coreNames = coreTemplates.value.flatMap((category) =>
             category.templates.map((template) => template.name)
@@ -451,6 +462,33 @@ export const useWorkflowTemplatesStore = defineStore(
       }
     }
 
+    function getEnglishMetadata(templateName: string): {
+      tags?: string[]
+      category?: string
+      useCase?: string
+      models?: string[]
+      license?: string
+    } | null {
+      if (englishTemplates.value.length === 0) {
+        return null
+      }
+
+      for (const category of englishTemplates.value) {
+        const template = category.templates.find((t) => t.name === templateName)
+        if (template) {
+          return {
+            tags: template.tags,
+            category: category.title,
+            useCase: template.useCase,
+            models: template.models,
+            license: template.license
+          }
+        }
+      }
+
+      return null
+    }
+
     return {
       groupedTemplates,
       navGroupedTemplates,
@@ -460,7 +498,8 @@ export const useWorkflowTemplatesStore = defineStore(
       isLoaded,
       loadWorkflowTemplates,
       knownTemplateNames,
-      getTemplateByName
+      getTemplateByName,
+      getEnglishMetadata
     }
   }
 )


### PR DESCRIPTION
## Summary

Track template metadata in English for analytics regardless of user's locale to enable consistent statistical analysis.

## Changes

- **What**: Load English template index alongside localized version (cloud builds only)
- **What**: Added getEnglishMetadata() method to workflowTemplatesStore that returns English versions of template tags, category, useCase, models, and license
- **What**: Updated MixpanelTelemetryProvider to prefer English metadata for analytics events, falling back to localized values

## Review Focus

English template fetch only triggers in cloud builds via isCloud flag. Non-cloud builds see no bundle size impact. Method returns null when English templates unavailable, with fallback to localized data ensuring analytics continue working in edge cases.

Backport of main PR to rh-test branch.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6305-feat-track-analytics-in-English-for-template-metadata-2986d73d365081d1acf6eeeaadb224b5) by [Unito](https://www.unito.io)
