### PR TITLE
refactor: centralized node mode management to layoutStore

### DIFF
--- a/src/components/rightSidePanel/settings/SetNodeState.vue
+++ b/src/components/rightSidePanel/settings/SetNodeState.vue
@@ -4,44 +4,41 @@ import { useI18n } from 'vue-i18n'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import FormSelectButton from '@/renderer/extensions/vueNodes/widgets/components/form/FormSelectButton.vue'
 
 import LayoutField from './LayoutField.vue'
 
-/**
- * Good design limits dependencies and simplifies the interface of the abstraction layer.
- * Here, we only care about the mode method,
- * and do not concern ourselves with other methods.
- */
-type PickedNode = Pick<LGraphNode, 'mode'>
-
-const { nodes } = defineProps<{ nodes: PickedNode[] }>()
+const { nodes } = defineProps<{ nodes: LGraphNode[] }>()
 const emit = defineEmits<{ (e: 'changed'): void }>()
 
 const { t } = useI18n()
 
 const nodeState = computed({
   get() {
-    let mode: LGraphNode['mode'] | null = null
-
     if (nodes.length === 0) return null
 
-    // For multiple nodes, if all nodes have the same mode, return that mode, otherwise return null
-    if (nodes.length > 1) {
-      mode = nodes[0].mode
-      if (!nodes.every((node) => node.mode === mode)) {
-        mode = null
-      }
-    } else {
-      mode = nodes[0].mode
-    }
+    const nodeIds = nodes.map((node) => node.id.toString())
+    const modes = nodeIds
+      .map((nodeId) => {
+        const nodeRef = layoutStore.getNodeLayoutRef(nodeId)
+        return nodeRef.value?.mode
+      })
+      .filter((mode): mode is number => mode !== undefined && mode !== null)
 
-    return mode
+    if (modes.length === 0) return null
+
+    // For multiple nodes, if all nodes have the same mode, return that mode, otherwise return null
+    const firstMode = modes[0]
+    const allSame = modes.every((mode) => mode === firstMode)
+
+    return allSame ? firstMode : null
   },
   set(value: LGraphNode['mode']) {
-    nodes.forEach((node) => {
-      node.mode = value
-    })
+    if (value === null || value === undefined) return
+
+    const nodeIds = nodes.map((node) => node.id.toString())
+    layoutStore.setNodesMode(nodeIds, value)
     emit('changed')
   }
 })

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -8,6 +8,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { patchLGraphNodeMode } from '@/renderer/core/layout/sync/patchLGraphNodeMode'
 import { useLayoutSync } from '@/renderer/core/layout/sync/useLayoutSync'
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
 import { ensureCorrectLayoutScale } from '@/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale'
@@ -36,7 +37,8 @@ function useVueNodeLifecycleIndividual() {
       size: [node.size[0], removeNodeTitleHeight(node.size[1])] as [
         number,
         number
-      ]
+      ],
+      mode: node.mode
     }))
     layoutStore.initializeFromLiteGraph(nodes)
 
@@ -58,6 +60,9 @@ function useVueNodeLifecycleIndividual() {
         link.target_slot
       )
     }
+
+    // Patch LGraphNode.changeMode to sync with layoutStore
+    patchLGraphNodeMode()
 
     // Initialize layout sync (one-way: Layout Store → LiteGraph)
     startSync(canvasStore.canvas)

--- a/src/extensions/core/groupOptions.ts
+++ b/src/extensions/core/groupOptions.ts
@@ -7,14 +7,14 @@ import {
   LGraphGroup,
   type LGraphNode
 } from '@/lib/litegraph/src/litegraph'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyExtension } from '@/types/comfy'
 
 import { app } from '../../scripts/app'
 
 function setNodeMode(node: LGraphNode, mode: number) {
-  node.mode = mode
-  node.graph?.change()
+  layoutStore.setNodeMode(node.id.toString(), mode)
 }
 
 function addNodesToGroup(group: LGraphGroup, items: Iterable<Positionable>) {

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1325,6 +1325,9 @@ export class LGraphNode
       case LGraphEventMode.ALWAYS:
         break
 
+      case LGraphEventMode.BYPASS:
+        break
+
       // @ts-expect-error Not impl.
       case LiteGraph.ON_REQUEST:
         break

--- a/src/renderer/core/layout/operations/layoutMutations.ts
+++ b/src/renderer/core/layout/operations/layoutMutations.ts
@@ -150,6 +150,7 @@ export function useLayoutMutations(): LayoutMutations {
       size: layout.size ?? { width: 200, height: 100 },
       zIndex: layout.zIndex ?? 0,
       visible: layout.visible ?? true,
+      mode: layout.mode ?? 0, // Default to ALWAYS
       bounds: {
         x: layout.position?.x ?? 0,
         y: layout.position?.y ?? 0,

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -17,6 +17,7 @@ describe('layoutStore CRDT operations', () => {
     size: { width: 200, height: 100 },
     zIndex: 0,
     visible: true,
+    mode: 0,
     bounds: { x: 100, y: 100, width: 200, height: 100 }
   })
 

--- a/src/renderer/core/layout/sync/patchLGraphNodeMode.ts
+++ b/src/renderer/core/layout/sync/patchLGraphNodeMode.ts
@@ -1,0 +1,33 @@
+/**
+ * Patches LGraphNode.changeMode to sync with layoutStore
+ * This ensures that mode changes from LiteGraph (e.g., keyboard shortcuts, context menus)
+ * are properly synchronized to the layout store.
+ */
+import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+
+let isPatched = false
+
+/**
+ * Patches LGraphNode.prototype.changeMode to sync with layoutStore.
+ * Should be called once during application initialization.
+ */
+export function patchLGraphNodeMode(): void {
+  if (isPatched) return
+
+  const originalChangeMode = LGraphNode.prototype.changeMode
+
+  LGraphNode.prototype.changeMode = function (modeTo: number): boolean {
+    const previousMode = this.mode
+    const result = originalChangeMode.call(this, modeTo)
+
+    // Sync to layoutStore if mode actually changed and the call succeeded
+    if (result && previousMode !== this.mode) {
+      layoutStore.setNodeMode(this.id.toString(), this.mode)
+    }
+
+    return result
+  }
+
+  isPatched = true
+}

--- a/src/renderer/core/layout/sync/useLayoutSync.ts
+++ b/src/renderer/core/layout/sync/useLayoutSync.ts
@@ -53,6 +53,11 @@ export function useLayoutSync() {
           // Use setSize() to trigger onResize callback
           liteNode.setSize([layout.size.width, layout.size.height])
         }
+
+        // Sync mode to LiteGraph node
+        if (liteNode.mode !== layout.mode) {
+          liteNode.changeMode(layout.mode)
+        }
       }
 
       // Trigger single redraw for all changes

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -48,6 +48,7 @@ export interface NodeLayout {
   size: Size
   zIndex: number
   visible: boolean
+  mode: number // LGraphEventMode: 0=ALWAYS, 2=NEVER, 4=BYPASS, etc.
   // Computed bounds for hit testing
   bounds: Bounds
 }
@@ -120,6 +121,7 @@ type OperationType =
   | 'moveNode'
   | 'resizeNode'
   | 'setNodeZIndex'
+  | 'setNodeMode'
   | 'createNode'
   | 'deleteNode'
   | 'setNodeVisibility'
@@ -155,6 +157,15 @@ export interface SetNodeZIndexOperation extends NodeOpBase {
   type: 'setNodeZIndex'
   zIndex: number
   previousZIndex: number
+}
+
+/**
+ * Set node mode operation
+ */
+export interface SetNodeModeOperation extends NodeOpBase {
+  type: 'setNodeMode'
+  mode: number
+  previousMode: number
 }
 
 /**
@@ -243,6 +254,7 @@ export type LayoutOperation =
   | MoveNodeOperation
   | ResizeNodeOperation
   | SetNodeZIndexOperation
+  | SetNodeModeOperation
   | CreateNodeOperation
   | DeleteNodeOperation
   | SetNodeVisibilityOperation

--- a/src/renderer/core/layout/utils/layoutMath.test.ts
+++ b/src/renderer/core/layout/utils/layoutMath.test.ts
@@ -62,6 +62,7 @@ describe('layoutMath utils', () => {
       size: { width, height },
       zIndex: 0,
       visible: true,
+      mode: 0,
       bounds: { x, y, width, height }
     })
 

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -10,6 +10,7 @@ export const NODE_LAYOUT_DEFAULTS: NodeLayout = {
   size: { width: 100, height: 50 },
   zIndex: 0,
   visible: true,
+  mode: 0, // LGraphEventMode.ALWAYS
   bounds: { x: 0, y: 0, width: 100, height: 50 }
 }
 
@@ -20,6 +21,7 @@ export function layoutToYNode(layout: NodeLayout): NodeLayoutMap {
   ynode.set('size', layout.size)
   ynode.set('zIndex', layout.zIndex)
   ynode.set('visible', layout.visible)
+  ynode.set('mode', layout.mode)
   ynode.set('bounds', layout.bounds)
   return ynode
 }
@@ -40,6 +42,7 @@ export function yNodeToLayout(ynode: NodeLayoutMap): NodeLayout {
     size: getOr(ynode, 'size', NODE_LAYOUT_DEFAULTS.size),
     zIndex: getOr(ynode, 'zIndex', NODE_LAYOUT_DEFAULTS.zIndex),
     visible: getOr(ynode, 'visible', NODE_LAYOUT_DEFAULTS.visible),
+    mode: getOr(ynode, 'mode', NODE_LAYOUT_DEFAULTS.mode),
     bounds: getOr(ynode, 'bounds', NODE_LAYOUT_DEFAULTS.bounds)
   }
 }

--- a/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
+++ b/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
@@ -34,6 +34,7 @@ describe('MinimapDataSource', () => {
             size: { width: 100, height: 50 },
             zIndex: 0,
             visible: true,
+            mode: 0,
             bounds: { x: 0, y: 0, width: 100, height: 50 }
           }
         ]

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -80,6 +80,7 @@ const mockData = vi.hoisted(() => {
     size: { width: 100, height: 100 },
     zIndex: 1,
     visible: true,
+    mode: 0,
     bounds: {
       x: 0,
       y: 0,


### PR DESCRIPTION
related https://github.com/Comfy-Org/ComfyUI_frontend/issues/8023, https://github.com/Comfy-Org/ComfyUI_frontend/pull/7812#discussion_r2685108687



> [!IMPORTANT]
>  I encountered an issue: layoutStore is specifically designed for Nodes 2.0. After switching to layoutStore, if Nodes 2.0 is not started, it will be impossible to modify the state of Nodes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8045-refactor-centralized-node-mode-management-to-layoutStore-2e86d73d3650818fbfe5cb1930211626) by [Unito](https://www.unito.io)
