### PR TITLE
Use useI18n in media asset actions

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -1,10 +1,10 @@
 import { useToast } from 'primevue/usetoast'
 import { inject } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import ConfirmationDialogContent from '@/components/dialog/content/ConfirmationDialogContent.vue'
 import { downloadFile } from '@/base/common/downloadUtil'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
-import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
 import { useWorkflowActionsService } from '@/platform/workflow/core/services/workflowActionsService'
 import { extractWorkflowFromAsset } from '@/platform/workflow/utils/workflowExtractionUtil'
@@ -25,6 +25,7 @@ import { MediaAssetKey } from '../schemas/mediaAssetSchema'
 import { assetService } from '../services/assetService'
 
 export function useMediaAssetActions() {
+  const { t } = useI18n()
   const toast = useToast()
   const dialogStore = useDialogStore()
   const mediaContext = inject(MediaAssetKey, null)
@@ -79,7 +80,7 @@ export function useMediaAssetActions() {
       toast.add({
         severity: 'success',
         summary: t('g.success'),
-        detail: t('g.downloadStarted'),
+        detail: t('mediaAsset.selection.downloadsStarted', { count: 1 }),
         life: 2000
       })
     } catch (error) {


### PR DESCRIPTION
Use useI18n for media asset action translations and fix missing translation string.

## What changed
- Switch the media asset actions composable to use `useI18n()` instead of the global `t`.
- Use the existing `mediaAsset.selection.downloadsStarted` key for the single-download toast to avoid missing strings.

## Why
- Aligns translation usage with the composition API and avoids referencing a non-existent key.
- Reuses existing translation keys without adding new strings.

## Evidence
- Tests: `pnpm lint:fix`, `pnpm typecheck`, `pnpm knip`

## References
- N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7744-Use-useI18n-in-media-asset-actions-2d26d73d365081f79cd1c5af105fc59b) by [Unito](https://www.unito.io)
