### PR TITLE
perf: remove autoplay from assets cards

### DIFF
--- a/src/platform/assets/components/MediaVideoTop.vue
+++ b/src/platform/assets/components/MediaVideoTop.vue
@@ -7,7 +7,6 @@
     <video
       :controls="shouldShowControls"
       preload="metadata"
-      autoplay
       muted
       loop
       playsinline


### PR DESCRIPTION
## Summary

It's rare that someone has enabled autoplay -- but when they have, scrolling through a large grid of videos and trying to play them all onload can cause extreme lag. We don't need the asset cards to be autoplaying, so the fix here is fine for perf and UX.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8325-perf-remove-autoplay-from-assets-cards-2f56d73d3650814e8103f01b1f21b2e2) by [Unito](https://www.unito.io)
