### PR TITLE
fix: normalize path separators in comfyAPIPlugin for Windows compatibility

### DIFF
--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -88,12 +88,14 @@ export function comfyAPIPlugin(isDev: boolean): Plugin {
 
         if (result.exports.length > 0) {
           const projectRoot = process.cwd()
-          const relativePath = path.relative(path.join(projectRoot, 'src'), id)
+          const relativePath = path
+            .relative(path.join(projectRoot, 'src'), id)
+            .replace(/\\/g, '/')
           const shimFileName = relativePath.replace(/\.ts$/, '.js')
 
           let shimContent = `// Shim for ${relativePath}\n`
 
-          const fileKey = relativePath.replace(/\.ts$/, '').replace(/\\/g, '/')
+          const fileKey = relativePath.replace(/\.ts$/, '')
           const warningMessage = getWarningMessage(fileKey, shimFileName)
 
           if (warningMessage) {


### PR DESCRIPTION
## Summary
Normalize the path separators by replacing all backslashes with forward slashes before using relativePath
Root Cause

In build/plugins/comfyAPIPlugin.ts, the path.relative() function generates relative paths that contain backslashes on Windows (e.g., scripts\ui.ts). When this path is directly embedded into a JavaScript string literal, the \u sequence is interpreted as the start of a Unicode escape sequence, causing the SyntaxError: Invalid Unicode escape  sequence error

## Screenshots
previous error
<img width="720" height="208" alt="image" src="https://github.com/user-attachments/assets/45b9a6e1-f35e-473d-af29-9e181bbe24eb" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7087-fix-normalize-path-separators-in-comfyAPIPlugin-for-Windows-compatibility-2bd6d73d365081cb88c1c6a0f168a5b5) by [Unito](https://www.unito.io)
