### PR TITLE
fix: prevent logged-in users from accessing login page unless switching accounts

### DIFF
--- a/src/onboardingCloudRoutes.ts
+++ b/src/onboardingCloudRoutes.ts
@@ -16,7 +16,23 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         path: 'login',
         name: 'cloud-login',
         component: () =>
-          import('@/platform/onboarding/cloud/CloudLoginView.vue')
+          import('@/platform/onboarding/cloud/CloudLoginView.vue'),
+        beforeEnter: async (to, _from, next) => {
+          // Only redirect if not explicitly switching accounts
+          if (!to.query.switchAccount) {
+            const { useCurrentUser } = await import(
+              '@/composables/auth/useCurrentUser'
+            )
+            const { isLoggedIn } = useCurrentUser()
+
+            if (isLoggedIn.value) {
+              // User is already logged in, redirect to user-check
+              // user-check will handle survey, waitlist, or main page routing
+              return next({ name: 'cloud-user-check' })
+            }
+          }
+          next()
+        }
       },
       {
         path: 'signup',

--- a/src/platform/onboarding/cloud/CloudClaimInviteView.vue
+++ b/src/platform/onboarding/cloud/CloudClaimInviteView.vue
@@ -98,7 +98,10 @@ const inviteCode = computed(() => route.query.inviteCode as string)
 const onSwitchAccounts = () => {
   void router.push({
     name: 'cloud-login',
-    query: { inviteCode: inviteCode.value }
+    query: {
+      switchAccount: 'true',
+      inviteCode: inviteCode.value
+    }
   })
 }
 const onClickSupport = () => {

--- a/src/platform/onboarding/cloud/CloudWaitlistView.vue
+++ b/src/platform/onboarding/cloud/CloudWaitlistView.vue
@@ -52,7 +52,8 @@ const router = useRouter()
 
 const onSwitchAccounts = () => {
   void router.push({
-    name: 'cloud-login'
+    name: 'cloud-login',
+    query: { switchAccount: 'true' }
   })
 }
 

--- a/src/platform/onboarding/cloud/UserCheckView.vue
+++ b/src/platform/onboarding/cloud/UserCheckView.vue
@@ -80,7 +80,7 @@ const {
     }
 
     // User is fully onboarded (active or whitelist check disabled)
-    await router.replace('/')
+    window.location.href = '/'
   }),
   null,
   { resetOnExecute: false }


### PR DESCRIPTION
## Summary
- Prevents logged-in users from viewing the login page unnecessarily  
- Adds explicit account switching flow with query parameter
- Fixes issue where logged-in users could see the login page when directly navigating to `/cloud/login`

## Changes
1. Added `beforeEnter` guard to `cloud-login` route to check authentication status
2. Redirect authenticated users to `cloud-user-check` (which handles survey, waitlist, and main page routing)
3. Added `switchAccount` query parameter to allow intentional access to login page for account switching
4. Updated CloudClaimInviteView and CloudWaitlistView to include the `switchAccount` parameter when users click "Switch accounts"
5. Reverted UserCheckView to use `window.location.href = '/'` instead of `router.replace('/')` to prevent infinite loading issue

## Context
The change in UserCheckView reverts to the original implementation (`window.location.href = '/'`) because using `router.replace('/')` caused an infinite loading issue. The direct window navigation avoids the router's internal state issues and ensures a clean redirect to the main application.

## Test plan
- [ ] Navigate to `/cloud/login` while logged in → Should redirect to appropriate page
- [ ] Click "Switch accounts" from waitlist or invite views → Should stay on login page
- [ ] Complete login flow → Should redirect properly based on user status
- [ ] Verify no infinite loading occurs when redirecting to main app

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6478-fix-prevent-logged-in-users-from-accessing-login-page-unless-switching-accounts-29d6d73d3650815a9d98c11951425241) by [Unito](https://www.unito.io)
