### PR TITLE
Reduce width of run button dock zone

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -257,7 +257,7 @@ watch(isDragging, (dragging) => {
 })
 const actionbarClass = computed(() =>
   cn(
-    'w-[265px] border-dashed border-blue-500 opacity-80',
+    'w-[200px] border-dashed border-blue-500 opacity-80',
     'm-1.5 flex items-center justify-center self-stretch',
     'rounded-md before:w-50 before:-ml-50 before:h-full',
     'pointer-events-auto',


### PR DESCRIPTION
Tiny PR to make the docking area line up with the new size of the actionbar after #6723
<img width="550" height="106" alt="image" src="https://github.com/user-attachments/assets/911d510e-351f-484f-807a-17f5428dea79" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6925-Reduce-width-of-run-button-dock-zone-2b66d73d36508137aa0cc18178172264) by [Unito](https://www.unito.io)
