### PR TITLE
fix: button text token on pricing table buttons

### DIFF
--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -122,8 +122,7 @@
           class="h-10 w-full"
           :pt="{
             label: {
-              class:
-                'font-inter text-sm font-bold leading-normal text-primary-foreground'
+              class: getButtonTextClass(tier)
             }
           }"
           @click="() => handleSubscribe(tier.key)"
@@ -272,6 +271,11 @@ const getButtonSeverity = (tier: PricingTierConfig): 'primary' | 'secondary' =>
     : tier.key === 'creator'
       ? 'primary'
       : 'secondary'
+
+const getButtonTextClass = (tier: PricingTierConfig): string =>
+  tier.key === 'creator'
+    ? 'font-inter text-sm font-bold leading-normal text-white'
+    : 'font-inter text-sm font-bold leading-normal text-primary-foreground'
 
 const initiateCheckout = async (tierKey: TierKey) => {
   const authHeader = await getAuthHeader()


### PR DESCRIPTION
Button text on middle button below was black before, here is after:

<img width="1703" height="1411" alt="image" src="https://github.com/user-attachments/assets/dc55b4cf-ee86-49ee-842a-0bed84f78dee" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7404-fix-button-text-token-on-pricing-table-buttons-2c76d73d365081349c63d6a349dee6ed) by [Unito](https://www.unito.io)
