### PR TITLE
make cloud onboarding survey disableable via runtime feature flag

### DIFF
--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -13,7 +13,8 @@ export enum ServerFeatureFlag {
   MODEL_UPLOAD_BUTTON_ENABLED = 'model_upload_button_enabled',
   ASSET_UPDATE_OPTIONS_ENABLED = 'asset_update_options_enabled',
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
-  SUBSCRIPTION_TIERS_ENABLED = 'subscription_tiers_enabled'
+  SUBSCRIPTION_TIERS_ENABLED = 'subscription_tiers_enabled',
+  ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled'
 }
 
 /**
@@ -65,6 +66,12 @@ export function useFeatureFlags() {
           ServerFeatureFlag.SUBSCRIPTION_TIERS_ENABLED,
           true // Default to true (new design)
         )
+      )
+    },
+    get onboardingSurveyEnabled() {
+      return (
+        remoteConfig.value.onboarding_survey_enabled ??
+        api.getServerFeature(ServerFeatureFlag.ONBOARDING_SURVEY_ENABLED, true)
       )
     }
   })

--- a/src/platform/cloud/onboarding/CloudSurveyView.vue
+++ b/src/platform/cloud/onboarding/CloudSurveyView.vue
@@ -236,9 +236,7 @@ import { useTelemetry } from '@/platform/telemetry'
 const { t } = useI18n()
 const router = useRouter()
 const { flags } = useFeatureFlags()
-const onboardingSurveyEnabled = computed(
-  () => flags.onboardingSurveyEnabled ?? true
-)
+const onboardingSurveyEnabled = computed(() => flags.onboardingSurveyEnabled)
 
 // Check if survey is already completed on mount
 onMounted(async () => {

--- a/src/platform/cloud/onboarding/CloudSurveyView.vue
+++ b/src/platform/cloud/onboarding/CloudSurveyView.vue
@@ -225,6 +225,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   getSurveyCompletedStatus,
   submitSurvey
@@ -234,14 +235,22 @@ import { useTelemetry } from '@/platform/telemetry'
 
 const { t } = useI18n()
 const router = useRouter()
+const { flags } = useFeatureFlags()
+const onboardingSurveyEnabled = computed(
+  () => flags.onboardingSurveyEnabled ?? true
+)
 
 // Check if survey is already completed on mount
 onMounted(async () => {
+  if (!onboardingSurveyEnabled.value) {
+    await router.replace({ name: 'cloud-user-check' })
+    return
+  }
   try {
     const surveyCompleted = await getSurveyCompletedStatus()
     if (surveyCompleted) {
-      // User already completed survey, redirect to waitlist
-      await router.replace({ name: 'cloud-waitlist' })
+      // User already completed survey, return to onboarding flow
+      await router.replace({ name: 'cloud-user-check' })
     } else {
       // Track survey opened event
       if (isCloud) {
@@ -342,6 +351,10 @@ const goTo = (step: number, activate: (val: string | number) => void) => {
 // Submit
 const onSubmitSurvey = async () => {
   try {
+    if (!onboardingSurveyEnabled.value) {
+      await router.replace({ name: 'cloud-user-check' })
+      return
+    }
     isSubmitting.value = true
     // prepare payload with consistent structure
     const payload = {

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -38,6 +38,7 @@ export type RemoteConfig = {
   asset_update_options_enabled?: boolean
   private_models_enabled?: boolean
   subscription_tiers_enabled?: boolean
+  onboarding_survey_enabled?: boolean
   stripe_publishable_key?: string
   stripe_pricing_table_id?: string
 }


### PR DESCRIPTION
## Summary

The survey is causing some friction. It incurs about 5-10% dropoff. Although that number is actually somewhat slow, the information has mostly served its purpose for now. We can toggle it freely once this PR is merged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7407-make-cloud-onboarding-survey-disableable-via-runtime-feature-flag-2c76d73d365081648195f322cb0d7a64) by [Unito](https://www.unito.io)
