### PR TITLE
Add functionality to quickly disconnect moved input links

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5015,6 +5015,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           }
         )
       }
+      if (renderLink instanceof MovingInputLink) this.setDirty(false, true)
 
       ctx.fillStyle = colour
       ctx.beginPath()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2,7 +2,7 @@ import { toString } from 'es-toolkit/compat'
 import { toValue } from 'vue'
 
 import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
-import { MovingLinkBase } from '@/lib/litegraph/src/canvas/MovingLinkBase'
+import { MovingInputLink } from '@/lib/litegraph/src/canvas/MovingInputLink'
 import { LitegraphLinkAdapter } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
 import type { LinkRenderContext } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
 import { getSlotPosition } from '@/renderer/core/canvas/litegraph/slotCalculations'
@@ -5015,8 +5015,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           }
         )
       }
-      if (renderLink instanceof MovingLinkBase)
-        renderLink.drawConnectionCircle(ctx)
+      if (renderLink instanceof MovingInputLink)
+        renderLink.drawConnectionCircle(ctx, this.graph_mouse)
 
       ctx.fillStyle = colour
       ctx.beginPath()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5016,7 +5016,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         )
       }
       if (renderLink instanceof MovingInputLink)
-        renderLink.drawConnectionCircle(ctx, this.graph_mouse)
+        renderLink.drawConnectionCircle(ctx, highlightPos)
 
       ctx.fillStyle = colour
       ctx.beginPath()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2,6 +2,7 @@ import { toString } from 'es-toolkit/compat'
 import { toValue } from 'vue'
 
 import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
+import { MovingLinkBase } from '@/lib/litegraph/src/canvas/MovingLinkBase'
 import { LitegraphLinkAdapter } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
 import type { LinkRenderContext } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
 import { getSlotPosition } from '@/renderer/core/canvas/litegraph/slotCalculations'
@@ -5014,6 +5015,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           }
         )
       }
+      if (renderLink instanceof MovingLinkBase)
+        renderLink.drawConnectionCircle(ctx)
 
       ctx.fillStyle = colour
       ctx.beginPath()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5911,7 +5911,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       if (!this.pointer.isDown) reroute.drawSlots(ctx)
     }
 
-    const highlightPos = this.#getHighlightPosition()
+    const highlightPos = this._getHighlightPosition()
     this.linkConnector.renderLinks
       .filter((rl) => rl instanceof MovingInputLink)
       .forEach((rl) => rl.drawConnectionCircle(ctx, highlightPos))

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5015,8 +5015,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           }
         )
       }
-      if (renderLink instanceof MovingInputLink)
-        renderLink.drawConnectionCircle(ctx, highlightPos)
 
       ctx.fillStyle = colour
       ctx.beginPath()
@@ -5911,6 +5909,12 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       // Never draw slots when the pointer is down
       if (!this.pointer.isDown) reroute.drawSlots(ctx)
     }
+
+    const highlightPos = this.#getHighlightPosition()
+    this.linkConnector.renderLinks
+      .filter((rl) => rl instanceof MovingInputLink)
+      .forEach((rl) => rl.drawConnectionCircle(ctx, highlightPos))
+
     ctx.globalAlpha = 1
   }
 

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -15,7 +15,8 @@ import type {
   INodeOutputSlot,
   ItemLocator,
   LinkNetwork,
-  LinkSegment
+  LinkSegment,
+  Point
 } from '@/lib/litegraph/src/interfaces'
 import { EmptySubgraphInput } from '@/lib/litegraph/src/subgraph/EmptySubgraphInput'
 import { EmptySubgraphOutput } from '@/lib/litegraph/src/subgraph/EmptySubgraphOutput'
@@ -132,7 +133,11 @@ export class LinkConnector {
   }
 
   /** Drag an existing link to a different input. */
-  moveInputLink(network: LinkNetwork, input: INodeInputSlot): void {
+  moveInputLink(
+    network: LinkNetwork,
+    input: INodeInputSlot,
+    opts?: { startPoint?: Point }
+  ): void {
     if (this.isConnecting) throw new Error('Already dragging links.')
 
     const { state, inputLinks, renderLinks } = this
@@ -223,7 +228,13 @@ export class LinkConnector {
         // Regular node links
         try {
           const reroute = network.getReroute(link.parentId)
-          const renderLink = new MovingInputLink(network, link, reroute)
+          const renderLink = new MovingInputLink(
+            network,
+            link,
+            reroute,
+            undefined,
+            opts?.startPoint
+          )
 
           const mayContinue = this.events.dispatch(
             'before-move-input',

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -1,3 +1,5 @@
+import { remove } from 'es-toolkit'
+
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
@@ -860,6 +862,11 @@ export class LinkConnector {
   }
 
   dropOnNothing(event: CanvasPointerEvent): void {
+    remove(
+      this.renderLinks,
+      (link) => link instanceof MovingLinkBase && link.dropOnCanvas(event)
+    ).forEach((link) => (link as MovingLinkBase).disconnect())
+    if (this.renderLinks.length === 0) return
     // For external event only.
     const mayContinue = this.events.dispatch('dropped-on-canvas', event)
     if (mayContinue === false) return

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -864,7 +864,7 @@ export class LinkConnector {
   dropOnNothing(event: CanvasPointerEvent): void {
     remove(
       this.renderLinks,
-      (link) => link instanceof MovingLinkBase && link.dropOnCanvas(event)
+      (link) => link instanceof MovingInputLink && link.disconnectOnDrop
     ).forEach((link) => (link as MovingLinkBase).disconnect())
     if (this.renderLinks.length === 0) return
     // For external event only.

--- a/src/lib/litegraph/src/canvas/MovingInputLink.ts
+++ b/src/lib/litegraph/src/canvas/MovingInputLink.ts
@@ -26,12 +26,14 @@ export class MovingInputLink extends MovingLinkBase {
   readonly fromDirection: LinkDirection
   readonly fromSlotIndex: number
   disconnectOnDrop: boolean
+  readonly disconnectOrigin: Point
 
   constructor(
     network: LinkNetwork,
     link: LLink,
     fromReroute?: Reroute,
-    dragDirection: LinkDirection = LinkDirection.CENTER
+    dragDirection: LinkDirection = LinkDirection.CENTER,
+    startPoint?: Point
   ) {
     super(network, link, 'input', fromReroute, dragDirection)
 
@@ -41,6 +43,7 @@ export class MovingInputLink extends MovingLinkBase {
     this.fromDirection = LinkDirection.NONE
     this.fromSlotIndex = this.outputIndex
     this.disconnectOnDrop = true
+    this.disconnectOrigin = startPoint ?? this.inputPos
   }
 
   canConnectToInput(
@@ -134,20 +137,22 @@ export class MovingInputLink extends MovingLinkBase {
     return this.inputNode.disconnectInput(this.inputIndex, true)
   }
 
-  drawConnectionCircle(ctx: CanvasRenderingContext2D, to: Point) {
+  drawConnectionCircle(ctx: CanvasRenderingContext2D, to: Readonly<Point>) {
     if (!this.disconnectOnDrop) return
+
+    const [originX, originY] = this.disconnectOrigin
     const radius = 35
+    const distSquared = (originX - to[0]) ** 2 + (originY - to[1]) ** 2
+
     ctx.save()
     ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR
     ctx.lineWidth = 2
     ctx.beginPath()
-    ctx.moveTo(this.inputPos[0] + radius, this.inputPos[1])
-    ctx.arc(...this.inputPos, radius, 0, Math.PI * 2)
+    ctx.moveTo(originX + radius, originY)
+    ctx.arc(originX, originY, radius, 0, Math.PI * 2)
     ctx.stroke()
     ctx.restore()
 
-    const [fromX, fromY] = this.inputPos
-    const distSquared = (fromX - to[0]) ** 2 + (fromY - to[1]) ** 2
     this.disconnectOnDrop = distSquared < radius ** 2
   }
 }

--- a/src/lib/litegraph/src/canvas/MovingInputLink.ts
+++ b/src/lib/litegraph/src/canvas/MovingInputLink.ts
@@ -1,4 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -24,6 +25,7 @@ export class MovingInputLink extends MovingLinkBase {
   readonly fromPos: Point
   readonly fromDirection: LinkDirection
   readonly fromSlotIndex: number
+  disconnectOnDrop: boolean
 
   constructor(
     network: LinkNetwork,
@@ -38,6 +40,7 @@ export class MovingInputLink extends MovingLinkBase {
     this.fromPos = fromReroute?.pos ?? this.outputPos
     this.fromDirection = LinkDirection.NONE
     this.fromSlotIndex = this.outputIndex
+    this.disconnectOnDrop = true
   }
 
   canConnectToInput(
@@ -129,5 +132,22 @@ export class MovingInputLink extends MovingLinkBase {
 
   disconnect(): boolean {
     return this.inputNode.disconnectInput(this.inputIndex, true)
+  }
+
+  drawConnectionCircle(ctx: CanvasRenderingContext2D, to: Point) {
+    if (!this.disconnectOnDrop) return
+    const radius = 35
+    ctx.save()
+    ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    ctx.moveTo(this.inputPos[0] + radius, this.inputPos[1])
+    ctx.arc(...this.inputPos, radius, 0, Math.PI * 2)
+    ctx.stroke()
+    ctx.restore()
+
+    const [fromX, fromY] = this.inputPos
+    const distSquared = (fromX - to[0]) ** 2 + (fromY - to[1]) ** 2
+    this.disconnectOnDrop = distSquared < radius ** 2
   }
 }

--- a/src/lib/litegraph/src/canvas/MovingLinkBase.ts
+++ b/src/lib/litegraph/src/canvas/MovingLinkBase.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { NodeLike } from '@/lib/litegraph/src/types/NodeLike'
 import { LinkDirection } from '@/lib/litegraph/src/types/globalEnums'
 
@@ -144,4 +145,19 @@ export abstract class MovingLinkBase implements RenderLink {
   ): void
 
   abstract disconnect(): boolean
+  dropOnCanvas(event: CanvasPointerEvent): boolean {
+    const fromPos = this.inputPos
+    const distSquared =
+      (fromPos[0] - event.canvasX) ** 2 + (fromPos[1] - event.canvasY) ** 2
+    return distSquared < 35 ** 2
+  }
+  drawConnectionCircle(ctx: CanvasRenderingContext2D) {
+    ctx.save()
+    ctx.strokeStyle = 'black'
+    ctx.beginPath()
+    ctx.moveTo(this.inputPos[0] + 35, this.inputPos[1])
+    ctx.arc(...this.inputPos, 35, 0, Math.PI * 2)
+    ctx.stroke()
+    ctx.restore()
+  }
 }

--- a/src/lib/litegraph/src/canvas/MovingLinkBase.ts
+++ b/src/lib/litegraph/src/canvas/MovingLinkBase.ts
@@ -11,7 +11,6 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
-import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { NodeLike } from '@/lib/litegraph/src/types/NodeLike'
 import { LinkDirection } from '@/lib/litegraph/src/types/globalEnums'
 
@@ -145,19 +144,4 @@ export abstract class MovingLinkBase implements RenderLink {
   ): void
 
   abstract disconnect(): boolean
-  dropOnCanvas(event: CanvasPointerEvent): boolean {
-    const fromPos = this.inputPos
-    const distSquared =
-      (fromPos[0] - event.canvasX) ** 2 + (fromPos[1] - event.canvasY) ** 2
-    return distSquared < 35 ** 2
-  }
-  drawConnectionCircle(ctx: CanvasRenderingContext2D) {
-    ctx.save()
-    ctx.strokeStyle = 'black'
-    ctx.beginPath()
-    ctx.moveTo(this.inputPos[0] + 35, this.inputPos[1])
-    ctx.arc(...this.inputPos, 35, 0, Math.PI * 2)
-    ctx.stroke()
-    ctx.restore()
-  }
 }

--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -1,4 +1,5 @@
 import type { SlotLayout } from '@/renderer/core/layout/types'
+import type { Point } from '@/lib/litegraph/src/interfaces'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
@@ -74,24 +75,22 @@ export class LinkConnectorAdapter {
     nodeId: NodeId,
     inputIndex: number,
     opts?: {
-      moveExisting?: boolean
       fromRerouteId?: RerouteId
-      layout: SlotLayout
+      layout?: SlotLayout
+      moveExisting?: boolean
     }
   ): void {
     const node = this.network.getNodeById(nodeId)
     const input = node?.inputs?.[inputIndex]
     if (!node || !input) return
-    if (opts?.layout)
-      input.pos = [
-        opts.layout.position.x - node.pos[0],
-        opts.layout.position.y - node.pos[1]
-      ]
 
     const fromReroute = this.network.getReroute(opts?.fromRerouteId)
 
     if (opts?.moveExisting) {
-      this.linkConnector.moveInputLink(this.network, input)
+      const startPoint: Point | undefined = opts.layout
+        ? [opts.layout.position.x, opts.layout.position.y]
+        : undefined
+      this.linkConnector.moveInputLink(this.network, input, { startPoint })
     } else {
       this.linkConnector.dragNewFromInput(
         this.network,

--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -1,3 +1,4 @@
+import type { SlotLayout } from '@/renderer/core/layout/types'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
@@ -72,11 +73,20 @@ export class LinkConnectorAdapter {
   beginFromInput(
     nodeId: NodeId,
     inputIndex: number,
-    opts?: { moveExisting?: boolean; fromRerouteId?: RerouteId }
+    opts?: {
+      moveExisting?: boolean
+      fromRerouteId?: RerouteId
+      layout: SlotLayout
+    }
   ): void {
     const node = this.network.getNodeById(nodeId)
     const input = node?.inputs?.[inputIndex]
     if (!node || !input) return
+    if (opts?.layout)
+      input.pos = [
+        opts.layout.position.x - node.pos[0],
+        opts.layout.position.y - node.pos[1]
+      ]
 
     const fromReroute = this.network.getReroute(opts?.fromRerouteId)
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -671,7 +671,8 @@ export function useSlotLinkInteraction({
       })
     } else {
       activeAdapter.beginFromInput(localNodeId, index, {
-        moveExisting: shouldMoveExistingInput
+        moveExisting: shouldMoveExistingInput,
+        layout
       })
     }
 


### PR DESCRIPTION
Disconnections are frequently performed by dragging a link from an input slot and dropping it on the canvas, but needing to wait for the searchbox to pop up, and then needing to manually close out of this can make it feel slow. Sometimes, this will even result in users disabling the link release action for more responsive graph building.

Instead, this PR introduces new functionality where a link which is moved only a short distance from a node input and dropped will be immediately disconnected instead of performing the default link release action.
![fast-disco_00001](https://github.com/user-attachments/assets/5b0795da-12c0-4347-8ea1-6fc1bcafaae2)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7459-Add-functionality-to-quickly-disconnect-moved-input-links-2c86d73d365081919052f3856db8e672) by [Unito](https://www.unito.io)
