### PR TITLE
feat: Comfy.VueNodes.AutoScaleLayout default true

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1072,7 +1072,7 @@ export const CORE_SETTINGS: SettingParams[] = [
       'Automatically scale node positions when switching to Vue rendering to prevent overlap',
     type: 'boolean',
     experimental: true,
-    defaultValue: false,
+    defaultValue: true,
     versionAdded: '1.30.3'
   },
   {


### PR DESCRIPTION
## Summary

Now that banner and toast are merged run the auto scale / node arrange function by default.

## Changes

- **What**:  Core settings Comfy.VueNodes.AutoScaleLayout defaultValue: true,

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6467-feat-Comfy-VueNodes-AutoScaleLayout-default-true-29c6d73d365081c2b317f7f3450cbaec) by [Unito](https://www.unito.io)
