### PR TITLE
feat: enable feedback button on nightly releases

### DIFF
--- a/src/extensions/core/cloudFeedbackTopbarButton.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.ts
@@ -1,5 +1,3 @@
-import { computed } from 'vue'
-
 import { t } from '@/i18n'
 import { getDistribution, ZENDESK_FIELDS } from '@/platform/support/config'
 import { useExtensionService } from '@/services/extensionService'
@@ -8,13 +6,12 @@ import type { ActionBarButton } from '@/types/comfy'
 const ZENDESK_BASE_URL = 'https://support.comfy.org/hc/en-us/requests/new'
 const ZENDESK_FEEDBACK_FORM_ID = '43066738713236'
 
-const feedbackUrl = computed(() => {
-  const params = new URLSearchParams({
-    ticket_form_id: ZENDESK_FEEDBACK_FORM_ID,
-    [ZENDESK_FIELDS.DISTRIBUTION]: getDistribution()
-  })
-  return `${ZENDESK_BASE_URL}?${params.toString()}`
+const distribution = getDistribution()
+const params = new URLSearchParams({
+  ticket_form_id: ZENDESK_FEEDBACK_FORM_ID,
+  [ZENDESK_FIELDS.DISTRIBUTION]: distribution
 })
+const feedbackUrl = `${ZENDESK_BASE_URL}?${params.toString()}`
 
 const buttons: ActionBarButton[] = [
   {
@@ -22,7 +19,7 @@ const buttons: ActionBarButton[] = [
     label: t('actionbar.feedback'),
     tooltip: t('actionbar.feedbackTooltip'),
     onClick: () => {
-      window.open(feedbackUrl.value, '_blank', 'noopener,noreferrer')
+      window.open(feedbackUrl, '_blank', 'noopener,noreferrer')
     }
   }
 ]

--- a/src/extensions/core/cloudFeedbackTopbarButton.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.ts
@@ -1,10 +1,20 @@
+import { computed } from 'vue'
+
 import { t } from '@/i18n'
+import { getDistribution, ZENDESK_FIELDS } from '@/platform/support/config'
 import { useExtensionService } from '@/services/extensionService'
 import type { ActionBarButton } from '@/types/comfy'
 
-// Zendesk feedback URL - update this with the actual URL
-const ZENDESK_FEEDBACK_URL =
-  'https://support.comfy.org/hc/en-us/requests/new?ticket_form_id=43066738713236'
+const ZENDESK_BASE_URL = 'https://support.comfy.org/hc/en-us/requests/new'
+const ZENDESK_FEEDBACK_FORM_ID = '43066738713236'
+
+const feedbackUrl = computed(() => {
+  const params = new URLSearchParams({
+    ticket_form_id: ZENDESK_FEEDBACK_FORM_ID,
+    [ZENDESK_FIELDS.DISTRIBUTION]: getDistribution()
+  })
+  return `${ZENDESK_BASE_URL}?${params.toString()}`
+})
 
 const buttons: ActionBarButton[] = [
   {
@@ -12,7 +22,7 @@ const buttons: ActionBarButton[] = [
     label: t('actionbar.feedback'),
     tooltip: t('actionbar.feedbackTooltip'),
     onClick: () => {
-      window.open(ZENDESK_FEEDBACK_URL, '_blank', 'noopener,noreferrer')
+      window.open(feedbackUrl.value, '_blank', 'noopener,noreferrer')
     }
   }
 ]

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -1,4 +1,4 @@
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isNightly } from '@/platform/distribution/types'
 
 import './clipspace'
 import './contextMenuFilter'
@@ -32,9 +32,13 @@ if (isCloud) {
   await import('./cloudRemoteConfig')
   await import('./cloudBadges')
   await import('./cloudSessionCookie')
-  await import('./cloudFeedbackTopbarButton')
 
   if (window.__CONFIG__?.subscription_required) {
     await import('./cloudSubscription')
   }
+}
+
+// Feedback button for cloud and nightly builds
+if (isCloud || isNightly) {
+  await import('./cloudFeedbackTopbarButton')
 }

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -18,7 +18,7 @@ export const ZENDESK_FIELDS = {
  * Gets the distribution identifier for Zendesk tracking.
  * Helps distinguish feedback from different build types.
  */
-export function getDistribution(): string {
+export function getDistribution(): 'ccloud' | 'oss-nightly' | 'oss' {
   if (isCloud) return 'ccloud'
   if (isNightly) return 'oss-nightly'
   return 'oss'

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -1,9 +1,9 @@
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isNightly } from '@/platform/distribution/types'
 
 /**
  * Zendesk ticket form field IDs.
  */
-const ZENDESK_FIELDS = {
+export const ZENDESK_FIELDS = {
   /** Distribution tag (cloud vs OSS) */
   DISTRIBUTION: 'tf_42243568391700',
   /** User email (anonymous requester) */
@@ -13,6 +13,16 @@ const ZENDESK_FIELDS = {
   /** User ID */
   USER_ID: 'tf_42515251051412'
 } as const
+
+/**
+ * Gets the distribution identifier for Zendesk tracking.
+ * Helps distinguish feedback from different build types.
+ */
+export function getDistribution(): string {
+  if (isCloud) return 'ccloud'
+  if (isNightly) return 'oss-nightly'
+  return 'oss'
+}
 
 const SUPPORT_BASE_URL = 'https://support.comfy.org/hc/en-us/requests/new'
 
@@ -28,7 +38,7 @@ export function buildSupportUrl(params?: {
   userId?: string | null
 }): string {
   const searchParams = new URLSearchParams({
-    [ZENDESK_FIELDS.DISTRIBUTION]: isCloud ? 'ccloud' : 'oss'
+    [ZENDESK_FIELDS.DISTRIBUTION]: getDistribution()
   })
 
   if (params?.userEmail) {

--- a/src/platform/telemetry/utils/surveyNormalization.ts
+++ b/src/platform/telemetry/utils/surveyNormalization.ts
@@ -526,7 +526,7 @@ const useCaseFuse = new Fuse(USE_CASE_CATEGORIES, FUSE_OPTIONS)
 /**
  * Normalize industry responses using Fuse.js fuzzy search
  */
-export function normalizeIndustry(rawIndustry: string): string {
+export function normalizeIndustry(rawIndustry: unknown): string {
   if (!rawIndustry || typeof rawIndustry !== 'string') {
     return 'Other / Undefined'
   }
@@ -554,7 +554,7 @@ export function normalizeIndustry(rawIndustry: string): string {
 /**
  * Normalize use case responses using Fuse.js fuzzy search
  */
-export function normalizeUseCase(rawUseCase: string): string {
+export function normalizeUseCase(rawUseCase: unknown): string {
   if (!rawUseCase || typeof rawUseCase !== 'string') {
     return 'Other / Undefined'
   }


### PR DESCRIPTION
## Summary

Enables the feedback button on nightly releases to collect user feedback and distinguish it from stable releases in Zendesk.

## Changes

- Add distribution tracking to feedback URL (cloud/nightly/stable)
- Export `getDistribution()` and `ZENDESK_FIELDS` from support config for reuse
- Enable feedback button for both cloud and nightly builds
- Track distribution in Zendesk as: `ccloud`, `oss-nightly`, or `oss`
- Fix type signatures for `normalizeIndustry`/`normalizeUseCase` to accept `unknown`

## Requirements

- [ ] Support team needs to add `oss-nightly` as a valid value for the distribution field in Zendesk

## Test plan

- [ ] Build and run nightly version, verify feedback button appears
- [ ] Click feedback button, verify Zendesk form opens with correct distribution parameter
- [ ] Verify cloud builds still show feedback button as before
- [ ] Verify stable OSS builds don't show feedback button

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8220-feat-enable-feedback-button-on-nightly-releases-2ef6d73d3650816db81ef970919770a4) by [Unito](https://www.unito.io)
