### PR TITLE
add warning when using legacy mask editor (indicating it will be removed in next version)

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -27,6 +27,9 @@ function openMaskEditor(node: LGraphNode): void {
   if (useNewEditor) {
     useMaskEditor().openMaskEditor(node)
   } else {
+    console.warn(
+      '[Comfy.MaskEditor] The legacy mask editor is deprecated and will be removed soon.'
+    )
     // Use old editor
     ComfyApp.copyToClipspace(node)
     // @ts-expect-error clipspace_return_node is an extension property added at runtime
@@ -122,6 +125,9 @@ app.registerExtension({
         'Comfy.MaskEditor.UseNewEditor'
       )
       if (!useNewEditor) {
+        console.warn(
+          '[Comfy.MaskEditor] The legacy mask editor is deprecated and will be removed soon.'
+        )
         const dlg = MaskEditorDialogOld.getInstance() as any
         if (dlg?.isOpened && !dlg.isOpened()) {
           dlg.show()

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1,13 +1,26 @@
 import _ from 'es-toolkit/compat'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
+import { t } from '@/i18n'
+import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { app } from '@/scripts/app'
 import { ComfyApp } from '@/scripts/app'
-import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useDialogStore } from '@/stores/dialogStore'
-import { MaskEditorDialogOld } from './maskEditorOld'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { ClipspaceDialog } from './clipspace'
-import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
+import { MaskEditorDialogOld } from './maskEditorOld'
+
+const warnLegacyMaskEditorDeprecation = () => {
+  const warningMessage = t('toastMessages.legacyMaskEditorDeprecated')
+  console.warn(`[Comfy.MaskEditor] ${warningMessage}`)
+  useToastStore().add({
+    severity: 'warn',
+    summary: 'Alert',
+    detail: warningMessage,
+    life: 4096
+  })
+}
 
 function openMaskEditor(node: LGraphNode): void {
   if (!node) {
@@ -27,9 +40,7 @@ function openMaskEditor(node: LGraphNode): void {
   if (useNewEditor) {
     useMaskEditor().openMaskEditor(node)
   } else {
-    console.warn(
-      '[Comfy.MaskEditor] The legacy mask editor is deprecated and will be removed soon.'
-    )
+    warnLegacyMaskEditorDeprecation()
     // Use old editor
     ComfyApp.copyToClipspace(node)
     // @ts-expect-error clipspace_return_node is an extension property added at runtime
@@ -125,9 +136,7 @@ app.registerExtension({
         'Comfy.MaskEditor.UseNewEditor'
       )
       if (!useNewEditor) {
-        console.warn(
-          '[Comfy.MaskEditor] The legacy mask editor is deprecated and will be removed soon.'
-        )
+        warnLegacyMaskEditorDeprecation()
         const dlg = MaskEditorDialogOld.getInstance() as any
         if (dlg?.isOpened && !dlg.isOpened()) {
           dlg.show()

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1674,6 +1674,7 @@
     "noTemplatesToExport": "No templates to export",
     "failedToFetchLogs": "Failed to fetch server logs",
     "migrateToLitegraphReroute": "Reroute nodes will be removed in future versions. Click to migrate to litegraph-native reroute.",
+    "legacyMaskEditorDeprecated": "The legacy mask editor is deprecated and will be removed soon.",
     "userNotAuthenticated": "User not authenticated",
     "failedToFetchBalance": "Failed to fetch balance: {error}",
     "failedToCreateCustomer": "Failed to create customer: {error}",


### PR DESCRIPTION
## Summary

Telemetry data shows zero users using the legacy mask editor. It has been considerable time since we switched to the new one, and there really is no reason to use the legacy version given how lacking it is.

Will add this warning for 1 minor version just for maximum safety then remove all legacy mask editor code.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7332-add-warning-when-using-legacy-mask-editor-indicating-it-will-be-removed-in-next-version-2c66d73d365081a0bad7d63ba4d414af) by [Unito](https://www.unito.io)
