### PR TITLE
fix: PrimitiveNode combo widget value not persisting in vueNodes mode

### DIFF
--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -239,6 +239,14 @@ export class PrimitiveNode extends LGraphNode {
       const theirWidget = node.widgets.find((w) => w.name === widgetName)
       if (theirWidget) {
         widget.value = theirWidget.value
+
+        widget.callback?.(
+          widget.value,
+          app.canvas,
+          this,
+          app.canvas?.graph_mouse,
+          {} as CanvasPointerEvent
+        )
       }
     }
 

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -239,14 +239,6 @@ export class PrimitiveNode extends LGraphNode {
       const theirWidget = node.widgets.find((w) => w.name === widgetName)
       if (theirWidget) {
         widget.value = theirWidget.value
-
-        widget.callback?.(
-          widget.value,
-          app.canvas,
-          this,
-          app.canvas?.graph_mouse,
-          {} as CanvasPointerEvent
-        )
       }
     }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -12,6 +12,7 @@
   />
   <WidgetWithControl
     v-else-if="widget.controlWidget"
+    v-model="modelValue"
     :component="WidgetSelectDefault"
     :widget="widget as StringControlWidget"
   />


### PR DESCRIPTION
## Summary
- Add missing v-model binding to WidgetWithControl in WidgetSelect.vue
- Trigger callback after setting widget value in PrimitiveNode to update linked widgets

The combo widget value was lost because PrimitiveNode creates combo widgets with controlWidget (via addValueControlWidgets), causing it to use the WidgetWithControl branch which was missing v-model binding.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7694 and https://github.com/Comfy-Org/ComfyUI_frontend/issues/7696

## Screenshots
before
https://github.com/user-attachments/assets/0a0dc668-eb71-4072-b5f7-0c20483fc1ff

after
https://github.com/user-attachments/assets/dfd2274c-8ebf-4105-821a-946063d87e9a



