### PR TITLE
feat: update subscription panel with tier-based design and improved UX

### DIFF
--- a/src/components/dialog/content/setting/LegacyCreditsPanel.vue
+++ b/src/components/dialog/content/setting/LegacyCreditsPanel.vue
@@ -1,5 +1,6 @@
 <template>
   <TabPanel value="Credits" class="credits-container h-full">
+    <!-- Legacy Design -->
     <div class="flex h-full flex-col">
       <h2 class="mb-2 text-2xl font-bold">
         {{ $t('credits.credits') }}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1878,7 +1878,7 @@
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud Logo",
     "beta": "BETA",
-    "perMonth": "USD / month",
+    "perMonth": "/ month",
     "renewsDate": "Renews {date}",
     "refreshesOn": "Refreshes to ${monthlyCreditBonusUsd} on {date}",
     "expiresDate": "Expires {date}",
@@ -1893,6 +1893,10 @@
     "monthlyBonusDescription": "Monthly credit bonus",
     "prepaidDescription": "Pre-paid credits",
     "prepaidCreditsInfo": "Pre-paid credits expire after 1 year from purchase date.",
+    "creditsRemainingThisMonth": "Credits remaining for this month",
+    "creditsYouveAdded": "Credits you've added",
+    "monthlyCreditsInfo": "These credits refresh monthly and don't roll over",
+    "viewMoreDetailsPlans": "View more details about plans & pricing",
     "nextBillingCycle": "next billing cycle",
     "yourPlanIncludes": "Your plan includes:",
     "viewMoreDetails": "View more details",
@@ -1902,6 +1906,54 @@
     "benefits": {
       "benefit1": "$10 in monthly credits for Partner Nodes — top up when needed",
       "benefit2": "Up to 30 min runtime per job"
+    },
+    "tiers": {
+      "founder": {
+        "name": "Founder's Edition Standard",
+        "price": "20.00",
+        "benefits": {
+          "monthlyCredits": "5,460 monthly credits",
+          "maxDuration": "30 min max duration of each workflow run",
+          "rtx6000": "RTX 6000 Pro (96GB VRAM)",
+          "addCredits": "Add more credits whenever"
+        }
+      },
+      "standard": {
+        "name": "Standard", 
+        "price": "20.00",
+        "benefits": {
+          "monthlyCredits": "4,200 monthly credits",
+          "maxDuration": "30 min max duration of each workflow run",
+          "rtx6000": "RTX 6000 Pro (96GB VRAM)",
+          "addCredits": "Add more credits whenever",
+          "customLoRAs": "Import your own LoRAs",
+          "videoEstimate": "164"
+        }
+      },
+      "creator": {
+        "name": "Creator",
+        "price": "35.00",
+        "benefits": {
+          "monthlyCredits": "7,400 monthly credits",
+          "maxDuration": "30 min max duration of each workflow run",
+          "rtx6000": "RTX 6000 Pro (96GB VRAM)",
+          "addCredits": "Add more credits whenever",
+          "customLoRAs": "Import your own LoRAs",
+          "videoEstimate": "288"
+        }
+      },
+      "pro": {
+        "name": "Pro",
+        "price": "100.00", 
+        "benefits": {
+          "monthlyCredits": "21,100 monthly credits",
+          "maxDuration": "1 hr max duration of each workflow run",
+          "rtx6000": "RTX 6000 Pro (96GB VRAM)", 
+          "addCredits": "Add more credits whenever",
+          "customLoRAs": "Import your own LoRAs",
+          "videoEstimate": "821"
+        }
+      }
     },
     "required": {
       "title": "Subscribe to",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1934,12 +1934,13 @@
         "name": "Creator",
         "price": "35.00",
         "benefits": {
-          "monthlyCredits": "7,400 monthly credits",
-          "maxDuration": "30 min max duration of each workflow run",
-          "rtx6000": "RTX 6000 Pro (96GB VRAM)",
-          "addCredits": "Add more credits whenever",
-          "customLoRAs": "Import your own LoRAs",
-          "videoEstimate": "288"
+          "monthlyCredits": "7,400",
+          "monthlyCreditsLabel": "monthly credits",
+          "maxDuration": "30 min",
+          "maxDurationLabel": "max duration of each workflow run",
+          "gpuLabel": "RTX 6000 Pro (96GB VRAM)",
+          "addCreditsLabel": "Add more credits whenever",
+          "customLoRAsLabel": "Import your own LoRAs"
         }
       },
       "pro": {

--- a/src/platform/cloud/subscription/components/SubscriptionBenefits.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionBenefits.vue
@@ -1,42 +1,19 @@
 <template>
-  <div class="flex flex-col items-start gap-1 self-stretch">
-    <div class="flex items-start gap-2">
-      <i class="pi pi-check mt-1 text-xs text-text-primary" />
+  <div class="flex flex-col items-start gap-0 self-stretch">
+    <div class="flex items-center gap-2 py-2">
+      <i class="pi pi-check text-xs text-text-primary" />
       <span class="text-sm text-text-primary">
         {{ $t('subscription.benefits.benefit1') }}
       </span>
     </div>
 
-    <div class="flex items-start gap-2">
-      <i class="pi pi-check mt-1 text-xs text-text-primary" />
+    <div class="flex items-center gap-2 py-2">
+      <i class="pi pi-check text-xs text-text-primary" />
       <span class="text-sm text-text-primary">
         {{ $t('subscription.benefits.benefit2') }}
       </span>
     </div>
-
-    <Button
-      :label="$t('subscription.viewMoreDetails')"
-      text
-      icon="pi pi-external-link"
-      icon-pos="left"
-      class="flex h-8 min-h-6 py-2 px-0 items-center gap-2 rounded text-text-secondary"
-      :pt="{
-        icon: {
-          class: 'text-xs text-text-secondary'
-        },
-        label: {
-          class: 'text-sm text-text-secondary'
-        }
-      }"
-      @click="handleViewMoreDetails"
-    />
   </div>
 </template>
 
-<script setup lang="ts">
-import Button from 'primevue/button'
-
-const handleViewMoreDetails = () => {
-  window.open('https://www.comfy.org/cloud/pricing', '_blank')
-}
-</script>
+<script setup lang="ts"></script>

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -387,29 +387,29 @@ const tierBenefits = computed(() => {
     {
       key: 'monthlyCredits',
       type: 'metric',
-      value: '7,400',
-      label: 'monthly credits'
+      value: t('subscription.tiers.creator.benefits.monthlyCredits'),
+      label: t('subscription.tiers.creator.benefits.monthlyCreditsLabel')
     },
     {
       key: 'maxDuration',
       type: 'metric',
-      value: '30 min',
-      label: 'max duration of each workflow run'
+      value: t('subscription.tiers.creator.benefits.maxDuration'),
+      label: t('subscription.tiers.creator.benefits.maxDurationLabel')
     },
     {
       key: 'gpu',
       type: 'feature',
-      label: 'RTX 6000 Pro (96GB VRAM)'
+      label: t('subscription.tiers.creator.benefits.gpuLabel')
     },
     {
       key: 'addCredits',
       type: 'feature',
-      label: 'Add more credits whenever'
+      label: t('subscription.tiers.creator.benefits.addCreditsLabel')
     },
     {
       key: 'customLoRAs',
       type: 'feature',
-      label: 'Import your own LoRAs'
+      label: t('subscription.tiers.creator.benefits.customLoRAsLabel')
     }
   ]
 

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -378,8 +378,8 @@ type BenefitType = 'metric' | 'feature'
 interface Benefit {
   key: string
   type: BenefitType
-  value?: string
   label: string
+  value?: string
 }
 
 const tierBenefits = computed(() => {

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -104,7 +104,7 @@
                   />
 
                   <div class="flex flex-col gap-2">
-                    <div class="text-xs text-muted">
+                    <div class="text-sm text-muted">
                       {{ $t('subscription.totalCredits') }}
                     </div>
                     <Skeleton
@@ -127,13 +127,13 @@
                       />
                       <div
                         v-else
-                        class="text-xs font-bold w-12 shrink-0 text-left text-muted"
+                        class="text-sm font-bold w-12 shrink-0 text-left text-muted"
                       >
                         {{ monthlyBonusCredits }}
                       </div>
                       <div class="flex items-center gap-1 min-w-0">
                         <div
-                          class="text-xs truncate text-muted"
+                          class="text-sm truncate text-muted"
                           :title="$t('subscription.creditsRemainingThisMonth')"
                         >
                           {{ $t('subscription.creditsRemainingThisMonth') }}
@@ -161,13 +161,13 @@
                       />
                       <div
                         v-else
-                        class="text-xs font-bold w-12 shrink-0 text-left text-muted"
+                        class="text-sm font-bold w-12 shrink-0 text-left text-muted"
                       >
                         {{ prepaidCredits }}
                       </div>
                       <div class="flex items-center gap-1 min-w-0">
                         <div
-                          class="text-xs truncate text-muted"
+                          class="text-sm truncate text-muted"
                           :title="$t('subscription.creditsYouveAdded')"
                         >
                           {{ $t('subscription.creditsYouveAdded') }}
@@ -194,7 +194,7 @@
                       href="https://platform.comfy.org/profile/usage"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="text-xs underline text-center text-muted"
+                      class="text-sm underline text-center text-muted"
                     >
                       {{ $t('subscription.viewUsageHistory') }}
                     </a>

--- a/src/platform/cloud/subscription/composables/useSubscriptionCredits.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCredits.ts
@@ -9,16 +9,20 @@ import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
  */
 export function useSubscriptionCredits() {
   const authStore = useFirebaseAuthStore()
-  const { t, locale } = useI18n()
+  const { locale } = useI18n()
 
   const formatBalance = (maybeCents?: number) => {
     // Backend returns cents despite the *_micros naming convention.
     const cents = maybeCents ?? 0
     const amount = formatCreditsFromCents({
       cents,
-      locale: locale.value
+      locale: locale.value,
+      numberOptions: {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }
     })
-    return `${amount} ${t('credits.credits')}`
+    return amount
   }
 
   const totalCredits = computed(() =>

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -85,7 +85,7 @@ export function useSettingUI(
       children: []
     },
     component: defineAsyncComponent(
-      () => import('@/components/dialog/content/setting/CreditsPanel.vue')
+      () => import('@/components/dialog/content/setting/LegacyCreditsPanel.vue')
     )
   }
 

--- a/tests-ui/tests/platform/cloud/subscription/composables/useSubscriptionCredits.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/composables/useSubscriptionCredits.test.ts
@@ -84,22 +84,22 @@ describe('useSubscriptionCredits', () => {
   })
 
   describe('totalCredits', () => {
-    it('should return "0.00 Credits" when balance is null', () => {
+    it('should return "0" when balance is null', () => {
       authStore.balance = null
       const { totalCredits } = useSubscriptionCredits()
-      expect(totalCredits.value).toBe('0.00 Credits')
+      expect(totalCredits.value).toBe('0')
     })
 
-    it('should return "0.00 Credits" when amount_micros is missing', () => {
+    it('should return "0" when amount_micros is missing', () => {
       authStore.balance = {} as GetCustomerBalanceResponse
       const { totalCredits } = useSubscriptionCredits()
-      expect(totalCredits.value).toBe('0.00 Credits')
+      expect(totalCredits.value).toBe('0')
     })
 
     it('should format amount_micros correctly', () => {
       authStore.balance = { amount_micros: 100 } as GetCustomerBalanceResponse
       const { totalCredits } = useSubscriptionCredits()
-      expect(totalCredits.value).toBe('211.00 Credits')
+      expect(totalCredits.value).toBe('211')
     })
 
     it('should handle formatting errors by throwing', async () => {
@@ -116,10 +116,10 @@ describe('useSubscriptionCredits', () => {
   })
 
   describe('monthlyBonusCredits', () => {
-    it('should return "0.00 Credits" when cloud_credit_balance_micros is missing', () => {
+    it('should return "0" when cloud_credit_balance_micros is missing', () => {
       authStore.balance = {} as GetCustomerBalanceResponse
       const { monthlyBonusCredits } = useSubscriptionCredits()
-      expect(monthlyBonusCredits.value).toBe('0.00 Credits')
+      expect(monthlyBonusCredits.value).toBe('0')
     })
 
     it('should format cloud_credit_balance_micros correctly', () => {
@@ -127,15 +127,15 @@ describe('useSubscriptionCredits', () => {
         cloud_credit_balance_micros: 200
       } as GetCustomerBalanceResponse
       const { monthlyBonusCredits } = useSubscriptionCredits()
-      expect(monthlyBonusCredits.value).toBe('422.00 Credits')
+      expect(monthlyBonusCredits.value).toBe('422')
     })
   })
 
   describe('prepaidCredits', () => {
-    it('should return "0.00 Credits" when prepaid_balance_micros is missing', () => {
+    it('should return "0" when prepaid_balance_micros is missing', () => {
       authStore.balance = {} as GetCustomerBalanceResponse
       const { prepaidCredits } = useSubscriptionCredits()
-      expect(prepaidCredits.value).toBe('0.00 Credits')
+      expect(prepaidCredits.value).toBe('0')
     })
 
     it('should format prepaid_balance_micros correctly', () => {
@@ -143,7 +143,7 @@ describe('useSubscriptionCredits', () => {
         prepaid_balance_micros: 300
       } as GetCustomerBalanceResponse
       const { prepaidCredits } = useSubscriptionCredits()
-      expect(prepaidCredits.value).toBe('633.00 Credits')
+      expect(prepaidCredits.value).toBe('633')
     })
   })
 


### PR DESCRIPTION
Transforms the subscription credits panel from legacy design to tier-based layout with Creator tier details, updated typography using design system tokens, improved responsive credit breakdown layout, and better subscription management flow. Updates credit formatting to remove unnecessary decimals and Credits suffix, replaces external Stripe billing portal with inline dialog, and reorganizes plan benefits section with proper v-for structure matching Figma specifications.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7307-feat-update-subscription-panel-with-tier-based-design-and-improved-UX-2c56d73d365081ef8b63e262a6822c72) by [Unito](https://www.unito.io)
