### PR TITLE
Expose LGraphNode.getSlotPosition

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -2,7 +2,8 @@ import { LGraphNodeProperties } from '@/lib/litegraph/src/LGraphNodeProperties'
 import {
   calculateInputSlotPos,
   calculateInputSlotPosFromSlot,
-  calculateOutputSlotPos
+  calculateOutputSlotPos,
+  getSlotPosition
 } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import type { SlotPositionContext } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
@@ -3352,6 +3353,16 @@ export class LGraphNode
       this.#getSlotPositionContext(),
       outputSlotIndex
     )
+  }
+
+  /**
+   * Get slot position using layout tree if available, fallback to node's position * Unified implementation used by both LitegraphLinkAdapter and useLinkLayoutSync
+   * @param slotIndex The slot index
+   * @param isInput Whether this is an input slot
+   * @returns Position of the slot center in graph coordinates
+   */
+  getSlotPosition(slotIndex: number, isInput: boolean): Point {
+    return getSlotPosition(this, slotIndex, isInput)
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
Before node v2, you could use getInputPos, getOutputPos. In node v2, that is not possible.

## Summary

Want to get the position of the output / inputs on the graph like before node v2.

## Changes

- **What**:  <!-- Core functionality added/modified --> Added LGraphNode.getSlotPosition

## Review Focus


## Screenshots (if applicable)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7042-Expose-LGraphNode-getSlotPosition-2ba6d73d36508195a0fed2d1fe2b64f6) by [Unito](https://www.unito.io)
