### PR TITLE
perf(ci): remove unnecessary pnpm install from merge-reports job

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -144,6 +144,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Download blob reports
         uses: actions/download-artifact@v4
         with:
@@ -154,10 +159,10 @@ jobs:
       - name: Merge into HTML Report
         run: |
           # Generate HTML report
-          npx @playwright/test merge-reports --reporter=html ./all-blob-reports
+          pnpm dlx @playwright/test merge-reports --reporter=html ./all-blob-reports
           # Generate JSON report separately with explicit output path
           PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json \
-          npx @playwright/test merge-reports --reporter=json ./all-blob-reports
+          pnpm dlx @playwright/test merge-reports --reporter=json ./all-blob-reports
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -144,10 +144,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      # Setup pnpm/node to run playwright merge-reports (no browsers needed)
-      - name: Setup frontend
-        uses: ./.github/actions/setup-frontend
-
       - name: Download blob reports
         uses: actions/download-artifact@v4
         with:
@@ -158,10 +154,10 @@ jobs:
       - name: Merge into HTML Report
         run: |
           # Generate HTML report
-          pnpm exec playwright merge-reports --reporter=html ./all-blob-reports
+          npx @playwright/test merge-reports --reporter=html ./all-blob-reports
           # Generate JSON report separately with explicit output path
           PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json \
-          pnpm exec playwright merge-reports --reporter=json ./all-blob-reports
+          npx @playwright/test merge-reports --reporter=json ./all-blob-reports
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Remove `setup-frontend` action from `merge-reports` job
- Use `npx @playwright/test` instead of `pnpm exec playwright`

## Why
The `merge-reports` job was spending ~16-18s on `pnpm install` just to run a CLI command that takes ~3s. Since `npx` is pre-installed on GitHub runners, we can eliminate the setup overhead entirely.

**Expected savings: ~16-18 seconds per CI run**

## Test Plan
- [ ] Verify merge-reports job completes successfully
- [ ] Verify HTML report is generated and uploaded correctly
- [ ] Compare job timing before/after

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8030-perf-ci-remove-unnecessary-pnpm-install-from-merge-reports-job-2e76d73d36508134b3e6c11726170f64) by [Unito](https://www.unito.io)
