### PR TITLE
fix: claude-review bails on cancelled and skipped checks

### DIFF
--- a/.github/workflows/pr-claude-review.yaml
+++ b/.github/workflows/pr-claude-review.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-regexp: '^(lint-and-format|test|playwright-tests)'
+          allowed-conclusions: success,skipped,failure,cancelled,neutral,action_required,timed_out,stale
           wait-interval: 30
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
## Summary

Expands the wait step in `pr-claude-review.yaml` so the `lewagon/wait-on-check-action` accepts every terminal GitHub conclusion instead of failing on outcomes like cancelled or failure. After the wait completes, the `check-status` script still inspects those check runs and only marks `should-proceed=true` when the tracked jobs finished successfully.

Fixes what happened here: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/18828179272/job/53714488799?pr=6298
