### PR TITLE
Minor/Lint: Fix two warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -38,6 +38,7 @@
     "typescript/no-redundant-type-constituents": "off",
     "typescript/restrict-template-expressions": "off",
     "typescript/unbound-method": "off",
-    "typescript/no-floating-promises": "error"
+    "typescript/no-floating-promises": "error",
+    "vue/no-import-compiler-macros": "error"
   }
 }

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -60,7 +60,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, withDefaults } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import QueueOverlayActive from '@/components/queue/QueueOverlayActive.vue'

--- a/src/composables/maskeditor/gpu/brushShaders.ts
+++ b/src/composables/maskeditor/gpu/brushShaders.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu'
+import { tgpu } from 'typegpu'
 import * as d from 'typegpu/data'
 import { BrushUniforms } from './gpuSchema'
 

--- a/src/composables/maskeditor/useBrushDrawing.ts
+++ b/src/composables/maskeditor/useBrushDrawing.ts
@@ -12,7 +12,7 @@ import type { Brush, Point } from '@/extensions/core/maskeditor/types'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useCoordinateTransform } from './useCoordinateTransform'
 import { resampleSegment } from './splineUtils'
-import TGPU from 'typegpu'
+import { tgpu } from 'typegpu'
 import { GPUBrushRenderer } from './gpu/GPUBrushRenderer'
 import { StrokeProcessor } from './StrokeProcessor'
 import { getEffectiveBrushSize, getEffectiveHardness } from './brushUtils'
@@ -276,7 +276,7 @@ export function useBrushDrawing(initialSettings?: {
     }
 
     try {
-      const root = await TGPU.init()
+      const root = await tgpu.init()
       store.tgpuRoot = root
       device = root.device
       console.warn('✅ TypeGPU initialized! Root:', root)


### PR DESCRIPTION
## Summary

Unnecessary import of a compiler macro and importing the default instead of the named export.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7045-Minor-Lint-Fix-two-warnings-2bb6d73d365081758369d14bafcd7aa0) by [Unito](https://www.unito.io)
