### PR TITLE
Fix: Restore assets API short-circuit in WidgetSelectDropdown

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -146,6 +146,9 @@ const outputItems = computed<DropdownItem[]>(() => {
 })
 
 const allItems = computed<DropdownItem[]>(() => {
+  if (props.isAssetMode && assetData) {
+    return assetData.dropdownItems.value
+  }
   return [...inputItems.value, ...outputItems.value]
 })
 


### PR DESCRIPTION
## Summary

Removed in #6985, but breaks the dropdown loading on Cloud.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7563-Fix-Restore-assets-API-short-circuit-in-WidgetSelectDropdown-2cb6d73d365081778a8dc65418d9f6be) by [Unito](https://www.unito.io)
