### PR TITLE
ci: fix "size report" (bundle size) markdown table comment formatting

### DIFF
--- a/scripts/size-report.js
+++ b/scripts/size-report.js
@@ -339,9 +339,11 @@ function renderCategoryBlock(category, hasBaseline) {
 
   summaryParts.push('</summary>')
   lines.push(summaryParts.join(''))
+  lines.push('')
 
   if (category.description) {
     lines.push(`_${category.description}_`)
+    lines.push('')
   }
 
   if (category.bundles.length === 0) {

--- a/scripts/size-report.js
+++ b/scripts/size-report.js
@@ -314,6 +314,11 @@ function renderCategoryDetails(report) {
 
   for (const category of report.categories) {
     lines.push(renderCategoryBlock(category, report.hasBaseline))
+    lines.push('')
+  }
+
+  if (report.categories.length > 0) {
+    lines.pop()
   }
 
   lines.push('</details>')
@@ -384,6 +389,7 @@ function renderCategoryBlock(category, hasBaseline) {
     })
 
   lines.push(markdownTable([headers, ...rows]))
+  lines.push('')
 
   const statusParts = []
   if (category.counts.added) statusParts.push(`${category.counts.added} added`)
@@ -395,10 +401,11 @@ function renderCategoryBlock(category, hasBaseline) {
     statusParts.push(`${category.counts.decreased} shrank`)
 
   if (statusParts.length > 0) {
-    lines.push(`\n_Status:_ ${statusParts.join(' / ')}`)
+    lines.push(`_Status:_ ${statusParts.join(' / ')}`)
+    lines.push('')
   }
 
-  lines.push('</details>\n')
+  lines.push('</details>')
   return lines.join('\n')
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/6136 by adding empty lines between html and markdown in the bundle size report comments.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6318-ci-fix-size-report-bundle-size-markdown-table-comment-formatting-2996d73d36508104872be56c238339a8) by [Unito](https://www.unito.io)
