### PR TITLE
feat: add feature usage tracker for nightly surveys

### DIFF
--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const STORAGE_KEY = 'comfy.featureUsage'
+const STORAGE_KEY = 'Comfy.FeatureUsage'
 
 describe('useFeatureUsageTracker', () => {
   beforeEach(() => {

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -94,16 +94,20 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('persists to localStorage', async () => {
-    const { useFeatureUsageTracker } = await import('./useFeatureUsageTracker')
-    const { trackUsage } = useFeatureUsageTracker('persisted-feature')
+    vi.useFakeTimers()
+    try {
+      const { useFeatureUsageTracker } =
+        await import('./useFeatureUsageTracker')
+      const { trackUsage } = useFeatureUsageTracker('persisted-feature')
 
-    trackUsage()
+      trackUsage()
+      await vi.runAllTimersAsync()
 
-    // useStorage flushes async, wait a tick
-    await new Promise((r) => setTimeout(r, 0))
-
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
-    expect(stored['persisted-feature']?.useCount).toBe(1)
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+      expect(stored['persisted-feature']?.useCount).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('loads existing data from localStorage', async () => {

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -49,16 +49,22 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('updates lastUsed on each use', async () => {
-    const { useFeatureUsageTracker } = await import('./useFeatureUsageTracker')
-    const { usage, trackUsage } = useFeatureUsageTracker('test-feature')
+    vi.useFakeTimers()
+    try {
+      const { useFeatureUsageTracker } =
+        await import('./useFeatureUsageTracker')
+      const { usage, trackUsage } = useFeatureUsageTracker('test-feature')
 
-    trackUsage()
-    const firstLastUsed = usage.value?.lastUsed ?? 0
+      trackUsage()
+      const firstLastUsed = usage.value?.lastUsed ?? 0
 
-    await new Promise((r) => setTimeout(r, 10))
-    trackUsage()
+      vi.advanceTimersByTime(10)
+      trackUsage()
 
-    expect(usage.value?.lastUsed).toBeGreaterThan(firstLastUsed)
+      expect(usage.value?.lastUsed).toBeGreaterThan(firstLastUsed)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('reset clears feature data', async () => {

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -33,19 +33,23 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('sets firstUsed only on first use', async () => {
-    const { useFeatureUsageTracker } = await import('./useFeatureUsageTracker')
-    const { usage, trackUsage } = useFeatureUsageTracker('test-feature')
+    vi.useFakeTimers()
+    const firstTs = 1000000
+    vi.setSystemTime(firstTs)
+    try {
+      const { useFeatureUsageTracker } =
+        await import('./useFeatureUsageTracker')
+      const { usage, trackUsage } = useFeatureUsageTracker('test-feature')
 
-    const beforeFirst = Date.now()
-    trackUsage()
-    const afterFirst = Date.now()
+      trackUsage()
+      expect(usage.value?.firstUsed).toBe(firstTs)
 
-    const firstUsed = usage.value?.firstUsed ?? 0
-    expect(firstUsed).toBeGreaterThanOrEqual(beforeFirst)
-    expect(firstUsed).toBeLessThanOrEqual(afterFirst)
-
-    trackUsage()
-    expect(usage.value?.firstUsed).toBe(firstUsed)
+      vi.setSystemTime(firstTs + 5000)
+      trackUsage()
+      expect(usage.value?.firstUsed).toBe(firstTs)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('updates lastUsed on each use', async () => {

--- a/src/platform/surveys/useFeatureUsageTracker.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.ts
@@ -1,0 +1,46 @@
+import { useStorage } from '@vueuse/core'
+import { computed } from 'vue'
+
+interface FeatureUsage {
+  useCount: number
+  firstUsed: number
+  lastUsed: number
+}
+
+type FeatureUsageRecord = Record<string, FeatureUsage>
+
+const STORAGE_KEY = 'comfy.featureUsage'
+
+/**
+ * Tracks feature usage for survey eligibility.
+ * Persists to localStorage.
+ */
+export function useFeatureUsageTracker(featureId: string) {
+  const usageData = useStorage<FeatureUsageRecord>(STORAGE_KEY, {})
+
+  const usage = computed(() => usageData.value[featureId])
+
+  const useCount = computed(() => usage.value?.useCount ?? 0)
+
+  function trackUsage() {
+    const now = Date.now()
+    const existing = usageData.value[featureId]
+
+    usageData.value[featureId] = {
+      useCount: (existing?.useCount ?? 0) + 1,
+      firstUsed: existing?.firstUsed ?? now,
+      lastUsed: now
+    }
+  }
+
+  function reset() {
+    delete usageData.value[featureId]
+  }
+
+  return {
+    usage,
+    useCount,
+    trackUsage,
+    reset
+  }
+}

--- a/src/platform/surveys/useFeatureUsageTracker.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.ts
@@ -9,7 +9,7 @@ interface FeatureUsage {
 
 type FeatureUsageRecord = Record<string, FeatureUsage>
 
-const STORAGE_KEY = 'comfy.featureUsage'
+const STORAGE_KEY = 'Comfy.FeatureUsage'
 
 /**
  * Tracks feature usage for survey eligibility.


### PR DESCRIPTION
Introduces `useFeatureUsageTracker` composable that tracks how many times a user has used a specific feature, along with first and last usage timestamps. Data persists to localStorage using `@vueuse/core`'s `useStorage`. This composable provides the foundation for triggering surveys after a configurable number of feature uses. Includes comprehensive unit tests.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8175-feat-add-feature-usage-tracker-for-nightly-surveys-2ee6d73d36508118859ece6fcf17561d) by [Unito](https://www.unito.io)
