### PR TITLE
fix(AssetCard): use tooltip instead of title for overflow text

### DIFF
--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -24,18 +24,19 @@
       <div>
         <h3
           :id="titleId"
+          v-tooltip.top="{ value: asset.name, showDelay: tooltipDelay }"
           :class="
             cn(
               'mb-2 m-0 text-base font-semibold line-clamp-2 wrap-anywhere',
               'text-base-foreground'
             )
           "
-          :title="asset.name"
         >
           {{ asset.name }}
         </h3>
         <p
           :id="descId"
+          v-tooltip.top="{ value: asset.description, showDelay: tooltipDelay }"
           :class="
             cn(
               'm-0 text-sm leading-6 overflow-hidden [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box]',
@@ -43,7 +44,6 @@
               'dark-theme:text-slate-100'
             )
           "
-          :title="asset.description"
         >
           {{ asset.description }}
         </p>
@@ -76,6 +76,7 @@ import { computed, useId } from 'vue'
 
 import AssetBadgeGroup from '@/platform/assets/components/AssetBadgeGroup.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { cn } from '@/utils/tailwindUtil'
 
 const props = defineProps<{
@@ -83,8 +84,14 @@ const props = defineProps<{
   interactive?: boolean
 }>()
 
+const settingStore = useSettingStore()
+
 const titleId = useId()
 const descId = useId()
+
+const tooltipDelay = computed<number>(() =>
+  settingStore.get('LiteGraph.Node.TooltipDelay')
+)
 
 const { error } = useImage({
   src: props.asset.preview_url ?? '',


### PR DESCRIPTION
## Summary

The default `title` attribute was too small and too slow to show for users. We were getting complaints about not being able to see the full name of the model.

Using [Prime Vue's tooltip](https://primevue.org/tooltip) instead.

## Screenshots (if applicable)

Before:

<img width="480" height="246" alt="image" src="https://github.com/user-attachments/assets/db4d1cc7-9e9a-40b3-bf16-57f2def93726" />


After:

<img width="518" height="720" alt="image" src="https://github.com/user-attachments/assets/500389e5-c781-4d3b-b62e-1e72d2b7e2c6" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6556-fix-AssetCard-use-tooltip-instead-of-title-for-overflow-text-2a06d73d365081939dc0d863b05f1e90) by [Unito](https://www.unito.io)
