### PR TITLE
Fix: Extra Scrollbars in Media Assets Sidebar

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -56,9 +56,9 @@
         class="pb-1 px-2 2xl:px-4"
         :show-generation-time-sort="activeTab === 'output'"
       />
+      <Divider type="dashed" class="my-2" />
     </template>
     <template #body>
-      <Divider type="dashed" class="my-2" />
       <div v-if="loading && !displayAssets.length">
         <ProgressSpinner class="absolute left-1/2 w-[50px] -translate-x-1/2" />
       </div>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -58,7 +58,7 @@
       />
     </template>
     <template #body>
-      <Divider type="dashed" class="m-2" />
+      <Divider type="dashed" class="my-2" />
       <div v-if="loading && !displayAssets.length">
         <ProgressSpinner class="absolute left-1/2 w-[50px] -translate-x-1/2" />
       </div>


### PR DESCRIPTION
## Summary

The Divider was throwing off the sizing assumptions for the sidebar tab's width and the interaction between the Sidebar Tab's container height and the ScrollPanel's and VirtualGrid's sizing calculations.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7508-Fix-Extra-Scrollbars-in-Media-Assets-Sidebar-2ca6d73d365081dd8475e209d9b062c0) by [Unito](https://www.unito.io)
