### PR TITLE
fix: remove unsafe type assertions in subscription credits

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscriptionCredits.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCredits.ts
@@ -23,10 +23,12 @@ export function useSubscriptionCredits() {
   })
 
   const monthlyBonusCredits = computed(() => {
-    const balance = authStore.balance as any
-    if (!balance?.cloud_credit_balance_micros) return '0.00'
+    if (!authStore.balance?.cloud_credit_balance_micros) return '0.00'
     try {
-      return formatMetronomeCurrency(balance.cloud_credit_balance_micros, 'usd')
+      return formatMetronomeCurrency(
+        authStore.balance.cloud_credit_balance_micros,
+        'usd'
+      )
     } catch (error) {
       console.error(
         '[useSubscriptionCredits] Error formatting monthly bonus credits:',
@@ -37,10 +39,12 @@ export function useSubscriptionCredits() {
   })
 
   const prepaidCredits = computed(() => {
-    const balance = authStore.balance as any
-    if (!balance?.prepaid_balance_micros) return '0.00'
+    if (!authStore.balance?.prepaid_balance_micros) return '0.00'
     try {
-      return formatMetronomeCurrency(balance.prepaid_balance_micros, 'usd')
+      return formatMetronomeCurrency(
+        authStore.balance.prepaid_balance_micros,
+        'usd'
+      )
     } catch (error) {
       console.error(
         '[useSubscriptionCredits] Error formatting prepaid credits:',


### PR DESCRIPTION
## Summary

Removes unsafe `as any` type assertions from subscription credits composable now that the OpenAPI spec has been updated with the missing balance breakdown fields.

The `GetCustomerBalance` API response now includes:
- `cloud_credit_balance_micros` - Monthly subscription credits
- `prepaid_balance_micros` - Pre-paid top-up credits

These fields were previously accessed with `as any` because they weren't in the TypeScript type definitions. With the OpenAPI spec update (PR #6531), these fields are now properly typed.


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6536-fix-remove-unsafe-type-assertions-in-subscription-credits-29f6d73d365081ffae52cc85c01c139b) by [Unito](https://www.unito.io)
