### PR TITLE
[bugfix] Extend missing combo value fix to dropdown widget

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -127,7 +127,18 @@ const dropdownItems = computed<DropdownItem[]>(() => {
   }
 })
 
+const invalid = computed(() => {
+  if (!localValue.value) return false
+  const values = props.widget.options?.values || []
+  return !values.includes(localValue.value)
+})
+
 const mediaPlaceholder = computed(() => {
+  // Show invalid value as placeholder (similar to WidgetSelectDefault)
+  if (invalid.value) {
+    return `${localValue.value}`
+  }
+
   const options = props.widget.options
 
   if (options?.placeholder) {


### PR DESCRIPTION
Extends the fix from PR #6555 to WidgetSelectDropdown (used for image/video/audio upload combos). When a loaded workflow uses a model or file which does not exist, the dropdown widget now displays the missing value as a placeholder, consistent with WidgetSelectDefault behavior.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6594-bugfix-Extend-missing-combo-value-fix-to-dropdown-widget-2a26d73d365081479d04d887207b84c8) by [Unito](https://www.unito.io)
