### PR TITLE
fix: unintended text selection when resizing the splitter

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -98,6 +98,7 @@
 
 <script setup lang="ts">
 import Splitter from 'primevue/splitter'
+import type { SplitterResizeStartEvent } from 'primevue/splitter'
 import SplitterPanel from 'primevue/splitterpanel'
 import { computed } from 'vue'
 
@@ -153,8 +154,7 @@ const getSplitterGutterClasses = computed(() => {
 /**
  * Avoid triggering default behaviors during drag-and-drop, such as text selection.
  */
-function onResizestart({ originalEvent: event }: { originalEvent: Event }) {
-  event.stopPropagation()
+function onResizestart({ originalEvent: event }: SplitterResizeStartEvent) {
   event.preventDefault()
 }
 </script>

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -51,6 +51,7 @@
             "
             state-key="bottom-panel-splitter"
             state-storage="local"
+            @resizestart="onResizestart"
           >
             <SplitterPanel class="graph-canvas-panel relative">
               <slot name="graph-canvas-panel" />

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -19,6 +19,7 @@
         :pt:gutter="getSplitterGutterClasses"
         :state-key="sidebarStateKey"
         state-storage="local"
+        @resizestart="onResizestart"
       >
         <SplitterPanel
           v-if="sidebarLocation === 'left'"
@@ -148,6 +149,14 @@ const getSplitterGutterClasses = computed(() => {
   // Empty string - let individual gutter styles handle visibility
   return ''
 })
+
+/**
+ * Avoid triggering default behaviors during drag-and-drop, such as text selection.
+ */
+function onResizestart({ originalEvent: event }: { originalEvent: Event }) {
+  event.stopPropagation()
+  event.preventDefault()
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7187-fix-unintended-text-selection-when-resizing-the-splitter-2c06d73d365081b38644daa1f07fa1fb) by [Unito](https://www.unito.io)
