### PR TITLE
fix: add cloud badges and server health alerts to second-row workflow tabs

### DIFF
--- a/src/components/topbar/SecondRowWorkflowTabs.vue
+++ b/src/components/topbar/SecondRowWorkflowTabs.vue
@@ -1,10 +1,12 @@
 <template>
-  <div class="w-auto max-w-full">
+  <div class="flex h-full w-auto max-w-full items-center">
     <WorkflowTabs />
+    <TopbarBadges />
   </div>
 </template>
 
 <script setup lang="ts">
+import TopbarBadges from '@/components/topbar/TopbarBadges.vue'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 </script>
 


### PR DESCRIPTION
## Summary

Fixes missing cloud badges and server health alerts when workflow tabs are in the second-row position.

## Problem

Badges were only visible when `Comfy.Workflow.WorkflowTabsPosition` was set to `'Topbar'`, but not when set to `'Topbar (2nd-row)'` which is the **default for screens < 1536px wide** on rh-test.

The `SecondRowWorkflowTabs.vue` component only rendered `<WorkflowTabs />` but was missing `<TopbarBadges />`.

## Changes

- Added `<TopbarBadges />` component to `SecondRowWorkflowTabs.vue`
- Updated container to use flex layout to match other topbar badge implementations
- Badges now display in both 'Topbar' and 'Topbar (2nd-row)' positions

## Testing

- Cloud badges should now be visible on screens < 1536px wide (default setting)
- Server health alerts from remote config should display properly in second-row tabs

## Note

This is an **rh-test only** issue. The main branch removed the 'Topbar (2nd-row)' option in the Floating Menus PR (#5980).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6515-fix-add-cloud-badges-and-server-health-alerts-to-second-row-workflow-tabs-29e6d73d365081c4a4defaf97d2e789e) by [Unito](https://www.unito.io)
