### PR TITLE
make jojodecayz and bigcat88 owners of partner node pricing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,6 +25,9 @@
 # Link rendering
 /src/renderer/core/canvas/links/                  @benceruleanlu
 
+# Partner Nodes
+/src/composables/node/useNodePricing.ts           @jojodecayz @bigcat88
+
 # Node help system
 /src/utils/nodeHelpUtil.ts                        @benceruleanlu
 /src/stores/workspace/nodeHelpStore.ts            @benceruleanlu


### PR DESCRIPTION
## Summary

Allows partner node team to quickly approve/merge each other's PRs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7284-make-jojodecayz-and-bigcat88-owners-of-partner-node-pricing-2c46d73d365081b08295d3204f8ca13c) by [Unito](https://www.unito.io)
