### PR TITLE
fix: workflow that creates release branch fails

### DIFF
--- a/.github/workflows/release-branch-create.yaml
+++ b/.github/workflows/release-branch-create.yaml
@@ -148,10 +148,10 @@ jobs:
           done
 
           {
-            echo "results<<'EOF'"
+            echo "results<<EOF"
             cat "$RESULTS_FILE"
             echo "EOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Ensure release labels
         if: steps.check_version.outputs.is_minor_bump == 'true'


### PR DESCRIPTION
Fixes 'create-release-branch' workflow. The script was emitting a multiline output using `echo "results<<'EOF'" … echo "EOF"`. GitHub treats the opening delimiter literally (`'EOF'` with quotes). Because the closing line omits the quotes, the runner never sees a matching terminator, so it aborts the file-command write and marks the step as failed even though the preceding git pushes succeeded.

Example of error: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/19520246619/job/55881876566

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6878-fix-workflow-that-creates-release-branch-fails-2b46d73d365081549651eacacd5cbfec) by [Unito](https://www.unito.io)
