### PR TITLE
Fix slot renaming in vue

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -43,7 +43,12 @@
           )
         "
       >
-        {{ slotData.localized_name || slotData.name || `Input ${index}` }}
+        {{
+          slotData.label ||
+          slotData.localized_name ||
+          slotData.name ||
+          `Input ${index}`
+        }}
       </span>
     </div>
   </div>


### PR DESCRIPTION
Adds an additional check for `slotData.label` so that renamed slots properly display in vue mode

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7748-Fix-slot-renaming-in-vue-2d36d73d365081dc8247f2d9e9e06a7a) by [Unito](https://www.unito.io)
