### PR TITLE
fix: ensure Escape key closes only the active dialog

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -57,11 +57,12 @@ function handleEscapeKey(event: KeyboardEvent) {
   const activeDialog = dialogStore.dialogStack.find(
     (d) => d.key === dialogStore.activeKey
   )
-  if (!activeDialog?.dialogComponentProps.closable) return
+  if (!activeDialog || activeDialog.dialogComponentProps.closable === false)
+    return
 
   event.stopImmediatePropagation()
   event.preventDefault()
-  dialogStore.closeDialog({ key: dialogStore.activeKey! })
+  dialogStore.closeDialog({ key: activeDialog.key })
 }
 
 useEventListener(document, 'keydown', handleEscapeKey, { capture: true })


### PR DESCRIPTION
## Summary
- Fixes the bug where pressing Escape closes the Settings dialog instead of the Sign In dialog when both are open
- Adds custom escape key handler with capture phase to intercept before PrimeVue's built-in handler
- Disables PrimeVue's `closeOnEscape` prop and uses `dialogStore.activeKey` to close only the correct dialog

## Test plan
- [ ] Open Settings dialog
- [ ] Click User tab → "Log in / create account" to open Sign In dialog
- [ ] Press Escape - verify Sign In dialog closes, Settings stays open
- [ ] Press Escape again - verify Settings dialog closes
- [ ] Test with other stacked dialog combinations

Fixes #3996

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8190-fix-ensure-Escape-key-closes-only-the-active-dialog-2ee6d73d3650814db965e1b3d8699a16) by [Unito](https://www.unito.io)
