### PR TITLE
Bump desktop-ui version from 0.0.4 to 0.0.6

### DIFF
--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/desktop-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "nx": {
     "tags": [

--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/desktop-ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "nx": {
     "tags": [


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7834-Bump-desktop-ui-version-from-0-0-4-to-0-0-5-2dd6d73d365081ffaceff4e192a15538) by [Unito](https://www.unito.io)
