### PR TITLE
chore(pnpm): allow building @sentry/cli for sourcemap uploads

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,6 +112,7 @@ onlyBuiltDependencies:
   - '@playwright/browser-chromium'
   - '@playwright/browser-firefox'
   - '@playwright/browser-webkit'
+  - '@sentry/cli'
   - '@tailwindcss/oxide'
   - esbuild
   - nx


### PR DESCRIPTION
- Add `@sentry/cli` to `onlyBuiltDependencies` in `pnpm-workspace.yaml` so its postinstall can run.
- Ensures the Sentry Vite plugin can upload sourcemaps in cloud builds when Sentry env vars are configured.
- No runtime code changes.

Checks run locally before commit:
- `pnpm lint:fix` ✓
- `pnpm typecheck` ✓

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6491-chore-pnpm-allow-building-sentry-cli-for-sourcemap-uploads-29d6d73d365081bd8548c19ef48d4f61) by [Unito](https://www.unito.io)
