### PR TITLE
Fix unit tests in rh test

### DIFF
--- a/tests-ui/tests/platform/cloud/subscription/composables/useSubscriptionCredits.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/composables/useSubscriptionCredits.test.ts
@@ -4,6 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSubscriptionCredits } from '@/platform/cloud/subscription/composables/useSubscriptionCredits'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 
+// Unmock firebaseAuthStore so we get the real Pinia store
+vi.unmock('@/stores/firebaseAuthStore')
+
 // Mock Firebase Auth and related modules
 vi.mock('vuefire', () => ({
   useFirebaseAuth: vi.fn(() => ({


### PR DESCRIPTION
This pull request makes a minor adjustment to the test setup for `useSubscriptionCredits`. The change ensures that the actual Pinia store implementation is used for `firebaseAuthStore` rather than a mocked version, which can help improve the reliability and accuracy of the tests.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6479-Fix-unit-tests-in-rh-test-29d6d73d365081be8a54c260b2ce10fe) by [Unito](https://www.unito.io)
