### PR TITLE
Hide queue overlay header menu on cloud

### DIFF
--- a/src/components/queue/QueueOverlayHeader.vue
+++ b/src/components/queue/QueueOverlayHeader.vue
@@ -17,7 +17,7 @@
         </span>
       </span>
     </div>
-    <div class="flex items-center gap-1">
+    <div v-if="!isCloud" class="flex items-center gap-1">
       <IconButton
         v-tooltip.top="moreTooltipConfig"
         type="transparent"
@@ -75,6 +75,7 @@ import { useI18n } from 'vue-i18n'
 import IconButton from '@/components/button/IconButton.vue'
 import IconTextButton from '@/components/button/IconTextButton.vue'
 import { buildTooltipConfig } from '@/composables/useTooltipConfig'
+import { isCloud } from '@/platform/distribution/types'
 
 defineProps<{
   headerTitle: string

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -335,7 +335,7 @@ const { startResize } = useNodeResize((result, element) => {
 
 const handleResizePointerDown = (event: PointerEvent) => {
   if (event.button !== 0) return
-  if(!shouldHandleNodePointerEvents.value) return
+  if (!shouldHandleNodePointerEvents.value) return
   if (nodeData.flags?.pinned) return
   startResize(event)
 }


### PR DESCRIPTION
Hide the QueueOverlayHeader more-options (…) menu when running in Cloud distribution

This is being hidden instead of fixed because it deletes all user assets on cloud, will be touched by /jobs, replaced by the second iteration of design changes, along with changes to asset deletion happening soon. It would be too risky to have a proper fix for it in the cloud deploy today.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7571-Hide-queue-overlay-header-menu-on-cloud-2cb6d73d3650815a8faac8a8f0de91f0) by [Unito](https://www.unito.io)
