### PR TITLE
feat(historyV2): create sythetic queue priority

### DIFF
--- a/src/platform/remote/comfyui/history/adapters/v2ToV1Adapter.ts
+++ b/src/platform/remote/comfyui/history/adapters/v2ToV1Adapter.ts
@@ -1,10 +1,7 @@
 /**
  * @fileoverview Adapter to convert V2 history format to V1 format
  * @module platform/remote/comfyui/history/adapters/v2ToV1Adapter
- *
- * Converts cloud API V2 response format to the V1 format expected by the app.
  */
-
 import type { HistoryTaskItem, TaskPrompt } from '../types/historyV1Types'
 import type {
   HistoryResponseV2,
@@ -13,31 +10,55 @@ import type {
   TaskPromptV2
 } from '../types/historyV2Types'
 
-/**
- * Maps V2 prompt format to V1 prompt tuple format.
- */
 function mapPromptV2toV1(
   promptV2: TaskPromptV2,
-  outputs: TaskOutput
+  outputs: TaskOutput,
+  syntheticPriority: number
 ): TaskPrompt {
-  const outputNodesIds = Object.keys(outputs)
-  const { priority, prompt_id, extra_data } = promptV2
-  return [priority, prompt_id, {}, extra_data, outputNodesIds]
+  return [
+    syntheticPriority,
+    promptV2.prompt_id,
+    {},
+    promptV2.extra_data,
+    Object.keys(outputs)
+  ]
 }
 
-/**
- * Maps V2 history format to V1 history format.
- */
+function getExecutionSuccessTimestamp(item: RawHistoryItemV2): number {
+  return (
+    item.status?.messages?.find((m) => m[0] === 'execution_success')?.[1]
+      ?.timestamp ?? 0
+  )
+}
+
 export function mapHistoryV2toHistory(
   historyV2Response: HistoryResponseV2
 ): HistoryTaskItem[] {
-  return historyV2Response.history.map(
-    ({ prompt, status, outputs, meta }: RawHistoryItemV2): HistoryTaskItem => ({
+  const history = historyV2Response.history
+
+  // Sort by execution_success timestamp, descending (newest first)
+  history.sort((a, b) => {
+    return getExecutionSuccessTimestamp(b) - getExecutionSuccessTimestamp(a)
+  })
+
+  // Count items with valid timestamps for synthetic priority calculation
+  const countWithTimestamps = history.filter(
+    (item) => getExecutionSuccessTimestamp(item) > 0
+  ).length
+
+  return history.map((item, index): HistoryTaskItem => {
+    const { prompt, outputs, status, meta } = item
+    const timestamp = getExecutionSuccessTimestamp(item)
+
+    // Items with timestamps get priority based on sorted position (highest first)
+    const syntheticPriority = timestamp > 0 ? countWithTimestamps - index : 0
+
+    return {
       taskType: 'History' as const,
-      prompt: mapPromptV2toV1(prompt, outputs),
+      prompt: mapPromptV2toV1(prompt, outputs, syntheticPriority),
       status,
       outputs,
       meta
-    })
-  )
+    }
+  })
 }

--- a/tests-ui/fixtures/historyFixtures.ts
+++ b/tests-ui/fixtures/historyFixtures.ts
@@ -233,12 +233,17 @@ export const historyV2Fixture: HistoryResponseV2 = {
 
 /**
  * Expected V1 transformation of historyV2Fixture
+ * Priority is now synthetic based on execution_success timestamp:
+ * - complete-item-id: has timestamp → priority 1 (only one with timestamp)
+ * - no-status-id: no status → priority 0
+ * - no-meta-id: empty messages → priority 0
+ * - multi-output-id: empty messages → priority 0
  */
 export const expectedV1Fixture: HistoryTaskItem[] = [
   {
     taskType: 'History',
     prompt: [
-      24,
+      1,
       'complete-item-id',
       {},
       {
@@ -295,7 +300,7 @@ export const expectedV1Fixture: HistoryTaskItem[] = [
   {
     taskType: 'History',
     prompt: [
-      23,
+      0,
       'no-status-id',
       {},
       {
@@ -319,7 +324,7 @@ export const expectedV1Fixture: HistoryTaskItem[] = [
   {
     taskType: 'History',
     prompt: [
-      22,
+      0,
       'no-meta-id',
       {},
       {
@@ -342,7 +347,7 @@ export const expectedV1Fixture: HistoryTaskItem[] = [
   {
     taskType: 'History',
     prompt: [
-      21,
+      0,
       'multi-output-id',
       {},
       {

--- a/tests-ui/fixtures/historySortingFixtures.ts
+++ b/tests-ui/fixtures/historySortingFixtures.ts
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Test fixtures for history V2 timestamp-based sorting
+ */
+import type { HistoryResponseV2 } from '@/platform/remote/comfyui/history/types/historyV2Types'
+
+export const historyV2WithMissingTimestamp: HistoryResponseV2 = {
+  history: [
+    {
+      prompt_id: 'item-timestamp-1000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-1000',
+        extra_data: {
+          client_id: 'test-client'
+        }
+      },
+      outputs: {
+        '1': {
+          images: [{ filename: 'test1.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-1000', timestamp: 1000 }
+          ]
+        ]
+      }
+    },
+    {
+      prompt_id: 'item-timestamp-2000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-2000',
+        extra_data: {
+          client_id: 'test-client'
+        }
+      },
+      outputs: {
+        '2': {
+          images: [{ filename: 'test2.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-2000', timestamp: 2000 }
+          ]
+        ]
+      }
+    },
+    {
+      prompt_id: 'item-no-timestamp',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-no-timestamp',
+        extra_data: {
+          client_id: 'test-client'
+        }
+      },
+      outputs: {
+        '3': {
+          images: [{ filename: 'test3.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: []
+      }
+    }
+  ]
+}
+
+export const historyV2FiveItemsSorting: HistoryResponseV2 = {
+  history: [
+    {
+      prompt_id: 'item-timestamp-3000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-3000',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '1': {
+          images: [{ filename: 'test1.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-3000', timestamp: 3000 }
+          ]
+        ]
+      }
+    },
+    {
+      prompt_id: 'item-timestamp-1000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-1000',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '2': {
+          images: [{ filename: 'test2.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-1000', timestamp: 1000 }
+          ]
+        ]
+      }
+    },
+    {
+      prompt_id: 'item-timestamp-5000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-5000',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '3': {
+          images: [{ filename: 'test3.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-5000', timestamp: 5000 }
+          ]
+        ]
+      }
+    },
+    {
+      prompt_id: 'item-timestamp-2000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-2000',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '4': {
+          images: [{ filename: 'test4.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-2000', timestamp: 2000 }
+          ]
+        ]
+      }
+    },
+    {
+      prompt_id: 'item-timestamp-4000',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-timestamp-4000',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '5': {
+          images: [{ filename: 'test5.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: [
+          [
+            'execution_success',
+            { prompt_id: 'item-timestamp-4000', timestamp: 4000 }
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Create display priority based on execution success timestamps.

Next up is displaying in progress prompts in the queue.

## Review Focus

@DrJKL and I discussed logic and decided for history, execution success (when the prompt finishes) is the best way to assign priority. 

This does differ from existing cloud logic which uses execution start time.

For prompt progress I intend to create a priority for them based on start time.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6336-feat-historyV2-create-sythetic-queue-priority-2996d73d365081ffa3a0f8071c178066) by [Unito](https://www.unito.io)
