### PR TITLE
[fix] improve FormDropdownMenu scrolling behavior

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -53,7 +53,7 @@ const searchQuery = defineModel<string>('searchQuery')
       :is-querying="isQuerying"
     />
     <!-- List -->
-    <div class="relative flex h-full overflow-hidden">
+    <div class="relative flex h-full mt-1 overflow-y-scroll">
       <div
         :class="
           cn(

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -53,7 +53,7 @@ const searchQuery = defineModel<string>('searchQuery')
       :is-querying="isQuerying"
     />
     <!-- List -->
-    <div class="relative flex h-full mt-1 overflow-y-scroll">
+    <div class="relative flex h-full mt-2 overflow-y-scroll">
       <div
         :class="
           cn(


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `FormDropdownMenu.vue` component. The change improves the dropdown menu's usability by allowing its contents to scroll vertically and adds a small top margin for better spacing.

* UI improvement: Changed the dropdown list container to use `overflow-y-scroll` and added a top margin (`mt-2`) for improved scrolling and spacing. (`src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue`)- Add top margin (mt-2) for better spacing
- Change overflow-hidden to overflow-y-scroll for scrollable list

## Current
https://github.com/user-attachments/assets/40cb4600-ff4e-41a5-89d6-a9aee48fa633

## Before

https://github.com/user-attachments/assets/fbe7a399-06d5-4cda-b850-f28b09f20d73

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6570-fix-improve-FormDropdownMenu-scrolling-behavior-2a16d73d3650815c883fcfeb7d9a3ace) by [Unito](https://www.unito.io)
