### PR TITLE
Fix asset selection in litegraph

### DIFF
--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -55,7 +55,7 @@ interface IWidgetKnobOptions extends IWidgetOptions<number[]> {
 }
 
 export interface IWidgetAssetOptions extends IWidgetOptions {
-  openModal: () => void
+  openModal: (widget: IBaseWidget) => void
 }
 
 /**

--- a/src/lib/litegraph/src/widgets/AssetWidget.ts
+++ b/src/lib/litegraph/src/widgets/AssetWidget.ts
@@ -53,6 +53,6 @@ export class AssetWidget
 
   override onClick() {
     //Open Modal
-    this.options.openModal()
+    this.options.openModal(this)
   }
 }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -94,7 +94,7 @@ const createAssetBrowserWidget = (
   const displayLabel = currentValue ?? t('widgets.selectModel')
   const assetBrowserDialog = useAssetBrowserDialog()
 
-  async function openModal(this: IBaseWidget) {
+  async function openModal(widget: IBaseWidget) {
     if (!isAssetWidget(widget)) {
       throw new Error(`Expected asset widget but received ${widget.type}`)
     }
@@ -129,7 +129,7 @@ const createAssetBrowserWidget = (
         }
 
         const oldValue = widget.value
-        this.value = validatedFilename.data
+        widget.value = validatedFilename.data
         node.onWidgetChanged?.(
           widget.name,
           validatedFilename.data,


### PR DESCRIPTION
#8074 included some refactoring to the asset dialogue to ensure that it wouldn't pop up multiple times in vue mode

But moving the openModal function to be contained in options means that `this` is no longer the widget, but instead the options object. This is fixed by requiring that widget be explicitly passed as a parameter.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8117-Fix-asset-selection-in-litegraph-2eb6d73d36508176b5a3f6d21964be39) by [Unito](https://www.unito.io)
