### PR TITLE
Centralize output asset resolution for folder view

### DIFF
--- a/src/platform/assets/utils/outputAssetUtil.test.ts
+++ b/src/platform/assets/utils/outputAssetUtil.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
+import type { ResultItemImpl } from '@/stores/queueStore'
+
+import { resolveOutputAssetItems } from './outputAssetUtil'
+
+const mocks = vi.hoisted(() => ({
+  getJobDetail: vi.fn(),
+  getPreviewableOutputsFromJobDetail: vi.fn()
+}))
+
+vi.mock('@/services/jobOutputCache', () => ({
+  getJobDetail: mocks.getJobDetail,
+  getPreviewableOutputsFromJobDetail: mocks.getPreviewableOutputsFromJobDetail
+}))
+
+type OutputOverrides = Partial<{
+  filename: string
+  subfolder: string
+  nodeId: string
+  url: string
+}>
+
+function createOutput(overrides: OutputOverrides = {}): ResultItemImpl {
+  return {
+    filename: 'file.png',
+    subfolder: 'sub',
+    nodeId: '1',
+    url: 'https://example.com/file.png',
+    ...overrides
+  } as ResultItemImpl
+}
+
+describe('resolveOutputAssetItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps outputs and excludes a filename', async () => {
+    const outputA = createOutput({
+      filename: 'a.png',
+      nodeId: '1',
+      url: 'https://example.com/a.png'
+    })
+    const outputB = createOutput({
+      filename: 'b.png',
+      nodeId: '2',
+      url: 'https://example.com/b.png'
+    })
+    const metadata: OutputAssetMetadata = {
+      promptId: 'prompt-1',
+      nodeId: '1',
+      subfolder: 'sub',
+      executionTimeInSeconds: 12.5,
+      outputCount: 2,
+      allOutputs: [outputA, outputB]
+    }
+
+    const results = await resolveOutputAssetItems(metadata, {
+      createdAt: '2025-01-01T00:00:00.000Z',
+      excludeOutputKey: 'b.png'
+    })
+
+    expect(mocks.getJobDetail).not.toHaveBeenCalled()
+    expect(results).toHaveLength(1)
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        id: 'prompt-1-1-a.png',
+        name: 'a.png',
+        created_at: '2025-01-01T00:00:00.000Z',
+        tags: ['output'],
+        preview_url: 'https://example.com/a.png'
+      })
+    )
+    expect(results[0].user_metadata).toEqual(
+      expect.objectContaining({
+        promptId: 'prompt-1',
+        nodeId: '1',
+        subfolder: 'sub',
+        executionTimeInSeconds: 12.5
+      })
+    )
+  })
+
+  it('loads full outputs when metadata indicates more outputs', async () => {
+    const previewOutput = createOutput({
+      filename: 'preview.png',
+      nodeId: '1',
+      url: 'https://example.com/preview.png'
+    })
+    const fullOutput = createOutput({
+      filename: 'full.png',
+      nodeId: '2',
+      url: 'https://example.com/full.png'
+    })
+    const metadata: OutputAssetMetadata = {
+      promptId: 'prompt-2',
+      nodeId: '1',
+      subfolder: 'sub',
+      outputCount: 3,
+      allOutputs: [previewOutput]
+    }
+    const jobDetail = { id: 'job-1' }
+
+    mocks.getJobDetail.mockResolvedValue(jobDetail)
+    mocks.getPreviewableOutputsFromJobDetail.mockReturnValue([
+      fullOutput,
+      previewOutput
+    ])
+
+    const results = await resolveOutputAssetItems(metadata)
+
+    expect(mocks.getJobDetail).toHaveBeenCalledWith('prompt-2')
+    expect(mocks.getPreviewableOutputsFromJobDetail).toHaveBeenCalledWith(
+      jobDetail
+    )
+    expect(results.map((asset) => asset.name)).toEqual([
+      'full.png',
+      'preview.png'
+    ])
+  })
+})

--- a/src/platform/assets/utils/outputAssetUtil.test.ts
+++ b/src/platform/assets/utils/outputAssetUtil.test.ts
@@ -37,7 +37,7 @@ describe('resolveOutputAssetItems', () => {
     vi.clearAllMocks()
   })
 
-  it('maps outputs and excludes a filename', async () => {
+  it('maps outputs and excludes a composite output key', async () => {
     const outputA = createOutput({
       filename: 'a.png',
       nodeId: '1',
@@ -59,14 +59,14 @@ describe('resolveOutputAssetItems', () => {
 
     const results = await resolveOutputAssetItems(metadata, {
       createdAt: '2025-01-01T00:00:00.000Z',
-      excludeOutputKey: 'b.png'
+      excludeOutputKey: '2-sub-b.png'
     })
 
     expect(mocks.getJobDetail).not.toHaveBeenCalled()
     expect(results).toHaveLength(1)
     expect(results[0]).toEqual(
       expect.objectContaining({
-        id: 'prompt-1-1-a.png',
+        id: 'prompt-1-1-sub-a.png',
         name: 'a.png',
         created_at: '2025-01-01T00:00:00.000Z',
         tags: ['output'],

--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -12,7 +12,7 @@ type OutputAssetMapOptions = {
   createdAt?: string
   executionTimeInSeconds?: number
   workflow?: OutputAssetMetadata['workflow']
-  excludeFilename?: string
+  excludeOutputKey?: string
 }
 
 type ResolveOutputAssetItemsOptions = {
@@ -31,20 +31,26 @@ function shouldLoadFullOutputs(
   )
 }
 
+function getOutputKey(output: ResultItemImpl): string {
+  return `${output.nodeId}-${output.subfolder}-${output.filename}`
+}
+
 function mapOutputsToAssetItems({
   promptId,
   outputs,
   createdAt,
   executionTimeInSeconds,
   workflow,
-  excludeFilename
+  excludeOutputKey
 }: OutputAssetMapOptions): AssetItem[] {
   const createdAtValue = createdAt ?? new Date().toISOString()
 
   return outputs
-    .filter((output) => output.filename && output.filename !== excludeFilename)
+    .filter(
+      (output) => output.filename && getOutputKey(output) !== excludeOutputKey
+    )
     .map((output) => ({
-      id: `${promptId}-${output.nodeId}-${output.filename}`,
+      id: `${promptId}-${getOutputKey(output)}`,
       name: output.filename,
       size: 0,
       created_at: createdAtValue,
@@ -79,6 +85,6 @@ export async function resolveOutputAssetItems(
     createdAt,
     executionTimeInSeconds: metadata.executionTimeInSeconds,
     workflow: metadata.workflow,
-    excludeFilename: excludeOutputKey
+    excludeOutputKey
   })
 }

--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -1,0 +1,84 @@
+import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import {
+  getJobDetail,
+  getPreviewableOutputsFromJobDetail
+} from '@/services/jobOutputCache'
+import type { ResultItemImpl } from '@/stores/queueStore'
+
+type OutputAssetMapOptions = {
+  promptId: string
+  outputs: readonly ResultItemImpl[]
+  createdAt?: string
+  executionTimeInSeconds?: number
+  workflow?: OutputAssetMetadata['workflow']
+  excludeFilename?: string
+}
+
+type ResolveOutputAssetItemsOptions = {
+  createdAt?: string
+  excludeOutputKey?: string
+}
+
+function shouldLoadFullOutputs(
+  outputCount: OutputAssetMetadata['outputCount'],
+  outputsLength: number
+): boolean {
+  return (
+    typeof outputCount === 'number' &&
+    outputCount > 1 &&
+    outputsLength < outputCount
+  )
+}
+
+function mapOutputsToAssetItems({
+  promptId,
+  outputs,
+  createdAt,
+  executionTimeInSeconds,
+  workflow,
+  excludeFilename
+}: OutputAssetMapOptions): AssetItem[] {
+  const createdAtValue = createdAt ?? new Date().toISOString()
+
+  return outputs
+    .filter((output) => output.filename && output.filename !== excludeFilename)
+    .map((output) => ({
+      id: `${promptId}-${output.nodeId}-${output.filename}`,
+      name: output.filename,
+      size: 0,
+      created_at: createdAtValue,
+      tags: ['output'],
+      preview_url: output.url,
+      user_metadata: {
+        promptId,
+        nodeId: output.nodeId,
+        subfolder: output.subfolder,
+        executionTimeInSeconds,
+        workflow
+      }
+    }))
+}
+
+export async function resolveOutputAssetItems(
+  metadata: OutputAssetMetadata,
+  { createdAt, excludeOutputKey }: ResolveOutputAssetItemsOptions = {}
+): Promise<AssetItem[]> {
+  let outputsToDisplay = metadata.allOutputs ?? []
+  if (shouldLoadFullOutputs(metadata.outputCount, outputsToDisplay.length)) {
+    const jobDetail = await getJobDetail(metadata.promptId)
+    const previewableOutputs = getPreviewableOutputsFromJobDetail(jobDetail)
+    if (previewableOutputs.length) {
+      outputsToDisplay = previewableOutputs
+    }
+  }
+
+  return mapOutputsToAssetItems({
+    promptId: metadata.promptId,
+    outputs: outputsToDisplay,
+    createdAt,
+    executionTimeInSeconds: metadata.executionTimeInSeconds,
+    workflow: metadata.workflow,
+    excludeFilename: excludeOutputKey
+  })
+}


### PR DESCRIPTION
Add output asset resolution helper for folder view.

## Summary
Introduce `resolveOutputAssetItems` to reuse output mapping/"load full outputs" logic and use it in folder view.

## Changes
- **What**: add `outputAssetUtil` with tests; refactor folder view to call the helper.
- **Dependencies**: stacks on PR #8293 (job output preview helper).

## Review Focus
- Output mapping correctness when full outputs must be loaded.
- Folder view behavior unchanged with the new helper.

## Screenshots (if applicable)
N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8295-Centralize-output-asset-resolution-for-folder-view-2f26d73d36508191970df187e27f4a77) by [Unito](https://www.unito.io)
