### PR TITLE
Fix "Markdown" and "Text Preview" widgets mouse events

### DIFF
--- a/src/components/graph/widgets/TextPreviewWidget.vue
+++ b/src/components/graph/widgets/TextPreviewWidget.vue
@@ -1,6 +1,8 @@
 <template>
   <div
     class="relative max-h-[200px] min-h-[28px] w-full overflow-y-auto rounded-lg px-4 py-2 text-xs"
+    @wheel="canvasInteractions.handleWheel"
+    @pointerdown="canvasInteractions.handlePointer"
   >
     <div class="flex items-center gap-2">
       <div class="flex flex-1 items-center gap-2 break-all">
@@ -16,6 +18,7 @@ import Skeleton from 'primevue/skeleton'
 import { computed, onMounted, ref, watch } from 'vue'
 
 import type { NodeId } from '@/lib/litegraph/src/litegraph'
+import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { useExecutionStore } from '@/stores/executionStore'
 import { linkifyHtml, nl2br } from '@/utils/formatUtil'
 
@@ -25,6 +28,7 @@ const props = defineProps<{
 }>()
 
 const executionStore = useExecutionStore()
+const canvasInteractions = useCanvasInteractions()
 const isParentNodeExecuting = ref(true)
 const formattedText = computed(() => {
   const src = modelValue.value

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
@@ -39,6 +39,9 @@ function addMarkdownWidget(
     editable: false
   })
 
+  // Cache the settingStore once
+  const settingStore = useSettingStore()
+
   const inputEl = editor.options.element as HTMLElement
   inputEl.classList.add('comfy-markdown')
   const textarea = document.createElement('textarea')
@@ -96,7 +99,8 @@ function addMarkdownWidget(
   })
 
   inputEl.addEventListener('wheel', (event: WheelEvent) => {
-    const gesturesEnabled = useSettingStore().get(
+    // Use the cached settingStore
+    const gesturesEnabled = settingStore.get(
       'LiteGraph.Pointer.TrackpadGestures'
     )
     const deltaX = event.deltaX

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
@@ -8,12 +8,9 @@ import TiptapStarterKit from '@tiptap/starter-kit'
 import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { useSettingStore } from '@/platform/settings/settingStore'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
-
-const TRACKPAD_DETECTION_THRESHOLD = 50
 
 function addMarkdownWidget(
   node: LGraphNode,
@@ -38,9 +35,6 @@ function addMarkdownWidget(
     content: opts.defaultVal,
     editable: false
   })
-
-  // Cache the settingStore once
-  const settingStore = useSettingStore()
 
   const inputEl = editor.options.element as HTMLElement
   inputEl.classList.add('comfy-markdown')
@@ -99,10 +93,6 @@ function addMarkdownWidget(
   })
 
   inputEl.addEventListener('wheel', (event: WheelEvent) => {
-    // Use the cached settingStore
-    const gesturesEnabled = settingStore.get(
-      'LiteGraph.Pointer.TrackpadGestures'
-    )
     const deltaX = event.deltaX
     const deltaY = event.deltaY
 
@@ -112,20 +102,6 @@ function addMarkdownWidget(
 
     // Prevent pinch zoom from zooming the page
     if (event.ctrlKey) {
-      event.preventDefault()
-      event.stopPropagation()
-      app.canvas.processMouseWheel(event)
-      return
-    }
-
-    // Detect if this is likely a trackpad gesture vs mouse wheel
-    // Trackpads usually have deltaX or smaller deltaY values (< TRACKPAD_DETECTION_THRESHOLD)
-    // Mouse wheels typically have larger discrete deltaY values (>= TRACKPAD_DETECTION_THRESHOLD)
-    const isLikelyTrackpad =
-      Math.abs(deltaX) > 0 || Math.abs(deltaY) < TRACKPAD_DETECTION_THRESHOLD
-
-    // Trackpad gestures: when enabled, trackpad panning goes to canvas
-    if (gesturesEnabled && isLikelyTrackpad) {
       event.preventDefault()
       event.stopPropagation()
       app.canvas.processMouseWheel(event)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -12,6 +12,9 @@ function addMultilineWidget(
   name: string,
   opts: { defaultVal: string; placeholder?: string }
 ) {
+  // Cache the settingStore once
+  const settingStore = useSettingStore()
+
   const inputEl = document.createElement('textarea')
   inputEl.className = 'comfy-multiline-input'
   inputEl.value = opts.defaultVal
@@ -54,7 +57,8 @@ function addMultilineWidget(
   })
 
   inputEl.addEventListener('wheel', (event: WheelEvent) => {
-    const gesturesEnabled = useSettingStore().get(
+    // Use the cached settingStore
+    const gesturesEnabled = settingStore.get(
       'LiteGraph.Pointer.TrackpadGestures'
     )
     const deltaX = event.deltaX

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -5,16 +5,11 @@ import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
 
-const TRACKPAD_DETECTION_THRESHOLD = 50
-
 function addMultilineWidget(
   node: LGraphNode,
   name: string,
   opts: { defaultVal: string; placeholder?: string }
 ) {
-  // Cache the settingStore once
-  const settingStore = useSettingStore()
-
   const inputEl = document.createElement('textarea')
   inputEl.className = 'comfy-multiline-input'
   inputEl.value = opts.defaultVal
@@ -57,10 +52,6 @@ function addMultilineWidget(
   })
 
   inputEl.addEventListener('wheel', (event: WheelEvent) => {
-    // Use the cached settingStore
-    const gesturesEnabled = settingStore.get(
-      'LiteGraph.Pointer.TrackpadGestures'
-    )
     const deltaX = event.deltaX
     const deltaY = event.deltaY
 
@@ -69,20 +60,6 @@ function addMultilineWidget(
 
     // Prevent pinch zoom from zooming the page
     if (event.ctrlKey) {
-      event.preventDefault()
-      event.stopPropagation()
-      app.canvas.processMouseWheel(event)
-      return
-    }
-
-    // Detect if this is likely a trackpad gesture vs mouse wheel
-    // Trackpads usually have deltaX or smaller deltaY values (< TRACKPAD_DETECTION_THRESHOLD)
-    // Mouse wheels typically have larger discrete deltaY values (>= TRACKPAD_DETECTION_THRESHOLD)
-    const isLikelyTrackpad =
-      Math.abs(deltaX) > 0 || Math.abs(deltaY) < TRACKPAD_DETECTION_THRESHOLD
-
-    // Trackpad gestures: when enabled, trackpad panning goes to canvas
-    if (gesturesEnabled && isLikelyTrackpad) {
       event.preventDefault()
       event.stopPropagation()
       app.canvas.processMouseWheel(event)


### PR DESCRIPTION
## Summary

Fixes canvas interaction issues in "Markdown" and "Text Preview" widgets by properly delegating wheel and pointer events to the canvas interaction system, preventing interaction blocking.

## Changes

- **What**: Added event handlers to delegate wheel and pointer events from widgets to the canvas interaction system
  - `useMarkdownWidget.ts`: Implemented comprehensive wheel handling with trackpad detection, pinch zoom prevention, and proper vertical scroll delegation
  - `TextPreviewWidget.vue`: Added wheel and pointerdown handlers using `useCanvasInteractions` composable

## Screenshots

### Before:

https://github.com/user-attachments/assets/ca874217-8c7c-4229-922a-2b6f10a8ac9e


### After:

https://github.com/user-attachments/assets/4fd07590-2fb7-4657-a572-2cc37921d64f

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7907-Fix-Markdown-and-Text-Preview-widgets-mouse-events-2e26d73d3650812bb512ea2e2b6f8237) by [Unito](https://www.unito.io)
