### PR TITLE
feat(historyV2): reconcile completed workflows

### DIFF
--- a/src/platform/remote/comfyui/history/adapters/v2ToV1Adapter.ts
+++ b/src/platform/remote/comfyui/history/adapters/v2ToV1Adapter.ts
@@ -34,7 +34,7 @@ function getExecutionSuccessTimestamp(item: RawHistoryItemV2): number {
 export function mapHistoryV2toHistory(
   historyV2Response: HistoryResponseV2
 ): HistoryTaskItem[] {
-  const history = historyV2Response.history
+  const { history } = historyV2Response
 
   // Sort by execution_success timestamp, descending (newest first)
   history.sort((a, b) => {

--- a/src/platform/remote/comfyui/history/reconciliation.ts
+++ b/src/platform/remote/comfyui/history/reconciliation.ts
@@ -14,7 +14,7 @@
 
 import type { TaskItem, TaskPrompt } from '@/schemas/apiSchema'
 
-export interface ReconciliationResult {
+interface ReconciliationResult {
   /** New items from server, sorted by queueIndex descending (newest first) */
   newItems: TaskItem[]
   /** PromptIds to reuse from client, in sorted order by queueIndex descending */

--- a/src/platform/remote/comfyui/history/reconciliation.ts
+++ b/src/platform/remote/comfyui/history/reconciliation.ts
@@ -3,7 +3,8 @@
  * @module platform/remote/comfyui/history/reconciliation
  *
  * Returns which items to reuse vs create new, allowing callers to preserve
- * existing class instances for better performance.
+ * existing class instances for better performance. Results are pre-sorted by
+ * queueIndex (newest first) to avoid sorting overhead in caller.
  *
  * V1: QueueIndex-based filtering for stable monotonic indices
  * V2: PromptId-based merging for synthetic priorities (V2 assigns synthetic
@@ -11,112 +12,126 @@
  *     than existing items)
  */
 
-import type { TaskItem } from '@/schemas/apiSchema'
+import type { TaskItem, TaskPrompt } from '@/schemas/apiSchema'
 
 export interface ReconciliationResult {
+  /** New items from server, sorted by queueIndex descending (newest first) */
   newItems: TaskItem[]
-  reusePromptIds: Set<string>
+  /** PromptIds to reuse from client, in sorted order by queueIndex descending */
+  reusePromptIds: string[]
 }
 
 /**
  * V1 reconciliation: QueueIndex-based filtering works because V1 has stable,
  * monotonically increasing queue indices.
+ *
+ * Sort order: Sorts serverHistory by queueIndex descending (newest first) to ensure
+ * consistent ordering. JavaScript .filter() maintains iteration order, so filtered
+ * results remain sorted. clientHistory is assumed already sorted from previous update.
  */
 export function reconcileHistory(
   serverHistory: TaskItem[],
-  clientHistory: { prompt: readonly [number, string, ...unknown[]] }[],
+  clientHistory: { prompt: TaskPrompt }[],
   lastKnownQueueIndex: number,
   maxItems: number
 ): ReconciliationResult {
-  const serverPromptIds = new Set(serverHistory.map((item) => item.prompt[1]))
+  // Sort server history newest first to ensure consistent ordering
+  const sortedServerHistory = serverHistory.sort(
+    (a, b) => b.prompt[0] - a.prompt[0]
+  )
 
-  const itemsAddedSinceLastSync = serverHistory.filter(
+  const serverPromptIds = new Set(
+    sortedServerHistory.map((item) => item.prompt[1])
+  )
+
+  const itemsAddedSinceLastSync = sortedServerHistory.filter(
     (item) => item.prompt[0] > lastKnownQueueIndex
   )
 
-  const clientPromptIdsStillOnServer = new Set<string>()
-  for (const item of clientHistory) {
-    const promptId = item.prompt[1]
-    if (serverPromptIds.has(promptId)) {
-      clientPromptIdsStillOnServer.add(promptId)
-    }
-  }
+  const clientItemsStillOnServer = clientHistory.filter((item) =>
+    serverPromptIds.has(item.prompt[1])
+  )
 
   const totalCount =
-    itemsAddedSinceLastSync.length + clientPromptIdsStillOnServer.size
+    itemsAddedSinceLastSync.length + clientItemsStillOnServer.length
 
   if (totalCount > maxItems) {
     const allowedReuseCount = maxItems - itemsAddedSinceLastSync.length
     if (allowedReuseCount <= 0) {
       return {
         newItems: itemsAddedSinceLastSync.slice(0, maxItems),
-        reusePromptIds: new Set()
+        reusePromptIds: []
       }
     }
-    const trimmedReuseIds = new Set(
-      Array.from(clientPromptIdsStillOnServer).slice(0, allowedReuseCount)
-    )
     return {
       newItems: itemsAddedSinceLastSync,
-      reusePromptIds: trimmedReuseIds
+      reusePromptIds: clientItemsStillOnServer
+        .slice(0, allowedReuseCount)
+        .map((item) => item.prompt[1])
     }
   }
 
   return {
     newItems: itemsAddedSinceLastSync,
-    reusePromptIds: clientPromptIdsStillOnServer
+    reusePromptIds: clientItemsStillOnServer.map((item) => item.prompt[1])
   }
 }
 
 /**
  * V2 reconciliation: PromptId-based merging because V2 assigns synthetic
  * priorities after sorting by timestamp.
+ *
+ * Sort order: Sorts serverHistory by queueIndex descending (newest first) to ensure
+ * consistent ordering. JavaScript .filter() maintains iteration order, so filtered
+ * results remain sorted. clientHistory is assumed already sorted from previous update.
  */
 export function reconcileHistoryCloud(
   serverHistory: TaskItem[],
-  clientHistory: { prompt: readonly [number, string, ...unknown[]] }[],
+  clientHistory: { prompt: TaskPrompt }[],
   maxItems: number
 ): ReconciliationResult {
-  const serverPromptIds = new Set(serverHistory.map((item) => item.prompt[1]))
+  // Sort server history newest first to ensure consistent ordering
+  const sortedServerHistory = serverHistory.sort(
+    (a, b) => b.prompt[0] - a.prompt[0]
+  )
+
+  const serverPromptIds = new Set(
+    sortedServerHistory.map((item) => item.prompt[1])
+  )
   const clientPromptIds = new Set(clientHistory.map((item) => item.prompt[1]))
 
   const newPromptIds = new Set(
     [...serverPromptIds].filter((id) => !clientPromptIds.has(id))
   )
 
-  const newItems = serverHistory.filter((item) =>
+  const newItems = sortedServerHistory.filter((item) =>
     newPromptIds.has(item.prompt[1])
   )
 
-  const clientPromptIdsStillOnServer = new Set<string>()
-  for (const item of clientHistory) {
-    const promptId = item.prompt[1]
-    if (serverPromptIds.has(promptId)) {
-      clientPromptIdsStillOnServer.add(promptId)
-    }
-  }
+  const clientItemsStillOnServer = clientHistory.filter((item) =>
+    serverPromptIds.has(item.prompt[1])
+  )
 
-  const totalCount = newItems.length + clientPromptIdsStillOnServer.size
+  const totalCount = newItems.length + clientItemsStillOnServer.length
 
   if (totalCount > maxItems) {
     const allowedReuseCount = maxItems - newItems.length
     if (allowedReuseCount <= 0) {
       return {
         newItems: newItems.slice(0, maxItems),
-        reusePromptIds: new Set()
+        reusePromptIds: []
       }
     }
-    const trimmedReuseIds = new Set(
-      Array.from(clientPromptIdsStillOnServer).slice(0, allowedReuseCount)
-    )
     return {
       newItems,
-      reusePromptIds: trimmedReuseIds
+      reusePromptIds: clientItemsStillOnServer
+        .slice(0, allowedReuseCount)
+        .map((item) => item.prompt[1])
     }
   }
 
   return {
     newItems,
-    reusePromptIds: clientPromptIdsStillOnServer
+    reusePromptIds: clientItemsStillOnServer.map((item) => item.prompt[1])
   }
 }

--- a/src/platform/remote/comfyui/history/reconciliation.ts
+++ b/src/platform/remote/comfyui/history/reconciliation.ts
@@ -11,14 +11,13 @@
  *     priorities after timestamp sorting, so new items may have lower priority
  *     than existing items)
  */
-
-import type { TaskItem, TaskPrompt } from '@/schemas/apiSchema'
+import type { PromptId, TaskItem, TaskPrompt } from '@/schemas/apiSchema'
 
 interface ReconciliationResult {
   /** New items from server, sorted by queueIndex descending (newest first) */
   newItems: TaskItem[]
   /** PromptIds to reuse from client, in sorted order by queueIndex descending */
-  reusePromptIds: string[]
+  reusePromptIds: PromptId[]
 }
 
 /**
@@ -35,7 +34,6 @@ export function reconcileHistory(
   lastKnownQueueIndex: number,
   maxItems: number
 ): ReconciliationResult {
-  // Sort server history newest first to ensure consistent ordering
   const sortedServerHistory = serverHistory.sort(
     (a, b) => b.prompt[0] - a.prompt[0]
   )
@@ -90,7 +88,6 @@ export function reconcileHistoryCloud(
   clientHistory: { prompt: TaskPrompt }[],
   maxItems: number
 ): ReconciliationResult {
-  // Sort server history newest first to ensure consistent ordering
   const sortedServerHistory = serverHistory.sort(
     (a, b) => b.prompt[0] - a.prompt[0]
   )

--- a/src/platform/remote/comfyui/history/reconciliation.ts
+++ b/src/platform/remote/comfyui/history/reconciliation.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview History reconciliation for V1 and V2 APIs
+ * @module platform/remote/comfyui/history/reconciliation
+ *
+ * V1: QueueIndex-based filtering for stable monotonic indices
+ * V2: PromptId-based merging for synthetic priorities
+ */
+
+import type { TaskItem } from '@/schemas/apiSchema'
+
+/**
+ * V1 reconciliation: QueueIndex-based filtering.
+ *
+ * Why queueIndex filtering works for V1:
+ * - V1 has stable, monotonically increasing queue indices
+ * - queueIndex > lastKnownQueueIndex reliably detects new items
+ * - Efficient incremental updates without full replacement
+ */
+export function reconcileHistory(
+  serverHistory: TaskItem[],
+  clientHistory: TaskItem[],
+  lastKnownQueueIndex: number,
+  maxItems: number
+): TaskItem[] {
+  const serverPromptIds = new Set(serverHistory.map((item) => item.prompt[1]))
+
+  const itemsAddedSinceLastSync = serverHistory.filter(
+    (item) => item.prompt[0] > lastKnownQueueIndex
+  )
+
+  const itemsStillOnServer = clientHistory.filter((item) =>
+    serverPromptIds.has(item.prompt[1])
+  )
+
+  return [...itemsAddedSinceLastSync, ...itemsStillOnServer].slice(0, maxItems)
+}
+
+/**
+ * V2 reconciliation: PromptId-based merging to handle synthetic priorities.
+ *
+ * Why not use queueIndex filtering:
+ * - V2 creates synthetic priorities after sorting by timestamp
+ * - New items may have lower synthetic priority than existing items
+ * - Must use promptId to identify truly new items
+ */
+export function reconcileHistoryCloud(
+  serverHistory: TaskItem[],
+  clientHistory: TaskItem[],
+  maxItems: number
+): TaskItem[] {
+  const serverPromptIds = new Set(serverHistory.map((item) => item.prompt[1]))
+  const clientPromptIds = new Set(clientHistory.map((item) => item.prompt[1]))
+
+  const newPromptIds = new Set(
+    [...serverPromptIds].filter((id) => !clientPromptIds.has(id))
+  )
+
+  const newItems = serverHistory.filter((item) =>
+    newPromptIds.has(item.prompt[1])
+  )
+
+  const existingItems = clientHistory.filter((item) =>
+    serverPromptIds.has(item.prompt[1])
+  )
+
+  return [...newItems, ...existingItems].slice(0, maxItems)
+}

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -13,6 +13,7 @@ import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 const zNodeType = z.string()
 export const zQueueIndex = z.number()
 export const zPromptId = z.string()
+export type PromptId = z.infer<typeof zPromptId>
 export const resultItemType = z.enum(['input', 'output', 'temp'])
 export type ResultItemType = z.infer<typeof resultItemType>
 

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -13,7 +13,6 @@ import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
 const zNodeType = z.string()
 export const zQueueIndex = z.number()
 export const zPromptId = z.string()
-export type PromptId = z.infer<typeof zPromptId>
 export const resultItemType = z.enum(['input', 'output', 'temp'])
 export type ResultItemType = z.infer<typeof resultItemType>
 

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -487,11 +487,12 @@ export const useQueueStore = defineStore('queue', () => {
           historyTasks.value,
           maxHistoryItems.value
         )
+        const reusePromptIdSet = new Set(reusePromptIds)
         const reusedImpls = historyTasks.value.filter((item) =>
-          reusePromptIds.has(item.promptId)
+          reusePromptIdSet.has(item.promptId)
         )
         const newImpls = toTaskItemImpls(newItems)
-        historyTasks.value = [...newImpls, ...reusedImpls].sort(sortNewestFirst)
+        historyTasks.value = [...newImpls, ...reusedImpls]
       } else {
         const { newItems, reusePromptIds } = reconcileHistory(
           history.History,
@@ -499,11 +500,12 @@ export const useQueueStore = defineStore('queue', () => {
           lastHistoryQueueIndex.value,
           maxHistoryItems.value
         )
+        const reusePromptIdSet = new Set(reusePromptIds)
         const reusedImpls = historyTasks.value.filter((item) =>
-          reusePromptIds.has(item.promptId)
+          reusePromptIdSet.has(item.promptId)
         )
         const newImpls = toTaskItemImpls(newItems)
-        historyTasks.value = [...newImpls, ...reusedImpls].sort(sortNewestFirst)
+        historyTasks.value = [...newImpls, ...reusedImpls]
       }
     } finally {
       isLoading.value = false

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -1,6 +1,6 @@
 import _ from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
-import { computed, ref, toRaw } from 'vue'
+import { computed, ref, shallowRef, toRaw } from 'vue'
 
 import { isCloud } from '@/platform/distribution/types'
 import {
@@ -445,9 +445,11 @@ const toTaskItemImpls = (tasks: TaskItem[]): TaskItemImpl[] =>
   )
 
 export const useQueueStore = defineStore('queue', () => {
-  const runningTasks = ref<TaskItemImpl[]>([])
-  const pendingTasks = ref<TaskItemImpl[]>([])
-  const historyTasks = ref<TaskItemImpl[]>([])
+  // Use shallowRef because TaskItemImpl instances are immutable and arrays are
+  // replaced entirely (not mutated), so deep reactivity would waste performance
+  const runningTasks = shallowRef<TaskItemImpl[]>([])
+  const pendingTasks = shallowRef<TaskItemImpl[]>([])
+  const historyTasks = shallowRef<TaskItemImpl[]>([])
   const maxHistoryItems = ref(64)
   const isLoading = ref(false)
 

--- a/tests-ui/fixtures/historySortingFixtures.ts
+++ b/tests-ui/fixtures/historySortingFixtures.ts
@@ -197,3 +197,62 @@ export const historyV2FiveItemsSorting: HistoryResponseV2 = {
     }
   ]
 }
+
+export const historyV2MultipleNoTimestamp: HistoryResponseV2 = {
+  history: [
+    {
+      prompt_id: 'item-no-timestamp-1',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-no-timestamp-1',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '1': {
+          images: [{ filename: 'test1.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: []
+      }
+    },
+    {
+      prompt_id: 'item-no-timestamp-2',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-no-timestamp-2',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '2': {
+          images: [{ filename: 'test2.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: []
+      }
+    },
+    {
+      prompt_id: 'item-no-timestamp-3',
+      prompt: {
+        priority: 0,
+        prompt_id: 'item-no-timestamp-3',
+        extra_data: { client_id: 'test-client' }
+      },
+      outputs: {
+        '3': {
+          images: [{ filename: 'test3.png', type: 'output', subfolder: '' }]
+        }
+      },
+      status: {
+        status_str: 'success',
+        completed: true,
+        messages: []
+      }
+    }
+  ]
+}

--- a/tests-ui/tests/platform/remote/comfyui/history/adapters/v2ToV1Adapter.test.ts
+++ b/tests-ui/tests/platform/remote/comfyui/history/adapters/v2ToV1Adapter.test.ts
@@ -13,8 +13,21 @@ import {
 } from '@tests-ui/fixtures/historyFixtures'
 import {
   historyV2FiveItemsSorting,
+  historyV2MultipleNoTimestamp,
   historyV2WithMissingTimestamp
 } from '@tests-ui/fixtures/historySortingFixtures'
+import type { HistoryTaskItem } from '@/platform/remote/comfyui/history/types/historyV1Types'
+
+function findResultByPromptId(
+  result: HistoryTaskItem[],
+  promptId: string
+): HistoryTaskItem {
+  const item = result.find((item) => item.prompt[1] === promptId)
+  if (!item) {
+    throw new Error(`Expected item with promptId ${promptId} not found`)
+  }
+  return item
+}
 
 describe('mapHistoryV2toHistory', () => {
   describe('fixture validation', () => {
@@ -128,22 +141,9 @@ describe('mapHistoryV2toHistory', () => {
 
       expect(result).toHaveLength(3)
 
-      const item1000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-1000'
-      )
-      const item2000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-2000'
-      )
-      const itemNoTimestamp = result.find(
-        (item) => item.prompt[1] === 'item-no-timestamp'
-      )
-
-      expect(item1000).toBeDefined()
-      expect(item2000).toBeDefined()
-      expect(itemNoTimestamp).toBeDefined()
-      if (!item1000 || !item2000 || !itemNoTimestamp) {
-        throw new Error('Expected items not found in result')
-      }
+      const item1000 = findResultByPromptId(result, 'item-timestamp-1000')
+      const item2000 = findResultByPromptId(result, 'item-timestamp-2000')
+      const itemNoTimestamp = findResultByPromptId(result, 'item-no-timestamp')
 
       expect(item2000.prompt[0]).toBe(2)
       expect(item1000.prompt[0]).toBe(1)
@@ -155,36 +155,31 @@ describe('mapHistoryV2toHistory', () => {
 
       expect(result).toHaveLength(5)
 
-      const item1000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-1000'
-      )
-      const item2000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-2000'
-      )
-      const item3000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-3000'
-      )
-      const item4000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-4000'
-      )
-      const item5000 = result.find(
-        (item) => item.prompt[1] === 'item-timestamp-5000'
-      )
-
-      expect(item1000).toBeDefined()
-      expect(item2000).toBeDefined()
-      expect(item3000).toBeDefined()
-      expect(item4000).toBeDefined()
-      expect(item5000).toBeDefined()
-      if (!item1000 || !item2000 || !item3000 || !item4000 || !item5000) {
-        throw new Error('Expected items not found in result')
-      }
+      const item1000 = findResultByPromptId(result, 'item-timestamp-1000')
+      const item2000 = findResultByPromptId(result, 'item-timestamp-2000')
+      const item3000 = findResultByPromptId(result, 'item-timestamp-3000')
+      const item4000 = findResultByPromptId(result, 'item-timestamp-4000')
+      const item5000 = findResultByPromptId(result, 'item-timestamp-5000')
 
       expect(item5000.prompt[0]).toBe(5)
       expect(item4000.prompt[0]).toBe(4)
       expect(item3000.prompt[0]).toBe(3)
       expect(item2000.prompt[0]).toBe(2)
       expect(item1000.prompt[0]).toBe(1)
+    })
+
+    it('assigns priority 0 to all items when multiple items lack timestamps', () => {
+      const result = mapHistoryV2toHistory(historyV2MultipleNoTimestamp)
+
+      expect(result).toHaveLength(3)
+
+      const item1 = findResultByPromptId(result, 'item-no-timestamp-1')
+      const item2 = findResultByPromptId(result, 'item-no-timestamp-2')
+      const item3 = findResultByPromptId(result, 'item-no-timestamp-3')
+
+      expect(item1.prompt[0]).toBe(0)
+      expect(item2.prompt[0]).toBe(0)
+      expect(item3.prompt[0]).toBe(0)
     })
   })
 })

--- a/tests-ui/tests/platform/remote/comfyui/history/reconciliation.test.ts
+++ b/tests-ui/tests/platform/remote/comfyui/history/reconciliation.test.ts
@@ -18,11 +18,11 @@ const createHistoryItem = (promptId: string, queueIndex = 0): TaskItem => ({
 
 const getAllPromptIds = (result: {
   newItems: TaskItem[]
-  reusePromptIds: Set<string>
+  reusePromptIds: string[]
 }): string[] => {
   return [
     ...result.newItems.map((item) => item.prompt[1]),
-    ...Array.from(result.reusePromptIds)
+    ...result.reusePromptIds
   ]
 }
 
@@ -71,7 +71,7 @@ describe('reconcileHistory (V1)', () => {
       const result = reconcileHistory(serverHistory, [], -1, 10)
 
       expect(result.newItems).toHaveLength(2)
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds).toHaveLength(0)
       expect(result.newItems[0].prompt[1]).toBe('item-1')
       expect(result.newItems[1].prompt[1]).toBe('item-2')
     })
@@ -144,7 +144,7 @@ describe('reconcileHistory (V1)', () => {
       expect(result.newItems).toHaveLength(2)
       expect(result.newItems[0].prompt[1]).toBe('new-1')
       expect(result.newItems[1].prompt[1]).toBe('new-2')
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
   })
 
@@ -167,14 +167,14 @@ describe('reconcileHistory (V1)', () => {
       const result = reconcileHistory([], clientHistory, 5, 10)
 
       expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
 
     it('should handle both empty', () => {
       const result = reconcileHistory([], [], -1, 10)
 
       expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
   })
 })
@@ -193,7 +193,7 @@ describe('reconcileHistoryCloud', () => {
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toHaveLength(2)
       expect(result.newItems[0].prompt[1]).toBe('new-item')
-      expect(result.reusePromptIds.has('existing-item')).toBe(true)
+      expect(result.reusePromptIds.includes('existing-item')).toBe(true)
     })
 
     it('should add multiple new items to front in server order', () => {
@@ -209,7 +209,7 @@ describe('reconcileHistoryCloud', () => {
       expect(result.newItems).toHaveLength(2)
       expect(result.newItems[0].prompt[1]).toBe('new-1')
       expect(result.newItems[1].prompt[1]).toBe('new-2')
-      expect(result.reusePromptIds.has('existing')).toBe(true)
+      expect(result.reusePromptIds.includes('existing')).toBe(true)
     })
   })
 
@@ -227,8 +227,8 @@ describe('reconcileHistoryCloud', () => {
       const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
 
       expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.has('item-1')).toBe(true)
-      expect(result.reusePromptIds.has('item-2')).toBe(true)
+      expect(result.reusePromptIds.includes('item-1')).toBe(true)
+      expect(result.reusePromptIds.includes('item-2')).toBe(true)
     })
 
     it('should drop client items not on server anymore', () => {
@@ -241,8 +241,8 @@ describe('reconcileHistoryCloud', () => {
       const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
 
       expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.has('item-1')).toBe(true)
-      expect(result.reusePromptIds.has('old-item')).toBe(false)
+      expect(result.reusePromptIds.includes('item-1')).toBe(true)
+      expect(result.reusePromptIds.includes('old-item')).toBe(false)
     })
   })
 
@@ -290,7 +290,7 @@ describe('reconcileHistoryCloud', () => {
       expect(result.newItems).toHaveLength(2)
       expect(result.newItems[0].prompt[1]).toBe('new-1')
       expect(result.newItems[1].prompt[1]).toBe('new-2')
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
   })
 
@@ -306,7 +306,7 @@ describe('reconcileHistoryCloud', () => {
       expect(result.newItems).toHaveLength(2)
       expect(result.newItems[0].prompt[1]).toBe('item-1')
       expect(result.newItems[1].prompt[1]).toBe('item-2')
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
 
     it('should handle empty server history', () => {
@@ -318,14 +318,14 @@ describe('reconcileHistoryCloud', () => {
       const result = reconcileHistoryCloud([], clientHistory, 10)
 
       expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
 
     it('should handle both empty', () => {
       const result = reconcileHistoryCloud([], [], 10)
 
       expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.size).toBe(0)
+      expect(result.reusePromptIds.length).toBe(0)
     })
   })
 })

--- a/tests-ui/tests/platform/remote/comfyui/history/reconciliation.test.ts
+++ b/tests-ui/tests/platform/remote/comfyui/history/reconciliation.test.ts
@@ -1,34 +1,38 @@
 /**
  * @fileoverview Tests for history reconciliation (V1 and V2)
  */
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  reconcileHistory,
-  reconcileHistoryCloud
-} from '@/platform/remote/comfyui/history/reconciliation'
+import { reconcileHistory } from '@/platform/remote/comfyui/history/reconciliation'
 import type { TaskItem } from '@/schemas/apiSchema'
 
-const createHistoryItem = (promptId: string, queueIndex = 0): TaskItem => ({
-  taskType: 'History',
-  prompt: [queueIndex, promptId, {}, {}, []],
-  status: { status_str: 'success', completed: true, messages: [] },
-  outputs: {}
-})
+// Mock distribution types
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false,
+  isDesktop: true
+}))
 
-const getAllPromptIds = (result: {
-  newItems: TaskItem[]
-  reusePromptIds: string[]
-}): string[] => {
-  return [
-    ...result.newItems.map((item) => item.prompt[1]),
-    ...result.reusePromptIds
-  ]
+function createHistoryItem(promptId: string, queueIndex = 0): TaskItem {
+  return {
+    taskType: 'History',
+    prompt: [queueIndex, promptId, {}, {}, []],
+    status: { status_str: 'success', completed: true, messages: [] },
+    outputs: {}
+  }
+}
+
+function getAllPromptIds(result: { items: TaskItem[] }): string[] {
+  return result.items.map((item) => item.prompt[1])
 }
 
 describe('reconcileHistory (V1)', () => {
-  describe('queueIndex-based filtering', () => {
-    it('should add items with queueIndex > lastKnownQueueIndex', () => {
+  beforeEach(async () => {
+    const distTypes = await import('@/platform/distribution/types')
+    vi.mocked(distTypes).isCloud = false
+  })
+
+  describe('when filtering by queueIndex', () => {
+    it('should retain items with queueIndex greater than lastKnownQueueIndex', () => {
       const serverHistory = [
         createHistoryItem('new-1', 11),
         createHistoryItem('new-2', 10),
@@ -36,7 +40,7 @@ describe('reconcileHistory (V1)', () => {
       ]
       const clientHistory = [createHistoryItem('old', 5)]
 
-      const result = reconcileHistory(serverHistory, clientHistory, 9, 10)
+      const result = reconcileHistory(serverHistory, clientHistory, 10, 9)
 
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toHaveLength(3)
@@ -45,7 +49,7 @@ describe('reconcileHistory (V1)', () => {
       expect(promptIds).toContain('old')
     })
 
-    it('should NOT add items with queueIndex <= lastKnownQueueIndex', () => {
+    it('should evict items with queueIndex less than or equal to lastKnownQueueIndex', () => {
       const serverHistory = [
         createHistoryItem('new', 11),
         createHistoryItem('existing', 10),
@@ -62,23 +66,22 @@ describe('reconcileHistory (V1)', () => {
       expect(promptIds).not.toContain('old-should-not-appear')
     })
 
-    it('should handle lastKnownQueueIndex of -1 (initial state)', () => {
+    it('should retain all server items when lastKnownQueueIndex is undefined', () => {
       const serverHistory = [
         createHistoryItem('item-1', 5),
         createHistoryItem('item-2', 4)
       ]
 
-      const result = reconcileHistory(serverHistory, [], -1, 10)
+      const result = reconcileHistory(serverHistory, [], 10, undefined)
 
-      expect(result.newItems).toHaveLength(2)
-      expect(result.reusePromptIds).toHaveLength(0)
-      expect(result.newItems[0].prompt[1]).toBe('item-1')
-      expect(result.newItems[1].prompt[1]).toBe('item-2')
+      expect(result.items).toHaveLength(2)
+      expect(result.items[0].prompt[1]).toBe('item-1')
+      expect(result.items[1].prompt[1]).toBe('item-2')
     })
   })
 
-  describe('client state preservation', () => {
-    it('should keep client items still on server', () => {
+  describe('when reconciling with existing client items', () => {
+    it('should retain client items that still exist on server', () => {
       const serverHistory = [
         createHistoryItem('new', 11),
         createHistoryItem('existing-1', 9),
@@ -98,7 +101,7 @@ describe('reconcileHistory (V1)', () => {
       expect(promptIds).toContain('existing-2')
     })
 
-    it('should drop client items not on server anymore', () => {
+    it('should evict client items that no longer exist on server', () => {
       const serverHistory = [
         createHistoryItem('new', 11),
         createHistoryItem('keep', 9)
@@ -118,19 +121,19 @@ describe('reconcileHistory (V1)', () => {
     })
   })
 
-  describe('limiting results', () => {
-    it('should limit results to maxItems', () => {
+  describe('when limiting the result count', () => {
+    it('should respect the maxItems constraint', () => {
       const serverHistory = Array.from({ length: 10 }, (_, i) =>
         createHistoryItem(`item-${i}`, 20 + i)
       )
 
-      const result = reconcileHistory(serverHistory, [], 15, 5)
+      const result = reconcileHistory(serverHistory, [], 5, 15)
 
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toHaveLength(5)
     })
 
-    it('should prioritize new items then existing when limiting', () => {
+    it('should evict lowest priority items when exceeding capacity', () => {
       const serverHistory = [
         createHistoryItem('new-1', 13),
         createHistoryItem('new-2', 12),
@@ -139,64 +142,66 @@ describe('reconcileHistory (V1)', () => {
       ]
       const clientHistory = [createHistoryItem('existing', 9)]
 
-      const result = reconcileHistory(serverHistory, clientHistory, 10, 2)
+      const result = reconcileHistory(serverHistory, clientHistory, 2, 10)
 
-      expect(result.newItems).toHaveLength(2)
-      expect(result.newItems[0].prompt[1]).toBe('new-1')
-      expect(result.newItems[1].prompt[1]).toBe('new-2')
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(2)
+      expect(result.items[0].prompt[1]).toBe('new-1')
+      expect(result.items[1].prompt[1]).toBe('new-2')
     })
   })
 
-  describe('edge cases', () => {
-    it('should handle empty client history', () => {
+  describe('when handling empty collections', () => {
+    it('should return all server items when client history is empty', () => {
       const serverHistory = [
         createHistoryItem('item-1', 10),
         createHistoryItem('item-2', 9)
       ]
 
-      const result = reconcileHistory(serverHistory, [], 8, 10)
+      const result = reconcileHistory(serverHistory, [], 10, 8)
 
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toHaveLength(2)
     })
 
-    it('should handle empty server history', () => {
+    it('should return empty result when server history is empty', () => {
       const clientHistory = [createHistoryItem('item-1', 5)]
 
-      const result = reconcileHistory([], clientHistory, 5, 10)
+      const result = reconcileHistory([], clientHistory, 10, 5)
 
-      expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(0)
     })
 
-    it('should handle both empty', () => {
-      const result = reconcileHistory([], [], -1, 10)
+    it('should return empty result when both collections are empty', () => {
+      const result = reconcileHistory([], [], 10, undefined)
 
-      expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(0)
     })
   })
 })
 
-describe('reconcileHistoryCloud', () => {
-  describe('adding new items', () => {
-    it('should add new item to front when promptId not in client history', () => {
+describe('reconcileHistory (V2/Cloud)', () => {
+  beforeEach(async () => {
+    const distTypes = await import('@/platform/distribution/types')
+    vi.mocked(distTypes).isCloud = true
+  })
+
+  describe('when adding new items from server', () => {
+    it('should retain items with promptIds not present in client history', () => {
       const serverHistory = [
         createHistoryItem('new-item'),
         createHistoryItem('existing-item')
       ]
       const clientHistory = [createHistoryItem('existing-item')]
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+      const result = reconcileHistory(serverHistory, clientHistory, 10)
 
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toHaveLength(2)
-      expect(result.newItems[0].prompt[1]).toBe('new-item')
-      expect(result.reusePromptIds.includes('existing-item')).toBe(true)
+      expect(promptIds).toContain('new-item')
+      expect(promptIds).toContain('existing-item')
     })
 
-    it('should add multiple new items to front in server order', () => {
+    it('should respect priority ordering when retaining multiple new items', () => {
       const serverHistory = [
         createHistoryItem('new-1'),
         createHistoryItem('new-2'),
@@ -204,17 +209,18 @@ describe('reconcileHistoryCloud', () => {
       ]
       const clientHistory = [createHistoryItem('existing')]
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+      const result = reconcileHistory(serverHistory, clientHistory, 10)
 
-      expect(result.newItems).toHaveLength(2)
-      expect(result.newItems[0].prompt[1]).toBe('new-1')
-      expect(result.newItems[1].prompt[1]).toBe('new-2')
-      expect(result.reusePromptIds.includes('existing')).toBe(true)
+      const promptIds = getAllPromptIds(result)
+      expect(promptIds).toHaveLength(3)
+      expect(promptIds).toContain('new-1')
+      expect(promptIds).toContain('new-2')
+      expect(promptIds).toContain('existing')
     })
   })
 
-  describe('keeping existing items', () => {
-    it('should keep client items that are still on server', () => {
+  describe('when reconciling with existing client items', () => {
+    it('should retain client items that still exist on server', () => {
       const serverHistory = [
         createHistoryItem('item-1'),
         createHistoryItem('item-2')
@@ -224,37 +230,39 @@ describe('reconcileHistoryCloud', () => {
         createHistoryItem('item-2')
       ]
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+      const result = reconcileHistory(serverHistory, clientHistory, 10)
 
-      expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.includes('item-1')).toBe(true)
-      expect(result.reusePromptIds.includes('item-2')).toBe(true)
+      const promptIds = getAllPromptIds(result)
+      expect(promptIds).toHaveLength(2)
+      expect(promptIds).toContain('item-1')
+      expect(promptIds).toContain('item-2')
     })
 
-    it('should drop client items not on server anymore', () => {
+    it('should evict client items that no longer exist on server', () => {
       const serverHistory = [createHistoryItem('item-1')]
       const clientHistory = [
         createHistoryItem('item-1'),
         createHistoryItem('old-item')
       ]
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+      const result = reconcileHistory(serverHistory, clientHistory, 10)
 
-      expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.includes('item-1')).toBe(true)
-      expect(result.reusePromptIds.includes('old-item')).toBe(false)
+      const promptIds = getAllPromptIds(result)
+      expect(promptIds).toHaveLength(1)
+      expect(promptIds).toContain('item-1')
+      expect(promptIds).not.toContain('old-item')
     })
   })
 
-  describe('synthetic priority handling', () => {
-    it('should not rely on queueIndex for detecting new items', () => {
+  describe('when detecting new items by promptId', () => {
+    it('should retain new items regardless of queueIndex values', () => {
       const serverHistory = [
         createHistoryItem('existing', 100),
         createHistoryItem('new-item', 50)
       ]
       const clientHistory = [createHistoryItem('existing', 100)]
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+      const result = reconcileHistory(serverHistory, clientHistory, 10)
 
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toContain('new-item')
@@ -262,8 +270,8 @@ describe('reconcileHistoryCloud', () => {
     })
   })
 
-  describe('limiting results', () => {
-    it('should limit results to maxItems', () => {
+  describe('when limiting the result count', () => {
+    it('should respect the maxItems constraint', () => {
       const serverHistory = Array.from({ length: 10 }, (_, i) =>
         createHistoryItem(`server-${i}`)
       )
@@ -271,13 +279,13 @@ describe('reconcileHistoryCloud', () => {
         createHistoryItem(`client-${i}`)
       )
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 5)
+      const result = reconcileHistory(serverHistory, clientHistory, 5)
 
       const promptIds = getAllPromptIds(result)
       expect(promptIds).toHaveLength(5)
     })
 
-    it('should prioritize new items when limiting', () => {
+    it('should evict lowest priority items when exceeding capacity', () => {
       const serverHistory = [
         createHistoryItem('new-1'),
         createHistoryItem('new-2'),
@@ -285,47 +293,43 @@ describe('reconcileHistoryCloud', () => {
       ]
       const clientHistory = [createHistoryItem('existing')]
 
-      const result = reconcileHistoryCloud(serverHistory, clientHistory, 2)
+      const result = reconcileHistory(serverHistory, clientHistory, 2)
 
-      expect(result.newItems).toHaveLength(2)
-      expect(result.newItems[0].prompt[1]).toBe('new-1')
-      expect(result.newItems[1].prompt[1]).toBe('new-2')
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(2)
+      expect(result.items[0].prompt[1]).toBe('new-1')
+      expect(result.items[1].prompt[1]).toBe('new-2')
     })
   })
 
-  describe('edge cases', () => {
-    it('should handle empty client history', () => {
+  describe('when handling empty collections', () => {
+    it('should return all server items when client history is empty', () => {
       const serverHistory = [
         createHistoryItem('item-1'),
         createHistoryItem('item-2')
       ]
 
-      const result = reconcileHistoryCloud(serverHistory, [], 10)
+      const result = reconcileHistory(serverHistory, [], 10)
 
-      expect(result.newItems).toHaveLength(2)
-      expect(result.newItems[0].prompt[1]).toBe('item-1')
-      expect(result.newItems[1].prompt[1]).toBe('item-2')
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(2)
+      expect(result.items[0].prompt[1]).toBe('item-1')
+      expect(result.items[1].prompt[1]).toBe('item-2')
     })
 
-    it('should handle empty server history', () => {
+    it('should return empty result when server history is empty', () => {
       const clientHistory = [
         createHistoryItem('item-1'),
         createHistoryItem('item-2')
       ]
 
-      const result = reconcileHistoryCloud([], clientHistory, 10)
+      const result = reconcileHistory([], clientHistory, 10)
 
-      expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(0)
     })
 
-    it('should handle both empty', () => {
-      const result = reconcileHistoryCloud([], [], 10)
+    it('should return empty result when both collections are empty', () => {
+      const result = reconcileHistory([], [], 10)
 
-      expect(result.newItems).toHaveLength(0)
-      expect(result.reusePromptIds.length).toBe(0)
+      expect(result.items).toHaveLength(0)
     })
   })
 })

--- a/tests-ui/tests/platform/remote/comfyui/history/reconciliation.test.ts
+++ b/tests-ui/tests/platform/remote/comfyui/history/reconciliation.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @fileoverview Tests for history reconciliation (V1 and V2)
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  reconcileHistory,
+  reconcileHistoryCloud
+} from '@/platform/remote/comfyui/history/reconciliation'
+import type { TaskItem } from '@/schemas/apiSchema'
+
+const createHistoryItem = (promptId: string, queueIndex = 0): TaskItem => ({
+  taskType: 'History',
+  prompt: [queueIndex, promptId, {}, {}, []],
+  status: { status_str: 'success', completed: true, messages: [] },
+  outputs: {}
+})
+
+describe('reconcileHistory (V1)', () => {
+  describe('queueIndex-based filtering', () => {
+    it('should add items with queueIndex > lastKnownQueueIndex', () => {
+      const serverHistory = [
+        createHistoryItem('new-1', 11),
+        createHistoryItem('new-2', 10),
+        createHistoryItem('old', 5)
+      ]
+      const clientHistory = [createHistoryItem('old', 5)]
+
+      const result = reconcileHistory(serverHistory, clientHistory, 9, 10)
+
+      expect(result).toHaveLength(3)
+      const promptIds = result.map((item) => item.prompt[1])
+      expect(promptIds).toContain('new-1')
+      expect(promptIds).toContain('new-2')
+      expect(promptIds).toContain('old')
+    })
+
+    it('should NOT add items with queueIndex <= lastKnownQueueIndex', () => {
+      const serverHistory = [
+        createHistoryItem('new', 11),
+        createHistoryItem('existing', 10),
+        createHistoryItem('old-should-not-appear', 5)
+      ]
+      const clientHistory = [createHistoryItem('existing', 10)]
+
+      const result = reconcileHistory(serverHistory, clientHistory, 10, 10)
+
+      expect(result).toHaveLength(2)
+      const promptIds = result.map((item) => item.prompt[1])
+      expect(promptIds).toContain('new')
+      expect(promptIds).toContain('existing')
+      expect(promptIds).not.toContain('old-should-not-appear')
+    })
+
+    it('should handle lastKnownQueueIndex of -1 (initial state)', () => {
+      const serverHistory = [
+        createHistoryItem('item-1', 5),
+        createHistoryItem('item-2', 4)
+      ]
+
+      const result = reconcileHistory(serverHistory, [], -1, 10)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].prompt[1]).toBe('item-1')
+      expect(result[1].prompt[1]).toBe('item-2')
+    })
+  })
+
+  describe('client state preservation', () => {
+    it('should keep client items still on server', () => {
+      const serverHistory = [
+        createHistoryItem('new', 11),
+        createHistoryItem('existing-1', 9),
+        createHistoryItem('existing-2', 8)
+      ]
+      const clientHistory = [
+        createHistoryItem('existing-1', 9),
+        createHistoryItem('existing-2', 8)
+      ]
+
+      const result = reconcileHistory(serverHistory, clientHistory, 10, 10)
+
+      expect(result).toHaveLength(3)
+      const promptIds = result.map((item) => item.prompt[1])
+      expect(promptIds).toContain('new')
+      expect(promptIds).toContain('existing-1')
+      expect(promptIds).toContain('existing-2')
+    })
+
+    it('should drop client items not on server anymore', () => {
+      const serverHistory = [
+        createHistoryItem('new', 11),
+        createHistoryItem('keep', 9)
+      ]
+      const clientHistory = [
+        createHistoryItem('keep', 9),
+        createHistoryItem('removed-from-server', 8)
+      ]
+
+      const result = reconcileHistory(serverHistory, clientHistory, 10, 10)
+
+      expect(result).toHaveLength(2)
+      const promptIds = result.map((item) => item.prompt[1])
+      expect(promptIds).toContain('new')
+      expect(promptIds).toContain('keep')
+      expect(promptIds).not.toContain('removed-from-server')
+    })
+  })
+
+  describe('limiting results', () => {
+    it('should limit results to maxItems', () => {
+      const serverHistory = Array.from({ length: 10 }, (_, i) =>
+        createHistoryItem(`item-${i}`, 20 + i)
+      )
+
+      const result = reconcileHistory(serverHistory, [], 15, 5)
+
+      expect(result).toHaveLength(5)
+    })
+
+    it('should prioritize new items then existing when limiting', () => {
+      const serverHistory = [
+        createHistoryItem('new-1', 13),
+        createHistoryItem('new-2', 12),
+        createHistoryItem('new-3', 11),
+        createHistoryItem('existing', 9)
+      ]
+      const clientHistory = [createHistoryItem('existing', 9)]
+
+      const result = reconcileHistory(serverHistory, clientHistory, 10, 2)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].prompt[1]).toBe('new-1')
+      expect(result[1].prompt[1]).toBe('new-2')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty client history', () => {
+      const serverHistory = [
+        createHistoryItem('item-1', 10),
+        createHistoryItem('item-2', 9)
+      ]
+
+      const result = reconcileHistory(serverHistory, [], 8, 10)
+
+      expect(result).toHaveLength(2)
+    })
+
+    it('should handle empty server history', () => {
+      const clientHistory = [createHistoryItem('item-1', 5)]
+
+      const result = reconcileHistory([], clientHistory, 5, 10)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle both empty', () => {
+      const result = reconcileHistory([], [], -1, 10)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+})
+
+describe('reconcileHistoryCloud', () => {
+  describe('adding new items', () => {
+    it('should add new item to front when promptId not in client history', () => {
+      const serverHistory = [
+        createHistoryItem('new-item'),
+        createHistoryItem('existing-item')
+      ]
+      const clientHistory = [createHistoryItem('existing-item')]
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].prompt[1]).toBe('new-item')
+      expect(result[1].prompt[1]).toBe('existing-item')
+    })
+
+    it('should add multiple new items to front in server order', () => {
+      const serverHistory = [
+        createHistoryItem('new-1'),
+        createHistoryItem('new-2'),
+        createHistoryItem('existing')
+      ]
+      const clientHistory = [createHistoryItem('existing')]
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+
+      expect(result).toHaveLength(3)
+      expect(result[0].prompt[1]).toBe('new-1')
+      expect(result[1].prompt[1]).toBe('new-2')
+      expect(result[2].prompt[1]).toBe('existing')
+    })
+  })
+
+  describe('keeping existing items', () => {
+    it('should keep client items that are still on server', () => {
+      const serverHistory = [
+        createHistoryItem('item-1'),
+        createHistoryItem('item-2')
+      ]
+      const clientHistory = [
+        createHistoryItem('item-1'),
+        createHistoryItem('item-2')
+      ]
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.prompt[1])).toContain('item-1')
+      expect(result.map((item) => item.prompt[1])).toContain('item-2')
+    })
+
+    it('should drop client items not on server anymore', () => {
+      const serverHistory = [createHistoryItem('item-1')]
+      const clientHistory = [
+        createHistoryItem('item-1'),
+        createHistoryItem('old-item')
+      ]
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].prompt[1]).toBe('item-1')
+    })
+  })
+
+  describe('synthetic priority handling', () => {
+    it('should not rely on queueIndex for detecting new items', () => {
+      // Server has new item with LOWER synthetic priority than existing
+      const serverHistory = [
+        createHistoryItem('existing', 100), // High priority
+        createHistoryItem('new-item', 50) // Lower priority but still new
+      ]
+      const clientHistory = [createHistoryItem('existing', 100)]
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 10)
+
+      // New item should still be added despite lower queueIndex
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.prompt[1])).toContain('new-item')
+    })
+  })
+
+  describe('limiting results', () => {
+    it('should limit results to maxItems', () => {
+      const serverHistory = Array.from({ length: 10 }, (_, i) =>
+        createHistoryItem(`server-${i}`)
+      )
+      const clientHistory = Array.from({ length: 5 }, (_, i) =>
+        createHistoryItem(`client-${i}`)
+      )
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 5)
+
+      expect(result).toHaveLength(5)
+    })
+
+    it('should prioritize new items when limiting', () => {
+      const serverHistory = [
+        createHistoryItem('new-1'),
+        createHistoryItem('new-2'),
+        createHistoryItem('existing')
+      ]
+      const clientHistory = [createHistoryItem('existing')]
+
+      const result = reconcileHistoryCloud(serverHistory, clientHistory, 2)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].prompt[1]).toBe('new-1')
+      expect(result[1].prompt[1]).toBe('new-2')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty client history', () => {
+      const serverHistory = [
+        createHistoryItem('item-1'),
+        createHistoryItem('item-2')
+      ]
+
+      const result = reconcileHistoryCloud(serverHistory, [], 10)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].prompt[1]).toBe('item-1')
+      expect(result[1].prompt[1]).toBe('item-2')
+    })
+
+    it('should handle empty server history', () => {
+      const clientHistory = [
+        createHistoryItem('item-1'),
+        createHistoryItem('item-2')
+      ]
+
+      const result = reconcileHistoryCloud([], clientHistory, 10)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle both empty', () => {
+      const result = reconcileHistoryCloud([], [], 10)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Running + Finished + History tasks now all work and reconcile correctly in the queue.

## Changes

1. Reconcile complete workflows so they show up in history.
2. Do the above in a way that minimizes recreation of `TaskItemImpls`
3. Address some CR feedback on #6336 

## Review Focus

I tried to optimize `TaskItemImpls` so we aren't recreating ones for history items tat already exist. Please give me feedback on if I did this correctly, or if it was even necessary. 

## Screenshots 🎃 


https://github.com/user-attachments/assets/afc08f31-cc09-4082-8e9d-cee977bc1e22

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6340-feat-historyV2-reconcile-completed-workflows-29a6d73d36508145a56aeb99cfa0e6ba) by [Unito](https://www.unito.io)
