### PR TITLE
hotfix: Stop clicks on the textarea from propagating to the node itself

### DIFF
--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -65,7 +65,9 @@ export class VueNodeHelpers {
    * Select a specific Vue node by ID
    */
   async selectNode(nodeId: string): Promise<void> {
-    await this.page.locator(`[data-node-id="${nodeId}"]`).click()
+    await this.page
+      .locator(`[data-node-id="${nodeId}"] > .lg-node-header`)
+      .click()
   }
 
   /**

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -66,7 +66,7 @@ export class VueNodeHelpers {
    */
   async selectNode(nodeId: string): Promise<void> {
     await this.page
-      .locator(`[data-node-id="${nodeId}"] > .lg-node-header`)
+      .locator(`[data-node-id="${nodeId}"] .lg-node-header`)
       .click()
   }
 

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -79,11 +79,13 @@ export class VueNodeHelpers {
     // Select first node normally
     await this.selectNode(nodeIds[0])
 
-    // Add additional nodes with Ctrl+click
+    // Add additional nodes with Ctrl+click on header
     for (let i = 1; i < nodeIds.length; i++) {
-      await this.page.locator(`[data-node-id="${nodeIds[i]}"]`).click({
-        modifiers: ['Control']
-      })
+      await this.page
+        .locator(`[data-node-id="${nodeIds[i]}"] .lg-node-header`)
+        .click({
+          modifiers: ['Control']
+        })
     }
   }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -12,6 +12,7 @@
       :disabled="widget.options?.read_only"
       fluid
       data-capture-wheel="true"
+      @pointerdown.capture.stop
     />
     <LODFallback />
   </div>


### PR DESCRIPTION
## Summary

Selecting text shouldn't drag the node.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6788-hotfix-Stop-clicks-on-the-textarea-from-propagating-to-the-node-itself-2b16d73d3650819c8d0dc427d5758580) by [Unito](https://www.unito.io)
