### PR TITLE
fix: don't use registry when only checking for presence of missing nodes

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -44,17 +44,22 @@ import { useI18n } from 'vue-i18n'
 
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import { app } from '@/scripts/app'
 import { useCommandStore } from '@/stores/commandStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useQueueSettingsStore } from '@/stores/queueStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { useMissingNodes } from '@/workbench/extensions/manager/composables/nodePack/useMissingNodes'
+import { graphHasMissingNodes } from '@/workbench/extensions/manager/utils/graphHasMissingNodes'
 
 import BatchCountEdit from '../BatchCountEdit.vue'
 
 const workspaceStore = useWorkspaceStore()
 const { mode: queueMode, batchCount } = storeToRefs(useQueueSettingsStore())
 
-const { hasMissingNodes } = useMissingNodes()
+const nodeDefStore = useNodeDefStore()
+const hasMissingNodes = computed(() =>
+  graphHasMissingNodes(app.graph, nodeDefStore.nodeDefsByName)
+)
 
 const { t } = useI18n()
 const queueModeMenuItemLookup = computed(() => {

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -64,11 +64,13 @@ import {
   ComfyWorkflow,
   useWorkflowStore
 } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useCommandStore } from '@/stores/commandStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { appendJsonExt } from '@/utils/formatUtil'
-import { useMissingNodes } from '@/workbench/extensions/manager/composables/nodePack/useMissingNodes'
+import { graphHasMissingNodes } from '@/workbench/extensions/manager/utils/graphHasMissingNodes'
 
 interface Props {
   item: MenuItem
@@ -79,7 +81,10 @@ const props = withDefaults(defineProps<Props>(), {
   isActive: false
 })
 
-const { hasMissingNodes } = useMissingNodes()
+const nodeDefStore = useNodeDefStore()
+const hasMissingNodes = computed(() =>
+  graphHasMissingNodes(app.graph, nodeDefStore.nodeDefsByName)
+)
 
 const { t } = useI18n()
 const menu = ref<InstanceType<typeof Menu> & MenuState>()

--- a/src/workbench/extensions/manager/utils/graphHasMissingNodes.ts
+++ b/src/workbench/extensions/manager/utils/graphHasMissingNodes.ts
@@ -1,0 +1,36 @@
+import { unref } from 'vue'
+import type { MaybeRef } from 'vue'
+
+import type {
+  LGraph,
+  LGraphNode,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
+import { collectAllNodes } from '@/utils/graphTraversalUtil'
+
+type NodeDefLookup = Record<string, unknown>
+
+const isNodeMissingDefinition = (
+  node: LGraphNode,
+  nodeDefsByName: NodeDefLookup
+) => {
+  const nodeName = node?.type
+  if (!nodeName) return false
+  return !nodeDefsByName[nodeName]
+}
+
+export const collectMissingNodes = (
+  graph: LGraph | Subgraph | null | undefined,
+  nodeDefsByName: MaybeRef<NodeDefLookup>
+): LGraphNode[] => {
+  if (!graph) return []
+  const lookup = unref(nodeDefsByName) ?? {}
+  return collectAllNodes(graph, (node) => isNodeMissingDefinition(node, lookup))
+}
+
+export const graphHasMissingNodes = (
+  graph: LGraph | Subgraph | null | undefined,
+  nodeDefsByName: MaybeRef<NodeDefLookup>
+) => {
+  return collectMissingNodes(graph, nodeDefsByName).length > 0
+}

--- a/src/workbench/extensions/manager/utils/graphHasMissingNodes.ts
+++ b/src/workbench/extensions/manager/utils/graphHasMissingNodes.ts
@@ -6,9 +6,10 @@ import type {
   LGraphNode,
   Subgraph
 } from '@/lib/litegraph/src/litegraph'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { collectAllNodes } from '@/utils/graphTraversalUtil'
 
-type NodeDefLookup = Record<string, unknown>
+export type NodeDefLookup = Record<string, ComfyNodeDefImpl | undefined>
 
 const isNodeMissingDefinition = (
   node: LGraphNode,
@@ -24,7 +25,7 @@ export const collectMissingNodes = (
   nodeDefsByName: MaybeRef<NodeDefLookup>
 ): LGraphNode[] => {
   if (!graph) return []
-  const lookup = unref(nodeDefsByName) ?? {}
+  const lookup = unref(nodeDefsByName)
   return collectAllNodes(graph, (node) => isNodeMissingDefinition(node, lookup))
 }
 

--- a/tests-ui/tests/workbench/extensions/manager/utils/graphHasMissingNodes.test.ts
+++ b/tests-ui/tests/workbench/extensions/manager/utils/graphHasMissingNodes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  LGraph,
+  LGraphNode,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
+import {
+  collectMissingNodes,
+  graphHasMissingNodes
+} from '@/workbench/extensions/manager/utils/graphHasMissingNodes'
+
+type NodeDefs = Record<string, unknown>
+
+const createGraph = (nodes: LGraphNode[] = []): LGraph => {
+  return { nodes } as unknown as LGraph
+}
+
+const createSubgraph = (nodes: LGraphNode[]): Subgraph => {
+  return { nodes } as unknown as Subgraph
+}
+
+const createNode = (
+  type?: string,
+  subgraphNodes?: LGraphNode[]
+): LGraphNode => {
+  return {
+    id: Math.random(),
+    type,
+    isSubgraphNode: subgraphNodes ? () => true : undefined,
+    subgraph: subgraphNodes ? createSubgraph(subgraphNodes) : undefined
+  } as unknown as LGraphNode
+}
+
+describe('graphHasMissingNodes', () => {
+  it('returns false when graph is null', () => {
+    expect(graphHasMissingNodes(null, {})).toBe(false)
+  })
+
+  it('returns false when every node has a definition', () => {
+    const graph = createGraph([createNode('FooNode'), createNode('BarNode')])
+    const nodeDefs: NodeDefs = {
+      FooNode: {},
+      BarNode: {}
+    }
+
+    expect(graphHasMissingNodes(graph, nodeDefs)).toBe(false)
+  })
+
+  it('returns true when at least one node is missing', () => {
+    const graph = createGraph([
+      createNode('FooNode'),
+      createNode('MissingNode')
+    ])
+    const nodeDefs: NodeDefs = {
+      FooNode: {}
+    }
+
+    expect(graphHasMissingNodes(graph, nodeDefs)).toBe(true)
+  })
+
+  it('checks nodes nested in subgraphs', () => {
+    const graph = createGraph([
+      createNode('ContainerNode', [createNode('InnerMissing')])
+    ])
+    const nodeDefs: NodeDefs = {
+      ContainerNode: {}
+    }
+
+    const missingNodes = collectMissingNodes(graph, nodeDefs)
+    expect(missingNodes).toHaveLength(1)
+    expect(missingNodes[0]?.type).toBe('InnerMissing')
+  })
+
+  it('ignores nodes without a type', () => {
+    const graph = createGraph([
+      createNode(undefined),
+      createNode(null as unknown as string)
+    ])
+
+    expect(graphHasMissingNodes(graph, {})).toBe(false)
+  })
+})


### PR DESCRIPTION
Changes the client-side validation of whether a graph has missing nodes to use a simpler check (is the node name in the node defs from `/object_info`), rather than using the Comfy Node Registry API (api.comfy.org). The Registry API is still needed to get full metadata/info about missing nodes, but that can be deferred until the user actually needs that info.

This also fixes an issue where a node you coded yourself locally which is neither a core node nor a node in the registry would be considered "missing."

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6965-fix-don-t-use-registry-when-only-checking-for-presence-of-missing-nodes-2b76d73d365081e7b8fbcb3f2a1c4502) by [Unito](https://www.unito.io)
