### PR TITLE
Fix snapshot updates commit stage

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -269,11 +269,11 @@ jobs:
           echo "CHANGES SUMMARY"
           echo "=========================================="
           echo ""
-          echo "Changed files in browser_tests:"
-          git diff --name-only browser_tests/ | head -20 || echo "No changes"
+          echo "Changed files in browser_tests (including untracked):"
+          git status --porcelain=v1 --untracked-files=all -- browser_tests/ | head -50 || echo "No changes"
           echo ""
           echo "Total changes:"
-          git diff --name-only browser_tests/ | wc -l || echo "0"
+          git status --porcelain=v1 --untracked-files=all -- browser_tests/ | wc -l || echo "0"
 
       - name: Commit updated expectations
         id: commit
@@ -281,7 +281,7 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
 
-          if git diff --quiet browser_tests/; then
+          if [ -z "$(git status --porcelain=v1 --untracked-files=all -- browser_tests/)" ]; then
             echo "No changes to commit"
             echo "has-changes=false" >> $GITHUB_OUTPUT
             exit 0

--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -128,8 +128,11 @@ jobs:
           echo "STAGING CHANGED SNAPSHOTS (Shard ${{ matrix.shardIndex }})"
           echo "=========================================="
 
-          # Get list of changed snapshot files
-          changed_files=$(git diff --name-only browser_tests/ 2>/dev/null | grep -E '\-snapshots/' || echo "")
+          # Get list of changed snapshot files (including untracked/new files)
+          changed_files=$( (
+            git diff --name-only browser_tests/ 2>/dev/null || true
+            git ls-files --others --exclude-standard browser_tests/ 2>/dev/null || true
+          ) | sort -u | grep -E '\-snapshots/' || true )
 
           if [ -z "$changed_files" ]; then
             echo "No snapshot changes in this shard"
@@ -151,6 +154,11 @@ jobs:
           # Strip 'browser_tests/' prefix to avoid double nesting
           echo "Copying changed files to staging directory..."
           while IFS= read -r file; do
+            # Skip paths that no longer exist (e.g. deletions)
+            if [ ! -f "$file" ]; then
+              echo "  → (skipped; not a file) $file"
+              continue
+            fi
             # Remove 'browser_tests/' prefix
             file_without_prefix="${file#browser_tests/}"
             # Create parent directories

--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -124,6 +124,7 @@ jobs:
       - name: Stage changed snapshot files
         id: changed-snapshots
         run: |
+          set -euo pipefail
           echo "=========================================="
           echo "STAGING CHANGED SNAPSHOTS (Shard ${{ matrix.shardIndex }})"
           echo "=========================================="
@@ -270,10 +271,18 @@ jobs:
           echo "=========================================="
           echo ""
           echo "Changed files in browser_tests (including untracked):"
-          git status --porcelain=v1 --untracked-files=all -- browser_tests/ | head -50 || echo "No changes"
-          echo ""
-          echo "Total changes:"
-          git status --porcelain=v1 --untracked-files=all -- browser_tests/ | wc -l || echo "0"
+          CHANGES=$(git status --porcelain=v1 --untracked-files=all -- browser_tests/)
+          if [ -z "$CHANGES" ]; then
+            echo "No changes"
+            echo ""
+            echo "Total changes:"
+            echo "0"
+          else
+            echo "$CHANGES" | head -50
+            echo ""
+            echo "Total changes:"
+            echo "$CHANGES" | wc -l
+          fi
 
       - name: Commit updated expectations
         id: commit


### PR DESCRIPTION
This pull request updates the `.github/workflows/pr-update-playwright-expectations.yaml` workflow to improve how changed Playwright snapshot files are detected and handled, ensuring that both tracked and untracked (new) files are included throughout the process. The changes also add robustness to file operations and improve the accuracy of change summaries.

**Improvements to snapshot detection and staging:**

* The workflow now detects both tracked and untracked (new) snapshot files in `browser_tests/` when preparing changed files for staging, ensuring that new snapshots are not missed.
* When copying changed files to the staging directory, the script now skips files that no longer exist (e.g., deleted files), preventing errors and unnecessary operations.

**Enhancements to change summary and commit logic:**

* The summary of changes now includes both tracked and untracked files in `browser_tests/`, and the output is expanded to show up to 50 files for better visibility.
* The logic for determining whether there are changes to commit now checks for both tracked and untracked changes, ensuring commits are only made when necessary.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7423-Fix-snapshot-updates-commit-stage-2c76d73d36508195914ec92f37937e67) by [Unito](https://www.unito.io)
