### PR TITLE
add save option for 3d node on context menu

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -3,6 +3,7 @@ import { nextTick } from 'vue'
 import Load3D from '@/components/load3d/Load3D.vue'
 import Load3DAnimation from '@/components/load3d/Load3DAnimation.vue'
 import Load3DViewerContent from '@/components/load3d/Load3dViewerContent.vue'
+import { createExportMenuOptions } from '@/extensions/core/load3d/exportMenuHelper'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
 import Load3dAnimation from '@/extensions/core/load3d/Load3dAnimation'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
@@ -297,6 +298,8 @@ useExtensionService().registerExtension({
     await nextTick()
 
     useLoad3dService().waitForLoad3d(node, (load3d) => {
+      node.getExtraMenuOptions = createExportMenuOptions(load3d)
+
       let cameraState = node.properties['Camera Info']
 
       const config = new Load3DConfiguration(load3d)
@@ -542,6 +545,8 @@ useExtensionService().registerExtension({
     const onExecuted = node.onExecuted
 
     useLoad3dService().waitForLoad3d(node, (load3d) => {
+      node.getExtraMenuOptions = createExportMenuOptions(load3d)
+
       const config = new Load3DConfiguration(load3d)
 
       const modelWidget = node.widgets?.find((w) => w.name === 'model_file')

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { type CustomInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 
 import { CameraManager } from './CameraManager'
@@ -22,6 +22,7 @@ import {
   type MaterialMode,
   type UpDirection
 } from './interfaces'
+import { app } from '@/scripts/app'
 
 class Load3d {
   renderer: THREE.WebGLRenderer
@@ -233,17 +234,11 @@ class Load3d {
     canvas.addEventListener('contextmenu', contextmenuHandler)
   }
 
-  private showNodeContextMenu(e: MouseEvent): void {
-    const app = (window as any).app
-    if (!app || !app.canvas || !this.node) return
-
+  private showNodeContextMenu(event: MouseEvent): void {
     const menuOptions = app.canvas.getNodeMenuOptions(this.node)
 
-    const LiteGraph = (window as any).LiteGraph
-    if (!LiteGraph || !LiteGraph.ContextMenu) return
-
     new LiteGraph.ContextMenu(menuOptions, {
-      event: e,
+      event,
       title: this.node.type,
       extra: this.node
     })

--- a/src/extensions/core/load3d/exportMenuHelper.ts
+++ b/src/extensions/core/load3d/exportMenuHelper.ts
@@ -1,0 +1,53 @@
+import { t } from '@/i18n'
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import Load3d from '@/extensions/core/load3d/Load3d'
+
+const EXPORT_FORMATS = [
+  { label: 'GLB', value: 'glb' },
+  { label: 'OBJ', value: 'obj' },
+  { label: 'STL', value: 'stl' }
+] as const
+
+export function createExportMenuOptions(load3d: Load3d) {
+  return function (
+    _canvas: LGraphCanvas,
+    options: (IContextMenuValue | null)[]
+  ): (IContextMenuValue | null)[] {
+    options.push(null, {
+      content: 'Save',
+      has_submenu: true,
+      callback: (_value, _options, event, prev_menu) => {
+        const submenuOptions = EXPORT_FORMATS.map((format) => ({
+          content: format.label,
+          callback: async () => {
+            try {
+              await load3d.exportModel(format.value)
+              useToastStore().add({
+                severity: 'success',
+                summary: t('toastMessages.exportSuccess', {
+                  format: format.label
+                })
+              })
+            } catch (error) {
+              console.error('Export failed:', error)
+              useToastStore().addAlert(
+                t('toastMessages.failedToExportModel', {
+                  format: format.label
+                })
+              )
+            }
+          }
+        }))
+
+        // @ts-expect-error
+        new LiteGraph.ContextMenu(submenuOptions, {
+          event,
+          parentMenu: prev_menu
+        })
+      }
+    })
+    return options
+  }
+}

--- a/src/extensions/core/saveMesh.ts
+++ b/src/extensions/core/saveMesh.ts
@@ -1,6 +1,7 @@
 import { nextTick } from 'vue'
 
 import Load3D from '@/components/load3d/Load3D.vue'
+import { createExportMenuOptions } from '@/extensions/core/load3d/exportMenuHelper'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
 import { type CustomInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
@@ -59,6 +60,10 @@ useExtensionService().registerExtension({
       const fileInfo = message['3d'][0]
 
       const load3d = useLoad3dService().getLoad3d(node)
+
+      if (load3d) {
+        node.getExtraMenuOptions = createExportMenuOptions(load3d)
+      }
 
       const modelWidget = node.widgets?.find((w) => w.name === 'image')
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1460,6 +1460,7 @@
     "failedToApplyTexture": "Failed to apply texture",
     "no3dSceneToExport": "No 3D scene to export",
     "failedToExportModel": "Failed to export model as {format}",
+    "exportSuccess": "Successfully exported model as {format}",
     "fileLoadError": "Unable to find workflow in {fileName}",
     "dropFileError": "Unable to process dropped item: {error}",
     "interrupted": "Execution has been interrupted",


### PR DESCRIPTION
## Summary

add save option for 3d node on context menu

## Changes
allow to export model from context menu, supported in preview3d/load3d/saveMesh



https://github.com/user-attachments/assets/1f0f1a93-9cdb-477f-8bd3-e298c7e3892b

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6319-add-save-option-for-3d-node-on-context-menu-2996d73d365081f7853cd2ae9c69fe4d) by [Unito](https://www.unito.io)
