### PR TITLE
Add .pnpm-store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn.lock
 .stylelintcache
 
 node_modules
+.pnpm-store
 dist
 dist-ssr
 *.local


### PR DESCRIPTION
Adds .pnpm-store to gitignore. It's a cache folder that sometimes appears in certain scenarios that would never need to be checked into git.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6566-Add-pnpm-store-to-gitignore-2a16d73d365081319220f90516cfad3c) by [Unito](https://www.unito.io)
