### PR TITLE
feat: make subgraphs blueprints appear higher in node library sidebar

### DIFF
--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -299,9 +299,10 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
 
   const nodeDefs = computed(() => {
     const subgraphStore = useSubgraphStore()
+    // Blueprints first for discoverability in the node library sidebar
     return [
-      ...Object.values(nodeDefsByName.value),
-      ...subgraphStore.subgraphBlueprints
+      ...subgraphStore.subgraphBlueprints,
+      ...Object.values(nodeDefsByName.value)
     ]
   })
   const nodeDataTypes = computed(() => {


### PR DESCRIPTION
## Summary

Changes insertion order so subgraph blueprints are inserted first and therefore appear highest in node library sidebar (when using default 'original' ordering).

<img width="1003" height="725" alt="image" src="https://github.com/user-attachments/assets/3f1ea61c-4191-4dd5-8c10-17cd91b6a732" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8140-feat-make-subgraphs-blueprints-appear-higher-in-node-library-sidebar-2ec6d73d3650816f8164f0991b81c116) by [Unito](https://www.unito.io)
