### PR TITLE
fix: update pricing table link

### DIFF
--- a/src/components/topbar/CurrentUserPopover.test.ts
+++ b/src/components/topbar/CurrentUserPopover.test.ts
@@ -248,7 +248,7 @@ describe('CurrentUserPopover', () => {
 
     // Verify window.open was called with the correct URL
     expect(window.open).toHaveBeenCalledWith(
-      'https://docs.comfy.org/tutorials/api-nodes/overview#api-nodes',
+      'https://docs.comfy.org/tutorials/partner-nodes/pricing',
       '_blank'
     )
 

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -205,7 +205,7 @@ const handleTopUp = () => {
 
 const handleOpenPartnerNodesInfo = () => {
   window.open(
-    buildDocsUrl('/tutorials/api-nodes/overview#api-nodes', {
+    buildDocsUrl('/tutorials/partner-nodes/pricing', {
       includeLocale: true
     }),
     '_blank'


### PR DESCRIPTION
## Summary

Update to https://docs.comfy.org/tutorials/partner-nodes/pricing -- actual link to the pricing table (before was sending to just the Partner Nodes docs).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7402-fix-update-pricing-table-link-2c76d73d365081f2b890ee6887c0314e) by [Unito](https://www.unito.io)
