### PR TITLE
feat: auto-focus the searchbox in asset dropdowns

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
@@ -66,6 +66,7 @@ function handleSortSelected(item: SortOption) {
       <input
         v-model="searchQuery"
         type="text"
+        autofocus
         :class="resetInputStyle"
         :placeholder="$t('g.search')"
       />


### PR DESCRIPTION
## Summary

On the assets dropdown in Vue Nodes loader nodes (e.g., Load Checkpoint, Load Video, Load Image), focus the search box first.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7554-feat-auto-focus-the-searchbox-in-asset-dropdowns-2cb6d73d3650812bbe3eef406864e034) by [Unito](https://www.unito.io)
