### PR TITLE
increase tracking heartbeat interval from 30sec to 5min

### DIFF
--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -330,7 +330,7 @@ const onGraphReady = () => {
         }
       }
 
-      // 30-second heartbeat interval
+      // 5-minute heartbeat interval
       tabCountInterval = window.setInterval(() => {
         const now = Date.now()
 
@@ -347,7 +347,7 @@ const onGraphReady = () => {
         // Track tab count (include current tab)
         const tabCount = activeTabs.size + 1
         telemetry.trackTabCount({ tab_count: tabCount })
-      }, 30000)
+      }, 60000 * 5)
 
       // Send initial heartbeat
       tabCountChannel.postMessage({ type: 'heartbeat', tabId: currentTabId })


### PR DESCRIPTION
This event is taking up too much of the quota, increase the interval for now.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6631-increase-tracking-heartbeat-interval-from-30sec-to-5min-2a46d73d3650814291c4fae50227d4ec) by [Unito](https://www.unito.io)
