### PR TITLE
Decrease timeout for chromium sharded tests

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -45,6 +45,7 @@ jobs:
   playwright-tests-chromium-sharded:
     needs: setup
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
## Summary

Reduce the timeout per shard from 6 hours to 1 hour.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7664-Decrease-timeout-for-chromium-sharded-tests-2cf6d73d36508164a60be3072daa9629) by [Unito](https://www.unito.io)
