### PR TITLE
Fix FIFO behavior in assetsStore

### DIFF
--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -173,11 +173,12 @@ export const useAssetsStore = defineStore('assets', () => {
     hasMoreHistory.value = history.History.length === BATCH_SIZE
 
     if (allHistoryItems.value.length > MAX_HISTORY_ITEMS) {
-      const removed = allHistoryItems.value.slice(MAX_HISTORY_ITEMS)
-      allHistoryItems.value = allHistoryItems.value.slice(0, MAX_HISTORY_ITEMS)
+      const excess = allHistoryItems.value.length - MAX_HISTORY_ITEMS
+      const removed = allHistoryItems.value.slice(0, excess)
+      allHistoryItems.value = allHistoryItems.value.slice(excess)
 
       // Clean up Set
-      removed.forEach((item) => loadedIds.delete(item.id))
+      removed.forEach(item => loadedIds.delete(item.id))
     }
 
     return allHistoryItems.value


### PR DESCRIPTION
## Summary

Fix FIFO behavior in `assetsStore` so the oldest history items are removed first when the maximum is exceeded.

## Changes

- **What**: Adjusted `allHistoryItems` trimming logic to remove oldest items and maintain correct FIFO order.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

- Confirm that `allHistoryItems` now correctly removes the oldest entries first.
- Ensure `loadedIds` set is cleaned up properly when items are removed.

<!-- Fixes #7458 -->
https://github.com/Comfy-Org/ComfyUI_frontend/issues/7458

## Screenshots (if applicable)

None

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7461-Fix-FIFO-behavior-in-assetsStore-2c86d73d365081788755e17bf10b56bd) by [Unito](https://www.unito.io)
