### PR TITLE
Handle HTML fallbacks for node help and skip blueprint docs

### DIFF
--- a/src/services/nodeHelpService.ts
+++ b/src/services/nodeHelpService.ts
@@ -7,6 +7,10 @@ class NodeHelpService {
   async fetchNodeHelp(node: ComfyNodeDefImpl, locale: string): Promise<string> {
     const nodeSource = getNodeSource(node.python_module)
 
+    if (nodeSource.type === NodeSourceType.Blueprint) {
+      return node.description || ''
+    }
+
     if (nodeSource.type === NodeSourceType.CustomNodes) {
       return this.fetchCustomNodeHelp(node, locale)
     } else {
@@ -25,19 +29,15 @@ class NodeHelpService {
 
     // Try locale-specific path first
     const localePath = `/extensions/${customNodeName}/docs/${node.name}/${locale}.md`
-    let res = await fetch(api.fileURL(localePath))
+    const localeDoc = await this.tryFetchMarkdown(localePath)
+    if (localeDoc) return localeDoc
 
-    if (!res.ok) {
-      // Fall back to non-locale path
-      const fallbackPath = `/extensions/${customNodeName}/docs/${node.name}.md`
-      res = await fetch(api.fileURL(fallbackPath))
-    }
+    // Fall back to non-locale path
+    const fallbackPath = `/extensions/${customNodeName}/docs/${node.name}.md`
+    const fallbackDoc = await this.tryFetchMarkdown(fallbackPath)
+    if (fallbackDoc) return fallbackDoc
 
-    if (!res.ok) {
-      throw new Error(res.statusText)
-    }
-
-    return res.text()
+    throw new Error('Help not found')
   }
 
   private async fetchCoreNodeHelp(
@@ -45,13 +45,36 @@ class NodeHelpService {
     locale: string
   ): Promise<string> {
     const mdUrl = `/docs/${node.name}/${locale}.md`
-    const res = await fetch(api.fileURL(mdUrl))
-
-    if (!res.ok) {
-      throw new Error(res.statusText)
+    const doc = await this.tryFetchMarkdown(mdUrl)
+    if (!doc) {
+      throw new Error('Help not found')
     }
 
-    return res.text()
+    return doc
+  }
+
+  /**
+   * Fetch a markdown file and return its text, guarding against HTML/SPA fallbacks.
+   * Returns null when not OK or when the content looks like HTML.
+   */
+  private async tryFetchMarkdown(path: string): Promise<string | null> {
+    const res = await fetch(api.fileURL(path))
+
+    if (!res.ok) {
+      return null
+    }
+
+    const contentType = res.headers.get('content-type') ?? ''
+    const text = await res.text()
+
+    const looksHtml =
+      contentType.includes('text/html') ||
+      /^\s*<!doctype html/i.test(text) ||
+      /^\s*<html/i.test(text)
+
+    if (looksHtml) return null
+
+    return text
   }
 }
 

--- a/src/workbench/utils/nodeHelpUtil.ts
+++ b/src/workbench/utils/nodeHelpUtil.ts
@@ -15,6 +15,9 @@ export function extractCustomNodeName(
 
 export function getNodeHelpBaseUrl(node: ComfyNodeDefImpl): string {
   const nodeSource = getNodeSource(node.python_module)
+  if (nodeSource.type === NodeSourceType.Blueprint) {
+    return ''
+  }
   if (nodeSource.type === NodeSourceType.CustomNodes) {
     const customNodeName = extractCustomNodeName(node.python_module)
     if (customNodeName) {

--- a/src/workbench/utils/nodeHelpUtil.ts
+++ b/src/workbench/utils/nodeHelpUtil.ts
@@ -15,9 +15,6 @@ export function extractCustomNodeName(
 
 export function getNodeHelpBaseUrl(node: ComfyNodeDefImpl): string {
   const nodeSource = getNodeSource(node.python_module)
-  if (nodeSource.type === NodeSourceType.Blueprint) {
-    return ''
-  }
   if (nodeSource.type === NodeSourceType.CustomNodes) {
     const customNodeName = extractCustomNodeName(node.python_module)
     if (customNodeName) {


### PR DESCRIPTION
explicitly prevents subgraphs from making an api call since they don't have docs, this was previously reliant on a non-ok resolution

also doesn't try returning anything that has contenttype of text/html to prevent the markdown renderer from crashing

## Summary
- short-circuit blueprint/subgraph nodes in help: skip doc fetch and return the node description, avoiding SPA fallback responses
- guard node help fetch against HTML/SPA fallbacks using content-type checks; treat them as missing and trigger the existing description fallback
- keep base URL logic unchanged for non-blueprint nodes

## Testing
- pnpm typecheck
- pnpm lint:fix
- pnpm test:unit