### PR TITLE
devex: Silence warning for misused spread in test.

### DIFF
--- a/src/composables/maskeditor/useCanvasHistory.test.ts
+++ b/src/composables/maskeditor/useCanvasHistory.test.ts
@@ -167,6 +167,7 @@ describe('useCanvasHistory', () => {
       const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
 
       mockRefs.maskCanvas = {
+        // oxlint-disable-next-line no-misused-spread
         ...mockRefs.maskCanvas,
         width: 0,
         height: 0


### PR DESCRIPTION
## Summary

Silences this warning:
```
  ⚠ typescript-eslint(no-misused-spread): Using the spread operator on class instances will lose their class prototype.
     ╭─[src/composables/maskeditor/useCanvasHistory.test.ts:171:9]
 170 │       mockRefs.maskCanvas = {
 171 │         ...mockRefs.maskCanvas,
     ·         ──────────────────────
 172 │         width: 0,
     ╰────
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8055-devex-Silence-warning-for-misused-spread-in-test-2e86d73d365081659d1fdbc61675a532) by [Unito](https://www.unito.io)
