### PR TITLE
On adding output matchType, initialize type

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -219,7 +219,8 @@ export const useLitegraphService = () => {
    */
   function addOutputs(node: LGraphNode, outputs: OutputSpec[]) {
     for (const output of outputs) {
-      const { name, type, is_list } = output
+      const { name, is_list } = output
+      const type = output.type === 'COMFY_MATCHTYPE_V3' ? '*' : output.type
       const shapeOptions = is_list ? { shape: LiteGraph.GRID_SHAPE } : {}
       const nameKey = `${nodeKey(node)}.outputs.${output.index}.name`
       const typeKey = `dataTypes.${normalizeI18nKey(type)}`

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -220,6 +220,7 @@ export const useLitegraphService = () => {
   function addOutputs(node: LGraphNode, outputs: OutputSpec[]) {
     for (const output of outputs) {
       const { name, is_list } = output
+      // TODO: Fix the typing at the node spec level
       const type = output.type === 'COMFY_MATCHTYPE_V3' ? '*' : output.type
       const shapeOptions = is_list ? { shape: LiteGraph.GRID_SHAPE } : {}
       const nameKey = `${nodeKey(node)}.outputs.${output.index}.name`


### PR DESCRIPTION
The output type of a matchType output is initialized to COMFY_MATCHTYPE_V3, but is updated soon after to the value calculated from input types. Under some difficult to reproduce circumstances, this output type may be incorrectly evaluated in connections to other switch nodes. Since the initial type is never a valid connection, this can produce errors.

Instead, the output type of a matchtype node is initialized to allow connections to anything to ensure that the subsequent restriction of output types is guaranteed to be directional

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7161-On-adding-output-matchType-initialize-type-2bf6d73d3650819ab169ffe9a4ecfeb4) by [Unito](https://www.unito.io)
