### PR TITLE
feat(api-nodes-pricing): add prices for Kling-v2-5-turbo for node KlingStartEndFrame

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -583,7 +583,12 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
         const modeValue = String(modeWidget.value)
 
         // Same pricing matrix as KlingTextToVideoNode
-        if (modeValue.includes('v2-1')) {
+        if (modeValue.includes('v2-5-turbo')) {
+          if (modeValue.includes('10')) {
+            return '$0.70/Run'
+          }
+          return '$0.35/Run' // 5s default
+        } else if (modeValue.includes('v2-1')) {
           if (modeValue.includes('10s')) {
             return '$0.98/Run' // pro, 10s
           }


### PR DESCRIPTION
## Summary

Pricing for new model for this node

## Screenshots (if applicable)

<img width="1174" height="422" alt="Screenshot From 2025-11-27 14-44-38" src="https://github.com/user-attachments/assets/78edb4d2-3aef-427c-98d5-ea9b6b18b203" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6996-feat-api-nodes-pricing-add-prices-for-Kling-v2-5-turbo-for-node-KlingStartEndFrame-2b86d73d36508171ba2cd186248228b7) by [Unito](https://www.unito.io)
