### PR TITLE
Fix: Disable pointer events on images to allow them to be drag targets

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -34,7 +34,7 @@
         ref="currentImageEl"
         :src="currentImageUrl"
         :alt="imageAltText"
-        class="block size-full object-contain"
+        class="block size-full object-contain pointer-events-none"
         @load="handleImageLoad"
         @error="handleImageError"
       />


### PR DESCRIPTION
## Summary

Allows SaveImage and other nodes with ImagePreviews to be dragged by the image.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6388-Fix-Disable-pointer-events-on-images-to-allow-them-to-be-drag-targets-29c6d73d365081e796f0e8171a860062) by [Unito](https://www.unito.io)
