### PR TITLE
fix: subpath routing for reverse proxy, embedded frontends, nginx/apache subpath hosting, etc. (like SwarmUI)

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -20,13 +20,17 @@ import { cloudOnboardingRoutes } from './platform/cloud/onboarding/onboardingClo
 
 const isFileProtocol = window.location.protocol === 'file:'
 
-// Determine base path for the router
-// - Electron: always root
-// - Web: rely on Vite's BASE_URL (configured via vite.config `base`)
+/**
+ * Determine base path for the router.
+ * - Electron: always root
+ * - Cloud: use Vite's BASE_URL (configured at build time)
+ * - Standard web (including reverse proxy subpaths): use window.location.pathname
+ *   to support deployments like http://mysite.com/ComfyUI/
+ */
 function getBasePath(): string {
   if (isElectron()) return '/'
-  // Vite injects BASE_URL at build/dev time; default to '/'
-  return import.meta.env?.BASE_URL || '/'
+  if (isCloud) return import.meta.env?.BASE_URL || '/'
+  return window.location.pathname
 }
 
 const basePath = getBasePath()


### PR DESCRIPTION
Fixes #6995 -- restores subpath routing for subpath deployments (e.g., SwarmUI, nginx/apache subpaths, etc.). Fix only applies to non-cloud, non-Electron deployments

As pointed out [here](https://github.com/Comfy-Org/ComfyUI_frontend/commit/693fbbd3e44c478c87b7f90826528d69cf30c13d#r171491977), [693fbbd](https://github.com/Comfy-Org/ComfyUI_frontend/commit/693fbbd3e44c478c87b7f90826528d69cf30c13d) changed router base path logic from `window.location.pathname` to `import.meta.env.BASE_URL`. Combined with [6c9743c1a](https://github.com/Comfy-Org/ComfyUI_frontend/commit/6c9743c1a615e9bd0896261616fa6c6addb23c24) setting `base: ''` for non-cloud builds, the router defaults to `/` and ignores actual subpaths.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7115-fix-subpath-routing-for-reverse-proxy-embedded-frontends-nginx-apache-subpath-hosting--2be6d73d365081188ec8d360c1cd88f7) by [Unito](https://www.unito.io)
