### PR TITLE
Fix zombie linkIds on node deletion, add safety check

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -3068,9 +3068,11 @@ export class LGraphNode
           graph instanceof Subgraph
         ) {
           const targetSlot = graph.outputNode.slots[link_info.target_slot]
-          if (targetSlot) targetSlot.linkIds.length = 0
-          else
+          if (targetSlot) {
+            targetSlot.linkIds.length = 0
+          } else {
             console.error('Missing subgraphOutput slot when disconnecting link')
+          }
         }
 
         const target = graph.getNodeById(link_info.target_id)

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -11,6 +11,7 @@ import { LayoutSource } from '@/renderer/core/layout/types'
 import { adjustColor } from '@/utils/colorUtil'
 import type { ColorAdjustOptions } from '@/utils/colorUtil'
 
+import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
 import type { DragAndScale } from './DragAndScale'
 import type { LGraph } from './LGraph'
 import { BadgePosition, LGraphBadge } from './LGraphBadge'
@@ -45,8 +46,8 @@ import type {
   Rect,
   Size
 } from './interfaces'
-import { LiteGraph } from './litegraph'
-import type { LGraphNodeConstructor, Subgraph, SubgraphNode } from './litegraph'
+import { LiteGraph, Subgraph } from './litegraph'
+import type { LGraphNodeConstructor, SubgraphNode } from './litegraph'
 import {
   createBounds,
   isInRect,
@@ -3062,6 +3063,11 @@ export class LGraphNode
       for (const link_id of links) {
         const link_info = graph._links.get(link_id)
         if (!link_info) continue
+        if (
+          link_info.target_id === SUBGRAPH_OUTPUT_ID &&
+          graph instanceof Subgraph
+        )
+          graph.outputNode.slots[link_info.target_slot].linkIds.length = 0
 
         const target = graph.getNodeById(link_info.target_id)
         graph._version++

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -3066,8 +3066,12 @@ export class LGraphNode
         if (
           link_info.target_id === SUBGRAPH_OUTPUT_ID &&
           graph instanceof Subgraph
-        )
-          graph.outputNode.slots[link_info.target_slot].linkIds.length = 0
+        ) {
+          const targetSlot = graph.outputNode.slots[link_info.target_slot]
+          if (targetSlot) targetSlot.linkIds.length = 0
+          else
+            console.error('Missing subgraphOutput slot when disconnecting link')
+        }
 
         const target = graph.getNodeById(link_info.target_id)
         graph._version++

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -158,6 +158,7 @@ export class SubgraphOutput extends SubgraphSlot {
     //should never have more than one connection
     for (const linkId of this.linkIds) {
       const link = subgraph.links[linkId]
+      if (!link) continue
       subgraph.removeLink(linkId)
       const { output, outputNode } = link.resolve(subgraph)
       if (output)


### PR DESCRIPTION
Resolves #7152

- Adds a safety check to make sure link exists.
- Actually solves the problem by making sure the linkId is removed from the subgraphOutput node when a node is deleted.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7153-Fix-zombie-linkIds-on-node-deletion-add-safety-check-2bf6d73d365081d98583e6a987431bd1) by [Unito](https://www.unito.io)
