### PR TITLE
feat: add Update ComfyUI option to Help Center for non-desktop environments

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -233,6 +233,7 @@ const showVersionUpdates = computed(() =>
 // Use conflict acknowledgment state from composable
 const { shouldShowRedDot: shouldShowManagerRedDot } =
   useConflictAcknowledgment()
+const { isNewManagerUI } = useManagerState()
 
 const moreItems = computed<MenuItem[]>(() => {
   const allMoreItems: MenuItem[] = [
@@ -373,7 +374,6 @@ const menuItems = computed<MenuItem[]>(() => {
     })
   }
   // Update ComfyUI - only for non-desktop, non-cloud with new manager UI
-  const { isNewManagerUI } = useManagerState()
   if (!isElectron() && !isCloud && isNewManagerUI.value) {
     items.push({
       key: 'update-comfyui',

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -570,26 +570,35 @@ const onUpdateComfyUI = async (): Promise<void> => {
     life: 3000
   })
 
-  const result = await updateComfyUI({ is_stable: true })
+  try {
+    const result = await updateComfyUI({ is_stable: true })
 
-  if (result === null && error.value) {
+    if (result === null || error.value) {
+      toast.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: error.value || t('helpCenter.updateComfyUIFailed'),
+        life: 5000
+      })
+      return
+    }
+
+    toast.add({
+      severity: 'success',
+      summary: t('helpCenter.updateComfyUISuccess'),
+      detail: t('helpCenter.updateComfyUISuccessDetail'),
+      life: 3000
+    })
+
+    await rebootComfyUI()
+  } catch (err) {
     toast.add({
       severity: 'error',
       summary: t('g.error'),
-      detail: error.value,
+      detail: err instanceof Error ? err.message : t('g.unknownError'),
       life: 5000
     })
-    return
   }
-
-  toast.add({
-    severity: 'success',
-    summary: t('helpCenter.updateComfyUISuccess'),
-    detail: t('helpCenter.updateComfyUISuccessDetail'),
-    life: 3000
-  })
-
-  await rebootComfyUI()
 }
 
 const onReleaseClick = (release: ReleaseNote): void => {

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -372,7 +372,9 @@ const menuItems = computed<MenuItem[]>(() => {
       }
     })
   }
-  if (!isElectron() && !isCloud) {
+  // Update ComfyUI - only for non-desktop, non-cloud with new manager UI
+  const { isNewManagerUI } = useManagerState()
+  if (!isElectron() && !isCloud && isNewManagerUI.value) {
     items.push({
       key: 'update-comfyui',
       type: 'item',

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -152,6 +152,7 @@
 </template>
 
 <script setup lang="ts">
+import { useToast } from 'primevue/usetoast'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import type { CSSProperties, Component } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -202,6 +203,7 @@ const SUBMENU_CONFIG = {
 
 // Composables
 const { t } = useI18n()
+const toast = useToast()
 const { staticUrls, buildDocsUrl } = useExternalLink()
 const releaseStore = useReleaseStore()
 const commandStore = useCommandStore()
@@ -558,11 +560,36 @@ const onReinstall = (): void => {
   }
 }
 
-const onUpdateComfyUI = (): void => {
-  const { updateComfyUI, rebootComfyUI } = useComfyManagerService()
-  void updateComfyUI({ is_stable: true }).then(() => {
-    void rebootComfyUI()
+const onUpdateComfyUI = async (): Promise<void> => {
+  const { updateComfyUI, rebootComfyUI, error } = useComfyManagerService()
+
+  toast.add({
+    severity: 'info',
+    summary: t('helpCenter.updateComfyUIStarted'),
+    detail: t('helpCenter.updateComfyUIStartedDetail'),
+    life: 3000
   })
+
+  const result = await updateComfyUI({ is_stable: true })
+
+  if (result === null && error.value) {
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: error.value,
+      life: 5000
+    })
+    return
+  }
+
+  toast.add({
+    severity: 'success',
+    summary: t('helpCenter.updateComfyUISuccess'),
+    detail: t('helpCenter.updateComfyUISuccessDetail'),
+    life: 3000
+  })
+
+  await rebootComfyUI()
 }
 
 const onReleaseClick = (release: ReleaseNote): void => {

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -168,6 +168,7 @@ import { electronAPI, isElectron } from '@/utils/envUtil'
 import { formatVersionAnchor } from '@/utils/formatUtil'
 import { useConflictAcknowledgment } from '@/workbench/extensions/manager/composables/useConflictAcknowledgment'
 import { useManagerState } from '@/workbench/extensions/manager/composables/useManagerState'
+import { useComfyManagerService } from '@/workbench/extensions/manager/services/comfyManagerService'
 import { ManagerTab } from '@/workbench/extensions/manager/types/comfyManagerTypes'
 
 // Types
@@ -369,6 +370,18 @@ const menuItems = computed<MenuItem[]>(() => {
       }
     })
   }
+  if (!isElectron() && !isCloud) {
+    items.push({
+      key: 'update-comfyui',
+      type: 'item',
+      icon: 'icon-[lucide--download]',
+      label: t('helpCenter.updateComfyUI'),
+      action: () => {
+        onUpdateComfyUI()
+        emit('close')
+      }
+    })
+  }
 
   items.push({
     key: 'more',
@@ -543,6 +556,13 @@ const onReinstall = (): void => {
   if (isElectron()) {
     void electronAPI().reinstall()
   }
+}
+
+const onUpdateComfyUI = (): void => {
+  const { updateComfyUI, rebootComfyUI } = useComfyManagerService()
+  void updateComfyUI({ is_stable: true }).then(() => {
+    void rebootComfyUI()
+  })
 }
 
 const onReleaseClick = (release: ReleaseNote): void => {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -778,7 +778,8 @@
     "updateComfyUIStarted": "Update Started",
     "updateComfyUIStartedDetail": "ComfyUI update has been queued. Please wait...",
     "updateComfyUISuccess": "Update Complete",
-    "updateComfyUISuccessDetail": "ComfyUI has been updated. Rebooting..."
+    "updateComfyUISuccessDetail": "ComfyUI has been updated. Rebooting...",
+    "updateComfyUIFailed": "Failed to update ComfyUI. Please try again."
   },
   "releaseToast": {
     "newVersionAvailable": "New update is out!",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -774,7 +774,11 @@
     "desktopUserGuide": "Desktop User Guide",
     "openDevTools": "Open Dev Tools",
     "reinstall": "Re-Install",
-    "updateComfyUI": "Update ComfyUI"
+    "updateComfyUI": "Update ComfyUI",
+    "updateComfyUIStarted": "Update Started",
+    "updateComfyUIStartedDetail": "ComfyUI update has been queued. Please wait...",
+    "updateComfyUISuccess": "Update Complete",
+    "updateComfyUISuccessDetail": "ComfyUI has been updated. Rebooting..."
   },
   "releaseToast": {
     "newVersionAvailable": "New update is out!",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -773,7 +773,8 @@
     "updateAvailable": "Update",
     "desktopUserGuide": "Desktop User Guide",
     "openDevTools": "Open Dev Tools",
-    "reinstall": "Re-Install"
+    "reinstall": "Re-Install",
+    "updateComfyUI": "Update ComfyUI"
   },
   "releaseToast": {
     "newVersionAvailable": "New update is out!",

--- a/src/workbench/extensions/manager/services/comfyManagerService.ts
+++ b/src/workbench/extensions/manager/services/comfyManagerService.ts
@@ -12,6 +12,7 @@ type ManagerQueueStatus = components['schemas']['QueueStatus']
 type InstallPackParams = components['schemas']['InstallPackParams']
 type InstalledPacksResponse = components['schemas']['InstalledPacksResponse']
 type UpdateAllPacksParams = components['schemas']['UpdateAllPacksParams']
+type UpdateComfyUIParams = components['schemas']['UpdateComfyUIParams']
 type ManagerTaskHistory = components['schemas']['HistoryResponse']
 type QueueTaskItem = components['schemas']['QueueTaskItem']
 
@@ -26,6 +27,7 @@ enum ManagerRoute {
   RESET_QUEUE = 'manager/queue/reset',
   QUEUE_STATUS = 'manager/queue/status',
   UPDATE_ALL = 'manager/queue/update_all',
+  UPDATE_COMFYUI = 'manager/queue/update_comfyui',
   LIST_INSTALLED = 'customnode/installed',
   GET_NODES = 'customnode/getmappings',
   IMPORT_FAIL_INFO = 'customnode/import_fail_info',
@@ -271,6 +273,33 @@ export const useComfyManagerService = () => {
     )
   }
 
+  const updateComfyUI = async (
+    params: UpdateComfyUIParams = { is_stable: true },
+    ui_id?: string,
+    signal?: AbortSignal
+  ) => {
+    const errorContext = 'Updating ComfyUI'
+    const routeSpecificErrors = {
+      400: 'Bad Request: Missing required parameters',
+      403: 'Forbidden: To use this action, a security_level of `middle or below` is required'
+    }
+
+    const queryParams = {
+      client_id: api.clientId ?? api.initialClientId ?? 'unknown',
+      ui_id: ui_id || uuidv4(),
+      ...params
+    }
+
+    return executeRequest<null>(
+      () =>
+        managerApiClient.get(ManagerRoute.UPDATE_COMFYUI, {
+          params: queryParams,
+          signal
+        }),
+      { errorContext, routeSpecificErrors, isQueueOperation: true }
+    )
+  }
+
   const rebootComfyUI = async (signal?: AbortSignal) => {
     const errorContext = 'Rebooting ComfyUI'
     const routeSpecificErrors = {
@@ -335,6 +364,7 @@ export const useComfyManagerService = () => {
     updateAllPacks,
 
     // System operations
+    updateComfyUI,
     rebootComfyUI,
     isLegacyManagerUI
   }

--- a/tests-ui/tests/store/comfyManagerStore.test.ts
+++ b/tests-ui/tests/store/comfyManagerStore.test.ts
@@ -95,6 +95,7 @@ describe('useComfyManagerStore', () => {
       disablePack: vi.fn().mockResolvedValue(null),
       updatePack: vi.fn().mockResolvedValue(null),
       updateAllPacks: vi.fn().mockResolvedValue(null),
+      updateComfyUI: vi.fn().mockResolvedValue(null),
       rebootComfyUI: vi.fn().mockResolvedValue(null),
       isLegacyManagerUI: vi.fn().mockResolvedValue(false)
     }


### PR DESCRIPTION
## Summary

- Adds "Update ComfyUI" menu item to Help Center for portable/localhost environments
- Wires existing `/v2/manager/queue/update_comfyui` endpoint to the frontend
- Only visible in non-desktop, non-cloud distributions (where Electron update mechanism isn't available)

## Changes

1. **Service layer**: Added `updateComfyUI()` method to `comfyManagerService.ts`
2. **UI**: Added menu item with download icon to `HelpCenterMenuContent.vue`
3. **i18n**: Added translation key for the new menu item

## Context

The new Manager UI (v4) lost the ability to update ComfyUI core in non-desktop environments. This restores that functionality by integrating the existing manager endpoint into the Help Center menu.

## Test plan

- [ ] Verify menu item appears in portable/localhost environments
- [ ] Verify menu item does NOT appear in desktop (Electron) environments
- [ ] Verify menu item does NOT appear in cloud environments
- [ ] Test clicking the menu item triggers update and reboot

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7578-feat-add-Update-ComfyUI-option-to-Help-Center-for-non-desktop-environments-2cc6d73d3650811e9e4fe55515f50333) by [Unito](https://www.unito.io)
