### PR TITLE
ci: fix cache step in release version bump workflow

### DIFF
--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -59,7 +59,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: 'pnpm'
 
       - name: Bump version
         id: bump-version


### PR DESCRIPTION
Removed the unnecessary `cache: 'pnpm'` configuration from the workflow since version bumping doesn't require dependency caching.

The workflow configured `cache: 'pnpm'` in the Node.js setup step but never ran `pnpm install` to create the cache directories. The cache action expects paths like `~/.pnpm-store` and `node_modules` to exist, but since this workflow only runs `pnpm version` (which doesn't require dependencies), those paths are never created.

Issue occurred here: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/19478181571/job/55743250471

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6740-ci-fix-cache-step-in-release-version-bump-workflow-2af6d73d3650813b84a8e9d3272ad8fd) by [Unito](https://www.unito.io)
