### PR TITLE
[feat] Add missing nodes warning UI to queue button and breadcrumb

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -15,20 +15,7 @@
       @click="queuePrompt"
     >
       <template #icon>
-        <i v-if="hasMissingNodes" class="icon-[lucide--triangle-alert]" />
-        <i
-          v-else-if="workspaceStore.shiftDown"
-          class="icon-[lucide--list-start]"
-        />
-        <i v-else-if="queueMode === 'disabled'" class="icon-[lucide--play]" />
-        <i
-          v-else-if="queueMode === 'instant'"
-          class="icon-[lucide--fast-forward]"
-        />
-        <i
-          v-else-if="queueMode === 'change'"
-          class="icon-[lucide--step-forward]"
-        />
+        <i :class="iconClass" />
       </template>
       <template #item="{ item }">
         <Button
@@ -162,6 +149,25 @@ const executingPrompt = computed(() => !!queueCountStore.count.value)
 const hasPendingTasks = computed(
   () => queueCountStore.count.value > 1 || queueMode.value !== 'disabled'
 )
+
+const iconClass = computed(() => {
+  if (hasMissingNodes.value) {
+    return 'icon-[lucide--triangle-alert]'
+  }
+  if (workspaceStore.shiftDown) {
+    return 'icon-[lucide--list-start]'
+  }
+  if (queueMode.value === 'disabled') {
+    return 'icon-[lucide--play]'
+  }
+  if (queueMode.value === 'instant') {
+    return 'icon-[lucide--fast-forward]'
+  }
+  if (queueMode.value === 'change') {
+    return 'icon-[lucide--step-forward]'
+  }
+  return ''
+})
 
 const queueButtonTooltip = computed(() => {
   if (hasMissingNodes.value) {

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -166,7 +166,7 @@ const iconClass = computed(() => {
   if (queueMode.value === 'change') {
     return 'icon-[lucide--step-forward]'
   }
-  return ''
+  return 'icon-[lucide--play]'
 })
 
 const queueButtonTooltip = computed(() => {

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -2,7 +2,7 @@
   <a
     ref="wrapperRef"
     v-tooltip.bottom="{
-      value: item.label,
+      value: tooltipText,
       showDelay: 512
     }"
     draggable="false"
@@ -16,6 +16,10 @@
     }"
     @click="handleClick"
   >
+    <i
+      v-if="hasMissingNodes && isRoot"
+      class="icon-[lucide--triangle-alert] text-gold-600"
+    />
     <span class="p-breadcrumb-item-label px-2">{{ item.label }}</span>
     <Tag v-if="item.isBlueprint" :value="'Blueprint'" severity="primary" />
     <i v-if="isActive" class="pi pi-angle-down text-[10px]"></i>
@@ -64,6 +68,7 @@ import { useDialogService } from '@/services/dialogService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { appendJsonExt } from '@/utils/formatUtil'
+import { useMissingNodes } from '@/workbench/extensions/manager/composables/nodePack/useMissingNodes'
 
 interface Props {
   item: MenuItem
@@ -73,6 +78,8 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   isActive: false
 })
+
+const { hasMissingNodes } = useMissingNodes()
 
 const { t } = useI18n()
 const menu = ref<InstanceType<typeof Menu> & MenuState>()
@@ -115,6 +122,14 @@ const rename = async (
 }
 
 const isRoot = props.item.key === 'root'
+
+const tooltipText = computed(() => {
+  if (hasMissingNodes.value && isRoot) {
+    return t('breadcrumbsMenu.missingNodesWarning')
+  }
+  return props.item.label
+})
+
 const menuItems = computed<MenuItem[]>(() => {
   return [
     {

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -18,7 +18,7 @@
   >
     <i
       v-if="hasMissingNodes && isRoot"
-      class="icon-[lucide--triangle-alert] text-gold-600"
+      class="icon-[lucide--triangle-alert] text-warning-background"
     />
     <span class="p-breadcrumb-item-label px-2">{{ item.label }}</span>
     <Tag v-if="item.isBlueprint" :value="'Blueprint'" severity="primary" />

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -779,6 +779,7 @@
     "onChangeTooltip": "The workflow will be queued once a change is made",
     "runWorkflow": "Run workflow (Shift to queue at front)",
     "runWorkflowFront": "Run workflow (Queue at front)",
+    "runWorkflowDisabled": "Workflow contains unsupported nodes (highlighted red). Remove these to run the workflow.",
     "run": "Run",
     "execute": "Execute",
     "interrupt": "Cancel current run",
@@ -1916,7 +1917,8 @@
     "clearWorkflow": "Clear Workflow",
     "deleteWorkflow": "Delete Workflow",
     "deleteBlueprint": "Delete Blueprint",
-    "enterNewName": "Enter new name"
+    "enterNewName": "Enter new name",
+    "missingNodesWarning": "Workflow contains unsupported nodes (highlighted red)."
   },
   "shortcuts": {
     "shortcuts": "Shortcuts",

--- a/src/workbench/extensions/manager/composables/nodePack/useMissingNodes.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/useMissingNodes.ts
@@ -1,6 +1,6 @@
 import { groupBy } from 'es-toolkit/compat'
 import { createSharedComposable } from '@vueuse/core'
-import { computed, onMounted, watch } from 'vue'
+import { computed, watch } from 'vue'
 
 import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -73,21 +73,13 @@ export const useMissingNodes = createSharedComposable(() => {
     )
   })
 
-  // Automatically fetch workflow pack data when composable is used
-  onMounted(async () => {
-    if (!workflowPacks.value.length && !isLoading.value) {
-      await startFetchWorkflowPacks()
-    }
-  })
-
   // Re-fetch workflow packs when active workflow changes
   watch(
     () => workflowStore.activeWorkflow,
-    async (newWorkflow, oldWorkflow) => {
-      if (newWorkflow !== oldWorkflow) {
-        await startFetchWorkflowPacks()
-      }
-    }
+    async () => {
+      await startFetchWorkflowPacks()
+    },
+    { immediate: true }
   )
 
   return {

--- a/src/workbench/extensions/manager/composables/nodePack/useMissingNodes.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/useMissingNodes.ts
@@ -1,8 +1,10 @@
 import { groupBy } from 'es-toolkit/compat'
-import { computed, onMounted } from 'vue'
+import { createSharedComposable } from '@vueuse/core'
+import { computed, onMounted, watch } from 'vue'
 
 import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { app } from '@/scripts/app'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import type { components } from '@/types/comfyRegistryTypes'
@@ -14,10 +16,12 @@ import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comf
  * Composable to find missing NodePacks from workflow
  * Uses the same filtering approach as ManagerDialogContent.vue
  * Automatically fetches workflow pack data when initialized
+ * This is a shared singleton composable - all components use the same instance
  */
-export const useMissingNodes = () => {
+export const useMissingNodes = createSharedComposable(() => {
   const nodeDefStore = useNodeDefStore()
   const comfyManagerStore = useComfyManagerStore()
+  const workflowStore = useWorkflowStore()
   const { workflowPacks, isLoading, error, startFetchWorkflowPacks } =
     useWorkflowPacks()
 
@@ -61,6 +65,14 @@ export const useMissingNodes = () => {
     return groupBy(missingNodes, (node) => String(node.properties?.ver || ''))
   })
 
+  // Check if workflow has any missing nodes
+  const hasMissingNodes = computed(() => {
+    return (
+      missingNodePacks.value.length > 0 ||
+      Object.keys(missingCoreNodes.value).length > 0
+    )
+  })
+
   // Automatically fetch workflow pack data when composable is used
   onMounted(async () => {
     if (!workflowPacks.value.length && !isLoading.value) {
@@ -68,10 +80,21 @@ export const useMissingNodes = () => {
     }
   })
 
+  // Re-fetch workflow packs when active workflow changes
+  watch(
+    () => workflowStore.activeWorkflow,
+    async (newWorkflow, oldWorkflow) => {
+      if (newWorkflow !== oldWorkflow) {
+        await startFetchWorkflowPacks()
+      }
+    }
+  )
+
   return {
     missingNodePacks,
     missingCoreNodes,
+    hasMissingNodes,
     isLoading,
     error
   }
-}
+})

--- a/tests-ui/tests/composables/useMissingNodes.test.ts
+++ b/tests-ui/tests/composables/useMissingNodes.test.ts
@@ -9,12 +9,12 @@ import { useMissingNodes } from '@/workbench/extensions/manager/composables/node
 import { useWorkflowPacks } from '@/workbench/extensions/manager/composables/nodePack/useWorkflowPacks'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 
-// Mock Vue's onMounted to execute immediately for testing
-vi.mock('vue', async () => {
-  const actual = await vi.importActual<typeof import('vue')>('vue')
+vi.mock('@vueuse/core', async () => {
+  const actual =
+    await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
   return {
     ...actual,
-    onMounted: (cb: () => void) => cb()
+    createSharedComposable: (fn: any) => fn
   }
 })
 
@@ -32,6 +32,12 @@ vi.mock('@/workbench/extensions/manager/stores/comfyManagerStore', () => ({
 
 vi.mock('@/stores/nodeDefStore', () => ({
   useNodeDefStore: vi.fn()
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: vi.fn(() => ({
+    activeWorkflow: null
+  }))
 }))
 
 vi.mock('@/scripts/app', () => ({
@@ -176,13 +182,13 @@ describe('useMissingNodes', () => {
   })
 
   describe('automatic data fetching', () => {
-    it('fetches workflow packs automatically when none exist', async () => {
+    it('fetches workflow packs automatically on initialization via watch with immediate:true', async () => {
       useMissingNodes()
 
       expect(mockStartFetchWorkflowPacks).toHaveBeenCalledOnce()
     })
 
-    it('does not fetch when packs already exist', async () => {
+    it('fetches even when packs already exist (watch always fires with immediate:true)', async () => {
       mockUseWorkflowPacks.mockReturnValue({
         workflowPacks: ref(mockWorkflowPacks),
         isLoading: ref(false),
@@ -194,10 +200,10 @@ describe('useMissingNodes', () => {
 
       useMissingNodes()
 
-      expect(mockStartFetchWorkflowPacks).not.toHaveBeenCalled()
+      expect(mockStartFetchWorkflowPacks).toHaveBeenCalledOnce()
     })
 
-    it('does not fetch when already loading', async () => {
+    it('fetches even when already loading (watch fires regardless of loading state)', async () => {
       mockUseWorkflowPacks.mockReturnValue({
         workflowPacks: ref([]),
         isLoading: ref(true),
@@ -209,7 +215,7 @@ describe('useMissingNodes', () => {
 
       useMissingNodes()
 
-      expect(mockStartFetchWorkflowPacks).not.toHaveBeenCalled()
+      expect(mockStartFetchWorkflowPacks).toHaveBeenCalledOnce()
     })
   })
 

--- a/tests-ui/tests/composables/useMissingNodes.test.ts
+++ b/tests-ui/tests/composables/useMissingNodes.test.ts
@@ -14,7 +14,7 @@ vi.mock('@vueuse/core', async () => {
     await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
   return {
     ...actual,
-    createSharedComposable: (fn: any) => fn
+    createSharedComposable: <Fn extends (...args: any[]) => any>(fn: Fn) => fn
   }
 })
 


### PR DESCRIPTION
## 📋 Summary

Add visual warning indicators to notify users when a workflow contains missing nodes.

## 🎯 Changes

### 1. Improve Missing Nodes Detection System

**Problem:**
- `useMissingNodes` composable was executing independently in each component, causing duplicate API calls
- ComfyQueueButton retained stale state even after workflow changes
- SubgraphBreadcrumbItem updated (due to remounting), but ComfyQueueButton remained stale (persistent component)

**Solution:**
```typescript
// useMissingNodes.ts
export const useMissingNodes = createSharedComposable(() => {
  // ... existing logic ...
  
  // Watch for workflow changes
  watch(
    () => workflowStore.activeWorkflow,
    async (newWorkflow, oldWorkflow) => {
      if (newWorkflow !== oldWorkflow) {
        await startFetchWorkflowPacks()
      }
    }
  )
})
```

**Why use `createSharedComposable`?**
- **Singleton pattern**: All components share the same instance
- **Prevent duplicate calls**: `startFetchWorkflowPacks()` executes only once
- **State synchronization**: ComfyQueueButton and SubgraphBreadcrumbItem always see the same data
- **Single watch registration**: Workflow change detection logic is not duplicated

**Why use `watch`?**
- **Add reactivity**: Automatically recalculates missing nodes when `activeWorkflow` changes
- **Handle persistent components**: Components like ComfyQueueButton (that don't remount) update automatically
- **No manual calls needed**: State refreshes automatically on workflow switches

### 2. Add UI Warning Indicators

**ComfyQueueButton (Run button)**
- ⚠️ Triangle warning icon display
- Button disabled state
- Tooltip: "Workflow contains unsupported nodes (highlighted red). Remove these to run the workflow."
- Text color always white

**SubgraphBreadcrumbItem (Workflow name)**
- ⚠️ Warning icon on root breadcrumb only
- Tooltip: "Workflow contains unsupported nodes (highlighted red)."

### 3. Add i18n Keys

```json
{
  "menu": {
    "runWorkflowDisabled": "Workflow contains unsupported nodes (highlighted red). Remove these to run the workflow."
  },
  "breadcrumbsMenu": {
    "missingNodesWarning": "Workflow contains unsupported nodes (highlighted red)."
  }
}
```

## 🧪 Testing

1. Open workflow with missing nodes
   - ✅ ComfyQueueButton shows warning icon + disabled state
   - ✅ Root breadcrumb shows warning icon
   - ✅ Appropriate tooltips displayed

2. Switch to workflow without missing nodes
   - ✅ Warning icons automatically disappear
   - ✅ ComfyQueueButton becomes enabled

3. Switch back to workflow with missing nodes
   - ✅ Warning icons reappear
   - ✅ State updates in real-time

## 📸 Visual Changes

- ComfyQueueButton: Warning icon (triangle) + disabled styling
- SubgraphBreadcrumbItem: Gold warning icon on the left

[queuebutton.webm](https://github.com/user-attachments/assets/8436b2ba-f40f-476f-9e69-1af2e9c03fa1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6674-feat-Add-missing-nodes-warning-UI-to-queue-button-and-breadcrumb-2aa6d73d36508190a9dbe144da90ec58) by [Unito](https://www.unito.io)
