### PR TITLE
Feat: Show Progress Text on Vue Nodes, Markdown for Preview as Text

### DIFF
--- a/src/extensions/core/previewAny.ts
+++ b/src/extensions/core/previewAny.ts
@@ -17,10 +17,10 @@ useExtensionService().registerExtension({
       nodeType.prototype.onNodeCreated = function () {
         onNodeCreated ? onNodeCreated.apply(this, []) : undefined
 
-        const showValueWidget = ComfyWidgets['STRING'](
+        const showValueWidget = ComfyWidgets['MARKDOWN'](
           this,
           'preview',
-          ['STRING', { multiline: true }],
+          ['MARKDOWN', {}],
           app
         ).widget as DOMWidget<HTMLTextAreaElement, string>
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -57,7 +57,7 @@ const renderedHtml = computed(() => {
 
 // Methods
 const startEditing = async () => {
-  if (isEditing.value) return
+  if (isEditing.value || widget.options?.read_only) return
 
   isEditing.value = true
   await nextTick()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
@@ -42,7 +42,8 @@ export function useTextPreviewWidget(
           widgetValue.value = typeof value === 'string' ? value : String(value)
         },
         getMinHeight: () => options.minHeight ?? 42 + PADDING,
-        serialize: false
+        serialize: false,
+        read_only: true
       },
       type: inputSpec.type
     })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
@@ -6,6 +6,7 @@ import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
 import type { ComponentWidgetStandardProps } from '@/scripts/domWidget'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 type TextPreviewCustomProps = Omit<
   InstanceType<typeof TextPreviewWidget>['$props'],
@@ -14,15 +15,15 @@ type TextPreviewCustomProps = Omit<
 
 const PADDING = 16
 
-export const useTextPreviewWidget = (
+export function useTextPreviewWidget(
   options: {
     minHeight?: number
   } = {}
-) => {
-  const widgetConstructor: ComfyWidgetConstructorV2 = (
+): ComfyWidgetConstructorV2 {
+  function widgetConstructor(
     node: LGraphNode,
     inputSpec: InputSpec
-  ) => {
+  ): IBaseWidget {
     const widgetValue = ref<string>('')
     const widget = new ComponentWidgetImpl<
       string | object,
@@ -42,7 +43,8 @@ export const useTextPreviewWidget = (
         },
         getMinHeight: () => options.minHeight ?? 42 + PADDING,
         serialize: false
-      }
+      },
+      type: inputSpec.type
     })
     addWidget(node, widget)
     return widget

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -115,7 +115,7 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     'textarea',
     {
       component: WidgetTextarea,
-      aliases: ['TEXTAREA', 'multiline', 'customtext', 'progressText'],
+      aliases: ['TEXTAREA', 'multiline', 'customtext'],
       essential: false
     }
   ],
@@ -134,7 +134,11 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
   ],
   [
     'markdown',
-    { component: WidgetMarkdown, aliases: ['MARKDOWN'], essential: false }
+    {
+      component: WidgetMarkdown,
+      aliases: ['MARKDOWN', 'progressText'],
+      essential: false
+    }
   ],
   ['legacy', { component: WidgetLegacy, aliases: [], essential: true }],
   [

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -115,7 +115,7 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     'textarea',
     {
       component: WidgetTextarea,
-      aliases: ['TEXTAREA', 'multiline', 'customtext'],
+      aliases: ['TEXTAREA', 'multiline', 'customtext', 'progressText'],
       essential: false
     }
   ],

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -303,10 +303,11 @@ export class ComponentWidgetImpl<
     inputSpec: InputSpec
     props?: P
     options: DOMWidgetOptions<V>
+    type?: string
   }) {
     super({
-      ...obj,
-      type: 'custom'
+      type: 'custom',
+      ...obj
     })
     this.component = obj.component
     this.inputSpec = obj.inputSpec


### PR DESCRIPTION
## Summary

Maps the progressText / text preview to a readonly Markdown widget.

## Review Focus

Anything else to tweak about this while I'm in here?

## Screenshots
<img width="1107" height="593" alt="image" src="https://github.com/user-attachments/assets/a445c07a-2fcb-480c-976e-bda6ff343f14" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6805-Feat-Show-Progress-Text-on-Vue-Nodes-2b26d73d3650814d93c4f2fbf0e00095) by [Unito](https://www.unito.io)
