### PR TITLE
fix: persist assets sidebar view mode

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -201,7 +201,12 @@
 </template>
 
 <script setup lang="ts">
-import { useDebounceFn, useElementHover, useResizeObserver } from '@vueuse/core'
+import {
+  useDebounceFn,
+  useElementHover,
+  useResizeObserver,
+  useStorage
+} from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import Divider from 'primevue/divider'
 import ProgressSpinner from 'primevue/progressspinner'
@@ -255,7 +260,10 @@ const activeTab = ref<'input' | 'output'>('output')
 const folderPromptId = ref<string | null>(null)
 const folderExecutionTime = ref<number | undefined>(undefined)
 const isInFolderView = computed(() => folderPromptId.value !== null)
-const viewMode = ref<'list' | 'grid'>('grid')
+const viewMode = useStorage<'list' | 'grid'>(
+  'Comfy.Assets.Sidebar.ViewMode',
+  'grid'
+)
 const isQueuePanelV2Enabled = computed(() =>
   settingStore.get('Comfy.Queue.QPOV2')
 )


### PR DESCRIPTION
## Summary

Persist assets sidebar view-mode preference so list/grid selection survives toggling the sidebar.

## Changes

- **What**: Store assets sidebar view mode in local storage via `useStorage`.

## Review Focus

- Confirm the list/grid choice persists after closing and reopening the Assets sidebar.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8299-fix-persist-assets-sidebar-view-mode-2f26d73d365081b3a1ecd9480fc1a123) by [Unito](https://www.unito.io)
