### PR TITLE
Fix: image upload widget value saved incorrectly

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -8,6 +8,7 @@ import type { ResultItem, ResultItemType } from '@/schemas/apiSchema'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { isImageUploadInput } from '@/types/nodeDefAugmentation'
 import { createAnnotatedPath } from '@/utils/createAnnotatedPath'
 import { addToComboValues } from '@/utils/litegraphUtil'
@@ -38,6 +39,8 @@ export const useImageUploadWidget = () => {
         'Image upload widget requires imageInputName augmentation'
       )
     }
+
+    const workflowStore = useWorkflowStore()
 
     const inputOptions = inputData[1]
     const { imageInputName, allow_batch, image_folder = 'input' } = inputOptions
@@ -85,6 +88,9 @@ export const useImageUploadWidget = () => {
         // @ts-expect-error litegraph combo value type does not support arrays yet
         fileComboWidget.value = newValue
         fileComboWidget.callback?.(newValue)
+
+        // Notify changeTracker, so we can save widget value correctly
+        workflowStore.activeWorkflow?.changeTracker?.checkState()
       }
     })
 


### PR DESCRIPTION
## Summary

image upload widget value was saved incorrectly(didn't trigger `changeTracker`)

## Changes

- call `workflowStore.activeWorkflow?.changeTracker?.checkState()` after value setted and callback has been called.

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7027-Fix-image-upload-widget-value-saved-incorrectly-2b96d73d36508104aa9ffe5d27360f98) by [Unito](https://www.unito.io)
