### PR TITLE
Desktop: wire release toast Update to updater

### DIFF
--- a/src/platform/updates/components/ReleaseNotificationToast.vue
+++ b/src/platform/updates/components/ReleaseNotificationToast.vue
@@ -69,6 +69,7 @@ import { default as DOMPurify } from 'dompurify'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useCommandStore } from '@/stores/commandStore'
 import { isElectron } from '@/utils/envUtil'
@@ -79,6 +80,7 @@ import type { ReleaseNote } from '../common/releaseService'
 import { useReleaseStore } from '../common/releaseStore'
 
 const { buildDocsUrl } = useExternalLink()
+const { toastErrorHandler } = useErrorHandling()
 const releaseStore = useReleaseStore()
 const { t } = useI18n()
 
@@ -176,8 +178,12 @@ const handleLearnMore = () => {
 
 const handleUpdate = async () => {
   if (isElectron()) {
-    await useCommandStore().execute('Comfy-Desktop.CheckForUpdates')
-    dismissToast()
+    try {
+      await useCommandStore().execute('Comfy-Desktop.CheckForUpdates')
+      dismissToast()
+    } catch (error) {
+      toastErrorHandler(error)
+    }
     return
   }
 

--- a/src/platform/updates/components/ReleaseNotificationToast.vue
+++ b/src/platform/updates/components/ReleaseNotificationToast.vue
@@ -69,7 +69,6 @@ import { default as DOMPurify } from 'dompurify'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useCommandStore } from '@/stores/commandStore'
 import { isElectron } from '@/utils/envUtil'
@@ -82,7 +81,6 @@ import { useReleaseStore } from '../common/releaseStore'
 const { buildDocsUrl } = useExternalLink()
 const releaseStore = useReleaseStore()
 const { t } = useI18n()
-const { toastErrorHandler } = useErrorHandling()
 
 // Local state for dismissed status
 const isDismissed = ref(false)
@@ -178,12 +176,8 @@ const handleLearnMore = () => {
 
 const handleUpdate = async () => {
   if (isElectron()) {
-    try {
-      await useCommandStore().execute('Comfy-Desktop.CheckForUpdates')
-      dismissToast()
-    } catch (error) {
-      toastErrorHandler(error)
-    }
+    await useCommandStore().execute('Comfy-Desktop.CheckForUpdates')
+    dismissToast()
     return
   }
 


### PR DESCRIPTION
Desktop builds should not send users to git-update docs from the release notification toast; route the toast “Update” action into the Desktop updater flow.

On Electron, the release toast “Update” button executes `Comfy-Desktop.CheckForUpdates`; failures surface via `useErrorHandling`.

Fixes #7543

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7549-Desktop-wire-release-toast-Update-to-updater-2cb6d73d3650815aadbccc15c724815d) by [Unito](https://www.unito.io)
