### PR TITLE
Fix loading of subgraph blueprints on cloud

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1,6 +1,7 @@
 import { promiseTimeout, until } from '@vueuse/core'
 import axios from 'axios'
 import { get } from 'es-toolkit/compat'
+import { trimEnd } from 'es-toolkit'
 
 import defaultClientFeatureFlags from '@/config/clientFeatureFlags.json' with { type: 'json' }
 import type {
@@ -1139,13 +1140,14 @@ export class ComfyApi extends EventTarget {
   }
 
   async listUserDataFullInfo(dir: string): Promise<UserDataFullInfo[]> {
+    const trimmedDir = trimEnd(dir, '/')
     const resp = await this.fetchApi(
-      `/userdata?dir=${encodeURIComponent(dir)}&recurse=true&split=false&full_info=true`
+      `/userdata?dir=${encodeURIComponent(trimmedDir)}&recurse=true&split=false&full_info=true`
     )
     if (resp.status === 404) return []
     if (resp.status !== 200) {
       throw new Error(
-        `Error getting user data list '${dir}': ${resp.status} ${resp.statusText}`
+        `Error getting user data list '${trimmedDir}': ${resp.status} ${resp.statusText}`
       )
     }
     return resp.json()

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -181,7 +181,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     }
 
     const userSubs = (
-      await api.listUserDataFullInfo(SubgraphBlueprint.basePath)
+      await api.listUserDataFullInfo(SubgraphBlueprint.basePath.slice(0, -1))
     ).filter((f) => f.path.endsWith('.json'))
     const settled = await Promise.allSettled([
       ...userSubs.map(loadBlueprint),

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -181,7 +181,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     }
 
     const userSubs = (
-      await api.listUserDataFullInfo(SubgraphBlueprint.basePath.slice(0, -1))
+      await api.listUserDataFullInfo(SubgraphBlueprint.basePath)
     ).filter((f) => f.path.endsWith('.json'))
     const settled = await Promise.allSettled([
       ...userSubs.map(loadBlueprint),


### PR DESCRIPTION
Cloud doesn't like the trailing slash when querying  directories.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7326-Fix-loading-of-subgraph-blueprints-on-cloud-2c56d73d36508136a6eae50668b15742) by [Unito](https://www.unito.io)
