### PR TITLE
feat(user-select): improve multi-user login selection

### DIFF
--- a/src/components/primevueOverride/AutoCompletePlus.test.ts
+++ b/src/components/primevueOverride/AutoCompletePlus.test.ts
@@ -1,0 +1,119 @@
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+
+import AutoCompletePlus from '@/components/primevueOverride/AutoCompletePlus.vue'
+
+describe('AutoCompletePlus', () => {
+  it('does not clear selection on change after option select when blurOnOptionSelect is enabled', () => {
+    const option = { userId: '1', username: 'jim' }
+    const wrapper = mount(AutoCompletePlus, {
+      attachTo: document.body,
+      global: {
+        plugins: [PrimeVue]
+      },
+      props: {
+        modelValue: 'ji',
+        suggestions: [option],
+        optionLabel: 'username',
+        forceSelection: true,
+        blurOnOptionSelect: true,
+        appendTo: 'self'
+      }
+    })
+
+    type AutoCompletePlusVm = {
+      onOptionSelect: (event: Event, option: unknown) => void
+      onChange: (event: Event) => void
+    }
+    const vm = wrapper.vm as unknown as AutoCompletePlusVm
+
+    vm.onOptionSelect(new Event('keydown'), option)
+    vm.onChange(new Event('change'))
+
+    const updates = wrapper.emitted('update:modelValue') ?? []
+    expect(updates.some((args) => args[0] === null)).toBe(false)
+  })
+
+  it('blurs input after selecting an option when blurOnOptionSelect is enabled', async () => {
+    const wrapper = mount(AutoCompletePlus, {
+      attachTo: document.body,
+      global: {
+        plugins: [PrimeVue]
+      },
+      props: {
+        modelValue: null,
+        suggestions: [{ userId: '1', username: 'alice' }],
+        optionLabel: 'username',
+        blurOnOptionSelect: true,
+        appendTo: 'self'
+      }
+    })
+
+    const input = wrapper.find('input')
+    const blurSpy = vi.spyOn(input.element as HTMLInputElement, 'blur')
+
+    type AutoCompletePlusVm = {
+      onOptionSelect: (event: Event, option: unknown) => void
+    }
+    const vm = wrapper.vm as unknown as AutoCompletePlusVm
+
+    vm.onOptionSelect(new Event('click'), {
+      userId: '1',
+      username: 'alice'
+    })
+
+    expect(blurSpy).toHaveBeenCalled()
+  })
+
+  it('emits complete with empty query when keepOpenOnEmptyInput is enabled', async () => {
+    const wrapper = mount(AutoCompletePlus, {
+      attachTo: document.body,
+      global: {
+        plugins: [PrimeVue]
+      },
+      props: {
+        modelValue: '',
+        suggestions: [],
+        keepOpenOnEmptyInput: true,
+        appendTo: 'self'
+      }
+    })
+
+    await wrapper.find('input').setValue('')
+
+    const completeEmits = wrapper.emitted('complete')
+    expect(completeEmits).toBeTruthy()
+    expect(completeEmits?.at(-1)?.[0]).toMatchObject({ query: '' })
+
+    expect(wrapper.emitted('clear')).toBeTruthy()
+  })
+
+  it('does not emit complete with empty query when keepOpenOnEmptyInput is disabled', async () => {
+    const wrapper = mount(AutoCompletePlus, {
+      attachTo: document.body,
+      global: {
+        plugins: [PrimeVue]
+      },
+      props: {
+        modelValue: '',
+        suggestions: [],
+        keepOpenOnEmptyInput: false,
+        appendTo: 'self'
+      }
+    })
+
+    await wrapper.find('input').setValue('')
+
+    const completeEmits = (wrapper.emitted('complete') ?? []) as unknown[][]
+    const emittedEmptyQuery = completeEmits.some((args) => {
+      const payload = args[0]
+      if (payload && typeof payload === 'object' && 'query' in payload) {
+        return (payload as Record<string, unknown>).query === ''
+      }
+      return false
+    })
+    expect(emittedEmptyQuery).toBe(false)
+    expect(wrapper.emitted('clear')).toBeTruthy()
+  })
+})

--- a/src/views/UserSelectView.test.ts
+++ b/src/views/UserSelectView.test.ts
@@ -1,0 +1,180 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import UserSelectView from '@/views/UserSelectView.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+const mockUsers = [
+  { userId: '1', username: 'alice' },
+  { userId: '2', username: 'bob' },
+  { userId: '3', username: 'admin' }
+]
+
+vi.mock('@/stores/userStore', () => ({
+  useUserStore: () => ({
+    users: mockUsers,
+    initialized: true,
+    initialize: vi.fn(),
+    createUser: vi.fn(),
+    login: vi.fn()
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      userSelect: {
+        newUser: 'New user',
+        enterUsername: 'Enter username',
+        existingUser: 'Existing user',
+        selectUser: 'Select a user',
+        next: 'Next'
+      }
+    }
+  }
+})
+
+const AutoCompletePlusStub = defineComponent({
+  name: 'AutoCompletePlus',
+  props: {
+    modelValue: { type: [String, Object], default: null },
+    suggestions: { type: Array, default: () => [] },
+    optionLabel: { type: String, default: '' },
+    inputId: { type: String, default: '' },
+    placeholder: { type: String, default: '' },
+    disabled: { type: Boolean, default: false },
+    completeOnFocus: { type: Boolean, default: false },
+    keepOpenOnEmptyInput: { type: Boolean, default: false },
+    blurOnOptionSelect: { type: Boolean, default: false }
+  },
+  emits: ['update:modelValue', 'complete', 'clear'],
+  setup(props, { emit, expose }) {
+    const show = vi.fn()
+    expose({ show })
+
+    const getDisplayValue = () => {
+      const value = props.modelValue
+      if (typeof value === 'string') return value
+      if (value && typeof value === 'object' && props.optionLabel) {
+        const record = value as Record<string, unknown>
+        const label = record[props.optionLabel]
+        return typeof label === 'string' ? label : ''
+      }
+      return ''
+    }
+
+    const onFocus = (event: FocusEvent) => {
+      if (props.completeOnFocus) {
+        emit('complete', { originalEvent: event, query: getDisplayValue() })
+      }
+    }
+
+    const onInput = (event: Event) => {
+      const query = (event.target as HTMLInputElement).value
+      emit('update:modelValue', query)
+      if (query === '') {
+        emit('clear')
+        if (props.keepOpenOnEmptyInput) {
+          emit('complete', { originalEvent: event, query: '' })
+        }
+        return
+      }
+      emit('complete', { originalEvent: event, query })
+    }
+
+    return () =>
+      h('div', [
+        h('input', {
+          id: props.inputId,
+          disabled: props.disabled,
+          placeholder: props.placeholder,
+          value: getDisplayValue(),
+          onFocus,
+          onInput
+        })
+      ])
+  }
+})
+
+describe('UserSelectView', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  const createWrapper = () => {
+    return mount(UserSelectView, {
+      attachTo: document.body,
+      global: {
+        plugins: [i18n],
+        stubs: {
+          BaseViewTemplate: { template: '<div><slot /></div>' },
+          Divider: { template: '<div />' },
+          Button: { template: '<button />' },
+          InputText: { template: '<input />' },
+          Message: { template: '<div><slot /></div>' },
+          AutoCompletePlus: AutoCompletePlusStub
+        }
+      }
+    })
+  }
+
+  it('shows all users when query is empty', async () => {
+    const wrapper = createWrapper()
+    await nextTick()
+
+    const input = wrapper.find('#existing-user-select')
+    await input.trigger('focus')
+    await nextTick()
+
+    const autoComplete = wrapper.findComponent(AutoCompletePlusStub)
+    expect(autoComplete.props('suggestions')).toEqual(mockUsers)
+  })
+
+  it('filters users using fuzzy search', async () => {
+    const wrapper = createWrapper()
+    await nextTick()
+
+    const input = wrapper.find('#existing-user-select')
+    await input.setValue('adm')
+    await nextTick()
+
+    const autoComplete = wrapper.findComponent(AutoCompletePlusStub)
+    const suggestions = autoComplete.props('suggestions') as typeof mockUsers
+    expect(suggestions.map((u) => u.username)).toContain('admin')
+  })
+
+  it('enables blur-on-option-select for existing user input', async () => {
+    const wrapper = createWrapper()
+    await nextTick()
+
+    const autoComplete = wrapper.findComponent(AutoCompletePlusStub)
+    expect(autoComplete.props('blurOnOptionSelect')).toBe(true)
+  })
+
+  it('shows all users after clearing input', async () => {
+    const wrapper = createWrapper()
+    await nextTick()
+
+    const input = wrapper.find('#existing-user-select')
+    await input.setValue('adm')
+    await nextTick()
+
+    const autoComplete = wrapper.findComponent(AutoCompletePlusStub)
+    const filteredSuggestions = autoComplete.props(
+      'suggestions'
+    ) as typeof mockUsers
+    expect(filteredSuggestions).not.toEqual(mockUsers)
+
+    await input.setValue('')
+    await nextTick()
+
+    expect(autoComplete.props('suggestions')).toEqual(mockUsers)
+  })
+})


### PR DESCRIPTION
**⚠️ Note**: This PR and code were generated with help from GPT‑5.2. I have **NO** frontend dev experience, so this should be considered a prototype for discussion. Please evaluate carefully before merging; if changes are needed, I may need maintainer guidance to apply them correctly.

---

## Summary

Improve the multi-user login experience by replacing the existing-user dropdown with a searchable, keyboard-friendly user picker that scales better with long user lists.

## Changes

- **What**: 
  - Update UserSelectView to use an autocomplete-style selector for existing users (type to filter, arrow keys + Enter to select, dropdown button supported).
  - Reuse the repo’s existing fuzzy search utilities to filter usernames locally.
  - Enhance AutoCompletePlus with opt-in props to avoid PrimeVue overlay/focus edge cases in this login flow:
  - Keep the dropdown open and show all users when the input is cleared.
  - Blur the input after a user is selected while preserving the selected value (mouse and Enter selection).
  - Add unit tests covering the new behavior and the PrimeVue edge cases guarded by the new opt-in props.


## Review Focus

- `AutoCompletePlus` opt-in behavior (`keepOpenOnEmptyInput`, `blurOnOptionSelect`) and whether the internal overrides are acceptable for upstream maintenance (they are disabled by default and only enabled on the multi-user login view).
- User selection behavior when typing partial matches and selecting via Enter vs mouse (no clearing, no flicker).
- Test coverage and whether the new component-level tests are sufficient.

Fixes #7555 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/3840f231-9e3a-40f9-ab79-4f33f4ca21d6


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7556-feat-user-select-improve-multi-user-login-selection-2cb6d73d36508166ab8ffce0d1792422) by [Unito](https://www.unito.io)
