### PR TITLE
fix: actionbar can get stuck behind floating menu and not be moved with drag handle

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -262,7 +262,7 @@ const actionbarClass = computed(() =>
 )
 const panelClass = computed(() =>
   cn(
-    'actionbar pointer-events-auto z-[1300]',
+    'actionbar pointer-events-auto z-1300',
     isDragging.value && 'select-none pointer-events-none',
     isDocked.value
       ? 'p-0 static mr-2 border-none bg-transparent'

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -10,7 +10,7 @@
     </div>
 
     <Panel
-      class="pointer-events-auto z-1010"
+      class="pointer-events-auto"
       :style="style"
       :class="panelClass"
       :pt="{
@@ -66,12 +66,7 @@ const storedPosition = useLocalStorage('Comfy.MenuPosition.Floating', {
   x: 0,
   y: 0
 })
-const {
-  x,
-  y,
-  style: style,
-  isDragging
-} = useDraggable(panelRef, {
+const { x, y, style, isDragging } = useDraggable(panelRef, {
   initialValue: { x: 0, y: 0 },
   handle: dragHandleRef,
   containerElement: document.body,
@@ -267,7 +262,7 @@ const actionbarClass = computed(() =>
 )
 const panelClass = computed(() =>
   cn(
-    'actionbar pointer-events-auto z1000',
+    'actionbar pointer-events-auto z-[1300]',
     isDragging.value && 'select-none pointer-events-none',
     isDocked.value
       ? 'p-0 static mr-2 border-none bg-transparent'


### PR DESCRIPTION
Fixes issue where actionbar (and therefore "Run" button) can get stuck behind the floating menus and not be physically moved (especially on mobile) leading to an inability to press "Run" button. 

`z1010` and `z1000` do not seem to be actual classes in our system.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7034-fix-actionbar-can-get-stuck-behind-floating-menu-and-not-be-moved-with-drag-handle-2b96d73d365081fc87d1ec4446a50e43) by [Unito](https://www.unito.io)
