### PR TITLE
feat(telemetry): include custom_node_count in run button click event

### DIFF
--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -175,6 +175,7 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
       subscribe_to_run: options?.subscribe_to_run || false,
       workflow_type: executionContext.is_template ? 'template' : 'custom',
       workflow_name: executionContext.workflow_name ?? 'untitled',
+      custom_node_count: executionContext.custom_node_count,
       total_node_count: executionContext.total_node_count,
       subgraph_count: executionContext.subgraph_count,
       has_api_nodes: executionContext.has_api_nodes,

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -42,6 +42,7 @@ export interface RunButtonProperties {
   subscribe_to_run: boolean
   workflow_type: 'template' | 'custom'
   workflow_name: string
+  custom_node_count: number
   total_node_count: number
   subgraph_count: number
   has_api_nodes: boolean


### PR DESCRIPTION
Summary
- Add custom_node_count to app:run_button_click telemetry payload, aligning with execution_start context naming.
- Keeps event name as app:run_button_click (no rename).

Changes
- src/platform/telemetry/types.ts: add custom_node_count to RunButtonProperties.
- src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts: include custom_node_count from execution context in trackRunButton payload.

Rationale
- execution_start already reports custom_node_count via ExecutionContext.
- This adds visibility at the moment of run initiation, improving funnel and pre-execution analysis.

Validation
- Ran pnpm lint:fix and pnpm typecheck locally; both passed.

Notes
- No runtime behavior changes outside telemetry payload.
- No user-facing strings changed.

Requested Reviewers
- Telemetry/analytics owners to confirm property naming and coverage.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6493-feat-telemetry-include-custom_node_count-in-run-button-click-event-29d6d73d365081a5b23bd02e72e0bafd) by [Unito](https://www.unito.io)
