### PR TITLE
feat(server-config): add legacy manager UI toggle

### DIFF
--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -392,8 +392,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'enable-manager-legacy-ui',
     name: 'Use legacy Manager UI',
-    tooltip:
-      'Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core.',
+    tooltip: 'Uses the legacy ComfyUI-Manager UI instead of the new UI.',
     type: 'boolean',
     defaultValue: false
   },

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -390,6 +390,14 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     defaultValue: false
   },
   {
+    id: 'enable-manager-legacy-ui',
+    name: 'Use legacy Manager UI',
+    tooltip:
+      'Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core.',
+    type: 'boolean',
+    defaultValue: false
+  },
+  {
     id: 'disable-all-custom-nodes',
     name: 'Disable loading all custom nodes.',
     type: 'boolean',

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1333,6 +1333,10 @@
     "disable-metadata": {
       "name": "Disable saving prompt metadata in files."
     },
+    "enable-manager-legacy-ui": {
+      "name": "Use legacy Manager UI",
+      "tooltip": "Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core."
+    },
     "disable-all-custom-nodes": {
       "name": "Disable loading all custom nodes."
     },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1335,7 +1335,7 @@
     },
     "enable-manager-legacy-ui": {
       "name": "Use legacy Manager UI",
-      "tooltip": "Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core."
+      "tooltip": "Uses the legacy ComfyUI-Manager UI instead of the new UI."
     },
     "disable-all-custom-nodes": {
       "name": "Disable loading all custom nodes."


### PR DESCRIPTION
Adds a Desktop (Electron) Server-Config setting for `--enable-manager-legacy-ui` so users can opt into ComfyUI-Manager’s legacy UI.

- Adds `enable-manager-legacy-ui` to `SERVER_CONFIG_ITEMS`
- Adds EN i18n label + tooltip

Note: this PR only adds the setting/flag wiring; it does not change restart behavior in Desktop.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7478-feat-server-config-add-legacy-manager-UI-toggle-2ca6d73d365081a79bb2c376506f5346) by [Unito](https://www.unito.io)


> [!NOTE]
> This is a stacked PR. (main <= https://github.com/Comfy-Org/ComfyUI_frontend/pull/7478 <= https://github.com/Comfy-Org/ComfyUI_frontend/pull/7479)
