### PR TITLE
Prevent nav item shrink

### DIFF
--- a/src/components/widget/nav/NavIcon.vue
+++ b/src/components/widget/nav/NavIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <i :class="icon" class="text-neutral text-sm" />
+  <i :class="icon" class="text-neutral text-sm shrink-0" />
 </template>
 
 <script setup lang="ts">

--- a/src/components/widget/nav/NavItem.vue
+++ b/src/components/widget/nav/NavItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex cursor-pointer items-center gap-2 rounded-md px-4 py-3 text-sm transition-colors text-base-foreground"
+    class="flex cursor-pointer items-start gap-2 rounded-md px-4 py-3 text-sm transition-colors text-base-foreground"
     :class="
       active
         ? 'bg-interface-menu-component-surface-selected'
@@ -9,7 +9,9 @@
     role="button"
     @click="onClick"
   >
-    <NavIcon v-if="icon" :icon="icon" />
+    <div v-if="icon" class="py-0.5">
+      <NavIcon :icon="icon" />
+    </div>
     <i v-else class="text-neutral icon-[lucide--folder] text-xs shrink-0" />
     <span class="flex items-center break-all">
       <slot></slot>

--- a/src/components/widget/nav/NavItem.vue
+++ b/src/components/widget/nav/NavItem.vue
@@ -10,8 +10,8 @@
     @click="onClick"
   >
     <NavIcon v-if="icon" :icon="icon" />
-    <i v-else class="text-neutral icon-[lucide--folder] text-xs" />
-    <span class="flex items-center">
+    <i v-else class="text-neutral icon-[lucide--folder] text-xs shrink-0" />
+    <span class="flex items-center break-all">
       <slot></slot>
     </span>
   </div>


### PR DESCRIPTION
## Screenshots (if applicable)

**Before**
<img width="1782" height="1110" alt="스크린샷 2026-01-07 오전 11 54 18" src="https://github.com/user-attachments/assets/37cb3bf8-0c29-4740-97ec-047689558c4c" />

**After**
<img width="1814" height="1131" alt="스크린샷 2026-01-07 오전 11 54 44" src="https://github.com/user-attachments/assets/2672220b-493b-4f41-9823-7721fc1accad" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7869-Prevent-nav-item-shrink-2e16d73d365081f1806cc0632536b7cc) by [Unito](https://www.unito.io)
