### PR TITLE
fix: add plurilization to node pack count in custom node manager dialog

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -157,6 +157,7 @@
     "choose_file_to_upload": "choose file to upload",
     "capture": "capture",
     "nodes": "Nodes",
+    "nodesCount": "{count} nodes | {count} node | {count} nodes",
     "community": "Community",
     "all": "All",
     "versionMismatchWarning": "Version Compatibility Warning",

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
@@ -10,15 +10,22 @@ import type {
   RegistryPack
 } from '@/workbench/extensions/manager/types/comfyManagerTypes'
 
+const translateMock = vi.hoisted(() =>
+  vi.fn((key: string, choice?: number) =>
+    typeof choice === 'number' ? `${key}-${choice}` : key
+  )
+)
+const dateMock = vi.hoisted(() => vi.fn(() => '2024. 1. 1.'))
+
 // Mock dependencies
 vi.mock('vue-i18n', () => ({
   useI18n: vi.fn(() => ({
-    d: vi.fn(() => '2024. 1. 1.'),
-    t: vi.fn((key: string) => key)
+    d: dateMock,
+    t: translateMock
   })),
   createI18n: vi.fn(() => ({
     global: {
-      t: vi.fn((key: string) => key),
+      t: translateMock,
       te: vi.fn(() => true)
     }
   }))
@@ -186,6 +193,18 @@ describe('PackCard', () => {
 
       // Should still render without errors
       expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should use localized singular/plural nodes label', () => {
+      const packWithNodes = {
+        ...mockNodePack,
+        comfy_nodes: ['node-a']
+      } as MergedNodePack
+
+      const wrapper = createWrapper({ nodePack: packWithNodes })
+
+      expect(wrapper.text()).toContain('g.nodesCount-1')
+      expect(translateMock).toHaveBeenCalledWith('g.nodesCount', 1)
     })
   })
 

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCard.vue
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCard.vue
@@ -36,8 +36,8 @@
           </p>
           <div class="flex flex-col gap-y-2">
             <div class="flex flex-1 items-center gap-2">
-              <div v-if="nodesCount" class="p-2 pl-0 text-xs">
-                {{ nodesCount }} {{ $t('g.nodes') }}
+              <div v-if="nodesLabel" class="p-2 pl-0 text-xs">
+                {{ nodesLabel }}
               </div>
               <PackVersionBadge
                 :node-pack="nodePack"
@@ -94,7 +94,7 @@ const { nodePack, isSelected = false } = defineProps<{
   isSelected?: boolean
 }>()
 
-const { d } = useI18n()
+const { d, t } = useI18n()
 
 const colorPaletteStore = useColorPaletteStore()
 const isLightTheme = computed(
@@ -114,6 +114,9 @@ const isDisabled = computed(
 
 const nodesCount = computed(() =>
   isMergedNodePack(nodePack) ? nodePack.comfy_nodes?.length : undefined
+)
+const nodesLabel = computed(() =>
+  nodesCount.value ? t('g.nodesCount', nodesCount.value) : ''
 )
 const publisherName = computed(() => {
   if (!nodePack) return null


### PR DESCRIPTION
## Summary
Fix manager pack cards showing “1 nodes” by switching to Vue I18n pluralization.

## Changes
- Use localized `nodesLabel` from `t('g.nodesCount', count)` on the card
- Add `g.nodesCount` plural string to the shared locale bundle
- Cover the new behavior with a PackCard unit test

## Review Focus
Ensure other locales add the new `g.nodesCount` key; English fallback already works.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8191-fix-add-plurilization-to-node-pack-count-in-custom-node-manager-dialog-2ee6d73d36508195ac47eb93ade4bde0) by [Unito](https://www.unito.io)
