### PR TITLE
Fix copypasted primitives inside subgraphs

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -80,6 +80,7 @@ import { SubgraphIONodeBase } from './subgraph/SubgraphIONodeBase'
 import type { SubgraphInputNode } from './subgraph/SubgraphInputNode'
 import { SubgraphNode } from './subgraph/SubgraphNode'
 import type { SubgraphOutputNode } from './subgraph/SubgraphOutputNode'
+import { mapAllNodes } from './subgraph/subgraphUtils'
 import type {
   CanvasPointerEvent,
   CanvasPointerExtensions
@@ -4057,6 +4058,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     layoutStore.batchUpdateNodeBounds(newPositions)
 
     this.selectItems(created)
+    const createdNodes = created.filter((p) => p instanceof LGraphNode)
+    mapAllNodes((n) => n.onGraphConfigured?.(), createdNodes)
+    mapAllNodes((n) => n.onAfterGraphConfigured?.(), createdNodes)
 
     graph.afterChange()
     this.emitAfterChange()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -8,6 +8,7 @@ import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMuta
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
+import { forEachNode } from '@/utils/graphTraversalUtil'
 
 import { CanvasPointer } from './CanvasPointer'
 import type { ContextMenu } from './ContextMenu'
@@ -80,7 +81,6 @@ import { SubgraphIONodeBase } from './subgraph/SubgraphIONodeBase'
 import type { SubgraphInputNode } from './subgraph/SubgraphInputNode'
 import { SubgraphNode } from './subgraph/SubgraphNode'
 import type { SubgraphOutputNode } from './subgraph/SubgraphOutputNode'
-import { forEachNode } from './subgraph/subgraphUtils'
 import type {
   CanvasPointerEvent,
   CanvasPointerExtensions
@@ -4058,9 +4058,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     layoutStore.batchUpdateNodeBounds(newPositions)
 
     this.selectItems(created)
-    const createdNodes = created.filter((p) => p instanceof LGraphNode)
-    forEachNode((n) => n.onGraphConfigured?.(), createdNodes)
-    forEachNode((n) => n.onAfterGraphConfigured?.(), createdNodes)
+    forEachNode(graph, (n) => n.onGraphConfigured?.())
+    forEachNode(graph, (n) => n.onAfterGraphConfigured?.())
 
     graph.afterChange()
     this.emitAfterChange()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -80,7 +80,7 @@ import { SubgraphIONodeBase } from './subgraph/SubgraphIONodeBase'
 import type { SubgraphInputNode } from './subgraph/SubgraphInputNode'
 import { SubgraphNode } from './subgraph/SubgraphNode'
 import type { SubgraphOutputNode } from './subgraph/SubgraphOutputNode'
-import { mapAllNodes } from './subgraph/subgraphUtils'
+import { forEachNode } from './subgraph/subgraphUtils'
 import type {
   CanvasPointerEvent,
   CanvasPointerExtensions
@@ -4059,8 +4059,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     this.selectItems(created)
     const createdNodes = created.filter((p) => p instanceof LGraphNode)
-    mapAllNodes((n) => n.onGraphConfigured?.(), createdNodes)
-    mapAllNodes((n) => n.onAfterGraphConfigured?.(), createdNodes)
+    forEachNode((n) => n.onGraphConfigured?.(), createdNodes)
+    forEachNode((n) => n.onAfterGraphConfigured?.(), createdNodes)
 
     graph.afterChange()
     this.emitAfterChange()

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -499,15 +499,3 @@ export function isNodeSlot(
     ('link' in slot || 'links' in slot)
   )
 }
-export function forEachNode(
-  func: (node: LGraphNode) => void,
-  nodes: LGraphNode[],
-  visited = new Set()
-) {
-  for (const node of nodes) {
-    func(node)
-    if (!node.isSubgraphNode() || visited.has(node.type)) continue
-    visited.add(node.type)
-    forEachNode(func, node.subgraph.nodes, visited)
-  }
-}

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -499,3 +499,15 @@ export function isNodeSlot(
     ('link' in slot || 'links' in slot)
   )
 }
+export function mapAllNodes(
+  func: (node: LGraphNode) => void,
+  nodes: LGraphNode[],
+  visited = new Set()
+) {
+  for (const node of nodes) {
+    func(node)
+    if (!node.isSubgraphNode() || visited.has(node.type)) continue
+    visited.add(node.type)
+    mapAllNodes(func, node.subgraph.nodes, visited)
+  }
+}

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -499,7 +499,7 @@ export function isNodeSlot(
     ('link' in slot || 'links' in slot)
   )
 }
-export function mapAllNodes(
+export function forEachNode(
   func: (node: LGraphNode) => void,
   nodes: LGraphNode[],
   visited = new Set()
@@ -508,6 +508,6 @@ export function mapAllNodes(
     func(node)
     if (!node.isSubgraphNode() || visited.has(node.type)) continue
     visited.add(node.type)
-    mapAllNodes(func, node.subgraph.nodes, visited)
+    forEachNode(func, node.subgraph.nodes, visited)
   }
 }


### PR DESCRIPTION
Copying a subgraph which contains primitive nodes would cause the primitives to fail to initialize. This was caused because they did not have their `onGraphConfigured` and `onAfterGraphConfigured` callbacks applied.

There's already a copy of `forEachNode` in `@/utils/graphTraversalUtil.ts`, but the method is small and I want to avoid litegraph referencing outside code.

See also #6606, where a similar fix was needed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8094-Fix-copypasted-primitives-inside-subgraphs-2ea6d73d365081f189f1ea4c9248f5ed) by [Unito](https://www.unito.io)
