### PR TITLE
feat: improve search alg in templates

### DIFF
--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -41,11 +41,11 @@ export function useTemplateFiltering(
     keys: [
       { name: 'name', weight: 0.3 },
       { name: 'title', weight: 0.3 },
-      { name: 'description', weight: 0.2 },
-      { name: 'tags', weight: 0.1 },
-      { name: 'models', weight: 0.1 }
+      { name: 'description', weight: 0.1 },
+      { name: 'tags', weight: 0.2 },
+      { name: 'models', weight: 0.3 }
     ],
-    threshold: 0.4,
+    threshold: 0.33,
     includeScore: true,
     includeMatches: true
   }


### PR DESCRIPTION
## Summary

Improves search alg on templates, especially for some highly searchd terms like "wan" or "3d."

<img width="3456" height="2166" alt="image" src="https://github.com/user-attachments/assets/2138e5c4-3536-4d33-8cd3-a408aea1fcd8" />

<img width="3456" height="2166" alt="image" src="https://github.com/user-attachments/assets/2c0ef2df-7a0d-465c-9063-f70d2a349400" />

<img width="3456" height="2166" alt="image" src="https://github.com/user-attachments/assets/8be9f056-26af-48bd-8214-63b16be68c16" />


<img width="3456" height="2166" alt="image" src="https://github.com/user-attachments/assets/9d6159ce-bbc4-4a40-9455-1972ddd6438a" />



[Context](https://comfy-organization.slack.com/archives/C07G75QB06Q/p1765398450984809)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7377-feat-improve-search-alg-in-templates-2c66d73d3650812996e5c8be53873e92) by [Unito](https://www.unito.io)
