### PR TITLE
fix: duplicate "refresh node definitions" in menu entries

### DIFF
--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -14,7 +14,6 @@ export const CORE_MENU_COMMANDS = [
   [['Edit'], ['Comfy.Undo', 'Comfy.Redo']],
   [['Edit'], ['Comfy.ClearWorkflow']],
   [['Edit'], ['Comfy.OpenClipspace']],
-  [['Edit'], ['Comfy.RefreshNodeDefinitions']],
   [
     ['Edit'],
     [


### PR DESCRIPTION
The "Refresh node definitions" menu entry was added in the Manager upstream but while in development was also added in a separate commit, leading to duplicate menu entries:

<img width="1460" height="324" alt="image" src="https://github.com/user-attachments/assets/66347cb3-1c52-457e-a4f1-8b32b615a1ca" />

This PR removes the second one.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6876-fix-duplicate-refresh-node-definitions-in-menu-entries-2b46d73d365081b98bdfcc60dc9bad36) by [Unito](https://www.unito.io)
