### PR TITLE
style-fix: Don't add body padding with no body.

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -9,7 +9,7 @@
     :data-node-id="nodeData.id"
     :class="
       cn(
-        'bg-component-node-background lg-node absolute pb-1 text-sm',
+        'bg-component-node-background lg-node absolute text-sm',
         'contain-style contain-layout min-w-[225px] min-h-(--node-height) w-(--node-width)',
         shapeClass,
         'touch-none flex flex-col',
@@ -31,7 +31,8 @@
 
         shouldHandleNodePointerEvents
           ? 'pointer-events-auto'
-          : 'pointer-events-none'
+          : 'pointer-events-none',
+        !isCollapsed && ' pb-1'
       )
     "
     :style="[


### PR DESCRIPTION
## Summary

Small fix for collapsed nodes.

## Screenshots (if applicable)

### Before

<img width="594" height="184" alt="image" src="https://github.com/user-attachments/assets/1ea39a32-738d-4a1b-87ad-b73abf640b45" />

### After
<img width="635" height="206" alt="image" src="https://github.com/user-attachments/assets/9050bf33-b37c-4ede-8e26-d88fef59bf4d" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7424-style-fix-Don-t-add-body-padding-with-no-body-2c86d73d3650817cb8f7ccf859e6ab3a) by [Unito](https://www.unito.io)
