### PR TITLE
ci: only run json check on PRs that change json files

### DIFF
--- a/.github/workflows/ci-json-validation.yaml
+++ b/.github/workflows/ci-json-validation.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - '**/*.json'
 
 jobs:
   json-lint:


### PR DESCRIPTION
Changes pull_request trigger to only include paths: ['**/*.json'], so JSON validation only runs on PRs whose diffs touch JSON files. Keeps the push trigger for all updates to main to account for direct pushes that bypass PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6656-ci-only-run-json-check-on-PRs-that-change-json-files-2a86d73d365081bc8743faee941022f4) by [Unito](https://www.unito.io)
