### PR TITLE
refactor: update outdated tooltip on menu setting

### DIFF
--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -351,7 +351,7 @@
   },
   "Comfy_UseNewMenu": {
     "name": "Use new menu",
-    "tooltip": "Menu bar position. On mobile devices, the menu is always shown at the top.",
+    "tooltip": "Enable the redesigned top menu bar.",
     "options": {
       "Disabled": "Disabled",
       "Top": "Top"

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -562,8 +562,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Use new menu',
     type: 'combo',
     options: ['Disabled', 'Top'],
-    tooltip:
-      'Menu bar position. On mobile devices, the menu is always shown at the top.',
+    tooltip: 'Enable the redesigned top menu bar.',
     migrateDeprecatedValue: (value: string) => {
       // Floating is now supported by dragging the docked actionbar off.
       if (value === 'Floating') {


### PR DESCRIPTION
Followup from https://github.com/Comfy-Org/ComfyUI_frontend/pull/4312: remove tooltip with outdated info discussing the bottom menu. The bottom menu setting is removed and even if it was not removed, the logic that forced the menu to the top on mobile was removed, so this tooltip is outdated and gives wrong info.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7330-refactor-update-outdated-tooltip-on-menu-setting-2c66d73d36508128b356c6f985d5b12b) by [Unito](https://www.unito.io)
