### PR TITLE
fix: adjust visibility classes for dividers in settings dialog

### DIFF
--- a/src/platform/settings/components/SettingDialogContent.vue
+++ b/src/platform/settings/components/SettingDialogContent.vue
@@ -27,8 +27,8 @@
         </template>
       </Listbox>
     </ScrollPanel>
-    <Divider layout="vertical" class="mx-1 hidden md:flex 2xl:mx-4" />
-    <Divider layout="horizontal" class="flex md:hidden" />
+    <Divider layout="vertical" class="mx-1 hidden md:!flex 2xl:mx-4" />
+    <Divider layout="horizontal" class="flex md:!hidden" />
     <Tabs :value="tabValue" :lazy="true" class="settings-content h-full w-full">
       <TabPanels class="settings-tab-panels h-full w-full pr-0">
         <PanelTemplate value="Search Results">


### PR DESCRIPTION
## Summary

Built version of frontend does not correctly apply style to primevue divider.
Force breakpoints with css importance (!) 

## Changes

- **What**: add ! to breakpoints in Divider component styling


## Review Focus

Relating to: #7334 - my PR is a temporary fix until this is inplace

## Screenshots 
![ee](https://github.com/user-attachments/assets/78e27fa7-2cb8-4e61-b883-ef0daeb2837e)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7351-fix-adjust-visibility-classes-for-dividers-in-settings-dialog-2c66d73d3650817f9303f8c448e63dce) by [Unito](https://www.unito.io)
