### PR TITLE
fix warning log

### DIFF
--- a/src/components/load3d/controls/viewer/ViewerCameraControls.vue
+++ b/src/components/load3d/controls/viewer/ViewerCameraControls.vue
@@ -1,26 +1,28 @@
 <template>
   <div class="space-y-4">
-    <label>
-      {{ t('load3d.viewer.cameraType') }}
-    </label>
-    <Select
-      v-model="cameraType"
-      :options="cameras"
-      option-label="title"
-      option-value="value"
-    >
-    </Select>
-  </div>
+    <div class="space-y-4">
+      <label>
+        {{ t('load3d.viewer.cameraType') }}
+      </label>
+      <Select
+        v-model="cameraType"
+        :options="cameras"
+        option-label="title"
+        option-value="value"
+      >
+      </Select>
+    </div>
 
-  <div v-if="showFOVButton" class="space-y-4">
-    <label>{{ t('load3d.fov') }}</label>
-    <Slider
-      v-model="fov"
-      :min="10"
-      :max="150"
-      :step="1"
-      :aria-label="t('load3d.fov')"
-    />
+    <div v-if="showFOVButton" class="space-y-4">
+      <label>{{ t('load3d.fov') }}</label>
+      <Slider
+        v-model="fov"
+        :min="10"
+        :max="150"
+        :step="1"
+        :aria-label="t('load3d.fov')"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/components/load3d/controls/viewer/ViewerExportControls.vue
+++ b/src/components/load3d/controls/viewer/ViewerExportControls.vue
@@ -1,15 +1,22 @@
 <template>
-  <Select
-    v-model="exportFormat"
-    :options="exportFormats"
-    option-label="label"
-    option-value="value"
-  >
-  </Select>
+  <div class="space-y-4">
+    <Select
+      v-model="exportFormat"
+      :options="exportFormats"
+      option-label="label"
+      option-value="value"
+    >
+    </Select>
 
-  <Button severity="secondary" text rounded @click="exportModel(exportFormat)">
-    {{ $t('load3d.export') }}
-  </Button>
+    <Button
+      severity="secondary"
+      text
+      rounded
+      @click="exportModel(exportFormat)"
+    >
+      {{ $t('load3d.export') }}
+    </Button>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/load3d/controls/viewer/ViewerLightControls.vue
+++ b/src/components/load3d/controls/viewer/ViewerLightControls.vue
@@ -1,13 +1,15 @@
 <template>
-  <label>{{ $t('load3d.lightIntensity') }}</label>
+  <div class="space-y-4">
+    <label>{{ $t('load3d.lightIntensity') }}</label>
 
-  <Slider
-    v-model="lightIntensity"
-    class="w-full"
-    :min="lightIntensityMinimum"
-    :max="lightIntensityMaximum"
-    :step="lightAdjustmentIncrement"
-  />
+    <Slider
+      v-model="lightIntensity"
+      class="w-full"
+      :min="lightIntensityMinimum"
+      :max="lightIntensityMaximum"
+      :step="lightAdjustmentIncrement"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary

we need to add root div to avoid warning

> Extraneous non-props attributes (data-v-inspector) were passed to
> component but could not be automatically inherited because component renders fragment or text or teleport root
> nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6650-fix-warning-log-2a86d73d365081a89c5af0c60cdaa618) by [Unito](https://www.unito.io)
