### PR TITLE
[i18n] Fix missing subscription.* translations

### DIFF
--- a/.github/.i18n-trigger
+++ b/.github/.i18n-trigger
@@ -1,6 +1,6 @@
 # This file is used to trigger the i18n workflow
 # See .github/workflows/i18n-update-core.yaml
-# 
+#
 # The workflow will automatically:
 # 1. Collect i18n strings from the UI
 # 2. Generate translations using OpenAI
@@ -8,3 +8,5 @@
 #
 # This trigger was created to fix missing subscription.* translations
 # that were added after the last automatic locale update.
+#
+# Re-triggering after fixing git commit workflow issue (2025-11-10)

--- a/.github/.i18n-trigger
+++ b/.github/.i18n-trigger
@@ -1,0 +1,10 @@
+# This file is used to trigger the i18n workflow
+# See .github/workflows/i18n-update-core.yaml
+# 
+# The workflow will automatically:
+# 1. Collect i18n strings from the UI
+# 2. Generate translations using OpenAI
+# 3. Commit updated locale files
+#
+# This trigger was created to fix missing subscription.* translations
+# that were added after the last automatic locale update.

--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -44,6 +44,14 @@ jobs:
       run: pnpm locale
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    - name: Debug locale state
+      run: |
+        echo "=== Checking if subscription exists in source (en) ==="
+        jq '.subscription | keys' src/locales/en/main.json || echo "No subscription section in en"
+        echo "=== Checking if subscription exists in target (zh) ==="
+        jq '.subscription | keys' src/locales/zh/main.json || echo "No subscription section in zh"
+        echo "=== Git working tree status ==="
+        git status --porcelain src/locales/
     - name: Commit updated locales
       run: |
         git config --global user.name 'github-actions'

--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -48,12 +48,10 @@ jobs:
       run: |
         git config --global user.name 'github-actions'
         git config --global user.email 'github-actions@github.com'
-        git fetch origin ${{ github.head_ref }}
-        # Stash any local changes before checkout
-        git stash -u
-        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
-        # Apply the stashed changes if any
-        git stash pop || true
         git add src/locales/
-        git diff --staged --quiet || git commit -m "Update locales"
-        git push origin HEAD:${{ github.head_ref }}
+        if ! git diff --staged --quiet; then
+          git commit -m "Update locales"
+          git push origin HEAD:${{ github.head_ref }}
+        else
+          echo "No locale changes to commit"
+        fi


### PR DESCRIPTION
## Summary

Fixes missing translations for `subscription.*` keys that were added after the last automatic locale update.

## Problem

The `subscription.titleUnsubscribed` key was added on **Nov 1, 2025** (commit f2aea9c82), but the last automatic locale update ran on **Oct 30, 2025**. The 1.32.2 release on Nov 6 did not include these translations because:

1. The i18n workflow (`.github/workflows/i18n-update-core.yaml`) only runs on `version-bump-*` branches
2. The subscription key was added after the last locale update
3. No locale generation was triggered during the 1.32.2 release

As a result, the `subscription.*` keys exist in English (`src/locales/en/main.json`) but are missing from all other locales (zh, zh-TW, ru, ja, ko, fr, es, ar, tr).

## Solution

This PR creates a `version-bump-*` branch to trigger the automatic i18n workflow, which will:
1. Run `pnpm collect-i18n` to collect i18n strings from the UI
2. Run `pnpm locale` to generate translations using OpenAI (lobe-i18n)
3. Automatically commit the updated locale files

The workflow will generate translations for the missing keys:
- `subscription.titleUnsubscribed`
- Any other subscription-related keys that may be missing

## Related

- **Notion issue**: [Research why subscription.* translation values were not auto-generated](https://www.notion.so/comfy-org/Research-why-subscription-translation-values-were-not-auto-generated-in-latest-release-2a36d73d3650817cbafee330395687de)
- **Related PR**: #6603 (1.32.2 release)
- **Commit that added the key**: f2aea9c82

## Testing

Once the i18n workflow completes, verify:
- [ ] `subscription.*` keys are translated in all locales (zh, zh-TW, ru, ja, ko, fr, es, ar, tr)
- [ ] Chinese translations use **Simplified Chinese** for zh locale (per .i18nrc.cjs guidelines)
- [ ] Chinese translations use **Traditional Chinese** for zh-TW locale

## Workflow Details

The i18n workflow is configured to:
- Only run on PRs to main from `version-bump-*` branches
- Use the OPENAI_API_KEY secret
- Follow translation guidelines in `.i18nrc.cjs` (including Chinese character requirements)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6610-i18n-Fix-missing-subscription-translations-2a36d73d3650814ab9f7f33202030040) by [Unito](https://www.unito.io)
