### PR TITLE
ci: add AI agent prompt to backport conflict comments

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -357,6 +357,17 @@ jobs:
         if: steps.filter-targets.outputs.skip != 'true' && failure() && steps.backport.outputs.failed
         env:
           GH_TOKEN: ${{ github.token }}
+          BACKPORT_AGENT_PROMPT_TEMPLATE: |
+            Backport PR #${PR_NUMBER} (${PR_URL}) to ${target}.
+            Cherry-pick merge commit ${MERGE_COMMIT} onto new branch
+            ${BACKPORT_BRANCH} from origin/${target}.
+            Resolve conflicts in: ${CONFLICTS_INLINE}.
+            For test snapshots (browser_tests/**/*-snapshots/), accept PR version if
+            changed in original PR, else keep target. For package.json versions, keep
+            target branch. For pnpm-lock.yaml, regenerate with pnpm install.
+            Ask user for non-obvious conflicts.
+            Create PR titled "[backport ${target}] <original title>" with label "backport".
+            See .github/workflows/pr-backport.yaml for workflow details.
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_DATA=$(gh pr view ${{ inputs.pr_number }} --json author,mergeCommit)
@@ -386,16 +397,8 @@ jobs:
               BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${SAFE_TARGET}"
               PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
 
-              AGENT_PROMPT="Backport PR #${PR_NUMBER} (${PR_URL}) to ${target}."$'\n'
-              AGENT_PROMPT+="Cherry-pick merge commit ${MERGE_COMMIT} onto new branch"$'\n'
-              AGENT_PROMPT+="${BACKPORT_BRANCH} from origin/${target}."$'\n'
-              AGENT_PROMPT+="Resolve conflicts in: ${CONFLICTS_INLINE}."$'\n'
-              AGENT_PROMPT+="For test snapshots (browser_tests/**/*-snapshots/), accept PR version if"$'\n'
-              AGENT_PROMPT+="changed in original PR, else keep target. For package.json versions, keep"$'\n'
-              AGENT_PROMPT+="target branch. For pnpm-lock.yaml, regenerate with pnpm install."$'\n'
-              AGENT_PROMPT+="Ask user for non-obvious conflicts."$'\n'
-              AGENT_PROMPT+="Create PR titled \"[backport ${target}] <original title>\" with label \"backport\"."$'\n'
-              AGENT_PROMPT+="See .github/workflows/pr-backport.yaml for workflow details."
+              export PR_NUMBER PR_URL MERGE_COMMIT target BACKPORT_BRANCH CONFLICTS_INLINE
+              AGENT_PROMPT=$(envsubst '${PR_NUMBER} ${PR_URL} ${target} ${MERGE_COMMIT} ${BACKPORT_BRANCH} ${CONFLICTS_INLINE}' <<<"$BACKPORT_AGENT_PROMPT_TEMPLATE")
 
               COMMENT_BODY="### ⚠️ Backport to \`${target}\` failed"$'\n\n'
               COMMENT_BODY+="**Reason:** Merge conflicts detected during cherry-pick of \`${MERGE_COMMIT:0:7}\`"$'\n\n'

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -398,6 +398,12 @@ jobs:
               PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
 
               export PR_NUMBER PR_URL MERGE_COMMIT target BACKPORT_BRANCH CONFLICTS_INLINE
+
+              # envsubst is provided by gettext-base
+              if ! command -v envsubst >/dev/null 2>&1; then
+                sudo apt-get update && sudo apt-get install -y gettext-base
+              fi
+
               AGENT_PROMPT=$(envsubst '${PR_NUMBER} ${PR_URL} ${target} ${MERGE_COMMIT} ${BACKPORT_BRANCH} ${CONFLICTS_INLINE}' <<<"$BACKPORT_AGENT_PROMPT_TEMPLATE")
 
               COMMENT_BODY="### ⚠️ Backport to \`${target}\` failed"$'\n\n'

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -381,8 +381,35 @@ jobs:
             elif [ "${reason}" = "conflicts" ]; then
               # Convert comma-separated conflicts back to newlines for display
               CONFLICTS_LIST=$(echo "${conflicts}" | tr ',' '\n' | sed 's/^/- /')
+              CONFLICTS_INLINE=$(echo "${conflicts}" | tr ',' ' ')
+              SAFE_TARGET=$(echo "$target" | tr '/' '-')
+              BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${SAFE_TARGET}"
+              PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
 
-              COMMENT_BODY="@${PR_AUTHOR} Backport to \`${target}\` failed: Merge conflicts detected."$'\n\n'"Please manually cherry-pick commit \`${MERGE_COMMIT}\` to the \`${target}\` branch."$'\n\n'"<details><summary>Conflicting files</summary>"$'\n\n'"${CONFLICTS_LIST}"$'\n\n'"</details>"
+              AGENT_PROMPT="Backport PR #${PR_NUMBER} (${PR_URL}) to ${target}."$'\n'
+              AGENT_PROMPT+="Cherry-pick merge commit ${MERGE_COMMIT} onto new branch"$'\n'
+              AGENT_PROMPT+="${BACKPORT_BRANCH} from origin/${target}."$'\n'
+              AGENT_PROMPT+="Resolve conflicts in: ${CONFLICTS_INLINE}."$'\n'
+              AGENT_PROMPT+="For test snapshots (browser_tests/**/*-snapshots/), accept PR version if"$'\n'
+              AGENT_PROMPT+="changed in original PR, else keep target. For package.json versions, keep"$'\n'
+              AGENT_PROMPT+="target branch. For pnpm-lock.yaml, regenerate with pnpm install."$'\n'
+              AGENT_PROMPT+="Ask user for non-obvious conflicts."$'\n'
+              AGENT_PROMPT+="Create PR titled \"[backport ${target}] <original title>\" with label \"backport\"."$'\n'
+              AGENT_PROMPT+="See .github/workflows/pr-backport.yaml for workflow details."
+
+              COMMENT_BODY="### ⚠️ Backport to \`${target}\` failed"$'\n\n'
+              COMMENT_BODY+="**Reason:** Merge conflicts detected during cherry-pick of \`${MERGE_COMMIT:0:7}\`"$'\n\n'
+              COMMENT_BODY+="<details>"$'\n'"<summary>📄 Conflicting files</summary>"$'\n\n'
+              COMMENT_BODY+="${CONFLICTS_LIST}"$'\n\n'
+              COMMENT_BODY+="</details>"$'\n\n'
+              COMMENT_BODY+="<details>"$'\n'"<summary>🤖 Prompt for AI Agents</summary>"$'\n\n'
+              COMMENT_BODY+="\`\`\`"$'\n'
+              COMMENT_BODY+="${AGENT_PROMPT}"$'\n'
+              COMMENT_BODY+="\`\`\`"$'\n\n'
+              COMMENT_BODY+="</details>"$'\n\n'
+              COMMENT_BODY+="---"$'\n'
+              COMMENT_BODY+="cc @${PR_AUTHOR}"
+
               gh pr comment "${PR_NUMBER}" --body "${COMMENT_BODY}"
             fi
           done

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -368,6 +368,31 @@ jobs:
             Ask user for non-obvious conflicts.
             Create PR titled "[backport ${target}] <original title>" with label "backport".
             See .github/workflows/pr-backport.yaml for workflow details.
+          COMMENT_BODY_TEMPLATE: |
+            ### ⚠️ Backport to `${target}` failed
+
+            **Reason:** Merge conflicts detected during cherry-pick of `${MERGE_COMMIT_SHORT}`
+
+            <details>
+            <summary>📄 Conflicting files</summary>
+
+            ```
+            ${CONFLICTS_BLOCK}
+            ```
+
+            </details>
+
+            <details>
+            <summary>🤖 Prompt for AI Agents</summary>
+
+            ```
+            ${AGENT_PROMPT}
+            ```
+
+            </details>
+
+            ---
+            cc @${PR_AUTHOR}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_DATA=$(gh pr view ${{ inputs.pr_number }} --json author,mergeCommit)
@@ -390,8 +415,6 @@ jobs:
               gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Commit \`${MERGE_COMMIT}\` already exists on branch \`${target}\`. No backport needed."
 
             elif [ "${reason}" = "conflicts" ]; then
-              # Convert comma-separated conflicts back to newlines for display
-              CONFLICTS_LIST=$(echo "${conflicts}" | tr ',' '\n' | sed 's/^/- /')
               CONFLICTS_INLINE=$(echo "${conflicts}" | tr ',' ' ')
               SAFE_TARGET=$(echo "$target" | tr '/' '-')
               BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${SAFE_TARGET}"
@@ -406,18 +429,12 @@ jobs:
 
               AGENT_PROMPT=$(envsubst '${PR_NUMBER} ${PR_URL} ${target} ${MERGE_COMMIT} ${BACKPORT_BRANCH} ${CONFLICTS_INLINE}' <<<"$BACKPORT_AGENT_PROMPT_TEMPLATE")
 
-              COMMENT_BODY="### ⚠️ Backport to \`${target}\` failed"$'\n\n'
-              COMMENT_BODY+="**Reason:** Merge conflicts detected during cherry-pick of \`${MERGE_COMMIT:0:7}\`"$'\n\n'
-              COMMENT_BODY+="<details>"$'\n'"<summary>📄 Conflicting files</summary>"$'\n\n'
-              COMMENT_BODY+="${CONFLICTS_LIST}"$'\n\n'
-              COMMENT_BODY+="</details>"$'\n\n'
-              COMMENT_BODY+="<details>"$'\n'"<summary>🤖 Prompt for AI Agents</summary>"$'\n\n'
-              COMMENT_BODY+="\`\`\`"$'\n'
-              COMMENT_BODY+="${AGENT_PROMPT}"$'\n'
-              COMMENT_BODY+="\`\`\`"$'\n\n'
-              COMMENT_BODY+="</details>"$'\n\n'
-              COMMENT_BODY+="---"$'\n'
-              COMMENT_BODY+="cc @${PR_AUTHOR}"
+              # Use fenced code block for conflicts to handle special chars in filenames
+              CONFLICTS_BLOCK=$(echo "${conflicts}" | tr ',' '\n')
+              MERGE_COMMIT_SHORT="${MERGE_COMMIT:0:7}"
+
+              export target MERGE_COMMIT_SHORT CONFLICTS_BLOCK AGENT_PROMPT PR_AUTHOR
+              COMMENT_BODY=$(envsubst '${target} ${MERGE_COMMIT_SHORT} ${CONFLICTS_BLOCK} ${AGENT_PROMPT} ${PR_AUTHOR}' <<<"$COMMENT_BODY_TEMPLATE")
 
               gh pr comment "${PR_NUMBER}" --body "${COMMENT_BODY}"
             fi


### PR DESCRIPTION
## Summary
- When backports fail due to merge conflicts, the comment now includes a copyable prompt for AI coding assistants
- Styled similar to CodeRabbit's "Prompt for AI Agents" feature
- Prompt includes all necessary context: PR URL, merge commit, target branch, conflict files, resolution guidelines

## Example Output

When a backport fails due to conflicts, the workflow now posts a cleaner comment with an AI agent prompt:

---

### ⚠️ Backport to `core/1.33` failed

**Reason:** Merge conflicts detected during cherry-pick of `5233749`

<details>
<summary>📄 Conflicting files</summary>

- src/scripts/app.ts

</details>

<details>
<summary>🤖 Prompt for AI Agents</summary>

```
Backport PR #7166 (https://github.com/Comfy-Org/ComfyUI_frontend/pull/7166) to core/1.33. Cherry-pick merge commit 5233749fe33fe03cf40bafa7218bdf6eaf74cddf onto new branch backport-7166-to-core-1.33 from origin/core/1.33. Resolve conflicts in: src/scripts/app.ts. For test snapshots (browser_tests/**/*-snapshots/), accept PR version if changed in original PR, else keep target. For package.json versions, keep target branch. For pnpm-lock.yaml, regenerate with pnpm install. Ask user for non-obvious conflicts. Create PR titled "[backport core/1.33] <original title>" with label "backport". See .github/workflows/pr-backport.yaml for workflow details.
```

</details>

---

The "Prompt for AI Agents" section can be copied directly into Claude Code, Cursor, or other AI coding assistants to resolve the conflicts automatically.


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7367-ci-add-AI-agent-prompt-to-backport-conflict-comments-2c66d73d365081e1a8fbcfdc48ea8777) by [Unito](https://www.unito.io)
