### PR TITLE
refactor(GraphCanvas): fix anti-patterns and improve robustness

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -322,7 +322,10 @@ watch(
 watch(
   () => colorPaletteStore.activePaletteId,
   async (newValue) => {
-    await settingStore.set('Comfy.ColorPalette', newValue)
+    // Guard against ping-pong: only set if value actually differs
+    if (newValue && settingStore.get('Comfy.ColorPalette') !== newValue) {
+      await settingStore.set('Comfy.ColorPalette', newValue)
+    }
   }
 )
 


### PR DESCRIPTION
Fixes anti-patterns in GraphCanvas.vue identified by code review.

## Changes

**Critical Fixes**
- Fixed dead `isNativeWindow` template condition
- Added disposed flag and cancellation guards after each await in onMounted
- Store and restore `onSelectionChange` callback in onUnmounted

**Performance Fixes**
- Removed unnecessary `deep: true` from progress watcher
- Added run-id race guards to locale/palette/background watchers

**Code Organization**
- Consolidated two Vue node lifecycle reset watchers into one
- Removed duplicate `useVueFeatureFlags()` call
- Cached store references at top level instead of repeated calls inside watchers

**Reactivity Fixes**
- Added ping-pong guard to palette setting watcher

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8315-refactor-GraphCanvas-fix-anti-patterns-and-improve-robustness-2f46d73d365081e1bd28d464cfbd76ee) by [Unito](https://www.unito.io)
