### PR TITLE
feat: enable new queue progress by default

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1169,7 +1169,8 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Queue.QPOV2',
     name: 'Use the unified job queue in the Assets side panel',
     type: 'boolean',
-    tooltip: 'Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout.',
+    tooltip:
+      'Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout.',
     defaultValue: true,
     experimental: true
   }

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1167,6 +1167,7 @@ export const CORE_SETTINGS: SettingParams[] = [
   },
   {
     id: 'Comfy.Queue.QPOV2',
+    category: ['Comfy', 'Queue', 'Layout'],
     name: 'Use the unified job queue in the Assets side panel',
     type: 'boolean',
     tooltip:

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1167,10 +1167,10 @@ export const CORE_SETTINGS: SettingParams[] = [
   },
   {
     id: 'Comfy.Queue.QPOV2',
-    name: 'Queue Panel V2',
-    type: 'hidden',
-    tooltip: 'Enable the new Assets Panel design with list/grid view toggle',
-    defaultValue: false,
+    name: 'Use the unified job queue in the Assets side panel',
+    type: 'boolean',
+    tooltip: 'Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout.',
+    defaultValue: true,
     experimental: true
   }
 ]


### PR DESCRIPTION
## Summary

Enable the new queue progress UI/UX by default in order to test it and be able to ask community members what they think (they can easily test with `--front-end-version Comfy-Org/ComfyUI_frontend@latest`).

More context: [thread](https://comfy-organization.slack.com/archives/C0A80028GTA/p1768534815533549)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8121-feat-enable-new-queue-progress-by-default-2eb6d73d365081a2ae23d71243369984) by [Unito](https://www.unito.io)
