### PR TITLE
Update Search Box IO filters to support multitype

### DIFF
--- a/src/services/nodeSearchService.ts
+++ b/src/services/nodeSearchService.ts
@@ -35,7 +35,9 @@ export class NodeSearchService {
       name: 'Input Type',
       invokeSequence: 'i',
       getItemOptions: (node) =>
-        Object.values(node.inputs ?? []).map((input) => input.type),
+        Object.values(node.inputs ?? []).flatMap((input) =>
+          input.type.split(',')
+        ),
       fuseOptions
     })
 
@@ -43,7 +45,8 @@ export class NodeSearchService {
       id: 'output',
       name: 'Output Type',
       invokeSequence: 'o',
-      getItemOptions: (node) => node.outputs.map((output) => output.type),
+      getItemOptions: (node) =>
+        node.outputs.flatMap((output) => output.type.split(',')),
       fuseOptions
     })
 

--- a/src/utils/fuseUtil.ts
+++ b/src/utils/fuseUtil.ts
@@ -62,9 +62,12 @@ export class FuseFilter<T, O = string> {
       return true
     }
     const options = this.getItemOptions(item)
-    return wildcard
-      ? options.some((option) => option === wildcard)
-      : options.includes(value)
+    if (wildcard) return options.some((option) => option === wildcard)
+    if (typeof value !== 'string' || !value.includes(','))
+      return options.includes(value)
+    const values = value.split(',')
+    //Alas, typescript doesn't understand string satisfies O
+    return values.some((v) => options.includes(v as O))
   }
 }
 


### PR DESCRIPTION
It doesn't feel like this further hurts the lackluster responsiveness of the searchbox, but second opinions would be appreciated.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/fb4b81f7-6eac-45bd-9bc8-17aebf739f0c"/>| <img width="360" alt="after" src="https://github.com/user-attachments/assets/7844cab4-0f73-4a3f-beb0-850efc09497a"  />|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7542-Update-Search-Box-IO-filters-to-support-multitype-2cb6d73d365081ccbeabf1a891351996) by [Unito](https://www.unito.io)
