### PR TITLE
[backport cloud/1.34] remove useless/misleading toast in topup dialog

### DIFF
--- a/src/components/dialog/content/TopUpCreditsDialogContent.vue
+++ b/src/components/dialog/content/TopUpCreditsDialogContent.vue
@@ -122,11 +122,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import {
-  creditsToUsd,
-  formatCredits,
-  formatUsd
-} from '@/base/credits/comfyCredits'
+import { creditsToUsd } from '@/base/credits/comfyCredits'
 import UserCredit from '@/components/common/UserCredit.vue'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
@@ -156,7 +152,7 @@ const { formattedRenewalDate } = useSubscription()
 // Use feature flag to determine design - defaults to true (new design)
 const useNewDesign = computed(() => flags.subscriptionTiersEnabled)
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const authActions = useFirebaseAuthActions()
 const telemetry = useTelemetry()
 const toast = useToast()
@@ -191,19 +187,6 @@ const handleBuy = async () => {
     const usdAmount = creditsToUsd(selectedCredits.value)
     telemetry?.trackApiCreditTopupButtonPurchaseClicked(usdAmount)
     await authActions.purchaseCredits(usdAmount)
-
-    toast.add({
-      severity: 'success',
-      summary: t('credits.topUp.purchaseSuccess'),
-      detail: t('credits.topUp.purchaseSuccessDetail', {
-        credits: formatCredits({
-          value: selectedCredits.value,
-          locale: locale.value
-        }),
-        amount: `$${formatUsd({ value: usdAmount, locale: locale.value })}`
-      }),
-      life: 3000
-    })
   } catch (error) {
     console.error('Purchase failed:', error)
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1843,8 +1843,6 @@
       "videosEstimate": "~{count} videos*",
       "templateNote": "*Generated with Wan Fun Control template",
       "buy": "Buy",
-      "purchaseSuccess": "Purchase Successful",
-      "purchaseSuccessDetail": "Successfully purchased {credits} credits for {amount}",
       "purchaseError": "Purchase Failed",
       "purchaseErrorDetail": "Failed to purchase credits: {error}",
       "unknownError": "An unknown error occurred"


### PR DESCRIPTION
## Summary
Backports the fix from main that removes the misleading "purchase successful" toast that appears immediately after clicking the buy button in the credit top-up dialog.

## Details
- Purchase actually happens on Stripe page, not immediately after clicking
- Toast was confusing users into thinking purchase completed when it hadn't
- Only error toast remains for actual failures
- Fixed merge conflict in `useCoreCommands.ts` by keeping cloud/1.34's `SubgraphNode` import

## Related
- Original PR: #7375 
- Cherry-picked from: 29af56c154977256967df9b1822f75e9fe7319db

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7380-backport-cloud-1-34-remove-useless-misleading-toast-in-topup-dialog-2c66d73d365081a1b46bdce6e3860a86) by [Unito](https://www.unito.io)
