### PR TITLE
fix: add filter for combo widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
@@ -3,6 +3,7 @@
     <Select
       v-model="modelValue"
       :invalid
+      :filter="selectOptions.length > 4"
       :options="selectOptions"
       v-bind="combinedProps"
       :class="cn(WidgetInputBaseClass, 'w-full text-xs')"


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `WidgetSelectDefault.vue` component. The change conditionally enables the filtering feature in the select dropdown when there are more than four options, improving usability for larger lists.


<img width="932" height="622" alt="Screenshot 2025-11-27 160239" src="https://github.com/user-attachments/assets/76f6080f-13c7-4fa9-a813-2799af15363e" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-6999-fix-add-filter-for-combo-widgets-2b86d73d365081f994e5caf78e64a196) by [Unito](https://www.unito.io)
