### PR TITLE
Fix pointer events passing through sideToolbar

### DIFF
--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <nav
     ref="sideToolbarRef"
-    class="side-tool-bar-container flex h-full flex-col items-center bg-transparent [.floating-sidebar]:-mr-2"
+    class="side-tool-bar-container flex h-full flex-col items-center bg-transparent [.floating-sidebar]:-mr-2 pointer-events-auto"
     :class="{
       'small-sidebar': isSmall,
       'connected-sidebar': isConnected,
@@ -145,7 +145,7 @@ const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
 const isOverflowing = ref(false)
 const groupClasses = computed(() =>
   cn(
-    'sidebar-item-group pointer-events-auto flex flex-col items-center overflow-hidden flex-shrink-0' +
+    'sidebar-item-group flex flex-col items-center overflow-hidden flex-shrink-0' +
       (isConnected.value ? '' : ' rounded-lg shadow-interface')
   )
 )


### PR DESCRIPTION
#6103 Made it so clicks in the gaps on the side toolbar would pass through to the canvas.  Since the gap has been removed from the side toolbar, this would incorrectly allow the canvas to be dragged through the toolbar as shown.
![unfix-mouse_00003](https://github.com/user-attachments/assets/301f9d61-b73b-448f-bfaa-d236509d7f1a)

Credit to @Kosinkadink for finding this.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6700-Fix-pointer-events-passing-through-sideToolbar-2ab6d73d365081d2948fceba909b7164) by [Unito](https://www.unito.io)
