### PR TITLE
Fix desktop menu docs links regression

### DIFF
--- a/src/composables/useExternalLink.ts
+++ b/src/composables/useExternalLink.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 
 import { electronAPI, isElectron } from '@/utils/envUtil'
-import { useI18n } from 'vue-i18n'
+import { i18n } from '@/i18n'
 
 /**
  * Composable for building docs.comfy.org URLs with automatic locale and platform detection
@@ -23,7 +23,7 @@ import { useI18n } from 'vue-i18n'
  * ```
  */
 export function useExternalLink() {
-  const { locale } = useI18n()
+  const locale = computed(() => String(i18n.global.locale.value))
 
   const isChinese = computed(() => {
     return locale.value === 'zh' || locale.value === 'zh-TW'

--- a/src/extensions/core/electronAdapter.ts
+++ b/src/extensions/core/electronAdapter.ts
@@ -1,5 +1,6 @@
 import log from 'loglevel'
 
+import { useExternalLink } from '@/composables/useExternalLink'
 import { PYTHON_MIRROR } from '@/constants/uvMirrors'
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -8,7 +9,6 @@ import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { checkMirrorReachable } from '@/utils/electronMirrorCheck'
 import { electronAPI as getElectronAPI, isElectron } from '@/utils/envUtil'
-import { i18n } from '@/i18n'
 ;(async () => {
   if (!isElectron()) return
 
@@ -16,36 +16,7 @@ import { i18n } from '@/i18n'
   const desktopAppVersion = await electronAPI.getElectronVersion()
   const workflowStore = useWorkflowStore()
   const toastStore = useToastStore()
-  // Build docs URLs without using useI18n (which requires a Vue setup context).
-  // This keeps the extension safe to load at module-eval time.
-  const staticUrls = {
-    githubElectron: 'https://github.com/Comfy-Org/electron'
-  }
-  const buildDocsUrl = (
-    path: string,
-    options: { includeLocale?: boolean; platform?: boolean } = {}
-  ) => {
-    const { includeLocale = false, platform: includePlatform = false } = options
-    const locale = String(i18n.global.locale.value)
-    const isChinese = locale === 'zh' || locale === 'zh-TW'
-
-    let url = 'https://docs.comfy.org'
-    if (includeLocale && isChinese) {
-      url += '/zh-CN'
-    }
-
-    const normalizedPath = path.startsWith('/') ? path : `/${path}`
-    url += normalizedPath
-
-    if (includePlatform) {
-      const platform = electronAPI.getPlatform()
-      const suffix = platform === 'darwin' ? 'macos' : 'windows'
-      url = url.endsWith('/') ? url : `${url}/`
-      url += suffix
-    }
-
-    return url
-  }
+  const { staticUrls, buildDocsUrl } = useExternalLink()
 
   const onChangeRestartApp = (newValue: string, oldValue: string) => {
     // Add a delay to allow changes to take effect before restarting.

--- a/tests-ui/tests/composables/useExternalLink.test.ts
+++ b/tests-ui/tests/composables/useExternalLink.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createI18n } from 'vue-i18n'
 
 // Mock the environment utilities
 vi.mock('@/utils/envUtil', () => ({
@@ -8,14 +7,13 @@ vi.mock('@/utils/envUtil', () => ({
 }))
 
 // Provide a minimal i18n instance for the composable
-const i18n = vi.hoisted(() =>
-  createI18n<Record<string, string>, string, false>({
-    legacy: false,
-    locale: 'en',
-    fallbackLocale: 'en',
-    messages: { en: {} }
-  })
-)
+const i18n = vi.hoisted(() => ({
+  global: {
+    locale: {
+      value: 'en'
+    }
+  }
+}))
 vi.mock('@/i18n', () => ({
   i18n
 }))

--- a/tests-ui/tests/composables/useExternalLink.test.ts
+++ b/tests-ui/tests/composables/useExternalLink.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
-
-import { useExternalLink } from '@/composables/useExternalLink'
+import { createI18n } from 'vue-i18n'
 
 // Mock the environment utilities
 vi.mock('@/utils/envUtil', () => ({
@@ -9,24 +7,28 @@ vi.mock('@/utils/envUtil', () => ({
   electronAPI: vi.fn()
 }))
 
-// Mock global i18n locale ref
-const mockLocale = ref('en')
+// Provide a minimal i18n instance for the composable
+const i18n = vi.hoisted(() =>
+  createI18n<Record<string, string>, string, false>({
+    legacy: false,
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: { en: {} }
+  })
+)
 vi.mock('@/i18n', () => ({
-  i18n: {
-    global: {
-      locale: mockLocale
-    }
-  }
+  i18n
 }))
 
 // Import after mocking to get the mocked versions
+import { useExternalLink } from '@/composables/useExternalLink'
 import { electronAPI, isElectron } from '@/utils/envUtil'
 
 describe('useExternalLink', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset to default state
-    mockLocale.value = 'en'
+    i18n.global.locale.value = 'en'
     vi.mocked(isElectron).mockReturnValue(false)
   })
 
@@ -55,7 +57,7 @@ describe('useExternalLink', () => {
 
   describe('buildDocsUrl', () => {
     it('should build basic docs URL without locale', () => {
-      mockLocale.value = 'en'
+      i18n.global.locale.value = 'en'
       const { buildDocsUrl } = useExternalLink()
 
       const url = buildDocsUrl('/changelog')
@@ -63,7 +65,7 @@ describe('useExternalLink', () => {
     })
 
     it('should build docs URL with Chinese (zh) locale when requested', () => {
-      mockLocale.value = 'zh'
+      i18n.global.locale.value = 'zh'
       const { buildDocsUrl } = useExternalLink()
 
       const url = buildDocsUrl('/changelog', { includeLocale: true })
@@ -71,7 +73,7 @@ describe('useExternalLink', () => {
     })
 
     it('should build docs URL with Chinese (zh-TW) locale when requested', () => {
-      mockLocale.value = 'zh-TW'
+      i18n.global.locale.value = 'zh-TW'
       const { buildDocsUrl } = useExternalLink()
 
       const url = buildDocsUrl('/changelog', { includeLocale: true })
@@ -79,7 +81,7 @@ describe('useExternalLink', () => {
     })
 
     it('should not include locale for English when requested', () => {
-      mockLocale.value = 'en'
+      i18n.global.locale.value = 'en'
       const { buildDocsUrl } = useExternalLink()
 
       const url = buildDocsUrl('/changelog', { includeLocale: true })
@@ -94,7 +96,7 @@ describe('useExternalLink', () => {
     })
 
     it('should add platform suffix when requested', () => {
-      mockLocale.value = 'en'
+      i18n.global.locale.value = 'en'
       vi.mocked(isElectron).mockReturnValue(true)
       vi.mocked(electronAPI).mockReturnValue({
         getPlatform: () => 'darwin'
@@ -106,7 +108,7 @@ describe('useExternalLink', () => {
     })
 
     it('should add platform suffix with trailing slash', () => {
-      mockLocale.value = 'en'
+      i18n.global.locale.value = 'en'
       vi.mocked(isElectron).mockReturnValue(true)
       vi.mocked(electronAPI).mockReturnValue({
         getPlatform: () => 'win32'
@@ -118,7 +120,7 @@ describe('useExternalLink', () => {
     })
 
     it('should combine locale and platform', () => {
-      mockLocale.value = 'zh'
+      i18n.global.locale.value = 'zh'
       vi.mocked(isElectron).mockReturnValue(true)
       vi.mocked(electronAPI).mockReturnValue({
         getPlatform: () => 'darwin'
@@ -135,7 +137,7 @@ describe('useExternalLink', () => {
     })
 
     it('should not add platform when not desktop', () => {
-      mockLocale.value = 'en'
+      i18n.global.locale.value = 'en'
       vi.mocked(isElectron).mockReturnValue(false)
 
       const { buildDocsUrl } = useExternalLink()

--- a/tests-ui/tests/composables/useExternalLink.test.ts
+++ b/tests-ui/tests/composables/useExternalLink.test.ts
@@ -9,12 +9,14 @@ vi.mock('@/utils/envUtil', () => ({
   electronAPI: vi.fn()
 }))
 
-// Mock vue-i18n
+// Mock global i18n locale ref
 const mockLocale = ref('en')
-vi.mock('vue-i18n', () => ({
-  useI18n: vi.fn(() => ({
-    locale: mockLocale
-  }))
+vi.mock('@/i18n', () => ({
+  i18n: {
+    global: {
+      locale: mockLocale
+    }
+  }
 }))
 
 // Import after mocking to get the mocked versions


### PR DESCRIPTION
## Summary
- make `useExternalLink` rely on the global i18n locale so it can be used safely outside setup
- restore `electronAdapter` to use the shared `useExternalLink` helper for docs URLs and static links

## Motivation
Desktop menu items disappeared because a top-level call to `useExternalLink` in `electronAdapter` triggered `useI18n` at module-eval time, throwing and blocking extension registration. By making the composable global-locale-only and using it in `electronAdapter`, the module can load without setup context while preserving link behavior.

## Testing
- pnpm typecheck
- pnpm lint:fix

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7181-Fix-desktop-menu-docs-links-regression-2c06d73d36508157ae48cff078b9173e) by [Unito](https://www.unito.io)
