### PR TITLE
Fix cloud routing issues caused by incorrect api_base calculation

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -326,7 +326,13 @@ export class ComfyApi extends EventTarget {
     super()
     this.user = ''
     this.api_host = location.host
-    this.api_base = location.pathname.split('/').slice(0, -1).join('/')
+    const pathname = location.pathname
+    const isCloudSpaRoute = isCloud && pathname.startsWith('/cloud/')
+    if (isCloudSpaRoute) {
+      this.api_base = ''
+    } else {
+      this.api_base = pathname.split('/').slice(0, -1).join('/')
+    }
     console.log('Running on', this.api_host)
     this.initialClientId = sessionStorage.getItem('clientId')
   }


### PR DESCRIPTION
## Summary
- Resolves multiple cloud environment issues when accessing `/cloud/user-check` directly
- Fixes API routing problems that caused 304 Not Modified errors and JSON parsing failures
- Maintains compatibility with subpath deployments for OSS users

## Root Cause
The `api_base` was incorrectly calculated as `/cloud` on cloud SPA routes, causing API calls to use wrong paths like `/cloud/api/user` instead of `/api/user`.

## Issues Fixed
- ❌ `/cloud/user-check` direct access resulted in infinite loading
- ❌ JSON parsing errors: `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
- ❌ 304 Not Modified responses on `/cloud/api/user`, `/cloud/api/settings/onboarding_survey`, `/cloud/api/system_stats`

## Solution
Added conditional `api_base` calculation in `ComfyApi` constructor:
- **Cloud SPA routes** (`/cloud/*`): Use empty `api_base` → API calls use `/api/*` paths
- **Regular deployments**: Keep existing logic → Supports subpath deployments

## Test Plan
- [x] Verify `/cloud/user-check` direct access works without infinite loading
- [x] Verify all API calls return 200 instead of 304
- [x] Verify OSS subpath deployment compatibility unchanged
- [x] Test authentication flow completion

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6572-Fix-cloud-routing-issues-caused-by-incorrect-api_base-calculation-2a16d73d36508163aeb2cbf6347b427d) by [Unito](https://www.unito.io)
