### PR TITLE
fix: preserve image preview when backend returns null output

### DIFF
--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -130,6 +130,11 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     outputs: ExecutedWsMessage['output'] | ResultItem,
     options: SetOutputOptions = {}
   ) {
+    // Skip if outputs is null/undefined - preserve existing output
+    // This can happen when backend returns null for cached/deduplicated nodes
+    // (e.g., two LoadImage nodes selecting the same image)
+    if (outputs == null) return
+
     if (options.merge) {
       const existingOutput = app.nodeOutputs[nodeLocatorId]
       if (existingOutput && outputs) {


### PR DESCRIPTION
## Summary

When two LoadImage nodes select the same image, the backend's cache mechanism returns null output for the second node (same cache signature). This was overwriting the existing image preview data.

Now skip setting outputs when null/undefined to preserve the preview.

Root cause chain https://github.com/Comfy-Org/ComfyUI/blob/07f2462eae7fa2daa34971dd1b15fd525686e958/execution.py#L421:

  1. When two LoadImage nodes select the same image, they have identical cache signatures (based on IS_CHANGED SHA256 hash + input parameters)
  2. First node executes: Actually runs load_image(), caches the result. But LoadImage's ui field is None (it only produces tensors, no UI output)
  3. Second node executes: Cache hit, directly returns cached_ui.get("output", None) = null
  4. Frontend receives null and overwrites the existing image preview

## Screenshots (if applicable)
Before

https://github.com/user-attachments/assets/7bd814f6-bf23-42cc-9fc3-fd9fec68b4f6


After

https://github.com/user-attachments/assets/b9cc6160-ea70-424e-8a3d-5dc9f244d0d0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8050-fix-preserve-image-preview-when-backend-returns-null-output-2e86d73d36508156ab32cb12a7f6b307) by [Unito](https://www.unito.io)
