### PR TITLE
Conditionally generate vendor import map outside cloud builds

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -222,41 +222,46 @@ export default defineConfig({
       : [vue()]),
     tailwindcss(),
     comfyAPIPlugin(IS_DEV),
-    generateImportMapPlugin([
-      {
-        name: 'vue',
-        pattern: 'vue',
-        entry: './dist/vue.esm-browser.prod.js'
-      },
-      {
-        name: 'vue-i18n',
-        pattern: 'vue-i18n',
-        entry: './dist/vue-i18n.esm-browser.prod.js'
-      },
-      {
-        name: 'primevue',
-        pattern: /^primevue\/?.*/,
-        entry: './index.mjs',
-        recursiveDependence: true
-      },
-      {
-        name: '@primevue/themes',
-        pattern: /^@primevue\/themes\/?.*/,
-        entry: './index.mjs',
-        recursiveDependence: true
-      },
-      {
-        name: '@primevue/forms',
-        pattern: /^@primevue\/forms\/?.*/,
-        entry: './index.mjs',
-        recursiveDependence: true,
-        override: {
-          '@primeuix/forms': {
-            entry: ''
-          }
-        }
-      }
-    ]),
+    // Skip import-map generation for cloud builds to keep bundle small
+    ...(DISTRIBUTION !== 'cloud'
+      ? [
+          generateImportMapPlugin([
+            {
+              name: 'vue',
+              pattern: 'vue',
+              entry: './dist/vue.esm-browser.prod.js'
+            },
+            {
+              name: 'vue-i18n',
+              pattern: 'vue-i18n',
+              entry: './dist/vue-i18n.esm-browser.prod.js'
+            },
+            {
+              name: 'primevue',
+              pattern: /^primevue\/?.*/,
+              entry: './index.mjs',
+              recursiveDependence: true
+            },
+            {
+              name: '@primevue/themes',
+              pattern: /^@primevue\/themes\/?.*/,
+              entry: './index.mjs',
+              recursiveDependence: true
+            },
+            {
+              name: '@primevue/forms',
+              pattern: /^@primevue\/forms\/?.*/,
+              entry: './index.mjs',
+              recursiveDependence: true,
+              override: {
+                '@primeuix/forms': {
+                  entry: ''
+                }
+              }
+            }
+          ])
+        ]
+      : []),
 
     Icons({
       compiler: 'vue3',


### PR DESCRIPTION
## Summary
- gate vendor import-map generation behind non-cloud distributions
- keep cloud bundles slim while preserving prebuilt chunks for desktop/localhost builds
- document the conditional to guide future CDN/cache work

## Testing
- [ ] DISTRIBUTION=cloud pnpm build
- [ ] DISTRIBUTION=desktop pnpm build

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6559-Conditionally-generate-vendor-import-map-outside-cloud-builds-2a06d73d3650819d96a0e2b6c006baf1) by [Unito](https://www.unito.io)
