### PR TITLE
hide "unload models" and "unload cache" menu entries on cloud

### DIFF
--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -1,3 +1,5 @@
+import { isCloud } from '@/platform/distribution/types'
+
 export const CORE_MENU_COMMANDS = [
   [[], ['Comfy.NewBlankWorkflow']],
   [[], []], // Separator after New
@@ -14,13 +16,16 @@ export const CORE_MENU_COMMANDS = [
   [['Edit'], ['Comfy.Undo', 'Comfy.Redo']],
   [['Edit'], ['Comfy.ClearWorkflow']],
   [['Edit'], ['Comfy.OpenClipspace']],
-  [['Edit'], ['Comfy.RefreshNodeDefinitions']],
   [
     ['Edit'],
     [
       'Comfy.RefreshNodeDefinitions',
-      'Comfy.Memory.UnloadModels',
-      'Comfy.Memory.UnloadModelsAndExecutionCache'
+      ...(isCloud
+        ? []
+        : [
+            'Comfy.Memory.UnloadModels',
+            'Comfy.Memory.UnloadModelsAndExecutionCache'
+          ])
     ]
   ],
   [['View'], []],


### PR DESCRIPTION
Hides these features which the user does not need when on cloud.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6879-hide-unload-models-and-unload-cache-menu-entries-on-cloud-2b46d73d3650816a8e22e913a848e4ac) by [Unito](https://www.unito.io)
