### PR TITLE
feat(server-config): restart required toast

### DIFF
--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -392,8 +392,7 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
   {
     id: 'enable-manager-legacy-ui',
     name: 'Use legacy Manager UI',
-    tooltip:
-      'Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core.',
+    tooltip: 'Uses the legacy ComfyUI-Manager UI instead of the new UI.',
     type: 'boolean',
     defaultValue: false
   },

--- a/src/constants/serverConfig.ts
+++ b/src/constants/serverConfig.ts
@@ -390,6 +390,14 @@ export const SERVER_CONFIG_ITEMS: ServerConfig<any>[] = [
     defaultValue: false
   },
   {
+    id: 'enable-manager-legacy-ui',
+    name: 'Use legacy Manager UI',
+    tooltip:
+      'Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core.',
+    type: 'boolean',
+    defaultValue: false
+  },
+  {
     id: 'disable-all-custom-nodes',
     name: 'Disable loading all custom nodes.',
     type: 'boolean',

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -631,7 +631,9 @@
   "serverConfig": {
     "modifiedConfigs": "You have modified the following server configurations. Restart to apply changes.",
     "revertChanges": "Revert Changes",
-    "restart": "Restart"
+    "restart": "Restart",
+    "restartRequiredToastSummary": "Restart required",
+    "restartRequiredToastDetail": "Restart the app to apply server configuration changes."
   },
   "shape": {
     "default": "Default",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1333,6 +1333,10 @@
     "disable-metadata": {
       "name": "Disable saving prompt metadata in files."
     },
+    "enable-manager-legacy-ui": {
+      "name": "Use legacy Manager UI",
+      "tooltip": "Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core."
+    },
     "disable-all-custom-nodes": {
       "name": "Disable loading all custom nodes."
     },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1335,7 +1335,7 @@
     },
     "enable-manager-legacy-ui": {
       "name": "Use legacy Manager UI",
-      "tooltip": "Uses the legacy ComfyUI-Manager UI instead of the new UI. Requires restarting ComfyUI core."
+      "tooltip": "Uses the legacy ComfyUI-Manager UI instead of the new UI."
     },
     "disable-all-custom-nodes": {
       "name": "Disable loading all custom nodes."


### PR DESCRIPTION
## Summary

Show a warning toast when leaving Server Config with pending changes, reminding users they must restart to apply changes.

## Changes

- **What**: Add a `onBeforeUnmount` toast in `ServerConfigPanel` when `modifiedConfigs` is non-empty and the user didn’t click Restart; add i18n strings.

## Review Focus

- Confirm the toast timing/conditions are correct (only fires on leaving the panel; suppressed when Restart is clicked).

> [!NOTE]
> This is a stacked PR. (main <= https://github.com/Comfy-Org/ComfyUI_frontend/pull/7478 <= https://github.com/Comfy-Org/ComfyUI_frontend/pull/7479)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7479-feat-server-config-restart-required-toast-2ca6d73d3650811f85f7f0c52c4cf8f0) by [Unito](https://www.unito.io)
