### PR TITLE
fix: allow dots in template URL parameter for version numbers

### DIFF
--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -33,9 +33,11 @@ export function useTemplateUrlLoader() {
 
   /**
    * Validates parameter format to prevent path traversal and injection attacks
+   * Allows: letters, numbers, underscores, hyphens, and dots (for version numbers)
+   * Blocks: path separators (/, \), special chars that could enable injection
    */
   const isValidParameter = (param: string): boolean => {
-    return /^[a-zA-Z0-9_-]+$/.test(param)
+    return /^[a-zA-Z0-9_.-]+$/.test(param)
   }
 
   /**

--- a/tests-ui/tests/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/tests-ui/tests/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -187,7 +187,8 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'flux-kontext-dev',
       'template123',
-      'My_Template-2'
+      'My_Template-2',
+      'templates-1_click_multiple_scene_angles-v1.0' // template with version number containing dot
     ]
 
     for (const template of validTemplates) {


### PR DESCRIPTION
## Summary
- Template names with dots (e.g., `templates-1_click_multiple_scene_angles-v1.0`) were being rejected by the URL parameter validation
- Updated validation regex from `^[a-zA-Z0-9_-]+$` to `^[a-zA-Z0-9_.-]+$` to allow dots for version numbers

## Test plan
- [x] Unit tests updated and passing
- [ ] Verify `?template=templates-1_click_multiple_scene_angles-v1.0` loads correctly

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7325-fix-allow-dots-in-template-URL-parameter-for-version-numbers-2c56d73d365081d48c28f20d979846d7) by [Unito](https://www.unito.io)
