### PR TITLE
refactor: rename size report workflows to match naming pattern of other workflows

### DIFF
--- a/.github/workflows/ci-size-data.yaml
+++ b/.github/workflows/ci-size-data.yaml
@@ -1,4 +1,4 @@
-name: size data
+name: "CI: Size Data"
 
 on:
   push:

--- a/.github/workflows/pr-size-report.yaml
+++ b/.github/workflows/pr-size-report.yaml
@@ -1,8 +1,8 @@
-name: size report
+name: "PR: Size Report"
 
 on:
   workflow_run:
-    workflows: ['size data']
+    workflows: ['CI: Size Data']
     types:
       - completed
   workflow_dispatch:
@@ -22,7 +22,7 @@ permissions:
   issues: write
 
 jobs:
-  size-report:
+  comment:
     runs-on: ubuntu-latest
     if: >
       github.repository == 'Comfy-Org/ComfyUI_frontend' &&
@@ -78,7 +78,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v11
         with:
           branch: ${{ steps.pr-base.outputs.content }}
-          workflow: size-data.yml
+          workflow: ci-size-data.yaml
           event: push
           name: size-data
           path: temp/size-prev


### PR DESCRIPTION
## Summary

Changes gh workflow names and job names to match the unified naming style of the other workflows.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6322-refactor-rename-size-report-workflows-to-match-naming-pattern-of-other-workflows-2996d73d365081c79cfcdfcb9013c3e1) by [Unito](https://www.unito.io)
