### PR TITLE
fix: prevent duplicate backport workflow runs for same PR

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -16,6 +16,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: backport-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   backport:
     if: >


### PR DESCRIPTION
## Summary

When multiple labels are added to a PR in quick succession (e.g., `needs-backport` and `core/1.33`), each label triggers a separate workflow run. Both runs would proceed independently, causing duplicate failure comments or redundant work. This adds a concurrency group keyed by PR number with `cancel-in-progress: false`, ensuring runs for the same PR are serialized rather than racing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7335-fix-prevent-duplicate-backport-workflow-runs-for-same-PR-2c66d73d36508140a603cd7110c42442) by [Unito](https://www.unito.io)
