### PR TITLE
feat: navigate to previously active tab when closing current tab

### DIFF
--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -215,9 +215,15 @@ export const useWorkflowService = () => {
     if (workflowStore.openWorkflows.length === 1) {
       await loadDefaultWorkflow()
     }
-    // If this is the active workflow, load the next workflow
+    // If this is the active workflow, load the most recent workflow from history
     if (workflowStore.isActive(workflow)) {
-      await loadNextOpenedWorkflow()
+      const mostRecentWorkflow = workflowStore.getMostRecentWorkflow()
+      if (mostRecentWorkflow) {
+        await openWorkflow(mostRecentWorkflow)
+      } else {
+        // Fallback to next workflow if no history
+        await loadNextOpenedWorkflow()
+      }
     }
 
     await workflowStore.closeWorkflow(workflow)


### PR DESCRIPTION
When closing a tab, the UI now returns to the most recently active tab instead of always going to the first/next tab. This matches standard browser tab behavior and prevents accidental edits in the wrong workflow. Implementation uses a lazy-cleanup history array (max 32 entries) that tracks tab activations and skips closed tabs when finding the previous tab to switch to. Fixes #6599

https://github.com/user-attachments/assets/0bb87969-fd01-4e6b-96e8-c0f741f23ff8

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6624-feat-navigate-to-previously-active-tab-when-closing-current-tab-2a36d73d365081f5be95db51ff7a03f6) by [Unito](https://www.unito.io)
