### PR TITLE
[bugfix] update survey response event to match exact survey schema 1-to-1

### DIFF
--- a/src/platform/onboarding/cloud/CloudSurveyView.vue
+++ b/src/platform/onboarding/cloud/CloudSurveyView.vue
@@ -356,15 +356,9 @@ const onSubmitSurvey = async () => {
     if (isCloud) {
       useTelemetry()?.trackSurvey('submitted', {
         industry: payload.industry,
-        team_size: undefined, // Not collected in this survey
-        use_case: payload.useCase,
+        useCase: payload.useCase,
         familiarity: payload.familiarity,
-        intended_use:
-          payload.useCase === 'personal'
-            ? 'personal'
-            : payload.useCase === 'client'
-              ? 'client'
-              : 'inhouse'
+        making: payload.making
       })
     }
 

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -195,15 +195,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
           const survey = surveyData as any
           this.mixpanel.people.set({
             survey_industry: survey.industry,
-            survey_team_size: survey.team_size,
             survey_use_case: survey.useCase,
             survey_familiarity: survey.familiarity,
-            survey_intended_use:
-              survey.useCase === 'personal'
-                ? 'personal'
-                : survey.useCase === 'client'
-                  ? 'client'
-                  : 'inhouse'
+            survey_making: survey.making
           })
         }
       }
@@ -219,15 +213,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
                 const survey = surveyData as any
                 this.mixpanel?.people.set({
                   survey_industry: survey.industry,
-                  survey_team_size: survey.team_size,
                   survey_use_case: survey.useCase,
                   survey_familiarity: survey.familiarity,
-                  survey_intended_use:
-                    survey.useCase === 'personal'
-                      ? 'personal'
-                      : survey.useCase === 'client'
-                        ? 'client'
-                        : 'inhouse'
+                  survey_making: survey.making
                 })
               }
             } catch (error) {
@@ -322,10 +310,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
       stage === 'submitted' && responses
         ? {
             industry: responses.industry,
-            team_size: responses.team_size,
-            use_case: responses.use_case,
+            useCase: responses.useCase,
             familiarity: responses.familiarity,
-            intended_use: responses.intended_use
+            making: responses.making
           }
         : undefined
 
@@ -351,10 +338,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     try {
       this.mixpanel.people.set({
         survey_industry: responses.industry,
-        survey_team_size: responses.team_size,
-        survey_use_case: responses.use_case,
+        survey_use_case: responses.useCase,
         survey_familiarity: responses.familiarity,
-        survey_intended_use: responses.intended_use
+        survey_making: responses.making
       })
     } catch (error) {
       console.error('Failed to set survey user properties:', error)


### PR DESCRIPTION
## Summary

Fixes all usages of `SurveyResponses` interface to match the updated structure.

## Problem

After PR #6314 updated the `SurveyResponses` interface, several files still used the old property names causing TypeScript errors:
- `team_size` (removed)
- `use_case` (should be `useCase`)
- `intended_use` (removed)

## Changes

Updated all survey response usages:

**CloudSurveyView.vue:**
- Updated `trackSurvey` call to use new field names
- Removed obsolete `team_size` and `intended_use` fields
- Added `making` field for content type tracking

**MixpanelTelemetryProvider.ts (4 locations):**
- User properties from cached store
- User properties from dynamic import  
- Event properties in `trackSurvey`
- `setSurveyUserProperties` method

## Testing

- [x] Type checking passes
- [x] Survey data now maps 1-to-1 with actual survey fields

## Related

Follow-up to PR #6314 which updated the interface definition.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6325-bugfix-update-survey-response-usage-to-match-new-interface-2996d73d36508128bb62deb545b76c7b) by [Unito](https://www.unito.io)
