### PR TITLE
devex: Add script to launch the dev server pointed at testcloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "size:collect": "node scripts/size-collect.js",
     "size:report": "node scripts/size-report.js",
     "collect-i18n": "pnpm exec playwright test --config=playwright.i18n.config.ts",
+    "dev:cloud": "cross-env DEV_SERVER_COMFYUI_URL='https://testcloud.comfy.org/' nx serve",
     "dev:desktop": "nx dev @comfyorg/desktop-ui",
     "dev:electron": "nx serve --config vite.electron.config.mts",
     "dev": "nx serve",


### PR DESCRIPTION
## Summary

No more need to edit `.env`

Just run
```sh
pnpm dev:cloud
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6605-devex-Add-script-to-launch-the-dev-server-pointed-at-testcloud-2a36d73d3650818e9cfeedba84c54ca1) by [Unito](https://www.unito.io)
