### PR TITLE
refactor: stop fighting the DOM

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -2,6 +2,7 @@
   <div
     v-if="imageUrls.length > 0"
     class="image-preview group relative flex size-full min-h-16 min-w-16 flex-col px-2 justify-center"
+    @keydown="handleKeyDown"
   >
     <!-- Image Wrapper -->
     <div
@@ -120,8 +121,7 @@
 import { useTimeoutFn } from '@vueuse/core'
 import { useToast } from 'primevue'
 import Skeleton from 'primevue/skeleton'
-import type { ShallowRef } from 'vue'
-import { computed, inject, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { downloadFile } from '@/base/common/downloadUtil'
@@ -169,15 +169,6 @@ const { start: startDelayedLoader, stop: stopDelayedLoader } = useTimeoutFn(
 const currentImageUrl = computed(() => props.imageUrls[currentIndex.value])
 const hasMultipleImages = computed(() => props.imageUrls.length > 1)
 const imageAltText = computed(() => `Node output ${currentIndex.value + 1}`)
-
-const keyEvent = inject<ShallowRef<KeyboardEvent | null>>('keyEvent')
-
-if (keyEvent) {
-  watch(keyEvent, (e) => {
-    if (!e) return
-    handleKeyDown(e)
-  })
-}
 
 // Watch for URL changes and reset state
 watch(

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -49,7 +49,6 @@
     @dragover.prevent="handleDragOver"
     @dragleave="handleDragLeave"
     @drop.stop.prevent="handleDrop"
-    @keydown="handleNodeKeydown"
   >
     <div class="flex flex-col justify-center items-center relative">
       <template v-if="isCollapsed">
@@ -132,16 +131,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import {
-  computed,
-  nextTick,
-  onErrorCaptured,
-  onMounted,
-  provide,
-  ref,
-  shallowRef,
-  watch
-} from 'vue'
+import { computed, nextTick, onErrorCaptured, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
@@ -207,13 +197,6 @@ const { selectedNodeIds } = storeToRefs(useCanvasStore())
 const isSelected = computed(() => {
   return selectedNodeIds.value.has(nodeData.id)
 })
-
-const keyEvent = shallowRef<KeyboardEvent | null>(null)
-provide('keyEvent', keyEvent)
-
-const handleNodeKeydown = (event: KeyboardEvent) => {
-  keyEvent.value = event
-}
 
 const nodeLocatorId = computed(() => getLocatorIdFromNodeData(nodeData))
 const { executing, progress } = useNodeExecutionState(nodeLocatorId)


### PR DESCRIPTION
## Summary

Remove keyDown provider on the LGraphNode, remove inject on widget.

## Changes

- **What**: LGraphNode.vue ImagePreview.vue
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7421-refactor-stop-fighting-the-DOM-2c76d73d365081e6b5e9c99a61bbd883) by [Unito](https://www.unito.io)
