### PR TITLE
fix: Note/MarkdownNote node color change not reactive in vueNodes mode

### DIFF
--- a/src/extensions/core/noteNode.ts
+++ b/src/extensions/core/noteNode.ts
@@ -14,13 +14,15 @@ app.registerExtension({
       static collapsable: boolean
       static title_mode: number
 
-      override color = LGraphCanvas.node_colors.yellow.color
-      override bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
       groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
       override isVirtualNode: boolean
 
       constructor(title: string) {
         super(title)
+
+        this.color = LGraphCanvas.node_colors.yellow.color
+        this.bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
+
         if (!this.properties) {
           this.properties = { text: '' }
         }
@@ -53,12 +55,14 @@ app.registerExtension({
     class MarkdownNoteNode extends LGraphNode {
       static override title = 'Markdown Note'
 
-      override color = LGraphCanvas.node_colors.yellow.color
-      override bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
       groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
 
       constructor(title: string) {
         super(title)
+
+        this.color = LGraphCanvas.node_colors.yellow.color
+        this.bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
+
         if (!this.properties) {
           this.properties = { text: '' }
         }


### PR DESCRIPTION
## Summary

Move color/bgcolor initialization from class field overrides to constructor to preserve LGraphNodeProperties getter/setter instrumentation. 

Class field overrides were replacing the reactive property descriptors set by the parent constructor, preventing change events from firing.

issue found while tesing in https://github.com/Comfy-Org/ComfyUI_frontend/issues/3449

## Screenshots
Before

https://github.com/user-attachments/assets/04499a3a-15c2-44fd-9819-6dd5f6849f20


After

https://github.com/user-attachments/assets/ba93278b-9761-4d45-abb3-2a57ff95a900

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7294-fix-Note-MarkdownNote-node-color-change-not-reactive-in-vueNodes-mode-2c46d73d3650818f8ee6f6f0c0e61d39) by [Unito](https://www.unito.io)
