### PR TITLE
When moving subgraphInput link, properly disconnect old link

### DIFF
--- a/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
+++ b/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
@@ -63,6 +63,9 @@ export class ToInputFromIoNodeLink implements RenderLink {
 
     if (existingLink) {
       // Moving an existing link
+      const { input, inputNode } = existingLink.resolve(this.network)
+      if (inputNode && input)
+        this.node._disconnectNodeInput(inputNode, input, existingLink)
       events.dispatch('input-moved', this)
     } else {
       // Creating a new link

--- a/tests-ui/tests/litegraph/canvas/LinkConnectorSubgraphInputValidation.test.ts
+++ b/tests-ui/tests/litegraph/canvas/LinkConnectorSubgraphInputValidation.test.ts
@@ -30,18 +30,19 @@ describe('LinkConnector SubgraphInput connection validation', () => {
 
       const fromTargetNode = new LGraphNode('TargetNode')
       fromTargetNode.addInput('number_in', 'number')
-      fromTargetNode.onConnectionsChange = vi.fn()
       subgraph.add(fromTargetNode)
 
       const toTargetNode = new LGraphNode('TargetNode')
       toTargetNode.addInput('number_in', 'number')
-      toTargetNode.onConnectionsChange = vi.fn()
       subgraph.add(toTargetNode)
 
       const startLink = subgraph.inputNode.slots[0].connect(
         fromTargetNode.inputs[0],
         fromTargetNode
       )
+
+      fromTargetNode.onConnectionsChange = vi.fn()
+      toTargetNode.onConnectionsChange = vi.fn()
 
       const renderLink = new ToInputFromIoNodeLink(
         subgraph,
@@ -59,8 +60,8 @@ describe('LinkConnector SubgraphInput connection validation', () => {
 
       expect(fromTargetNode.inputs[0].link).toBeNull()
       expect(toTargetNode.inputs[0].link).not.toBeNull()
-      expect(toTargetNode.onConnectionsChange).toHaveBeenCalled()
-      expect(fromTargetNode.onConnectionsChange).toHaveBeenCalled()
+      expect(toTargetNode.onConnectionsChange).toHaveBeenCalledTimes(1)
+      expect(fromTargetNode.onConnectionsChange).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
When moving an existing link with subgraphInput as source to a new node, the prior link is removed, but the previous target node would not have it's link property cleared.

Resolves #7225

Also re-enables several functional skipped tests.

It feels like I'm having to play whack-a-mole reimplementing the same fixes on every permutation of subgraphIO links. I'd like to setup up a unified test set that covers them all, but wouldn't want the added work to further delay this fix.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7229-When-moving-subgraphInput-link-properly-disconnect-old-link-2c36d73d36508149aca0ce477fee5c9e) by [Unito](https://www.unito.io)
