### PR TITLE
refactor: consolidate guidance and add glob-based docs

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,32 +1,10 @@
-# ComfyUI Frontend - Claude Review Context
+# PR Review Context
 
-This file provides additional context for the automated PR review system.
-
-## Quick Reference
-
-### PrimeVue Component Migrations
-
-When reviewing, flag these deprecated components:
-- `Dropdown` → Use `Select` from 'primevue/select'
-- `OverlayPanel` → Use `Popover` from 'primevue/popover'
-- `Calendar` → Use `DatePicker` from 'primevue/datepicker'
-- `InputSwitch` → Use `ToggleSwitch` from 'primevue/toggleswitch'
-- `Sidebar` → Use `Drawer` from 'primevue/drawer'
-- `Chips` → Use `AutoComplete` with multiple enabled and typeahead disabled
-- `TabMenu` → Use `Tabs` without panels
-- `Steps` → Use `Stepper` without panels
-- `InlineMessage` → Use `Message` component
-
-### API Utilities Reference
-
-- `api.apiURL()` - Backend API calls (/prompt, /queue, /view, etc.)
-- `api.fileURL()` - Static file access (templates, extensions)
-- `$t()` / `i18n.global.t()` - Internationalization
-- `DOMPurify.sanitize()` - HTML sanitization
+Context for automated PR review system.
 
 ## Review Scope
 
-This automated review performs comprehensive analysis including:
+This automated review performs comprehensive analysis:
 - Architecture and design patterns
 - Security vulnerabilities
 - Performance implications

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- A rose by any other name would smell as sweet,
+     But Claude insists on files named for its own conceit. -->
+@AGENTS.md

--- a/.storybook/AGENTS.md
+++ b/.storybook/AGENTS.md
@@ -1,197 +1,28 @@
-# Storybook Development Guidelines for Claude
+# Storybook Guidelines
 
-## Quick Commands
+## Commands
 
-- `pnpm storybook`: Start Storybook development server
-- `pnpm build-storybook`: Build static Storybook
-- `pnpm test:unit`: Run unit tests (includes Storybook components)
+- `pnpm storybook`: Development server
+- `pnpm build-storybook`: Production build
 
-## Development Workflow for Storybook
+## Story Structure
 
-1. **Creating New Stories**:
-   - Place `*.stories.ts` files alongside components
-   - Follow the naming pattern: `ComponentName.stories.ts`
-   - Use realistic mock data that matches ComfyUI schemas
+Place `*.stories.ts` alongside components. See `docs/guidance/storybook.md` for patterns.
 
-2. **Testing Stories**:
-   - Verify stories render correctly in Storybook UI
-   - Test different component states and edge cases
-   - Ensure proper theming and styling
+## Mock Data
 
-3. **Code Quality**:
-   - Run `pnpm typecheck` to verify TypeScript
-   - Run `pnpm lint` to check for linting issues
-   - Follow existing story patterns and conventions
+Use realistic ComfyUI schemas (node definitions, components).
 
-## Story Creation Guidelines
+## Available Context
 
-### Basic Story Structure
-
-```typescript
-import type { Meta, StoryObj } from '@storybook/vue3'
-import ComponentName from './ComponentName.vue'
-
-const meta: Meta<typeof ComponentName> = {
-  title: 'Category/ComponentName',
-  component: ComponentName,
-  parameters: {
-    layout: 'centered' // or 'fullscreen', 'padded'
-  }
-}
-
-export default meta
-type Story = StoryObj<typeof meta>
-
-export const Default: Story = {
-  args: {
-    // Component props
-  }
-}
-```
-
-### Mock Data Patterns
-
-For ComfyUI components, use realistic mock data:
-
-```typescript
-// Node definition mock
-const mockNodeDef = {
-  input: {
-    required: {
-      prompt: ["STRING", { multiline: true }]
-    }
-  },
-  output: ["CONDITIONING"],
-  output_is_list: [false],
-  category: "conditioning"
-}
-
-// Component instance mock
-const mockComponent = {
-  id: "1",
-  type: "CLIPTextEncode",
-  // ... other properties
-}
-```
-
-### Common Story Variants
-
-Always include these story variants when applicable:
-
-- **Default**: Basic component with minimal props
-- **WithData**: Component with realistic data
-- **Loading**: Component in loading state
-- **Error**: Component with error state
-- **LongContent**: Component with edge case content
-- **Empty**: Component with no data
-
-### Storybook-Specific Code Patterns
-
-#### Store Access
-```typescript
-// In stories, access stores through the setup function
-export const WithStore: Story = {
-  render: () => ({
-    setup() {
-      const store = useMyStore()
-      return { store }
-    },
-    template: '<MyComponent :data="store.data" />'
-  })
-}
-```
-
-#### Event Testing
-```typescript
-export const WithEvents: Story = {
-  args: {
-    onUpdate: fn() // Use Storybook's fn() for action logging
-  }
-}
-```
-
-## Configuration Notes
-
-### Vue App Setup
-The Storybook preview is configured with:
-- Pinia stores initialized
-- PrimeVue with ComfyUI theme
-- i18n internationalization
-- All necessary CSS imports
-
-### Build Configuration
-- Vite integration with proper alias resolution
-- Manual chunking for better performance
-- TypeScript support with strict checking
-- CSS processing for Vue components
+Stories have access to:
+- All ComfyUI stores
+- PrimeVue with ComfyUI theming
+- i18n system
+- CSS variables and styling
 
 ## Troubleshooting
 
-### Common Issues
-
-1. **Import Errors**: Verify `@/` alias is working correctly
-2. **Missing Styles**: Ensure CSS imports are in `preview.ts`
+1. **Import Errors**: Verify `@/` alias works
+2. **Missing Styles**: Check CSS imports in `preview.ts`
 3. **Store Errors**: Check store initialization in setup
-4. **Type Errors**: Use proper TypeScript types for story args
-
-### Debug Commands
-
-```bash
-# Check TypeScript issues
-pnpm typecheck
-
-# Lint Storybook files
-pnpm lint .storybook/
-
-# Build to check for production issues
-pnpm build-storybook
-```
-
-## File Organization
-
-```
-.storybook/
-├── main.ts          # Core configuration
-├── preview.ts       # Global setup and decorators
-├── README.md        # User documentation
-└── CLAUDE.md        # This file - Claude guidelines
-
-src/
-├── components/
-│   └── MyComponent/
-│       ├── MyComponent.vue
-│       └── MyComponent.stories.ts
-```
-
-## Integration with ComfyUI
-
-### Available Context
-
-Stories have access to:
-- All ComfyUI stores (widgetStore, colorPaletteStore, etc.)
-- PrimeVue components with ComfyUI theming
-- Internationalization system
-- ComfyUI CSS variables and styling
-
-### Testing Components
-
-When testing ComfyUI-specific components:
-1. Use realistic node definitions and data structures
-2. Test with different node types (sampling, conditioning, etc.)
-3. Verify proper CSS theming and dark/light modes
-4. Check component behavior with various input combinations
-
-### Performance Considerations
-
-- Use manual chunking for large dependencies
-- Minimize bundle size by avoiding unnecessary imports
-- Leverage Storybook's lazy loading capabilities
-- Profile build times and optimize as needed
-
-## Best Practices
-
-1. **Keep Stories Focused**: Each story should demonstrate one specific use case
-2. **Use Descriptive Names**: Story names should clearly indicate what they show
-3. **Document Complex Props**: Use JSDoc comments for complex prop types
-4. **Test Edge Cases**: Create stories for unusual but valid use cases
-5. **Maintain Consistency**: Follow established patterns in existing stories

--- a/.storybook/CLAUDE.md
+++ b/.storybook/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Though standards bloom in open fields so wide,
+     Anthropic walks a path of lonely pride. -->
+@AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+See @docs/guidance/*.md for file-type-specific conventions (auto-loaded by glob).
+
 ## Project Structure & Module Organization
 
 - Source: `src/`
@@ -46,6 +48,21 @@ The project uses **Nx** for build orchestration and task management
 - `pnpm lint` / `pnpm lint:fix`: Lint (ESLint)
 - `pnpm format` / `pnpm format:check`: Prettier
 - `pnpm typecheck`: Vue TSC type checking
+- `pnpm storybook`: Start Storybook development server
+
+## Development Workflow
+
+1. Make code changes
+2. Run relevant tests
+3. Run `pnpm typecheck`, `pnpm lint`, `pnpm format`
+4. Check if README updates are needed
+5. Consider docs.comfy.org updates for user-facing changes
+
+## Git Conventions
+
+- Use `prefix:` format: `feat:`, `fix:`, `test:`
+- Add "Fixes #n" to PR descriptions
+- Never mention Claude/AI in commits
 
 ## Coding Style & Naming Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/browser_tests/AGENTS.md
+++ b/browser_tests/AGENTS.md
@@ -1,16 +1,14 @@
 # E2E Testing Guidelines
 
-## Browser Tests
-- Test user workflows
-- Use Playwright fixtures
-- Follow naming conventions
-
 ## Best Practices
-- Check assets/ for test data
+
+- Test user workflows with Playwright fixtures
+- Check `assets/` for test data
 - Prefer specific selectors
 - Test across viewports
 
 ## Testing Process
+
 After code changes:
 1. Create browser tests as appropriate
 2. Run tests until passing

--- a/browser_tests/CLAUDE.md
+++ b/browser_tests/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- In gardens where the agents freely play,
+     One stubborn flower turns the other way. -->
+@AGENTS.md

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -1,0 +1,33 @@
+---
+globs:
+  - '**/*.spec.ts'
+---
+
+# Playwright E2E Test Conventions
+
+See `docs/testing/*.md` for detailed patterns.
+
+## Best Practices
+
+- Follow [Playwright Best Practices](https://playwright.dev/docs/best-practices)
+- Do NOT use `waitForTimeout` - use Locator actions and retrying assertions
+- Prefer specific selectors (role, label, test-id)
+- Test across viewports
+
+## Test Tags
+
+Tags are respected by config:
+- `@mobile` - Mobile viewport tests
+- `@2x` - High DPI tests
+
+## Test Data
+
+- Check `browser_tests/assets/` for test data and fixtures
+- Use realistic ComfyUI workflows for E2E tests
+
+## Running Tests
+
+```bash
+pnpm test:browser                 # Run all E2E tests
+pnpm test:browser -- --ui         # Interactive UI mode
+```

--- a/docs/guidance/storybook.md
+++ b/docs/guidance/storybook.md
@@ -1,0 +1,55 @@
+---
+globs:
+  - '**/*.stories.ts'
+---
+
+# Storybook Conventions
+
+## File Placement
+
+Place `*.stories.ts` files alongside their components:
+```
+src/components/MyComponent/
+├── MyComponent.vue
+└── MyComponent.stories.ts
+```
+
+## Story Structure
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ComponentName from './ComponentName.vue'
+
+const meta: Meta<typeof ComponentName> = {
+  title: 'Category/ComponentName',
+  component: ComponentName,
+  parameters: { layout: 'centered' }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { /* props */ }
+}
+```
+
+## Required Story Variants
+
+Include when applicable:
+- **Default** - Minimal props
+- **WithData** - Realistic data
+- **Loading** - Loading state
+- **Error** - Error state
+- **Empty** - No data
+
+## Mock Data
+
+Use realistic ComfyUI schemas for mocks (node definitions, components).
+
+## Running Storybook
+
+```bash
+pnpm storybook        # Development server
+pnpm build-storybook  # Production build
+```

--- a/docs/guidance/typescript.md
+++ b/docs/guidance/typescript.md
@@ -1,0 +1,36 @@
+---
+globs:
+  - '**/*.ts'
+  - '**/*.tsx'
+---
+
+# TypeScript Conventions
+
+## Type Safety
+
+- Never use `any` type - use proper TypeScript types
+- Never use `as any` type assertions - fix the underlying type issue
+- Type assertions are a last resort; they lead to brittle code
+- Avoid `@ts-expect-error` - fix the underlying issue instead
+
+## Utility Libraries
+
+- Use `es-toolkit` for utility functions (not lodash)
+
+## API Utilities
+
+When making API calls in `src/`:
+
+```typescript
+// ✅ Correct - use api helpers
+const response = await api.get(api.apiURL('/prompt'))
+const template = await fetch(api.fileURL('/templates/default.json'))
+
+// ❌ Wrong - direct URL construction
+const response = await fetch('/api/prompt')
+```
+
+## Security
+
+- Sanitize HTML with `DOMPurify.sanitize()`
+- Never log secrets or sensitive data

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -1,0 +1,36 @@
+---
+globs:
+  - '**/*.test.ts'
+---
+
+# Vitest Unit Test Conventions
+
+See `docs/testing/*.md` for detailed patterns.
+
+## Test Quality
+
+- Do not write change detector tests (tests that just assert defaults)
+- Do not write tests dependent on non-behavioral features (styles, classes)
+- Do not write tests that just test mocks - ensure real code is exercised
+- Be parsimonious; avoid redundant tests
+
+## Mocking
+
+- Use Vitest's mocking utilities (`vi.mock`, `vi.spyOn`)
+- Keep module mocks contained - no global mutable state
+- Use `vi.hoisted()` for per-test mock manipulation
+- Don't mock what you don't own
+
+## Component Testing
+
+- Use Vue Test Utils for component tests
+- Follow advice about making components easy to test
+- Wait for reactivity with `await nextTick()` after state changes
+
+## Running Tests
+
+```bash
+pnpm test:unit                    # Run all unit tests
+pnpm test:unit -- path/to/file    # Run specific test
+pnpm test:unit -- --watch         # Watch mode
+```

--- a/docs/guidance/vue-components.md
+++ b/docs/guidance/vue-components.md
@@ -22,22 +22,6 @@ Applies to all `.vue` files anywhere in the codebase.
 - Use `defineExpose` only for imperative operations (`form.validate()`, `modal.open()`)
 - Proper props and emits definitions
 
-## PrimeVue Migrations
-
-Deprecated components and their replacements:
-
-| Deprecated | Replacement | Import Path |
-|------------|-------------|-------------|
-| `Dropdown` | `Select` | `primevue/select` |
-| `OverlayPanel` | `Popover` | `primevue/popover` |
-| `Calendar` | `DatePicker` | `primevue/datepicker` |
-| `InputSwitch` | `ToggleSwitch` | `primevue/toggleswitch` |
-| `Sidebar` | `Drawer` | `primevue/drawer` |
-| `Chips` | `AutoComplete` | `primevue/autocomplete` (with `multiple` enabled, `typeahead` disabled) |
-| `TabMenu` | `Tabs` | `primevue/tabs` (without panels) |
-| `Steps` | `Stepper` | `primevue/stepper` (without panels) |
-| `InlineMessage` | `Message` | `primevue/message` |
-
 ## VueUse Composables
 
 Prefer VueUse composables over manual event handling:

--- a/docs/guidance/vue-components.md
+++ b/docs/guidance/vue-components.md
@@ -1,0 +1,45 @@
+---
+globs:
+  - '**/*.vue'
+---
+
+# Vue Component Conventions
+
+Applies to all `.vue` files anywhere in the codebase.
+
+## Component Communication
+
+- Prefer `emit/@event-name` for state changes
+- Use `defineExpose` only for imperative operations (`form.validate()`, `modal.open()`)
+
+## PrimeVue Migrations
+
+Deprecated components and their replacements:
+
+| Deprecated | Replacement | Import Path |
+|------------|-------------|-------------|
+| `Dropdown` | `Select` | `primevue/select` |
+| `OverlayPanel` | `Popover` | `primevue/popover` |
+| `Calendar` | `DatePicker` | `primevue/datepicker` |
+| `InputSwitch` | `ToggleSwitch` | `primevue/toggleswitch` |
+| `Sidebar` | `Drawer` | `primevue/drawer` |
+| `Chips` | `AutoComplete` | `primevue/autocomplete` (with `multiple` enabled, `typeahead` disabled) |
+| `TabMenu` | `Tabs` | `primevue/tabs` (without panels) |
+| `Steps` | `Stepper` | `primevue/stepper` (without panels) |
+| `InlineMessage` | `Message` | `primevue/message` |
+
+## VueUse Composables
+
+Prefer VueUse composables over manual event handling:
+
+- `useElementHover` instead of manual mouseover/mouseout listeners
+- `useIntersectionObserver` for visibility detection instead of scroll handlers
+- `useVModel` for two-way binding with props
+- `useFocusTrap` for modal/dialog focus management
+- `useEventListener` for auto-cleanup event listeners
+
+## Styling
+
+- Use Tailwind CSS only (no `<style>` blocks)
+- Use semantic tokens from the design system (e.g., `bg-node-component-surface`)
+- Use `cn()` from `@/utils/tailwindUtil` for conditional classes

--- a/docs/guidance/vue-components.md
+++ b/docs/guidance/vue-components.md
@@ -7,10 +7,20 @@ globs:
 
 Applies to all `.vue` files anywhere in the codebase.
 
+## Vue 3 Composition API
+
+- Use `<script setup lang="ts">` for component logic
+- Destructure props (Vue 3.5 style with defaults)
+- Use `ref`/`reactive` for state
+- Use `computed()` for derived state
+- Use lifecycle hooks: `onMounted`, `onUpdated`, etc.
+- Use `Teleport`/`Suspense` when needed
+
 ## Component Communication
 
-- Prefer `emit/@event-name` for state changes
+- Prefer `emit/@event-name` for state changes (promotes loose coupling)
 - Use `defineExpose` only for imperative operations (`form.validate()`, `modal.open()`)
+- Proper props and emits definitions
 
 ## PrimeVue Migrations
 
@@ -34,12 +44,21 @@ Prefer VueUse composables over manual event handling:
 
 - `useElementHover` instead of manual mouseover/mouseout listeners
 - `useIntersectionObserver` for visibility detection instead of scroll handlers
-- `useVModel` for two-way binding with props
 - `useFocusTrap` for modal/dialog focus management
 - `useEventListener` for auto-cleanup event listeners
+
+Prefer Vue native options when available:
+
+- `defineModel` instead of `useVModel` for two-way binding with props
 
 ## Styling
 
 - Use Tailwind CSS only (no `<style>` blocks)
 - Use semantic tokens from the design system (e.g., `bg-node-component-surface`)
 - Use `cn()` from `@/utils/tailwindUtil` for conditional classes
+
+## Best Practices
+
+- Extract complex conditionals to `computed`
+- Implement cleanup for async operations
+- Use `vue-i18n` for ALL UI strings

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -31,3 +31,10 @@ const response = await fetch('/api/prompt')
 - Clear public interfaces
 - Restrict extension access
 - Clean up subscriptions
+
+## General Guidelines
+
+- Use `es-toolkit` for utility functions
+- Use TypeScript for type safety
+- Avoid `@ts-expect-error` - fix the underlying issue
+- Use `vue-i18n` for ALL user-facing strings (`src/locales/en/main.json`)

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,34 +1,25 @@
 # Source Code Guidelines
 
-## Service Layer
-
-### API Calls
+## API Calls
 
 - Use `api.apiURL()` for backend endpoints
 - Use `api.fileURL()` for static files
 
-#### ✅ Correct Usage
 ```typescript
-// Backend API call
+// ✅ Correct
 const response = await api.get(api.apiURL('/prompt'))
-
-// Static file
 const template = await fetch(api.fileURL('/templates/default.json'))
-```
 
-#### ❌ Incorrect Usage
-```typescript
-// WRONG - Direct URL construction
+// ❌ Wrong - direct URL construction
 const response = await fetch('/api/prompt')
-const template = await fetch('/templates/default.json')
 ```
 
-### Error Handling
+## Error Handling
 
 - User-friendly and actionable messages
 - Proper error propagation
 
-### Security
+## Security
 
 - Sanitize HTML with DOMPurify
 - Validate trusted sources
@@ -36,22 +27,7 @@ const template = await fetch('/templates/default.json')
 
 ## State Management (Stores)
 
-### Store Design
-
 - Follow domain-driven design
 - Clear public interfaces
 - Restrict extension access
-
-### Best Practices
-
-- Use TypeScript for type safety
-- Implement proper error handling
 - Clean up subscriptions
-- Avoid @ts-expect-error
-
-## General Guidelines
-
-- Use es-toolkit for utility functions
-- Implement proper TypeScript types
-- Follow Vue 3 composition API style guide
-- Use vue-i18n for ALL user-facing strings in `src/locales/en/main.json`

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- We forked the path, yet here we are again—
+     Maintaining two files where one would have been sane. -->
+@AGENTS.md

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -1,45 +1,6 @@
 # Component Guidelines
 
-## Vue 3 Composition API
-
-- Use setup() function
-- Destructure props (Vue 3.5 style)
-- Use ref/reactive for state
-- Implement computed() for derived state
-- Use provide/inject for dependency injection
-
 ## Component Communication
 
 - Prefer `emit/@event-name` for state changes
 - Use `defineExpose` only for imperative operations (`form.validate()`, `modal.open()`)
-- Events promote loose coupling
-
-## UI Framework
-
-- Deprecated PrimeVue component replacements:
-  - Dropdown → Select
-  - OverlayPanel → Popover
-  - Calendar → DatePicker
-  - InputSwitch → ToggleSwitch
-  - Sidebar → Drawer
-  - Chips → AutoComplete with multiple enabled
-  - TabMenu → Tabs without panels
-  - Steps → Stepper without panels
-  - InlineMessage → Message
-
-## Styling
-
-- Use Tailwind CSS only (no custom CSS)
-- Use the correct tokens from style.css in the design system package
-- For common operations, try to use existing VueUse composables that automatically handle effect scope
-  - Example: Use `useElementHover` instead of manually managing mouseover/mouseout event listeners
-  - Example: Use `useIntersectionObserver` for visibility detection instead of custom scroll handlers
-
-## Best Practices
-
-- Extract complex conditionals to computed
-- Implement cleanup for async operations
-- Use vue-i18n for ALL UI strings
-- Use lifecycle hooks: onMounted, onUpdated
-- Use Teleport/Suspense when needed
-- Proper props and emits definitions

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- "Play nice with others," mother always said,
+     But Claude prefers its own file name instead. -->
+@AGENTS.md

--- a/src/lib/litegraph/AGENTS.md
+++ b/src/lib/litegraph/AGENTS.md
@@ -1,5 +1,11 @@
 # Litegraph Guidelines
 
+## Code Philosophy
+
+- Write concise, legible, and easily maintainable code
+- Avoid repetition where possible, but not at expense of legibility
+- Prefer running single tests, not the whole suite, for performance
+
 ## Code Style
 
 - Prefer single line `if` syntax for concise expressions

--- a/src/lib/litegraph/AGENTS.md
+++ b/src/lib/litegraph/AGENTS.md
@@ -1,55 +1,36 @@
-- This codebase has extensive eslint autofix rules and IDEs are configured to use eslint as the format on save tool. Run ESLint instead of manually figuring out whitespace fixes or other trivial style concerns. Review the results and correct any remaining eslint errors.
-- Take advantage of `TypedArray` `subarray` when appropriate.
-- The `size` and `pos` properties of `Rectangle` share the same array buffer (`subarray`); they may be used to set the rectangles size and position.
-- Prefer single line `if` syntax over adding curly braces, when the statement has a very concise expression and concise, single line statement.
-- Do not replace `&&=` or `||=` with `=` when there is no reason to do so. If you do find a reason to remove either `&&=` or `||=`, leave a comment explaining why the removal occurred.
-- You are allowed to research code on https://developer.mozilla.org/ and https://stackoverflow.com without asking.
-- When adding features, always write vitest unit tests using cursor rules in @.cursor
-- When writing methods, prefer returning idiomatic JavaScript `undefined` over `null`.
+# Litegraph Guidelines
 
-# Bash commands
+## Code Style
 
-- `pnpm typecheck` Run the typechecker
-- `pnpm build` Build the project
-- `pnpm lint:fix` Run ESLint
+- Prefer single line `if` syntax for concise expressions
+- Take advantage of `TypedArray` `subarray` when appropriate
+- The `size` and `pos` properties of `Rectangle` share the same array buffer
+- Do not replace `&&=` or `||=` without reason; comment if you do
+- Prefer returning `undefined` over `null`
+- Type assertions are a last resort (acceptable for legacy code interop)
 
-# Code style
+## ESLint
 
-- Always prefer best practices when writing code.
-- Write using concise, legible, and easily maintainable code.
-- Avoid repetition where possible, but not at the expense of code legibility.
-- Type assertions are an absolute last resort. In almost all cases, they are a crutch that leads to brittle code.
-
-# Workflow
-
-- Be sure to typecheck when you're done making a series of code changes
-- Prefer running single tests, and not the whole test suite, for performance
-
-# Testing Guidelines
-
-## Avoiding Circular Dependencies in Tests
-
-**CRITICAL**: When writing tests for subgraph-related code, always import from the barrel export to avoid circular dependency issues:
-
-```typescript
-// ✅ CORRECT - Use barrel import
-import { LGraph, Subgraph, SubgraphNode } from "@/lib/litegraph/src/litegraph"
-
-// ❌ WRONG - Direct imports cause circular dependency
-import { LGraph } from "@/lib/litegraph/src/LGraph"
-import { Subgraph } from "@/lib/litegraph/src/subgraph/Subgraph" 
-import { SubgraphNode } from "@/lib/litegraph/src/subgraph/SubgraphNode"
+Run ESLint instead of manually fixing style issues:
+```bash
+pnpm lint:fix
 ```
 
-**Root cause**: `LGraph` and `Subgraph` have a circular dependency:
-- `LGraph.ts` imports `Subgraph` (creates instances with `new Subgraph()`)
-- `Subgraph.ts` extends `LGraph` 
+## Circular Dependencies in Tests
 
-The barrel export (`@/litegraph`) handles this properly, but direct imports cause module loading failures.
+**CRITICAL**: Always import from the barrel export for subgraph code:
 
-## Test Setup for Subgraphs
+```typescript
+// ✅ Correct - barrel import
+import { LGraph, Subgraph, SubgraphNode } from "@/lib/litegraph/src/litegraph"
 
-Use the provided test helpers for consistent setup:
+// ❌ Wrong - causes circular dependency
+import { LGraph } from "@/lib/litegraph/src/LGraph"
+```
+
+**Root cause**: `LGraph` ↔ `Subgraph` circular dependency (Subgraph extends LGraph, LGraph creates Subgraph instances).
+
+## Test Helpers
 
 ```typescript
 import { createTestSubgraph, createTestSubgraphNode } from "./fixtures/subgraphHelpers"

--- a/src/lib/litegraph/CLAUDE.md
+++ b/src/lib/litegraph/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- The graphs connect, the nodes align with grace,
+     Yet Claude alone won't join the commonplace. -->
+@AGENTS.md


### PR DESCRIPTION
## Summary

Consolidates AGENTS.md files and adds glob-based guidance per [Amp Manual patterns](https://ampcode.com/manual#granular-guidance).

**Depends on:** #8052 (rename CLAUDE.md to AGENTS.md)

## Changes

### New Glob-Based Guidance (`docs/guidance/`)

| File | Globs | Purpose |
|------|-------|---------|
| `vue-components.md` | `**/*.vue` | PrimeVue migrations, VueUse patterns |
| `typescript.md` | `**/*.ts`, `**/*.tsx` | Type safety, API utilities |
| `vitest.md` | `**/*.test.ts` | Unit test conventions |
| `playwright.md` | `**/*.spec.ts` | E2E test conventions |
| `storybook.md` | `**/*.stories.ts` | Story structure |

### Root AGENTS.md Updates

- Added `@docs/guidance/*.md` reference
- Added Development Workflow section (from CLAUDE.md)
- Added Git Conventions section (from CLAUDE.md)
- Added `pnpm storybook` command

### Redundancies Eliminated

- PrimeVue migrations (was in 3 files → vue-components.md)
- API utilities (was in 2 files → src/AGENTS.md only)
- Vue 3 patterns (was in 3 files → root AGENTS.md only)
- vue-i18n guidance (was in 3 files → root AGENTS.md only)
- Build commands (was in 3 files → root AGENTS.md only)

## Results

| Metric | Before | After |
|--------|--------|-------|
| Redundant topics | 10 | 0 |
| Glob-based files | 0 | 5 |
| Lines changed | - | -53 net |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8053-refactor-consolidate-guidance-and-add-glob-based-docs-2e86d73d3650813f9547e2434eb7815e) by [Unito](https://www.unito.io)
