### PR TITLE
Fix issue No#7155: Nodes 2.0: Load Audio node is broken

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetAudioUI.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetAudioUI.vue
@@ -1,14 +1,15 @@
 <template>
-  <div class="w-full">
-    <WidgetSelect v-model="modelValue" :widget />
-    <div class="my-4">
-      <AudioPreviewPlayer
-        :audio-url="audioUrlFromWidget"
-        :readonly="readonly"
-        :hide-when-empty="isOutputNodeRef"
-        :show-options-button="true"
-      />
-    </div>
+  <div
+    class="w-full col-span-2 widget-expands grid grid-cols-[minmax(80px,max-content)_minmax(125px,auto)] gap-y-3 p-3"
+  >
+    <WidgetSelect v-model="modelValue" :widget class="col-span-2" />
+    <AudioPreviewPlayer
+      class="col-span-2"
+      :audio-url="audioUrlFromWidget"
+      :readonly="readonly"
+      :hide-when-empty="isOutputNodeRef"
+      :show-options-button="true"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
### Fix: Fail to load audio node

## Summary
When using Modern Node Design (Nodes 2.0), the Load Audio node is able to work as expected. 
https://github.com/Comfy-Org/ComfyUI_frontend/issues/7155

## Changes

Aligned `Load Audio` node appearance with the `Load Image` (/src/renderer/extensions/vueNodes/components/NodeWidgets.vue) node for consistency.

## Screenshots 

<img width="674" height="464" alt="zzzzw" src="https://github.com/user-attachments/assets/a7bf6a81-00e3-41a8-962b-560e7acb5c41" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7175-Fix-issue-No-7155-Nodes-2-0-Load-Audio-node-is-broken-2c06d73d365081ae9ab3c2ea20f061a4) by [Unito](https://www.unito.io)
