### PR TITLE
add prices for Kling Motion Control node

### DIFF
--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -116,6 +116,31 @@ const makeOmniProDurationCalculator =
     return formatCreditsLabel(cost)
   }
 
+const klingMotionControlPricingCalculator: PricingFunction = (
+  node: LGraphNode
+): string => {
+  const modeWidget = node.widgets?.find(
+    (w) => w.name === 'mode'
+  ) as IComboWidget
+
+  if (!modeWidget) {
+    return formatCreditsListLabel([0.07, 0.112], {
+      suffix: '/second',
+      note: '(std/pro)'
+    })
+  }
+
+  const mode = String(modeWidget.value).toLowerCase()
+
+  if (mode === 'pro') return formatCreditsLabel(0.112, { suffix: '/second' })
+  if (mode === 'std') return formatCreditsLabel(0.07, { suffix: '/second' })
+
+  return formatCreditsListLabel([0.07, 0.112], {
+    suffix: '/second',
+    note: '(std/pro)'
+  })
+}
+
 const pixversePricingCalculator = (node: LGraphNode): string => {
   const durationWidget = node.widgets?.find(
     (w) => w.name === 'duration_seconds'
@@ -1033,6 +1058,9 @@ const apiNodeCosts: Record<string, { displayPrice: string | PricingFunction }> =
     },
     KlingOmniProVideoToVideoNode: {
       displayPrice: makeOmniProDurationCalculator(0.168)
+    },
+    KlingMotionControl: {
+      displayPrice: klingMotionControlPricingCalculator
     },
     KlingOmniProEditVideoNode: {
       displayPrice: formatCreditsLabel(0.168, { suffix: '/second' })
@@ -2117,6 +2145,7 @@ export const useNodePricing = () => {
       KlingOmniProFirstLastFrameNode: ['duration'],
       KlingOmniProImageToVideoNode: ['duration'],
       KlingOmniProVideoToVideoNode: ['duration'],
+      KlingMotionControl: ['mode'],
       MinimaxHailuoVideoNode: ['resolution', 'duration'],
       OpenAIDalle3: ['size', 'quality'],
       OpenAIDalle2: ['size', 'n'],


### PR DESCRIPTION
## Summary

<img width="559" height="723" alt="Screenshot From 2025-12-24 15-26-31" src="https://github.com/user-attachments/assets/1ef263dd-1970-4feb-9d0b-05bfa17e72be" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7756-add-prices-for-Kling-Motion-Control-node-2d36d73d3650814193f3c84f25624518) by [Unito](https://www.unito.io)
