### PR TITLE
fix: remove unused X-Reconnecting header check

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -433,12 +433,8 @@ export class ComfyApi extends EventTarget {
     await this.#waitForAuthInitialization()
 
     // Add Firebase JWT token if user is logged in
-    // Force refresh token on reconnection to avoid 401 errors
-    const isReconnecting =
-      options.headers && 'X-Reconnecting' in options.headers
     try {
-      const authHeader =
-        await useFirebaseAuthStore().getAuthHeader(isReconnecting)
+      const authHeader = await useFirebaseAuthStore().getAuthHeader()
       if (authHeader) {
         if (Array.isArray(options.headers)) {
           for (const [key, value] of Object.entries(authHeader)) {


### PR DESCRIPTION
## Summary

Remove dead code that checks for X-Reconnecting header which is never actually set anywhere in the codebase.

## Changes

- Remove X-Reconnecting header check in fetchApi() method  
- Simplify getAuthHeader() call to not pass unused parameter

## Context

The X-Reconnecting header was being checked but never set, making this code non-functional. This cleanup removes the confusion and simplifies the authentication flow.

## Test Plan

- Code builds without errors
- TypeScript validation passes  
- Linting passes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6495-fix-remove-unused-X-Reconnecting-header-check-29e6d73d365081df88faeb46b1789a83) by [Unito](https://www.unito.io)
