### PR TITLE
Backport PR #6476 to rh-test: workflow_opened + open_source + missing node metrics

### DIFF
--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -5,12 +5,20 @@ import type {
   ExecutionContext,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
+  NodeSearchMetadata,
+  NodeSearchResultMetadata,
+  PageVisibilityMetadata,
   RunButtonProperties,
   SurveyResponses,
+  TabCountMetadata,
   TelemetryEventName,
   TelemetryEventProperties,
   TelemetryProvider,
-  TemplateMetadata
+  TemplateFilterMetadata,
+  TemplateLibraryClosedMetadata,
+  TemplateLibraryMetadata,
+  TemplateMetadata,
+  WorkflowImportMetadata
 } from '../../types'
 import { TelemetryEvents } from '../../types'
 
@@ -351,6 +359,41 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.TEMPLATE_WORKFLOW_OPENED, metadata)
   }
 
+  trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void {
+    this.trackEvent(TelemetryEvents.TEMPLATE_LIBRARY_OPENED, metadata)
+  }
+
+  trackTemplateLibraryClosed(metadata: TemplateLibraryClosedMetadata): void {
+    this.trackEvent(TelemetryEvents.TEMPLATE_LIBRARY_CLOSED, metadata)
+  }
+
+  trackWorkflowImported(metadata: WorkflowImportMetadata): void {
+    this.trackEvent(TelemetryEvents.WORKFLOW_IMPORTED, metadata)
+  }
+
+  trackWorkflowOpened(metadata: WorkflowImportMetadata): void {
+    this.trackEvent(TelemetryEvents.WORKFLOW_OPENED, metadata)
+  }
+
+  trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void {
+    this.trackEvent(TelemetryEvents.PAGE_VISIBILITY_CHANGED, metadata)
+  }
+
+  trackTabCount(metadata: TabCountMetadata): void {
+    this.trackEvent(TelemetryEvents.TAB_COUNT_TRACKING, metadata)
+  }
+
+  trackNodeSearch(metadata: NodeSearchMetadata): void {
+    this.trackEvent(TelemetryEvents.NODE_SEARCH, metadata)
+  }
+
+  trackNodeSearchResultSelected(metadata: NodeSearchResultMetadata): void {
+    this.trackEvent(TelemetryEvents.NODE_SEARCH_RESULT_SELECTED, metadata)
+  }
+
+  trackTemplateFilterChanged(metadata: TemplateFilterMetadata): void {
+    this.trackEvent(TelemetryEvents.TEMPLATE_FILTER_CHANGED, metadata)
+  }
   trackWorkflowExecution(): void {
     if (this.isOnboardingMode) {
       // During onboarding, track basic execution without workflow context

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -90,6 +90,97 @@ export interface TemplateMetadata {
 }
 
 /**
+ * Credit topup metadata
+ */
+export interface CreditTopupMetadata {
+  credit_amount: number
+}
+
+/**
+ * Workflow import metadata
+ */
+export interface WorkflowImportMetadata {
+  missing_node_count: number
+  missing_node_types: string[]
+  /**
+   * The source of the workflow open/import action
+   */
+  open_source?: 'file_button' | 'file_drop' | 'template' | 'unknown'
+}
+
+/**
+ * Workflow open metadata
+ */
+/**
+ * Enumerated sources for workflow open/import actions.
+ */
+export type WorkflowOpenSource = NonNullable<
+  WorkflowImportMetadata['open_source']
+>
+
+/**
+ * Template library metadata
+ */
+export interface TemplateLibraryMetadata {
+  source: 'sidebar' | 'menu' | 'command'
+}
+
+/**
+ * Template library closed metadata
+ */
+export interface TemplateLibraryClosedMetadata {
+  template_selected: boolean
+  time_spent_seconds: number
+}
+
+/**
+ * Page visibility metadata
+ */
+export interface PageVisibilityMetadata {
+  visibility_state: 'visible' | 'hidden'
+}
+
+/**
+ * Tab count metadata
+ */
+export interface TabCountMetadata {
+  tab_count: number
+}
+
+/**
+ * Node search metadata
+ */
+export interface NodeSearchMetadata {
+  query: string
+}
+
+/**
+ * Node search result selection metadata
+ */
+export interface NodeSearchResultMetadata {
+  node_type: string
+  last_query: string
+}
+
+/**
+ * Template filter tracking metadata
+ */
+export interface TemplateFilterMetadata {
+  search_query?: string
+  selected_models: string[]
+  selected_use_cases: string[]
+  selected_licenses: string[]
+  sort_by:
+    | 'default'
+    | 'alphabetical'
+    | 'newest'
+    | 'vram-low-to-high'
+    | 'model-size-low-to-high'
+  filtered_count: number
+  total_count: number
+}
+
+/**
  * Core telemetry provider interface
  */
 export interface TelemetryProvider {
@@ -106,6 +197,25 @@ export interface TelemetryProvider {
 
   // Template workflow events
   trackTemplate(metadata: TemplateMetadata): void
+  trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void
+  trackTemplateLibraryClosed(metadata: TemplateLibraryClosedMetadata): void
+
+  // Workflow management events
+  trackWorkflowImported(metadata: WorkflowImportMetadata): void
+  trackWorkflowOpened(metadata: WorkflowImportMetadata): void
+
+  // Page visibility events
+  trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void
+
+  // Tab tracking events
+  trackTabCount(metadata: TabCountMetadata): void
+
+  // Node search analytics events
+  trackNodeSearch(metadata: NodeSearchMetadata): void
+  trackNodeSearchResultSelected(metadata: NodeSearchResultMetadata): void
+
+  // Template filter tracking events
+  trackTemplateFilterChanged(metadata: TemplateFilterMetadata): void
 
   // Workflow execution events
   trackWorkflowExecution(): void
@@ -140,6 +250,25 @@ export const TelemetryEvents = {
 
   // Template Tracking
   TEMPLATE_WORKFLOW_OPENED: 'app:template_workflow_opened',
+  TEMPLATE_LIBRARY_OPENED: 'app:template_library_opened',
+  TEMPLATE_LIBRARY_CLOSED: 'app:template_library_closed',
+
+  // Workflow Management
+  WORKFLOW_IMPORTED: 'app:workflow_imported',
+  WORKFLOW_OPENED: 'app:workflow_opened',
+
+  // Page Visibility
+  PAGE_VISIBILITY_CHANGED: 'app:page_visibility_changed',
+
+  // Tab Tracking
+  TAB_COUNT_TRACKING: 'app:tab_count_tracking',
+
+  // Node Search Analytics
+  NODE_SEARCH: 'app:node_search',
+  NODE_SEARCH_RESULT_SELECTED: 'app:node_search_result_selected',
+
+  // Template Filter Analytics
+  TEMPLATE_FILTER_CHANGED: 'app:template_filter_changed',
 
   // Execution Lifecycle
   EXECUTION_START: 'execution_start',
@@ -157,6 +286,15 @@ export type TelemetryEventProperties =
   | AuthMetadata
   | SurveyResponses
   | TemplateMetadata
+  | TemplateLibraryMetadata
+  | TemplateLibraryClosedMetadata
+  | WorkflowImportMetadata
+  | PageVisibilityMetadata
+  | TabCountMetadata
+  | NodeSearchMetadata
+  | NodeSearchResultMetadata
+  | TemplateFilterMetadata
+  | CreditTopupMetadata
   | ExecutionContext
   | RunButtonProperties
   | ExecutionErrorMetadata

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -138,7 +138,9 @@ export function useTemplateWorkflows() {
         }
 
         dialogStore.closeDialog()
-        await app.loadGraphData(json, true, true, workflowName)
+        await app.loadGraphData(json, true, true, workflowName, {
+          openSource: 'template'
+        })
 
         return true
       }
@@ -159,7 +161,9 @@ export function useTemplateWorkflows() {
       }
 
       dialogStore.closeDialog()
-      await app.loadGraphData(json, true, true, workflowName)
+      await app.loadGraphData(json, true, true, workflowName, {
+        openSource: 'template'
+      })
 
       return true
     } catch (error) {

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -398,7 +398,7 @@ export class ComfyUI {
       parent: document.body,
       onchange: async () => {
         // @ts-expect-error fixme ts strict error
-        await app.handleFile(fileInput.files[0])
+        await app.handleFile(fileInput.files[0], 'file_button')
         fileInput.value = ''
       }
     })


### PR DESCRIPTION
Backport of PR #6476 onto rh-test.

Summary
- Adds app:workflow_opened event and plumbs open_source across file open (button + drag/drop), workspace, and templates
- Tracks missing_node_count and missing_node_types on workflow_opened and workflow_imported
- Reuses WorkflowOpenSource type; no breaking changes to loadGraphData callers (keeps 5th param options object, with optional openSource)

Files changed
- src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
- src/platform/telemetry/types.ts
- src/platform/workflow/templates/composables/useTemplateWorkflows.ts
- src/scripts/app.ts
- src/scripts/ui.ts

Validation
- pnpm lint:fix
- pnpm typecheck

Notes
- Telemetry only runs in cloud builds; OSS remains unchanged.

Cherry-picked commit: 6abff41f08fc922923c54fc738a1e18c3aa9e279