### PR TITLE
fix: npm link in release notification comment

### DIFF
--- a/.github/actions/comment-release-links/action.yaml
+++ b/.github/actions/comment-release-links/action.yaml
@@ -57,11 +57,11 @@ runs:
           package.json)
             LINKS_VALUE=$(printf '%s\n%s' \
               'PyPI|https://pypi.org/project/comfyui-frontend-package/{{version}}/' \
-              'npm types|https://npm.im/@comfyorg/comfyui-frontend-types@{{version}}')
+              'npm types|https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/{{version}}')
             ;;
           apps/desktop-ui/package.json)
             MARKER='desktop-release-summary'
-            LINKS_VALUE='npm desktop UI|https://npm.im/@comfyorg/desktop-ui@{{version}}'
+            LINKS_VALUE='npm desktop UI|https://www.npmjs.com/package/@comfyorg/desktop-ui/v/{{version}}'
             ;;
         esac
 
@@ -74,7 +74,7 @@ runs:
           echo "<!--$MARKER:$DIFF_PREFIX$NEW_VERSION-->"
           echo "$MESSAGE"
           echo ""
-          echo "- $DIFF_LABEL: [$DIFF_PREFIX$PREV_VERSION...$DIFF_PREFIX$NEW_VERSION]($DIFF_URL)"
+          echo "- $DIFF_LABEL: [\`$DIFF_PREFIX$PREV_VERSION...$DIFF_PREFIX$NEW_VERSION\`]($DIFF_URL)"
 
           while IFS= read -r RAW_LINE; do
             LINE=$(echo "$RAW_LINE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -87,7 +87,7 @@ runs:
             URL_TEMPLATE=${LINE#*|}
             URL=${URL_TEMPLATE//\{\{version\}\}/$NEW_VERSION}
             URL=${URL//\{\{prev_version\}\}/$PREV_VERSION}
-            echo "- $LABEL: $URL"
+            echo "- $LABEL: [\`$NEW_VERSION\`]($URL)"
           done <<< "$LINKS_VALUE"
 
           echo ""


### PR DESCRIPTION
Changes to correct URL syntax for npm package link (types package).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6683-fix-npm-link-in-release-notification-comment-2aa6d73d365081729c54efabc76a833a) by [Unito](https://www.unito.io)
