### PR TITLE
Fix selectionToolbox not being on node

### DIFF
--- a/src/composables/canvas/useSelectionToolboxPosition.ts
+++ b/src/composables/canvas/useSelectionToolboxPosition.ts
@@ -5,7 +5,11 @@ import type { Ref } from 'vue'
 import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
-import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  LGraphGroup,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { isLGraphGroup, isLGraphNode } from '@/utils/litegraphUtil'
@@ -95,8 +99,12 @@ export function useSelectionToolboxPosition(
       } else {
         // Fallback to LiteGraph bounds for regular nodes or non-string IDs
         if (item instanceof LGraphNode || item instanceof LGraphGroup) {
-          const bounds = item.getBounding()
-          allBounds.push([bounds[0], bounds[1], bounds[2], bounds[3]] as const)
+          allBounds.push([
+            item.pos[0],
+            item.pos[1] - LiteGraph.NODE_TITLE_HEIGHT,
+            item.size[0],
+            item.size[1] + LiteGraph.NODE_TITLE_HEIGHT
+          ])
         }
       }
     }


### PR DESCRIPTION
`getBounding()` doesn't work if a draw hasn't occurred.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6401-Fix-selectionToolbox-not-being-on-node-29c6d73d3650812cbfbff116a9b8159d) by [Unito](https://www.unito.io)
