### PR TITLE
fix: version mismatch warning appearing in Playwright tests despite DisableWarnings setting

### DIFF
--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.ts
@@ -1,5 +1,5 @@
 import { whenever } from '@vueuse/core'
-import { computed, onMounted } from 'vue'
+import { computed, nextTick, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useToastStore } from './toastStore'
@@ -65,9 +65,12 @@ export function useFrontendVersionMismatchWarning(
     versionCompatibilityStore.dismissWarning()
   }
 
-  onMounted(() => {
+  onMounted(async () => {
     // Only set up the watcher if immediate is true
     if (immediate) {
+      // Wait for next tick to ensure reactive updates from settings load have propagated
+      await nextTick()
+
       whenever(
         () => versionCompatibilityStore.shouldShowWarning,
         () => {

--- a/src/platform/updates/common/versionCompatibilityStore.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.ts
@@ -88,11 +88,16 @@ export const useVersionCompatibilityStore = defineStore(
       return Date.now() < dismissedUntil
     })
 
+    const warningsDisabled = computed(() =>
+      settingStore.get('Comfy.VersionCompatibility.DisableWarnings')
+    )
+
     const shouldShowWarning = computed(() => {
-      const warningsDisabled = settingStore.get(
-        'Comfy.VersionCompatibility.DisableWarnings'
+      return (
+        hasVersionMismatch.value &&
+        !isDismissed.value &&
+        !warningsDisabled.value
       )
-      return hasVersionMismatch.value && !isDismissed.value && !warningsDisabled
     })
 
     const warningMessage = computed(() => {


### PR DESCRIPTION
PR #7004 added a setting to disable version warnings in e2e tests, but it wasn't working on release branches. The issue was a race condition (hypothesis): the version check ran before settings finished loading from the backend, so the DisableWarnings setting read its default value (false) instead of the configured value (true).

Fixed by making the warningsDisabled check reactive so it updates when settings load and adding `nextTick` (settings are loaded, but ref updates flush in a microtask. The immediate `whenever` runs before that flush, so computeds may see stale/default values -- `nextTick` waits for reactive microtasks to flush, so computeds will be correct. It's fine).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8036-fix-version-mismatch-warning-appearing-in-Playwright-tests-despite-DisableWarnings-setti-2e86d73d36508132b4d1fd73ade76e63) by [Unito](https://www.unito.io)
