### PR TITLE
Fix: the wrong selection under the hand mode

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -335,6 +335,7 @@ const { startResize } = useNodeResize((result, element) => {
 
 const handleResizePointerDown = (event: PointerEvent) => {
   if (event.button !== 0) return
+  if(!shouldHandleNodePointerEvents.value) return
   if (nodeData.flags?.pinned) return
   startResize(event)
 }


### PR DESCRIPTION
## Summary

Fixed an inconsistency where nodes were resizable in Hand mode. Resizing is now restricted to Selection mode only tomatch standard LiteGraph behavior (Hand mode should only be for panning).

## Changes

What: Disabled node resizing logic when the canvas is set to Hand mode.

## Review Focus

Try toggling between Selection and Hand modes. Verify that resize handles are unresponsive in Hand mode but work
normally in Selection mode.

## Screenshots

Before

https://github.com/user-attachments/assets/2707cdd9-93f5-4820-9282-893081778dff


After

https://github.com/user-attachments/assets/4d4ee027-b74a-481a-8b2a-97c58799534a

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7541-Fix-the-wrong-selection-under-the-hand-mode-2cb6d73d3650812b950ef385809130bb) by [Unito](https://www.unito.io)
