### PR TITLE
fix: remove negative margin from legacy widget canvas

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
@@ -104,7 +104,7 @@ function handleMove(e: PointerEvent) {
   >
     <canvas
       ref="canvasEl"
-      class="absolute mt-[-13px] w-full cursor-crosshair"
+      class="absolute w-full cursor-crosshair"
       @pointerdown="handleDown"
       @pointerup="handleUp"
       @pointermove="handleMove"


### PR DESCRIPTION
## Summary

Removes mt-[-13px] from WidgetLegacy canvas to fix legacy widgets overlapping with output slots in vueNodes mode.

## Screenshots
before
<img width="2560" height="939" alt="image" src="https://github.com/user-attachments/assets/cbee2bee-b6b2-4d21-b1b6-78d1a8e09949" />

after
<img width="1213" height="920" alt="image" src="https://github.com/user-attachments/assets/a3a26514-b425-4771-b234-06da65f525bc" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7925-fix-remove-negative-margin-from-legacy-widget-canvas-2e36d73d36508113aea4f2301cccff3c) by [Unito](https://www.unito.io)
