### PR TITLE
fix: wrap image preview navigation dots when overflowing node width

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -99,7 +99,10 @@
       </span>
     </div>
     <!-- Multiple Images Navigation -->
-    <div v-if="hasMultipleImages" class="flex justify-center gap-1 pt-4">
+    <div
+      v-if="hasMultipleImages"
+      class="flex flex-wrap justify-center gap-1 pt-4"
+    >
       <button
         v-for="(_, index) in imageUrls"
         :key="index"


### PR DESCRIPTION
## Summary

When Preview Image node has many images, the navigation dots would overflow beyond the node boundaries. Adding flex-wrap ensures dots wrap to multiple lines instead of overflowing.

## Screenshots
before
<img width="1175" height="1357" alt="image" src="https://github.com/user-attachments/assets/1903ae13-c304-4c75-a947-aa879ef9c2e1" />

after
<img width="654" height="840" alt="image" src="https://github.com/user-attachments/assets/37012379-b72f-4b7d-9355-08bac11b094b" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7891-fix-wrap-image-preview-navigation-dots-when-overflowing-node-width-2e26d73d36508130a5edf0a0d34f966c) by [Unito](https://www.unito.io)
