### PR TITLE
add telemetry event for subscription cancellation

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -105,7 +105,7 @@ function useSubscriptionInternal() {
     void dialogService.showSubscriptionRequiredDialog()
   }
 
-  const shouldWatchCancellation = () =>
+  const shouldWatchCancellation = (): boolean =>
     Boolean(isCloud && window.__CONFIG__?.subscription_required)
 
   const { startCancellationWatcher, stopCancellationWatcher } =

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.ts
@@ -1,0 +1,122 @@
+import { onScopeDispose, ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
+import { useEventListener } from '@vueuse/core'
+
+import type { TelemetryProvider } from '@/platform/telemetry/types'
+
+import type { CloudSubscriptionStatusResponse } from './useSubscription'
+
+const MAX_CANCELLATION_ATTEMPTS = 4
+const CANCELLATION_BASE_DELAY_MS = 5000
+
+type CancellationWatcherOptions = {
+  fetchStatus: () => Promise<CloudSubscriptionStatusResponse | null | void>
+  isActiveSubscription: ComputedRef<boolean>
+  subscriptionStatus: Ref<CloudSubscriptionStatusResponse | null>
+  telemetry: Pick<TelemetryProvider, 'trackMonthlySubscriptionCancelled'> | null
+  shouldWatchCancellation: () => boolean
+}
+
+export function useSubscriptionCancellationWatcher({
+  fetchStatus,
+  isActiveSubscription,
+  subscriptionStatus,
+  telemetry,
+  shouldWatchCancellation
+}: CancellationWatcherOptions) {
+  const watcherActive = ref(false)
+  const cancellationAttempts = ref(0)
+  const cancellationTracked = ref(false)
+  const cancellationCheckInFlight = ref(false)
+  const cancellationTimeoutId = ref<number | null>(null)
+
+  const clearScheduledCheck = () => {
+    if (cancellationTimeoutId.value !== null) {
+      clearTimeout(cancellationTimeoutId.value)
+      cancellationTimeoutId.value = null
+    }
+  }
+
+  const stopCancellationWatcher = () => {
+    watcherActive.value = false
+    clearScheduledCheck()
+    cancellationAttempts.value = 0
+    cancellationCheckInFlight.value = false
+  }
+
+  const scheduleNextCancellationCheck = () => {
+    if (!watcherActive.value || typeof window === 'undefined') return
+
+    if (cancellationAttempts.value >= MAX_CANCELLATION_ATTEMPTS) {
+      stopCancellationWatcher()
+      return
+    }
+
+    const delay = CANCELLATION_BASE_DELAY_MS * 3 ** cancellationAttempts.value
+    cancellationAttempts.value += 1
+    cancellationTimeoutId.value = window.setTimeout(() => {
+      void checkForCancellation()
+    }, delay)
+  }
+
+  const checkForCancellation = async (triggeredFromFocus = false) => {
+    if (!watcherActive.value || cancellationCheckInFlight.value) return
+
+    cancellationCheckInFlight.value = true
+    try {
+      await fetchStatus()
+
+      if (!isActiveSubscription.value) {
+        if (!cancellationTracked.value) {
+          cancellationTracked.value = true
+          telemetry?.trackMonthlySubscriptionCancelled()
+        }
+        stopCancellationWatcher()
+        return
+      }
+
+      if (!triggeredFromFocus) {
+        scheduleNextCancellationCheck()
+      }
+    } catch (error) {
+      console.error('[Subscription] Error checking cancellation status:', error)
+      scheduleNextCancellationCheck()
+    } finally {
+      cancellationCheckInFlight.value = false
+    }
+  }
+
+  const startCancellationWatcher = () => {
+    if (
+      !shouldWatchCancellation() ||
+      !subscriptionStatus.value?.is_active ||
+      typeof window === 'undefined'
+    ) {
+      return
+    }
+
+    stopCancellationWatcher()
+    watcherActive.value = true
+    cancellationTracked.value = false
+    cancellationAttempts.value = 0
+    scheduleNextCancellationCheck()
+  }
+
+  const stopFocusListener =
+    typeof window !== 'undefined'
+      ? useEventListener(window, 'focus', () => {
+          if (!watcherActive.value) return
+          void checkForCancellation(true)
+        })
+      : () => {}
+
+  onScopeDispose(() => {
+    stopFocusListener()
+    stopCancellationWatcher()
+  })
+
+  return {
+    startCancellationWatcher,
+    stopCancellationWatcher
+  }
+}

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -175,6 +175,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED)
   }
 
+  trackMonthlySubscriptionCancelled(): void {
+    this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_CANCELLED)
+  }
+
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void {
     const metadata: CreditTopupMetadata = {
       credit_amount: amount

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -175,6 +175,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED)
   }
 
+  /**
+   * Track when a user completes a subscription cancellation flow.
+   * Fired after we detect the backend reports `is_active: false` and the UI stops polling.
+   */
   trackMonthlySubscriptionCancelled(): void {
     this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_CANCELLED)
   }

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -265,6 +265,7 @@ export interface TelemetryProvider {
   // Subscription flow events
   trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void
   trackMonthlySubscriptionSucceeded(): void
+  trackMonthlySubscriptionCancelled(): void
   trackAddApiCreditButtonClicked(): void
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void
   trackApiCreditTopupSucceeded(): void
@@ -344,6 +345,7 @@ export const TelemetryEvents = {
   SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'app:subscription_required_modal_opened',
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
   MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
+  MONTHLY_SUBSCRIPTION_CANCELLED: 'app:monthly_subscription_cancelled',
   ADD_API_CREDIT_BUTTON_CLICKED: 'app:add_api_credit_button_clicked',
   API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED:
     'app:api_credit_topup_button_purchase_clicked',

--- a/tests-ui/tests/platform/cloud/subscription/useSubscription.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/useSubscription.test.ts
@@ -11,6 +11,10 @@ const mockShowSubscriptionRequiredDialog = vi.fn()
 const mockGetAuthHeader = vi.fn(() =>
   Promise.resolve({ Authorization: 'Bearer test-token' })
 )
+const mockTelemetry = {
+  trackSubscription: vi.fn(),
+  trackMonthlySubscriptionCancelled: vi.fn()
+}
 
 // Mock dependencies
 vi.mock('@/composables/auth/useCurrentUser', () => ({
@@ -20,7 +24,7 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 }))
 
 vi.mock('@/platform/telemetry', () => ({
-  useTelemetry: vi.fn(() => null)
+  useTelemetry: vi.fn(() => mockTelemetry)
 }))
 
 vi.mock('@/composables/auth/useFirebaseAuthActions', () => ({
@@ -72,6 +76,11 @@ describe('useSubscription', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsLoggedIn.value = false
+    mockTelemetry.trackSubscription.mockReset()
+    mockTelemetry.trackMonthlySubscriptionCancelled.mockReset()
+    window.__CONFIG__ = {
+      subscription_required: true
+    } as typeof window.__CONFIG__
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -320,6 +329,50 @@ describe('useSubscription', () => {
       await manageSubscription()
 
       expect(mockAccessBillingPortal).toHaveBeenCalled()
+    })
+
+    it('tracks cancellation after manage subscription when status flips', async () => {
+      vi.useFakeTimers()
+      mockIsLoggedIn.value = true
+
+      const activeResponse = {
+        ok: true,
+        json: async () => ({
+          is_active: true,
+          subscription_id: 'sub_active',
+          renewal_date: '2025-11-16'
+        })
+      }
+
+      const cancelledResponse = {
+        ok: true,
+        json: async () => ({
+          is_active: false,
+          subscription_id: 'sub_cancelled',
+          renewal_date: '2025-11-16',
+          end_date: '2025-12-01'
+        })
+      }
+
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(activeResponse as Response)
+        .mockResolvedValueOnce(activeResponse as Response)
+        .mockResolvedValueOnce(cancelledResponse as Response)
+
+      try {
+        const { fetchStatus, manageSubscription } = useSubscription()
+
+        await fetchStatus()
+        await manageSubscription()
+
+        await vi.advanceTimersByTimeAsync(5000)
+
+        expect(
+          mockTelemetry.trackMonthlySubscriptionCancelled
+        ).toHaveBeenCalledTimes(1)
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 })

--- a/tests-ui/tests/platform/cloud/subscription/useSubscriptionCancellationWatcher.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/useSubscriptionCancellationWatcher.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref } from 'vue'
+
+import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
+import { useSubscriptionCancellationWatcher } from '@/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher'
+
+describe('useSubscriptionCancellationWatcher', () => {
+  const trackMonthlySubscriptionCancelled = vi.fn()
+  const telemetryMock: Pick<
+    import('@/platform/telemetry/types').TelemetryProvider,
+    'trackMonthlySubscriptionCancelled'
+  > = {
+    trackMonthlySubscriptionCancelled
+  }
+
+  const baseStatus: CloudSubscriptionStatusResponse = {
+    is_active: true,
+    subscription_id: 'sub_123',
+    renewal_date: '2025-11-16'
+  }
+
+  const subscriptionStatus = ref<CloudSubscriptionStatusResponse | null>(
+    baseStatus
+  )
+  const isActive = ref(true)
+  const isActiveSubscription = computed(() => isActive.value)
+
+  const shouldWatchCancellation = () => true
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    trackMonthlySubscriptionCancelled.mockReset()
+    subscriptionStatus.value = { ...baseStatus }
+    isActive.value = true
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('polls with exponential backoff and fires telemetry once cancellation detected', async () => {
+    const fetchStatus = vi.fn(async () => {
+      if (fetchStatus.mock.calls.length === 2) {
+        isActive.value = false
+        subscriptionStatus.value = {
+          is_active: false,
+          subscription_id: 'sub_cancelled',
+          renewal_date: '2025-11-16',
+          end_date: '2025-12-01'
+        }
+      }
+    })
+
+    const { startCancellationWatcher } = useSubscriptionCancellationWatcher({
+      fetchStatus,
+      isActiveSubscription,
+      subscriptionStatus,
+      telemetry: telemetryMock,
+      shouldWatchCancellation
+    })
+
+    startCancellationWatcher()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fetchStatus).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(15000)
+    expect(fetchStatus).toHaveBeenCalledTimes(2)
+    expect(
+      telemetryMock.trackMonthlySubscriptionCancelled
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggers a check immediately when window regains focus', async () => {
+    const fetchStatus = vi.fn(async () => {
+      isActive.value = false
+      subscriptionStatus.value = {
+        ...baseStatus,
+        is_active: false,
+        end_date: '2025-12-01'
+      }
+    })
+
+    const { startCancellationWatcher } = useSubscriptionCancellationWatcher({
+      fetchStatus,
+      isActiveSubscription,
+      subscriptionStatus,
+      telemetry: telemetryMock,
+      shouldWatchCancellation
+    })
+
+    startCancellationWatcher()
+
+    window.dispatchEvent(new Event('focus'))
+    await Promise.resolve()
+
+    expect(fetchStatus).toHaveBeenCalledTimes(1)
+    expect(
+      telemetryMock.trackMonthlySubscriptionCancelled
+    ).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests-ui/tests/platform/cloud/subscription/useSubscriptionCancellationWatcher.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/useSubscriptionCancellationWatcher.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, effectScope, ref } from 'vue'
 import type { EffectScope } from 'vue'
 


### PR DESCRIPTION
emits event after going to dashboard and returning to page and having subscription status change from subscribed to not subscribed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6684-add-telemetry-event-for-subscription-cancellation-2aa6d73d365081009770de6d1db2b701) by [Unito](https://www.unito.io)
