### PR TITLE
Fix: Allow click and drag selection when editing text (e.g. Node name)

### DIFF
--- a/src/components/common/EditableText.vue
+++ b/src/components/common/EditableText.vue
@@ -21,6 +21,8 @@
       @keyup.enter="blurInputElement"
       @keyup.escape="cancelEditing"
       @click.stop
+      @pointerdown.stop.capture
+      @pointermove.stop.capture
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Previously, the node would be dragged when trying to select text.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6385-Fix-Allow-click-and-drag-selection-when-editing-text-e-g-Node-name-29b6d73d36508197b73fc8f965bb34ef) by [Unito](https://www.unito.io)
