### PR TITLE
Fix/run button floating calc

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -142,9 +142,8 @@ const setInitialPosition = () => {
   }
 }
 
-//The ComfyRunButton is a dynamic import, we cant calculate the setInitialPosition onMount because the width and height will be
-//wrong (the COmfyRunButton has not loaded in yet.) So we need to watch this components wxh and when it changes for the first time
-//then setInitialPosition
+// This prevents the floating button from being off-screen after browser resize between sessions.
+// Dynamic import means dimensions are wrong on mount - wait for first resize to set initial position.
 watch(
   [panelWidth, panelHeight],
   ([w, h]) => {


### PR DESCRIPTION
## Summary

Ensures the undocked ComfyRunButton resets to a valid position when the app reopens after a browser resize. Since the component is dynamically imported, we defer setInitialPosition until the suspense boundary has been resolved rather than calling it on mount (when the import has not been loaded / wxh are incorrect).

## Changes

- **What**:  ComfyActionbar.vue
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

 Fixes: https://www.notion.so/comfy-org/Bug-Run-button-missing-after-undocking-moving-to-bottom-right-and-resizing-window-2c06d73d3650810f89e5eb5692f08b83?source=copy_link

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7340-Fix-run-button-floating-calc-2c66d73d36508122b489c90c81c6129a) by [Unito](https://www.unito.io)
