### PR TITLE
Fix node header height for subgraphs

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -71,6 +71,7 @@
           size="sm"
           type="transparent"
           data-testid="subgraph-enter-button"
+          class="h-5"
           @click.stop="handleEnterSubgraph"
           @dblclick.stop
         >

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -68,10 +68,9 @@
         <IconButton
           v-if="isSubgraphNode"
           v-tooltip.top="enterSubgraphTooltipConfig"
-          size="sm"
           type="transparent"
           data-testid="subgraph-enter-button"
-          class="h-5"
+          class="size-5"
           @click.stop="handleEnterSubgraph"
           @dblclick.stop
         >


### PR DESCRIPTION
Node headers are slightly too tall on subgraph nodes due to the height of the "enter subgraph" button. This is fixed by explicitly setting the height of the enter subgraph button.
<img width="991" height="171" alt="image" src="https://github.com/user-attachments/assets/34d049a7-1dee-46c2-ab28-169c3f546347" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6525-Fix-node-header-height-for-subgraphs-29f6d73d3650810eaf95e7a6d107c2bd) by [Unito](https://www.unito.io)
