### PR TITLE
fix: Button sizing in modals and asset browser

### DIFF
--- a/src/components/widget/layout/BaseModalLayout.vue
+++ b/src/components/widget/layout/BaseModalLayout.vue
@@ -13,10 +13,11 @@
       <i class="icon-[lucide--panel-right] text-sm" />
     </Button>
     <Button
-      class="absolute top-4 right-6 z-10 transition-opacity duration-200"
+      size="lg"
+      class="absolute top-4 right-6 z-10 transition-opacity duration-200 w-10"
       @click="closeDialog"
     >
-      <i class="pi pi-times text-sm"></i>
+      <i class="pi pi-times" />
     </Button>
     <div class="flex h-full w-full">
       <Transition name="slide-panel">

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -32,7 +32,7 @@
         <Button
           v-if="isUploadButtonEnabled"
           variant="primary"
-          :size="breakpoints.md ? 'md' : 'icon'"
+          :size="breakpoints.md ? 'lg' : 'icon'"
           data-attr="upload-model-button"
           @click="showUploadDialog"
         >


### PR DESCRIPTION
## Summary

Fix button sizing inconsistencies in modal dialogs and the asset browser.

## Changes

- **What**: Fix Import button using responsive size (`lg`/`icon` based on breakpoint) and ensure Modal Close button has explicit `w-10` width for consistent sizing.

## Review Focus

Button sizing consistency across the modal UI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7920-fix-Button-sizing-in-modals-and-asset-browser-2e36d73d365081fc997af8be1e928049) by [Unito](https://www.unito.io)
