### PR TITLE
[backport core/1.34] style-fix: Don't add body padding with no body.

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -8,8 +8,7 @@
     :data-node-id="nodeData.id"
     :class="
       cn(
-        'bg-component-node-background lg-node absolute pb-1',
-
+        'bg-component-node-background lg-node absolute',
         'contain-style contain-layout min-w-[225px] min-h-(--node-height) w-(--node-width)',
         shapeClass,
         'touch-none flex flex-col',
@@ -31,7 +30,8 @@
 
         shouldHandleNodePointerEvents
           ? 'pointer-events-auto'
-          : 'pointer-events-none'
+          : 'pointer-events-none',
+        !isCollapsed && ' pb-1'
       )
     "
     :style="[


### PR DESCRIPTION
## Summary

Backport of #7424 to core/1.34.

Small fix for collapsed nodes - don't add body padding when node is collapsed.

### Changes
- Removed unconditional `pb-1` from node base classes
- Added conditional `!isCollapsed && ' pb-1'` to only apply padding when node is expanded

Original PR: #7424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7523-backport-core-1-34-style-fix-Don-t-add-body-padding-with-no-body-2ca6d73d36508134b515e49284b8d6e4) by [Unito](https://www.unito.io)
