### PR TITLE
Fix component widget state on graph change

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -41,7 +41,11 @@ import {
   isComboInputSpecV1,
   isComboInputSpecV2
 } from '@/schemas/nodeDefSchema'
-import { type BaseDOMWidget, DOMWidgetImpl } from '@/scripts/domWidget'
+import {
+  type BaseDOMWidget,
+  ComponentWidgetImpl,
+  DOMWidgetImpl
+} from '@/scripts/domWidget'
 import { useDialogService } from '@/services/dialogService'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { useExtensionService } from '@/services/extensionService'
@@ -812,7 +816,10 @@ export class ComfyApp {
         > = Object.fromEntries(
           newGraph.nodes
             .flatMap((node) => node.widgets ?? [])
-            .filter((w) => w instanceof DOMWidgetImpl)
+            .filter(
+              (w) =>
+                w instanceof DOMWidgetImpl || w instanceof ComponentWidgetImpl
+            )
             .map((w) => [w.id, w])
         )
 


### PR DESCRIPTION
## Summary

Component widgets (e.g. Load3D) in the root graph stay inactive after leaving a subgraph.

## Changes

-  Adds component widget class to the active widget filter.

## Screenshots

|Before|After|
|-|-|
|![ComponentBefore](https://github.com/user-attachments/assets/a931bcb7-bc46-424d-8a80-d7b3e6acba5e)|![ComponentAfter](https://github.com/user-attachments/assets/8673f777-c69c-4bce-9df0-ada28bf67b8d)|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7648-Fix-component-widget-state-on-graph-change-2ce6d73d365081aabff5d6c07430da3d) by [Unito](https://www.unito.io)
