### PR TITLE
feat: Add cloud E2E testing infrastructure

### DIFF
--- a/.github/workflows/ci-tests-e2e-cloud.yaml
+++ b/.github/workflows/ci-tests-e2e-cloud.yaml
@@ -2,12 +2,11 @@ name: "CI: Tests E2E Cloud"
 description: "Cloud E2E testing with Playwright against stagingcloud.comfy.org"
 
 on:
-  workflow_dispatch: # Manual trigger for now
-  # Uncomment to enable on push/PR:
-  # push:
-  #   branches: [cloud/*, main]
-  # pull_request:
-  #   branches: [main]
+  workflow_dispatch:
+  push:
+    branches: [cloud/*, main]
+  pull_request:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-tests-e2e-cloud.yaml
+++ b/.github/workflows/ci-tests-e2e-cloud.yaml
@@ -1,0 +1,52 @@
+name: "CI: Tests E2E Cloud"
+description: "Cloud E2E testing with Playwright against stagingcloud.comfy.org"
+
+on:
+  workflow_dispatch: # Manual trigger for now
+  # Uncomment to enable on push/PR:
+  # push:
+  #   branches: [cloud/*, main]
+  # pull_request:
+  #   branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright-tests-cloud:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: false # Cloud tests don't need build
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Run Playwright cloud tests
+        id: playwright
+        env:
+          CLOUD_TEST_EMAIL: ${{ secrets.CLOUD_TEST_EMAIL }}
+          CLOUD_TEST_PASSWORD: ${{ secrets.CLOUD_TEST_PASSWORD }}
+        run: |
+          PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json \
+          pnpm exec playwright test --config=playwright.cloud.config.ts \
+            --reporter=list \
+            --reporter=html \
+            --reporter=json
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-cloud
+          path: ./playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage/
 /playwright/.cache/
 browser_tests/**/*-win32.png
 browser_tests/local/
+browser_tests/.auth/
 
 .env
 

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -140,7 +140,7 @@ When writing new tests, follow these patterns:
 
 ```typescript
 // Import the test fixture
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Feature Name', () => {
   // Set up test environment if needed

--- a/browser_tests/fixtures/CloudComfyPage.ts
+++ b/browser_tests/fixtures/CloudComfyPage.ts
@@ -1,0 +1,40 @@
+import type { APIRequestContext, Page } from '@playwright/test'
+
+import { ComfyPage } from './ComfyPage'
+import type { FolderStructure } from './ComfyPage'
+
+/**
+ * Cloud-specific implementation of ComfyPage.
+ * Uses Firebase auth persistence and cloud API for settings.
+ */
+export class CloudComfyPage extends ComfyPage {
+  constructor(page: Page, request: APIRequestContext) {
+    super(page, request)
+  }
+
+  async setupUser(username: string): Promise<string | null> {
+    // No-op for cloud - user already authenticated via Firebase in globalSetup
+    // Firebase auth is persisted via storageState in the fixture
+    return null
+  }
+
+  async setupSettings(settings: Record<string, any>): Promise<void> {
+    // Cloud uses batch settings API (not devtools)
+    // Firebase auth token is automatically included from restored localStorage
+    const resp = await this.request.post(`${this.url}/api/settings`, {
+      data: settings
+    })
+
+    if (!resp.ok()) {
+      throw new Error(`Failed to setup cloud settings: ${await resp.text()}`)
+    }
+  }
+
+  async setupWorkflowsDirectory(structure: FolderStructure): Promise<void> {
+    // Cloud workflow API not yet implemented
+    // For initial smoke tests, we can skip this functionality
+    console.warn(
+      'setupWorkflowsDirectory: not yet implemented for cloud mode - skipping'
+    )
+  }
+}

--- a/browser_tests/fixtures/CloudComfyPage.ts
+++ b/browser_tests/fixtures/CloudComfyPage.ts
@@ -8,8 +8,12 @@ import type { FolderStructure } from './ComfyPage'
  * Uses Firebase auth persistence and cloud API for settings.
  */
 export class CloudComfyPage extends ComfyPage {
-  constructor(page: Page, request: APIRequestContext) {
-    super(page, request)
+  constructor(
+    page: Page,
+    request: APIRequestContext,
+    parallelIndex: number = 0
+  ) {
+    super(page, request, parallelIndex)
   }
 
   async setupUser(username: string): Promise<string | null> {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1591,7 +1591,6 @@ export abstract class ComfyPage {
 
 // Re-export shared constants and fixture
 export { testComfySnapToGridGridSize } from './constants'
-export { comfyPageFixture } from './comfyPageFixture'
 
 const makeMatcher = function <T>(
   getValue: (node: NodeReference) => Promise<T> | T,

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1589,9 +1589,8 @@ export abstract class ComfyPage {
   }
 }
 
-export const testComfySnapToGridGridSize = 50
-
-// Re-export fixture from separate file to avoid circular dependencies
+// Re-export shared constants and fixture
+export { testComfySnapToGridGridSize } from './constants'
 export { comfyPageFixture } from './comfyPageFixture'
 
 const makeMatcher = function <T>(

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -158,12 +158,13 @@ export abstract class ComfyPage {
 
   /** Test user ID for the current context */
   get id() {
-    return this.userIds[comfyPageFixture.info().parallelIndex]
+    return this.userIds[this.parallelIndex]
   }
 
   constructor(
     public readonly page: Page,
-    public readonly request: APIRequestContext
+    public readonly request: APIRequestContext,
+    public readonly parallelIndex: number = 0
   ) {
     this.url = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
     this.canvas = page.locator('#graph-canvas')

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1,5 +1,5 @@
 import type { APIRequestContext, Locator, Page } from '@playwright/test'
-import { test as base, expect } from '@playwright/test'
+import { expect } from '@playwright/test'
 import dotenv from 'dotenv'
 import * as fs from 'fs'
 
@@ -7,11 +7,8 @@ import type { LGraphNode } from '../../src/lib/litegraph/src/litegraph'
 import type { NodeId } from '../../src/platform/workflow/validation/schemas/workflowSchema'
 import type { KeyCombo } from '../../src/schemas/keyBindingSchema'
 import type { useWorkspaceStore } from '../../src/stores/workspaceStore'
-import { NodeBadgeMode } from '../../src/types/nodeSource'
 import { ComfyActionbar } from '../helpers/actionbar'
 import { ComfyTemplates } from '../helpers/templates'
-import { ComfyMouse } from './ComfyMouse'
-import { LocalhostComfyPage } from './LocalhostComfyPage'
 import { VueNodeHelpers } from './VueNodeHelpers'
 import { ComfyNodeSearchBox } from './components/ComfyNodeSearchBox'
 import { SettingDialog } from './components/SettingDialog'
@@ -1594,50 +1591,8 @@ export abstract class ComfyPage {
 
 export const testComfySnapToGridGridSize = 50
 
-export const comfyPageFixture = base.extend<{
-  comfyPage: ComfyPage
-  comfyMouse: ComfyMouse
-}>({
-  comfyPage: async ({ page, request }, use, testInfo) => {
-    const comfyPage = new LocalhostComfyPage(page, request)
-
-    const { parallelIndex } = testInfo
-    const username = `playwright-test-${parallelIndex}`
-    const userId = await comfyPage.setupUser(username)
-    if (userId) {
-      comfyPage.userIds[parallelIndex] = userId
-    }
-
-    try {
-      await comfyPage.setupSettings({
-        'Comfy.UseNewMenu': 'Top',
-        // Hide canvas menu/info/selection toolbox by default.
-        'Comfy.Graph.CanvasInfo': false,
-        'Comfy.Graph.CanvasMenu': false,
-        'Comfy.Canvas.SelectionToolbox': false,
-        // Hide all badges by default.
-        'Comfy.NodeBadge.NodeIdBadgeMode': NodeBadgeMode.None,
-        'Comfy.NodeBadge.NodeSourceBadgeMode': NodeBadgeMode.None,
-        // Disable tooltips by default to avoid flakiness.
-        'Comfy.EnableTooltips': false,
-        'Comfy.userId': userId,
-        // Set tutorial completed to true to avoid loading the tutorial workflow.
-        'Comfy.TutorialCompleted': true,
-        'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize,
-        'Comfy.VueNodes.AutoScaleLayout': false
-      })
-    } catch (e) {
-      console.error(e)
-    }
-
-    await comfyPage.setup()
-    await use(comfyPage)
-  },
-  comfyMouse: async ({ comfyPage }, use) => {
-    const comfyMouse = new ComfyMouse(comfyPage)
-    await use(comfyMouse)
-  }
-})
+// Re-export fixture from separate file to avoid circular dependencies
+export { comfyPageFixture } from './comfyPageFixture'
 
 const makeMatcher = function <T>(
   getValue: (node: NodeReference) => Promise<T> | T,

--- a/browser_tests/fixtures/ComfyPageCloud.ts
+++ b/browser_tests/fixtures/ComfyPageCloud.ts
@@ -1,0 +1,48 @@
+import { test as base } from '@playwright/test'
+
+import { CloudComfyPage } from './CloudComfyPage'
+import { ComfyMouse } from './ComfyMouse'
+import type { ComfyPage } from './ComfyPage'
+
+/**
+ * Cloud-specific fixture for ComfyPage.
+ * Uses Firebase auth persisted from globalSetupCloud.ts.
+ */
+export const comfyPageCloudFixture = base.extend<{
+  comfyPage: ComfyPage
+  comfyMouse: ComfyMouse
+}>({
+  // Use the storageState saved by globalSetupCloud
+  storageState: 'browser_tests/.auth/cloudUser.json',
+
+  comfyPage: async ({ page, request }, use) => {
+    const comfyPage = new CloudComfyPage(page, request)
+
+    // Note: No setupUser needed - Firebase auth persisted via storageState
+    // Setup cloud-specific settings (optional - can customize per test)
+    try {
+      await comfyPage.setupSettings({
+        'Comfy.UseNewMenu': 'Top',
+        // Hide canvas menu/info/selection toolbox by default.
+        'Comfy.Graph.CanvasInfo': false,
+        'Comfy.Graph.CanvasMenu': false,
+        'Comfy.Canvas.SelectionToolbox': false,
+        // Disable tooltips by default to avoid flakiness.
+        'Comfy.EnableTooltips': false,
+        // Set tutorial completed to true to avoid loading the tutorial workflow.
+        'Comfy.TutorialCompleted': true
+      })
+    } catch (e) {
+      console.error('Failed to setup cloud settings:', e)
+    }
+
+    // Don't mock releases for cloud - cloud handles its own releases
+    await comfyPage.setup({ mockReleases: false })
+    await use(comfyPage)
+  },
+
+  comfyMouse: async ({ comfyPage }, use) => {
+    const comfyMouse = new ComfyMouse(comfyPage)
+    await use(comfyMouse)
+  }
+})

--- a/browser_tests/fixtures/LocalhostComfyPage.ts
+++ b/browser_tests/fixtures/LocalhostComfyPage.ts
@@ -8,8 +8,12 @@ import type { FolderStructure } from './ComfyPage'
  * Uses devtools API and multi-user mode for test isolation.
  */
 export class LocalhostComfyPage extends ComfyPage {
-  constructor(page: Page, request: APIRequestContext) {
-    super(page, request)
+  constructor(
+    page: Page,
+    request: APIRequestContext,
+    parallelIndex: number = 0
+  ) {
+    super(page, request, parallelIndex)
   }
 
   async setupWorkflowsDirectory(structure: FolderStructure): Promise<void> {

--- a/browser_tests/fixtures/LocalhostComfyPage.ts
+++ b/browser_tests/fixtures/LocalhostComfyPage.ts
@@ -1,0 +1,74 @@
+import type { APIRequestContext, Page } from '@playwright/test'
+
+import { ComfyPage } from './ComfyPage'
+import type { FolderStructure } from './ComfyPage'
+
+/**
+ * Localhost-specific implementation of ComfyPage.
+ * Uses devtools API and multi-user mode for test isolation.
+ */
+export class LocalhostComfyPage extends ComfyPage {
+  constructor(page: Page, request: APIRequestContext) {
+    super(page, request)
+  }
+
+  async setupWorkflowsDirectory(structure: FolderStructure): Promise<void> {
+    const resp = await this.request.post(
+      `${this.url}/api/devtools/setup_folder_structure`,
+      {
+        data: {
+          tree_structure: this.convertLeafToContent(structure),
+          base_path: `user/${this.id}/workflows`
+        }
+      }
+    )
+
+    if (resp.status() !== 200) {
+      throw new Error(
+        `Failed to setup workflows directory: ${await resp.text()}`
+      )
+    }
+
+    await this.page.evaluate(async () => {
+      await window['app'].extensionManager.workflow.syncWorkflows()
+    })
+  }
+
+  async setupUser(username: string): Promise<string | null> {
+    const res = await this.request.get(`${this.url}/api/users`)
+    if (res.status() !== 200)
+      throw new Error(`Failed to retrieve users: ${await res.text()}`)
+
+    const apiRes = await res.json()
+    const user = Object.entries(apiRes?.users ?? {}).find(
+      ([, name]) => name === username
+    )
+    const id = user?.[0]
+
+    return id ? id : await this.createUser(username)
+  }
+
+  private async createUser(username: string): Promise<string> {
+    const resp = await this.request.post(`${this.url}/api/users`, {
+      data: { username }
+    })
+
+    if (resp.status() !== 200)
+      throw new Error(`Failed to create user: ${await resp.text()}`)
+
+    return await resp.json()
+  }
+
+  async setupSettings(settings: Record<string, any>): Promise<void> {
+    const resp = await this.request.post(
+      `${this.url}/api/devtools/set_settings`,
+      {
+        data: settings
+      }
+    )
+
+    if (resp.status() !== 200) {
+      throw new Error(`Failed to setup settings: ${await resp.text()}`)
+    }
+  }
+}

--- a/browser_tests/fixtures/comfyPageFixture.ts
+++ b/browser_tests/fixtures/comfyPageFixture.ts
@@ -2,8 +2,8 @@ import { test as base } from '@playwright/test'
 
 import { NodeBadgeMode } from '../../src/types/nodeSource'
 import type { ComfyPage } from './ComfyPage'
-import { testComfySnapToGridGridSize } from './ComfyPage'
 import { ComfyMouse } from './ComfyMouse'
+import { testComfySnapToGridGridSize } from './constants'
 import { LocalhostComfyPage } from './LocalhostComfyPage'
 
 /**

--- a/browser_tests/fixtures/comfyPageFixture.ts
+++ b/browser_tests/fixtures/comfyPageFixture.ts
@@ -1,0 +1,56 @@
+import { test as base } from '@playwright/test'
+
+import { NodeBadgeMode } from '../../src/types/nodeSource'
+import type { ComfyPage } from './ComfyPage'
+import { testComfySnapToGridGridSize } from './ComfyPage'
+import { ComfyMouse } from './ComfyMouse'
+import { LocalhostComfyPage } from './LocalhostComfyPage'
+
+/**
+ * Localhost fixture for ComfyPage.
+ * Creates a test user and sets up default settings for stable testing.
+ */
+export const comfyPageFixture = base.extend<{
+  comfyPage: ComfyPage
+  comfyMouse: ComfyMouse
+}>({
+  comfyPage: async ({ page, request }, use, testInfo) => {
+    const comfyPage = new LocalhostComfyPage(page, request)
+
+    const { parallelIndex } = testInfo
+    const username = `playwright-test-${parallelIndex}`
+    const userId = await comfyPage.setupUser(username)
+    if (userId) {
+      comfyPage.userIds[parallelIndex] = userId
+    }
+
+    try {
+      await comfyPage.setupSettings({
+        'Comfy.UseNewMenu': 'Top',
+        // Hide canvas menu/info/selection toolbox by default.
+        'Comfy.Graph.CanvasInfo': false,
+        'Comfy.Graph.CanvasMenu': false,
+        'Comfy.Canvas.SelectionToolbox': false,
+        // Hide all badges by default.
+        'Comfy.NodeBadge.NodeIdBadgeMode': NodeBadgeMode.None,
+        'Comfy.NodeBadge.NodeSourceBadgeMode': NodeBadgeMode.None,
+        // Disable tooltips by default to avoid flakiness.
+        'Comfy.EnableTooltips': false,
+        'Comfy.userId': userId,
+        // Set tutorial completed to true to avoid loading the tutorial workflow.
+        'Comfy.TutorialCompleted': true,
+        'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize,
+        'Comfy.VueNodes.AutoScaleLayout': false
+      })
+    } catch (e) {
+      console.error(e)
+    }
+
+    await comfyPage.setup()
+    await use(comfyPage)
+  },
+  comfyMouse: async ({ comfyPage }, use) => {
+    const comfyMouse = new ComfyMouse(comfyPage)
+    await use(comfyMouse)
+  }
+})

--- a/browser_tests/fixtures/comfyPageFixture.ts
+++ b/browser_tests/fixtures/comfyPageFixture.ts
@@ -15,9 +15,9 @@ export const comfyPageFixture = base.extend<{
   comfyMouse: ComfyMouse
 }>({
   comfyPage: async ({ page, request }, use, testInfo) => {
-    const comfyPage = new LocalhostComfyPage(page, request)
-
     const { parallelIndex } = testInfo
+    const comfyPage = new LocalhostComfyPage(page, request, parallelIndex)
+
     const username = `playwright-test-${parallelIndex}`
     const userId = await comfyPage.setupUser(username)
     if (userId) {

--- a/browser_tests/fixtures/constants.ts
+++ b/browser_tests/fixtures/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Shared constants for browser tests
+ */
+export const testComfySnapToGridGridSize = 50

--- a/browser_tests/globalSetupCloud.ts
+++ b/browser_tests/globalSetupCloud.ts
@@ -1,0 +1,66 @@
+import { chromium } from '@playwright/test'
+import type { FullConfig } from '@playwright/test'
+import dotenv from 'dotenv'
+import * as fs from 'fs'
+import * as path from 'path'
+
+dotenv.config()
+
+/**
+ * Global setup for cloud tests.
+ * Authenticates with Firebase and saves auth state for test reuse.
+ */
+export default async function globalSetupCloud(config: FullConfig) {
+  const CLOUD_TEST_EMAIL = process.env.CLOUD_TEST_EMAIL
+  const CLOUD_TEST_PASSWORD = process.env.CLOUD_TEST_PASSWORD
+
+  if (!CLOUD_TEST_EMAIL || !CLOUD_TEST_PASSWORD) {
+    throw new Error(
+      'CLOUD_TEST_EMAIL and CLOUD_TEST_PASSWORD must be set in environment variables'
+    )
+  }
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  try {
+    // Navigate to cloud login page
+    await page.goto('https://stagingcloud.comfy.org/cloud/login', {
+      waitUntil: 'networkidle',
+      timeout: 30000
+    })
+
+    // Fill in email and password
+    await page.fill('input[type="email"]', CLOUD_TEST_EMAIL)
+    await page.fill('input[type="password"]', CLOUD_TEST_PASSWORD)
+
+    // Click login button
+    await page.click('button[type="submit"]')
+
+    // Wait for redirect to main app (adjust selector as needed)
+    await page.waitForURL('**/', { timeout: 30000 })
+
+    // Wait for app to be fully loaded
+    await page.waitForFunction(
+      () => window['app'] && window['app'].extensionManager,
+      { timeout: 30000 }
+    )
+
+    // Ensure .auth directory exists
+    const authDir = path.join(__dirname, '.auth')
+    if (!fs.existsSync(authDir)) {
+      fs.mkdirSync(authDir, { recursive: true })
+    }
+
+    // Save authentication state (includes localStorage with Firebase tokens)
+    await context.storageState({
+      path: 'browser_tests/.auth/cloudUser.json'
+    })
+  } catch (error) {
+    console.error('❌ Failed to authenticate:', error)
+    throw error
+  } finally {
+    await browser.close()
+  }
+}

--- a/browser_tests/globalSetupCloud.ts
+++ b/browser_tests/globalSetupCloud.ts
@@ -32,8 +32,8 @@ export default async function globalSetupCloud(config: FullConfig) {
     })
 
     // Fill in email and password
-    await page.fill('input[type="email"]', CLOUD_TEST_EMAIL)
-    await page.fill('input[type="password"]', CLOUD_TEST_PASSWORD)
+    await page.fill('#cloud-sign-in-email', CLOUD_TEST_EMAIL)
+    await page.fill('#cloud-sign-in-password', CLOUD_TEST_PASSWORD)
 
     // Click login button
     await page.click('button[type="submit"]')

--- a/browser_tests/globalSetupCloud.ts
+++ b/browser_tests/globalSetupCloud.ts
@@ -38,14 +38,11 @@ export default async function globalSetupCloud(config: FullConfig) {
     // Click login button
     await page.click('button[type="submit"]')
 
-    // Wait for redirect to main app (adjust selector as needed)
-    await page.waitForURL('**/', { timeout: 30000 })
+    // Wait for redirect to main app
+    await page.waitForURL('**/cloud', { timeout: 30000 })
 
-    // Wait for app to be fully loaded
-    await page.waitForFunction(
-      () => window['app'] && window['app'].extensionManager,
-      { timeout: 30000 }
-    )
+    // Wait a bit for auth tokens to be written to localStorage
+    await page.waitForTimeout(2000)
 
     // Ensure .auth directory exists
     const authDir = path.join(__dirname, '.auth')

--- a/browser_tests/tests/CLOUD_TESTS.md
+++ b/browser_tests/tests/CLOUD_TESTS.md
@@ -1,0 +1,36 @@
+# Cloud E2E Tests
+
+## Setup
+
+Cloud tests run against `https://stagingcloud.comfy.org` with Firebase authentication.
+
+### Required GitHub Secrets
+
+Add these to repository settings → Secrets → Actions:
+
+- `CLOUD_TEST_EMAIL`: Firebase test account email
+- `CLOUD_TEST_PASSWORD`: Firebase test account password
+
+### Running Locally
+
+```bash
+# Set environment variables
+export CLOUD_TEST_EMAIL="your-test-email@example.com"
+export CLOUD_TEST_PASSWORD="your-password"
+
+# Run cloud tests
+pnpm exec playwright test --config=playwright.cloud.config.ts
+```
+
+### Running in CI
+
+Workflow: `.github/workflows/ci-tests-e2e-cloud.yaml`
+
+Trigger manually via Actions tab → "CI: Tests E2E Cloud" → Run workflow
+
+### Test Structure
+
+- Tests tagged with `@cloud` run only in cloud config
+- Auth handled once in `globalSetupCloud.ts`
+- Auth state saved to `browser_tests/.auth/cloudUser.json`
+- Cloud fixture in `fixtures/ComfyPageCloud.ts`

--- a/browser_tests/tests/actionbar.spec.ts
+++ b/browser_tests/tests/actionbar.spec.ts
@@ -2,7 +2,7 @@ import type { Response } from '@playwright/test'
 import { expect, mergeTests } from '@playwright/test'
 
 import type { StatusWsMessage } from '../../src/schemas/apiSchema.ts'
-import { comfyPageFixture } from '../fixtures/ComfyPage.ts'
+import { comfyPageFixture } from '../fixtures/comfyPageFixture.ts'
 import { webSocketFixture } from '../fixtures/ws.ts'
 
 const test = mergeTests(comfyPageFixture, webSocketFixture)

--- a/browser_tests/tests/backgroundImageUpload.spec.ts
+++ b/browser_tests/tests/backgroundImageUpload.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/bottomPanelShortcuts.spec.ts
+++ b/browser_tests/tests/bottomPanelShortcuts.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Bottom Panel Shortcuts', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/browserTabTitle.spec.ts
+++ b/browser_tests/tests/browserTabTitle.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Browser tab title', () => {
   test.describe('Beta Menu', () => {

--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -1,8 +1,6 @@
 import type { ComfyPage } from '../fixtures/ComfyPage'
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../fixtures/ComfyPage'
 
 async function beforeChange(comfyPage: ComfyPage) {
   await comfyPage.page.evaluate(() => {

--- a/browser_tests/tests/chatHistory.spec.ts
+++ b/browser_tests/tests/chatHistory.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @cloud
+ * Cloud E2E tests.
+ * Tests run against stagingcloud.comfy.org with authenticated user.
+ */
+
+import { expect } from '@playwright/test'
+
+import { comfyPageCloudFixture as test } from '../fixtures/ComfyPageCloud'
+
+test.describe('Cloud E2E @cloud', () => {
+  test('loads app with authentication', async ({ comfyPage }) => {
+    // App should be loaded from setup()
+    await expect(comfyPage.canvas).toBeVisible()
+
+    // Verify we're authenticated (cloud-specific check)
+    const isAuthenticated = await comfyPage.page.evaluate(() => {
+      // Check for Firebase auth in localStorage
+      const keys = Object.keys(localStorage)
+      return keys.some(
+        (key) => key.startsWith('firebase:') || key.includes('authUser')
+      )
+    })
+    expect(isAuthenticated).toBe(true)
+  })
+
+  test('can interact with canvas', async ({ comfyPage }) => {
+    // Basic canvas interaction
+    await comfyPage.doubleClickCanvas()
+    await expect(comfyPage.searchBox.input).toBeVisible()
+
+    // Close search box
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(comfyPage.searchBox.input).not.toBeVisible()
+  })
+
+  test('can access settings dialog', async ({ comfyPage }) => {
+    // Open settings dialog
+    await comfyPage.page.click('button[data-testid="settings-button"]', {
+      timeout: 10000
+    })
+
+    // Settings dialog should be visible
+    await expect(comfyPage.page.locator('.p-dialog')).toBeVisible()
+
+    // Close settings
+    await comfyPage.closeDialog()
+  })
+})

--- a/browser_tests/tests/colorPalette.spec.ts
+++ b/browser_tests/tests/colorPalette.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
 import type { Palette } from '../../src/schemas/colorPaletteSchema'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/commands.spec.ts
+++ b/browser_tests/tests/commands.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/customIcons.spec.ts
+++ b/browser_tests/tests/customIcons.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 async function verifyCustomIconSvg(iconElement: Locator) {
   const svgVariable = await iconElement.evaluate((element) => {

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -2,7 +2,7 @@ import type { Locator } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import type { Keybinding } from '../../src/schemas/keyBindingSchema'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/domWidget.spec.ts
+++ b/browser_tests/tests/domWidget.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/execution.spec.ts
+++ b/browser_tests/tests/execution.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/extensionAPI.spec.ts
+++ b/browser_tests/tests/extensionAPI.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
 import type { SettingParams } from '../../src/platform/settings/types'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Topbar commands', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/featureFlags.spec.ts
+++ b/browser_tests/tests/featureFlags.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/graph.spec.ts
+++ b/browser_tests/tests/graph.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/graphCanvasMenu.spec.ts
+++ b/browser_tests/tests/graphCanvasMenu.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 import type { ComfyPage } from '../fixtures/ComfyPage'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 import type { NodeReference } from '../fixtures/utils/litegraphUtils'
 
 test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -2,11 +2,9 @@ import type { Locator } from '@playwright/test'
 import { expect } from '@playwright/test'
 import type { Position } from '@vueuse/core'
 
-import {
-  comfyPageFixture as test,
-  testComfySnapToGridGridSize
-} from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 import type { ComfyPage } from '../fixtures/ComfyPage'
+import { testComfySnapToGridGridSize } from '../fixtures/ComfyPage'
 import type { NodeReference } from '../fixtures/utils/litegraphUtils'
 
 test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/keybindings.spec.ts
+++ b/browser_tests/tests/keybindings.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/litegraphEvent.spec.ts
+++ b/browser_tests/tests/litegraphEvent.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/loadWorkflowInMedia.spec.ts
+++ b/browser_tests/tests/loadWorkflowInMedia.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/lodThreshold.spec.ts
+++ b/browser_tests/tests/lodThreshold.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/menu.spec.ts
+++ b/browser_tests/tests/menu.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Menu', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/minimap.spec.ts
+++ b/browser_tests/tests/minimap.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Minimap', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/nodeBadge.spec.ts
+++ b/browser_tests/tests/nodeBadge.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test'
 
 import type { ComfyApp } from '../../src/scripts/app'
 import { NodeBadgeMode } from '../../src/types/nodeSource'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/nodeDisplay.spec.ts
+++ b/browser_tests/tests/nodeDisplay.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/nodeHelp.spec.ts
+++ b/browser_tests/tests/nodeHelp.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../fixtures/ComfyPage'
+} from '../fixtures/comfyPageFixture'
 
 // TODO: there might be a better solution for this
 // Helper function to pan canvas and select node

--- a/browser_tests/tests/nodeHelp.spec.ts
+++ b/browser_tests/tests/nodeHelp.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../fixtures/ComfyPage'
 
 // TODO: there might be a better solution for this
 // Helper function to pan canvas and select node

--- a/browser_tests/tests/nodeSearchBox.spec.ts
+++ b/browser_tests/tests/nodeSearchBox.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../fixtures/ComfyPage'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/nodeSearchBox.spec.ts
+++ b/browser_tests/tests/nodeSearchBox.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../fixtures/ComfyPage'
+} from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/noteNode.spec.ts
+++ b/browser_tests/tests/noteNode.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/primitiveNode.spec.ts
+++ b/browser_tests/tests/primitiveNode.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 import type { NodeReference } from '../fixtures/utils/litegraphUtils'
 
 test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/recordAudio.spec.ts
+++ b/browser_tests/tests/recordAudio.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Release Notifications', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/remoteWidgets.spec.ts
+++ b/browser_tests/tests/remoteWidgets.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 import type { ComfyPage } from '../fixtures/ComfyPage'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 
 test.describe('Remote COMBO Widget', () => {
   const mockOptions = ['d', 'c', 'b', 'a']

--- a/browser_tests/tests/rerouteNode.spec.ts
+++ b/browser_tests/tests/rerouteNode.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 import { getMiddlePoint } from '../fixtures/utils/litegraphUtils'
 
 test.describe('Reroute Node', () => {

--- a/browser_tests/tests/rightClickMenu.spec.ts
+++ b/browser_tests/tests/rightClickMenu.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
 import { NodeBadgeMode } from '../../src/types/nodeSource'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/selectionToolbox.spec.ts
+++ b/browser_tests/tests/selectionToolbox.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture } from '../fixtures/ComfyPage'
+import { comfyPageFixture } from '../fixtures/comfyPageFixture'
 
 const test = comfyPageFixture
 

--- a/browser_tests/tests/selectionToolboxSubmenus.spec.ts
+++ b/browser_tests/tests/selectionToolboxSubmenus.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/sidebar/nodeLibrary.spec.ts
+++ b/browser_tests/tests/sidebar/nodeLibrary.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../../fixtures/comfyPageFixture'
 
 test.describe('Node library sidebar', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/sidebar/queue.spec.ts
+++ b/browser_tests/tests/sidebar/queue.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../../fixtures/comfyPageFixture'
 
 test.describe.skip('Queue sidebar', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../../fixtures/comfyPageFixture'
 
 test.describe('Workflows sidebar', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/subgraph-rename-dialog.spec.ts
+++ b/browser_tests/tests/subgraph-rename-dialog.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 // Constants
 const INITIAL_NAME = 'initial_slot_name'

--- a/browser_tests/tests/subgraph.spec.ts
+++ b/browser_tests/tests/subgraph.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 // Constants
 const RENAMED_INPUT_NAME = 'renamed_input'

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 async function checkTemplateFileExists(
   page: Page,

--- a/browser_tests/tests/useSettingSearch.spec.ts
+++ b/browser_tests/tests/useSettingSearch.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/versionMismatchWarnings.spec.ts
+++ b/browser_tests/tests/versionMismatchWarnings.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
 import type { SystemStats } from '../../src/schemas/apiSchema'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.describe('Version Mismatch Warnings', () => {
   const ALWAYS_AHEAD_OF_INSTALLED_VERSION = '100.100.100'

--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 const CREATE_GROUP_HOTKEY = 'Control+g'
 

--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 const CREATE_GROUP_HOTKEY = 'Control+g'
 

--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Nodes Canvas Pan', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 
 test.describe('Vue Nodes Canvas Pan', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/canvas/zoom.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/zoom.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 
 test.describe('Vue Nodes Zoom', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/canvas/zoom.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/zoom.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Nodes Zoom', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -5,7 +5,7 @@ import { getSlotKey } from '../../../../../src/renderer/core/layout/slots/slotId
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 import { getMiddlePoint } from '../../../../fixtures/utils/litegraphUtils'
 import { fitToViewInstant } from '../../../../helpers/fitToView'
 

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -2,10 +2,8 @@ import type { Locator, Page } from '@playwright/test'
 
 import type { NodeId } from '../../../../../src/platform/workflow/validation/schemas/workflowSchema'
 import { getSlotKey } from '../../../../../src/renderer/core/layout/slots/slotIdentifier'
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 import { getMiddlePoint } from '../../../../fixtures/utils/litegraphUtils'
 import { fitToViewInstant } from '../../../../helpers/fitToView'
 

--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -1,8 +1,8 @@
 import {
-  type ComfyPage,
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
+import type { ComfyPage } from '../../../../fixtures/comfyPageFixture'
 import type { Position } from '../../../../fixtures/types'
 
 test.describe('Vue Node Moving', () => {

--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -1,8 +1,6 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
-import type { ComfyPage } from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
+import type { ComfyPage } from '../../../../fixtures/ComfyPage'
 import type { Position } from '../../../../fixtures/types'
 
 test.describe('Vue Node Moving', () => {

--- a/browser_tests/tests/vueNodes/interactions/node/remove.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/remove.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../../../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 
 test.describe('Vue Nodes Renaming', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Nodes Renaming', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/select.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/vueNodes/nodeStates/bypass.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/bypass.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 const BYPASS_HOTKEY = 'Control+b'
 const BYPASS_CLASS = /before:bg-bypass\/60/

--- a/browser_tests/tests/vueNodes/nodeStates/bypass.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/bypass.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 const BYPASS_HOTKEY = 'Control+b'
 const BYPASS_CLASS = /before:bg-bypass\/60/

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 test.describe('Vue Node Collapse', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Node Collapse', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/nodeStates/colors.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/colors.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 test.describe('Vue Node Custom Colors', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/nodeStates/colors.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/colors.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Node Custom Colors', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 const ERROR_CLASS = /border-node-stroke-error/
 

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 const ERROR_CLASS = /border-node-stroke-error/
 

--- a/browser_tests/tests/vueNodes/nodeStates/lod.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/lod.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/vueNodes/nodeStates/mute.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/mute.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 const MUTE_HOTKEY = 'Control+m'
 const MUTE_OPACITY = '0.5'

--- a/browser_tests/tests/vueNodes/nodeStates/mute.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/mute.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 const MUTE_HOTKEY = 'Control+m'
 const MUTE_OPACITY = '0.5'

--- a/browser_tests/tests/vueNodes/nodeStates/pin.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/pin.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 const PIN_HOTKEY = 'p'
 const PIN_INDICATOR = '[data-testid="node-pin-indicator"]'

--- a/browser_tests/tests/vueNodes/nodeStates/pin.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/pin.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 const PIN_HOTKEY = 'p'
 const PIN_INDICATOR = '[data-testid="node-pin-indicator"]'

--- a/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Integer Widget', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 
 test.describe('Vue Integer Widget', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
 
 test.describe('Vue Upload Widgets', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Upload Widgets', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -1,8 +1,6 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../../fixtures/comfyPageFixture'
-import type { ComfyPage } from '../../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../../fixtures/ComfyPage'
+import type { ComfyPage } from '../../../../fixtures/ComfyPage'
 
 test.describe('Vue Multiline String Widget', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -1,8 +1,8 @@
 import {
-  type ComfyPage,
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../../fixtures/ComfyPage'
+} from '../../../../fixtures/comfyPageFixture'
+import type { ComfyPage } from '../../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Multiline String Widget', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyExpect as expect,
   comfyPageFixture as test
-} from '../../../fixtures/ComfyPage'
+} from '../../../fixtures/comfyPageFixture'
 
 test.describe('Vue Widget Reactivity', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
@@ -1,7 +1,5 @@
-import {
-  comfyExpect as expect,
-  comfyPageFixture as test
-} from '../../../fixtures/comfyPageFixture'
+import { comfyPageFixture as test } from '../../../fixtures/comfyPageFixture'
+import { comfyExpect as expect } from '../../../fixtures/ComfyPage'
 
 test.describe('Vue Widget Reactivity', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.setSetting('Comfy.UseNewMenu', 'Disabled')

--- a/browser_tests/tests/workflowTabThumbnail.spec.ts
+++ b/browser_tests/tests/workflowTabThumbnail.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 
-import { type ComfyPage, comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/comfyPageFixture'
+import type { ComfyPage } from '../fixtures/ComfyPage'
 
 test.describe('Workflow Tab Thumbnails', () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/playwright.cloud.config.ts
+++ b/playwright.cloud.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright configuration for cloud E2E tests.
+ * Tests run against stagingcloud.comfy.org with authenticated user.
+ */
+export default defineConfig({
+  testDir: './browser_tests/tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  reporter: 'html',
+
+  // Cloud tests need more time due to network latency
+  timeout: 75000, // 5x the default 15000ms
+  retries: process.env.CI ? 2 : 0,
+
+  use: {
+    trace: 'on-first-retry',
+    // Cloud URL - can override with PLAYWRIGHT_TEST_URL env var
+    baseURL: process.env.PLAYWRIGHT_TEST_URL || 'https://stagingcloud.comfy.org'
+  },
+
+  // Authenticate once before all tests
+  globalSetup: './browser_tests/globalSetupCloud.ts',
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      timeout: 75000,
+      grep: /@cloud/ // Only run tests tagged with @cloud
+    }
+  ]
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
       timeout: 15000,
-      grepInvert: /@mobile/ // Run all tests except those tagged with @mobile
+      grepInvert: /@mobile|@cloud/ // Run all tests except those tagged with @mobile or @cloud
     },
 
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     "eslint.config.ts",
     "global.d.ts",
     "knip.config.ts",
+    "playwright.cloud.config.ts",
     "src/**/*.vue",
     "src/**/*",
     "src/types/**/*.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     "eslint.config.ts",
     "global.d.ts",
     "knip.config.ts",
+    "playwright.config.ts",
     "playwright.cloud.config.ts",
     "src/**/*.vue",
     "src/**/*",


### PR DESCRIPTION
## Summary
Adds Playwright tests for cloud with Firebase auth.

## Changes
- Refactor ComfyPage to abstract base class (3 backend-specific methods)
- Add LocalhostComfyPage (existing devtools) and CloudComfyPage (cloud settings API)
- Add globalSetupCloud for Firebase login (runs once, saves auth state)
- Add playwright.cloud.config.ts (5x timeout, @cloud grep)
- Add basic cloud tests

## Setup
Requires env vars:
- CLOUD_TEST_EMAIL
- CLOUD_TEST_PASSWORD

## Run
```bash
pnpm exec playwright test --config=playwright.cloud.config.ts
```

## Goal
Validate approach before expanding coverage or adding CI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6625-feat-Add-cloud-E2E-testing-infrastructure-2a36d73d3650814a9f4bda5e69fc16ec) by [Unito](https://www.unito.io)
