### PR TITLE
[fix] add extension context menu for vueNodes

### DIFF
--- a/src/composables/graph/useExtensionMenuOptions.ts
+++ b/src/composables/graph/useExtensionMenuOptions.ts
@@ -1,0 +1,97 @@
+import type {
+  IContextMenuValue,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import { app } from '@/scripts/app'
+
+import type { MenuOption, SubMenuOption } from './useMoreOptionsMenu'
+
+/**
+ * Composable for collecting menu options from extensions
+ */
+export function useExtensionMenuOptions() {
+  const convertSubmenuItems = (
+    items: readonly (IContextMenuValue | string | null)[]
+  ): SubMenuOption[] => {
+    const result: SubMenuOption[] = []
+
+    for (const item of items) {
+      if (item === null) continue
+
+      if (typeof item === 'string') {
+        result.push({
+          label: item,
+          action: () => {}
+        })
+        continue
+      }
+
+      if (!item.content) continue
+
+      if (item.disabled) continue
+
+      const callback = item.callback
+      result.push({
+        label: item.content,
+        action: callback
+          ? () => {
+              void callback.call(null as never)
+            }
+          : () => {}
+      })
+    }
+
+    return result
+  }
+
+  const convertExtensionMenuItems = (
+    items: (IContextMenuValue | null)[]
+  ): MenuOption[] => {
+    const result: MenuOption[] = []
+
+    for (const item of items) {
+      if (item === null) {
+        result.push({ type: 'divider' })
+        continue
+      }
+
+      if (!item.content) continue
+
+      if (item.disabled) continue
+
+      const menuOption: MenuOption = {
+        label: item.content
+      }
+
+      if (item.callback) {
+        const callback = item.callback
+        menuOption.action = () => {
+          void callback.call(null as never)
+        }
+      }
+
+      if (item.has_submenu && item.submenu?.options) {
+        menuOption.hasSubmenu = true
+        menuOption.submenu = convertSubmenuItems(item.submenu.options)
+      }
+
+      result.push(menuOption)
+    }
+
+    return result
+  }
+
+  /**
+   * Collects menu items from all registered extensions for the given node
+   * @param node - The node to collect menu items for
+   * @returns Array of MenuOption items from extensions
+   */
+  const getExtensionMenuOptions = (node: LGraphNode): MenuOption[] => {
+    const extensionItems = app.collectNodeMenuItems(node)
+    return convertExtensionMenuItems(extensionItems)
+  }
+
+  return {
+    getExtensionMenuOptions
+  }
+}

--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -4,6 +4,7 @@ import type { Ref } from 'vue'
 import type { LGraphGroup } from '@/lib/litegraph/src/litegraph'
 import { isLGraphGroup } from '@/utils/litegraphUtil'
 
+import { useExtensionMenuOptions } from './useExtensionMenuOptions'
 import { useGroupMenuOptions } from './useGroupMenuOptions'
 import { useImageMenuOptions } from './useImageMenuOptions'
 import { useNodeMenuOptions } from './useNodeMenuOptions'
@@ -92,6 +93,7 @@ export function useMoreOptionsMenu() {
   } = useSelectionState()
 
   const { getImageMenuOptions } = useImageMenuOptions()
+  const { getExtensionMenuOptions } = useExtensionMenuOptions()
   const {
     getNodeInfoOption,
     getAdjustSizeOption,
@@ -207,7 +209,16 @@ export function useMoreOptionsMenu() {
       options.push(getRunBranchOption())
     }
 
-    // Section 12: Final divider and Delete
+    // Section 12: Extension menu items (from registered extensions)
+    // Only add for single node selection (not groups)
+    if (!groupContext && selectedNodes.value.length === 1) {
+      const extensionItems = getExtensionMenuOptions(selectedNodes.value[0])
+      if (extensionItems.length > 0) {
+        options.push(...extensionItems)
+      }
+    }
+
+    // Section 13: Final divider and Delete
     options.push({ type: 'divider' })
     options.push(getDeleteOption())
 


### PR DESCRIPTION
## Summary
VueNodes doesn't support context menu from extension, but it should
Added extension context menu for vueNodes

## Review Focus
you should test with some extensions have context menu, I am using my personal project https://github.com/jtydhr88/ComfyUI-AudioMass

## Screenshots (if applicable)

<img width="791" height="1053" alt="image" src="https://github.com/user-attachments/assets/9f596340-71fd-4109-a161-e4636070cfc8" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7065-fix-add-extension-context-menu-for-vueNodes-2bc6d73d36508107ae0bf31a67f432b4) by [Unito](https://www.unito.io)
