### PR TITLE
fix: trigger widget callback when model is selected

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -150,6 +150,13 @@ const renderedRoot = computed<TreeExplorerNode<ModelOrFolder>>(() => {
             if (widget) {
               // @ts-expect-error fixme ts strict error
               widget.value = model.file_name
+              if (model) {
+                widget.callback?.(model!.file_name)
+                // Force the reactive widgets array to update
+                if (node.widgets) {
+                  node.widgets = [...node.widgets]
+                }
+              }
             }
           }
         } else {

--- a/src/composables/useCanvasDrop.ts
+++ b/src/composables/useCanvasDrop.ts
@@ -73,6 +73,11 @@ export const useCanvasDrop = (canvasRef: Ref<HTMLCanvasElement | null>) => {
             )
             if (widget) {
               widget.value = model.file_name
+              widget.callback?.(model.file_name)
+              // Force the reactive widgets array to update
+              if (targetGraphNode.widgets) {
+                targetGraphNode.widgets = [...targetGraphNode.widgets]
+              }
             }
           }
         } else if (node.data instanceof ComfyWorkflow) {


### PR DESCRIPTION
## Summary
- Call widget callback when model is selected from library or dropped onto canvas
- Force reactive widgets array update to ensure UI reflects changes

## Before

https://github.com/user-attachments/assets/dd9fcab3-0cf2-40b5-a813-ad1dd812d7b7



## Test plan
- [ ] Select a model from model library sidebar and verify dropdown updates
- [ ] Drag and drop a model onto canvas and verify widget updates

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7304-fix-trigger-widget-callback-when-model-is-selected-2c56d73d3650811795f2f3cbe3b8bba4) by [Unito](https://www.unito.io)
