### PR TITLE
fix: Use environment-specific log API endpoints for Cloud and OSS

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1135,15 +1135,22 @@ export class ComfyApi extends EventTarget {
   }
 
   async getLogs(): Promise<string> {
-    return (await axios.get(this.internalURL('/logs'))).data
+    const url = isCloud ? this.apiURL('/logs') : this.internalURL('/logs')
+    return (await axios.get(url)).data
   }
 
   async getRawLogs(): Promise<LogsRawResponse> {
-    return (await axios.get(this.internalURL('/logs/raw'))).data
+    const url = isCloud
+      ? this.apiURL('/logs/raw')
+      : this.internalURL('/logs/raw')
+    return (await axios.get(url)).data
   }
 
   async subscribeLogs(enabled: boolean): Promise<void> {
-    return await axios.patch(this.internalURL('/logs/subscribe'), {
+    const url = isCloud
+      ? this.apiURL('/logs/subscribe')
+      : this.internalURL('/logs/subscribe')
+    return await axios.patch(url, {
       enabled,
       clientId: this.clientId
     })


### PR DESCRIPTION
## Problem
401 authentication errors were persistently occurring when calling log-related APIs in the Cloud environment.

## Root Cause
- Frontend was calling `/internal/logs/*` endpoints in all environments
- Cloud backend provides public APIs at `/api/logs/*` (no authentication required)
- OSS (open source) backend uses `/internal/logs/*` paths
- This caused Cloud to call non-existent paths → resulting in 401 errors

## Solution
Modified to use appropriate API endpoints based on environment using the `isCloud` flag:
- Cloud environment: Use `/api/logs/*`
- OSS environment: Use `/internal/logs/*`

## Changes
- `getLogs()`: Added environment-specific URL branching
- `getRawLogs()`: Added environment-specific URL branching
- `subscribeLogs()`: Added environment-specific URL branching

## Testing
- [x] Verified log functionality works correctly in local (OSS) environment
- [x] Confirmed 401 errors are resolved in Cloud environment

## Related Issues
This resolves the 401 errors tracked in Sentry for log API endpoints.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6538-fix-Use-environment-specific-log-API-endpoints-for-Cloud-and-OSS-29f6d73d3650817ba2ccd3e5f6cadd6a) by [Unito](https://www.unito.io)
