### PR TITLE
Fix: Add slot for footer (used by Assets Sidebar)

### DIFF
--- a/src/components/sidebar/tabs/SidebarTabTemplate.vue
+++ b/src/components/sidebar/tabs/SidebarTabTemplate.vue
@@ -27,6 +27,7 @@
     <ScrollPanel class="comfy-vue-side-bar-body h-0 grow">
       <slot name="body" />
     </ScrollPanel>
+    <slot name="footer" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary

It contains the selected items controls.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7532-Fix-Add-slot-for-footer-used-by-Assets-Sidebar-2ca6d73d36508138b044da226dd24cea) by [Unito](https://www.unito.io)
