### PR TITLE
fix: prevent middle-click paste duplicating workflow on Linux

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1965,6 +1965,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     canvas.addEventListener('pointercancel', this._mousecancel_callback, true)
 
     canvas.addEventListener('contextmenu', this._doNothing)
+    // Prevent middle-click paste on Linux (PRIMARY clipboard) - fixes #4464
+    canvas.addEventListener('auxclick', this._doNothing)
 
     // Keyboard
     this._key_callback = this.processKey.bind(this)
@@ -2003,6 +2005,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     canvas.removeEventListener('keydown', this._key_callback!)
     document.removeEventListener('keyup', this._key_callback!)
     canvas.removeEventListener('contextmenu', this._doNothing)
+    canvas.removeEventListener('auxclick', this._doNothing)
     canvas.removeEventListener('dragenter', this._doReturnTrue)
 
     this._mousedown_callback = undefined

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -172,7 +172,7 @@ interface IDialogExtensions extends ICloseable {
   is_modified: boolean
 }
 
-interface IDialog extends HTMLDivElement, IDialogExtensions {}
+interface IDialog extends HTMLDivElement, IDialogExtensions { }
 type PromptDialog = Omit<IDialog, 'modified'>
 
 interface IDialogOptions {
@@ -839,15 +839,15 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           const linkReleaseContext =
             this.linkConnector.state.connectingTo === 'input'
               ? {
-                  node_from: firstLink.node as LGraphNode,
-                  slot_from: firstLink.fromSlot as INodeOutputSlot,
-                  type_filter_in: firstLink.fromSlot.type
-                }
+                node_from: firstLink.node as LGraphNode,
+                slot_from: firstLink.fromSlot as INodeOutputSlot,
+                type_filter_in: firstLink.fromSlot.type
+              }
               : {
-                  node_to: firstLink.node as LGraphNode,
-                  slot_to: firstLink.fromSlot as INodeInputSlot,
-                  type_filter_out: firstLink.fromSlot.type
-                }
+                node_to: firstLink.node as LGraphNode,
+                slot_to: firstLink.fromSlot as INodeInputSlot,
+                type_filter_out: firstLink.fromSlot.type
+              }
 
           const afterRerouteId = firstLink.fromReroute?.id
 
@@ -1221,8 +1221,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     }
   }
 
-  static onMenuCollapseAll() {}
-  static onMenuNodeEdit() {}
+  static onMenuCollapseAll() { }
+  static onMenuNodeEdit() { }
 
   /** @param _options Parameter is never used */
   static showMenuNodeOptionalOutputs(
@@ -1930,6 +1930,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     return false
   }
 
+  /** Prevents default for middle-click auxclick only. */
+  _preventMiddleAuxClick(e: MouseEvent): void {
+    if (e.button === 1) e.preventDefault()
+  }
+
   /** Captures an event and prevents default - returns true. */
   _doReturnTrue(e: Event): boolean {
     e.preventDefault()
@@ -1965,8 +1970,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     canvas.addEventListener('pointercancel', this._mousecancel_callback, true)
 
     canvas.addEventListener('contextmenu', this._doNothing)
-    // Prevent middle-click paste on Linux (PRIMARY clipboard) - fixes #4464
-    canvas.addEventListener('auxclick', this._doNothing)
+    // Prevent middle-click paste (PRIMARY clipboard on Linux) - fixes #4464
+    canvas.addEventListener('auxclick', this._preventMiddleAuxClick)
 
     // Keyboard
     this._key_callback = this.processKey.bind(this)
@@ -2005,7 +2010,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     canvas.removeEventListener('keydown', this._key_callback!)
     document.removeEventListener('keyup', this._key_callback!)
     canvas.removeEventListener('contextmenu', this._doNothing)
-    canvas.removeEventListener('auxclick', this._doNothing)
+    canvas.removeEventListener('auxclick', this._preventMiddleAuxClick)
     canvas.removeEventListener('dragenter', this._doReturnTrue)
 
     this._mousedown_callback = undefined
@@ -2453,9 +2458,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         let isLinkHit =
           hitSegment &&
           linkSegment.id ===
-            (linkSegment instanceof Reroute
-              ? hitSegment.rerouteId
-              : hitSegment.linkId)
+          (linkSegment instanceof Reroute
+            ? hitSegment.rerouteId
+            : hitSegment.linkId)
 
         if (!isLinkHit && linkSegment.path) {
           // Fallback to direct path hit testing if not found in layout store
@@ -2799,7 +2804,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           ) {
             node.onTitleButtonClick(button, this)
             // Set a no-op click handler to prevent fallback canvas dragging
-            pointer.onClick = () => {}
+            pointer.onClick = () => { }
             return
           }
         }
@@ -2809,7 +2814,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       if (node.onMouseDown?.(e, pos, this)) {
         // Node handled the event (e.g., title button clicked)
         // Set a no-op click handler to prevent fallback canvas dragging
-        pointer.onClick = () => {}
+        pointer.onClick = () => { }
         return
       }
 
@@ -3069,7 +3074,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         const alphaPosY =
           0.5 -
           (mClikSlot_index + 1) /
-            (mClikSlot_isOut ? outputs.length : inputs.length)
+          (mClikSlot_isOut ? outputs.length : inputs.length)
         const node_bounding = node.getBounding()
         // estimate a position: this is a bad semi-bad-working mess .. REFACTOR with
         // a correct autoplacement that knows about the others slots and nodes
@@ -4921,8 +4926,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   #getHighlightPosition(): Readonly<Point> {
     return LiteGraph.snaps_for_comfy
       ? (this.linkConnector.state.snapLinksPos ??
-          this._highlight_pos ??
-          this.graph_mouse)
+        this._highlight_pos ??
+        this.graph_mouse)
       : this.graph_mouse
   }
 
@@ -5464,7 +5469,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     const render_title =
       title_mode == TitleMode.TRANSPARENT_TITLE ||
-      title_mode == TitleMode.NO_TITLE
+        title_mode == TitleMode.NO_TITLE
         ? false
         : true
 
@@ -6179,7 +6184,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     this.setDirty(true, true)
   }
 
-  onNodeSelectionChange(): void {}
+  onNodeSelectionChange(): void { }
 
   /**
    * Determines the furthest nodes in each direction for the currently selected nodes
@@ -7041,7 +7046,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
             // @ts-expect-error Property missing from interface definition
             options.type_filter_in !== false &&
             String(options.type_filter_in).toLowerCase() ==
-              String(aSlots[iK]).toLowerCase()
+            String(aSlots[iK]).toLowerCase()
           ) {
             opt.selected = true
           }
@@ -7067,7 +7072,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           if (
             options.type_filter_out !== false &&
             String(options.type_filter_out).toLowerCase() ==
-              String(aSlot).toLowerCase()
+            String(aSlot).toLowerCase()
           ) {
             opt.selected = true
           }
@@ -7956,8 +7961,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       const nodeCol =
         node.color !== undefined
           ? Object.keys(LGraphCanvas.node_colors).filter(function (nK) {
-              return LGraphCanvas.node_colors[nK].color == node.color
-            })
+            return LGraphCanvas.node_colors[nK].color == node.color
+          })
           : ''
 
       panel.addWidget(

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -172,7 +172,7 @@ interface IDialogExtensions extends ICloseable {
   is_modified: boolean
 }
 
-interface IDialog extends HTMLDivElement, IDialogExtensions { }
+interface IDialog extends HTMLDivElement, IDialogExtensions {}
 type PromptDialog = Omit<IDialog, 'modified'>
 
 interface IDialogOptions {
@@ -839,15 +839,15 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           const linkReleaseContext =
             this.linkConnector.state.connectingTo === 'input'
               ? {
-                node_from: firstLink.node as LGraphNode,
-                slot_from: firstLink.fromSlot as INodeOutputSlot,
-                type_filter_in: firstLink.fromSlot.type
-              }
+                  node_from: firstLink.node as LGraphNode,
+                  slot_from: firstLink.fromSlot as INodeOutputSlot,
+                  type_filter_in: firstLink.fromSlot.type
+                }
               : {
-                node_to: firstLink.node as LGraphNode,
-                slot_to: firstLink.fromSlot as INodeInputSlot,
-                type_filter_out: firstLink.fromSlot.type
-              }
+                  node_to: firstLink.node as LGraphNode,
+                  slot_to: firstLink.fromSlot as INodeInputSlot,
+                  type_filter_out: firstLink.fromSlot.type
+                }
 
           const afterRerouteId = firstLink.fromReroute?.id
 
@@ -1221,8 +1221,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     }
   }
 
-  static onMenuCollapseAll() { }
-  static onMenuNodeEdit() { }
+  static onMenuCollapseAll() {}
+  static onMenuNodeEdit() {}
 
   /** @param _options Parameter is never used */
   static showMenuNodeOptionalOutputs(
@@ -2458,9 +2458,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         let isLinkHit =
           hitSegment &&
           linkSegment.id ===
-          (linkSegment instanceof Reroute
-            ? hitSegment.rerouteId
-            : hitSegment.linkId)
+            (linkSegment instanceof Reroute
+              ? hitSegment.rerouteId
+              : hitSegment.linkId)
 
         if (!isLinkHit && linkSegment.path) {
           // Fallback to direct path hit testing if not found in layout store
@@ -2804,7 +2804,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           ) {
             node.onTitleButtonClick(button, this)
             // Set a no-op click handler to prevent fallback canvas dragging
-            pointer.onClick = () => { }
+            pointer.onClick = () => {}
             return
           }
         }
@@ -2814,7 +2814,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       if (node.onMouseDown?.(e, pos, this)) {
         // Node handled the event (e.g., title button clicked)
         // Set a no-op click handler to prevent fallback canvas dragging
-        pointer.onClick = () => { }
+        pointer.onClick = () => {}
         return
       }
 
@@ -3074,7 +3074,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         const alphaPosY =
           0.5 -
           (mClikSlot_index + 1) /
-          (mClikSlot_isOut ? outputs.length : inputs.length)
+            (mClikSlot_isOut ? outputs.length : inputs.length)
         const node_bounding = node.getBounding()
         // estimate a position: this is a bad semi-bad-working mess .. REFACTOR with
         // a correct autoplacement that knows about the others slots and nodes
@@ -4926,8 +4926,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   #getHighlightPosition(): Readonly<Point> {
     return LiteGraph.snaps_for_comfy
       ? (this.linkConnector.state.snapLinksPos ??
-        this._highlight_pos ??
-        this.graph_mouse)
+          this._highlight_pos ??
+          this.graph_mouse)
       : this.graph_mouse
   }
 
@@ -5469,7 +5469,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     const render_title =
       title_mode == TitleMode.TRANSPARENT_TITLE ||
-        title_mode == TitleMode.NO_TITLE
+      title_mode == TitleMode.NO_TITLE
         ? false
         : true
 
@@ -6184,7 +6184,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     this.setDirty(true, true)
   }
 
-  onNodeSelectionChange(): void { }
+  onNodeSelectionChange(): void {}
 
   /**
    * Determines the furthest nodes in each direction for the currently selected nodes
@@ -7046,7 +7046,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
             // @ts-expect-error Property missing from interface definition
             options.type_filter_in !== false &&
             String(options.type_filter_in).toLowerCase() ==
-            String(aSlots[iK]).toLowerCase()
+              String(aSlots[iK]).toLowerCase()
           ) {
             opt.selected = true
           }
@@ -7072,7 +7072,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           if (
             options.type_filter_out !== false &&
             String(options.type_filter_out).toLowerCase() ==
-            String(aSlot).toLowerCase()
+              String(aSlot).toLowerCase()
           ) {
             opt.selected = true
           }
@@ -7961,8 +7961,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       const nodeCol =
         node.color !== undefined
           ? Object.keys(LGraphCanvas.node_colors).filter(function (nK) {
-            return LGraphCanvas.node_colors[nK].color == node.color
-          })
+              return LGraphCanvas.node_colors[nK].color == node.color
+            })
           : ''
 
       panel.addWidget(


### PR DESCRIPTION
## Summary

Adds `auxclick` event listener to prevent the browser's default middle-click paste behavior on Linux systems.

**Problem:** On Linux, middle-clicking anywhere triggers a paste from the PRIMARY clipboard. When middle-dragging to pan the canvas, this causes the entire workflow to be duplicated as new nodes on mouse release.

**Solution:** Add `auxclick` event listener with `preventDefault()` to the graph canvas, blocking the paste while preserving pan functionality.

## Changes

- Add `auxclick` event listener in `bindEvents()` 
- Add corresponding `removeEventListener` in `unbindEvents()`

## Test Plan

- [ ] On Linux: Middle-drag to pan canvas - should pan without duplicating nodes
- [ ] On Linux: Verify left/right click behaviors unchanged
- [ ] On Windows/macOS: Verify no regression (auxclick should have no effect)

Fixes #4464

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8259-fix-prevent-middle-click-paste-duplicating-workflow-on-Linux-2f16d73d3650812b98f9cada699f5508) by [Unito](https://www.unito.io)
