### PR TITLE
fix: prevent middle mouse button from triggering node resize in vueNodes mode

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -327,6 +327,7 @@ const { startResize } = useNodeResize((result, element) => {
 })
 
 const handleResizePointerDown = (event: PointerEvent) => {
+  if (event.button !== 0) return
   if (nodeData.flags?.pinned) return
   startResize(event)
 }


### PR DESCRIPTION
## Summary
Only left mouse button (button === 0) should trigger resize, matching litegraph behavior.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7476

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7511-fix-prevent-middle-mouse-button-from-triggering-node-resize-in-vueNodes-mode-2ca6d73d3650817b9553f4abbdde3784) by [Unito](https://www.unito.io)
