### PR TITLE
improve logic of 3d scene size

### DIFF
--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -187,17 +187,18 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
       const width = node.widgets?.find((w) => w.name === 'width')
       const height = node.widgets?.find((w) => w.name === 'height')
 
+      const hasTargetDimensions = !!(width && height)
+
       load3d = new Load3d(containerRef, {
         width: width ? (toRaw(width).value as number) : undefined,
         height: height ? (toRaw(height).value as number) : undefined,
-        getDimensions:
-          width && height
-            ? () => ({
-                width: width.value as number,
-                height: height.value as number
-              })
-            : undefined,
-        isViewerMode: true
+        getDimensions: hasTargetDimensions
+          ? () => ({
+              width: width.value as number,
+              height: height.value as number
+            })
+          : undefined,
+        isViewerMode: hasTargetDimensions
       })
 
       await useLoad3dService().copyLoad3dState(source, load3d)

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -43,8 +43,8 @@ class Load3d {
   STATUS_MOUSE_ON_VIEWER: boolean
   INITIAL_RENDER_DONE: boolean = false
 
-  targetWidth: number = 512
-  targetHeight: number = 512
+  targetWidth: number = 0
+  targetHeight: number = 0
   targetAspectRatio: number = 1
   isViewerMode: boolean = false
 

--- a/tests-ui/tests/composables/useLoad3dViewer.test.ts
+++ b/tests-ui/tests/composables/useLoad3dViewer.test.ts
@@ -164,7 +164,7 @@ describe('useLoad3dViewer', () => {
         width: undefined,
         height: undefined,
         getDimensions: undefined,
-        isViewerMode: true
+        isViewerMode: false
       })
 
       expect(mockLoad3dService.copyLoad3dState).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

improve 3d scene size logic, for preview3d, it should not have target size

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7619-improve-logic-of-3d-scene-size-2cd6d73d36508101b9f5dcef9bbe1314) by [Unito](https://www.unito.io)
