### PR TITLE
fix: Change h-screen to h-svh in BaseViewTemplate

### DIFF
--- a/src/views/templates/BaseViewTemplate.vue
+++ b/src/views/templates/BaseViewTemplate.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex h-screen w-screen flex-col font-sans"
+    class="flex h-svh w-screen flex-col font-sans"
     :class="[
       dark
         ? 'dark-theme bg-neutral-900 text-neutral-300'


### PR DESCRIPTION
## Summary
- Fixed height issue in BaseViewTemplate by changing `h-screen` to `h-svh` for better viewport handling

## Changes
- Updated `BaseViewTemplate.vue` to use `h-svh` (small viewport height) instead of `h-screen`
- This ensures proper height calculation on mobile devices with dynamic browser UI

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6529-fix-Change-h-screen-to-h-svh-in-BaseViewTemplate-29f6d73d36508117871cd4ff165c2109) by [Unito](https://www.unito.io)
