### PR TITLE
[bugfix] use raw template ID for workflow_name in telemetry tracking

### DIFF
--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -132,7 +132,7 @@ export function useTemplateWorkflows() {
 
         if (isCloud) {
           useTelemetry()?.trackTemplate({
-            workflow_name: workflowName,
+            workflow_name: id,
             template_source: actualSourceModule
           })
         }
@@ -153,7 +153,7 @@ export function useTemplateWorkflows() {
 
       if (isCloud) {
         useTelemetry()?.trackTemplate({
-          workflow_name: workflowName,
+          workflow_name: id,
           template_source: sourceModule
         })
       }


### PR DESCRIPTION
## Summary

Fixes `trackTemplate` calls to use raw template ID instead of translated workflow name for analytics tracking.

## Problem

When users load templates with non-English locale, the `workflow_name` field was being tracked in their language (e.g., "默认工作流" for Chinese users) instead of English. This makes statistical analysis difficult.

## Changes

- Updated both `trackTemplate` calls in `useTemplateWorkflows.ts` to use raw `id` instead of translated `workflowName`
- The translated name is still used for display purposes in `loadGraphData`

**Before:**
```typescript
useTelemetry()?.trackTemplate({
  workflow_name: workflowName, // Could be "默认工作流"
  template_source: sourceModule
})
```

**After:**
```typescript
useTelemetry()?.trackTemplate({
  workflow_name: id, // Always "default"
  template_source: sourceModule
})
```

## Testing

- [x] Type checking passes
- [x] Verified translated names still used for display

## Related

Part of comprehensive i18n audit for telemetry tracking. Related to template metadata English tracking in PR #6304.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6320-bugfix-use-raw-template-ID-for-workflow_name-in-telemetry-tracking-2996d73d365081d8aef3fa2529a10247) by [Unito](https://www.unito.io)
