### PR TITLE
Nesting support for autogrow

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -21,7 +21,7 @@ import { useLitegraphService } from '@/services/litegraphService'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
 
-const INLINE_INPUTS = true
+const INLINE_INPUTS = false
 
 type MatchTypeNode = LGraphNode &
   Pick<Required<LGraphNode>, 'comfyMatchType' | 'onConnectionsChange'>

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -481,6 +481,7 @@ function autogrowInputDisconnected(index: number, node: AutogrowNode) {
     lastInput.link = null
   }
   app.canvas?.setDirty(true, true)
+  if (groupInputs.length / stride <= min) return
   //if all second to last ordinals disconnected, consider for removal
   const penultimateInputs = groupInputs.slice(-stride * 2)
   if (

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -416,8 +416,7 @@ export class LGraphNode
   selected?: boolean
   showAdvanced?: boolean
 
-  declare comfyMatchType?: Record<string, Record<string, string>>
-  declare comfyAutogrow?: unknown
+  declare comfyDynamic?: Record<string, object>
   declare comfyClass?: string
   declare isVirtualNode?: boolean
   applyToGraph?(extraLinks?: LLink[]): void

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -417,6 +417,7 @@ export class LGraphNode
   showAdvanced?: boolean
 
   declare comfyMatchType?: Record<string, Record<string, string>>
+  declare comfyAutogrow?: unknown
   declare comfyClass?: string
   declare isVirtualNode?: boolean
   applyToGraph?(extraLinks?: LLink[]): void

--- a/tests-ui/tests/widgets/dynamicCombo.test.ts
+++ b/tests-ui/tests/widgets/dynamicCombo.test.ts
@@ -118,8 +118,8 @@ describe('Autogrow', () => {
     connectInput(node, 1, graph)
     connectInput(node, 2, graph)
     expect(node.inputs.length).toBe(4)
-    expect(node.inputs[0].name).toBe('test0')
-    expect(node.inputs[2].name).toBe('test2')
+    expect(node.inputs[0].name).toBe('0.test0')
+    expect(node.inputs[2].name).toBe('0.test2')
   })
   test('Can name by list of names', () => {
     const graph = new LGraph()
@@ -130,8 +130,8 @@ describe('Autogrow', () => {
     connectInput(node, 1, graph)
     connectInput(node, 2, graph)
     expect(node.inputs.length).toBe(3)
-    expect(node.inputs[0].name).toBe('a')
-    expect(node.inputs[2].name).toBe('c')
+    expect(node.inputs[0].name).toBe('0.a')
+    expect(node.inputs[2].name).toBe('0.c')
   })
   test('Can add autogrow with min input count', () => {
     const node = testNode()


### PR DESCRIPTION
- Modifies autogrow inputs to be named by key
- Allows autogrow inputs to be added after initialization.
  - Such as when added by another dynamic combo
- Groups dynamic input information under a single comfyDynamic property which is opaque to Litegraph

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7275-Nesting-support-for-autogrow-2c46d73d36508171893ec43275f5b644) by [Unito](https://www.unito.io)
