### PR TITLE
🤖 Agent file location rules (and CSS prohibition)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,9 +269,9 @@ When referencing Comfy-Org repos:
 - NEVER use `!important` or the `!` important prefix for tailwind classes
   - Find existing `!important` classes that are interfering with the styling and propose corrections of those instead.
 
-## Agent only rules
+## Agent-only rules
 
-Rules for agent based coding tasks.
+Rules for agent-based coding tasks.
 
 ### Temporary Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,16 @@ When referencing Comfy-Org repos:
   - Always use `import { cn } from '@/utils/tailwindUtil'`
     - e.g. `<div :class="cn('text-node-component-header-icon', hasError && 'text-danger')" />`
   - Use `cn()` inline in the template when feasible instead of creating a `computed` to hold the value
+- NEVER use `!important` or the `!` important prefix for tailwind classes
+  - Find existing `!important` classes that are interfering with the styling and propose corrections of those instead.
+
+## Agent only rules
+
+Rules for agent based coding tasks.
+
+### Temporary Files
+
+- Put planning documents under `/temp/plans/`
+- Put scripts used under `/temp/scripts/`
+- Put summaries of work performed under `/temp/summaries/`
+- Put TODOs and status updates under `/temp/in_progress/`


### PR DESCRIPTION
Add rule for agents to use the gitignored temp directory for plans/scripts
Add rule to avoid `!important`
Add more rules around temporary files

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7691-Agent-file-location-rules-and-CSS-prohibition-2d06d73d365081a6b3a2f619cd67cb91) by [Unito](https://www.unito.io)
