### PR TITLE
Feat/vue nodes autoscale false

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,6 +112,7 @@ onlyBuiltDependencies:
   - '@playwright/browser-chromium'
   - '@playwright/browser-firefox'
   - '@playwright/browser-webkit'
+  - '@sentry/cli'
   - '@tailwindcss/oxide'
   - esbuild
   - nx

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,7 +112,6 @@ onlyBuiltDependencies:
   - '@playwright/browser-chromium'
   - '@playwright/browser-firefox'
   - '@playwright/browser-webkit'
-  - '@sentry/cli'
   - '@tailwindcss/oxide'
   - esbuild
   - nx

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1072,7 +1072,7 @@ export const CORE_SETTINGS: SettingParams[] = [
       'Automatically scale node positions when switching to Vue rendering to prevent overlap',
     type: 'boolean',
     experimental: true,
-    defaultValue: true,
+    defaultValue: false,
     versionAdded: '1.30.3'
   },
   {


### PR DESCRIPTION
## Summary

Switch back to false, for now. Because its a destructive action. Edge cases and user information can come next. This saves us time so we can cut a nightly release and move on.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6469-Feat-vue-nodes-autoscale-false-29c6d73d365081deabf0dc284a9b41ab) by [Unito](https://www.unito.io)
