### PR TITLE
[don't backport to main] fix: topbar badges bg color on cloud (uses old menus style)

### DIFF
--- a/src/components/topbar/CloudBadge.vue
+++ b/src/components/topbar/CloudBadge.vue
@@ -27,7 +27,7 @@ withDefaults(
     displayMode: 'full',
     reverseOrder: false,
     noPadding: false,
-    backgroundColor: 'var(--comfy-menu-bg)'
+    backgroundColor: 'var(--comfy-menu-secondary-bg)'
   }
 )
 

--- a/src/components/topbar/TopbarBadge.vue
+++ b/src/components/topbar/TopbarBadge.vue
@@ -141,7 +141,7 @@ const props = withDefaults(
     displayMode: 'full',
     reverseOrder: false,
     noPadding: false,
-    backgroundColor: 'var(--comfy-menu-bg)'
+    backgroundColor: 'var(--comfy-menu-secondary-bg)'
   }
 )
 

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -5,7 +5,10 @@
         <h2 class="text-2xl">
           {{ $t('subscription.title') }}
         </h2>
-        <CloudBadge reverse-order background-color="var(--p-dialog-background)" />
+        <CloudBadge
+          reverse-order
+          background-color="var(--p-dialog-background)"
+        />
       </div>
 
       <div class="grow overflow-auto">

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -5,7 +5,7 @@
         <h2 class="text-2xl">
           {{ $t('subscription.title') }}
         </h2>
-        <CloudBadge reverse-order />
+        <CloudBadge reverse-order background-color="var(--p-dialog-background)" />
       </div>
 
       <div class="grow overflow-auto">


### PR DESCRIPTION
## Summary

The topbar badges and cloud badges were changed to work with the new menu system because it was developed on main - but on the cloud RC branch, the old menu system still presides which uses a different topbar background color. This PR fixes the badges to align with that.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6332-don-t-backport-to-main-fix-topbar-badges-bg-color-on-cloud-uses-old-menus-style-2996d73d365081328f61f1e0fccbbbe5) by [Unito](https://www.unito.io)
