### PR TITLE
fix: prevent 'no results' flash during assets tab switching

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -59,10 +59,10 @@
     </template>
     <template #body>
       <Divider type="dashed" class="m-2" />
-      <div v-if="loading && !displayAssets.length">
+      <div v-if="loading || isTransitioning">
         <ProgressSpinner class="absolute left-1/2 w-[50px] -translate-x-1/2" />
       </div>
-      <div v-else-if="!loading && !displayAssets.length">
+      <div v-else-if="!displayAssets.length">
         <NoResultsPlaceholder
           icon="pi pi-info-circle"
           :title="
@@ -205,6 +205,7 @@ import { ResultItemImpl } from '@/stores/queueStore'
 import { formatDuration, getMediaTypeFromFilename } from '@/utils/formatUtil'
 
 const activeTab = ref<'input' | 'output'>('output')
+const isTransitioning = ref(false)
 const folderPromptId = ref<string | null>(null)
 const folderExecutionTime = ref<number | undefined>(undefined)
 const isInFolderView = computed(() => folderPromptId.value !== null)
@@ -366,12 +367,14 @@ const refreshAssets = async () => {
 
 watch(
   activeTab,
-  () => {
+  async () => {
+    isTransitioning.value = true
     clearSelection()
     // Clear search when switching tabs
     searchQuery.value = ''
     // Reset pagination state when tab changes
-    void refreshAssets()
+    await refreshAssets()
+    isTransitioning.value = false
   },
   { immediate: true }
 )


### PR DESCRIPTION
## Summary

This PR fixes an issue in the media assets sidebar where switching between Generated and Imported tabs would show "no results found" placeholder even when results existed. The issue occurred because the loading state would become false before the display assets finished updating, creating a moment where the template condition `!loading && !displayAssets.length` was incorrectly met. The fix adds an `isTransitioning` state that remains true during tab switches until asset fetching completes, ensuring the spinner displays throughout the transition and prevents the erroneous placeholder from appearing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7507-fix-prevent-no-results-flash-during-assets-tab-switching-2ca6d73d36508174be2cee202bb11085) by [Unito](https://www.unito.io)
