### PR TITLE
fix: image selection modal Inputs Outputs filtering is not working

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -78,6 +78,8 @@ const maxSelectable = computed(() => {
   return 1
 })
 
+const itemsKey = computed(() => props.items.map((item) => item.id).join('|'))
+
 const filteredItems = ref<DropdownItem[]>([])
 
 const defaultSorter = computed<SortOption['sorter']>(() => {
@@ -209,7 +211,7 @@ async function customSearcher(
         :items="sortedItems"
         :is-selected="internalIsSelected"
         :max-selectable="maxSelectable"
-        :update-key="items"
+        :update-key="itemsKey"
         @close="closeDropdown"
         @item-click="handleSelection"
       />

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -209,6 +209,7 @@ async function customSearcher(
         :items="sortedItems"
         :is-selected="internalIsSelected"
         :max-selectable="maxSelectable"
+        :update-key="items"
         @close="closeDropdown"
         @item-click="handleSelection"
       />

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { MaybeRefOrGetter } from 'vue'
+
 import { cn } from '@/utils/tailwindUtil'
 
 import FormDropdownMenuActions from './FormDropdownMenuActions.vue'
@@ -21,6 +23,7 @@ interface Props {
     query: string,
     onCleanup: (cleanupFn: () => void) => void
   ) => Promise<void>
+  updateKey?: MaybeRefOrGetter<unknown>
 }
 
 defineProps<Props>()
@@ -54,6 +57,7 @@ const searchQuery = defineModel<string>('searchQuery')
       v-model:search-query="searchQuery"
       :sort-options="sortOptions"
       :searcher
+      :update-key="updateKey"
     />
     <!-- List -->
     <div class="relative flex h-full mt-2 overflow-y-scroll">

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { MaybeRefOrGetter } from 'vue'
+
 import Popover from 'primevue/popover'
 import { ref, useTemplateRef } from 'vue'
 
@@ -13,6 +15,7 @@ defineProps<{
     onCleanup: (cleanupFn: () => void) => void
   ) => Promise<void>
   sortOptions: SortOption[]
+  updateKey?: MaybeRefOrGetter<unknown>
 }>()
 
 const layoutMode = defineModel<LayoutMode>('layoutMode')
@@ -53,6 +56,7 @@ function handleSortSelected(item: SortOption) {
     <FormSearchInput
       v-model="searchQuery"
       :searcher
+      :update-key="updateKey"
       :class="
         cn(
           actionButtonStyle,


### PR DESCRIPTION
filteredItems only updates during search, and does not update when the filter changes. Trigger a re-search when items change through the updateKey prop chain.