### PR TITLE
Remove Object URL usage for image previews

### DIFF
--- a/src/components/sidebar/tabs/queue/TaskItem.vue
+++ b/src/components/sidebar/tabs/queue/TaskItem.vue
@@ -177,10 +177,12 @@ const formatTime = (time?: number) => {
 
 const onProgressPreviewReceived = async ({ detail }: CustomEvent) => {
   if (props.task.displayStatus === TaskItemDisplayStatus.Running) {
-    if (progressPreviewBlobUrl.value) {
-      URL.revokeObjectURL(progressPreviewBlobUrl.value)
+    const reader = new FileReader()
+    reader.onloadend = () => {
+      if (typeof reader.result !== 'string') return
+      progressPreviewBlobUrl.value = reader.result
     }
-    progressPreviewBlobUrl.value = URL.createObjectURL(detail)
+    reader.readAsDataURL(detail)
   }
 }
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -719,18 +719,18 @@ export class ComfyApp {
     api.addEventListener('b_preview_with_metadata', ({ detail }) => {
       // Enhanced preview with explicit node context
       const { blob, displayNodeId } = detail
-      const { setNodePreviewsByExecutionId, revokePreviewsByExecutionId } =
-        useNodeOutputStore()
-      // Ensure clean up if `executing` event is missed.
-      revokePreviewsByExecutionId(displayNodeId)
-      const blobUrl = URL.createObjectURL(blob)
-      // Preview cleanup is handled in progress_state event to support multiple concurrent previews
+      const { setNodePreviewsByExecutionId } = useNodeOutputStore()
+      const reader = new FileReader()
       const nodeParents = displayNodeId.split(':')
-      for (let i = 1; i <= nodeParents.length; i++) {
-        setNodePreviewsByExecutionId(nodeParents.slice(0, i).join(':'), [
-          blobUrl
-        ])
+      reader.onloadend = () => {
+        if (typeof reader.result !== 'string') return
+        for (let i = 1; i <= nodeParents.length; i++) {
+          setNodePreviewsByExecutionId(nodeParents.slice(0, i).join(':'), [
+            reader.result
+          ])
+        }
       }
+      reader.readAsDataURL(blob)
     })
 
     api.init()

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -261,10 +261,6 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     const previews = app.nodePreviewImages[nodeLocatorId]
     if (!previews?.[Symbol.iterator]) return
 
-    for (const url of previews) {
-      URL.revokeObjectURL(url)
-    }
-
     delete app.nodePreviewImages[nodeLocatorId]
     delete nodePreviewImages.value[nodeLocatorId]
   }


### PR DESCRIPTION
If an [Object URL](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/blob) is not revoked after being created, it causes a memory leak. [Data URLs](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) don't have this issue, but they can clutter the DOM, require more memory due to the base64 encoding, and may result in duplicate copies being kept in memory.

This is a WIP testing branch to determine
- If this overhead is significant
- If this affects the reports of memory leaks in the frontend

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6524-Remove-Object-URL-usage-for-image-previews-29e6d73d3650818cbe3cd1ba7b3e0f22) by [Unito](https://www.unito.io)
