### PR TITLE
Update diffusion_models display to 'Diffusion' in asset browser

### DIFF
--- a/src/platform/assets/utils/categoryLabel.ts
+++ b/src/platform/assets/utils/categoryLabel.ts
@@ -3,6 +3,9 @@ const ACRONYM_TAGS = new Set(['VAE', 'CLIP', 'GLIGEN'])
 export function formatCategoryLabel(raw?: string): string {
   if (!raw) return 'Models'
 
+  // Special display name mappings
+  if (raw === 'diffusion_models') return 'Diffusion'
+
   return raw
     .split('_')
     .map((segment) => {


### PR DESCRIPTION
## Summary
- Update the display label for `diffusion_models` category from "Diffusion Models" to "Diffusion" in the asset browser/gallery UI
- Added special case handling in `formatCategoryLabel` function for cleaner display
- This is a display-only change that does not affect underlying data structures or API calls

## Test plan
- [x] Unit tests pass
- [x] Linter passes
- [x] Formatter passes
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6533-Update-diffusion_models-display-to-Diffusion-in-asset-browser-29f6d73d365081009fa5cb396861570b) by [Unito](https://www.unito.io)
