### PR TITLE
fix: force token refresh for session cookie creation

### DIFF
--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -15,7 +15,7 @@ export const useSessionCookie = () => {
     if (!isCloud) return
 
     const authStore = useFirebaseAuthStore()
-    const authHeader = await authStore.getAuthHeader()
+    const authHeader = await authStore.getAuthHeader(true)
 
     if (!authHeader) {
       throw new Error('No auth header available for session creation')


### PR DESCRIPTION
## Summary
- Force token refresh when creating session cookies to prevent authentication failures
- Fixes Sentry issue #6976234063 affecting 29 users

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6477-fix-force-token-refresh-for-session-cookie-creation-29d6d73d365081c394c1d8f672884fd8) by [Unito](https://www.unito.io)
