### PR TITLE
feat: Enable system notifications on cloud

### DIFF
--- a/src/stores/systemStatsStore.ts
+++ b/src/stores/systemStatsStore.ts
@@ -1,6 +1,7 @@
 import { useAsyncState } from '@vueuse/core'
 import { defineStore } from 'pinia'
 
+import { isCloud } from '@/platform/distribution/types'
 import type { SystemStats } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { isElectron } from '@/utils/envUtil'
@@ -30,6 +31,10 @@ export const useSystemStatsStore = defineStore('systemStats', () => {
   )
 
   function getFormFactor(): string {
+    if (isCloud) {
+      return 'cloud'
+    }
+
     if (!systemStats.value?.system?.os) {
       return 'other'
     }

--- a/tests-ui/tests/store/releaseStore.test.ts
+++ b/tests-ui/tests/store/releaseStore.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { compare as semverCompare } from 'semver'
+import { compare, valid } from 'semver'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useReleaseStore } from '@/platform/updates/common/releaseStore'
@@ -7,6 +7,7 @@ import { useReleaseStore } from '@/platform/updates/common/releaseStore'
 // Mock the dependencies
 vi.mock('semver')
 vi.mock('@/utils/envUtil')
+vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
 vi.mock('@/platform/updates/common/releaseService')
 vi.mock('@/platform/settings/settingStore')
 vi.mock('@/stores/systemStatsStore')
@@ -72,6 +73,7 @@ describe('useReleaseStore', () => {
     vi.mocked(useSettingStore).mockReturnValue(mockSettingStore)
     vi.mocked(useSystemStatsStore).mockReturnValue(mockSystemStatsStore)
     vi.mocked(isElectron).mockReturnValue(true)
+    vi.mocked(valid).mockReturnValue('1.0.0')
 
     // Default showVersionUpdates to true
     mockSettingStore.get.mockImplementation((key: string) => {
@@ -116,14 +118,14 @@ describe('useReleaseStore', () => {
     })
 
     it('should show update button (shouldShowUpdateButton)', () => {
-      vi.mocked(semverCompare).mockReturnValue(1) // newer version available
+      vi.mocked(compare).mockReturnValue(1) // newer version available
 
       store.releases = [mockRelease]
       expect(store.shouldShowUpdateButton).toBe(true)
     })
 
     it('should not show update button when no new version', () => {
-      vi.mocked(semverCompare).mockReturnValue(-1) // current version is newer
+      vi.mocked(compare).mockReturnValue(-1) // current version is newer
 
       store.releases = [mockRelease]
       expect(store.shouldShowUpdateButton).toBe(false)
@@ -144,14 +146,14 @@ describe('useReleaseStore', () => {
       })
 
       it('should show toast for medium/high attention releases', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
         store.releases = [mockRelease]
 
         expect(store.shouldShowToast).toBe(true)
       })
 
       it('should not show toast for low attention releases', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         const lowAttentionRelease = {
           ...mockRelease,
@@ -164,7 +166,7 @@ describe('useReleaseStore', () => {
       })
 
       it('should show red dot for new versions', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         expect(store.shouldShowRedDot).toBe(true)
       })
@@ -172,7 +174,7 @@ describe('useReleaseStore', () => {
       it('should show popup for latest version', () => {
         mockSystemStatsStore.systemStats.system.comfyui_version = '1.2.0'
 
-        vi.mocked(semverCompare).mockReturnValue(0)
+        vi.mocked(compare).mockReturnValue(0)
 
         expect(store.shouldShowPopup).toBe(true)
       })
@@ -200,13 +202,13 @@ describe('useReleaseStore', () => {
       })
 
       it('should not show toast even with new version available', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         expect(store.shouldShowToast).toBe(false)
       })
 
       it('should not show red dot even with new version available', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         expect(store.shouldShowRedDot).toBe(false)
       })
@@ -214,7 +216,7 @@ describe('useReleaseStore', () => {
       it('should not show popup even for latest version', () => {
         mockSystemStatsStore.systemStats.system.comfyui_version = '1.2.0'
 
-        vi.mocked(semverCompare).mockReturnValue(0)
+        vi.mocked(compare).mockReturnValue(0)
 
         expect(store.shouldShowPopup).toBe(false)
       })
@@ -494,7 +496,7 @@ describe('useReleaseStore', () => {
         return null
       })
 
-      vi.mocked(semverCompare).mockReturnValue(1)
+      vi.mocked(compare).mockReturnValue(1)
 
       store.releases = [mockRelease]
 
@@ -502,7 +504,7 @@ describe('useReleaseStore', () => {
     })
 
     it('should show red dot for new versions', () => {
-      vi.mocked(semverCompare).mockReturnValue(1)
+      vi.mocked(compare).mockReturnValue(1)
       mockSettingStore.get.mockImplementation((key: string) => {
         if (key === 'Comfy.Notification.ShowVersionUpdates') return true
         return null
@@ -520,7 +522,7 @@ describe('useReleaseStore', () => {
         return null
       })
 
-      vi.mocked(semverCompare).mockReturnValue(0) // versions are equal (latest version)
+      vi.mocked(compare).mockReturnValue(0) // versions are equal (latest version)
 
       store.releases = [mockRelease]
 
@@ -578,14 +580,14 @@ describe('useReleaseStore', () => {
       })
 
       it('should show toast when conditions are met', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
         store.releases = [mockRelease]
 
         expect(store.shouldShowToast).toBe(true)
       })
 
       it('should show red dot when new version available', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         expect(store.shouldShowRedDot).toBe(true)
       })
@@ -593,7 +595,7 @@ describe('useReleaseStore', () => {
       it('should show popup for latest version', () => {
         mockSystemStatsStore.systemStats.system.comfyui_version = '1.2.0'
 
-        vi.mocked(semverCompare).mockReturnValue(0)
+        vi.mocked(compare).mockReturnValue(0)
 
         expect(store.shouldShowPopup).toBe(true)
       })
@@ -606,7 +608,7 @@ describe('useReleaseStore', () => {
       })
 
       it('should NOT show toast even when all other conditions are met', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         // Set up all conditions that would normally show toast
         store.releases = [mockRelease]
@@ -615,13 +617,13 @@ describe('useReleaseStore', () => {
       })
 
       it('should NOT show red dot even when new version available', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         expect(store.shouldShowRedDot).toBe(false)
       })
 
       it('should NOT show toast regardless of attention level', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         // Test with high attention releases
         const highRelease = {
@@ -640,7 +642,7 @@ describe('useReleaseStore', () => {
       })
 
       it('should NOT show red dot even with high attention release', () => {
-        vi.mocked(semverCompare).mockReturnValue(1)
+        vi.mocked(compare).mockReturnValue(1)
 
         store.releases = [{ ...mockRelease, attention: 'high' as const }]
 
@@ -650,7 +652,7 @@ describe('useReleaseStore', () => {
       it('should NOT show popup even for latest version', () => {
         mockSystemStatsStore.systemStats.system.comfyui_version = '1.2.0'
 
-        vi.mocked(semverCompare).mockReturnValue(0)
+        vi.mocked(compare).mockReturnValue(0)
 
         expect(store.shouldShowPopup).toBe(false)
       })

--- a/tests-ui/tests/store/systemStatsStore.test.ts
+++ b/tests-ui/tests/store/systemStatsStore.test.ts
@@ -17,6 +17,8 @@ vi.mock('@/utils/envUtil', () => ({
   isElectron: vi.fn()
 }))
 
+vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
+
 describe('useSystemStatsStore', () => {
   let store: ReturnType<typeof useSystemStatsStore>
 


### PR DESCRIPTION
Re-enables the system notification popup for cloud distribution, allowing cloud devs to notify cloud users about new features and updates without requiring a new release.

Cloud now fetches release notes from the "cloud" project (instead of "comfyui") and uses the `cloud_version` field for version comparison. Since cloud versions are git hashes rather than semver, a helper handles both formats gracefully.

The "What's New" popup is enabled for cloud, while the update toast and red dot indicator remain desktop-only since cloud auto-updates and doesn't require user action.

You can test this by doing `pnpm dev:cloud` and you will see a notification I added (for testing):

<img width="1891" height="2077" alt="image" src="https://github.com/user-attachments/assets/6599a6dc-a3e1-406f-a22d-14262be1f258" />

Content is controlled by non-devs at cms.comfy.org.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7277-feat-Enable-system-notifications-on-cloud-2c46d73d365081bcb33cd79ec18faefe) by [Unito](https://www.unito.io)
