### PR TITLE
feat: position properties panel opposite to sidebar

### DIFF
--- a/browser_tests/tests/propertiesPanel/propertiesPanelPosition.spec.ts
+++ b/browser_tests/tests/propertiesPanel/propertiesPanelPosition.spec.ts
@@ -14,7 +14,9 @@ test.describe('Properties panel position', () => {
     await comfyPage.nextFrame()
 
     const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
-    const sidebar = comfyPage.page.locator('.side-bar-panel')
+    const sidebar = comfyPage.page.getByRole('complementary', {
+      name: 'Sidebar'
+    })
 
     const propsBoundingBox = await propertiesPanel.boundingBox()
     const sidebarBoundingBox = await sidebar.boundingBox()
@@ -35,7 +37,9 @@ test.describe('Properties panel position', () => {
     await comfyPage.nextFrame()
 
     const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
-    const sidebar = comfyPage.page.locator('.side-bar-panel')
+    const sidebar = comfyPage.page.getByRole('complementary', {
+      name: 'Sidebar'
+    })
 
     const propsBoundingBox = await propertiesPanel.boundingBox()
     const sidebarBoundingBox = await sidebar.boundingBox()
@@ -61,7 +65,7 @@ test.describe('Properties panel position', () => {
     const closeButtonLeft = propertiesPanel
       .locator('button[aria-label*="toggle"]')
       .locator('i')
-    await expect(closeButtonLeft).toHaveClass(/panel-right/)
+    await expect(closeButtonLeft).toHaveClass(/icon-\[lucide--panel-right\]/)
 
     // When sidebar is on the right, panel is on the left
     await comfyPage.setSetting('Comfy.Sidebar.Location', 'right')
@@ -70,6 +74,6 @@ test.describe('Properties panel position', () => {
     const closeButtonRight = propertiesPanel
       .locator('button[aria-label*="toggle"]')
       .locator('i')
-    await expect(closeButtonRight).toHaveClass(/panel-left/)
+    await expect(closeButtonRight).toHaveClass(/icon-\[lucide--panel-left\]/)
   })
 })

--- a/browser_tests/tests/propertiesPanel/propertiesPanelPosition.spec.ts
+++ b/browser_tests/tests/propertiesPanel/propertiesPanelPosition.spec.ts
@@ -4,6 +4,8 @@ import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
 
 test.describe('Properties panel position', () => {
   test.beforeEach(async ({ comfyPage }) => {
+    // Open a sidebar tab to ensure sidebar is visible
+    await comfyPage.menu.nodeLibraryTab.open()
     await comfyPage.actionbar.propertiesButton.click()
   })
 
@@ -14,9 +16,10 @@ test.describe('Properties panel position', () => {
     await comfyPage.nextFrame()
 
     const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
-    const sidebar = comfyPage.page.getByRole('complementary', {
-      name: 'Sidebar'
-    })
+    const sidebar = comfyPage.page.locator('.side-bar-panel').first()
+
+    await expect(propertiesPanel).toBeVisible()
+    await expect(sidebar).toBeVisible()
 
     const propsBoundingBox = await propertiesPanel.boundingBox()
     const sidebarBoundingBox = await sidebar.boundingBox()
@@ -37,9 +40,10 @@ test.describe('Properties panel position', () => {
     await comfyPage.nextFrame()
 
     const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
-    const sidebar = comfyPage.page.getByRole('complementary', {
-      name: 'Sidebar'
-    })
+    const sidebar = comfyPage.page.locator('.side-bar-panel').first()
+
+    await expect(propertiesPanel).toBeVisible()
+    await expect(sidebar).toBeVisible()
 
     const propsBoundingBox = await propertiesPanel.boundingBox()
     const sidebarBoundingBox = await sidebar.boundingBox()
@@ -62,18 +66,21 @@ test.describe('Properties panel position', () => {
     await comfyPage.setSetting('Comfy.Sidebar.Location', 'left')
     await comfyPage.nextFrame()
 
+    await expect(propertiesPanel).toBeVisible()
     const closeButtonLeft = propertiesPanel
-      .locator('button[aria-label*="toggle"]')
+      .locator('button[aria-pressed]')
       .locator('i')
-    await expect(closeButtonLeft).toHaveClass(/icon-\[lucide--panel-right\]/)
+    await expect(closeButtonLeft).toBeVisible()
+    await expect(closeButtonLeft).toHaveClass(/lucide--panel-right/)
 
     // When sidebar is on the right, panel is on the left
     await comfyPage.setSetting('Comfy.Sidebar.Location', 'right')
     await comfyPage.nextFrame()
 
     const closeButtonRight = propertiesPanel
-      .locator('button[aria-label*="toggle"]')
+      .locator('button[aria-pressed]')
       .locator('i')
-    await expect(closeButtonRight).toHaveClass(/icon-\[lucide--panel-left\]/)
+    await expect(closeButtonRight).toBeVisible()
+    await expect(closeButtonRight).toHaveClass(/lucide--panel-left/)
   })
 })

--- a/browser_tests/tests/propertiesPanel/propertiesPanelPosition.spec.ts
+++ b/browser_tests/tests/propertiesPanel/propertiesPanelPosition.spec.ts
@@ -1,0 +1,75 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+
+test.describe('Properties panel position', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.actionbar.propertiesButton.click()
+  })
+
+  test('positions on the right when sidebar is on the left', async ({
+    comfyPage
+  }) => {
+    await comfyPage.setSetting('Comfy.Sidebar.Location', 'left')
+    await comfyPage.nextFrame()
+
+    const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
+    const sidebar = comfyPage.page.locator('.side-bar-panel')
+
+    const propsBoundingBox = await propertiesPanel.boundingBox()
+    const sidebarBoundingBox = await sidebar.boundingBox()
+
+    expect(propsBoundingBox).not.toBeNull()
+    expect(sidebarBoundingBox).not.toBeNull()
+
+    // Properties panel should be to the right of the sidebar
+    expect(propsBoundingBox!.x).toBeGreaterThan(
+      sidebarBoundingBox!.x + sidebarBoundingBox!.width
+    )
+  })
+
+  test('positions on the left when sidebar is on the right', async ({
+    comfyPage
+  }) => {
+    await comfyPage.setSetting('Comfy.Sidebar.Location', 'right')
+    await comfyPage.nextFrame()
+
+    const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
+    const sidebar = comfyPage.page.locator('.side-bar-panel')
+
+    const propsBoundingBox = await propertiesPanel.boundingBox()
+    const sidebarBoundingBox = await sidebar.boundingBox()
+
+    expect(propsBoundingBox).not.toBeNull()
+    expect(sidebarBoundingBox).not.toBeNull()
+
+    // Properties panel should be to the left of the sidebar
+    expect(propsBoundingBox!.x + propsBoundingBox!.width).toBeLessThan(
+      sidebarBoundingBox!.x
+    )
+  })
+
+  test('close button icon updates based on sidebar location', async ({
+    comfyPage
+  }) => {
+    const propertiesPanel = comfyPage.page.getByTestId('properties-panel')
+
+    // When sidebar is on the left, panel is on the right
+    await comfyPage.setSetting('Comfy.Sidebar.Location', 'left')
+    await comfyPage.nextFrame()
+
+    const closeButtonLeft = propertiesPanel
+      .locator('button[aria-label*="toggle"]')
+      .locator('i')
+    await expect(closeButtonLeft).toHaveClass(/panel-right/)
+
+    // When sidebar is on the right, panel is on the left
+    await comfyPage.setSetting('Comfy.Sidebar.Location', 'right')
+    await comfyPage.nextFrame()
+
+    const closeButtonRight = propertiesPanel
+      .locator('button[aria-label*="toggle"]')
+      .locator('i')
+    await expect(closeButtonRight).toHaveClass(/panel-left/)
+  })
+})

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -22,6 +22,18 @@
         state-storage="local"
         @resizestart="onResizestart"
       >
+        <!-- Properties Panel on left when sidebar is on right -->
+        <SplitterPanel
+          v-if="
+            rightSidePanelVisible && !focusMode && sidebarLocation === 'right'
+          "
+          class="bg-comfy-menu-bg pointer-events-auto"
+          :min-size="15"
+          :size="20"
+        >
+          <slot name="right-side-panel" />
+        </SplitterPanel>
+
         <SplitterPanel
           v-if="sidebarLocation === 'left' && !focusMode"
           :class="
@@ -96,9 +108,11 @@
           />
         </SplitterPanel>
 
-        <!-- Right Side Panel - independent of sidebar -->
+        <!-- Properties Panel on right when sidebar is on left (default) -->
         <SplitterPanel
-          v-if="rightSidePanelVisible && !focusMode"
+          v-if="
+            rightSidePanelVisible && !focusMode && sidebarLocation === 'left'
+          "
           class="bg-comfy-menu-bg pointer-events-auto"
           :min-size="15"
           :size="20"
@@ -159,12 +173,16 @@ function onResizestart({ originalEvent: event }: SplitterResizeStartEvent) {
 }
 
 /*
- * Force refresh the splitter when right panel visibility changes to recalculate the width
+ * Force refresh the splitter when right panel visibility or sidebar location changes
+ * to recalculate the width and panel order
  */
 const splitterRefreshKey = computed(() => {
-  return rightSidePanelVisible.value
-    ? 'main-splitter-with-right-panel'
-    : 'main-splitter'
+  const parts = ['main-splitter']
+  if (rightSidePanelVisible.value) {
+    parts.push('with-right-panel')
+  }
+  parts.push(sidebarLocation.value)
+  return parts.join('-')
 })
 </script>
 

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -22,43 +22,42 @@
         state-storage="local"
         @resizestart="onResizestart"
       >
-        <!-- Properties Panel on left when sidebar is on right -->
+        <!-- First panel: sidebar when left, properties when right -->
         <SplitterPanel
           v-if="
-            rightSidePanelVisible && !focusMode && sidebarLocation === 'right'
+            !focusMode && (sidebarLocation === 'left' || rightSidePanelVisible)
           "
-          class="bg-comfy-menu-bg pointer-events-auto"
-          :min-size="15"
-          :size="20"
-        >
-          <slot name="right-side-panel" />
-        </SplitterPanel>
-
-        <SplitterPanel
-          v-if="sidebarLocation === 'left' && !focusMode"
           :class="
-            cn(
-              'side-bar-panel bg-comfy-menu-bg pointer-events-auto',
-              sidebarPanelVisible && 'min-w-78'
-            )
+            sidebarLocation === 'left'
+              ? cn(
+                  'side-bar-panel bg-comfy-menu-bg pointer-events-auto',
+                  sidebarPanelVisible && 'min-w-78'
+                )
+              : 'bg-comfy-menu-bg pointer-events-auto'
           "
-          :min-size="10"
+          :min-size="sidebarLocation === 'left' ? 10 : 15"
           :size="20"
-          :style="{
-            display:
-              sidebarPanelVisible && sidebarLocation === 'left'
-                ? 'flex'
-                : 'none'
-          }"
-          role="complementary"
-          :aria-label="t('sideToolbar.sidebar')"
+          :style="
+            sidebarLocation === 'left'
+              ? { display: sidebarPanelVisible ? 'flex' : 'none' }
+              : undefined
+          "
+          :role="sidebarLocation === 'left' ? 'complementary' : undefined"
+          :aria-label="
+            sidebarLocation === 'left' ? t('sideToolbar.sidebar') : undefined
+          "
         >
           <slot
-            v-if="sidebarPanelVisible && sidebarLocation === 'left'"
+            v-if="sidebarLocation === 'left' && sidebarPanelVisible"
             name="side-bar-panel"
+          />
+          <slot
+            v-else-if="sidebarLocation === 'right'"
+            name="right-side-panel"
           />
         </SplitterPanel>
 
+        <!-- Main panel (always present) -->
         <SplitterPanel :size="80" class="flex flex-col">
           <slot name="topmenu" :sidebar-panel-visible />
 
@@ -87,41 +86,36 @@
           </Splitter>
         </SplitterPanel>
 
-        <SplitterPanel
-          v-if="sidebarLocation === 'right' && !focusMode"
-          :class="
-            cn(
-              'side-bar-panel pointer-events-auto',
-              sidebarPanelVisible && 'min-w-78'
-            )
-          "
-          :min-size="10"
-          :size="20"
-          :style="{
-            display:
-              sidebarPanelVisible && sidebarLocation === 'right'
-                ? 'flex'
-                : 'none'
-          }"
-          role="complementary"
-          :aria-label="t('sideToolbar.sidebar')"
-        >
-          <slot
-            v-if="sidebarPanelVisible && sidebarLocation === 'right'"
-            name="side-bar-panel"
-          />
-        </SplitterPanel>
-
-        <!-- Properties Panel on right when sidebar is on left (default) -->
+        <!-- Last panel: properties when left, sidebar when right -->
         <SplitterPanel
           v-if="
-            rightSidePanelVisible && !focusMode && sidebarLocation === 'left'
+            !focusMode && (sidebarLocation === 'right' || rightSidePanelVisible)
           "
-          class="bg-comfy-menu-bg pointer-events-auto"
-          :min-size="15"
+          :class="
+            sidebarLocation === 'right'
+              ? cn(
+                  'side-bar-panel bg-comfy-menu-bg pointer-events-auto',
+                  sidebarPanelVisible && 'min-w-78'
+                )
+              : 'bg-comfy-menu-bg pointer-events-auto'
+          "
+          :min-size="sidebarLocation === 'right' ? 10 : 15"
           :size="20"
+          :style="
+            sidebarLocation === 'right'
+              ? { display: sidebarPanelVisible ? 'flex' : 'none' }
+              : undefined
+          "
+          :role="sidebarLocation === 'right' ? 'complementary' : undefined"
+          :aria-label="
+            sidebarLocation === 'right' ? t('sideToolbar.sidebar') : undefined
+          "
         >
-          <slot name="right-side-panel" />
+          <slot v-if="sidebarLocation === 'left'" name="right-side-panel" />
+          <slot
+            v-else-if="sidebarLocation === 'right' && sidebarPanelVisible"
+            name="side-bar-panel"
+          />
         </SplitterPanel>
       </Splitter>
     </div>

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -37,11 +37,7 @@
           "
           :min-size="sidebarLocation === 'left' ? 10 : 15"
           :size="20"
-          :style="
-            sidebarLocation === 'left'
-              ? { display: sidebarPanelVisible ? 'flex' : 'none' }
-              : undefined
-          "
+          :style="firstPanelStyle"
           :role="sidebarLocation === 'left' ? 'complementary' : undefined"
           :aria-label="
             sidebarLocation === 'left' ? t('sideToolbar.sidebar') : undefined
@@ -101,11 +97,7 @@
           "
           :min-size="sidebarLocation === 'right' ? 10 : 15"
           :size="20"
-          :style="
-            sidebarLocation === 'right'
-              ? { display: sidebarPanelVisible ? 'flex' : 'none' }
-              : undefined
-          "
+          :style="lastPanelStyle"
           :role="sidebarLocation === 'right' ? 'complementary' : undefined"
           :aria-label="
             sidebarLocation === 'right' ? t('sideToolbar.sidebar') : undefined
@@ -182,6 +174,20 @@ const splitterRefreshKey = computed(() => {
   }
   parts.push(sidebarLocation.value)
   return parts.join('-')
+})
+
+const firstPanelStyle = computed(() => {
+  if (sidebarLocation.value === 'left') {
+    return { display: sidebarPanelVisible.value ? 'flex' : 'none' }
+  }
+  return undefined
+})
+
+const lastPanelStyle = computed(() => {
+  if (sidebarLocation.value === 'right') {
+    return { display: sidebarPanelVisible.value ? 'flex' : 'none' }
+  }
+  return undefined
 })
 </script>
 

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -121,8 +121,8 @@ import Splitter from 'primevue/splitter'
 import type { SplitterResizeStartEvent } from 'primevue/splitter'
 import SplitterPanel from 'primevue/splitterpanel'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
@@ -133,6 +133,7 @@ const workspaceStore = useWorkspaceStore()
 const settingStore = useSettingStore()
 const rightSidePanelStore = useRightSidePanelStore()
 const sidebarTabStore = useSidebarTabStore()
+const { t } = useI18n()
 const sidebarLocation = computed<'left' | 'right'>(() =>
   settingStore.get('Comfy.Sidebar.Location')
 )

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -168,12 +168,7 @@ function onResizestart({ originalEvent: event }: SplitterResizeStartEvent) {
  * to recalculate the width and panel order
  */
 const splitterRefreshKey = computed(() => {
-  const parts = ['main-splitter']
-  if (rightSidePanelVisible.value) {
-    parts.push('with-right-panel')
-  }
-  parts.push(sidebarLocation.value)
-  return parts.join('-')
+  return `main-splitter${rightSidePanelVisible.value ? '-with-right-panel' : ''}-${sidebarLocation.value}`
 })
 
 const firstPanelStyle = computed(() => {

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -50,6 +50,8 @@
                 ? 'flex'
                 : 'none'
           }"
+          role="complementary"
+          :aria-label="t('sideToolbar.sidebar')"
         >
           <slot
             v-if="sidebarPanelVisible && sidebarLocation === 'left'"
@@ -101,6 +103,8 @@
                 ? 'flex'
                 : 'none'
           }"
+          role="complementary"
+          :aria-label="t('sideToolbar.sidebar')"
         >
           <slot
             v-if="sidebarPanelVisible && sidebarLocation === 'right'"
@@ -132,6 +136,7 @@ import type { SplitterResizeStartEvent } from 'primevue/splitter'
 import SplitterPanel from 'primevue/splitterpanel'
 import { computed } from 'vue'
 
+import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'

--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -9,6 +9,7 @@ import TabList from '@/components/tab/TabList.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import type { RightSidePanelTab } from '@/stores/workspace/rightSidePanelStore'
@@ -22,10 +23,22 @@ import SubgraphEditor from './subgraph/SubgraphEditor.vue'
 
 const canvasStore = useCanvasStore()
 const rightSidePanelStore = useRightSidePanelStore()
+const settingStore = useSettingStore()
 const { t } = useI18n()
 
 const { selectedItems } = storeToRefs(canvasStore)
 const { activeTab, isEditingSubgraph } = storeToRefs(rightSidePanelStore)
+
+const sidebarLocation = computed<'left' | 'right'>(() =>
+  settingStore.get('Comfy.Sidebar.Location')
+)
+
+// Panel is on the left when sidebar is on the right, and vice versa
+const panelIcon = computed(() =>
+  sidebarLocation.value === 'right'
+    ? 'icon-[lucide--panel-left]'
+    : 'icon-[lucide--panel-right]'
+)
 
 const hasSelection = computed(() => selectedItems.value.length > 0)
 
@@ -160,7 +173,7 @@ function handleTitleCancel() {
             :aria-label="t('rightSidePanel.togglePanel')"
             @click="closePanel"
           >
-            <i class="icon-[lucide--panel-right] size-4" />
+            <i :class="cn(panelIcon, 'size-4')" />
           </Button>
         </div>
       </div>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -648,6 +648,7 @@
     "box": "Box"
   },
   "sideToolbar": {
+    "sidebar": "Sidebar",
     "themeToggle": "Toggle Theme",
     "helpCenter": "Help Center",
     "logout": "Logout",


### PR DESCRIPTION
## Problem

When sidebar is positioned on the right, the properties panel also appears on the right, causing both panels to compete for space and creating a poor layout.

## Solution

Properties panel now dynamically positions itself opposite to the sidebar:
- Sidebar left → Properties panel right (default)
- Sidebar right → Properties panel left

## Changes

- Modified `LiteGraphCanvasSplitterOverlay.vue` to conditionally render properties panel based on sidebar location
- Updated splitter refresh key to recalculate layout when sidebar position changes
- Added dynamic close button icon in `RightSidePanel.vue` that points in the correct direction

## Testing

- Created E2E tests to verify positioning behavior
- Manually verified visual behavior in browser

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7647-feat-position-properties-panel-opposite-to-sidebar-2ce6d73d365081049683e74c8d03dbdd) by [Unito](https://www.unito.io)
