### PR TITLE
[feat] Add copy job ID action and shared asset utilities

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2044,7 +2044,8 @@
       "downloadsStarted": "Started downloading {count} file(s)",
       "assetsDeletedSuccessfully": "{count} asset(s) deleted successfully",
       "failedToDeleteAssets": "Failed to delete selected assets"
-    }
+    },
+    "noJobIdFound": "No job ID found for this asset"
   },
   "actionbar": {
     "dockToTop": "Dock to top",

--- a/src/platform/assets/utils/assetTypeUtil.ts
+++ b/src/platform/assets/utils/assetTypeUtil.ts
@@ -1,0 +1,24 @@
+/**
+ * Utilities for working with asset types
+ */
+
+import type { AssetItem } from '../schemas/assetSchema'
+
+/**
+ * Extract asset type from an asset's tags array
+ * Falls back to a default type if tags are not present
+ *
+ * @param asset The asset to extract type from
+ * @param defaultType Default type to use if tags are empty (default: 'output')
+ * @returns The asset type ('input', 'output', 'temp', etc.)
+ *
+ * @example
+ * getAssetType(asset) // Returns 'output' or first tag
+ * getAssetType(asset, 'input') // Returns 'input' if no tags
+ */
+export function getAssetType(
+  asset: AssetItem,
+  defaultType: 'input' | 'output' = 'output'
+): string {
+  return asset.tags?.[0] || defaultType
+}

--- a/src/platform/assets/utils/assetUrlUtil.ts
+++ b/src/platform/assets/utils/assetUrlUtil.ts
@@ -1,0 +1,29 @@
+/**
+ * Utilities for constructing asset URLs
+ */
+
+import { api } from '@/scripts/api'
+import type { AssetItem } from '../schemas/assetSchema'
+import { getAssetType } from './assetTypeUtil'
+
+/**
+ * Get the download/view URL for an asset
+ * Constructs the proper URL with filename encoding and type parameter
+ *
+ * @param asset The asset to get URL for
+ * @param defaultType Default type if asset doesn't have tags (default: 'output')
+ * @returns Full URL for viewing/downloading the asset
+ *
+ * @example
+ * const url = getAssetUrl(asset)
+ * downloadFile(url, asset.name)
+ */
+export function getAssetUrl(
+  asset: AssetItem,
+  defaultType: 'input' | 'output' = 'output'
+): string {
+  const assetType = getAssetType(asset, defaultType)
+  return api.apiURL(
+    `/view?filename=${encodeURIComponent(asset.name)}&type=${assetType}`
+  )
+}

--- a/src/utils/typeGuardUtil.ts
+++ b/src/utils/typeGuardUtil.ts
@@ -4,6 +4,7 @@ import type {
   LGraphNode,
   Subgraph
 } from '@/lib/litegraph/src/litegraph'
+import type { ResultItemType } from '@/schemas/apiSchema'
 
 /**
  * Check if an error is an AbortError triggered by `AbortController#abort`
@@ -48,4 +49,14 @@ export const isSlotObject = (obj: unknown): obj is INodeSlot => {
     'type' in obj &&
     'boundingRect' in obj
   )
+}
+
+/**
+ * Type guard to check if a string is a valid ResultItemType
+ * ResultItemType is used for asset categorization (input/output/temp)
+ */
+export const isResultItemType = (
+  value: string | undefined
+): value is ResultItemType => {
+  return value === 'input' || value === 'output' || value === 'temp'
 }


### PR DESCRIPTION
## Summary

This PR introduces the **Copy Job ID** feature for media assets along with shared utility functions that will be reused across multiple asset actions.

This is the first of three PRs that split the original #6696 into smaller, more reviewable changes.

## Changes

### Features
- **Copy Job ID**: Copy the job/prompt ID to clipboard from media asset context menu
  - OSS compatibility: Checks `asset.id` first, falls back to metadata
  - Uses `useCopyToClipboard` composable for consistent UX
  - Proper error handling with user-friendly toast messages

### Shared Utilities
Created reusable utility functions:
- **`assetTypeUtil.ts`**: Extract asset type from tags with fallback
- **`assetUrlUtil.ts`**: Construct asset URLs for download/view endpoints
- **`typeGuardUtil.ts`**: Added `isResultItemType` type guard

### Refactoring
- Unified asset deletion logic with `deleteAssetApi` helper function
- Replaced inline URL construction with `getAssetUrl` utility (2 occurrences)
- Improved error handling with Cloud-specific warning messages
- Better error propagation in batch deletion operations

## Files Changed
- `src/platform/assets/composables/useMediaAssetActions.ts` - Added copyJobId function + refactoring
- `src/platform/assets/utils/assetTypeUtil.ts` - New utility file
- `src/platform/assets/utils/assetUrlUtil.ts` - New utility file  
- `src/utils/typeGuardUtil.ts` - Added type guard
- `src/locales/en/main.json` - Added i18n string

## Related PRs
- Part 1 (this PR): Copy Job ID + Shared Utilities
- Part 2 (upcoming): Add to Current Workflow
- Part 3 (upcoming): Open/Export Workflow Actions

Closes part of #6696

## Test Plan
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Prettier formatting applied
- [ ] Manual testing: Copy job ID for OSS assets
- [ ] Manual testing: Copy job ID for Cloud assets
- [ ] Manual testing: Error handling for assets without job ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6718-feat-Add-copy-job-ID-action-and-shared-asset-utilities-2ae6d73d3650813f9aebd3d651467f2a) by [Unito](https://www.unito.io)
