### PR TITLE
fix subscription panel badge bg color

### DIFF
--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -5,7 +5,10 @@
         <h2 class="text-2xl">
           {{ $t('subscription.title') }}
         </h2>
-        <CloudBadge reverse-order />
+        <CloudBadge
+          reverse-order
+          background-color="var(--p-dialog-background)"
+        />
       </div>
 
       <div class="grow overflow-auto">


### PR DESCRIPTION
## Summary

This should use the dialog bg color instead of menu bg when it is on a dialog.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6334-fix-subscription-panel-badge-bg-color-2996d73d36508171bf5bd2a8dc54f7c3) by [Unito](https://www.unito.io)
