### PR TITLE
feat(api-nodes): add pricing for seedream4.5

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -1768,6 +1768,9 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
     },
     ByteDanceSeedreamNode: {
       displayPrice: (node: LGraphNode): string => {
+        const modelWidget = node.widgets?.find(
+          (w) => w.name === 'model'
+        ) as IComboWidget
         const sequentialGenerationWidget = node.widgets?.find(
           (w) => w.name === 'sequential_image_generation'
         ) as IComboWidget
@@ -1775,21 +1778,31 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
           (w) => w.name === 'max_images'
         ) as IComboWidget
 
-        if (!sequentialGenerationWidget || !maxImagesWidget)
-          return '$0.03/Run ($0.03 for one output image)'
-
-        if (
-          String(sequentialGenerationWidget.value).toLowerCase() === 'disabled'
-        ) {
-          return '$0.03/Run'
+        const model = String(modelWidget?.value ?? '').toLowerCase()
+        let pricePerImage = 0.03 // default for seedream-4-0-250828 and fallback
+        if (model.includes('seedream-4-5-251128')) {
+          pricePerImage = 0.04
+        } else if (model.includes('seedream-4-0-250828')) {
+          pricePerImage = 0.03
         }
 
-        const maxImages = Number(maxImagesWidget.value)
+        if (!sequentialGenerationWidget || !maxImagesWidget) {
+          return `$${pricePerImage}/Run ($${pricePerImage} for one output image)`
+        }
+
+        const seqMode = String(sequentialGenerationWidget.value).toLowerCase()
+        if (seqMode === 'disabled') {
+          return `$${pricePerImage}/Run`
+        }
+
+        const maxImagesRaw = Number(maxImagesWidget.value)
+        const maxImages =
+          Number.isFinite(maxImagesRaw) && maxImagesRaw > 0 ? maxImagesRaw : 1
         if (maxImages === 1) {
-          return '$0.03/Run'
+          return `$${pricePerImage}/Run`
         }
-        const cost = (0.03 * maxImages).toFixed(2)
-        return `$${cost}/Run ($0.03 for one output image)`
+        const totalCost = (pricePerImage * maxImages).toFixed(2)
+        return `$${totalCost}/Run ($${pricePerImage} for one output image)`
       }
     },
     ByteDanceTextToVideoNode: {


### PR DESCRIPTION
## Summary

The same logic, with price increased by 25% compared to previous version of this model.

## Screenshots (if applicable)

<img width="1438" height="685" alt="Screenshot From 2025-12-05 20-47-45" src="https://github.com/user-attachments/assets/3d2846ff-c1c7-4e2f-a789-45dc32018e25" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7189-feat-api-nodes-add-pricing-for-seedream4-5-2c06d73d3650817b975cf6dc64cbe084) by [Unito](https://www.unito.io)
