### PR TITLE
[docs] Add /output.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ storybook-static
 .github/instructions/nx.instructions.md
 vite.config.*.timestamp*
 vitest.config.*.timestamp*
+
+# Weekly docs check output
+/output.txt


### PR DESCRIPTION
## Summary
- Adds `/output.txt` to `.gitignore` to prevent tracking the output file generated by the weekly-docs-check.yaml workflow

## Rationale
The weekly docs check workflow emits an `output.txt` file that is not intended to be committed to the repository. This change ensures the file is properly ignored by git.

## Test plan
- [x] Verify `output.txt` is no longer tracked by git
- [x] Confirm weekly-docs-check workflow still functions correctly

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6456-docs-Add-output-txt-to-gitignore-29c6d73d365081688d99f3855337d887) by [Unito](https://www.unito.io)
