### PR TITLE
Fix subscription dialog appearing during onboarding

### DIFF
--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -55,14 +55,17 @@ export const useFirebaseAuthActions = () => {
       life: 5000
     })
 
-    // Redirect to login page if we're on cloud domain
+    // CRITICAL: Use full page navigation for logout to prevent stale app state
+    // Issue: SPA routing during logout can leave extensions loaded with stale auth state
+    // This causes subscription dialogs to appear incorrectly during re-login onboarding
+    // Full page reload ensures complete app state reset and proper onboarding flow
     const hostname = window.location.hostname
     if (hostname.includes('cloud.comfy.org')) {
       if (route.query.inviteCode) {
         const inviteCode = route.query.inviteCode
-        await router.push({ name: 'cloud-login', query: { inviteCode } })
+        window.location.href = `/cloud/login?inviteCode=${encodeURIComponent(inviteCode)}`
       } else {
-        await router.push({ name: 'cloud-login' })
+        window.location.href = '/cloud/login'
       }
     }
   }, reportError)

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -1,4 +1,5 @@
 import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
@@ -91,6 +92,14 @@ export function useSubscription() {
   }
 
   const requireActiveSubscription = async (): Promise<void> => {
+    // DEFENSIVE: Never show subscription dialogs during onboarding flows
+    // All cloud onboarding routes start with '/cloud/' (login, signup, survey, waitlist, etc.)
+    // This prevents subscription enforcement from interfering with user onboarding
+    const route = useRoute()
+    if (route.path.startsWith('/cloud/')) {
+      return
+    }
+
     await fetchSubscriptionStatus()
 
     if (!isActiveSubscription.value) {


### PR DESCRIPTION
Fixes subscription dialog incorrectly appearing on cloud onboarding pages (email verification, survey, waitlist). Root cause: logout uses SPA routing leaving extensions with stale auth state. Solution: (1) use full page navigation for logout to reset app state, (2) add defensive route guard to skip subscription checks on /cloud/* paths. Prevents subscription modal from showing during account switching and onboarding flows.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6367-Fix-subscription-dialog-appearing-during-onboarding-29b6d73d3650818d88e0d59ade7de02e) by [Unito](https://www.unito.io)
