### PR TITLE
fix: remove incorrect tooltip on remaining credit balance

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1895,7 +1895,6 @@
     "perMonth": "/ month",
     "usdPerMonth": "USD / month",
     "renewsDate": "Renews {date}",
-    "refreshesOn": "Refreshes to ${monthlyCreditBonusUsd} on {date}",
     "expiresDate": "Expires {date}",
     "manageSubscription": "Manage subscription",
     "partnerNodesBalance": "\"Partner Nodes\" Credit Balance",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1908,7 +1908,7 @@
     "monthlyBonusDescription": "Monthly credit bonus",
     "prepaidDescription": "Pre-paid credits",
     "prepaidCreditsInfo": "Pre-paid credits expire after 1 year from purchase date.",
-    "creditsRemainingThisMonth": "Credits remaining for this month",
+    "creditsRemainingThisMonth": "Credits remaining this month",
     "creditsYouveAdded": "Credits you've added",
     "monthlyCreditsInfo": "These credits refresh monthly and don't roll over",
     "viewMoreDetailsPlans": "View more details about plans & pricing",

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -138,19 +138,6 @@
                         >
                           {{ $t('subscription.creditsRemainingThisMonth') }}
                         </div>
-                        <Button
-                          v-tooltip="refreshTooltip"
-                          icon="pi pi-question-circle"
-                          text
-                          rounded
-                          size="small"
-                          class="h-4 w-4 shrink-0"
-                          :pt="{
-                            icon: {
-                              class: 'text-text-secondary text-xs'
-                            }
-                          }"
-                        />
                       </div>
                     </div>
                     <div class="flex items-center gap-4">
@@ -440,7 +427,6 @@ const { totalCredits, monthlyBonusCredits, prepaidCredits, isLoadingBalance } =
 
 const {
   isLoadingSupport,
-  refreshTooltip,
   handleAddApiCredits,
   handleMessageSupport,
   handleRefresh,

--- a/src/platform/cloud/subscription/composables/useSubscriptionActions.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionActions.ts
@@ -1,5 +1,4 @@
-import { computed, onMounted, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
+import { onMounted, ref } from 'vue'
 
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
@@ -8,29 +7,17 @@ import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import { useCommandStore } from '@/stores/commandStore'
 
-const MONTHLY_CREDIT_BONUS_USD = 10
-
 /**
  * Composable for handling subscription panel actions and loading states
  */
 export function useSubscriptionActions() {
-  const { t } = useI18n()
   const dialogService = useDialogService()
   const authActions = useFirebaseAuthActions()
   const commandStore = useCommandStore()
   const telemetry = useTelemetry()
-  const { fetchStatus, formattedRenewalDate } = useSubscription()
+  const { fetchStatus } = useSubscription()
 
   const isLoadingSupport = ref(false)
-
-  const refreshTooltip = computed(() => {
-    const date =
-      formattedRenewalDate.value || t('subscription.nextBillingCycle')
-    return t('subscription.refreshesOn', {
-      monthlyCreditBonusUsd: MONTHLY_CREDIT_BONUS_USD,
-      date
-    })
-  })
 
   onMounted(() => {
     void handleRefresh()
@@ -72,7 +59,6 @@ export function useSubscriptionActions() {
 
   return {
     isLoadingSupport,
-    refreshTooltip,
     handleAddApiCredits,
     handleMessageSupport,
     handleRefresh,

--- a/tests-ui/tests/platform/cloud/subscription/components/SubscriptionPanel.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/components/SubscriptionPanel.test.ts
@@ -42,7 +42,6 @@ const mockCreditsData = {
 
 const mockActionsData = {
   isLoadingSupport: false,
-  refreshTooltip: 'Refreshes on 2024-12-31',
   handleAddApiCredits: vi.fn(),
   handleMessageSupport: vi.fn(),
   handleRefresh: vi.fn(),

--- a/tests-ui/tests/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
+++ b/tests-ui/tests/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
@@ -7,23 +7,6 @@ const mockFetchBalance = vi.fn()
 const mockFetchStatus = vi.fn()
 const mockShowTopUpCreditsDialog = vi.fn()
 const mockExecute = vi.fn()
-const mockT = vi.fn((key: string, values?: any) => {
-  if (key === 'subscription.nextBillingCycle') return 'next billing cycle'
-  if (key === 'subscription.refreshesOn') {
-    return `Refreshes to $${values?.monthlyCreditBonusUsd} on ${values?.date}`
-  }
-  return key
-})
-
-vi.mock('vue-i18n', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('vue-i18n')>()
-  return {
-    ...actual,
-    useI18n: () => ({
-      t: mockT
-    })
-  }
-})
 
 vi.mock('@/composables/auth/useFirebaseAuthActions', () => ({
   useFirebaseAuthActions: () => ({
@@ -31,12 +14,9 @@ vi.mock('@/composables/auth/useFirebaseAuthActions', () => ({
   })
 }))
 
-const mockFormattedRenewalDate = { value: '2024-12-31' }
-
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
-    fetchStatus: mockFetchStatus,
-    formattedRenewalDate: mockFormattedRenewalDate
+    fetchStatus: mockFetchStatus
   })
 }))
 
@@ -62,23 +42,6 @@ Object.defineProperty(window, 'open', {
 describe('useSubscriptionActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFormattedRenewalDate.value = '2024-12-31'
-  })
-
-  describe('refreshTooltip', () => {
-    it('should format tooltip with renewal date', () => {
-      const { refreshTooltip } = useSubscriptionActions()
-      expect(refreshTooltip.value).toBe('Refreshes to $10 on 2024-12-31')
-    })
-
-    it('should use fallback text when no renewal date', () => {
-      mockFormattedRenewalDate.value = ''
-      const { refreshTooltip } = useSubscriptionActions()
-      expect(refreshTooltip.value).toBe(
-        'Refreshes to $10 on next billing cycle'
-      )
-      expect(mockT).toHaveBeenCalledWith('subscription.nextBillingCycle')
-    })
   })
 
   describe('handleAddApiCredits', () => {


### PR DESCRIPTION
## Summary
Removed incorrect tooltip displayed on the remaining credit balance in the subscription panel.

## Changes
- **What**: Removed unused `refreshTooltip` destructure and i18n translation key
- **Breaking**: None

Fixes #6694

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7383-fix-remove-incorrect-tooltip-on-remaining-credit-balance-2c66d73d3650814eaee0f3c9006b7bd6) by [Unito](https://www.unito.io)
