### PR TITLE
Fix roundness of slot error indicator in vue

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -6,7 +6,7 @@
     :class="
       cn(
         'lg-slot lg-slot--input flex items-center group rounded-r-lg m-0',
-        'cursor-crosshair',
+        'cursor-crosshair relative',
         props.dotOnly ? 'lg-slot--dot-only' : 'pr-6',
         {
           'lg-slot--connected': props.connected,
@@ -17,15 +17,14 @@
       )
     "
   >
+    <div
+      v-if="hasSlotError"
+      class="absolute size-4 ring-2 ring-error rounded-full size-3 -translate-x-1/2"
+    />
     <!-- Connection Dot -->
     <SlotConnectionDot
       ref="connectionDotRef"
-      :class="
-        cn(
-          '-translate-x-1/2 w-3',
-          hasSlotError && 'ring-2 ring-error ring-offset-0 rounded-full'
-        )
-      "
+      class="-translate-x-1/2 w-3"
       :slot-data
       @click="onClick"
       @dblclick="onDoubleClick"

--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -6,7 +6,7 @@
     :class="
       cn(
         'lg-slot lg-slot--input flex items-center group rounded-r-lg m-0',
-        'cursor-crosshair relative',
+        'cursor-crosshair',
         props.dotOnly ? 'lg-slot--dot-only' : 'pr-6',
         {
           'lg-slot--connected': props.connected,
@@ -17,14 +17,16 @@
       )
     "
   >
-    <div
-      v-if="hasSlotError"
-      class="absolute size-4 ring-2 ring-error rounded-full -translate-x-1/2"
-    />
     <!-- Connection Dot -->
     <SlotConnectionDot
       ref="connectionDotRef"
-      class="-translate-x-1/2 w-3"
+      :class="
+        cn(
+          '-translate-x-1/2 w-3',
+          hasSlotError &&
+            'before:ring-2 before:ring-error before:ring-offset-0 before:size-4 before:absolute before:rounded-full before:pointer-events-none'
+        )
+      "
       :slot-data
       @click="onClick"
       @dblclick="onDoubleClick"

--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -19,7 +19,7 @@
   >
     <div
       v-if="hasSlotError"
-      class="absolute size-4 ring-2 ring-error rounded-full size-3 -translate-x-1/2"
+      class="absolute size-4 ring-2 ring-error rounded-full -translate-x-1/2"
     />
     <!-- Connection Dot -->
     <SlotConnectionDot


### PR DESCRIPTION
When a node has a missing input connection, the slot is highlighted with a red outline. This PR makes the error indicator round like the slot instead of an oval.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/2d5ebc93-fa74-492d-92a7-3a1b3af4754f" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/57c15503-d94a-48d7-8c35-7760f1b860e6" />|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8123-Fix-roundness-of-slot-error-indicator-in-vue-2eb6d73d3650810383a2f5532117c29f) by [Unito](https://www.unito.io)
