### PR TITLE
mark vue nodes menu toggle with beta tag

### DIFF
--- a/src/components/sidebar/ComfyMenuButton.vue
+++ b/src/components/sidebar/ComfyMenuButton.vue
@@ -73,6 +73,7 @@
         @click.stop="handleNodes2ToggleClick"
       >
         <span class="p-menubar-item-label text-nowrap">{{ item.label }}</span>
+        <Tag severity="info" class="ml-2 text-xs">{{ $t('g.beta') }}</Tag>
         <ToggleSwitch
           v-model="nodes2Enabled"
           class="ml-4"
@@ -101,6 +102,7 @@
 
 <script setup lang="ts">
 import type { MenuItem } from 'primevue/menuitem'
+import Tag from 'primevue/tag'
 import TieredMenu from 'primevue/tieredmenu'
 import type { TieredMenuMethods, TieredMenuState } from 'primevue/tieredmenu'
 import ToggleSwitch from 'primevue/toggleswitch'

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1,5 +1,6 @@
 {
   "g": {
+    "beta": "Beta",
     "user": "User",
     "currentUser": "Current user",
     "empty": "Empty",


### PR DESCRIPTION
## Summary

Adds a "Beta" tag next to the Nodes 2.0 menu item toggle to better indicate to users, especially new users, that the feature is in beta.

<img width="752" height="918" alt="Selection_2477" src="https://github.com/user-attachments/assets/cf341b2b-1af6-4259-8449-bf157989b7b3" />

<img width="433" height="880" alt="Selection_2476" src="https://github.com/user-attachments/assets/a0f658bf-1904-4d79-9ca7-c81c458adc54" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7047-mark-vue-nodes-menu-toggle-with-beta-tag-2bb6d73d3650815e8a9aceaa9250c02e) by [Unito](https://www.unito.io)
