### PR TITLE
feat: implement progressive pagination for Asset Browser model assets

### DIFF
--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -112,13 +112,9 @@ const cacheKey = computed(() => {
 })
 
 // Read directly from store cache - reactive to any store updates
-const fetchedAssets = computed(
-  () => assetStore.modelAssetsByNodeType.get(cacheKey.value) ?? []
-)
+const fetchedAssets = computed(() => assetStore.getAssets(cacheKey.value))
 
-const isStoreLoading = computed(
-  () => assetStore.modelLoadingByNodeType.get(cacheKey.value) ?? false
-)
+const isStoreLoading = computed(() => assetStore.isModelLoading(cacheKey.value))
 
 // Only show loading spinner when loading AND no cached data
 const isLoading = computed(

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -121,14 +121,12 @@ const isLoading = computed(
   () => isStoreLoading.value && fetchedAssets.value.length === 0
 )
 
-async function refreshAssets(): Promise<AssetItem[]> {
+async function refreshAssets(): Promise<void> {
   if (props.nodeType) {
-    return await assetStore.updateModelsForNodeType(props.nodeType)
+    await assetStore.updateModelsForNodeType(props.nodeType)
+  } else if (props.assetType) {
+    await assetStore.updateModelsForTag(props.assetType)
   }
-  if (props.assetType) {
-    return await assetStore.updateModelsForTag(props.assetType)
-  }
-  return []
 }
 
 // Trigger background refresh on mount

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -160,7 +160,7 @@ describe('assetService', () => {
       const result = await assetService.getAssetModels('checkpoints')
 
       expect(api.fetchApi).toHaveBeenCalledWith(
-        '/assets?include_tags=models,checkpoints&limit=500'
+        '/assets?include_tags=models%2Ccheckpoints&limit=500'
       )
       expect(result).toEqual([
         expect.objectContaining({ name: 'valid.safetensors', pathIndex: 0 })
@@ -400,7 +400,7 @@ describe('assetService', () => {
       })
 
       expect(api.fetchApi).toHaveBeenCalledWith(
-        '/assets?include_tags=models&limit=500&include_public=true&offset=50'
+        '/assets?include_tags=models&limit=500&offset=50&include_public=true'
       )
       expect(result).toEqual(testAssets)
     })
@@ -415,7 +415,7 @@ describe('assetService', () => {
       })
 
       expect(api.fetchApi).toHaveBeenCalledWith(
-        '/assets?include_tags=input&limit=100&include_public=false&offset=25'
+        '/assets?include_tags=input&limit=100&offset=25&include_public=false'
       )
       expect(result).toEqual(testAssets)
     })

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -231,9 +231,9 @@ describe('assetService', () => {
       )
       expect(result).toEqual(testAssets)
 
-      // Verify API call includes correct category
+      // Verify API call includes correct category (comma is URL-encoded by URLSearchParams)
       expect(api.fetchApi).toHaveBeenCalledWith(
-        '/assets?include_tags=models,checkpoints&limit=500'
+        '/assets?include_tags=models%2Ccheckpoints&limit=500'
       )
     })
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -23,6 +23,11 @@ export interface PaginationOptions {
   offset?: number
 }
 
+export interface AssetRequestOptions extends PaginationOptions {
+  includeTags: string[]
+  includePublic?: boolean
+}
+
 /**
  * Maps CivitAI validation error codes to localized error messages
  */
@@ -83,9 +88,27 @@ function createAssetService() {
    * Handles API response with consistent error handling and Zod validation
    */
   async function handleAssetRequest(
-    url: string,
+    options: AssetRequestOptions,
     context: string
   ): Promise<AssetResponse> {
+    const {
+      includeTags,
+      limit = DEFAULT_LIMIT,
+      offset,
+      includePublic
+    } = options
+    const queryParams = new URLSearchParams({
+      include_tags: includeTags.join(','),
+      limit: limit.toString()
+    })
+    if (offset !== undefined && offset > 0) {
+      queryParams.set('offset', offset.toString())
+    }
+    if (includePublic !== undefined) {
+      queryParams.set('include_public', includePublic ? 'true' : 'false')
+    }
+
+    const url = `${ASSETS_ENDPOINT}?${queryParams.toString()}`
     const res = await api.fetchApi(url)
     if (!res.ok) {
       throw new Error(
@@ -107,7 +130,7 @@ function createAssetService() {
    */
   async function getAssetModelFolders(): Promise<ModelFolder[]> {
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG}&limit=${DEFAULT_LIMIT}`,
+      { includeTags: [MODELS_TAG] },
       'model folders'
     )
 
@@ -136,7 +159,7 @@ function createAssetService() {
    */
   async function getAssetModels(folder: string): Promise<ModelFile[]> {
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG},${folder}&limit=${DEFAULT_LIMIT}`,
+      { includeTags: [MODELS_TAG, folder] },
       `models for ${folder}`
     )
 
@@ -196,18 +219,9 @@ function createAssetService() {
       return []
     }
 
-    const queryParams = new URLSearchParams({
-      include_tags: `${MODELS_TAG},${category}`,
-      limit: limit.toString()
-    })
-
-    if (offset > 0) {
-      queryParams.set('offset', offset.toString())
-    }
-
     // Fetch assets for this category using same API pattern as getAssetModels
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?${queryParams.toString()}`,
+      { includeTags: [MODELS_TAG, category], limit, offset },
       `assets for ${nodeType}`
     )
 
@@ -265,18 +279,8 @@ function createAssetService() {
     includePublic: boolean = true,
     { limit = DEFAULT_LIMIT, offset = 0 }: PaginationOptions = {}
   ): Promise<AssetItem[]> {
-    const queryParams = new URLSearchParams({
-      include_tags: tag,
-      limit: limit.toString(),
-      include_public: includePublic ? 'true' : 'false'
-    })
-
-    if (offset > 0) {
-      queryParams.set('offset', offset.toString())
-    }
-
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?${queryParams.toString()}`,
+      { includeTags: [tag], limit, offset, includePublic },
       `assets for tag ${tag}`
     )
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -2,10 +2,6 @@ import { fromZodError } from 'zod-validation-error'
 
 import { st } from '@/i18n'
 
-export interface PaginationOptions {
-  limit?: number
-  offset?: number
-}
 import {
   assetItemSchema,
   assetResponseSchema,
@@ -21,6 +17,11 @@ import type {
 } from '@/platform/assets/schemas/assetSchema'
 import { api } from '@/scripts/api'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+
+export interface PaginationOptions {
+  limit?: number
+  offset?: number
+}
 
 /**
  * Maps CivitAI validation error codes to localized error messages

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -1,6 +1,11 @@
 import { fromZodError } from 'zod-validation-error'
 
 import { st } from '@/i18n'
+
+export interface PaginationOptions {
+  limit?: number
+  offset?: number
+}
 import {
   assetItemSchema,
   assetResponseSchema,
@@ -169,9 +174,15 @@ function createAssetService() {
    * and fetching all assets with that category tag
    *
    * @param nodeType - The ComfyUI node type (e.g., 'CheckpointLoaderSimple')
+   * @param options - Pagination options
+   * @param options.limit - Maximum number of assets to return (default: 500)
+   * @param options.offset - Number of assets to skip (default: 0)
    * @returns Promise<AssetItem[]> - Full asset objects with preserved metadata
    */
-  async function getAssetsForNodeType(nodeType: string): Promise<AssetItem[]> {
+  async function getAssetsForNodeType(
+    nodeType: string,
+    { limit = DEFAULT_LIMIT, offset = 0 }: PaginationOptions = {}
+  ): Promise<AssetItem[]> {
     if (!nodeType || typeof nodeType !== 'string') {
       return []
     }
@@ -184,9 +195,18 @@ function createAssetService() {
       return []
     }
 
+    const queryParams = new URLSearchParams({
+      include_tags: `${MODELS_TAG},${category}`,
+      limit: limit.toString()
+    })
+
+    if (offset > 0) {
+      queryParams.set('offset', offset.toString())
+    }
+
     // Fetch assets for this category using same API pattern as getAssetModels
     const data = await handleAssetRequest(
-      `${ASSETS_ENDPOINT}?include_tags=${MODELS_TAG},${category}&limit=${DEFAULT_LIMIT}`,
+      `${ASSETS_ENDPOINT}?${queryParams.toString()}`,
       `assets for ${nodeType}`
     )
 
@@ -242,10 +262,7 @@ function createAssetService() {
   async function getAssetsByTag(
     tag: string,
     includePublic: boolean = true,
-    {
-      limit = DEFAULT_LIMIT,
-      offset = 0
-    }: { limit?: number; offset?: number } = {}
+    { limit = DEFAULT_LIMIT, offset = 0 }: PaginationOptions = {}
   ): Promise<AssetItem[]> {
     const queryParams = new URLSearchParams({
       include_tags: tag,

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -23,7 +23,7 @@ export interface PaginationOptions {
   offset?: number
 }
 
-export interface AssetRequestOptions extends PaginationOptions {
+interface AssetRequestOptions extends PaginationOptions {
   includeTags: string[]
   includePublic?: boolean
 }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
@@ -12,9 +12,9 @@ const mockGetCategoryForNodeType = vi.fn()
 
 vi.mock('@/stores/assetsStore', () => ({
   useAssetsStore: () => ({
-    modelAssetsByNodeType: new Map(),
-    modelLoadingByNodeType: new Map(),
-    modelErrorByNodeType: new Map(),
+    getAssets: () => [],
+    isModelLoading: () => false,
+    getError: () => undefined,
     updateModelsForNodeType: mockUpdateModelsForNodeType
   })
 }))

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
@@ -8,17 +8,17 @@ vi.mock('@/platform/distribution/types', () => ({
   isCloud: true
 }))
 
-const mockModelAssetsByNodeType = new Map<string, AssetItem[]>()
-const mockModelLoadingByNodeType = new Map<string, boolean>()
-const mockModelErrorByNodeType = new Map<string, Error | null>()
+const mockAssetsByKey = new Map<string, AssetItem[]>()
+const mockLoadingByKey = new Map<string, boolean>()
+const mockErrorByKey = new Map<string, Error | undefined>()
 const mockUpdateModelsForNodeType = vi.fn()
 const mockGetCategoryForNodeType = vi.fn()
 
 vi.mock('@/stores/assetsStore', () => ({
   useAssetsStore: () => ({
-    modelAssetsByNodeType: mockModelAssetsByNodeType,
-    modelLoadingByNodeType: mockModelLoadingByNodeType,
-    modelErrorByNodeType: mockModelErrorByNodeType,
+    getAssets: (key: string) => mockAssetsByKey.get(key) ?? [],
+    isModelLoading: (key: string) => mockLoadingByKey.get(key) ?? false,
+    getError: (key: string) => mockErrorByKey.get(key),
     updateModelsForNodeType: mockUpdateModelsForNodeType
   })
 }))
@@ -32,9 +32,9 @@ vi.mock('@/stores/modelToNodeStore', () => ({
 describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockModelAssetsByNodeType.clear()
-    mockModelLoadingByNodeType.clear()
-    mockModelErrorByNodeType.clear()
+    mockAssetsByKey.clear()
+    mockLoadingByKey.clear()
+    mockErrorByKey.clear()
     mockGetCategoryForNodeType.mockReturnValue(undefined)
 
     mockUpdateModelsForNodeType.mockImplementation(
@@ -76,8 +76,8 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
     mockUpdateModelsForNodeType.mockImplementation(
       async (_nodeType: string): Promise<AssetItem[]> => {
-        mockModelAssetsByNodeType.set(_nodeType, mockAssets)
-        mockModelLoadingByNodeType.set(_nodeType, false)
+        mockAssetsByKey.set(_nodeType, mockAssets)
+        mockLoadingByKey.set(_nodeType, false)
         return mockAssets
       }
     )
@@ -108,9 +108,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
     mockUpdateModelsForNodeType.mockImplementation(
       async (_nodeType: string): Promise<AssetItem[]> => {
-        mockModelErrorByNodeType.set(_nodeType, mockError)
-        mockModelAssetsByNodeType.set(_nodeType, [])
-        mockModelLoadingByNodeType.set(_nodeType, false)
+        mockErrorByKey.set(_nodeType, mockError)
+        mockAssetsByKey.set(_nodeType, [])
+        mockLoadingByKey.set(_nodeType, false)
         return []
       }
     )
@@ -130,8 +130,8 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
     mockUpdateModelsForNodeType.mockImplementation(
       async (_nodeType: string): Promise<AssetItem[]> => {
-        mockModelAssetsByNodeType.set(_nodeType, [])
-        mockModelLoadingByNodeType.set(_nodeType, false)
+        mockAssetsByKey.set(_nodeType, [])
+        mockLoadingByKey.set(_nodeType, false)
         return []
       }
     )
@@ -154,8 +154,8 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       mockGetCategoryForNodeType.mockReturnValue('checkpoints')
       mockUpdateModelsForNodeType.mockImplementation(
         async (_nodeType: string): Promise<AssetItem[]> => {
-          mockModelAssetsByNodeType.set(_nodeType, mockAssets)
-          mockModelLoadingByNodeType.set(_nodeType, false)
+          mockAssetsByKey.set(_nodeType, mockAssets)
+          mockLoadingByKey.set(_nodeType, false)
           return mockAssets
         }
       )
@@ -182,8 +182,8 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       mockGetCategoryForNodeType.mockReturnValue('loras')
       mockUpdateModelsForNodeType.mockImplementation(
         async (_nodeType: string): Promise<AssetItem[]> => {
-          mockModelAssetsByNodeType.set(_nodeType, mockAssets)
-          mockModelLoadingByNodeType.set(_nodeType, false)
+          mockAssetsByKey.set(_nodeType, mockAssets)
+          mockLoadingByKey.set(_nodeType, false)
           return mockAssets
         }
       )
@@ -209,8 +209,8 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       mockGetCategoryForNodeType.mockReturnValue('checkpoints')
       mockUpdateModelsForNodeType.mockImplementation(
         async (_nodeType: string): Promise<AssetItem[]> => {
-          mockModelAssetsByNodeType.set(_nodeType, mockAssets)
-          mockModelLoadingByNodeType.set(_nodeType, false)
+          mockAssetsByKey.set(_nodeType, mockAssets)
+          mockLoadingByKey.set(_nodeType, false)
           return mockAssets
         }
       )

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -48,7 +48,7 @@ export function useAssetWidgetData(
     })
 
     const dropdownItems = computed<DropdownItem[]>(() => {
-      return assets.value.map((asset) => ({
+      return (assets.value ?? []).map((asset) => ({
         id: asset.id,
         name:
           (asset.user_metadata?.filename as string | undefined) ?? asset.name,
@@ -65,7 +65,8 @@ export function useAssetWidgetData(
           return
         }
 
-        const hasData = assetsStore.getAssets(currentNodeType).length > 0
+        const existingAssets = assetsStore.getAssets(currentNodeType) ?? []
+        const hasData = existingAssets.length > 0
 
         if (!hasData) {
           await assetsStore.updateModelsForNodeType(currentNodeType)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -48,7 +48,7 @@ export function useAssetWidgetData(
     })
 
     const dropdownItems = computed<DropdownItem[]>(() => {
-      return (assets.value ?? []).map((asset) => ({
+      return assets.value.map((asset) => ({
         id: asset.id,
         name:
           (asset.user_metadata?.filename as string | undefined) ?? asset.name,
@@ -65,7 +65,7 @@ export function useAssetWidgetData(
           return
         }
 
-        const existingAssets = assetsStore.getAssets(currentNodeType) ?? []
+        const existingAssets = assetsStore.getAssets(currentNodeType)
         const hasData = existingAssets.length > 0
 
         if (!hasData) {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -34,23 +34,17 @@ export function useAssetWidgetData(
 
     const assets = computed<AssetItem[]>(() => {
       const resolvedType = toValue(nodeType)
-      return resolvedType
-        ? (assetsStore.modelAssetsByNodeType.get(resolvedType) ?? [])
-        : []
+      return resolvedType ? assetsStore.getAssets(resolvedType) : []
     })
 
     const isLoading = computed(() => {
       const resolvedType = toValue(nodeType)
-      return resolvedType
-        ? (assetsStore.modelLoadingByNodeType.get(resolvedType) ?? false)
-        : false
+      return resolvedType ? assetsStore.isModelLoading(resolvedType) : false
     })
 
     const error = computed<Error | null>(() => {
       const resolvedType = toValue(nodeType)
-      return resolvedType
-        ? (assetsStore.modelErrorByNodeType.get(resolvedType) ?? null)
-        : null
+      return resolvedType ? (assetsStore.getError(resolvedType) ?? null) : null
     })
 
     const dropdownItems = computed<DropdownItem[]>(() => {
@@ -71,7 +65,7 @@ export function useAssetWidgetData(
           return
         }
 
-        const hasData = assetsStore.modelAssetsByNodeType.has(currentNodeType)
+        const hasData = assetsStore.getAssets(currentNodeType).length > 0
 
         if (!hasData) {
           await assetsStore.updateModelsForNodeType(currentNodeType)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -34,7 +34,7 @@ export function useAssetWidgetData(
 
     const assets = computed<AssetItem[]>(() => {
       const resolvedType = toValue(nodeType)
-      return resolvedType ? assetsStore.getAssets(resolvedType) : []
+      return resolvedType ? (assetsStore.getAssets(resolvedType) ?? []) : []
     })
 
     const isLoading = computed(() => {
@@ -65,7 +65,7 @@ export function useAssetWidgetData(
           return
         }
 
-        const existingAssets = assetsStore.getAssets(currentNodeType)
+        const existingAssets = assetsStore.getAssets(currentNodeType) ?? []
         const hasData = existingAssets.length > 0
 
         if (!hasData) {

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -541,16 +541,19 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
         ).toHaveBeenCalledTimes(2)
       })
 
-      // Cache the current array reference
-      const firstArrayRef = store.getAssets(nodeType)
-      expect(firstArrayRef).toHaveLength(501)
+      const assets = store.getAssets(nodeType)
+      expect(assets).toHaveLength(501)
+      expect(assets.map((a) => a.id)).toContain('new-asset')
+    })
 
-      // Call getAssets again - should return same cached array (same reference)
-      const secondArrayRef = store.getAssets(nodeType)
-      expect(secondArrayRef).toBe(firstArrayRef)
+    it('should return cached array on subsequent getAssets calls', () => {
+      const store = useAssetsStore()
+      const nodeType = 'TestLoader'
 
-      // Verify the new asset is included (cache was properly invalidated before mutation)
-      expect(secondArrayRef.map((a) => a.id)).toContain('new-asset')
+      const firstCall = store.getAssets(nodeType)
+      const secondCall = store.getAssets(nodeType)
+
+      expect(secondCall).toBe(firstCall)
     })
   })
 

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, watch } from 'vue'
 
@@ -121,7 +122,7 @@ describe('assetsStore - Refactored (Option A)', () => {
   })
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useAssetsStore()
     vi.clearAllMocks()
   })
@@ -462,6 +463,7 @@ describe('assetsStore - Refactored (Option A)', () => {
 
 describe('assetsStore - Model Assets Cache (Cloud)', () => {
   beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
     mockIsCloud.value = true
     vi.clearAllMocks()
   })
@@ -481,7 +483,6 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
 
   describe('getAssets cache invalidation', () => {
     it('should invalidate cache before mutating assets during batch loading', async () => {
-      setActivePinia(createPinia())
       const store = useAssetsStore()
       const nodeType = 'CheckpointLoaderSimple'
 
@@ -514,7 +515,6 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
     })
 
     it('should not return stale cached array after background batch completes', async () => {
-      setActivePinia(createPinia())
       const store = useAssetsStore()
       const nodeType = 'LoraLoader'
 
@@ -556,7 +556,6 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
 
   describe('concurrent request handling', () => {
     it('should discard stale request when newer request starts', async () => {
-      setActivePinia(createPinia())
       const store = useAssetsStore()
       const nodeType = 'CheckpointLoaderSimple'
       const firstBatch = Array.from({ length: 5 }, (_, i) =>
@@ -599,7 +598,6 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
 
   describe('shallowReactive state reactivity', () => {
     it('should trigger reactivity on isModelLoading change', async () => {
-      setActivePinia(createPinia())
       const store = useAssetsStore()
       const nodeType = 'CheckpointLoaderSimple'
 

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, watch } from 'vue'
 
 import { useAssetsStore } from '@/stores/assetsStore'
 import { api } from '@/scripts/api'
@@ -550,6 +551,28 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
 
       // Verify the new asset is included (cache was properly invalidated before mutation)
       expect(secondArrayRef.map((a) => a.id)).toContain('new-asset')
+    })
+  })
+
+  describe('shallowReactive state reactivity', () => {
+    it('should trigger reactivity on isModelLoading change', async () => {
+      setActivePinia(createPinia())
+      const store = useAssetsStore()
+      const nodeType = 'CheckpointLoaderSimple'
+
+      const loadingStates: boolean[] = []
+      watch(
+        () => store.isModelLoading(nodeType),
+        (val) => loadingStates.push(val),
+        { immediate: true }
+      )
+
+      vi.mocked(assetService.getAssetsForNodeType).mockResolvedValue([])
+      await store.updateModelsForNodeType(nodeType)
+      await nextTick()
+
+      expect(loadingStates).toContain(true)
+      expect(loadingStates).toContain(false)
     })
   })
 })

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -585,13 +585,8 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       const firstRequest = store.updateModelsForNodeType(nodeType)
       const secondRequest = store.updateModelsForNodeType(nodeType)
       resolveFirst!(firstBatch)
-      const [firstResult, secondResult] = await Promise.all([
-        firstRequest,
-        secondRequest
-      ])
+      await Promise.all([firstRequest, secondRequest])
 
-      expect(firstResult).toEqual([])
-      expect(secondResult).toHaveLength(10)
       expect(store.getAssets(nodeType)).toHaveLength(10)
       expect(
         store.getAssets(nodeType).every((a) => a.id.startsWith('second-'))

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -1,6 +1,6 @@
 import { useAsyncState, whenever } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, reactive, ref, shallowReactive } from 'vue'
+import { computed, ref, shallowReactive } from 'vue'
 import {
   mapInputFileToAssetItem,
   mapTaskOutputToAssetItem
@@ -282,7 +282,7 @@ export const useAssetsStore = defineStore('assets', () => {
           hasMore: true,
           isLoading: false
         }
-        return reactive(state)
+        return shallowReactive(state)
       }
 
       function getOrCreateState(key: string): ModelPaginationState {

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -1,6 +1,6 @@
 import { useAsyncState, whenever } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, ref, shallowReactive } from 'vue'
+import { computed, reactive, ref, shallowReactive } from 'vue'
 import {
   mapInputFileToAssetItem,
   mapTaskOutputToAssetItem
@@ -276,7 +276,7 @@ export const useAssetsStore = defineStore('assets', () => {
       >()
 
       function createState(): ModelPaginationState {
-        return shallowReactive({
+        return reactive({
           assets: new Map(),
           offset: 0,
           hasMore: true,

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -375,10 +375,6 @@ export const useAssetsStore = defineStore('assets', () => {
 
               if (isFirstBatch) {
                 state.isLoading = false
-                if (state.hasMore) {
-                  void loadBatches()
-                }
-                return
               }
 
               if (state.hasMore) {

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -387,6 +387,8 @@ export const useAssetsStore = defineStore('assets', () => {
               console.error(`Error loading batch for ${key}:`, err)
               if (state.offset === 0) {
                 state.isLoading = false
+                pendingRequestByKey.delete(key)
+                // TODO: Add toast indicator for first-batch load failures
               }
               return
             }

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -332,7 +332,13 @@ export const useAssetsStore = defineStore('assets', () => {
       ): Promise<void> {
         const state = createState()
         state.isLoading = true
-        pendingRequestByKey.set(key, state)
+
+        const hasExistingData = modelStateByKey.value.has(key)
+        if (hasExistingData) {
+          pendingRequestByKey.set(key, state)
+        } else {
+          modelStateByKey.value.set(key, state)
+        }
 
         async function loadBatches(): Promise<void> {
           while (state.hasMore) {
@@ -347,8 +353,10 @@ export const useAssetsStore = defineStore('assets', () => {
               const isFirstBatch = state.offset === 0
               if (isFirstBatch) {
                 assetsArrayCache.delete(key)
-                pendingRequestByKey.delete(key)
-                modelStateByKey.value.set(key, state)
+                if (hasExistingData) {
+                  pendingRequestByKey.delete(key)
+                  modelStateByKey.value.set(key, state)
+                }
                 state.assets = new Map(newAssets.map((a) => [a.id, a]))
               } else {
                 const assetsToAdd = newAssets.filter(

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -294,10 +294,12 @@ export const useAssetsStore = defineStore('assets', () => {
         return modelStateByKey.value.get(key) !== state
       }
 
+      const EMPTY_ASSETS: AssetItem[] = []
+
       function getAssets(key: string): AssetItem[] {
         const state = modelStateByKey.value.get(key)
         const assetsMap = state?.assets
-        if (!assetsMap) return []
+        if (!assetsMap) return EMPTY_ASSETS
 
         const cached = assetsArrayCache.get(key)
         if (cached && cached.source === assetsMap) {

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -1,13 +1,13 @@
 import { useAsyncState, whenever } from '@vueuse/core'
-import { isEqual } from 'es-toolkit'
 import { defineStore } from 'pinia'
-import { computed, shallowReactive, ref } from 'vue'
+import { computed, reactive, ref, shallowReactive } from 'vue'
 import {
   mapInputFileToAssetItem,
   mapTaskOutputToAssetItem
 } from '@/platform/assets/composables/media/assetMappers'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
+import type { PaginationOptions } from '@/platform/assets/services/assetService'
 import { isCloud } from '@/platform/distribution/types'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { api } from '@/scripts/api'
@@ -251,6 +251,16 @@ export const useAssetsStore = defineStore('assets', () => {
     return inputAssetsByFilename.value.get(filename)?.name ?? filename
   }
 
+  const MODEL_BATCH_SIZE = 500
+
+  interface ModelPaginationState {
+    assets: Map<string, AssetItem>
+    offset: number
+    hasMore: boolean
+    isLoading: boolean
+    error?: Error
+  }
+
   /**
    * Model assets cached by node type (e.g., 'CheckpointLoaderSimple', 'LoraLoader')
    * Used by multiple loader nodes to avoid duplicate fetches
@@ -258,62 +268,116 @@ export const useAssetsStore = defineStore('assets', () => {
    */
   const getModelState = () => {
     if (isCloud) {
-      const modelAssetsByNodeType = shallowReactive(
-        new Map<string, AssetItem[]>()
-      )
-      const modelLoadingByNodeType = shallowReactive(new Map<string, boolean>())
-      const modelErrorByNodeType = shallowReactive(
-        new Map<string, Error | null>()
-      )
+      const modelStateByKey = ref(new Map<string, ModelPaginationState>())
 
-      const stateByNodeType = shallowReactive(
-        new Map<string, ReturnType<typeof useAsyncState<AssetItem[]>>>()
-      )
+      function createInitialState(): ModelPaginationState {
+        const state: ModelPaginationState = {
+          assets: new Map(),
+          offset: 0,
+          hasMore: true,
+          isLoading: false
+        }
+        return reactive(state)
+      }
+
+      function getOrCreateState(key: string): ModelPaginationState {
+        if (!modelStateByKey.value.has(key)) {
+          modelStateByKey.value.set(key, createInitialState())
+        }
+        return modelStateByKey.value.get(key)!
+      }
+
+      function resetPaginationForKey(key: string) {
+        const state = getOrCreateState(key)
+        state.assets = new Map()
+        state.offset = 0
+        state.hasMore = true
+        delete state.error
+      }
+
+      function getAssets(key: string): AssetItem[] {
+        return Array.from(modelStateByKey.value.get(key)?.assets.values() ?? [])
+      }
+
+      function isLoading(key: string): boolean {
+        return modelStateByKey.value.get(key)?.isLoading ?? false
+      }
+
+      function getError(key: string): Error | undefined {
+        return modelStateByKey.value.get(key)?.error
+      }
+
+      function hasMore(key: string): boolean {
+        return modelStateByKey.value.get(key)?.hasMore ?? false
+      }
 
       /**
-       * Internal helper to fetch and cache assets with a given key and fetcher
+       * Internal helper to fetch and cache assets with a given key and fetcher.
+       * Loads first batch immediately, then progressively loads remaining batches.
        */
       async function updateModelsForKey(
         key: string,
-        fetcher: () => Promise<AssetItem[]>
+        fetcher: (options: PaginationOptions) => Promise<AssetItem[]>
       ): Promise<AssetItem[]> {
-        if (!stateByNodeType.has(key)) {
-          stateByNodeType.set(
-            key,
-            useAsyncState(fetcher, [], {
-              immediate: false,
-              resetOnExecute: false,
-              onError: (err) => {
-                console.error(`Error fetching model assets for ${key}:`, err)
-              }
-            })
-          )
-        }
+        const state = getOrCreateState(key)
 
-        const state = stateByNodeType.get(key)!
-
-        modelLoadingByNodeType.set(key, true)
-        modelErrorByNodeType.set(key, null)
+        resetPaginationForKey(key)
+        state.isLoading = true
 
         try {
-          await state.execute()
+          const assets = await fetcher({
+            limit: MODEL_BATCH_SIZE,
+            offset: 0
+          })
+
+          state.assets = new Map(assets.map((a) => [a.id, a]))
+          state.offset = assets.length
+          state.hasMore = assets.length === MODEL_BATCH_SIZE
+
+          if (state.hasMore) {
+            void loadRemainingBatches(key, fetcher)
+          }
+
+          return assets
+        } catch (err) {
+          state.error = err instanceof Error ? err : new Error(String(err))
+          console.error(`Error fetching model assets for ${key}:`, err)
+          return []
         } finally {
-          modelLoadingByNodeType.set(key, state.isLoading.value)
+          state.isLoading = false
         }
+      }
 
-        const assets = state.state.value
-        const existingAssets = modelAssetsByNodeType.get(key)
+      /**
+       * Progressively load remaining batches until complete
+       */
+      async function loadRemainingBatches(
+        key: string,
+        fetcher: (options: PaginationOptions) => Promise<AssetItem[]>
+      ): Promise<void> {
+        const state = modelStateByKey.value.get(key)
+        if (!state) return
 
-        if (!isEqual(existingAssets, assets)) {
-          modelAssetsByNodeType.set(key, assets)
+        while (state.hasMore) {
+          try {
+            const newAssets = await fetcher({
+              limit: MODEL_BATCH_SIZE,
+              offset: state.offset
+            })
+
+            for (const asset of newAssets) {
+              if (!state.assets.has(asset.id)) {
+                state.assets.set(asset.id, asset)
+              }
+            }
+
+            state.offset += newAssets.length
+            state.hasMore = newAssets.length === MODEL_BATCH_SIZE
+          } catch (err) {
+            console.error(`Error loading batch for ${key}:`, err)
+            break
+          }
         }
-
-        modelErrorByNodeType.set(
-          key,
-          state.error.value instanceof Error ? state.error.value : null
-        )
-
-        return assets
       }
 
       /**
@@ -324,8 +388,8 @@ export const useAssetsStore = defineStore('assets', () => {
       async function updateModelsForNodeType(
         nodeType: string
       ): Promise<AssetItem[]> {
-        return updateModelsForKey(nodeType, () =>
-          assetService.getAssetsForNodeType(nodeType)
+        return updateModelsForKey(nodeType, (opts) =>
+          assetService.getAssetsForNodeType(nodeType, opts)
         )
       }
 
@@ -336,31 +400,37 @@ export const useAssetsStore = defineStore('assets', () => {
        */
       async function updateModelsForTag(tag: string): Promise<AssetItem[]> {
         const key = `tag:${tag}`
-        return updateModelsForKey(key, () => assetService.getAssetsByTag(tag))
+        return updateModelsForKey(key, (opts) =>
+          assetService.getAssetsByTag(tag, true, opts)
+        )
       }
 
       return {
-        modelAssetsByNodeType,
-        modelLoadingByNodeType,
-        modelErrorByNodeType,
+        getAssets,
+        isLoading,
+        getError,
+        hasMore,
         updateModelsForNodeType,
         updateModelsForTag
       }
     }
 
+    const emptyAssets: AssetItem[] = []
     return {
-      modelAssetsByNodeType: shallowReactive(new Map<string, AssetItem[]>()),
-      modelLoadingByNodeType: shallowReactive(new Map<string, boolean>()),
-      modelErrorByNodeType: shallowReactive(new Map<string, Error | null>()),
-      updateModelsForNodeType: async () => [],
-      updateModelsForTag: async () => []
+      getAssets: () => emptyAssets,
+      isLoading: () => false,
+      getError: () => undefined,
+      hasMore: () => false,
+      updateModelsForNodeType: async () => emptyAssets,
+      updateModelsForTag: async () => emptyAssets
     }
   }
 
   const {
-    modelAssetsByNodeType,
-    modelLoadingByNodeType,
-    modelErrorByNodeType,
+    getAssets,
+    isLoading: isModelLoading,
+    getError,
+    hasMore,
     updateModelsForNodeType,
     updateModelsForTag
   } = getModelState()
@@ -422,10 +492,13 @@ export const useAssetsStore = defineStore('assets', () => {
     inputAssetsByFilename,
     getInputName,
 
-    // Model assets
-    modelAssetsByNodeType,
-    modelLoadingByNodeType,
-    modelErrorByNodeType,
+    // Model assets - accessors
+    getAssets,
+    isModelLoading,
+    getError,
+    hasMore,
+
+    // Model assets - actions
     updateModelsForNodeType,
     updateModelsForTag
   }

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -332,7 +332,6 @@ export const useAssetsStore = defineStore('assets', () => {
         fetcher: (options: PaginationOptions) => Promise<AssetItem[]>
       ): Promise<void> {
         const state = startNewRequest(key)
-        assetsArrayCache.delete(key)
         state.isLoading = true
 
         async function loadBatches(): Promise<void> {
@@ -347,6 +346,7 @@ export const useAssetsStore = defineStore('assets', () => {
 
               const isFirstBatch = state.offset === 0
               if (isFirstBatch) {
+                assetsArrayCache.delete(key)
                 state.assets = new Map(newAssets.map((a) => [a.id, a]))
               } else {
                 const assetsToAdd = newAssets.filter(

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -382,15 +382,12 @@ export const useAssetsStore = defineStore('assets', () => {
               offset: state.offset
             })
 
-            let addedAny = false
-            for (const asset of newAssets) {
-              if (!state.assets.has(asset.id)) {
-                state.assets.set(asset.id, asset)
-                addedAny = true
-              }
-            }
-            if (addedAny) {
+            const assetsToAdd = newAssets.filter((a) => !state.assets.has(a.id))
+            if (assetsToAdd.length > 0) {
               assetsArrayCache.delete(key)
+              for (const asset of assetsToAdd) {
+                state.assets.set(asset.id, asset)
+              }
             }
 
             state.offset += newAssets.length


### PR DESCRIPTION
## Summary

Implements progressive pagination for model assets - returns the first batch immediately while loading remaining batches in the background.

## Changes

### Store (`assetsStore.ts`)
- Adds `ModelPaginationState` tracking (assets Map, offset, hasMore, loading, error)
- `updateModelsForKey()` returns first batch, then calls `loadRemainingBatches()` to fetch the rest
- Accessor functions `getAssets(key)`, `isModelLoading(key)` replace direct Map access

### API (`assetService.ts`)
- Adds `PaginationOptions` interface (`{ limit?, offset? }`)

### Components
- `AssetBrowserModal.vue` uses new accessor API

### Tests
- Updated mocks for new accessor pattern

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8212-feat-implement-progressive-pagination-for-Asset-Browser-model-assets-2ef6d73d36508157af04d1264780997e) by [Unito](https://www.unito.io)
