### PR TITLE
style: redesign user popover with improved layout and integration with design system

### DIFF
--- a/src/components/topbar/CurrentUserPopover.test.ts
+++ b/src/components/topbar/CurrentUserPopover.test.ts
@@ -184,7 +184,7 @@ describe('CurrentUserPopover', () => {
     const wrapper = mountComponent()
 
     expect(formatCreditsFromCents).toHaveBeenCalledWith({
-      cents: 100000,
+      cents: 100_000,
       locale: 'en',
       numberOptions: {
         minimumFractionDigits: 0,

--- a/src/components/topbar/CurrentUserPopover.test.ts
+++ b/src/components/topbar/CurrentUserPopover.test.ts
@@ -75,7 +75,7 @@ vi.mock('@/stores/firebaseAuthStore', () => ({
     getAuthHeader: vi
       .fn()
       .mockResolvedValue({ Authorization: 'Bearer mock-token' }),
-    balance: { amount_micros: 100000 }, // 100,000 cents = ~211,000 credits
+    balance: { amount_micros: 100_000 }, // 100,000 cents = ~211,000 credits
     isFetchingBalance: false
   }))
 }))

--- a/src/components/topbar/CurrentUserPopover.test.ts
+++ b/src/components/topbar/CurrentUserPopover.test.ts
@@ -75,7 +75,7 @@ vi.mock('@/stores/firebaseAuthStore', () => ({
     getAuthHeader: vi
       .fn()
       .mockResolvedValue({ Authorization: 'Bearer mock-token' }),
-    balance: { amount_micros: 100000 }, // 100 credits worth in cents
+    balance: { amount_micros: 100000 }, // 100,000 cents = ~211,000 credits
     isFetchingBalance: false
   }))
 }))
@@ -259,7 +259,6 @@ describe('CurrentUserPopover', () => {
   it('opens top-up dialog and emits close event when top-up button is clicked', async () => {
     const wrapper = mountComponent()
 
-    // Find the top-up button (this is still a Button component)
     const buttons = wrapper.findAllComponents(Button)
     const topUpButton = buttons.find(
       (button) =>
@@ -268,8 +267,11 @@ describe('CurrentUserPopover', () => {
     )
     expect(topUpButton).toBeTruthy()
 
-    // Click the top-up button
-    await topUpButton!.trigger('click')
+    if (!topUpButton) {
+      throw new Error('Top-up button not found')
+    }
+
+    await topUpButton.trigger('click')
 
     // Verify showTopUpCreditsDialog was called
     expect(mockShowTopUpCreditsDialog).toHaveBeenCalled()

--- a/src/components/topbar/CurrentUserPopover.test.ts
+++ b/src/components/topbar/CurrentUserPopover.test.ts
@@ -1,6 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import Button from 'primevue/button'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -181,8 +180,8 @@ describe('CurrentUserPopover', () => {
     expect(wrapper.text()).toContain('test@example.com')
   })
 
-  it('calls formatCreditsFromCents with correct parameters', () => {
-    mountComponent()
+  it('calls formatCreditsFromCents with correct parameters and displays formatted credits', () => {
+    const wrapper = mountComponent()
 
     expect(formatCreditsFromCents).toHaveBeenCalledWith({
       cents: 100000,
@@ -192,29 +191,26 @@ describe('CurrentUserPopover', () => {
         maximumFractionDigits: 2
       }
     })
+
+    // Verify the formatted credit string (1000) is rendered in the DOM
+    expect(wrapper.text()).toContain('1000')
   })
 
   it('renders logout menu item with correct text', () => {
     const wrapper = mountComponent()
 
-    const logoutIcon = wrapper.find('.icon-\\[lucide--log-out\\]')
-    expect(logoutIcon.exists()).toBe(true)
+    const logoutItem = wrapper.find('[data-testid="logout-menu-item"]')
+    expect(logoutItem.exists()).toBe(true)
     expect(wrapper.text()).toContain('Log Out')
   })
 
   it('opens user settings and emits close event when settings item is clicked', async () => {
     const wrapper = mountComponent()
 
-    const settingsIcon = wrapper.find('.icon-\\[lucide--settings-2\\]')
-    const settingsItem = settingsIcon.element?.closest('div')
-    expect(settingsItem).toBeTruthy()
+    const settingsItem = wrapper.find('[data-testid="user-settings-menu-item"]')
+    expect(settingsItem.exists()).toBe(true)
 
-    if (!settingsItem || !(settingsItem instanceof HTMLElement)) {
-      throw new Error('Settings item not found or not an HTMLElement')
-    }
-
-    settingsItem.click()
-    await wrapper.vm.$nextTick()
+    await settingsItem.trigger('click')
 
     // Verify showSettingsDialog was called with 'user'
     expect(mockShowSettingsDialog).toHaveBeenCalledWith('user')
@@ -227,13 +223,10 @@ describe('CurrentUserPopover', () => {
   it('calls logout function and emits close event when logout item is clicked', async () => {
     const wrapper = mountComponent()
 
-    // Find the logout menu item by its icon
-    const logoutIcon = wrapper.find('.icon-\\[lucide--log-out\\]')
-    const logoutItem = logoutIcon.element?.closest('div')
-    expect(logoutItem).toBeTruthy()
+    const logoutItem = wrapper.find('[data-testid="logout-menu-item"]')
+    expect(logoutItem.exists()).toBe(true)
 
-    // Click the logout item
-    await wrapper.find('.icon-\\[lucide--log-out\\]').trigger('click')
+    await logoutItem.trigger('click')
 
     // Verify handleSignOut was called
     expect(mockHandleSignOut).toHaveBeenCalled()
@@ -246,13 +239,12 @@ describe('CurrentUserPopover', () => {
   it('opens API pricing docs and emits close event when partner nodes item is clicked', async () => {
     const wrapper = mountComponent()
 
-    // Find the partner nodes menu item by its icon
-    const partnerNodesIcon = wrapper.find('.icon-\\[lucide--tag\\]')
-    const partnerNodesItem = partnerNodesIcon.element?.closest('div')
-    expect(partnerNodesItem).toBeTruthy()
+    const partnerNodesItem = wrapper.find(
+      '[data-testid="partner-nodes-menu-item"]'
+    )
+    expect(partnerNodesItem.exists()).toBe(true)
 
-    // Click the partner nodes item
-    await wrapper.find('.icon-\\[lucide--tag\\]').trigger('click')
+    await partnerNodesItem.trigger('click')
 
     // Verify window.open was called with the correct URL
     expect(window.open).toHaveBeenCalledWith(
@@ -268,17 +260,8 @@ describe('CurrentUserPopover', () => {
   it('opens top-up dialog and emits close event when top-up button is clicked', async () => {
     const wrapper = mountComponent()
 
-    const buttons = wrapper.findAllComponents(Button)
-    const topUpButton = buttons.find(
-      (button) =>
-        button.props('label')?.includes('Add credits') ||
-        button.text().includes('Add credits')
-    )
-    expect(topUpButton).toBeTruthy()
-
-    if (!topUpButton) {
-      throw new Error('Top-up button not found')
-    }
+    const topUpButton = wrapper.find('[data-testid="add-credits-button"]')
+    expect(topUpButton.exists()).toBe(true)
 
     await topUpButton.trigger('click')
 

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -1,120 +1,126 @@
 <!-- A popover that shows current user information and actions -->
 <template>
-  <div class="current-user-popover w-72">
+  <div
+    class="current-user-popover w-80 -m-3 p-2 rounded-lg border border-border-default bg-base-background shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+  >
     <!-- User Info Section -->
-    <div class="p-3">
-      <div class="flex flex-col items-center">
-        <UserAvatar
-          class="mb-3"
-          :photo-url="userPhotoUrl"
-          :pt:icon:class="{
-            'text-2xl!': !userPhotoUrl
-          }"
-          size="large"
-        />
+    <div class="flex flex-col items-center px-0 py-3 mb-4">
+      <UserAvatar
+        class="mb-1"
+        :photo-url="userPhotoUrl"
+        :pt:icon:class="{
+          'text-2xl!': !userPhotoUrl
+        }"
+        size="large"
+      />
 
-        <!-- User Details -->
-        <h3 class="my-0 mb-1 truncate text-lg font-semibold">
-          {{ userDisplayName || $t('g.user') }}
-        </h3>
-        <p v-if="userEmail" class="my-0 truncate text-sm text-muted">
-          {{ userEmail }}
-        </p>
-      </div>
+      <!-- User Details -->
+      <h3 class="my-0 mb-1 truncate text-base font-bold text-base-foreground">
+        {{ userDisplayName || $t('g.user') }}
+      </h3>
+      <p v-if="userEmail" class="my-0 truncate text-sm text-muted">
+        {{ userEmail }}
+      </p>
     </div>
 
-    <div v-if="isActiveSubscription" class="flex items-center justify-between">
-      <div class="flex flex-col gap-1">
-        <UserCredit text-class="text-2xl" />
-        <div
-          v-if="flags.subscriptionTiersEnabled"
-          class="flex items-center gap-2"
-        >
-          <i
-            v-tooltip="{
-              value: $t('credits.unified.tooltip'),
-              showDelay: 300,
-              hideDelay: 300
-            }"
-            class="icon-[lucide--circle-help] text-muted cursor-help text-xs"
-          />
-          <span class="text-xs text-muted">{{
-            $t('credits.unified.message')
-          }}</span>
-        </div>
-        <Button
-          :label="$t('subscription.partnerNodesCredits')"
-          severity="secondary"
-          text
-          size="small"
-          class="pl-6 p-0 h-auto justify-start"
-          :pt="{
-            root: {
-              class: 'hover:bg-transparent active:bg-transparent'
-            }
-          }"
-          @click="handleOpenPartnerNodesInfo"
-        />
-      </div>
+    <!-- Credits Section -->
+    <div v-if="isActiveSubscription" class="flex items-center gap-2 px-4 py-2">
+      <i class="icon-[lucide--component] text-amber-400 text-sm" />
+      <span class="text-base font-normal text-white flex-1">{{
+        formattedBalance
+      }}</span>
       <Button
-        :label="$t('credits.topUp.topUp')"
+        :label="$t('subscription.addCredits')"
         severity="secondary"
         size="small"
+        class="text-base-foreground"
         @click="handleTopUp"
       />
     </div>
+
     <SubscribeButton
       v-else
+      class="mx-4"
       :label="$t('subscription.subscribeToComfyCloud')"
       size="small"
       variant="gradient"
       @subscribed="handleSubscribed"
     />
 
-    <Divider class="my-2" />
+    <!-- Credits info row -->
+    <div
+      v-if="flags.subscriptionTiersEnabled && isActiveSubscription"
+      class="flex items-center gap-2 px-4 py-0"
+    >
+      <i
+        v-tooltip="{
+          value: $t('credits.unified.tooltip'),
+          showDelay: 300,
+          hideDelay: 300
+        }"
+        class="icon-[lucide--circle-help] cursor-help text-xs text-muted-foreground"
+      />
+      <span class="text-sm text-muted-foreground">{{
+        $t('credits.unified.message')
+      }}</span>
+    </div>
 
-    <Button
-      class="justify-start"
-      :label="$t('userSettings.title')"
-      icon="pi pi-cog"
-      text
-      fluid
-      severity="secondary"
-      @click="handleOpenUserSettings"
-    />
+    <Divider class="my-2 mx-0" />
 
-    <Button
+    <!-- Menu Items -->
+    <!-- Partner nodes row -->
+    <div
       v-if="isActiveSubscription"
-      class="justify-start"
-      :label="$t(planSettingsLabel)"
-      icon="pi pi-receipt"
-      text
-      fluid
-      severity="secondary"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
+      @click="handleOpenPartnerNodesInfo"
+    >
+      <i class="icon-[lucide--tag] text-muted-foreground text-sm" />
+      <span class="text-sm text-white flex-1">{{
+        $t('subscription.partnerNodesCredits')
+      }}</span>
+    </div>
+
+    <div
+      v-if="isActiveSubscription"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
       @click="handleOpenPlanAndCreditsSettings"
-    />
+    >
+      <i class="icon-[lucide--receipt-text] text-muted-foreground text-sm" />
+      <span class="text-sm text-white flex-1">{{ $t(planSettingsLabel) }}</span>
+    </div>
 
-    <Divider class="my-2" />
+    <div
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
+      @click="handleOpenUserSettings"
+    >
+      <i class="icon-[lucide--settings-2] text-muted-foreground text-sm" />
+      <span class="text-sm text-white flex-1">{{
+        $t('userSettings.title')
+      }}</span>
+    </div>
 
-    <Button
-      class="justify-start"
-      :label="$t('auth.signOut.signOut')"
-      icon="pi pi-sign-out"
-      text
-      fluid
-      severity="secondary"
+    <Divider class="my-2 mx-0" />
+
+    <div
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
       @click="handleLogout"
-    />
+    >
+      <i class="icon-[lucide--log-out] text-muted-foreground text-sm" />
+      <span class="text-sm text-white flex-1">{{
+        $t('auth.signOut.signOut')
+      }}</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import Button from 'primevue/button'
 import Divider from 'primevue/divider'
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 
+import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
 import UserAvatar from '@/components/common/UserAvatar.vue'
-import UserCredit from '@/components/common/UserCredit.vue'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -124,6 +130,7 @@ import { useSubscription } from '@/platform/cloud/subscription/composables/useSu
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
+import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 
 const emit = defineEmits<{
   close: []
@@ -138,9 +145,24 @@ const planSettingsLabel = isCloud
 const { userDisplayName, userEmail, userPhotoUrl, handleSignOut } =
   useCurrentUser()
 const authActions = useFirebaseAuthActions()
+const authStore = useFirebaseAuthStore()
 const dialogService = useDialogService()
 const { isActiveSubscription, fetchStatus } = useSubscription()
 const { flags } = useFeatureFlags()
+const { locale } = useI18n()
+
+const formattedBalance = computed(() => {
+  // Backend returns cents despite the *_micros naming convention.
+  const cents = authStore.balance?.amount_micros ?? 0
+  return formatCreditsFromCents({
+    cents,
+    locale: locale.value,
+    numberOptions: {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2
+    }
+  })
+})
 
 const handleOpenUserSettings = () => {
   dialogService.showSettingsDialog('user')
@@ -187,3 +209,9 @@ onMounted(() => {
   void authActions.fetchBalance()
 })
 </script>
+
+<style scoped>
+.menu-item-hover:hover {
+  background-color: var(--secondary-background-hover);
+}
+</style>

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -67,8 +67,6 @@
 
     <Divider class="my-2 mx-0" />
 
-    <!-- Menu Items -->
-    <!-- Partner nodes row -->
     <div
       v-if="isActiveSubscription"
       class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -70,7 +70,7 @@
 
     <div
       v-if="isActiveSubscription"
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-secondary-background-hover"
       data-testid="partner-nodes-menu-item"
       @click="handleOpenPartnerNodesInfo"
     >
@@ -82,7 +82,7 @@
 
     <div
       v-if="isActiveSubscription"
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-secondary-background-hover"
       data-testid="plan-credits-menu-item"
       @click="handleOpenPlanAndCreditsSettings"
     >
@@ -93,7 +93,7 @@
     </div>
 
     <div
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-secondary-background-hover"
       data-testid="user-settings-menu-item"
       @click="handleOpenUserSettings"
     >
@@ -106,7 +106,7 @@
     <Divider class="my-2 mx-0" />
 
     <div
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-secondary-background-hover"
       data-testid="logout-menu-item"
       @click="handleLogout"
     >

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -34,6 +34,7 @@
         severity="secondary"
         size="small"
         class="text-base-foreground"
+        data-testid="add-credits-button"
         @click="handleTopUp"
       />
     </div>
@@ -70,6 +71,7 @@
     <div
       v-if="isActiveSubscription"
       class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      data-testid="partner-nodes-menu-item"
       @click="handleOpenPartnerNodesInfo"
     >
       <i class="icon-[lucide--tag] text-muted-foreground text-sm" />
@@ -81,6 +83,7 @@
     <div
       v-if="isActiveSubscription"
       class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      data-testid="plan-credits-menu-item"
       @click="handleOpenPlanAndCreditsSettings"
     >
       <i class="icon-[lucide--receipt-text] text-muted-foreground text-sm" />
@@ -91,6 +94,7 @@
 
     <div
       class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      data-testid="user-settings-menu-item"
       @click="handleOpenUserSettings"
     >
       <i class="icon-[lucide--settings-2] text-muted-foreground text-sm" />
@@ -103,6 +107,7 @@
 
     <div
       class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
+      data-testid="logout-menu-item"
       @click="handleLogout"
     >
       <i class="icon-[lucide--log-out] text-muted-foreground text-sm" />

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -26,7 +26,7 @@
     <!-- Credits Section -->
     <div v-if="isActiveSubscription" class="flex items-center gap-2 px-4 py-2">
       <i class="icon-[lucide--component] text-amber-400 text-sm" />
-      <span class="text-base font-normal text-white flex-1">{{
+      <span class="text-base font-normal text-base-foreground flex-1">{{
         formattedBalance
       }}</span>
       <Button
@@ -71,30 +71,32 @@
     <!-- Partner nodes row -->
     <div
       v-if="isActiveSubscription"
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
       @click="handleOpenPartnerNodesInfo"
     >
       <i class="icon-[lucide--tag] text-muted-foreground text-sm" />
-      <span class="text-sm text-white flex-1">{{
+      <span class="text-sm text-base-foreground flex-1">{{
         $t('subscription.partnerNodesCredits')
       }}</span>
     </div>
 
     <div
       v-if="isActiveSubscription"
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
       @click="handleOpenPlanAndCreditsSettings"
     >
       <i class="icon-[lucide--receipt-text] text-muted-foreground text-sm" />
-      <span class="text-sm text-white flex-1">{{ $t(planSettingsLabel) }}</span>
+      <span class="text-sm text-base-foreground flex-1">{{
+        $t(planSettingsLabel)
+      }}</span>
     </div>
 
     <div
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
       @click="handleOpenUserSettings"
     >
       <i class="icon-[lucide--settings-2] text-muted-foreground text-sm" />
-      <span class="text-sm text-white flex-1">{{
+      <span class="text-sm text-base-foreground flex-1">{{
         $t('userSettings.title')
       }}</span>
     </div>
@@ -102,11 +104,11 @@
     <Divider class="my-2 mx-0" />
 
     <div
-      class="flex items-center gap-2 px-4 py-2 cursor-pointer menu-item-hover"
+      class="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-[var(--secondary-background-hover)]"
       @click="handleLogout"
     >
       <i class="icon-[lucide--log-out] text-muted-foreground text-sm" />
-      <span class="text-sm text-white flex-1">{{
+      <span class="text-sm text-base-foreground flex-1">{{
         $t('auth.signOut.signOut')
       }}</span>
     </div>
@@ -209,9 +211,3 @@ onMounted(() => {
   void authActions.fetchBalance()
 })
 </script>
-
-<style scoped>
-.menu-item-hover:hover {
-  background-color: var(--secondary-background-hover);
-}
-</style>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1922,10 +1922,10 @@
     "haveQuestions": "Have questions or wondering about enterprise?",
     "contactUs": "Contact us",
     "viewEnterprise": "view enterprise",
-    "partnerNodesCredits": "Partner Nodes pricing table"
+    "partnerNodesCredits": "Partner nodes pricing"
   },
   "userSettings": {
-    "title": "User Settings",
+    "title": "My Account Settings",
     "name": "Name",
     "email": "Email",
     "provider": "Sign-in Provider",


### PR DESCRIPTION
Implements new Figma design for the user popover with cleaner row-based layout, proper design system tokens, and improved spacing. Replaces PrimeVue icons with Lucide icons, fixes credits display to show whole numbers without unnecessary decimals, updates menu item order to match design specifications, and ensures consistent hover states and typography throughout. All styling now uses Tailwind classes with proper semantic design tokens instead of inline styles.

| Before                                                                                                                                | After                                                                                                                                         |
| --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="815" height="973" alt="image" src="https://github.com/user-attachments/assets/b2c15fa0-f545-4dcf-b224-cee846885337" /> | <img width="815" height="973" alt="image" src="https://github.com/user-attachments/assets/1f0bf488-5e15-4bb9-84b7-019cdd5105ae" /> |



