### PR TITLE
feat(api-nodes-pricing): add pricing for gemini-3-pro-preview model

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1537,6 +1537,8 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           return '$0.00125/$0.01 per 1K tokens'
         } else if (model.includes('gemini-2.5-pro')) {
           return '$0.00125/$0.01 per 1K tokens'
+        } else if (model.includes('gemini-3-pro-preview')) {
+          return '$0.002/$0.012 per 1K tokens'
         }
         // For other Gemini models, show token-based pricing info
         return 'Token-based'

--- a/tests-ui/tests/composables/node/useNodePricing.test.ts
+++ b/tests-ui/tests/composables/node/useNodePricing.test.ts
@@ -1646,6 +1646,10 @@ describe('useNodePricing', () => {
             expected: '$0.00125/$0.01 per 1K tokens'
           },
           {
+            model: 'gemini-3-pro-preview',
+            expected: '$0.002/$0.012 per 1K tokens'
+          },
+          {
             model: 'gemini-2.5-flash-preview-04-17',
             expected: '$0.0003/$0.0025 per 1K tokens'
           },


### PR DESCRIPTION
## Summary

Pricing is a little bit higher then for `2.5` models:

https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models-3

## Screenshots (if applicable)

<img width="1202" height="821" alt="Screenshot From 2025-11-18 19-28-21" src="https://github.com/user-attachments/assets/c4a279f3-8981-4424-93c5-efa7b68f0578" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6735-feat-api-nodes-pricing-add-pricing-for-gemini-3-pro-preview-model-2af6d73d36508196afaedaf1eeb21c52) by [Unito](https://www.unito.io)
