### PR TITLE
fix: downgrade vite to 7.3.0 for extension compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
   },
   "pnpm": {
     "overrides": {
-      "vite": "^8.0.0-beta.8"
+      "vite": "^7.3.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
Vite 8.0.0-beta.8 (Rolldown-powered) breaks custom node extensions that use bare module imports like `import { ref } from "vue"`.

Extensions built with `external: ['vue']` in their vite config expect these imports to be resolved at runtime, but Vite 8's new module resolution behavior prevents this, causing infinite page refresh errors.

This reverts to Vite 7.3.0 which properly handles these imports.

Affected extensions include ComfyUI-StableStudio and potentially others using similar build configurations.

it may fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/8153

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8208-fix-downgrade-vite-to-7-3-0-for-extension-compatibility-2ef6d73d36508139a7b7dcb7103fbbd7) by [Unito](https://www.unito.io)
