### PR TITLE
[bugfix] Add spacing between action buttons in node library sidebar

### DIFF
--- a/src/components/common/TreeExplorerTreeNode.vue
+++ b/src/components/common/TreeExplorerTreeNode.vue
@@ -28,7 +28,7 @@
       />
     </div>
     <div
-      class="node-actions touch:opacity-100 motion-safe:opacity-0 motion-safe:group-hover/tree-node:opacity-100"
+      class="node-actions flex gap-1 touch:opacity-100 motion-safe:opacity-0 motion-safe:group-hover/tree-node:opacity-100"
     >
       <slot name="actions" :node="props.node" />
     </div>


### PR DESCRIPTION
## Summary
Add proper spacing between action buttons in node library sidebar to improve visual clarity.

## Changes
- Add `flex gap-1` classes to the `node-actions` container in `TreeExplorerTreeNode.vue`
- Applies to both blueprint nodes (edit/delete buttons) and regular nodes (bookmark/help buttons)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8172-bugfix-Add-spacing-between-action-buttons-in-node-library-sidebar-2ee6d73d365081599ce2f536478d43d3) by [Unito](https://www.unito.io)
