### PR TITLE
feat(assets): add ModelInfoPanel for asset browser right panel

### DIFF
--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -30,6 +30,10 @@ describe('MyStore', () => {
 
 **Why `stubActions: false`?** By default, testing pinia stubs all actions. Set to `false` when testing actual store behavior.
 
+## i18n in Component Tests
+
+Use real `createI18n` with empty messages instead of mocking `vue-i18n`. See `SearchBox.test.ts` for example.
+
 ## Mock Patterns
 
 ### Reset all mocks at once

--- a/src/components/rightSidePanel/layout/PropertiesAccordionItem.vue
+++ b/src/components/rightSidePanel/layout/PropertiesAccordionItem.vue
@@ -5,25 +5,32 @@ import { cn } from '@/utils/tailwindUtil'
 
 import TransitionCollapse from './TransitionCollapse.vue'
 
-const props = defineProps<{
+const {
+  disabled,
+  label,
+  enableEmptyState,
+  tooltip,
+  class: className
+} = defineProps<{
   disabled?: boolean
   label?: string
   enableEmptyState?: boolean
   tooltip?: string
+  class?: string
 }>()
 
 const isCollapse = defineModel<boolean>('collapse', { default: false })
 
-const isExpanded = computed(() => !isCollapse.value && !props.disabled)
+const isExpanded = computed(() => !isCollapse.value && !disabled)
 
 const tooltipConfig = computed(() => {
-  if (!props.tooltip) return undefined
-  return { value: props.tooltip, showDelay: 1000 }
+  if (!tooltip) return undefined
+  return { value: tooltip, showDelay: 1000 }
 })
 </script>
 
 <template>
-  <div class="flex flex-col bg-comfy-menu-bg">
+  <div :class="cn('flex flex-col bg-comfy-menu-bg', className)">
     <div
       class="sticky top-0 z-10 flex items-center justify-between backdrop-blur-xl bg-inherit"
     >

--- a/src/components/widget/nav/NavItem.vue
+++ b/src/components/widget/nav/NavItem.vue
@@ -35,6 +35,7 @@ import { computed, ref } from 'vue'
 
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import type { NavItemData } from '@/types/navTypes'
+import { cn } from '@/utils/tailwindUtil'
 
 import NavIcon from './NavIcon.vue'
 

--- a/src/components/widget/nav/NavItem.vue
+++ b/src/components/widget/nav/NavItem.vue
@@ -35,7 +35,6 @@ import { computed, ref } from 'vue'
 
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import type { NavItemData } from '@/types/navTypes'
-import { cn } from '@/utils/tailwindUtil'
 
 import NavIcon from './NavIcon.vue'
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2422,6 +2422,8 @@
       "modelTagging": "Model Tagging",
       "modelType": "Model Type",
       "compatibleBaseModels": "Compatible Base Models",
+      "addBaseModel": "Add base model...",
+      "baseModelUnknown": "Base model unknown",
       "additionalTags": "Additional Tags",
       "modelDescription": "Model Description",
       "triggerPhrases": "Trigger Phrases",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2429,7 +2429,8 @@
       "noAdditionalTags": "No additional tags",
       "modelDescription": "Model Description",
       "triggerPhrases": "Trigger Phrases",
-      "description": "Description"
+      "description": "Description",
+      "descriptionPlaceholder": "Add a description for this model..."
     },
     "media": {
       "threeDModelPlaceholder": "3D Model",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2421,6 +2421,7 @@
       "viewOnSource": "View on {source}",
       "modelTagging": "Model Tagging",
       "modelType": "Model Type",
+      "selectModelType": "Select model type...",
       "compatibleBaseModels": "Compatible Base Models",
       "addBaseModel": "Add base model...",
       "baseModelUnknown": "Base model unknown",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2412,6 +2412,21 @@
       "assetCard": "{name} - {type} asset",
       "loadingAsset": "Loading asset"
     },
+    "modelInfo": {
+      "title": "Model Info",
+      "basicInfo": "Basic Info",
+      "displayName": "Display Name",
+      "fileName": "File Name",
+      "source": "Source",
+      "viewOnSource": "View on {source}",
+      "modelTagging": "Model Tagging",
+      "modelType": "Model Type",
+      "compatibleBaseModels": "Compatible Base Models",
+      "additionalTags": "Additional Tags",
+      "modelDescription": "Model Description",
+      "triggerPhrases": "Trigger Phrases",
+      "description": "Description"
+    },
     "media": {
       "threeDModelPlaceholder": "3D Model",
       "audioPlaceholder": "Audio"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -184,6 +184,7 @@
     "source": "Source",
     "filter": "Filter",
     "apply": "Apply",
+    "use": "Use",
     "enabled": "Enabled",
     "installed": "Installed",
     "restart": "Restart",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2433,6 +2433,7 @@
       "modelDescription": "Model Description",
       "triggerPhrases": "Trigger Phrases",
       "description": "Description",
+      "descriptionNotSet": "No description set",
       "descriptionPlaceholder": "Add a description for this model..."
     },
     "media": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2425,6 +2425,8 @@
       "addBaseModel": "Add base model...",
       "baseModelUnknown": "Base model unknown",
       "additionalTags": "Additional Tags",
+      "addTag": "Add tag...",
+      "noAdditionalTags": "No additional tags",
       "modelDescription": "Model Description",
       "triggerPhrases": "Trigger Phrases",
       "description": "Description"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2415,6 +2415,7 @@
     },
     "modelInfo": {
       "title": "Model Info",
+      "selectModelPrompt": "Select a model to see its information",
       "basicInfo": "Basic Info",
       "displayName": "Display Name",
       "fileName": "File Name",

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -5,6 +5,7 @@
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"
+    :right-panel-title="$t('assetBrowser.modelInfo.title')"
     @close="handleClose"
   >
     <template v-if="shouldShowLeftPanel" #leftPanel>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,13 +1,11 @@
 <template>
   <BaseModalLayout
-    :hide-right-panel-button="true"
-    :right-panel-open="isPanelOpen"
+    v-model:right-panel-open="isRightPanelOpen"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"
     :right-panel-title="$t('assetBrowser.modelInfo.title')"
     @close="handleClose"
-    @update:right-panel-open="handlePanelClose"
   >
     <template v-if="shouldShowLeftPanel" #leftPanel>
       <LeftSidePanel
@@ -75,7 +73,7 @@
 </template>
 
 <script setup lang="ts">
-import { breakpointsTailwind, refDebounced, useBreakpoints } from '@vueuse/core'
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import { computed, provide, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -163,14 +161,7 @@ const {
 } = useAssetBrowser(fetchedAssets)
 
 const focusedAsset = ref<AssetDisplayItem | null>(null)
-
-// Debounce panel visibility to prevent flicker when switching between assets
-// (blur fires before focus when clicking a different card)
-const isPanelOpen = refDebounced(
-  computed(() => !!focusedAsset.value),
-  16,
-  { maxWait: 16 }
-)
+const isRightPanelOpen = ref(false)
 
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []
@@ -220,11 +211,5 @@ function handleAssetFocus(asset: AssetDisplayItem) {
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
   emit('asset-select', asset)
   props.onSelect?.(asset)
-}
-
-function handlePanelClose(isOpen: boolean) {
-  if (!isOpen) {
-    focusedAsset.value = null
-  }
 }
 </script>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -63,6 +63,7 @@
         @asset-blur="focusedAsset = null"
         @asset-select="handleAssetSelectAndEmit"
         @asset-deleted="refreshAssets"
+        @asset-show-info="handleShowInfo"
       />
     </template>
 
@@ -212,6 +213,11 @@ function handleClose() {
 
 function handleAssetFocus(asset: AssetDisplayItem) {
   focusedAsset.value = asset
+}
+
+function handleShowInfo(asset: AssetDisplayItem) {
+  focusedAsset.value = asset
+  isRightPanelOpen.value = true
 }
 
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,6 +1,6 @@
 <template>
   <BaseModalLayout
-    :hide-right-panel-button="!!focusedAsset"
+    :hide-right-panel-button="true"
     :right-panel-open="!!focusedAsset"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -68,6 +68,12 @@
 
     <template #rightPanel>
       <ModelInfoPanel v-if="focusedAsset" :asset="focusedAsset" :cache-key />
+      <div
+        v-else
+        class="flex h-full items-center justify-center break-words p-6 text-center text-muted"
+      >
+        {{ $t('assetBrowser.modelInfo.selectModelPrompt') }}
+      </div>
     </template>
   </BaseModalLayout>
 </template>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,7 +1,7 @@
 <template>
   <BaseModalLayout
     :hide-right-panel-button="true"
-    :right-panel-open="!!focusedAsset"
+    :right-panel-open="isPanelOpen"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"
@@ -74,7 +74,7 @@
 </template>
 
 <script setup lang="ts">
-import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+import { breakpointsTailwind, refDebounced, useBreakpoints } from '@vueuse/core'
 import { computed, provide, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -162,6 +162,14 @@ const {
 } = useAssetBrowser(fetchedAssets)
 
 const focusedAsset = ref<AssetDisplayItem | null>(null)
+
+// Debounce panel visibility to prevent flicker when switching between assets
+// (blur fires before focus when clicking a different card)
+const isPanelOpen = refDebounced(
+  computed(() => !!focusedAsset.value),
+  16,
+  { maxWait: 16 }
+)
 
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -7,6 +7,7 @@
     :content-title="displayTitle"
     :right-panel-title="$t('assetBrowser.modelInfo.title')"
     @close="handleClose"
+    @update:right-panel-open="handlePanelClose"
   >
     <template v-if="shouldShowLeftPanel" #leftPanel>
       <LeftSidePanel
@@ -219,5 +220,11 @@ function handleAssetFocus(asset: AssetDisplayItem) {
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
   emit('asset-select', asset)
   props.onSelect?.(asset)
+}
+
+function handlePanelClose(isOpen: boolean) {
+  if (!isOpen) {
+    focusedAsset.value = null
+  }
 }
 </script>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -49,7 +49,6 @@
     <template #contentFilter>
       <AssetFilterBar
         :assets="categoryFilteredAssets"
-        :all-assets="fetchedAssets"
         @filter-change="updateFilters"
       />
     </template>
@@ -59,6 +58,7 @@
         :assets="filteredAssets"
         :loading="isLoading"
         :focused-asset-id="focusedAsset?.id"
+        :empty-message
         @asset-focus="handleAssetFocus"
         @asset-blur="focusedAsset = null"
         @asset-select="handleAssetSelectAndEmit"
@@ -164,6 +164,7 @@ const {
   navItems,
   categoryFilteredAssets,
   filteredAssets,
+  isImportedSelected,
   updateFilters
 } = useAssetBrowser(fetchedAssets)
 
@@ -204,6 +205,14 @@ const displayTitle = computed(() => {
 
 const shouldShowLeftPanel = computed(() => {
   return props.showLeftPanel ?? true
+})
+
+const emptyMessage = computed(() => {
+  if (!isImportedSelected.value) return undefined
+
+  return isUploadButtonEnabled.value
+    ? t('assetBrowser.emptyImported.canImport')
+    : t('assetBrowser.emptyImported.restricted')
 })
 
 function handleClose() {

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -60,12 +60,16 @@
         @asset-deleted="refreshAssets"
       />
     </template>
+
+    <template v-if="selectedAsset" #rightPanel>
+      <ModelInfoPanel :asset="selectedAsset" />
+    </template>
   </BaseModalLayout>
 </template>
 
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import { computed, provide } from 'vue'
+import { computed, provide, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SearchBox from '@/components/common/SearchBox.vue'
@@ -74,6 +78,7 @@ import BaseModalLayout from '@/components/widget/layout/BaseModalLayout.vue'
 import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
 import AssetFilterBar from '@/platform/assets/components/AssetFilterBar.vue'
 import AssetGrid from '@/platform/assets/components/AssetGrid.vue'
+import ModelInfoPanel from '@/platform/assets/components/modelInfo/ModelInfoPanel.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
@@ -145,6 +150,8 @@ const {
   updateFilters
 } = useAssetBrowser(fetchedAssets)
 
+const selectedAsset = ref<AssetDisplayItem | null>(null)
+
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []
   const tagFromAssets = assets
@@ -187,6 +194,7 @@ function handleClose() {
 }
 
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
+  selectedAsset.value = asset
   emit('asset-select', asset)
   // onSelect callback is provided by dialog composable layer
   // It handles the appropriate transformation (filename extraction or full asset)

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,5 +1,7 @@
 <template>
   <BaseModalLayout
+    :hide-right-panel-button="true"
+    :right-panel-open="!!focusedAsset"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"
@@ -56,13 +58,16 @@
       <AssetGrid
         :assets="filteredAssets"
         :loading="isLoading"
+        :focused-asset-id="focusedAsset?.id"
+        @asset-focus="handleAssetFocus"
+        @asset-blur="focusedAsset = null"
         @asset-select="handleAssetSelectAndEmit"
         @asset-deleted="refreshAssets"
       />
     </template>
 
-    <template v-if="selectedAsset" #rightPanel>
-      <ModelInfoPanel :asset="selectedAsset" />
+    <template #rightPanel>
+      <ModelInfoPanel v-if="focusedAsset" :asset="focusedAsset" />
     </template>
   </BaseModalLayout>
 </template>
@@ -150,7 +155,7 @@ const {
   updateFilters
 } = useAssetBrowser(fetchedAssets)
 
-const selectedAsset = ref<AssetDisplayItem | null>(null)
+const focusedAsset = ref<AssetDisplayItem | null>(null)
 
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []
@@ -193,11 +198,12 @@ function handleClose() {
   emit('close')
 }
 
+function handleAssetFocus(asset: AssetDisplayItem) {
+  focusedAsset.value = asset
+}
+
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
-  selectedAsset.value = asset
   emit('asset-select', asset)
-  // onSelect callback is provided by dialog composable layer
-  // It handles the appropriate transformation (filename extraction or full asset)
   props.onSelect?.(asset)
 }
 </script>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -68,7 +68,7 @@
     </template>
 
     <template #rightPanel>
-      <ModelInfoPanel v-if="focusedAsset" :asset="focusedAsset" />
+      <ModelInfoPanel v-if="focusedAsset" :asset="focusedAsset" :cache-key />
     </template>
   </BaseModalLayout>
 </template>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,6 +1,6 @@
 <template>
   <BaseModalLayout
-    :hide-right-panel-button="true"
+    :hide-right-panel-button="!!focusedAsset"
     :right-panel-open="!!focusedAsset"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
@@ -87,6 +87,7 @@ import AssetGrid from '@/platform/assets/components/AssetGrid.vue'
 import ModelInfoPanel from '@/platform/assets/components/modelInfo/ModelInfoPanel.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
+import { useModelTypes } from '@/platform/assets/composables/useModelTypes'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { formatCategoryLabel } from '@/platform/assets/utils/categoryLabel'
@@ -142,6 +143,10 @@ async function refreshAssets(): Promise<void> {
 
 // Trigger background refresh on mount
 void refreshAssets()
+
+// Eagerly fetch model types so they're available when ModelInfoPanel loads
+const { fetchModelTypes } = useModelTypes()
+void fetchModelTypes()
 
 const { isUploadButtonEnabled, showUploadDialog } =
   useModelUpload(refreshAssets)

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -25,7 +25,7 @@
     <template #header>
       <div
         class="flex w-full items-center justify-between gap-2"
-        @click="focusedAsset = null"
+        @click.self="focusedAsset = null"
       >
         <SearchBox
           v-model="searchQuery"
@@ -53,7 +53,7 @@
       <AssetFilterBar
         :assets="categoryFilteredAssets"
         @filter-change="updateFilters"
-        @click="focusedAsset = null"
+        @click.self="focusedAsset = null"
       />
     </template>
 

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -23,7 +23,10 @@
     </template>
 
     <template #header>
-      <div class="flex w-full items-center justify-between gap-2">
+      <div
+        class="flex w-full items-center justify-between gap-2"
+        @click="focusedAsset = null"
+      >
         <SearchBox
           v-model="searchQuery"
           :autofocus="true"
@@ -50,6 +53,7 @@
       <AssetFilterBar
         :assets="categoryFilteredAssets"
         @filter-change="updateFilters"
+        @click="focusedAsset = null"
       />
     </template>
 
@@ -60,10 +64,10 @@
         :focused-asset-id="focusedAsset?.id"
         :empty-message
         @asset-focus="handleAssetFocus"
-        @asset-blur="focusedAsset = null"
         @asset-select="handleAssetSelectAndEmit"
         @asset-deleted="refreshAssets"
         @asset-show-info="handleShowInfo"
+        @click="focusedAsset = null"
       />
     </template>
 

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -14,7 +14,6 @@
       )
     "
     @click.stop="interactive && $emit('focus', asset)"
-    @dblclick="interactive && $emit('select', asset)"
     @keydown.enter.self="interactive && $emit('select', asset)"
   >
     <div class="relative aspect-square w-full overflow-hidden rounded-xl">
@@ -95,19 +94,36 @@
       >
         {{ asset.description }}
       </p>
-      <div class="flex gap-4 text-xs text-muted-foreground mt-auto">
-        <span v-if="asset.stats.stars" class="flex items-center gap-1">
-          <i class="icon-[lucide--star] size-3" />
-          {{ asset.stats.stars }}
-        </span>
-        <span v-if="asset.stats.downloadCount" class="flex items-center gap-1">
-          <i class="icon-[lucide--download] size-3" />
-          {{ asset.stats.downloadCount }}
-        </span>
-        <span v-if="asset.stats.formattedDate" class="flex items-center gap-1">
-          <i class="icon-[lucide--clock] size-3" />
-          {{ asset.stats.formattedDate }}
-        </span>
+      <div class="flex items-center justify-between gap-2 mt-auto">
+        <div class="flex gap-3 text-xs text-muted-foreground">
+          <span v-if="asset.stats.stars" class="flex items-center gap-1">
+            <i class="icon-[lucide--star] size-3" />
+            {{ asset.stats.stars }}
+          </span>
+          <span
+            v-if="asset.stats.downloadCount"
+            class="flex items-center gap-1"
+          >
+            <i class="icon-[lucide--download] size-3" />
+            {{ asset.stats.downloadCount }}
+          </span>
+          <span
+            v-if="asset.stats.formattedDate"
+            class="flex items-center gap-1"
+          >
+            <i class="icon-[lucide--clock] size-3" />
+            {{ asset.stats.formattedDate }}
+          </span>
+        </div>
+        <Button
+          v-if="interactive"
+          variant="secondary"
+          size="lg"
+          class="shrink-0"
+          @click.stop="$emit('select', asset)"
+        >
+          {{ $t('g.use') }}
+        </Button>
       </div>
     </div>
   </div>

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -14,6 +14,7 @@
       )
     "
     @click.stop="interactive && $emit('focus', asset)"
+    @focus="interactive && $emit('focus', asset)"
     @keydown.enter.self="interactive && $emit('select', asset)"
   >
     <div class="relative aspect-square w-full overflow-hidden rounded-xl">

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    ref="card"
     data-component-id="AssetCard"
     :data-asset-id="asset.id"
     :aria-labelledby="titleId"
@@ -10,7 +9,8 @@
       cn(
         'rounded-2xl overflow-hidden transition-all duration-200 bg-modal-card-background p-2 gap-2 flex flex-col h-full',
         interactive &&
-          'group appearance-none bg-transparent m-0 outline-none text-left hover:bg-secondary-background focus:bg-secondary-background border-none focus:outline-solid outline-base-foreground outline-4'
+          'group appearance-none bg-transparent m-0 outline-none text-left hover:bg-secondary-background focus:bg-secondary-background border-none focus:outline-solid outline-base-foreground outline-4',
+        focused && 'bg-secondary-background outline-solid'
       )
     "
     @click.stop="interactive && $emit('focus', asset)"
@@ -131,7 +131,7 @@
 </template>
 
 <script setup lang="ts">
-import { onClickOutside, useImage } from '@vueuse/core'
+import { useImage } from '@vueuse/core'
 import { computed, ref, toValue, useId, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -150,11 +150,7 @@ import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { cn } from '@/utils/tailwindUtil'
 
-const {
-  asset,
-  interactive,
-  focused = false
-} = defineProps<{
+const { asset, interactive, focused } = defineProps<{
   asset: AssetDisplayItem
   interactive?: boolean
   focused?: boolean
@@ -162,7 +158,6 @@ const {
 
 const emit = defineEmits<{
   focus: [asset: AssetDisplayItem]
-  blur: []
   select: [asset: AssetDisplayItem]
   deleted: [asset: AssetDisplayItem]
   showInfo: [asset: AssetDisplayItem]
@@ -174,30 +169,8 @@ const { closeDialog } = useDialogStore()
 const { flags } = useFeatureFlags()
 const { isDownloadedThisSession, acknowledgeAsset } = useAssetDownloadStore()
 
-const cardRef = useTemplateRef<HTMLDivElement>('card')
 const dropdownMenuButton = useTemplateRef<InstanceType<typeof MoreButton>>(
   'dropdown-menu-button'
-)
-
-onClickOutside(
-  cardRef,
-  () => {
-    if (focused) {
-      const activeElement = document.activeElement
-      const isInPanel = !!activeElement?.closest(
-        '[data-component-id="ModelInfoPanel"]'
-      )
-      if (isInPanel) return
-
-      emit('blur')
-    }
-  },
-  {
-    ignore: [
-      '[data-component-id="ModelInfoPanel"]',
-      '[data-component-id="RightPanelHeader"]'
-    ]
-  }
 )
 
 const titleId = useId()

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -127,6 +127,7 @@ import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import AssetBadgeGroup from '@/platform/assets/components/AssetBadgeGroup.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import { assetService } from '@/platform/assets/services/assetService'
+import { getAssetDisplayName } from '@/platform/assets/utils/assetMetadataUtils'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -181,7 +182,9 @@ const descId = useId()
 const isEditing = ref(false)
 const newNameRef = ref<string>()
 
-const displayName = computed(() => newNameRef.value ?? asset.name)
+const displayName = computed(
+  () => newNameRef.value ?? getAssetDisplayName(asset)
+)
 
 const showAssetOptions = computed(
   () =>
@@ -260,10 +263,10 @@ async function assetRename(newName?: string) {
     newNameRef.value = newName
     try {
       const result = await assetService.updateAsset(asset.id, {
-        name: newName
+        user_metadata: { name: newName }
       })
       // Update with the actual name once the server responds
-      newNameRef.value = result.name
+      newNameRef.value = getAssetDisplayName(result)
     } catch (err: unknown) {
       console.error(err)
       toastStore.add({

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -30,7 +30,6 @@
 
       <AssetBadgeGroup :badges="asset.badges" />
       <IconGroup
-        v-if="showAssetOptions"
         :class="
           cn(
             'absolute top-2 right-2 invisible group-hover:visible',
@@ -38,7 +37,19 @@
           )
         "
       >
-        <MoreButton ref="dropdown-menu-button" size="sm">
+        <Button
+          v-tooltip.bottom="$t('assetBrowser.modelInfo.title')"
+          variant="secondary"
+          size="sm"
+          @click.stop="$emit('showInfo', asset)"
+        >
+          <i class="icon-[lucide--info]" />
+        </Button>
+        <MoreButton
+          v-if="showAssetOptions"
+          ref="dropdown-menu-button"
+          size="sm"
+        >
           <template #default>
             <Button
               v-if="flags.assetDeletionEnabled"
@@ -146,6 +157,7 @@ const emit = defineEmits<{
   blur: []
   select: [asset: AssetDisplayItem]
   deleted: [asset: AssetDisplayItem]
+  showInfo: [asset: AssetDisplayItem]
 }>()
 
 const { t } = useI18n()

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -115,7 +115,7 @@
 
 <script setup lang="ts">
 import { onClickOutside, useImage } from '@vueuse/core'
-import { computed, ref, toValue, useId, useTemplateRef, watch } from 'vue'
+import { computed, ref, toValue, useId, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import IconGroup from '@/components/button/IconGroup.vue'
@@ -160,21 +160,19 @@ const dropdownMenuButton = useTemplateRef<InstanceType<typeof MoreButton>>(
   'dropdown-menu-button'
 )
 
-const stopClickOutside = ref<(() => void) | null>(null)
-
-watch(
-  () => focused,
-  (isFocused) => {
-    stopClickOutside.value?.()
-    stopClickOutside.value = null
-
-    if (isFocused && cardRef.value) {
-      stopClickOutside.value = onClickOutside(cardRef, () => {
-        emit('blur')
-      })
+onClickOutside(
+  cardRef,
+  () => {
+    if (focused) {
+      emit('blur')
     }
   },
-  { immediate: true }
+  {
+    ignore: [
+      '[data-component-id="ModelInfoPanel"]',
+      '[data-component-id="RightPanelHeader"]'
+    ]
+  }
 )
 
 const titleId = useId()

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -166,10 +166,10 @@ onClickOutside(
   () => {
     if (focused) {
       const activeElement = document.activeElement
-      const isSelectInPanel =
-        activeElement?.tagName === 'SELECT' &&
-        activeElement.closest('[data-component-id="ModelInfoPanel"]')
-      if (isSelectInPanel) return
+      const isInPanel = !!activeElement?.closest(
+        '[data-component-id="ModelInfoPanel"]'
+      )
+      if (isInPanel) return
 
       emit('blur')
     }

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -165,6 +165,12 @@ onClickOutside(
   cardRef,
   () => {
     if (focused) {
+      const activeElement = document.activeElement
+      const isSelectInPanel =
+        activeElement?.tagName === 'SELECT' &&
+        activeElement.closest('[data-component-id="ModelInfoPanel"]')
+      if (isSelectInPanel) return
+
       emit('blur')
     }
   },

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -39,6 +39,7 @@
       >
         <Button
           v-tooltip.bottom="$t('assetBrowser.modelInfo.title')"
+          :aria-label="$t('assetBrowser.modelInfo.title')"
           variant="secondary"
           size="sm"
           @click.stop="$emit('showInfo', asset)"

--- a/src/platform/assets/components/AssetFilterBar.test.ts
+++ b/src/platform/assets/components/AssetFilterBar.test.ts
@@ -10,11 +10,15 @@ import {
   createAssetWithoutBaseModel
 } from '@/platform/assets/fixtures/ui-mock-assets'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { createI18n } from 'vue-i18n'
 
-// Mock @/i18n directly since component imports { t } from '@/i18n'
-vi.mock('@/i18n', () => ({
-  t: (key: string) => key
-}))
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {}
+  }
+})
 
 // Mock components with minimal functionality for business logic testing
 vi.mock('@/components/input/MultiSelect.vue', () => ({
@@ -66,6 +70,7 @@ function mountAssetFilterBar(props = {}) {
   return mount(AssetFilterBar, {
     props,
     global: {
+      plugins: [i18n],
       mocks: {
         $t: (key: string) => key
       }

--- a/src/platform/assets/components/AssetFilterBar.test.ts
+++ b/src/platform/assets/components/AssetFilterBar.test.ts
@@ -86,10 +86,6 @@ function findBaseModelsFilter(wrapper: ReturnType<typeof mountAssetFilterBar>) {
   return wrapper.findComponent('[data-component-id="asset-filter-base-models"]')
 }
 
-function findOwnershipFilter(wrapper: ReturnType<typeof mountAssetFilterBar>) {
-  return wrapper.findComponent('[data-component-id="asset-filter-ownership"]')
-}
-
 function findSortFilter(wrapper: ReturnType<typeof mountAssetFilterBar>) {
   return wrapper.findComponent('[data-component-id="asset-filter-sort"]')
 }
@@ -267,91 +263,6 @@ describe('AssetFilterBar', () => {
 
       expect(fileFormatSelect.exists()).toBe(false)
       expect(baseModelSelect.exists()).toBe(false)
-    })
-
-    it('hides ownership filter when no mutable assets', () => {
-      const assets = [
-        createAssetWithSpecificExtension('safetensors', true) // immutable
-      ]
-      const wrapper = mountAssetFilterBar({ assets })
-
-      const ownershipSelect = findOwnershipFilter(wrapper)
-      expect(ownershipSelect.exists()).toBe(false)
-    })
-
-    it('shows ownership filter when mutable assets exist', () => {
-      const assets = [
-        createAssetWithSpecificExtension('safetensors', false) // mutable
-      ]
-      const wrapper = mountAssetFilterBar({ assets })
-
-      const ownershipSelect = findOwnershipFilter(wrapper)
-      expect(ownershipSelect.exists()).toBe(true)
-    })
-
-    it('shows ownership filter when mixed assets exist', () => {
-      const assets = [
-        createAssetWithSpecificExtension('safetensors', true), // immutable
-        createAssetWithSpecificExtension('ckpt', false) // mutable
-      ]
-      const wrapper = mountAssetFilterBar({ assets })
-
-      const ownershipSelect = findOwnershipFilter(wrapper)
-      expect(ownershipSelect.exists()).toBe(true)
-    })
-
-    it('shows ownership filter with allAssets when provided', () => {
-      const assets = [
-        createAssetWithSpecificExtension('safetensors', true) // immutable
-      ]
-      const allAssets = [
-        createAssetWithSpecificExtension('safetensors', true), // immutable
-        createAssetWithSpecificExtension('ckpt', false) // mutable
-      ]
-      const wrapper = mountAssetFilterBar({ assets, allAssets })
-
-      const ownershipSelect = findOwnershipFilter(wrapper)
-      expect(ownershipSelect.exists()).toBe(true)
-    })
-  })
-
-  describe('Ownership Filter', () => {
-    it('emits ownership filter changes', async () => {
-      const assets = [
-        createAssetWithSpecificExtension('safetensors', false) // mutable
-      ]
-      const wrapper = mountAssetFilterBar({ assets })
-
-      const ownershipSelect = findOwnershipFilter(wrapper)
-      expect(ownershipSelect.exists()).toBe(true)
-
-      const ownershipSelectElement = ownershipSelect.find('select')
-      ownershipSelectElement.element.value = 'my-models'
-      await ownershipSelectElement.trigger('change')
-      await nextTick()
-
-      const emitted = wrapper.emitted('filterChange')
-      expect(emitted).toBeTruthy()
-
-      const filterState = emitted![emitted!.length - 1][0] as FilterState
-      expect(filterState.ownership).toBe('my-models')
-    })
-
-    it('ownership filter defaults to "all"', async () => {
-      const assets = [
-        createAssetWithSpecificExtension('safetensors', false) // mutable
-      ]
-      const wrapper = mountAssetFilterBar({ assets })
-
-      const sortSelect = findSortFilter(wrapper)
-      const sortSelectElement = sortSelect.find('select')
-      sortSelectElement.element.value = 'recent'
-      await sortSelectElement.trigger('change')
-      await nextTick()
-
-      const emitted = wrapper.emitted('filterChange')
-      const filterState = emitted![0][0] as FilterState
-      expect(filterState.ownership).toBe('all')
     })
   })
 })

--- a/src/platform/assets/components/AssetFilterBar.test.ts
+++ b/src/platform/assets/components/AssetFilterBar.test.ts
@@ -70,10 +70,14 @@ function mountAssetFilterBar(props = {}) {
   return mount(AssetFilterBar, {
     props,
     global: {
-      plugins: [i18n],
-      mocks: {
-        $t: (key: string) => key
-      }
+function mountAssetFilterBar(props = {}) {
+  return mount(AssetFilterBar, {
+    props,
+    global: {
+      plugins: [i18n]
+    }
+  })
+}
     }
   })
 }

--- a/src/platform/assets/components/AssetFilterBar.test.ts
+++ b/src/platform/assets/components/AssetFilterBar.test.ts
@@ -70,14 +70,7 @@ function mountAssetFilterBar(props = {}) {
   return mount(AssetFilterBar, {
     props,
     global: {
-function mountAssetFilterBar(props = {}) {
-  return mount(AssetFilterBar, {
-    props,
-    global: {
       plugins: [i18n]
-    }
-  })
-}
     }
   })
 }

--- a/src/platform/assets/components/AssetFilterBar.vue
+++ b/src/platform/assets/components/AssetFilterBar.vue
@@ -26,16 +26,6 @@
         data-component-id="asset-filter-base-models"
         @update:model-value="handleFilterChange"
       />
-
-      <SingleSelect
-        v-if="hasMutableAssets"
-        v-model="ownership"
-        :label="$t('assetBrowser.ownership')"
-        :options="ownershipOptions"
-        class="min-w-42"
-        data-component-id="asset-filter-ownership"
-        @update:model-value="handleFilterChange"
-      />
     </div>
 
     <div class="flex items-center" data-component-id="asset-filter-bar-right">
@@ -57,55 +47,40 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import MultiSelect from '@/components/input/MultiSelect.vue'
 import SingleSelect from '@/components/input/SingleSelect.vue'
 import type { SelectOption } from '@/components/input/types'
-import { t } from '@/i18n'
-import type { OwnershipOption } from '@/platform/assets/composables/useAssetBrowser'
 import { useAssetFilterOptions } from '@/platform/assets/composables/useAssetFilterOptions'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
-const SORT_OPTIONS = [
-  { name: t('assetBrowser.sortRecent'), value: 'recent' },
-  { name: t('assetBrowser.sortAZ'), value: 'name-asc' },
-  { name: t('assetBrowser.sortZA'), value: 'name-desc' }
-] as const
+const { t } = useI18n()
 
-type SortOption = (typeof SORT_OPTIONS)[number]['value']
+type SortOption = 'recent' | 'name-asc' | 'name-desc'
 
-const sortOptions = [...SORT_OPTIONS]
-
-const ownershipOptions = [
-  { name: t('assetBrowser.ownershipAll'), value: 'all' },
-  { name: t('assetBrowser.ownershipMyModels'), value: 'my-models' },
-  { name: t('assetBrowser.ownershipPublicModels'), value: 'public-models' }
-]
+const sortOptions = computed(() => [
+  { name: t('assetBrowser.sortRecent'), value: 'recent' as const },
+  { name: t('assetBrowser.sortAZ'), value: 'name-asc' as const },
+  { name: t('assetBrowser.sortZA'), value: 'name-desc' as const }
+])
 
 export interface FilterState {
   fileFormats: string[]
   baseModels: string[]
   sortBy: string
-  ownership: OwnershipOption
 }
 
-const { assets = [], allAssets = [] } = defineProps<{
+const { assets = [] } = defineProps<{
   assets?: AssetItem[]
-  allAssets?: AssetItem[]
 }>()
 
 const fileFormats = ref<SelectOption[]>([])
 const baseModels = ref<SelectOption[]>([])
 const sortBy = ref<SortOption>('recent')
-const ownership = ref<OwnershipOption>('all')
 
 const { availableFileFormats, availableBaseModels } =
   useAssetFilterOptions(assets)
-
-const hasMutableAssets = computed(() => {
-  const assetsToCheck = allAssets.length ? allAssets : assets
-  return assetsToCheck.some((asset) => asset.is_immutable === false)
-})
 
 const emit = defineEmits<{
   filterChange: [filters: FilterState]
@@ -115,8 +90,7 @@ function handleFilterChange() {
   emit('filterChange', {
     fileFormats: fileFormats.value.map((option: SelectOption) => option.value),
     baseModels: baseModels.value.map((option: SelectOption) => option.value),
-    sortBy: sortBy.value,
-    ownership: ownership.value
+    sortBy: sortBy.value
   })
 }
 </script>

--- a/src/platform/assets/components/AssetFilterBar.vue
+++ b/src/platform/assets/components/AssetFilterBar.vue
@@ -68,7 +68,7 @@ const sortOptions = computed(() => [
 export interface FilterState {
   fileFormats: string[]
   baseModels: string[]
-  sortBy: string
+  sortBy: SortOption
 }
 
 const { assets = [] } = defineProps<{

--- a/src/platform/assets/components/AssetGrid.vue
+++ b/src/platform/assets/components/AssetGrid.vue
@@ -79,7 +79,7 @@ const isLg = breakpoints.greaterOrEqual('lg')
 const isMd = breakpoints.greaterOrEqual('md')
 const maxColumns = computed(() => {
   if (is2Xl.value) return 5
-  if (isXl.value) return 4
+  if (isXl.value) return 3
   if (isLg.value) return 3
   if (isMd.value) return 2
   return 1

--- a/src/platform/assets/components/AssetGrid.vue
+++ b/src/platform/assets/components/AssetGrid.vue
@@ -35,6 +35,9 @@
         <AssetCard
           :asset="item"
           :interactive="true"
+          :focused="item.id === focusedAssetId"
+          @focus="$emit('assetFocus', $event)"
+          @blur="$emit('assetBlur')"
           @select="$emit('assetSelect', $event)"
           @deleted="$emit('assetDeleted', $event)"
         />
@@ -52,12 +55,15 @@ import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import AssetCard from '@/platform/assets/components/AssetCard.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 
-const { assets } = defineProps<{
+const { assets, focusedAssetId } = defineProps<{
   assets: AssetDisplayItem[]
   loading?: boolean
+  focusedAssetId?: string | null
 }>()
 
 defineEmits<{
+  assetFocus: [asset: AssetDisplayItem]
+  assetBlur: []
   assetSelect: [asset: AssetDisplayItem]
   assetDeleted: [asset: AssetDisplayItem]
 }>()

--- a/src/platform/assets/components/AssetGrid.vue
+++ b/src/platform/assets/components/AssetGrid.vue
@@ -19,9 +19,11 @@
     >
       <i class="mb-4 icon-[lucide--search] size-10" />
       <h3 class="mb-2 text-lg font-medium">
-        {{ $t('assetBrowser.noAssetsFound') }}
+        {{ emptyTitle ?? $t('assetBrowser.noAssetsFound') }}
       </h3>
-      <p class="text-sm">{{ $t('assetBrowser.tryAdjustingFilters') }}</p>
+      <p class="text-sm">
+        {{ emptyMessage ?? $t('assetBrowser.tryAdjustingFilters') }}
+      </p>
     </div>
     <VirtualGrid
       v-else
@@ -56,10 +58,12 @@ import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import AssetCard from '@/platform/assets/components/AssetCard.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 
-const { assets, focusedAssetId } = defineProps<{
+const { assets, focusedAssetId, emptyTitle, emptyMessage } = defineProps<{
   assets: AssetDisplayItem[]
   loading?: boolean
   focusedAssetId?: string | null
+  emptyTitle?: string
+  emptyMessage?: string
 }>()
 
 defineEmits<{

--- a/src/platform/assets/components/AssetGrid.vue
+++ b/src/platform/assets/components/AssetGrid.vue
@@ -40,6 +40,7 @@
           @blur="$emit('assetBlur')"
           @select="$emit('assetSelect', $event)"
           @deleted="$emit('assetDeleted', $event)"
+          @show-info="$emit('assetShowInfo', $event)"
         />
       </template>
     </VirtualGrid>
@@ -66,6 +67,7 @@ defineEmits<{
   assetBlur: []
   assetSelect: [asset: AssetDisplayItem]
   assetDeleted: [asset: AssetDisplayItem]
+  assetShowInfo: [asset: AssetDisplayItem]
 }>()
 
 const assetsWithKey = computed(() =>

--- a/src/platform/assets/components/AssetGrid.vue
+++ b/src/platform/assets/components/AssetGrid.vue
@@ -39,7 +39,6 @@
           :interactive="true"
           :focused="item.id === focusedAssetId"
           @focus="$emit('assetFocus', $event)"
-          @blur="$emit('assetBlur')"
           @select="$emit('assetSelect', $event)"
           @deleted="$emit('assetDeleted', $event)"
           @show-info="$emit('assetShowInfo', $event)"
@@ -68,7 +67,6 @@ const { assets, focusedAssetId, emptyTitle, emptyMessage } = defineProps<{
 
 defineEmits<{
   assetFocus: [asset: AssetDisplayItem]
-  assetBlur: []
   assetSelect: [asset: AssetDisplayItem]
   assetDeleted: [asset: AssetDisplayItem]
   assetShowInfo: [asset: AssetDisplayItem]

--- a/src/platform/assets/components/modelInfo/ModelInfoField.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoField.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="flex flex-col gap-1 px-4 py-2">
+    <span class="text-xs text-muted-foreground">{{ label }}</span>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+}>()
+</script>

--- a/src/platform/assets/components/modelInfo/ModelInfoField.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoField.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col gap-1 px-4 py-2">
-    <span class="text-xs text-muted-foreground">{{ label }}</span>
+  <div class="flex flex-col gap-1 px-4 py-2 text-sm text-muted-foreground">
+    <span>{{ label }}</span>
     <slot />
   </div>
 </template>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
@@ -1,0 +1,212 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
+
+import ModelInfoPanel from './ModelInfoPanel.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key
+  })
+}))
+
+vi.mock(
+  '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue',
+  () => ({
+    default: {
+      name: 'PropertiesAccordionItem',
+      template: `
+      <div data-testid="accordion-item">
+        <div data-testid="accordion-label"><slot name="label" /></div>
+        <div data-testid="accordion-content"><slot /></div>
+      </div>
+    `
+    }
+  })
+)
+
+vi.mock('./ModelInfoField.vue', () => ({
+  default: {
+    name: 'ModelInfoField',
+    props: ['label'],
+    template: `
+      <div data-testid="model-info-field" :data-label="label">
+        <span>{{ label }}</span>
+        <slot />
+      </div>
+    `
+  }
+}))
+
+describe('ModelInfoPanel', () => {
+  const createMockAsset = (
+    overrides: Partial<AssetDisplayItem> = {}
+  ): AssetDisplayItem => ({
+    id: 'test-id',
+    name: 'test-model.safetensors',
+    asset_hash: 'hash123',
+    size: 1024,
+    mime_type: 'application/octet-stream',
+    tags: ['models', 'checkpoints'],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    last_access_time: '2024-01-01T00:00:00Z',
+    description: 'A test model description',
+    badges: [],
+    stats: {},
+    ...overrides
+  })
+
+  const mountPanel = (asset: AssetDisplayItem) => {
+    return mount(ModelInfoPanel, {
+      props: { asset },
+      global: {
+        mocks: {
+          $t: (key: string, params?: Record<string, string>) =>
+            params ? `${key}:${JSON.stringify(params)}` : key
+        }
+      }
+    })
+  }
+
+  describe('Basic Info Section', () => {
+    it('renders panel title', () => {
+      const wrapper = mountPanel(createMockAsset())
+      expect(wrapper.text()).toContain('assetBrowser.modelInfo.title')
+    })
+
+    it('displays asset filename', () => {
+      const asset = createMockAsset({ name: 'my-model.safetensors' })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('my-model.safetensors')
+    })
+
+    it('displays display_name from user_metadata when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { display_name: 'My Custom Model' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('My Custom Model')
+    })
+
+    it('falls back to asset name when display_name not present', () => {
+      const asset = createMockAsset({ name: 'fallback-model.safetensors' })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('fallback-model.safetensors')
+    })
+
+    it('renders source link when source_url is present', () => {
+      const asset = createMockAsset({
+        user_metadata: { source_url: 'https://civitai.com/models/123' }
+      })
+      const wrapper = mountPanel(asset)
+      const link = wrapper.find('a[href="https://civitai.com/models/123"]')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('target')).toBe('_blank')
+    })
+
+    it('displays correct source name for Civitai', () => {
+      const asset = createMockAsset({
+        user_metadata: { source_url: 'https://civitai.com/models/123' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('Civitai')
+    })
+
+    it('displays correct source name for Hugging Face', () => {
+      const asset = createMockAsset({
+        user_metadata: { source_url: 'https://huggingface.co/org/model' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('Hugging Face')
+    })
+
+    it('does not render source field when source_url is absent', () => {
+      const asset = createMockAsset()
+      const wrapper = mountPanel(asset)
+      const links = wrapper.findAll('a')
+      expect(links).toHaveLength(0)
+    })
+  })
+
+  describe('Model Tagging Section', () => {
+    it('displays model type from tags', () => {
+      const asset = createMockAsset({ tags: ['models', 'loras'] })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('loras')
+    })
+
+    it('extracts last segment from nested tag path', () => {
+      const asset = createMockAsset({
+        tags: ['models', 'checkpoints/sd15']
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('sd15')
+    })
+
+    it('displays base_model when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { base_model: 'SDXL' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('SDXL')
+    })
+
+    it('renders additional tags as badges', () => {
+      const asset = createMockAsset({
+        user_metadata: { tags: ['anime', 'portrait', 'detailed'] }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('anime')
+      expect(wrapper.text()).toContain('portrait')
+      expect(wrapper.text()).toContain('detailed')
+    })
+  })
+
+  describe('Model Description Section', () => {
+    it('renders trigger phrases when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { trigger_phrases: ['trigger1', 'trigger2'] }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('trigger1')
+      expect(wrapper.text()).toContain('trigger2')
+    })
+
+    it('renders description when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { description: 'A detailed model description' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('A detailed model description')
+    })
+
+    it('does not render trigger phrases field when empty', () => {
+      const asset = createMockAsset()
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).not.toContain(
+        'assetBrowser.modelInfo.triggerPhrases'
+      )
+    })
+  })
+
+  describe('Accordion Structure', () => {
+    it('renders three accordion sections', () => {
+      const wrapper = mountPanel(createMockAsset())
+      const accordions = wrapper.findAll('[data-testid="accordion-item"]')
+      expect(accordions).toHaveLength(3)
+    })
+
+    it('renders correct section labels', () => {
+      const wrapper = mountPanel(createMockAsset())
+      const labels = wrapper.findAll('[data-testid="accordion-label"]')
+      expect(labels[0].text()).toContain('assetBrowser.modelInfo.basicInfo')
+      expect(labels[1].text()).toContain('assetBrowser.modelInfo.modelTagging')
+      expect(labels[2].text()).toContain(
+        'assetBrowser.modelInfo.modelDescription'
+      )
+    })
+  })
+})

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
@@ -38,11 +38,7 @@ describe('ModelInfoPanel', () => {
     return mount(ModelInfoPanel, {
       props: { asset },
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
-        mocks: {
-          $t: (key: string, params?: Record<string, string>) =>
-            params ? `${key}:${JSON.stringify(params)}` : key
-        }
+        plugins: [createTestingPinia({ stubActions: false }), i18n]
       }
     })
   }
@@ -85,12 +81,14 @@ describe('ModelInfoPanel', () => {
       expect(link.attributes('target')).toBe('_blank')
     })
 
-    it('displays correct source name for Civitai', () => {
+    it('displays Civitai icon for Civitai source', () => {
       const asset = createMockAsset({
         user_metadata: { source_arn: 'civitai:model:123:version:456' }
       })
       const wrapper = mountPanel(asset)
-      expect(wrapper.text()).toContain('Civitai')
+      expect(
+        wrapper.find('img[src="/assets/images/civitai.svg"]').exists()
+      ).toBe(true)
     })
 
     it('does not render source field when source_arn is absent', () => {
@@ -114,7 +112,7 @@ describe('ModelInfoPanel', () => {
 
     it('renders base models field', () => {
       const asset = createMockAsset({
-        user_metadata: { base_models: ['SDXL'] }
+        user_metadata: { base_model: ['SDXL'] }
       })
       const wrapper = mountPanel(asset)
       expect(wrapper.text()).toContain(

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -1,103 +1,98 @@
 <template>
-  <div class="flex h-full flex-col bg-comfy-menu-bg">
-    <div class="flex h-18 items-center border-b border-divider px-4">
-      <h2 class="text-lg font-semibold">
-        {{ $t('assetBrowser.modelInfo.title') }}
-      </h2>
-    </div>
-
-    <div class="flex-1 overflow-y-auto scrollbar-custom">
-      <PropertiesAccordionItem>
-        <template #label>
-          <span class="text-xs uppercase">
-            {{ $t('assetBrowser.modelInfo.basicInfo') }}
-          </span>
-        </template>
-        <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
-          <span class="text-sm">{{ displayName }}</span>
-        </ModelInfoField>
-        <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
-          <span class="text-sm">{{ asset.name }}</span>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="sourceUrl"
-          :label="$t('assetBrowser.modelInfo.source')"
+  <div
+    data-component-id="ModelInfoPanel"
+    class="flex h-full flex-col scrollbar-custom"
+  >
+    <PropertiesAccordionItem class="bg-transparent">
+      <template #label>
+        <span class="text-xs uppercase font-inter">
+          {{ $t('assetBrowser.modelInfo.basicInfo') }}
+        </span>
+      </template>
+      <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
+        <span class="text-sm break-all">{{ displayName }}</span>
+      </ModelInfoField>
+      <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
+        <span class="text-sm break-all">{{ asset.name }}</span>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="sourceUrl"
+        :label="$t('assetBrowser.modelInfo.source')"
+      >
+        <a
+          :href="sourceUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-sm text-link hover:underline"
         >
-          <a
-            :href="sourceUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-sm text-link hover:underline"
+          {{
+            $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
+          }}
+        </a>
+      </ModelInfoField>
+    </PropertiesAccordionItem>
+
+    <PropertiesAccordionItem class="bg-transparent">
+      <template #label>
+        <span class="text-xs uppercase font-inter">
+          {{ $t('assetBrowser.modelInfo.modelTagging') }}
+        </span>
+      </template>
+      <ModelInfoField
+        v-if="modelType"
+        :label="$t('assetBrowser.modelInfo.modelType')"
+      >
+        <span class="text-sm">{{ modelType }}</span>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="baseModel"
+        :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
+      >
+        <span class="text-sm">{{ baseModel }}</span>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="additionalTags.length > 0"
+        :label="$t('assetBrowser.modelInfo.additionalTags')"
+      >
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="tag in additionalTags"
+            :key="tag"
+            class="rounded px-2 py-0.5 text-xs"
           >
-            {{
-              $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
-            }}
-          </a>
-        </ModelInfoField>
-      </PropertiesAccordionItem>
-
-      <PropertiesAccordionItem>
-        <template #label>
-          <span class="text-xs uppercase">
-            {{ $t('assetBrowser.modelInfo.modelTagging') }}
+            {{ tag }}
           </span>
-        </template>
-        <ModelInfoField
-          v-if="modelType"
-          :label="$t('assetBrowser.modelInfo.modelType')"
-        >
-          <span class="text-sm">{{ modelType }}</span>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="baseModel"
-          :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
-        >
-          <span class="text-sm">{{ baseModel }}</span>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="additionalTags.length > 0"
-          :label="$t('assetBrowser.modelInfo.additionalTags')"
-        >
-          <div class="flex flex-wrap gap-1">
-            <span
-              v-for="tag in additionalTags"
-              :key="tag"
-              class="rounded bg-surface-container px-2 py-0.5 text-xs"
-            >
-              {{ tag }}
-            </span>
-          </div>
-        </ModelInfoField>
-      </PropertiesAccordionItem>
+        </div>
+      </ModelInfoField>
+    </PropertiesAccordionItem>
 
-      <PropertiesAccordionItem>
-        <template #label>
-          <span class="text-xs uppercase">
-            {{ $t('assetBrowser.modelInfo.modelDescription') }}
+    <PropertiesAccordionItem class="bg-transparent">
+      <template #label>
+        <span class="text-xs uppercase font-inter">
+          {{ $t('assetBrowser.modelInfo.modelDescription') }}
+        </span>
+      </template>
+      <ModelInfoField
+        v-if="triggerPhrases.length > 0"
+        :label="$t('assetBrowser.modelInfo.triggerPhrases')"
+      >
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="phrase in triggerPhrases"
+            :key="phrase"
+            class="rounded px-2 py-0.5 text-xs"
+          >
+            {{ phrase }}
           </span>
-        </template>
-        <ModelInfoField
-          v-if="triggerPhrases.length > 0"
-          :label="$t('assetBrowser.modelInfo.triggerPhrases')"
-        >
-          <div class="flex flex-wrap gap-1">
-            <span
-              v-for="phrase in triggerPhrases"
-              :key="phrase"
-              class="rounded bg-surface-container px-2 py-0.5 text-xs"
-            >
-              {{ phrase }}
-            </span>
-          </div>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="description"
-          :label="$t('assetBrowser.modelInfo.description')"
-        >
-          <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
-        </ModelInfoField>
-      </PropertiesAccordionItem>
-    </div>
+        </div>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="description"
+        :label="$t('assetBrowser.modelInfo.description')"
+      >
+        <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
+      </ModelInfoField>
+    </PropertiesAccordionItem>
   </div>
 </template>
 

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="flex h-full flex-col bg-comfy-menu-bg">
+    <div class="flex h-18 items-center border-b border-divider px-4">
+      <h2 class="text-lg font-semibold">
+        {{ $t('assetBrowser.modelInfo.title') }}
+      </h2>
+    </div>
+
+    <div class="flex-1 overflow-y-auto scrollbar-custom">
+      <PropertiesAccordionItem>
+        <template #label>
+          <span class="text-xs uppercase">
+            {{ $t('assetBrowser.modelInfo.basicInfo') }}
+          </span>
+        </template>
+        <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
+          <span class="text-sm">{{ displayName }}</span>
+        </ModelInfoField>
+        <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
+          <span class="text-sm">{{ asset.name }}</span>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="sourceUrl"
+          :label="$t('assetBrowser.modelInfo.source')"
+        >
+          <a
+            :href="sourceUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-link hover:underline"
+          >
+            {{
+              $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
+            }}
+          </a>
+        </ModelInfoField>
+      </PropertiesAccordionItem>
+
+      <PropertiesAccordionItem>
+        <template #label>
+          <span class="text-xs uppercase">
+            {{ $t('assetBrowser.modelInfo.modelTagging') }}
+          </span>
+        </template>
+        <ModelInfoField
+          v-if="modelType"
+          :label="$t('assetBrowser.modelInfo.modelType')"
+        >
+          <span class="text-sm">{{ modelType }}</span>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="baseModel"
+          :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
+        >
+          <span class="text-sm">{{ baseModel }}</span>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="additionalTags.length > 0"
+          :label="$t('assetBrowser.modelInfo.additionalTags')"
+        >
+          <div class="flex flex-wrap gap-1">
+            <span
+              v-for="tag in additionalTags"
+              :key="tag"
+              class="rounded bg-surface-container px-2 py-0.5 text-xs"
+            >
+              {{ tag }}
+            </span>
+          </div>
+        </ModelInfoField>
+      </PropertiesAccordionItem>
+
+      <PropertiesAccordionItem>
+        <template #label>
+          <span class="text-xs uppercase">
+            {{ $t('assetBrowser.modelInfo.modelDescription') }}
+          </span>
+        </template>
+        <ModelInfoField
+          v-if="triggerPhrases.length > 0"
+          :label="$t('assetBrowser.modelInfo.triggerPhrases')"
+        >
+          <div class="flex flex-wrap gap-1">
+            <span
+              v-for="phrase in triggerPhrases"
+              :key="phrase"
+              class="rounded bg-surface-container px-2 py-0.5 text-xs"
+            >
+              {{ phrase }}
+            </span>
+          </div>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="description"
+          :label="$t('assetBrowser.modelInfo.description')"
+        >
+          <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
+        </ModelInfoField>
+      </PropertiesAccordionItem>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import PropertiesAccordionItem from '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue'
+import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
+import {
+  getAssetBaseModel,
+  getAssetDescription,
+  getAssetDisplayName,
+  getAssetSourceUrl,
+  getAssetTags,
+  getAssetTriggerPhrases,
+  getSourceName
+} from '@/platform/assets/utils/assetMetadataUtils'
+
+import ModelInfoField from './ModelInfoField.vue'
+
+const { asset } = defineProps<{
+  asset: AssetDisplayItem
+}>()
+
+const displayName = computed(() => getAssetDisplayName(asset))
+const sourceUrl = computed(() => getAssetSourceUrl(asset))
+const sourceName = computed(() =>
+  sourceUrl.value ? getSourceName(sourceUrl.value) : ''
+)
+const baseModel = computed(() => getAssetBaseModel(asset))
+const description = computed(() => getAssetDescription(asset))
+const triggerPhrases = computed(() => getAssetTriggerPhrases(asset))
+const additionalTags = computed(() => getAssetTags(asset))
+
+const modelType = computed(() => {
+  const typeTag = asset.tags.find((tag) => tag !== 'models')
+  if (!typeTag) return null
+  return typeTag.includes('/') ? typeTag.split('/').pop() : typeTag
+})
+</script>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -140,7 +140,7 @@
           :disabled="isImmutable"
           :placeholder="$t('assetBrowser.modelInfo.descriptionPlaceholder')"
           rows="3"
-          class="w-full resize-y rounded-lg border-2 border-transparent bg-secondary-background px-3 py-2 text-sm text-base-foreground outline-none focus:border-node-component-border disabled:cursor-not-allowed disabled:opacity-50"
+          class="w-full resize-y rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm text-component-node-foreground outline-none transition-colors focus:bg-component-node-widget-background disabled:pointer-events-none"
         />
       </ModelInfoField>
     </PropertiesAccordionItem>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -134,6 +134,15 @@
       >
         <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
       </ModelInfoField>
+      <ModelInfoField :label="$t('assetBrowser.modelInfo.description')">
+        <textarea
+          v-model="userDescription"
+          :disabled="isImmutable"
+          :placeholder="$t('assetBrowser.modelInfo.descriptionPlaceholder')"
+          rows="3"
+          class="w-full resize-y rounded-lg border-2 border-transparent bg-secondary-background px-3 py-2 text-sm text-base-foreground outline-none focus:border-node-component-border disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </ModelInfoField>
     </PropertiesAccordionItem>
   </div>
 </template>
@@ -158,6 +167,7 @@ import {
   getAssetModelType,
   getAssetSourceUrl,
   getAssetTriggerPhrases,
+  getAssetUserDescription,
   getSourceName
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { useAssetsStore } from '@/stores/assetsStore'
@@ -181,12 +191,14 @@ const additionalTags = ref<string[]>(getAssetAdditionalTags(asset))
 const selectedModelType = ref<string | undefined>(
   getAssetModelType(asset) ?? undefined
 )
+const userDescription = ref<string>(getAssetUserDescription(asset))
 watch(
   () => asset,
   () => {
     baseModels.value = getAssetBaseModels(asset)
     additionalTags.value = getAssetAdditionalTags(asset)
     selectedModelType.value = getAssetModelType(asset) ?? undefined
+    userDescription.value = getAssetUserDescription(asset)
   }
 )
 const description = computed(() => getAssetDescription(asset))
@@ -205,7 +217,8 @@ async function saveMetadata() {
     {
       ...asset.user_metadata,
       base_model: baseModels.value,
-      additional_tags: additionalTags.value
+      additional_tags: additionalTags.value,
+      user_description: userDescription.value
     },
     cacheKey
   )
@@ -225,5 +238,6 @@ async function saveModelType(newModelType: string | undefined) {
 
 watchDebounced(baseModels, saveMetadata, { debounce: 500 })
 watchDebounced(additionalTags, saveMetadata, { debounce: 500 })
+watchDebounced(userDescription, saveMetadata, { debounce: 500 })
 watchDebounced(selectedModelType, saveModelType, { debounce: 500 })
 </script>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -136,11 +136,13 @@
       </ModelInfoField>
       <ModelInfoField :label="$t('assetBrowser.modelInfo.description')">
         <textarea
+          ref="descriptionTextarea"
           v-model="userDescription"
           :disabled="isImmutable"
           :placeholder="$t('assetBrowser.modelInfo.descriptionPlaceholder')"
           rows="3"
           class="w-full resize-y rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm text-component-node-foreground outline-none transition-colors focus:bg-component-node-widget-background disabled:pointer-events-none"
+          @keydown.escape.stop="descriptionTextarea?.blur()"
         />
       </ModelInfoField>
     </PropertiesAccordionItem>
@@ -149,7 +151,7 @@
 
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 
 import PropertiesAccordionItem from '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue'
 import TagsInput from '@/components/ui/tags-input/TagsInput.vue'
@@ -175,6 +177,10 @@ import { useAssetsStore } from '@/stores/assetsStore'
 import { cn } from '@/utils/tailwindUtil'
 
 import ModelInfoField from './ModelInfoField.vue'
+
+const descriptionTextarea = useTemplateRef<HTMLTextAreaElement>(
+  'descriptionTextarea'
+)
 
 const accordionClass = cn(
   'bg-modal-panel-background border-t border-border-default'

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -53,19 +53,22 @@
         </span>
       </template>
       <ModelInfoField :label="$t('assetBrowser.modelInfo.modelType')">
-        <select
-          v-model="selectedModelType"
-          :disabled="isImmutable"
-          class="w-full rounded-lg border-2 border-transparent bg-secondary-background px-3 py-2 text-sm text-base-foreground outline-none focus:border-node-component-border"
-        >
-          <option
-            v-for="option in modelTypes"
-            :key="option.value"
-            :value="option.value"
-          >
-            {{ option.name }}
-          </option>
-        </select>
+        <Select v-model="selectedModelType" :disabled="isImmutable">
+          <SelectTrigger class="w-full">
+            <SelectValue
+              :placeholder="$t('assetBrowser.modelInfo.selectModelType')"
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="option in modelTypes"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.name }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </ModelInfoField>
       <ModelInfoField
         :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
@@ -162,6 +165,11 @@ import { computed, ref, useTemplateRef, watch } from 'vue'
 
 import EditableText from '@/components/common/EditableText.vue'
 import PropertiesAccordionItem from '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue'
+import Select from '@/components/ui/select/Select.vue'
+import SelectContent from '@/components/ui/select/SelectContent.vue'
+import SelectItem from '@/components/ui/select/SelectItem.vue'
+import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
+import SelectValue from '@/components/ui/select/SelectValue.vue'
 import TagsInput from '@/components/ui/tags-input/TagsInput.vue'
 import TagsInputInput from '@/components/ui/tags-input/TagsInputInput.vue'
 import TagsInputItem from '@/components/ui/tags-input/TagsInputItem.vue'

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -13,7 +13,7 @@
         <EditableText
           :model-value="displayName"
           :is-editing="isEditingDisplayName"
-          class="break-all"
+          class="break-all text-base-foreground"
           @dblclick="isEditingDisplayName = !isImmutable"
           @edit="handleDisplayNameEdit"
           @cancel="isEditingDisplayName = false"

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -172,10 +172,13 @@ import {
   getSourceName
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { useAssetsStore } from '@/stores/assetsStore'
+import { cn } from '@/utils/tailwindUtil'
 
 import ModelInfoField from './ModelInfoField.vue'
 
-const accordionClass = 'bg-transparent border-t border-border-default'
+const accordionClass = cn(
+  'bg-modal-panel-background border-t border-border-default'
+)
 
 const { asset, cacheKey } = defineProps<{
   asset: AssetDisplayItem

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -244,7 +244,7 @@ const debouncedFlushMetadata = useDebounceFn(() => {
   if (isImmutable.value) return
   assetsStore.updateAssetMetadata(
     asset.id,
-    { ...asset.user_metadata, ...pendingUpdates.value },
+    { ...(asset.user_metadata ?? {}), ...pendingUpdates.value },
     cacheKey
   )
 }, 500)

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -77,19 +77,25 @@
           />
         </TagsInput>
       </ModelInfoField>
-      <ModelInfoField
-        v-if="additionalTags.length > 0"
-        :label="$t('assetBrowser.modelInfo.additionalTags')"
-      >
-        <div class="flex flex-wrap gap-1">
-          <span
-            v-for="tag in additionalTags"
-            :key="tag"
-            class="rounded px-2 py-0.5 text-xs"
-          >
-            {{ tag }}
-          </span>
-        </div>
+      <ModelInfoField :label="$t('assetBrowser.modelInfo.additionalTags')">
+        <TagsInput
+          v-slot="{ isEmpty }"
+          v-model="additionalTags"
+          :disabled="isImmutable"
+        >
+          <TagsInputItem v-for="tag in additionalTags" :key="tag" :value="tag">
+            <TagsInputItemText />
+            <TagsInputItemDelete />
+          </TagsInputItem>
+          <TagsInputInput
+            :is-empty="isEmpty"
+            :placeholder="
+              isImmutable
+                ? $t('assetBrowser.modelInfo.noAdditionalTags')
+                : $t('assetBrowser.modelInfo.addTag')
+            "
+          />
+        </TagsInput>
       </ModelInfoField>
     </PropertiesAccordionItem>
 
@@ -134,11 +140,11 @@ import TagsInputItemDelete from '@/components/ui/tags-input/TagsInputItemDelete.
 import TagsInputItemText from '@/components/ui/tags-input/TagsInputItemText.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import {
+  getAssetAdditionalTags,
   getAssetBaseModels,
   getAssetDescription,
   getAssetDisplayName,
   getAssetSourceUrl,
-  getAssetTags,
   getAssetTriggerPhrases,
   getSourceName
 } from '@/platform/assets/utils/assetMetadataUtils'
@@ -157,15 +163,16 @@ const sourceName = computed(() =>
   sourceUrl.value ? getSourceName(sourceUrl.value) : ''
 )
 const baseModels = ref<string[]>(getAssetBaseModels(asset))
+const additionalTags = ref<string[]>(getAssetAdditionalTags(asset))
 watch(
   () => asset,
   () => {
     baseModels.value = getAssetBaseModels(asset)
+    additionalTags.value = getAssetAdditionalTags(asset)
   }
 )
 const description = computed(() => getAssetDescription(asset))
 const triggerPhrases = computed(() => getAssetTriggerPhrases(asset))
-const additionalTags = computed(() => getAssetTags(asset))
 const isImmutable = computed(() => asset.is_immutable ?? true)
 
 const modelType = computed(() => {

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -52,10 +52,30 @@
         <span class="text-sm">{{ modelType }}</span>
       </ModelInfoField>
       <ModelInfoField
-        v-if="baseModel"
         :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
       >
-        <span class="text-sm">{{ baseModel }}</span>
+        <TagsInput
+          v-slot="{ isEmpty }"
+          v-model="baseModels"
+          :disabled="isImmutable"
+        >
+          <TagsInputItem
+            v-for="model in baseModels"
+            :key="model"
+            :value="model"
+          >
+            <TagsInputItemText />
+            <TagsInputItemDelete />
+          </TagsInputItem>
+          <TagsInputInput
+            :is-empty="isEmpty"
+            :placeholder="
+              isImmutable
+                ? $t('assetBrowser.modelInfo.baseModelUnknown')
+                : $t('assetBrowser.modelInfo.addBaseModel')
+            "
+          />
+        </TagsInput>
       </ModelInfoField>
       <ModelInfoField
         v-if="additionalTags.length > 0"
@@ -104,12 +124,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import PropertiesAccordionItem from '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue'
+import TagsInput from '@/components/ui/tags-input/TagsInput.vue'
+import TagsInputInput from '@/components/ui/tags-input/TagsInputInput.vue'
+import TagsInputItem from '@/components/ui/tags-input/TagsInputItem.vue'
+import TagsInputItemDelete from '@/components/ui/tags-input/TagsInputItemDelete.vue'
+import TagsInputItemText from '@/components/ui/tags-input/TagsInputItemText.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import {
-  getAssetBaseModel,
+  getAssetBaseModels,
   getAssetDescription,
   getAssetDisplayName,
   getAssetSourceUrl,
@@ -131,10 +156,17 @@ const sourceUrl = computed(() => getAssetSourceUrl(asset))
 const sourceName = computed(() =>
   sourceUrl.value ? getSourceName(sourceUrl.value) : ''
 )
-const baseModel = computed(() => getAssetBaseModel(asset))
+const baseModels = ref<string[]>(getAssetBaseModels(asset))
+watch(
+  () => asset,
+  () => {
+    baseModels.value = getAssetBaseModels(asset)
+  }
+)
 const description = computed(() => getAssetDescription(asset))
 const triggerPhrases = computed(() => getAssetTriggerPhrases(asset))
 const additionalTags = computed(() => getAssetTags(asset))
+const isImmutable = computed(() => asset.is_immutable ?? true)
 
 const modelType = computed(() => {
   const typeTag = asset.tags.find((tag) => tag !== 'models')

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -206,7 +206,9 @@ const pendingUpdates = ref<AssetUserMetadata>({})
 const isEditingDisplayName = ref(false)
 
 const isImmutable = computed(() => asset.is_immutable ?? true)
-const displayName = computed(() => getAssetDisplayName(asset))
+const displayName = computed(
+  () => pendingUpdates.value.name ?? getAssetDisplayName(asset)
+)
 const sourceUrl = computed(() => getAssetSourceUrl(asset))
 const sourceName = computed(() =>
   sourceUrl.value ? getSourceName(sourceUrl.value) : ''

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -149,9 +149,18 @@
           ref="descriptionTextarea"
           v-model="userDescription"
           :disabled="isImmutable"
-          :placeholder="$t('assetBrowser.modelInfo.descriptionPlaceholder')"
+          :placeholder="
+            isImmutable
+              ? $t('assetBrowser.modelInfo.descriptionNotSet')
+              : $t('assetBrowser.modelInfo.descriptionPlaceholder')
+          "
           rows="3"
-          class="w-full resize-y rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm text-component-node-foreground outline-none transition-colors focus:bg-component-node-widget-background disabled:pointer-events-none"
+          :class="
+            cn(
+              'w-full resize-y rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm text-component-node-foreground outline-none transition-colors focus:bg-component-node-widget-background',
+              isImmutable && 'cursor-not-allowed'
+            )
+          "
           @keydown.escape.stop="descriptionTextarea?.blur()"
         />
       </ModelInfoField>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -10,10 +10,10 @@
         </span>
       </template>
       <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
-        <span class="text-sm break-all">{{ displayName }}</span>
+        <span class="break-all">{{ displayName }}</span>
       </ModelInfoField>
       <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
-        <span class="text-sm break-all">{{ asset.name }}</span>
+        <span class="break-all">{{ asset.name }}</span>
       </ModelInfoField>
       <ModelInfoField
         v-if="sourceUrl"
@@ -23,11 +23,18 @@
           :href="sourceUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-sm text-link hover:underline"
+          class="inline-flex items-center gap-1.5 text-muted-foreground no-underline transition-colors hover:text-foreground"
         >
+          <img
+            v-if="sourceName === 'Civitai'"
+            src="/assets/images/civitai.svg"
+            alt=""
+            class="size-4 shrink-0"
+          />
           {{
             $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
           }}
+          <i class="icon-[lucide--external-link] size-4 shrink-0" />
         </a>
       </ModelInfoField>
     </PropertiesAccordionItem>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -6,10 +6,10 @@
     <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
-          {{ $t('assetBrowser.modelInfo.basicInfo') }}
+          {{ t('assetBrowser.modelInfo.basicInfo') }}
         </span>
       </template>
-      <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
+      <ModelInfoField :label="t('assetBrowser.modelInfo.displayName')">
         <EditableText
           :model-value="displayName"
           :is-editing="isEditingDisplayName"
@@ -19,12 +19,12 @@
           @cancel="isEditingDisplayName = false"
         />
       </ModelInfoField>
-      <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
+      <ModelInfoField :label="t('assetBrowser.modelInfo.fileName')">
         <span class="break-all">{{ asset.name }}</span>
       </ModelInfoField>
       <ModelInfoField
         v-if="sourceUrl"
-        :label="$t('assetBrowser.modelInfo.source')"
+        :label="t('assetBrowser.modelInfo.source')"
       >
         <a
           :href="sourceUrl"
@@ -38,9 +38,7 @@
             alt=""
             class="size-4 shrink-0"
           />
-          {{
-            $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
-          }}
+          {{ t('assetBrowser.modelInfo.viewOnSource', { source: sourceName }) }}
           <i class="icon-[lucide--external-link] size-4 shrink-0" />
         </a>
       </ModelInfoField>
@@ -49,14 +47,14 @@
     <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
-          {{ $t('assetBrowser.modelInfo.modelTagging') }}
+          {{ t('assetBrowser.modelInfo.modelTagging') }}
         </span>
       </template>
-      <ModelInfoField :label="$t('assetBrowser.modelInfo.modelType')">
+      <ModelInfoField :label="t('assetBrowser.modelInfo.modelType')">
         <Select v-model="selectedModelType" :disabled="isImmutable">
           <SelectTrigger class="w-full">
             <SelectValue
-              :placeholder="$t('assetBrowser.modelInfo.selectModelType')"
+              :placeholder="t('assetBrowser.modelInfo.selectModelType')"
             />
           </SelectTrigger>
           <SelectContent>
@@ -70,9 +68,7 @@
           </SelectContent>
         </Select>
       </ModelInfoField>
-      <ModelInfoField
-        :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
-      >
+      <ModelInfoField :label="t('assetBrowser.modelInfo.compatibleBaseModels')">
         <TagsInput
           v-slot="{ isEmpty }"
           v-model="baseModels"
@@ -90,13 +86,13 @@
             :is-empty="isEmpty"
             :placeholder="
               isImmutable
-                ? $t('assetBrowser.modelInfo.baseModelUnknown')
-                : $t('assetBrowser.modelInfo.addBaseModel')
+                ? t('assetBrowser.modelInfo.baseModelUnknown')
+                : t('assetBrowser.modelInfo.addBaseModel')
             "
           />
         </TagsInput>
       </ModelInfoField>
-      <ModelInfoField :label="$t('assetBrowser.modelInfo.additionalTags')">
+      <ModelInfoField :label="t('assetBrowser.modelInfo.additionalTags')">
         <TagsInput
           v-slot="{ isEmpty }"
           v-model="additionalTags"
@@ -110,8 +106,8 @@
             :is-empty="isEmpty"
             :placeholder="
               isImmutable
-                ? $t('assetBrowser.modelInfo.noAdditionalTags')
-                : $t('assetBrowser.modelInfo.addTag')
+                ? t('assetBrowser.modelInfo.noAdditionalTags')
+                : t('assetBrowser.modelInfo.addTag')
             "
           />
         </TagsInput>
@@ -121,12 +117,12 @@
     <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
-          {{ $t('assetBrowser.modelInfo.modelDescription') }}
+          {{ t('assetBrowser.modelInfo.modelDescription') }}
         </span>
       </template>
       <ModelInfoField
         v-if="triggerPhrases.length > 0"
-        :label="$t('assetBrowser.modelInfo.triggerPhrases')"
+        :label="t('assetBrowser.modelInfo.triggerPhrases')"
       >
         <div class="flex flex-wrap gap-1">
           <span
@@ -140,19 +136,19 @@
       </ModelInfoField>
       <ModelInfoField
         v-if="description"
-        :label="$t('assetBrowser.modelInfo.description')"
+        :label="t('assetBrowser.modelInfo.description')"
       >
         <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
       </ModelInfoField>
-      <ModelInfoField :label="$t('assetBrowser.modelInfo.description')">
+      <ModelInfoField :label="t('assetBrowser.modelInfo.description')">
         <textarea
           ref="descriptionTextarea"
           v-model="userDescription"
           :disabled="isImmutable"
           :placeholder="
             isImmutable
-              ? $t('assetBrowser.modelInfo.descriptionNotSet')
-              : $t('assetBrowser.modelInfo.descriptionPlaceholder')
+              ? t('assetBrowser.modelInfo.descriptionNotSet')
+              : t('assetBrowser.modelInfo.descriptionPlaceholder')
           "
           rows="3"
           :class="
@@ -171,6 +167,7 @@
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
 import { computed, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import EditableText from '@/components/common/EditableText.vue'
 import PropertiesAccordionItem from '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue'
@@ -202,6 +199,8 @@ import { useAssetsStore } from '@/stores/assetsStore'
 import { cn } from '@/utils/tailwindUtil'
 
 import ModelInfoField from './ModelInfoField.vue'
+
+const { t } = useI18n()
 
 const descriptionTextarea = useTemplateRef<HTMLTextAreaElement>(
   'descriptionTextarea'

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -13,7 +13,7 @@
         <EditableText
           :model-value="displayName"
           :is-editing="isEditingDisplayName"
-          class="break-all text-base-foreground"
+          :class="cn('break-all', !isImmutable && 'text-base-foreground')"
           @dblclick="isEditingDisplayName = !isImmutable"
           @edit="handleDisplayNameEdit"
           @cancel="isEditingDisplayName = false"

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -3,7 +3,7 @@
     data-component-id="ModelInfoPanel"
     class="flex h-full flex-col scrollbar-custom"
   >
-    <PropertiesAccordionItem class="bg-transparent">
+    <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
           {{ $t('assetBrowser.modelInfo.basicInfo') }}
@@ -32,7 +32,7 @@
       </ModelInfoField>
     </PropertiesAccordionItem>
 
-    <PropertiesAccordionItem class="bg-transparent">
+    <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
           {{ $t('assetBrowser.modelInfo.modelTagging') }}
@@ -66,7 +66,7 @@
       </ModelInfoField>
     </PropertiesAccordionItem>
 
-    <PropertiesAccordionItem class="bg-transparent">
+    <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
           {{ $t('assetBrowser.modelInfo.modelDescription') }}
@@ -112,6 +112,8 @@ import {
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 import ModelInfoField from './ModelInfoField.vue'
+
+const accordionClass = 'bg-transparent border-t border-border-default'
 
 const { asset } = defineProps<{
   asset: AssetDisplayItem

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -384,7 +384,7 @@ describe('useAssetBrowser', () => {
       const { updateFilters, filteredAssets } = useAssetBrowser(ref(assets))
 
       updateFilters({
-        sortBy: 'name',
+        sortBy: 'name-asc',
         fileFormats: [],
         baseModels: [],
         ownership: 'all'

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -295,8 +295,7 @@ describe('useAssetBrowser', () => {
       updateFilters({
         sortBy: 'name-asc',
         fileFormats: ['safetensors'],
-        baseModels: [],
-        ownership: 'all'
+        baseModels: []
       })
       await nextTick()
 
@@ -331,8 +330,7 @@ describe('useAssetBrowser', () => {
       updateFilters({
         sortBy: 'name-asc',
         fileFormats: [],
-        baseModels: ['SDXL'],
-        ownership: 'all'
+        baseModels: ['SDXL']
       })
       await nextTick()
 
@@ -386,8 +384,7 @@ describe('useAssetBrowser', () => {
       updateFilters({
         sortBy: 'name-asc',
         fileFormats: [],
-        baseModels: [],
-        ownership: 'all'
+        baseModels: []
       })
       await nextTick()
 
@@ -411,8 +408,7 @@ describe('useAssetBrowser', () => {
       updateFilters({
         sortBy: 'recent',
         fileFormats: [],
-        baseModels: [],
-        ownership: 'all'
+        baseModels: []
       })
       await nextTick()
 
@@ -444,8 +440,7 @@ describe('useAssetBrowser', () => {
       updateFilters({
         sortBy: 'name-asc',
         fileFormats: [],
-        baseModels: [],
-        ownership: 'all'
+        baseModels: []
       })
       await nextTick()
 

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -9,7 +9,8 @@ import type { FilterState } from '@/platform/assets/components/AssetFilterBar.vu
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
   getAssetBaseModels,
-  getAssetDescription
+  getAssetDescription,
+  getAssetDisplayName
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import type { NavGroupData, NavItemData } from '@/types/navTypes'
@@ -266,7 +267,7 @@ export function useAssetBrowser(
     sortedAssets.sort((a, b) => {
       switch (filters.value.sortBy) {
         case 'name-desc':
-          return b.name.localeCompare(a.name)
+          return getAssetDisplayName(b).localeCompare(getAssetDisplayName(a))
         case 'recent':
           return (
             new Date(b.created_at ?? 0).getTime() -
@@ -274,7 +275,7 @@ export function useAssetBrowser(
           )
         case 'name-asc':
         default:
-          return a.name.localeCompare(b.name)
+          return getAssetDisplayName(a).localeCompare(getAssetDisplayName(b))
       }
     })
 

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -238,7 +238,9 @@ export function useAssetBrowser(
         { name: 'user_metadata.name', weight: 0.4 },
         { name: 'user_metadata.additional_tags', weight: 0.3 },
         { name: 'user_metadata.trained_words', weight: 0.3 },
-        { name: 'user_metadata.user_description', weight: 0.3 }
+        { name: 'user_metadata.user_description', weight: 0.3 },
+        { name: 'metadata.name', weight: 0.4 },
+        { name: 'metadata.trained_words', weight: 0.3 }
       ],
       threshold: 0.4, // Higher threshold for typo tolerance (0.0 = exact, 1.0 = match all)
       ignoreLocation: true, // Search anywhere in the string, not just at the beginning

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -268,8 +268,6 @@ export function useAssetBrowser(
             new Date(b.created_at ?? 0).getTime() -
             new Date(a.created_at ?? 0).getTime()
           )
-        case 'popular':
-          return a.name.localeCompare(b.name)
         case 'name-asc':
         default:
           return a.name.localeCompare(b.name)

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -233,7 +233,11 @@ export function useAssetBrowser(
     fuseOptions: {
       keys: [
         { name: 'name', weight: 0.4 },
-        { name: 'tags', weight: 0.3 }
+        { name: 'tags', weight: 0.3 },
+        { name: 'user_metadata.name', weight: 0.4 },
+        { name: 'user_metadata.additional_tags', weight: 0.3 },
+        { name: 'user_metadata.trained_words', weight: 0.3 },
+        { name: 'user_metadata.user_description', weight: 0.3 }
       ],
       threshold: 0.4, // Higher threshold for typo tolerance (0.0 = exact, 1.0 = match all)
       ignoreLocation: true, // Search anywhere in the string, not just at the beginning

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -14,7 +14,7 @@ import {
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import type { NavGroupData, NavItemData } from '@/types/navTypes'
 
-export type OwnershipOption = 'all' | 'my-models' | 'public-models'
+type OwnershipOption = 'all' | 'my-models' | 'public-models'
 
 type NavId = 'all' | 'imported' | (string & {})
 
@@ -95,8 +95,7 @@ export function useAssetBrowser(
   const filters = ref<FilterState>({
     sortBy: 'recent',
     fileFormats: [],
-    baseModels: [],
-    ownership: 'all'
+    baseModels: []
   })
 
   const selectedOwnership = computed<OwnershipOption>(() => {

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -8,7 +8,7 @@ import { d, t } from '@/i18n'
 import type { FilterState } from '@/platform/assets/components/AssetFilterBar.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
-  getAssetBaseModel,
+  getAssetBaseModels,
   getAssetDescription
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
@@ -48,8 +48,8 @@ function filterByBaseModels(models: string[]) {
   return (asset: AssetItem) => {
     if (models.length === 0) return true
     const modelSet = new Set(models)
-    const baseModel = getAssetBaseModel(asset)
-    return baseModel ? modelSet.has(baseModel) : false
+    const assetBaseModels = getAssetBaseModels(asset)
+    return assetBaseModels.some((model) => modelSet.has(model))
   }
 }
 
@@ -135,13 +135,10 @@ export function useAssetBrowser(
       badges.push({ label: badgeLabel, type: 'type' })
     }
 
-    // Base model badge from metadata
-    const baseModel = getAssetBaseModel(asset)
-    if (baseModel) {
-      badges.push({
-        label: baseModel,
-        type: 'base'
-      })
+    // Base model badges from metadata
+    const baseModels = getAssetBaseModels(asset)
+    for (const model of baseModels) {
+      badges.push({ label: model, type: 'base' })
     }
 
     // Create display stats from API data

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -146,7 +146,9 @@ export function useAssetBrowser(
 
     // Create display stats from API data
     const stats = {
-      formattedDate: d(new Date(asset.created_at), { dateStyle: 'short' }),
+      formattedDate: asset.created_at
+        ? d(new Date(asset.created_at), { dateStyle: 'short' })
+        : undefined,
       downloadCount: undefined, // Not available in API
       stars: undefined // Not available in API
     }
@@ -267,7 +269,8 @@ export function useAssetBrowser(
           return b.name.localeCompare(a.name)
         case 'recent':
           return (
-            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+            new Date(b.created_at ?? 0).getTime() -
+            new Date(a.created_at ?? 0).getTime()
           )
         case 'popular':
           return a.name.localeCompare(b.name)

--- a/src/platform/assets/composables/useAssetFilterOptions.ts
+++ b/src/platform/assets/composables/useAssetFilterOptions.ts
@@ -4,6 +4,7 @@ import type { MaybeRefOrGetter } from 'vue'
 
 import type { SelectOption } from '@/components/input/types'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { getAssetBaseModels } from '@/platform/assets/utils/assetMetadataUtils'
 
 /**
  * Composable that extracts available filter options from asset data
@@ -37,12 +38,7 @@ export function useAssetFilterOptions(assets: MaybeRefOrGetter<AssetItem[]>) {
    */
   const availableBaseModels = computed<SelectOption[]>(() => {
     const assetList = toValue(assets)
-    const models = assetList
-      .map((asset) => asset.user_metadata?.base_model)
-      .filter(
-        (baseModel): baseModel is string =>
-          baseModel !== undefined && typeof baseModel === 'string'
-      )
+    const models = assetList.flatMap((asset) => getAssetBaseModels(asset))
 
     const uniqueModels = uniqWith(models, (a, b) => a === b)
 

--- a/src/platform/assets/composables/useModelTypes.ts
+++ b/src/platform/assets/composables/useModelTypes.ts
@@ -75,9 +75,9 @@ export const useModelTypes = createSharedComposable(() => {
     }
   )
 
-  function fetchModelTypes() {
+  async function fetchModelTypes() {
     if (isReady.value || isLoading.value) return
-    return execute()
+    await execute()
   }
 
   return {

--- a/src/platform/assets/composables/useModelTypes.ts
+++ b/src/platform/assets/composables/useModelTypes.ts
@@ -46,9 +46,10 @@ const DISALLOWED_MODEL_TYPES = ['nlf'] as const
 export const useModelTypes = createSharedComposable(() => {
   const {
     state: modelTypes,
+    isReady,
     isLoading,
     error,
-    execute: fetchModelTypes
+    execute
   } = useAsyncState(
     async (): Promise<ModelTypeOption[]> => {
       const response = await api.getModelFolders()
@@ -73,6 +74,11 @@ export const useModelTypes = createSharedComposable(() => {
       }
     }
   )
+
+  function fetchModelTypes() {
+    if (isReady.value || isLoading.value) return
+    return execute()
+  }
 
   return {
     modelTypes,

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -96,7 +96,7 @@ export type AssetUpdatePayload = Partial<
 >
 
 /** User-editable metadata fields for model assets */
-export const zAssetUserMetadata = z.object({
+const zAssetUserMetadata = z.object({
   base_model: z.array(z.string()).optional(),
   additional_tags: z.array(z.string()).optional(),
   user_description: z.string().optional()

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -10,7 +10,7 @@ const zAsset = z.object({
   tags: z.array(z.string()).optional().default([]),
   preview_id: z.string().nullable().optional(),
   preview_url: z.string().optional(),
-  created_at: z.string(),
+  created_at: z.string().optional(),
   updated_at: z.string().optional(),
   is_immutable: z.boolean().optional(),
   last_access_time: z.string().optional(),

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -90,6 +90,11 @@ export type AsyncUploadResponse = z.infer<typeof zAsyncUploadResponse>
 export type ModelFolder = z.infer<typeof zModelFolder>
 export type ModelFile = z.infer<typeof zModelFile>
 
+/** Payload for updating an asset via PUT /assets/:id */
+export type AssetUpdatePayload = Partial<
+  Pick<AssetItem, 'name' | 'tags' | 'user_metadata'>
+>
+
 // Legacy interface for backward compatibility (now aligned with Zod schema)
 export interface ModelFolderInfo {
   name: string

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -97,6 +97,7 @@ export type AssetUpdatePayload = Partial<
 
 /** User-editable metadata fields for model assets */
 const zAssetUserMetadata = z.object({
+  name: z.string().optional(),
   base_model: z.array(z.string()).optional(),
   additional_tags: z.array(z.string()).optional(),
   user_description: z.string().optional()

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -95,6 +95,15 @@ export type AssetUpdatePayload = Partial<
   Pick<AssetItem, 'name' | 'tags' | 'user_metadata'>
 >
 
+/** User-editable metadata fields for model assets */
+export const zAssetUserMetadata = z.object({
+  base_model: z.array(z.string()).optional(),
+  additional_tags: z.array(z.string()).optional(),
+  user_description: z.string().optional()
+})
+
+export type AssetUserMetadata = z.infer<typeof zAssetUserMetadata>
+
 // Legacy interface for backward compatibility (now aligned with Zod schema)
 export interface ModelFolderInfo {
   name: string

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -14,6 +14,7 @@ const zAsset = z.object({
   updated_at: z.string().optional(),
   is_immutable: z.boolean().optional(),
   last_access_time: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(), // API allows arbitrary key-value pairs
   user_metadata: z.record(z.unknown()).optional() // API allows arbitrary key-value pairs
 })
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -11,6 +11,7 @@ import type {
   AssetItem,
   AssetMetadata,
   AssetResponse,
+  AssetUpdatePayload,
   AsyncUploadResponse,
   ModelFile,
   ModelFolder
@@ -320,7 +321,7 @@ function createAssetService() {
    */
   async function updateAsset(
     id: string,
-    newData: Partial<AssetMetadata>
+    newData: AssetUpdatePayload
   ): Promise<AssetItem> {
     const res = await api.fetchApi(`${ASSETS_ENDPOINT}/${id}`, {
       method: 'PUT',

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -28,20 +28,17 @@ describe('assetMetadataUtils', () => {
   }
 
   describe('getAssetDescription', () => {
-    it('should return string description when present', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { description: 'A test model' }
-      }
-      expect(getAssetDescription(asset)).toBe('A test model')
-    })
-
-    it('should return null when description is not a string', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { description: 123 }
-      }
-      expect(getAssetDescription(asset)).toBeNull()
+    it.for([
+      {
+        name: 'returns string description when present',
+        description: 'A test model',
+        expected: 'A test model'
+      },
+      { name: 'returns null for non-string', description: 123, expected: null },
+      { name: 'returns null for null', description: null, expected: null }
+    ])('$name', ({ description, expected }) => {
+      const asset = { ...mockAsset, user_metadata: { description } }
+      expect(getAssetDescription(asset)).toBe(expected)
     })
 
     it('should return null when no metadata', () => {
@@ -50,20 +47,17 @@ describe('assetMetadataUtils', () => {
   })
 
   describe('getAssetBaseModel', () => {
-    it('should return string base_model when present', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { base_model: 'SDXL' }
-      }
-      expect(getAssetBaseModel(asset)).toBe('SDXL')
-    })
-
-    it('should return null when base_model is not a string', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { base_model: 123 }
-      }
-      expect(getAssetBaseModel(asset)).toBeNull()
+    it.for([
+      {
+        name: 'returns string base_model when present',
+        base_model: 'SDXL',
+        expected: 'SDXL'
+      },
+      { name: 'returns null for non-string', base_model: 123, expected: null },
+      { name: 'returns null for null', base_model: null, expected: null }
+    ])('$name', ({ base_model, expected }) => {
+      const asset = { ...mockAsset, user_metadata: { base_model } }
+      expect(getAssetBaseModel(asset)).toBe(expected)
     })
 
     it('should return null when no metadata', () => {
@@ -72,52 +66,44 @@ describe('assetMetadataUtils', () => {
   })
 
   describe('getAssetDisplayName', () => {
-    it('should return name from user_metadata when present', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { name: 'My Custom Name' }
+    it.for([
+      {
+        name: 'returns name from user_metadata when present',
+        user_metadata: { name: 'My Custom Name' },
+        expected: 'My Custom Name'
+      },
+      {
+        name: 'falls back to asset name for non-string',
+        user_metadata: { name: 123 },
+        expected: 'test-model'
+      },
+      {
+        name: 'falls back to asset name for undefined',
+        user_metadata: undefined,
+        expected: 'test-model'
       }
-      expect(getAssetDisplayName(asset)).toBe('My Custom Name')
-    })
-
-    it('should fall back to asset name when user_metadata.name is not a string', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { name: 123 }
-      }
-      expect(getAssetDisplayName(asset)).toBe('test-model')
-    })
-
-    it('should fall back to asset name when no metadata', () => {
-      expect(getAssetDisplayName(mockAsset)).toBe('test-model')
+    ])('$name', ({ user_metadata, expected }) => {
+      const asset = { ...mockAsset, user_metadata }
+      expect(getAssetDisplayName(asset)).toBe(expected)
     })
   })
 
   describe('getAssetSourceUrl', () => {
-    it('should construct URL from source_arn with civitai format', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { source_arn: 'civitai:model:123:version:456' }
+    it.for([
+      {
+        name: 'constructs URL from civitai format',
+        source_arn: 'civitai:model:123:version:456',
+        expected: 'https://civitai.com/models/123?modelVersionId=456'
+      },
+      { name: 'returns null for non-string', source_arn: 123, expected: null },
+      {
+        name: 'returns null for unrecognized format',
+        source_arn: 'unknown:format',
+        expected: null
       }
-      expect(getAssetSourceUrl(asset)).toBe(
-        'https://civitai.com/models/123?modelVersionId=456'
-      )
-    })
-
-    it('should return null when source_arn is not a string', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { source_arn: 123 }
-      }
-      expect(getAssetSourceUrl(asset)).toBeNull()
-    })
-
-    it('should return null when source_arn format is not recognized', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { source_arn: 'unknown:format' }
-      }
-      expect(getAssetSourceUrl(asset)).toBeNull()
+    ])('$name', ({ source_arn, expected }) => {
+      const asset = { ...mockAsset, user_metadata: { source_arn } }
+      expect(getAssetSourceUrl(asset)).toBe(expected)
     })
 
     it('should return null when no metadata', () => {
@@ -126,28 +112,25 @@ describe('assetMetadataUtils', () => {
   })
 
   describe('getAssetTriggerPhrases', () => {
-    it('should return array of trigger phrases when array present', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { trained_words: ['phrase1', 'phrase2'] }
+    it.for([
+      {
+        name: 'returns array when array present',
+        trained_words: ['phrase1', 'phrase2'],
+        expected: ['phrase1', 'phrase2']
+      },
+      {
+        name: 'wraps single string in array',
+        trained_words: 'single phrase',
+        expected: ['single phrase']
+      },
+      {
+        name: 'filters non-string values from array',
+        trained_words: ['valid', 123, 'also valid', null],
+        expected: ['valid', 'also valid']
       }
-      expect(getAssetTriggerPhrases(asset)).toEqual(['phrase1', 'phrase2'])
-    })
-
-    it('should wrap single string in array', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { trained_words: 'single phrase' }
-      }
-      expect(getAssetTriggerPhrases(asset)).toEqual(['single phrase'])
-    })
-
-    it('should filter non-string values from array', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { trained_words: ['valid', 123, 'also valid', null] }
-      }
-      expect(getAssetTriggerPhrases(asset)).toEqual(['valid', 'also valid'])
+    ])('$name', ({ trained_words, expected }) => {
+      const asset = { ...mockAsset, user_metadata: { trained_words } }
+      expect(getAssetTriggerPhrases(asset)).toEqual(expected)
     })
 
     it('should return empty array when no metadata', () => {
@@ -156,28 +139,25 @@ describe('assetMetadataUtils', () => {
   })
 
   describe('getAssetAdditionalTags', () => {
-    it('should return array of tags when present', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { additional_tags: ['tag1', 'tag2'] }
+    it.for([
+      {
+        name: 'returns array of tags when present',
+        additional_tags: ['tag1', 'tag2'],
+        expected: ['tag1', 'tag2']
+      },
+      {
+        name: 'filters non-string values from array',
+        additional_tags: ['valid', 123, 'also valid'],
+        expected: ['valid', 'also valid']
+      },
+      {
+        name: 'returns empty array for non-array',
+        additional_tags: 'not an array',
+        expected: []
       }
-      expect(getAssetAdditionalTags(asset)).toEqual(['tag1', 'tag2'])
-    })
-
-    it('should filter non-string values from array', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { additional_tags: ['valid', 123, 'also valid'] }
-      }
-      expect(getAssetAdditionalTags(asset)).toEqual(['valid', 'also valid'])
-    })
-
-    it('should return empty array when additional_tags is not an array', () => {
-      const asset = {
-        ...mockAsset,
-        user_metadata: { additional_tags: 'not an array' }
-      }
-      expect(getAssetAdditionalTags(asset)).toEqual([])
+    ])('$name', ({ additional_tags, expected }) => {
+      const asset = { ...mockAsset, user_metadata: { additional_tags } }
+      expect(getAssetAdditionalTags(asset)).toEqual(expected)
     })
 
     it('should return empty array when no metadata', () => {
@@ -186,18 +166,24 @@ describe('assetMetadataUtils', () => {
   })
 
   describe('getSourceName', () => {
-    it('should return Civitai for civitai.com URLs', () => {
-      expect(getSourceName('https://civitai.com/models/123')).toBe('Civitai')
-    })
-
-    it('should return Hugging Face for huggingface.co URLs', () => {
-      expect(getSourceName('https://huggingface.co/org/model')).toBe(
-        'Hugging Face'
-      )
-    })
-
-    it('should return Source for unknown URLs', () => {
-      expect(getSourceName('https://example.com/model')).toBe('Source')
+    it.for([
+      {
+        name: 'returns Civitai for civitai.com',
+        url: 'https://civitai.com/models/123',
+        expected: 'Civitai'
+      },
+      {
+        name: 'returns Hugging Face for huggingface.co',
+        url: 'https://huggingface.co/org/model',
+        expected: 'Hugging Face'
+      },
+      {
+        name: 'returns Source for unknown URLs',
+        url: 'https://example.com/model',
+        expected: 'Source'
+      }
+    ])('$name', ({ url, expected }) => {
+      expect(getSourceName(url)).toBe(expected)
     })
   })
 

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
   getAssetBaseModel,
-  getAssetDescription
+  getAssetDescription,
+  getAssetDisplayName,
+  getAssetSourceUrl,
+  getAssetTags,
+  getAssetTriggerPhrases,
+  getSourceName
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 describe('assetMetadataUtils', () => {
@@ -60,6 +65,126 @@ describe('assetMetadataUtils', () => {
 
     it('should return null when no metadata', () => {
       expect(getAssetBaseModel(mockAsset)).toBeNull()
+    })
+  })
+
+  describe('getAssetDisplayName', () => {
+    it('should return display_name when present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { display_name: 'My Custom Name' }
+      }
+      expect(getAssetDisplayName(asset)).toBe('My Custom Name')
+    })
+
+    it('should fall back to asset name when display_name is not a string', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { display_name: 123 }
+      }
+      expect(getAssetDisplayName(asset)).toBe('test-model')
+    })
+
+    it('should fall back to asset name when no metadata', () => {
+      expect(getAssetDisplayName(mockAsset)).toBe('test-model')
+    })
+  })
+
+  describe('getAssetSourceUrl', () => {
+    it('should return source_url when present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { source_url: 'https://civitai.com/models/123' }
+      }
+      expect(getAssetSourceUrl(asset)).toBe('https://civitai.com/models/123')
+    })
+
+    it('should return null when source_url is not a string', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { source_url: 123 }
+      }
+      expect(getAssetSourceUrl(asset)).toBeNull()
+    })
+
+    it('should return null when no metadata', () => {
+      expect(getAssetSourceUrl(mockAsset)).toBeNull()
+    })
+  })
+
+  describe('getAssetTriggerPhrases', () => {
+    it('should return array of trigger phrases when array present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { trigger_phrases: ['phrase1', 'phrase2'] }
+      }
+      expect(getAssetTriggerPhrases(asset)).toEqual(['phrase1', 'phrase2'])
+    })
+
+    it('should wrap single string in array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { trigger_phrases: 'single phrase' }
+      }
+      expect(getAssetTriggerPhrases(asset)).toEqual(['single phrase'])
+    })
+
+    it('should filter non-string values from array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { trigger_phrases: ['valid', 123, 'also valid', null] }
+      }
+      expect(getAssetTriggerPhrases(asset)).toEqual(['valid', 'also valid'])
+    })
+
+    it('should return empty array when no metadata', () => {
+      expect(getAssetTriggerPhrases(mockAsset)).toEqual([])
+    })
+  })
+
+  describe('getAssetTags', () => {
+    it('should return array of tags when present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { tags: ['tag1', 'tag2'] }
+      }
+      expect(getAssetTags(asset)).toEqual(['tag1', 'tag2'])
+    })
+
+    it('should filter non-string values from array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { tags: ['valid', 123, 'also valid'] }
+      }
+      expect(getAssetTags(asset)).toEqual(['valid', 'also valid'])
+    })
+
+    it('should return empty array when tags is not an array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { tags: 'not an array' }
+      }
+      expect(getAssetTags(asset)).toEqual([])
+    })
+
+    it('should return empty array when no metadata', () => {
+      expect(getAssetTags(mockAsset)).toEqual([])
+    })
+  })
+
+  describe('getSourceName', () => {
+    it('should return Civitai for civitai.com URLs', () => {
+      expect(getSourceName('https://civitai.com/models/123')).toBe('Civitai')
+    })
+
+    it('should return Hugging Face for huggingface.co URLs', () => {
+      expect(getSourceName('https://huggingface.co/org/model')).toBe(
+        'Hugging Face'
+      )
+    })
+
+    it('should return Source for unknown URLs', () => {
+      expect(getSourceName('https://example.com/model')).toBe('Source')
     })
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -32,20 +32,29 @@ export function getAssetBaseModel(asset: AssetItem): string | null {
  * @returns The display name or filename
  */
 export function getAssetDisplayName(asset: AssetItem): string {
-  return typeof asset.user_metadata?.display_name === 'string'
-    ? asset.user_metadata.display_name
+  return typeof asset.user_metadata?.name === 'string'
+    ? asset.user_metadata.name
     : asset.name
 }
 
 /**
- * Safely extracts source URL from asset metadata
+ * Constructs source URL from asset's source_arn
  * @param asset - The asset to extract source URL from
- * @returns The source URL or null if not present
+ * @returns The source URL or null if not present/parseable
  */
 export function getAssetSourceUrl(asset: AssetItem): string | null {
-  return typeof asset.user_metadata?.source_url === 'string'
-    ? asset.user_metadata.source_url
-    : null
+  const sourceArn = asset.user_metadata?.source_arn
+  if (typeof sourceArn !== 'string') return null
+
+  const civitaiMatch = sourceArn.match(
+    /^civitai:model:(\d+):version:(\d+)(?::file:\d+)?$/
+  )
+  if (civitaiMatch) {
+    const [, modelId, versionId] = civitaiMatch
+    return `https://civitai.com/models/${modelId}?modelVersionId=${versionId}`
+  }
+
+  return null
 }
 
 /**
@@ -54,7 +63,7 @@ export function getAssetSourceUrl(asset: AssetItem): string | null {
  * @returns Array of trigger phrases
  */
 export function getAssetTriggerPhrases(asset: AssetItem): string[] {
-  const phrases = asset.user_metadata?.trigger_phrases
+  const phrases = asset.user_metadata?.trained_words
   if (Array.isArray(phrases)) {
     return phrases.filter((p): p is string => typeof p === 'string')
   }

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -110,3 +110,14 @@ export function getSourceName(url: string): string {
   if (url.includes('huggingface.co')) return 'Hugging Face'
   return 'Source'
 }
+
+/**
+ * Extracts the model type from asset tags
+ * @param asset - The asset to extract model type from
+ * @returns The model type string or null if not present
+ */
+export function getAssetModelType(asset: AssetItem): string | null {
+  const typeTag = asset.tags?.find((tag) => tag !== 'models')
+  if (!typeTag) return null
+  return typeTag.includes('/') ? (typeTag.split('/').pop() ?? null) : typeTag
+}

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -134,7 +134,7 @@ export function getSourceName(url: string): string {
  * @returns The model type string or null if not present
  */
 export function getAssetModelType(asset: AssetItem): string | null {
-  const typeTag = asset.tags?.find((tag) => tag !== 'models')
+  const typeTag = asset.tags?.find((tag) => tag && tag !== 'models')
   if (!typeTag) return null
   return typeTag.includes('/') ? (typeTag.split('/').pop() ?? null) : typeTag
 }

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -92,8 +92,8 @@ export function getAssetTriggerPhrases(asset: AssetItem): string[] {
  * @param asset - The asset to extract tags from
  * @returns Array of user-defined tags
  */
-export function getAssetTags(asset: AssetItem): string[] {
-  const tags = asset.user_metadata?.tags
+export function getAssetAdditionalTags(asset: AssetItem): string[] {
+  const tags = asset.user_metadata?.additional_tags
   if (Array.isArray(tags)) {
     return tags.filter((t): t is string => typeof t === 'string')
   }

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -67,16 +67,6 @@ export function getAssetDisplayName(asset: AssetItem): string {
 }
 
 /**
- * Extracts filename from asset metadata
- * Checks user_metadata first, then metadata, then returns null
- * @param asset - The asset to extract filename from
- * @returns The filename string or null if not present
- */
-export function getAssetFilename(asset: AssetItem): string | null {
-  return getStringProperty(asset, 'filename') ?? null
-}
-
-/**
  * Constructs source URL from asset's source_arn
  * @param asset - The asset to extract source URL from
  * @returns The source URL or null if not present/parseable

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -121,3 +121,14 @@ export function getAssetModelType(asset: AssetItem): string | null {
   if (!typeTag) return null
   return typeTag.includes('/') ? (typeTag.split('/').pop() ?? null) : typeTag
 }
+
+/**
+ * Extracts user description from asset user_metadata
+ * @param asset - The asset to extract user description from
+ * @returns The user description string or empty string if not present
+ */
+export function getAssetUserDescription(asset: AssetItem): string {
+  return typeof asset.user_metadata?.user_description === 'string'
+    ? asset.user_metadata.user_description
+    : ''
+}

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -25,3 +25,63 @@ export function getAssetBaseModel(asset: AssetItem): string | null {
     ? asset.user_metadata.base_model
     : null
 }
+
+/**
+ * Gets the display name for an asset, falling back to filename
+ * @param asset - The asset to get display name from
+ * @returns The display name or filename
+ */
+export function getAssetDisplayName(asset: AssetItem): string {
+  return typeof asset.user_metadata?.display_name === 'string'
+    ? asset.user_metadata.display_name
+    : asset.name
+}
+
+/**
+ * Safely extracts source URL from asset metadata
+ * @param asset - The asset to extract source URL from
+ * @returns The source URL or null if not present
+ */
+export function getAssetSourceUrl(asset: AssetItem): string | null {
+  return typeof asset.user_metadata?.source_url === 'string'
+    ? asset.user_metadata.source_url
+    : null
+}
+
+/**
+ * Extracts trigger phrases from asset metadata
+ * @param asset - The asset to extract trigger phrases from
+ * @returns Array of trigger phrases
+ */
+export function getAssetTriggerPhrases(asset: AssetItem): string[] {
+  const phrases = asset.user_metadata?.trigger_phrases
+  if (Array.isArray(phrases)) {
+    return phrases.filter((p): p is string => typeof p === 'string')
+  }
+  if (typeof phrases === 'string') return [phrases]
+  return []
+}
+
+/**
+ * Extracts additional tags from asset user_metadata
+ * @param asset - The asset to extract tags from
+ * @returns Array of user-defined tags
+ */
+export function getAssetTags(asset: AssetItem): string[] {
+  const tags = asset.user_metadata?.tags
+  if (Array.isArray(tags)) {
+    return tags.filter((t): t is string => typeof t === 'string')
+  }
+  return []
+}
+
+/**
+ * Determines the source name from a URL
+ * @param url - The source URL
+ * @returns Human-readable source name
+ */
+export function getSourceName(url: string): string {
+  if (url.includes('civitai.com')) return 'Civitai'
+  if (url.includes('huggingface.co')) return 'Hugging Face'
+  return 'Source'
+}

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -27,6 +27,22 @@ export function getAssetBaseModel(asset: AssetItem): string | null {
 }
 
 /**
+ * Extracts base models as an array from asset metadata
+ * @param asset - The asset to extract base models from
+ * @returns Array of base model strings
+ */
+export function getAssetBaseModels(asset: AssetItem): string[] {
+  const baseModel = asset.user_metadata?.base_model
+  if (Array.isArray(baseModel)) {
+    return baseModel.filter((m): m is string => typeof m === 'string')
+  }
+  if (typeof baseModel === 'string' && baseModel) {
+    return [baseModel]
+  }
+  return []
+}
+
+/**
  * Gets the display name for an asset, falling back to filename
  * @param asset - The asset to get display name from
  * @returns The display name or filename

--- a/src/renderer/extensions/linearMode/LinearPreview.vue
+++ b/src/renderer/extensions/linearMode/LinearPreview.vue
@@ -45,7 +45,7 @@ const timeOptions = {
   second: 'numeric'
 } as const
 
-function formatTime(time: string) {
+function formatTime(time?: string) {
   if (!time) return ''
   const date = new Date(time)
   return `${d(date, dateOptions)} | ${d(date, timeOptions)}`

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/stores/assetsStore', () => ({
     getAssets: () => [],
     isModelLoading: () => false,
     getError: () => undefined,
+    hasAssetKey: () => false,
     updateModelsForNodeType: mockUpdateModelsForNodeType
   })
 }))

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/platform/distribution/types', () => ({
 const mockAssetsByKey = new Map<string, AssetItem[]>()
 const mockLoadingByKey = new Map<string, boolean>()
 const mockErrorByKey = new Map<string, Error | undefined>()
+const mockInitializedKeys = new Set<string>()
 const mockUpdateModelsForNodeType = vi.fn()
 const mockGetCategoryForNodeType = vi.fn()
 
@@ -19,6 +20,7 @@ vi.mock('@/stores/assetsStore', () => ({
     getAssets: (key: string) => mockAssetsByKey.get(key) ?? [],
     isModelLoading: (key: string) => mockLoadingByKey.get(key) ?? false,
     getError: (key: string) => mockErrorByKey.get(key),
+    hasAssetKey: (key: string) => mockInitializedKeys.has(key),
     updateModelsForNodeType: mockUpdateModelsForNodeType
   })
 }))
@@ -35,6 +37,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
     mockAssetsByKey.clear()
     mockLoadingByKey.clear()
     mockErrorByKey.clear()
+    mockInitializedKeys.clear()
     mockGetCategoryForNodeType.mockReturnValue(undefined)
 
     mockUpdateModelsForNodeType.mockImplementation(
@@ -76,6 +79,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
     mockUpdateModelsForNodeType.mockImplementation(
       async (_nodeType: string): Promise<AssetItem[]> => {
+        mockInitializedKeys.add(_nodeType)
         mockAssetsByKey.set(_nodeType, mockAssets)
         mockLoadingByKey.set(_nodeType, false)
         return mockAssets
@@ -108,6 +112,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
     mockUpdateModelsForNodeType.mockImplementation(
       async (_nodeType: string): Promise<AssetItem[]> => {
+        mockInitializedKeys.add(_nodeType)
         mockErrorByKey.set(_nodeType, mockError)
         mockAssetsByKey.set(_nodeType, [])
         mockLoadingByKey.set(_nodeType, false)
@@ -130,6 +135,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
     mockUpdateModelsForNodeType.mockImplementation(
       async (_nodeType: string): Promise<AssetItem[]> => {
+        mockInitializedKeys.add(_nodeType)
         mockAssetsByKey.set(_nodeType, [])
         mockLoadingByKey.set(_nodeType, false)
         return []
@@ -154,6 +160,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       mockGetCategoryForNodeType.mockReturnValue('checkpoints')
       mockUpdateModelsForNodeType.mockImplementation(
         async (_nodeType: string): Promise<AssetItem[]> => {
+          mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
           return mockAssets
@@ -182,6 +189,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       mockGetCategoryForNodeType.mockReturnValue('loras')
       mockUpdateModelsForNodeType.mockImplementation(
         async (_nodeType: string): Promise<AssetItem[]> => {
+          mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
           return mockAssets
@@ -209,6 +217,7 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       mockGetCategoryForNodeType.mockReturnValue('checkpoints')
       mockUpdateModelsForNodeType.mockImplementation(
         async (_nodeType: string): Promise<AssetItem[]> => {
+          mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
           return mockAssets

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -65,10 +65,10 @@ export function useAssetWidgetData(
           return
         }
 
-        const existingAssets = assetsStore.getAssets(currentNodeType) ?? []
-        const hasData = existingAssets.length > 0
+        const isLoading = assetsStore.isModelLoading(currentNodeType)
+        const hasBeenInitialized = assetsStore.hasAssetKey(currentNodeType)
 
-        if (!hasData) {
+        if (!isLoading && !hasBeenInitialized) {
           await assetsStore.updateModelsForNodeType(currentNodeType)
         }
       },

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -48,7 +48,7 @@ export function useAssetWidgetData(
     })
 
     const dropdownItems = computed<DropdownItem[]>(() => {
-      return assets.value.map((asset) => ({
+      return (assets.value ?? []).map((asset) => ({
         id: asset.id,
         name:
           (asset.user_metadata?.filename as string | undefined) ?? asset.name,

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -319,8 +319,8 @@ describe('assetsStore - Refactored (Option A)', () => {
 
       // Verify sorting (newest first - lower index = newer)
       for (let i = 1; i < store.historyAssets.length; i++) {
-        const prevDate = new Date(store.historyAssets[i - 1].created_at)
-        const currDate = new Date(store.historyAssets[i].created_at)
+        const prevDate = new Date(store.historyAssets[i - 1].created_at ?? 0)
+        const currDate = new Date(store.historyAssets[i].created_at ?? 0)
         expect(prevDate.getTime()).toBeGreaterThanOrEqual(currDate.getTime())
       }
     })
@@ -435,8 +435,8 @@ describe('assetsStore - Refactored (Option A)', () => {
 
       // Should still maintain sorting
       for (let i = 1; i < store.historyAssets.length; i++) {
-        const prevDate = new Date(store.historyAssets[i - 1].created_at)
-        const currDate = new Date(store.historyAssets[i].created_at)
+        const prevDate = new Date(store.historyAssets[i - 1].created_at ?? 0)
+        const currDate = new Date(store.historyAssets[i].created_at ?? 0)
         expect(prevDate.getTime()).toBeGreaterThanOrEqual(currDate.getTime())
       }
     })

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -419,13 +419,59 @@ export const useAssetsStore = defineStore('assets', () => {
         )
       }
 
+      /**
+       * Optimistically update an asset in the cache
+       * @param assetId The asset ID to update
+       * @param updates Partial asset data to merge
+       * @param cacheKey Optional cache key to target (nodeType or 'tag:xxx')
+       */
+      function updateAssetInCache(
+        assetId: string,
+        updates: Partial<AssetItem>,
+        cacheKey?: string
+      ) {
+        const keysToCheck = cacheKey
+          ? [cacheKey]
+          : Array.from(modelAssetsByNodeType.keys())
+
+        for (const key of keysToCheck) {
+          const assets = modelAssetsByNodeType.get(key)
+          if (!assets) continue
+
+          const index = assets.findIndex((a) => a.id === assetId)
+          if (index !== -1) {
+            const updatedAsset = { ...assets[index], ...updates }
+            const newAssets = [...assets]
+            newAssets[index] = updatedAsset
+            modelAssetsByNodeType.set(key, newAssets)
+            if (cacheKey) return
+          }
+        }
+      }
+
+      /**
+       * Update asset metadata with optimistic cache update
+       * @param assetId The asset ID to update
+       * @param userMetadata The user_metadata to save
+       * @param cacheKey Optional cache key to target for optimistic update
+       */
+      async function updateAssetMetadata(
+        assetId: string,
+        userMetadata: Record<string, unknown>,
+        cacheKey?: string
+      ) {
+        updateAssetInCache(assetId, { user_metadata: userMetadata }, cacheKey)
+        await assetService.updateAsset(assetId, { user_metadata: userMetadata })
+      }
+
       return {
         getAssets,
         isLoading,
         getError,
         hasMore,
         updateModelsForNodeType,
-        updateModelsForTag
+        updateModelsForTag,
+        updateAssetMetadata
       }
     }
 
@@ -436,7 +482,8 @@ export const useAssetsStore = defineStore('assets', () => {
       getError: () => undefined,
       hasMore: () => false,
       updateModelsForNodeType: async () => {},
-      updateModelsForTag: async () => {}
+      updateModelsForTag: async () => {},
+      updateAssetMetadata: async () => {}
     }
   }
 
@@ -446,7 +493,8 @@ export const useAssetsStore = defineStore('assets', () => {
     getError,
     hasMore,
     updateModelsForNodeType,
-    updateModelsForTag
+    updateModelsForTag,
+    updateAssetMetadata
   } = getModelState()
 
   // Watch for completed downloads and refresh model caches
@@ -514,6 +562,7 @@ export const useAssetsStore = defineStore('assets', () => {
 
     // Model assets - actions
     updateModelsForNodeType,
-    updateModelsForTag
+    updateModelsForTag,
+    updateAssetMetadata
   }
 })

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -322,6 +322,10 @@ export const useAssetsStore = defineStore('assets', () => {
         return modelStateByKey.value.get(key)?.hasMore ?? false
       }
 
+      function hasAssetKey(key: string): boolean {
+        return modelStateByKey.value.has(key)
+      }
+
       /**
        * Internal helper to fetch and cache assets with a given key and fetcher.
        * Loads first batch immediately, then progressively loads remaining batches.
@@ -484,6 +488,7 @@ export const useAssetsStore = defineStore('assets', () => {
         isLoading,
         getError,
         hasMore,
+        hasAssetKey,
         updateModelsForNodeType,
         updateModelsForTag,
         updateAssetMetadata,
@@ -497,6 +502,7 @@ export const useAssetsStore = defineStore('assets', () => {
       isLoading: () => false,
       getError: () => undefined,
       hasMore: () => false,
+      hasAssetKey: () => false,
       updateModelsForNodeType: async () => {},
       updateModelsForTag: async () => {},
       updateAssetMetadata: async () => {},
@@ -509,6 +515,7 @@ export const useAssetsStore = defineStore('assets', () => {
     isLoading: isModelLoading,
     getError,
     hasMore,
+    hasAssetKey,
     updateModelsForNodeType,
     updateModelsForTag,
     updateAssetMetadata,
@@ -577,6 +584,7 @@ export const useAssetsStore = defineStore('assets', () => {
     isModelLoading,
     getError,
     hasMore,
+    hasAssetKey,
 
     // Model assets - actions
     updateModelsForNodeType,

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -433,18 +433,17 @@ export const useAssetsStore = defineStore('assets', () => {
       ) {
         const keysToCheck = cacheKey
           ? [cacheKey]
-          : Array.from(modelAssetsByNodeType.keys())
+          : Array.from(modelStateByKey.value.keys())
 
         for (const key of keysToCheck) {
-          const assets = modelAssetsByNodeType.get(key)
-          if (!assets) continue
+          const state = modelStateByKey.value.get(key)
+          if (!state?.assets) continue
 
-          const index = assets.findIndex((a) => a.id === assetId)
-          if (index !== -1) {
-            const updatedAsset = { ...assets[index], ...updates }
-            const newAssets = [...assets]
-            newAssets[index] = updatedAsset
-            modelAssetsByNodeType.set(key, newAssets)
+          const existingAsset = state.assets.get(assetId)
+          if (existingAsset) {
+            const updatedAsset = { ...existingAsset, ...updates }
+            state.assets.set(assetId, updatedAsset)
+            assetsArrayCache.delete(key)
             if (cacheKey) return
           }
         }

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -464,6 +464,21 @@ export const useAssetsStore = defineStore('assets', () => {
         await assetService.updateAsset(assetId, { user_metadata: userMetadata })
       }
 
+      /**
+       * Update asset tags with optimistic cache update
+       * @param assetId The asset ID to update
+       * @param tags The tags array to save
+       * @param cacheKey Optional cache key to target for optimistic update
+       */
+      async function updateAssetTags(
+        assetId: string,
+        tags: string[],
+        cacheKey?: string
+      ) {
+        updateAssetInCache(assetId, { tags }, cacheKey)
+        await assetService.updateAsset(assetId, { tags })
+      }
+
       return {
         getAssets,
         isLoading,
@@ -471,7 +486,8 @@ export const useAssetsStore = defineStore('assets', () => {
         hasMore,
         updateModelsForNodeType,
         updateModelsForTag,
-        updateAssetMetadata
+        updateAssetMetadata,
+        updateAssetTags
       }
     }
 
@@ -483,7 +499,8 @@ export const useAssetsStore = defineStore('assets', () => {
       hasMore: () => false,
       updateModelsForNodeType: async () => {},
       updateModelsForTag: async () => {},
-      updateAssetMetadata: async () => {}
+      updateAssetMetadata: async () => {},
+      updateAssetTags: async () => {}
     }
   }
 
@@ -494,7 +511,8 @@ export const useAssetsStore = defineStore('assets', () => {
     hasMore,
     updateModelsForNodeType,
     updateModelsForTag,
-    updateAssetMetadata
+    updateAssetMetadata,
+    updateAssetTags
   } = getModelState()
 
   // Watch for completed downloads and refresh model caches
@@ -563,6 +581,7 @@ export const useAssetsStore = defineStore('assets', () => {
     // Model assets - actions
     updateModelsForNodeType,
     updateModelsForTag,
-    updateAssetMetadata
+    updateAssetMetadata,
+    updateAssetTags
   }
 })

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -78,7 +78,8 @@ function mapHistoryToAssets(historyItems: JobListItem[]): AssetItem[] {
 
   return assetItems.sort(
     (a, b) =>
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      new Date(b.created_at ?? 0).getTime() -
+      new Date(a.created_at ?? 0).getTime()
   )
 }
 
@@ -145,9 +146,9 @@ export const useAssetsStore = defineStore('assets', () => {
         loadedIds.add(asset.id)
 
         // Find insertion index to maintain sorted order (newest first)
-        const assetTime = new Date(asset.created_at).getTime()
+        const assetTime = new Date(asset.created_at ?? 0).getTime()
         const insertIndex = allHistoryItems.value.findIndex(
-          (item) => new Date(item.created_at).getTime() < assetTime
+          (item) => new Date(item.created_at ?? 0).getTime() < assetTime
         )
 
         if (insertIndex === -1) {


### PR DESCRIPTION
## Summary

Adds an editable Model Info Panel to show and modify asset details in the asset browser.

## Changes

- Add `ModelInfoPanel` component with editable display name, description, model type, base models, and tags
- Add `updateAssetMetadata` action in `assetsStore` with optimistic cache updates
- Add shadcn-vue `Select` components with design system styling
- Add utility functions in `assetMetadataUtils` for extracting model metadata
- Convert `BaseModalLayout` right panel state to `defineModel` pattern
- Add slide-in animation and collapse button for right panel
- Add `class` prop to `PropertiesAccordionItem` for custom styling
- Fix keyboard handling: Escape in TagsInput/TextArea doesn't close parent modal

## Testing

- Unit tests for `ModelInfoPanel` component
- Unit tests for `assetMetadataUtils` functions
