### PR TITLE
Color links as common type

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -10,6 +10,7 @@ import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMuta
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { adjustColor } from '@/utils/colorUtil'
 import type { ColorAdjustOptions } from '@/utils/colorUtil'
+import { commonType, toClass } from '@/lib/litegraph/src/utils/type'
 
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
 import type { DragAndScale } from './DragAndScale'
@@ -84,7 +85,6 @@ import { findFreeSlotOfType } from './utils/collections'
 import { warnDeprecated } from './utils/feedback'
 import { distributeSpace } from './utils/spaceDistribution'
 import { truncateText } from './utils/textUtils'
-import { toClass } from './utils/type'
 import { BaseWidget } from './widgets/BaseWidget'
 import { toConcreteWidget } from './widgets/widgetMap'
 import type { WidgetTypeMap } from './widgets/widgetMap'
@@ -2832,9 +2832,12 @@ export class LGraphNode
       inputNode.disconnectInput(inputIndex, true)
     }
 
+    const maybeCommonType =
+      input.type && output.type && commonType(input.type, output.type)
+
     const link = new LLink(
       ++graph.state.lastLinkId,
-      input.type || output.type,
+      maybeCommonType || input.type || output.type,
       this.id,
       outputIndex,
       inputNode.id,

--- a/src/lib/litegraph/src/utils/type.ts
+++ b/src/lib/litegraph/src/utils/type.ts
@@ -49,7 +49,7 @@ function intersection(...sets: string[][]): string[] {
     for (const item of new Set(set))
       itemCounts[item] = (itemCounts[item] ?? 0) + 1
   return Object.entries(itemCounts)
-    .filter(([, count]) => count == sets.length)
+    .filter(([, count]) => count === sets.length)
     .map(([key]) => key)
 }
 

--- a/src/lib/litegraph/src/utils/type.ts
+++ b/src/lib/litegraph/src/utils/type.ts
@@ -1,4 +1,6 @@
-import type { IColorable } from '@/lib/litegraph/src/interfaces'
+import { without } from 'es-toolkit'
+
+import type { IColorable, ISlotType } from '@/lib/litegraph/src/interfaces'
 
 /**
  * Converts a plain object to a class instance if it is not already an instance of the class.
@@ -25,4 +27,32 @@ export function isColorable(obj: unknown): obj is IColorable {
     'setColorOption' in obj &&
     'getColorOption' in obj
   )
+}
+
+export function commonType(...types: ISlotType[]): ISlotType | undefined {
+  if (!isStrings(types)) return undefined
+
+  const withoutWildcards = without(types, '*')
+  if (withoutWildcards.length === 0) return '*'
+
+  const typeLists: string[][] = withoutWildcards.map((type) => type.split(','))
+
+  const combinedTypes = intersection(...typeLists)
+  if (combinedTypes.length === 0) return undefined
+
+  return combinedTypes.join(',')
+}
+
+function intersection(...sets: string[][]): string[] {
+  const itemCounts: Record<string, number> = {}
+  for (const set of sets)
+    for (const item of new Set(set))
+      itemCounts[item] = (itemCounts[item] ?? 0) + 1
+  return Object.entries(itemCounts)
+    .filter(([, count]) => count == sets.length)
+    .map(([key]) => key)
+}
+
+function isStrings(types: unknown[]): types is string[] {
+  return types.every((t) => typeof t === 'string')
 }

--- a/src/utils/typeGuardUtil.ts
+++ b/src/utils/typeGuardUtil.ts
@@ -60,7 +60,3 @@ export const isResultItemType = (
 ): value is ResultItemType => {
   return value === 'input' || value === 'output' || value === 'temp'
 }
-
-export function isStrings(types: unknown[]): types is string[] {
-  return types.every((t) => typeof t === 'string')
-}


### PR DESCRIPTION
Previously the color of a link would simply use the type of the target slot and fallback to the type of the origin slot. When a connection is made to a node that accepts the any type ('*'), the link has the green color of an unknown type.

Instead, when a connection is made, the type of a link is now calculated as the greatest common type of the source and destination. This means that connections to reroutes are correctly colored.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/a5544730-e69a-4c85-af33-b303bb30ae71" />| <img width="360" alt="after" src="https://github.com/user-attachments/assets/7d7b59fd-1b79-440b-a97d-a1657313c484" />|

The code for calculating common types already exists, it has simply been moved into litegraph and given a more descriptive name.

Resolves #7196

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7211-Color-links-as-common-type-2c16d73d365081188460f6b5973db962) by [Unito](https://www.unito.io)
