### PR TITLE
fix: correct grammar in pricing table description

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2006,7 +2006,7 @@
     "gpuLabel": "RTX 6000 Pro (96GB VRAM)",
     "addCreditsLabel": "Add more credits whenever",
     "customLoRAsLabel": "Import your own LoRAs",
-    "videoEstimateLabel": "Approx. amount of 5s videos generated with Wan Fun Control template",
+    "videoEstimateLabel": "Approx. number of 5s videos generated with Wan Fun Control template",
     "videoEstimateHelp": "What is this?",
     "videoEstimateExplanation": "These estimates are based on the Wan Fun Control template for 5-second videos.",
     "videoEstimateTryTemplate": "Try the Wan Fun Control template →",
@@ -2424,3 +2424,4 @@
     "helpCenterMenu": "Help Center Menu"
   }
 }
+


### PR DESCRIPTION
## Summary

Change "amount" to "number," as "video" is a countable noun.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7403-fix-correct-grammar-in-pricing-table-description-2c76d73d36508144828fd060b046c1a5) by [Unito](https://www.unito.io)
