### PR TITLE
docs(locale zh): confused with the original EmptyImageLatent, two identical options are displayed on the interface but they aren't the same.

### DIFF
--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -2327,7 +2327,7 @@
     }
   },
   "EmptyHunyuanImageLatent": {
-    "display_name": "空Latent图像",
+    "display_name": "空Latent图像（Hunyuan）",
     "inputs": {
       "batch_size": {
         "name": "批次大小"


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8273-docs-locale-zh-confused-with-the-original-EmptyImageLatent-two-identical-options-are-d-2f16d73d3650811b9a01dcfd058c1348) by [Unito](https://www.unito.io)
