### PR TITLE
DONOTMERGE feat: add retry logic for session cookie creation with token refresh

### DIFF
--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSessionCookie } from './useSessionCookie'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Mock api.apiURL
+vi.mock('@/scripts/api', () => ({
+  api: {
+    apiURL: vi.fn((path: string) => `https://test-api.com${path}`)
+  }
+}))
+
+// Mock isCloud to always return true for testing
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: true
+}))
+
+// Mock useFirebaseAuthStore
+const mockGetAuthHeader = vi.fn()
+vi.mock('@/stores/firebaseAuthStore', () => ({
+  useFirebaseAuthStore: vi.fn(() => ({
+    getAuthHeader: mockGetAuthHeader
+  }))
+}))
+
+describe('useSessionCookie', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockFetch.mockReset()
+    mockGetAuthHeader.mockReset()
+  })
+
+  describe('createSession', () => {
+    it('should succeed on first attempt', async () => {
+      // Mock successful auth header and API response
+      mockGetAuthHeader.mockResolvedValue({ Authorization: 'Bearer token' })
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200
+      })
+
+      const { createSession } = useSessionCookie()
+      await createSession()
+
+      expect(mockGetAuthHeader).toHaveBeenCalledWith(false) // First attempt with cached token
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://test-api.com/auth/session',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/json'
+          }
+        }
+      )
+    })
+
+    it('should retry with fresh token after 401 error and succeed', async () => {
+      // First attempt: auth header success but API returns 401
+      // Second attempt: fresh token and API success
+      mockGetAuthHeader
+        .mockResolvedValueOnce({ Authorization: 'Bearer cached-token' })
+        .mockResolvedValueOnce({ Authorization: 'Bearer fresh-token' })
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          json: () => Promise.resolve({ message: 'Token expired' })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200
+        })
+
+      const { createSession } = useSessionCookie()
+      await createSession()
+
+      expect(mockGetAuthHeader).toHaveBeenCalledTimes(2)
+      expect(mockGetAuthHeader).toHaveBeenNthCalledWith(1, false) // First attempt with cached token
+      expect(mockGetAuthHeader).toHaveBeenNthCalledWith(2, true) // Second attempt with forced refresh
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://test-api.com/auth/session',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Authorization: 'Bearer cached-token',
+            'Content-Type': 'application/json'
+          }
+        }
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://test-api.com/auth/session',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Authorization: 'Bearer fresh-token',
+            'Content-Type': 'application/json'
+          }
+        }
+      )
+    })
+
+    it('should fail after all retries with API error', async () => {
+      // All attempts return auth headers but API always fails
+      mockGetAuthHeader.mockResolvedValue({ Authorization: 'Bearer token' })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ message: 'Server error' })
+      })
+
+      const { createSession } = useSessionCookie()
+
+      await expect(createSession()).rejects.toThrow(
+        'Failed to create session: Server error'
+      )
+
+      expect(mockGetAuthHeader).toHaveBeenCalledTimes(3)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should succeed after auth header null then fresh token success', async () => {
+      // First attempt: no auth header (token timing issue)
+      // Second attempt: fresh token success
+      mockGetAuthHeader
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ Authorization: 'Bearer fresh-token' })
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200
+      })
+
+      const { createSession } = useSessionCookie()
+      await createSession()
+
+      expect(mockGetAuthHeader).toHaveBeenCalledTimes(2)
+      expect(mockGetAuthHeader).toHaveBeenNthCalledWith(1, false) // First attempt with cached token
+      expect(mockGetAuthHeader).toHaveBeenNthCalledWith(2, true) // Second attempt with forced refresh
+
+      expect(mockFetch).toHaveBeenCalledTimes(1) // Only called when auth header is available
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://test-api.com/auth/session',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Authorization: 'Bearer fresh-token',
+            'Content-Type': 'application/json'
+          }
+        }
+      )
+    })
+
+    it('should fail when no auth header is available after all retries', async () => {
+      // All attempts fail to get auth header (complete auth failure)
+      mockGetAuthHeader.mockResolvedValue(null)
+
+      const { createSession } = useSessionCookie()
+
+      await expect(createSession()).rejects.toThrow(
+        'No auth header available for session creation after retries'
+      )
+
+      expect(mockGetAuthHeader).toHaveBeenCalledTimes(3)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('should handle mixed auth header failures and successes', async () => {
+      // First attempt: no auth header
+      // Second attempt: auth header but API fails
+      // Third attempt: auth header and API success
+      mockGetAuthHeader
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ Authorization: 'Bearer token' })
+        .mockResolvedValueOnce({ Authorization: 'Bearer fresh-token' })
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          json: () => Promise.resolve({ message: 'Token expired' })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200
+        })
+
+      const { createSession } = useSessionCookie()
+      await createSession()
+
+      expect(mockGetAuthHeader).toHaveBeenCalledTimes(3)
+      expect(mockFetch).toHaveBeenCalledTimes(2) // Only called when auth header is available
+    })
+
+    it('should handle JSON parsing errors gracefully', async () => {
+      mockGetAuthHeader.mockResolvedValue({ Authorization: 'Bearer token' })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.reject(new Error('Invalid JSON'))
+      })
+
+      const { createSession } = useSessionCookie()
+
+      await expect(createSession()).rejects.toThrow(
+        'Failed to create session: Internal Server Error'
+      )
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('should successfully delete session', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200
+      })
+
+      const { deleteSession } = useSessionCookie()
+      await deleteSession()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://test-api.com/auth/session',
+        {
+          method: 'DELETE',
+          credentials: 'include'
+        }
+      )
+    })
+
+    it('should handle delete session errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: () => Promise.resolve({ message: 'Session not found' })
+      })
+
+      const { deleteSession } = useSessionCookie()
+
+      await expect(deleteSession()).rejects.toThrow(
+        'Failed to delete session: Session not found'
+      )
+    })
+
+    it('should handle delete session JSON parsing errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.reject(new Error('Invalid JSON'))
+      })
+
+      const { deleteSession } = useSessionCookie()
+
+      await expect(deleteSession()).rejects.toThrow(
+        'Failed to delete session: Internal Server Error'
+      )
+    })
+  })
+})

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -33,14 +33,17 @@ export const useSessionCookie = () => {
           }
         })
 
-        if (!response.ok) {
+        if (response.ok) {
+          return // Success
+        }
+
+        // API error - continue retry loop if not the last attempt
+        if (attempt === 2) {
           const errorData = await response.json().catch(() => ({}))
           throw new Error(
             `Failed to create session: ${errorData.message || response.statusText}`
           )
         }
-
-        return // Success
       }
 
       // Exponential backoff before retry (except for last attempt)

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -106,10 +106,12 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     }
   })
 
-  const getIdToken = async (): Promise<string | undefined> => {
+  const getIdToken = async (
+    forceRefresh = false
+  ): Promise<string | undefined> => {
     if (!currentUser.value) return
     try {
-      return await currentUser.value.getIdToken()
+      return await currentUser.value.getIdToken(forceRefresh)
     } catch (error: unknown) {
       if (
         error instanceof FirebaseError &&
@@ -135,14 +137,17 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
    * 1. Firebase authentication token (if user is logged in)
    * 2. API key (if stored in the browser's credential manager)
    *
+   * @param forceRefresh - If true, forces a refresh of the Firebase token
    * @returns {Promise<AuthHeader | null>}
    *   - A LoggedInAuthHeader with Bearer token if Firebase authenticated
    *   - An ApiKeyAuthHeader with X-API-KEY if API key exists
    *   - null if neither authentication method is available
    */
-  const getAuthHeader = async (): Promise<AuthHeader | null> => {
+  const getAuthHeader = async (
+    forceRefresh = false
+  ): Promise<AuthHeader | null> => {
     // If available, set header with JWT used to identify the user to Firebase service
-    const token = await getIdToken()
+    const token = await getIdToken(forceRefresh)
     if (token) {
       return {
         Authorization: `Bearer ${token}`


### PR DESCRIPTION
## 🐛 Problem

Intermittent "No auth header available for session creation" errors during session cookie creation

## 🔍 Root Cause Analysis

Temporary token unavailability during Firebase token refresh process:
- At the time of `onIdTokenChanged` event trigger
- `getAuthHeader()` temporarily returns null while fetching new token
- Results in session creation failure → user authentication issues

## ✅ Solution

### 1. Add Retry Logic (useSessionCookie.ts)
- Maximum 3 retry attempts
- First attempt: uses cached token (performance optimization)
- On retry: forces token refresh with `forceRefresh: true`
- Exponential backoff: 500ms, 1s intervals

### 2. Support forceRefresh Parameter (firebaseAuthStore.ts)
- Add `getAuthHeader(forceRefresh?: boolean)` parameter
- Add `getIdToken(forceRefresh?: boolean)` parameter
- Utilize Firebase SDK's forced token refresh capability on retry
- **Note: This feature is already implemented in the rh-test branch and is also needed in main**

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6540-feat-add-retry-logic-for-session-cookie-creation-with-token-refresh-29f6d73d3650812a932cfb3f8f760520) by [Unito](https://www.unito.io)
