### PR TITLE
[bugfix] Fix weekly docs workflow PR creation

### DIFF
--- a/.github/workflows/weekly-docs-check.yaml
+++ b/.github/workflows/weekly-docs-check.yaml
@@ -128,18 +128,30 @@ jobs:
           EOF
           fi
 
-      - name: Create or Update Pull Request
+      - name: Configure Git
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'docs: weekly documentation accuracy update'
-          branch: docs/weekly-update
-          delete-branch: true
-          title: 'docs: Weekly Documentation Update'
-          body-path: /tmp/pr-body-${{ github.run_id }}.md
-          labels: |
-            documentation
-            automated
-          draft: true
-          assignees: ${{ github.repository_owner }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git checkout -b docs/weekly-update-${{ github.run_id }}
+          git add .
+          git commit -m "docs: weekly documentation accuracy update"
+          git push origin docs/weekly-update-${{ github.run_id }}
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          PR_BODY=$(cat /tmp/pr-body-${{ github.run_id }}.md)
+          gh pr create \
+            --title "docs: Weekly Documentation Update" \
+            --body "$PR_BODY" \
+            --label "documentation,automated" \
+            --draft \
+            --base main \
+            --head docs/weekly-update-${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the weekly documentation check workflow that was failing with permission errors when trying to create pull requests.

## Problem

The workflow was configured with correct permissions:
```yaml
permissions:
  contents: write
  pull-requests: write
  id-token: write
```

But failed with: **"GitHub Actions is not permitted to create or approve pull requests"**

This is a repository-level setting in GitHub that blocks workflows from creating PRs, regardless of workflow permissions.

## Solution

Check this checkbox: https://github.com/Comfy-Org/ComfyUI_frontend/settings/actions

<img width="1034" height="225" alt="image" src="https://github.com/user-attachments/assets/63361ffb-b301-4be2-941e-627431a9b767" />

ref:

Workflow permissions https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#workflow-permissions
For this action to work you must explicitly allow GitHub Actions to create pull requests. This setting can be found in a repository's settings under Actions > General > Workflow permissions.


(please ignore all code changes in this PR, I believe that checkbox works)

## Testing

Can be tested by triggering the workflow manually via workflow_dispatch.

🤖 Fixes workflow run https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/18894912354

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6361-bugfix-Fix-weekly-docs-workflow-PR-creation-29b6d73d3650814fb832c7846367e1e2) by [Unito](https://www.unito.io)
