### PR TITLE
Devex: Convert .env_example sections to comment toggles

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -14,25 +14,25 @@ DEV_SERVER_COMFYUI_URL=http://127.0.0.1:8188
 # Allow dev server access from remote IP addresses.
 # If true, the vite dev server will listen on all addresses, including LAN
 # and public addresses.
-VITE_REMOTE_DEV=false
+# VITE_REMOTE_DEV=true
 
 # The directory containing the ComfyUI installation used to run Playwright tests.
 # If you aren't using a separate install for testing, point this to your regular install.
 TEST_COMFYUI_DIR=/home/ComfyUI
 
 # Whether to enable minification of the frontend code.
-ENABLE_MINIFY=true
+# ENABLE_MINIFY=true
 
 # Whether to disable proxying the `/templates` route. If true, allows you to
 # serve templates from the ComfyUI_frontend/public/templates folder (for
 # locally testing changes to templates). When false or nonexistent, the
 # templates are served via the normal method from the server's python site
 # packages.
-DISABLE_TEMPLATES_PROXY=false
+# DISABLE_TEMPLATES_PROXY=true
 
 # If playwright tests are being run via vite dev server, Vue plugins will
 # invalidate screenshots.  When `true`, vite plugins will not be loaded.
-DISABLE_VUE_PLUGINS=false
+# DISABLE_VUE_PLUGINS=true
 
 # Algolia credentials required for developing with the new custom node manager.
 ALGOLIA_APP_ID=4E0RO38HS8


### PR DESCRIPTION
## Summary

Set to true, but commented out so that a developer can just toggle comment on that line to enable the behavior described.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7587-Devex-Convert-env_example-sections-to-comment-toggles-2cc6d73d365081db9907f107ee1b77e7) by [Unito](https://www.unito.io)
