### PR TITLE
Support on slot click listeners in vue

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -897,7 +897,7 @@ test.describe('Vue Node Link Interaction', () => {
         0,
         false
       )
-      const dropPos = { x: outputCenter.x + 200, y: outputCenter.y - 120 }
+      const dropPos = { x: outputCenter.x + 200, y: outputCenter.y - 100 }
 
       await comfyMouse.move(outputCenter)
       await comfyPage.page.keyboard.down('Shift')

--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -6,7 +6,11 @@
       ref="connectionDotRef"
       :color="slotColor"
       :class="cn('-translate-x-1/2 w-3', errorClassesDot)"
-      @pointerdown="onPointerDown"
+      @click="onClick"
+      @dblclick="onDoubleClick"
+      @pointerdown.stop.prevent="pointerDown"
+      @pointerup.stop.prevent="pointerUp"
+      @pointerleave.stop.prevent="(e: PointerEvent) => pointerLeave(e)"
     />
 
     <!-- Slot Name -->
@@ -142,9 +146,20 @@ useSlotElementTracking({
   element: slotElRef
 })
 
-const { onPointerDown } = useSlotLinkInteraction({
+const { onClick, onDoubleClick, onPointerDown } = useSlotLinkInteraction({
   nodeId: props.nodeId ?? '',
   index: props.index,
   type: 'input'
 })
+
+let pointerLeave: (leavEvent: PointerEvent) => void = () => {}
+function pointerDown(e: PointerEvent) {
+  pointerLeave = () => {
+    onPointerDown(e)
+    pointerLeave = () => {}
+  }
+}
+function pointerUp() {
+  pointerLeave = () => {}
+}
 </script>

--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -8,9 +8,7 @@
       :class="cn('-translate-x-1/2 w-3', errorClassesDot)"
       @click="onClick"
       @dblclick="onDoubleClick"
-      @pointerdown.stop.prevent="pointerDown"
-      @pointerup.stop.prevent="pointerUp"
-      @pointerleave.stop.prevent="(e: PointerEvent) => pointerLeave(e)"
+      @pointerdown="onPointerDown"
     />
 
     <!-- Slot Name -->
@@ -151,15 +149,4 @@ const { onClick, onDoubleClick, onPointerDown } = useSlotLinkInteraction({
   index: props.index,
   type: 'input'
 })
-
-let pointerLeave: (leavEvent: PointerEvent) => void = () => {}
-function pointerDown(e: PointerEvent) {
-  pointerLeave = () => {
-    onPointerDown(e)
-    pointerLeave = () => {}
-  }
-}
-function pointerUp() {
-  pointerLeave = () => {}
-}
 </script>

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -504,7 +504,7 @@ export function useSlotLinkInteraction({
 
     const hasConnected = connectByPriority(canvasEvent.target, snappedCandidate)
 
-    if (!hasConnected) {
+    if (!hasConnected && event.target === app.canvas?.canvas) {
       activeAdapter?.dropOnCanvas(canvasEvent)
     }
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -2,7 +2,6 @@ import { tryOnScopeDispose, useEventListener } from '@vueuse/core'
 import type { Fn } from '@vueuse/core'
 
 import { useSharedCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
@@ -721,8 +720,7 @@ export function useSlotLinkInteraction({
   })
 
   function onDoubleClick(e: PointerEvent) {
-    const canvas = useCanvasStore().getCanvas()
-    const { graph } = canvas
+    const { graph } = app.canvas
     if (!graph) return
     const node = graph.getNodeById(nodeId)
     if (!node) return
@@ -730,8 +728,7 @@ export function useSlotLinkInteraction({
     node.onInputDblClick?.(index, e)
   }
   function onClick(e: PointerEvent) {
-    const canvas = useCanvasStore().getCanvas()
-    const { graph } = canvas
+    const { graph } = app.canvas
     if (!graph) return
     const node = graph.getNodeById(nodeId)
     if (!node) return

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -30,7 +30,7 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import type { Point } from '@/renderer/core/layout/types'
 import { toPoint } from '@/renderer/core/layout/utils/geometry'
 import { createSlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
-import { translateEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
+import { augmentToCanvasPointerEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
 import { app } from '@/scripts/app'
 import { createRafBatch } from '@/utils/rafBatch'
 
@@ -726,7 +726,7 @@ export function useSlotLinkInteraction({
     if (!graph) return
     const node = graph.getNodeById(nodeId)
     if (!node) return
-    translateEvent(app.canvas, node, e)
+    augmentToCanvasPointerEvent(e, node, app.canvas)
     node.onInputDblClick?.(index, e)
   }
   function onClick(e: PointerEvent) {
@@ -735,7 +735,7 @@ export function useSlotLinkInteraction({
     if (!graph) return
     const node = graph.getNodeById(nodeId)
     if (!node) return
-    translateEvent(app.canvas, node, e)
+    augmentToCanvasPointerEvent(e, node, app.canvas)
     node.onInputClick?.(index, e)
   }
 

--- a/src/renderer/extensions/vueNodes/utils/eventUtils.ts
+++ b/src/renderer/extensions/vueNodes/utils/eventUtils.ts
@@ -1,0 +1,13 @@
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+
+export function translateEvent(
+  canvas: LGraphCanvas,
+  node: LGraphNode,
+  e: PointerEvent
+): asserts e is CanvasPointerEvent {
+  canvas.adjustMouseEvent(e)
+  canvas.graph_mouse[0] = e.offsetX + node.pos[0]
+  canvas.graph_mouse[1] = e.offsetY + node.pos[1]
+}

--- a/src/renderer/extensions/vueNodes/utils/eventUtils.ts
+++ b/src/renderer/extensions/vueNodes/utils/eventUtils.ts
@@ -2,10 +2,10 @@ import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 
-export function translateEvent(
-  canvas: LGraphCanvas,
+export function augmentToCanvasPointerEvent(
+  e: PointerEvent,
   node: LGraphNode,
-  e: PointerEvent
+  canvas: LGraphCanvas
 ): asserts e is CanvasPointerEvent {
   canvas.adjustMouseEvent(e)
   canvas.graph_mouse[0] = e.offsetX + node.pos[0]

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
@@ -8,7 +8,7 @@ import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { translateEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
+import { augmentToCanvasPointerEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -67,7 +67,7 @@ function draw() {
 //See LGraphCanvas.processWidgetClick
 function handleDown(e: PointerEvent) {
   if (!node || !widgetInstance || !pointer) return
-  translateEvent(canvas, node, e)
+  augmentToCanvasPointerEvent(e, node, canvas)
   pointer.down(e)
   if (widgetInstance.mouse)
     pointer.onDrag = (e) =>
@@ -77,13 +77,13 @@ function handleDown(e: PointerEvent) {
 }
 function handleUp(e: PointerEvent) {
   if (!pointer || !node) return
-  translateEvent(canvas, node, e)
+  augmentToCanvasPointerEvent(e, node, canvas)
   e.click_time = e.timeStamp - (pointer?.eDown?.timeStamp ?? 0)
   pointer.up(e)
 }
 function handleMove(e: PointerEvent) {
   if (!pointer || !node) return
-  translateEvent(canvas, node, e)
+  augmentToCanvasPointerEvent(e, node, canvas)
   pointer.move(e)
 }
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
@@ -6,9 +6,9 @@ import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { translateEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -64,16 +64,10 @@ function draw() {
   ctx.scale(scaleFactor, scaleFactor)
   widgetInstance.draw?.(ctx, node, width, 1, height)
 }
-function translateEvent(e: PointerEvent): asserts e is CanvasPointerEvent {
-  if (!node) return
-  canvas.adjustMouseEvent(e)
-  canvas.graph_mouse[0] = e.offsetX + node.pos[0]
-  canvas.graph_mouse[1] = e.offsetY + node.pos[1]
-}
 //See LGraphCanvas.processWidgetClick
 function handleDown(e: PointerEvent) {
   if (!node || !widgetInstance || !pointer) return
-  translateEvent(e)
+  translateEvent(canvas, node, e)
   pointer.down(e)
   if (widgetInstance.mouse)
     pointer.onDrag = (e) =>
@@ -82,14 +76,14 @@ function handleDown(e: PointerEvent) {
   canvas.processWidgetClick(e, node, widgetInstance, pointer)
 }
 function handleUp(e: PointerEvent) {
-  if (!pointer) return
-  translateEvent(e)
+  if (!pointer || !node) return
+  translateEvent(canvas, node, e)
   e.click_time = e.timeStamp - (pointer?.eDown?.timeStamp ?? 0)
   pointer.up(e)
 }
 function handleMove(e: PointerEvent) {
-  if (!pointer) return
-  translateEvent(e)
+  if (!pointer || !node) return
+  translateEvent(canvas, node, e)
   pointer.move(e)
 }
 </script>


### PR DESCRIPTION
Adds support for the `node.onInputDblClick` and `node.onInputClick` callbacks in vue
- Fixes vue link drop code so that a link which is not dropped on the canvas does not fallback to the dropped on canvas code.
![input-double-click_00001](https://github.com/user-attachments/assets/8b138a6e-e569-4a5d-b59a-cd688ff062e6)

Resolves #7037

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7059-Support-on-slot-click-listeners-in-vue-2bb6d73d3650812993fdef244e91683b) by [Unito](https://www.unito.io)
