### PR TITLE
[backport cloud/1.32] Fix: node preview background color

### DIFF
--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -3,7 +3,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 -->
 <template>
   <LGraphNodePreview v-if="shouldRenderVueNodes" :node-def="nodeDef" />
-  <div v-else class="_sb_node_preview">
+  <div v-else class="_sb_node_preview bg-component-node-background">
     <div class="_sb_table">
       <div
         class="node_header mr-4 text-ellipsis"
@@ -200,7 +200,6 @@ const truncateDefaultValue = (value: any, charLimit: number = 32): string => {
 }
 
 ._sb_node_preview {
-  background-color: var(--comfy-menu-bg);
   font-family: 'Open Sans', sans-serif;
   color: var(--descrip-text);
   border: 1px solid var(--descrip-text);


### PR DESCRIPTION
## Summary
Backports the node preview background color fix from main to cloud/1.32.

Changes node previews to use background color from color palette instead of the menu color.

Original PR: #6768
Cherry-picked from: 836cd7f9ba90f67434cb1f38462e46f88ae9b179

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6859-Backport-Fix-node-preview-background-color-2b46d73d365081d0b188eea8f1dadcec) by [Unito](https://www.unito.io)
