### PR TITLE
fix: enhance snapshot update process to include untracked files

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -128,8 +128,11 @@ jobs:
           echo "STAGING CHANGED SNAPSHOTS (Shard ${{ matrix.shardIndex }})"
           echo "=========================================="
 
-          # Get list of changed snapshot files
-          changed_files=$(git diff --name-only browser_tests/ 2>/dev/null | grep -E '\-snapshots/' || echo "")
+          # Get list of changed snapshot files (including untracked/new files)
+          changed_files=$( (
+            git diff --name-only browser_tests/ 2>/dev/null || true
+            git ls-files --others --exclude-standard browser_tests/ 2>/dev/null || true
+          ) | sort -u | grep -E '\-snapshots/' || true )
 
           if [ -z "$changed_files" ]; then
             echo "No snapshot changes in this shard"
@@ -151,6 +154,11 @@ jobs:
           # Strip 'browser_tests/' prefix to avoid double nesting
           echo "Copying changed files to staging directory..."
           while IFS= read -r file; do
+            # Skip paths that no longer exist (e.g. deletions)
+            if [ ! -f "$file" ]; then
+              echo "  → (skipped; not a file) $file"
+              continue
+            fi
             # Remove 'browser_tests/' prefix
             file_without_prefix="${file#browser_tests/}"
             # Create parent directories


### PR DESCRIPTION
This pull request improves the snapshot staging process in the Playwright expectations update workflow. The main focus is to ensure both modified and newly added snapshot files are correctly detected and handled, and to avoid errors when files have been deleted.

**Snapshot file detection and handling improvements:**

* The workflow now detects both modified and untracked (new) snapshot files by combining output from `git diff` and `git ls-files --others`, ensuring all relevant snapshot changes are staged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7422-fix-enhance-snapshot-update-process-to-include-untracked-files-2c76d73d365081cc8023d9ed29b8781f) by [Unito](https://www.unito.io)
