### PR TITLE
[bugfix] fix survey properties mapping to match actual survey data

### DIFF
--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -26,13 +26,13 @@ export interface AuthMetadata {
 
 /**
  * Survey response data for user profiling
+ * Maps 1-to-1 with actual survey fields
  */
 export interface SurveyResponses {
-  industry?: string
-  team_size?: string
-  use_case?: string
   familiarity?: string
-  intended_use?: 'personal' | 'client' | 'inhouse'
+  industry?: string
+  useCase?: string
+  making?: string[]
 }
 
 /**


### PR DESCRIPTION
## Summary

Updates `SurveyResponses` interface to match actual survey fields 1-to-1 based on analytics requirements.

## Changes

- Remove `team_size` property (no corresponding survey question exists)
- Change `use_case` to `useCase` to match actual survey field name
- Remove `intended_use` property (doesn't exist in actual survey)
- Add `making` field array for content generation type tracking (video, image, etc.)

This fixes a Mixpanel analytics issue where survey properties weren't mapping 1-to-1 with actual survey questions, making statistical analysis difficult.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6314-bugfix-fix-survey-properties-mapping-to-match-actual-survey-data-2996d73d36508158a335e6b73e3e14ef) by [Unito](https://www.unito.io)
