### PR TITLE
fix: backport workflow fails when label description has single quote

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -78,8 +78,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             LABELS=$(gh pr view ${{ inputs.pr_number }} --json labels | jq -r '.labels[].name')
           else
-            LABELS='${{ toJSON(github.event.pull_request.labels) }}'
-            LABELS=$(echo "$LABELS" | jq -r '.[].name')
+            LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
           fi
 
           add_target() {


### PR DESCRIPTION
Fixes issue with backporting workflow when the target PR has a label whose description has quotes ([example](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/19580741998/job/56077744515))

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6814-fix-backport-workflow-fails-when-label-description-has-single-quote-2b26d73d36508143bbefe6c4314fd370) by [Unito](https://www.unito.io)
