### PR TITLE
Further number widget fixes

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
@@ -202,9 +202,13 @@ const sliderWidth = computed(() => {
       :class="cn(WidgetInputBaseClass, 'grow text-xs flex h-7 relative')"
     >
       <div
-        class="bg-primary-background/15 absolute left-0 bottom-0 h-full rounded-lg pointer-events-none"
-        :style="{ width: `${sliderWidth}%` }"
-      />
+        class="absolute size-full rounded-lg pointer-events-none overflow-clip"
+      >
+        <div
+          class="bg-primary-background/15 size-full"
+          :style="{ width: `${sliderWidth}%` }"
+        />
+      </div>
       <Button
         v-if="!buttonsDisabled"
         data-testid="decrement"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
@@ -159,14 +159,15 @@ function handleMouseMove(e: PointerEvent) {
 function handleMouseUp() {
   const newValue = dragValue.value
   if (newValue === undefined) return
-  modelValue.value = newValue
-  dragValue.value = undefined
 
-  if (dragDelta.value === 0) {
+  if (newValue === modelValue.value) {
     textEdit.value = true
     inputField.value?.focus()
     inputField.value?.setSelectionRange(0, -1)
   }
+
+  modelValue.value = newValue
+  dragValue.value = undefined
   dragDelta.value = 0
 }
 


### PR DESCRIPTION
- The slider indicator is now only rounded at the ends and doesn't display outside the widget at small values
- Prevents a bug where scrubbing would result in a 1/10 chance of causing text selection after a completed scrub.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/94d1a232-4667-4f99-8fce-93567a10b2f3" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/66a44109-906f-4c1e-809e-118c9c96eb4a" />|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8251-Further-number-widget-fixes-2f06d73d3650811f9548ded527ca16ae) by [Unito](https://www.unito.io)
