### PR TITLE
[fix] Weekly release workflow adjustments

### DIFF
--- a/.github/workflows/release-weekly-comfyui.yaml
+++ b/.github/workflows/release-weekly-comfyui.yaml
@@ -146,11 +146,24 @@ jobs:
       - name: Sync with upstream
         working-directory: comfyui
         run: |
+          set -euo pipefail
+
           # Fetch latest upstream to base our branch on fresh code
           # Note: This only affects the local checkout, NOT the fork's master branch
           # We only push the automation branch, leaving the fork's master untouched
-          git fetch https://github.com/comfyanonymous/ComfyUI.git master
-          git checkout FETCH_HEAD
+          echo "Fetching upstream master..."
+          if ! git fetch https://github.com/comfyanonymous/ComfyUI.git master; then
+            echo "Failed to fetch upstream master"
+            exit 1
+          fi
+
+          echo "Checking out upstream master..."
+          if ! git checkout FETCH_HEAD; then
+            echo "Failed to checkout FETCH_HEAD"
+            exit 1
+          fi
+
+          echo "Successfully synced with upstream master"
 
       - name: Update requirements.txt
         working-directory: comfyui

--- a/.github/workflows/release-weekly-comfyui.yaml
+++ b/.github/workflows/release-weekly-comfyui.yaml
@@ -143,6 +143,15 @@ jobs:
           token: ${{ secrets.PR_GH_TOKEN }}
           path: comfyui
 
+      - name: Sync with upstream
+        working-directory: comfyui
+        run: |
+          # Fetch latest upstream to base our branch on fresh code
+          # Note: This only affects the local checkout, NOT the fork's master branch
+          # We only push the automation branch, leaving the fork's master untouched
+          git fetch https://github.com/comfyanonymous/ComfyUI.git master
+          git checkout FETCH_HEAD
+
       - name: Update requirements.txt
         working-directory: comfyui
         run: |

--- a/.github/workflows/release-weekly-comfyui.yaml
+++ b/.github/workflows/release-weekly-comfyui.yaml
@@ -1,5 +1,5 @@
 # Automated weekly workflow to bump ComfyUI frontend RC releases
-name: "Weekly ComfyUI Release"
+name: "Release: Weekly ComfyUI"
 
 on:
   # Schedule for Monday at 12:00 PM PST (20:00 UTC)


### PR DESCRIPTION
Follow-up adjustments to the weekly ComfyUI release automation workflow.

## Changes

1. **Rename workflow to follow conventions**
   - File: `weekly-comfyui-release.yaml` → `release-weekly-comfyui.yaml`
   - Name: "Weekly ComfyUI Release" → "Release: Weekly ComfyUI"
   - Matches pattern of other `release-*` workflows

2. **Sync fork with upstream before creating PR**
   - Fetches latest upstream/master before making changes
   - Ensures PR only shows requirements.txt diff, not stale fork commits
   - Does not modify fork's master branch (only pushes automation branch)

## Testing

After merge, can test via manual workflow dispatch in Actions tab.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7060-fix-Weekly-release-workflow-adjustments-2bb6d73d365081008436d1b9e5f7dd65) by [Unito](https://www.unito.io)
