### PR TITLE
Fix cloud queue cancel to target specific jobs

### DIFF
--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -264,7 +264,10 @@ const cancelQueuedWorkflows = wrapWithErrorHandlingAsync(async () => {
 
 const interruptAll = wrapWithErrorHandlingAsync(async () => {
   const tasks = queueStore.runningTasks
-  const promptIds = tasks.map((task) => String(task.promptId))
+  const promptIds = tasks
+    .map((task) => task.promptId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    .map((id) => String(id))
 
   if (!promptIds.length) return
 

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -267,7 +267,6 @@ const interruptAll = wrapWithErrorHandlingAsync(async () => {
   const promptIds = tasks
     .map((task) => task.promptId)
     .filter((id): id is string => typeof id === 'string' && id.length > 0)
-    .map((id) => String(id))
 
   if (!promptIds.length) return
 


### PR DESCRIPTION
## Summary
- switch QueueProgressOverlay cancel action to target explicit prompt ids on cloud via /api/queue delete
- keep non-cloud behavior using /interrupt for local installs
- ensure prompt id list generation is straightforward

## Testing
- pnpm typecheck
- pnpm lint:fix

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7176-Fix-cloud-queue-cancel-to-target-specific-jobs-2c06d73d365081b38ab2f81d71f62186) by [Unito](https://www.unito.io)
