### PR TITLE
fix protovis coordinate calculation for DOM widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
@@ -2,6 +2,7 @@
 import { onMounted, ref } from 'vue'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useProtovisCoordinate } from '@/renderer/extensions/vueNodes/widgets/composables/useProtovisCoordinate'
 import { isDOMWidget } from '@/scripts/domWidget'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -21,16 +22,11 @@ onMounted(() => {
   const widget = node.widgets?.find((w) => w.name === props.widget.name)
   if (!widget || !isDOMWidget(widget)) return
   domEl.value.replaceChildren(widget.element)
+
+  // Apply protovis coordinate fix if this widget uses protovis
+  useProtovisCoordinate(domEl.value)
 })
 </script>
 <template>
-  <div
-    ref="domEl"
-    @pointerdown.stop
-    @pointermove.stop
-    @pointerup.stop
-    @mousedown.stop
-    @mousemove.stop
-    @mouseup.stop
-  />
+  <div ref="domEl" @pointerdown.stop @pointermove.stop @pointerup.stop />
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/composables/useProtovisCoordinate.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useProtovisCoordinate.ts
@@ -1,0 +1,115 @@
+/**
+ * Composable to fix protovis coordinate calculation in vueNodes mode.
+ *
+ * Problem: Protovis calculates mouse position using pageX/pageY minus the offsetParent chain.
+ * But CSS transform on TransformPane changes where elements appear visually without
+ * affecting offsetLeft/offsetTop.
+ *
+ * Solution: Patch pv.Mark.prototype.mouse to use getBoundingClientRect() which accounts
+ * for CSS transforms, then apply protovis internal transforms.
+ */
+
+interface PvTransform {
+  k: number
+  x: number
+  y: number
+  translate: (x: number, y: number) => PvTransform
+  times: (t: PvTransform) => PvTransform
+  invert: () => PvTransform
+}
+
+interface PvMark {
+  mouse: () => { x: number; y: number }
+  root: { canvas: () => HTMLElement }
+  parent: PvMark | null
+  properties: { transform?: unknown }
+  left: () => number
+  top: () => number
+  transform: () => PvTransform
+}
+
+interface Pv {
+  Mark: { prototype: PvMark }
+  Transform: { identity: PvTransform }
+  event: MouseEvent | null
+  vector: (x: number, y: number) => { x: number; y: number }
+}
+
+let originalMouseFn: (() => { x: number; y: number }) | null = null
+
+const DATA_ATTR = 'data-vue-dom-widget-protovis'
+
+function patchProtovisMouse() {
+  const pv = (window as unknown as { pv?: Pv }).pv
+  if (!pv?.Mark?.prototype?.mouse) return
+
+  if (originalMouseFn) return
+  originalMouseFn = pv.Mark.prototype.mouse
+
+  pv.Mark.prototype.mouse = function (this: PvMark) {
+    const e = pv.event
+    if (!e) return pv.vector(0, 0)
+
+    const svgCanvas = this.root.canvas()
+    if (!svgCanvas) return pv.vector(0, 0)
+
+    const widgetContainer = svgCanvas.closest(`[${DATA_ATTR}]`)
+    if (!widgetContainer) {
+      // Not in vueNodes mode or not a protovis widget, use original calculation
+      return originalMouseFn!.call(this)
+    }
+
+    const rect = svgCanvas.getBoundingClientRect()
+
+    const b = e.clientX - rect.left
+    const c = e.clientY - rect.top
+
+    let d: PvTransform = pv.Transform.identity
+    const markWithTransform = this.properties.transform ? this : this.parent
+    const marks: PvMark[] = []
+    let current: PvMark | null = markWithTransform
+    while (current) {
+      marks.push(current)
+      current = current.parent
+    }
+    for (let i = marks.length - 1; i >= 0; i--) {
+      const mark = marks[i]
+      d = d.translate(mark.left(), mark.top()).times(mark.transform())
+    }
+    d = d.invert()
+
+    return pv.vector(b * d.k + d.x, c * d.k + d.y)
+  }
+}
+
+/**
+ * Check if a DOM element contains protovis content.
+ * Protovis creates SVG elements with specific class patterns.
+ */
+function hasProtovisContent(element: HTMLElement): boolean {
+  const pv = (window as unknown as { pv?: Pv }).pv
+  if (!pv) return false
+
+  const svg = element.querySelector('svg')
+  if (!svg) return false
+
+  return (
+    svg.querySelector('g[transform]') !== null ||
+    svg.querySelector('circle') !== null ||
+    svg.querySelector('path') !== null
+  )
+}
+
+/**
+ * Apply protovis coordinate fix to a DOM widget container.
+ * Call this in onMounted after the widget element is added.
+ */
+export function useProtovisCoordinate(element: HTMLElement | undefined) {
+  if (!element) return
+
+  if (!hasProtovisContent(element)) return
+
+  element.setAttribute(DATA_ATTR, 'true')
+
+  patchProtovisMouse()
+}


### PR DESCRIPTION
## Summary

Fixes drag interaction in protovis-based widgets (like KJNodes Spline Editor and Points Editor) when running in vueNodes mode.

Problem: Protovis calculates mouse position using pageX/pageY minus the offsetParent chain, but CSS transform on TransformPane changes visual position without affecting offsetLeft/offsetTop.

Solution:
- Add useProtovisCoordinate composable that patches pv.Mark.prototype.mouse
- Use getBoundingClientRect() which accounts for CSS transforms
- Only apply patch when widget contains protovis content
- Stop pointer events (not mouse events) to prevent node drag while
  allowing protovis mouse events to propagate

Need KJNodes PR https://github.com/kijai/ComfyUI-KJNodes/pull/497 merged

## Screenshots (if applicable)
Before

https://github.com/user-attachments/assets/8494ef2f-5185-4d47-8fb6-7ffe5d9a93d1

After

https://github.com/user-attachments/assets/daff7445-a4b2-4e6a-8470-b1fc28bb8b26

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7963-fix-protovis-coordinate-calculation-for-DOM-widgets-2e66d73d3650810db7ebe91c279def5b) by [Unito](https://www.unito.io)
