### PR TITLE
[bugfix] Fix inconsistent menu icon sizes in ComfyMenuButton

### DIFF
--- a/src/components/sidebar/ComfyMenuButton.vue
+++ b/src/components/sidebar/ComfyMenuButton.vue
@@ -219,7 +219,7 @@ const extraMenuItems = computed(() => [
   {
     key: 'settings',
     label: t('g.settings'),
-    icon: 'mdi mdi-cog-outline',
+    icon: 'icon-[lucide--settings]',
     command: () => {
       telemetry?.trackUiButtonClicked({
         button_id: 'sidebar_settings_menu_opened'
@@ -230,7 +230,7 @@ const extraMenuItems = computed(() => [
   {
     key: 'manage-extensions',
     label: t('menu.manageExtensions'),
-    icon: 'mdi mdi-puzzle-outline',
+    icon: 'icon-[lucide--puzzle]',
     command: showManageExtensions
   }
 ])


### PR DESCRIPTION
## Summary
Replace MDI font icons with Tailwind Iconify (Lucide) icons for Settings and Manage Extensions menu items to fix size inconsistency with Browse Template icon.

## Changes
- **What**: MDI font icons (`mdi mdi-cog-outline`, `mdi mdi-puzzle-outline`) rendered at 14px (`text-sm` font-size), while the Tailwind Iconify icon (`icon-[comfy--template]`) rendered at ~16.8px due to `scale: 1.2` in the Tailwind plugin config. Replaced with `icon-[lucide--settings]` and `icon-[lucide--puzzle]` so all icons use the same rendering pipeline.

## Review Focus
- Visual consistency of the three menu icons at the same size

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8268-bugfix-Fix-inconsistent-menu-icon-sizes-in-ComfyMenuButton-2f16d73d3650819ab94cc84b89cf4b46) by [Unito](https://www.unito.io)
