### PR TITLE
Add test id for startup status text

### DIFF
--- a/apps/desktop-ui/src/components/common/StartupDisplay.vue
+++ b/apps/desktop-ui/src/components/common/StartupDisplay.vue
@@ -22,7 +22,11 @@
         <h1 v-if="title" class="font-inter font-bold text-3xl text-neutral-300">
           {{ title }}
         </h1>
-        <p v-if="statusText" class="text-lg text-neutral-400">
+        <p
+          v-if="statusText"
+          class="text-lg text-neutral-400"
+          data-testid="startup-status-text"
+        >
           {{ statusText }}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- add `data-testid="startup-status-text"` to the status text in StartupDisplay
- keep the status element targetable for Playwright masks

## Why
Desktop’s Playwright tests mask the troubleshooting version line; this test id is needed there to keep screenshots stable across releases.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6882-Add-test-id-for-startup-status-text-2b56d73d365081b6a2e4ddca9aa985a4) by [Unito](https://www.unito.io)
