### PR TITLE
remove fraction digits on topup credit number

### DIFF
--- a/src/components/common/UserCredit.vue
+++ b/src/components/common/UserCredit.vue
@@ -64,7 +64,8 @@ const formattedCreditsOnly = computed(() => {
   const cents = authStore.balance?.amount_micros ?? 0
   const amount = formatCreditsFromCents({
     cents,
-    locale: locale.value
+    locale: locale.value,
+    numberOptions: { minimumFractionDigits: 0, maximumFractionDigits: 0 }
   })
   return amount
 })


### PR DESCRIPTION
## Summary

Don't show fraction digits on credits in the topup dialog.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7345-remove-fraction-digits-on-topup-credit-number-2c66d73d365081028ef8cf73113dd20c) by [Unito](https://www.unito.io)
