### PR TITLE
fix: set transparent border for gradient subscribe button

### DIFF
--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -13,6 +13,13 @@
       background: 'var(--color-subscription-button-gradient)',
       color: 'var(--color-white)'
     }"
+    :pt="{
+      root: {
+        style: {
+          borderColor: 'transparent'
+        }
+      }
+    }"
     data-testid="subscribe-to-run-button"
     @click="handleSubscribeToRun"
   />


### PR DESCRIPTION
## Summary
- Fixed the subscribe to run button border to be transparent, allowing the gradient background to display properly
- Used PrimeVue's `pt` (passthrough) props to customize the border color

## Context
The subscribe to run button was recently updated to use a gradient background via inline styles, but the border was still using the default color which clashed with the gradient.

## Changes
- Added `:pt` prop to the Button component in `SubscribeToRun.vue`
- Set `borderColor: 'transparent'` on the root element to remove the default border color

## Test Plan
- [ ] Visual inspection of the subscribe to run button
- [ ] Verify the gradient background displays without border color clash
- [ ] Ensure the button still functions correctly when clicked

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6510-fix-set-transparent-border-for-gradient-subscribe-button-29e6d73d3650816d9ecfcb63e2ffb7d3) by [Unito](https://www.unito.io)
