### PR TITLE
fix: tabindex prop should be number type in MultiSelect component

### DIFF
--- a/src/components/input/MultiSelect.vue
+++ b/src/components/input/MultiSelect.vue
@@ -83,7 +83,7 @@
     role="combobox"
     :aria-expanded="false"
     aria-haspopup="listbox"
-    tabindex="0"
+    :tabindex="0"
   >
     <template
       v-if="showSearchBox || showSelectedCount || showClearButton"


### PR DESCRIPTION
Change to use number prop to fix warnings:

```
WorkflowTemplateSelectorDialog.vue:7 [Vue warn]: Invalid prop: type check failed for prop "tabindex". Expected Number with value 0, got String with value "0".
  at <MultiSelect modelValue= [] onUpdate:modelValue=fn class="w-[250px]"  ... >
  at <MultiSelect modelValue= [] onUpdate:modelValue=fn search-query=""  ... >
  at <BaseModalLayout content-title="Get Started with a Template" class="workflow-template-selector-dialog" maximized=false >
  at <WorkflowTemplateSelectorDialog ref_for=true onClose=fn<hide> maximized=false >
  at <BaseTransition onEnter=fn onAfterEnter=fn<bound onAfterEnter> onBeforeLeave=fn<bound onBeforeLeave>  ... > 
  at <Transition name="p-dialog" onEnter=fn<bound onEnter> onAfterEnter=fn<bound onAfterEnter>  ... > 
  at <Portal appendTo="body" > 
  at <Dialog key="global-workflow-template-selector" visible=true onUpdate:visible=fn<onUpdate:visible>  ... >
  at <GlobalDialog > 
  at <App>
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6875-fix-tabindex-prop-should-be-number-type-in-MultiSelect-component-2b46d73d3650816d8288fec4cc0f7e7f) by [Unito](https://www.unito.io)
