### PR TITLE
add title to asset names in model browser

### DIFF
--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -31,6 +31,7 @@
               'dark-theme:text-white'
             )
           "
+          :title="asset.name"
         >
           {{ asset.name }}
         </h3>


### PR DESCRIPTION
Show full title when hovering the text.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6338-add-title-to-asset-names-in-model-browser-29a6d73d36508106a1d5ce9c09007b78) by [Unito](https://www.unito.io)
