### PR TITLE
ci: add shellcheck linter for ci scripts

### DIFF
--- a/.github/workflows/ci-shell-validation.yaml
+++ b/.github/workflows/ci-shell-validation.yaml
@@ -15,7 +15,7 @@ jobs:
   shell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install shellcheck
         run: |

--- a/.github/workflows/ci-shell-validation.yaml
+++ b/.github/workflows/ci-shell-validation.yaml
@@ -23,4 +23,4 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: Run shellcheck
-        run: ./scripts/cicd/check-shell.sh
+        run: bash ./scripts/cicd/check-shell.sh

--- a/.github/workflows/ci-shell-validation.yaml
+++ b/.github/workflows/ci-shell-validation.yaml
@@ -1,0 +1,26 @@
+# Description: Runs shellcheck on tracked shell scripts when they change
+name: "CI: Shell Validation"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.sh'
+  pull_request:
+    paths:
+      - '**/*.sh'
+
+jobs:
+  shell-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run shellcheck
+        run: ./scripts/cicd/check-shell.sh

--- a/scripts/cicd/check-shell.sh
+++ b/scripts/cicd/check-shell.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "Error: shellcheck is required but not installed" >&2
+  exit 127
+fi
+
+mapfile -t shell_files < <(git ls-files '*.sh')
+
+if [[ ${#shell_files[@]} -eq 0 ]]; then
+  echo 'No shell scripts found.'
+  exit 0
+fi
+
+shellcheck --format=gcc "${shell_files[@]}"

--- a/scripts/cicd/check-shell.sh
+++ b/scripts/cicd/check-shell.sh
@@ -9,7 +9,7 @@ if ! command -v shellcheck >/dev/null 2>&1; then
   exit 127
 fi
 
-mapfile -t shell_files < <(git ls-files '*.sh')
+mapfile -t shell_files < <(git ls-files -- '*.sh')
 
 if [[ ${#shell_files[@]} -eq 0 ]]; then
   echo 'No shell scripts found.'


### PR DESCRIPTION
## Summary

Adds [shellcheck](https://www.shellcheck.net/) to the PR linting CI steps -- when a PR has changed a `*.sh` file.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7331-ci-add-shellcheck-linter-for-ci-scripts-2c66d73d365081be889bf256cde92281) by [Unito](https://www.unito.io)
