### PR TITLE
fix: Mark comfy-api-plugin as build-time only

### DIFF
--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -76,6 +76,7 @@ function getModuleName(id: string): string {
 export function comfyAPIPlugin(isDev: boolean): Plugin {
   return {
     name: 'comfy-api-plugin',
+    apply: 'build',
     transform(code: string, id: string) {
       if (isDev) return null
 

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

Marks the `comfy-api-plugin` Vite plugin as build-time only by adding `apply: 'build'`.

This prevents the plugin's transform from running during development (`vite dev`), improving dev server startup time and avoiding unnecessary processing when the plugin's output is not needed in development mode.

Also updates `build/tsconfig.json` to use `moduleResolution: "bundler"` which is the recommended setting for Vite projects.

## Changes

- **build/plugins/comfyAPIPlugin.ts**: Add `apply: 'build'` to restrict plugin to production builds
- **build/tsconfig.json**: Update `moduleResolution` from `"node"` to `"bundler"`

## Testing

- `pnpm typecheck` passes
- `pnpm build` produces correct output

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8224-fix-Mark-comfy-api-plugin-as-build-time-only-2ef6d73d36508145a48ae849087fbad7) by [Unito](https://www.unito.io)
