### PR TITLE
When filtering by IO type, put wildcards last

### DIFF
--- a/src/services/nodeSearchService.ts
+++ b/src/services/nodeSearchService.ts
@@ -79,9 +79,22 @@ export class NodeSearchService {
     const results = matchedNodes.filter((node) => {
       return filters.every((filterAndValue) => {
         const { filterDef, value } = filterAndValue
-        return filterDef.matches(node, value, { wildcard })
+        return filterDef.matches(node, value)
       })
     })
+    if (matchWildcards) {
+      const alreadyValid = new Set(results.map((result) => result.name))
+      results.push(
+        ...matchedNodes
+          .filter((node) => !alreadyValid.has(node.name))
+          .filter((node) => {
+            return filters.every((filterAndValue) => {
+              const { filterDef, value } = filterAndValue
+              return filterDef.matches(node, value, { wildcard })
+            })
+          })
+      )
+    }
 
     return options?.limit ? results.slice(0, options.limit) : results
   }

--- a/src/utils/fuseUtil.ts
+++ b/src/utils/fuseUtil.ts
@@ -62,10 +62,9 @@ export class FuseFilter<T, O = string> {
       return true
     }
     const options = this.getItemOptions(item)
-    return (
-      options.includes(value) ||
-      (!!wildcard && options.some((option) => option === wildcard))
-    )
+    return wildcard
+      ? options.some((option) => option === wildcard)
+      : options.includes(value)
   }
 }
 


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/628057b2-4844-490d-9899-fce82d8e2d58" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/2825f15f-c084-4e3d-8b22-cc0aa3febdce" /> |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6829-When-filtering-by-IO-type-put-wildcards-last-2b36d73d36508196a41fed40b62f5b84) by [Unito](https://www.unito.io)
