### PR TITLE
[backport core/1.37] feat: add isCloud guard to team workspaces feature flag

### DIFF
--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -1,5 +1,6 @@
 import { computed, reactive, readonly } from 'vue'
 
+import { isCloud } from '@/platform/distribution/types'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import { api } from '@/scripts/api'
 
@@ -16,7 +17,8 @@ export enum ServerFeatureFlag {
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   HUGGINGFACE_MODEL_IMPORT_ENABLED = 'huggingface_model_import_enabled',
-  ASYNC_MODEL_UPLOAD_ENABLED = 'async_model_upload_enabled'
+  ASYNC_MODEL_UPLOAD_ENABLED = 'async_model_upload_enabled',
+  TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled'
 }
 
 /**
@@ -84,6 +86,14 @@ export function useFeatureFlags() {
           ServerFeatureFlag.ASYNC_MODEL_UPLOAD_ENABLED,
           false
         )
+      )
+    },
+    get teamWorkspacesEnabled() {
+      if (!isCloud) return false
+
+      return (
+        remoteConfig.value.team_workspaces_enabled ??
+        api.getServerFeature(ServerFeatureFlag.TEAM_WORKSPACES_ENABLED, false)
       )
     }
   })

--- a/src/platform/assets/components/MediaAssetFilterBar.vue
+++ b/src/platform/assets/components/MediaAssetFilterBar.vue
@@ -5,36 +5,38 @@
       :placeholder="$t('sideToolbar.searchAssets') + '...'"
       @update:model-value="handleSearchChange"
     />
-    <MediaAssetFilterButton
-      v-if="isCloud"
-      v-tooltip.top="{ value: $t('assetBrowser.filterBy') }"
-      size="md"
-    >
-      <template #default="{ close }">
-        <MediaAssetFilterMenu
-          :media-type-filters="mediaTypeFilters"
-          :close="close"
-          @update:media-type-filters="handleMediaTypeFiltersChange"
-        />
-      </template>
-    </MediaAssetFilterButton>
-    <AssetSortButton
-      v-if="isCloud"
-      v-tooltip.top="{ value: $t('assetBrowser.sortBy') }"
-      size="md"
-    >
-      <template #default="{ close }">
-        <MediaAssetSortMenu
-          v-model:sort-by="sortBy"
-          :show-generation-time-sort
-          :close="close"
-        />
-      </template>
-    </AssetSortButton>
-    <MediaAssetViewModeToggle
-      v-if="isQueuePanelV2Enabled"
-      v-model:view-mode="viewMode"
-    />
+    <div class="flex gap-1.5 items-center">
+      <MediaAssetFilterButton
+        v-if="isCloud"
+        v-tooltip.top="{ value: $t('assetBrowser.filterBy') }"
+        size="md"
+      >
+        <template #default="{ close }">
+          <MediaAssetFilterMenu
+            :media-type-filters
+            :close
+            @update:media-type-filters="handleMediaTypeFiltersChange"
+          />
+        </template>
+      </MediaAssetFilterButton>
+      <AssetSortButton
+        v-if="isCloud"
+        v-tooltip.top="{ value: $t('assetBrowser.sortBy') }"
+        size="md"
+      >
+        <template #default="{ close }">
+          <MediaAssetSortMenu
+            v-model:sort-by="sortBy"
+            :show-generation-time-sort
+            :close
+          />
+        </template>
+      </AssetSortButton>
+      <MediaAssetViewModeToggle
+        v-if="isQueuePanelV2Enabled"
+        v-model:view-mode="viewMode"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -41,4 +41,5 @@ export type RemoteConfig = {
   onboarding_survey_enabled?: boolean
   huggingface_model_import_enabled?: boolean
   async_model_upload_enabled?: boolean
+  team_workspaces_enabled?: boolean
 }


### PR DESCRIPTION
## Summary

Backport of #8192 to core/1.37

- Ensures the team_workspaces_enabled feature flag only returns true when running in cloud environment
- Prevents the feature from activating in local/desktop installations
- Added team_workspaces_enabled type to RemoteConfig (required dependency for the feature)

## Conflict Resolution

- **src/composables/useFeatureFlags.ts**: Added TEAM_WORKSPACES_ENABLED enum and teamWorkspacesEnabled getter with isCloud guard
- **src/platform/assets/components/MediaAssetFilterBar.vue**: Accepted PR version with wrapper div and shorthand prop syntax
- **src/platform/remoteConfig/types.ts**: Added team_workspaces_enabled type (required for TypeScript compilation)

## Test plan

- Verify feature flag returns false when not in cloud environment
- Verify feature flag works correctly in cloud environment

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8201-backport-core-1-37-feat-add-isCloud-guard-to-team-workspaces-feature-flag-2ef6d73d36508108be9acdeaf01b2da8) by [Unito](https://www.unito.io)
