### PR TITLE
fix: Add 3D file support to Media Asset Panel

### DIFF
--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -23,6 +23,7 @@ import { api } from '@/scripts/api'
 import type { ComfyApp } from '@/scripts/app'
 import { useExtensionService } from '@/services/extensionService'
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
+import { getMediaTypeFromFilename } from '@/utils/formatUtil'
 
 // Task type used in the API.
 type APITaskType = 'queue' | 'history'
@@ -202,8 +203,12 @@ export class ResultItemImpl {
     )
   }
 
+  get is3D(): boolean {
+    return getMediaTypeFromFilename(this.filename) === '3D'
+  }
+
   get supportsPreview(): boolean {
-    return this.isImage || this.isVideo || this.isAudio
+    return this.isImage || this.isVideo || this.isAudio || this.is3D
   }
 }
 


### PR DESCRIPTION
## Summary
Fix bug where 3D files were not displayed in the Media Asset Panel's Generated tab

## Problem
- 3D files (`.obj`, `.fbx`, `.gltf`, `.glb`) appear correctly in QueueSidebarTab
- 3D files do not appear in Media Asset Panel's Generated tab

## Root Cause
`ResultItemImpl.supportsPreview` getter only checked for Image, Video, and Audio files, excluding 3D files. This caused:
1. 3D files to be filtered out in `TaskItemImpl.previewOutput`
2. Items with undefined `previewOutput` to be skipped in `mapHistoryToAssets`
3. 3D files not appearing in the Media Asset Panel

## Solution
- Add `is3D` getter to `ResultItemImpl`
- Include 3D file support in `supportsPreview`
- Use `getMediaTypeFromFilename` utility to detect 3D file types based on extension

## Changes
- `src/stores/queueStore.ts`:
  - Import `getMediaTypeFromFilename`
  - Add `is3D` getter
  - Update `supportsPreview` to include `|| this.is3D`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6699-fix-Add-3D-file-support-to-Media-Asset-Panel-2ab6d73d3650817d8bceecb3e3526582) by [Unito](https://www.unito.io)
