### PR TITLE
fix: expand assets dropdown body to show entire "no results placeholder"

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -67,13 +67,15 @@ const searchQuery = defineModel<string>('searchQuery')
         "
       >
         <div class="pointer-events-none absolute inset-x-3 top-0 z-10 h-5" />
-        <div v-if="items.length === 0" class="h-50">
-          <div class="absolute inset-0 flex items-center justify-center">
-            <i
-              :title="$t('g.noItems')"
-              class="icon-[lucide--circle-off] size-30 text-zinc-500/20"
-            />
-          </div>
+        <div
+          v-if="items.length === 0"
+          class="h-50 col-span-full flex items-center justify-center"
+        >
+          <i
+            :title="$t('g.noItems')"
+            :aria-label="$t('g.noItems')"
+            class="icon-[lucide--circle-off] size-30 text-zinc-500/20"
+          />
         </div>
         <!-- Item -->
         <FormDropdownMenuItem

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -67,14 +67,13 @@ const searchQuery = defineModel<string>('searchQuery')
         "
       >
         <div class="pointer-events-none absolute inset-x-3 top-0 z-10 h-5" />
-        <div
-          v-if="items.length === 0"
-          class="absolute inset-0 flex items-center justify-center"
-        >
-          <i
-            :title="$t('g.noItems')"
-            class="icon-[lucide--circle-off] size-30 text-zinc-500/20"
-          />
+        <div v-if="items.length === 0" class="h-50">
+          <div class="absolute inset-0 flex items-center justify-center">
+            <i
+              :title="$t('g.noItems')"
+              class="icon-[lucide--circle-off] size-30 text-zinc-500/20"
+            />
+          </div>
         </div>
         <!-- Item -->
         <FormDropdownMenuItem


### PR DESCRIPTION
Currently, when the assets dropdown has no assets available, the "No Results Placeholder" text is not fully visible because the dropdown body doesn't expand to accommodate the full message.

Make the body of the assets dropdown expand to show the entire "No Results Placeholder" message when there are no assets present.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7586-fix-expand-assets-dropdown-body-to-show-entire-no-results-placeholder-2cc6d73d365081f4a142e927621f936d) by [Unito](https://www.unito.io)
