### PR TITLE
fix load image from outputs node combo value displays on cloud

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -38,6 +38,7 @@ const getDefaultValue = (inputSpec: ComboInputSpec) => {
 // Map node types to expected media types
 const NODE_MEDIA_TYPE_MAP: Record<string, 'image' | 'video' | 'audio'> = {
   LoadImage: 'image',
+  LoadImageOutput: 'image',
   LoadVideo: 'video',
   LoadAudio: 'audio'
 }
@@ -45,6 +46,7 @@ const NODE_MEDIA_TYPE_MAP: Record<string, 'image' | 'video' | 'audio'> = {
 // Map node types to placeholder i18n keys
 const NODE_PLACEHOLDER_MAP: Record<string, string> = {
   LoadImage: 'widgets.uploadSelect.placeholderImage',
+  LoadImageOutput: 'widgets.uploadSelect.placeholderImage',
   LoadVideo: 'widgets.uploadSelect.placeholderVideo',
   LoadAudio: 'widgets.uploadSelect.placeholderAudio'
 }


### PR DESCRIPTION
show filenames instead of hashes when on cloud

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6874-fix-load-image-from-outputs-node-combo-value-displays-on-cloud-2b46d73d365081948b48ef9ff912dc20) by [Unito](https://www.unito.io)
