### PR TITLE
fix: release notifications unit tests missing i18n mocks

### DIFF
--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -20,6 +20,11 @@ vi.mock('vue-i18n', () => ({
       }
       return translations[key] || key
     })
+  })),
+  createI18n: vi.fn(() => ({
+    global: {
+      locale: { value: 'en' }
+    }
   }))
 }))
 

--- a/src/platform/updates/components/WhatsNewPopup.test.ts
+++ b/src/platform/updates/components/WhatsNewPopup.test.ts
@@ -16,6 +16,13 @@ const mockTranslations: Record<string, string> = {
 }
 
 vi.mock('@/i18n', () => ({
+  i18n: {
+    global: {
+      locale: {
+        value: 'en'
+      }
+    }
+  },
   t: (key: string, params?: Record<string, string>) => {
     return params
       ? `${mockTranslations[key] || key}:${JSON.stringify(params)}`


### PR DESCRIPTION
## Summary
- Fix missing `i18n` export in `@/i18n` mock for WhatsNewPopup tests
- Fix missing `createI18n` export in `vue-i18n` mock for ReleaseNotificationToast tests

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7281-fix-release-notifications-unit-tests-missing-i18n-mocks-2c46d73d365081e595eadaca6a4ace5d) by [Unito](https://www.unito.io)
