### PR TITLE
Hotfix: Make the actionbar at least higher than the comfyui-body-bottom

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -10,7 +10,7 @@
     </div>
 
     <Panel
-      class="pointer-events-auto z-1000"
+      class="pointer-events-auto z-1010"
       :style="style"
       :class="panelClass"
       :pt="{


### PR DESCRIPTION
## Summary

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/6739

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6743-Hotfix-Make-the-actionbar-at-least-higher-than-the-comfyui-body-bottom-2b06d73d365081adb107e6aa2c4ca813) by [Unito](https://www.unito.io)
