### PR TITLE
cloud: increase feature flag polling interval to 10min (from 30s)

### DIFF
--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -9,7 +9,7 @@ useExtensionService().registerExtension({
   name: 'Comfy.Cloud.RemoteConfig',
 
   setup: async () => {
-    // Poll for config updates every 30 seconds
-    setInterval(() => void loadRemoteConfig(), 30000)
+    // Poll for config updates every 10 minutes
+    setInterval(() => void loadRemoteConfig(), 1000 * 60 * 10)
   }
 })

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -10,6 +10,6 @@ useExtensionService().registerExtension({
 
   setup: async () => {
     // Poll for config updates every 10 minutes
-    setInterval(() => void loadRemoteConfig(), 1000 * 60 * 10)
+    setInterval(() => void loadRemoteConfig(), 600_000)
   }
 })


### PR DESCRIPTION
Increases the `/features` endpoint polling interval (runtime config polling) from the current 30 seconds to 10 minutes.

## Background

The polling was originally added for two main purposes:

1. Server alert badges
2. Extra assurance that states are synchronized between frontend and backend

However, both of these use cases are not critical:

- Server alert badges are unlikely to be needed in practice. WebSocket (WS) can be used eventually as an alternative
- For synchronization, the system should be redesigned to be explicit about marking client state as stale, or use WebSocket/Server-Sent Events (WS/SSE) on a per-data basis rather than polling for the entire feature flag set

## Motivation

The reason to reduce polling frequency is that per-user feature flags are being added, which will make `/features` endpoint handling significantly heavier. The endpoint will no longer just return static JSON with high cache age, making frequent polling more costly.

## Future Considerations

- Eventually migrate server alert badges to use WebSocket
- Design a system that explicitly marks client state as stale when needed
- Consider using WebSocket or Server-Sent Events for targeted data updates instead of polling entire feature flag set

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7100-cloud-increase-feature-flag-polling-interval-to-10min-from-30s-2bd6d73d365081dfa8abeec901d0d975) by [Unito](https://www.unito.io)
