### PR TITLE
feat(canvas): show 'Show Advanced' button on nodes with advanced widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -505,7 +505,6 @@ function handleShowAdvancedInputs() {
     rightSidePanelStore.focusSection('advanced-inputs')
   } else {
     node.showAdvanced = true
-    useCanvasStore().canvas?.setDirty(true, true)
   }
 }
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -482,18 +482,31 @@ const lgraphNode = computed(() => {
 
 const showAdvancedInputsButton = computed(() => {
   const node = lgraphNode.value
-  if (!node || !(node instanceof SubgraphNode)) return false
+  if (!node) return false
 
-  // Check if there are hidden inputs (widgets not promoted)
-  const interiorNodes = node.subgraph.nodes
-  const allInteriorWidgets = interiorNodes.flatMap((n) => n.widgets ?? [])
+  // For subgraph nodes: check for unpromoted widgets
+  if (node instanceof SubgraphNode) {
+    const interiorNodes = node.subgraph.nodes
+    const allInteriorWidgets = interiorNodes.flatMap((n) => n.widgets ?? [])
+    return allInteriorWidgets.some((w) => !w.computedDisabled && !w.promoted)
+  }
 
-  return allInteriorWidgets.some((w) => !w.computedDisabled && !w.promoted)
+  // For regular nodes: show button if there are advanced widgets and they're currently hidden
+  const hasAdvancedWidgets = nodeData.widgets?.some((w) => w.options?.advanced)
+  return hasAdvancedWidgets && !node.showAdvanced
 })
 
 function handleShowAdvancedInputs() {
-  const rightSidePanelStore = useRightSidePanelStore()
-  rightSidePanelStore.focusSection('advanced-inputs')
+  const node = lgraphNode.value
+  if (!node) return
+
+  if (node instanceof SubgraphNode) {
+    const rightSidePanelStore = useRightSidePanelStore()
+    rightSidePanelStore.focusSection('advanced-inputs')
+  } else {
+    node.showAdvanced = true
+    useCanvasStore().canvas?.setDirty(true, true)
+  }
 }
 
 const nodeMedia = computed(() => {


### PR DESCRIPTION
Extends the existing 'Show Advanced' button (previously subgraph-only) to also appear on regular nodes that have widgets marked with `options.advanced = true`.

## Changes
- Updates `showAdvancedInputsButton` computed to check for advanced widgets on regular nodes
- Updates `handleShowAdvancedInputs` to set `node.showAdvanced = true` and trigger canvas redraw for regular nodes

## Related
- Backend PR that adds `advanced` flag: comfyanonymous/ComfyUI#11939
- Canvas hide PR: feat/advanced-widgets-canvas-hide (this PR provides the toggle for that)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8148-feat-canvas-show-Show-Advanced-button-on-nodes-with-advanced-widgets-2ec6d73d36508155a8adfa0a8ec84d46) by [Unito](https://www.unito.io)
