### PR TITLE
refactor(EditableText): standardize API with defineModel and doubleClickToEdit

### DIFF
--- a/src/components/common/TreeExplorerTreeNode.vue
+++ b/src/components/common/TreeExplorerTreeNode.vue
@@ -17,6 +17,7 @@
           :model-value="node.label"
           :is-editing="isEditing"
           @edit="handleRename"
+          @cancel="handleRename(node.label)"
         />
         <slot name="after-label" :node="props.node" />
       </span>

--- a/src/components/graph/TitleEditor.vue
+++ b/src/components/graph/TitleEditor.vue
@@ -8,6 +8,7 @@
       :is-editing="showInput"
       :model-value="editedTitle"
       @edit="onEdit"
+      @cancel="onCancel"
     />
   </div>
 </template>
@@ -47,6 +48,12 @@ const titleEditorStore = useTitleEditorStore()
 const canvasStore = useCanvasStore()
 const previousCanvasDraggable = ref(true)
 
+const closeEditor = () => {
+  showInput.value = false
+  titleEditorStore.titleEditorTarget = null
+  canvasStore.canvas!.allow_dragcanvas = previousCanvasDraggable.value
+}
+
 const onEdit = (newValue: string) => {
   if (titleEditorStore.titleEditorTarget && newValue?.trim()) {
     const trimmedTitle = newValue.trim()
@@ -60,9 +67,11 @@ const onEdit = (newValue: string) => {
 
     app.canvas.setDirty(true, true)
   }
-  showInput.value = false
-  titleEditorStore.titleEditorTarget = null
-  canvasStore.canvas!.allow_dragcanvas = previousCanvasDraggable.value
+  closeEditor()
+}
+
+const onCancel = () => {
+  closeEditor()
 }
 
 watch(

--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -198,13 +198,13 @@ function handleTitleCancel() {
         <h3 class="my-3.5 text-sm font-semibold line-clamp-2 cursor-default">
           <template v-if="allowTitleEdit">
             <EditableText
+              v-model:is-editing="isEditing"
               :model-value="panelTitle"
-              :is-editing="isEditing"
               :input-attrs="{ 'data-testid': 'node-title-input' }"
+              double-click-to-edit
               class="cursor-text"
               @edit="handleTitleEdit"
               @cancel="handleTitleCancel"
-              @click="isEditing = true"
             />
             <i
               v-if="!isEditing"

--- a/src/components/rightSidePanel/layout/PropertiesAccordionItem.vue
+++ b/src/components/rightSidePanel/layout/PropertiesAccordionItem.vue
@@ -5,25 +5,32 @@ import { cn } from '@/utils/tailwindUtil'
 
 import TransitionCollapse from './TransitionCollapse.vue'
 
-const props = defineProps<{
+const {
+  disabled,
+  label,
+  enableEmptyState,
+  tooltip,
+  class: className
+} = defineProps<{
   disabled?: boolean
   label?: string
   enableEmptyState?: boolean
   tooltip?: string
+  class?: string
 }>()
 
 const isCollapse = defineModel<boolean>('collapse', { default: false })
 
-const isExpanded = computed(() => !isCollapse.value && !props.disabled)
+const isExpanded = computed(() => !isCollapse.value && !disabled)
 
 const tooltipConfig = computed(() => {
-  if (!props.tooltip) return undefined
-  return { value: props.tooltip, showDelay: 1000 }
+  if (!tooltip) return undefined
+  return { value: tooltip, showDelay: 1000 }
 })
 </script>
 
 <template>
-  <div class="flex flex-col bg-comfy-menu-bg">
+  <div :class="cn('flex flex-col bg-comfy-menu-bg', className)">
     <div
       class="sticky top-0 z-10 flex items-center justify-between backdrop-blur-xl bg-inherit"
     >

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, customRef, ref } from 'vue'
+import { computed, customRef } from 'vue'
 
 import EditableText from '@/components/common/EditableText.vue'
 import { getSharedWidgetEnhancements } from '@/composables/graph/useGraphNodeManager'
@@ -40,7 +40,6 @@ const {
 
 const canvasStore = useCanvasStore()
 const favoritedWidgetsStore = useFavoritedWidgetsStore()
-const isEditing = ref(false)
 
 const widgetComponent = computed(() => {
   const component = getComponent(widget.type, widget.name)
@@ -87,8 +86,6 @@ const displayLabel = customRef((track, trigger) => {
       return widget.label || widget.name
     },
     set(newValue: string) {
-      isEditing.value = false
-
       const trimmedLabel = newValue.trim()
 
       const success = renameWidget(widget, node, trimmedLabel, parents)
@@ -123,13 +120,11 @@ const displayLabel = customRef((track, trigger) => {
     >
       <EditableText
         v-if="widget.name"
-        v-model:is-editing="isEditing"
         :model-value="displayLabel"
         :input-attrs="{ placeholder: widget.name }"
         double-click-to-edit
         class="text-sm leading-8 p-0 m-0 truncate pointer-events-auto cursor-text"
         @edit="displayLabel = $event"
-        @cancel="isEditing = false"
       />
 
       <span

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -123,13 +123,13 @@ const displayLabel = customRef((track, trigger) => {
     >
       <EditableText
         v-if="widget.name"
+        v-model:is-editing="isEditing"
         :model-value="displayLabel"
-        :is-editing="isEditing"
         :input-attrs="{ placeholder: widget.name }"
+        double-click-to-edit
         class="text-sm leading-8 p-0 m-0 truncate pointer-events-auto cursor-text"
         @edit="displayLabel = $event"
         @cancel="isEditing = false"
-        @click="isEditing = true"
       />
 
       <span

--- a/src/components/widget/layout/BaseModalLayout.vue
+++ b/src/components/widget/layout/BaseModalLayout.vue
@@ -67,11 +67,11 @@
         </div>
         <aside
           v-if="hasRightPanel && isRightPanelOpen"
-          class="flex w-72 shrink-0 bg-modal-panel-background flex-col border-l border-border-default"
+          class="flex w-72 shrink-0 bg-modal-panel-background flex-col"
         >
           <header
             data-component-id="RightPanelHeader"
-            class="flex h-16 shrink-0 items-center gap-2 border-b border-border-default px-4"
+            class="flex h-16 shrink-0 items-center gap-2 px-4"
           >
             <h2 v-if="rightPanelTitle" class="flex-1 text-lg font-semibold">
               {{ rightPanelTitle }}

--- a/src/components/widget/layout/BaseModalLayout.vue
+++ b/src/components/widget/layout/BaseModalLayout.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="base-widget-layout rounded-2xl overflow-hidden relative">
     <Button
-      v-show="!isRightPanelOpen && hasRightPanel"
+      v-show="!isRightPanelOpen && showRightPanelButton"
       size="icon"
       :class="
         cn('absolute top-4 right-18 z-10', 'transition-opacity duration-200', {
-          'opacity-0 pointer-events-none': isRightPanelOpen || !hasRightPanel
+          'opacity-0 pointer-events-none':
+            isRightPanelOpen || !showRightPanelButton
         })
       "
       @click="toggleRightPanel"
@@ -58,12 +59,14 @@
               :class="
                 cn(
                   'flex justify-end gap-2 w-0',
-                  hasRightPanel && !isRightPanelOpen ? 'min-w-22' : 'min-w-10'
+                  showRightPanelButton && !isRightPanelOpen
+                    ? 'min-w-22'
+                    : 'min-w-10'
                 )
               "
             >
               <Button
-                v-if="isRightPanelOpen && hasRightPanel"
+                v-if="isRightPanelOpen && showRightPanelButton"
                 size="icon"
                 @click="toggleRightPanel"
               >
@@ -92,7 +95,7 @@
           v-if="hasRightPanel && isRightPanelOpen"
           class="w-1/4 min-w-40 max-w-80"
         >
-          <slot name="rightPanel"></slot>
+          <slot name="rightPanel" />
         </aside>
       </div>
     </div>
@@ -111,6 +114,21 @@ const { contentTitle } = defineProps<{
   contentTitle: string
 }>()
 
+const isRightPanelOpen = defineModel<boolean>('rightPanelOpen', {
+  default: false
+})
+
+const slots = useSlots()
+const hasRightPanel = computed(() => !!slots.rightPanel)
+
+const hideRightPanelButton = defineModel<boolean>('hideRightPanelButton', {
+  default: false
+})
+
+const showRightPanelButton = computed(
+  () => hasRightPanel.value && !hideRightPanelButton.value
+)
+
 const BREAKPOINTS = { md: 880 }
 const PANEL_SIZES = {
   width: 'w-1/3',
@@ -118,17 +136,13 @@ const PANEL_SIZES = {
   maxWidth: 'max-w-56'
 }
 
-const slots = useSlots()
 const closeDialog = inject(OnCloseKey, () => {})
 
 const breakpoints = useBreakpoints(BREAKPOINTS)
 const notMobile = breakpoints.greater('md')
 
 const isLeftPanelOpen = ref<boolean>(true)
-const isRightPanelOpen = ref<boolean>(false)
 const mobileMenuOpen = ref<boolean>(false)
-
-const hasRightPanel = computed(() => !!slots.rightPanel)
 
 watch(notMobile, (isDesktop) => {
   if (!isDesktop) {

--- a/src/components/widget/layout/BaseModalLayout.vue
+++ b/src/components/widget/layout/BaseModalLayout.vue
@@ -1,25 +1,5 @@
 <template>
   <div class="base-widget-layout rounded-2xl overflow-hidden relative">
-    <Button
-      v-show="!isRightPanelOpen && showRightPanelButton"
-      size="icon"
-      :class="
-        cn('absolute top-4 right-18 z-10', 'transition-opacity duration-200', {
-          'opacity-0 pointer-events-none':
-            isRightPanelOpen || !showRightPanelButton
-        })
-      "
-      @click="toggleRightPanel"
-    >
-      <i class="icon-[lucide--panel-right] text-sm" />
-    </Button>
-    <Button
-      size="lg"
-      class="absolute top-4 right-6 z-10 transition-opacity duration-200 w-10"
-      @click="closeDialog"
-    >
-      <i class="pi pi-times" />
-    </Button>
     <div class="flex h-full w-full">
       <Transition name="slide-panel">
         <nav
@@ -55,24 +35,18 @@
               <slot name="header"></slot>
             </div>
             <slot name="header-right-area"></slot>
-            <div
-              :class="
-                cn(
-                  'flex justify-end gap-2 w-0',
-                  showRightPanelButton && !isRightPanelOpen
-                    ? 'min-w-22'
-                    : 'min-w-10'
-                )
-              "
-            >
+            <template v-if="!isRightPanelOpen">
               <Button
-                v-if="isRightPanelOpen && showRightPanelButton"
+                v-if="showRightPanelButton"
                 size="icon"
                 @click="toggleRightPanel"
               >
-                <i class="icon-[lucide--panel-right-close]" />
+                <i class="icon-[lucide--panel-right] text-sm" />
               </Button>
-            </div>
+              <Button size="lg" class="w-10" @click="closeDialog">
+                <i class="pi pi-times" />
+              </Button>
+            </template>
           </header>
 
           <main class="flex min-h-0 flex-1 flex-col">
@@ -93,9 +67,33 @@
         </div>
         <aside
           v-if="hasRightPanel && isRightPanelOpen"
-          class="w-1/4 min-w-40 max-w-80"
+          class="flex w-72 shrink-0 bg-modal-panel-background flex-col border-l border-border-default"
         >
-          <slot name="rightPanel" />
+          <header
+            data-component-id="RightPanelHeader"
+            class="flex h-16 shrink-0 items-center gap-2 border-b border-border-default px-4"
+          >
+            <h2 v-if="rightPanelTitle" class="flex-1 text-lg font-semibold">
+              {{ rightPanelTitle }}
+            </h2>
+            <div v-else class="flex-1">
+              <slot name="rightPanelHeaderTitle" />
+            </div>
+            <slot name="rightPanelHeaderActions" />
+            <Button
+              v-if="showRightPanelButton"
+              size="icon"
+              @click="toggleRightPanel"
+            >
+              <i class="icon-[lucide--panel-right-close] text-sm" />
+            </Button>
+            <Button size="icon" @click="closeDialog">
+              <i class="pi pi-times" />
+            </Button>
+          </header>
+          <div class="min-h-0 flex-1 overflow-y-auto">
+            <slot name="rightPanel" />
+          </div>
         </aside>
       </div>
     </div>
@@ -110,8 +108,9 @@ import Button from '@/components/ui/button/Button.vue'
 import { OnCloseKey } from '@/types/widgetTypes'
 import { cn } from '@/utils/tailwindUtil'
 
-const { contentTitle } = defineProps<{
+const { contentTitle, rightPanelTitle } = defineProps<{
   contentTitle: string
+  rightPanelTitle?: string
 }>()
 
 const isRightPanelOpen = defineModel<boolean>('rightPanelOpen', {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2385,6 +2385,21 @@
       "assetCard": "{name} - {type} asset",
       "loadingAsset": "Loading asset"
     },
+    "modelInfo": {
+      "title": "Model Info",
+      "basicInfo": "Basic Info",
+      "displayName": "Display Name",
+      "fileName": "File Name",
+      "source": "Source",
+      "viewOnSource": "View on {source}",
+      "modelTagging": "Model Tagging",
+      "modelType": "Model Type",
+      "compatibleBaseModels": "Compatible Base Models",
+      "additionalTags": "Additional Tags",
+      "modelDescription": "Model Description",
+      "triggerPhrases": "Trigger Phrases",
+      "description": "Description"
+    },
     "media": {
       "threeDModelPlaceholder": "3D Model",
       "audioPlaceholder": "Audio"

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -5,6 +5,7 @@
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"
+    :right-panel-title="$t('assetBrowser.modelInfo.title')"
     @close="handleClose"
   >
     <template v-if="shouldShowLeftPanel" #leftPanel>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,5 +1,7 @@
 <template>
   <BaseModalLayout
+    :hide-right-panel-button="true"
+    :right-panel-open="!!focusedAsset"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"
@@ -56,13 +58,16 @@
       <AssetGrid
         :assets="filteredAssets"
         :loading="isLoading"
+        :focused-asset-id="focusedAsset?.id"
+        @asset-focus="handleAssetFocus"
+        @asset-blur="focusedAsset = null"
         @asset-select="handleAssetSelectAndEmit"
         @asset-deleted="refreshAssets"
       />
     </template>
 
-    <template v-if="selectedAsset" #rightPanel>
-      <ModelInfoPanel :asset="selectedAsset" />
+    <template #rightPanel>
+      <ModelInfoPanel v-if="focusedAsset" :asset="focusedAsset" />
     </template>
   </BaseModalLayout>
 </template>
@@ -155,7 +160,7 @@ const {
   updateFilters
 } = useAssetBrowser(fetchedAssets)
 
-const selectedAsset = ref<AssetDisplayItem | null>(null)
+const focusedAsset = ref<AssetDisplayItem | null>(null)
 
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []
@@ -198,11 +203,12 @@ function handleClose() {
   emit('close')
 }
 
+function handleAssetFocus(asset: AssetDisplayItem) {
+  focusedAsset.value = asset
+}
+
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
-  selectedAsset.value = asset
   emit('asset-select', asset)
-  // onSelect callback is provided by dialog composable layer
-  // It handles the appropriate transformation (filename extraction or full asset)
   props.onSelect?.(asset)
 }
 </script>

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -60,12 +60,16 @@
         @asset-deleted="refreshAssets"
       />
     </template>
+
+    <template v-if="selectedAsset" #rightPanel>
+      <ModelInfoPanel :asset="selectedAsset" />
+    </template>
   </BaseModalLayout>
 </template>
 
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import { computed, provide } from 'vue'
+import { computed, provide, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SearchBox from '@/components/common/SearchBox.vue'
@@ -74,6 +78,7 @@ import BaseModalLayout from '@/components/widget/layout/BaseModalLayout.vue'
 import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
 import AssetFilterBar from '@/platform/assets/components/AssetFilterBar.vue'
 import AssetGrid from '@/platform/assets/components/AssetGrid.vue'
+import ModelInfoPanel from '@/platform/assets/components/modelInfo/ModelInfoPanel.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
@@ -150,6 +155,8 @@ const {
   updateFilters
 } = useAssetBrowser(fetchedAssets)
 
+const selectedAsset = ref<AssetDisplayItem | null>(null)
+
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []
   const tagFromAssets = assets
@@ -192,6 +199,7 @@ function handleClose() {
 }
 
 function handleAssetSelectAndEmit(asset: AssetDisplayItem) {
+  selectedAsset.value = asset
   emit('asset-select', asset)
   // onSelect callback is provided by dialog composable layer
   // It handles the appropriate transformation (filename extraction or full asset)

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -81,7 +81,7 @@
           :is-editing="isEditing"
           :input-attrs="{ 'data-testid': 'asset-name-input' }"
           @edit="assetRename"
-          @cancel="assetRename()"
+          @cancel="isEditing = false"
         />
       </h3>
       <p

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -115,7 +115,7 @@
 
 <script setup lang="ts">
 import { onClickOutside, useImage } from '@vueuse/core'
-import { computed, ref, toValue, useId, useTemplateRef, watch } from 'vue'
+import { computed, ref, toValue, useId, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import IconGroup from '@/components/button/IconGroup.vue'
@@ -160,21 +160,19 @@ const dropdownMenuButton = useTemplateRef<InstanceType<typeof MoreButton>>(
   'dropdown-menu-button'
 )
 
-const stopClickOutside = ref<(() => void) | null>(null)
-
-watch(
-  () => focused,
-  (isFocused) => {
-    stopClickOutside.value?.()
-    stopClickOutside.value = null
-
-    if (isFocused && cardRef.value) {
-      stopClickOutside.value = onClickOutside(cardRef, () => {
-        emit('blur')
-      })
+onClickOutside(
+  cardRef,
+  () => {
+    if (focused) {
+      emit('blur')
     }
   },
-  { immediate: true }
+  {
+    ignore: [
+      '[data-component-id="ModelInfoPanel"]',
+      '[data-component-id="RightPanelHeader"]'
+    ]
+  }
 )
 
 const titleId = useId()

--- a/src/platform/assets/components/AssetGrid.vue
+++ b/src/platform/assets/components/AssetGrid.vue
@@ -34,6 +34,9 @@
         <AssetCard
           :asset="item"
           :interactive="true"
+          :focused="item.id === focusedAssetId"
+          @focus="$emit('assetFocus', $event)"
+          @blur="$emit('assetBlur')"
           @select="$emit('assetSelect', $event)"
           @deleted="$emit('assetDeleted', $event)"
         />
@@ -50,12 +53,15 @@ import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import AssetCard from '@/platform/assets/components/AssetCard.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 
-const { assets } = defineProps<{
+const { assets, focusedAssetId } = defineProps<{
   assets: AssetDisplayItem[]
   loading?: boolean
+  focusedAssetId?: string | null
 }>()
 
 defineEmits<{
+  assetFocus: [asset: AssetDisplayItem]
+  assetBlur: []
   assetSelect: [asset: AssetDisplayItem]
   assetDeleted: [asset: AssetDisplayItem]
 }>()

--- a/src/platform/assets/components/modelInfo/ModelInfoField.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoField.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="flex flex-col gap-1 px-4 py-2">
+    <span class="text-xs text-muted-foreground">{{ label }}</span>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+}>()
+</script>

--- a/src/platform/assets/components/modelInfo/ModelInfoField.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoField.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col gap-1 px-4 py-2">
-    <span class="text-xs text-muted-foreground">{{ label }}</span>
+  <div class="flex flex-col gap-1 px-4 py-2 text-sm text-muted-foreground">
+    <span>{{ label }}</span>
     <slot />
   </div>
 </template>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
@@ -1,0 +1,212 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
+
+import ModelInfoPanel from './ModelInfoPanel.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key
+  })
+}))
+
+vi.mock(
+  '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue',
+  () => ({
+    default: {
+      name: 'PropertiesAccordionItem',
+      template: `
+      <div data-testid="accordion-item">
+        <div data-testid="accordion-label"><slot name="label" /></div>
+        <div data-testid="accordion-content"><slot /></div>
+      </div>
+    `
+    }
+  })
+)
+
+vi.mock('./ModelInfoField.vue', () => ({
+  default: {
+    name: 'ModelInfoField',
+    props: ['label'],
+    template: `
+      <div data-testid="model-info-field" :data-label="label">
+        <span>{{ label }}</span>
+        <slot />
+      </div>
+    `
+  }
+}))
+
+describe('ModelInfoPanel', () => {
+  const createMockAsset = (
+    overrides: Partial<AssetDisplayItem> = {}
+  ): AssetDisplayItem => ({
+    id: 'test-id',
+    name: 'test-model.safetensors',
+    asset_hash: 'hash123',
+    size: 1024,
+    mime_type: 'application/octet-stream',
+    tags: ['models', 'checkpoints'],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    last_access_time: '2024-01-01T00:00:00Z',
+    description: 'A test model description',
+    badges: [],
+    stats: {},
+    ...overrides
+  })
+
+  const mountPanel = (asset: AssetDisplayItem) => {
+    return mount(ModelInfoPanel, {
+      props: { asset },
+      global: {
+        mocks: {
+          $t: (key: string, params?: Record<string, string>) =>
+            params ? `${key}:${JSON.stringify(params)}` : key
+        }
+      }
+    })
+  }
+
+  describe('Basic Info Section', () => {
+    it('renders panel title', () => {
+      const wrapper = mountPanel(createMockAsset())
+      expect(wrapper.text()).toContain('assetBrowser.modelInfo.title')
+    })
+
+    it('displays asset filename', () => {
+      const asset = createMockAsset({ name: 'my-model.safetensors' })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('my-model.safetensors')
+    })
+
+    it('displays display_name from user_metadata when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { display_name: 'My Custom Model' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('My Custom Model')
+    })
+
+    it('falls back to asset name when display_name not present', () => {
+      const asset = createMockAsset({ name: 'fallback-model.safetensors' })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('fallback-model.safetensors')
+    })
+
+    it('renders source link when source_url is present', () => {
+      const asset = createMockAsset({
+        user_metadata: { source_url: 'https://civitai.com/models/123' }
+      })
+      const wrapper = mountPanel(asset)
+      const link = wrapper.find('a[href="https://civitai.com/models/123"]')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('target')).toBe('_blank')
+    })
+
+    it('displays correct source name for Civitai', () => {
+      const asset = createMockAsset({
+        user_metadata: { source_url: 'https://civitai.com/models/123' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('Civitai')
+    })
+
+    it('displays correct source name for Hugging Face', () => {
+      const asset = createMockAsset({
+        user_metadata: { source_url: 'https://huggingface.co/org/model' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('Hugging Face')
+    })
+
+    it('does not render source field when source_url is absent', () => {
+      const asset = createMockAsset()
+      const wrapper = mountPanel(asset)
+      const links = wrapper.findAll('a')
+      expect(links).toHaveLength(0)
+    })
+  })
+
+  describe('Model Tagging Section', () => {
+    it('displays model type from tags', () => {
+      const asset = createMockAsset({ tags: ['models', 'loras'] })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('loras')
+    })
+
+    it('extracts last segment from nested tag path', () => {
+      const asset = createMockAsset({
+        tags: ['models', 'checkpoints/sd15']
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('sd15')
+    })
+
+    it('displays base_model when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { base_model: 'SDXL' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('SDXL')
+    })
+
+    it('renders additional tags as badges', () => {
+      const asset = createMockAsset({
+        user_metadata: { tags: ['anime', 'portrait', 'detailed'] }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('anime')
+      expect(wrapper.text()).toContain('portrait')
+      expect(wrapper.text()).toContain('detailed')
+    })
+  })
+
+  describe('Model Description Section', () => {
+    it('renders trigger phrases when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { trigger_phrases: ['trigger1', 'trigger2'] }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('trigger1')
+      expect(wrapper.text()).toContain('trigger2')
+    })
+
+    it('renders description when present', () => {
+      const asset = createMockAsset({
+        user_metadata: { description: 'A detailed model description' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('A detailed model description')
+    })
+
+    it('does not render trigger phrases field when empty', () => {
+      const asset = createMockAsset()
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).not.toContain(
+        'assetBrowser.modelInfo.triggerPhrases'
+      )
+    })
+  })
+
+  describe('Accordion Structure', () => {
+    it('renders three accordion sections', () => {
+      const wrapper = mountPanel(createMockAsset())
+      const accordions = wrapper.findAll('[data-testid="accordion-item"]')
+      expect(accordions).toHaveLength(3)
+    })
+
+    it('renders correct section labels', () => {
+      const wrapper = mountPanel(createMockAsset())
+      const labels = wrapper.findAll('[data-testid="accordion-label"]')
+      expect(labels[0].text()).toContain('assetBrowser.modelInfo.basicInfo')
+      expect(labels[1].text()).toContain('assetBrowser.modelInfo.modelTagging')
+      expect(labels[2].text()).toContain(
+        'assetBrowser.modelInfo.modelDescription'
+      )
+    })
+  })
+})

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -1,103 +1,98 @@
 <template>
-  <div class="flex h-full flex-col bg-comfy-menu-bg">
-    <div class="flex h-18 items-center border-b border-divider px-4">
-      <h2 class="text-lg font-semibold">
-        {{ $t('assetBrowser.modelInfo.title') }}
-      </h2>
-    </div>
-
-    <div class="flex-1 overflow-y-auto scrollbar-custom">
-      <PropertiesAccordionItem>
-        <template #label>
-          <span class="text-xs uppercase">
-            {{ $t('assetBrowser.modelInfo.basicInfo') }}
-          </span>
-        </template>
-        <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
-          <span class="text-sm">{{ displayName }}</span>
-        </ModelInfoField>
-        <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
-          <span class="text-sm">{{ asset.name }}</span>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="sourceUrl"
-          :label="$t('assetBrowser.modelInfo.source')"
+  <div
+    data-component-id="ModelInfoPanel"
+    class="flex h-full flex-col scrollbar-custom"
+  >
+    <PropertiesAccordionItem class="bg-transparent">
+      <template #label>
+        <span class="text-xs uppercase font-inter">
+          {{ $t('assetBrowser.modelInfo.basicInfo') }}
+        </span>
+      </template>
+      <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
+        <span class="text-sm break-all">{{ displayName }}</span>
+      </ModelInfoField>
+      <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
+        <span class="text-sm break-all">{{ asset.name }}</span>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="sourceUrl"
+        :label="$t('assetBrowser.modelInfo.source')"
+      >
+        <a
+          :href="sourceUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-sm text-link hover:underline"
         >
-          <a
-            :href="sourceUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-sm text-link hover:underline"
+          {{
+            $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
+          }}
+        </a>
+      </ModelInfoField>
+    </PropertiesAccordionItem>
+
+    <PropertiesAccordionItem class="bg-transparent">
+      <template #label>
+        <span class="text-xs uppercase font-inter">
+          {{ $t('assetBrowser.modelInfo.modelTagging') }}
+        </span>
+      </template>
+      <ModelInfoField
+        v-if="modelType"
+        :label="$t('assetBrowser.modelInfo.modelType')"
+      >
+        <span class="text-sm">{{ modelType }}</span>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="baseModel"
+        :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
+      >
+        <span class="text-sm">{{ baseModel }}</span>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="additionalTags.length > 0"
+        :label="$t('assetBrowser.modelInfo.additionalTags')"
+      >
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="tag in additionalTags"
+            :key="tag"
+            class="rounded px-2 py-0.5 text-xs"
           >
-            {{
-              $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
-            }}
-          </a>
-        </ModelInfoField>
-      </PropertiesAccordionItem>
-
-      <PropertiesAccordionItem>
-        <template #label>
-          <span class="text-xs uppercase">
-            {{ $t('assetBrowser.modelInfo.modelTagging') }}
+            {{ tag }}
           </span>
-        </template>
-        <ModelInfoField
-          v-if="modelType"
-          :label="$t('assetBrowser.modelInfo.modelType')"
-        >
-          <span class="text-sm">{{ modelType }}</span>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="baseModel"
-          :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
-        >
-          <span class="text-sm">{{ baseModel }}</span>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="additionalTags.length > 0"
-          :label="$t('assetBrowser.modelInfo.additionalTags')"
-        >
-          <div class="flex flex-wrap gap-1">
-            <span
-              v-for="tag in additionalTags"
-              :key="tag"
-              class="rounded bg-surface-container px-2 py-0.5 text-xs"
-            >
-              {{ tag }}
-            </span>
-          </div>
-        </ModelInfoField>
-      </PropertiesAccordionItem>
+        </div>
+      </ModelInfoField>
+    </PropertiesAccordionItem>
 
-      <PropertiesAccordionItem>
-        <template #label>
-          <span class="text-xs uppercase">
-            {{ $t('assetBrowser.modelInfo.modelDescription') }}
+    <PropertiesAccordionItem class="bg-transparent">
+      <template #label>
+        <span class="text-xs uppercase font-inter">
+          {{ $t('assetBrowser.modelInfo.modelDescription') }}
+        </span>
+      </template>
+      <ModelInfoField
+        v-if="triggerPhrases.length > 0"
+        :label="$t('assetBrowser.modelInfo.triggerPhrases')"
+      >
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="phrase in triggerPhrases"
+            :key="phrase"
+            class="rounded px-2 py-0.5 text-xs"
+          >
+            {{ phrase }}
           </span>
-        </template>
-        <ModelInfoField
-          v-if="triggerPhrases.length > 0"
-          :label="$t('assetBrowser.modelInfo.triggerPhrases')"
-        >
-          <div class="flex flex-wrap gap-1">
-            <span
-              v-for="phrase in triggerPhrases"
-              :key="phrase"
-              class="rounded bg-surface-container px-2 py-0.5 text-xs"
-            >
-              {{ phrase }}
-            </span>
-          </div>
-        </ModelInfoField>
-        <ModelInfoField
-          v-if="description"
-          :label="$t('assetBrowser.modelInfo.description')"
-        >
-          <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
-        </ModelInfoField>
-      </PropertiesAccordionItem>
-    </div>
+        </div>
+      </ModelInfoField>
+      <ModelInfoField
+        v-if="description"
+        :label="$t('assetBrowser.modelInfo.description')"
+      >
+        <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
+      </ModelInfoField>
+    </PropertiesAccordionItem>
   </div>
 </template>
 

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="flex h-full flex-col bg-comfy-menu-bg">
+    <div class="flex h-18 items-center border-b border-divider px-4">
+      <h2 class="text-lg font-semibold">
+        {{ $t('assetBrowser.modelInfo.title') }}
+      </h2>
+    </div>
+
+    <div class="flex-1 overflow-y-auto scrollbar-custom">
+      <PropertiesAccordionItem>
+        <template #label>
+          <span class="text-xs uppercase">
+            {{ $t('assetBrowser.modelInfo.basicInfo') }}
+          </span>
+        </template>
+        <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
+          <span class="text-sm">{{ displayName }}</span>
+        </ModelInfoField>
+        <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
+          <span class="text-sm">{{ asset.name }}</span>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="sourceUrl"
+          :label="$t('assetBrowser.modelInfo.source')"
+        >
+          <a
+            :href="sourceUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-link hover:underline"
+          >
+            {{
+              $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
+            }}
+          </a>
+        </ModelInfoField>
+      </PropertiesAccordionItem>
+
+      <PropertiesAccordionItem>
+        <template #label>
+          <span class="text-xs uppercase">
+            {{ $t('assetBrowser.modelInfo.modelTagging') }}
+          </span>
+        </template>
+        <ModelInfoField
+          v-if="modelType"
+          :label="$t('assetBrowser.modelInfo.modelType')"
+        >
+          <span class="text-sm">{{ modelType }}</span>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="baseModel"
+          :label="$t('assetBrowser.modelInfo.compatibleBaseModels')"
+        >
+          <span class="text-sm">{{ baseModel }}</span>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="additionalTags.length > 0"
+          :label="$t('assetBrowser.modelInfo.additionalTags')"
+        >
+          <div class="flex flex-wrap gap-1">
+            <span
+              v-for="tag in additionalTags"
+              :key="tag"
+              class="rounded bg-surface-container px-2 py-0.5 text-xs"
+            >
+              {{ tag }}
+            </span>
+          </div>
+        </ModelInfoField>
+      </PropertiesAccordionItem>
+
+      <PropertiesAccordionItem>
+        <template #label>
+          <span class="text-xs uppercase">
+            {{ $t('assetBrowser.modelInfo.modelDescription') }}
+          </span>
+        </template>
+        <ModelInfoField
+          v-if="triggerPhrases.length > 0"
+          :label="$t('assetBrowser.modelInfo.triggerPhrases')"
+        >
+          <div class="flex flex-wrap gap-1">
+            <span
+              v-for="phrase in triggerPhrases"
+              :key="phrase"
+              class="rounded bg-surface-container px-2 py-0.5 text-xs"
+            >
+              {{ phrase }}
+            </span>
+          </div>
+        </ModelInfoField>
+        <ModelInfoField
+          v-if="description"
+          :label="$t('assetBrowser.modelInfo.description')"
+        >
+          <p class="text-sm whitespace-pre-wrap">{{ description }}</p>
+        </ModelInfoField>
+      </PropertiesAccordionItem>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import PropertiesAccordionItem from '@/components/rightSidePanel/layout/PropertiesAccordionItem.vue'
+import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
+import {
+  getAssetBaseModel,
+  getAssetDescription,
+  getAssetDisplayName,
+  getAssetSourceUrl,
+  getAssetTags,
+  getAssetTriggerPhrases,
+  getSourceName
+} from '@/platform/assets/utils/assetMetadataUtils'
+
+import ModelInfoField from './ModelInfoField.vue'
+
+const { asset } = defineProps<{
+  asset: AssetDisplayItem
+}>()
+
+const displayName = computed(() => getAssetDisplayName(asset))
+const sourceUrl = computed(() => getAssetSourceUrl(asset))
+const sourceName = computed(() =>
+  sourceUrl.value ? getSourceName(sourceUrl.value) : ''
+)
+const baseModel = computed(() => getAssetBaseModel(asset))
+const description = computed(() => getAssetDescription(asset))
+const triggerPhrases = computed(() => getAssetTriggerPhrases(asset))
+const additionalTags = computed(() => getAssetTags(asset))
+
+const modelType = computed(() => {
+  const typeTag = asset.tags.find((tag) => tag !== 'models')
+  if (!typeTag) return null
+  return typeTag.includes('/') ? typeTag.split('/').pop() : typeTag
+})
+</script>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -10,10 +10,10 @@
         </span>
       </template>
       <ModelInfoField :label="$t('assetBrowser.modelInfo.displayName')">
-        <span class="text-sm break-all">{{ displayName }}</span>
+        <span class="break-all">{{ displayName }}</span>
       </ModelInfoField>
       <ModelInfoField :label="$t('assetBrowser.modelInfo.fileName')">
-        <span class="text-sm break-all">{{ asset.name }}</span>
+        <span class="break-all">{{ asset.name }}</span>
       </ModelInfoField>
       <ModelInfoField
         v-if="sourceUrl"
@@ -23,11 +23,18 @@
           :href="sourceUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-sm text-link hover:underline"
+          class="inline-flex items-center gap-1.5 text-muted-foreground no-underline transition-colors hover:text-foreground"
         >
+          <img
+            v-if="sourceName === 'Civitai'"
+            src="/assets/images/civitai.svg"
+            alt=""
+            class="size-4 shrink-0"
+          />
           {{
             $t('assetBrowser.modelInfo.viewOnSource', { source: sourceName })
           }}
+          <i class="icon-[lucide--external-link] size-4 shrink-0" />
         </a>
       </ModelInfoField>
     </PropertiesAccordionItem>

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -3,7 +3,7 @@
     data-component-id="ModelInfoPanel"
     class="flex h-full flex-col scrollbar-custom"
   >
-    <PropertiesAccordionItem class="bg-transparent">
+    <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
           {{ $t('assetBrowser.modelInfo.basicInfo') }}
@@ -32,7 +32,7 @@
       </ModelInfoField>
     </PropertiesAccordionItem>
 
-    <PropertiesAccordionItem class="bg-transparent">
+    <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
           {{ $t('assetBrowser.modelInfo.modelTagging') }}
@@ -66,7 +66,7 @@
       </ModelInfoField>
     </PropertiesAccordionItem>
 
-    <PropertiesAccordionItem class="bg-transparent">
+    <PropertiesAccordionItem :class="accordionClass">
       <template #label>
         <span class="text-xs uppercase font-inter">
           {{ $t('assetBrowser.modelInfo.modelDescription') }}
@@ -112,6 +112,8 @@ import {
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 import ModelInfoField from './ModelInfoField.vue'
+
+const accordionClass = 'bg-transparent border-t border-border-default'
 
 const { asset } = defineProps<{
   asset: AssetDisplayItem

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
   getAssetBaseModel,
-  getAssetDescription
+  getAssetDescription,
+  getAssetDisplayName,
+  getAssetSourceUrl,
+  getAssetTags,
+  getAssetTriggerPhrases,
+  getSourceName
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 describe('assetMetadataUtils', () => {
@@ -60,6 +65,126 @@ describe('assetMetadataUtils', () => {
 
     it('should return null when no metadata', () => {
       expect(getAssetBaseModel(mockAsset)).toBeNull()
+    })
+  })
+
+  describe('getAssetDisplayName', () => {
+    it('should return display_name when present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { display_name: 'My Custom Name' }
+      }
+      expect(getAssetDisplayName(asset)).toBe('My Custom Name')
+    })
+
+    it('should fall back to asset name when display_name is not a string', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { display_name: 123 }
+      }
+      expect(getAssetDisplayName(asset)).toBe('test-model')
+    })
+
+    it('should fall back to asset name when no metadata', () => {
+      expect(getAssetDisplayName(mockAsset)).toBe('test-model')
+    })
+  })
+
+  describe('getAssetSourceUrl', () => {
+    it('should return source_url when present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { source_url: 'https://civitai.com/models/123' }
+      }
+      expect(getAssetSourceUrl(asset)).toBe('https://civitai.com/models/123')
+    })
+
+    it('should return null when source_url is not a string', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { source_url: 123 }
+      }
+      expect(getAssetSourceUrl(asset)).toBeNull()
+    })
+
+    it('should return null when no metadata', () => {
+      expect(getAssetSourceUrl(mockAsset)).toBeNull()
+    })
+  })
+
+  describe('getAssetTriggerPhrases', () => {
+    it('should return array of trigger phrases when array present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { trigger_phrases: ['phrase1', 'phrase2'] }
+      }
+      expect(getAssetTriggerPhrases(asset)).toEqual(['phrase1', 'phrase2'])
+    })
+
+    it('should wrap single string in array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { trigger_phrases: 'single phrase' }
+      }
+      expect(getAssetTriggerPhrases(asset)).toEqual(['single phrase'])
+    })
+
+    it('should filter non-string values from array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { trigger_phrases: ['valid', 123, 'also valid', null] }
+      }
+      expect(getAssetTriggerPhrases(asset)).toEqual(['valid', 'also valid'])
+    })
+
+    it('should return empty array when no metadata', () => {
+      expect(getAssetTriggerPhrases(mockAsset)).toEqual([])
+    })
+  })
+
+  describe('getAssetTags', () => {
+    it('should return array of tags when present', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { tags: ['tag1', 'tag2'] }
+      }
+      expect(getAssetTags(asset)).toEqual(['tag1', 'tag2'])
+    })
+
+    it('should filter non-string values from array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { tags: ['valid', 123, 'also valid'] }
+      }
+      expect(getAssetTags(asset)).toEqual(['valid', 'also valid'])
+    })
+
+    it('should return empty array when tags is not an array', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { tags: 'not an array' }
+      }
+      expect(getAssetTags(asset)).toEqual([])
+    })
+
+    it('should return empty array when no metadata', () => {
+      expect(getAssetTags(mockAsset)).toEqual([])
+    })
+  })
+
+  describe('getSourceName', () => {
+    it('should return Civitai for civitai.com URLs', () => {
+      expect(getSourceName('https://civitai.com/models/123')).toBe('Civitai')
+    })
+
+    it('should return Hugging Face for huggingface.co URLs', () => {
+      expect(getSourceName('https://huggingface.co/org/model')).toBe(
+        'Hugging Face'
+      )
+    })
+
+    it('should return Source for unknown URLs', () => {
+      expect(getSourceName('https://example.com/model')).toBe('Source')
     })
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -25,3 +25,63 @@ export function getAssetBaseModel(asset: AssetItem): string | null {
     ? asset.user_metadata.base_model
     : null
 }
+
+/**
+ * Gets the display name for an asset, falling back to filename
+ * @param asset - The asset to get display name from
+ * @returns The display name or filename
+ */
+export function getAssetDisplayName(asset: AssetItem): string {
+  return typeof asset.user_metadata?.display_name === 'string'
+    ? asset.user_metadata.display_name
+    : asset.name
+}
+
+/**
+ * Safely extracts source URL from asset metadata
+ * @param asset - The asset to extract source URL from
+ * @returns The source URL or null if not present
+ */
+export function getAssetSourceUrl(asset: AssetItem): string | null {
+  return typeof asset.user_metadata?.source_url === 'string'
+    ? asset.user_metadata.source_url
+    : null
+}
+
+/**
+ * Extracts trigger phrases from asset metadata
+ * @param asset - The asset to extract trigger phrases from
+ * @returns Array of trigger phrases
+ */
+export function getAssetTriggerPhrases(asset: AssetItem): string[] {
+  const phrases = asset.user_metadata?.trigger_phrases
+  if (Array.isArray(phrases)) {
+    return phrases.filter((p): p is string => typeof p === 'string')
+  }
+  if (typeof phrases === 'string') return [phrases]
+  return []
+}
+
+/**
+ * Extracts additional tags from asset user_metadata
+ * @param asset - The asset to extract tags from
+ * @returns Array of user-defined tags
+ */
+export function getAssetTags(asset: AssetItem): string[] {
+  const tags = asset.user_metadata?.tags
+  if (Array.isArray(tags)) {
+    return tags.filter((t): t is string => typeof t === 'string')
+  }
+  return []
+}
+
+/**
+ * Determines the source name from a URL
+ * @param url - The source URL
+ * @returns Human-readable source name
+ */
+export function getSourceName(url: string): string {
+  if (url.includes('civitai.com')) return 'Civitai'
+  if (url.includes('huggingface.co')) return 'Hugging Face'
+  return 'Source'
+}

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -16,7 +16,6 @@
       opacity: useSettingStore().get('Comfy.Node.Opacity') ?? 1
     }"
     :data-testid="`node-header-${nodeData?.id || ''}`"
-    @dblclick="handleDoubleClick"
   >
     <div class="flex items-center justify-between gap-2.5 min-w-0">
       <!-- Collapse/Expand Button -->
@@ -53,11 +52,11 @@
         >
           <div class="truncate min-w-0 flex-1">
             <EditableText
+              v-model:is-editing="isEditing"
               :model-value="displayTitle"
-              :is-editing="isEditing"
               :input-attrs="{ 'data-testid': 'node-title-input' }"
+              double-click-to-edit
               @edit="handleTitleEdit"
-              @cancel="handleTitleCancel"
             />
           </div>
         </div>
@@ -242,21 +241,11 @@ const handleCollapse = () => {
   emit('collapse')
 }
 
-const handleDoubleClick = () => {
-  isEditing.value = true
-}
-
 const handleTitleEdit = (newTitle: string) => {
-  isEditing.value = false
   const trimmedTitle = newTitle.trim()
   if (trimmedTitle && trimmedTitle !== displayTitle.value) {
-    // Emit for litegraph sync
     emit('update:title', trimmedTitle)
   }
-}
-
-const handleTitleCancel = () => {
-  isEditing.value = false
 }
 
 const handleEnterSubgraph = () => {


### PR DESCRIPTION
## Summary

Standardizes the `EditableText` component API to support two-way binding and built-in double-click editing behavior, then migrates existing usage sites.

## Changes

### Phase 1+2: EditableText API Improvements
- Convert `isEditing` prop to `defineModel` for two-way binding via `v-model:is-editing`
- Add `doubleClickToEdit` prop (default: false) - when true, double-clicking enters edit mode
- Component automatically manages `isEditing` state on edit/cancel

### Phase 3: Migrate Existing Components
- **RightSidePanel**: Use `double-click-to-edit` and `v-model:is-editing`
- **WidgetItem**: Remove redundant `isEditing` ref, let EditableText manage state
- **NodeHeader**: Remove manual double-click handlers, use new props
- **TitleEditor**: Add missing `@cancel` handler
- **TreeExplorerTreeNode**: Add missing `@cancel` handler
- **AssetCard**: Fix unusual cancel handling

## Testing
- Added unit tests for `defineModel` behavior
- Added unit tests for `doubleClickToEdit` prop (3 tests)
- All existing tests pass

## Related
- Child branch of `drjkl__some-people-call-it-a-yard-sale`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8103-refactor-EditableText-standardize-API-with-defineModel-and-doubleClickToEdit-2ea6d73d3650812389ebdfdd5f41da87) by [Unito](https://www.unito.io)
