### PR TITLE
Fix promoted assets not being assets in vue

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -168,12 +168,13 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       name: widget.name,
       type: widget.type,
       value: widget.value,
-      label: widget.label,
-      options: widgetOptions,
-      callback: widget.callback,
-      spec: widget.spec,
       borderStyle: widget.borderStyle,
-      controlWidget: widget.controlWidget
+      callback: widget.callback,
+      controlWidget: widget.controlWidget,
+      label: widget.label,
+      nodeType: widget.nodeType,
+      options: widgetOptions,
+      spec: widget.spec
     }
 
     function updateHandler(value: WidgetValue) {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -1,8 +1,9 @@
 <template>
   <WidgetSelectDropdown
     v-if="isDropdownUIWidget"
-    v-bind="props"
     v-model="modelValue"
+    :widget
+    :node-type="widget.nodeType ?? nodeType"
     :asset-kind="assetKind"
     :allow-upload="allowUpload"
     :upload-folder="uploadFolder"
@@ -89,10 +90,9 @@ const isAssetMode = computed(() => {
   if (isCloud) {
     const settingStore = useSettingStore()
     const isUsingAssetAPI = settingStore.get('Comfy.Assets.UseAssetAPI')
-    const isEligible = assetService.isAssetBrowserEligible(
-      props.nodeType,
-      props.widget.name
-    )
+    const isEligible =
+      assetService.isAssetBrowserEligible(props.nodeType, props.widget.name) ||
+      props.widget.type === 'asset'
 
     return isUsingAssetAPI && isEligible
   }

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -368,9 +368,11 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     const widget = node.widgets?.find((w) => w.name === widgetName)
     //TODO: resolve spec for linked
     if (!widget || !isProxyWidget(widget)) return undefined
+
     const { nodeId, widgetName: subWidgetName } = widget._overlay
     const subNode = node.subgraph.getNodeById(nodeId)
     if (!subNode) return undefined
+
     return getInputSpecForWidget(subNode, subWidgetName)
   }
 

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -3,6 +3,7 @@ import _ from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
+import { isProxyWidget } from '@/core/graph/subgraph/proxyWidget'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { transformNodeDefV1ToV2 } from '@/schemas/nodeDef/migration'
 import type {
@@ -358,10 +359,19 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     node: LGraphNode,
     widgetName: string
   ): InputSpecV2 | undefined {
-    const nodeDef = fromLGraphNode(node)
-    if (!nodeDef) return undefined
+    if (!node.isSubgraphNode()) {
+      const nodeDef = fromLGraphNode(node)
+      if (!nodeDef) return undefined
 
-    return nodeDef.inputs[widgetName]
+      return nodeDef.inputs[widgetName]
+    }
+    const widget = node.widgets?.find((w) => w.name === widgetName)
+    //TODO: resolve spec for linked
+    if (!widget || !isProxyWidget(widget)) return undefined
+    const { nodeId, widgetName: subWidgetName } = widget._overlay
+    const subNode = node.subgraph.getNodeById(nodeId)
+    if (!subNode) return undefined
+    return getInputSpecForWidget(subNode, subWidgetName)
   }
 
   /**

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -64,6 +64,9 @@ export interface SimplifiedWidget<
   /** Widget options including filtered PrimeVue props */
   options?: O
 
+  /** Override for use with subgraph promoted asset widgets*/
+  nodeType?: string
+
   /** Optional serialization method for custom value handling */
   serializeValue?: () => any
 


### PR DESCRIPTION
- Fixes asset widgets which have been promoted failing to display as asset widgets and having red names in vue mode.
- Fixes promoted subgraph widgets failing to resolve inputSpec for use in vue mode.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/6c2d2763-6ac3-4769-82c5-b1ab1cc5e945"/> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/742e218b-ec42-411a-b5a2-021820031e2a"  />|

I'm not excited that this creates further bloat of SimplifiedWidget.

Known issue
- Similar to #7550, subgraph widgets will have an incorrect callback and will fail to update value on a fresh reload. This can be "fixed" (made worse) by entering and exiting the subgraph. Since this creates a 'leaked' widget callback which will then be called.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7576-Fix-promoted-assets-not-being-assets-in-vue-2cc6d73d3650814b8734f69b225b0228) by [Unito](https://www.unito.io)
