### PR TITLE
feat(ci): Add Windows runner for Playwright E2E tests

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -149,20 +149,13 @@ jobs:
 
   playwright-tests-windows:
     timeout-minutes: 20
-    needs: setup
+    # needs: setup -- removed dependency on setup job cache
     runs-on: windows-latest
     permissions:
       contents: read
     steps:
-      - name: Wait for cache propagation
-        run: sleep 10
-        shell: bash
-      - name: Restore cached setup
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          fail-on-cache-miss: true
-          path: .
-          key: comfyui-setup-${{ needs.setup.outputs.cache-key }}
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
       - name: Setup ComfyUI server
         uses: ./.github/actions/setup-comfyui-server
@@ -170,6 +163,8 @@ jobs:
           launch_server: true
       - name: Setup nodejs, pnpm, reuse built frontend
         uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: true # Build explicitly on Windows since we aren't restoring cache
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
 
@@ -264,7 +259,7 @@ jobs:
 
   # Deploy and comment for non-forked PRs only
   deploy-and-comment:
-    needs: [playwright-tests, merge-reports]
+    needs: [playwright-tests, merge-reports, playwright-tests-windows]
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     permissions:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -153,6 +153,10 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -171,29 +175,23 @@ jobs:
       - name: Run Playwright tests (Windows - chromium)
         id: playwright
         run: |
-          pnpm exec playwright test --project=chromium --reporter=blob
+          pnpm exec playwright test --project=chromium --reporter=blob --shard=${{ matrix.shard }}/8
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
         shell: bash
 
-      - name: Generate HTML and JSON reports
-        if: always()
-        run: |
-          pnpm exec playwright merge-reports --reporter=html ./blob-report
-          PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json pnpm exec playwright merge-reports --reporter=json ./blob-report
-        shell: bash
-
-      - name: Upload Playwright report
+      - name: Upload Blob Report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-windows-chromium
-          path: ./playwright-report/
-          retention-days: 30
+          # Use a unique name for each shard's blob report
+          name: blob-report-windows-${{ matrix.shard }}
+          path: ./blob-report
+          retention-days: 1
 
   # Merge sharded test reports
   merge-reports:
-    needs: [playwright-tests-chromium-sharded]
+    needs: [playwright-tests-chromium-sharded, playwright-tests-windows]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
@@ -210,7 +208,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./all-blob-reports
-          pattern: blob-report-chromium-*
+          pattern: blob-report-*
           merge-multiple: true
 
       - name: Merge into HTML Report

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -147,6 +147,55 @@ jobs:
           path: ./playwright-report/
           retention-days: 30
 
+  playwright-tests-windows:
+    timeout-minutes: 20
+    needs: setup
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Wait for cache propagation
+        run: sleep 10
+        shell: bash
+      - name: Restore cached setup
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          fail-on-cache-miss: true
+          path: .
+          key: comfyui-setup-${{ needs.setup.outputs.cache-key }}
+
+      - name: Setup ComfyUI server
+        uses: ./.github/actions/setup-comfyui-server
+        with:
+          launch_server: true
+      - name: Setup nodejs, pnpm, reuse built frontend
+        uses: ./.github/actions/setup-frontend
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Run Playwright tests (Windows - chromium)
+        id: playwright
+        run: |
+          pnpm exec playwright test --project=chromium --reporter=blob
+        env:
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
+        shell: bash
+
+      - name: Generate HTML and JSON reports
+        if: always()
+        run: |
+          pnpm exec playwright merge-reports --reporter=html ./blob-report
+          PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json pnpm exec playwright merge-reports --reporter=json ./blob-report
+        shell: bash
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-windows-chromium
+          path: ./playwright-report/
+          retention-days: 30
+
   # Merge sharded test reports
   merge-reports:
     needs: [playwright-tests-chromium-sharded]


### PR DESCRIPTION
This PR adds a Windows runner job to the E2E test workflow to ensure cross-platform compatibility for browser tests.

Fixes #3197

**Changes:**
- Added \playwright-tests-windows\ job to \.github/workflows/ci-tests-e2e.yaml\
- Uses \windows-latest\ runner
- Reuses existing setup actions with \shell: bash\ for compatibility

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7769-feat-ci-Add-Windows-runner-for-Playwright-E2E-tests-2d66d73d365081118a6ec69d6575d20b) by [Unito](https://www.unito.io)
