### PR TITLE
Telemetry: API node usage details (execution_start + run_button_clicked)

### DIFF
--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -175,7 +175,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
       workflow_type: executionContext.is_template ? 'template' : 'custom',
       workflow_name: executionContext.workflow_name ?? 'untitled',
       total_node_count: executionContext.total_node_count,
-      subgraph_count: executionContext.subgraph_count
+      subgraph_count: executionContext.subgraph_count,
+      has_api_nodes: executionContext.has_api_nodes,
+      api_node_names: executionContext.api_node_names
     }
 
     this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
@@ -277,27 +279,49 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     const activeWorkflow = workflowStore.activeWorkflow
 
     // Calculate node metrics in a single traversal
-    const nodeMetrics = reduceAllNodes(
+    type NodeMetrics = {
+      custom_node_count: number
+      api_node_count: number
+      subgraph_count: number
+      total_node_count: number
+      has_api_nodes: boolean
+      api_node_names: string[]
+    }
+
+    const nodeCounts = reduceAllNodes<NodeMetrics>(
       app.graph,
-      (acc, node) => {
+      (metrics, node) => {
         const nodeDef = nodeDefStore.nodeDefsByName[node.type]
         const isCustomNode =
           nodeDef?.nodeSource?.type === NodeSourceType.CustomNodes
         const isApiNode = nodeDef?.api_node === true
         const isSubgraph = node.isSubgraphNode?.() === true
 
-        return {
-          custom_node_count: acc.custom_node_count + (isCustomNode ? 1 : 0),
-          api_node_count: acc.api_node_count + (isApiNode ? 1 : 0),
-          subgraph_count: acc.subgraph_count + (isSubgraph ? 1 : 0),
-          total_node_count: acc.total_node_count + 1
+        if (isApiNode) {
+          metrics.has_api_nodes = true
+          const canonicalName = nodeDef?.name
+          if (
+            canonicalName &&
+            !metrics.api_node_names.includes(canonicalName)
+          ) {
+            metrics.api_node_names.push(canonicalName)
+          }
         }
+
+        metrics.custom_node_count += isCustomNode ? 1 : 0
+        metrics.api_node_count += isApiNode ? 1 : 0
+        metrics.subgraph_count += isSubgraph ? 1 : 0
+        metrics.total_node_count += 1
+
+        return metrics
       },
       {
         custom_node_count: 0,
         api_node_count: 0,
         subgraph_count: 0,
-        total_node_count: 0
+        total_node_count: 0,
+        has_api_nodes: false,
+        api_node_names: []
       }
     )
 
@@ -324,21 +348,21 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
           template_models: englishMetadata?.models ?? template?.models,
           template_use_case: englishMetadata?.useCase ?? template?.useCase,
           template_license: englishMetadata?.license ?? template?.license,
-          ...nodeMetrics
+          ...nodeCounts
         }
       }
 
       return {
         is_template: false,
         workflow_name: activeWorkflow.filename,
-        ...nodeMetrics
+        ...nodeCounts
       }
     }
 
     return {
       is_template: false,
       workflow_name: undefined,
-      ...nodeMetrics
+      ...nodeCounts
     }
   }
 }

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -174,7 +174,8 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
       subscribe_to_run: options?.subscribe_to_run || false,
       workflow_type: executionContext.is_template ? 'template' : 'custom',
       workflow_name: executionContext.workflow_name ?? 'untitled',
-      total_node_count: executionContext.total_node_count
+      total_node_count: executionContext.total_node_count,
+      subgraph_count: executionContext.subgraph_count
     }
 
     this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -44,6 +44,8 @@ export interface RunButtonProperties {
   workflow_name: string
   total_node_count: number
   subgraph_count: number
+  has_api_nodes: boolean
+  api_node_names: string[]
 }
 
 /**
@@ -64,6 +66,8 @@ export interface ExecutionContext {
   api_node_count: number
   subgraph_count: number
   total_node_count: number
+  has_api_nodes: boolean
+  api_node_names: string[]
 }
 
 /**

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -43,6 +43,7 @@ export interface RunButtonProperties {
   workflow_type: 'template' | 'custom'
   workflow_name: string
   total_node_count: number
+  subgraph_count: number
 }
 
 /**


### PR DESCRIPTION
Summary
- Add API node usage to run_button_clicked and execution_start telemetry.
- Include has_api_nodes (boolean) and api_node_names (canonical nodeDef.name array).
- Compute metrics within a typed reducer for maintainability; stable ordering for names.

Implementation
- types: src/platform/telemetry/types.ts
  - Extend RunButtonProperties and ExecutionContext with has_api_nodes, api_node_names
- provider: src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
  - Build NodeMetrics in single traversal using reduceAllNodes
  - Use canonical names (nodeDef.name), dedupe, sort
  - Emit fields on app:run_button_click and execution_start

Notes
- Subgraph and total node counts unchanged.
- Lint and typecheck passed locally.

Requested review
- Confirm Mixpanel property schema alignment for new fields.
- Approve naming: has_api_nodes, api_node_names (alternatives: api_node_types).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6473-Telemetry-API-node-usage-details-execution_start-run_button_clicked-29d6d73d365081a5bd1cc55da7e106ab) by [Unito](https://www.unito.io)
