### PR TITLE
fix: enable workflow validation

### DIFF
--- a/browser_tests/tests/graph.spec.ts
+++ b/browser_tests/tests/graph.spec.ts
@@ -19,6 +19,7 @@ test.describe('Graph', () => {
   })
 
   test('Validate workflow links', async ({ comfyPage }) => {
+    await comfyPage.setSetting('Comfy.Validation.Workflows', true)
     await comfyPage.loadWorkflow('links/bad_link')
     await expect(comfyPage.getVisibleToastCount()).resolves.toBe(2)
   })


### PR DESCRIPTION
### Problem
The "Validate workflow links" test fails because workflow validation is disabled by default, preventing toast notifications from appearing.

### Solution
Enable the `Comfy.Validation.Workflows` setting before loading the bad_link workflow in the test.

### Changes
Modified `browser_tests/tests/graph.spec.ts` to enable workflow validation setting before test execution

### Root Cause
The `Comfy.Validation.Workflows` setting defaults to `false` (per `src/stores/settingStore.ts`). Without this setting enabled, the validation code path in `src/scripts/app.ts#L1085` is skipped, so no toast notifications are generated.

## Testing

- Test now passes locally and should pass in CI
- Verified setting enables validation flow that generates expected 2 toasts:
  1. "Workflow Validation" with validation logs
  2. "Workflow Links Fixed" confirming successful fixes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7833-fix-enable-workflow-validation-2dc6d73d36508152b863f2e64ae57ecb) by [Unito](https://www.unito.io)
