### PR TITLE
fix: Use PR_GH_TOKEN instead of GITHUB_TOKEN in weekly-docs-check workflow

### DIFF
--- a/.github/workflows/weekly-docs-check.yaml
+++ b/.github/workflows/weekly-docs-check.yaml
@@ -132,7 +132,7 @@ jobs:
         if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PR_GH_TOKEN }}
           commit-message: 'docs: weekly documentation accuracy update'
           branch: docs/weekly-update
           delete-branch: true


### PR DESCRIPTION
## Summary
- Updated weekly-docs-check.yaml to use `PR_GH_TOKEN` secret instead of `GITHUB_TOKEN`

## Problem
The weekly documentation check workflow uses `GITHUB_TOKEN` when creating pull requests, which can cause permission issues. The default `GITHUB_TOKEN` has limited permissions and may not trigger other workflows or perform certain PR operations.

## Solution
Changed the token in the "Create or Update Pull Request" step from `secrets.GITHUB_TOKEN` to `secrets.PR_GH_TOKEN` to use a more permissive token that can properly create and manage PRs.

## Changes Made
- `.github/workflows/weekly-docs-check.yaml:135` - Updated token parameter

## Test Plan
- Workflow should now successfully create PRs with proper permissions
- Other workflows should be triggered correctly when PRs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6364-fix-Use-PR_GH_TOKEN-instead-of-GITHUB_TOKEN-in-weekly-docs-check-workflow-29b6d73d3650812cbaddc1ea10aeb995) by [Unito](https://www.unito.io)
