### PR TITLE
[bugfix] Fix bulk action context menu not emitting events

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -486,7 +486,10 @@ function handleAssetContextMenu(event: MouseEvent, asset: AssetItem) {
 }
 
 function handleContextMenuHide() {
-  contextMenuAsset.value = null
+  // Delay clearing to allow command callbacks to emit before component unmounts
+  requestAnimationFrame(() => {
+    contextMenuAsset.value = null
+  })
 }
 
 const handleZoomClick = (asset: AssetItem) => {

--- a/src/platform/assets/components/MediaAssetContextMenu.vue
+++ b/src/platform/assets/components/MediaAssetContextMenu.vue
@@ -63,10 +63,10 @@ const {
 
 const emit = defineEmits<{
   zoom: []
+  hide: []
   'asset-deleted': []
   'bulk-download': [assets: AssetItem[]]
   'bulk-delete': [assets: AssetItem[]]
-  hide: []
   'bulk-add-to-workflow': [assets: AssetItem[]]
   'bulk-open-workflow': [assets: AssetItem[]]
   'bulk-export-workflow': [assets: AssetItem[]]


### PR DESCRIPTION
## Summary
Fix context menu bulk actions (download, delete, add to workflow, etc.) not working when multiple assets are selected.

## Changes
- **What**: Delay `contextMenuAsset.value = null` using `requestAnimationFrame` so command callbacks can emit events before the component unmounts
- **Root cause**: PrimeVue ContextMenu fires `hide` event before executing `command` callbacks. The immediate null assignment caused the component to unmount before emits could reach the parent.

## Review Focus
- The timing fix ensures emit() calls complete before v-if removes the component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8065-bugfix-Fix-bulk-action-context-menu-not-emitting-events-2e96d73d365081e1b206e9923b5af6f4) by [Unito](https://www.unito.io)
