### PR TITLE
[bugfix] Fix double-click required after pasting URL in upload model dialog

### DIFF
--- a/src/components/common/UrlInput.vue
+++ b/src/components/common/UrlInput.vue
@@ -35,7 +35,6 @@ import { ValidationState } from '@/utils/validationUtil'
 const props = defineProps<{
   modelValue: string
   validateUrlFn?: (url: string) => Promise<boolean>
-  disableValidation?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -102,8 +101,6 @@ const defaultValidateUrl = async (url: string): Promise<boolean> => {
 }
 
 const validateUrl = async (value: string) => {
-  if (props.disableValidation) return
-
   if (validationState.value === ValidationState.LOADING) return
 
   const url = cleanInput(value)

--- a/src/platform/assets/components/UploadModelUrlInput.vue
+++ b/src/platform/assets/components/UploadModelUrlInput.vue
@@ -14,10 +14,10 @@
       <label class="text-sm text-muted mb-0">
         {{ $t('assetBrowser.civitaiLinkLabel') }}
       </label>
-      <UrlInput
+      <InputText
         v-model="url"
         :placeholder="$t('assetBrowser.civitaiLinkPlaceholder')"
-        :disable-validation="true"
+        class="w-full"
       />
       <p v-if="error" class="text-xs text-error">
         {{ error }}
@@ -30,9 +30,8 @@
 </template>
 
 <script setup lang="ts">
+import InputText from 'primevue/inputtext'
 import { computed } from 'vue'
-
-import UrlInput from '@/components/common/UrlInput.vue'
 
 const props = defineProps<{
   modelValue: string

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -63,11 +63,11 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
     if (!canFetchMetadata.value) return
 
     // Clean and normalize URL
-    let cleanedUrl = wizardData.value.url.replace(/\s+/g, '')
+    let cleanedUrl = wizardData.value.url.trim()
     try {
-      cleanedUrl = new URL(cleanedUrl).toString()
+      cleanedUrl = new URL(encodeURI(cleanedUrl)).toString()
     } catch {
-      // If URL parsing fails, just use the cleaned input
+      // If URL parsing fails, just use the trimmed input
     }
     wizardData.value.url = cleanedUrl
 

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -62,6 +62,15 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
   async function fetchMetadata() {
     if (!canFetchMetadata.value) return
 
+    // Clean and normalize URL
+    let cleanedUrl = wizardData.value.url.replace(/\s+/g, '')
+    try {
+      cleanedUrl = new URL(cleanedUrl).toString()
+    } catch {
+      // If URL parsing fails, just use the cleaned input
+    }
+    wizardData.value.url = cleanedUrl
+
     if (!isCivitaiUrl(wizardData.value.url)) {
       uploadError.value = st(
         'assetBrowser.onlyCivitaiUrlsSupported',


### PR DESCRIPTION
## Summary
Fixed an issue where users had to click twice to continue after pasting a URL in the upload model dialog - once to blur the input, then again to click the button.

## Changes
- **What**: Replaced `UrlInput` with plain `InputText` in `UploadModelUrlInput` to emit value immediately on input instead of only on blur
- **Cleanup**: Moved URL cleaning/normalization to the `fetchMetadata` handler, removed unused `disableValidation` prop from `UrlInput` component

## Review Focus
- URL normalization logic in `useUploadModelWizard.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6801-bugfix-Fix-double-click-required-after-pasting-URL-in-upload-model-dialog-2b26d73d3650811881aed0cc064efcc7) by [Unito](https://www.unito.io)
