### PR TITLE
fix(ui): Add relative positioning to queue button

### DIFF
--- a/src/components/TopMenuSection.vue
+++ b/src/components/TopMenuSection.vue
@@ -40,6 +40,7 @@
             v-tooltip.bottom="queueHistoryTooltipConfig"
             type="destructive"
             size="icon"
+            class="relative"
             :aria-pressed="isQueueOverlayExpanded"
             :aria-label="
               t('sideToolbar.queueProgressOverlay.expandCollapsedQueue')


### PR DESCRIPTION
## Summary

Fixes #7903

Added `relative` positioning class to the queue history button for proper badge alignment, ensuring the queued task count badge is correctly positioned relative to its parent button.

## Changes

- **What**: Added `class="relative"` to the queue history button component on line 43, enabling the absolute positioned queued count badge to align correctly within the button instead of using a distant ancestor as positioning context.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

This is a minor CSS positioning fix. The change ensures the queued count badge is positioned relative to the button itself, improving visual accuracy of the notification badge placement.

## Screenshots (if applicable)

Before:
<img width="404" height="157" alt="before" src="https://github.com/user-attachments/assets/bad6e90f-7149-4299-8ad4-2e94aef1a3b4" />

After:
<img width="382" height="137" alt="after" src="https://github.com/user-attachments/assets/98130e0e-a394-422f-a47f-aaf30380e000" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7904-fix-ui-Add-relative-positioning-to-queue-button-2e26d73d3650816dac1bc8ec68f93fea) by [Unito](https://www.unito.io)
