### PR TITLE
fix: prevent image preview resize issues when switching to vueNodes mode

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.ts
@@ -368,7 +368,8 @@ export const useImagePreviewWidget = () => {
   ) => {
     return node.addCustomWidget(
       new ImagePreviewWidget(node, inputSpec.name, {
-        serialize: false
+        serialize: false,
+        canvasOnly: true
       })
     )
   }


### PR DESCRIPTION
## Summary
- Fix duplicate rendering issue for image preview nodes when switching from litegraph to vueNodes mode by setting canvasOnly: true on ImagePreviewWidget

## Problem

 When switching from litegraph to vueNodes mode, image preview nodes (LoadImage, PreviewImage) had two issues:

  1. Node becoming longer: The ImagePreviewWidget was being rendered twice - once as a WidgetLegacy canvas (with stale computedHeight from litegraph mode) and once as Vue's ImagePreview component

## Solution

  1. Set canvasOnly: true for ImagePreviewWidget so it won't render as WidgetLegacy in Vue mode (Vue's ImagePreview.vue already handles image display)


## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/925c4fb4-bc9a-4da5-b8ae-3557c2d3836b


after

https://github.com/user-attachments/assets/5faa6878-c56d-44dd-86f5-728bff9ad58a

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7868-fix-prevent-image-preview-resize-issues-when-switching-to-vueNodes-mode-2e16d73d36508106a058da2f8d17c410) by [Unito](https://www.unito.io)
