### PR TITLE
fix: stop pointer/mouse event propagation in vueNodes widget containers

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
@@ -24,5 +24,13 @@ onMounted(() => {
 })
 </script>
 <template>
-  <div ref="domEl" />
+  <div
+    ref="domEl"
+    @pointerdown.stop
+    @pointermove.stop
+    @pointerup.stop
+    @mousedown.stop
+    @mousemove.stop
+    @mouseup.stop
+  />
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
@@ -105,9 +105,9 @@ function handleMove(e: PointerEvent) {
     <canvas
       ref="canvasEl"
       class="absolute w-full cursor-crosshair"
-      @pointerdown="handleDown"
-      @pointerup="handleUp"
-      @pointermove="handleMove"
+      @pointerdown.stop="handleDown"
+      @pointerup.stop="handleUp"
+      @pointermove.stop="handleMove"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
Prevents custom widget drag interactions from triggering node drag in vueNodes mode. Custom plugins like KJNodes Points Editor use their own drag handlers which were bubbling up to the node container.

## Screenshots (if applicable)
before


https://github.com/user-attachments/assets/bc4c3095-d454-45f6-a4ec-60178e8f47df


after

https://github.com/user-attachments/assets/a32a5591-120e-4842-a0e0-3dd972127376

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7953-fix-stop-pointer-mouse-event-propagation-in-vueNodes-widget-containers-2e56d73d3650810398f2c582a91d767b) by [Unito](https://www.unito.io)
