### PR TITLE
fix(vueNodes): sync node size changes from extensions to Vue components

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -776,8 +776,10 @@ export class LGraph
       let max_size = 100
       let y = margin + LiteGraph.NODE_TITLE_HEIGHT
       for (const node of column) {
-        node.pos[0] = layout == LiteGraph.VERTICAL_LAYOUT ? y : x
-        node.pos[1] = layout == LiteGraph.VERTICAL_LAYOUT ? x : y
+        node.setPos(
+          layout == LiteGraph.VERTICAL_LAYOUT ? y : x,
+          layout == LiteGraph.VERTICAL_LAYOUT ? x : y
+        )
         const max_size_index = layout == LiteGraph.VERTICAL_LAYOUT ? 1 : 0
         if (node.size[max_size_index] > max_size) {
           max_size = node.size[max_size_index]
@@ -1759,7 +1761,10 @@ export class LGraph
     )
 
     //Correct for title height. It's included in bounding box, but not _posSize
-    subgraphNode.pos[1] += LiteGraph.NODE_TITLE_HEIGHT / 2
+    subgraphNode.setPos(
+      subgraphNode.pos[0],
+      subgraphNode.pos[1] + LiteGraph.NODE_TITLE_HEIGHT / 2
+    )
 
     // Add the subgraph node to the graph
     this.add(subgraphNode)
@@ -1926,8 +1931,7 @@ export class LGraph
 
       this.add(node, true)
       node.configure(n_info)
-      node.pos[0] += offsetX
-      node.pos[1] += offsetY
+      node.setPos(node.pos[0] + offsetX, node.pos[1] + offsetY)
       for (const input of node.inputs) {
         input.link = null
       }

--- a/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
@@ -13,7 +13,9 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
     querySlotAtPoint: vi.fn(),
     queryRerouteAtPoint: vi.fn(),
     getNodeLayoutRef: vi.fn(() => ({ value: null })),
-    getSlotLayout: vi.fn()
+    getSlotLayout: vi.fn(),
+    setSource: vi.fn(),
+    batchUpdateNodeBounds: vi.fn()
   }
 }))
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -490,6 +490,17 @@ export class LGraphNode
 
     this._pos[0] = value[0]
     this._pos[1] = value[1]
+
+    const mutations = useLayoutMutations()
+    mutations.setSource(LayoutSource.Canvas)
+    mutations.moveNode(String(this.id), { x: value[0], y: value[1] })
+  }
+
+  /**
+   * Set the node position to an absolute location.
+   */
+  setPos(x: number, y: number): void {
+    this.pos = [x, y]
   }
 
   public get size() {
@@ -501,6 +512,13 @@ export class LGraphNode
 
     this._size[0] = value[0]
     this._size[1] = value[1]
+
+    const mutations = useLayoutMutations()
+    mutations.setSource(LayoutSource.Canvas)
+    mutations.resizeNode(String(this.id), {
+      width: value[0],
+      height: value[1]
+    })
   }
 
   /**
@@ -2032,8 +2050,7 @@ export class LGraphNode
       return
     }
 
-    this.pos[0] += deltaX
-    this.pos[1] += deltaY
+    this.pos = [this._pos[0] + deltaX, this._pos[1] + deltaY]
   }
 
   /**

--- a/src/lib/litegraph/src/utils/arrange.ts
+++ b/src/lib/litegraph/src/utils/arrange.ts
@@ -138,8 +138,7 @@ export function alignNodes(
   })
 
   for (const { node, newPos } of nodePositions) {
-    node.pos[0] = newPos.x
-    node.pos[1] = newPos.y
+    node.setPos(newPos.x, newPos.y)
   }
   return nodePositions
 }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -555,7 +555,7 @@ export class ComfyApp {
         try {
           workspace.spinner = true
           if (fileMaybe instanceof File) {
-              await this.handleFile(fileMaybe, 'file_drop')
+            await this.handleFile(fileMaybe, 'file_drop')
           }
 
           if (fileMaybe instanceof FileList) {
@@ -1575,7 +1575,6 @@ export class ComfyApp {
     this.showErrorOnFileLoad(file)
   }
 
-
   /**
    * Loads multiple files, connects to a batch node, and selects them
    * @param {FileList} fileList
@@ -1602,19 +1601,19 @@ export class ComfyApp {
    */
   positionBatchNodes(nodes: LGraphNode[], batchNode: LGraphNode): void {
     const [x, y, width] = nodes[0].getBounding()
-    batchNode.pos = [ x + width + 100, y + 30 ]
+    batchNode.pos = [x + width + 100, y + 30]
 
     // Retrieving Node Height is inconsistent
-    let height = 0;
+    let height = 0
     if (nodes[0].type === 'LoadImage') {
       height = 344
     }
 
     nodes.forEach((node, index) => {
       if (index > 0) {
-        node.pos = [ x, y + (height * index) + (25 * (index + 1)) ]
+        node.pos = [x, y + height * index + 25 * (index + 1)]
       }
-    });
+    })
 
     this.canvas.graph?.change()
   }


### PR DESCRIPTION
## Summary
When extensions like KJNodes call node.setSize(), the Vue component now properly updates its CSS variables to reflect the new size.

## Changes:
- LGraphNode pos/size setters now always sync to layoutStore with Canvas source
- LGraphNode.vue listens to layoutStore changes and updates CSS variables
- Fixed height calculation to account for NODE_TITLE_HEIGHT difference
- Removed _syncToLayoutStore flag (simplified - layoutStore ignores non-existent nodes)
- Use setPos() helper method instead of direct pos[0]/pos[1] assignment

## Screenshots (if applicable)
before
https://github.com/user-attachments/assets/236a173a-e41d-485b-8c63-5c28ef1c69bf


after
https://github.com/user-attachments/assets/5fc3f7e4-35c7-40e1-81ac-38a35ee0ac1b

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-7993-fix-vueNodes-sync-node-size-changes-from-extensions-to-Vue-components-2e76d73d3650815799c5f2d9d8c7dcbf) by [Unito](https://www.unito.io)
