### PR TITLE
fix: preserve node selection on right-click

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -127,6 +127,10 @@ export function useNodePointerInteractions(
       safeDragEnd(event)
       return
     }
+
+    // Skip selection handling for right-click (button 2) - context menu handles its own selection
+    if (event.button === 2) return
+
     const multiSelect = isMultiSelectKey(event)
 
     const nodeId = toValue(nodeIdRef)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1457,7 +1457,9 @@ export class ComfyApp {
           })
           return
         } else {
-          console.error('Invalid workflow structure, trying parameters fallback')
+          console.error(
+            'Invalid workflow structure, trying parameters fallback'
+          )
           this.showErrorOnFileLoad(file)
         }
       } catch (err) {


### PR DESCRIPTION
Previously, right-clicking on a Vue node would deselect all other selected nodes because the pointerup event handler was calling toggleNodeSelectionAfterPointerUp regardless of which mouse button was released.

This fix skips selection handling when the right mouse button (button 2) is released, allowing the context menu to operate on the existing selection.

  ## Summary
  - Fixes right-click deselecting all selected nodes when using Vue node rendering
  - Now right-clicking preserves the existing selection, allowing context menu
  actions on multiple nodes

  ## Problem
  When multiple nodes were selected and user right-clicked on one of them, the
  `pointerup` event handler would call `toggleNodeSelectionAfterPointerUp`, which
  deselected everything except the clicked node. This broke multi-node context menu
  operations.

  ## Solution
  Skip selection handling in `onPointerup` when `event.button === 2` (right-click).
  The context menu handler manages selection independently
fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7136
Before 

https://github.com/user-attachments/assets/23ac5e03-c464-44b7-8950-67c14da9e02b





After

https://github.com/user-attachments/assets/9d1bd6a8-6386-442b-9dc4-6bc8fbe4a0a8

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7162-fix-preserve-node-selection-on-right-click-2bf6d73d365081acaf75f2fc845bbffb) by [Unito](https://www.unito.io)
