### PR TITLE
[fix] Remove unreliable CI wait logic from Claude review workflow

### DIFF
--- a/.github/workflows/pr-claude-review.yaml
+++ b/.github/workflows/pr-claude-review.yaml
@@ -17,40 +17,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait-for-ci:
+  claude-review:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'claude-review'
-    outputs:
-      should-proceed: ${{ steps.check-status.outputs.proceed }}
-    steps:
-      - name: Wait for other CI checks
-        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-regexp: '^(lint-and-format|test|playwright-tests)'
-          allowed-conclusions: success,skipped,failure,cancelled,neutral,action_required,timed_out,stale
-          wait-interval: 30
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Check if we should proceed
-        id: check-status
-        run: |
-          CHECK_RUNS=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs --jq '.check_runs[] | select(.name | test("lint-and-format")) | {name, conclusion}')
-
-          if echo "$CHECK_RUNS" | grep -Eq '"conclusion": "(failure|cancelled|timed_out|action_required)"'; then
-            echo "Some CI checks failed - skipping Claude review"
-            echo "proceed=false" >> $GITHUB_OUTPUT
-          else
-            echo "All CI checks passed - proceeding with Claude review"
-            echo "proceed=true" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  claude-review:
-    needs: wait-for-ci
-    if: needs.wait-for-ci.outputs.should-proceed == 'true'
-    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Removes the wait-for-ci job that has been causing random workflow skips and reliability issues due to race conditions with CI check creation. Multiple attempts to fix timing issues have resulted in ongoing edge cases, so this simplifies the workflow to run immediately when the claude-review label is added. Reviews can now run in parallel with CI checks, and while they may occasionally run on PRs with failing CI, the review feedback is often valuable regardless of CI status.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6548-fix-Remove-unreliable-CI-wait-logic-from-Claude-review-workflow-29f6d73d36508125910ef4feba5abdf4) by [Unito](https://www.unito.io)
