### PR TITLE
fix: subscribe button overflow on cloud

### DIFF
--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -39,14 +39,15 @@
       />
     </div>
 
-    <SubscribeButton
-      v-else
-      class="mx-4"
-      :label="$t('subscription.subscribeToComfyCloud')"
-      size="small"
-      variant="gradient"
-      @subscribed="handleSubscribed"
-    />
+    <div v-else class="flex justify-center px-4">
+      <SubscribeButton
+        :fluid="false"
+        :label="$t('subscription.subscribeToComfyCloud')"
+        size="small"
+        variant="gradient"
+        @subscribed="handleSubscribed"
+      />
+    </div>
 
     <!-- Credits info row -->
     <div


### PR DESCRIPTION
## Summary


| Before                                                                                                                                        | After                                                                                                                                         |
| --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="958" height="724" alt="image" src="https://github.com/user-attachments/assets/4c19c94e-646d-4247-8824-471e5a161930" /> | <img width="493" height="559" alt="Screenshot from 2025-12-10 21-13-36" src="https://github.com/user-attachments/assets/6e915a50-e44c-4d07-a850-27ad36aed546" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7343-fix-subscribe-button-overflow-on-cloud-2c66d73d36508101be6bca61a9172c94) by [Unito](https://www.unito.io)
