### PR TITLE
fix: flaky legacy context menu e2e test

### DIFF
--- a/browser_tests/tests/nodeSearchBox.spec.ts
+++ b/browser_tests/tests/nodeSearchBox.spec.ts
@@ -260,6 +260,8 @@ test.describe('Release context menu', () => {
 
   test('Can trigger on link release', async ({ comfyPage }) => {
     await comfyPage.disconnectEdge()
+    const contextMenu = comfyPage.page.locator('.litecontextmenu')
+    await expect(contextMenu).toBeVisible()
     await comfyPage.page.mouse.move(10, 10)
     await comfyPage.nextFrame()
     await expect(comfyPage.canvas).toHaveScreenshot(

--- a/browser_tests/tests/nodeSearchBox.spec.ts
+++ b/browser_tests/tests/nodeSearchBox.spec.ts
@@ -261,7 +261,11 @@ test.describe('Release context menu', () => {
   test('Can trigger on link release', async ({ comfyPage }) => {
     await comfyPage.disconnectEdge()
     const contextMenu = comfyPage.page.locator('.litecontextmenu')
-    await expect(contextMenu).toBeVisible()
+    // Wait for context menu with correct title (slot name | slot type)
+    // The title shows the output slot name and type from the disconnected link
+    await expect(contextMenu.locator('.litemenu-title')).toContainText(
+      'CLIP | CLIP'
+    )
     await comfyPage.page.mouse.move(10, 10)
     await comfyPage.nextFrame()
     await expect(comfyPage.canvas).toHaveScreenshot(


### PR DESCRIPTION
## Summary

Fixes this test which became flaky after removing the timeout. Now simply wait for the title text in the context menu, which has built-in timeout, then take snapshot.

<img width="1515" height="1155" alt="image" src="https://github.com/user-attachments/assets/f2986ed9-31c4-44a1-89bc-982d1c18109b" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7373-WIP-fix-legacy-context-menu-e2e-test-2c66d73d3650819eb9baceb5bdebfbe8) by [Unito](https://www.unito.io)
