### PR TITLE
filter out templates that have custom nodes when not on cloud (temporary)

### DIFF
--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -244,8 +244,7 @@ export const useWorkflowTemplatesStore = defineStore(
       const filteredTemplates = isCloud
         ? allTemplates
         : allTemplates.filter(
-            (template) =>
-              !template.requiresCustomNodes?.length
+            (template) => !template.requiresCustomNodes?.length
           )
 
       return filteredTemplates

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -237,7 +237,19 @@ export const useWorkflowTemplatesStore = defineStore(
         }
       )
 
-      return allTemplates
+      // TODO: Temporary filtering of custom node templates on local installations
+      // Future: Add UX that allows local users to opt-in to templates with custom nodes,
+      // potentially conditional on whether they have those specific custom nodes installed.
+      // This would provide better template discovery while respecting local user workflows.
+      const filteredTemplates = isCloud
+        ? allTemplates
+        : allTemplates.filter(
+            (template) =>
+              !template.requiresCustomNodes ||
+              template.requiresCustomNodes.length === 0
+          )
+
+      return filteredTemplates
     })
 
     /**

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -245,8 +245,7 @@ export const useWorkflowTemplatesStore = defineStore(
         ? allTemplates
         : allTemplates.filter(
             (template) =>
-              !template.requiresCustomNodes ||
-              template.requiresCustomNodes.length === 0
+              !template.requiresCustomNodes?.length
           )
 
       return filteredTemplates

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -27,6 +27,11 @@ export interface TemplateInfo {
    * Whether this template uses open source models. When false, indicates partner/API node templates.
    */
   openSource?: boolean
+  /**
+   * Array of custom node package IDs required for this template (from Custom Node Registry).
+   * Templates with this field will be hidden on local installations temporarily.
+   */
+  requiresCustomNodes?: string[]
 }
 
 export interface WorkflowTemplates {


### PR DESCRIPTION
Templates are being added that have custom nodes. As a temporary measure, filter these out on local. In a followup, add a UX to allow local users to do something like opt-in to use these or to show these on the condition that the user has these custom nodes installed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6690-filter-out-templates-that-have-custom-nodes-when-not-on-cloud-temporary-2ab6d73d3650819981c0e9b26d34acff) by [Unito](https://www.unito.io)
