### PR TITLE
feat(workspace): 2/5 Store and composables with tests

### DIFF
--- a/src/platform/auth/workspace/useWorkspaceSwitch.ts
+++ b/src/platform/auth/workspace/useWorkspaceSwitch.ts
@@ -2,13 +2,13 @@ import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
-import { useWorkspaceAuthStore } from '@/stores/workspaceAuthStore'
 
 export function useWorkspaceSwitch() {
   const { t } = useI18n()
-  const workspaceAuthStore = useWorkspaceAuthStore()
-  const { currentWorkspace } = storeToRefs(workspaceAuthStore)
+  const workspaceStore = useTeamWorkspaceStore()
+  const { activeWorkspace } = storeToRefs(workspaceStore)
   const workflowStore = useWorkflowStore()
   const dialogService = useDialogService()
 
@@ -17,7 +17,7 @@ export function useWorkspaceSwitch() {
   }
 
   async function switchWithConfirmation(workspaceId: string): Promise<boolean> {
-    if (currentWorkspace.value?.id === workspaceId) {
+    if (activeWorkspace.value?.id === workspaceId) {
       return true
     }
 
@@ -34,8 +34,8 @@ export function useWorkspaceSwitch() {
     }
 
     try {
-      await workspaceAuthStore.switchWorkspace(workspaceId)
-      window.location.reload()
+      await workspaceStore.switchWorkspace(workspaceId)
+      // Note: switchWorkspace triggers page reload internally
       return true
     } catch {
       return false

--- a/src/platform/workspace/composables/useInviteUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useInviteUrlLoader.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useInviteUrlLoader } from './useInviteUrlLoader'
+
+/**
+ * Unit tests for useInviteUrlLoader composable
+ *
+ * Tests the behavior of accepting workspace invites via URL query parameters:
+ * - ?invite=TOKEN accepts the invite and shows success toast
+ * - Invalid/missing token is handled gracefully
+ * - API errors show error toast
+ * - URL is cleaned up after processing
+ * - Preserved query is restored after login redirect
+ */
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  clearPreservedQuery: vi.fn(),
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn()
+}))
+
+vi.mock(
+  '@/platform/navigation/preservedQueryManager',
+  () => preservedQueryMocks
+)
+
+const mockRouteQuery = vi.hoisted(() => ({
+  value: {} as Record<string, string>
+}))
+const mockRouterReplace = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: mockRouteQuery.value
+  }),
+  useRouter: () => ({
+    replace: mockRouterReplace
+  })
+}))
+
+const mockToastAdd = vi.hoisted(() => vi.fn())
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: mockToastAdd
+  })
+}))
+
+vi.mock('vue-i18n', () => ({
+  createI18n: () => ({
+    global: {
+      t: (key: string) => key
+    }
+  }),
+  useI18n: () => ({
+    t: vi.fn((key: string, params?: Record<string, unknown>) => {
+      if (key === 'workspace.inviteAccepted') return 'Invite Accepted'
+      if (key === 'workspace.addedToWorkspace') {
+        return `You have been added to ${params?.workspaceName}`
+      }
+      if (key === 'workspace.inviteFailed') return 'Failed to Accept Invite'
+      if (key === 'g.unknownError') return 'Unknown error'
+      return key
+    })
+  })
+}))
+
+const mockAcceptInvite = vi.hoisted(() => vi.fn())
+vi.mock('../stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    acceptInvite: mockAcceptInvite
+  })
+}))
+
+describe('useInviteUrlLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('loadInviteFromUrl', () => {
+    it('does nothing when no invite param present', async () => {
+      mockRouteQuery.value = {}
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+
+    it('restores preserved query and processes invite', async () => {
+      mockRouteQuery.value = {}
+      preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+        invite: 'preserved-token'
+      })
+      mockAcceptInvite.mockResolvedValue({
+        workspaceId: 'ws-123',
+        workspaceName: 'Test Workspace'
+      })
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
+        'invite'
+      )
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        query: { invite: 'preserved-token' }
+      })
+      expect(mockAcceptInvite).toHaveBeenCalledWith('preserved-token')
+    })
+
+    it('accepts invite and shows success toast on success', async () => {
+      mockRouteQuery.value = { invite: 'valid-token' }
+      mockAcceptInvite.mockResolvedValue({
+        workspaceId: 'ws-123',
+        workspaceName: 'Test Workspace'
+      })
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(mockAcceptInvite).toHaveBeenCalledWith('valid-token')
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: 'success',
+        summary: 'Invite Accepted',
+        detail: 'You have been added to Test Workspace',
+        life: 5000
+      })
+    })
+
+    it('shows error toast when invite acceptance fails', async () => {
+      mockRouteQuery.value = { invite: 'invalid-token' }
+      mockAcceptInvite.mockRejectedValue(new Error('Invalid invite'))
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(mockAcceptInvite).toHaveBeenCalledWith('invalid-token')
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Failed to Accept Invite',
+        detail: 'Invalid invite',
+        life: 5000
+      })
+    })
+
+    it('cleans up URL after processing invite', async () => {
+      mockRouteQuery.value = { invite: 'valid-token', other: 'param' }
+      mockAcceptInvite.mockResolvedValue({
+        workspaceId: 'ws-123',
+        workspaceName: 'Test Workspace'
+      })
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      // Should replace with query without invite param
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        query: { other: 'param' }
+      })
+    })
+
+    it('clears preserved query after processing', async () => {
+      mockRouteQuery.value = { invite: 'valid-token' }
+      mockAcceptInvite.mockResolvedValue({
+        workspaceId: 'ws-123',
+        workspaceName: 'Test Workspace'
+      })
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+        'invite'
+      )
+    })
+
+    it('clears preserved query even on error', async () => {
+      mockRouteQuery.value = { invite: 'invalid-token' }
+      mockAcceptInvite.mockRejectedValue(new Error('Invalid invite'))
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+        'invite'
+      )
+    })
+
+    it('sends any token format to backend for validation', async () => {
+      mockRouteQuery.value = { invite: 'any-token-format==' }
+      mockAcceptInvite.mockRejectedValue(new Error('Invalid token'))
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      // Token is sent to backend, which validates and rejects
+      expect(mockAcceptInvite).toHaveBeenCalledWith('any-token-format==')
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Failed to Accept Invite',
+        detail: 'Invalid token',
+        life: 5000
+      })
+    })
+
+    it('ignores empty invite param', async () => {
+      mockRouteQuery.value = { invite: '' }
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(mockAcceptInvite).not.toHaveBeenCalled()
+    })
+
+    it('ignores non-string invite param', async () => {
+      mockRouteQuery.value = { invite: ['array', 'value'] as unknown as string }
+
+      const { loadInviteFromUrl } = useInviteUrlLoader()
+      await loadInviteFromUrl()
+
+      expect(mockAcceptInvite).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/platform/workspace/composables/useInviteUrlLoader.ts
+++ b/src/platform/workspace/composables/useInviteUrlLoader.ts
@@ -1,0 +1,106 @@
+import { useToast } from 'primevue/usetoast'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  hydratePreservedQuery,
+  mergePreservedQueryIntoQuery
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+
+import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
+
+/**
+ * Composable for loading workspace invites from URL query parameters
+ *
+ * Supports URLs like:
+ * - /?invite=TOKEN (accepts workspace invite)
+ *
+ * The invite token is preserved through login redirects via the
+ * preserved query system (sessionStorage), following the same pattern
+ * as the template URL loader.
+ */
+export function useInviteUrlLoader() {
+  const route = useRoute()
+  const router = useRouter()
+  const { t } = useI18n()
+  const toast = useToast()
+  const workspaceStore = useTeamWorkspaceStore()
+  const INVITE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.INVITE
+
+  /**
+   * Hydrates preserved query from sessionStorage and merges into route.
+   * This restores the invite token after login redirects.
+   */
+  const ensureInviteQueryFromIntent = async () => {
+    hydratePreservedQuery(INVITE_NAMESPACE)
+    const mergedQuery = mergePreservedQueryIntoQuery(
+      INVITE_NAMESPACE,
+      route.query
+    )
+
+    if (mergedQuery) {
+      await router.replace({ query: mergedQuery })
+    }
+
+    return mergedQuery ?? route.query
+  }
+
+  /**
+   * Removes invite parameter from URL using Vue Router
+   */
+  const cleanupUrlParams = () => {
+    const newQuery = { ...route.query }
+    delete newQuery.invite
+    void router.replace({ query: newQuery })
+  }
+
+  /**
+   * Loads and accepts workspace invite from URL query parameters if present.
+   * Handles errors internally and shows appropriate user feedback.
+   *
+   * Flow:
+   * 1. Restore preserved query (for post-login redirect)
+   * 2. Check for invite token in route.query
+   * 3. Accept the invite via API (backend validates token)
+   * 4. Show toast notification
+   * 5. Clean up URL and preserved query
+   */
+  const loadInviteFromUrl = async () => {
+    // Restore preserved query from sessionStorage (handles login redirect case)
+    const query = await ensureInviteQueryFromIntent()
+
+    const inviteParam = query.invite
+    if (!inviteParam || typeof inviteParam !== 'string') {
+      return
+    }
+
+    try {
+      const result = await workspaceStore.acceptInvite(inviteParam)
+
+      toast.add({
+        severity: 'success',
+        summary: t('workspace.inviteAccepted'),
+        detail: t('workspace.addedToWorkspace', {
+          workspaceName: result.workspaceName
+        }),
+        life: 5000
+      })
+    } catch (error) {
+      toast.add({
+        severity: 'error',
+        summary: t('workspace.inviteFailed'),
+        detail: error instanceof Error ? error.message : t('g.unknownError'),
+        life: 5000
+      })
+    } finally {
+      cleanupUrlParams()
+      clearPreservedQuery(INVITE_NAMESPACE)
+    }
+  }
+
+  return {
+    loadInviteFromUrl
+  }
+}

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -1,0 +1,177 @@
+import { computed, ref } from 'vue'
+import { createSharedComposable } from '@vueuse/core'
+
+import type { WorkspaceRole, WorkspaceType } from '../api/workspaceApi'
+import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
+
+/** Permission flags for workspace actions */
+interface WorkspacePermissions {
+  canViewOtherMembers: boolean
+  canViewPendingInvites: boolean
+  canInviteMembers: boolean
+  canManageInvites: boolean
+  canRemoveMembers: boolean
+  canLeaveWorkspace: boolean
+  canAccessWorkspaceMenu: boolean
+  canManageSubscription: boolean
+}
+
+/** UI configuration for workspace role */
+interface WorkspaceUIConfig {
+  showMembersList: boolean
+  showPendingTab: boolean
+  showSearch: boolean
+  showDateColumn: boolean
+  showRoleBadge: boolean
+  membersGridCols: string
+  pendingGridCols: string
+  headerGridCols: string
+  showEditWorkspaceMenuItem: boolean
+  workspaceMenuAction: 'leave' | 'delete' | null
+  workspaceMenuDisabledTooltip: string | null
+}
+
+function getPermissions(
+  type: WorkspaceType,
+  role: WorkspaceRole
+): WorkspacePermissions {
+  if (type === 'personal') {
+    return {
+      canViewOtherMembers: false,
+      canViewPendingInvites: false,
+      canInviteMembers: false,
+      canManageInvites: false,
+      canRemoveMembers: false,
+      canLeaveWorkspace: false,
+      canAccessWorkspaceMenu: true,
+      canManageSubscription: true
+    }
+  }
+
+  if (role === 'owner') {
+    return {
+      canViewOtherMembers: true,
+      canViewPendingInvites: true,
+      canInviteMembers: true,
+      canManageInvites: true,
+      canRemoveMembers: true,
+      canLeaveWorkspace: true,
+      canAccessWorkspaceMenu: true,
+      canManageSubscription: true
+    }
+  }
+
+  // member role
+  return {
+    canViewOtherMembers: true,
+    canViewPendingInvites: false,
+    canInviteMembers: false,
+    canManageInvites: false,
+    canRemoveMembers: false,
+    canLeaveWorkspace: true,
+    canAccessWorkspaceMenu: true,
+    canManageSubscription: false
+  }
+}
+
+function getUIConfig(
+  type: WorkspaceType,
+  role: WorkspaceRole
+): WorkspaceUIConfig {
+  if (type === 'personal') {
+    return {
+      showMembersList: false,
+      showPendingTab: false,
+      showSearch: false,
+      showDateColumn: false,
+      showRoleBadge: false,
+      membersGridCols: 'grid-cols-1',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-1',
+      showEditWorkspaceMenuItem: true,
+      workspaceMenuAction: null,
+      workspaceMenuDisabledTooltip: null
+    }
+  }
+
+  if (role === 'owner') {
+    return {
+      showMembersList: true,
+      showPendingTab: true,
+      showSearch: true,
+      showDateColumn: true,
+      showRoleBadge: true,
+      membersGridCols: 'grid-cols-[50%_40%_10%]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[50%_40%_10%]',
+      showEditWorkspaceMenuItem: true,
+      workspaceMenuAction: 'delete',
+      workspaceMenuDisabledTooltip:
+        'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
+    }
+  }
+
+  // member role
+  return {
+    showMembersList: true,
+    showPendingTab: false,
+    showSearch: true,
+    showDateColumn: true,
+    showRoleBadge: true,
+    membersGridCols: 'grid-cols-[1fr_auto]',
+    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+    headerGridCols: 'grid-cols-[1fr_auto]',
+    showEditWorkspaceMenuItem: false,
+    workspaceMenuAction: 'leave',
+    workspaceMenuDisabledTooltip: null
+  }
+}
+
+/**
+ * Internal implementation of UI configuration composable.
+ */
+function useWorkspaceUIInternal() {
+  const store = useTeamWorkspaceStore()
+
+  // Tab management (shared UI state)
+  const activeTab = ref<string>('plan')
+
+  function setActiveTab(tab: string | number) {
+    activeTab.value = String(tab)
+  }
+
+  const workspaceType = computed<WorkspaceType>(
+    () => store.activeWorkspace?.type ?? 'personal'
+  )
+
+  const workspaceRole = computed<WorkspaceRole>(
+    () => store.activeWorkspace?.role ?? 'owner'
+  )
+
+  const permissions = computed<WorkspacePermissions>(() =>
+    getPermissions(workspaceType.value, workspaceRole.value)
+  )
+
+  const uiConfig = computed<WorkspaceUIConfig>(() =>
+    getUIConfig(workspaceType.value, workspaceRole.value)
+  )
+
+  return {
+    // Tab management
+    activeTab: computed(() => activeTab.value),
+    setActiveTab,
+
+    // Permissions and config
+    permissions,
+    uiConfig,
+    workspaceType,
+    workspaceRole
+  }
+}
+
+/**
+ * UI configuration composable derived from workspace state.
+ * Controls what UI elements are visible/enabled based on role and workspace type.
+ * Uses createSharedComposable to ensure tab state is shared across components.
+ */
+export const useWorkspaceUI = createSharedComposable(useWorkspaceUIInternal)

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -1,0 +1,1069 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTeamWorkspaceStore } from './teamWorkspaceStore'
+
+// Mock sessionManager
+const mockSessionManager = vi.hoisted(() => ({
+  getCurrentWorkspaceId: vi.fn(),
+  setCurrentWorkspaceId: vi.fn(),
+  clearCurrentWorkspaceId: vi.fn(),
+  getLastWorkspaceId: vi.fn(),
+  setLastWorkspaceId: vi.fn(),
+  clearLastWorkspaceId: vi.fn(),
+  getWorkspaceToken: vi.fn(),
+  setWorkspaceToken: vi.fn(),
+  clearWorkspaceToken: vi.fn(),
+  switchWorkspaceAndReload: vi.fn(),
+  clearAndReload: vi.fn()
+}))
+
+vi.mock('../services/sessionManager', () => ({
+  sessionManager: mockSessionManager
+}))
+
+// Mock workspaceApi
+const mockWorkspaceApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  leave: vi.fn(),
+  listMembers: vi.fn(),
+  removeMember: vi.fn(),
+  listInvites: vi.fn(),
+  createInvite: vi.fn(),
+  revokeInvite: vi.fn(),
+  acceptInvite: vi.fn(),
+  exchangeToken: vi.fn(),
+  getBillingPortalUrl: vi.fn()
+}))
+
+const mockWorkspaceApiError = vi.hoisted(
+  () =>
+    class WorkspaceApiError extends Error {
+      constructor(
+        message: string,
+        public readonly status?: number,
+        public readonly code?: string
+      ) {
+        super(message)
+        this.name = 'WorkspaceApiError'
+      }
+    }
+)
+
+vi.mock('../api/workspaceApi', () => ({
+  workspaceApi: mockWorkspaceApi,
+  WorkspaceApiError: mockWorkspaceApiError
+}))
+
+// Test data
+const mockPersonalWorkspace = {
+  id: 'ws-personal-123',
+  name: 'Personal',
+  type: 'personal' as const,
+  role: 'owner' as const
+}
+
+const mockTeamWorkspace = {
+  id: 'ws-team-456',
+  name: 'Team Alpha',
+  type: 'team' as const,
+  role: 'owner' as const
+}
+
+const mockMemberWorkspace = {
+  id: 'ws-team-789',
+  name: 'Team Beta',
+  type: 'team' as const,
+  role: 'member' as const
+}
+
+const mockTokenResponse = {
+  token: 'workspace-token-abc',
+  expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+  workspace: {
+    id: mockTeamWorkspace.id,
+    name: mockTeamWorkspace.name,
+    type: mockTeamWorkspace.type
+  },
+  role: 'owner' as const,
+  permissions: ['owner:*']
+}
+
+describe('useTeamWorkspaceStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    sessionStorage.clear()
+
+    // Default mock responses
+    mockWorkspaceApi.list.mockResolvedValue({
+      workspaces: [mockPersonalWorkspace, mockTeamWorkspace]
+    })
+    mockWorkspaceApi.exchangeToken.mockResolvedValue(mockTokenResponse)
+    mockSessionManager.getCurrentWorkspaceId.mockReturnValue(null)
+    mockSessionManager.getLastWorkspaceId.mockReturnValue(null)
+    mockSessionManager.getWorkspaceToken.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('initial state', () => {
+    it('has correct initial state values', () => {
+      const store = useTeamWorkspaceStore()
+
+      expect(store.initState).toBe('uninitialized')
+      expect(store.workspaces).toEqual([])
+      expect(store.activeWorkspaceId).toBeNull()
+      expect(store.error).toBeNull()
+      expect(store.isCreating).toBe(false)
+      expect(store.isDeleting).toBe(false)
+      expect(store.isSwitching).toBe(false)
+      expect(store.isFetchingWorkspaces).toBe(false)
+    })
+
+    it('computed properties return correct defaults', () => {
+      const store = useTeamWorkspaceStore()
+
+      expect(store.activeWorkspace).toBeNull()
+      expect(store.personalWorkspace).toBeNull()
+      expect(store.isInPersonalWorkspace).toBe(false)
+      expect(store.sharedWorkspaces).toEqual([])
+      expect(store.ownedWorkspacesCount).toBe(0)
+      expect(store.canCreateWorkspace).toBe(true)
+      expect(store.members).toEqual([])
+      expect(store.pendingInvites).toEqual([])
+    })
+  })
+
+  describe('initialize', () => {
+    it('fetches workspaces and sets active workspace to personal by default', async () => {
+      const store = useTeamWorkspaceStore()
+
+      await store.initialize()
+
+      expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(1)
+      expect(store.initState).toBe('ready')
+      expect(store.workspaces).toHaveLength(2)
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+      expect(mockSessionManager.setCurrentWorkspaceId).toHaveBeenCalledWith(
+        mockPersonalWorkspace.id
+      )
+      expect(mockSessionManager.setLastWorkspaceId).toHaveBeenCalledWith(
+        mockPersonalWorkspace.id
+      )
+    })
+
+    it('restores workspace from sessionStorage if valid', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
+    })
+
+    it('falls back to localStorage if sessionStorage is empty', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(null)
+      mockSessionManager.getLastWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
+    })
+
+    it('falls back to personal if stored workspace not in list', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        'non-existent-workspace'
+      )
+      mockSessionManager.getLastWorkspaceId.mockReturnValue(
+        'another-non-existent'
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+    })
+
+    it('restores valid token from sessionStorage', async () => {
+      const futureExpiry = Date.now() + 3600 * 1000
+      mockSessionManager.getWorkspaceToken.mockReturnValue({
+        token: 'cached-token',
+        expiresAt: futureExpiry
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      // Should not call exchangeToken since we have a valid cached token
+      expect(mockWorkspaceApi.exchangeToken).not.toHaveBeenCalled()
+    })
+
+    it('exchanges token if cached token is expired', async () => {
+      const pastExpiry = Date.now() - 1000
+      mockSessionManager.getWorkspaceToken.mockReturnValue({
+        token: 'expired-token',
+        expiresAt: pastExpiry
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledWith(
+        mockPersonalWorkspace.id
+      )
+    })
+
+    it('sets error state when workspaces fetch fails', async () => {
+      mockWorkspaceApi.list.mockRejectedValue(new Error('Network error'))
+
+      const store = useTeamWorkspaceStore()
+
+      await expect(store.initialize()).rejects.toThrow('Network error')
+      expect(store.initState).toBe('error')
+      expect(store.error).toBeInstanceOf(Error)
+    })
+
+    it('does not reinitialize if already initialized', async () => {
+      const store = useTeamWorkspaceStore()
+
+      await store.initialize()
+      await store.initialize()
+
+      expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws when no workspaces available', async () => {
+      mockWorkspaceApi.list.mockResolvedValue({ workspaces: [] })
+
+      const store = useTeamWorkspaceStore()
+
+      await expect(store.initialize()).rejects.toThrow(
+        'No workspaces available'
+      )
+      expect(store.initState).toBe('error')
+    })
+  })
+
+  describe('token refresh scheduling', () => {
+    it('schedules token refresh 5 minutes before expiry', async () => {
+      const now = Date.now()
+      const expiresInMs = 3600 * 1000 // 1 hour
+      const tokenResponseWithFutureExpiry = {
+        ...mockTokenResponse,
+        expires_at: new Date(now + expiresInMs).toISOString()
+      }
+
+      // Return very far future expiry on refresh to prevent another refresh cycle
+      const farFutureResponse = {
+        ...mockTokenResponse,
+        expires_at: new Date(now + 24 * 3600 * 1000).toISOString() // 24 hours
+      }
+
+      mockWorkspaceApi.exchangeToken
+        .mockResolvedValueOnce(tokenResponseWithFutureExpiry) // Initial
+        .mockResolvedValue(farFutureResponse) // All subsequent
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(1)
+
+      // Advance time to just before refresh (55 minutes)
+      const refreshBufferMs = 5 * 60 * 1000
+      const refreshDelay = expiresInMs - refreshBufferMs
+
+      vi.advanceTimersByTime(refreshDelay - 1)
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(1)
+
+      // Advance to trigger refresh
+      await vi.advanceTimersByTimeAsync(2)
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries with exponential backoff on transient failures', async () => {
+      const now = Date.now()
+      const expiresInMs = 3600 * 1000
+      const tokenResponseWithFutureExpiry = {
+        ...mockTokenResponse,
+        expires_at: new Date(now + expiresInMs).toISOString()
+      }
+
+      // Return very far future expiry on success to prevent another refresh cycle
+      const farFutureResponse = {
+        ...mockTokenResponse,
+        expires_at: new Date(now + 24 * 3600 * 1000).toISOString()
+      }
+
+      // First call succeeds (initialization), then fail twice, then succeed with far future
+      mockWorkspaceApi.exchangeToken
+        .mockResolvedValueOnce(tokenResponseWithFutureExpiry) // Initial
+        .mockRejectedValueOnce(new Error('Network error')) // Refresh attempt 1
+        .mockRejectedValueOnce(new Error('Network error')) // Retry 1
+        .mockResolvedValueOnce(farFutureResponse) // Retry 2 succeeds
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(1)
+
+      // Advance to trigger refresh
+      const refreshBufferMs = 5 * 60 * 1000
+      const refreshDelay = expiresInMs - refreshBufferMs
+      await vi.advanceTimersByTimeAsync(refreshDelay)
+
+      // First attempt fires immediately, then waits 1s for retry
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(2)
+
+      // Wait for first retry (1s backoff)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(3)
+
+      // Wait for second retry (2s backoff)
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(4)
+    })
+
+    it('clears context when refresh fails with ACCESS_DENIED', async () => {
+      const expiresInMs = 3600 * 1000
+      const tokenResponseWithFutureExpiry = {
+        ...mockTokenResponse,
+        expires_at: new Date(Date.now() + expiresInMs).toISOString()
+      }
+
+      mockWorkspaceApi.exchangeToken
+        .mockResolvedValueOnce(tokenResponseWithFutureExpiry)
+        .mockRejectedValueOnce(
+          new mockWorkspaceApiError('Access denied', 403, 'ACCESS_DENIED')
+        )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(mockSessionManager.setWorkspaceToken).toHaveBeenCalled()
+
+      // Advance to trigger refresh
+      const refreshBufferMs = 5 * 60 * 1000
+      const refreshDelay = expiresInMs - refreshBufferMs
+      await vi.advanceTimersByTimeAsync(refreshDelay + 100)
+
+      // Should clear token on permanent error
+      expect(mockSessionManager.clearWorkspaceToken).toHaveBeenCalled()
+    })
+
+    it('aborts stale refresh when workspace context changes', async () => {
+      const expiresInMs = 3600 * 1000
+      const tokenResponseWithFutureExpiry = {
+        ...mockTokenResponse,
+        expires_at: new Date(Date.now() + expiresInMs).toISOString()
+      }
+      mockWorkspaceApi.exchangeToken.mockResolvedValue(
+        tokenResponseWithFutureExpiry
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      // Start refresh timer, then switch workspace (which clears token context)
+      const refreshBufferMs = 5 * 60 * 1000
+      const refreshDelay = expiresInMs - refreshBufferMs
+
+      // Advance partway
+      vi.advanceTimersByTime(refreshDelay - 1000)
+
+      // Switch workspace clears token context and increments request ID
+      await store.switchWorkspace(mockTeamWorkspace.id)
+
+      // Advance past when refresh would have fired
+      await vi.advanceTimersByTimeAsync(2000)
+
+      // exchangeToken should only have been called once (during init)
+      // because switchWorkspace triggers a reload, not another exchange
+      expect(mockWorkspaceApi.exchangeToken).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('switchWorkspace', () => {
+    it('does nothing if switching to current workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const currentId = store.activeWorkspaceId
+      await store.switchWorkspace(currentId!)
+
+      expect(mockSessionManager.switchWorkspaceAndReload).not.toHaveBeenCalled()
+    })
+
+    it('calls switchWorkspaceAndReload for valid workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await store.switchWorkspace(mockTeamWorkspace.id)
+
+      expect(mockSessionManager.switchWorkspaceAndReload).toHaveBeenCalledWith(
+        mockTeamWorkspace.id
+      )
+    })
+
+    it('sets isSwitching flag during operation', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.isSwitching).toBe(false)
+
+      const switchPromise = store.switchWorkspace(mockTeamWorkspace.id)
+      expect(store.isSwitching).toBe(true)
+
+      await switchPromise
+      // Note: isSwitching stays true because page reloads
+    })
+
+    it('refreshes workspace list if target not found', async () => {
+      const newWorkspace = {
+        id: 'ws-new-999',
+        name: 'New Workspace',
+        type: 'team' as const,
+        role: 'member' as const
+      }
+
+      // First list returns without new workspace
+      mockWorkspaceApi.list
+        .mockResolvedValueOnce({
+          workspaces: [mockPersonalWorkspace, mockTeamWorkspace]
+        })
+        // Second list (refresh) includes new workspace
+        .mockResolvedValueOnce({
+          workspaces: [mockPersonalWorkspace, mockTeamWorkspace, newWorkspace]
+        })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await store.switchWorkspace(newWorkspace.id)
+
+      expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(2)
+      expect(mockSessionManager.switchWorkspaceAndReload).toHaveBeenCalledWith(
+        newWorkspace.id
+      )
+    })
+
+    it('throws if workspace not found after refresh', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await expect(
+        store.switchWorkspace('non-existent-workspace')
+      ).rejects.toThrow('Workspace not found or access denied')
+
+      expect(store.isSwitching).toBe(false)
+    })
+  })
+
+  describe('createWorkspace', () => {
+    it('creates workspace and triggers reload', async () => {
+      const newWorkspace = {
+        id: 'ws-new-created',
+        name: 'Created Workspace',
+        type: 'team' as const,
+        role: 'owner' as const
+      }
+      mockWorkspaceApi.create.mockResolvedValue(newWorkspace)
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.createWorkspace('Created Workspace')
+
+      expect(mockWorkspaceApi.create).toHaveBeenCalledWith({
+        name: 'Created Workspace'
+      })
+      expect(result.id).toBe(newWorkspace.id)
+      expect(store.workspaces).toContainEqual(
+        expect.objectContaining({ id: newWorkspace.id })
+      )
+      expect(mockSessionManager.switchWorkspaceAndReload).toHaveBeenCalledWith(
+        newWorkspace.id
+      )
+    })
+
+    it('sets isCreating flag during operation', async () => {
+      let resolveCreate: (value: unknown) => void
+      const createPromise = new Promise((resolve) => {
+        resolveCreate = resolve
+      })
+      mockWorkspaceApi.create.mockReturnValue(createPromise)
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.isCreating).toBe(false)
+
+      const resultPromise = store.createWorkspace('New Workspace')
+      expect(store.isCreating).toBe(true)
+
+      resolveCreate!({
+        id: 'ws-new',
+        name: 'New Workspace',
+        type: 'team',
+        role: 'owner'
+      })
+      await resultPromise
+    })
+
+    it('resets isCreating on error', async () => {
+      mockWorkspaceApi.create.mockRejectedValue(new Error('Creation failed'))
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await expect(store.createWorkspace('New Workspace')).rejects.toThrow(
+        'Creation failed'
+      )
+      expect(store.isCreating).toBe(false)
+    })
+  })
+
+  describe('deleteWorkspace', () => {
+    it('deletes non-active workspace without reload', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      // Active is personal, delete team workspace
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+
+      await store.deleteWorkspace(mockTeamWorkspace.id)
+
+      expect(mockWorkspaceApi.delete).toHaveBeenCalledWith(mockTeamWorkspace.id)
+      expect(store.workspaces).not.toContainEqual(
+        expect.objectContaining({ id: mockTeamWorkspace.id })
+      )
+      expect(mockSessionManager.switchWorkspaceAndReload).not.toHaveBeenCalled()
+    })
+
+    it('deletes active workspace and reloads to personal', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
+
+      await store.deleteWorkspace()
+
+      expect(mockWorkspaceApi.delete).toHaveBeenCalledWith(mockTeamWorkspace.id)
+      expect(mockSessionManager.switchWorkspaceAndReload).toHaveBeenCalledWith(
+        mockPersonalWorkspace.id
+      )
+    })
+
+    it('throws when trying to delete personal workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await expect(
+        store.deleteWorkspace(mockPersonalWorkspace.id)
+      ).rejects.toThrow('Cannot delete personal workspace')
+    })
+
+    it('throws when workspace not found', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await expect(store.deleteWorkspace('non-existent')).rejects.toThrow(
+        'Workspace not found'
+      )
+    })
+  })
+
+  describe('renameWorkspace', () => {
+    it('updates workspace name locally', async () => {
+      mockWorkspaceApi.update.mockResolvedValue({
+        ...mockTeamWorkspace,
+        name: 'Renamed Workspace'
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await store.renameWorkspace(mockTeamWorkspace.id, 'Renamed Workspace')
+
+      expect(mockWorkspaceApi.update).toHaveBeenCalledWith(
+        mockTeamWorkspace.id,
+        {
+          name: 'Renamed Workspace'
+        }
+      )
+
+      const updated = store.workspaces.find(
+        (w) => w.id === mockTeamWorkspace.id
+      )
+      expect(updated?.name).toBe('Renamed Workspace')
+    })
+  })
+
+  describe('leaveWorkspace', () => {
+    it('leaves workspace and reloads to personal', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockMemberWorkspace.id
+      )
+      mockWorkspaceApi.list.mockResolvedValue({
+        workspaces: [mockPersonalWorkspace, mockMemberWorkspace]
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await store.leaveWorkspace()
+
+      expect(mockWorkspaceApi.leave).toHaveBeenCalled()
+      expect(mockSessionManager.switchWorkspaceAndReload).toHaveBeenCalledWith(
+        mockPersonalWorkspace.id
+      )
+    })
+
+    it('throws when trying to leave personal workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      // Active is personal by default
+      await expect(store.leaveWorkspace()).rejects.toThrow(
+        'Cannot leave personal workspace'
+      )
+    })
+  })
+
+  describe('computed properties', () => {
+    it('activeWorkspace returns correct workspace', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.activeWorkspace?.id).toBe(mockTeamWorkspace.id)
+      expect(store.activeWorkspace?.name).toBe(mockTeamWorkspace.name)
+    })
+
+    it('personalWorkspace returns personal workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.personalWorkspace?.id).toBe(mockPersonalWorkspace.id)
+      expect(store.personalWorkspace?.type).toBe('personal')
+    })
+
+    it('isInPersonalWorkspace returns true when in personal', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.isInPersonalWorkspace).toBe(true)
+    })
+
+    it('isInPersonalWorkspace returns false when in team', async () => {
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.isInPersonalWorkspace).toBe(false)
+    })
+
+    it('sharedWorkspaces excludes personal workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.sharedWorkspaces).toHaveLength(1)
+      expect(store.sharedWorkspaces[0].id).toBe(mockTeamWorkspace.id)
+    })
+
+    it('ownedWorkspacesCount counts owned workspaces', async () => {
+      mockWorkspaceApi.list.mockResolvedValue({
+        workspaces: [
+          mockPersonalWorkspace,
+          mockTeamWorkspace,
+          mockMemberWorkspace
+        ]
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      // personal (owner) + team (owner) = 2, member workspace doesn't count
+      expect(store.ownedWorkspacesCount).toBe(2)
+    })
+
+    it('canCreateWorkspace respects limit', async () => {
+      // Create 10 owned workspaces (max limit)
+      const manyWorkspaces = Array.from({ length: 10 }, (_, i) => ({
+        id: `ws-owned-${i}`,
+        name: `Owned ${i}`,
+        type: 'team' as const,
+        role: 'owner' as const
+      }))
+
+      mockWorkspaceApi.list.mockResolvedValue({
+        workspaces: [mockPersonalWorkspace, ...manyWorkspaces]
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.ownedWorkspacesCount).toBe(11) // personal + 10
+      expect(store.canCreateWorkspace).toBe(false)
+    })
+  })
+
+  describe('member actions', () => {
+    it('fetchMembers updates active workspace members', async () => {
+      const mockMembers = [
+        {
+          id: 'user-1',
+          name: 'User One',
+          email: 'one@test.com',
+          joined_at: '2024-01-01T00:00:00Z'
+        },
+        {
+          id: 'user-2',
+          name: 'User Two',
+          email: 'two@test.com',
+          joined_at: '2024-01-02T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: mockMembers,
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.fetchMembers()
+
+      expect(result).toHaveLength(2)
+      expect(store.members).toHaveLength(2)
+      expect(store.members[0].name).toBe('User One')
+    })
+
+    it('fetchMembers returns empty for personal workspace', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.fetchMembers()
+
+      expect(result).toEqual([])
+      expect(mockWorkspaceApi.listMembers).not.toHaveBeenCalled()
+    })
+
+    it('removeMember removes from local list', async () => {
+      const mockMembers = [
+        {
+          id: 'user-1',
+          name: 'User One',
+          email: 'one@test.com',
+          joined_at: '2024-01-01T00:00:00Z'
+        },
+        {
+          id: 'user-2',
+          name: 'User Two',
+          email: 'two@test.com',
+          joined_at: '2024-01-02T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: mockMembers,
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      expect(store.members).toHaveLength(2)
+
+      await store.removeMember('user-1')
+
+      expect(mockWorkspaceApi.removeMember).toHaveBeenCalledWith('user-1')
+      expect(store.members).toHaveLength(1)
+      expect(store.members[0].id).toBe('user-2')
+    })
+  })
+
+  describe('invite actions', () => {
+    it('fetchPendingInvites updates active workspace invites', async () => {
+      const mockInvites = [
+        {
+          id: 'inv-1',
+          email: 'invite@test.com',
+          token: 'token-abc',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.fetchPendingInvites()
+
+      expect(result).toHaveLength(1)
+      expect(store.pendingInvites).toHaveLength(1)
+      expect(store.pendingInvites[0].email).toBe('invite@test.com')
+    })
+
+    it('createInvite adds to local list', async () => {
+      const newInvite = {
+        id: 'inv-new',
+        email: 'new@test.com',
+        token: 'token-new',
+        invited_at: '2024-01-01T00:00:00Z',
+        expires_at: '2024-01-08T00:00:00Z'
+      }
+      mockWorkspaceApi.createInvite.mockResolvedValue(newInvite)
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.createInvite('new@test.com')
+
+      expect(mockWorkspaceApi.createInvite).toHaveBeenCalledWith({
+        email: 'new@test.com'
+      })
+      expect(result.email).toBe('new@test.com')
+      expect(store.pendingInvites).toContainEqual(
+        expect.objectContaining({ email: 'new@test.com' })
+      )
+    })
+
+    it('revokeInvite removes from local list', async () => {
+      const mockInvites = [
+        {
+          id: 'inv-1',
+          email: 'one@test.com',
+          token: 'token-1',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        },
+        {
+          id: 'inv-2',
+          email: 'two@test.com',
+          token: 'token-2',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchPendingInvites()
+
+      await store.revokeInvite('inv-1')
+
+      expect(mockWorkspaceApi.revokeInvite).toHaveBeenCalledWith('inv-1')
+      expect(store.pendingInvites).toHaveLength(1)
+      expect(store.pendingInvites[0].id).toBe('inv-2')
+    })
+
+    it('acceptInvite refreshes workspace list', async () => {
+      mockWorkspaceApi.acceptInvite.mockResolvedValue({
+        workspace_id: 'ws-joined',
+        workspace_name: 'Joined Workspace'
+      })
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.acceptInvite('invite-token')
+
+      expect(mockWorkspaceApi.acceptInvite).toHaveBeenCalledWith('invite-token')
+      expect(result.workspaceId).toBe('ws-joined')
+      expect(result.workspaceName).toBe('Joined Workspace')
+      // list is called twice: once in init, once after accept
+      expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('invite link helpers', () => {
+    it('getInviteLink returns link for existing invite', async () => {
+      const mockInvites = [
+        {
+          id: 'inv-1',
+          email: 'test@test.com',
+          token: 'secret-token',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchPendingInvites()
+
+      const link = store.getInviteLink('inv-1')
+
+      expect(link).toContain('?invite=secret-token')
+    })
+
+    it('getInviteLink returns null for non-existent invite', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const link = store.getInviteLink('non-existent')
+
+      expect(link).toBeNull()
+    })
+
+    it('createInviteLink creates invite and returns link', async () => {
+      const newInvite = {
+        id: 'inv-new',
+        email: 'new@test.com',
+        token: 'new-token',
+        invited_at: '2024-01-01T00:00:00Z',
+        expires_at: '2024-01-08T00:00:00Z'
+      }
+      mockWorkspaceApi.createInvite.mockResolvedValue(newInvite)
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const link = await store.createInviteLink('new@test.com')
+
+      expect(link).toContain('?invite=new-token')
+    })
+  })
+
+  describe('cleanup', () => {
+    it('destroy clears token context and stops refresh timer', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      store.destroy()
+
+      expect(mockSessionManager.clearWorkspaceToken).toHaveBeenCalled()
+    })
+  })
+
+  describe('totalMemberSlots and isInviteLimitReached', () => {
+    it('calculates total slots from members and invites', async () => {
+      const mockMembers = [
+        {
+          id: 'user-1',
+          name: 'User One',
+          email: 'one@test.com',
+          joined_at: '2024-01-01T00:00:00Z'
+        }
+      ]
+      const mockInvites = [
+        {
+          id: 'inv-1',
+          email: 'invite@test.com',
+          token: 'token-1',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        },
+        {
+          id: 'inv-2',
+          email: 'invite2@test.com',
+          token: 'token-2',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: mockMembers,
+        pagination: { offset: 0, limit: 50, total: 1 }
+      })
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+      await store.fetchPendingInvites()
+
+      expect(store.totalMemberSlots).toBe(3) // 1 member + 2 invites
+      expect(store.isInviteLimitReached).toBe(false)
+    })
+
+    it('isInviteLimitReached returns true at 50 slots', async () => {
+      const mockMembers = Array.from({ length: 48 }, (_, i) => ({
+        id: `user-${i}`,
+        name: `User ${i}`,
+        email: `user${i}@test.com`,
+        joined_at: '2024-01-01T00:00:00Z'
+      }))
+      const mockInvites = [
+        {
+          id: 'inv-1',
+          email: 'invite1@test.com',
+          token: 'token-1',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        },
+        {
+          id: 'inv-2',
+          email: 'invite2@test.com',
+          token: 'token-2',
+          invited_at: '2024-01-01T00:00:00Z',
+          expires_at: '2024-01-08T00:00:00Z'
+        }
+      ]
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: mockMembers,
+        pagination: { offset: 0, limit: 50, total: 48 }
+      })
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
+      mockSessionManager.getCurrentWorkspaceId.mockReturnValue(
+        mockTeamWorkspace.id
+      )
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+      await store.fetchPendingInvites()
+
+      expect(store.totalMemberSlots).toBe(50)
+      expect(store.isInviteLimitReached).toBe(true)
+    })
+  })
+})

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -1,0 +1,780 @@
+import { defineStore } from 'pinia'
+import { computed, ref, shallowRef } from 'vue'
+
+import { TOKEN_REFRESH_BUFFER_MS } from '@/platform/auth/workspace/workspaceConstants'
+
+import { sessionManager } from '../services/sessionManager'
+import type {
+  ExchangeTokenResponse,
+  ListMembersParams,
+  Member,
+  PendingInvite as ApiPendingInvite,
+  WorkspaceWithRole
+} from '../api/workspaceApi'
+import { workspaceApi, WorkspaceApiError } from '../api/workspaceApi'
+
+// Extended member type for UI (adds joinDate as Date)
+export interface WorkspaceMember {
+  id: string
+  name: string
+  email: string
+  joinDate: Date
+}
+
+// Extended invite type for UI (adds dates as Date objects)
+export interface PendingInvite {
+  id: string
+  email: string
+  token: string
+  inviteDate: Date
+  expiryDate: Date
+}
+
+type SubscriptionPlan = 'PRO_MONTHLY' | 'PRO_YEARLY' | null
+
+interface WorkspaceState extends WorkspaceWithRole {
+  isSubscribed: boolean
+  subscriptionPlan: SubscriptionPlan
+  members: WorkspaceMember[]
+  pendingInvites: PendingInvite[]
+}
+
+type InitState = 'uninitialized' | 'loading' | 'ready' | 'error'
+
+function mapApiMemberToWorkspaceMember(member: Member): WorkspaceMember {
+  return {
+    id: member.id,
+    name: member.name,
+    email: member.email,
+    joinDate: new Date(member.joined_at)
+  }
+}
+
+function mapApiInviteToPendingInvite(invite: ApiPendingInvite): PendingInvite {
+  return {
+    id: invite.id,
+    email: invite.email,
+    token: invite.token,
+    inviteDate: new Date(invite.invited_at),
+    expiryDate: new Date(invite.expires_at)
+  }
+}
+
+function createWorkspaceState(workspace: WorkspaceWithRole): WorkspaceState {
+  return {
+    ...workspace,
+    isSubscribed: false,
+    subscriptionPlan: null,
+    members: [],
+    pendingInvites: []
+  }
+}
+
+// Workspace limits
+const MAX_OWNED_WORKSPACES = 10
+const MAX_WORKSPACE_MEMBERS = 50
+
+export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
+  // ════════════════════════════════════════════════════════════
+  // STATE
+  // ════════════════════════════════════════════════════════════
+
+  const initState = ref<InitState>('uninitialized')
+  const workspaces = shallowRef<WorkspaceState[]>([])
+  const activeWorkspaceId = ref<string | null>(null)
+  const error = ref<Error | null>(null)
+
+  // Loading states for UI
+  const isCreating = ref(false)
+  const isDeleting = ref(false)
+  const isSwitching = ref(false)
+  const isFetchingWorkspaces = ref(false)
+
+  // Token refresh timer state
+  let refreshTimerId: ReturnType<typeof setTimeout> | null = null
+  // Request ID to prevent stale refresh operations from overwriting newer workspace contexts
+  let tokenRefreshRequestId = 0
+
+  // ════════════════════════════════════════════════════════════
+  // COMPUTED
+  // ════════════════════════════════════════════════════════════
+
+  const activeWorkspace = computed(
+    () => workspaces.value.find((w) => w.id === activeWorkspaceId.value) ?? null
+  )
+
+  const personalWorkspace = computed(
+    () => workspaces.value.find((w) => w.type === 'personal') ?? null
+  )
+
+  const isInPersonalWorkspace = computed(
+    () => activeWorkspace.value?.type === 'personal'
+  )
+
+  const sharedWorkspaces = computed(() =>
+    workspaces.value.filter((w) => w.type !== 'personal')
+  )
+
+  const ownedWorkspacesCount = computed(
+    () => workspaces.value.filter((w) => w.role === 'owner').length
+  )
+
+  const canCreateWorkspace = computed(
+    () => ownedWorkspacesCount.value < MAX_OWNED_WORKSPACES
+  )
+
+  const members = computed<WorkspaceMember[]>(
+    () => activeWorkspace.value?.members ?? []
+  )
+
+  const pendingInvites = computed<PendingInvite[]>(
+    () => activeWorkspace.value?.pendingInvites ?? []
+  )
+
+  const totalMemberSlots = computed(
+    () => members.value.length + pendingInvites.value.length
+  )
+
+  const isInviteLimitReached = computed(
+    () => totalMemberSlots.value >= MAX_WORKSPACE_MEMBERS
+  )
+
+  const workspaceId = computed(() => activeWorkspace.value?.id ?? null)
+
+  const workspaceName = computed(() => activeWorkspace.value?.name ?? '')
+
+  const isWorkspaceSubscribed = computed(
+    () => activeWorkspace.value?.isSubscribed ?? false
+  )
+
+  const subscriptionPlan = computed(
+    () => activeWorkspace.value?.subscriptionPlan ?? null
+  )
+
+  // ════════════════════════════════════════════════════════════
+  // INTERNAL HELPERS
+  // ════════════════════════════════════════════════════════════
+
+  function updateWorkspace(
+    workspaceId: string,
+    updates: Partial<WorkspaceState>
+  ) {
+    const index = workspaces.value.findIndex((w) => w.id === workspaceId)
+    if (index === -1) return
+
+    const current = workspaces.value[index]
+    const updated = { ...current, ...updates }
+    workspaces.value = [
+      ...workspaces.value.slice(0, index),
+      updated,
+      ...workspaces.value.slice(index + 1)
+    ]
+  }
+
+  function updateActiveWorkspace(updates: Partial<WorkspaceState>) {
+    if (!activeWorkspaceId.value) return
+    updateWorkspace(activeWorkspaceId.value, updates)
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // TOKEN MANAGEMENT
+  // ════════════════════════════════════════════════════════════
+
+  function stopRefreshTimer(): void {
+    if (refreshTimerId !== null) {
+      clearTimeout(refreshTimerId)
+      refreshTimerId = null
+    }
+  }
+
+  function scheduleTokenRefresh(expiresAt: number): void {
+    stopRefreshTimer()
+    const now = Date.now()
+    const refreshAt = expiresAt - TOKEN_REFRESH_BUFFER_MS
+    const delay = Math.max(0, refreshAt - now)
+
+    refreshTimerId = setTimeout(() => {
+      void refreshWorkspaceToken()
+    }, delay)
+  }
+
+  /**
+   * Exchange Firebase token for workspace-scoped token.
+   * Stores the token in sessionStorage and schedules refresh.
+   */
+  async function exchangeAndStoreToken(
+    workspaceId: string
+  ): Promise<ExchangeTokenResponse> {
+    const response = await workspaceApi.exchangeToken(workspaceId)
+    const expiresAt = new Date(response.expires_at).getTime()
+
+    if (isNaN(expiresAt)) {
+      throw new Error('Invalid token expiry timestamp from server')
+    }
+
+    // Store token in sessionStorage
+    sessionManager.setWorkspaceToken(response.token, expiresAt)
+
+    // Schedule refresh before expiry
+    scheduleTokenRefresh(expiresAt)
+
+    return response
+  }
+
+  /**
+   * Refresh the workspace token.
+   * Called automatically before token expires.
+   * Includes retry logic for transient failures.
+   */
+  async function refreshWorkspaceToken(): Promise<void> {
+    if (!activeWorkspaceId.value) return
+
+    const workspaceId = activeWorkspaceId.value
+    const capturedRequestId = tokenRefreshRequestId
+    const maxRetries = 3
+    const baseDelayMs = 1000
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      // Check if workspace context changed during refresh
+      if (capturedRequestId !== tokenRefreshRequestId) {
+        console.warn(
+          '[workspaceStore] Aborting stale token refresh: workspace context changed'
+        )
+        return
+      }
+
+      try {
+        await exchangeAndStoreToken(workspaceId)
+        return
+      } catch (err) {
+        const isApiError = err instanceof WorkspaceApiError
+
+        // Permanent errors - don't retry
+        const isPermanentError =
+          isApiError &&
+          (err.code === 'ACCESS_DENIED' ||
+            err.code === 'WORKSPACE_NOT_FOUND' ||
+            err.code === 'INVALID_FIREBASE_TOKEN' ||
+            err.code === 'NOT_AUTHENTICATED')
+
+        if (isPermanentError) {
+          if (capturedRequestId === tokenRefreshRequestId) {
+            console.error(
+              '[workspaceStore] Workspace access revoked or auth invalid:',
+              err
+            )
+            clearTokenContext()
+          }
+          return
+        }
+
+        // Transient errors - retry with backoff
+        if (attempt < maxRetries) {
+          const delay = baseDelayMs * Math.pow(2, attempt)
+          console.warn(
+            `[workspaceStore] Token refresh failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`,
+            err
+          )
+          await new Promise((resolve) => setTimeout(resolve, delay))
+          continue
+        }
+
+        // All retries exhausted
+        if (capturedRequestId === tokenRefreshRequestId) {
+          console.error(
+            '[workspaceStore] Failed to refresh token after retries:',
+            err
+          )
+          clearTokenContext()
+        }
+      }
+    }
+  }
+
+  /**
+   * Clear token context (on auth failure or workspace switch).
+   */
+  function clearTokenContext(): void {
+    tokenRefreshRequestId++
+    stopRefreshTimer()
+    sessionManager.clearWorkspaceToken()
+  }
+
+  /**
+   * Check if we have a valid token in sessionStorage (for page refresh).
+   * If valid, schedule refresh timer. If expired, return false.
+   */
+  function initializeTokenFromSession(): boolean {
+    const tokenData = sessionManager.getWorkspaceToken()
+    if (!tokenData) return false
+
+    const { expiresAt } = tokenData
+    if (Date.now() >= expiresAt) {
+      // Token expired, clear it
+      sessionManager.clearWorkspaceToken()
+      return false
+    }
+
+    // Token still valid, schedule refresh
+    scheduleTokenRefresh(expiresAt)
+    return true
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // INITIALIZATION
+  // ════════════════════════════════════════════════════════════
+
+  /**
+   * Initialize the workspace store.
+   * Fetches workspaces and resolves the active workspace from session/localStorage.
+   * Call once on app boot.
+   */
+  async function initialize(): Promise<void> {
+    if (initState.value !== 'uninitialized') return
+
+    initState.value = 'loading'
+    isFetchingWorkspaces.value = true
+    error.value = null
+
+    try {
+      // 1. Fetch all workspaces
+      const response = await workspaceApi.list()
+      workspaces.value = response.workspaces.map(createWorkspaceState)
+
+      if (workspaces.value.length === 0) {
+        throw new Error('No workspaces available')
+      }
+
+      // 2. Determine active workspace (priority: sessionStorage > localStorage > personal)
+      let targetWorkspaceId: string | null = null
+
+      // Try sessionStorage first (page refresh)
+      const sessionId = sessionManager.getCurrentWorkspaceId()
+      if (sessionId && workspaces.value.some((w) => w.id === sessionId)) {
+        targetWorkspaceId = sessionId
+      }
+
+      // Try localStorage (cross-session persistence)
+      if (!targetWorkspaceId) {
+        const lastId = sessionManager.getLastWorkspaceId()
+        if (lastId && workspaces.value.some((w) => w.id === lastId)) {
+          targetWorkspaceId = lastId
+        }
+      }
+
+      // Fall back to personal workspace
+      if (!targetWorkspaceId) {
+        const personal = workspaces.value.find((w) => w.type === 'personal')
+        targetWorkspaceId = personal?.id ?? workspaces.value[0].id
+      }
+
+      // 3. Set active workspace
+      activeWorkspaceId.value = targetWorkspaceId
+      sessionManager.setCurrentWorkspaceId(targetWorkspaceId)
+      sessionManager.setLastWorkspaceId(targetWorkspaceId)
+
+      // 4. Initialize workspace token
+      // First check if we have a valid token from session (page refresh case)
+      const hasValidToken = initializeTokenFromSession()
+
+      if (!hasValidToken) {
+        // No valid token - exchange Firebase token for workspace token
+        try {
+          await exchangeAndStoreToken(targetWorkspaceId)
+        } catch (tokenError) {
+          // Log but don't fail initialization - API calls will fall back to Firebase token
+          console.error(
+            '[workspaceStore] Token exchange failed during init:',
+            tokenError
+          )
+        }
+      }
+
+      initState.value = 'ready'
+    } catch (e) {
+      error.value = e instanceof Error ? e : new Error('Unknown error')
+      initState.value = 'error'
+      throw e
+    } finally {
+      isFetchingWorkspaces.value = false
+    }
+  }
+
+  /**
+   * Re-fetch workspaces from API without changing active workspace.
+   */
+  async function refreshWorkspaces(): Promise<void> {
+    isFetchingWorkspaces.value = true
+    try {
+      const response = await workspaceApi.list()
+      workspaces.value = response.workspaces.map(createWorkspaceState)
+    } finally {
+      isFetchingWorkspaces.value = false
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // WORKSPACE ACTIONS
+  // ════════════════════════════════════════════════════════════
+
+  /**
+   * Switch to a different workspace.
+   * Sets session storage and reloads the page.
+   */
+  async function switchWorkspace(workspaceId: string): Promise<void> {
+    if (workspaceId === activeWorkspaceId.value) return
+
+    // Invalidate any in-flight token refresh for the old workspace
+    clearTokenContext()
+
+    isSwitching.value = true
+
+    try {
+      // Verify workspace exists in our list (user has access)
+      const workspace = workspaces.value.find((w) => w.id === workspaceId)
+      if (!workspace) {
+        // Workspace not in list - try refetching in case it was added
+        await refreshWorkspaces()
+        const refreshedWorkspace = workspaces.value.find(
+          (w) => w.id === workspaceId
+        )
+        if (!refreshedWorkspace) {
+          throw new Error('Workspace not found or access denied')
+        }
+      }
+
+      // Success - switch and reload
+      sessionManager.switchWorkspaceAndReload(workspaceId)
+      // Code after this won't run (page reloads)
+    } catch (e) {
+      isSwitching.value = false
+      throw e
+    }
+  }
+
+  /**
+   * Create a new workspace and switch to it.
+   */
+  async function createWorkspace(name: string): Promise<WorkspaceState> {
+    isCreating.value = true
+
+    try {
+      const newWorkspace = await workspaceApi.create({ name })
+      const workspaceState = createWorkspaceState(newWorkspace)
+
+      // Add to local list
+      workspaces.value = [...workspaces.value, workspaceState]
+
+      // Switch to new workspace (triggers reload)
+      sessionManager.switchWorkspaceAndReload(newWorkspace.id)
+
+      // Code after this won't run (page reloads)
+      return workspaceState
+    } catch (e) {
+      isCreating.value = false
+      throw e
+    }
+  }
+
+  /**
+   * Delete a workspace.
+   * If deleting active workspace, switches to personal.
+   */
+  async function deleteWorkspace(workspaceId?: string): Promise<void> {
+    const targetId = workspaceId ?? activeWorkspaceId.value
+    if (!targetId) throw new Error('No workspace to delete')
+
+    const workspace = workspaces.value.find((w) => w.id === targetId)
+    if (!workspace) throw new Error('Workspace not found')
+    if (workspace.type === 'personal') {
+      throw new Error('Cannot delete personal workspace')
+    }
+
+    isDeleting.value = true
+
+    try {
+      await workspaceApi.delete(targetId)
+
+      if (targetId === activeWorkspaceId.value) {
+        // Deleted active workspace - go to personal
+        const personal = personalWorkspace.value
+        if (personal) {
+          sessionManager.switchWorkspaceAndReload(personal.id)
+        } else {
+          sessionManager.clearAndReload()
+        }
+        // Code after this won't run (page reloads)
+      } else {
+        // Deleted non-active workspace - just update local list
+        workspaces.value = workspaces.value.filter((w) => w.id !== targetId)
+        isDeleting.value = false
+      }
+    } catch (e) {
+      isDeleting.value = false
+      throw e
+    }
+  }
+
+  /**
+   * Rename a workspace. No reload needed.
+   */
+  async function renameWorkspace(
+    workspaceId: string,
+    newName: string
+  ): Promise<void> {
+    const updated = await workspaceApi.update(workspaceId, { name: newName })
+    updateWorkspace(workspaceId, { name: updated.name })
+  }
+
+  /**
+   * Update workspace name (convenience for current workspace).
+   */
+  async function updateWorkspaceName(name: string): Promise<void> {
+    if (!activeWorkspaceId.value) {
+      throw new Error('No active workspace')
+    }
+    await renameWorkspace(activeWorkspaceId.value, name)
+  }
+
+  /**
+   * Leave the current workspace.
+   * Switches to personal workspace after leaving.
+   */
+  async function leaveWorkspace(): Promise<void> {
+    const current = activeWorkspace.value
+    if (!current || current.type === 'personal') {
+      throw new Error('Cannot leave personal workspace')
+    }
+
+    await workspaceApi.leave()
+
+    // Go to personal workspace
+    const personal = personalWorkspace.value
+    if (personal) {
+      sessionManager.switchWorkspaceAndReload(personal.id)
+    } else {
+      sessionManager.clearAndReload()
+    }
+    // Code after this won't run (page reloads)
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // MEMBER ACTIONS
+  // ════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch members for the current workspace.
+   */
+  async function fetchMembers(
+    params?: ListMembersParams
+  ): Promise<WorkspaceMember[]> {
+    if (!activeWorkspaceId.value) return []
+    if (activeWorkspace.value?.type === 'personal') return []
+
+    const response = await workspaceApi.listMembers(params)
+    const members = response.members.map(mapApiMemberToWorkspaceMember)
+    updateActiveWorkspace({ members })
+    return members
+  }
+
+  /**
+   * Remove a member from the current workspace.
+   */
+  async function removeMember(userId: string): Promise<void> {
+    await workspaceApi.removeMember(userId)
+    const current = activeWorkspace.value
+    if (current) {
+      updateActiveWorkspace({
+        members: current.members.filter((m) => m.id !== userId)
+      })
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // INVITE ACTIONS
+  // ════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch pending invites for the current workspace.
+   */
+  async function fetchPendingInvites(): Promise<PendingInvite[]> {
+    if (!activeWorkspaceId.value) return []
+    if (activeWorkspace.value?.type === 'personal') return []
+
+    const response = await workspaceApi.listInvites()
+    const invites = response.invites.map(mapApiInviteToPendingInvite)
+    updateActiveWorkspace({ pendingInvites: invites })
+    return invites
+  }
+
+  /**
+   * Create an invite for the current workspace.
+   */
+  async function createInvite(email: string): Promise<PendingInvite> {
+    const response = await workspaceApi.createInvite({ email })
+    const invite = mapApiInviteToPendingInvite(response)
+
+    const current = activeWorkspace.value
+    if (current) {
+      updateActiveWorkspace({
+        pendingInvites: [...current.pendingInvites, invite]
+      })
+    }
+
+    return invite
+  }
+
+  /**
+   * Revoke a pending invite.
+   */
+  async function revokeInvite(inviteId: string): Promise<void> {
+    await workspaceApi.revokeInvite(inviteId)
+    const current = activeWorkspace.value
+    if (current) {
+      updateActiveWorkspace({
+        pendingInvites: current.pendingInvites.filter((i) => i.id !== inviteId)
+      })
+    }
+  }
+
+  /**
+   * Accept a workspace invite.
+   * Returns workspace info so UI can offer "View Workspace" button.
+   */
+  async function acceptInvite(
+    token: string
+  ): Promise<{ workspaceId: string; workspaceName: string }> {
+    const response = await workspaceApi.acceptInvite(token)
+
+    // Refresh workspace list to include newly joined workspace
+    await refreshWorkspaces()
+
+    return {
+      workspaceId: response.workspace_id,
+      workspaceName: response.workspace_name
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // INVITE LINK HELPERS
+  // ════════════════════════════════════════════════════════════
+
+  function buildInviteLink(token: string): string {
+    const baseUrl = window.location.origin
+    return `${baseUrl}?invite=${encodeURIComponent(token)}`
+  }
+
+  /**
+   * Get the invite link for a pending invite.
+   */
+  function getInviteLink(inviteId: string): string | null {
+    const invite = activeWorkspace.value?.pendingInvites.find(
+      (i) => i.id === inviteId
+    )
+    return invite ? buildInviteLink(invite.token) : null
+  }
+
+  /**
+   * Create an invite link for a given email.
+   */
+  async function createInviteLink(email: string): Promise<string> {
+    const invite = await createInvite(email)
+    return buildInviteLink(invite.token)
+  }
+
+  /**
+   * Copy an invite link to clipboard.
+   */
+  async function copyInviteLink(inviteId: string): Promise<string> {
+    const invite = activeWorkspace.value?.pendingInvites.find(
+      (i) => i.id === inviteId
+    )
+    if (!invite) {
+      throw new Error('Invite not found')
+    }
+    const inviteLink = buildInviteLink(invite.token)
+    await navigator.clipboard.writeText(inviteLink)
+    return inviteLink
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // SUBSCRIPTION (placeholder for future integration)
+  // ════════════════════════════════════════════════════════════
+
+  function subscribeWorkspace(plan: SubscriptionPlan = 'PRO_MONTHLY') {
+    console.warn(plan, 'Billing endpoint has not been added yet.')
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // CLEANUP
+  // ════════════════════════════════════════════════════════════
+
+  /**
+   * Clean up store resources (timers, etc.).
+   * Call when the store is no longer needed.
+   */
+  function destroy(): void {
+    clearTokenContext()
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // RETURN
+  // ════════════════════════════════════════════════════════════
+
+  return {
+    // State
+    initState,
+    workspaces,
+    activeWorkspaceId,
+    error,
+    isCreating,
+    isDeleting,
+    isSwitching,
+    isFetchingWorkspaces,
+
+    // Computed
+    activeWorkspace,
+    personalWorkspace,
+    isInPersonalWorkspace,
+    sharedWorkspaces,
+    ownedWorkspacesCount,
+    canCreateWorkspace,
+    members,
+    pendingInvites,
+    totalMemberSlots,
+    isInviteLimitReached,
+    workspaceId,
+    workspaceName,
+    isWorkspaceSubscribed,
+    subscriptionPlan,
+
+    // Initialization & Cleanup
+    initialize,
+    destroy,
+    refreshWorkspaces,
+
+    // Workspace Actions
+    switchWorkspace,
+    createWorkspace,
+    deleteWorkspace,
+    renameWorkspace,
+    updateWorkspaceName,
+    leaveWorkspace,
+
+    // Member Actions
+    fetchMembers,
+    removeMember,
+
+    // Invite Actions
+    fetchPendingInvites,
+    createInvite,
+    revokeInvite,
+    acceptInvite,
+    getInviteLink,
+    createInviteLink,
+    copyInviteLink,
+
+    // Subscription
+    subscribeWorkspace
+  }
+})


### PR DESCRIPTION
**Stack: 2/5** ← depends on #8181

Core Pinia store for workspace state, token refresh, and member management. Includes `useWorkspaceUI` for role-based permissions and `useInviteUrlLoader` for invite handling. **1,400+ lines of tests** (59% coverage). Store not instantiated until flag enabled.

**Files:** `teamWorkspaceStore.ts`, `useWorkspaceUI.ts`, `useInviteUrlLoader.ts`, `useWorkspaceSwitch.ts` + tests

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8182-feat-workspace-2-5-Store-and-composables-with-tests-2ee6d73d3650810ea6fbde0b11aad62b) by [Unito](https://www.unito.io)
