### PR TITLE
fix: await needsLogin

### DIFF
--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -42,10 +42,11 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   }))
 }))
 
+const mockNeedsLogin = ref(false)
 vi.mock('@/stores/userStore', () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: false
+    needsLogin: mockNeedsLogin
   }))
 }))
 
@@ -65,6 +66,7 @@ describe('bootstrapStore', () => {
   beforeEach(() => {
     mockIsSettingsReady.value = false
     mockIsFirebaseInitialized.value = false
+    mockNeedsLogin.value = false
     mockDistributionTypes.isCloud = false
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()


### PR DESCRIPTION
## Summary

Add additional protection for bootstrap order issues.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8340-fix-await-needsLogin-2f56d73d365081c9b3c6d5a091c1eb8d) by [Unito](https://www.unito.io)
