### PR TITLE
Enable shift-drop context menu test

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -828,55 +828,55 @@ test.describe('Vue Node Link Interaction', () => {
   })
 
   test.describe('Release actions (Shift-drop)', () => {
-    test.fixme(
-      'Context menu opens and endpoint is pinned on Shift-drop',
-      async ({ comfyPage, comfyMouse }) => {
-        await comfyPage.setSetting(
-          'Comfy.LinkRelease.ActionShift',
-          'context menu'
-        )
+    test('Context menu opens and endpoint is pinned on Shift-drop', async ({
+      comfyPage,
+      comfyMouse
+    }) => {
+      await comfyPage.setSetting(
+        'Comfy.LinkRelease.ActionShift',
+        'context menu'
+      )
 
-        const samplerNode = (await comfyPage.getNodeRefsByType('KSampler'))[0]
-        expect(samplerNode).toBeTruthy()
+      const samplerNode = (await comfyPage.getNodeRefsByType('KSampler'))[0]
+      expect(samplerNode).toBeTruthy()
 
-        const outputCenter = await getSlotCenter(
-          comfyPage.page,
-          samplerNode.id,
-          0,
-          false
-        )
+      const outputCenter = await getSlotCenter(
+        comfyPage.page,
+        samplerNode.id,
+        0,
+        false
+      )
 
-        const dropPos = { x: outputCenter.x + 180, y: outputCenter.y - 140 }
+      const dropPos = { x: outputCenter.x + 90, y: outputCenter.y - 70 }
 
-        await comfyMouse.move(outputCenter)
-        await comfyPage.page.keyboard.down('Shift')
-        try {
-          await comfyMouse.drag(dropPos)
-          await comfyMouse.drop()
-        } finally {
-          await comfyPage.page.keyboard.up('Shift').catch(() => {})
-        }
-
-        // Context menu should be visible
-        const contextMenu = comfyPage.page.locator('.litecontextmenu')
-        await expect(contextMenu).toBeVisible()
-
-        // Pinned endpoint should not change with mouse movement while menu is open
-        const before = await comfyPage.page.evaluate(() => {
-          const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
-          return Array.isArray(snap) ? [snap[0], snap[1]] : null
-        })
-        expect(before).not.toBeNull()
-
-        // Move mouse elsewhere and verify snap position is unchanged
-        await comfyMouse.move({ x: dropPos.x + 160, y: dropPos.y + 100 })
-        const after = await comfyPage.page.evaluate(() => {
-          const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
-          return Array.isArray(snap) ? [snap[0], snap[1]] : null
-        })
-        expect(after).toEqual(before)
+      await comfyMouse.move(outputCenter)
+      await comfyPage.page.keyboard.down('Shift')
+      try {
+        await comfyMouse.drag(dropPos)
+        await comfyMouse.drop()
+      } finally {
+        await comfyPage.page.keyboard.up('Shift').catch(() => {})
       }
-    )
+
+      // Context menu should be visible
+      const contextMenu = comfyPage.page.locator('.litecontextmenu')
+      await expect(contextMenu).toBeVisible()
+
+      // Pinned endpoint should not change with mouse movement while menu is open
+      const before = await comfyPage.page.evaluate(() => {
+        const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
+        return Array.isArray(snap) ? [snap[0], snap[1]] : null
+      })
+      expect(before).not.toBeNull()
+
+      // Move mouse elsewhere and verify snap position is unchanged
+      await comfyMouse.move({ x: dropPos.x + 160, y: dropPos.y + 100 })
+      const after = await comfyPage.page.evaluate(() => {
+        const snap = window['app']?.canvas?.linkConnector?.state?.snapLinksPos
+        return Array.isArray(snap) ? [snap[0], snap[1]] : null
+      })
+      expect(after).toEqual(before)
+    })
 
     test('Context menu -> Search pre-filters by link type and connects after selection', async ({
       comfyPage,


### PR DESCRIPTION
## Summary
- turn the shift-drop context menu release action test back on
- keep the drag distance shorter to reduce flake risk while preserving behavior

## Testing
- pnpm typecheck
- pnpm lint:fix

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7140-Enable-shift-drop-context-menu-test-2be6d73d36508104a913d55279d4d3e5) by [Unito](https://www.unito.io)
