### PR TITLE
test: deflake templates locale coverage

### DIFF
--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -113,7 +113,9 @@ test.describe('Templates', () => {
 
     await comfyPage.executeCommand('Comfy.BrowseTemplates')
 
-    const dialog = comfyPage.page.getByRole('dialog', { name: 'Modèles' })
+    const dialog = comfyPage.page.getByRole('dialog').filter({
+      has: comfyPage.page.getByRole('heading', { name: 'Modèles', exact: true })
+    })
     await expect(dialog).toBeVisible()
 
     // Validate that French-localized strings from the templates index are rendered

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -113,18 +113,15 @@ test.describe('Templates', () => {
 
     await comfyPage.executeCommand('Comfy.BrowseTemplates')
 
-    const templatesContent = comfyPage.templates.content
-    await expect(templatesContent).toBeVisible()
+    const dialog = comfyPage.page.getByRole('dialog', { name: 'Modèles' })
+    await expect(dialog).toBeVisible()
 
     // Validate that French-localized strings from the templates index are rendered
     await expect(
-      templatesContent.getByRole('heading', {
-        name: 'Modèles',
-        exact: true
-      })
+      dialog.getByRole('heading', { name: 'Modèles', exact: true })
     ).toBeVisible()
     await expect(
-      comfyPage.page.getByText('Tous les modèles', { exact: true })
+      dialog.getByRole('button', { name: 'Tous les modèles', exact: true })
     ).toBeVisible()
 
     // Ensure the English fallback copy is not shown anywhere

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -117,14 +117,19 @@ test.describe('Templates', () => {
     await expect(templatesContent).toBeVisible()
 
     // Validate that French-localized strings from the templates index are rendered
-    await expect(templatesContent.getByText('Tous les modèles')).toBeVisible()
     await expect(
-      templatesContent.getByText('Créer un nouveau flux de travail vierge')
+      templatesContent.getByRole('heading', {
+        name: 'Modèles',
+        exact: true
+      })
+    ).toBeVisible()
+    await expect(
+      comfyPage.page.getByText('Tous les modèles', { exact: true })
     ).toBeVisible()
 
-    // Ensure the English fallback copy is not shown
+    // Ensure the English fallback copy is not shown anywhere
     await expect(
-      templatesContent.getByText('All Templates', { exact: true })
+      comfyPage.page.getByText('All Templates', { exact: true })
     ).toHaveCount(0)
   })
 

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -109,22 +109,23 @@ test.describe('Templates', () => {
   })
 
   test('Uses proper locale files for templates', async ({ comfyPage }) => {
-    // Load the templates dialog and wait for the French index file request
-    const requestPromise = comfyPage.page.waitForRequest(
-      '**/templates/index.fr.json'
-    )
-
-    // Set locale to French before opening templates
     await comfyPage.setSetting('Comfy.Locale', 'fr')
 
     await comfyPage.executeCommand('Comfy.BrowseTemplates')
 
-    const request = await requestPromise
+    const templatesContent = comfyPage.templates.content
+    await expect(templatesContent).toBeVisible()
 
-    // Verify French index was requested
-    expect(request.url()).toContain('templates/index.fr.json')
+    // Validate that French-localized strings from the templates index are rendered
+    await expect(templatesContent.getByText('Tous les modèles')).toBeVisible()
+    await expect(
+      templatesContent.getByText('Créer un nouveau flux de travail vierge')
+    ).toBeVisible()
 
-    await expect(comfyPage.templates.content).toBeVisible()
+    // Ensure the English fallback copy is not shown
+    await expect(
+      templatesContent.getByText('All Templates', { exact: true })
+    ).toHaveCount(0)
   })
 
   test('Falls back to English templates when locale file not found', async ({


### PR DESCRIPTION
## Summary
Ensure the templates locale Playwright test validates localized UI text instead of waiting on a flaky network request.

## Changes
- **What**: Update `Templates >> Uses proper locale files for templates` to assert on French strings rendered in the dialog and confirm English fallback is absent

## Review Focus
- Confirm the chosen French strings always appear when the localized bundle loads so the test meaningfully covers the regression

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7705-test-deflake-templates-locale-coverage-2d16d73d365081ffbf9adc1623a36733) by [Unito](https://www.unito.io)
