### PR TITLE
fix: Vue Nodes dropdown doesn't show selected model from Asset Browser

### DIFF
--- a/src/platform/assets/utils/createModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/createModelNodeFromAsset.ts
@@ -199,8 +199,11 @@ export function createModelNodeFromAsset(
     }
   }
 
-  targetGraph.add(node)
+  // Set widget value BEFORE adding to graph so the node is created with correct value
   widget.value = filename
+
+  // Now add the node to the graph with the correct widget value already set
+  targetGraph.add(node)
 
   return { success: true, value: node }
 }


### PR DESCRIPTION
## Summary
Fixes Vue Nodes 2.0 dropdowns not displaying the selected model when created from the Asset Browser.

## Root Cause
Widget values were set AFTER the node was added to the graph, causing Vue's reactivity system to capture stale initial values.

## Solution
Set widget value BEFORE adding node to graph in `createModelNodeFromAsset.ts`.

## Changes
- **1 file changed**: `createModelNodeFromAsset.ts`
- **4 lines added, 1 removed**: Move widget value assignment before graph.add()

This ensures Vue's reactivity system captures the correct initial widget value when the node is created.
