### PR TITLE
feat(api-nodes): add pricing badge for Kling O1 Image

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -741,6 +741,9 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
     KlingOmniProEditVideoNode: {
       displayPrice: '$0.168/second'
     },
+    KlingOmniProImageNode: {
+      displayPrice: '$0.028/Run'
+    },
     LumaImageToVideoNode: {
       displayPrice: (node: LGraphNode): string => {
         // Same pricing as LumaVideoNode per CSV


### PR DESCRIPTION
## Summary

Constant price was taken from here: https://docs.qingque.cn/d/home/eZQD5BNdCmt-tey_FeJgDFhkW?identityId=2KgtueybT0e#section=h.mdw6dhbeg7pz

## Screenshots (if applicable)

<img width="1131" height="528" alt="Screenshot From 2025-12-10 10-30-24" src="https://github.com/user-attachments/assets/62d53df0-410a-466a-bd7e-e1db8e534c7d" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7315-feat-api-nodes-add-pricing-badge-for-Kling-O1-Image-2c56d73d365081569b00c3bb24b93ca4) by [Unito](https://www.unito.io)
