### PR TITLE
Style: Thicker node status indicator

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -378,16 +378,14 @@ const { latestPreviewUrl, shouldShowPreviewImg } = useNodePreviewState(
 
 const borderClass = computed(() => {
   if (hasAnyError.value) return 'border-node-stroke-error'
-  if (executing.value) return 'border-node-stroke-executing'
-  return 'border-node-stroke'
+  return ''
 })
 
 const outlineClass = computed(() => {
   return cn(
-    isSelected.value &&
-      ((hasAnyError.value && 'outline-error ') ||
-        (executing.value && 'outline-node-executing') ||
-        'outline-node-component-outline')
+    isSelected.value && 'outline-node-component-outline',
+    hasAnyError.value && 'outline-node-stroke-error',
+    executing.value && 'outline-node-stroke-executing'
   )
 })
 

--- a/tests-ui/tests/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -199,6 +199,6 @@ describe('LGraphNode', () => {
 
     const wrapper = mountLGraphNode({ nodeData: mockNodeData })
 
-    expect(wrapper.classes()).toContain('border-node-stroke-executing')
+    expect(wrapper.classes()).toContain('outline-node-stroke-executing')
   })
 })


### PR DESCRIPTION
## Summary

The outline is already thicker and this means we can use it as an indicator without squishing the node internals.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7409-Style-Thicker-node-status-indicator-2c76d73d36508132a5defd3a8514013d) by [Unito](https://www.unito.io)
