### PR TITLE
fix minimap navigation on touch devices

### DIFF
--- a/src/renderer/extensions/minimap/MiniMap.vue
+++ b/src/renderer/extensions/minimap/MiniMap.vue
@@ -61,11 +61,12 @@
       <div class="minimap-viewport" :style="viewportStyles" />
 
       <div
-        class="absolute inset-0"
+        class="minimap-interaction-layer absolute inset-0"
         @pointerdown="handlePointerDown"
         @pointermove="handlePointerMove"
         @pointerup="handlePointerUp"
         @pointerleave="handlePointerUp"
+        @pointercancel="handlePointerCancel"
         @wheel="handleWheel"
       />
     </div>
@@ -105,6 +106,7 @@ const {
   handlePointerDown,
   handlePointerMove,
   handlePointerUp,
+  handlePointerCancel,
   handleWheel,
   setMinimapRef
 } = useMinimap()
@@ -143,5 +145,9 @@ onUnmounted(() => {
   top: 0;
   left: 0;
   pointer-events: none;
+}
+
+.minimap-interaction-layer {
+  touch-action: none;
 }
 </style>

--- a/src/renderer/extensions/minimap/MiniMap.vue
+++ b/src/renderer/extensions/minimap/MiniMap.vue
@@ -61,7 +61,7 @@
       <div class="minimap-viewport" :style="viewportStyles" />
 
       <div
-        class="minimap-interaction-layer absolute inset-0"
+        class="absolute inset-0 touch-none"
         @pointerdown="handlePointerDown"
         @pointermove="handlePointerMove"
         @pointerup="handlePointerUp"
@@ -145,9 +145,5 @@ onUnmounted(() => {
   top: 0;
   left: 0;
   pointer-events: none;
-}
-
-.minimap-interaction-layer {
-  touch-action: none;
 }
 </style>

--- a/src/renderer/extensions/minimap/composables/useMinimap.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.ts
@@ -244,6 +244,7 @@ export function useMinimap() {
     handlePointerDown: interaction.handlePointerDown,
     handlePointerMove: interaction.handlePointerMove,
     handlePointerUp: interaction.handlePointerUp,
+    handlePointerCancel: interaction.handlePointerCancel,
     handleWheel: interaction.handleWheel,
     setMinimapRef,
     updateOption

--- a/src/renderer/extensions/minimap/composables/useMinimapInteraction.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapInteraction.ts
@@ -58,6 +58,7 @@ export function useMinimapInteraction(
   }
 
   const releasePointer = (e?: PointerEvent) => {
+    isDragging.value = false
     if (!e) return
 
     const target = e.currentTarget
@@ -69,15 +70,9 @@ export function useMinimapInteraction(
     }
   }
 
-  const handlePointerUp = (e?: PointerEvent) => {
-    releasePointer(e)
-    isDragging.value = false
-  }
+  const handlePointerUp = releasePointer
 
-  const handlePointerCancel = (e: PointerEvent) => {
-    releasePointer(e)
-    isDragging.value = false
-  }
+  const handlePointerCancel = releasePointer
 
   const handleWheel = (e: WheelEvent) => {
     e.preventDefault()

--- a/src/renderer/extensions/minimap/composables/useMinimapInteraction.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapInteraction.ts
@@ -35,6 +35,10 @@ export function useMinimapInteraction(
   const handlePointerDown = (e: PointerEvent) => {
     isDragging.value = true
     updateContainerRect()
+    const target = e.currentTarget
+    if (target instanceof HTMLElement) {
+      target.setPointerCapture(e.pointerId)
+    }
     handlePointerMove(e)
   }
 
@@ -53,7 +57,25 @@ export function useMinimapInteraction(
     centerViewOn(worldX, worldY)
   }
 
-  const handlePointerUp = () => {
+  const releasePointer = (e?: PointerEvent) => {
+    if (!e) return
+
+    const target = e.currentTarget
+    if (
+      target instanceof HTMLElement &&
+      target.hasPointerCapture(e.pointerId)
+    ) {
+      target.releasePointerCapture(e.pointerId)
+    }
+  }
+
+  const handlePointerUp = (e?: PointerEvent) => {
+    releasePointer(e)
+    isDragging.value = false
+  }
+
+  const handlePointerCancel = (e: PointerEvent) => {
+    releasePointer(e)
     isDragging.value = false
   }
 
@@ -102,6 +124,7 @@ export function useMinimapInteraction(
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handlePointerCancel,
     handleWheel
   }
 }


### PR DESCRIPTION
Fixes minimap navigation (dragging the viewport box on the minimap) on touch devices.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6580-fix-minimap-navigation-on-touch-devices-2a16d73d36508195b070da2b8e4b908a) by [Unito](https://www.unito.io)
