### PR TITLE
fix: add missing pwa icon in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,13 @@
   "short_name": "ComfyUI",
   "description": "ComfyUI: AI image generation platform",
   "start_url": "/",
+  "icons": [
+    {
+      "src": "/assets/images/comfy-logo-single.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ],
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#000000"


### PR DESCRIPTION
## Summary

Icon is required for PWA in most browsers. In the best case it hides the install button inside "save and share" menu, and uses the favicon of low quality or the first letter of the title for icon. In the worst case the app is not installable

If you don't see the change in the browser - clear browser's cache. I had an issue with it 

## Changes

- **What**: added "icons" into "manifest.json"

## Screenshots

<img width="1087" height="556" alt="Screenshot_20260115_065548" src="https://github.com/user-attachments/assets/61c13bb2-9230-4aae-a8ae-7f505d9a6bec" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8071-fix-add-missing-pwa-icon-in-manifest-json-2e96d73d3650818f9f10e79e4cc8cd5d) by [Unito](https://www.unito.io)
