### PR TITLE
fix: run E2E tests after i18n completes on release PRs

### DIFF
--- a/.github/workflows/ci-tests-e2e-release.yaml
+++ b/.github/workflows/ci-tests-e2e-release.yaml
@@ -1,0 +1,65 @@
+# Description: Runs E2E tests for release PRs after i18n workflow completes
+name: 'CI: Tests E2E (Release PRs)'
+
+on:
+  workflow_run:
+    workflows: ['i18n: Update Core']
+    types: [completed]
+
+jobs:
+  check-eligibility:
+    runs-on: ubuntu-latest
+    # Only run if:
+    # 1. This is the main repository
+    # 2. The i18n workflow was triggered by a pull_request
+    # 3. The i18n workflow completed successfully or was skipped (no locale changes)
+    # 4. The branch is a version-bump branch
+    # 5. The PR is from the main repo (not a fork)
+    if: |
+      github.repository == 'Comfy-Org/ComfyUI_frontend' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'skipped') &&
+      startsWith(github.event.workflow_run.head_branch, 'version-bump-') &&
+      github.event.workflow_run.head_repository.full_name == github.event.workflow_run.repository.full_name
+    outputs:
+      pr_number: ${{ steps.pr.outputs.result }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Log workflow trigger info
+        run: |
+          echo "Repository: ${{ github.repository }}"
+          echo "Event: ${{ github.event.workflow_run.event }}"
+          echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
+          echo "Head branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "Head SHA: ${{ github.event.workflow_run.head_sha }}"
+          echo "Head repo: ${{ github.event.workflow_run.head_repository.full_name }}"
+
+      - name: Get PR Number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            const pr = prs.find(p => p.head.sha === context.payload.workflow_run.head_sha);
+
+            if (!pr) {
+              console.log('No PR found for SHA:', context.payload.workflow_run.head_sha);
+              return null;
+            }
+
+            console.log(`Found PR #${pr.number} for version bump: ${context.payload.workflow_run.head_branch}`);
+            return pr.number;
+
+  run-e2e-tests:
+    needs: check-eligibility
+    if: needs.check-eligibility.outputs.pr_number != 'null'
+    uses: ./.github/workflows/ci-tests-e2e.yaml
+    with:
+      ref: ${{ needs.check-eligibility.outputs.head_sha }}
+      pr_number: ${{ needs.check-eligibility.outputs.pr_number }}
+    secrets: inherit

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -7,17 +7,35 @@ on:
   pull_request:
     branches-ignore:
       [wip/*, draft/*, temp/*, vue-nodes-migration, sno-playwright-*]
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        required: true
+        type: string
+      pr_number:
+        description: 'PR number for commenting'
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
   setup:
     runs-on: ubuntu-latest
+    # Skip version-bump PRs on pull_request trigger (they use ci-tests-e2e-release.yaml)
+    # Always run for push, workflow_call, or non-version-bump PRs
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_call' ||
+      !startsWith(github.head_ref, 'version-bump-')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
         with:
@@ -52,6 +70,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
       - name: Download built frontend
         uses: actions/download-artifact@v4
         with:
@@ -99,6 +119,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
       - name: Download built frontend
         uses: actions/download-artifact@v4
         with:
@@ -143,6 +165,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -178,12 +202,16 @@ jobs:
   # Post starting comment for non-forked PRs
   comment-on-pr-start:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'workflow_call' && inputs.pr_number != '')
     permissions:
       pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Get start time
         id: start-time
@@ -195,8 +223,8 @@ jobs:
         run: |
           chmod +x scripts/cicd/pr-playwright-deploy-and-comment.sh
           ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.head_ref }}" \
+            "${{ inputs.pr_number || github.event.pull_request.number }}" \
+            "${{ github.head_ref || inputs.ref }}" \
             "starting" \
             "${{ steps.start-time.outputs.time }}"
 
@@ -204,13 +232,19 @@ jobs:
   deploy-and-comment:
     needs: [playwright-tests, merge-reports]
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: |
+      always() && (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+        (github.event_name == 'workflow_call' && inputs.pr_number != '')
+      )
     permissions:
       pull-requests: write
       contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Download all playwright reports
         uses: actions/download-artifact@v4
@@ -223,10 +257,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_SHA: ${{ inputs.ref || github.event.pull_request.head.sha }}
         run: |
           bash ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.head_ref }}" \
+            "${{ inputs.pr_number || github.event.pull_request.number }}" \
+            "${{ github.head_ref || inputs.ref }}" \
             "completed"
   #### END Deployment and commenting (non-forked PRs only)


### PR DESCRIPTION
## Summary
- Fixes issue where locale commits would cancel in-progress E2E tests on release PRs
- E2E tests now run **once** after i18n workflow completes for version-bump PRs

## Changes
1. **Modified `ci-tests-e2e.yaml`**:
   - Added `workflow_call` trigger with `ref` and `pr_number` inputs
   - Added skip condition for version-bump PRs on `pull_request` trigger
   - Updated checkout steps to use `inputs.ref` when called via `workflow_call`

2. **Created `ci-tests-e2e-release.yaml`**:
   - Triggers on `workflow_run` completion of `i18n: Update Core`
   - Only runs for version-bump PRs from main repo
   - Calls original E2E workflow via `workflow_call` (no job duplication)

## How it works
**Regular PRs:** `CI: Tests E2E` runs normally via `pull_request` trigger

**Version-bump PRs:**
1. `CI: Tests E2E` skips (setup job condition fails)
2. `i18n: Update Core` runs and commits locale updates
3. `CI: Tests E2E (Release PRs)` triggers after i18n completes
4. Calls `CI: Tests E2E` via `workflow_call`
5. E2E tests run to completion without cancellation

## Test plan
- [x] Tested workflow_call chain on fork
- [x] Verify version-bump PR skips regular E2E workflow
- [x] Verify E2E runs after i18n completes on next release

Fixes the issue identified during v1.38.2 release where locale commits caused E2E tests to restart multiple times.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8091-fix-run-E2E-tests-after-i18n-completes-on-release-PRs-2ea6d73d36508151a315ed1f415afcc6) by [Unito](https://www.unito.io)
