### PR TITLE
fix: use pre-bundled wwobjloader2 worker for production builds

### DIFF
--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -6,7 +6,9 @@ import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
 import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
 import { MtlObjBridge, OBJLoader2Parallel } from 'wwobjloader2'
-import OBJLoader2WorkerUrl from 'wwobjloader2/worker?url'
+// Use pre-bundled worker module (has all dependencies included)
+// The unbundled 'wwobjloader2/worker' has ES imports that fail in production builds
+import OBJLoader2WorkerUrl from 'wwobjloader2/bundle/worker/module?url'
 
 import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'


### PR DESCRIPTION
## Summary

The unbundled worker from 'wwobjloader2/worker' has ES module imports that fail in production builds because Vite's ?url suffix doesn't bundle dependencies. 
Switch to 'wwobjloader2/bundle/worker/module' which is self-contained with all dependencies included.

Fixes OBJ loading failing in production with Worker error events.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7879-fix-use-pre-bundled-wwobjloader2-worker-for-production-builds-2e16d73d365081f4a485c993852be1d3) by [Unito](https://www.unito.io)
