### PR TITLE
Make sure toggle visibility checks remote config

### DIFF
--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -44,7 +44,9 @@
         <SidebarBottomPanelToggleButton :is-small="isSmall" />
         <SidebarShortcutsToggleButton :is-small="isSmall" />
         <SidebarSettingsButton :is-small="isSmall" />
-        <ModeToggle v-if="menuItemStore.hasSeenLinear || linearFeatureFlag" />
+        <ModeToggle
+          v-if="menuItemStore.hasSeenLinear || flags.linearToggleEnabled"
+        />
       </div>
     </div>
     <HelpCenterPopups :is-small="isSmall" />
@@ -88,11 +90,7 @@ const menuItemStore = useMenuItemStore()
 const sideToolbarRef = ref<HTMLElement>()
 const topToolbarRef = ref<HTMLElement>()
 const bottomToolbarRef = ref<HTMLElement>()
-
-const linearFeatureFlag = useFeatureFlags().featureFlag(
-  'linearToggleEnabled',
-  false
-)
+const { flags } = useFeatureFlags()
 
 const isSmall = computed(
   () => settingStore.get('Comfy.Sidebar.Size') === 'small'


### PR DESCRIPTION
The previous fix, with `.featureFlag()` does not actually result in remoteConfig being checked

This time, I did extra manual testing to verify that remoteConfig is populated on cloud and that the visibility of the toggle is actually reactive to changes to remoteConfig.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8086-Make-sure-toggle-visibility-checks-remote-config-2ea6d73d36508182807bce3b0bb52868) by [Unito](https://www.unito.io)
