### PR TITLE
Lint: Start cleanup of the i18n imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -68,9 +68,10 @@
           {
             "name": "@/i18n",
             "importNames": [
+              "d",
               "st",
               "t",
-              "te"
+              "te",
             ],
             "message": "Don't import `@/i18n` directly, prefer `useI18n()`"
           }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,16 +2,21 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": [
     ".i18nrc.cjs",
-    "components.d.ts",
-    "lint-staged.config.js",
-    "vitest.setup.ts",
+    ".nx/*",
     "**/vite.config.*.timestamp*",
     "**/vitest.config.*.timestamp*",
+    "components.d.ts",
+    "coverage/*",
+    "dist/*",
+    "lint-staged.config.js",
     "packages/registry-types/src/comfyRegistryTypes.ts",
+    "playwright-report/*",
     "src/extensions/core/*",
     "src/scripts/*",
     "src/types/generatedManagerTypes.ts",
-    "src/types/vue-shim.d.ts"
+    "src/types/vue-shim.d.ts",
+    "test-results/*",
+    "vitest.setup.ts"
   ],
   "plugins": [
     "eslint",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,9 +24,45 @@
   ],
   "rules": {
     "no-async-promise-executor": "off",
+    "no-console": [
+      "error",
+      {
+        "allow": [
+          "warn",
+          "error"
+        ]
+      }
+    ],
     "no-control-regex": "off",
     "no-eval": "off",
     "no-redeclare": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "primevue/calendar",
+            "message": "Calendar is deprecated in PrimeVue 4+. Use DatePicker instead: import DatePicker from 'primevue/datepicker'"
+          },
+          {
+            "name": "primevue/dropdown",
+            "message": "Dropdown is deprecated in PrimeVue 4+. Use Select instead: import Select from 'primevue/select'"
+          },
+          {
+            "name": "primevue/inputswitch",
+            "message": "InputSwitch is deprecated in PrimeVue 4+. Use ToggleSwitch instead: import ToggleSwitch from 'primevue/toggleswitch'"
+          },
+          {
+            "name": "primevue/overlaypanel",
+            "message": "OverlayPanel is deprecated in PrimeVue 4+. Use Popover instead: import Popover from 'primevue/popover'"
+          },
+          {
+            "name": "primevue/sidebar",
+            "message": "Sidebar is deprecated in PrimeVue 4+. Use Drawer instead: import Drawer from 'primevue/drawer'"
+          }
+        ]
+      }
+    ],
     "no-self-assign": "allow",
     "no-unused-expressions": "off",
     "no-unused-private-class-members": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -109,5 +109,16 @@
     "typescript/no-floating-promises": "error",
     "vue/no-import-compiler-macros": "error",
     "vue/no-dupe-keys": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.{stories,test,spec}.ts",
+        "**/*.stories.vue"
+      ],
+      "rules": {
+        "no-console": "allow"
+      }
+    }
+  ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -59,6 +59,15 @@
           {
             "name": "primevue/sidebar",
             "message": "Sidebar is deprecated in PrimeVue 4+. Use Drawer instead: import Drawer from 'primevue/drawer'"
+          },
+          {
+            "name": "@/i18n",
+            "importNames": [
+              "st",
+              "t",
+              "te"
+            ],
+            "message": "Don't import `@/i18n` directly, prefer `useI18n()`"
           }
         ]
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,7 +8,6 @@
     "components.d.ts",
     "coverage/*",
     "dist/*",
-    "lint-staged.config.js",
     "packages/registry-types/src/comfyRegistryTypes.ts",
     "playwright-report/*",
     "src/extensions/core/*",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -66,12 +66,12 @@
             "message": "Sidebar is deprecated in PrimeVue 4+. Use Drawer instead: import Drawer from 'primevue/drawer'"
           },
           {
-            "name": "@/i18n",
+            "name": "@/i18n--to-enable",
             "importNames": [
-              "d",
               "st",
               "t",
               "te",
+              "d"
             ],
             "message": "Don't import `@/i18n` directly, prefer `useI18n()`"
           }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -234,12 +234,6 @@ export default defineConfig([
     }
   },
   {
-    files: ['**/*.{test,spec,stories}.ts', '**/*.stories.vue'],
-    rules: {
-      'no-console': 'off'
-    }
-  },
-  {
     files: ['scripts/**/*.js'],
     languageOptions: {
       globals: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -68,7 +68,6 @@ export default defineConfig([
       'components.d.ts',
       'coverage/*',
       'dist/*',
-      'lint-staged.config.js',
       'packages/registry-types/src/comfyRegistryTypes.ts',
       'playwright-report/*',
       'src/extensions/core/*',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -103,24 +103,17 @@ export default defineConfig([
 
   tseslintConfigs.recommended,
   // Difference in typecheck on CI vs Local
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore Bad types in the plugin
   pluginVue.configs['flat/recommended'],
   eslintPluginPrettierRecommended,
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore Type incompatibility between import-x plugin and ESLint config types
   storybook.configs['flat/recommended'],
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore Type incompatibility between import-x plugin and ESLint config types
+  // @ts-expect-error Type incompatibility between import-x plugin and ESLint config types
   importX.flatConfigs.recommended,
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore Type incompatibility between import-x plugin and ESLint config types
+  // @ts-expect-error Type incompatibility between import-x plugin and ESLint config types
   importX.flatConfigs.typescript,
   {
     plugins: {
       'unused-imports': unusedImports,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore Type incompatibility in i18n plugin
+      // @ts-expect-error Type incompatibility in i18n plugin
       '@intlify/vue-i18n': pluginI18n
     },
     rules: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -138,7 +138,6 @@ export default defineConfig([
       'import-x/no-useless-path-segments': 'error',
       'import-x/no-relative-packages': 'error',
       'unused-imports/no-unused-imports': 'error',
-      'no-console': ['error', { allow: ['warn', 'error'] }],
       'vue/no-v-html': 'off',
       // Prohibit dark-theme: and dark: prefixes
       'vue/no-restricted-class': ['error', '/^dark(-theme)?:/'],
@@ -153,39 +152,7 @@ export default defineConfig([
       'vue/no-use-v-else-with-v-for': 'error',
       'vue/one-component-per-file': 'error',
       'vue/require-default-prop': 'off', // TODO: fix -- this one is very worthwhile
-      // Restrict deprecated PrimeVue components
-      'no-restricted-imports': [
-        'error',
-        {
-          paths: [
-            {
-              name: 'primevue/calendar',
-              message:
-                'Calendar is deprecated in PrimeVue 4+. Use DatePicker instead: import DatePicker from "primevue/datepicker"'
-            },
-            {
-              name: 'primevue/dropdown',
-              message:
-                'Dropdown is deprecated in PrimeVue 4+. Use Select instead: import Select from "primevue/select"'
-            },
-            {
-              name: 'primevue/inputswitch',
-              message:
-                'InputSwitch is deprecated in PrimeVue 4+. Use ToggleSwitch instead: import ToggleSwitch from "primevue/toggleswitch"'
-            },
-            {
-              name: 'primevue/overlaypanel',
-              message:
-                'OverlayPanel is deprecated in PrimeVue 4+. Use Popover instead: import Popover from "primevue/popover"'
-            },
-            {
-              name: 'primevue/sidebar',
-              message:
-                'Sidebar is deprecated in PrimeVue 4+. Use Drawer instead: import Drawer from "primevue/drawer"'
-            }
-          ]
-        }
-      ],
+
       // i18n rules
       '@intlify/vue-i18n/no-raw-text': [
         'error',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,16 +62,21 @@ export default defineConfig([
   {
     ignores: [
       '.i18nrc.cjs',
-      'components.d.ts',
-      'lint-staged.config.js',
-      'vitest.setup.ts',
+      '.nx/*',
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
+      'components.d.ts',
+      'coverage/*',
+      'dist/*',
+      'lint-staged.config.js',
       'packages/registry-types/src/comfyRegistryTypes.ts',
+      'playwright-report/*',
       'src/extensions/core/*',
       'src/scripts/*',
       'src/types/generatedManagerTypes.ts',
-      'src/types/vue-shim.d.ts'
+      'src/types/vue-shim.d.ts',
+      'test-results/*',
+      'vitest.setup.ts'
     ]
   },
   {

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 export default {
   './**/*.js': (stagedFiles) => formatAndEslint(stagedFiles),
 
@@ -9,18 +11,7 @@ export default {
 
 function formatAndEslint(fileNames) {
   // Convert absolute paths to relative paths for better ESLint resolution
-const path = require('path')
-
-function formatAndEslint(fileNames) {
-  // Convert absolute paths to relative paths for better ESLint resolution
   const relativePaths = fileNames.map((f) => path.relative(process.cwd(), f))
-  const joinedPaths = relativePaths.map((p) => `"${p}"`).join(' ')
-  return [
-    `pnpm exec prettier --cache --write ${joinedPaths}`,
-    `pnpm exec oxlint --fix ${joinedPaths}`,
-    `pnpm exec eslint --cache --fix --no-warn-ignored ${joinedPaths}`
-  ]
-}
   const joinedPaths = relativePaths.map((p) => `"${p}"`).join(' ')
   return [
     `pnpm exec prettier --cache --write ${joinedPaths}`,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -10,9 +10,10 @@ export default {
 function formatAndEslint(fileNames) {
   // Convert absolute paths to relative paths for better ESLint resolution
   const relativePaths = fileNames.map((f) => f.replace(process.cwd() + '/', ''))
+  const joinedPaths = relativePaths.map((p) => `"${p}"`).join(' ')
   return [
-    `pnpm exec prettier --cache --write ${relativePaths.join(' ')}`,
-    `pnpm exec oxlint --fix ${relativePaths.join(' ')}`,
-    `pnpm exec eslint --cache --fix --no-warn-ignored ${relativePaths.join(' ')}`
+    `pnpm exec prettier --cache --write ${joinedPaths}`,
+    `pnpm exec oxlint --fix ${joinedPaths}`,
+    `pnpm exec eslint --cache --fix --no-warn-ignored ${joinedPaths}`
   ]
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -11,7 +11,8 @@ function formatAndEslint(fileNames) {
   // Convert absolute paths to relative paths for better ESLint resolution
   const relativePaths = fileNames.map((f) => f.replace(process.cwd() + '/', ''))
   return [
-    `pnpm exec eslint --cache --fix ${relativePaths.join(' ')}`,
-    `pnpm exec prettier --cache --write ${relativePaths.join(' ')}`
+    `pnpm exec prettier --cache --write ${relativePaths.join(' ')}`,
+    `pnpm exec oxlint --fix ${relativePaths.join(' ')}`,
+    `pnpm exec eslint --cache --fix ${relativePaths.join(' ')}`
   ]
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -9,7 +9,18 @@ export default {
 
 function formatAndEslint(fileNames) {
   // Convert absolute paths to relative paths for better ESLint resolution
-  const relativePaths = fileNames.map((f) => f.replace(process.cwd() + '/', ''))
+const path = require('path')
+
+function formatAndEslint(fileNames) {
+  // Convert absolute paths to relative paths for better ESLint resolution
+  const relativePaths = fileNames.map((f) => path.relative(process.cwd(), f))
+  const joinedPaths = relativePaths.map((p) => `"${p}"`).join(' ')
+  return [
+    `pnpm exec prettier --cache --write ${joinedPaths}`,
+    `pnpm exec oxlint --fix ${joinedPaths}`,
+    `pnpm exec eslint --cache --fix --no-warn-ignored ${joinedPaths}`
+  ]
+}
   const joinedPaths = relativePaths.map((p) => `"${p}"`).join(' ')
   return [
     `pnpm exec prettier --cache --write ${joinedPaths}`,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -13,6 +13,6 @@ function formatAndEslint(fileNames) {
   return [
     `pnpm exec prettier --cache --write ${relativePaths.join(' ')}`,
     `pnpm exec oxlint --fix ${relativePaths.join(' ')}`,
-    `pnpm exec eslint --cache --fix ${relativePaths.join(' ')}`
+    `pnpm exec eslint --cache --fix --no-warn-ignored ${relativePaths.join(' ')}`
   ]
 }

--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -1,15 +1,15 @@
 import path from 'node:path'
 
 export default {
-  './**/*.js': (stagedFiles) => formatAndEslint(stagedFiles),
+  './**/*.js': (stagedFiles: string[]) => formatAndEslint(stagedFiles),
 
-  './**/*.{ts,tsx,vue,mts}': (stagedFiles) => [
+  './**/*.{ts,tsx,vue,mts}': (stagedFiles: string[]) => [
     ...formatAndEslint(stagedFiles),
     'pnpm typecheck'
   ]
 }
 
-function formatAndEslint(fileNames) {
+function formatAndEslint(fileNames: string[]) {
   // Convert absolute paths to relative paths for better ESLint resolution
   const relativePaths = fileNames.map((f) => path.relative(process.cwd(), f))
   const joinedPaths = relativePaths.map((p) => `"${p}"`).join(' ')

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -197,6 +197,7 @@ export const i18n = createI18n({
 })
 
 /** Convenience shorthand: i18n.global */
+/** @deprecated use useI18n */
 export const { t, te, d } = i18n.global
 
 /**
@@ -204,7 +205,8 @@ export const { t, te, d } = i18n.global
  *
  * @param key - The key to translate.
  * @param fallbackMessage - The fallback message to use if the key is not found.
+ * @deprecated Remove, use the defaultMsg overload
  */
 export function st(key: string, fallbackMessage: string) {
-  return te(key) ? t(key) : fallbackMessage
+  return t(key, fallbackMessage)
 }

--- a/src/workbench/extensions/manager/components/manager/registrySearchBar/SearchFilterDropdown.vue
+++ b/src/workbench/extensions/manager/components/manager/registrySearchBar/SearchFilterDropdown.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup lang="ts" generic="T">
-// eslint-disable-next-line no-restricted-imports -- TODO: Migrate to Select component
+// oxlint-disable-next-line no-restricted-imports -- TODO: Migrate to Select component
 import Dropdown from 'primevue/dropdown'
 
 import type { SearchOption } from '@/workbench/extensions/manager/types/comfyManagerTypes'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     "eslint.config.ts",
     "global.d.ts",
     "knip.config.ts",
+    "lint-staged.config.ts",
     "src/**/*.vue",
     "src/**/*",
     "src/types/**/*.d.ts",


### PR DESCRIPTION
## Summary

Avoid direct access of i18n instance to favor useI18n

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7327-Lint-Start-cleanup-of-the-i18n-imports-2c56d73d3650811d9214c9a02863a5a3) by [Unito](https://www.unito.io)
