### PR TITLE
fix: pricing table links to wrong page in docs (p2)

### DIFF
--- a/src/components/dialog/content/setting/LegacyCreditsPanel.vue
+++ b/src/components/dialog/content/setting/LegacyCreditsPanel.vue
@@ -139,7 +139,7 @@ interface CreditHistoryItemData {
   isPositive: boolean
 }
 
-const { buildDocsUrl } = useExternalLink()
+const { buildDocsUrl, docsPaths } = useExternalLink()
 const dialogService = useDialogService()
 const authStore = useFirebaseAuthStore()
 const authActions = useFirebaseAuthActions()
@@ -194,9 +194,7 @@ const handleFaqClick = () => {
 
 const handleOpenPartnerNodesInfo = () => {
   window.open(
-    buildDocsUrl('/tutorials/api-nodes/overview#api-nodes', {
-      includeLocale: true
-    }),
+    buildDocsUrl(docsPaths.partnerNodesPricing, { includeLocale: true }),
     '_blank'
   )
 }

--- a/src/components/topbar/CurrentUserPopover.test.ts
+++ b/src/components/topbar/CurrentUserPopover.test.ts
@@ -117,7 +117,10 @@ vi.mock('@/base/credits/comfyCredits', () => ({
 // Mock useExternalLink
 vi.mock('@/composables/useExternalLink', () => ({
   useExternalLink: vi.fn(() => ({
-    buildDocsUrl: vi.fn((path) => `https://docs.comfy.org${path}`)
+    buildDocsUrl: vi.fn((path) => `https://docs.comfy.org${path}`),
+    docsPaths: {
+      partnerNodesPricing: '/tutorials/partner-nodes/pricing'
+    }
   }))
 }))
 

--- a/src/components/topbar/CurrentUserPopover.vue
+++ b/src/components/topbar/CurrentUserPopover.vue
@@ -152,7 +152,7 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { buildDocsUrl } = useExternalLink()
+const { buildDocsUrl, docsPaths } = useExternalLink()
 
 const planSettingsLabel = isCloud
   ? 'settingsCategories.PlanCredits'
@@ -205,9 +205,7 @@ const handleTopUp = () => {
 
 const handleOpenPartnerNodesInfo = () => {
   window.open(
-    buildDocsUrl('/tutorials/partner-nodes/pricing', {
-      includeLocale: true
-    }),
+    buildDocsUrl(docsPaths.partnerNodesPricing, { includeLocale: true }),
     '_blank'
   )
   emit('close')

--- a/src/composables/useExternalLink.ts
+++ b/src/composables/useExternalLink.ts
@@ -92,8 +92,14 @@ export function useExternalLink() {
     comfyOrg: 'https://www.comfy.org/'
   }
 
+  /** Common doc paths for use with buildDocsUrl */
+  const docsPaths = {
+    partnerNodesPricing: '/tutorials/partner-nodes/pricing'
+  }
+
   return {
     buildDocsUrl,
-    staticUrls
+    staticUrls,
+    docsPaths
   }
 }

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -378,7 +378,7 @@ type TierKey = (typeof TIER_TO_I18N_KEY)[SubscriptionTier]
 
 const DEFAULT_TIER_KEY: TierKey = 'standard'
 
-const { buildDocsUrl } = useExternalLink()
+const { buildDocsUrl, docsPaths } = useExternalLink()
 const authActions = useFirebaseAuthActions()
 const { t } = useI18n()
 
@@ -469,9 +469,7 @@ const {
 
 const handleOpenPartnerNodesInfo = () => {
   window.open(
-    buildDocsUrl('/tutorials/api-nodes/overview#api-nodes', {
-      includeLocale: true
-    }),
+    buildDocsUrl(docsPaths.partnerNodesPricing, { includeLocale: true }),
     '_blank'
   )
 }


### PR DESCRIPTION
## Summary

Continuation of updating pricing table link (p1 was https://github.com/Comfy-Org/ComfyUI_frontend/pull/7402). Create a constant since it's now used in multiple locations.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7434-fix-pricing-table-links-to-wrong-page-in-docs-p2-2c86d73d36508199b320d49faa6a0c73) by [Unito](https://www.unito.io)
