### PR TITLE
fix: Conditionally hide bottom border in missing nodes modal on non-cloud environments

### DIFF
--- a/src/components/dialog/content/MissingNodesContent.vue
+++ b/src/components/dialog/content/MissingNodesContent.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    class="flex w-[490px] flex-col border-t-1 border-b-1 border-border-default"
+    class="flex w-[490px] flex-col border-t-1 border-border-default"
+    :class="isCloud ? 'border-b-1' : ''"
   >
     <div class="flex h-full w-full flex-col gap-4 p-4">
       <!-- Description -->


### PR DESCRIPTION
## Summary
- Conditionally hide the bottom border of the missing nodes modal content when not running in cloud environment
- The footer is not visible in non-cloud environments, so the bottom border was appearing disconnected

## Changes
- Added conditional `border-b-1` class based on `isCloud` flag in `MissingNodesContent.vue`
- Keeps top border visible in all environments
- Bottom border only shows in cloud environment where footer is present

## Test plan
- [ ] Open missing nodes dialog in cloud environment - bottom border should be visible
- [ ] Open missing nodes dialog in non-cloud environment - bottom border should be hidden
- [ ] Verify top border remains visible in both environments

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6779-fix-Conditionally-hide-bottom-border-in-missing-nodes-modal-on-non-cloud-environments-2b16d73d365081cea1c8c98b11878045) by [Unito](https://www.unito.io)
