### PR TITLE
fix: text-white usage causes video dimensions to be invisible on light theme

### DIFF
--- a/src/renderer/extensions/vueNodes/VideoPreview.vue
+++ b/src/renderer/extensions/vueNodes/VideoPreview.vue
@@ -90,7 +90,7 @@
     </div>
 
     <!-- Video Dimensions -->
-    <div class="mt-2 text-center text-xs text-white">
+    <div class="mt-2 text-center text-xs text-muted-foreground">
       <span v-if="videoError" class="text-red-400">
         {{ $t('g.errorLoadingVideo') }}
       </span>


### PR DESCRIPTION
## Summary

All other usages of `text-white` in the codebase require also changing the bg color to be a semantic token. This is the only case where the bg is theme-aware and the text is hardcoded.


| Before                                                                                                                                        | After                                                                                                                                         |
| --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1515" height="1155" alt="Screenshot from 2025-12-12 00-03-15" src="https://github.com/user-attachments/assets/f15bfc48-ded6-4a20-b693-f8d2a2f4cc5b" /> | <img width="1515" height="1155" alt="Screenshot from 2025-12-12 00-03-22" src="https://github.com/user-attachments/assets/5dfd7345-0052-48ea-ad77-ecd7f3aa4b89" /> |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7408-fix-text-white-usage-causes-video-dimensions-to-be-invisible-on-light-theme-2c76d73d365081668eafef95639a42f9) by [Unito](https://www.unito.io)
