### PR TITLE
fix: flaky e2e test for dropping assets on nodes

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -624,6 +624,14 @@ export class ComfyPage {
     // Dropping a URL (e.g., dropping image across browser tabs in Firefox)
     if (url) evaluateParams.url = url
 
+    // Set up response waiter for file uploads before triggering the drop
+    const uploadResponsePromise = fileName
+      ? this.page.waitForResponse(
+          (resp) => resp.url().includes('/upload/') && resp.status() === 200,
+          { timeout: 10000 }
+        )
+      : null
+
     // Execute the drag and drop in the browser
     await this.page.evaluate(async (params) => {
       const dataTransfer = new DataTransfer()
@@ -689,6 +697,11 @@ export class ComfyPage {
         }
       }
     }, evaluateParams)
+
+    // Wait for file upload to complete
+    if (uploadResponsePromise) {
+      await uploadResponsePromise
+    }
 
     await this.nextFrame()
   }

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -585,9 +585,15 @@ export class ComfyPage {
       fileName?: string
       url?: string
       dropPosition?: Position
+      waitForUpload?: boolean
     } = {}
   ) {
-    const { dropPosition = { x: 100, y: 100 }, fileName, url } = options
+    const {
+      dropPosition = { x: 100, y: 100 },
+      fileName,
+      url,
+      waitForUpload = false
+    } = options
 
     if (!fileName && !url)
       throw new Error('Must provide either fileName or url')
@@ -625,7 +631,7 @@ export class ComfyPage {
     if (url) evaluateParams.url = url
 
     // Set up response waiter for file uploads before triggering the drop
-    const uploadResponsePromise = fileName
+    const uploadResponsePromise = waitForUpload
       ? this.page.waitForResponse(
           (resp) => resp.url().includes('/upload/') && resp.status() === 200,
           { timeout: 10000 }
@@ -708,7 +714,7 @@ export class ComfyPage {
 
   async dragAndDropFile(
     fileName: string,
-    options: { dropPosition?: Position } = {}
+    options: { dropPosition?: Position; waitForUpload?: boolean } = {}
   ) {
     return this.dragAndDropExternalResource({ fileName, ...options })
   }

--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -252,7 +252,8 @@ test.describe('Animated image widget', () => {
 
     // Drag and drop image file onto the load animated webp node
     await comfyPage.dragAndDropFile('animated_webp.webp', {
-      dropPosition: { x, y }
+      dropPosition: { x, y },
+      waitForUpload: true
     })
 
     // Expect the filename combo value to be updated


### PR DESCRIPTION
Fix flaky "Can drag-and-drop animated webp image" test that was reading the widget value before the upload completed, causing intermittent failures where filenames appeared truncated. Added `waitForUpload` option to `dragAndDropFile` helper that waits for the `/upload/` response before returning. This is opt-in since not all drag-and-drop operations trigger uploads (e.g., loading workflows from media files).