### PR TITLE
refactor: type the checkout request and response

### DIFF
--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -258,11 +258,13 @@ import {
   FirebaseAuthStoreError,
   useFirebaseAuthStore
 } from '@/stores/firebaseAuthStore'
-import type { components } from '@/types/comfyRegistryTypes'
+import type { components, operations } from '@/types/comfyRegistryTypes'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
 type TierKey = 'standard' | 'creator' | 'pro'
 type CheckoutTier = TierKey | `${TierKey}-yearly`
+type CheckoutResponse =
+  operations['createCloudSubscriptionCheckoutTier']['responses']['201']['content']['application/json']
 
 type BillingCycle = 'monthly' | 'yearly'
 
@@ -391,7 +393,9 @@ const getAnnualTotal = (tier: PricingTierConfig): number =>
 const getCreditsDisplay = (tier: PricingTierConfig): number =>
   tier.pricing.credits * (currentBillingCycle.value === 'yearly' ? 12 : 1)
 
-const initiateCheckout = async (tierKey: TierKey) => {
+const initiateCheckout = async (
+  tierKey: TierKey
+): Promise<CheckoutResponse> => {
   const authHeader = await getAuthHeader()
   if (!authHeader) {
     throw new FirebaseAuthStoreError(t('toastMessages.userNotAuthenticated'))
@@ -429,7 +433,7 @@ const initiateCheckout = async (tierKey: TierKey) => {
     )
   }
 
-  return await response.json()
+  return (await response.json()) as CheckoutResponse
 }
 
 const handleSubscribe = wrapWithErrorHandlingAsync(async (tierKey: TierKey) => {


### PR DESCRIPTION
## Summary

Refactor: use openapi.yml types for the strip checkout api.

Currently the types do not include the yearly subscription tier. But will once https://github.com/Comfy-Org/comfy-api/pull/757 is merged. So will want to tie the tier types to openapi after.

## Changes

- **What**: PricingTable.vue
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7600-refactor-type-the-checkout-request-and-response-2cd6d73d3650813ca536f6184ec988f3) by [Unito](https://www.unito.io)
