### PR TITLE
test: temporarily mark linkInteraction.spec.ts as test case as `fixme`

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -828,55 +828,55 @@ test.describe('Vue Node Link Interaction', () => {
   })
 
   test.describe('Release actions (Shift-drop)', () => {
-    test.fixme('Context menu opens and endpoint is pinned on Shift-drop', async ({
-      comfyPage,
-      comfyMouse
-    }) => {
-      await comfyPage.setSetting(
-        'Comfy.LinkRelease.ActionShift',
-        'context menu'
-      )
+    test.fixme(
+      'Context menu opens and endpoint is pinned on Shift-drop',
+      async ({ comfyPage, comfyMouse }) => {
+        await comfyPage.setSetting(
+          'Comfy.LinkRelease.ActionShift',
+          'context menu'
+        )
 
-      const samplerNode = (await comfyPage.getNodeRefsByType('KSampler'))[0]
-      expect(samplerNode).toBeTruthy()
+        const samplerNode = (await comfyPage.getNodeRefsByType('KSampler'))[0]
+        expect(samplerNode).toBeTruthy()
 
-      const outputCenter = await getSlotCenter(
-        comfyPage.page,
-        samplerNode.id,
-        0,
-        false
-      )
+        const outputCenter = await getSlotCenter(
+          comfyPage.page,
+          samplerNode.id,
+          0,
+          false
+        )
 
-      const dropPos = { x: outputCenter.x + 180, y: outputCenter.y - 140 }
+        const dropPos = { x: outputCenter.x + 180, y: outputCenter.y - 140 }
 
-      await comfyMouse.move(outputCenter)
-      await comfyPage.page.keyboard.down('Shift')
-      try {
-        await comfyMouse.drag(dropPos)
-        await comfyMouse.drop()
-      } finally {
-        await comfyPage.page.keyboard.up('Shift').catch(() => {})
+        await comfyMouse.move(outputCenter)
+        await comfyPage.page.keyboard.down('Shift')
+        try {
+          await comfyMouse.drag(dropPos)
+          await comfyMouse.drop()
+        } finally {
+          await comfyPage.page.keyboard.up('Shift').catch(() => {})
+        }
+
+        // Context menu should be visible
+        const contextMenu = comfyPage.page.locator('.litecontextmenu')
+        await expect(contextMenu).toBeVisible()
+
+        // Pinned endpoint should not change with mouse movement while menu is open
+        const before = await comfyPage.page.evaluate(() => {
+          const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
+          return Array.isArray(snap) ? [snap[0], snap[1]] : null
+        })
+        expect(before).not.toBeNull()
+
+        // Move mouse elsewhere and verify snap position is unchanged
+        await comfyMouse.move({ x: dropPos.x + 160, y: dropPos.y + 100 })
+        const after = await comfyPage.page.evaluate(() => {
+          const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
+          return Array.isArray(snap) ? [snap[0], snap[1]] : null
+        })
+        expect(after).toEqual(before)
       }
-
-      // Context menu should be visible
-      const contextMenu = comfyPage.page.locator('.litecontextmenu')
-      await expect(contextMenu).toBeVisible()
-
-      // Pinned endpoint should not change with mouse movement while menu is open
-      const before = await comfyPage.page.evaluate(() => {
-        const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
-        return Array.isArray(snap) ? [snap[0], snap[1]] : null
-      })
-      expect(before).not.toBeNull()
-
-      // Move mouse elsewhere and verify snap position is unchanged
-      await comfyMouse.move({ x: dropPos.x + 160, y: dropPos.y + 100 })
-      const after = await comfyPage.page.evaluate(() => {
-        const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
-        return Array.isArray(snap) ? [snap[0], snap[1]] : null
-      })
-      expect(after).toEqual(before)
-    })
+    )
 
     test('Context menu -> Search pre-filters by link type and connects after selection', async ({
       comfyPage,

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -828,7 +828,7 @@ test.describe('Vue Node Link Interaction', () => {
   })
 
   test.describe('Release actions (Shift-drop)', () => {
-    test('Context menu opens and endpoint is pinned on Shift-drop', async ({
+    test.fixme('Context menu opens and endpoint is pinned on Shift-drop', async ({
       comfyPage,
       comfyMouse
     }) => {


### PR DESCRIPTION

This test https://github.com/Comfy-Org/ComfyUI_frontend/blob/68274134c88d210c0929a616ceb3c4cf77aa8a9f/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts#L830-L879

started failing after https://github.com/Comfy-Org/ComfyUI_frontend/pull/6952

https://14e0c969.comfyui-playwright-chromium.pages.dev/trace/?trace=https://14e0c969.comfyui-playwright-chromium.pages.dev/data/cf5b5bf984069c2f397270ac6c0c7e92479d3d31.zip

No idea how they could be related, disabling temporarily to not mess up the CI signal on `main`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7129-test-temporarily-mark-linkInteraction-spec-ts-as-test-case-as-fixme-2be6d73d36508172925af3e7fa681f25) by [Unito](https://www.unito.io)
