### PR TITLE
cleanup: remove now-unused stripe pricing table remnants

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -42,7 +42,3 @@ ALGOLIA_API_KEY=684d998c36b67a9a9fce8fc2d8860579
 # SENTRY_AUTH_TOKEN=private-token # get from sentry
 # SENTRY_ORG=comfy-org
 # SENTRY_PROJECT=cloud-frontend-staging
-
-# Stripe pricing table configuration (used by feature-flagged subscription tiers UI)
-# VITE_STRIPE_PUBLISHABLE_KEY=pk_test_123
-# VITE_STRIPE_PRICING_TABLE_ID=prctbl_123

--- a/global.d.ts
+++ b/global.d.ts
@@ -13,8 +13,6 @@ interface Window {
     max_upload_size?: number
     comfy_api_base_url?: string
     comfy_platform_base_url?: string
-    stripe_publishable_key?: string
-    stripe_pricing_table_id?: string
     firebase_config?: {
       apiKey: string
       authDomain: string

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1989,12 +1989,6 @@
       "waitingForSubscription": "Complete your subscription in the new tab. We'll automatically detect when you're done!",
       "subscribe": "Subscribe"
     },
-    "pricingTable": {
-      "description": "Access cloud-powered ComfyUI workflows with straightforward, usage-based pricing.",
-      "loading": "Loading pricing options...",
-      "loadError": "We couldn't load the pricing table. Please refresh and try again.",
-      "missingConfig": "Stripe pricing table configuration missing. Provide the publishable key and pricing table ID via remote config or .env."
-    },
     "subscribeToRun": "Subscribe",
     "subscribeToRunFull": "Subscribe to Run",
     "subscribeNow": "Subscribe Now",

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -39,6 +39,4 @@ export type RemoteConfig = {
   private_models_enabled?: boolean
   subscription_tiers_enabled?: boolean
   onboarding_survey_enabled?: boolean
-  stripe_publishable_key?: string
-  stripe_pricing_table_id?: string
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -17,7 +17,9 @@ declare global {
     __COMFYUI_FRONTEND_VERSION__: string
   }
 
-  interface ImportMetaEnv {}
+  interface ImportMetaEnv {
+    VITE_APP_VERSION?: string
+  }
 
   interface ImportMeta {
     readonly env: ImportMetaEnv

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -17,10 +17,7 @@ declare global {
     __COMFYUI_FRONTEND_VERSION__: string
   }
 
-  interface ImportMetaEnv {
-    readonly VITE_STRIPE_PUBLISHABLE_KEY?: string
-    readonly VITE_STRIPE_PRICING_TABLE_ID?: string
-  }
+  interface ImportMetaEnv {}
 
   interface ImportMeta {
     readonly env: ImportMetaEnv


### PR DESCRIPTION
Removes vestigial remnants of the Stripe pricing table integration, which was replaced in https://github.com/Comfy-Org/ComfyUI_frontend/pull/7359. The feature flag is now obsolete, but was forgotten about in that PR. This PR cleans everything up fully.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7557-cleanup-remove-now-unused-stripe-pricing-table-remnants-2cb6d73d3650812aaa5efe91f766fb20) by [Unito](https://www.unito.io)
