### PR TITLE
fix: disabling queue button

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -10,7 +10,6 @@
       severity="primary"
       size="small"
       :model="queueModeMenuItems"
-      :disabled="hasMissingNodes"
       data-testid="queue-button"
       @click="queuePrompt"
     >


### PR DESCRIPTION
## Summary
- Removed the `disabled` prop binding from the queue button that was incorrectly disabling it when there were missing nodes

## Changes
- Removed `:disabled="hasMissingNodes"` from ComfyQueueButton.vue:13

## Test plan
- [x] Verify queue button is no longer incorrectly disabled when there are missing nodes
- [x] Verify queue functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6797-fix-disabling-queue-button-2b26d73d3650810783cedd44fce757be) by [Unito](https://www.unito.io)
