### PR TITLE
refactor: use orderBy for queue list sorting

### DIFF
--- a/src/composables/queue/useJobList.ts
+++ b/src/composables/queue/useJobList.ts
@@ -1,3 +1,4 @@
+import { orderBy } from 'es-toolkit/array'
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -205,10 +206,7 @@ export function useJobList() {
       ...queueStore.runningTasks,
       ...queueStore.historyTasks
     ]
-    return all.sort((a, b) => {
-      const delta = mostRecentTimestamp(b) - mostRecentTimestamp(a)
-      return delta === 0 ? 0 : delta
-    })
+    return orderBy(all, [mostRecentTimestamp], ['desc'])
   })
 
   const tasksWithJobState = computed<TaskWithState[]>(() =>


### PR DESCRIPTION
Use es-toolkit orderBy for queue list sorting.

The queue overlay list already sorts by create time, but the implementation used Array.sort with a custom comparator and mutated the array in place. Switch to es-toolkit's orderBy to make the sort intent explicit, avoid mutation, and align with the utility set we already depend on. Sorting keys and direction remain the same, so behavior is unchanged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8228-fix-use-orderBy-for-queue-list-sorting-2f06d73d365081e791fff7d2212537f8) by [Unito](https://www.unito.io)
