### PR TITLE
feat(ui): add TagsInput component with click-to-edit behavior

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -282,7 +282,7 @@
    --modal-card-border-highlighted: var(--secondary-background-selected);
    --modal-card-button-surface: var(--color-smoke-300);
    --modal-card-placeholder-background: var(--color-smoke-600);
-   --modal-card-tag-background: var(--color-smoke-400);
+   --modal-card-tag-background: var(--color-smoke-200);
    --modal-card-tag-foreground: var(--base-foreground);
    --modal-panel-background: var(--color-white);
 }

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -47,12 +47,12 @@ export const Default: Story = {
       return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80" v-slot="{ isEmpty }">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
         </TagsInputItem>
-        <TagsInputInput placeholder="Add tag..." />
+        <TagsInputInput :is-empty="isEmpty" placeholder="Add tag..." />
       </TagsInput>
       <div class="mt-4 text-sm text-muted-foreground">
         Tags: {{ tags.join(', ') }}
@@ -79,12 +79,12 @@ export const Empty: Story = {
       return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80" v-slot="{ isEmpty }">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
         </TagsInputItem>
-        <TagsInputInput placeholder="Start typing to add tags..." />
+        <TagsInputInput :is-empty="isEmpty" placeholder="Start typing to add tags..." />
       </TagsInput>
     `
   })
@@ -113,12 +113,12 @@ export const ManyTags: Story = {
       return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" :disabled="args.disabled" class="w-96">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-96" v-slot="{ isEmpty }">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
         </TagsInputItem>
-        <TagsInputInput placeholder="Add technology..." />
+        <TagsInputInput :is-empty="isEmpty" placeholder="Add technology..." />
       </TagsInput>
     `
   })
@@ -142,12 +142,12 @@ export const Disabled: Story = {
       return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80" v-slot="{ isEmpty }">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
         </TagsInputItem>
-        <TagsInputInput placeholder="Cannot add tags..." />
+        <TagsInputInput :is-empty="isEmpty" placeholder="Cannot add tags..." />
       </TagsInput>
     `
   })
@@ -167,12 +167,12 @@ export const CustomWidth: Story = {
       return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" :disabled="args.disabled" class="w-full">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-full" v-slot="{ isEmpty }">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
         </TagsInputItem>
-        <TagsInputInput placeholder="Add tag..." />
+        <TagsInputInput :is-empty="isEmpty" placeholder="Add tag..." />
       </TagsInput>
     `
   })

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import type { ComponentExposed } from 'vue-component-type-helpers'
 import { ref } from 'vue'
 
 import TagsInput from './TagsInput.vue'
@@ -7,7 +8,11 @@ import TagsInputItem from './TagsInputItem.vue'
 import TagsInputItemDelete from './TagsInputItemDelete.vue'
 import TagsInputItemText from './TagsInputItemText.vue'
 
-const meta: Meta<typeof TagsInput> = {
+interface GenericMeta<C> extends Omit<Meta<C>, 'component'> {
+  component: ComponentExposed<C>
+}
+
+const meta: GenericMeta<typeof TagsInput> = {
   title: 'Components/TagsInput',
   component: TagsInput,
   tags: ['autodocs'],

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -18,7 +18,8 @@ const meta: Meta<typeof TagsInput> = {
     },
     disabled: {
       control: 'boolean',
-      description: 'Whether the input is disabled'
+      description:
+        'When true (default), shows read-only state with edit icon. Click to enable editing.'
     },
     'onUpdate:modelValue': { action: 'update:modelValue' }
   }

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -66,6 +66,9 @@ export const Default: Story = {
 }
 
 export const Empty: Story = {
+  args: {
+    disabled: false
+  },
   render: (args) => ({
     components: {
       TagsInput,

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -38,10 +38,10 @@ export const Default: Story = {
     },
     setup() {
       const tags = ref(args.modelValue || ['tag1', 'tag2'])
-      return { tags }
+      return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" class="w-80">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
@@ -54,12 +54,13 @@ export const Default: Story = {
     `
   }),
   args: {
-    modelValue: ['Vue', 'TypeScript']
+    modelValue: ['Vue', 'TypeScript'],
+    disabled: false
   }
 }
 
 export const Empty: Story = {
-  render: () => ({
+  render: (args) => ({
     components: {
       TagsInput,
       TagsInputInput,
@@ -69,10 +70,10 @@ export const Empty: Story = {
     },
     setup() {
       const tags = ref<string[]>([])
-      return { tags }
+      return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" class="w-80">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
@@ -84,7 +85,7 @@ export const Empty: Story = {
 }
 
 export const ManyTags: Story = {
-  render: () => ({
+  render: (args) => ({
     components: {
       TagsInput,
       TagsInputInput,
@@ -103,10 +104,10 @@ export const ManyTags: Story = {
         'Python',
         'Rust'
       ])
-      return { tags }
+      return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" class="w-96">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-96">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
@@ -118,7 +119,11 @@ export const ManyTags: Story = {
 }
 
 export const Disabled: Story = {
-  render: () => ({
+  args: {
+    disabled: true
+  },
+
+  render: (args) => ({
     components: {
       TagsInput,
       TagsInputInput,
@@ -128,10 +133,10 @@ export const Disabled: Story = {
     },
     setup() {
       const tags = ref(['Read', 'Only', 'Tags'])
-      return { tags }
+      return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" :disabled="true" class="w-80 opacity-60">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-80">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />
@@ -143,7 +148,7 @@ export const Disabled: Story = {
 }
 
 export const CustomWidth: Story = {
-  render: () => ({
+  render: (args) => ({
     components: {
       TagsInput,
       TagsInputInput,
@@ -153,10 +158,10 @@ export const CustomWidth: Story = {
     },
     setup() {
       const tags = ref(['Full', 'Width'])
-      return { tags }
+      return { tags, args }
     },
     template: `
-      <TagsInput v-model="tags" class="w-full">
+      <TagsInput v-model="tags" :disabled="args.disabled" class="w-full">
         <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
           <TagsInputItemText />
           <TagsInputItemDelete />

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<typeof TagsInput> = {
     disabled: {
       control: 'boolean',
       description:
-        'When true (default), shows read-only state with edit icon. Click to enable editing.'
+        'When true, completely disables the component. When false (default), shows read-only state with edit icon until clicked.'
     },
     'onUpdate:modelValue': { action: 'update:modelValue' }
   }

--- a/src/components/ui/tags-input/TagsInput.stories.ts
+++ b/src/components/ui/tags-input/TagsInput.stories.ts
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
+
+import TagsInput from './TagsInput.vue'
+import TagsInputInput from './TagsInputInput.vue'
+import TagsInputItem from './TagsInputItem.vue'
+import TagsInputItemDelete from './TagsInputItemDelete.vue'
+import TagsInputItemText from './TagsInputItemText.vue'
+
+const meta: Meta<typeof TagsInput> = {
+  title: 'Components/TagsInput',
+  component: TagsInput,
+  tags: ['autodocs'],
+  argTypes: {
+    modelValue: {
+      control: 'object',
+      description: 'Array of tag values'
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the input is disabled'
+    },
+    'onUpdate:modelValue': { action: 'update:modelValue' }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: {
+      TagsInput,
+      TagsInputInput,
+      TagsInputItem,
+      TagsInputItemDelete,
+      TagsInputItemText
+    },
+    setup() {
+      const tags = ref(args.modelValue || ['tag1', 'tag2'])
+      return { tags }
+    },
+    template: `
+      <TagsInput v-model="tags" class="w-80">
+        <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
+          <TagsInputItemText />
+          <TagsInputItemDelete />
+        </TagsInputItem>
+        <TagsInputInput placeholder="Add tag..." />
+      </TagsInput>
+      <div class="mt-4 text-sm text-muted-foreground">
+        Tags: {{ tags.join(', ') }}
+      </div>
+    `
+  }),
+  args: {
+    modelValue: ['Vue', 'TypeScript']
+  }
+}
+
+export const Empty: Story = {
+  render: () => ({
+    components: {
+      TagsInput,
+      TagsInputInput,
+      TagsInputItem,
+      TagsInputItemDelete,
+      TagsInputItemText
+    },
+    setup() {
+      const tags = ref<string[]>([])
+      return { tags }
+    },
+    template: `
+      <TagsInput v-model="tags" class="w-80">
+        <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
+          <TagsInputItemText />
+          <TagsInputItemDelete />
+        </TagsInputItem>
+        <TagsInputInput placeholder="Start typing to add tags..." />
+      </TagsInput>
+    `
+  })
+}
+
+export const ManyTags: Story = {
+  render: () => ({
+    components: {
+      TagsInput,
+      TagsInputInput,
+      TagsInputItem,
+      TagsInputItemDelete,
+      TagsInputItemText
+    },
+    setup() {
+      const tags = ref([
+        'JavaScript',
+        'TypeScript',
+        'Vue',
+        'React',
+        'Svelte',
+        'Node.js',
+        'Python',
+        'Rust'
+      ])
+      return { tags }
+    },
+    template: `
+      <TagsInput v-model="tags" class="w-96">
+        <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
+          <TagsInputItemText />
+          <TagsInputItemDelete />
+        </TagsInputItem>
+        <TagsInputInput placeholder="Add technology..." />
+      </TagsInput>
+    `
+  })
+}
+
+export const Disabled: Story = {
+  render: () => ({
+    components: {
+      TagsInput,
+      TagsInputInput,
+      TagsInputItem,
+      TagsInputItemDelete,
+      TagsInputItemText
+    },
+    setup() {
+      const tags = ref(['Read', 'Only', 'Tags'])
+      return { tags }
+    },
+    template: `
+      <TagsInput v-model="tags" :disabled="true" class="w-80 opacity-60">
+        <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
+          <TagsInputItemText />
+          <TagsInputItemDelete />
+        </TagsInputItem>
+        <TagsInputInput placeholder="Cannot add tags..." />
+      </TagsInput>
+    `
+  })
+}
+
+export const CustomWidth: Story = {
+  render: () => ({
+    components: {
+      TagsInput,
+      TagsInputInput,
+      TagsInputItem,
+      TagsInputItemDelete,
+      TagsInputItemText
+    },
+    setup() {
+      const tags = ref(['Full', 'Width'])
+      return { tags }
+    },
+    template: `
+      <TagsInput v-model="tags" class="w-full">
+        <TagsInputItem v-for="tag in tags" :key="tag" :value="tag">
+          <TagsInputItemText />
+          <TagsInputItemDelete />
+        </TagsInputItem>
+        <TagsInputInput placeholder="Add tag..." />
+      </TagsInput>
+    `
+  })
+}

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -46,32 +46,23 @@ describe('TagsInput with child components', () => {
     })
   }
 
-  it('renders tags as child items', () => {
-    const wrapper = mountFullTagsInput(['Vue', 'TypeScript'])
+  it('renders tags structure and content', () => {
+    const tags = ['tag1', 'tag2']
+    const wrapper = mountFullTagsInput(tags)
 
     const items = wrapper.findAllComponents(TagsInputItem)
-    expect(items).toHaveLength(2)
-  })
-
-  it('renders input for adding new tags', () => {
-    const wrapper = mountFullTagsInput()
-
-    const input = wrapper.findComponent(TagsInputInput)
-    expect(input.exists()).toBe(true)
-  })
-
-  it('renders delete buttons for each tag', () => {
-    const wrapper = mountFullTagsInput(['tag1', 'tag2'])
-
-    const deleteButtons = wrapper.findAllComponents(TagsInputItemDelete)
-    expect(deleteButtons).toHaveLength(2)
-  })
-
-  it('renders tag text for each tag', () => {
-    const wrapper = mountFullTagsInput(['tag1', 'tag2'])
-
     const textElements = wrapper.findAllComponents(TagsInputItemText)
-    expect(textElements).toHaveLength(2)
+    const deleteButtons = wrapper.findAllComponents(TagsInputItemDelete)
+
+    expect(items).toHaveLength(tags.length)
+    expect(textElements).toHaveLength(tags.length)
+    expect(deleteButtons).toHaveLength(tags.length)
+
+    textElements.forEach((el, i) => {
+      expect(el.text()).toBe(tags[i])
+    })
+
+    expect(wrapper.findComponent(TagsInputInput).exists()).toBe(true)
   })
 
   it('updates model value when adding a tag', async () => {

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -23,8 +23,7 @@ describe('TagsInput', () => {
     const wrapper = mountTagsInput()
 
     expect(wrapper.classes()).toContain('flex')
-    expect(wrapper.classes()).toContain('rounded-md')
-    expect(wrapper.classes()).toContain('border')
+    expect(wrapper.classes()).toContain('rounded-lg')
   })
 
   it('applies custom class prop', () => {
@@ -39,11 +38,11 @@ describe('TagsInput', () => {
     expect(wrapper.text()).toContain('Slot Content')
   })
 
-  it('applies design system border and background tokens', () => {
+  it('applies design system styling tokens', () => {
     const wrapper = mountTagsInput()
 
-    expect(wrapper.classes()).toContain('border-secondary-background-hover')
-    expect(wrapper.classes()).toContain('bg-base-background')
+    expect(wrapper.classes()).toContain('bg-transparent')
+    expect(wrapper.classes()).toContain('rounded-lg')
   })
 
   it('has focus ring styling', () => {

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -44,7 +44,6 @@ describe('TagsInput', () => {
 
     expect(wrapper.classes()).toContain('border-secondary-background-hover')
     expect(wrapper.classes()).toContain('bg-base-background')
-    expect(wrapper.classes()).toContain('text-base-foreground')
   })
 
   it('has focus ring styling', () => {

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -99,4 +99,64 @@ describe('TagsInput with child components', () => {
 
     expect(currentTags).toContain('newTag')
   })
+
+  it('does not enter edit mode when disabled', async () => {
+    const wrapper = mount<typeof TagsInput<string>>(TagsInput, {
+      props: {
+        modelValue: ['tag1'],
+        disabled: true
+      },
+      slots: {
+        default: () => h(TagsInputInput, { placeholder: 'Add tag...' })
+      }
+    })
+
+    expect(wrapper.find('input').exists()).toBe(false)
+
+    await wrapper.trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('input').exists()).toBe(false)
+  })
+
+  it('exits edit mode when clicking outside', async () => {
+    const wrapper = mount<typeof TagsInput<string>>(TagsInput, {
+      props: {
+        modelValue: ['tag1']
+      },
+      slots: {
+        default: () => h(TagsInputInput, { placeholder: 'Add tag...' })
+      },
+      attachTo: document.body
+    })
+
+    await wrapper.trigger('click')
+    await nextTick()
+    expect(wrapper.find('input').exists()).toBe(true)
+
+    document.body.click()
+    await nextTick()
+
+    expect(wrapper.find('input').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('shows placeholder when modelValue is empty', async () => {
+    const wrapper = mount<typeof TagsInput<string>>(TagsInput, {
+      props: {
+        modelValue: []
+      },
+      slots: {
+        default: ({ isEmpty }: { isEmpty: boolean }) =>
+          h(TagsInputInput, { placeholder: 'Add tag...', isEmpty })
+      }
+    })
+
+    await nextTick()
+
+    const input = wrapper.find('input')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('placeholder')).toBe('Add tag...')
+  })
 })

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -1,12 +1,19 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { h, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
 
 import TagsInput from './TagsInput.vue'
 import TagsInputInput from './TagsInputInput.vue'
 import TagsInputItem from './TagsInputItem.vue'
 import TagsInputItemDelete from './TagsInputItemDelete.vue'
 import TagsInputItemText from './TagsInputItemText.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: { g: { removeTag: 'Remove tag' } } }
+})
 
 describe('TagsInput', () => {
   function mountTagsInput(props = {}, slots = {}) {
@@ -29,6 +36,7 @@ describe('TagsInput', () => {
 describe('TagsInput with child components', () => {
   function mountFullTagsInput(tags: string[] = ['tag1', 'tag2']) {
     return mount(TagsInput, {
+      global: { plugins: [i18n] },
       props: {
         modelValue: tags
       },

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -9,7 +9,7 @@ import TagsInputItemDelete from './TagsInputItemDelete.vue'
 import TagsInputItemText from './TagsInputItemText.vue'
 
 describe('TagsInput', () => {
-  const mountTagsInput = (props = {}, slots = {}) => {
+  function mountTagsInput(props = {}, slots = {}) {
     return mount(TagsInput, {
       props: {
         modelValue: [],
@@ -19,37 +19,10 @@ describe('TagsInput', () => {
     })
   }
 
-  it('renders with default styling classes', () => {
-    const wrapper = mountTagsInput()
-
-    expect(wrapper.classes()).toContain('flex')
-    expect(wrapper.classes()).toContain('rounded-lg')
-  })
-
-  it('applies custom class prop', () => {
-    const wrapper = mountTagsInput({ class: 'custom-class' })
-
-    expect(wrapper.classes()).toContain('custom-class')
-  })
-
   it('renders slot content', () => {
     const wrapper = mountTagsInput({}, { default: '<span>Slot Content</span>' })
 
     expect(wrapper.text()).toContain('Slot Content')
-  })
-
-  it('applies design system styling tokens', () => {
-    const wrapper = mountTagsInput()
-
-    expect(wrapper.classes()).toContain('bg-transparent')
-    expect(wrapper.classes()).toContain('rounded-lg')
-  })
-
-  it('has focus ring styling', () => {
-    const wrapper = mountTagsInput()
-
-    expect(wrapper.classes()).toContain('focus-within:ring-1')
-    expect(wrapper.classes()).toContain('focus-within:ring-primary-background')
   })
 })
 
@@ -101,27 +74,23 @@ describe('TagsInput with child components', () => {
     expect(textElements).toHaveLength(2)
   })
 
-  it('renders X icons in delete buttons', () => {
-    const wrapper = mountFullTagsInput(['tag1'])
-
-    const icon = wrapper.find('i.icon-\\[lucide--x\\]')
-    expect(icon.exists()).toBe(true)
-  })
-
   it('updates model value when adding a tag', async () => {
     let currentTags = ['existing']
 
-    const wrapper = mount(TagsInput, {
+    const wrapper = mount<typeof TagsInput<string>>(TagsInput, {
       props: {
         modelValue: currentTags,
-        'onUpdate:modelValue': (payload: unknown[]) => {
-          currentTags = payload as string[]
+        'onUpdate:modelValue': (payload) => {
+          currentTags = payload
         }
       },
       slots: {
         default: () => h(TagsInputInput, { placeholder: 'Add tag...' })
       }
     })
+
+    await wrapper.trigger('click')
+    await nextTick()
 
     const input = wrapper.find('input')
     await input.setValue('newTag')

--- a/src/components/ui/tags-input/TagsInput.test.ts
+++ b/src/components/ui/tags-input/TagsInput.test.ts
@@ -1,0 +1,135 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { h, nextTick } from 'vue'
+
+import TagsInput from './TagsInput.vue'
+import TagsInputInput from './TagsInputInput.vue'
+import TagsInputItem from './TagsInputItem.vue'
+import TagsInputItemDelete from './TagsInputItemDelete.vue'
+import TagsInputItemText from './TagsInputItemText.vue'
+
+describe('TagsInput', () => {
+  const mountTagsInput = (props = {}, slots = {}) => {
+    return mount(TagsInput, {
+      props: {
+        modelValue: [],
+        ...props
+      },
+      slots
+    })
+  }
+
+  it('renders with default styling classes', () => {
+    const wrapper = mountTagsInput()
+
+    expect(wrapper.classes()).toContain('flex')
+    expect(wrapper.classes()).toContain('rounded-md')
+    expect(wrapper.classes()).toContain('border')
+  })
+
+  it('applies custom class prop', () => {
+    const wrapper = mountTagsInput({ class: 'custom-class' })
+
+    expect(wrapper.classes()).toContain('custom-class')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mountTagsInput({}, { default: '<span>Slot Content</span>' })
+
+    expect(wrapper.text()).toContain('Slot Content')
+  })
+
+  it('applies design system border and background tokens', () => {
+    const wrapper = mountTagsInput()
+
+    expect(wrapper.classes()).toContain('border-secondary-background-hover')
+    expect(wrapper.classes()).toContain('bg-base-background')
+    expect(wrapper.classes()).toContain('text-base-foreground')
+  })
+
+  it('has focus ring styling', () => {
+    const wrapper = mountTagsInput()
+
+    expect(wrapper.classes()).toContain('focus-within:ring-1')
+    expect(wrapper.classes()).toContain('focus-within:ring-primary-background')
+  })
+})
+
+describe('TagsInput with child components', () => {
+  function mountFullTagsInput(tags: string[] = ['tag1', 'tag2']) {
+    return mount(TagsInput, {
+      props: {
+        modelValue: tags
+      },
+      slots: {
+        default: () => [
+          ...tags.map((tag) =>
+            h(TagsInputItem, { key: tag, value: tag }, () => [
+              h(TagsInputItemText),
+              h(TagsInputItemDelete)
+            ])
+          ),
+          h(TagsInputInput, { placeholder: 'Add tag...' })
+        ]
+      }
+    })
+  }
+
+  it('renders tags as child items', () => {
+    const wrapper = mountFullTagsInput(['Vue', 'TypeScript'])
+
+    const items = wrapper.findAllComponents(TagsInputItem)
+    expect(items).toHaveLength(2)
+  })
+
+  it('renders input for adding new tags', () => {
+    const wrapper = mountFullTagsInput()
+
+    const input = wrapper.findComponent(TagsInputInput)
+    expect(input.exists()).toBe(true)
+  })
+
+  it('renders delete buttons for each tag', () => {
+    const wrapper = mountFullTagsInput(['tag1', 'tag2'])
+
+    const deleteButtons = wrapper.findAllComponents(TagsInputItemDelete)
+    expect(deleteButtons).toHaveLength(2)
+  })
+
+  it('renders tag text for each tag', () => {
+    const wrapper = mountFullTagsInput(['tag1', 'tag2'])
+
+    const textElements = wrapper.findAllComponents(TagsInputItemText)
+    expect(textElements).toHaveLength(2)
+  })
+
+  it('renders X icons in delete buttons', () => {
+    const wrapper = mountFullTagsInput(['tag1'])
+
+    const icon = wrapper.find('i.icon-\\[lucide--x\\]')
+    expect(icon.exists()).toBe(true)
+  })
+
+  it('updates model value when adding a tag', async () => {
+    let currentTags = ['existing']
+
+    const wrapper = mount(TagsInput, {
+      props: {
+        modelValue: currentTags,
+        'onUpdate:modelValue': (payload: unknown[]) => {
+          currentTags = payload as string[]
+        }
+      },
+      slots: {
+        default: () => h(TagsInputInput, { placeholder: 'Add tag...' })
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.setValue('newTag')
+    await input.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+
+    expect(currentTags).toContain('newTag')
+  })
+})

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -70,6 +70,7 @@ onClickOutside(rootEl, () => {
     <slot :is-empty="modelValue.length === 0" />
     <i
       v-if="!disabled && !isEditing"
+      aria-hidden="true"
       class="icon-[lucide--square-pen] absolute bottom-2 right-2 size-4 text-muted-foreground"
     />
   </TagsInputRoot>

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { reactiveOmit } from '@vueuse/core'
+import type { TagsInputRootEmits, TagsInputRootProps } from 'reka-ui'
+import { TagsInputRoot, useForwardPropsEmits } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const props = defineProps<
+  // eslint-disable-next-line vue/no-unused-properties
+  TagsInputRootProps & { class?: HTMLAttributes['class'] }
+>()
+const emits = defineEmits<TagsInputRootEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <TagsInputRoot
+    v-bind="forwarded"
+    :class="
+      cn(
+        'flex flex-wrap gap-2 items-center rounded-md border border-input bg-background px-3 py-1.5 text-sm',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </TagsInputRoot>
+</template>

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -11,7 +11,7 @@ import { tagsInputFocusKey } from './tagsInputContext'
 import type { FocusCallback } from './tagsInputContext'
 
 const {
-  disabled = true,
+  disabled = false,
   class: className,
   ...restProps
 } = defineProps<TagsInputRootProps & { class?: HTMLAttributes['class'] }>()
@@ -25,7 +25,7 @@ provide(tagsInputFocusKey, (callback: FocusCallback) => {
   focusInput.value = callback
 })
 
-const internalDisabled = computed(() => disabled && !isEditing.value)
+const internalDisabled = computed(() => disabled || !isEditing.value)
 
 const delegatedProps = computed(() => ({
   ...restProps,
@@ -35,7 +35,7 @@ const delegatedProps = computed(() => ({
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 async function enableEditing() {
-  if (disabled && !isEditing.value) {
+  if (!disabled && !isEditing.value) {
     isEditing.value = true
     await nextTick()
     focusInput.value?.()
@@ -55,7 +55,7 @@ onClickOutside(rootEl, () => {
         'group relative flex flex-wrap items-center gap-2 rounded-lg bg-transparent p-2 text-xs text-base-foreground',
         !internalDisabled &&
           'hover:bg-modal-card-background-hovered focus-within:bg-modal-card-background-hovered',
-        internalDisabled && 'cursor-pointer',
+        !disabled && !isEditing && 'cursor-pointer',
         className
       )
     "
@@ -63,7 +63,7 @@ onClickOutside(rootEl, () => {
   >
     <slot />
     <i
-      v-if="disabled"
+      v-if="!disabled && !isEditing"
       class="icon-[lucide--square-pen] absolute bottom-2 right-2 size-4 text-muted-foreground"
     />
   </TagsInputRoot>

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -1,6 +1,10 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends AcceptableInputValue = string">
 import { onClickOutside, useCurrentElement } from '@vueuse/core'
-import type { TagsInputRootEmits, TagsInputRootProps } from 'reka-ui'
+import type {
+  AcceptableInputValue,
+  TagsInputRootEmits,
+  TagsInputRootProps
+} from 'reka-ui'
 import { TagsInputRoot, useForwardPropsEmits } from 'reka-ui'
 import { computed, nextTick, provide, ref } from 'vue'
 import type { HTMLAttributes } from 'vue'
@@ -14,8 +18,8 @@ const {
   disabled = false,
   class: className,
   ...restProps
-} = defineProps<TagsInputRootProps & { class?: HTMLAttributes['class'] }>()
-const emits = defineEmits<TagsInputRootEmits>()
+} = defineProps<TagsInputRootProps<T> & { class?: HTMLAttributes['class'] }>()
+const emits = defineEmits<TagsInputRootEmits<T>>()
 
 const isEditing = ref(false)
 const rootEl = useCurrentElement<HTMLElement>()

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -11,7 +11,7 @@ import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-import { tagsInputFocusKey } from './tagsInputContext'
+import { tagsInputFocusKey, tagsInputIsEditingKey } from './tagsInputContext'
 import type { FocusCallback } from './tagsInputContext'
 
 const {
@@ -28,6 +28,7 @@ const focusInput = ref<FocusCallback>()
 provide(tagsInputFocusKey, (callback: FocusCallback) => {
   focusInput.value = callback
 })
+provide(tagsInputIsEditingKey, isEditing)
 
 const internalDisabled = computed(() => disabled || !isEditing.value)
 
@@ -53,6 +54,7 @@ onClickOutside(rootEl, () => {
 
 <template>
   <TagsInputRoot
+    v-slot="{ modelValue }"
     v-bind="forwarded"
     :class="
       cn(
@@ -65,7 +67,7 @@ onClickOutside(rootEl, () => {
     "
     @click="enableEditing"
   >
-    <slot />
+    <slot :is-empty="modelValue.length === 0" />
     <i
       v-if="!disabled && !isEditing"
       class="icon-[lucide--square-pen] absolute bottom-2 right-2 size-4 text-muted-foreground"

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -22,7 +22,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     v-bind="forwarded"
     :class="
       cn(
-        'flex flex-wrap items-center gap-2 rounded-md border border-secondary-background-hover bg-base-background px-3 py-1.5 text-sm text-base-foreground focus-within:ring-1 focus-within:ring-primary-background',
+        'flex flex-wrap items-center gap-2 rounded-lg bg-modal-card-background-hovered p-2 text-xs text-base-foreground focus-within:ring-1 focus-within:ring-primary-background',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -2,6 +2,7 @@
 import { reactiveOmit } from '@vueuse/core'
 import type { TagsInputRootEmits, TagsInputRootProps } from 'reka-ui'
 import { TagsInputRoot, useForwardPropsEmits } from 'reka-ui'
+import { toRef } from 'vue'
 import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
@@ -12,6 +13,7 @@ const props = defineProps<
 >()
 const emits = defineEmits<TagsInputRootEmits>()
 
+const disabled = toRef(props, 'disabled')
 const delegatedProps = reactiveOmit(props, 'class')
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
@@ -22,7 +24,8 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     v-bind="forwarded"
     :class="
       cn(
-        'flex flex-wrap items-center gap-2 rounded-lg bg-modal-card-background-hovered p-2 text-xs text-base-foreground focus-within:ring-1 focus-within:ring-primary-background',
+        'flex flex-wrap items-center gap-2 rounded-lg bg-transparent p-2 text-xs text-base-foreground',
+        !disabled && 'hover:bg-modal-card-background-hovered',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -24,8 +24,9 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     v-bind="forwarded"
     :class="
       cn(
-        'flex flex-wrap items-center gap-2 rounded-lg bg-transparent p-2 text-xs text-base-foreground',
-        !disabled && 'hover:bg-modal-card-background-hovered',
+        'group flex flex-wrap items-center gap-2 rounded-lg bg-transparent p-2 text-xs text-base-foreground',
+        !disabled &&
+          'hover:bg-modal-card-background-hovered focus-within:bg-modal-card-background-hovered',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInput.vue
+++ b/src/components/ui/tags-input/TagsInput.vue
@@ -22,7 +22,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     v-bind="forwarded"
     :class="
       cn(
-        'flex flex-wrap gap-2 items-center rounded-md border border-input bg-background px-3 py-1.5 text-sm',
+        'flex flex-wrap items-center gap-2 rounded-md border border-secondary-background-hover bg-base-background px-3 py-1.5 text-sm text-base-foreground focus-within:ring-1 focus-within:ring-primary-background',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'text-sm min-h-5 focus:outline-none flex-1 bg-transparent px-1',
+        'min-h-6 flex-1 bg-transparent px-1 text-sm text-base-foreground placeholder:text-muted-foreground focus:outline-none',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'min-h-6 flex-1 bg-transparent px-1 text-sm text-base-foreground placeholder:text-muted-foreground focus:outline-none',
+        'min-h-6 flex-1 bg-transparent text-xs text-muted-foreground placeholder:text-muted-foreground focus:outline-none appearance-none border-none',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -1,18 +1,24 @@
 <script setup lang="ts">
 import type { TagsInputInputProps } from 'reka-ui'
 import { TagsInputInput, useForwardExpose, useForwardProps } from 'reka-ui'
-import { inject, onMounted, onUnmounted } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref } from 'vue'
 import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-import { tagsInputFocusKey } from './tagsInputContext'
+import { tagsInputFocusKey, tagsInputIsEditingKey } from './tagsInputContext'
 
-const { class: className, ...restProps } = defineProps<
-  TagsInputInputProps & { class?: HTMLAttributes['class'] }
+const {
+  isEmpty = false,
+  class: className,
+  ...restProps
+} = defineProps<
+  TagsInputInputProps & { class?: HTMLAttributes['class']; isEmpty?: boolean }
 >()
 
 const forwardedProps = useForwardProps(restProps)
+const isEditing = inject(tagsInputIsEditingKey, ref(true))
+const showInput = computed(() => isEditing.value || isEmpty)
 
 const { forwardRef, currentElement } = useForwardExpose()
 const registerFocus = inject(tagsInputFocusKey, undefined)
@@ -28,11 +34,13 @@ onUnmounted(() => {
 
 <template>
   <TagsInputInput
+    v-if="showInput"
     :ref="forwardRef"
     v-bind="forwardedProps"
     :class="
       cn(
-        'min-h-6 flex-1 bg-transparent text-xs text-muted-foreground placeholder:text-muted-foreground focus:outline-none appearance-none border-none group-data-[disabled]:hidden',
+        'min-h-6 flex-1 bg-transparent text-xs text-muted-foreground placeholder:text-muted-foreground focus:outline-none appearance-none border-none',
+        !isEditing && 'pointer-events-none',
         className
       )
     "

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'min-h-6 flex-1 bg-transparent text-xs text-muted-foreground placeholder:text-muted-foreground focus:outline-none appearance-none border-none',
+        'min-h-6 flex-1 bg-transparent text-xs text-muted-foreground placeholder:text-muted-foreground focus:outline-none appearance-none border-none group-data-[disabled]:hidden',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -1,28 +1,39 @@
 <script setup lang="ts">
-import { reactiveOmit } from '@vueuse/core'
 import type { TagsInputInputProps } from 'reka-ui'
 import { TagsInputInput, useForwardProps } from 'reka-ui'
+import { inject, onMounted, onUnmounted, useTemplateRef } from 'vue'
 import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-const props = defineProps<
-  // eslint-disable-next-line vue/no-unused-properties
+import { tagsInputFocusKey } from './tagsInputContext'
+
+const { class: className, ...restProps } = defineProps<
   TagsInputInputProps & { class?: HTMLAttributes['class'] }
 >()
 
-const delegatedProps = reactiveOmit(props, 'class')
+const forwardedProps = useForwardProps(restProps)
 
-const forwardedProps = useForwardProps(delegatedProps)
+const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
+const registerFocus = inject(tagsInputFocusKey, undefined)
+
+onMounted(() => {
+  registerFocus?.(() => inputRef.value?.focus())
+})
+
+onUnmounted(() => {
+  registerFocus?.(undefined)
+})
 </script>
 
 <template>
   <TagsInputInput
+    ref="inputRef"
     v-bind="forwardedProps"
     :class="
       cn(
         'min-h-6 flex-1 bg-transparent text-xs text-muted-foreground placeholder:text-muted-foreground focus:outline-none appearance-none border-none group-data-[disabled]:hidden',
-        props.class
+        className
       )
     "
   />

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { reactiveOmit } from '@vueuse/core'
+import type { TagsInputInputProps } from 'reka-ui'
+import { TagsInputInput, useForwardProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const props = defineProps<
+  // eslint-disable-next-line vue/no-unused-properties
+  TagsInputInputProps & { class?: HTMLAttributes['class'] }
+>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputInput
+    v-bind="forwardedProps"
+    :class="
+      cn(
+        'text-sm min-h-5 focus:outline-none flex-1 bg-transparent px-1',
+        props.class
+      )
+    "
+  />
+</template>

--- a/src/components/ui/tags-input/TagsInputInput.vue
+++ b/src/components/ui/tags-input/TagsInputInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TagsInputInputProps } from 'reka-ui'
-import { TagsInputInput, useForwardProps } from 'reka-ui'
-import { inject, onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { TagsInputInput, useForwardExpose, useForwardProps } from 'reka-ui'
+import { inject, onMounted, onUnmounted } from 'vue'
 import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
@@ -14,11 +14,11 @@ const { class: className, ...restProps } = defineProps<
 
 const forwardedProps = useForwardProps(restProps)
 
-const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
+const { forwardRef, currentElement } = useForwardExpose()
 const registerFocus = inject(tagsInputFocusKey, undefined)
 
 onMounted(() => {
-  registerFocus?.(() => inputRef.value?.focus())
+  registerFocus?.(() => currentElement.value?.focus())
 })
 
 onUnmounted(() => {
@@ -28,7 +28,7 @@ onUnmounted(() => {
 
 <template>
   <TagsInputInput
-    ref="inputRef"
+    :ref="forwardRef"
     v-bind="forwardedProps"
     :class="
       cn(

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'flex h-6 items-center rounded-md bg-secondary-background text-base-foreground ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1',
+        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { reactiveOmit } from '@vueuse/core'
+import type { TagsInputItemProps } from 'reka-ui'
+import { TagsInputItem, useForwardProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const props = defineProps<
+  // eslint-disable-next-line vue/no-unused-properties
+  TagsInputItemProps & { class?: HTMLAttributes['class'] }
+>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputItem
+    v-bind="forwardedProps"
+    :class="
+      cn(
+        'flex h-5 items-center rounded-md bg-secondary data-[state=active]:ring-ring data-[state=active]:ring-2 data-[state=active]:ring-offset-2 ring-offset-background',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </TagsInputItem>
+</template>

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1',
+        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1 data-[disabled]:pr-2',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -17,7 +17,7 @@ const forwardedProps = useForwardProps(restProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1 data-[disabled]:pr-2',
+        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-base-foreground data-[state=active]:ring-offset-1 data-[disabled]:pr-2',
         className
       )
     "

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -17,7 +17,7 @@ const forwardedProps = useForwardProps(restProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-base-foreground data-[state=active]:ring-offset-1 data-[disabled]:pr-2',
+        'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-base-foreground data-[state=active]:ring-offset-1',
         className
       )
     "

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="
       cn(
-        'flex h-5 items-center rounded-md bg-secondary data-[state=active]:ring-ring data-[state=active]:ring-2 data-[state=active]:ring-offset-2 ring-offset-background',
+        'flex h-6 items-center rounded-md bg-secondary-background text-base-foreground ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1',
         props.class
       )
     "

--- a/src/components/ui/tags-input/TagsInputItem.vue
+++ b/src/components/ui/tags-input/TagsInputItem.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
-import { reactiveOmit } from '@vueuse/core'
 import type { TagsInputItemProps } from 'reka-ui'
 import { TagsInputItem, useForwardProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-const props = defineProps<
-  // eslint-disable-next-line vue/no-unused-properties
+const { class: className, ...restProps } = defineProps<
   TagsInputItemProps & { class?: HTMLAttributes['class'] }
 >()
 
-const delegatedProps = reactiveOmit(props, 'class')
-
-const forwardedProps = useForwardProps(delegatedProps)
+const forwardedProps = useForwardProps(restProps)
 </script>
 
 <template>
@@ -22,7 +18,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     :class="
       cn(
         'flex h-6 items-center gap-1 rounded-sm bg-modal-card-tag-background py-1 pl-2 pr-1 text-modal-card-tag-foreground backdrop-blur-sm ring-offset-base-background data-[state=active]:ring-2 data-[state=active]:ring-primary-background data-[state=active]:ring-offset-1 data-[disabled]:pr-2',
-        props.class
+        className
       )
     "
   >

--- a/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -4,6 +4,7 @@ import type { TagsInputItemDeleteProps } from 'reka-ui'
 import { TagsInputItemDelete, useForwardProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
+import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@/utils/tailwindUtil'
 
 const props = defineProps<
@@ -19,15 +20,15 @@ const forwardedProps = useForwardProps(delegatedProps)
 <template>
   <TagsInputItemDelete
     v-bind="forwardedProps"
+    :as="Button"
+    variant="textonly"
+    size="icon-sm"
     :class="
-      cn(
-        'mr-1 flex rounded bg-transparent text-muted-foreground transition-colors hover:text-base-foreground focus:outline-none',
-        props.class
-      )
+      cn('opacity-60 hover:bg-transparent hover:opacity-100', props.class)
     "
   >
     <slot>
-      <i class="icon-[lucide--x] size-3.5" />
+      <i class="icon-[lucide--x] size-4" />
     </slot>
   </TagsInputItemDelete>
 </template>

--- a/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -19,10 +19,15 @@ const forwardedProps = useForwardProps(delegatedProps)
 <template>
   <TagsInputItemDelete
     v-bind="forwardedProps"
-    :class="cn('flex rounded bg-transparent mr-1', props.class)"
+    :class="
+      cn(
+        'mr-1 flex rounded bg-transparent text-muted-foreground transition-colors hover:text-base-foreground focus:outline-none',
+        props.class
+      )
+    "
   >
     <slot>
-      <i class="icon-[lucide--x] size-4" />
+      <i class="icon-[lucide--x] size-3.5" />
     </slot>
   </TagsInputItemDelete>
 </template>

--- a/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -24,7 +24,10 @@ const forwardedProps = useForwardProps(delegatedProps)
     variant="textonly"
     size="icon-sm"
     :class="
-      cn('opacity-60 hover:bg-transparent hover:opacity-100', props.class)
+      cn(
+        'opacity-60 hover:bg-transparent hover:opacity-100 transition-[opacity,width] duration-150 w-4 data-[disabled]:w-0 data-[disabled]:opacity-0 data-[disabled]:pointer-events-none overflow-hidden',
+        props.class
+      )
     "
   >
     <slot>

--- a/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -2,6 +2,7 @@
 import type { TagsInputItemDeleteProps } from 'reka-ui'
 import { TagsInputItemDelete, useForwardProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@/utils/tailwindUtil'
@@ -11,6 +12,7 @@ const { class: className, ...restProps } = defineProps<
 >()
 
 const forwardedProps = useForwardProps(restProps)
+const { t } = useI18n()
 </script>
 
 <template>
@@ -19,6 +21,7 @@ const forwardedProps = useForwardProps(restProps)
     :as="Button"
     variant="textonly"
     size="icon-sm"
+    :aria-label="t('g.removeTag')"
     :class="
       cn(
         'opacity-60 hover:bg-transparent hover:opacity-100 transition-[opacity,width] duration-150 w-4 data-[disabled]:w-0 data-[disabled]:opacity-0 data-[disabled]:pointer-events-none overflow-hidden',

--- a/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { reactiveOmit } from '@vueuse/core'
+import type { TagsInputItemDeleteProps } from 'reka-ui'
+import { TagsInputItemDelete, useForwardProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const props = defineProps<
+  // eslint-disable-next-line vue/no-unused-properties
+  TagsInputItemDeleteProps & { class?: HTMLAttributes['class'] }
+>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputItemDelete
+    v-bind="forwardedProps"
+    :class="cn('flex rounded bg-transparent mr-1', props.class)"
+  >
+    <slot>
+      <i class="icon-[lucide--x] size-4" />
+    </slot>
+  </TagsInputItemDelete>
+</template>

--- a/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { reactiveOmit } from '@vueuse/core'
 import type { TagsInputItemDeleteProps } from 'reka-ui'
 import { TagsInputItemDelete, useForwardProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
@@ -7,14 +6,11 @@ import type { HTMLAttributes } from 'vue'
 import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@/utils/tailwindUtil'
 
-const props = defineProps<
-  // eslint-disable-next-line vue/no-unused-properties
+const { class: className, ...restProps } = defineProps<
   TagsInputItemDeleteProps & { class?: HTMLAttributes['class'] }
 >()
 
-const delegatedProps = reactiveOmit(props, 'class')
-
-const forwardedProps = useForwardProps(delegatedProps)
+const forwardedProps = useForwardProps(restProps)
 </script>
 
 <template>
@@ -26,7 +22,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     :class="
       cn(
         'opacity-60 hover:bg-transparent hover:opacity-100 transition-[opacity,width] duration-150 w-4 data-[disabled]:w-0 data-[disabled]:opacity-0 data-[disabled]:pointer-events-none overflow-hidden',
-        props.class
+        className
       )
     "
   >

--- a/src/components/ui/tags-input/TagsInputItemText.vue
+++ b/src/components/ui/tags-input/TagsInputItemText.vue
@@ -19,6 +19,6 @@ const forwardedProps = useForwardProps(delegatedProps)
 <template>
   <TagsInputItemText
     v-bind="forwardedProps"
-    :class="cn('py-0.5 px-2 text-sm rounded bg-transparent', props.class)"
+    :class="cn('rounded bg-transparent px-2 py-0.5 text-sm', props.class)"
   />
 </template>

--- a/src/components/ui/tags-input/TagsInputItemText.vue
+++ b/src/components/ui/tags-input/TagsInputItemText.vue
@@ -1,24 +1,20 @@
 <script setup lang="ts">
-import { reactiveOmit } from '@vueuse/core'
 import type { TagsInputItemTextProps } from 'reka-ui'
 import { TagsInputItemText, useForwardProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-const props = defineProps<
-  // eslint-disable-next-line vue/no-unused-properties
+const { class: className, ...restProps } = defineProps<
   TagsInputItemTextProps & { class?: HTMLAttributes['class'] }
 >()
 
-const delegatedProps = reactiveOmit(props, 'class')
-
-const forwardedProps = useForwardProps(delegatedProps)
+const forwardedProps = useForwardProps(restProps)
 </script>
 
 <template>
   <TagsInputItemText
     v-bind="forwardedProps"
-    :class="cn('bg-transparent text-xs', props.class)"
+    :class="cn('bg-transparent text-xs', className)"
   />
 </template>

--- a/src/components/ui/tags-input/TagsInputItemText.vue
+++ b/src/components/ui/tags-input/TagsInputItemText.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { reactiveOmit } from '@vueuse/core'
+import type { TagsInputItemTextProps } from 'reka-ui'
+import { TagsInputItemText, useForwardProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const props = defineProps<
+  // eslint-disable-next-line vue/no-unused-properties
+  TagsInputItemTextProps & { class?: HTMLAttributes['class'] }
+>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputItemText
+    v-bind="forwardedProps"
+    :class="cn('py-0.5 px-2 text-sm rounded bg-transparent', props.class)"
+  />
+</template>

--- a/src/components/ui/tags-input/TagsInputItemText.vue
+++ b/src/components/ui/tags-input/TagsInputItemText.vue
@@ -19,6 +19,6 @@ const forwardedProps = useForwardProps(delegatedProps)
 <template>
   <TagsInputItemText
     v-bind="forwardedProps"
-    :class="cn('rounded bg-transparent px-2 py-0.5 text-sm', props.class)"
+    :class="cn('bg-transparent text-xs', props.class)"
   />
 </template>

--- a/src/components/ui/tags-input/index.ts
+++ b/src/components/ui/tags-input/index.ts
@@ -1,0 +1,5 @@
+export { default as TagsInput } from "./TagsInput.vue"
+export { default as TagsInputInput } from "./TagsInputInput.vue"
+export { default as TagsInputItem } from "./TagsInputItem.vue"
+export { default as TagsInputItemDelete } from "./TagsInputItemDelete.vue"
+export { default as TagsInputItemText } from "./TagsInputItemText.vue"

--- a/src/components/ui/tags-input/index.ts
+++ b/src/components/ui/tags-input/index.ts
@@ -1,5 +1,0 @@
-export { default as TagsInput } from "./TagsInput.vue"
-export { default as TagsInputInput } from "./TagsInputInput.vue"
-export { default as TagsInputItem } from "./TagsInputItem.vue"
-export { default as TagsInputItemDelete } from "./TagsInputItemDelete.vue"
-export { default as TagsInputItemText } from "./TagsInputItemText.vue"

--- a/src/components/ui/tags-input/tagsInputContext.ts
+++ b/src/components/ui/tags-input/tagsInputContext.ts
@@ -1,7 +1,10 @@
-import type { InjectionKey } from 'vue'
+import type { InjectionKey, Ref } from 'vue'
 
 export type FocusCallback = (() => void) | undefined
 
 export const tagsInputFocusKey: InjectionKey<
   (callback: FocusCallback) => void
 > = Symbol('tagsInputFocus')
+
+export const tagsInputIsEditingKey: InjectionKey<Ref<boolean>> =
+  Symbol('tagsInputIsEditing')

--- a/src/components/ui/tags-input/tagsInputContext.ts
+++ b/src/components/ui/tags-input/tagsInputContext.ts
@@ -1,0 +1,7 @@
+import type { InjectionKey } from 'vue'
+
+export type FocusCallback = (() => void) | undefined
+
+export const tagsInputFocusKey: InjectionKey<
+  (callback: FocusCallback) => void
+> = Symbol('tagsInputFocus')

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -16,6 +16,7 @@
     "increment": "Increment",
     "removeImage": "Remove image",
     "removeVideo": "Remove video",
+    "removeTag": "Remove tag",
     "chart": "Chart",
     "chartLowercase": "chart",
     "file": "file",


### PR DESCRIPTION
## Summary

Add TagsInput component based on shadcn-vue/Reka UI primitives with a click-to-edit UX pattern.

## Features

- **Click-to-edit behavior**: Starts in read-only state; clicking enables editing and focuses input; clicking outside exits edit mode
- **Disabled state**: When `disabled=true`, component is completely inert
- **Empty state placeholder**: Shows input placeholder when tag list is empty
- **Animated transitions**: Delete button animates when toggling edit mode
