### PR TITLE
fix: Handle vite:preloadError for graceful deployment asset updates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,10 @@ import { computed, onMounted } from 'vue'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
+import { t } from '@/i18n'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
+import { useDialogService } from '@/services/dialogService'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
 
@@ -23,6 +27,8 @@ import { electronAPI, isElectron } from './utils/envUtil'
 
 const workspaceStore = useWorkspaceStore()
 const conflictDetection = useConflictDetection()
+const workflowStore = useWorkflowStore()
+const dialogService = useDialogService()
 const isLoading = computed<boolean>(() => workspaceStore.spinner)
 const handleKey = (e: KeyboardEvent) => {
   workspaceStore.shiftDown = e.shiftKey
@@ -47,6 +53,28 @@ onMounted(() => {
   if (isElectron()) {
     document.addEventListener('contextmenu', showContextMenu)
   }
+
+  // Handle Vite preload errors (e.g., when assets are deleted after deployment)
+  window.addEventListener('vite:preloadError', (event) => {
+    // Auto-reload if app is not ready or no unsaved changes
+    if (!app.vueAppReady || !workflowStore.activeWorkflow?.isModified) {
+      window.location.reload()
+      event.preventDefault()
+    } else {
+      // Show confirmation dialog if there are unsaved changes
+      void dialogService
+        .confirm({
+          title: t('g.vitePreloadErrorTitle'),
+          message: t('g.vitePreloadErrorMessage')
+        })
+        .then((confirmed) => {
+          if (confirmed) {
+            window.location.reload()
+          }
+        })
+      event.preventDefault()
+    }
+  })
 
   // Initialize conflict detection in background
   // This runs async and doesn't block UI setup

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,14 +55,13 @@ onMounted(() => {
   }
 
   // Handle Vite preload errors (e.g., when assets are deleted after deployment)
-  window.addEventListener('vite:preloadError', (event) => {
-    // Auto-reload if app is not ready or no unsaved changes
+  window.addEventListener('vite:preloadError', async (_event) => {
+    // Auto-reload if app is not ready or there are no unsaved changes
     if (!app.vueAppReady || !workflowStore.activeWorkflow?.isModified) {
       window.location.reload()
-      event.preventDefault()
     } else {
       // Show confirmation dialog if there are unsaved changes
-      void dialogService
+      await dialogService
         .confirm({
           title: t('g.vitePreloadErrorTitle'),
           message: t('g.vitePreloadErrorMessage')
@@ -72,7 +71,6 @@ onMounted(() => {
             window.location.reload()
           }
         })
-      event.preventDefault()
     }
   })
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -41,7 +41,7 @@
     "refresh": "Refresh",
     "refreshNode": "Refresh Node",
     "vitePreloadErrorTitle": "New Version Available",
-    "vitePreloadErrorMessage": "A new version of the app was shipped, do you want to reload (if not, some parts of the app might not work as expected) feel free to reject and save progress first then reload",
+    "vitePreloadErrorMessage": "A new version of the app has been released. Would you like to reload?\nIf not, some parts of the app might not work as expected.\nFeel free to decline and save your progress before reloading.",
     "terminal": "Terminal",
     "logs": "Logs",
     "videoFailedToLoad": "Video failed to load",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -40,6 +40,8 @@
     "comfy": "Comfy",
     "refresh": "Refresh",
     "refreshNode": "Refresh Node",
+    "vitePreloadErrorTitle": "New Version Available",
+    "vitePreloadErrorMessage": "A new version of the app was shipped, do you want to reload (if not, some parts of the app might not work as expected) feel free to reject and save progress first then reload",
     "terminal": "Terminal",
     "logs": "Logs",
     "videoFailedToLoad": "Video failed to load",


### PR DESCRIPTION
## Summary
- Implement graceful handling of Vite preload errors that occur when assets are deleted after new deployments
- Auto-reload when safe (no unsaved changes), show confirmation dialog when user has unsaved work
- Add i18n support for user-friendly error messages

## Implementation Details
- Add `vite:preloadError` event listener in App.vue 
- Smart reload logic: check `app.vueAppReady` and `workflowStore.activeWorkflow?.isModified`
- User confirmation dialog using existing `dialogService.confirm`
- Comprehensive i18n keys for title and message

## Background
This addresses the issue described in [Vite documentation](https://vite.dev/guide/build.html#load-error-handling) where users encounter import errors when hosting services delete old assets after new deployments.

[screen-capture (1).webm](https://github.com/user-attachments/assets/beed3b8e-6f32-4288-a560-55da391a79a1)

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6609-fix-Handle-vite-preloadError-for-graceful-deployment-asset-updates-2a36d73d365081a0b3adeac9fcd1e1dc) by [Unito](https://www.unito.io)
