### PR TITLE
Revert "feat: add showScrollbar prop to VirtualGrid"

### DIFF
--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -117,7 +117,16 @@ onBeforeUnmount(() => {
 .scroll-container {
   height: 100%;
   overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--dialog-surface) transparent;
+
+  /* Firefox */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    width: 1px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: transparent;
+  }
 }
 </style>


### PR DESCRIPTION
Reverts Comfy-Org/ComfyUI_frontend#7227

Reason: seems to mess up the scrollbars. I see three different ones. The scrollbar it is showing is hidden behind the scrollpanel scrollbar, which also should be hidden.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7498-Revert-feat-add-showScrollbar-prop-to-VirtualGrid-2ca6d73d365081329889ddddb45f4c17) by [Unito](https://www.unito.io)
