### PR TITLE
[feat] Filter out nlf model type from Upload Model flow

### DIFF
--- a/src/platform/assets/composables/useModelTypes.ts
+++ b/src/platform/assets/composables/useModelTypes.ts
@@ -37,6 +37,8 @@ interface ModelTypeOption {
   value: string // Actual tag value
 }
 
+const DISALLOWED_MODEL_TYPES = ['nlf'] as const
+
 /**
  * Composable for fetching and managing model types from the API
  * Uses shared state to ensure data is only fetched once
@@ -51,6 +53,12 @@ export const useModelTypes = createSharedComposable(() => {
     async (): Promise<ModelTypeOption[]> => {
       const response = await api.getModelFolders()
       return response
+        .filter(
+          (folder) =>
+            !DISALLOWED_MODEL_TYPES.includes(
+              folder.name as (typeof DISALLOWED_MODEL_TYPES)[number]
+            )
+        )
         .map((folder) => ({
           name: formatDisplayName(folder.name),
           value: folder.name


### PR DESCRIPTION
## Summary
Filters out the "nlf" (no-license-file) model type from the Upload Model wizard's model type dropdown, preventing users from selecting this internal category.

## Changes
- **What**: Added DISALLOWED_MODEL_TYPES constant and filter in useModelTypes composable
- **Scope**: Only affects Upload Model flow (used by UploadModelDialog and UploadModelConfirmation)

## Test plan
- [ ] Open Upload Model dialog and verify "nlf" does not appear in model type dropdown
- [ ] Verify other model types still appear correctly
- [ ] Verify dropdown still functions as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7793-feat-Filter-out-nlf-model-type-from-Upload-Model-flow-2d86d73d3650811f88e1fcc8dd7040cd) by [Unito](https://www.unito.io)
