### PR TITLE
fix: continue rendering when 3D animation is playing

### DIFF
--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -392,7 +392,8 @@ class Load3d {
       this.STATUS_MOUSE_ON_SCENE ||
       this.STATUS_MOUSE_ON_VIEWER ||
       this.isRecording() ||
-      !this.INITIAL_RENDER_DONE
+      !this.INITIAL_RENDER_DONE ||
+      this.animationManager.isAnimationPlaying
     )
   }
 


### PR DESCRIPTION
## Summary

Previously, the 3D viewer would pause rendering when the mouse left the node to save resources. This caused GLB/FBX animations to freeze when the user moved the mouse away, which was a poor user experience.

Now the renderer stays active while an animation is playing, and only pauses when the animation is stopped.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7827

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7836-fix-continue-rendering-when-3D-animation-is-playing-2de6d73d365081a6a365f6c0ccfce7b4) by [Unito](https://www.unito.io)
