### PR TITLE
Hotfix: Templates spec

### DIFF
--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -169,9 +169,7 @@ test.describe('Templates', () => {
     expect(englishRequest.url()).toContain('templates/index.json')
 
     // Verify English titles are shown as fallback
-    await expect(
-      comfyPage.templates.content.getByText('All Templates')
-    ).toBeVisible()
+    await expect(comfyPage.page.getByText('All Templates')).toBeVisible()
   })
 
   test('template cards are dynamically sized and responsive', async ({

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -169,7 +169,9 @@ test.describe('Templates', () => {
     expect(englishRequest.url()).toContain('templates/index.json')
 
     // Verify English titles are shown as fallback
-    await expect(comfyPage.page.getByText('All Templates')).toBeVisible()
+    await expect(
+      comfyPage.page.getByRole('main').getByText('All Templates')
+    ).toBeVisible()
   })
 
   test('template cards are dynamically sized and responsive', async ({

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -170,9 +170,7 @@ test.describe('Templates', () => {
 
     // Verify English titles are shown as fallback
     await expect(
-      comfyPage.templates.content.getByRole('heading', {
-        name: 'All Templates'
-      })
+      comfyPage.templates.content.getByText('All Templates')
     ).toBeVisible()
   })
 

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -171,7 +171,7 @@ test.describe('Templates', () => {
     // Verify English titles are shown as fallback
     await expect(
       comfyPage.templates.content.getByRole('heading', {
-        name: 'Image Generation'
+        name: 'All Templates'
       })
     ).toBeVisible()
   })


### PR DESCRIPTION
## Summary

Top row of templates no longer contains an Image Generation. That's interesting, huh?

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7235-Hotfix-Templates-spec-2c36d73d36508129866bdff1583d2e1e) by [Unito](https://www.unito.io)
