### PR TITLE
fix: resolve no-misused-spread lint warnings in test files

### DIFF
--- a/src/components/graph/selectionToolbox/BypassButton.test.ts
+++ b/src/components/graph/selectionToolbox/BypassButton.test.ts
@@ -85,11 +85,10 @@ describe('BypassButton', () => {
   })
 
   it('should show bypassed styling when node is bypassed', async () => {
-    const bypassedNode: Partial<LGraphNode> = {
-      ...getMockLGraphNode(),
+    const bypassedNode = Object.assign(getMockLGraphNode(), {
       mode: LGraphEventMode.BYPASS
-    }
-    canvasStore.selectedItems = [bypassedNode as LGraphNode]
+    })
+    canvasStore.selectedItems = [bypassedNode]
     vi.spyOn(commandStore, 'execute').mockResolvedValue()
     const wrapper = mountComponent()
 

--- a/src/composables/graph/useGraphHierarchy.test.ts
+++ b/src/composables/graph/useGraphHierarchy.test.ts
@@ -14,11 +14,13 @@ import { useGraphHierarchy } from './useGraphHierarchy'
 vi.mock('@/renderer/core/canvas/canvasStore')
 
 function createMockNode(overrides: Partial<LGraphNode> = {}): LGraphNode {
-  return {
-    ...createMockLGraphNode(),
-    boundingRect: new Rectangle(100, 100, 50, 50),
-    ...overrides
-  } as LGraphNode
+  return Object.assign(
+    createMockLGraphNode(),
+    {
+      boundingRect: new Rectangle(100, 100, 50, 50)
+    },
+    overrides
+  ) as LGraphNode
 }
 
 function createMockGroup(overrides: Partial<LGraphGroup> = {}): LGraphGroup {

--- a/src/composables/graph/useGraphHierarchy.test.ts
+++ b/src/composables/graph/useGraphHierarchy.test.ts
@@ -20,7 +20,7 @@ function createMockNode(overrides: Partial<LGraphNode> = {}): LGraphNode {
       boundingRect: new Rectangle(100, 100, 50, 50)
     },
     overrides
-  ) as LGraphNode
+  )
 }
 
 function createMockGroup(overrides: Partial<LGraphGroup> = {}): LGraphGroup {

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -191,13 +191,15 @@ export function createMockLGraphNodeWithArrayBoundingRect(
  * Creates a mock FileList from an array of files
  */
 export function createMockFileList(files: File[]): FileList {
-  const fileList = {
-    ...files,
-    length: files.length,
-    item: (index: number) => files[index] ?? null,
-    [Symbol.iterator]: function* () {
-      yield* files
-    }
-  }
+  const fileList = Object.assign(
+    {
+      length: files.length,
+      item: (index: number) => files[index] ?? null,
+      [Symbol.iterator]: function* () {
+        yield* files
+      }
+    },
+    files
+  )
   return fileList as FileList
 }


### PR DESCRIPTION
## Summary

Replace spread operators with Object.assign() to fix 3 no-misused-spread lint warnings in test utilities and test files.

## Changes

- **What**: Replaced spread operators with Object.assign() in createMockFileList and mock node creation functions to avoid spreading arrays into objects and class instances that could lose prototypes. Simplified BypassButton.test.ts by removing redundant type annotations.
- **Breaking**: None

## Review Focus

Type safety is preserved without using weak TypeScript patterns (no `any`, `as unknown as`, or unnecessary casts).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8318-fix-resolve-no-misused-spread-lint-warnings-in-test-files-2f46d73d365081aca3f6cf208556d492) by [Unito](https://www.unito.io)
