### PR TITLE
re-enable "reconnecting WS" toast on cloud

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -944,7 +944,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Toast.DisableReconnectingToast',
     name: 'Disable toasts when reconnecting or reconnected',
     type: 'hidden',
-    defaultValue: isCloud ? true : false,
+    defaultValue: false,
     versionAdded: '1.15.12'
   },
   {


### PR DESCRIPTION
This error should not actually happen frequently at all, so we can re-enable without fear of spamming an error that most users would have no context to understand -- primary benefit is to help user report better errors should they occur.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6348-re-enable-reconnecting-WS-toast-on-cloud-29a6d73d36508106b893cc0c0aee09fd) by [Unito](https://www.unito.io)
