### PR TITLE
[bugfix] Fix search bar height alignment in MediaAssetFilterBar

### DIFF
--- a/src/platform/assets/components/MediaAssetFilterBar.vue
+++ b/src/platform/assets/components/MediaAssetFilterBar.vue
@@ -9,8 +9,8 @@
       <MediaAssetFilterButton v-if="isCloud" v-tooltip.top="{ value: $t('assetBrowser.filterBy') }" size="md">
         <template #default="{ close }">
           <MediaAssetFilterMenu
-            :media-type-filters="mediaTypeFilters"
-            :close="close"
+            :media-type-filters
+            :close
             @update:media-type-filters="handleMediaTypeFiltersChange" />
         </template>
       </MediaAssetFilterButton>

--- a/src/platform/assets/components/MediaAssetFilterBar.vue
+++ b/src/platform/assets/components/MediaAssetFilterBar.vue
@@ -1,40 +1,26 @@
 <template>
-  <div class="flex gap-3">
+  <div class="flex gap-3 items-center">
     <SearchBox
       :model-value="searchQuery"
       :placeholder="$t('sideToolbar.searchAssets') + '...'"
       @update:model-value="handleSearchChange"
     />
-    <MediaAssetFilterButton
-      v-if="isCloud"
-      v-tooltip.top="{ value: $t('assetBrowser.filterBy') }"
-      size="md"
-    >
-      <template #default="{ close }">
-        <MediaAssetFilterMenu
-          :media-type-filters="mediaTypeFilters"
-          :close="close"
-          @update:media-type-filters="handleMediaTypeFiltersChange"
-        />
-      </template>
-    </MediaAssetFilterButton>
-    <AssetSortButton
-      v-if="isCloud"
-      v-tooltip.top="{ value: $t('assetBrowser.sortBy') }"
-      size="md"
-    >
-      <template #default="{ close }">
-        <MediaAssetSortMenu
-          v-model:sort-by="sortBy"
-          :show-generation-time-sort
-          :close="close"
-        />
-      </template>
-    </AssetSortButton>
-    <MediaAssetViewModeToggle
-      v-if="isQueuePanelV2Enabled"
-      v-model:view-mode="viewMode"
-    />
+    <div class="flex gap-1.5 items-center">
+      <MediaAssetFilterButton v-if="isCloud" v-tooltip.top="{ value: $t('assetBrowser.filterBy') }" size="md">
+        <template #default="{ close }">
+          <MediaAssetFilterMenu
+            :media-type-filters="mediaTypeFilters"
+            :close="close"
+            @update:media-type-filters="handleMediaTypeFiltersChange" />
+        </template>
+      </MediaAssetFilterButton>
+      <AssetSortButton v-if="isCloud" v-tooltip.top="{ value: $t('assetBrowser.sortBy') }" size="md">
+        <template #default="{ close }">
+          <MediaAssetSortMenu v-model:sort-by="sortBy" :show-generation-time-sort :close="close" />
+        </template>
+      </AssetSortButton>
+      <MediaAssetViewModeToggle v-if="isQueuePanelV2Enabled" v-model:view-mode="viewMode" />
+    </div>
   </div>
 </template>
 

--- a/src/platform/assets/components/MediaAssetFilterBar.vue
+++ b/src/platform/assets/components/MediaAssetFilterBar.vue
@@ -16,7 +16,7 @@
       </MediaAssetFilterButton>
       <AssetSortButton v-if="isCloud" v-tooltip.top="{ value: $t('assetBrowser.sortBy') }" size="md">
         <template #default="{ close }">
-          <MediaAssetSortMenu v-model:sort-by="sortBy" :show-generation-time-sort :close="close" />
+          <MediaAssetSortMenu v-model:sort-by="sortBy" :show-generation-time-sort :close />
         </template>
       </AssetSortButton>
       <MediaAssetViewModeToggle v-if="isQueuePanelV2Enabled" v-model:view-mode="viewMode" />


### PR DESCRIPTION
## Summary
Fix vertical alignment of search bar and filter buttons in the media asset filter bar by adding `items-center` and grouping the buttons.

## Changes
- **What**: Added `items-center` to outer container and wrapped filter/sort/view-mode buttons in a grouped div with consistent gap spacing

## Review Focus
- Visual alignment of the search bar with adjacent buttons

<img width="594" height="455" alt="스크린샷 2026-01-20 오전 11 31 54" src="https://github.com/user-attachments/assets/4f19a47a-bf6a-4393-a1f9-df0ac8b068d6" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8171-bugfix-Fix-search-bar-height-alignment-in-MediaAssetFilterBar-2ee6d73d365081439bf8e46226b18165) by [Unito](https://www.unito.io)
