### PR TITLE
fix: remove custom LoRA from subscription benefits display

### DIFF
--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -417,8 +417,7 @@ const BENEFITS_BY_TIER: Record<
     { key: 'monthlyCredits', type: 'metric' },
     { key: 'maxDuration', type: 'metric' },
     { key: 'gpu', type: 'feature' },
-    { key: 'addCredits', type: 'feature' },
-    { key: 'customLoRAs', type: 'feature' }
+    { key: 'addCredits', type: 'feature' }
   ]
 }
 


### PR DESCRIPTION
## Summary
Removes custom LoRA feature from subscription benefits display for standard and founder tiers.

## Changes
- **What**: Removed `customLoRAs` benefit entry from `BENEFITS_BY_TIER` for standard and founder tiers

## Review Focus
- Verify custom LoRA feature is completely removed from subscription UI

Related to #7391