### PR TITLE
fix: make flaky legacy prompt dialog test use locator rather than snapshot

### DIFF
--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -308,6 +308,7 @@ test.describe('Node Interaction', () => {
     })
     const legacyPrompt = comfyPage.page.locator('.graphdialog')
     await expect(legacyPrompt).toBeVisible()
+    await comfyPage.delay(300)
     await comfyPage.canvas.click({
       position: {
         x: 10,
@@ -330,6 +331,7 @@ test.describe('Node Interaction', () => {
     })
     const legacyPrompt = comfyPage.page.locator('.graphdialog')
     await expect(legacyPrompt).toBeVisible()
+    await comfyPage.delay(300)
     await comfyPage.canvas.click({
       position: {
         x: 10,

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -306,14 +306,15 @@ test.describe('Node Interaction', () => {
     await comfyPage.canvas.click({
       position: numberWidgetPos
     })
-    await expect(comfyPage.canvas).toHaveScreenshot('prompt-dialog-opened.png')
+    const legacyPrompt = comfyPage.page.locator('.graphdialog')
+    await expect(legacyPrompt).toBeVisible()
     await comfyPage.canvas.click({
       position: {
         x: 10,
         y: 10
       }
     })
-    await expect(comfyPage.canvas).toHaveScreenshot('prompt-dialog-closed.png')
+    await expect(legacyPrompt).toBeHidden()
   })
 
   test('Can close prompt dialog with canvas click (text widget)', async ({
@@ -327,18 +328,15 @@ test.describe('Node Interaction', () => {
     await comfyPage.canvas.click({
       position: textWidgetPos
     })
-    await expect(comfyPage.canvas).toHaveScreenshot(
-      'prompt-dialog-opened-text.png'
-    )
+    const legacyPrompt = comfyPage.page.locator('.graphdialog')
+    await expect(legacyPrompt).toBeVisible()
     await comfyPage.canvas.click({
       position: {
         x: 10,
         y: 10
       }
     })
-    await expect(comfyPage.canvas).toHaveScreenshot(
-      'prompt-dialog-closed-text.png'
-    )
+    await expect(legacyPrompt).toBeHidden()
   })
 
   test('Can double click node title to edit', async ({ comfyPage }) => {


### PR DESCRIPTION
## Summary

Fix the flakiness of [this test](https://fad8c753.comfyui-playwright-chromium.pages.dev/#?testId=967c1c643b6ca86a362c-8b516e2c224693bf7657) by converting it from using snapshots to just normal locators.

The LiteGraph prompt that opens when click canvas widgets (number/string) is still the raw DOM dialog created by `LGraphCanvas.prototype.prompt`. That implementation wires its "click outside to close" handler inside a `setTimeout` and ignores outside clicks for ~256 ms after the dialog appears. It also never updates Vue state or exposes a ready attribute/event we can observe from Playwright.

Because the UI offers no deterministic signal, using a short intentional wait that matches the real guard is reasonable. We assert the dialog becomes visible, call `await comfyPage.delay(300)` (just longer than the 256 ms guard), and then click outside. Without this wait the closing click fires before the handler exists, so the dialog remains visible and the test flakes. Until the widget exposes a ready hook, this scoped delay is the most reliable approach and stays within Playwright guidance ("only sleep when there is no observable condition to await").


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7371-fix-make-flaky-legacy-prompt-dialog-test-use-locator-rather-than-snapshot-2c66d73d36508125b388e68861d7cd28) by [Unito](https://www.unito.io)
