### PR TITLE
Frontend code for custom number nodes

### DIFF
--- a/src/extensions/core/customCombo.ts
+++ b/src/extensions/core/customCombo.ts
@@ -170,7 +170,16 @@ function onCustomFloatCreated(this: LGraphNode) {
       if (this.properties.step) return this.properties.step
 
       const { precision } = this.properties
-      return typeof precision === 'number' ? 10 ** precision : 1
+      return typeof precision === 'number' ? 5 * 10 ** -precision : 1
+    },
+    set: (v) => (this.properties.step = v)
+  })
+  Object.defineProperty(valueWidget.options, 'round', {
+    get: () => {
+      if (this.properties.round) return this.properties.round
+
+      const { precision } = this.properties
+      return typeof precision === 'number' ? 10 ** -precision : 0.1
     },
     set: (v) => (this.properties.step = v)
   })

--- a/src/extensions/core/customCombo.ts
+++ b/src/extensions/core/customCombo.ts
@@ -181,7 +181,10 @@ function onCustomFloatCreated(this: LGraphNode) {
       const { precision } = this.properties
       return typeof precision === 'number' ? 10 ** -precision : 0.1
     },
-    set: (v) => (this.properties.step = v)
+    set: (v) => {
+      this.properties.round = v
+      valueWidget.callback?.(valueWidget.value)
+    }
   })
 }
 

--- a/src/extensions/core/customCombo.ts
+++ b/src/extensions/core/customCombo.ts
@@ -132,7 +132,7 @@ function onCustomIntCreated(this: LGraphNode) {
       valueWidget.callback?.(valueWidget.value)
     }
   })
-  Object.defineProperty(valueWidget.options, 'step', {
+  Object.defineProperty(valueWidget.options, 'step2', {
     get: () => this.properties.step ?? 1,
     set: (v) => {
       this.properties.step = v

--- a/src/extensions/core/customCombo.ts
+++ b/src/extensions/core/customCombo.ts
@@ -115,78 +115,64 @@ function onCustomComboCreated(this: LGraphNode) {
 }
 
 function onCustomIntCreated(this: LGraphNode) {
-  const [valueWidget, , stepWidget, minWidget, maxWidget] = this.widgets ?? []
-  if (!maxWidget) return
-  if (typeof stepWidget.value === 'number')
-    valueWidget.options.step2 = stepWidget.value
-  if (typeof minWidget.value === 'number')
-    valueWidget.options.min = minWidget.value
-  if (typeof maxWidget.value === 'number')
-    valueWidget.options.max = maxWidget.value
-  Object.defineProperty(stepWidget, 'value', {
-    get() {
-      return valueWidget.options.step2
-    },
-    set(v: number) {
-      valueWidget.options.step2 = v
-      valueWidget.callback!(valueWidget.value)
+  const valueWidget = this.widgets?.[0]
+  if (!valueWidget) return
+
+  Object.defineProperty(valueWidget.options, 'min', {
+    get: () => this.properties.min ?? -(2 ** 63),
+    set: (v) => {
+      this.properties.min = v
+      valueWidget.callback?.(valueWidget.value)
     }
   })
-  Object.defineProperty(minWidget, 'value', {
-    get() {
-      return valueWidget.options.min
-    },
-    set(v: number) {
-      valueWidget.options.min = v
-      valueWidget.callback!(valueWidget.value)
+  Object.defineProperty(valueWidget.options, 'max', {
+    get: () => this.properties.max ?? 2 ** 63,
+    set: (v) => {
+      this.properties.max = v
+      valueWidget.callback?.(valueWidget.value)
     }
   })
-  Object.defineProperty(maxWidget, 'value', {
-    get() {
-      return valueWidget.options.max
-    },
-    set(v: number) {
-      valueWidget.options.max = v
-      valueWidget.callback!(valueWidget.value)
+  Object.defineProperty(valueWidget.options, 'step', {
+    get: () => this.properties.step ?? 1,
+    set: (v) => {
+      this.properties.step = v
+      valueWidget.callback?.(valueWidget.value) // for vue reactivity
     }
   })
 }
 function onCustomFloatCreated(this: LGraphNode) {
-  const [valueWidget, precisionWidget, minWidget, maxWidget] =
-    this.widgets ?? []
-  if (!maxWidget) return
-  if (typeof precisionWidget.value === 'number')
-    valueWidget.options.precision = precisionWidget.value
-  if (typeof minWidget.value === 'number')
-    valueWidget.options.min = minWidget.value
-  if (typeof maxWidget.value === 'number')
-    valueWidget.options.max = maxWidget.value
-  Object.defineProperty(precisionWidget, 'value', {
-    get() {
-      return valueWidget.options.precision
-    },
-    set(v: number) {
-      valueWidget.options.precision = v
-      valueWidget.options.step2 = 10 ** v
+  const valueWidget = this.widgets?.[0]
+  if (!valueWidget) return
+
+  Object.defineProperty(valueWidget.options, 'min', {
+    get: () => this.properties.min ?? -Infinity,
+    set: (v) => {
+      this.properties.min = v
+      valueWidget.callback?.(valueWidget.value)
     }
   })
-  Object.defineProperty(minWidget, 'value', {
-    get() {
-      return valueWidget.options.min
-    },
-    set(v: number) {
-      valueWidget.options.min = v
-      valueWidget.callback!(valueWidget.value)
+  Object.defineProperty(valueWidget.options, 'max', {
+    get: () => this.properties.max ?? Infinity,
+    set: (v) => {
+      this.properties.max = v
+      valueWidget.callback?.(valueWidget.value)
     }
   })
-  Object.defineProperty(maxWidget, 'value', {
-    get() {
-      return valueWidget.options.max
-    },
-    set(v: number) {
-      valueWidget.options.max = v
-      valueWidget.callback!(valueWidget.value)
+  Object.defineProperty(valueWidget.options, 'precision', {
+    get: () => this.properties.precision ?? 1,
+    set: (v) => {
+      this.properties.precision = v
+      valueWidget.callback?.(valueWidget.value)
     }
+  })
+  Object.defineProperty(valueWidget.options, 'step2', {
+    get: () => {
+      if (this.properties.step) return this.properties.step
+
+      const { precision } = this.properties
+      return typeof precision === 'number' ? 10 ** precision : 1
+    },
+    set: (v) => (this.properties.step = v)
   })
 }
 

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -189,7 +189,7 @@ function onCustomFloatCreated(this: LGraphNode) {
 }
 
 app.registerExtension({
-  name: 'Comfy.CustomCombo',
+  name: 'Comfy.CustomWidgets',
   beforeRegisterNodeDef(nodeType, nodeData) {
     if (nodeData?.name === 'CustomCombo')
       nodeType.prototype.onNodeCreated = useChainCallback(

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -2,7 +2,7 @@ import { isCloud, isNightly } from '@/platform/distribution/types'
 
 import './clipspace'
 import './contextMenuFilter'
-import './customCombo'
+import './customWidgets'
 import './dynamicPrompts'
 import './editAttention'
 import './electronAdapter'


### PR DESCRIPTION
Allows creation of Int and Float widgets with configurable, min, max, step, and precision.  
This PR has been fairly heavily reworked.  Options are no longer exposed as widgets, but set as properties on the node.

Since the changes no longer modify the sizing or serialization of the node, backend changes are no longer required and the extended functionality has been added directly onto the existing PrimitiveFloat and PrimitiveInt nodes.

There's intent to expose these configuration parameters on the new properties panel, but this PR can be merged as is.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7768-Frontend-code-for-custom-number-nodes-2d66d73d365081879541cbda7db3c24f) by [Unito](https://www.unito.io)
