### PR TITLE
Allow graph navigation by browser forward/backward

### DIFF
--- a/browser_tests/fixtures/ws.ts
+++ b/browser_tests/fixtures/ws.ts
@@ -29,7 +29,7 @@ export const webSocketFixture = base.extend<{
             function ([data, url]) {
               if (!url) {
                 // If no URL specified, use page URL
-                const u = new URL(window.location.toString())
+                const u = new URL(window.location.toString().split('#')[0])
                 u.protocol = 'ws:'
                 u.pathname = '/'
                 url = u.toString() + 'ws'

--- a/browser_tests/fixtures/ws.ts
+++ b/browser_tests/fixtures/ws.ts
@@ -29,7 +29,8 @@ export const webSocketFixture = base.extend<{
             function ([data, url]) {
               if (!url) {
                 // If no URL specified, use page URL
-                const u = new URL(window.location.toString().split('#')[0])
+                const u = new URL(window.location.href)
+                u.hash = ''
                 u.protocol = 'ws:'
                 u.pathname = '/'
                 url = u.toString() + 'ws'

--- a/browser_tests/tests/subgraph.spec.ts
+++ b/browser_tests/tests/subgraph.spec.ts
@@ -767,11 +767,9 @@ test.describe('Subgraph Operations', { tag: ['@slow', '@subgraph'] }, () => {
       })
 
       // Click breadcrumb to navigate back to parent graph
-      const homeBreadcrumb = comfyPage.page.getByRole('link', {
-        // In the subgraph navigation breadcrumbs, the home/top level
-        // breadcrumb is just the workflow name without the folder path
-        name: 'subgraph-with-promoted-text-widget'
-      })
+      const homeBreadcrumb = comfyPage.page.locator(
+        '.p-breadcrumb-list > :first-child'
+      )
       await homeBreadcrumb.waitFor({ state: 'visible' })
       await homeBreadcrumb.click()
       await comfyPage.nextFrame()

--- a/browser_tests/tests/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraphPromotion.spec.ts
@@ -743,15 +743,7 @@ test.describe(
         await comfyPage.nextFrame()
 
         // Navigate back via breadcrumb
-        await comfyPage.page
-          .getByTestId(TestIds.breadcrumb.subgraph)
-          .waitFor({ state: 'visible', timeout: 5000 })
-        const homeBreadcrumb = comfyPage.page.getByRole('link', {
-          name: 'subgraph-with-promoted-text-widget'
-        })
-        await homeBreadcrumb.waitFor({ state: 'visible' })
-        await homeBreadcrumb.click()
-        await comfyPage.nextFrame()
+        await exitSubgraphToParent(comfyPage)
 
         // Widget count should be reduced
         const finalWidgetCount = await getPromotedWidgetCount(comfyPage, '11')

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@tiptap/starter-kit": "catalog:",
     "@vueuse/core": "catalog:",
     "@vueuse/integrations": "catalog:",
+    "@vueuse/router": "^14.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/xterm": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@tiptap/starter-kit": "catalog:",
     "@vueuse/core": "catalog:",
     "@vueuse/integrations": "catalog:",
-    "@vueuse/router": "^14.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/xterm": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,9 +461,6 @@ importers:
       '@vueuse/integrations':
         specifier: 'catalog:'
         version: 14.2.0(axios@1.13.5)(fuse.js@7.0.0)(vue@3.5.13(typescript@5.9.3))
-      '@vueuse/router':
-        specifier: ^14.2.0
-        version: 14.2.1(vue-router@4.4.3(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -4430,22 +4427,11 @@ packages:
   '@vueuse/metadata@14.2.0':
     resolution: {integrity: sha512-i3axTGjU8b13FtyR4Keeama+43iD+BwX9C2TmzBVKqjSHArF03hjkp2SBZ1m72Jk2UtrX0aYCugBq2R1fhkuAQ==}
 
-  '@vueuse/router@14.2.1':
-    resolution: {integrity: sha512-SbZfJe+qn5bj78zNOXT4nYbnp8OIFMyAsdcJb4Y0y9vXi1TsOfglF+YIazi5DPO2lk6/ZukpN5DEQe6KrNOjMw==}
-    peerDependencies:
-      vue: ^3.5.0
-      vue-router: ^4.0.0 || ^5.0.0
-
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
   '@vueuse/shared@14.2.0':
     resolution: {integrity: sha512-Z0bmluZTlAXgUcJ4uAFaML16JcD8V0QG00Db3quR642I99JXIDRa2MI2LGxiLVhcBjVnL1jOzIvT5TT2lqJlkA==}
-    peerDependencies:
-      vue: ^3.5.0
-
-  '@vueuse/shared@14.2.1':
-    resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -12809,12 +12795,6 @@ snapshots:
 
   '@vueuse/metadata@14.2.0': {}
 
-  '@vueuse/router@14.2.1(vue-router@4.4.3(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))':
-    dependencies:
-      '@vueuse/shared': 14.2.1(vue@3.5.13(typescript@5.9.3))
-      vue: 3.5.13(typescript@5.9.3)
-      vue-router: 4.4.3(vue@3.5.13(typescript@5.9.3))
-
   '@vueuse/shared@12.8.2(typescript@5.9.3)':
     dependencies:
       vue: 3.5.13(typescript@5.9.3)
@@ -12822,10 +12802,6 @@ snapshots:
       - typescript
 
   '@vueuse/shared@14.2.0(vue@3.5.13(typescript@5.9.3))':
-    dependencies:
-      vue: 3.5.13(typescript@5.9.3)
-
-  '@vueuse/shared@14.2.1(vue@3.5.13(typescript@5.9.3))':
     dependencies:
       vue: 3.5.13(typescript@5.9.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       '@vueuse/integrations':
         specifier: 'catalog:'
         version: 14.2.0(axios@1.13.5)(fuse.js@7.0.0)(vue@3.5.13(typescript@5.9.3))
+      '@vueuse/router':
+        specifier: ^14.2.0
+        version: 14.2.1(vue-router@4.4.3(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -4427,11 +4430,22 @@ packages:
   '@vueuse/metadata@14.2.0':
     resolution: {integrity: sha512-i3axTGjU8b13FtyR4Keeama+43iD+BwX9C2TmzBVKqjSHArF03hjkp2SBZ1m72Jk2UtrX0aYCugBq2R1fhkuAQ==}
 
+  '@vueuse/router@14.2.1':
+    resolution: {integrity: sha512-SbZfJe+qn5bj78zNOXT4nYbnp8OIFMyAsdcJb4Y0y9vXi1TsOfglF+YIazi5DPO2lk6/ZukpN5DEQe6KrNOjMw==}
+    peerDependencies:
+      vue: ^3.5.0
+      vue-router: ^4.0.0 || ^5.0.0
+
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
   '@vueuse/shared@14.2.0':
     resolution: {integrity: sha512-Z0bmluZTlAXgUcJ4uAFaML16JcD8V0QG00Db3quR642I99JXIDRa2MI2LGxiLVhcBjVnL1jOzIvT5TT2lqJlkA==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/shared@14.2.1':
+    resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -12795,6 +12809,12 @@ snapshots:
 
   '@vueuse/metadata@14.2.0': {}
 
+  '@vueuse/router@14.2.1(vue-router@4.4.3(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/shared': 14.2.1(vue@3.5.13(typescript@5.9.3))
+      vue: 3.5.13(typescript@5.9.3)
+      vue-router: 4.4.3(vue@3.5.13(typescript@5.9.3))
+
   '@vueuse/shared@12.8.2(typescript@5.9.3)':
     dependencies:
       vue: 3.5.13(typescript@5.9.3)
@@ -12802,6 +12822,10 @@ snapshots:
       - typescript
 
   '@vueuse/shared@14.2.0(vue@3.5.13(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.13(typescript@5.9.3)
+
+  '@vueuse/shared@14.2.1(vue@3.5.13(typescript@5.9.3))':
     dependencies:
       vue: 3.5.13(typescript@5.9.3)
 

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <a
+  <div
     ref="wrapperRef"
     v-tooltip.bottom="{
       value: tooltipText,
@@ -22,7 +22,7 @@
     <span class="p-breadcrumb-item-label px-2">{{ item.label }}</span>
     <Tag v-if="item.isBlueprint" value="Blueprint" severity="primary" />
     <i v-if="isActive" class="pi pi-angle-down text-[10px]"></i>
-  </a>
+  </div>
   <Menu
     v-if="isActive || isRoot"
     ref="menu"

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -6,7 +6,6 @@
       showDelay: 512
     }"
     draggable="false"
-    href="#"
     class="p-breadcrumb-item-link h-8 cursor-pointer px-2"
     :class="{
       'flex items-center gap-1': isActive,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1399,7 +1399,7 @@ export class ComfyApp {
         useWorkflowService().showPendingWarnings()
       }
 
-      useSubgraphNavigationStore().updateHash()
+      void useSubgraphNavigationStore().updateHash()
       requestAnimationFrame(() => {
         this.canvas.setDirty(true, true)
       })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -74,6 +74,7 @@ import { useModelStore } from '@/stores/modelStore'
 import { SYSTEM_NODE_DEFS, useNodeDefStore } from '@/stores/nodeDefStore'
 import { useNodeReplacementStore } from '@/platform/nodeReplacement/nodeReplacementStore'
 
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
 import { useWidgetStore } from '@/stores/widgetStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
@@ -1398,6 +1399,7 @@ export class ComfyApp {
         useWorkflowService().showPendingWarnings()
       }
 
+      useSubgraphNavigationStore().updateHash()
       requestAnimationFrame(() => {
         this.canvas.setDirty(true, true)
       })

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -47,6 +47,7 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 vi.mock('@/utils/graphTraversalUtil', () => ({
   findSubgraphPathById: vi.fn()
 }))
+vi.mock('@vueuse/router', () => ({ useRouteHash: vi.fn() }))
 
 describe('useSubgraphNavigationStore', () => {
   beforeEach(() => {

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
@@ -46,6 +46,10 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 vi.mock('@/utils/graphTraversalUtil', () => ({
   findSubgraphPathById: vi.fn()
+}))
+
+vi.mock('@vueuse/router', () => ({
+  useRouteHash: () => ref('')
 }))
 
 describe('useSubgraphNavigationStore', () => {

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
 
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
@@ -46,10 +46,6 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 vi.mock('@/utils/graphTraversalUtil', () => ({
   findSubgraphPathById: vi.fn()
-}))
-
-vi.mock('@vueuse/router', () => ({
-  useRouteHash: () => ref('')
 }))
 
 describe('useSubgraphNavigationStore', () => {

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -1,7 +1,6 @@
 import QuickLRU from '@alloc/quick-lru'
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef, watch } from 'vue'
-import { useRouteHash } from '@vueuse/router'
 
 import type { DragAndScaleState } from '@/lib/litegraph/src/DragAndScale'
 import type { Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -158,7 +157,12 @@ export const useSubgraphNavigationStore = defineStore(
         onNavigated(newValue, oldValue)
       }
     )
-    const routeHash = useRouteHash()
+    const routeHash = ref(window.location.hash)
+    const originalOnHashChange = window.onhashchange
+    window.onhashchange = (...args) => {
+      routeHash.value = window.location.hash
+      return originalOnHashChange?.apply(window, args)
+    }
     let blockHashUpdate = false
     let initialLoad = true
 

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -207,7 +207,7 @@ export const useSubgraphNavigationStore = defineStore(
     function updateHash() {
       if (blockHashUpdate) return
       if (!routeHash.value) {
-        router.replace('#' + window.location.hash.slice(1) || app.graph.id)
+        router.replace('#' + (window.location.hash.slice(1) || app.graph.id))
       } else if (initialLoad) {
         initialLoad = false
         navigateToHash(routeHash.value)

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -160,11 +160,10 @@ export const useSubgraphNavigationStore = defineStore(
 
     //Allow navigation with forward/back buttons
     const routeHash = ref(window.location.hash)
-    const originalOnHashChange = window.onhashchange
-    window.onhashchange = (...args) => {
-      routeHash.value = window.location.hash
-      return originalOnHashChange?.apply(window, args)
-    }
+    addEventListener(
+      'hashchange',
+      () => (routeHash.value = window.location.hash)
+    )
     let blockHashUpdate = false
     let initialLoad = true
 

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -207,6 +207,7 @@ export const useSubgraphNavigationStore = defineStore(
     async function updateHash() {
       if (blockHashUpdate) return
       if (!routeHash.value) {
+        initialLoad = false
         await router.replace(
           '#' + (window.location.hash.slice(1) || app.graph.id)
         )

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -165,7 +165,11 @@ export const useSubgraphNavigationStore = defineStore(
     //Allow navigation with forward/back buttons
     //TODO: Extend for dialogues?
     //TODO: force update widget.promoted
-    async function navigateToHash(newHash: string | undefined | null) {
+    async function navigateToHash(
+      newHash: string | undefined | null,
+      oldHash: string | undefined | null
+    ) {
+      if (!oldHash) return
       const root = app.graph
       const locatorId = newHash?.slice(1) ?? root.id
       const canvas = canvasStore.getCanvas()
@@ -206,17 +210,16 @@ export const useSubgraphNavigationStore = defineStore(
 
     async function updateHash() {
       if (blockHashUpdate) return
-      if (!routeHash.value) {
+      if (initialLoad) {
         initialLoad = false
-        await router.replace(
-          '#' + (window.location.hash.slice(1) || app.graph.id)
-        )
-      } else if (initialLoad) {
-        initialLoad = false
-        await navigateToHash(routeHash.value)
+        if (!routeHash.value) return
+        await navigateToHash(routeHash.value, 'placeholder')
         const graph = canvasStore.getCanvas().graph
         if (isSubgraph(graph)) workflowStore.activeSubgraph = graph
         return
+      }
+      if (!routeHash.value) {
+        await router.replace('#' + app.graph.id)
       }
       const newId = canvasStore.getCanvas().graph?.id ?? ''
       const currentId = window.location.hash.slice(1)

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -204,13 +204,15 @@ export const useSubgraphNavigationStore = defineStore(
       }
     }
 
-    function updateHash() {
+    async function updateHash() {
       if (blockHashUpdate) return
       if (!routeHash.value) {
-        router.replace('#' + (window.location.hash.slice(1) || app.graph.id))
+        await router.replace(
+          '#' + (window.location.hash.slice(1) || app.graph.id)
+        )
       } else if (initialLoad) {
         initialLoad = false
-        navigateToHash(routeHash.value)
+        await navigateToHash(routeHash.value)
         const graph = canvasStore.getCanvas().graph
         if (isSubgraph(graph)) workflowStore.activeSubgraph = graph
         return
@@ -218,7 +220,7 @@ export const useSubgraphNavigationStore = defineStore(
       const newId = canvasStore.getCanvas().graph?.id ?? ''
       const currentId = window.location.hash.slice(1)
       if (!newId || newId === (currentId || app.graph.id)) return
-      router.push('#' + newId)
+      await router.push('#' + newId)
     }
     //update navigation hash
     //NOTE: Doesn't apply on workflow load

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -174,7 +174,7 @@ export const useSubgraphNavigationStore = defineStore(
       oldHash: string | undefined | null
     ) {
       if (!oldHash) return
-      const root = app.graph
+      const root = app.rootGraph
       const locatorId = newHash?.slice(1) ?? root.id
       const canvas = canvasStore.getCanvas()
       if (canvas.graph?.id === locatorId) return
@@ -199,9 +199,9 @@ export const useSubgraphNavigationStore = defineStore(
             blockHashUpdate = false
           }
           const targetGraph =
-            app.graph.id === locatorId
-              ? app.graph
-              : app.graph.subgraphs.get(locatorId)
+            app.rootGraph.id === locatorId
+              ? app.rootGraph
+              : app.rootGraph.subgraphs.get(locatorId)
           if (!targetGraph) {
             console.error('subgraph poofed after load?')
             return
@@ -223,11 +223,11 @@ export const useSubgraphNavigationStore = defineStore(
         return
       }
       if (!routeHash.value) {
-        await router.replace('#' + app.graph.id)
+        await router.replace('#' + app.rootGraph.id)
       }
       const newId = canvasStore.getCanvas().graph?.id ?? ''
       const currentId = window.location.hash.slice(1)
-      if (!newId || newId === (currentId || app.graph.id)) return
+      if (!newId || newId === (currentId || app.rootGraph.id)) return
       await router.push('#' + newId)
     }
     //update navigation hash

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -157,6 +157,8 @@ export const useSubgraphNavigationStore = defineStore(
         onNavigated(newValue, oldValue)
       }
     )
+
+    //Allow navigation with forward/back buttons
     const routeHash = ref(window.location.hash)
     const originalOnHashChange = window.onhashchange
     window.onhashchange = (...args) => {
@@ -166,16 +168,9 @@ export const useSubgraphNavigationStore = defineStore(
     let blockHashUpdate = false
     let initialLoad = true
 
-    //Allow navigation with forward/back buttons
-    //TODO: Extend for dialogues?
-    //TODO: force update widget.promoted
-    async function navigateToHash(
-      newHash: string | undefined | null,
-      oldHash: string | undefined | null
-    ) {
-      if (!oldHash) return
+    async function navigateToHash(newHash: string) {
       const root = app.rootGraph
-      const locatorId = newHash?.slice(1) ?? root.id
+      const locatorId = newHash?.slice(1) || root.id
       const canvas = canvasStore.getCanvas()
       if (canvas.graph?.id === locatorId) return
       const targetGraph =
@@ -217,7 +212,7 @@ export const useSubgraphNavigationStore = defineStore(
       if (initialLoad) {
         initialLoad = false
         if (!routeHash.value) return
-        await navigateToHash(routeHash.value, 'placeholder')
+        await navigateToHash(routeHash.value)
         const graph = canvasStore.getCanvas().graph
         if (isSubgraph(graph)) workflowStore.activeSubgraph = graph
         return
@@ -229,6 +224,7 @@ export const useSubgraphNavigationStore = defineStore(
       const currentId = window.location.hash.slice(1)
       if (!newId || newId === (currentId || app.rootGraph.id)) return
       await router.push('#' + newId)
+      routeHash.value = '#' + newId
     }
     //update navigation hash
     //NOTE: Doesn't apply on workflow load

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -215,13 +215,12 @@ export const useSubgraphNavigationStore = defineStore(
         return
       }
 
-      if (!routeHash.value) await router.replace('#' + app.rootGraph.id)
       const newId = canvasStore.getCanvas().graph?.id ?? ''
+      if (!routeHash.value) await router.replace('#' + app.rootGraph.id)
       const currentId = routeHash.value?.slice(1)
-      if (!newId || newId === (currentId || app.rootGraph.id)) return
+      if (!newId || newId === currentId) return
 
       await router.push('#' + newId)
-      routeHash.value = '#' + newId
     }
     //update navigation hash
     //NOTE: Doesn't apply on workflow load

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -1,13 +1,14 @@
 import QuickLRU from '@alloc/quick-lru'
+import { useRouteHash } from '@vueuse/router'
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef, watch } from 'vue'
+import { useRouter } from 'vue-router'
 
 import type { DragAndScaleState } from '@/lib/litegraph/src/DragAndScale'
 import type { Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import router from '@/router'
 import { app } from '@/scripts/app'
 import { findSubgraphPathById } from '@/utils/graphTraversalUtil'
 import { isNonNullish, isSubgraph } from '@/utils/typeGuardUtil'
@@ -22,6 +23,8 @@ export const useSubgraphNavigationStore = defineStore(
   () => {
     const workflowStore = useWorkflowStore()
     const canvasStore = useCanvasStore()
+    const router = useRouter()
+    const routeHash = useRouteHash()
 
     /** The currently opened subgraph. */
     const activeSubgraph = shallowRef<Subgraph>()
@@ -159,11 +162,6 @@ export const useSubgraphNavigationStore = defineStore(
     )
 
     //Allow navigation with forward/back buttons
-    const routeHash = ref(window.location.hash)
-    addEventListener(
-      'hashchange',
-      () => (routeHash.value = window.location.hash)
-    )
     let blockHashUpdate = false
     let initialLoad = true
 
@@ -216,19 +214,19 @@ export const useSubgraphNavigationStore = defineStore(
         if (isSubgraph(graph)) workflowStore.activeSubgraph = graph
         return
       }
-      if (!routeHash.value) {
-        await router.replace('#' + app.rootGraph.id)
-      }
+
+      if (!routeHash.value) await router.replace('#' + app.rootGraph.id)
       const newId = canvasStore.getCanvas().graph?.id ?? ''
-      const currentId = window.location.hash.slice(1)
+      const currentId = routeHash.value?.slice(1)
       if (!newId || newId === (currentId || app.rootGraph.id)) return
+
       await router.push('#' + newId)
       routeHash.value = '#' + newId
     }
     //update navigation hash
     //NOTE: Doesn't apply on workflow load
     watch(() => canvasStore.currentGraph, updateHash)
-    watch(routeHash, navigateToHash)
+    watch(routeHash, () => navigateToHash(String(routeHash.value)))
 
     return {
       activeSubgraph,

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -46,6 +46,7 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
     getCanvas: () => app.canvas
   })
 }))
+vi.mock('@vueuse/router', () => ({ useRouteHash: vi.fn() }))
 
 // Get reference to mock canvas
 const mockCanvas = app.canvas

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
 
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -45,10 +45,6 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({
     getCanvas: () => app.canvas
   })
-}))
-
-vi.mock('@vueuse/router', () => ({
-  useRouteHash: () => ref('')
 }))
 
 // Get reference to mock canvas

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -45,6 +45,10 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({
     getCanvas: () => app.canvas
   })
+}))
+
+vi.mock('@vueuse/router', () => ({
+  useRouteHash: () => ref('')
 }))
 
 // Get reference to mock canvas

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -7,9 +7,10 @@ import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
-import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
+
+import { useLitegraphService } from '@/services/litegraphService'
 
 import {
   createTestSubgraph,


### PR DESCRIPTION
- On graph change, set the `graph.id` as location hash
- On hash change, navigate to the target `graph.id` either in the current, or any other loaded workflow.

`canvasStore.currentGraph` does not trigger when `app.loadGraphData` is called. A trigger could be forced here, but I'm concerned about side effects. Instead `updateHash` is manually called.

Code search shows that there are no current custom nodes using `onhashchange`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6811-Allow-graph-navigation-by-browser-forward-backward-2b26d73d365081bb8414fdf7c3686124) by [Unito](https://www.unito.io)
