### PR TITLE
Cleanup: Remove test block from vite.config.ts since we already have a vitest.config.ts

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -482,12 +482,6 @@ export default defineConfig({
       : []
   },
 
-  test: {
-    globals: true,
-    environment: 'happy-dom',
-    setupFiles: ['./vitest.setup.ts']
-  },
-
   define: {
     __COMFYUI_FRONTEND_VERSION__: JSON.stringify(
       process.env.npm_package_version


### PR DESCRIPTION
## Summary

Just removing the extra configuration.
https://vitest.dev/config/

We _could_ go the other direction and move the vitest configuration options into the main vite config file.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7873-Cleanup-Remove-test-block-from-vite-config-ts-since-we-already-have-a-vitest-config-ts-2e16d73d3650819ea07bd3bf3416bf11) by [Unito](https://www.unito.io)
