### PR TITLE
[fix] Fall back to current minor when next minor branch doesn't exist

### DIFF
--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -134,22 +134,38 @@ function resolveRelease(
 
   const [major, currentMinor, patch] = currentVersion.split('.').map(Number)
 
-  // Calculate target minor version (next minor)
-  const targetMinor = currentMinor + 1
-  const targetBranch = `core/1.${targetMinor}`
-
-  // Check if target branch exists in frontend repo
+  // Fetch all branches
   exec('git fetch origin', frontendRepoPath)
-  const branchExists = exec(
+
+  // Try next minor first, fall back to current minor if not available
+  let targetMinor = currentMinor + 1
+  let targetBranch = `core/1.${targetMinor}`
+
+  const nextMinorExists = exec(
     `git rev-parse --verify origin/${targetBranch}`,
     frontendRepoPath
   )
 
-  if (!branchExists) {
-    console.error(
-      `Target branch ${targetBranch} does not exist in frontend repo`
+  if (!nextMinorExists) {
+    // Fall back to current minor for patch releases
+    targetMinor = currentMinor
+    targetBranch = `core/1.${targetMinor}`
+
+    const currentMinorExists = exec(
+      `git rev-parse --verify origin/${targetBranch}`,
+      frontendRepoPath
     )
-    return null
+
+    if (!currentMinorExists) {
+      console.error(
+        `Neither core/1.${currentMinor + 1} nor core/1.${currentMinor} branches exist in frontend repo`
+      )
+      return null
+    }
+
+    console.error(
+      `Next minor branch core/1.${currentMinor + 1} not found, falling back to core/1.${currentMinor} for patch release`
+    )
   }
 
   // Get latest patch tag for target minor


### PR DESCRIPTION
## Summary
- When the next minor branch (e.g., `core/1.35`) doesn't exist yet, fall back to current minor (`core/1.34`) for patch releases instead of failing
- Fixes the weekly release workflow failure when ComfyUI is on version 1.33.x and `core/1.34` doesn't exist yet

## Test plan
- [x] Tested locally with version where next minor exists (1.33.5 → finds core/1.34)
- [x] Tested fallback when next minor doesn't exist (1.34.7 → falls back to core/1.34)
- [x] Tested error case when neither branch exists

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7286-fix-Fall-back-to-current-minor-when-next-minor-branch-doesn-t-exist-2c46d73d365081009762c732954e148d) by [Unito](https://www.unito.io)
