### PR TITLE
Prevent configuring a node to a placeholder nodeId

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -137,6 +137,13 @@ describe('LGraphNode', () => {
     expect(node.id).toEqual(1)
     expect(node.outputs.length).toEqual(1)
   })
+  test('should not allow configuring id to -1', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('TestNode')
+    graph.add(node)
+    node.configure(getMockISerialisedNode({ id: -1 }))
+    expect(node.id).not.toBe(-1)
+  })
 
   describe('Disconnect I/O Slots', () => {
     test('should disconnect input correctly', () => {

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -785,7 +785,7 @@ export class LGraphNode
     if (this.graph) {
       this.graph._version++
     }
-    if (info.id == -1) info.id = this.id
+    if (info.id === -1) info.id = this.id
     for (const j in info) {
       if (j == 'properties') {
         // i don't want to clone properties, I want to reuse the old container

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -785,6 +785,7 @@ export class LGraphNode
     if (this.graph) {
       this.graph._version++
     }
+    if (info.id == -1) info.id = this.id
     for (const j in info) {
       if (j == 'properties') {
         // i don't want to clone properties, I want to reuse the old container


### PR DESCRIPTION
Litegraph uses `-1 ` as a placeholder node id to indicate that a node should be assigned a new node id when added to the graph. Under some unknown circumstances it's possible for a node to have this placeholder id saved in a workflow file. 

When this occurs, the node is loaded and assigned a new id, but then configured back to the placeholder id. This PR makes it so the newly assigned id is kept instead.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8342-Prevent-configuring-a-node-to-a-placehodler-nodeId-2f56d73d365081ed8217e989187b15c8) by [Unito](https://www.unito.io)
