### PR TITLE
skip system notifications on cloud

### DIFF
--- a/src/platform/updates/common/releaseStore.ts
+++ b/src/platform/updates/common/releaseStore.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { compare } from 'semver'
 import { computed, ref } from 'vue'
 
+import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { isElectron } from '@/utils/envUtil'
@@ -81,7 +82,7 @@ export const useReleaseStore = defineStore('release', () => {
   // Show toast if needed
   const shouldShowToast = computed(() => {
     // Only show on desktop version
-    if (!isElectron()) {
+    if (!isElectron() || isCloud) {
       return false
     }
 
@@ -113,7 +114,7 @@ export const useReleaseStore = defineStore('release', () => {
   // Show red-dot indicator
   const shouldShowRedDot = computed(() => {
     // Only show on desktop version
-    if (!isElectron()) {
+    if (!isElectron() || isCloud) {
       return false
     }
 
@@ -160,7 +161,7 @@ export const useReleaseStore = defineStore('release', () => {
   // Show "What's New" popup
   const shouldShowPopup = computed(() => {
     // Only show on desktop version
-    if (!isElectron()) {
+    if (!isElectron() || isCloud) {
       return false
     }
 


### PR DESCRIPTION
## Summary

This code has no effect but adding it so that when the `!isElectron()` condition is removed, maintainers will remember this extra condition that must still be enforced.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6333-skip-system-notifications-on-cloud-2996d73d3650818b8335d395c86badf3) by [Unito](https://www.unito.io)
