### PR TITLE
Control widget fixes

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2545,6 +2545,7 @@ export class Subgraph
 
     this.inputNode.configure(data.inputNode)
     this.outputNode.configure(data.outputNode)
+    for (const node of this.nodes) node.updateComputedDisabled()
   }
 
   override configure(

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -141,6 +141,7 @@ export abstract class BaseWidget<
       // @ts-expect-error Prevent naming conflicts with custom nodes.
       labelBaseline,
       promoted,
+      linkedWidgets,
       ...safeValues
     } = widget
 


### PR DESCRIPTION
#8112 updated control widgets to be disabled when the controlled widget is disabled.  However, some workflows already exist that contain a promoted control widget which does not function. This widget wouldn't be marked as disabled (and thus, demoted) until the interior subgraph was entered as updating `computedDisabled` is tacked to node draw. This is fixed by having subgraphs eagerly update the `computedDisabled` state on each node when configured.

Additionally, when `createCopyForNode` was used, linkedWidget retained pointers to widgets which no longer have relation to the newly cloned widget. This is resolved by instead not copying linkedWidgets. Functionally, linkedWidgets is only used for control widgets and not copying has the effect of ensuring that seed widgets linked to a subgraph input will not display a control popover button in vue mode which does nothing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8160-Control-widget-fixes-2ed6d73d3650816cb397f83f558471b3) by [Unito](https://www.unito.io)
