### PR TITLE
make vue node settings appear higher in the settings dialog

### DIFF
--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -335,11 +335,11 @@
     "name": "Validate workflows"
   },
   "Comfy_VueNodes_AutoScaleLayout": {
-    "name": "Auto-scale layout (Vue nodes)",
+    "name": "Auto-scale layout (Nodes 2.0)",
     "tooltip": "Automatically scale node positions when switching to Vue rendering to prevent overlap"
   },
   "Comfy_VueNodes_Enabled": {
-    "name": "Modern Node Design (Vue Nodes)",
+    "name": "Modern Node Design (Nodes 2.0)",
     "tooltip": "Modern: DOM-based rendering with enhanced interactivity, native browser features, and updated visual design. Classic: Traditional canvas rendering."
   },
   "Comfy_WidgetControlMode": {

--- a/src/platform/settings/components/SettingDialogContent.vue
+++ b/src/platform/settings/components/SettingDialogContent.vue
@@ -107,10 +107,17 @@ const {
 
 const authActions = useFirebaseAuthActions()
 
+// Get max sortOrder from settings in a group
+const getGroupSortOrder = (group: SettingTreeNode): number =>
+  Math.max(0, ...flattenTree<SettingParams>(group).map((s) => s.sortOrder ?? 0))
+
 // Sort groups for a category
 const sortedGroups = (category: SettingTreeNode): ISettingGroup[] => {
   return [...(category.children ?? [])]
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) => {
+      const orderDiff = getGroupSortOrder(b) - getGroupSortOrder(a)
+      return orderDiff !== 0 ? orderDiff : a.label.localeCompare(b.label)
+    })
     .map((group) => ({
       label: group.label,
       settings: flattenTree<SettingParams>(group).sort((a, b) => {

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1082,24 +1082,28 @@ export const CORE_SETTINGS: SettingParams[] = [
   },
 
   /**
-   * Vue Node System Settings
+   * Nodes 2.0 Settings
    */
   {
     id: 'Comfy.VueNodes.Enabled',
-    name: 'Modern Node Design (Vue Nodes)',
+    category: ['Comfy', 'Nodes 2.0', 'VueNodesEnabled'],
+    name: 'Modern Node Design (Nodes 2.0)',
     type: 'boolean',
     tooltip:
       'Modern: DOM-based rendering with enhanced interactivity, native browser features, and updated visual design. Classic: Traditional canvas rendering.',
     defaultValue: false,
+    sortOrder: 100,
     experimental: true,
     versionAdded: '1.27.1'
   },
   {
     id: 'Comfy.VueNodes.AutoScaleLayout',
-    name: 'Auto-scale layout (Vue nodes)',
+    category: ['Comfy', 'Nodes 2.0', 'AutoScaleLayout'],
+    name: 'Auto-scale layout (Nodes 2.0)',
     tooltip:
       'Automatically scale node positions when switching to Vue rendering to prevent overlap',
     type: 'boolean',
+    sortOrder: 50,
     experimental: true,
     defaultValue: true,
     versionAdded: '1.30.3'


### PR DESCRIPTION
makes setting groups/categories be sorted by highest internal setting field `sortOrder` and adds high `sortOrder` values to the Vue Nodes (Nodes 2.0) settings.


<img width="2282" height="1872" alt="Selection_2371" src="https://github.com/user-attachments/assets/71e7e76b-4637-42b5-9f0c-2617622cda23" />
