### PR TITLE
cleanup: remove unused queue setting

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -327,13 +327,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'hidden',
     defaultValue: {}
   },
-  // Hidden setting used by the queue for how to fit images
-  {
-    id: 'Comfy.Queue.ImageFit',
-    name: 'Queue image fit',
-    type: 'hidden',
-    defaultValue: 'cover'
-  },
   {
     id: 'Comfy.GroupSelectedNodes.Padding',
     category: ['LiteGraph', 'Group', 'Padding'],

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -430,7 +430,6 @@ const zSettings = z.object({
   'Comfy.TreeExplorer.ItemPadding': z.number(),
   'Comfy.Validation.Workflows': z.boolean(),
   'Comfy.Workflow.SortNodeIdOnSave': z.boolean(),
-  'Comfy.Queue.ImageFit': z.enum(['contain', 'cover']),
   'Comfy.Workflow.WorkflowTabsPosition': z.enum(['Sidebar', 'Topbar']),
   'Comfy.Node.DoubleClickTitleToEdit': z.boolean(),
   'Comfy.WidgetControlMode': z.enum(['before', 'after']),


### PR DESCRIPTION
## Summary

Removes setting which no longer has any effect due to the Queue panel being removed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7353-cleanup-remove-unused-queue-setting-2c66d73d36508100b514f07e16d5b0f6) by [Unito](https://www.unito.io)
