### PR TITLE
Fix: Selected assets count not updating in Imported tab

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -214,7 +214,7 @@ const shouldShowDeleteButton = computed(() => {
 
 const getOutputCount = (item: AssetItem): number => {
   const count = item.user_metadata?.outputCount
-  return typeof count === 'number' && count > 0 ? count : 0
+  return typeof count === 'number' && count > 0 ? count : 1
 }
 
 const shouldShowOutputCount = (item: AssetItem): boolean => {


### PR DESCRIPTION
## Summary
- Fix bug where the "Selected assets count" displayed as 0 in the Imported tab when selecting assets

## Root Cause
The `getOutputCount` function was returning `0` when `user_metadata.outputCount` was not present.

- **Generated tab**: Works correctly because `outputCount` metadata is set during generation
- **Imported tab**: `outputCount` metadata is never set, so it always returns `0` → selected count shows as 0

## Solution
Changed the default return value from `0` to `1` when `outputCount` metadata is not present, ensuring every asset counts as at least 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6842-Fix-Selected-assets-count-not-updating-in-Imported-tab-2b46d73d365081928676e1ff7c70ce28) by [Unito](https://www.unito.io)
