### PR TITLE
Reconcile asset selection with visible items

### DIFF
--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -264,6 +264,7 @@ const focusAssetInSidebar = async (item: JobListItem) => {
     throw new Error('Asset not found in media assets panel')
   }
   assetSelectionStore.setSelection([assetId])
+  assetSelectionStore.setLastSelectedAssetId(assetId)
 }
 
 const inspectJobAsset = wrapWithErrorHandlingAsync(

--- a/src/platform/assets/composables/useAssetSelection.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.test.ts
@@ -1,0 +1,89 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import { useAssetSelection } from './useAssetSelection'
+import { useAssetSelectionStore } from './useAssetSelectionStore'
+
+vi.mock('@vueuse/core', () => ({
+  useKeyModifier: vi.fn(() => ref(false))
+}))
+
+describe('useAssetSelection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('prunes selection to visible assets', () => {
+    const selection = useAssetSelection()
+    const store = useAssetSelectionStore()
+    const assets: AssetItem[] = [
+      { id: 'a', name: 'a.png', tags: [] },
+      { id: 'b', name: 'b.png', tags: [] }
+    ]
+
+    store.setSelection(['a', 'b'])
+    store.setLastSelectedIndex(1)
+    store.setLastSelectedAssetId('b')
+
+    selection.reconcileSelection([assets[1]])
+
+    expect(Array.from(store.selectedAssetIds)).toEqual(['b'])
+    expect(store.lastSelectedIndex).toBe(0)
+    expect(store.lastSelectedAssetId).toBe('b')
+  })
+
+  it('clears selection when no visible assets remain', () => {
+    const selection = useAssetSelection()
+    const store = useAssetSelectionStore()
+
+    store.setSelection(['a'])
+    store.setLastSelectedIndex(0)
+    store.setLastSelectedAssetId('a')
+
+    selection.reconcileSelection([])
+
+    expect(store.selectedAssetIds.size).toBe(0)
+    expect(store.lastSelectedIndex).toBe(-1)
+    expect(store.lastSelectedAssetId).toBeNull()
+  })
+
+  it('recomputes the anchor index when assets reorder', () => {
+    const selection = useAssetSelection()
+    const store = useAssetSelectionStore()
+    const assets: AssetItem[] = [
+      { id: 'a', name: 'a.png', tags: [] },
+      { id: 'b', name: 'b.png', tags: [] }
+    ]
+
+    store.setSelection(['a'])
+    store.setLastSelectedIndex(0)
+    store.setLastSelectedAssetId('a')
+
+    selection.reconcileSelection([assets[1], assets[0]])
+
+    expect(store.lastSelectedIndex).toBe(1)
+    expect(store.lastSelectedAssetId).toBe('a')
+  })
+
+  it('clears anchor when the anchored asset is no longer visible', () => {
+    const selection = useAssetSelection()
+    const store = useAssetSelectionStore()
+    const assets: AssetItem[] = [
+      { id: 'a', name: 'a.png', tags: [] },
+      { id: 'b', name: 'b.png', tags: [] }
+    ]
+
+    store.setSelection(['a', 'b'])
+    store.setLastSelectedIndex(0)
+    store.setLastSelectedAssetId('a')
+
+    selection.reconcileSelection([assets[1]])
+
+    expect(Array.from(store.selectedAssetIds)).toEqual(['b'])
+    expect(store.lastSelectedIndex).toBe(-1)
+    expect(store.lastSelectedAssetId).toBeNull()
+  })
+})

--- a/src/platform/assets/composables/useAssetSelectionStore.ts
+++ b/src/platform/assets/composables/useAssetSelectionStore.ts
@@ -5,6 +5,7 @@ export const useAssetSelectionStore = defineStore('assetSelection', () => {
   // State
   const selectedAssetIds = ref<Set<string>>(new Set())
   const lastSelectedIndex = ref<number>(-1)
+  const lastSelectedAssetId = ref<string | null>(null)
 
   // Getters
   const selectedCount = computed(() => selectedAssetIds.value.size)
@@ -34,6 +35,7 @@ export const useAssetSelectionStore = defineStore('assetSelection', () => {
   function clearSelection() {
     selectedAssetIds.value.clear()
     lastSelectedIndex.value = -1
+    lastSelectedAssetId.value = null
   }
 
   function toggleSelection(assetId: string) {
@@ -52,16 +54,15 @@ export const useAssetSelectionStore = defineStore('assetSelection', () => {
     lastSelectedIndex.value = index
   }
 
-  // Reset function for cleanup
-  function reset() {
-    selectedAssetIds.value.clear()
-    lastSelectedIndex.value = -1
+  function setLastSelectedAssetId(assetId: string | null) {
+    lastSelectedAssetId.value = assetId
   }
 
   return {
     // State
     selectedAssetIds: computed(() => selectedAssetIds.value),
     lastSelectedIndex: computed(() => lastSelectedIndex.value),
+    lastSelectedAssetId: computed(() => lastSelectedAssetId.value),
 
     // Getters
     selectedCount,
@@ -76,6 +77,6 @@ export const useAssetSelectionStore = defineStore('assetSelection', () => {
     toggleSelection,
     isSelected,
     setLastSelectedIndex,
-    reset
+    setLastSelectedAssetId
   }
 })


### PR DESCRIPTION
Reconcile asset selection and anchor state with visible assets.

## Summary
Track selection anchor by asset id and prune selection when assets are hidden or reordered so list/gallery actions stay aligned.

## Changes
- **What**: add selection anchor id to the store and reconciliation logic in `useAssetSelection`, plus coverage and queue overlay alignment.
- **Dependencies**: stacks on PR #8295.

## Review Focus
- Selection anchor updates on prune/reorder.
- Queue overlay selection updates now also set anchor id.

## Screenshots (if applicable)
N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8296-Reconcile-asset-selection-with-visible-items-2f26d73d365081f0811cc832082c2a26) by [Unito](https://www.unito.io)
