### PR TITLE
Bump desktop-ui to 0.0.4

### DIFF
--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/desktop-ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "nx": {
     "tags": [


### PR DESCRIPTION
This contains a change to clarify to what is the base path issue after restrictions were tightened.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6933-Bump-desktop-ui-to-0-0-4-2b66d73d3650816e9f3bed7202455ddb) by [Unito](https://www.unito.io)
