### PR TITLE
feat: add model download progress dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ The project uses **Nx** for build orchestration and task management
 8. Implement proper error handling
 9. Follow Vue 3 style guide and naming conventions
 10. Use Vite for fast development and building
-11. Use vue-i18n in composition API for any string literals. Place new translation entries in src/locales/en/main.json
+11. Use vue-i18n in composition API for any string literals. Place new translation entries in src/locales/en/main.json. Use the plurals system in i18n instead of hardcoding pluralization in templates.
 12. Avoid new usage of PrimeVue components
 13. Write tests for all changes, especially bug fixes to catch future regressions
 14. Write code that is expressive and self-documenting to the furthest degree possible. This reduces the need for code comments which can get out of sync with the code itself. Try to avoid comments unless absolutely necessary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,9 @@ The project uses **Nx** for build orchestration and task management
 - Imports:
   - sorted/grouped by plugin
   - run `pnpm format` before committing
+  - use separate `import type` statements, not inline `type` in mixed imports
+    - ✅ `import type { Foo } from './foo'` + `import { bar } from './foo'`
+    - ❌ `import { bar, type Foo } from './foo'`
 - ESLint:
   - Vue + TS rules
   - no floating promises

--- a/src/components/common/StatusBadge.vue
+++ b/src/components/common/StatusBadge.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+type Severity = 'default' | 'secondary' | 'warn' | 'danger' | 'contrast'
+
+const { label, severity = 'default' } = defineProps<{
+  label: string
+  severity?: Severity
+}>()
+
+function badgeClasses(sev: Severity): string {
+  const baseClasses =
+    'inline-flex h-3.5 items-center justify-center rounded-full px-1 text-xxxs font-semibold uppercase'
+
+  switch (sev) {
+    case 'danger':
+      return `${baseClasses} bg-destructive-background text-white`
+    case 'contrast':
+      return `${baseClasses} bg-base-foreground text-base-background`
+    case 'warn':
+      return `${baseClasses} bg-warning-background text-base-background`
+    case 'secondary':
+      return `${baseClasses} bg-secondary-background text-base-foreground`
+    default:
+      return `${baseClasses} bg-primary-background text-white`
+  }
+}
+</script>
+
+<template>
+  <span :class="badgeClasses(severity)">{{ label }}</span>
+</template>

--- a/src/components/common/StatusBadge.vue
+++ b/src/components/common/StatusBadge.vue
@@ -20,7 +20,7 @@ function badgeClasses(sev: Severity): string {
     case 'secondary':
       return `${baseClasses} bg-secondary-background text-base-foreground`
     default:
-      return `${baseClasses} bg-primary-background text-white`
+      return `${baseClasses} bg-primary-background text-base-foreground`
   }
 }
 </script>

--- a/src/components/toast/ProgressToastItem.vue
+++ b/src/components/toast/ProgressToastItem.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import type { AssetDownload } from '@/stores/assetDownloadStore'
+import { cn } from '@/utils/tailwindUtil'
+
+const { job } = defineProps<{
+  job: AssetDownload
+}>()
+
+const { t } = useI18n()
+
+const progressPercent = computed(() => Math.round(job.progress * 100))
+const isCompleted = computed(() => job.status === 'completed')
+const isFailed = computed(() => job.status === 'failed')
+const isRunning = computed(() => job.status === 'running')
+const isPending = computed(() => job.status === 'created')
+</script>
+
+<template>
+  <div
+    :class="
+      cn(
+        'flex items-center justify-between rounded-lg bg-modal-card-background px-4 py-3',
+        isCompleted && 'opacity-50'
+      )
+    "
+  >
+    <div class="flex flex-col">
+      <span class="text-sm text-base-foreground">{{ job.assetName }}</span>
+      <span v-if="isRunning" class="text-xs text-muted-foreground">
+        {{ progressPercent }}%
+      </span>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <template v-if="isFailed">
+        <i
+          class="icon-[lucide--circle-alert] size-4 text-destructive-background"
+        />
+        <StatusBadge :label="t('progressToast.failed')" severity="danger" />
+      </template>
+
+      <template v-else-if="isCompleted">
+        <StatusBadge :label="t('progressToast.finished')" severity="contrast" />
+      </template>
+
+      <template v-else-if="isRunning">
+        <i
+          class="icon-[lucide--loader-circle] size-4 animate-spin text-primary-background"
+        />
+        <span class="text-xs text-primary-background">
+          {{ progressPercent }}%
+        </span>
+      </template>
+
+      <template v-else-if="isPending">
+        <span class="text-xs text-muted-foreground">
+          {{ t('progressToast.pending') }}
+        </span>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2474,5 +2474,20 @@
   "help": {
     "recentReleases": "Recent releases",
     "helpCenterMenu": "Help Center Menu"
+  },
+  "progressToast": {
+    "importingModels": "Importing Models",
+    "downloadingModel": "Downloading model...",
+    "downloadsFailed": "{count} downloads failed | {count} download failed | {count} downloads failed",
+    "allDownloadsCompleted": "All downloads completed",
+    "noImportsInQueue": "No {filter} in queue",
+    "failed": "Failed",
+    "finished": "Finished",
+    "pending": "Pending",
+    "filter": {
+      "all": "All",
+      "completed": "Completed",
+      "failed": "Failed"
+    }
   }
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2484,6 +2484,7 @@
     "failed": "Failed",
     "finished": "Finished",
     "pending": "Pending",
+    "progressCount": "{completed} of {total}",
     "filter": {
       "all": "All",
       "completed": "Completed",

--- a/src/platform/assets/components/ModelImportProgressDialog.vue
+++ b/src/platform/assets/components/ModelImportProgressDialog.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import ProgressToastItem from '@/components/toast/ProgressToastItem.vue'
+import Button from '@/components/ui/button/Button.vue'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { cn } from '@/utils/tailwindUtil'
 
@@ -105,31 +106,36 @@ function handleClickOutside(event: MouseEvent) {
           <div class="flex items-center gap-2">
             <!-- Filter Dropdown -->
             <div class="filter-dropdown relative" @click.stop>
-              <button
-                class="flex h-8 items-center gap-1.5 rounded-lg bg-secondary-background px-2 text-xs text-base-foreground hover:bg-secondary-background-hover"
+              <Button
+                variant="secondary"
+                size="md"
+                class="gap-1.5 px-2"
                 @click="showFilterMenu = !showFilterMenu"
               >
                 <i class="icon-[lucide--list-filter] size-4" />
                 <span>{{ activeFilterLabel }}</span>
                 <i class="icon-[lucide--chevron-down] size-3" />
-              </button>
+              </Button>
               <div
                 v-if="showFilterMenu"
-                class="absolute right-0 top-full z-50 mt-1 min-w-[120px] rounded-md bg-secondary-background py-1 shadow-lg"
+                class="absolute right-0 top-full z-50 mt-1 flex min-w-[120px] flex-col items-stretch rounded-lg border border-interface-stroke bg-interface-panel-surface px-2 py-3 shadow-lg"
               >
-                <button
+                <Button
                   v-for="option in filterOptions"
                   :key="option.value"
-                  class="w-full px-3 py-1.5 text-left text-sm transition-colors"
+                  variant="textonly"
+                  size="sm"
                   :class="
-                    activeFilter === option.value
-                      ? 'bg-secondary-background-selected text-base-foreground'
-                      : 'text-muted-foreground hover:bg-secondary-background-hover hover:text-base-foreground'
+                    cn(
+                      'w-full justify-start bg-transparent',
+                      activeFilter === option.value &&
+                        'bg-secondary-background-selected'
+                    )
                   "
                   @click="setFilter(option.value)"
                 >
                   {{ t(`progressToast.filter.${option.label}`) }}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -216,28 +222,28 @@ function handleClickOutside(event: MouseEvent) {
 
             <div class="flex items-center">
               <!-- Expand/Collapse Button -->
-              <button
-                class="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary-background-hover hover:text-base-foreground"
-                @click.stop="toggle"
-              >
+              <Button variant="muted-textonly" size="icon" @click.stop="toggle">
                 <i
-                  :class="[
-                    'size-4',
-                    isExpanded
-                      ? 'icon-[lucide--chevron-down]'
-                      : 'icon-[lucide--chevron-up]'
-                  ]"
+                  :class="
+                    cn(
+                      'size-4',
+                      isExpanded
+                        ? 'icon-[lucide--chevron-down]'
+                        : 'icon-[lucide--chevron-up]'
+                    )
+                  "
                 />
-              </button>
+              </Button>
 
               <!-- Close Button (only when all downloads completed) -->
-              <button
+              <Button
                 v-if="!isInProgress"
-                class="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary-background-hover hover:text-base-foreground"
+                variant="muted-textonly"
+                size="icon"
                 @click.stop="closeDialog"
               >
                 <i class="icon-[lucide--x] size-4" />
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/platform/assets/components/ModelImportProgressDialog.vue
+++ b/src/platform/assets/components/ModelImportProgressDialog.vue
@@ -226,7 +226,16 @@ function closeDialog() {
             </span>
 
             <div class="flex items-center">
-              <Button variant="muted-textonly" size="icon" @click.stop="toggle">
+              <Button
+                variant="muted-textonly"
+                size="icon"
+                :aria-label="
+                  isExpanded
+                    ? t('contextMenu.Collapse')
+                    : t('contextMenu.Expand')
+                "
+                @click.stop="toggle"
+              >
                 <i
                   :class="
                     cn(
@@ -243,6 +252,7 @@ function closeDialog() {
                 v-if="!isInProgress"
                 variant="muted-textonly"
                 size="icon"
+                :aria-label="t('g.close')"
                 @click.stop="closeDialog"
               >
                 <i class="icon-[lucide--x] size-4" />

--- a/src/platform/assets/components/ModelImportProgressDialog.vue
+++ b/src/platform/assets/components/ModelImportProgressDialog.vue
@@ -222,7 +222,12 @@ function closeDialog() {
 
           <div class="flex items-center gap-2">
             <span v-if="isInProgress" class="text-sm text-muted-foreground">
-              {{ completedCount }} {{ t('g.progressCountOf') }} {{ totalCount }}
+              {{
+                t('progressToast.progressCount', {
+                  completed: completedCount,
+                  total: totalCount
+                })
+              }}
             </span>
 
             <div class="flex items-center">

--- a/src/platform/assets/components/ModelImportProgressDialog.vue
+++ b/src/platform/assets/components/ModelImportProgressDialog.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import ProgressToastItem from '@/components/toast/ProgressToastItem.vue'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { cn } from '@/utils/tailwindUtil'
+
+const { t } = useI18n()
+const assetDownloadStore = useAssetDownloadStore()
+
+const visible = computed(() => assetDownloadStore.hasDownloads)
+
+const isExpanded = ref(false)
+const activeFilter = ref<'all' | 'completed' | 'failed'>('all')
+const showFilterMenu = ref(false)
+
+function toggle() {
+  isExpanded.value = !isExpanded.value
+}
+
+const filterOptions = [
+  { value: 'all', label: 'all' },
+  { value: 'completed', label: 'completed' },
+  { value: 'failed', label: 'failed' }
+] as const
+
+function setFilter(filter: typeof activeFilter.value) {
+  activeFilter.value = filter
+  showFilterMenu.value = false
+}
+
+const downloadJobs = computed(() => assetDownloadStore.downloadList)
+const completedJobs = computed(() =>
+  assetDownloadStore.finishedDownloads.filter((d) => d.status === 'completed')
+)
+const failedJobs = computed(() =>
+  assetDownloadStore.finishedDownloads.filter((d) => d.status === 'failed')
+)
+
+const isInProgress = computed(() => assetDownloadStore.hasActiveDownloads)
+const currentJobName = computed(() => {
+  const activeJob = downloadJobs.value.find((job) => job.status === 'running')
+  return activeJob?.assetName || t('progressToast.downloadingModel')
+})
+
+const completedCount = computed(
+  () => completedJobs.value.length + failedJobs.value.length
+)
+const totalCount = computed(() => downloadJobs.value.length)
+
+const filteredJobs = computed(() => {
+  switch (activeFilter.value) {
+    case 'completed':
+      return completedJobs.value
+    case 'failed':
+      return failedJobs.value
+    default:
+      return downloadJobs.value
+  }
+})
+
+const activeFilterLabel = computed(() => {
+  const option = filterOptions.find((f) => f.value === activeFilter.value)
+  return option
+    ? t(`progressToast.filter.${option.label}`)
+    : t('progressToast.filter.all')
+})
+
+function closeDialog() {
+  assetDownloadStore.clearFinishedDownloads()
+  isExpanded.value = false
+}
+
+function handleClickOutside(event: MouseEvent) {
+  const target = event.target as HTMLElement
+  if (!target.closest('.filter-dropdown')) {
+    showFilterMenu.value = false
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-all duration-300 ease-out"
+      enter-from-class="translate-y-full opacity-0"
+      enter-to-class="translate-y-0 opacity-100"
+      leave-active-class="transition-all duration-200 ease-in"
+      leave-from-class="translate-y-0 opacity-100"
+      leave-to-class="translate-y-full opacity-0"
+    >
+      <div
+        v-if="visible"
+        class="fixed inset-x-0 bottom-6 z-[9999] mx-auto w-[80%] max-w-3xl overflow-hidden rounded-lg border border-border-default bg-base-background shadow-lg"
+        @click="handleClickOutside"
+      >
+        <!-- Header -->
+        <div
+          class="flex h-12 items-center justify-between border-b border-border-default px-4"
+        >
+          <h3 class="text-sm font-bold text-base-foreground">
+            {{ t('progressToast.importingModels') }}
+          </h3>
+          <div class="flex items-center gap-2">
+            <!-- Filter Dropdown -->
+            <div class="filter-dropdown relative" @click.stop>
+              <button
+                class="flex h-8 items-center gap-1.5 rounded-lg bg-secondary-background px-2 text-xs text-base-foreground hover:bg-secondary-background-hover"
+                @click="showFilterMenu = !showFilterMenu"
+              >
+                <i class="icon-[lucide--list-filter] size-4" />
+                <span>{{ activeFilterLabel }}</span>
+                <i class="icon-[lucide--chevron-down] size-3" />
+              </button>
+              <div
+                v-if="showFilterMenu"
+                class="absolute right-0 top-full z-50 mt-1 min-w-[120px] rounded-md bg-secondary-background py-1 shadow-lg"
+              >
+                <button
+                  v-for="option in filterOptions"
+                  :key="option.value"
+                  class="w-full px-3 py-1.5 text-left text-sm transition-colors"
+                  :class="
+                    activeFilter === option.value
+                      ? 'bg-secondary-background-selected text-base-foreground'
+                      : 'text-muted-foreground hover:bg-secondary-background-hover hover:text-base-foreground'
+                  "
+                  @click="setFilter(option.value)"
+                >
+                  {{ t(`progressToast.filter.${option.label}`) }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Expandable content -->
+        <div
+          :class="
+            cn(
+              'overflow-hidden transition-all duration-300',
+              isExpanded ? 'max-h-[300px]' : 'max-h-0'
+            )
+          "
+        >
+          <div class="relative max-h-[300px] overflow-y-auto px-4 py-4">
+            <!-- Scrollbar indicator -->
+            <div
+              v-if="filteredJobs.length > 3"
+              class="absolute right-1 top-4 h-12 w-1 rounded-full bg-muted-foreground"
+            />
+
+            <div class="flex flex-col gap-2">
+              <ProgressToastItem
+                v-for="job in filteredJobs"
+                :key="job.taskId"
+                :job="job"
+              />
+            </div>
+
+            <!-- Empty State -->
+            <div
+              v-if="filteredJobs.length === 0"
+              class="flex flex-col items-center justify-center py-6 text-center"
+            >
+              <span class="text-sm text-muted-foreground">
+                {{
+                  t('progressToast.noImportsInQueue', {
+                    filter: activeFilterLabel
+                  })
+                }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer / Status bar -->
+        <div
+          class="flex h-12 items-center justify-between border-t border-border-default px-4"
+        >
+          <div class="flex items-center gap-2 text-sm">
+            <template v-if="isInProgress">
+              <i
+                class="icon-[lucide--loader-circle] size-4 animate-spin text-muted-foreground"
+              />
+              <span class="font-bold text-base-foreground">{{
+                currentJobName
+              }}</span>
+            </template>
+            <template v-else-if="failedJobs.length > 0">
+              <i
+                class="icon-[lucide--circle-alert] size-4 text-destructive-background"
+              />
+              <span class="font-bold text-base-foreground">
+                {{
+                  t('progressToast.downloadsFailed', {
+                    count: failedJobs.length
+                  })
+                }}
+              </span>
+            </template>
+            <template v-else>
+              <i class="icon-[lucide--check-circle] size-4 text-jade-600" />
+              <span class="font-bold text-base-foreground">
+                {{ t('progressToast.allDownloadsCompleted') }}
+              </span>
+            </template>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <!-- Progress Count -->
+            <span v-if="isInProgress" class="text-sm text-muted-foreground">
+              {{ completedCount }} {{ t('g.progressCountOf') }} {{ totalCount }}
+            </span>
+
+            <div class="flex items-center">
+              <!-- Expand/Collapse Button -->
+              <button
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary-background-hover hover:text-base-foreground"
+                @click.stop="toggle"
+              >
+                <i
+                  :class="[
+                    'size-4',
+                    isExpanded
+                      ? 'icon-[lucide--chevron-down]'
+                      : 'icon-[lucide--chevron-up]'
+                  ]"
+                />
+              </button>
+
+              <!-- Close Button (only when all downloads completed) -->
+              <button
+                v-if="!isInProgress"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary-background-hover hover:text-base-foreground"
+                @click.stop="closeDialog"
+              >
+                <i class="icon-[lucide--x] size-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/src/stores/assetDownloadStore.ts
+++ b/src/stores/assetDownloadStore.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { useEventListener } from '@vueuse/core'
 
 import type { AssetDownloadWsMessage } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
@@ -115,16 +114,7 @@ export const useAssetDownloadStore = defineStore('assetDownload', () => {
     }
   }
 
-  let stopListener: (() => void) | undefined
-
-  function setup() {
-    stopListener = useEventListener(api, 'asset_download', handleAssetDownload)
-  }
-
-  function teardown() {
-    stopListener?.()
-    stopListener = undefined
-  }
+  api.addEventListener('asset_download', handleAssetDownload)
 
   function clearFinishedDownloads() {
     for (const download of finishedDownloads.value) {
@@ -140,8 +130,6 @@ export const useAssetDownloadStore = defineStore('assetDownload', () => {
     downloadList,
     completedDownloads,
     trackDownload,
-    clearFinishedDownloads,
-    setup,
-    teardown
+    clearFinishedDownloads
   }
 })

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -17,6 +17,7 @@
 
   <GlobalToast />
   <RerouteMigrationToast />
+  <ModelImportProgressDialog />
   <UnloadWindowConfirmDialog v-if="!isElectron()" />
   <MenuHamburger />
 </template>
@@ -49,6 +50,7 @@ import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useProgressFavicon } from '@/composables/useProgressFavicon'
 import { SERVER_CONFIG_ITEMS } from '@/constants/serverConfig'
 import { i18n, loadLocale } from '@/i18n'
+import ModelImportProgressDialog from '@/platform/assets/components/ModelImportProgressDialog.vue'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -62,7 +62,6 @@ import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { setupAutoQueueHandler } from '@/services/autoQueueService'
 import { useKeybindingService } from '@/services/keybindingService'
-import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -90,7 +89,6 @@ const { t } = useI18n()
 const toast = useToast()
 const settingStore = useSettingStore()
 const executionStore = useExecutionStore()
-const assetDownloadStore = useAssetDownloadStore()
 const colorPaletteStore = useColorPaletteStore()
 const queueStore = useQueueStore()
 const assetsStore = useAssetsStore()
@@ -258,7 +256,6 @@ onMounted(() => {
   api.addEventListener('reconnecting', onReconnecting)
   api.addEventListener('reconnected', onReconnected)
   executionStore.bindExecutionEvents()
-  assetDownloadStore.setup()
 
   try {
     init()
@@ -275,7 +272,6 @@ onBeforeUnmount(() => {
   api.removeEventListener('reconnecting', onReconnecting)
   api.removeEventListener('reconnected', onReconnected)
   executionStore.unbindExecutionEvents()
-  assetDownloadStore.teardown()
 
   // Clean up page visibility listener
   if (visibilityListener) {


### PR DESCRIPTION
## Summary

Add a progress dialog for model downloads that appears when downloads are active.

## Changes

- Add `ModelImportProgressDialog` component for showing download progress
- Add `ProgressToastItem` component for individual download job display
- Add `StatusBadge` component for status indicators
- Extend `assetDownloadStore` with:
  - `finishedDownloads` computed for completed/failed jobs
  - `hasDownloads` computed for dialog visibility
  - `clearFinishedDownloads()` to dismiss finished downloads
- Dialog visibility driven by store state
- Closing dialog clears finished downloads
- Filter dropdown to show all/completed/failed downloads
- Expandable/collapsible UI with animated transitions
- Update AGENTS.md with import type convention and pluralization note

## Testing

- Start a model download and verify the dialog appears
- Verify expand/collapse animation works
- Verify filter dropdown works
- Verify closing the dialog clears finished downloads
- Verify dialog hides when no downloads remain

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7897-feat-add-model-download-progress-dialog-2e26d73d36508116960eff6fbe7dc392) by [Unito](https://www.unito.io)
