### PR TITLE
temporary add lineart back in 3d node

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -359,10 +359,11 @@ useExtensionService().registerExtension({
             height.value as number
           )
 
-          const [data, dataMask, dataNormal] = await Promise.all([
+          const [data, dataMask, dataNormal, dataLineart] = await Promise.all([
             Load3dUtils.uploadTempImage(imageData, 'scene'),
             Load3dUtils.uploadTempImage(maskData, 'scene_mask'),
-            Load3dUtils.uploadTempImage(normalData, 'scene_normal')
+            Load3dUtils.uploadTempImage(normalData, 'scene_normal'),
+            Load3dUtils.uploadTempImage(imageData, 'scene_lineart') //FIXME placeholder for compatibility, will remove later
           ])
 
           currentLoad3d.handleResize()
@@ -373,7 +374,8 @@ useExtensionService().registerExtension({
             normal: `threed/${dataNormal.name} [temp]`,
             camera_info:
               (node.properties['Camera Config'] as any)?.state || null,
-            recording: ''
+            recording: '',
+            lineart: `threed/${dataLineart.name} [temp]` //FIXME placeholder for compatibility, will remove later
           }
 
           const recordingData = currentLoad3d.getRecordingData()


### PR DESCRIPTION
## Summary

Add lineart back in 3d node temporarily to fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/6706.


## Changes

After @jtydhr88  refactored 3D nodes, lineart has been removed from the frontend.
However the corresponed backend changes https://github.com/comfyanonymous/ComfyUI/pull/10025 has not been merged yet which leads to the issue https://github.com/Comfy-Org/ComfyUI_frontend/issues/6706, in order to fix this, we should add it back temporarily. Once the BE changes merged, we can remove it safely.

## Screenshots

<!-- Add screenshots or video recording to help explain your changes -->
<img width="2002" height="1688" alt="Weixin Image_20251125195741_1760_1138" src="https://github.com/user-attachments/assets/5ff3166b-df76-4a35-954b-96e369f5e5ad" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6951-temporary-add-lineart-back-in-3d-node-2b76d73d36508190b372cccbfabf482d) by [Unito](https://www.unito.io)
