### PR TITLE
style: fix typography in credits/account panel to be uniform

### DIFF
--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -53,13 +53,13 @@
                 v-if="isActiveSubscription"
                 :label="$t('subscription.manageSubscription')"
                 severity="secondary"
-                class="text-xs bg-interface-menu-component-surface-selected"
+                class="bg-interface-menu-component-surface-selected"
                 :pt="{
                   root: {
                     style: 'border-radius: 8px; padding: 8px 16px;'
                   },
                   label: {
-                    class: 'text-text-primary'
+                    class: 'text-sm font-normal text-text-primary'
                   }
                 }"
                 @click="showSubscriptionDialog"
@@ -195,7 +195,7 @@
                           style: 'border-radius: 8px;'
                         },
                         label: {
-                          class: 'text-sm'
+                          class: 'text-sm font-normal text-text-primary'
                         }
                       }"
                       @click="handleAddApiCredits"


### PR DESCRIPTION
## Summary

Updates typography on the "Manage Subscription" and "Add credits" button to be uniform and match Figma.

After:

<img width="1515" height="1155" alt="Screenshot from 2025-12-11 23-29-36" src="https://github.com/user-attachments/assets/a2e5c0bc-d478-45e4-a7f0-d409a233cc0b" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7406-style-fix-typography-in-credits-account-panel-to-be-uniform-2c76d73d365081b69b43dd2e6be50431) by [Unito](https://www.unito.io)
