### PR TITLE
fix: ImagePreview i18n teardown

### DIFF
--- a/tests-ui/tests/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/tests-ui/tests/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
+import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -41,9 +42,10 @@ describe('ImagePreview', () => {
       '/api/view?filename=test2.png&type=output'
     ]
   }
+  const wrapperRegistry = new Set<VueWrapper>()
 
   const mountImagePreview = (props = {}) => {
-    return mount(ImagePreview, {
+    const wrapper = mount(ImagePreview, {
       props: { ...defaultProps, ...props },
       global: {
         plugins: [
@@ -61,7 +63,16 @@ describe('ImagePreview', () => {
         }
       }
     })
+    wrapperRegistry.add(wrapper)
+    return wrapper
   }
+
+  afterEach(() => {
+    wrapperRegistry.forEach((wrapper) => {
+      wrapper.unmount()
+    })
+    wrapperRegistry.clear()
+  })
 
   it('renders image preview when imageUrls provided', () => {
     const wrapper = mountImagePreview()


### PR DESCRIPTION
Ensure ImagePreview component tests explicitly unmount their wrappers so vue-i18n/Intlify watchers stop running before Vitest tears down happy-dom’s window, eliminating the window is not defined failure noted after merging #7142.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7412-fix-ImagePreview-i18n-teardown-2c76d73d36508122b94ac66864a0d3f2) by [Unito](https://www.unito.io)
