### PR TITLE
[feat] Add video help dialog to Upload Model flow

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2113,6 +2113,7 @@
     "uploadingModel": "Importing model...",
     "uploadSuccess": "Model imported successfully!",
     "uploadFailed": "Import failed",
+    "uploadModelHelpVideo": "Upload Model Help Video",
     "modelAssociatedWithLink": "The model associated with the link you provided:",
     "modelTypeSelectorLabel": "What type of model is this?",
     "modelTypeSelectorPlaceholder": "Select model type",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2114,6 +2114,7 @@
     "uploadSuccess": "Model imported successfully!",
     "uploadFailed": "Import failed",
     "uploadModelHelpVideo": "Upload Model Help Video",
+    "uploadModelHowDoIFindThis": "How do I find this?",
     "modelAssociatedWithLink": "The model associated with the link you provided:",
     "modelTypeSelectorLabel": "What type of model is this?",
     "modelTypeSelectorPlaceholder": "Select model type",

--- a/src/platform/assets/components/UploadModelFooter.vue
+++ b/src/platform/assets/components/UploadModelFooter.vue
@@ -1,18 +1,14 @@
 <template>
   <div class="flex justify-end gap-2 w-full">
-    <span
+    <button
       v-if="currentStep === 1"
-      class="text-muted-foreground mr-auto underline flex items-center gap-2"
+      class="text-muted-foreground mr-auto underline flex items-center gap-2 cursor-pointer bg-transparent border-0 p-0"
+      data-attr="upload-model-step1-help-link"
+      @click="showVideoHelp = true"
     >
       <i class="icon-[lucide--circle-question-mark]" />
-      <a
-        href="#"
-        target="_blank"
-        class="text-muted-foreground"
-        data-attr="upload-model-step1-help-link"
-        >{{ $t('How do I find this?') }}</a
-      >
-    </span>
+      <span>{{ $t('How do I find this?') }}</span>
+    </button>
     <TextButton
       v-if="currentStep === 1"
       :label="$t('g.cancel')"
@@ -73,12 +69,23 @@
       data-attr="upload-model-step3-finish-button"
       @click="emit('close')"
     />
+    <VideoHelpDialog
+      v-model="showVideoHelp"
+      video-url="https://media.comfy.org/compressed_768/civitai_howto.webm"
+      loop
+      :show-controls="false"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
+
 import IconTextButton from '@/components/button/IconTextButton.vue'
 import TextButton from '@/components/button/TextButton.vue'
+import VideoHelpDialog from '@/platform/assets/components/VideoHelpDialog.vue'
+
+const showVideoHelp = ref(false)
 
 defineProps<{
   currentStep: number

--- a/src/platform/assets/components/UploadModelFooter.vue
+++ b/src/platform/assets/components/UploadModelFooter.vue
@@ -1,14 +1,18 @@
 <template>
   <div class="flex justify-end gap-2 w-full">
-    <button
+    <IconTextButton
       v-if="currentStep === 1"
-      class="text-muted-foreground mr-auto underline flex items-center gap-2 cursor-pointer bg-transparent border-0 p-0"
+      :label="$t('assetBrowser.uploadModelHowDoIFindThis')"
+      type="transparent"
+      size="md"
+      class="mr-auto underline text-muted-foreground"
       data-attr="upload-model-step1-help-link"
       @click="showVideoHelp = true"
     >
-      <i class="icon-[lucide--circle-question-mark]" />
-      <span>{{ $t('assetBrowser.uploadModelHowDoIFindThis') }}</span>
-    </button>
+      <template #icon>
+        <i class="icon-[lucide--circle-question-mark]" />
+      </template>
+    </IconTextButton>
     <TextButton
       v-if="currentStep === 1"
       :label="$t('g.cancel')"
@@ -73,8 +77,6 @@
       v-model="showVideoHelp"
       video-url="https://media.comfy.org/compressed_768/civitai_howto.webm"
       :aria-label="$t('assetBrowser.uploadModelHelpVideo')"
-      loop
-      :show-controls="false"
     />
   </div>
 </template>

--- a/src/platform/assets/components/UploadModelFooter.vue
+++ b/src/platform/assets/components/UploadModelFooter.vue
@@ -72,6 +72,7 @@
     <VideoHelpDialog
       v-model="showVideoHelp"
       video-url="https://media.comfy.org/compressed_768/civitai_howto.webm"
+      :aria-label="$t('assetBrowser.uploadModelHelpVideo')"
       loop
       :show-controls="false"
     />

--- a/src/platform/assets/components/UploadModelFooter.vue
+++ b/src/platform/assets/components/UploadModelFooter.vue
@@ -7,7 +7,7 @@
       @click="showVideoHelp = true"
     >
       <i class="icon-[lucide--circle-question-mark]" />
-      <span>{{ $t('How do I find this?') }}</span>
+      <span>{{ $t('assetBrowser.uploadModelHowDoIFindThis') }}</span>
     </button>
     <TextButton
       v-if="currentStep === 1"

--- a/src/platform/assets/components/VideoHelpDialog.vue
+++ b/src/platform/assets/components/VideoHelpDialog.vue
@@ -1,0 +1,86 @@
+<template>
+  <Dialog
+    v-model:visible="isVisible"
+    modal
+    :closable="false"
+    :close-on-escape="false"
+    :dismissable-mask="true"
+    :pt="{
+      root: { class: 'video-help-dialog' },
+      header: { class: '!hidden' },
+      content: { class: '!p-0' },
+      mask: { class: '!bg-black/70' }
+    }"
+    :style="{ width: '90vw', maxWidth: '800px' }"
+  >
+    <div class="relative">
+      <IconButton
+        class="absolute top-4 right-6 z-10"
+        :aria-label="$t('g.close')"
+        @click="isVisible = false"
+      >
+        <i class="pi pi-times text-sm" />
+      </IconButton>
+      <video
+        :controls="showControls"
+        autoplay
+        :loop="loop"
+        class="w-full rounded-lg"
+        :src="videoUrl"
+      >
+        {{ $t('g.videoFailedToLoad') }}
+      </video>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import Dialog from 'primevue/dialog'
+import { computed, onUnmounted, watch } from 'vue'
+
+import IconButton from '@/components/button/IconButton.vue'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    videoUrl: string
+    loop?: boolean
+    showControls?: boolean
+  }>(),
+  {
+    loop: true,
+    showControls: false
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+const isVisible = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const handleEscapeKey = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && isVisible.value) {
+    event.stopImmediatePropagation()
+    event.stopPropagation()
+    event.preventDefault()
+    isVisible.value = false
+  }
+}
+
+watch(isVisible, (visible) => {
+  if (visible) {
+    // Add listener with capture phase to intercept before parent dialogs
+    document.addEventListener('keydown', handleEscapeKey, { capture: true })
+  } else {
+    document.removeEventListener('keydown', handleEscapeKey, { capture: true })
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleEscapeKey, { capture: true })
+})
+</script>

--- a/src/platform/assets/components/VideoHelpDialog.vue
+++ b/src/platform/assets/components/VideoHelpDialog.vue
@@ -38,7 +38,7 @@
 <script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
 import Dialog from 'primevue/dialog'
-import { watch } from 'vue'
+import { onWatcherCleanup, watch } from 'vue'
 
 import IconButton from '@/components/button/IconButton.vue'
 
@@ -50,7 +50,7 @@ const { videoUrl, ariaLabel = 'Help video' } = defineProps<{
 }>()
 
 const handleEscapeKey = (event: KeyboardEvent) => {
-  if (event.key === 'Escape' && isVisible.value) {
+  if (event.key === 'Escape') {
     event.stopImmediatePropagation()
     event.stopPropagation()
     event.preventDefault()
@@ -64,7 +64,10 @@ watch(
   isVisible,
   (visible) => {
     if (visible) {
-      useEventListener(document, 'keydown', handleEscapeKey, { capture: true })
+      const stop = useEventListener(document, 'keydown', handleEscapeKey, {
+        capture: true
+      })
+      onWatcherCleanup(stop)
     }
   },
   { immediate: true }

--- a/src/platform/assets/components/VideoHelpDialog.vue
+++ b/src/platform/assets/components/VideoHelpDialog.vue
@@ -24,7 +24,9 @@
       <video
         :controls="showControls"
         autoplay
+        muted
         :loop="loop"
+        :aria-label="ariaLabel"
         class="w-full rounded-lg"
         :src="videoUrl"
       >
@@ -44,10 +46,12 @@ const props = withDefaults(
   defineProps<{
     modelValue: boolean
     videoUrl: string
+    ariaLabel?: string
     loop?: boolean
     showControls?: boolean
   }>(),
   {
+    ariaLabel: 'Help video',
     loop: true,
     showControls: false
   }
@@ -71,14 +75,20 @@ const handleEscapeKey = (event: KeyboardEvent) => {
   }
 }
 
-watch(isVisible, (visible) => {
-  if (visible) {
-    // Add listener with capture phase to intercept before parent dialogs
-    document.addEventListener('keydown', handleEscapeKey, { capture: true })
-  } else {
-    document.removeEventListener('keydown', handleEscapeKey, { capture: true })
-  }
-})
+watch(
+  isVisible,
+  (visible) => {
+    if (visible) {
+      // Add listener with capture phase to intercept before parent dialogs
+      document.addEventListener('keydown', handleEscapeKey, { capture: true })
+    } else {
+      document.removeEventListener('keydown', handleEscapeKey, {
+        capture: true
+      })
+    }
+  },
+  { immediate: true }
+)
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleEscapeKey, { capture: true })


### PR DESCRIPTION
## Summary
Adds an interactive video tutorial dialog to help users find CivitAI model URLs during the Upload Model wizard.

## Changes
- **New Component**: Created reusable `VideoHelpDialog.vue` component
  - Full-width video player with floating close button
  - Configurable props: `videoUrl`, `loop`, `showControls`
  - Custom ESC key handling to prevent parent dialog from closing
  - Click backdrop to dismiss
  - 70% dark backdrop for better video focus
- **Upload Model Flow**: Integrated video help button in step 1 footer
  - "How do I find this?" button opens tutorial video
  - Video demonstrates finding model URLs on CivitAI
  - PostHog tracking attribute maintained (`upload-model-step1-help-link`)

## Review Focus
- ESC key event handling uses capture phase to prevent propagation to parent dialogs
- Component follows existing patterns from `MediaVideoTop.vue` and `BaseModalLayout.vue`
- Video player accessibility (ARIA labels, keyboard navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7177-feat-Add-video-help-dialog-to-Upload-Model-flow-2c06d73d36508148963ad9ee60038ea3) by [Unito](https://www.unito.io)
