### PR TITLE
Allow updating position and mode on missing nodes

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -882,7 +882,7 @@ export class LGraphNode
 
     // special case for when there were errors
     if (this.constructor === LGraphNode && this.last_serialization)
-      return this.last_serialization
+      return { ...this.last_serialization, mode: o.mode, pos: o.pos }
 
     if (this.inputs)
       o.inputs = this.inputs.map((input) => inputAsSerialisable(input))


### PR DESCRIPTION
When a node is missing, attempts to serialize it will return the "last known good" serialization to ensure that the node will still be functional in the future (the node pack is installed/comfyui is updated). However, this means even small and safe changes (like moving the node out of the way or bypassing it so the workflow can be run) will be discarded on reload. 

This is resolved by including the updated position and mode when returning early.

| Before | After |
| ------ | ----- |
| <img width="360" height="360" alt="before" src="https://github.com/user-attachments/assets/8452682c-9531-4153-a258-158c634df3e8" /> | <img width="360" height="360" alt="after" src="https://github.com/user-attachments/assets/8825ce5e-c4a6-4f4a-be20-97e4aca69964" /> |

Thanks to @Kosinkadink for bringing this up

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6792-Allow-updating-position-and-mode-on-missing-nodes-2b26d73d365081ed8c22fafe5348c49f) by [Unito](https://www.unito.io)
