### PR TITLE
Replace QPO with opening assets tab

### DIFF
--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -156,7 +156,7 @@ describe('TopMenuSection', () => {
   })
 
   it('opens the assets sidebar tab when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -167,5 +167,22 @@ describe('TopMenuSection', () => {
     await wrapper.find('[data-testid="queue-overlay-toggle"]').trigger('click')
 
     expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
+  })
+
+  it('toggles the assets sidebar tab when QPO V2 is enabled', async () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const settingStore = useSettingStore(pinia)
+    vi.mocked(settingStore.get).mockImplementation((key) =>
+      key === 'Comfy.Queue.QPOV2' ? true : undefined
+    )
+    const wrapper = createWrapper(pinia)
+    const sidebarTabStore = useSidebarTabStore(pinia)
+    const toggleButton = wrapper.find('[data-testid="queue-overlay-toggle"]')
+
+    await toggleButton.trigger('click')
+    expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
+
+    await toggleButton.trigger('click')
+    expect(sidebarTabStore.activeSidebarTabId).toBe(null)
   })
 })

--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -13,6 +13,7 @@ import type {
   JobStatus
 } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { isElectron } from '@/utils/envUtil'
@@ -160,6 +161,22 @@ describe('TopMenuSection', () => {
     expect(
       wrapper.findComponent({ name: 'QueueProgressOverlay' }).exists()
     ).toBe(false)
+  })
+
+  it('toggles the queue progress overlay when QPO V2 is disabled', async () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const settingStore = useSettingStore(pinia)
+    vi.mocked(settingStore.get).mockImplementation((key) =>
+      key === 'Comfy.Queue.QPOV2' ? false : undefined
+    )
+    const wrapper = createWrapper(pinia)
+    const commandStore = useCommandStore(pinia)
+
+    await wrapper.find('[data-testid="queue-overlay-toggle"]').trigger('click')
+
+    expect(commandStore.execute).toHaveBeenCalledWith(
+      'Comfy.Queue.ToggleOverlay'
+    )
   })
 
   it('opens the assets sidebar tab when QPO V2 is enabled', async () => {

--- a/src/components/TopMenuSection.vue
+++ b/src/components/TopMenuSection.vue
@@ -183,7 +183,7 @@ onMounted(() => {
 
 const toggleQueueOverlay = () => {
   if (isQueuePanelV2Enabled.value) {
-    sidebarTabStore.activeSidebarTabId = 'assets'
+    sidebarTabStore.toggleSidebarTab('assets')
     return
   }
   commandStore.execute('Comfy.Queue.ToggleOverlay')

--- a/src/components/TopMenuSection.vue
+++ b/src/components/TopMenuSection.vue
@@ -48,7 +48,7 @@
             :aria-pressed="
               isQueuePanelV2Enabled
                 ? activeSidebarTabId === 'assets'
-                : isQueueProgressOverlayVisible
+                : isQueueProgressOverlayEnabled
                   ? isQueueOverlayExpanded
                   : undefined
             "
@@ -87,7 +87,7 @@
         </div>
       </div>
       <QueueProgressOverlay
-        v-if="isQueueProgressOverlayVisible"
+        v-if="isQueueProgressOverlayEnabled"
         v-model:expanded="isQueueOverlayExpanded"
         :menu-hovered="isTopMenuHovered"
       />
@@ -161,7 +161,7 @@ const isIntegratedTabBar = computed(
 const isQueuePanelV2Enabled = computed(() =>
   settingStore.get('Comfy.Queue.QPOV2')
 )
-const isQueueProgressOverlayVisible = computed(
+const isQueueProgressOverlayEnabled = computed(
   () => !isQueuePanelV2Enabled.value
 )
 const queueHistoryTooltipConfig = computed(() =>

--- a/src/components/TopMenuSection.vue
+++ b/src/components/TopMenuSection.vue
@@ -46,7 +46,11 @@
             type="destructive"
             size="md"
             :aria-pressed="
-              isQueueProgressOverlayVisible ? isQueueOverlayExpanded : undefined
+              isQueuePanelV2Enabled
+                ? activeSidebarTabId === 'assets'
+                : isQueueProgressOverlayVisible
+                  ? isQueueOverlayExpanded
+                  : undefined
             "
             class="px-3"
             data-testid="queue-overlay-toggle"
@@ -137,6 +141,7 @@ const queueUIStore = useQueueUIStore()
 const sidebarTabStore = useSidebarTabStore()
 const { activeJobsCount } = storeToRefs(queueStore)
 const { isOverlayExpanded: isQueueOverlayExpanded } = storeToRefs(queueUIStore)
+const { activeSidebarTabId } = storeToRefs(sidebarTabStore)
 const releaseStore = useReleaseStore()
 const { shouldShowRedDot: showReleaseRedDot } = storeToRefs(releaseStore)
 const { shouldShowRedDot: shouldShowConflictRedDot } =


### PR DESCRIPTION
Route the queue progress button to toggle the Assets sidebar when QPO V2 is enabled.

This effectively "removes" the QPO for users with QPOV2 enabled.

https://github.com/user-attachments/assets/fa76482d-2dc7-4c28-8810-c15c338c51e4