### PR TITLE
Disable desktop release notifications

### DIFF
--- a/src/platform/updates/common/releaseStore.ts
+++ b/src/platform/updates/common/releaseStore.ts
@@ -94,8 +94,9 @@ export const useReleaseStore = defineStore('release', () => {
 
   // Show toast if needed
   const shouldShowToast = computed(() => {
-    // Only show on desktop version
-    if (!isElectron() || isCloud) {
+    // Disable on desktop; updates are handled by todesktop
+    // Disable on cloud; users do not update cloud
+    if (isElectron() || isCloud) {
       return false
     }
 
@@ -126,8 +127,9 @@ export const useReleaseStore = defineStore('release', () => {
 
   // Show red-dot indicator
   const shouldShowRedDot = computed(() => {
-    // Only show on desktop version
-    if (!isElectron() || isCloud) {
+    // Disable on desktop; updates are handled by todesktop
+    // Disable on cloud; users do not update cloud
+    if (isElectron() || isCloud) {
       return false
     }
 

--- a/tests-ui/tests/store/releaseStore.test.ts
+++ b/tests-ui/tests/store/releaseStore.test.ts
@@ -71,7 +71,7 @@ describe('useReleaseStore', () => {
     vi.mocked(useReleaseService).mockReturnValue(mockReleaseService)
     vi.mocked(useSettingStore).mockReturnValue(mockSettingStore)
     vi.mocked(useSystemStatsStore).mockReturnValue(mockSystemStatsStore)
-    vi.mocked(isElectron).mockReturnValue(true)
+    vi.mocked(isElectron).mockReturnValue(false)
     vi.mocked(valid).mockReturnValue('1.0.0')
 
     // Default showVersionUpdates to true
@@ -170,10 +170,13 @@ describe('useReleaseStore', () => {
         expect(store.shouldShowRedDot).toBe(true)
       })
 
-      it('should show popup for latest version', () => {
+      it('should show popup for latest version', async () => {
         mockSystemStatsStore.systemStats.system.comfyui_version = '1.2.0'
 
         vi.mocked(compare).mockReturnValue(0)
+
+        const { isElectron } = await import('@/utils/envUtil')
+        vi.mocked(isElectron).mockReturnValue(true)
 
         expect(store.shouldShowPopup).toBe(true)
       })
@@ -514,7 +517,7 @@ describe('useReleaseStore', () => {
       expect(store.shouldShowRedDot).toBe(true)
     })
 
-    it('should show popup for latest version', () => {
+    it('should show popup for latest version', async () => {
       mockSystemStatsStore.systemStats.system.comfyui_version = '1.2.0' // Same as release
       mockSettingStore.get.mockImplementation((key: string) => {
         if (key === 'Comfy.Notification.ShowVersionUpdates') return true
@@ -522,6 +525,9 @@ describe('useReleaseStore', () => {
       })
 
       vi.mocked(compare).mockReturnValue(0) // versions are equal (latest version)
+
+      const { isElectron } = await import('@/utils/envUtil')
+      vi.mocked(isElectron).mockReturnValue(true)
 
       store.releases = [mockRelease]
 
@@ -578,17 +584,17 @@ describe('useReleaseStore', () => {
         vi.mocked(isElectron).mockReturnValue(true)
       })
 
-      it('should show toast when conditions are met', () => {
+      it('should not show toast when conditions are met', () => {
         vi.mocked(compare).mockReturnValue(1)
         store.releases = [mockRelease]
 
-        expect(store.shouldShowToast).toBe(true)
+        expect(store.shouldShowToast).toBe(false)
       })
 
-      it('should show red dot when new version available', () => {
+      it('should not show red dot when new version available', () => {
         vi.mocked(compare).mockReturnValue(1)
 
-        expect(store.shouldShowRedDot).toBe(true)
+        expect(store.shouldShowRedDot).toBe(false)
       })
 
       it('should show popup for latest version', () => {
@@ -606,22 +612,22 @@ describe('useReleaseStore', () => {
         vi.mocked(isElectron).mockReturnValue(false)
       })
 
-      it('should NOT show toast even when all other conditions are met', () => {
+      it('should show toast when all other conditions are met', () => {
         vi.mocked(compare).mockReturnValue(1)
 
         // Set up all conditions that would normally show toast
         store.releases = [mockRelease]
 
-        expect(store.shouldShowToast).toBe(false)
+        expect(store.shouldShowToast).toBe(true)
       })
 
-      it('should NOT show red dot even when new version available', () => {
+      it('should show red dot when new version available', () => {
         vi.mocked(compare).mockReturnValue(1)
 
-        expect(store.shouldShowRedDot).toBe(false)
+        expect(store.shouldShowRedDot).toBe(true)
       })
 
-      it('should NOT show toast regardless of attention level', () => {
+      it('should show toast for medium/high attention releases', () => {
         vi.mocked(compare).mockReturnValue(1)
 
         // Test with high attention releases
@@ -637,15 +643,15 @@ describe('useReleaseStore', () => {
         }
         store.releases = [highRelease, mediumRelease]
 
-        expect(store.shouldShowToast).toBe(false)
+        expect(store.shouldShowToast).toBe(true)
       })
 
-      it('should NOT show red dot even with high attention release', () => {
+      it('should show red dot with high attention release', () => {
         vi.mocked(compare).mockReturnValue(1)
 
         store.releases = [{ ...mockRelease, attention: 'high' as const }]
 
-        expect(store.shouldShowRedDot).toBe(false)
+        expect(store.shouldShowRedDot).toBe(true)
       })
 
       it('should NOT show popup even for latest version', () => {


### PR DESCRIPTION
Disable desktop release toast and red-dot notifications.

## What changed
- Stop showing release toast and update red-dot on Electron builds; keep them for non-desktop platforms.
- Update releaseStore unit tests to reflect the desktop/web behavior split.

## Why
- Desktop updates are handled by todesktop, so showing core version update notifications is misleading.
- This keeps the existing release UX for web while avoiding duplicate or confusing prompts on desktop.
- Tradeoff: desktop no longer surfaces core version release indicators; that remains the responsibility of todesktop notifications.

## Evidence
- None

## References
- None

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7630-Disable-desktop-release-notifications-2ce6d73d365081648fd4c3256ac912bb) by [Unito](https://www.unito.io)
