### PR TITLE
feat: display and upload Civitai preview images in model upload flow

### DIFF
--- a/src/platform/assets/components/UploadModelConfirmation.vue
+++ b/src/platform/assets/components/UploadModelConfirmation.vue
@@ -10,7 +10,7 @@
         <img
           v-if="previewImage"
           :src="previewImage"
-          alt=""
+          :alt="metadata?.filename || metadata?.name || 'Model preview'"
           class="w-14 h-14 rounded object-cover flex-shrink-0"
         />
         <p class="m-0 text-base-foreground">

--- a/src/platform/assets/components/UploadModelConfirmation.vue
+++ b/src/platform/assets/components/UploadModelConfirmation.vue
@@ -49,8 +49,8 @@ import { useModelTypes } from '@/platform/assets/composables/useModelTypes'
 import type { AssetMetadata } from '@/platform/assets/schemas/assetSchema'
 
 defineProps<{
-  metadata: AssetMetadata | null
-  previewImage?: string | null
+  metadata?: AssetMetadata
+  previewImage?: string
 }>()
 
 const modelValue = defineModel<string | undefined>()

--- a/src/platform/assets/components/UploadModelConfirmation.vue
+++ b/src/platform/assets/components/UploadModelConfirmation.vue
@@ -1,13 +1,22 @@
 <template>
   <div class="flex flex-col gap-4 text-sm text-muted-foreground">
-    <!-- Model Info Section -->
     <div class="flex flex-col gap-2">
       <p class="m-0">
         {{ $t('assetBrowser.modelAssociatedWithLink') }}
       </p>
-      <p class="mt-0 text-base-foreground rounded-lg">
-        {{ metadata?.filename || metadata?.name }}
-      </p>
+      <div
+        class="flex items-center gap-3 bg-secondary-background p-3 rounded-lg"
+      >
+        <img
+          v-if="previewImage"
+          :src="previewImage"
+          alt=""
+          class="w-14 h-14 rounded object-cover flex-shrink-0"
+        />
+        <p class="m-0 text-base-foreground">
+          {{ metadata?.filename || metadata?.name }}
+        </p>
+      </div>
     </div>
 
     <!-- Model Type Selection -->
@@ -41,6 +50,7 @@ import type { AssetMetadata } from '@/platform/assets/schemas/assetSchema'
 
 defineProps<{
   metadata: AssetMetadata | null
+  previewImage?: string | null
 }>()
 
 const modelValue = defineModel<string | undefined>()

--- a/src/platform/assets/components/UploadModelDialog.vue
+++ b/src/platform/assets/components/UploadModelDialog.vue
@@ -14,6 +14,7 @@
       v-else-if="currentStep === 2"
       v-model="selectedModelType"
       :metadata="wizardData.metadata"
+      :preview-image="wizardData.previewImage"
     />
 
     <!-- Step 3: Upload Progress -->
@@ -23,6 +24,7 @@
       :error="uploadError"
       :metadata="wizardData.metadata"
       :model-type="selectedModelType"
+      :preview-image="wizardData.previewImage"
     />
 
     <!-- Navigation Footer -->

--- a/src/platform/assets/components/UploadModelProgress.vue
+++ b/src/platform/assets/components/UploadModelProgress.vue
@@ -25,8 +25,14 @@
       </p>
 
       <div
-        class="flex flex-row items-start p-4 bg-modal-card-background rounded-lg"
+        class="flex flex-row items-center gap-3 p-4 bg-modal-card-background rounded-lg"
       >
+        <img
+          v-if="previewImage"
+          :src="previewImage"
+          alt=""
+          class="w-14 h-14 rounded object-cover flex-shrink-0"
+        />
         <div class="flex flex-col justify-center items-start gap-1 flex-1">
           <p class="text-base-foreground m-0">
             {{ metadata?.filename || metadata?.name }}
@@ -65,5 +71,6 @@ defineProps<{
   error?: string
   metadata: AssetMetadata | null
   modelType: string | undefined
+  previewImage?: string | null
 }>()
 </script>

--- a/src/platform/assets/components/UploadModelProgress.vue
+++ b/src/platform/assets/components/UploadModelProgress.vue
@@ -69,8 +69,8 @@ import type { AssetMetadata } from '@/platform/assets/schemas/assetSchema'
 defineProps<{
   status: 'idle' | 'uploading' | 'success' | 'error'
   error?: string
-  metadata: AssetMetadata | null
-  modelType: string | undefined
-  previewImage?: string | null
+  metadata?: AssetMetadata
+  modelType?: string
+  previewImage?: string
 }>()
 </script>

--- a/src/platform/assets/components/UploadModelProgress.vue
+++ b/src/platform/assets/components/UploadModelProgress.vue
@@ -30,7 +30,7 @@
         <img
           v-if="previewImage"
           :src="previewImage"
-          alt=""
+          :alt="metadata?.filename || metadata?.name || 'Model preview'"
           class="w-14 h-14 rounded object-cover flex-shrink-0"
         />
         <div class="flex flex-col justify-center items-start gap-1 flex-1">

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -144,9 +144,10 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
       // Upload preview image first if available
       if (wizardData.value.previewImage) {
         try {
+          const baseFilename = filename.split('.')[0]
           const previewAsset = await assetService.uploadAssetFromBase64({
             data: wizardData.value.previewImage,
-            name: `${filename}_preview.png`,
+            name: `${baseFilename}_preview.png`,
             tags: ['preview']
           })
           previewId = previewAsset.id

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -145,9 +145,19 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
       if (wizardData.value.previewImage) {
         try {
           const baseFilename = filename.split('.')[0]
+
+          // Extract extension from data URL MIME type
+          let extension = 'png'
+          const mimeMatch = wizardData.value.previewImage.match(
+            /^data:image\/([^;]+);/
+          )
+          if (mimeMatch) {
+            extension = mimeMatch[1] === 'jpeg' ? 'jpg' : mimeMatch[1]
+          }
+
           const previewAsset = await assetService.uploadAssetFromBase64({
             data: wizardData.value.previewImage,
-            name: `${baseFilename}_preview.png`,
+            name: `${baseFilename}_preview.${extension}`,
             tags: ['preview']
           })
           previewId = previewAsset.id

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -9,10 +9,10 @@ import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 
 interface WizardData {
   url: string
-  metadata: AssetMetadata | null
+  metadata?: AssetMetadata
   name: string
   tags: string[]
-  previewImage: string | null
+  previewImage?: string
 }
 
 interface ModelTypeOption {
@@ -31,10 +31,8 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
 
   const wizardData = ref<WizardData>({
     url: '',
-    metadata: null,
     name: '',
-    tags: [],
-    previewImage: null
+    tags: []
   })
 
   const selectedModelType = ref<string>()
@@ -94,7 +92,7 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
       wizardData.value.name = metadata.filename || metadata.name || ''
 
       // Store preview image if available
-      wizardData.value.previewImage = metadata.preview_image || null
+      wizardData.value.previewImage = metadata.preview_image
 
       // Pre-fill model type from metadata tags if available
       if (metadata.tags && metadata.tags.length > 0) {

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -54,6 +54,7 @@ const zAssetMetadata = z.object({
   name: z.string().optional(),
   tags: z.array(z.string()).optional(),
   preview_url: z.string().optional(),
+  preview_image: z.string().optional(),
   validation: zValidationResult.optional()
 })
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -409,6 +409,13 @@ function createAssetService() {
     tags?: string[]
     user_metadata?: Record<string, any>
   }): Promise<AssetItem & { created_new: boolean }> {
+    // Validate that data is a data URL
+    if (!params.data || !params.data.startsWith('data:')) {
+      throw new Error(
+        'Invalid data URL: expected a string starting with "data:"'
+      )
+    }
+
     // Convert base64 data URL to Blob
     const blob = await fetch(params.data).then((r) => r.blob())
 
@@ -431,10 +438,7 @@ function createAssetService() {
 
     if (!res.ok) {
       throw new Error(
-        st(
-          'assetBrowser.errorUploadFailed',
-          'Failed to upload asset. Please try again.'
-        )
+        `Failed to upload asset from base64: ${res.status} ${res.statusText}`
       )
     }
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -392,6 +392,55 @@ function createAssetService() {
     return await res.json()
   }
 
+  /**
+   * Uploads an asset from base64 data
+   *
+   * @param params - Upload parameters
+   * @param params.data - Base64 data URL (e.g., "data:image/png;base64,...")
+   * @param params.name - Display name (determines extension)
+   * @param params.tags - Optional freeform tags
+   * @param params.user_metadata - Optional custom metadata object
+   * @returns Promise<AssetItem & { created_new: boolean }> - Asset object with created_new flag
+   * @throws Error if upload fails
+   */
+  async function uploadAssetFromBase64(params: {
+    data: string
+    name: string
+    tags?: string[]
+    user_metadata?: Record<string, any>
+  }): Promise<AssetItem & { created_new: boolean }> {
+    // Convert base64 data URL to Blob
+    const blob = await fetch(params.data).then((r) => r.blob())
+
+    // Create FormData and append the blob
+    const formData = new FormData()
+    formData.append('file', blob, params.name)
+
+    if (params.tags) {
+      formData.append('tags', JSON.stringify(params.tags))
+    }
+
+    if (params.user_metadata) {
+      formData.append('user_metadata', JSON.stringify(params.user_metadata))
+    }
+
+    const res = await api.fetchApi(ASSETS_ENDPOINT, {
+      method: 'POST',
+      body: formData
+    })
+
+    if (!res.ok) {
+      throw new Error(
+        st(
+          'assetBrowser.errorUploadFailed',
+          'Failed to upload asset. Please try again.'
+        )
+      )
+    }
+
+    return await res.json()
+  }
+
   return {
     getAssetModelFolders,
     getAssetModels,
@@ -402,7 +451,8 @@ function createAssetService() {
     deleteAsset,
     updateAsset,
     getAssetMetadata,
-    uploadAssetFromUrl
+    uploadAssetFromUrl,
+    uploadAssetFromBase64
   }
 }
 


### PR DESCRIPTION
## Summary
Stores and displays base64-encoded preview images from Civitai during the model upload flow, uploading the preview as a separate asset linked to the model.

## Changes
- **Schema**: Added `preview_image` field to `AssetMetadata` schema
- **Service**: Added `uploadAssetFromBase64` method to convert base64 data to blob and upload via FormData
- **Upload Flow**: Modified wizard to first upload preview image as asset, then link it to model via `preview_id`
- **UI**: Display 56x56px preview thumbnail alongside model filename in confirmation and success steps

## Review Focus
- Base64 to blob conversion and FormData upload implementation
- Sequential upload flow (preview first, then model with preview_id reference)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7274-feat-display-and-upload-Civitai-preview-images-in-model-upload-flow-2c46d73d365081ff9b74c1791d23f6dd) by [Unito](https://www.unito.io)
