### PR TITLE
feat: add telemetry to answer for user failed to find template

### DIFF
--- a/src/components/sidebar/ComfyMenuButton.vue
+++ b/src/components/sidebar/ComfyMenuButton.vue
@@ -76,6 +76,7 @@ import { useI18n } from 'vue-i18n'
 
 import SettingDialogHeader from '@/components/dialog/header/SettingDialogHeader.vue'
 import ComfyLogoTransparent from '@/components/icons/ComfyLogoTransparent.vue'
+import { useWorkflowTemplateSelectorDialog } from '@/composables/useWorkflowTemplateSelectorDialog'
 import SettingDialogContent from '@/platform/settings/components/SettingDialogContent.vue'
 import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useCommandStore } from '@/stores/commandStore'
@@ -160,7 +161,7 @@ const extraMenuItems = computed(() => [
     key: 'browse-templates',
     label: t('menuLabels.Browse Templates'),
     icon: 'icon-[comfy--template]',
-    command: () => commandStore.execute('Comfy.BrowseTemplates')
+    command: () => useWorkflowTemplateSelectorDialog().show('menu')
   },
   {
     key: 'settings',

--- a/src/components/sidebar/SidebarTemplatesButton.vue
+++ b/src/components/sidebar/SidebarTemplatesButton.vue
@@ -12,19 +12,18 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+import { useWorkflowTemplateSelectorDialog } from '@/composables/useWorkflowTemplateSelectorDialog'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { useCommandStore } from '@/stores/commandStore'
 
 import SidebarIcon from './SidebarIcon.vue'
 
 const settingStore = useSettingStore()
-const commandStore = useCommandStore()
 
 const isSmall = computed(
   () => settingStore.get('Comfy.Sidebar.Size') === 'small'
 )
 
 const openTemplates = () => {
-  void commandStore.execute('Comfy.BrowseTemplates')
+  useWorkflowTemplateSelectorDialog().show('sidebar')
 }
 </script>

--- a/src/composables/useWorkflowTemplateSelectorDialog.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.ts
@@ -13,8 +13,8 @@ export const useWorkflowTemplateSelectorDialog = () => {
     dialogStore.closeDialog({ key: DIALOG_KEY })
   }
 
-  function show() {
-    useTelemetry()?.trackTemplateLibraryOpened({ source: 'command' })
+  function show(source: 'sidebar' | 'menu' | 'command' = 'command') {
+    useTelemetry()?.trackTemplateLibraryOpened({ source })
 
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -26,6 +26,7 @@ import type {
   TelemetryProvider,
   TemplateFilterMetadata,
   TemplateLibraryMetadata,
+  TemplateLibraryClosedMetadata,
   TemplateMetadata,
   WorkflowImportMetadata
 } from '../../types'
@@ -233,6 +234,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
 
   trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void {
     this.trackEvent(TelemetryEvents.TEMPLATE_LIBRARY_OPENED, metadata)
+  }
+
+  trackTemplateLibraryClosed(metadata: TemplateLibraryClosedMetadata): void {
+    this.trackEvent(TelemetryEvents.TEMPLATE_LIBRARY_CLOSED, metadata)
   }
 
   trackWorkflowImported(metadata: WorkflowImportMetadata): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -123,6 +123,14 @@ export interface TemplateLibraryMetadata {
 }
 
 /**
+ * Template library closed metadata
+ */
+export interface TemplateLibraryClosedMetadata {
+  template_selected: boolean
+  time_spent_seconds: number
+}
+
+/**
  * Page visibility metadata
  */
 export interface PageVisibilityMetadata {
@@ -193,6 +201,7 @@ export interface TelemetryProvider {
   // Template workflow events
   trackTemplate(metadata: TemplateMetadata): void
   trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void
+  trackTemplateLibraryClosed(metadata: TemplateLibraryClosedMetadata): void
 
   // Workflow management events
   trackWorkflowImported(metadata: WorkflowImportMetadata): void
@@ -249,6 +258,7 @@ export const TelemetryEvents = {
   // Template Tracking
   TEMPLATE_WORKFLOW_OPENED: 'app:template_workflow_opened',
   TEMPLATE_LIBRARY_OPENED: 'app:template_library_opened',
+  TEMPLATE_LIBRARY_CLOSED: 'app:template_library_closed',
 
   // Workflow Management
   WORKFLOW_IMPORTED: 'app:workflow_imported',
@@ -289,6 +299,7 @@ export type TelemetryEventProperties =
   | CreditTopupMetadata
   | WorkflowImportMetadata
   | TemplateLibraryMetadata
+  | TemplateLibraryClosedMetadata
   | PageVisibilityMetadata
   | TabCountMetadata
   | NodeSearchMetadata


### PR DESCRIPTION
## Summary

Adds mixpanel telemetry with goal of: "We currently only know when a user opens a template workflow. But we also want to know if they failed to find what they want"

Example mixpanel query: 

```
app:template_library_closed
  WHERE template_selected = false AND time_spent_seconds >= 10
  ```

But can drill down further into what filters were selected etc to answer what they were looking for but couldn't find. 

```
 1. Event: app:template_filter_changed
  2. Filter:
    - Add formula: "Where user also triggered app:template_library_closed with template_selected = false in same session"
  3. Breakdown by: search_query
  4. Sort by: Total Count (descending)

  Search Query           Failed Sessions
  -----------------------------------
  "flux video"             45 times
  "sdxl controlnet"     32 times
  "upscaler"               28 times
  (empty/just filter)   20 times
```

```
 Event: app:template_filter_changed
  WHERE filtered_count = 0
    AND user did app:template_library_closed
    with template_selected = false

  Breakdown by: search_query
  ```
  etc.

https://www.notion.so/comfy-org/Number-of-users-who-open-the-template-library-and-where-do-they-click-29b6d73d36508044a595c0fb653ca6dc?source=copy_link

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6489-feat-add-telemetry-to-answer-for-user-failed-to-find-template-29d6d73d365081cdad72fd7c6ada5dc7) by [Unito](https://www.unito.io)
