### PR TITLE
Change node-component-header-surface color variable

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -194,7 +194,7 @@
   --node-component-executing: var(--color-blue-500);
   --node-component-header: var(--fg-color);
   --node-component-header-icon: var(--color-ash-800);
-  --node-component-header-surface: var(--color-white);
+  --node-component-header-surface: var(--color-smoke-400);
   --node-component-outline: var(--color-black);
   --node-component-ring: rgb(from var(--color-smoke-500) r g b / 50%);
   --node-component-slot-dot-outline-opacity-mult: 1;


### PR DESCRIPTION
## Summary

Light mode node header color update.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6990-Change-node-component-header-surface-color-variable-2b86d73d36508197937cfe2b8e7ab970) by [Unito](https://www.unito.io)
