### PR TITLE
feat(manager): add Try Update button for nightly packs

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -295,6 +295,8 @@
     "uninstall": "Uninstall",
     "uninstalling": "Uninstalling {id}",
     "update": "Update",
+    "tryUpdate": "Try Update",
+    "tryUpdateTooltip": "Pull latest changes from repository. Nightly versions may have updates that cannot be detected automatically.",
     "uninstallSelected": "Uninstall Selected",
     "updateSelected": "Update Selected",
     "updateAll": "Update All",

--- a/src/workbench/extensions/manager/components/manager/PackVersionBadge.vue
+++ b/src/workbench/extensions/manager/components/manager/PackVersionBadge.vue
@@ -63,7 +63,7 @@ const {
   fill?: boolean
 }>()
 
-const { isUpdateAvailable } = usePackUpdateStatus(nodePack)
+const { isUpdateAvailable } = usePackUpdateStatus(() => nodePack)
 const popoverRef = ref()
 
 const managerStore = useComfyManagerStore()

--- a/src/workbench/extensions/manager/components/manager/button/PackTryUpdateButton.vue
+++ b/src/workbench/extensions/manager/components/manager/button/PackTryUpdateButton.vue
@@ -1,0 +1,63 @@
+<template>
+  <IconTextButton
+    v-tooltip.top="$t('manager.tryUpdateTooltip')"
+    v-bind="$attrs"
+    type="transparent"
+    :label="computedLabel"
+    :border="true"
+    :size="size"
+    :disabled="isUpdating"
+    @click="tryUpdate"
+  >
+    <template v-if="isUpdating" #icon>
+      <DotSpinner duration="1s" :size="size === 'sm' ? 12 : 16" />
+    </template>
+  </IconTextButton>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import IconTextButton from '@/components/button/IconTextButton.vue'
+import DotSpinner from '@/components/common/DotSpinner.vue'
+import type { ButtonSize } from '@/types/buttonTypes'
+import type { components } from '@/types/comfyRegistryTypes'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+
+type NodePack = components['schemas']['Node']
+
+const { nodePack, size = 'sm' } = defineProps<{
+  nodePack: NodePack
+  size?: ButtonSize
+}>()
+
+const { t } = useI18n()
+const managerStore = useComfyManagerStore()
+
+const isUpdating = ref(false)
+
+async function tryUpdate() {
+  if (!nodePack.id) {
+    console.warn('Pack missing required id:', nodePack)
+    return
+  }
+
+  isUpdating.value = true
+  try {
+    await managerStore.updatePack.call({
+      id: nodePack.id,
+      version: 'nightly'
+    })
+    managerStore.updatePack.clear()
+  } catch (error) {
+    console.error('Nightly update failed:', error)
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const computedLabel = computed(() =>
+  isUpdating.value ? t('g.updating') : t('manager.tryUpdate')
+)
+</script>

--- a/src/workbench/extensions/manager/components/manager/infoPanel/InfoPanel.vue
+++ b/src/workbench/extensions/manager/components/manager/infoPanel/InfoPanel.vue
@@ -7,8 +7,9 @@
           :has-conflict="hasCompatibilityIssues"
         >
           <template v-if="canTryNightlyUpdate" #install-button>
-            <div class="flex w-full gap-2">
+            <div class="flex w-full justify-center gap-2">
               <PackTryUpdateButton :node-pack="nodePack" size="md" />
+              <PackUninstallButton :node-packs="[nodePack]" size="md" />
             </div>
           </template>
         </InfoPanelHeader>
@@ -75,6 +76,7 @@ import PackStatusMessage from '@/workbench/extensions/manager/components/manager
 import PackVersionBadge from '@/workbench/extensions/manager/components/manager/PackVersionBadge.vue'
 import PackEnableToggle from '@/workbench/extensions/manager/components/manager/button/PackEnableToggle.vue'
 import PackTryUpdateButton from '@/workbench/extensions/manager/components/manager/button/PackTryUpdateButton.vue'
+import PackUninstallButton from '@/workbench/extensions/manager/components/manager/button/PackUninstallButton.vue'
 import InfoPanelHeader from '@/workbench/extensions/manager/components/manager/infoPanel/InfoPanelHeader.vue'
 import InfoTabs from '@/workbench/extensions/manager/components/manager/infoPanel/InfoTabs.vue'
 import MetadataRow from '@/workbench/extensions/manager/components/manager/infoPanel/MetadataRow.vue'

--- a/src/workbench/extensions/manager/components/manager/infoPanel/InfoPanel.vue
+++ b/src/workbench/extensions/manager/components/manager/infoPanel/InfoPanel.vue
@@ -5,7 +5,13 @@
         <InfoPanelHeader
           :node-packs="[nodePack]"
           :has-conflict="hasCompatibilityIssues"
-        />
+        >
+          <template v-if="canTryNightlyUpdate" #install-button>
+            <div class="flex w-full gap-2">
+              <PackTryUpdateButton :node-pack="nodePack" size="md" />
+            </div>
+          </template>
+        </InfoPanelHeader>
       </div>
       <div
         ref="scrollContainer"
@@ -68,9 +74,11 @@ import type { components } from '@/types/comfyRegistryTypes'
 import PackStatusMessage from '@/workbench/extensions/manager/components/manager/PackStatusMessage.vue'
 import PackVersionBadge from '@/workbench/extensions/manager/components/manager/PackVersionBadge.vue'
 import PackEnableToggle from '@/workbench/extensions/manager/components/manager/button/PackEnableToggle.vue'
+import PackTryUpdateButton from '@/workbench/extensions/manager/components/manager/button/PackTryUpdateButton.vue'
 import InfoPanelHeader from '@/workbench/extensions/manager/components/manager/infoPanel/InfoPanelHeader.vue'
 import InfoTabs from '@/workbench/extensions/manager/components/manager/infoPanel/InfoTabs.vue'
 import MetadataRow from '@/workbench/extensions/manager/components/manager/infoPanel/MetadataRow.vue'
+import { usePackUpdateStatus } from '@/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
 import { useImportFailedDetection } from '@/workbench/extensions/manager/composables/useImportFailedDetection'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
@@ -98,6 +106,8 @@ provide(IsInstallingKey, isInstalling)
 whenever(isInstalled, () => {
   isInstalling.value = false
 })
+
+const { canTryNightlyUpdate } = usePackUpdateStatus(nodePack)
 
 const { checkNodeCompatibility } = useConflictDetection()
 const { getConflictsForPackageByID } = useConflictDetectionStore()

--- a/src/workbench/extensions/manager/components/manager/infoPanel/InfoPanel.vue
+++ b/src/workbench/extensions/manager/components/manager/infoPanel/InfoPanel.vue
@@ -109,7 +109,7 @@ whenever(isInstalled, () => {
   isInstalling.value = false
 })
 
-const { canTryNightlyUpdate } = usePackUpdateStatus(nodePack)
+const { canTryNightlyUpdate } = usePackUpdateStatus(() => nodePack)
 
 const { checkNodeCompatibility } = useConflictDetection()
 const { getConflictsForPackageByID } = useConflictDetectionStore()

--- a/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.ts
@@ -1,21 +1,26 @@
+import { toValue } from '@vueuse/core'
 import { compare, valid } from 'semver'
+import type { MaybeRefOrGetter } from 'vue'
 import { computed } from 'vue'
 
 import type { components } from '@/types/comfyRegistryTypes'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 
 export const usePackUpdateStatus = (
-  nodePack: components['schemas']['Node']
+  nodePackSource: MaybeRefOrGetter<components['schemas']['Node']>
 ) => {
   const { isPackInstalled, isPackEnabled, getInstalledPackVersion } =
     useComfyManagerStore()
 
-  const isInstalled = computed(() => isPackInstalled(nodePack?.id))
-  const isEnabled = computed(() => isPackEnabled(nodePack?.id))
+  // Use toValue to unwrap the source reactively inside computeds
+  const nodePack = computed(() => toValue(nodePackSource))
+
+  const isInstalled = computed(() => isPackInstalled(nodePack.value?.id))
+  const isEnabled = computed(() => isPackEnabled(nodePack.value?.id))
   const installedVersion = computed(() =>
-    getInstalledPackVersion(nodePack.id ?? '')
+    getInstalledPackVersion(nodePack.value?.id ?? '')
   )
-  const latestVersion = computed(() => nodePack.latest_version?.version)
+  const latestVersion = computed(() => nodePack.value?.latest_version?.version)
 
   const isNightlyPack = computed(
     () => !!installedVersion.value && !valid(installedVersion.value)

--- a/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.ts
@@ -7,9 +7,11 @@ import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comf
 export const usePackUpdateStatus = (
   nodePack: components['schemas']['Node']
 ) => {
-  const { isPackInstalled, getInstalledPackVersion } = useComfyManagerStore()
+  const { isPackInstalled, isPackEnabled, getInstalledPackVersion } =
+    useComfyManagerStore()
 
   const isInstalled = computed(() => isPackInstalled(nodePack?.id))
+  const isEnabled = computed(() => isPackEnabled(nodePack?.id))
   const installedVersion = computed(() =>
     getInstalledPackVersion(nodePack.id ?? '')
   )
@@ -31,9 +33,19 @@ export const usePackUpdateStatus = (
     return compare(latestVersion.value, installedVersion.value) > 0
   })
 
+  /**
+   * Nightly packs can always "try update" since we cannot compare git hashes
+   * to determine if an update is actually available. This allows users to
+   * pull the latest changes from the repository.
+   */
+  const canTryNightlyUpdate = computed(
+    () => isInstalled.value && isEnabled.value && isNightlyPack.value
+  )
+
   return {
     isUpdateAvailable,
     isNightlyPack,
+    canTryNightlyUpdate,
     installedVersion,
     latestVersion
   }

--- a/src/workbench/extensions/manager/composables/nodePack/usePacksSelection.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePacksSelection.ts
@@ -1,3 +1,4 @@
+import { valid } from 'semver'
 import { computed } from 'vue'
 import type { Ref } from 'vue'
 
@@ -41,12 +42,30 @@ export function usePacksSelection(nodePacks: Ref<NodePack[]>) {
     return 'mixed'
   })
 
+  /**
+   * Nightly packs are installed packs with a non-semver version (git hash)
+   * that are also enabled
+   */
+  const nightlyPacks = computed(() =>
+    installedPacks.value.filter((pack) => {
+      if (!pack.id) return false
+      const version = managerStore.getInstalledPackVersion(pack.id)
+      const isNightly = !!version && !valid(version)
+      const isEnabled = managerStore.isPackEnabled(pack.id)
+      return isNightly && isEnabled
+    })
+  )
+
+  const hasNightlyPacks = computed(() => nightlyPacks.value.length > 0)
+
   return {
     installedPacks,
     notInstalledPacks,
     isAllInstalled,
     isNoneInstalled,
     isMixed,
-    selectionState
+    selectionState,
+    nightlyPacks,
+    hasNightlyPacks
   }
 }


### PR DESCRIPTION
## Summary
- Add "Try Update" button in InfoPanel for installed nightly packs
- Allows users to pull latest changes from repository for nightly versions
- Nightly updates cannot be auto-detected (git hashes vs semver), so users trigger manually

## Test plan
- [x] Install a nightly version of any pack
- [x] Select the pack in Manager
- [x] Verify "Try Update" button appears in InfoPanel
- [x] Click "Try Update" and verify update request is sent



https://github.com/user-attachments/assets/87443eb2-adc6-4d1c-afc9-171d301cca92


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7610-feat-manager-add-Try-Update-button-for-nightly-packs-2cd6d73d36508167adcbc07c6a07938c) by [Unito](https://www.unito.io)
