### PR TITLE
Backport: API credit top-up telemetry + topupTrackerStore (#6500)

### DIFF
--- a/src/components/dialog/content/setting/UsageLogsTable.vue
+++ b/src/components/dialog/content/setting/UsageLogsTable.vue
@@ -101,12 +101,14 @@ import {
   EventType,
   useCustomerEventsService
 } from '@/services/customerEventsService'
+import { useTopupTrackerStore } from '@/stores/topupTrackerStore'
 
 const events = ref<AuditLog[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 
 const customerEventService = useCustomerEventsService()
+const topupTracker = useTopupTrackerStore()
 
 const pagination = ref({
   page: 1,
@@ -159,6 +161,8 @@ const loadEvents = async () => {
       if (response.totalPages) {
         pagination.value.totalPages = response.totalPages
       }
+
+      void topupTracker.reconcileWithEvents(response.events)
     } else {
       error.value = customerEventService.error.value || 'Failed to load events'
     }

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -6,6 +6,7 @@ import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
+import { useTopupTrackerStore } from '@/stores/topupTrackerStore'
 import { usdToMicros } from '@/utils/formatUtil'
 
 /**
@@ -98,7 +99,7 @@ export const useFirebaseAuthActions = () => {
       )
     }
 
-    // Go to Stripe checkout page
+    useTopupTrackerStore().startTopup(amount)
     window.open(response.checkout_url, '_blank')
   }, reportError)
 
@@ -115,7 +116,9 @@ export const useFirebaseAuthActions = () => {
   }, reportError)
 
   const fetchBalance = wrapWithErrorHandlingAsync(async () => {
-    return await authStore.fetchBalance()
+    const result = await authStore.fetchBalance()
+    void useTopupTrackerStore().reconcileByFetchingEvents()
+    return result
   }, reportError)
 
   const signInWithGoogle = (errorHandler = reportError) =>

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -3,7 +3,6 @@ import type { OverridedMixpanel } from 'mixpanel-browser'
 import type {
   AuthMetadata,
   CreditTopupMetadata,
-  CreditTopupSucceededMetadata,
   ExecutionContext,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
@@ -302,8 +301,8 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     )
   }
 
-  trackApiCreditTopupSucceeded(metadata: CreditTopupSucceededMetadata): void {
-    this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED, metadata)
+  trackApiCreditTopupSucceeded(): void {
+    this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED)
   }
   trackRunButton(options?: { subscribe_to_run?: boolean }): void {
     if (this.isOnboardingMode) {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -2,6 +2,8 @@ import type { OverridedMixpanel } from 'mixpanel-browser'
 
 import type {
   AuthMetadata,
+  CreditTopupMetadata,
+  CreditTopupSucceededMetadata,
   ExecutionContext,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
@@ -282,6 +284,27 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(eventName)
   }
 
+  trackAddApiCreditButtonClicked(): void {
+    this.trackEvent(TelemetryEvents.ADD_API_CREDIT_BUTTON_CLICKED)
+  }
+
+  trackMonthlySubscriptionSucceeded(): void {
+    this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED)
+  }
+
+  trackApiCreditTopupButtonPurchaseClicked(amount: number): void {
+    const metadata: CreditTopupMetadata = {
+      credit_amount: amount
+    }
+    this.trackEvent(
+      TelemetryEvents.API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED,
+      metadata
+    )
+  }
+
+  trackApiCreditTopupSucceeded(metadata: CreditTopupSucceededMetadata): void {
+    this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED, metadata)
+  }
   trackRunButton(options?: { subscribe_to_run?: boolean }): void {
     if (this.isOnboardingMode) {
       // During onboarding, track basic run button click without workflow context

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -97,15 +97,6 @@ export interface CreditTopupMetadata {
 }
 
 /**
- * Credit top-up succeeded metadata
- */
-export interface CreditTopupSucceededMetadata {
-  credit_amount: number
-  payment_method?: string
-  transaction_id?: string
-}
-
-/**
  * Workflow import metadata
  */
 export interface WorkflowImportMetadata {
@@ -188,7 +179,7 @@ export interface TelemetryProvider {
   trackMonthlySubscriptionSucceeded(): void
   trackAddApiCreditButtonClicked(): void
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void
-  trackApiCreditTopupSucceeded(metadata: CreditTopupSucceededMetadata): void
+  trackApiCreditTopupSucceeded(): void
   trackRunButton(options?: { subscribe_to_run?: boolean }): void
 
   // Survey flow events
@@ -293,7 +284,6 @@ export type TelemetryEventProperties =
   | ExecutionErrorMetadata
   | ExecutionSuccessMetadata
   | CreditTopupMetadata
-  | CreditTopupSucceededMetadata
   | WorkflowImportMetadata
   | TemplateLibraryMetadata
   | TemplateLibraryClosedMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -90,6 +90,22 @@ export interface TemplateMetadata {
 }
 
 /**
+ * Credit topup metadata
+ */
+export interface CreditTopupMetadata {
+  credit_amount: number
+}
+
+/**
+ * Credit top-up succeeded metadata
+ */
+export interface CreditTopupSucceededMetadata {
+  credit_amount: number
+  payment_method?: string
+  transaction_id?: string
+}
+
+/**
  * Workflow import metadata
  */
 export interface WorkflowImportMetadata {
@@ -169,6 +185,10 @@ export interface TelemetryProvider {
 
   // Subscription flow events
   trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void
+  trackMonthlySubscriptionSucceeded(): void
+  trackAddApiCreditButtonClicked(): void
+  trackApiCreditTopupButtonPurchaseClicked(amount: number): void
+  trackApiCreditTopupSucceeded(metadata: CreditTopupSucceededMetadata): void
   trackRunButton(options?: { subscribe_to_run?: boolean }): void
 
   // Survey flow events
@@ -221,6 +241,11 @@ export const TelemetryEvents = {
   RUN_BUTTON_CLICKED: 'app:run_button_click',
   SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'app:subscription_required_modal_opened',
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
+  MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
+  ADD_API_CREDIT_BUTTON_CLICKED: 'app:add_api_credit_button_clicked',
+  API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED:
+    'app:api_credit_topup_button_purchase_clicked',
+  API_CREDIT_TOPUP_SUCCEEDED: 'app:api_credit_topup_succeeded',
 
   // Onboarding Survey
   USER_SURVEY_OPENED: 'app:user_survey_opened',
@@ -267,6 +292,8 @@ export type TelemetryEventProperties =
   | RunButtonProperties
   | ExecutionErrorMetadata
   | ExecutionSuccessMetadata
+  | CreditTopupMetadata
+  | CreditTopupSucceededMetadata
   | WorkflowImportMetadata
   | TemplateLibraryMetadata
   | TemplateLibraryClosedMetadata

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -4,7 +4,6 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { COMFY_API_BASE_URL } from '@/config/comfyApi'
-import { useTelemetry } from '@/platform/telemetry'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import type { components, operations } from '@/types/comfyRegistryTypes'
 import { isAbortError } from '@/utils/typeGuardUtil'
@@ -35,7 +34,6 @@ export const useCustomerEventsService = () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const { d } = useI18n()
-  const telemetry = useTelemetry()
 
   const handleRequestError = (
     err: unknown,
@@ -189,12 +187,6 @@ export const useCustomerEventsService = () => {
         }),
       { errorContext, routeSpecificErrors }
     )
-
-    for (const event of result?.events ?? []) {
-      if (event?.event_type === EventType.CREDIT_ADDED) {
-        telemetry?.trackApiCreditTopupSucceeded()
-      }
-    }
 
     return result
   }

--- a/src/stores/topupTrackerStore.ts
+++ b/src/stores/topupTrackerStore.ts
@@ -1,0 +1,155 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+
+import { useTelemetry } from '@/platform/telemetry'
+import type { AuditLog } from '@/services/customerEventsService'
+import {
+  EventType,
+  useCustomerEventsService
+} from '@/services/customerEventsService'
+import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
+
+type PendingTopupRecord = {
+  startedAtIso: string
+  amountUsd?: number
+  expectedCents?: number
+}
+
+const storageKeyForUser = (userId: string) => `topupTracker:pending:${userId}`
+
+export const useTopupTrackerStore = defineStore('topupTracker', () => {
+  const telemetry = useTelemetry()
+  const authStore = useFirebaseAuthStore()
+  const pendingTopup = ref<PendingTopupRecord | null>(null)
+  const storageListenerInitialized = ref(false)
+
+  const loadFromStorage = () => {
+    const userId = authStore.userId
+    if (!userId) return
+    try {
+      const rawValue = localStorage.getItem(storageKeyForUser(userId))
+      if (!rawValue) return
+      const parsedValue = JSON.parse(rawValue) as PendingTopupRecord
+      pendingTopup.value = parsedValue
+    } catch {
+      pendingTopup.value = null
+    }
+  }
+
+  const persistToStorage = () => {
+    const userId = authStore.userId
+    if (!userId) return
+    if (pendingTopup.value) {
+      localStorage.setItem(
+        storageKeyForUser(userId),
+        JSON.stringify(pendingTopup.value)
+      )
+    } else {
+      localStorage.removeItem(storageKeyForUser(userId))
+    }
+  }
+
+  const initializeStorageSynchronization = () => {
+    if (storageListenerInitialized.value) return
+    storageListenerInitialized.value = true
+    loadFromStorage()
+    window.addEventListener('storage', (e: StorageEvent) => {
+      const userId = authStore.userId
+      if (!userId) return
+      if (e.key === storageKeyForUser(userId)) {
+        loadFromStorage()
+      }
+    })
+
+    watch(
+      () => authStore.userId,
+      (newUserId, oldUserId) => {
+        if (newUserId && newUserId !== oldUserId) {
+          loadFromStorage()
+          return
+        }
+        if (!newUserId && oldUserId) {
+          pendingTopup.value = null
+        }
+      }
+    )
+  }
+
+  const startTopup = (amountUsd: number) => {
+    const userId = authStore.userId
+    if (!userId) return
+    const expectedCents = Math.round(amountUsd * 100)
+    pendingTopup.value = {
+      startedAtIso: new Date().toISOString(),
+      amountUsd,
+      expectedCents
+    }
+    persistToStorage()
+  }
+
+  const clearTopup = () => {
+    pendingTopup.value = null
+    persistToStorage()
+  }
+
+  const reconcileWithEvents = async (
+    events: AuditLog[] | undefined | null
+  ): Promise<boolean> => {
+    if (!events || events.length === 0) return false
+    if (!pendingTopup.value) return false
+
+    const startedAt = new Date(pendingTopup.value.startedAtIso)
+    if (Number.isNaN(+startedAt)) {
+      clearTopup()
+      return false
+    }
+
+    const withinWindow = (createdAt: string) => {
+      const created = new Date(createdAt)
+      if (Number.isNaN(+created)) return false
+      const maxAgeMs = 1000 * 60 * 60 * 24
+      return (
+        created >= startedAt &&
+        created.getTime() - startedAt.getTime() <= maxAgeMs
+      )
+    }
+
+    let matched = events.filter((e) => {
+      if (e.event_type !== EventType.CREDIT_ADDED) return false
+      if (!e.createdAt || !withinWindow(e.createdAt)) return false
+      return true
+    })
+
+    if (pendingTopup.value.expectedCents != null) {
+      matched = matched.filter((e) =>
+        typeof e.params?.amount === 'number'
+          ? e.params.amount === pendingTopup.value?.expectedCents
+          : true
+      )
+    }
+
+    if (matched.length === 0) return false
+
+    telemetry?.trackApiCreditTopupSucceeded()
+    await authStore.fetchBalance().catch(() => {})
+    clearTopup()
+    return true
+  }
+
+  const reconcileByFetchingEvents = async (): Promise<boolean> => {
+    const service = useCustomerEventsService()
+    const response = await service.getMyEvents({ page: 1, limit: 10 })
+    if (!response) return false
+    return await reconcileWithEvents(response.events)
+  }
+
+  initializeStorageSynchronization()
+
+  return {
+    pendingTopup,
+    startTopup,
+    clearTopup,
+    reconcileWithEvents,
+    reconcileByFetchingEvents
+  }
+})


### PR DESCRIPTION
Backport of #6500 onto `rh-test`.

Summary of changes
- Add TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED and provider method
- Implement topupTrackerStore to persist pending top-ups, reconcile against recent `credit_added` audit logs, emit telemetry on success, refresh balance, and clear pending
- Wire reconciliation triggers in purchase flow and usage logs table
- Minor refactor to customerEventsService to await/return explicitly

Notes
- The window and pagination issue will be resolved by a follow-up PR to core and cloud.

Validation
- Cherry-picked commits from #6500 cleanly on top of `rh-test`
- Ran `pnpm lint:fix` and `pnpm typecheck` locally

Please review backport diffs for any `rh-test` branch-specific interactions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6502-Backport-API-credit-top-up-telemetry-topupTrackerStore-6500-29e6d73d3650817cb9d6cdcaa53a67de) by [Unito](https://www.unito.io)
