### PR TITLE
Backport setting changes telemetry into rh-test

### DIFF
--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -9,6 +9,7 @@ import type {
   NodeSearchResultMetadata,
   PageVisibilityMetadata,
   RunButtonProperties,
+  SettingChangedMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryEventName,
@@ -411,6 +412,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
 
   trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
     this.trackEvent(TelemetryEvents.EXECUTION_SUCCESS, metadata)
+  }
+
+  trackSettingChanged(metadata: SettingChangedMetadata): void {
+    this.trackEvent(TelemetryEvents.SETTING_CHANGED, metadata)
   }
 
   getExecutionContext(): ExecutionContext {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -127,6 +127,18 @@ export interface TabCountMetadata {
 }
 
 /**
+ * Settings change metadata
+ */
+export interface SettingChangedMetadata {
+  setting_id: string
+  input_type?: string
+  category?: string
+  sub_category?: string
+  previous_value?: unknown
+  new_value?: unknown
+}
+
+/**
  * Node search metadata
  */
 export interface NodeSearchMetadata {
@@ -200,6 +212,9 @@ export interface TelemetryProvider {
   trackExecutionError(metadata: ExecutionErrorMetadata): void
   trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void
 
+  // Settings events
+  trackSettingChanged(metadata: SettingChangedMetadata): void
+
   // App lifecycle management
   markAppReady?(): void
   identifyUser?(userId: string): void
@@ -247,6 +262,9 @@ export const TelemetryEvents = {
   // Template Filter Analytics
   TEMPLATE_FILTER_CHANGED: 'app:template_filter_changed',
 
+  // Settings
+  SETTING_CHANGED: 'app:setting_changed',
+
   // Execution Lifecycle
   EXECUTION_START: 'execution_start',
   EXECUTION_ERROR: 'execution_error',
@@ -275,3 +293,4 @@ export type TelemetryEventProperties =
   | NodeSearchMetadata
   | NodeSearchResultMetadata
   | TemplateFilterMetadata
+  | SettingChangedMetadata


### PR DESCRIPTION
Backport setting change telemetry into rh-test as a single squashed commit.

Summary
- Source: branch `chief-pig`
- Base: branch `rh-test`
- Range: `origin/main..origin/chief-pig` (5 commits)
- Strategy: cherry-picked with `--no-commit`, resolved conflicts once, squashed to a single commit
- Validation: ran `pnpm lint:fix && pnpm typecheck`

Included commits (oldest → newest)
- f2952e9ef2b647021dc42f252f5288d5da5ee4ad
- 5d7321e23a18bec64727f30dea8a41795e6df912
- 75857b35b5091bc9961a5e6d826dffd0af69ef69
- bf032537091721fdc68fbd2e03d4839003771d8a
- df68b56483b2ddbc0fd6ffeea9766c13f89f0f96

Conflict resolution notes
- src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts: removed stray imports introduced by merge markers
- src/platform/telemetry/types.ts: unified interface to include both `trackSettingChanged` and lifecycle hooks `markAppReady?` / `identifyUser?`

QA checklist
- pnpm lint:fix → clean
- pnpm typecheck → clean
- No UI changes expected; telemetry types and provider updated

If you prefer preserving individual commit history instead of a single squashed backport, I can adjust this PR accordingly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6507-Backport-chief-pig-into-rh-test-29e6d73d36508142b4f0f5ac10c15a9a) by [Unito](https://www.unito.io)
