### PR TITLE
add api node link

### DIFF
--- a/src/components/dialog/content/setting/CreditsPanel.vue
+++ b/src/components/dialog/content/setting/CreditsPanel.vue
@@ -93,6 +93,13 @@
           @click="handleFaqClick"
         />
         <Button
+          :label="$t('subscription.partnerNodesCredits')"
+          text
+          severity="secondary"
+          icon="pi pi-question-circle"
+          @click="handleOpenPartnerNodesInfo"
+        />
+        <Button
           :label="$t('credits.messageSupport')"
           text
           severity="secondary"
@@ -166,6 +173,13 @@ const handleMessageSupport = async () => {
 
 const handleFaqClick = () => {
   window.open('https://docs.comfy.org/tutorials/api-nodes/faq', '_blank')
+}
+
+const handleOpenPartnerNodesInfo = () => {
+  window.open(
+    'https://docs.comfy.org/tutorials/api-nodes/overview#api-nodes',
+    '_blank'
+  )
 }
 
 const creditHistory = ref<CreditHistoryItemData[]>([])

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -244,6 +244,22 @@
             @click="handleLearnMoreClick"
           />
           <Button
+            :label="$t('subscription.partnerNodesCredits')"
+            text
+            severity="secondary"
+            icon="pi pi-question-circle"
+            class="text-xs"
+            :pt="{
+              label: {
+                class: 'text-text-secondary'
+              },
+              icon: {
+                class: 'text-text-secondary text-xs'
+              }
+            }"
+            @click="handleOpenPartnerNodesInfo"
+          />
+          <Button
             :label="$t('subscription.messageSupport')"
             text
             severity="secondary"
@@ -318,6 +334,13 @@ const {
   handleRefresh,
   handleLearnMoreClick
 } = useSubscriptionActions()
+
+const handleOpenPartnerNodesInfo = () => {
+  window.open(
+    'https://docs.comfy.org/tutorials/api-nodes/overview#api-nodes',
+    '_blank'
+  )
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

add api node page link on credit and subscription pannel

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6494-add-api-node-link-29e6d73d365081aaa2f4d1647683ecda) by [Unito](https://www.unito.io)
