### PR TITLE
Feat/vue nodes try it now banner

### DIFF
--- a/browser_tests/fixtures/utils/litegraphUtils.ts
+++ b/browser_tests/fixtures/utils/litegraphUtils.ts
@@ -503,7 +503,7 @@ export class NodeReference {
       for (const position of clickPositions) {
         // Clear any selection first
         await this.comfyPage.canvas.click({
-          position: { x: 50, y: 50 },
+          position: { x: 250, y: 250 },
           force: true
         })
         await this.comfyPage.nextFrame()

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -4,6 +4,7 @@
   synced with the stateStorage (localStorage). -->
   <LiteGraphCanvasSplitterOverlay v-if="comfyAppReady">
     <template v-if="showUI && workflowTabsPosition === 'Topbar'" #workflow-tabs>
+      <TryVueNodeBanner />
       <div
         class="workflow-tabs-container pointer-events-auto relative h-9.5 w-full"
       >
@@ -151,6 +152,8 @@ import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { isNativeWindow } from '@/utils/envUtil'
+
+import TryVueNodeBanner from '../topbar/TryVueNodeBanner.vue'
 
 const emit = defineEmits<{
   ready: []

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -3,9 +3,10 @@
   <!-- If load immediately, the top-level splitter stateKey won't be correctly
   synced with the stateStorage (localStorage). -->
   <LiteGraphCanvasSplitterOverlay v-if="comfyAppReady">
-    <template v-if="showUI && workflowTabsPosition === 'Topbar'" #workflow-tabs>
+    <template v-if="showUI" #workflow-tabs>
       <TryVueNodeBanner />
       <div
+        v-if="workflowTabsPosition === 'Topbar'"
         class="workflow-tabs-container pointer-events-auto relative h-9.5 w-full"
       >
         <!-- Native drag area for Electron -->

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -66,6 +66,7 @@ function updateToastPosition() {
     .p-toast.p-component.p-toast-top-right {
       top: ${rect.top + 100}px !important;
       right: ${window.innerWidth - (rect.left + rect.width) + 20}px !important;
+       z-index: 10000 !important;
     }
   `
 }

--- a/src/components/topbar/TryVueNodeBanner.vue
+++ b/src/components/topbar/TryVueNodeBanner.vue
@@ -1,0 +1,73 @@
+<template>
+  <div
+    v-if="showVueNodesBannerRef"
+    class="pointer-events-auto w-full h-10 bg-gradient-to-r from-blue-600 to-blue-700 flex items-center justify-between px-4"
+  >
+    <div class="w-5 h-5"></div>
+    <div class="flex items-center">
+      <i class="icon-[lucide--sparkles]"></i>
+      <h5 class="pl-2">{{ $t('vueNodesBanner.message') }}</h5>
+      <Button
+        class="cursor-pointer bg-transparent rounded h-7 px-3 border border-white text-white ml-4 text-xs"
+        @click="handleTryItOut"
+      >
+        {{ $t('vueNodesBanner.tryItOut') }}
+      </Button>
+    </div>
+    <Button
+      class="cursor-pointer bg-transparent border-0 outline-0 grid place-items-center"
+      unstyled
+      @click="handleDismiss"
+    >
+      <i class="w-5 h-5 icon-[lucide--x]"></i>
+    </Button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { onMounted, ref } from 'vue'
+
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+const STORAGE_KEY = 'vueNodesBannerDismissed'
+
+const settingStore = useSettingStore()
+const showVueNodesBannerRef = ref(false)
+
+const checkLocalStorage = (): boolean => {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY)
+    // Return true if the banner was NOT dismissed (value is null or 'false')
+    return value !== 'true'
+  } catch (error) {
+    // If localStorage is not available (e.g., private browsing), show the banner
+    console.warn('localStorage not available:', error)
+    return true
+  }
+}
+
+const handleDismiss = (): void => {
+  showVueNodesBannerRef.value = false
+  try {
+    localStorage.setItem(STORAGE_KEY, 'true')
+  } catch (error) {
+    // Silently fail if localStorage is not available
+    console.warn('Failed to save banner dismissal:', error)
+  }
+}
+
+const handleTryItOut = async (): Promise<void> => {
+  try {
+    await settingStore.set('Comfy.VueNodes.Enabled', true)
+  } catch (error) {
+    console.error('Failed to enable Vue nodes:', error)
+  } finally {
+    handleDismiss()
+  }
+}
+
+onMounted(() => {
+  showVueNodesBannerRef.value = checkLocalStorage()
+})
+</script>

--- a/src/components/topbar/TryVueNodeBanner.vue
+++ b/src/components/topbar/TryVueNodeBanner.vue
@@ -1,12 +1,11 @@
 <template>
   <div
-    v-if="showVueNodesBannerRef"
-    class="pointer-events-auto w-full h-10 bg-gradient-to-r from-blue-600 to-blue-700 flex items-center justify-between px-4"
+    v-if="showVueNodesBanner"
+    class="pointer-events-auto relative w-full h-10 bg-gradient-to-r from-blue-600 to-blue-700 flex items-center justify-center px-4"
   >
-    <div class="w-5 h-5"></div>
     <div class="flex items-center">
       <i class="icon-[lucide--sparkles]"></i>
-      <h5 class="pl-2">{{ $t('vueNodesBanner.message') }}</h5>
+      <span class="pl-2">{{ $t('vueNodesBanner.message') }}</span>
       <Button
         class="cursor-pointer bg-transparent rounded h-7 px-3 border border-white text-white ml-4 text-xs"
         @click="handleTryItOut"
@@ -15,7 +14,7 @@
       </Button>
     </div>
     <Button
-      class="cursor-pointer bg-transparent border-0 outline-0 grid place-items-center"
+      class="cursor-pointer bg-transparent border-0 outline-0 grid place-items-center absolute right-4"
       unstyled
       @click="handleDismiss"
     >
@@ -25,34 +24,39 @@
 </template>
 
 <script setup lang="ts">
+import { useLocalStorage } from '@vueuse/core'
 import Button from 'primevue/button'
-import { onMounted, ref } from 'vue'
+import { computed } from 'vue'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
 
 const STORAGE_KEY = 'vueNodesBannerDismissed'
 
 const settingStore = useSettingStore()
-const showVueNodesBannerRef = ref(false)
+const bannerDismissed = useLocalStorage(STORAGE_KEY, false)
 
-const checkLocalStorage = (): boolean => {
+const vueNodesEnabled = computed(() => {
   try {
-    const value = localStorage.getItem(STORAGE_KEY)
-
-    return value !== 'true'
-  } catch (error) {
-    console.warn('localStorage not available:', error)
-    return true
+    return settingStore.get('Comfy.VueNodes.Enabled') ?? false
+  } catch {
+    return false
   }
-}
+})
+
+const showVueNodesBanner = computed(() => {
+  if (vueNodesEnabled.value) {
+    return false
+  }
+
+  if (bannerDismissed.value) {
+    return false
+  }
+
+  return true
+})
 
 const handleDismiss = (): void => {
-  showVueNodesBannerRef.value = false
-  try {
-    localStorage.setItem(STORAGE_KEY, 'true')
-  } catch (error) {
-    console.warn('Failed to save banner dismissal:', error)
-  }
+  bannerDismissed.value = true
 }
 
 const handleTryItOut = async (): Promise<void> => {
@@ -64,8 +68,4 @@ const handleTryItOut = async (): Promise<void> => {
     handleDismiss()
   }
 }
-
-onMounted(() => {
-  showVueNodesBannerRef.value = checkLocalStorage()
-})
 </script>

--- a/src/components/topbar/TryVueNodeBanner.vue
+++ b/src/components/topbar/TryVueNodeBanner.vue
@@ -38,10 +38,9 @@ const showVueNodesBannerRef = ref(false)
 const checkLocalStorage = (): boolean => {
   try {
     const value = localStorage.getItem(STORAGE_KEY)
-    // Return true if the banner was NOT dismissed (value is null or 'false')
+
     return value !== 'true'
   } catch (error) {
-    // If localStorage is not available (e.g., private browsing), show the banner
     console.warn('localStorage not available:', error)
     return true
   }
@@ -52,7 +51,6 @@ const handleDismiss = (): void => {
   try {
     localStorage.setItem(STORAGE_KEY, 'true')
   } catch (error) {
-    // Silently fail if localStorage is not available
     console.warn('Failed to save banner dismissal:', error)
   }
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1819,5 +1819,9 @@
         "Close": "Close"
       }
     }
+  },
+  "vueNodesBanner": {
+    "message": "Nodes just got a new look and feel",
+    "tryItOut": "Try it out"
   }
 }


### PR DESCRIPTION
## Summary

Banner to try vue nodes. Clicking try it now will flip shouldRenderVueNodes = true.

## Screenshots (if applicable)

<img width="1512" height="824" alt="image" src="https://github.com/user-attachments/assets/dfd4bdc3-6753-45ee-86f1-ed7dc077f868" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6362-Feat-vue-nodes-try-it-now-banner-29b6d73d365081c29f04f9126f06ee9d) by [Unito](https://www.unito.io)
