### PR TITLE
fix: disable frustum culling for SkinnedMesh to prevent clipping during animation

### DIFF
--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -166,6 +166,10 @@ export class LoaderManager implements LoaderManagerInterface {
         fbxModel.traverse((child) => {
           if (child instanceof THREE.Mesh) {
             this.modelManager.originalMaterials.set(child, child.material)
+
+            if (child instanceof THREE.SkinnedMesh) {
+              child.frustumCulled = false
+            }
           }
         })
         break
@@ -212,6 +216,10 @@ export class LoaderManager implements LoaderManagerInterface {
           if (child instanceof THREE.Mesh) {
             child.geometry.computeVertexNormals()
             this.modelManager.originalMaterials.set(child, child.material)
+
+            if (child instanceof THREE.SkinnedMesh) {
+              child.frustumCulled = false
+            }
           }
         })
         break


### PR DESCRIPTION
## Summary

SkinnedMesh bounding box is computed at rest pose and doesn't update during animation, causing incorrect frustum culling when bones move outside the original bounds.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/7847

## Screenshots
before
<img width="396" height="520" alt="image" src="https://github.com/user-attachments/assets/d2c854b5-c859-4664-9e0e-11c83775b3e7" />

after
<img width="949" height="656" alt="image" src="https://github.com/user-attachments/assets/ce93d04f-1562-429f-8f2c-cb5c0ea404ae" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7856-fix-disable-frustum-culling-for-SkinnedMesh-to-prevent-clipping-during-animation-2e06d73d365081d8b585e9e4afa52d67) by [Unito](https://www.unito.io)
