### PR TITLE
Fix inability to select image from batch in vue

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -226,7 +226,7 @@ const setCurrentIndex = (index: number) => {
   if (index >= 0 && index < props.imageUrls.length) {
     currentIndex.value = index
     actualDimensions.value = null
-    isLoading.value = true
+    isLoading.value = false
     imageError.value = false
   }
 }

--- a/tests-ui/tests/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -208,10 +208,6 @@ describe('ImagePreview', () => {
     await navigationDots[1].trigger('click')
     await nextTick()
 
-    // After clicking, component shows loading state (Skeleton), not img
-    expect(wrapper.find('skeleton-stub').exists()).toBe(true)
-    expect(wrapper.find('img').exists()).toBe(false)
-
     // Simulate image load event to clear loading state
     const component = wrapper.vm as any
     component.isLoading = false


### PR DESCRIPTION
Selecting a new image from a batch sets isLoading to true, but handleImageLoad is never triggered so the image never displays.

Swapping to a different image from a batch is currently the only place isLoading is set to true. This change, even if temporary, results in a good chunk of dead code.

To my understanding, ImagePreviews are always object URLs and should never need to load, so I don't foresee the loading placeholder being needed here.

Resolves #6458

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6521-Fix-inability-to-select-image-from-batch-in-vue-29e6d73d36508162abeaeece7c5e0eed) by [Unito](https://www.unito.io)
