### PR TITLE
feat: add preview version badge for nightly builds

### DIFF
--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -1,4 +1,4 @@
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isNightly } from '@/platform/distribution/types'
 
 import './clipspace'
 import './contextMenuFilter'
@@ -37,4 +37,9 @@ if (isCloud) {
   if (window.__CONFIG__?.subscription_required) {
     await import('./cloudSubscription')
   }
+}
+
+// Nightly-only extensions
+if (isNightly) {
+  await import('./nightlyBadges')
 }

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -40,6 +40,6 @@ if (isCloud) {
 }
 
 // Nightly-only extensions
-if (isNightly) {
+if (isNightly && !isCloud) {
   await import('./nightlyBadges')
 }

--- a/src/extensions/core/nightlyBadges.ts
+++ b/src/extensions/core/nightlyBadges.ts
@@ -1,0 +1,17 @@
+import { t } from '@/i18n'
+import { useExtensionService } from '@/services/extensionService'
+import type { TopbarBadge } from '@/types/comfy'
+
+const badges: TopbarBadge[] = [
+  {
+    text: t('nightly.badge.label'),
+    label: t('g.nightly'),
+    variant: 'info',
+    tooltip: t('nightly.badge.tooltip')
+  }
+]
+
+useExtensionService().registerExtension({
+  name: 'Comfy.Nightly.Badges',
+  topbarBadges: badges
+})

--- a/src/extensions/core/nightlyBadges.ts
+++ b/src/extensions/core/nightlyBadges.ts
@@ -6,7 +6,7 @@ const badges: TopbarBadge[] = [
   {
     text: t('nightly.badge.label'),
     label: t('g.nightly'),
-    variant: 'info',
+    variant: 'warning',
     tooltip: t('nightly.badge.tooltip')
   }
 ]

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -275,6 +275,7 @@
     "1x": "1x",
     "2x": "2x",
     "beta": "BETA",
+    "nightly": "NIGHTLY",
     "profile": "Profile",
     "noItems": "No items"
   },
@@ -2626,6 +2627,12 @@
       "accessDenied": "You do not have access to this workspace",
       "workspaceNotFound": "Workspace not found",
       "tokenExchangeFailed": "Failed to authenticate with workspace: {error}"
+    }
+  },
+  "nightly": {
+    "badge": {
+      "label": "Preview Version",
+      "tooltip": "You are using a nightly version of ComfyUI. Please use the feedback button to share your thoughts about these features."
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a "Preview Version" badge to the topbar on nightly builds to help users identify when they're using an unreleased version and encourage feedback.

## Changes

- Add `nightly.badge` i18n translations (label and tooltip)
- Create `nightlyBadges.ts` extension with info variant badge
- Load nightly badges extension when `isNightly` is true
- Badge tooltip encourages users to provide feedback via the feedback button

## Test plan

- [ ] Build and run nightly version, verify "NIGHTLY | Preview Version" badge appears in topbar
- [ ] Hover over badge, verify tooltip shows: "You are using a nightly version of ComfyUI. Please use the feedback button to share your thoughts about these features."
- [ ] Verify stable OSS builds don't show the badge
- [ ] Verify cloud builds don't show the nightly badge

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8222-feat-add-preview-version-badge-for-nightly-builds-2ef6d73d36508102aa0dfc22ef14c9c1) by [Unito](https://www.unito.io)
