### PR TITLE
Fix properties context menu

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1350,12 +1350,12 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     })
 
     function inner_clicked(
-      this: ContextMenu<string>,
+      this: ContextMenuDivElement,
       v?: string | IContextMenuValue<string>
     ) {
       if (!node || typeof v === 'string' || !v?.value) return
 
-      const rect = this.root.getBoundingClientRect()
+      const rect = this.getBoundingClientRect()
       canvas.showEditPropertyValue(node, v.value, {
         position: [rect.left, rect.top]
       })


### PR DESCRIPTION
A tiny fix for a regression introduced in #7817 that prevented changing a node's properties through the litegraph context menu.
<img width="838" height="568" alt="image" src="https://github.com/user-attachments/assets/a73e8da4-f5ff-4e65-8003-55883f8d08be" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8188-Fix-properties-context-menu-2ee6d73d365081ba8844dd3c8d74432d) by [Unito](https://www.unito.io)
