### PR TITLE
fix(queue): Cancel button now works for pending jobs

### DIFF
--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -197,7 +197,17 @@ const displayedJobGroups = computed(() => groupedJobItems.value)
 const onCancelItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
   const promptId = item.taskRef?.promptId
   if (!promptId) return
-  await api.interrupt(promptId)
+
+  if (item.state === 'running' || item.state === 'initialization') {
+    // Running/initializing jobs: interrupt execution
+    await api.interrupt(promptId)
+  } else if (item.state === 'pending') {
+    // Pending jobs: remove from queue
+    await api.deleteItem('queue', promptId)
+  }
+
+  // Refresh queue state
+  await queueStore.update()
 })
 
 const onDeleteItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -201,13 +201,12 @@ const onCancelItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
   if (item.state === 'running' || item.state === 'initialization') {
     // Running/initializing jobs: interrupt execution
     await api.interrupt(promptId)
+    await queueStore.update()
   } else if (item.state === 'pending') {
     // Pending jobs: remove from queue
     await api.deleteItem('queue', promptId)
+    await queueStore.update()
   }
-
-  // Refresh queue state
-  await queueStore.update()
 })
 
 const onDeleteItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {


### PR DESCRIPTION
## Summary

Fixes the cancel button on queue job items to properly handle pending (queued) jobs.

## Problem

The cancel button was calling `api.interrupt()` for all jobs, but interrupt only affects running/initializing jobs. For pending jobs, it silently fails with log message: `"Prompt ... is not currently running, skipping interrupt"`.

The "Cancel job" option in the context menu worked correctly because it checks the job state first.

Reported in #7758.

## Changes

Update `onCancelItem` in `QueueProgressOverlay.vue` to mirror the behavior of `cancelJob()` in `useJobMenu.ts`:

- Check `item.state` before deciding which API to call
- Call `api.interrupt(promptId)` for `running` or `initialization` states
- Call `api.deleteItem('queue', promptId)` for `pending` state
- Refresh queue state after cancel action with `queueStore.update()`

## Testing

- All 3816 unit tests pass
- Type check passes
- Lint passes (prettier, oxlint, eslint)

## Steps to Reproduce (before fix)

1. Queue more than 1 job
2. Open job history
3. Click "Cancel" button on any "in queue" job
4. Observe nothing happens (job remains in queue)

After this fix, clicking Cancel on a pending job will remove it from the queue.

Fixes #7758

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7777-fix-queue-Cancel-button-now-works-for-pending-jobs-2d76d73d365081d49717fb9070700909) by [Unito](https://www.unito.io)
