### PR TITLE
when on cloud, link to cloud version of "getting started" page for "docs" button

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -280,7 +280,8 @@ const menuItems = computed<MenuItem[]>(() => {
       label: t('helpCenter.docs'),
       action: () => {
         trackResourceClick('docs', true)
-        openExternalLink(buildDocsUrl('/', { includeLocale: true }))
+        const path = isCloud ? '/get_started/cloud' : '/'
+        openExternalLink(buildDocsUrl(path, { includeLocale: true }))
         emit('close')
       }
     },


### PR DESCRIPTION
Changes docs button in bottom left help center to open https://docs.comfy.org/get_started/cloud when on cloud (as opposed to https://docs.comfy.org/).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7041-when-on-cloud-link-to-cloud-version-of-getting-started-page-for-docs-button-2ba6d73d365081b79bcaf91cfeb3dffd) by [Unito](https://www.unito.io)
