### PR TITLE
fix: loader node widget value shows placeholder instead of filename on cloud

### DIFF
--- a/cloud-loader-dropdown.md
+++ b/cloud-loader-dropdown.md
@@ -1,0 +1,24 @@
+Fixes loader dropdown placeholder
+===============================
+
+Cloud loader dropdowns hydrate via `useAssetWidgetData(nodeType)`, so `dropdownItems` stays empty until the Asset API returns friendly filenames. Meanwhile `modelValue` already holds the saved asset and the watcher at [WidgetSelectDropdown.vue#L215-L227](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue#L215-L227) only tracks `modelValue`. It runs before assets load, fails to find a match, clears `selectedSet`, and the placeholder persists.
+
+```ts
+watch(
+  modelValue,
+  (currentValue) => {
+    if (currentValue === undefined) {
+      selectedSet.value.clear()
+      return
+    }
+    const item = dropdownItems.value.find((item) => item.name === currentValue)
+    if (item) {
+      selectedSet.value.clear()
+      selectedSet.value.add(item.id)
+    }
+  },
+  { immediate: true }
+)
+```
+
+Once the API resolves, `dropdownItems` recomputes but nothing resyncs because the watcher never sees that change. Desktop doesn’t hit this because it still reads from `widget.options.values` immediately.

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -213,12 +213,13 @@ const acceptTypes = computed(() => {
 const layoutMode = ref<LayoutMode>(props.defaultLayoutMode ?? 'grid')
 
 watch(
-  modelValue,
-  (currentValue) => {
+  [modelValue, dropdownItems],
+  ([currentValue]) => {
     if (currentValue === undefined) {
       selectedSet.value.clear()
       return
     }
+
     const item = dropdownItems.value.find((item) => item.name === currentValue)
     if (item) {
       selectedSet.value.clear()

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -214,7 +214,7 @@ const layoutMode = ref<LayoutMode>(props.defaultLayoutMode ?? 'grid')
 
 watch(
   [modelValue, dropdownItems],
-  ([currentValue]) => {
+  ([currentValue, _dropdownItems]) => {
     if (currentValue === undefined) {
       selectedSet.value.clear()
       return


### PR DESCRIPTION
Fixes issue on cloud where the Loader node dropdowns showed placeholder values (after refresh) in the widget UI despite a value being loaded.

Cloud loader dropdowns hydrate via `useAssetWidgetData(nodeType)`, so `dropdownItems` stays empty until the Asset API returns friendly filenames. Meanwhile `modelValue` already holds the saved asset and the watcher only tracks `modelValue`: https://github.com/Comfy-Org/ComfyUI_frontend/blob/df653d6ce183fde7a67feb81c1a029143e521458/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue#L215-L226

This watcher runs before assets load, fails to find a match, clears `selectedSet`, and the placeholder persists:

https://github.com/Comfy-Org/ComfyUI_frontend/blob/df653d6ce183fde7a67feb81c1a029143e521458/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue#L222-L224

Once the assets API resolves, `dropdownItems` recomputes but nothing resyncs because the watcher never sees that change. Desktop doesn’t hit this because it still reads from `widget.options.values` immediately.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7005-fix-loader-node-widget-value-shows-placeholder-instead-of-filename-on-cloud-2b86d73d36508125a16de5c9e366b014) by [Unito](https://www.unito.io)
