### PR TITLE
Fix copy not working when text is selected in dialogs

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1457,9 +1457,7 @@ export class ComfyApp {
           })
           return
         } else {
-          console.error(
-            'Invalid workflow structure, trying parameters fallback'
-          )
+          console.error('Invalid workflow structure, trying parameters fallback')
           this.showErrorOnFileLoad(file)
         }
       } catch (err) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1457,7 +1457,9 @@ export class ComfyApp {
           })
           return
         } else {
-          console.error('Invalid workflow structure, trying parameters fallback')
+          console.error(
+            'Invalid workflow structure, trying parameters fallback'
+          )
           this.showErrorOnFileLoad(file)
         }
       } catch (err) {

--- a/src/workbench/eventHelpers.ts
+++ b/src/workbench/eventHelpers.ts
@@ -4,6 +4,14 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
  */
 
 /**
+ * Check if there is selected text in the document.
+ */
+function hasTextSelection(): boolean {
+  const selection = window.getSelection()
+  return selection !== null && selection.toString().trim().length > 0
+}
+
+/**
  * Used by clipboard handlers to determine if copy/paste events should be
  * intercepted for graph operations vs. allowing default browser behavior
  * for text inputs and other UI elements.
@@ -12,7 +20,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
  * @returns true if copy paste events will be handled by target
  */
 export function shouldIgnoreCopyPaste(target: EventTarget | null): boolean {
-  return (
+  const isTextInput =
     target instanceof HTMLTextAreaElement ||
     (target instanceof HTMLInputElement &&
       ![
@@ -26,7 +34,6 @@ export function shouldIgnoreCopyPaste(target: EventTarget | null): boolean {
         'reset',
         'search',
         'submit'
-      ].includes(target.type)) ||
-    useCanvasStore().linearMode
-  )
+      ].includes(target.type))
+  return isTextInput || useCanvasStore().linearMode || hasTextSelection()
 }


### PR DESCRIPTION
## Summary
- Allow default browser copy (Ctrl+C / Cmd+C) when text is selected anywhere in the document
- Previously, the graph node copy handler intercepted copy events even in dialogs

## Problem
Users could not copy error messages from the PromptExecutionError dialog or other modal dialogs. When pressing Ctrl+C with text selected in a dialog, the graph copy handler would intercept the event and prevent the default browser copy behavior.

## Solution
Add a `hasTextSelection()` check to `shouldIgnoreCopyPaste()`. When the user has any text selected in the document, the function returns `true`, allowing the default browser copy to proceed.

## Test plan
- [ ] Open an error dialog (trigger a workflow error)
- [ ] Click "Show Report" to expand error details
- [ ] Select some text in the dialog
- [ ] Press Ctrl+C (or Cmd+C on Mac)
- [ ] Paste elsewhere to verify the text was copied
- [ ] Verify graph node copy still works when no text is selected


https://github.com/user-attachments/assets/30a0c501-95ee-4148-b321-3d60339a41c5

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7166-Fix-copy-not-working-when-text-is-selected-in-dialogs-2bf6d73d36508182a240fd3153cb6969) by [Unito](https://www.unito.io)
