### PR TITLE
[backport cloud/1.35] Fix: the wrong selection under the hand mode

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -328,7 +328,7 @@ const { startResize } = useNodeResize((result, element) => {
 
 const handleResizePointerDown = (event: PointerEvent) => {
   if (event.button !== 0) return
-  if(!shouldHandleNodePointerEvents.value) return
+  if (!shouldHandleNodePointerEvents.value) return
   if (nodeData.flags?.pinned) return
   startResize(event)
 }

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -327,6 +327,8 @@ const { startResize } = useNodeResize((result, element) => {
 })
 
 const handleResizePointerDown = (event: PointerEvent) => {
+  if (event.button !== 0) return
+  if(!shouldHandleNodePointerEvents.value) return
   if (nodeData.flags?.pinned) return
   startResize(event)
 }


### PR DESCRIPTION
## Summary

Backport of #7541 to cloud/1.35.

Fixed an inconsistency where nodes were resizable in Hand mode. Resizing is now restricted to Selection mode only to match standard LiteGraph behavior (Hand mode should only be for panning).

## Changes

- Added guard clause to prevent resize in Hand mode (`shouldHandleNodePointerEvents` check)
- Added `event.button !== 0` check for non-primary mouse buttons

## Original PR

https://github.com/Comfy-Org/ComfyUI_frontend/pull/7541

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7716-backport-cloud-1-35-Fix-the-wrong-selection-under-the-hand-mode-2d16d73d365081c7b558f652952bb590) by [Unito](https://www.unito.io)
