### PR TITLE
fix(vite): use dynamic base URL based on cloud distribution

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -122,7 +122,7 @@ const gcsRedirectProxyConfig: ProxyOptions = {
 }
 
 export default defineConfig({
-  base: '',
+  base: DISTRIBUTION === 'cloud' ? '/' : '',
   server: {
     host: VITE_REMOTE_DEV ? '0.0.0.0' : undefined,
     watch: {


### PR DESCRIPTION
## Summary
- Replace hardcoded `<base href="/">` in index.html with dynamic vite base config
- Set `base: DISTRIBUTION === 'cloud' ? '/' : ''` in vite.config.mts
- Ensures proper asset loading across different deployment contexts

## Test plan
- [ ] Verify cloud distribution builds work correctly
- [ ] Verify localhost/desktop distributions work correctly
- [ ] Test asset loading in both contexts

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6562-fix-vite-use-dynamic-base-URL-based-on-cloud-distribution-2a06d73d365081c8b5d2e58870ebd14d) by [Unito](https://www.unito.io)
