### PR TITLE
[don't backport to main] fix sidebar broken from past merge conflict resolution

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -18,7 +18,7 @@
         </div>
       </div>
     </template>
-    <template v-if="showUI" #side-toolbar>
+    <template v-if="!workspaceStore.focusMode" #side-bar-panel>
       <SideToolbar />
     </template>
     <template v-if="!workspaceStore.focusMode" #bottom-panel>


### PR DESCRIPTION
## Summary

Fixes sidebar not showing on test cloud due to merge conflict with main that brought in changes form the V3 tabs and menu rework PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6323-don-t-backport-to-main-fix-sidebar-broken-from-past-merge-conflict-resolution-2996d73d3650813f820dde1ec25f53f4) by [Unito](https://www.unito.io)
