### PR TITLE
feat(panel): add collapsible Advanced Inputs section for widgets marked advanced

### DIFF
--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -21,15 +21,35 @@ const { t } = useI18n()
 const rightSidePanelStore = useRightSidePanelStore()
 const { searchQuery } = storeToRefs(rightSidePanelStore)
 
+const advancedInputsCollapsed = ref(true)
+
 const widgetsSectionDataList = computed((): NodeWidgetsListList => {
   return nodes.map((node) => {
     const { widgets = [] } = node
     const shownWidgets = widgets
-      .filter((w) => !(w.options?.canvasOnly || w.options?.hidden))
+      .filter(
+        (w) =>
+          !(w.options?.canvasOnly || w.options?.hidden || w.options?.advanced)
+      )
       .map((widget) => ({ node, widget }))
 
     return { widgets: shownWidgets, node }
   })
+})
+
+const advancedWidgetsSectionDataList = computed((): NodeWidgetsListList => {
+  return nodes
+    .map((node) => {
+      const { widgets = [] } = node
+      const advancedWidgets = widgets
+        .filter(
+          (w) =>
+            !(w.options?.canvasOnly || w.options?.hidden) && w.options?.advanced
+        )
+        .map((widget) => ({ node, widget }))
+      return { widgets: advancedWidgets, node }
+    })
+    .filter(({ widgets }) => widgets.length > 0)
 })
 
 const isMultipleNodesSelected = computed(
@@ -93,4 +113,17 @@ const label = computed(() => {
       class="border-b border-interface-stroke"
     />
   </TransitionGroup>
+  <template
+    v-if="advancedWidgetsSectionDataList.some(({ widgets }) => widgets.length > 0)"
+  >
+    <SectionWidgets
+      v-for="{ widgets, node } in advancedWidgetsSectionDataList"
+      :key="`advanced-${node.id}`"
+      v-model:collapse="advancedInputsCollapsed"
+      :node
+      :label="t('rightSidePanel.advancedInputs')"
+      :widgets
+      class="border-b border-interface-stroke"
+    />
+  </template>
 </template>

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -76,9 +76,9 @@ const label = computed(() => {
 })
 
 const advancedLabel = computed(() => {
-  return isMultipleNodesSelected.value
-    ? undefined // SectionWidgets display node titles by default
-    : t('rightSidePanel.advancedInputs')
+  return !mustShowNodeTitle && !isMultipleNodesSelected.value
+    ? t('rightSidePanel.advancedInputs')
+    : undefined // SectionWidgets display node titles by default
 })
 </script>
 

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -74,6 +74,12 @@ const label = computed(() => {
       : t('rightSidePanel.inputsNone')
     : undefined // SectionWidgets display node titles by default
 })
+
+const advancedLabel = computed(() => {
+  return isMultipleNodesSelected.value
+    ? undefined // SectionWidgets display node titles by default
+    : t('rightSidePanel.advancedInputs')
+})
 </script>
 
 <template>
@@ -117,8 +123,9 @@ const label = computed(() => {
       :key="`advanced-${node.id}`"
       :collapse="true"
       :node
-      :label="t('rightSidePanel.advancedInputs')"
+      :label="advancedLabel"
       :widgets
+      :show-locate-button="isMultipleNodesSelected"
       class="border-b border-interface-stroke"
     />
   </template>

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -117,7 +117,7 @@ const advancedLabel = computed(() => {
       class="border-b border-interface-stroke"
     />
   </TransitionGroup>
-  <template v-if="advancedWidgetsSectionDataList.length > 0">
+  <template v-if="advancedWidgetsSectionDataList.length > 0 && !isSearching">
     <SectionWidgets
       v-for="{ widgets, node } in advancedWidgetsSectionDataList"
       :key="`advanced-${node.id}`"

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -114,7 +114,9 @@ const label = computed(() => {
     />
   </TransitionGroup>
   <template
-    v-if="advancedWidgetsSectionDataList.some(({ widgets }) => widgets.length > 0)"
+    v-if="
+      advancedWidgetsSectionDataList.some(({ widgets }) => widgets.length > 0)
+    "
   >
     <SectionWidgets
       v-for="{ widgets, node } in advancedWidgetsSectionDataList"

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -113,11 +113,7 @@ const label = computed(() => {
       class="border-b border-interface-stroke"
     />
   </TransitionGroup>
-  <template
-    v-if="
-      advancedWidgetsSectionDataList.some(({ widgets }) => widgets.length > 0)
-    "
-  >
+  <template v-if="advancedWidgetsSectionDataList.length > 0">
     <SectionWidgets
       v-for="{ widgets, node } in advancedWidgetsSectionDataList"
       :key="`advanced-${node.id}`"

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -21,8 +21,6 @@ const { t } = useI18n()
 const rightSidePanelStore = useRightSidePanelStore()
 const { searchQuery } = storeToRefs(rightSidePanelStore)
 
-const advancedInputsCollapsed = ref(true)
-
 const widgetsSectionDataList = computed((): NodeWidgetsListList => {
   return nodes.map((node) => {
     const { widgets = [] } = node
@@ -117,7 +115,7 @@ const label = computed(() => {
     <SectionWidgets
       v-for="{ widgets, node } in advancedWidgetsSectionDataList"
       :key="`advanced-${node.id}`"
-      v-model:collapse="advancedInputsCollapsed"
+      :collapse="true"
       :node
       :label="t('rightSidePanel.advancedInputs')"
       :widgets


### PR DESCRIPTION
Adds a collapsible 'Advanced Inputs' section to the right-side panel that displays widgets marked with `options.advanced = true`.

<img width="1903" height="875" alt="image" src="https://github.com/user-attachments/assets/5f76e680-7904-4c43-b42b-1b98f8f78458" />


## Changes
- Filters normal widgets to exclude advanced ones
- Adds new `advancedWidgetsSectionDataList` computed for advanced widgets
- Renders a collapsible section (collapsed by default) for advanced widgets

## Related
- Backend PR that adds `advanced` flag: comfyanonymous/ComfyUI#11939

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8146-feat-panel-add-collapsible-Advanced-Inputs-section-for-widgets-marked-advanced-2ec6d73d36508120af1af27110a6fb96) by [Unito](https://www.unito.io)
