### PR TITLE
Road to No Explicit Any Part 4: LiteGraph Cleanup

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -842,8 +842,13 @@ export class LGraph
     if (!list_of_graphcanvas) return
 
     for (const c of list_of_graphcanvas) {
-      // eslint-disable-next-line prefer-spread
-      c[action]?.apply(c, params)
+      const method = c[action]
+       
+      if (typeof method === 'function') {
+        const args =
+          params == null ? [] : Array.isArray(params) ? params : [params]
+        ;(method as (...args: unknown[]) => unknown).apply(c, args)
+      }
     }
   }
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -843,7 +843,7 @@ export class LGraph
 
     for (const c of list_of_graphcanvas) {
       const method = c[action]
-       
+
       if (typeof method === 'function') {
         const args =
           params == null ? [] : Array.isArray(params) ? params : [params]

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -237,6 +237,15 @@ interface ICreatePanelOptions {
   height?: number | string
 }
 
+interface SlotTypeDefaultNodeOpts {
+  node?: string
+  title?: string
+  properties?: Record<string, NodeProperty>
+  inputs?: [string, string][]
+  outputs?: [string, string][]
+  json?: Parameters<LGraphNode['configure']>[0]
+}
+
 const cursors = {
   NE: 'nesw-resize',
   SE: 'nwse-resize',
@@ -6379,15 +6388,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         nodeNewType = slotTypesDefault[fromSlotType]
       }
       if (nodeNewType) {
-        interface SlotTypeDefaultNodeOpts {
-          node?: string
-          title?: string
-          properties?: Record<string, NodeProperty>
-          inputs?: [string, string][]
-          outputs?: [string, string][]
-          json?: Parameters<LGraphNode['configure']>[0]
-        }
-
         let nodeNewOpts: SlotTypeDefaultNodeOpts | undefined
         let nodeTypeStr: string
         if (typeof nodeNewType == 'object') {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6417,7 +6417,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
             if (nodeNewOpts.inputs) {
               newNode.inputs = []
               for (const input of nodeNewOpts.inputs) {
-                newNode.addOutput(input[0], input[1])
+                newNode.addInput(input[0], input[1])
               }
             }
             if (nodeNewOpts.outputs) {
@@ -7249,13 +7249,13 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         const filter = graphcanvas.filter || graphcanvas.graph.filter
 
         // filter by type preprocess
-        let sIn: HTMLInputElement | null = null
-        let sOut: HTMLInputElement | null = null
+        let sIn: HTMLSelectElement | null = null
+        let sOut: HTMLSelectElement | null = null
         if (options.do_type_filter && that.search_box) {
-          sIn = that.search_box.querySelector<HTMLInputElement>(
+          sIn = that.search_box.querySelector<HTMLSelectElement>(
             '.slot_in_type_filter'
           )
-          sOut = that.search_box.querySelector<HTMLInputElement>(
+          sOut = that.search_box.querySelector<HTMLSelectElement>(
             '.slot_out_type_filter'
           )
         }

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -7817,7 +7817,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         value_element.textContent = str_value ?? ''
 
         value_element.addEventListener('click', function (event) {
-          const values = (options?.values || []) as string[]
+          const values = options?.values || []
           const propname = this.parentElement?.dataset['property']
           const inner_clicked = (v?: string) => {
             this.textContent = v ?? null

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -41,6 +41,7 @@ import type {
   INodeSlotContextItem,
   IPinnable,
   ISlotType,
+  Panel,
   Point,
   Positionable,
   ReadOnlyRect,
@@ -98,7 +99,10 @@ export type NodeProperty = string | number | boolean | object
 interface INodePropertyInfo {
   name: string
   type?: string
-  default_value: NodeProperty | undefined
+  default_value?: NodeProperty
+  widget?: string
+  label?: string
+  values?: TWidgetValue[]
 }
 
 interface IMouseOverData {
@@ -606,8 +610,8 @@ export class LGraphNode
     target_slot: number,
     requested_slot?: number | string
   ): number | false | null
-  onShowCustomPanelInfo?(this: LGraphNode, panel: any): void
-  onAddPropertyToPanel?(this: LGraphNode, pName: string, panel: any): boolean
+  onShowCustomPanelInfo?(this: LGraphNode, panel: Panel): void
+  onAddPropertyToPanel?(this: LGraphNode, pName: string, panel: Panel): boolean
   onWidgetChanged?(
     this: LGraphNode,
     name: string,
@@ -667,8 +671,7 @@ export class LGraphNode
     index: number,
     e: CanvasPointerEvent
   ): void
-  // TODO: Return type
-  onGetPropertyInfo?(this: LGraphNode, property: string): any
+  onGetPropertyInfo?(this: LGraphNode, property: string): INodePropertyInfo
   onNodeOutputAdd?(this: LGraphNode, value: unknown): void
   onNodeInputAdd?(this: LGraphNode, value: unknown): void
   onMenuNodeInputs?(

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -97,7 +97,7 @@ export type NodeId = number | string
 export type NodeProperty = string | number | boolean | object
 
 interface INodePropertyInfo {
-  name: string
+  name?: string
   type?: string
   default_value?: NodeProperty
   widget?: string

--- a/src/lib/litegraph/src/contextMenuCompat.ts
+++ b/src/lib/litegraph/src/contextMenuCompat.ts
@@ -81,6 +81,7 @@ class LegacyMenuCompat {
         return currentImpl
       },
       set: (newImpl: LGraphCanvas[K]) => {
+        if (!newImpl) return
         const fnKey = `${methodName as string}:${newImpl.toString().slice(0, 100)}`
         if (!this.hasWarned.has(fnKey) && this.currentExtension) {
           this.hasWarned.add(fnKey)

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -511,7 +511,7 @@ export interface PanelWidgetOptions {
   label?: string
   type?: string
   widget?: string
-  values?: unknown[]
+  values?: Array<string | IContextMenuValue<unknown, unknown, unknown> | null>
   callback?: PanelWidgetCallback
   [key: string]: unknown
 }

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -1,5 +1,6 @@
 import type { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
 
 import type { ContextMenu } from './ContextMenu'
 import type { LGraphNode, NodeId } from './LGraphNode'
@@ -492,4 +493,70 @@ export interface Hoverable extends HasBoundingRect {
   onPointerMove(e: CanvasPointerEvent): void
   onPointerEnter?(e?: CanvasPointerEvent): void
   onPointerLeave?(e?: CanvasPointerEvent): void
+}
+
+/**
+ * Callback for panel widget value changes.
+ */
+export type PanelWidgetCallback = (
+  name: string | undefined,
+  value: TWidgetValue,
+  options: PanelWidgetOptions
+) => void
+
+/**
+ * Options for panel widgets.
+ */
+export interface PanelWidgetOptions {
+  label?: string
+  type?: string
+  widget?: string
+  values?: unknown[]
+  callback?: PanelWidgetCallback
+  [key: string]: unknown
+}
+
+/**
+ * A button element with optional options property.
+ */
+export interface PanelButton extends HTMLButtonElement {
+  options?: unknown
+}
+
+/**
+ * A widget element with options and value properties.
+ */
+export interface PanelWidget extends HTMLDivElement {
+  options?: PanelWidgetOptions
+  value?: TWidgetValue
+}
+
+/**
+ * A dialog panel created by LGraphCanvas.createPanel().
+ * Extends HTMLDivElement with additional properties and methods for panel management.
+ */
+export interface Panel extends HTMLDivElement {
+  header: HTMLElement
+  title_element: HTMLSpanElement
+  content: HTMLDivElement
+  alt_content: HTMLDivElement
+  footer: HTMLDivElement
+  node?: LGraphNode
+  onOpen?: () => void
+  onClose?: () => void
+  close(): void
+  toggleAltContent(force?: boolean): void
+  toggleFooterVisibility(force?: boolean): void
+  clear(): void
+  addHTML(code: string, classname?: string, on_footer?: boolean): HTMLDivElement
+  addButton(name: string, callback: () => void, options?: unknown): PanelButton
+  addSeparator(): void
+  addWidget(
+    type: string,
+    name: string,
+    value: TWidgetValue,
+    options?: PanelWidgetOptions,
+    callback?: PanelWidgetCallback
+  ): PanelWidget
+  inner_showCodePad?(property: string): void
 }

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -513,7 +513,6 @@ export interface PanelWidgetOptions {
   widget?: string
   values?: Array<string | IContextMenuValue<unknown, unknown, unknown> | null>
   callback?: PanelWidgetCallback
-  [key: string]: unknown
 }
 
 /**

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -195,7 +195,7 @@ export abstract class SubgraphIONodeBase<
     if (!(options.length > 0)) return
 
     new LiteGraph.ContextMenu(options, {
-      event: event as any,
+      event,
       title: slot.name || 'Subgraph Output',
       callback: (item: IContextMenuValue) => {
         this.#onSlotMenuAction(item, slot, event)


### PR DESCRIPTION
## Summary
- Remove all remaining `any` types from LiteGraph module
- Define proper `Panel` interface for createPanel function and related callbacks
- Type `SlotTypeDefaultNodeOpts` for slot type defaults configuration
- Fix type inference issues in sendActionToCanvas and contextMenuCompat

## Changes
- **SubgraphIONodeBase.ts**: Remove unnecessary `as any` cast in showSlotContextMenu
- **interfaces.ts**: Add Panel, PanelButton, PanelWidget, PanelWidgetOptions, PanelWidgetCallback types
- **LGraphNode.ts**: Type panel callbacks (onShowCustomPanelInfo, onAddPropertyToPanel) and onGetPropertyInfo
- **LGraphCanvas.ts**: 
  - Type node_panel and options_panel as Panel
  - Type inner_clicked callback parameters
  - Type local variables (nodeNewType, nodeNewOpts, prevent_timeout, iS, sIn, sOut)
  - Add SlotTypeDefaultNodeOpts interface for slot type configuration
- **LGraph.ts**: Fix sendActionToCanvas type inference with proper array handling
- **contextMenuCompat.ts**: Add null guard for newImpl parameter

## Test plan
- [x] pnpm typecheck passes
- [x] pnpm lint passes
- [x] knip passes (no unused exports)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7970-Road-to-No-Explicit-Any-Part-4-LiteGraph-Cleanup-2e66d73d3650812c939bf9b2cb0ff2f5) by [Unito](https://www.unito.io)
