### PR TITLE
fix: remove unnecessary route guard from subscription enforcement

### DIFF
--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -1,6 +1,6 @@
 import { FirebaseError } from 'firebase/app'
 import { ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute } from 'vue-router'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
@@ -17,7 +17,6 @@ export const useFirebaseAuthActions = () => {
   const authStore = useFirebaseAuthStore()
   const toastStore = useToastStore()
   const route = useRoute()
-  const router = useRouter()
   const { wrapWithErrorHandlingAsync, toastErrorHandler } = useErrorHandling()
 
   const accessError = ref(false)
@@ -62,8 +61,10 @@ export const useFirebaseAuthActions = () => {
     const hostname = window.location.hostname
     if (hostname.includes('cloud.comfy.org')) {
       if (route.query.inviteCode) {
-        const inviteCode = route.query.inviteCode
-        window.location.href = `/cloud/login?inviteCode=${encodeURIComponent(inviteCode)}`
+        const inviteCode = Array.isArray(route.query.inviteCode) 
+          ? route.query.inviteCode[0] 
+          : route.query.inviteCode
+        window.location.href = `/cloud/login?inviteCode=${encodeURIComponent(inviteCode || '')}`
       } else {
         window.location.href = '/cloud/login'
       }

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -61,8 +61,8 @@ export const useFirebaseAuthActions = () => {
     const hostname = window.location.hostname
     if (hostname.includes('cloud.comfy.org')) {
       if (route.query.inviteCode) {
-        const inviteCode = Array.isArray(route.query.inviteCode) 
-          ? route.query.inviteCode[0] 
+        const inviteCode = Array.isArray(route.query.inviteCode)
+          ? route.query.inviteCode[0]
           : route.query.inviteCode
         window.location.href = `/cloud/login?inviteCode=${encodeURIComponent(inviteCode || '')}`
       } else {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -1,5 +1,4 @@
 import { computed, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
@@ -109,14 +108,6 @@ export function useSubscription() {
   }
 
   const requireActiveSubscription = async (): Promise<void> => {
-    // DEFENSIVE: Never show subscription dialogs during onboarding flows
-    // All cloud onboarding routes start with '/cloud/' (login, signup, survey, waitlist, etc.)
-    // This prevents subscription enforcement from interfering with user onboarding
-    const route = useRoute()
-    if (route.path.startsWith('/cloud/')) {
-      return
-    }
-
     await fetchSubscriptionStatus()
 
     if (!isActiveSubscription.value) {


### PR DESCRIPTION
Removes the route guard logic from requireActiveSubscription that was checking for /cloud/* paths. The logout fix already prevents stale extension state by using full page navigation, making this route checking unnecessary and overly complex.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6377-fix-remove-unnecessary-route-guard-from-subscription-enforcement-29b6d73d365081738620e9c1d4efe1b2) by [Unito](https://www.unito.io)
