### PR TITLE
fix: autofocus filter input in Select dropdowns to prevent shortcut triggers

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
@@ -4,6 +4,7 @@
       v-model="modelValue"
       :invalid
       :filter="selectOptions.length > 4"
+      :auto-filter-focus="selectOptions.length > 4"
       :options="selectOptions"
       v-bind="combinedProps"
       :class="cn(WidgetInputBaseClass, 'w-full text-xs')"


### PR DESCRIPTION
## Summary
- Adds `auto-filter-focus` prop to Select component when filtering is enabled
- When the dropdown opens, the filter input is automatically focused
- This prevents keystrokes from triggering global shortcuts while the user is trying to filter options

## Root Cause
When a user opens a Select dropdown with a filter and starts typing without explicitly clicking the search box, the filter input doesn't have focus. Keystrokes are then captured by global shortcut handlers (e.g., pressing "R" triggers "refresh nodes") instead of filtering the options.

## Solution
PrimeVue's Select component has an `auto-filter-focus` prop that automatically focuses the filter input when the dropdown opens. By enabling this whenever filtering is enabled (`selectOptions.length > 4`), users can immediately start typing to filter without needing to click the search box first.

## Test plan
- [ ] Open a Select dropdown with more than 4 options (e.g., Load Checkpoint's ckpt_name)
- [ ] Verify the filter input is automatically focused when the dropdown opens
- [ ] Type a character and verify it filters the list instead of triggering shortcuts
- [ ] Verify no console errors when opening/closing the dropdown

Fixes #7221

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7253-fix-autofocus-filter-input-in-Select-dropdowns-to-prevent-shortcut-triggers-2c46d73d365081feacd1f3301aa3b413) by [Unito](https://www.unito.io)
