### PR TITLE
fix: hide node name badge on cloud builds

### DIFF
--- a/src/components/sidebar/tabs/queue/TaskItem.vue
+++ b/src/components/sidebar/tabs/queue/TaskItem.vue
@@ -36,7 +36,7 @@
 
     <div class="task-item-details">
       <div class="tag-wrapper status-tag-group">
-        <Tag v-if="isFlatTask && task.isHistory" class="node-name-tag">
+        <Tag v-if="!isCloud && isFlatTask && task.isHistory" class="node-name-tag">
           <Button
             class="task-node-link"
             :label="`${node?.type} (#${node?.id})`"
@@ -78,6 +78,7 @@ import Button from 'primevue/button'
 import Tag from 'primevue/tag'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 
+import { isCloud } from '@/platform/distribution/types'
 import type { ComfyNode } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { api } from '@/scripts/api'
 import { useLitegraphService } from '@/services/litegraphService'

--- a/src/components/sidebar/tabs/queue/TaskItem.vue
+++ b/src/components/sidebar/tabs/queue/TaskItem.vue
@@ -36,7 +36,10 @@
 
     <div class="task-item-details">
       <div class="tag-wrapper status-tag-group">
-        <Tag v-if="!isCloud && isFlatTask && task.isHistory" class="node-name-tag">
+        <Tag
+          v-if="!isCloud && isFlatTask && task.isHistory"
+          class="node-name-tag"
+        >
           <Button
             class="task-node-link"
             :label="`${node?.type} (#${node?.id})`"


### PR DESCRIPTION
## Summary

Hides the node name badge in queue task items on cloud builds since workflow data is not available.

## Problem

On cloud distribution, `extra_data.extra_pnginfo.workflow` is omitted from history task items to reduce memory usage. The node name badge relies on this workflow data to:
1. Get the `nodeId` from the task output
2. Find the matching node in `workflow.nodes[]`
3. Display `node.type (#node.id)` (e.g., "SaveImage (#8)")

Without workflow data, the badge would be empty or show undefined values.

## Changes

- Added `isCloud` check to the node badge `v-if` condition
- Badge now only renders when `!isCloud && isFlatTask && task.isHistory`
- Imported `isCloud` from `@/platform/distribution/types`

## Impact

- **Cloud builds**: Node name badge hidden in flat list view (workflow data unavailable)
- **OSS/localhost builds**: Node name badge continues to show normally (workflow data available)

## Note

This is an **rh-test only** change since cloud builds use this branch.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6517-fix-hide-node-name-badge-on-cloud-builds-29e6d73d36508163818acb07be90cf74) by [Unito](https://www.unito.io)
