### PR TITLE
Support display_name on frontend

### DIFF
--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -27,6 +27,7 @@ export const zBaseInputOptions = z
   .object({
     default: z.any().optional(),
     defaultInput: z.boolean().optional(),
+    display_name: z.string().optional(),
     forceInput: z.boolean().optional(),
     tooltip: z.string().optional(),
     socketless: z.boolean().optional(),

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -95,10 +95,11 @@ export const useLitegraphService = () => {
     )
     if (widgetConstructor && !inputSpec.forceInput) return
 
-    node.addInput(inputName, inputSpec.type, {
+    const input = node.addInput(inputName, inputSpec.type, {
       shape: inputSpec.isOptional ? RenderShape.HollowCircle : undefined,
       localized_name: st(nameKey, inputName)
     })
+    input.label ??= inputSpec.display_name
   }
   /**
    * @internal Setup stroke styles for the node under various conditions.
@@ -164,7 +165,10 @@ export const useLitegraphService = () => {
     ) ?? {}
 
     if (widget) {
-      widget.label = st(nameKey, widget.label ?? inputName)
+      widget.label = st(
+        nameKey,
+        widget.label ?? widgetInputSpec.display_name ?? inputName
+      )
       widget.options ??= {}
       Object.assign(widget.options, {
         advanced: inputSpec.advanced,


### PR DESCRIPTION
The v3 schema allows defining a `display_name` on inputs, but this was previously ignored on the frontend.  It is now used to designate a default value for the label of a widget or input.

CC: @Kosinkadink

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6922-Support-display_name-on-frontend-2b66d73d365081d992cbea07abc27a0f) by [Unito](https://www.unito.io)
