### PR TITLE
fix: reset touch state when iPad Safari loses focus

### DIFF
--- a/src/extensions/core/simpleTouchSupport.ts
+++ b/src/extensions/core/simpleTouchSupport.ts
@@ -82,6 +82,29 @@ app.registerExtension({
       }
     )
 
+    // Reset touch state when page loses visibility (e.g., switching apps on iPad)
+    // This prevents touchCount from getting stuck when touchend events are missed
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        touchCount = 0
+        touchZooming = false
+        touchTime = null
+        lastTouch = null
+        lastScale = null
+        touchDist = null
+      }
+    })
+
+    // Also handle touchcancel which fires when touch is interrupted
+    app.canvasEl.parentElement?.addEventListener('touchcancel', () => {
+      touchCount = 0
+      touchZooming = false
+      touchTime = null
+      lastTouch = null
+      lastScale = null
+      touchDist = null
+    })
+
     app.canvasEl.parentElement?.addEventListener(
       'touchmove',
       (e) => {

--- a/src/extensions/core/simpleTouchSupport.ts
+++ b/src/extensions/core/simpleTouchSupport.ts
@@ -1,6 +1,6 @@
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 
-import { app } from '../../scripts/app'
+import { app } from '@/scripts/app'
 
 let touchZooming = false
 let touchCount = 0
@@ -82,28 +82,25 @@ app.registerExtension({
       }
     )
 
-    // Reset touch state when page loses visibility (e.g., switching apps on iPad)
-    // This prevents touchCount from getting stuck when touchend events are missed
-    document.addEventListener('visibilitychange', () => {
-      if (document.hidden) {
-        touchCount = 0
-        touchZooming = false
-        touchTime = null
-        lastTouch = null
-        lastScale = null
-        touchDist = null
-      }
-    })
-
-    // Also handle touchcancel which fires when touch is interrupted
-    app.canvasEl.parentElement?.addEventListener('touchcancel', () => {
+    const resetTouchState = () => {
       touchCount = 0
       touchZooming = false
       touchTime = null
       lastTouch = null
       lastScale = null
       touchDist = null
+    }
+
+    // Reset touch state when page loses visibility (e.g., switching apps on iPad)
+    // This prevents touchCount from getting stuck when touchend events are missed
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        resetTouchState()
+      }
     })
+
+    // Also handle touchcancel which fires when touch is interrupted
+    app.canvasEl.parentElement?.addEventListener('touchcancel', resetTouchState)
 
     app.canvasEl.parentElement?.addEventListener(
       'touchmove',


### PR DESCRIPTION
## Summary
When the browser loses focus (e.g., switching apps, showing the dock), touchend events may not fire, causing touchCount to remain non-zero. This blocks all subsequent single-finger interactions since processMouseDown returns early when touchCount > 0.  

Added visibilitychange and touchcancel event listeners to reset touch state when the page becomes hidden or touch is interrupted by the system.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/6721

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7134-fix-reset-touch-state-when-iPad-Safari-loses-focus-2be6d73d3650819abc7cf9c602909228) by [Unito](https://www.unito.io)
