### PR TITLE
Fix partial execution inside subgraphs

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -526,6 +526,15 @@ export function useCoreCommands(): ComfyCommand[] {
         // Get execution IDs for all selected output nodes and their descendants
         const executionIds =
           getExecutionIdsForSelectedNodes(selectedOutputNodes)
+        if (executionIds.length === 0) {
+          toastStore.add({
+            severity: 'error',
+            summary: t('toastMessages.failedToQueue'),
+            detail: t('toastMessages.failedExecutionPathResolution'),
+            life: 3000
+          })
+          return
+        }
         await app.queuePrompt(0, batchCount, executionIds)
       }
     },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1472,6 +1472,8 @@
   "toastMessages": {
     "nothingToQueue": "Nothing to queue",
     "pleaseSelectOutputNodes": "Please select output nodes",
+    "failedToQueue": "Failed to queue",
+    "failedExecutionPathResolution": "Could not resolve path to selected nodes",
     "no3dScene": "No 3D scene to apply texture",
     "failedToApplyTexture": "Failed to apply texture",
     "no3dSceneToExport": "No 3D scene to export",

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -541,8 +541,16 @@ export function collectFromNodes<T = LGraphNode, C = void>(
  * @returns Array of execution IDs for selected nodes and all nodes within selected subgraphs
  */
 export function getExecutionIdsForSelectedNodes(
-  selectedNodes: LGraphNode[]
+  selectedNodes: LGraphNode[],
+  startGraph = selectedNodes[0].graph
 ): NodeExecutionId[] {
+  if (!startGraph) return []
+  const rootGraph = startGraph.rootGraph
+  const parentPath = startGraph?.isRootGraph
+    ? ''
+    : findPartialExecutionPathToGraph(startGraph, rootGraph)
+  if (parentPath === undefined) return []
+
   return collectFromNodes<NodeExecutionId, string>(selectedNodes, {
     collector: (node, parentExecutionId) => {
       const nodeId = String(node.id)
@@ -552,7 +560,20 @@ export function getExecutionIdsForSelectedNodes(
       const nodeId = String(node.id)
       return parentExecutionId ? `${parentExecutionId}:${nodeId}` : nodeId
     },
-    initialContext: '',
+    initialContext: parentPath,
     expandSubgraphs: true
   })
+}
+
+function findPartialExecutionPathToGraph(
+  target: LGraph,
+  root: LGraph
+): string | undefined {
+  for (const node of root.nodes)
+    if (node.isSubgraphNode()) {
+      if (node.subgraph === target) return `${node.id}`
+      const subpath = findPartialExecutionPathToGraph(target, node.subgraph)
+      if (subpath !== undefined) return node.id + ':' + subpath
+    }
+  return undefined
 }

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -542,7 +542,7 @@ export function collectFromNodes<T = LGraphNode, C = void>(
  */
 export function getExecutionIdsForSelectedNodes(
   selectedNodes: LGraphNode[],
-  startGraph = selectedNodes[0].graph
+  startGraph = selectedNodes[0]?.graph
 ): NodeExecutionId[] {
   if (!startGraph) return []
   const rootGraph = startGraph.rootGraph

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -546,7 +546,7 @@ export function getExecutionIdsForSelectedNodes(
 ): NodeExecutionId[] {
   if (!startGraph) return []
   const rootGraph = startGraph.rootGraph
-  const parentPath = startGraph?.isRootGraph
+  const parentPath = startGraph.isRootGraph
     ? ''
     : findPartialExecutionPathToGraph(startGraph, rootGraph)
   if (parentPath === undefined) return []
@@ -569,11 +569,13 @@ function findPartialExecutionPathToGraph(
   target: LGraph,
   root: LGraph
 ): string | undefined {
-  for (const node of root.nodes)
-    if (node.isSubgraphNode()) {
-      if (node.subgraph === target) return `${node.id}`
-      const subpath = findPartialExecutionPathToGraph(target, node.subgraph)
-      if (subpath !== undefined) return node.id + ':' + subpath
-    }
+  for (const node of root.nodes) {
+    if (!node.isSubgraphNode()) continue
+
+    if (node.subgraph === target) return `${node.id}`
+
+    const subpath = findPartialExecutionPathToGraph(target, node.subgraph)
+    if (subpath !== undefined) return node.id + ':' + subpath
+  }
   return undefined
 }


### PR DESCRIPTION
`getExecutionIdsForSelectedNodes`  is only used for partial execution. The prior implementation solved the wrong problem. Given a list of nodes, it would explore into subgraphs and return a list of partial ExecutionIds for all contained nodes. Because this does not resolve the partial execution path to the current subgraph, this is incorrect when the current graph is not the root graph. Woefully, this incorrect functionality is never useful because the recursive exploration only applies to subgraph nodes which never satisfy the outputNode filter applied by the parent function.

An extra function is used to correctly append the parent execution path, but the existing, probably never useful code for recursively collecting children is otherwise left in place.

Resolves #6480

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6487-Fix-partial-execution-inside-subgraphs-29d6d73d36508197924bfb3a0fb6699e) by [Unito](https://www.unito.io)
