### PR TITLE
feat: add Hugging Face model source support

### DIFF
--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -50,6 +50,12 @@
             alt=""
             class="size-4 shrink-0"
           />
+          <img
+            v-else-if="sourceName === 'Hugging Face'"
+            src="/assets/images/hf-logo.svg"
+            alt=""
+            class="size-4 shrink-0"
+          />
           {{ t('assetBrowser.modelInfo.viewOnSource', { source: sourceName }) }}
           <i class="icon-[lucide--external-link] size-4 shrink-0" />
         </a>

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -72,6 +72,9 @@ export function getAssetDisplayName(asset: AssetItem): string {
  * @returns The source URL or null if not present/parseable
  */
 export function getAssetSourceUrl(asset: AssetItem): string | null {
+  if (typeof asset.metadata?.repo_url === 'string') {
+    return asset.metadata.repo_url
+  }
   // Note: Reversed priority for backwards compatibility
   const sourceArn =
     asset.metadata?.source_arn ?? asset.user_metadata?.source_arn


### PR DESCRIPTION
Add support for Hugging Face as a model source in the Model Info Panel.

- Display HF logo for Hugging Face sources
- Extract source URL from `repo_url` metadata field

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8330-feat-add-Hugging-Face-model-source-support-2f56d73d3650816b8a01d903411ee3a1) by [Unito](https://www.unito.io)
