### PR TITLE
feat: add isCloud guard to team workspaces feature flag

### DIFF
--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -1,5 +1,6 @@
 import { computed, reactive, readonly } from 'vue'
 
+import { isCloud } from '@/platform/distribution/types'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import { api } from '@/scripts/api'
 
@@ -95,6 +96,8 @@ export function useFeatureFlags() {
       )
     },
     get teamWorkspacesEnabled() {
+      if (!isCloud) return false
+
       return (
         remoteConfig.value.team_workspaces_enabled ??
         api.getServerFeature(ServerFeatureFlag.TEAM_WORKSPACES_ENABLED, false)

--- a/src/platform/assets/components/MediaAssetFilterBar.vue
+++ b/src/platform/assets/components/MediaAssetFilterBar.vue
@@ -6,20 +6,36 @@
       @update:model-value="handleSearchChange"
     />
     <div class="flex gap-1.5 items-center">
-      <MediaAssetFilterButton v-if="isCloud" v-tooltip.top="{ value: $t('assetBrowser.filterBy') }" size="md">
+      <MediaAssetFilterButton
+        v-if="isCloud"
+        v-tooltip.top="{ value: $t('assetBrowser.filterBy') }"
+        size="md"
+      >
         <template #default="{ close }">
           <MediaAssetFilterMenu
             :media-type-filters
             :close
-            @update:media-type-filters="handleMediaTypeFiltersChange" />
+            @update:media-type-filters="handleMediaTypeFiltersChange"
+          />
         </template>
       </MediaAssetFilterButton>
-      <AssetSortButton v-if="isCloud" v-tooltip.top="{ value: $t('assetBrowser.sortBy') }" size="md">
+      <AssetSortButton
+        v-if="isCloud"
+        v-tooltip.top="{ value: $t('assetBrowser.sortBy') }"
+        size="md"
+      >
         <template #default="{ close }">
-          <MediaAssetSortMenu v-model:sort-by="sortBy" :show-generation-time-sort :close />
+          <MediaAssetSortMenu
+            v-model:sort-by="sortBy"
+            :show-generation-time-sort
+            :close
+          />
         </template>
       </AssetSortButton>
-      <MediaAssetViewModeToggle v-if="isQueuePanelV2Enabled" v-model:view-mode="viewMode" />
+      <MediaAssetViewModeToggle
+        v-if="isQueuePanelV2Enabled"
+        v-model:view-mode="viewMode"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Ensures the team_workspaces_enabled feature flag only returns true when running in cloud environment, preventing the feature from activating in local/desktop installations.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8192-feat-add-isCloud-guard-to-team-workspaces-feature-flag-2ee6d73d3650810bb1d7c1721ebcdd44) by [Unito](https://www.unito.io)
