### PR TITLE
fix: respect node resizable property in vueNodes mode

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -75,6 +75,7 @@ export interface VueNodeData {
   hasErrors?: boolean
   inputs?: INodeInputSlot[]
   outputs?: INodeOutputSlot[]
+  resizable?: boolean
   shape?: number
   subgraphId?: string | null
   titleMode?: TitleMode
@@ -325,6 +326,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
       flags: node.flags ? { ...node.flags } : undefined,
       color: node.color || undefined,
       bgcolor: node.bgcolor || undefined,
+      resizable: node.resizable,
       shape: node.shape
     }
   }

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -124,7 +124,7 @@
 
     <!-- Resize handle (bottom-right only) -->
     <div
-      v-if="!isCollapsed"
+      v-if="!isCollapsed && nodeData.resizable !== false"
       role="button"
       :aria-label="t('g.resizeFromBottomRight')"
       :class="cn(baseResizeHandleClasses, 'right-0 bottom-0 cursor-se-resize')"
@@ -341,6 +341,7 @@ const handleResizePointerDown = (event: PointerEvent) => {
   if (event.button !== 0) return
   if (!shouldHandleNodePointerEvents.value) return
   if (nodeData.flags?.pinned) return
+  if (nodeData.resizable === false) return
   startResize(event)
 }
 


### PR DESCRIPTION
## Summary
Custom nodes like ComfyUI-KJNodes set `this.resizable = false` to disable resizing. This worked in litegraph but was ignored in vueNodes mode.

Extract the resizable property from LGraphNode to VueNodeData and use it to conditionally render the resize handle and block resize interactions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7934-fix-respect-node-resizable-property-in-vueNodes-mode-2e36d73d365081a0a92ade8b23ee3ce8) by [Unito](https://www.unito.io)
