### PR TITLE
[fix] Fix tsx command not found in weekly release workflow

### DIFF
--- a/.github/workflows/release-weekly-comfyui.yaml
+++ b/.github/workflows/release-weekly-comfyui.yaml
@@ -63,7 +63,7 @@ jobs:
           set -euo pipefail
 
           # Run the resolver script
-          if ! RESULT=$(tsx scripts/cicd/resolve-comfyui-release.ts ../comfyui .); then
+          if ! RESULT=$(pnpm exec tsx scripts/cicd/resolve-comfyui-release.ts ../comfyui .); then
             echo "Failed to resolve release information"
             exit 1
           fi


### PR DESCRIPTION
Fixes the "tsx: command not found" error from the manual dispatch test run.

## Issue

The workflow failed with:


## Fix

Changed  to  since tsx is a devDependency and needs to be run through pnpm.

## Related

- Failed run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/19833631926/job/56825533678

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7099-fix-Fix-tsx-command-not-found-in-weekly-release-workflow-2bd6d73d3650812fb401fb8010154bf6) by [Unito](https://www.unito.io)
