### PR TITLE
feat: add relative positioning to queue toggle button in TopMenuSection

### DIFF
--- a/src/components/TopMenuSection.vue
+++ b/src/components/TopMenuSection.vue
@@ -49,6 +49,7 @@
             :aria-label="
               t('sideToolbar.queueProgressOverlay.expandCollapsedQueue')
             "
+            class="relative"
             @click="toggleQueueOverlay"
           >
             <i class="icon-[lucide--history] size-4" />


### PR DESCRIPTION
## Summary

Fix queue history badge positioning by anchoring it to the button container so the count renders in the expected spot.

## Changes

- **What**: Add relative positioning to the queue history button to correctly place the queued count badge.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

Confirm queued count badge alignment across layouts and states (hover/expanded).

## Screenshots (if applicable)

![Untitled 4](https://github.com/user-attachments/assets/860658db-9cb4-4ef7-b61e-7bbae422c81d)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7929-feat-add-relative-positioning-to-queue-toggle-button-in-TopMenuSection-2e36d73d365081228310e1ee2fa44f0c) by [Unito](https://www.unito.io)
