### PR TITLE
fix mask editor icon missing

### DIFF
--- a/src/components/graph/selectionToolbox/MaskEditorButton.vue
+++ b/src/components/graph/selectionToolbox/MaskEditorButton.vue
@@ -7,10 +7,10 @@
     }"
     severity="secondary"
     text
+    icon="pi pi-pencil"
+    icon-class="w-4 h-4"
     @click="openMaskEditor"
-  >
-    <i-comfy:mask class="!h-4 !w-4" />
-  </Button>
+  />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
tiny fix for missing mask editor icon
before
<img width="581" height="843" alt="image" src="https://github.com/user-attachments/assets/062b66f7-ae55-4ca6-9dbe-78e0ca0c0cc6" />
after
<img width="589" height="859" alt="image" src="https://github.com/user-attachments/assets/4a607c5f-3aaf-43c4-9e0b-f7832ccc850d" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6346-fix-mask-editor-icon-missing-29a6d73d365081fcb6ceea5d9f5c03a1) by [Unito](https://www.unito.io)
