### PR TITLE
Hide browser tab star when autosave is enabled

### DIFF
--- a/src/composables/useBrowserTabTitle.ts
+++ b/src/composables/useBrowserTabTitle.ts
@@ -5,6 +5,7 @@ import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 const DEFAULT_TITLE = 'ComfyUI'
 const TITLE_SUFFIX = ' - ComfyUI'
@@ -13,6 +14,7 @@ export const useBrowserTabTitle = () => {
   const executionStore = useExecutionStore()
   const settingStore = useSettingStore()
   const workflowStore = useWorkflowStore()
+  const workspaceStore = useWorkspaceStore()
 
   const executionText = computed(() =>
     executionStore.isIdle
@@ -24,11 +26,27 @@ export const useBrowserTabTitle = () => {
     () => settingStore.get('Comfy.UseNewMenu') !== 'Disabled'
   )
 
+  const isAutoSaveEnabled = computed(
+    () => settingStore.get('Comfy.Workflow.AutoSave') === 'after delay'
+  )
+
+  const isActiveWorkflowModified = computed(
+    () => !!workflowStore.activeWorkflow?.isModified
+  )
+  const isActiveWorkflowPersisted = computed(
+    () => !!workflowStore.activeWorkflow?.isPersisted
+  )
+
+  const shouldShowUnsavedIndicator = computed(() => {
+    if (workspaceStore.shiftDown) return false
+    if (isAutoSaveEnabled.value) return false
+    if (!isActiveWorkflowPersisted.value) return true
+    if (isActiveWorkflowModified.value) return true
+    return false
+  })
+
   const isUnsavedText = computed(() =>
-    workflowStore.activeWorkflow?.isModified ||
-    !workflowStore.activeWorkflow?.isPersisted
-      ? ' *'
-      : ''
+    shouldShowUnsavedIndicator.value ? ' *' : ''
   )
   const workflowNameText = computed(() => {
     const workflowName = workflowStore.activeWorkflow?.filename


### PR DESCRIPTION
- Hide "*" indicator in the browser tab title when autosave is enabled (Comfy.Workflow.AutoSave === 'after delay').
- Refactor: extract readable computed values (`shouldShowUnsavedIndicator`, `isActiveWorkflowModified`, `isActiveWorkflowPersisted`).
- Aligns with workflow tab behavior; also hides while Shift is held (matches in-app tab logic).

Files touched:
- src/composables/useBrowserTabTitle.ts

Validation:
- Ran `pnpm lint:fix` and `pnpm typecheck` — both passed.

Manual test suggestions:
- With autosave set to 'after delay': modify a workflow → browser tab should not show `*`.
- With autosave 'off': modify or open non-persisted workflow → browser tab shows `*`.
- Hold Shift: indicator hidden while held (consistent with workflow tab).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6568-Hide-browser-tab-star-when-autosave-is-enabled-refactor-title-logic-2a16d73d365081549906e9d1fed07a42) by [Unito](https://www.unito.io)
