### PR TITLE
Allow unsetting widget labels

### DIFF
--- a/src/components/dialog/content/PromptDialogContent.vue
+++ b/src/components/dialog/content/PromptDialogContent.vue
@@ -4,6 +4,7 @@
       <InputText
         ref="inputRef"
         v-model="inputValue"
+        :placeholder
         autofocus
         @keyup.enter="onConfirm"
         @focus="selectAllText"
@@ -28,6 +29,7 @@ const props = defineProps<{
   message: string
   defaultValue: string
   onConfirm: (value: string) => void
+  placeholder?: string
 }>()
 
 const inputValue = ref<string>(props.defaultValue)

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -304,11 +304,13 @@ export const useDialogService = () => {
   async function prompt({
     title,
     message,
-    defaultValue = ''
+    defaultValue = '',
+    placeholder
   }: {
     title: string
     message: string
     defaultValue?: string
+    placeholder?: string
   }): Promise<string | null> {
     return new Promise((resolve) => {
       dialogStore.showDialog({
@@ -320,7 +322,8 @@ export const useDialogService = () => {
           defaultValue,
           onConfirm: (value: string) => {
             resolve(value)
-          }
+          },
+          placeholder
         },
         dialogComponentProps: {
           onClose: () => {

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -839,7 +839,7 @@ export const useLitegraphService = () => {
                 defaultValue: overWidget.label,
                 placeholder: overWidget.name
               })
-              if (!newLabel === null) return
+              if (newLabel === null) return
               overWidget.label = newLabel || undefined
               input.label = newLabel || undefined
               useCanvasStore().canvas?.setDirty(true)

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -836,11 +836,12 @@ export const useLitegraphService = () => {
               const newLabel = await useDialogService().prompt({
                 title: t('g.rename'),
                 message: t('g.enterNewName') + ':',
-                defaultValue: overWidget.label ?? overWidget.name
+                defaultValue: overWidget.label,
+                placeholder: overWidget.name
               })
-              if (!newLabel) return
-              overWidget.label = newLabel
-              input.label = newLabel
+              if (!newLabel === null) return
+              overWidget.label = newLabel || undefined
+              input.label = newLabel || undefined
               useCanvasStore().canvas?.setDirty(true)
             }
           })


### PR DESCRIPTION
https://github.com/user-attachments/assets/af344318-dac2-4611-b080-910cdfa1e87d

Quick followup to #6752
- Adds support for placeholder values in dialogService.prompt
- When label is unset, initial prompt is empty
- Display original widget name as placeholder
- When prompt returns an empty string (as opposed to null for a canceled operation), remove widget label

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6773-Allow-unsetting-widget-labels-2b16d73d365081ae9f5dd085d0081733) by [Unito](https://www.unito.io)
