### PR TITLE
Feat: Add is_immutable gate for model edit button.

### DIFF
--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -33,7 +33,7 @@
 
       <AssetBadgeGroup :badges="asset.badges" />
       <IconGroup
-        v-if="flags.assetUpdateOptionsEnabled"
+        v-if="flags.assetUpdateOptionsEnabled && !(asset.is_immutable ?? true)"
         :class="
           cn(
             'absolute top-2 right-2 invisible group-hover:visible',

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -12,6 +12,7 @@ const zAsset = z.object({
   preview_url: z.string().optional(),
   created_at: z.string(),
   updated_at: z.string().optional(),
+  is_immutable: z.boolean().optional(),
   last_access_time: z.string().optional(),
   user_metadata: z.record(z.unknown()).optional() // API allows arbitrary key-value pairs
 })


### PR DESCRIPTION
## Summary

Only show the buttons for models that can be _mutated_.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7091-Feat-Add-is_immutable-gate-for-model-edit-button-2bd6d73d3650812e98c4e5cfb8726242) by [Unito](https://www.unito.io)
