### PR TITLE
Allow augmenting input spec by property

### DIFF
--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -132,7 +132,7 @@ const zCustomInputSpec = zBaseInputOptions.extend({
   isOptional: z.boolean().optional()
 })
 
-const zInputSpec = z.union([
+export const zInputSpec = z.union([
   zIntInputSpec,
   zFloatInputSpec,
   zBooleanInputSpec,

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -36,6 +36,7 @@ import type { NodeId } from '@/platform/workflow/validation/schemas/workflowSche
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useDialogService } from '@/services/dialogService'
 import { transformInputSpecV2ToV1 } from '@/schemas/nodeDef/migration'
+import { zInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type {
   ComfyNodeDef as ComfyNodeDefV2,
   InputSpec,
@@ -465,6 +466,8 @@ export const useLitegraphService = () => {
               : output
           }
         )
+        const maybeDef = zInputSpec.safeParse(data.properties?.dynamicSpec).data
+        if (maybeDef) addNodeInput(this, maybeDef)
 
         data.widgets_values = migrateWidgetsValues(
           ComfyNode.nodeData.inputs,


### PR DESCRIPTION
In order for GLSL nodes to be configurable by subgraph, it's desirable that there be a way to provide a dynamicCombo adjacent experience which is defined in workflow, similar to the the custom numbers or custom combo.

This PR adds support for a special `dynamicSpec` property on nodes which, if present and safely parsable to an inputSpecV2, will add a corresponding input to the node.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8312-Allow-augmenting-input-spec-by-property-2f36d73d36508143bc32fc57f5190cfe) by [Unito](https://www.unito.io)
