### PR TITLE
disable workflow validation warnings by default

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -27,7 +27,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Validation.Workflows',
     name: 'Validate workflows',
     type: 'boolean',
-    defaultValue: isCloud ? false : true
+    defaultValue: false
   },
   {
     id: 'Comfy.NodeSearchBoxImpl',


### PR DESCRIPTION
# Background

Currently, validation warnings about zod schema violations are shown to all users when loading workflows. These warnings appear in a dialog that users must dismiss, and they reappear every time the workflow is reloaded.

## User Pain Points

- Many users (especially from the Chinese community) are asking how to disable these alerts
- The zod schema information is too technical for end users
- Users don't understand what action they should take when seeing the warning
- The warnings cannot be permanently dismissed - they reappear every time
- The warnings don't actually prevent workflow execution

## Problem Statement

The validation warning just means the serialized workflow doesn't conform to the official schema. Sometimes that makes the workflow unusable; sometimes it still runs fine. While these checks have historically surfaced real issues and are important for maintaining static types internally, the current UX isn't helpful to regular users.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7795-disable-workflow-validation-warnings-by-default-2d86d73d36508102a0f7c46d43189e38) by [Unito](https://www.unito.io)
