### PR TITLE
feat(telemetry): add unified run_triggered event for all run initiations

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -159,7 +159,6 @@ const queuePrompt = async (e: Event) => {
     : 'Comfy.QueuePrompt'
 
   if (isCloud) {
-    useTelemetry()?.trackRunTriggered({ trigger_source: 'button' })
     useTelemetry()?.trackRunButton({ subscribe_to_run: false })
   }
 

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -158,9 +158,10 @@ const queuePrompt = async (e: Event) => {
     ? 'Comfy.QueuePromptFront'
     : 'Comfy.QueuePrompt'
 
-  if (isCloud) {
-    useTelemetry()?.trackRunButton({ subscribe_to_run: false })
-  }
+    if (isCloud) {
+      useTelemetry()?.trackRunTriggered({ trigger_source: 'button' })
+      useTelemetry()?.trackRunButton({ subscribe_to_run: false })
+    }
 
   await commandStore.execute(commandId)
 }

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -158,10 +158,10 @@ const queuePrompt = async (e: Event) => {
     ? 'Comfy.QueuePromptFront'
     : 'Comfy.QueuePrompt'
 
-    if (isCloud) {
-      useTelemetry()?.trackRunTriggered({ trigger_source: 'button' })
-      useTelemetry()?.trackRunButton({ subscribe_to_run: false })
-    }
+  if (isCloud) {
+    useTelemetry()?.trackRunTriggered({ trigger_source: 'button' })
+    useTelemetry()?.trackRunButton({ subscribe_to_run: false })
+  }
 
   await commandStore.execute(commandId)
 }

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -185,10 +185,12 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
   }
 
-  trackRunTriggered(metadata: {
-    trigger_source: 'button' | 'keybinding' | 'menu'
-  }): void {
-    this.trackEvent(TelemetryEvents.RUN_TRIGGERED, metadata)
+  trackRunTriggeredViaKeybinding(): void {
+    this.trackEvent(TelemetryEvents.RUN_TRIGGERED_KEYBINDING)
+  }
+
+  trackRunTriggeredViaMenu(): void {
+    this.trackEvent(TelemetryEvents.RUN_TRIGGERED_MENU)
   }
 
   trackSurvey(

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -185,6 +185,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
   }
 
+  trackRunTriggered(metadata: { trigger_source: 'button' | 'keybinding' | 'menu' }): void {
+    this.trackEvent(TelemetryEvents.RUN_TRIGGERED, metadata)
+  }
+
   trackSurvey(
     stage: 'opened' | 'submitted',
     responses?: SurveyResponses

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -185,7 +185,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
   }
 
-  trackRunTriggered(metadata: { trigger_source: 'button' | 'keybinding' | 'menu' }): void {
+  trackRunTriggered(metadata: {
+    trigger_source: 'button' | 'keybinding' | 'menu'
+  }): void {
     this.trackEvent(TelemetryEvents.RUN_TRIGGERED, metadata)
   }
 

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -50,13 +50,6 @@ export interface RunButtonProperties {
 }
 
 /**
- * Run trigger metadata for unified run initiation tracking
- */
-interface RunTriggeredMetadata {
-  trigger_source: 'button' | 'keybinding' | 'menu'
-}
-
-/**
  * Execution context for workflow tracking
  */
 export interface ExecutionContext {
@@ -213,7 +206,8 @@ export interface TelemetryProvider {
   trackAddApiCreditButtonClicked(): void
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void
   trackRunButton(options?: { subscribe_to_run?: boolean }): void
-  trackRunTriggered(metadata: RunTriggeredMetadata): void
+  trackRunTriggeredViaKeybinding(): void
+  trackRunTriggeredViaMenu(): void
 
   // Survey flow events
   trackSurvey(stage: 'opened' | 'submitted', responses?: SurveyResponses): void
@@ -263,7 +257,8 @@ export const TelemetryEvents = {
 
   // Subscription Flow
   RUN_BUTTON_CLICKED: 'app:run_button_click',
-  RUN_TRIGGERED: 'app:run_triggered',
+  RUN_TRIGGERED_KEYBINDING: 'app:run_triggered_keybinding',
+  RUN_TRIGGERED_MENU: 'app:run_triggered_menu',
   SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'app:subscription_required_modal_opened',
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
   MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
@@ -320,7 +315,6 @@ export type TelemetryEventProperties =
   | TemplateMetadata
   | ExecutionContext
   | RunButtonProperties
-  | RunTriggeredMetadata
   | ExecutionErrorMetadata
   | ExecutionSuccessMetadata
   | CreditTopupMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -52,7 +52,7 @@ export interface RunButtonProperties {
 /**
  * Run trigger metadata for unified run initiation tracking
  */
-export interface RunTriggeredMetadata {
+interface RunTriggeredMetadata {
   trigger_source: 'button' | 'keybinding' | 'menu'
 }
 

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -50,6 +50,13 @@ export interface RunButtonProperties {
 }
 
 /**
+ * Run trigger metadata for unified run initiation tracking
+ */
+export interface RunTriggeredMetadata {
+  trigger_source: 'button' | 'keybinding' | 'menu'
+}
+
+/**
  * Execution context for workflow tracking
  */
 export interface ExecutionContext {
@@ -206,6 +213,7 @@ export interface TelemetryProvider {
   trackAddApiCreditButtonClicked(): void
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void
   trackRunButton(options?: { subscribe_to_run?: boolean }): void
+  trackRunTriggered(metadata: RunTriggeredMetadata): void
 
   // Survey flow events
   trackSurvey(stage: 'opened' | 'submitted', responses?: SurveyResponses): void
@@ -255,6 +263,7 @@ export const TelemetryEvents = {
 
   // Subscription Flow
   RUN_BUTTON_CLICKED: 'app:run_button_click',
+  RUN_TRIGGERED: 'app:run_triggered',
   SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'app:subscription_required_modal_opened',
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
   MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
@@ -311,6 +320,7 @@ export type TelemetryEventProperties =
   | TemplateMetadata
   | ExecutionContext
   | RunButtonProperties
+  | RunTriggeredMetadata
   | ExecutionErrorMetadata
   | ExecutionSuccessMetadata
   | CreditTopupMetadata

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -474,7 +474,7 @@ export class ComfyUI {
           textContent: 'Queue Prompt',
           onclick: () => {
             if (isCloud) {
-              useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
+              useTelemetry()?.trackRunTriggeredViaMenu()
             }
             app.queuePrompt(0, this.batchCount)
           }
@@ -581,7 +581,7 @@ export class ComfyUI {
             textContent: 'Queue Front',
             onclick: () => {
               if (isCloud) {
-                useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
+                useTelemetry()?.trackRunTriggeredViaMenu()
               }
               app.queuePrompt(-1, this.batchCount)
             }

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -576,16 +576,16 @@ export class ComfyUI {
           ]
         ),
         $el('div.comfy-menu-btns', [
-            $el('button', {
-              id: 'queue-front-button',
-              textContent: 'Queue Front',
-              onclick: () => {
-                if (isCloud) {
-                  useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
-                }
-                app.queuePrompt(-1, this.batchCount)
+          $el('button', {
+            id: 'queue-front-button',
+            textContent: 'Queue Front',
+            onclick: () => {
+              if (isCloud) {
+                useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
               }
-            }),
+              app.queuePrompt(-1, this.batchCount)
+            }
+          }),
           $el('button', {
             $: (b) => (this.queue.button = b as HTMLButtonElement),
             id: 'comfy-view-queue-button',

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -2,6 +2,8 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { WORKFLOW_ACCEPT_STRING } from '@/platform/workflow/core/types/formats'
 import { type StatusWsMessageStatus, type TaskItem } from '@/schemas/apiSchema'
 import { useDialogService } from '@/services/dialogService'
+import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
@@ -470,7 +472,12 @@ export class ComfyUI {
         $el('button.comfy-queue-btn', {
           id: 'queue-button',
           textContent: 'Queue Prompt',
-          onclick: () => app.queuePrompt(0, this.batchCount)
+          onclick: () => {
+            if (isCloud) {
+              useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
+            }
+            app.queuePrompt(0, this.batchCount)
+          }
         }),
         $el('div', {}, [
           $el('label', { innerHTML: 'Extra options' }, [
@@ -569,11 +576,16 @@ export class ComfyUI {
           ]
         ),
         $el('div.comfy-menu-btns', [
-          $el('button', {
-            id: 'queue-front-button',
-            textContent: 'Queue Front',
-            onclick: () => app.queuePrompt(-1, this.batchCount)
-          }),
+            $el('button', {
+              id: 'queue-front-button',
+              textContent: 'Queue Front',
+              onclick: () => {
+                if (isCloud) {
+                  useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
+                }
+                app.queuePrompt(-1, this.batchCount)
+              }
+            }),
           $el('button', {
             $: (b) => (this.queue.button = b as HTMLButtonElement),
             id: 'comfy-view-queue-button',

--- a/src/services/keybindingService.ts
+++ b/src/services/keybindingService.ts
@@ -1,5 +1,7 @@
 import { CORE_KEYBINDINGS } from '@/constants/coreKeybindings'
+import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useTelemetry } from '@/platform/telemetry'
 import { app } from '@/scripts/app'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -64,6 +66,14 @@ export const useKeybindingService = () => {
 
       // Prevent default browser behavior first, then execute the command
       event.preventDefault()
+      if (
+        isCloud &&
+        (keybinding.commandId === 'Comfy.QueuePrompt' ||
+          keybinding.commandId === 'Comfy.QueuePromptFront' ||
+          keybinding.commandId === 'Comfy.QueueSelectedOutputNodes')
+      ) {
+        useTelemetry()?.trackRunTriggered({ trigger_source: 'keybinding' })
+      }
       await commandStore.execute(keybinding.commandId)
       return
     }

--- a/src/services/keybindingService.ts
+++ b/src/services/keybindingService.ts
@@ -72,7 +72,7 @@ export const useKeybindingService = () => {
           keybinding.commandId === 'Comfy.QueuePromptFront' ||
           keybinding.commandId === 'Comfy.QueueSelectedOutputNodes')
       ) {
-        useTelemetry()?.trackRunTriggered({ trigger_source: 'keybinding' })
+        useTelemetry()?.trackRunTriggeredViaKeybinding()
       }
       await commandStore.execute(keybinding.commandId)
       return

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -3,6 +3,8 @@ import type { MenuItem } from 'primevue/menuitem'
 import { ref } from 'vue'
 
 import { CORE_MENU_COMMANDS } from '@/constants/coreMenuCommands'
+import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
 import type { ComfyExtension } from '@/types/comfy'
 
 import { useCommandStore } from './commandStore'
@@ -62,7 +64,17 @@ export const useMenuItemStore = defineStore('menuItem', () => {
       .map(
         (command) =>
           ({
-            command: () => commandStore.execute(command.id),
+            command: () => {
+              if (
+                isCloud &&
+                (command.id === 'Comfy.QueuePrompt' ||
+                  command.id === 'Comfy.QueuePromptFront' ||
+                  command.id === 'Comfy.QueueSelectedOutputNodes')
+              ) {
+                useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
+              }
+              return commandStore.execute(command.id)
+            },
             label: command.menubarLabel,
             icon: command.icon,
             tooltip: command.tooltip,

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -71,7 +71,7 @@ export const useMenuItemStore = defineStore('menuItem', () => {
                   command.id === 'Comfy.QueuePromptFront' ||
                   command.id === 'Comfy.QueueSelectedOutputNodes')
               ) {
-                useTelemetry()?.trackRunTriggered({ trigger_source: 'menu' })
+                useTelemetry()?.trackRunTriggeredViaMenu()
               }
               return commandStore.execute(command.id)
             },


### PR DESCRIPTION
Summary
- Add new telemetry event: `app:run_triggered` with `{ trigger_source: 'button' | 'keybinding' | 'menu' }`.
- Instrument all run initiation paths:
  - UI Queue button emits `run_triggered` (source `button`) and keeps emitting `run_button_click` for UI-only tracking.
  - Keybindings (Ctrl+Enter / Ctrl+Shift+Enter) emit `run_triggered` (source `keybinding`).
  - Menus (menubar + legacy menu buttons) emit `run_triggered` (source `menu`).
- Mixpanel provider now supports `trackRunTriggered` and forwards `run_triggered`.
- `execution_start` tracking remains unchanged.

Motivation
GTM observed more `execution_start` events than `run_button_click`. This change clarifies attribution by adding a unified event across all triggers while preserving the UI-only `run_button_click` metric.

Files
- src/platform/telemetry/types.ts: Add `RunTriggeredMetadata`, `RUN_TRIGGERED`, provider method signature.
- src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts: Implement `trackRunTriggered`.
- src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue: Emit `run_triggered` on button path.
- src/services/keybindingService.ts: Emit `run_triggered` when queue commands are invoked via keybindings.
- src/stores/menuItemStore.ts: Emit `run_triggered` for queue commands invoked via menubar.
- src/scripts/ui.ts: Emit `run_triggered` for legacy menu queue buttons.

Notes
- `run_button_click` continues to represent UI button presses only.
- `run_triggered` now represents all user-initiated runs with clear source attribution.

QA
- Cloud build: verify `app:run_triggered` appears with the correct `trigger_source` for button, keybinding, and menu triggers.
- Verify `app:run_button_click` only fires for the button path.
- Confirm `execution_start` still tracks as before.

If preferred, we can extend `run_triggered` with additional fields (e.g., queue mode, batchCount) in a follow-up.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6499-feat-telemetry-add-unified-run_triggered-event-for-all-run-initiations-29e6d73d3650819fb481d3e0e925c50f) by [Unito](https://www.unito.io)
