### PR TITLE
fix: keep topbar badges in main topbar regardless of workflow tabs position

### DIFF
--- a/src/components/topbar/SecondRowWorkflowTabs.vue
+++ b/src/components/topbar/SecondRowWorkflowTabs.vue
@@ -1,12 +1,10 @@
 <template>
-  <div class="flex h-full w-auto max-w-full items-center">
+  <div class="w-auto max-w-full">
     <WorkflowTabs />
-    <TopbarBadges />
   </div>
 </template>
 
 <script setup lang="ts">
-import TopbarBadges from '@/components/topbar/TopbarBadges.vue'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 </script>
 

--- a/src/components/topbar/TopMenubar.vue
+++ b/src/components/topbar/TopMenubar.vue
@@ -6,7 +6,6 @@
       style="background: var(--border-color)"
     >
       <WorkflowTabs />
-      <TopbarBadges />
     </div>
     <div
       v-show="showTopMenu"
@@ -20,6 +19,7 @@
         ref="menuRight"
         class="comfyui-menu-right flex-shrink-1 overflow-auto"
       />
+      <TopbarBadges />
       <Actionbar />
       <CurrentUserButton class="shrink-0" />
     </div>


### PR DESCRIPTION
## Summary

Fixes incorrect badge placement from PR #6515. Badges should remain in the main topbar row at all times, not move to the second row with workflow tabs.

## Problem

PR #6515 added `TopbarBadges` to `SecondRowWorkflowTabs.vue`, causing badges to appear in the second row when workflow tabs position was set to `'Topbar (2nd-row)'`.

The original issue was that badges weren't visible when tabs were in second-row mode because they were conditionally rendered only when `workflowTabsPosition === 'Topbar'`.

## Changes

- Remove `TopbarBadges` from `SecondRowWorkflowTabs.vue` (badges should never be in second row)
- Move `TopbarBadges` from conditional workflow tabs row to main topbar in `TopMenubar.vue`
- Badges now always display in main topbar regardless of workflow tabs position

## Testing

- Badges visible in main topbar when `workflowTabsPosition === 'Topbar'`
- Badges visible in main topbar when `workflowTabsPosition === 'Topbar (2nd-row)'`
- Workflow tabs correctly move to second row without badges

Fixes issue introduced in #6515