### PR TITLE
test: add setting to ignore version compatibility toast warnings in e2e tests

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1652,7 +1652,8 @@ export const comfyPageFixture = base.extend<{
         'Comfy.TutorialCompleted': true,
         'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize,
         'Comfy.VueNodes.AutoScaleLayout': false,
-        // Disable version compatibility warnings for testing.
+        // Disable toast warning about version compatibility, as they may or
+        // may not appear - depending on upstream ComfyUI dependencies
         'Comfy.VersionCompatibility.DisableWarnings': true
       })
     } catch (e) {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1651,7 +1651,9 @@ export const comfyPageFixture = base.extend<{
         // Set tutorial completed to true to avoid loading the tutorial workflow.
         'Comfy.TutorialCompleted': true,
         'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize,
-        'Comfy.VueNodes.AutoScaleLayout': false
+        'Comfy.VueNodes.AutoScaleLayout': false,
+        // Disable version compatibility warnings for testing.
+        'Comfy.VersionCompatibility.DisableWarnings': true
       })
     } catch (e) {
       console.error(e)

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1116,5 +1116,12 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip: 'Use new Asset API for model browsing',
     defaultValue: isCloud ? true : false,
     experimental: true
+  },
+  {
+    id: 'Comfy.VersionCompatibility.DisableWarnings',
+    name: 'Disable version compatibility warnings',
+    type: 'hidden',
+    defaultValue: false,
+    versionAdded: '1.31.0'
   }
 ]

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1122,6 +1122,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Disable version compatibility warnings',
     type: 'hidden',
     defaultValue: false,
-    versionAdded: '1.31.0'
+    versionAdded: '1.34.1'
   }
 ]

--- a/src/platform/updates/common/versionCompatibilityStore.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.ts
@@ -4,6 +4,7 @@ import { gt, valid } from 'semver'
 import { computed } from 'vue'
 
 import config from '@/config'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 
 const DISMISSAL_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
@@ -12,6 +13,7 @@ export const useVersionCompatibilityStore = defineStore(
   'versionCompatibility',
   () => {
     const systemStatsStore = useSystemStatsStore()
+    const settingStore = useSettingStore()
 
     const frontendVersion = computed(() => config.app_version)
     const backendVersion = computed(
@@ -87,7 +89,10 @@ export const useVersionCompatibilityStore = defineStore(
     })
 
     const shouldShowWarning = computed(() => {
-      return hasVersionMismatch.value && !isDismissed.value
+      const warningsDisabled = settingStore.get(
+        'Comfy.VersionCompatibility.DisableWarnings'
+      )
+      return hasVersionMismatch.value && !isDismissed.value && !warningsDisabled
     })
 
     const warningMessage = computed(() => {

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -523,7 +523,9 @@ const zSettings = z.object({
   'main.sub.setting.name': z.any(),
   'single.setting': z.any(),
   'LiteGraph.Node.DefaultPadding': z.boolean(),
-  'LiteGraph.Pointer.TrackpadGestures': z.boolean()
+  'LiteGraph.Pointer.TrackpadGestures': z.boolean(),
+  /** Version compatibility settings */
+  'Comfy.VersionCompatibility.DisableWarnings': z.boolean()
 })
 
 export type EmbeddingsResponse = z.infer<typeof zEmbeddingsResponse>

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -524,7 +524,6 @@ const zSettings = z.object({
   'single.setting': z.any(),
   'LiteGraph.Node.DefaultPadding': z.boolean(),
   'LiteGraph.Pointer.TrackpadGestures': z.boolean(),
-  /** Version compatibility settings */
   'Comfy.VersionCompatibility.DisableWarnings': z.boolean()
 })
 


### PR DESCRIPTION
There's a warning toast shown if the frontend is considered out-of-date (relative to the version in the requirements.txt of comfyanonymous/ComfyUI). As a result, e2e tests run on older release branches (e.g., when backporting or hotfixing) can sometimes trigger the warning which obviously causes visual regression tests to fail. This PR adds a hidden setting to disable the warning and sets it to `true` in the e2e test fixtures.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7004-test-add-setting-to-ignore-version-compatibility-toast-warnings-in-e2e-tests-2b86d73d3650812d9e07f54a0c86b996) by [Unito](https://www.unito.io)
