### PR TITLE
feat: add dynamic Fuse.js options loading for template filtering

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -816,7 +816,6 @@ const pageTitle = computed(() => {
 // Initialize templates loading with useAsyncState
 const { isLoading } = useAsyncState(
   async () => {
-    // Run all operations in parallel for better performance
     await Promise.all([
       loadTemplates(),
       workflowTemplatesStore.loadWorkflowTemplates(),

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -563,7 +563,8 @@ const {
   availableRunsOn,
   filteredCount,
   totalCount,
-  resetFilters
+  resetFilters,
+  loadFuseOptions
 } = useTemplateFiltering(navigationFilteredTemplates)
 
 /**
@@ -818,7 +819,8 @@ const { isLoading } = useAsyncState(
     // Run all operations in parallel for better performance
     await Promise.all([
       loadTemplates(),
-      workflowTemplatesStore.loadWorkflowTemplates()
+      workflowTemplatesStore.loadWorkflowTemplates(),
+      loadFuseOptions()
     ])
     return true
   },

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import type { IFuseOptions } from 'fuse.js'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
 
@@ -292,7 +293,7 @@ describe('useTemplateFiltering', () => {
         }
       ])
 
-      const customFuseOptions = {
+      const customFuseOptions: IFuseOptions<TemplateInfo> = {
         keys: [
           { name: 'name', weight: 0.5 },
           { name: 'description', weight: 0.5 }

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -42,6 +42,13 @@ vi.mock('@/platform/telemetry', () => ({
   }))
 }))
 
+const mockGetFuseOptions = vi.hoisted(() => vi.fn())
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getFuseOptions: mockGetFuseOptions
+  }
+}))
+
 const { useTemplateFiltering } =
   await import('@/composables/useTemplateFiltering')
 
@@ -49,6 +56,7 @@ describe('useTemplateFiltering', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockGetFuseOptions.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -271,5 +279,119 @@ describe('useTemplateFiltering', () => {
       'alpha-starter',
       'beta-pro'
     ])
+  })
+
+  describe('loadFuseOptions', () => {
+    it('updates fuseOptions when getFuseOptions returns valid options', async () => {
+      const templates = ref<TemplateInfo[]>([
+        {
+          name: 'test-template',
+          description: 'Test template',
+          mediaType: 'image',
+          mediaSubtype: 'png'
+        }
+      ])
+
+      const customFuseOptions = {
+        keys: [
+          { name: 'name', weight: 0.5 },
+          { name: 'description', weight: 0.5 }
+        ],
+        threshold: 0.4,
+        includeScore: true
+      }
+
+      mockGetFuseOptions.mockResolvedValueOnce(customFuseOptions)
+
+      const { loadFuseOptions, filteredTemplates } =
+        useTemplateFiltering(templates)
+
+      await loadFuseOptions()
+
+      expect(mockGetFuseOptions).toHaveBeenCalledTimes(1)
+      expect(filteredTemplates.value).toBeDefined()
+    })
+
+    it('does not update fuseOptions when getFuseOptions returns null', async () => {
+      const templates = ref<TemplateInfo[]>([
+        {
+          name: 'test-template',
+          description: 'Test template',
+          mediaType: 'image',
+          mediaSubtype: 'png'
+        }
+      ])
+
+      mockGetFuseOptions.mockResolvedValueOnce(null)
+
+      const { loadFuseOptions, filteredTemplates } =
+        useTemplateFiltering(templates)
+
+      const initialResults = filteredTemplates.value
+
+      await loadFuseOptions()
+
+      expect(mockGetFuseOptions).toHaveBeenCalledTimes(1)
+      expect(filteredTemplates.value).toEqual(initialResults)
+    })
+
+    it('handles errors when getFuseOptions fails', async () => {
+      const templates = ref<TemplateInfo[]>([
+        {
+          name: 'test-template',
+          description: 'Test template',
+          mediaType: 'image',
+          mediaSubtype: 'png'
+        }
+      ])
+
+      mockGetFuseOptions.mockRejectedValueOnce(new Error('Network error'))
+
+      const { loadFuseOptions, filteredTemplates } =
+        useTemplateFiltering(templates)
+
+      const initialResults = filteredTemplates.value
+
+      await expect(loadFuseOptions()).rejects.toThrow('Network error')
+      expect(filteredTemplates.value).toEqual(initialResults)
+    })
+
+    it('recreates Fuse instance when fuseOptions change', async () => {
+      const templates = ref<TemplateInfo[]>([
+        {
+          name: 'searchable-template',
+          description: 'This is a searchable template',
+          mediaType: 'image',
+          mediaSubtype: 'png'
+        },
+        {
+          name: 'another-template',
+          description: 'Another template',
+          mediaType: 'image',
+          mediaSubtype: 'png'
+        }
+      ])
+
+      const { loadFuseOptions, searchQuery, filteredTemplates } =
+        useTemplateFiltering(templates)
+
+      const customFuseOptions = {
+        keys: [{ name: 'name', weight: 1.0 }],
+        threshold: 0.2,
+        includeScore: true,
+        includeMatches: true
+      }
+
+      mockGetFuseOptions.mockResolvedValueOnce(customFuseOptions)
+
+      await loadFuseOptions()
+      await nextTick()
+
+      searchQuery.value = 'searchable'
+      await nextTick()
+
+      expect(filteredTemplates.value.length).toBeGreaterThan(0)
+      expect(mockGetFuseOptions).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -12,7 +12,7 @@ import { debounce } from 'es-toolkit/compat'
 import { api } from '@/scripts/api'
 
 // Fuse.js configuration for fuzzy search
-const defaultFuseOptions = {
+const defaultFuseOptions: IFuseOptions<TemplateInfo> = {
   keys: [
     { name: 'name', weight: 0.3 },
     { name: 'title', weight: 0.3 },
@@ -51,7 +51,7 @@ export function useTemplateFiltering(
     | 'model-size-low-to-high'
   >(settingStore.get('Comfy.Templates.SortBy'))
 
-  const fuseOptions = ref<IFuseOptions<unknown>>(defaultFuseOptions)
+  const fuseOptions = ref<IFuseOptions<TemplateInfo>>(defaultFuseOptions)
 
   const templatesArray = computed(() => {
     const templateData = 'value' in templates ? templates.value : templates

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -1,6 +1,6 @@
 import { refDebounced, watchDebounced } from '@vueuse/core'
-import Fuse from 'fuse.js';
-import type { IFuseOptions } from 'fuse.js';
+import Fuse from 'fuse.js'
+import type { IFuseOptions } from 'fuse.js'
 import { computed, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -1,4 +1,3 @@
-import Fuse from 'fuse.js'
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
@@ -248,24 +247,6 @@ export const useWorkflowTemplatesStore = defineStore(
           )
 
       return filteredTemplates
-    })
-
-    /**
-     * Fuse.js instance for advanced template searching and filtering
-     */
-    const templateFuse = computed(() => {
-      const fuseOptions = {
-        keys: [
-          { name: 'searchableText', weight: 0.4 },
-          { name: 'title', weight: 0.3 },
-          { name: 'name', weight: 0.2 },
-          { name: 'tags', weight: 0.1 }
-        ],
-        threshold: 0.3,
-        includeScore: true
-      }
-
-      return new Fuse(enhancedTemplates.value, fuseOptions)
     })
 
     /**
@@ -548,7 +529,6 @@ export const useWorkflowTemplatesStore = defineStore(
       groupedTemplates,
       navGroupedTemplates,
       enhancedTemplates,
-      templateFuse,
       filterTemplatesByCategory,
       isLoaded,
       loadWorkflowTemplates,

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1288,7 +1288,8 @@ export class ComfyApi extends EventTarget {
           }
         }
       )
-      return res?.data ?? null
+      const contentType = res.headers['content-type']
+      return contentType?.includes('application/json') ? res.data : null
     } catch (error) {
       console.error('Error loading fuse options:', error)
       return null

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -51,6 +51,7 @@ import type { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import type { AuthHeader } from '@/types/authTypes'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
 import { fetchHistory } from '@/platform/remote/comfyui/history'
+import type { IFuseOptions } from 'fuse.js'
 
 interface QueuePromptRequestBody {
   client_id: string
@@ -1266,6 +1267,22 @@ export class ComfyApi extends EventTarget {
         summary: 'An error occurred while trying to unload models.',
         life: 5000
       })
+    }
+  }
+
+  /**
+   * Gets the Fuse options from the server.
+   *
+   * @returns The Fuse options, or null if not found or invalid
+   */
+  async getFuseOptions(): Promise<IFuseOptions<unknown> | null> {
+    try {
+      const res = await axios.get(this.fileURL('/templates/fuse_options.json'))
+      const contentType = res.headers['content-type']
+      return contentType?.includes('application/json') ? res.data : null
+    } catch (error) {
+      console.error('Error loading fuse options:', error)
+      return null
     }
   }
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -10,7 +10,10 @@ import type {
 } from '@/platform/assets/schemas/assetSchema'
 import { isCloud } from '@/platform/distribution/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { type WorkflowTemplates } from '@/platform/workflow/templates/types/template'
+import {
+  type TemplateInfo,
+  type WorkflowTemplates
+} from '@/platform/workflow/templates/types/template'
 import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON,
@@ -1275,11 +1278,17 @@ export class ComfyApi extends EventTarget {
    *
    * @returns The Fuse options, or null if not found or invalid
    */
-  async getFuseOptions(): Promise<IFuseOptions<unknown> | null> {
+  async getFuseOptions(): Promise<IFuseOptions<TemplateInfo> | null> {
     try {
-      const res = await axios.get(this.fileURL('/templates/fuse_options.json'))
-      const contentType = res.headers['content-type']
-      return contentType?.includes('application/json') ? res.data : null
+      const res = await axios.get(
+        this.fileURL('/templates/fuse_options.json'),
+        {
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }
+      )
+      return res?.data ?? null
     } catch (error) {
       console.error('Error loading fuse options:', error)
       return null


### PR DESCRIPTION
## Summary

PRD: https://www.notion.so/comfy-org/Implement-Move-search-config-to-templates-repo-for-template-owner-adjustability-2c76d73d365081ad81c4ed33332eda09

Move search config to templates repo for template owner adjustability

## Changes

- **What**: 
  - Made `fuseOptions` reactive in `useTemplateFiltering` composable to support dynamic updates
  - Added `getFuseOptions()` API method to fetch Fuse.js configuration from `/templates/fuse_options.json`
  - Added `loadFuseOptions()` function to `useTemplateFiltering` that fetches and applies server-provided options
  - Removed unused `templateFuse` computed property from `workflowTemplatesStore`
  - Added comprehensive unit tests covering success, null response, error handling, and Fuse instance recreation scenarios

- **Breaking**: None

- **Dependencies**: None (uses existing `fuse.js` and `axios` dependencies)

## Review Focus

- Verify that the API endpoint path `/templates/fuse_options.json` is correct and accessible
- Confirm that the reactive `fuseOptions` properly triggers Fuse instance recreation when updated
- Check that error handling gracefully falls back to default options when server fetch fails
- Ensure the watch on `fuseOptions` is necessary or can be removed (currently just recreates Fuse via computed)
- Review test coverage to ensure all edge cases are handled

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7822-feat-add-dynamic-Fuse-js-options-loading-for-template-filtering-2db6d73d365081828103d8ee70844b2e) by [Unito](https://www.unito.io)
