### PR TITLE
fix: Count dragging slot as a free slot for targeting

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -2569,7 +2569,12 @@ export class LGraphNode
   findInputByType(
     type: ISlotType
   ): { index: number; slot: INodeInputSlot } | undefined {
-    return findFreeSlotOfType(this.inputs, type, (input) => input.link == null)
+    return findFreeSlotOfType(
+      this.inputs,
+      type,
+      (input) =>
+        input.link == null || !!this.graph?.getLink(input.link)?._dragging
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary

Prioritizes the slot that previously held the link instead of the first valid slot for a given type.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6370-fix-Count-dragging-slot-as-a-free-slot-for-targeting-29b6d73d365081709034e272cef38320) by [Unito](https://www.unito.io)
