### PR TITLE
Fix: Clear apiKey on failed auth

### DIFF
--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -24,7 +24,12 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const isAuthenticated = computed(() => !!currentUser.value)
 
   const initializeUserFromApiKey = async () => {
-    const createCustomerResponse = await firebaseAuthStore.createCustomer()
+    const createCustomerResponse = await firebaseAuthStore
+      .createCustomer()
+      .catch((err) => {
+        console.error(err)
+        return
+      })
     if (!createCustomerResponse) {
       apiKey.value = null
       throw new Error(t('auth.login.noAssociatedUser'))


### PR DESCRIPTION
## Summary

Handles the case where an API key is structurally valid but not in our DB.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6816-Fix-Clear-apiKey-on-failed-auth-2b26d73d3650817ab34edfa380795178) by [Unito](https://www.unito.io)
