### PR TITLE
feat: Make the text for the value control a clickable label

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import RadioButton from 'primevue/radiobutton'
+import Button from '@/components/ui/button/Button.vue'
 import { computed } from 'vue'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -64,14 +65,17 @@ const controlMode = defineModel<ControlOptions>()
     </div>
 
     <div class="space-y-2">
-      <div
+      <Button
         v-for="option in controlOptions"
         :key="option.mode"
-        class="flex items-center justify-between py-2 gap-7"
+        as="label"
+        variant="textonly"
+        size="lg"
+        class="flex w-full h-[unset] text-left items-center justify-between py-2 gap-7"
+        :for="option.mode"
       >
-        <label
-          class="flex items-center gap-2 flex-1 min-w-0"
-          :for="option.mode"
+        <div
+          class="flex items-center gap-2 flex-1 min-w-0 text-wrap"
         >
           <div
             class="flex items-center justify-center w-8 h-8 rounded-lg flex-shrink-0 bg-secondary-background border border-border-subtle"
@@ -101,15 +105,15 @@ const controlMode = defineModel<ControlOptions>()
               {{ $t(`widgets.valueControl.${option.description}`) }}
             </div>
           </div>
-        </label>
+        </div>
 
         <RadioButton
           v-model="controlMode"
-          class="flex-shrink-0"
+          class="shrink"
           :input-id="option.mode"
           :value="option.mode"
         />
-      </div>
+      </Button>
     </div>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.vue
@@ -69,7 +69,10 @@ const controlMode = defineModel<ControlOptions>()
         :key="option.mode"
         class="flex items-center justify-between py-2 gap-7"
       >
-        <div class="flex items-center gap-2 flex-1 min-w-0">
+        <label
+          class="flex items-center gap-2 flex-1 min-w-0"
+          :for="option.mode"
+        >
           <div
             class="flex items-center justify-center w-8 h-8 rounded-lg flex-shrink-0 bg-secondary-background border border-border-subtle"
           >
@@ -98,7 +101,7 @@ const controlMode = defineModel<ControlOptions>()
               {{ $t(`widgets.valueControl.${option.description}`) }}
             </div>
           </div>
-        </div>
+        </label>
 
         <RadioButton
           v-model="controlMode"

--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.vue
@@ -74,9 +74,7 @@ const controlMode = defineModel<ControlOptions>()
         class="flex w-full h-[unset] text-left items-center justify-between py-2 gap-7"
         :for="option.mode"
       >
-        <div
-          class="flex items-center gap-2 flex-1 min-w-0 text-wrap"
-        >
+        <div class="flex items-center gap-2 flex-1 min-w-0 text-wrap">
           <div
             class="flex items-center justify-center w-8 h-8 rounded-lg flex-shrink-0 bg-secondary-background border border-border-subtle"
           >


### PR DESCRIPTION
## Summary

More clickable!

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8334-feat-Make-the-text-for-the-value-control-a-clickable-label-2f56d73d365081e79886eddeec03458e) by [Unito](https://www.unito.io)
