### PR TITLE
fix: run E2E tests after i18n completes on release PRs

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main, master, core/*, desktop/*]
   pull_request:
     branches-ignore:
-      [wip/*, draft/*, temp/*, vue-nodes-migration, sno-playwright-*, version-bump-*]
+      [wip/*, draft/*, temp/*, vue-nodes-migration, version-bump-*]
   # Run after i18n workflow completes for version-bump PRs
   workflow_run:
     workflows: ['i18n: Update Core']

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -7,17 +7,25 @@ on:
   pull_request:
     branches-ignore:
       [wip/*, draft/*, temp/*, vue-nodes-migration, sno-playwright-*]
+  # Run after i18n workflow completes for version-bump PRs
+  workflow_run:
+    workflows: ['i18n: Update Core']
+    types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:
   setup:
     runs-on: ubuntu-latest
+    # Skip version-bump PRs on pull_request (they run via workflow_run after i18n completes)
+    if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'version-bump-')) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
         with:
@@ -52,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Download built frontend
         uses: actions/download-artifact@v4
         with:
@@ -99,6 +109,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Download built frontend
         uses: actions/download-artifact@v4
         with:
@@ -143,6 +155,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -178,12 +192,30 @@ jobs:
   # Post starting comment for non-forked PRs
   comment-on-pr-start:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'workflow_run')
     permissions:
       pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+
+      - name: Get PR number for workflow_run
+        id: get-pr
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+            const pr = prs.find(p => p.head.sha === context.payload.workflow_run.head_sha);
+            return pr?.number || '';
 
       - name: Get start time
         id: start-time
@@ -193,10 +225,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          PR_NUMBER="${{ github.event.pull_request.number || steps.get-pr.outputs.result }}"
+          BRANCH="${{ github.head_ref || github.event.workflow_run.head_branch }}"
           chmod +x scripts/cicd/pr-playwright-deploy-and-comment.sh
           ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.head_ref }}" \
+            "$PR_NUMBER" \
+            "$BRANCH" \
             "starting" \
             "${{ steps.start-time.outputs.time }}"
 
@@ -204,13 +238,33 @@ jobs:
   deploy-and-comment:
     needs: [playwright-tests, merge-reports]
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: |
+      always() && (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+        (github.event_name == 'workflow_run')
+      )
     permissions:
       pull-requests: write
       contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+
+      - name: Get PR number for workflow_run
+        id: get-pr
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+            const pr = prs.find(p => p.head.sha === context.payload.workflow_run.head_sha);
+            return pr?.number || '';
 
       - name: Download all playwright reports
         uses: actions/download-artifact@v4
@@ -223,10 +277,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
         run: |
+          PR_NUMBER="${{ github.event.pull_request.number || steps.get-pr.outputs.result }}"
+          BRANCH="${{ github.head_ref || github.event.workflow_run.head_branch }}"
           bash ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.head_ref }}" \
+            "$PR_NUMBER" \
+            "$BRANCH" \
             "completed"
   #### END Deployment and commenting (non-forked PRs only)

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -250,13 +250,16 @@ jobs:
       - name: Post starting comment
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.get-pr-info.outputs.pr_number }}
+          BRANCH: ${{ needs.get-pr-info.outputs.branch }}
+          START_TIME: ${{ steps.start-time.outputs.time }}
         run: |
           chmod +x scripts/cicd/pr-playwright-deploy-and-comment.sh
           ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "${{ needs.get-pr-info.outputs.pr_number }}" \
-            "${{ needs.get-pr-info.outputs.branch }}" \
+            "$PR_NUMBER" \
+            "$BRANCH" \
             "starting" \
-            "${{ steps.start-time.outputs.time }}"
+            "$START_TIME"
 
   # Deploy and comment for non-forked PRs only
   deploy-and-comment:
@@ -284,9 +287,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ needs.get-pr-info.outputs.pr_number }}
+          BRANCH: ${{ needs.get-pr-info.outputs.branch }}
         run: |
           bash ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "${{ needs.get-pr-info.outputs.pr_number }}" \
-            "${{ needs.get-pr-info.outputs.branch }}" \
+            "$PR_NUMBER" \
+            "$BRANCH" \
             "completed"
   #### END Deployment and commenting (non-forked PRs only)

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -187,12 +187,54 @@ jobs:
   # when using pull_request event, we have permission to comment directly
   # if its a forked repo, we need to use workflow_run event in a separate workflow (pr-playwright-deploy.yaml)
 
-  # Post starting comment for non-forked PRs
-  comment-on-pr-start:
+  # Get PR info once for reuse by comment jobs
+  get-pr-info:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'workflow_run')
+    outputs:
+      pr_number: ${{ steps.get-pr.outputs.result }}
+      branch: ${{ steps.get-branch.outputs.branch }}
+    steps:
+      - name: Get PR number
+        id: get-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'pull_request') {
+              return context.payload.pull_request.number;
+            }
+
+            // First check pull_requests from payload (most reliable)
+            const prs = context.payload.workflow_run.pull_requests;
+            if (prs && prs.length > 0) {
+              return prs[0].number;
+            }
+
+            // Fallback: branch-based lookup with pagination
+            const head = `${context.repo.owner}:${context.payload.workflow_run.head_branch}`;
+
+            for await (const response of github.paginate.iterator(
+              github.rest.pulls.list,
+              { owner: context.repo.owner, repo: context.repo.repo, state: 'open', head, per_page: 100 }
+            )) {
+              if (response.data.length > 0) {
+                return response.data[0].number;
+              }
+            }
+
+            console.log('No PR found');
+            return '';
+
+      - name: Get branch name
+        id: get-branch
+        run: echo "branch=${{ github.head_ref || github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+
+  # Post starting comment for non-forked PRs
+  comment-on-pr-start:
+    needs: get-pr-info
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
@@ -200,20 +242,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
-
-      - name: Get PR number for workflow_run
-        id: get-pr
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-            });
-            const pr = prs.find(p => p.head.sha === context.payload.workflow_run.head_sha);
-            return pr?.number || '';
 
       - name: Get start time
         id: start-time
@@ -223,24 +251,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number || steps.get-pr.outputs.result }}"
-          BRANCH="${{ github.head_ref || github.event.workflow_run.head_branch }}"
           chmod +x scripts/cicd/pr-playwright-deploy-and-comment.sh
           ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "$PR_NUMBER" \
-            "$BRANCH" \
+            "${{ needs.get-pr-info.outputs.pr_number }}" \
+            "${{ needs.get-pr-info.outputs.branch }}" \
             "starting" \
             "${{ steps.start-time.outputs.time }}"
 
   # Deploy and comment for non-forked PRs only
   deploy-and-comment:
-    needs: [playwright-tests, merge-reports]
+    needs: [playwright-tests, merge-reports, get-pr-info]
     runs-on: ubuntu-latest
-    if: |
-      always() && (
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
-        (github.event_name == 'workflow_run')
-      )
+    if: always()
     permissions:
       pull-requests: write
       contents: read
@@ -249,20 +271,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
-
-      - name: Get PR number for workflow_run
-        id: get-pr
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-            });
-            const pr = prs.find(p => p.head.sha === context.payload.workflow_run.head_sha);
-            return pr?.number || '';
 
       - name: Download all playwright reports
         uses: actions/download-artifact@v4
@@ -277,10 +285,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number || steps.get-pr.outputs.result }}"
-          BRANCH="${{ github.head_ref || github.event.workflow_run.head_branch }}"
           bash ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
-            "$PR_NUMBER" \
-            "$BRANCH" \
+            "${{ needs.get-pr-info.outputs.pr_number }}" \
+            "${{ needs.get-pr-info.outputs.branch }}" \
             "completed"
   #### END Deployment and commenting (non-forked PRs only)

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -194,42 +194,24 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'workflow_run')
     outputs:
-      pr_number: ${{ steps.get-pr.outputs.result }}
-      branch: ${{ steps.get-branch.outputs.branch }}
+      pr_number: ${{ steps.get-pr.outputs.number }}
+      branch: ${{ steps.get-pr.outputs.branch }}
     steps:
       - name: Get PR number
         id: get-pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.eventName === 'pull_request') {
-              return context.payload.pull_request.number;
-            }
-
-            // First check pull_requests from payload (most reliable)
-            const prs = context.payload.workflow_run.pull_requests;
-            if (prs && prs.length > 0) {
-              return prs[0].number;
-            }
-
-            // Fallback: branch-based lookup with pagination
-            const head = `${context.repo.owner}:${context.payload.workflow_run.head_branch}`;
-
-            for await (const response of github.paginate.iterator(
-              github.rest.pulls.list,
-              { owner: context.repo.owner, repo: context.repo.repo, state: 'open', head, per_page: 100 }
-            )) {
-              if (response.data.length > 0) {
-                return response.data[0].number;
-              }
-            }
-
-            console.log('No PR found');
-            return '';
-
-      - name: Get branch name
-        id: get-branch
-        run: echo "branch=${{ github.head_ref || github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.head_ref || github.event.workflow_run.head_branch }}
+        run: |
+          echo "branch=${PR_BRANCH}" >> $GITHUB_OUTPUT
+          if [ -n "$PR_NUMBER" ]; then
+            echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          else
+            gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+              --json 'number' --jq '"number=\(.number)"' >> $GITHUB_OUTPUT
+          fi
 
   # Post starting comment for non-forked PRs
   comment-on-pr-start:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main, master, core/*, desktop/*]
   pull_request:
     branches-ignore:
-      [wip/*, draft/*, temp/*, vue-nodes-migration, sno-playwright-*]
+      [wip/*, draft/*, temp/*, vue-nodes-migration, sno-playwright-*, version-bump-*]
   # Run after i18n workflow completes for version-bump PRs
   workflow_run:
     workflows: ['i18n: Update Core']
@@ -19,8 +19,6 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    # Skip version-bump PRs on pull_request (they run via workflow_run after i18n completes)
-    if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'version-bump-')) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Adds `workflow_run` trigger to run E2E tests after i18n workflow completes on version-bump PRs
- Skips E2E tests on `pull_request` trigger for version-bump branches to avoid cancellation by i18n commits
- Updates checkout refs and PR comment jobs to handle `workflow_run` events

## Problem
When a version-bump PR is created, both E2E tests and i18n workflow trigger simultaneously. The i18n workflow commits locale updates after ~5-8 minutes, which triggers a new E2E run that cancels the in-progress tests due to `cancel-in-progress: true`.

## Solution
Skip E2E on `pull_request` for version-bump PRs, run via `workflow_run` after i18n completes instead.

## Test plan
- [ ] Verify regular PRs still run E2E tests normally
- [ ] Verify version-bump PRs skip E2E on initial trigger
- [ ] Verify E2E runs after i18n workflow completes on version-bump PRs

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8111-fix-run-E2E-tests-after-i18n-completes-on-release-PRs-2ea6d73d365081458fd8c0e4fda4ad48) by [Unito](https://www.unito.io)
