### PR TITLE
fix: add missing background color to right sidebar panel

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -77,7 +77,7 @@
           v-if="sidebarLocation === 'right' && !focusMode"
           :class="
             cn(
-              'side-bar-panel pointer-events-auto',
+              'side-bar-panel bg-comfy-menu-bg pointer-events-auto',
               sidebarPanelVisible && 'min-w-78'
             )
           "


### PR DESCRIPTION
## Summary
- Adds the missing `bg-comfy-menu-bg` class to the right sidebar panel

## Problem
When "Sidebar location" is set to "right" in settings, the sidebar background is transparent instead of opaque. This is because the right sidebar panel was missing the `bg-comfy-menu-bg` class that the left sidebar panel has.

## Solution
Add the `bg-comfy-menu-bg` class to the right sidebar panel, matching the left sidebar panel styling.

## Testing
1. Open ComfyUI settings
2. Set "Sidebar location" to "right"
3. Verify the sidebar background is now opaque (not transparent)
4. Verify the left sidebar still works correctly when switched back

Fixes #7585

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7778-fix-add-missing-background-color-to-right-sidebar-panel-2d76d73d36508109bfbccb2a9a57942a) by [Unito](https://www.unito.io)
