### PR TITLE
Improve subscription dialog width for laptop screens

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -28,9 +28,7 @@ export const useSubscriptionDialog = () => {
       key: DIALOG_KEY,
       component: defineAsyncComponent(
         () =>
-          import(
-            '@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue'
-          )
+          import('@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue')
       ),
       props: {
         onClose: hide

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -38,7 +38,7 @@ export const useSubscriptionDialog = () => {
       dialogComponentProps: {
         style: showStripeDialog.value
           ? 'width: min(1200px, 95vw); max-height: 90vh;'
-          : 'width: min(800px, 90vw);',
+          : 'width: 700px;',
         pt: showStripeDialog.value
           ? {
               root: {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -28,15 +28,17 @@ export const useSubscriptionDialog = () => {
       key: DIALOG_KEY,
       component: defineAsyncComponent(
         () =>
-          import('@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue')
+          import(
+            '@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue'
+          )
       ),
       props: {
         onClose: hide
       },
       dialogComponentProps: {
         style: showStripeDialog.value
-          ? 'width: min(1100px, 90vw); max-height: 90vh;'
-          : 'width: 700px;',
+          ? 'width: min(1200px, 95vw); max-height: 90vh;'
+          : 'width: min(800px, 90vw);',
         pt: showStripeDialog.value
           ? {
               root: {


### PR DESCRIPTION
## Summary
- Increase Stripe subscription dialog width for better experience on laptop screens

When too narrow, it forces pricing options grid to go into single column layout which looks bad and should only happen when absolutely necessary (e.g,. mobile viewport).
