### PR TITLE
fix: restore bypass/mute visual effect on preview images

### DIFF
--- a/src/renderer/extensions/vueNodes/VideoPreview.vue
+++ b/src/renderer/extensions/vueNodes/VideoPreview.vue
@@ -42,7 +42,13 @@
       <video
         v-if="!videoError"
         :src="currentVideoUrl"
-        :class="cn('block size-full object-contain', showLoader && 'invisible')"
+        :class="
+          cn(
+            'block size-full object-contain',
+            showLoader && 'invisible',
+            props.inactive && 'opacity-50 grayscale'
+          )
+        "
         controls
         loop
         playsinline
@@ -126,6 +132,8 @@ interface VideoPreviewProps {
   readonly imageUrls: readonly string[] // Named imageUrls for consistency with parent components
   /** Optional node ID for context-aware actions */
   readonly nodeId?: string
+  /** Whether the node is bypassed or muted */
+  readonly inactive?: boolean
 }
 
 const props = defineProps<VideoPreviewProps>()

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -43,10 +43,11 @@
         ref="currentImageEl"
         :src="currentImageUrl"
         :alt="imageAltText"
-        :class="[
-          'block size-full object-contain pointer-events-none',
-          { 'opacity-50 grayscale': props.inactive }
-        ]"
+        :class="
+          cn('block size-full object-contain pointer-events-none', {
+            'opacity-50 grayscale': props.inactive
+          })
+        "
         @load="handleImageLoad"
         @error="handleImageError"
       />
@@ -131,6 +132,7 @@ import { downloadFile } from '@/base/common/downloadUtil'
 import { app } from '@/scripts/app'
 import { useCommandStore } from '@/stores/commandStore'
 import { useNodeOutputStore } from '@/stores/imagePreviewStore'
+import { cn } from '@/utils/tailwindUtil'
 
 interface ImagePreviewProps {
   /** Array of image URLs to display */

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -43,7 +43,10 @@
         ref="currentImageEl"
         :src="currentImageUrl"
         :alt="imageAltText"
-        class="block size-full object-contain pointer-events-none"
+        :class="[
+          'block size-full object-contain pointer-events-none',
+          { 'opacity-50 grayscale': props.inactive }
+        ]"
         @load="handleImageLoad"
         @error="handleImageError"
       />
@@ -134,6 +137,8 @@ interface ImagePreviewProps {
   readonly imageUrls: readonly string[]
   /** Optional node ID for context-aware actions */
   readonly nodeId?: string
+  /** Whether the node is bypassed or muted */
+  readonly inactive?: boolean
 }
 
 const props = defineProps<ImagePreviewProps>()

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -113,11 +113,18 @@
         <NodeWidgets v-if="nodeData.widgets?.length" :node-data="nodeData" />
 
         <div v-if="hasCustomContent" class="min-h-0 flex-1 flex">
-          <NodeContent :node-data="nodeData" :media="nodeMedia" />
+          <NodeContent
+            :node-data="nodeData"
+            :media="nodeMedia"
+            :inactive="bypassed || muted"
+          />
         </div>
         <!-- Live mid-execution preview images -->
         <div v-if="shouldShowPreviewImg" class="min-h-0 flex-1 px-4">
-          <LivePreview :image-url="latestPreviewUrl || null" />
+          <LivePreview
+            :image-url="latestPreviewUrl || null"
+            :inactive="bypassed || muted"
+          />
         </div>
       </div>
     </template>

--- a/src/renderer/extensions/vueNodes/components/LivePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LivePreview.vue
@@ -18,7 +18,10 @@
         v-else
         :src="imageUrl"
         :alt="$t('g.liveSamplingPreview')"
-        class="pointer-events-none h-full w-full object-contain object-center"
+        :class="[
+          'pointer-events-none h-full w-full object-contain object-center',
+          { 'opacity-50 grayscale': props.inactive }
+        ]"
         @load="handleImageLoad"
         @error="handleImageError"
       />
@@ -41,6 +44,8 @@ import { ref, watch } from 'vue'
 interface LivePreviewProps {
   /** Image URL to display */
   imageUrl: string | null
+  /** Whether the node is bypassed or muted */
+  inactive?: boolean
 }
 
 const props = defineProps<LivePreviewProps>()

--- a/src/renderer/extensions/vueNodes/components/LivePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LivePreview.vue
@@ -18,10 +18,11 @@
         v-else
         :src="imageUrl"
         :alt="$t('g.liveSamplingPreview')"
-        :class="[
-          'pointer-events-none h-full w-full object-contain object-center',
-          { 'opacity-50 grayscale': props.inactive }
-        ]"
+        :class="
+          cn('pointer-events-none h-full w-full object-contain object-center', {
+            'opacity-50 grayscale': props.inactive
+          })
+        "
         @load="handleImageLoad"
         @error="handleImageError"
       />
@@ -40,6 +41,8 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
 
 interface LivePreviewProps {
   /** Image URL to display */

--- a/src/renderer/extensions/vueNodes/components/NodeContent.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeContent.vue
@@ -9,12 +9,14 @@
         v-if="hasMedia && media?.type === 'video'"
         :image-urls="media.urls"
         :node-id="nodeId"
+        :inactive="props.inactive"
         class="mt-2"
       />
       <ImagePreview
         v-else-if="hasMedia && media?.type === 'image'"
         :image-urls="media.urls"
         :node-id="nodeId"
+        :inactive="props.inactive"
         class="mt-2"
       />
     </slot>
@@ -37,6 +39,8 @@ interface NodeContentProps {
     type: 'image' | 'video'
     urls: string[]
   }
+  /** Whether the node is bypassed or muted */
+  inactive?: boolean
 }
 
 const props = defineProps<NodeContentProps>()


### PR DESCRIPTION
## Summary
- Restores the visual effect (opacity + grayscale) on preview images when a node is bypassed or muted
- Affects ImagePreview, LivePreview, and VideoPreview components

## Problem
When a node is bypassed or muted, the preview image inside it no longer shows the visual effect (grayscale/opacity reduction). This worked in frontend 1.33.5 but regressed in newer versions.

The issue is that while `LGraphNode.vue` applies opacity to the node container and an overlay for bypass/mute state, the preview image components weren't receiving or applying this state to the actual images.

## Solution
Pass the `inactive` prop (bypassed || muted) from LGraphNode through NodeContent to the preview components (ImagePreview, LivePreview, VideoPreview), and apply `opacity-50 grayscale` CSS classes when the node is inactive.

## Changes
- `LGraphNode.vue`: Pass `inactive` prop to NodeContent and LivePreview
- `NodeContent.vue`: Accept and pass `inactive` prop to child preview components  
- `ImagePreview.vue`: Accept `inactive` prop and apply visual effect to image
- `LivePreview.vue`: Accept `inactive` prop and apply visual effect to image
- `VideoPreview.vue`: Accept `inactive` prop and apply visual effect to video

## Testing
1. Add a PreviewImage node and generate an image
2. Bypass the node (Ctrl+B) - image should become grayed out with reduced opacity
3. Mute the node - image should become grayed out with reduced opacity
4. Un-bypass/un-mute - image should return to normal

Fixes #7773

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7779-fix-restore-bypass-mute-visual-effect-on-preview-images-2d76d73d3650810693caca0b18fc30bd) by [Unito](https://www.unito.io)
