### PR TITLE
fix: should only trigger asset panel when it opening

### DIFF
--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -206,19 +206,25 @@ const init = () => {
 }
 
 const queuePendingTaskCountStore = useQueuePendingTaskCountStore()
+const sidebarTabStore = useSidebarTabStore()
+
 const onStatus = async (e: CustomEvent<StatusWsMessageStatus>) => {
   queuePendingTaskCountStore.update(e)
-  await Promise.all([
-    queueStore.update(),
-    assetsStore.updateHistory() // Update history assets when status changes
-  ])
+  await queueStore.update()
+  // Only update assets if the assets sidebar is currently open
+  // When sidebar is closed, AssetsSidebarTab.vue will refresh on mount
+  if (sidebarTabStore.activeSidebarTabId === 'assets') {
+    await assetsStore.updateHistory()
+  }
 }
 
 const onExecutionSuccess = async () => {
-  await Promise.all([
-    queueStore.update(),
-    assetsStore.updateHistory() // Update history assets on execution success
-  ])
+  await queueStore.update()
+  // Only update assets if the assets sidebar is currently open
+  // When sidebar is closed, AssetsSidebarTab.vue will refresh on mount
+  if (sidebarTabStore.activeSidebarTabId === 'assets') {
+    await assetsStore.updateHistory()
+  }
 }
 
 const reconnectingMessage: ToastMessageOptions = {


### PR DESCRIPTION
## Summary

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7097

## Screenshots

<!-- Add screenshots or video recording to help explain your changes -->
before
<img width="2085" height="452" alt="image" src="https://github.com/user-attachments/assets/437f85f0-103f-422a-ba07-2e4e43f763d4" />

after
<img width="1208" height="265" alt="image" src="https://github.com/user-attachments/assets/bcb246ee-d963-4c74-9e0b-8d02266cc6ac" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7098-fix-should-only-trigger-asset-panel-when-it-opening-2bd6d73d36508118a8a6e7db994da775) by [Unito](https://www.unito.io)
