### PR TITLE
fix: group recompute in item selection for properties panel

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4283,6 +4283,12 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     item.selected = true
     this.selectedItems.add(item)
     this.state.selectionChanged = true
+
+    if (item instanceof LGraphGroup) {
+      item.recomputeInsideNodes()
+      return
+    }
+
     if (!(item instanceof LGraphNode)) return
 
     // Node-specific handling


### PR DESCRIPTION
Group first click displays an empty node list in Right Side Panel. The reason is that when clicking the group, only `processSelect()` is called, and `recomputeInsideNodes()` is not called.

related https://github.com/Comfy-Org/ComfyUI_frontend/pull/8275

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8274-fix-group-recompute-in-item-selection-for-properties-panel-2f16d73d3650812ca394dc9de3d6855b) by [Unito](https://www.unito.io)
