### PR TITLE
fix: include items array in purchase dataLayer

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -237,10 +237,14 @@ describe('useSubscription', () => {
         event: 'purchase',
         transaction_id: 'sub_123',
         currency: 'USD',
-        item_id: 'monthly_creator',
-        item_variant: 'monthly',
-        item_category: 'subscription',
-        quantity: 1
+        items: [
+          {
+            item_id: 'monthly_creator',
+            item_variant: 'monthly',
+            item_category: 'subscription',
+            quantity: 1
+          }
+        ]
       })
       expect(localStorage.getItem('pending_subscription_purchase')).toBeNull()
     })

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -121,18 +121,21 @@ function useSubscriptionInternal() {
       : baseName
     const unitPrice = getTierPrice(tierKey, isYearly)
     const value = isYearly && tierKey !== 'founder' ? unitPrice * 12 : unitPrice
-
     pushDataLayerEvent({
       event: 'purchase',
       transaction_id: status.subscription_id,
       value,
       currency: 'USD',
-      item_id: `${billingCycle}_${tierKey}`,
-      item_name: planName,
-      item_category: 'subscription',
-      item_variant: billingCycle,
-      price: value,
-      quantity: 1
+      items: [
+        {
+          item_id: `${billingCycle}_${tierKey}`,
+          item_name: planName,
+          item_category: 'subscription',
+          item_variant: billingCycle,
+          price: value,
+          quantity: 1
+        }
+      ]
     })
 
     clearPendingSubscriptionPurchase()


### PR DESCRIPTION
Include GA4-style `items` payload for subscription purchase events so GTM receives the full item array.

So, to align with GA4's ecommerce standards, we changed it to an items array: https://developers.google.com/analytics/devguides/collection/ga4/item-scoped-ecommerce
