### PR TITLE
fix: Prioritize filename over name in model upload dialogs

### DIFF
--- a/src/platform/assets/components/UploadModelConfirmation.vue
+++ b/src/platform/assets/components/UploadModelConfirmation.vue
@@ -5,10 +5,8 @@
       <p class="m-0">
         {{ $t('assetBrowser.modelAssociatedWithLink') }}
       </p>
-      <p
-        class="mt-0 bg-modal-card-background text-base-foreground p-3 rounded-lg"
-      >
-        {{ metadata?.name || metadata?.filename }}
+      <p class="mt-0 text-base-foreground rounded-lg">
+        {{ metadata?.filename || metadata?.name }}
       </p>
     </div>
 

--- a/src/platform/assets/components/UploadModelProgress.vue
+++ b/src/platform/assets/components/UploadModelProgress.vue
@@ -29,7 +29,7 @@
       >
         <div class="flex flex-col justify-center items-start gap-1 flex-1">
           <p class="text-base-foreground m-0">
-            {{ metadata?.name || metadata?.filename }}
+            {{ metadata?.filename || metadata?.name }}
           </p>
           <p class="text-sm text-muted m-0">
             <!-- Going to want to add another translation here to get a nice display name. -->


### PR DESCRIPTION
## Summary
Updates model upload dialogs to display filename instead of name and removes redundant background styling from confirmation dialog.

## Changes
- **What**: Swap priority of filename/name display in upload confirmation and progress dialogs
- **What**: Remove background styling from filename display in confirmation dialog

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7203-fix-Prioritize-filename-over-name-in-model-upload-dialogs-2c16d73d365081b788deec1bb2989ed5) by [Unito](https://www.unito.io)
