### PR TITLE
fix: prevent custom context menu when editing text

### DIFF
--- a/src/components/common/EditableText.vue
+++ b/src/components/common/EditableText.vue
@@ -21,6 +21,7 @@
       @keyup.enter.capture.stop="blurInputElement"
       @keyup.escape.stop="cancelEditing"
       @click.stop
+      @contextmenu.stop
       @pointerdown.stop.capture
       @pointermove.stop.capture
     />


### PR DESCRIPTION
## Summary
- Stop contextmenu event propagation in EditableText component
- Allows browser's native context menu (copy/paste) when renaming nodes

## Test plan
- [ ] Double-click a node title to enter edit mode
- [ ] Select text and right-click
- [ ] Verify browser's native context menu appears (not the node context menu)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7633-fix-prevent-custom-context-menu-when-editing-text-2ce6d73d365081e38461d080abe12b32) by [Unito](https://www.unito.io)
