### PR TITLE
chore: migrate Vite config to Vite 8 beta (Rolldown)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -96,15 +96,15 @@ const config: StorybookConfig = {
           }
         ]
       },
-      esbuild: {
-        // Prevent minification of identifiers to preserve _sfc_main
-        minifyIdentifiers: false,
-        keepNames: true
-      },
       build: {
-        rollupOptions: {
-          // Disable tree-shaking for Storybook to prevent Vue SFC exports from being removed
+        rolldownOptions: {
+          experimental: {
+            strictExecutionOrder: true
+          },
           treeshake: false,
+          output: {
+            keepNames: true
+          },
           onwarn: (warning, warn) => {
             // Suppress specific warnings
             if (

--- a/apps/desktop-ui/vite.config.mts
+++ b/apps/desktop-ui/vite.config.mts
@@ -64,7 +64,7 @@ export default defineConfig(() => {
       })
     ],
     build: {
-      minify: SHOULD_MINIFY ? ('esbuild' as const) : false,
+      minify: SHOULD_MINIFY,
       target: 'es2022',
       sourcemap: true
     }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -416,7 +416,28 @@ export default defineConfig({
     target: 'es2022',
     sourcemap: GENERATE_SOURCEMAP,
     rolldownOptions: {
-      treeshake: true,
+      treeshake: {
+        manualPureFunctions: [
+          'console.clear',
+          'console.count',
+          'console.countReset',
+          'console.debug',
+          'console.dir',
+          'console.dirxml',
+          'console.group',
+          'console.groupCollapsed',
+          'console.groupEnd',
+          'console.info',
+          'console.log',
+          'console.profile',
+          'console.profileEnd',
+          'console.table',
+          'console.time',
+          'console.timeEnd',
+          'console.timeLog',
+          'console.trace'
+        ]
+      },
       experimental: {
         strictExecutionOrder: true
       },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -412,77 +412,59 @@ export default defineConfig({
   ],
 
   build: {
-    minify: SHOULD_MINIFY ? 'esbuild' : false,
+    minify: SHOULD_MINIFY,
     target: 'es2022',
     sourcemap: GENERATE_SOURCEMAP,
-    rollupOptions: {
+    rolldownOptions: {
       treeshake: true,
       output: {
-        manualChunks: (id) => {
-          if (!id.includes('node_modules')) {
-            return undefined
-          }
-
-          if (id.includes('primevue') || id.includes('@primeuix')) {
-            return 'vendor-primevue'
-          }
-
-          if (id.includes('@tiptap')) {
-            return 'vendor-tiptap'
-          }
-
-          if (id.includes('chart.js')) {
-            return 'vendor-chart'
-          }
-
-          if (id.includes('three') || id.includes('@sparkjsdev')) {
-            return 'vendor-three'
-          }
-
-          if (id.includes('@xterm')) {
-            return 'vendor-xterm'
-          }
-
-          if (id.includes('/vue') || id.includes('pinia')) {
-            return 'vendor-vue'
-          }
-          if (id.includes('reka-ui')) {
-            return 'vendor-reka-ui'
-          }
-
-          return 'vendor-other'
+        keepNames: true,
+        codeSplitting: {
+          groups: [
+            {
+              name: 'vendor-primevue',
+              test: /[\\/]node_modules[\\/](@?primevue|@primeuix)[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-tiptap',
+              test: /[\\/]node_modules[\\/]@tiptap[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-chart',
+              test: /[\\/]node_modules[\\/]chart\.js[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-three',
+              test: /[\\/]node_modules[\\/](three|@sparkjsdev)[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-xterm',
+              test: /[\\/]node_modules[\\/]@xterm[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-vue',
+              test: /[\\/]node_modules[\\/](vue|pinia)[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-reka-ui',
+              test: /[\\/]node_modules[\\/]reka-ui[\\/]/,
+              priority: 10
+            },
+            {
+              name: 'vendor-other',
+              test: /[\\/]node_modules[\\/]/,
+              priority: 0
+            }
+          ]
         }
       }
     }
-  },
-
-  esbuild: {
-    minifyIdentifiers: SHOULD_MINIFY,
-    keepNames: true,
-    minifySyntax: SHOULD_MINIFY,
-    minifyWhitespace: SHOULD_MINIFY,
-    pure: SHOULD_MINIFY
-      ? [
-          'console.log',
-          'console.debug',
-          'console.info',
-          'console.trace',
-          'console.dir',
-          'console.dirxml',
-          'console.group',
-          'console.groupCollapsed',
-          'console.groupEnd',
-          'console.table',
-          'console.time',
-          'console.timeEnd',
-          'console.timeLog',
-          'console.count',
-          'console.countReset',
-          'console.profile',
-          'console.profileEnd',
-          'console.clear'
-        ]
-      : []
   },
 
   define: {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -417,6 +417,9 @@ export default defineConfig({
     sourcemap: GENERATE_SOURCEMAP,
     rolldownOptions: {
       treeshake: true,
+      experimental: {
+        strictExecutionOrder: true
+      },
       output: {
         keepNames: true,
         codeSplitting: {


### PR DESCRIPTION
Prepares Vite config for Vite 8 by migrating from esbuild/Rollup to Rolldown/Oxc.

## Changes
- Migrate `build.rollupOptions` → `build.rolldownOptions`
- Replace `manualChunks` with `codeSplitting.groups`
- Update Storybook config with `strictExecutionOrder` for module loading compatibility

## Testing
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test:unit` passes
