### PR TITLE
feat: Don't hide scrollbar in BaseModalLayout

### DIFF
--- a/src/components/widget/layout/BaseModalLayout.vue
+++ b/src/components/widget/layout/BaseModalLayout.vue
@@ -162,7 +162,7 @@ const rightAreaClasses = computed(() => {
 })
 
 const contentContainerClasses = computed(() => {
-  return cn('min-h-0 px-6 pt-0 pb-10', 'overflow-y-auto scrollbar-hide')
+  return cn('min-h-0 px-6 pt-0 pb-10', 'overflow-y-auto')
 })
 
 const rightPanelClasses = computed(() => {


### PR DESCRIPTION
## Summary
- Add showScrollbar prop to BaseModalLayout component to control scrollbar visibility
- Enable scrollbar in Templates dialog for better navigation when content overflows

The original implementation used scrollbar-hide class by default. Since the intent behind hiding the scrollbar wasn't documented in the original PR (#5290), this change preserves the default behavior (showScrollbar: false) while allowing individual dialogs to opt-in to visible scrollbars.

The Templates dialog specifically benefits from a visible scrollbar as it contains a large grid of template cards that requires scrolling.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/6915

## Screenshots (if applicable)
<img width="2490" height="1097" alt="image" src="https://github.com/user-attachments/assets/711b060c-9752-4cee-84c0-d90210969f5a" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7226-feat-add-showScrollbar-prop-to-BaseModalLayout-2c36d73d365081b1b55bdcd50ca89030) by [Unito](https://www.unito.io)
