### PR TITLE
fix: restore mask editor compatibility with Impact-Pack plugin

### DIFF
--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -104,7 +104,8 @@ export function useMaskEditorLoader() {
       // If we have a widget filename, we should prioritize it over the node image
       // because the node image might be stale (e.g. from a previous save)
       // while the widget value reflects the current selection.
-      if (widgetFilename) {
+      // Skip internal reference formats (e.g. "$35-0" used by some plugins like Impact-Pack)
+      if (widgetFilename && !widgetFilename.startsWith('$')) {
         try {
           // Parse the widget value which might be in format "subfolder/filename [type]" or just "filename"
           let filename = widgetFilename

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -5,7 +5,6 @@ import { app, ComfyApp } from '@/scripts/app'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
-import { ClipspaceDialog } from './clipspace'
 
 function openMaskEditor(node: LGraphNode): void {
   if (!node) {
@@ -36,15 +35,6 @@ function openMaskEditorFromClipspace(): void {
 // Check if the dialog is already opened
 function isOpened(): boolean {
   return useDialogStore().isDialogOpen('global-mask-editor')
-}
-
-// Context predicate for ClipspaceDialog button
-function contextPredicate(): boolean {
-  return !!(
-    ComfyApp.clipspace &&
-    ComfyApp.clipspace.imgs &&
-    ComfyApp.clipspace.imgs.length > 0
-  )
 }
 
 app.registerExtension({
@@ -104,17 +94,10 @@ app.registerExtension({
   init() {
     // Set up ComfyApp static methods for plugin compatibility (deprecated)
     ComfyApp.open_maskeditor = openMaskEditorFromClipspace
-    ComfyApp.maskeditor_is_opended = isOpened
-    console.warn(
-      '[MaskEditor] ComfyApp.open_maskeditor and ComfyApp.maskeditor_is_opended are deprecated. ' +
-        'Plugins should migrate to using the command system or direct node context menu integration.'
-    )
 
-    // Register button in ClipspaceDialog
-    ClipspaceDialog.registerButton(
-      'MaskEditor',
-      contextPredicate,
-      openMaskEditorFromClipspace
+    console.warn(
+      '[MaskEditor] ComfyApp.open_maskeditor is deprecated. ' +
+        'Plugins should migrate to using the command system or direct node context menu integration.'
     )
   }
 })


### PR DESCRIPTION
## Summary

- Skip widget filenames starting with '$' (internal reference format)
- Add deprecated ComfyApp.open_maskeditor for plugin compatibility
- Register MaskEditor button in ClipspaceDialog

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7665 and 
https://github.com/ltdrdata/ComfyUI-Impact-Pack/issues/1165
https://github.com/ltdrdata/ComfyUI-Impact-Pack/issues/1158
https://github.com/ltdrdata/ComfyUI-Impact-Pack/issues/1157

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/356dd920-8b64-40f4-8839-90b955ffafc3

after

https://github.com/user-attachments/assets/dff9abcd-530a-4995-bb4b-51f408d4eca9

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7762-fix-restore-mask-editor-compatibility-with-Impact-Pack-plugin-2d46d73d36508199bdaecbd5ba838483) by [Unito](https://www.unito.io)
