### PR TITLE
add 'SaveVideo' into saveNodeTypes

### DIFF
--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -4,6 +4,7 @@ import { app } from '../../scripts/app'
 
 const saveNodeTypes = new Set([
   'SaveImage',
+  'SaveVideo',
   'SaveAnimatedWEBP',
   'SaveWEBM',
   'SaveAudio',


### PR DESCRIPTION
## Summary

add 'SaveVideo' into saveNodeTypes to fix [ComfyUI 10285](https://github.com/comfyanonymous/ComfyUI/issues/10285) and [ComfyUI 10479](https://github.com/comfyanonymous/ComfyUI/issues/10479)

## Changes

add 'SaveVideo' into saveNodeTypes values

## Review Focus

is this enough?

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6647-add-SaveVideo-into-saveNodeTypes-2a76d73d365081d9bb7eccc358c9836d) by [Unito](https://www.unito.io)
