### PR TITLE
fix: node preview background color

### DIFF
--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -5,8 +5,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
   <LGraphNodePreview v-if="shouldRenderVueNodes" :node-def="nodeDef" />
   <div
     v-else
-    class="_sb_node_preview"
-    :style="{ backgroundColor: litegraphColors.NODE_DEFAULT_COLOR }"
+    class="_sb_node_preview bg-component-node-background"
   >
     <div class="_sb_table">
       <div

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -3,7 +3,11 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 -->
 <template>
   <LGraphNodePreview v-if="shouldRenderVueNodes" :node-def="nodeDef" />
-  <div v-else class="_sb_node_preview">
+  <div
+    v-else
+    class="_sb_node_preview"
+    :style="{ backgroundColor: litegraphColors.NODE_DEFAULT_COLOR }"
+  >
     <div class="_sb_table">
       <div
         class="node_header mr-4 text-ellipsis"
@@ -200,7 +204,6 @@ const truncateDefaultValue = (value: any, charLimit: number = 32): string => {
 }
 
 ._sb_node_preview {
-  background-color: var(--comfy-menu-bg);
   font-family: 'Open Sans', sans-serif;
   color: var(--descrip-text);
   border: 1px solid var(--descrip-text);

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -3,10 +3,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 -->
 <template>
   <LGraphNodePreview v-if="shouldRenderVueNodes" :node-def="nodeDef" />
-  <div
-    v-else
-    class="_sb_node_preview bg-component-node-background"
-  >
+  <div v-else class="_sb_node_preview bg-component-node-background">
     <div class="_sb_table">
       <div
         class="node_header mr-4 text-ellipsis"


### PR DESCRIPTION
## Summary

Changes node previews to use background color from color palette instead of the menu color.

| Before | After |
| ------ | ----- |
| <img width="1700" height="1248" alt="Selection_2345" src="https://github.com/user-attachments/assets/cc1d0e97-9551-4f88-8e92-4fe6bcdd8c21" /> | <img width="2144" height="1138" alt="Selection_2347" src="https://github.com/user-attachments/assets/16e64be3-3623-4900-ad18-c599a1aee59b" /> |

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/6576

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6768-fix-node-preview-background-color-2b16d73d365081868644e1e6b7c7e3be) by [Unito](https://www.unito.io)
