### PR TITLE
Fix: TextArea context menu

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -13,6 +13,9 @@
       fluid
       data-capture-wheel="true"
       @pointerdown.capture.stop
+      @pointermove.capture.stop
+      @pointerup.capture.stop
+      @contextmenu.capture.stop
     />
     <LODFallback />
   </div>


### PR DESCRIPTION
## Summary

Allow the default browser context menu within textareas on Vue Nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6834-Fix-TextArea-context-menu-2b36d73d3650814e9706e76163dda59a) by [Unito](https://www.unito.io)
