### PR TITLE
feat: Add display_name support for DynamicCombo options

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -78,6 +78,12 @@ function dynamicComboWidget(
   const options = Object.fromEntries(
     inputData[1].options.map(({ key, inputs }) => [key, inputs])
   )
+  const displayNameMap = Object.fromEntries(
+    inputData[1].options.map(({ key, display_name }) => [
+      key,
+      display_name ?? key
+    ])
+  )
   const subSpec: ComboInputSpec = [Object.keys(options), {}]
   const { widget, minWidth, minHeight } = app.widgets['COMBO'](
     node,
@@ -86,6 +92,8 @@ function dynamicComboWidget(
     appArg,
     widgetName
   )
+  widget.options.getOptionLabel = (value?: string | null) =>
+    value ? (displayNameMap[value] ?? value) : ''
   function isInGroup(e: { name: string }): boolean {
     return e.name.startsWith(inputName + '.')
   }

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -245,7 +245,8 @@ export const zDynamicComboInputSpec = z.tuple([
     options: z.array(
       z.object({
         inputs: zComfyInputsSpec,
-        key: z.string()
+        key: z.string(),
+        display_name: z.string().optional()
       })
     )
   })


### PR DESCRIPTION
## Summary

Adds support for `display_name` field in DynamicCombo options, allowing backend nodes to define user-friendly labels that differ from the internal key values.

https://github.com/user-attachments/assets/9b16c2b9-0d30-46bf-b428-1df411b4396d

## Changes

### Schema (`src/schemas/nodeDefSchema.ts`)
- Added optional `display_name: z.string().optional()` field to DynamicCombo option schema

### Widget (`src/core/graph/widgets/dynamicWidgets.ts`)
- Create a `displayNameMap` from options that maps key → display_name (falling back to key)
- Use `widget.options.getOptionLabel` callback to display the custom labels in the dropdown

## Behavior
- If `display_name` is provided, it shows in the dropdown instead of the key
- If `display_name` is not provided, falls back to showing the key (backward compatible)
- The actual stored/serialized value remains the key, preserving workflow compatibility

## Related

- **Backend PR**: https://github.com/Comfy-Org/ComfyUI/pull/12013 (adds `display_name` to `DynamicCombo.Option` in `_io.py`)
- This enables the ResizeImageMaskNode to show friendly labels like "To Size" instead of "scale dimensions"

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8237-feat-Add-display_name-support-for-DynamicCombo-options-2f06d73d365081ff8e97f0d063712501) by [Unito](https://www.unito.io)
