### PR TITLE
Feat: update the load 3d widget

### DIFF
--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -142,29 +142,6 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       }
 
       handleEvents('add')
-
-      const meshWidget = node.widgets?.find((w) => w.name === 'model_file')
-      if (meshWidget) {
-        const originalCallback = meshWidget.callback
-        meshWidget.callback = (v: any, ...args: any[]) => {
-          originalCallback?.(v, ...args)
-          const meshUrl = getMeshUrl(v)
-          if (meshUrl) {
-            loading.value = true
-            loadingMessage.value = t('load3d.loadingModel')
-            load3d
-              ?.loadModel(meshUrl)
-              .catch((error) => {
-                console.error('Failed to reload model:', error)
-                useToastStore().addAlert(t('toastMessages.failedToLoadModel'))
-              })
-              .finally(() => {
-                loading.value = false
-                loadingMessage.value = ''
-              })
-          }
-        }
-      }
     } catch (error) {
       console.error('Error initializing Load3d:', error)
       useToastStore().addAlert(t('toastMessages.failedToInitializeLoad3d'))

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -143,17 +143,17 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
 
       handleEvents('add')
 
-      const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
-      if (modelWidget) {
-        const originalCallback = modelWidget.callback
-        modelWidget.callback = (v: any, ...args: any[]) => {
+      const meshWidget = node.widgets?.find((w) => w.name === 'model_file')
+      if (meshWidget) {
+        const originalCallback = meshWidget.callback
+        meshWidget.callback = (v: any, ...args: any[]) => {
           originalCallback?.(v, ...args)
-          const modelUrl = getModelUrl(v)
-          if (modelUrl) {
+          const meshUrl = getMeshUrl(v)
+          if (meshUrl) {
             loading.value = true
             loadingMessage.value = t('load3d.loadingModel')
             load3d
-              ?.loadModel(modelUrl)
+              ?.loadModel(meshUrl)
               .catch((error) => {
                 console.error('Failed to reload model:', error)
                 useToastStore().addAlert(t('toastMessages.failedToLoadModel'))
@@ -201,14 +201,14 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       lightConfig.value = savedLightConfig
     }
 
-    const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
-    if (modelWidget?.value) {
-      const modelUrl = getModelUrl(modelWidget.value as string)
-      if (modelUrl) {
+    const meshWidget = node.widgets?.find((w) => w.name === 'model_file')
+    if (meshWidget?.value) {
+      const meshUrl = getMeshUrl(meshWidget.value as string)
+      if (meshUrl) {
         loading.value = true
         loadingMessage.value = t('load3d.reloadingModel')
         try {
-          await load3d.loadModel(modelUrl)
+          await load3d.loadModel(meshUrl)
 
           if (cameraStateToRestore) {
             await nextTick()
@@ -227,19 +227,19 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     }
   }
 
-  const getModelUrl = (modelPath: string): string | null => {
-    if (!modelPath) return null
+  const getMeshUrl = (meshPath: string): string | null => {
+    if (!meshPath) return null
 
     try {
-      if (modelPath.startsWith('http')) {
-        return modelPath
+      if (meshPath.startsWith('http')) {
+        return meshPath
       }
 
-      let cleanPath = modelPath
+      let cleanPath = meshPath
       let forcedType: 'output' | 'input' | undefined
 
-      if (modelPath.trim().endsWith('[output]')) {
-        cleanPath = modelPath.replace(/\s*\[output\]$/, '')
+      if (meshPath.trim().endsWith('[output]')) {
+        cleanPath = meshPath.replace(/\s*\[output\]$/, '')
         forcedType = 'output'
       }
 
@@ -252,7 +252,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         )
       )
     } catch (error) {
-      console.error('Failed to construct model URL:', error)
+      console.error('Error getting model URL:', error)
       return null
     }
   }

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -35,7 +35,7 @@ const inputSpecPreview3D: CustomInputSpec = {
 async function handleModelUpload(files: FileList, node: any) {
   if (!files?.length) return
 
-  const modelWidget = node.widgets?.find(
+  const meshWidget = node.widgets?.find(
     (w: any) => w.name === 'model_file'
   ) as IStringWidget
 
@@ -53,7 +53,7 @@ async function handleModelUpload(files: FileList, node: any) {
       return
     }
 
-    const modelUrl = api.apiURL(
+    const meshUrl = api.apiURL(
       Load3dUtils.getResourceURL(
         ...Load3dUtils.splitFilePath(uploadPath),
         'input'
@@ -62,18 +62,18 @@ async function handleModelUpload(files: FileList, node: any) {
 
     useLoad3d(node).waitForLoad3d((load3d) => {
       try {
-        load3d.loadModel(modelUrl)
+        load3d.loadModel(meshUrl)
       } catch (error) {
         useToastStore().addAlert(t('toastMessages.failedToLoadModel'))
       }
     })
 
-    if (uploadPath && modelWidget) {
-      if (!modelWidget.options?.values?.includes(uploadPath)) {
-        modelWidget.options?.values?.push(uploadPath)
+    if (uploadPath && meshWidget) {
+      if (!meshWidget.options?.values?.includes(uploadPath)) {
+        meshWidget.options?.values?.push(uploadPath)
       }
 
-      modelWidget.value = uploadPath
+      meshWidget.value = uploadPath
     }
   } catch (error) {
     console.error('Model upload failed:', error)
@@ -285,9 +285,9 @@ useExtensionService().registerExtension({
             load3d.clearModel()
           })
 
-          const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
-          if (modelWidget) {
-            modelWidget.value = ''
+          const meshWidget = node.widgets?.find((w) => w.name === 'model_file')
+          if (meshWidget) {
+            meshWidget.value = ''
           }
         })
 
@@ -335,15 +335,15 @@ useExtensionService().registerExtension({
 
       const config = new Load3DConfiguration(load3d, node.properties)
 
-      const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
+      const meshWidget = node.widgets?.find((w) => w.name === 'model_file')
       const width = node.widgets?.find((w) => w.name === 'width')
       const height = node.widgets?.find((w) => w.name === 'height')
       const sceneWidget = node.widgets?.find((w) => w.name === 'image')
 
-      if (modelWidget && width && height && sceneWidget) {
+      if (meshWidget && width && height && sceneWidget) {
         const settings = {
           loadFolder: 'input',
-          modelWidget: modelWidget,
+          meshWidget: meshWidget,
           cameraState: cameraState,
           width: width,
           height: height
@@ -464,20 +464,20 @@ useExtensionService().registerExtension({
     useLoad3d(node).waitForLoad3d((load3d) => {
       const config = new Load3DConfiguration(load3d, node.properties)
 
-      const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
+      const meshWidget = node.widgets?.find((w) => w.name === 'model_file')
 
-      if (modelWidget) {
+      if (meshWidget) {
         const lastTimeModelFile = node.properties['Last Time Model File']
 
         if (lastTimeModelFile) {
-          modelWidget.value = lastTimeModelFile
+          meshWidget.value = lastTimeModelFile
 
           const cameraConfig = node.properties['Camera Config'] as any
           const cameraState = cameraConfig?.state
 
           const settings = {
             loadFolder: 'output',
-            modelWidget: modelWidget,
+            meshWidget: meshWidget,
             cameraState: cameraState
           }
 
@@ -498,13 +498,13 @@ useExtensionService().registerExtension({
           let cameraState = message.result[1]
           let bgImagePath = message.result[2]
 
-          modelWidget.value = filePath.replaceAll('\\', '/')
+          meshWidget.value = filePath.replaceAll('\\', '/')
 
-          node.properties['Last Time Model File'] = modelWidget.value
+          node.properties['Last Time Model File'] = meshWidget.value
 
           const settings = {
             loadFolder: 'output',
-            modelWidget: modelWidget,
+            meshWidget: meshWidget,
             cameraState: cameraState,
             bgImagePath: bgImagePath
           }

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -15,7 +15,7 @@ import { api } from '@/scripts/api'
 
 type Load3DConfigurationSettings = {
   loadFolder: string
-  modelWidget: IBaseWidget
+  meshWidget: IBaseWidget
   cameraState?: CameraState
   width?: IBaseWidget
   height?: IBaseWidget
@@ -29,19 +29,19 @@ class Load3DConfiguration {
   ) {}
 
   configureForSaveMesh(loadFolder: 'input' | 'output', filePath: string) {
-    this.setupModelHandlingForSaveMesh(filePath, loadFolder)
+    this.setupMeshHandlingForSaveMesh(filePath, loadFolder)
     this.setupDefaultProperties()
   }
 
   configure(setting: Load3DConfigurationSettings) {
-    this.setupModelHandling(
-      setting.modelWidget,
+    this.setupMeshHandling(
+      setting.meshWidget,
       setting.loadFolder,
       setting.cameraState
     )
 
-    if (setting.modelWidget.options?.values) {
-      let values = setting.modelWidget.options.values as string[]
+    if (setting.meshWidget.options?.values) {
+      let values = setting.meshWidget.options.values as string[]
 
       try {
         const stored = localStorage.getItem('Comfy.Load3D.HiddenFiles')
@@ -57,7 +57,7 @@ class Load3DConfiguration {
         values = values.slice(0, 12)
       }
 
-      setting.modelWidget.options.values = values
+      setting.meshWidget.options.values = values
     }
 
     this.setupTargetSize(setting.width, setting.height)
@@ -78,46 +78,46 @@ class Load3DConfiguration {
     }
   }
 
-  private setupModelHandlingForSaveMesh(filePath: string, loadFolder: string) {
-    const onModelWidgetUpdate = this.createModelUpdateHandler(loadFolder)
+  private setupMeshHandlingForSaveMesh(filePath: string, loadFolder: string) {
+    const onMeshWidgetUpdate = this.createMeshUpdateHandler(loadFolder)
 
     if (filePath) {
-      onModelWidgetUpdate(filePath)
+      onMeshWidgetUpdate(filePath)
     }
   }
 
-  private setupModelHandling(
-    modelWidget: IBaseWidget,
+  private setupMeshHandling(
+    meshWidget: IBaseWidget,
     loadFolder: string,
     cameraState?: CameraState
   ) {
-    const onModelWidgetUpdate = this.createModelUpdateHandler(
+    const onMeshWidgetUpdate = this.createMeshUpdateHandler(
       loadFolder,
       cameraState
     )
-    if (modelWidget.value) {
-      onModelWidgetUpdate(modelWidget.value)
+    if (meshWidget.value) {
+      onMeshWidgetUpdate(meshWidget.value)
     }
 
-    const originalCallback = modelWidget.callback
+    const originalCallback = meshWidget.callback
 
-    let currentValue = modelWidget.value
-    Object.defineProperty(modelWidget, 'value', {
+    let currentValue = meshWidget.value
+    Object.defineProperty(meshWidget, 'value', {
       get() {
         return currentValue
       },
       set(newValue) {
         currentValue = newValue
-        if (modelWidget.callback && newValue !== undefined && newValue !== '') {
-          modelWidget.callback(newValue)
+        if (meshWidget.callback && newValue !== undefined && newValue !== '') {
+          meshWidget.callback(newValue)
         }
       },
       enumerable: true,
       configurable: true
     })
 
-    modelWidget.callback = (value: string | number | boolean | object) => {
-      onModelWidgetUpdate(value)
+    meshWidget.callback = (value: string | number | boolean | object) => {
+      onMeshWidgetUpdate(value)
 
       if (originalCallback) {
         originalCallback(value)
@@ -215,7 +215,7 @@ class Load3DConfiguration {
     this.load3d.setMaterialMode(config.materialMode)
   }
 
-  private createModelUpdateHandler(
+  private createMeshUpdateHandler(
     loadFolder: string,
     cameraState?: CameraState
   ) {
@@ -227,14 +227,14 @@ class Load3DConfiguration {
 
       this.setResourceFolder(filename)
 
-      const modelUrl = api.apiURL(
+      const meshUrl = api.apiURL(
         Load3dUtils.getResourceURL(
           ...Load3dUtils.splitFilePath(filename),
           loadFolder
         )
       )
 
-      await this.load3d.loadModel(modelUrl, filename)
+      await this.load3d.loadModel(meshUrl, filename)
 
       const modelConfig = this.loadModelConfig()
       this.applyModelConfig(modelConfig)

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -43,7 +43,6 @@ class Load3DConfiguration {
     if (setting.modelWidget.options?.values) {
       let values = setting.modelWidget.options.values as string[]
 
-      // 1. Remove hidden files
       try {
         const stored = localStorage.getItem('Comfy.Load3D.HiddenFiles')
         const hiddenFiles = stored ? JSON.parse(stored) : []
@@ -54,9 +53,7 @@ class Load3DConfiguration {
         console.error('Failed to read hidden files from localStorage', e)
       }
 
-      // 2. Limit to latest 12 items
       if (values.length > 12) {
-        // Keep only the latest 12 items (assuming latest are at the top)
         values = values.slice(0, 12)
       }
 

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -39,6 +39,30 @@ class Load3DConfiguration {
       setting.loadFolder,
       setting.cameraState
     )
+
+    if (setting.modelWidget.options?.values) {
+      let values = setting.modelWidget.options.values as string[]
+
+      // 1. Remove hidden files
+      try {
+        const stored = localStorage.getItem('Comfy.Load3D.HiddenFiles')
+        const hiddenFiles = stored ? JSON.parse(stored) : []
+        if (hiddenFiles.length > 0) {
+          values = values.filter((v) => !hiddenFiles.includes(v))
+        }
+      } catch (e) {
+        console.error('Failed to read hidden files from localStorage', e)
+      }
+
+      // 2. Limit to latest 12 items
+      if (values.length > 12) {
+        // Keep only the latest 12 items (assuming latest are at the top)
+        values = values.slice(0, 12)
+      }
+
+      setting.modelWidget.options.values = values
+    }
+
     this.setupTargetSize(setting.width, setting.height)
     this.setupDefaultProperties(setting.bgImagePath)
   }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -136,6 +136,7 @@ const uploadFolder = computed<ResultItemType>(() => {
 })
 const uploadSubfolder = computed(() => specDescriptor.value.subfolder)
 const defaultLayoutMode = computed<LayoutMode>(() => {
+  if (assetKind.value === 'model') return 'list'
   return isAssetMode.value ? 'list' : 'grid'
 })
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -91,7 +91,6 @@ const specDescriptor = computed<{
   } else if (isLoad3DModel) {
     kind = 'model'
   }
-  // TODO: add support for models (checkpoints, VAE, LoRAs, etc.) -- get widgetType from spec
 
   const allowUpload =
     image_upload === true ||
@@ -100,7 +99,6 @@ const specDescriptor = computed<{
     audio_upload === true ||
     isLoad3DModel
 
-  // Load3D uses '3d' subfolder in standard upload logic
   const subfolder = isLoad3DModel ? '3d' : undefined
   const folder = isLoad3DModel ? 'input' : image_folder
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -61,11 +61,11 @@ const specDescriptor = computed<{
   folder: ResultItemType | undefined
   subfolder?: string
 }>(() => {
-  const isLoad3DModel =
+  const isLoad3DMesh =
     props.nodeType === 'Load3D' && props.widget.name === 'model_file'
 
   const spec = comboSpec.value
-  if (!spec && !isLoad3DModel) {
+  if (!spec && !isLoad3DMesh) {
     return {
       kind: 'unknown',
       allowUpload: false,
@@ -88,8 +88,8 @@ const specDescriptor = computed<{
     kind = 'image'
   } else if (audio_upload) {
     kind = 'audio'
-  } else if (isLoad3DModel) {
-    kind = 'model'
+  } else if (isLoad3DMesh) {
+    kind = 'mesh'
   }
 
   // TODO: add support for models (checkpoints, VAE, LoRAs, etc.) -- get widgetType from spec
@@ -99,10 +99,10 @@ const specDescriptor = computed<{
     animated_image_upload === true ||
     video_upload === true ||
     audio_upload === true ||
-    isLoad3DModel
+    isLoad3DMesh
 
-  const subfolder = isLoad3DModel ? '3d' : undefined
-  const folder = isLoad3DModel ? 'input' : image_folder
+  const subfolder = isLoad3DMesh ? '3d' : undefined
+  const folder = isLoad3DMesh ? 'input' : image_folder
 
   return {
     kind,
@@ -136,7 +136,7 @@ const uploadFolder = computed<ResultItemType>(() => {
 })
 const uploadSubfolder = computed(() => specDescriptor.value.subfolder)
 const defaultLayoutMode = computed<LayoutMode>(() => {
-  if (assetKind.value === 'model') return 'list'
+  if (assetKind.value === 'mesh') return 'list'
   return isAssetMode.value ? 'list' : 'grid'
 })
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue
@@ -92,6 +92,8 @@ const specDescriptor = computed<{
     kind = 'model'
   }
 
+  // TODO: add support for models (checkpoints, VAE, LoRAs, etc.) -- get widgetType from spec
+
   const allowUpload =
     image_upload === true ||
     animated_image_upload === true ||

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -308,14 +308,27 @@ async function handleFilesUpdate(files: File[]) {
     }
 
     // 2. Update widget options to include new files
-    // This simulates what addToComboValues does but for SimplifiedWidget
     if (props.widget.options?.values) {
-      uploadedPaths.forEach((path) => {
-        const values = props.widget.options!.values as string[]
-        if (!values.includes(path)) {
-          values.push(path)
+      const values = props.widget.options.values as string[]
+
+      // Add new files to the START (newest first)
+      // Reverse uploadedPaths so the very last uploaded is at absolute top if multiple
+      uploadedPaths.reverse().forEach((path) => {
+        // Remove existing duplicates to move them to top
+        const existingIndex = values.indexOf(path)
+        if (existingIndex > -1) {
+          values.splice(existingIndex, 1)
         }
+        values.unshift(path)
       })
+
+      // Enforce limit of 12
+      if (values.length > 12) {
+        values.splice(12) // Remove anything beyond index 11
+      }
+
+      // Update the reactive array (Vue 3 might need assignment trigger depending on depth, simply modifying array is often enough but splice above does it)
+      // props.widget.options.values = values // redundant if referencing same object, but safe
     }
 
     // 3. Update widget value to the first uploaded file

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -115,7 +115,7 @@ const inputItems = computed<DropdownItem[]>(() => {
   }))
 })
 const outputItems = computed<DropdownItem[]>(() => {
-  if (!['image', 'video'].includes(props.assetKind ?? '')) return []
+  if (!['image', 'video', 'model'].includes(props.assetKind ?? '')) return []
 
   const outputs = new Set<string>()
 
@@ -124,7 +124,8 @@ const outputItems = computed<DropdownItem[]>(() => {
     task.flatOutputs.forEach((output) => {
       const isTargetType =
         (props.assetKind === 'image' && output.mediaType === 'images') ||
-        (props.assetKind === 'video' && output.mediaType === 'video')
+        (props.assetKind === 'video' && output.mediaType === 'video') ||
+        (props.assetKind === 'model' && output.is3D)
 
       if (output.type === 'output' && isTargetType) {
         const path = output.subfolder

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -32,6 +32,7 @@ interface Props {
   assetKind?: AssetKind
   allowUpload?: boolean
   uploadFolder?: ResultItemType
+  uploadSubfolder?: string
   isAssetMode?: boolean
   defaultLayoutMode?: LayoutMode
 }
@@ -206,6 +207,8 @@ const acceptTypes = computed(() => {
       return 'video/*'
     case 'audio':
       return 'audio/*'
+    case 'model':
+      return '.obj,.stl,.ply,.spz'
     default:
       return undefined // model or unknown
   }
@@ -251,11 +254,13 @@ function updateSelectedItems(selectedItems: Set<SelectedKey>) {
 const uploadFile = async (
   file: File,
   isPasted: boolean = false,
-  formFields: Partial<{ type: ResultItemType }> = {}
+  formFields: Partial<{ type: ResultItemType; subfolder: string }> = {}
 ) => {
   const body = new FormData()
   body.append('image', file)
   if (isPasted) body.append('subfolder', 'pasted')
+  else if (formFields.subfolder) body.append('subfolder', formFields.subfolder)
+
   if (formFields.type) body.append('type', formFields.type)
 
   const resp = await api.fetchApi('/upload/image', {
@@ -282,8 +287,9 @@ const uploadFile = async (
 // Handle multiple file uploads
 const uploadFiles = async (files: File[]): Promise<string[]> => {
   const folder = props.uploadFolder ?? 'input'
+  const subfolder = props.uploadSubfolder
   const uploadPromises = files.map((file) =>
-    uploadFile(file, false, { type: folder })
+    uploadFile(file, false, { type: folder, subfolder })
   )
   const results = await Promise.all(uploadPromises)
   return results.filter((path): path is string => path !== null)

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -115,7 +115,7 @@ const inputItems = computed<DropdownItem[]>(() => {
   }))
 })
 const outputItems = computed<DropdownItem[]>(() => {
-  if (!['image', 'video', 'model'].includes(props.assetKind ?? '')) return []
+  if (!['image', 'video', 'mesh'].includes(props.assetKind ?? '')) return []
 
   const outputs = new Set<string>()
 
@@ -125,7 +125,7 @@ const outputItems = computed<DropdownItem[]>(() => {
       const isTargetType =
         (props.assetKind === 'image' && output.mediaType === 'images') ||
         (props.assetKind === 'video' && output.mediaType === 'video') ||
-        (props.assetKind === 'model' && output.is3D)
+        (props.assetKind === 'mesh' && output.is3D)
 
       if (output.type === 'output' && isTargetType) {
         const path = output.subfolder
@@ -184,7 +184,7 @@ const mediaPlaceholder = computed(() => {
       return t('widgets.uploadSelect.placeholderVideo')
     case 'audio':
       return t('widgets.uploadSelect.placeholderAudio')
-    case 'model':
+    case 'mesh':
       return t('widgets.uploadSelect.placeholderModel')
     case 'unknown':
       return t('widgets.uploadSelect.placeholderUnknown')
@@ -208,7 +208,7 @@ const acceptTypes = computed(() => {
       return 'video/*'
     case 'audio':
       return 'audio/*'
-    case 'model':
+    case 'mesh':
       return '.obj,.stl,.ply,.spz'
     default:
       return undefined // model or unknown
@@ -330,6 +330,7 @@ async function handleFilesUpdate(files: File[]) {
     }
     // 3. Update widget value to the first uploaded file
     modelValue.value = uploadedPaths[0]
+
     // 4. Trigger callback to notify underlying LiteGraph widget
     if (props.widget.callback) {
       props.widget.callback(uploadedPaths[0])

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -308,6 +308,7 @@ async function handleFilesUpdate(files: File[]) {
     }
 
     // 2. Update widget options to include new files
+    // This simulates what addToComboValues does but for SimplifiedWidget
     if (props.widget.options?.values) {
       const values = props.widget.options.values as string[]
 
@@ -326,9 +327,9 @@ async function handleFilesUpdate(files: File[]) {
         values.splice(12)
       }
     }
-
+    // 3. Update widget value to the first uploaded file
     modelValue.value = uploadedPaths[0]
-
+    // 4. Trigger callback to notify underlying LiteGraph widget
     if (props.widget.callback) {
       props.widget.callback(uploadedPaths[0])
     }

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
@@ -65,6 +65,7 @@ function handleVideoLoad(event: Event) {
             layout === 'list',
           'flex-row text-left hover:bg-component-node-widget-background-hovered rounded-lg':
             layout === 'list-small',
+          // selection
           'ring-2 ring-component-node-widget-background-highlighted':
             layout === 'list' && selected
         }
@@ -72,6 +73,7 @@ function handleVideoLoad(event: Event) {
     "
     @click="handleClick"
   >
+    <!-- Image -->
     <div
       v-if="layout !== 'list-small'"
       :class="
@@ -83,12 +85,14 @@ function handleVideoLoad(event: Event) {
             'min-w-16 max-w-16 rounded-l-lg': layout === 'list',
             'rounded-sm group-hover/item:scale-108 group-active/item:scale-95':
               layout === 'grid',
+            // selection
             'ring-2 ring-component-node-widget-background-highlighted':
               layout === 'grid' && selected
           }
         )
       "
     >
+      <!-- Selected Icon -->
       <div
         v-if="selected"
         class="absolute top-1 left-1 size-4 rounded-full border-1 border-base-foreground bg-primary-background"
@@ -119,6 +123,7 @@ function handleVideoLoad(event: Event) {
         <i class="pi pi-box text-slate-400" style="font-size: 2.5rem" />
       </div>
     </div>
+    <!-- Name -->
     <div
       :class="
         cn('flex gap-1', {
@@ -135,12 +140,14 @@ function handleVideoLoad(event: Event) {
           cn(
             'block text-xs line-clamp-2 break-words overflow-hidden',
             'transition-colors duration-150',
+            // selection
             !!selected && 'text-base-foreground'
           )
         "
       >
         {{ label ?? name }}
       </span>
+      <!-- Meta Data -->
       <span class="text-secondary block text-xs">{{
         metadata || actualDimensions
       }}</span>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
@@ -65,7 +65,6 @@ function handleVideoLoad(event: Event) {
             layout === 'list',
           'flex-row text-left hover:bg-component-node-widget-background-hovered rounded-lg':
             layout === 'list-small',
-          // selection
           'ring-2 ring-component-node-widget-background-highlighted':
             layout === 'list' && selected
         }
@@ -73,7 +72,6 @@ function handleVideoLoad(event: Event) {
     "
     @click="handleClick"
   >
-    <!-- Image -->
     <div
       v-if="layout !== 'list-small'"
       :class="
@@ -85,14 +83,12 @@ function handleVideoLoad(event: Event) {
             'min-w-16 max-w-16 rounded-l-lg': layout === 'list',
             'rounded-sm group-hover/item:scale-108 group-active/item:scale-95':
               layout === 'grid',
-            // selection
             'ring-2 ring-component-node-widget-background-highlighted':
               layout === 'grid' && selected
           }
         )
       "
     >
-      <!-- Selected Icon -->
       <div
         v-if="selected"
         class="absolute top-1 left-1 size-4 rounded-full border-1 border-base-foreground bg-primary-background"
@@ -123,7 +119,6 @@ function handleVideoLoad(event: Event) {
         <i class="pi pi-box text-slate-400" style="font-size: 2.5rem" />
       </div>
     </div>
-    <!-- Name -->
     <div
       :class="
         cn('flex gap-1', {
@@ -140,14 +135,12 @@ function handleVideoLoad(event: Event) {
           cn(
             'block text-xs line-clamp-2 break-words overflow-hidden',
             'transition-colors duration-150',
-            // selection
             !!selected && 'text-base-foreground'
           )
         "
       >
         {{ label ?? name }}
       </span>
-      <!-- Meta Data -->
       <span class="text-secondary block text-xs">{{
         metadata || actualDimensions
       }}</span>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
@@ -114,7 +114,7 @@ function handleVideoLoad(event: Event) {
       />
       <div
         v-else
-        class="size-full flex items-center justify-center bg-slate-100"
+        class="size-full flex items-center justify-center bg-slate-50"
       >
         <i class="pi pi-box text-slate-400" style="font-size: 2.5rem" />
       </div>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
@@ -118,8 +118,10 @@ function handleVideoLoad(event: Event) {
       />
       <div
         v-else
-        class="size-full bg-gradient-to-tr from-blue-400 via-teal-500 to-green-400"
-      />
+        class="size-full flex items-center justify-center bg-slate-100"
+      >
+        <i class="pi pi-box text-slate-400" style="font-size: 2.5rem" />
+      </div>
     </div>
     <!-- Name -->
     <div

--- a/src/types/widgetTypes.ts
+++ b/src/types/widgetTypes.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey } from 'vue'
 
-export type AssetKind = 'image' | 'video' | 'audio' | 'model' | 'unknown'
+export type AssetKind = 'image' | 'video' | 'audio' | 'mesh' | 'unknown'
 
 export const OnCloseKey: InjectionKey<() => void> = Symbol()


### PR DESCRIPTION
## Summary

Enable the rich `WidgetSelectDropdown` component for the `model_file` input on "Load 3D" nodes in Vue (Nodes 2.0) mode. This will provide grid/list views, search, and upload capabilities directly in the dropdown, matching the "Load Image" node experience.

## Changes

- **What**:  The core logic is in the `src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue` and `src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.vue`

## Review Focus

Drag and drop a 3D file onto the dropdown (or use upload button if enabled in dropdown).

## Screenshots


https://github.com/user-attachments/assets/115ebac1-a374-4d0d-b3c0-d88b352dce40

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7842-Feat-update-the-load-3d-widget-2de6d73d365081d6bb80c486b073742c) by [Unito](https://www.unito.io)
