### PR TITLE
fix: remove custom LoRA feature from standard tier

### DIFF
--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -344,16 +344,17 @@ import type { components } from '@/types/comfyRegistryTypes'
 import { cn } from '@/utils/tailwindUtil'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
+type TierKey = 'standard' | 'creator' | 'pro' | 'founder'
 
 /** Maps API subscription tier values to i18n translation keys */
-const TIER_TO_I18N_KEY: Record<SubscriptionTier, string> = {
+const TIER_TO_I18N_KEY: Record<SubscriptionTier, TierKey> = {
   STANDARD: 'standard',
   CREATOR: 'creator',
   PRO: 'pro',
   FOUNDERS_EDITION: 'founder'
 }
 
-const DEFAULT_TIER_KEY = 'standard'
+const DEFAULT_TIER_KEY: TierKey = 'standard'
 
 const { buildDocsUrl } = useExternalLink()
 const { t } = useI18n()
@@ -387,39 +388,50 @@ interface Benefit {
   value?: string
 }
 
-const tierBenefits = computed(() => {
-  const key = tierKey.value
-  const baseBenefits: Benefit[] = [
-    {
-      key: 'monthlyCredits',
-      type: 'metric',
-      value: t(`subscription.tiers.${key}.benefits.monthlyCredits`),
-      label: t(`subscription.tiers.${key}.benefits.monthlyCreditsLabel`)
-    },
-    {
-      key: 'maxDuration',
-      type: 'metric',
-      value: t(`subscription.tiers.${key}.benefits.maxDuration`),
-      label: t(`subscription.tiers.${key}.benefits.maxDurationLabel`)
-    },
-    {
-      key: 'gpu',
-      type: 'feature',
-      label: t(`subscription.tiers.${key}.benefits.gpuLabel`)
-    },
-    {
-      key: 'addCredits',
-      type: 'feature',
-      label: t(`subscription.tiers.${key}.benefits.addCreditsLabel`)
-    },
-    {
-      key: 'customLoRAs',
-      type: 'feature',
-      label: t(`subscription.tiers.${key}.benefits.customLoRAsLabel`)
-    }
+const BENEFITS_BY_TIER: Record<
+  TierKey,
+  ReadonlyArray<Omit<Benefit, 'label' | 'value'>>
+> = {
+  standard: [
+    { key: 'monthlyCredits', type: 'metric' },
+    { key: 'maxDuration', type: 'metric' },
+    { key: 'gpu', type: 'feature' },
+    { key: 'addCredits', type: 'feature' }
+  ],
+  creator: [
+    { key: 'monthlyCredits', type: 'metric' },
+    { key: 'maxDuration', type: 'metric' },
+    { key: 'gpu', type: 'feature' },
+    { key: 'addCredits', type: 'feature' },
+    { key: 'customLoRAs', type: 'feature' }
+  ],
+  pro: [
+    { key: 'monthlyCredits', type: 'metric' },
+    { key: 'maxDuration', type: 'metric' },
+    { key: 'gpu', type: 'feature' },
+    { key: 'addCredits', type: 'feature' },
+    { key: 'customLoRAs', type: 'feature' }
+  ],
+  founder: [
+    { key: 'monthlyCredits', type: 'metric' },
+    { key: 'maxDuration', type: 'metric' },
+    { key: 'gpu', type: 'feature' },
+    { key: 'addCredits', type: 'feature' },
+    { key: 'customLoRAs', type: 'feature' }
   ]
+}
 
-  return baseBenefits
+const tierBenefits = computed(() => {
+  const key = tierKey.value as TierKey
+  const benefitConfig = BENEFITS_BY_TIER[key]
+
+  return benefitConfig.map((config) => ({
+    ...config,
+    ...(config.type === 'metric' && {
+      value: t(`subscription.tiers.${key}.benefits.${config.key}`)
+    }),
+    label: t(`subscription.tiers.${key}.benefits.${config.key}Label`)
+  }))
 })
 
 const { totalCredits, monthlyBonusCredits, prepaidCredits, isLoadingBalance } =

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -344,15 +344,16 @@ import type { components } from '@/types/comfyRegistryTypes'
 import { cn } from '@/utils/tailwindUtil'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
-type TierKey = 'standard' | 'creator' | 'pro' | 'founder'
 
 /** Maps API subscription tier values to i18n translation keys */
-const TIER_TO_I18N_KEY: Record<SubscriptionTier, TierKey> = {
+const TIER_TO_I18N_KEY = {
   STANDARD: 'standard',
   CREATOR: 'creator',
   PRO: 'pro',
   FOUNDERS_EDITION: 'founder'
-}
+} as const satisfies Record<SubscriptionTier, string>
+
+type TierKey = (typeof TIER_TO_I18N_KEY)[SubscriptionTier]
 
 const DEFAULT_TIER_KEY: TierKey = 'standard'
 

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -422,7 +422,7 @@ const BENEFITS_BY_TIER: Record<
 }
 
 const tierBenefits = computed(() => {
-  const key = tierKey.value as TierKey
+  const key = tierKey.value
   const benefitConfig = BENEFITS_BY_TIER[key]
 
   return benefitConfig.map((config) => ({


### PR DESCRIPTION
## Summary
Standard tier was incorrectly displaying custom LoRA as a benefit. Refactored to use strongly-typed benefit configuration.

## Changes
- **What**: Created `BENEFITS_BY_TIER` configuration to explicitly define tier benefits
- **Type Safety**: Added `TierKey` type and improved type constraints throughout
- **Fix**: Excluded `customLoRAs` from standard tier (only creator/pro/founder get this feature)

## Review Focus
Verify standard tier no longer shows custom LoRA feature in subscription panel

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7391-fix-remove-custom-LoRA-feature-from-standard-tier-2c66d73d36508149ad6ff7bba6333109) by [Unito](https://www.unito.io)
