### PR TITLE
fix wrong 3d node def after refactor

### DIFF
--- a/src/locales/en/nodeDefs.json
+++ b/src/locales/en/nodeDefs.json
@@ -4799,7 +4799,7 @@
     }
   },
   "Load3D": {
-    "display_name": "Load 3D",
+    "display_name": "Load 3D & Animation",
     "inputs": {
       "model_file": {
         "name": "model_file"
@@ -4816,46 +4816,6 @@
       "clear": {},
       "upload 3d model": {},
       "upload extra resources": {}
-    },
-    "outputs": {
-      "0": {
-        "name": "image"
-      },
-      "1": {
-        "name": "mask"
-      },
-      "2": {
-        "name": "mesh_path"
-      },
-      "3": {
-        "name": "normal"
-      },
-      "4": {
-        "name": "lineart"
-      },
-      "5": {
-        "name": "camera_info"
-      },
-      "6": {
-        "name": "recording_video"
-      }
-    }
-  },
-  "Load3DAnimation": {
-    "display_name": "Load 3D - Animation",
-    "inputs": {
-      "model_file": {
-        "name": "model_file"
-      },
-      "image": {
-        "name": "image"
-      },
-      "width": {
-        "name": "width"
-      },
-      "height": {
-        "name": "height"
-      }
     },
     "outputs": {
       "0": {
@@ -9026,7 +8986,7 @@
     }
   },
   "Preview3D": {
-    "display_name": "Preview 3D",
+    "display_name": "Preview 3D & Animation",
     "inputs": {
       "model_file": {
         "name": "model_file"
@@ -9036,17 +8996,6 @@
       },
       "image": {
         "name": "image"
-      }
-    }
-  },
-  "Preview3DAnimation": {
-    "display_name": "Preview 3D - Animation",
-    "inputs": {
-      "model_file": {
-        "name": "model_file"
-      },
-      "camera_info": {
-        "name": "camera_info"
       }
     }
   },


### PR DESCRIPTION
## Summary

fix wrong node def for 3d load after refactor, to match BE change in https://github.com/comfyanonymous/ComfyUI/pull/10025

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7054-fix-wrong-3d-node-def-after-refactor-2bb6d73d365081da956cdee057f1e8b3) by [Unito](https://www.unito.io)
