### PR TITLE
feat: support dev-only nodes

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -261,20 +261,6 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
-  const devModeEnabled = settingStore.get('Comfy.DevMode')
-  nodeDefStore.showDevOnly = devModeEnabled
-
-  // Update skip_list on all registered node types for dev-only nodes
-  // This ensures LiteGraph's getNodeTypesCategories/getNodeTypesInCategory
-  // correctly filter dev-only nodes from the right-click context menu
-  for (const nodeType of Object.values(LiteGraph.registered_node_types)) {
-    if (nodeType.nodeData?.dev_only) {
-      nodeType.skip_list = !devModeEnabled
-    }
-  }
-})
-
-watchEffect(() => {
   const spellcheckEnabled = settingStore.get('Comfy.TextareaWidget.Spellcheck')
   const textareas = document.querySelectorAll<HTMLTextAreaElement>(
     'textarea.comfy-multiline-input'

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -261,7 +261,17 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
-  nodeDefStore.showDevOnly = settingStore.get('Comfy.DevMode')
+  const devModeEnabled = settingStore.get('Comfy.DevMode')
+  nodeDefStore.showDevOnly = devModeEnabled
+
+  // Update skip_list on all registered node types for dev-only nodes
+  // This ensures LiteGraph's getNodeTypesCategories/getNodeTypesInCategory
+  // correctly filter dev-only nodes from the right-click context menu
+  for (const nodeType of Object.values(LiteGraph.registered_node_types)) {
+    if (nodeType.nodeData?.dev_only) {
+      nodeType.skip_list = !devModeEnabled
+    }
+  }
 })
 
 watchEffect(() => {

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -261,6 +261,10 @@ watchEffect(() => {
 })
 
 watchEffect(() => {
+  nodeDefStore.showDevOnly = settingStore.get('Comfy.DevMode')
+})
+
+watchEffect(() => {
   const spellcheckEnabled = settingStore.get('Comfy.TextareaWidget.Spellcheck')
   const textareas = document.querySelectorAll<HTMLTextAreaElement>(
     'textarea.comfy-multiline-input'

--- a/src/components/searchbox/NodeSearchItem.vue
+++ b/src/components/searchbox/NodeSearchItem.vue
@@ -22,15 +22,16 @@
     </div>
     <div class="option-badges">
       <Tag
-        v-if="nodeDef.experimental"
-        :value="$t('g.experimental')"
-        severity="primary"
-      />
-      <Tag
         v-if="nodeDef.deprecated"
         :value="$t('g.deprecated')"
         severity="danger"
       />
+      <Tag
+        v-if="nodeDef.experimental"
+        :value="$t('g.experimental')"
+        severity="primary"
+      />
+      <Tag v-if="nodeDef.dev_only" :value="$t('g.devOnly')" severity="info" />
       <Tag
         v-if="showNodeFrequency && nodeFrequency > 0"
         :value="formatNumberWithSuffix(nodeFrequency, { roundToInt: true })"

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -237,7 +237,9 @@ export class LGraphNode
     dev_only?: boolean
     deprecated?: boolean
     experimental?: boolean
-    [key: string]: unknown
+    output_node?: boolean
+    api_node?: boolean
+    name?: string
   }
 
   static resizeHandleSize = 15

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -233,6 +233,12 @@ export class LGraphNode
   static description?: string
   static filter?: string
   static skip_list?: boolean
+  static nodeData?: {
+    dev_only?: boolean
+    deprecated?: boolean
+    experimental?: boolean
+    [key: string]: unknown
+  }
 
   static resizeHandleSize = 15
   static resizeEdgeSize = 5

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -121,6 +121,7 @@
     "customize": "Customize",
     "experimental": "BETA",
     "deprecated": "DEPR",
+    "devOnly": "DEV",
     "loadWorkflow": "Load Workflow",
     "goToNode": "Go to Node",
     "setAsBackground": "Set as Background",

--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -174,6 +174,7 @@ export const zComfyNodeDef = z.object({
   python_module: z.string(),
   deprecated: z.boolean().optional(),
   experimental: z.boolean().optional(),
+  dev_only: z.boolean().optional(),
   api_node: z.boolean().optional()
 })
 

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -257,6 +257,7 @@ export const zComfyNodeDef = z.object({
   python_module: z.string(),
   deprecated: z.boolean().optional(),
   experimental: z.boolean().optional(),
+  dev_only: z.boolean().optional(),
   /**
    * Whether the node is an API node. Running API nodes requires login to
    * Comfy Org account.

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -261,7 +261,7 @@ export const useLitegraphService = () => {
       static comfyClass: string
       static override title: string
       static override category: string
-      static nodeData: ComfyNodeDefV1 & ComfyNodeDefV2
+      static override nodeData: ComfyNodeDefV1 & ComfyNodeDefV2
 
       _initialMinSize = { width: 1, height: 1 }
 
@@ -394,7 +394,7 @@ export const useLitegraphService = () => {
       static comfyClass: string
       static override title: string
       static override category: string
-      static nodeData: ComfyNodeDefV1 & ComfyNodeDefV2
+      static override nodeData: ComfyNodeDefV1 & ComfyNodeDefV2
 
       _initialMinSize = { width: 1, height: 1 }
 
@@ -496,6 +496,13 @@ export const useLitegraphService = () => {
     // because `registerNodeType` will overwrite the assignments.
     node.category = nodeDef.category
     node.title = nodeDef.display_name || nodeDef.name
+
+    // Set skip_list for dev-only nodes based on current DevMode setting
+    // This ensures nodes registered after initial load respect the current setting
+    if (nodeDef.dev_only) {
+      const settingStore = useSettingStore()
+      node.skip_list = !settingStore.get('Comfy.DevMode')
+    }
   }
 
   /**

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -41,6 +41,7 @@ export class ComfyNodeDefImpl
   readonly help: string
   readonly deprecated: boolean
   readonly experimental: boolean
+  readonly dev_only: boolean
   readonly output_node: boolean
   readonly api_node: boolean
   /**
@@ -133,6 +134,7 @@ export class ComfyNodeDefImpl
     this.deprecated = obj.deprecated ?? obj.category === ''
     this.experimental =
       obj.experimental ?? obj.category.startsWith('_for_testing')
+    this.dev_only = obj.dev_only ?? false
     this.output_node = obj.output_node
     this.api_node = !!obj.api_node
     this.input = obj.input ?? {}
@@ -174,6 +176,7 @@ export class ComfyNodeDefImpl
   get nodeLifeCycleBadgeText(): string {
     if (this.deprecated) return '[DEPR]'
     if (this.experimental) return '[BETA]'
+    if (this.dev_only) return '[DEV]'
     return ''
   }
 }
@@ -303,6 +306,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   const nodeDefsByDisplayName = ref<Record<string, ComfyNodeDefImpl>>({})
   const showDeprecated = ref(false)
   const showExperimental = ref(false)
+  const showDevOnly = ref(false)
   const nodeDefFilters = ref<NodeDefFilter[]>([])
 
   const nodeDefs = computed(() => {
@@ -422,6 +426,14 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
       predicate: (nodeDef) => showExperimental.value || !nodeDef.experimental
     })
 
+    // Dev-only nodes filter
+    registerNodeDefFilter({
+      id: 'core.dev_only',
+      name: 'Hide Dev-Only Nodes',
+      description: 'Hides nodes marked as dev-only unless dev mode is enabled',
+      predicate: (nodeDef) => showDevOnly.value || !nodeDef.dev_only
+    })
+
     // Subgraph nodes filter
     // Filter out litegraph typed subgraphs, saved blueprints are added in separately
     registerNodeDefFilter({
@@ -446,6 +458,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     nodeDefsByDisplayName,
     showDeprecated,
     showExperimental,
+    showDevOnly,
     nodeDefFilters,
 
     nodeDefs,

--- a/src/utils/nodeFilterUtil.test.ts
+++ b/src/utils/nodeFilterUtil.test.ts
@@ -11,7 +11,7 @@ describe('nodeFilterUtil', () => {
   ): LGraphNode => {
     // Create a custom class with the nodeData static property
     class MockNode extends LGraphNode {
-      static nodeData = isOutputNode ? { output_node: true } : {}
+      static override nodeData = isOutputNode ? { output_node: true } : {}
     }
 
     const node = new MockNode('')
@@ -72,7 +72,7 @@ describe('nodeFilterUtil', () => {
 
     it('should handle nodes with undefined output_node', () => {
       class MockNodeWithOtherData extends LGraphNode {
-        static nodeData = { someOtherProperty: true }
+        static override nodeData = { someOtherProperty: true }
       }
 
       const node = new MockNodeWithOtherData('')

--- a/src/utils/nodeFilterUtil.test.ts
+++ b/src/utils/nodeFilterUtil.test.ts
@@ -71,11 +71,11 @@ describe('nodeFilterUtil', () => {
     })
 
     it('should handle nodes with undefined output_node', () => {
-      class MockNodeWithOtherData extends LGraphNode {
-        static override nodeData = { someOtherProperty: true }
+      class MockNodeWithEmptyData extends LGraphNode {
+        static override nodeData = {}
       }
 
-      const node = new MockNodeWithOtherData('')
+      const node = new MockNodeWithEmptyData('')
       node.id = 1
 
       const result = filterOutputNodes([node])


### PR DESCRIPTION
## Summary

Support `dev_only` property to node definitions that hides nodes from search and menus unless dev mode is enabled. Dev-only nodes display a "DEV" badge when visible.

This functionality is primarily intended to support unit-testing nodes on Comfy Cloud, but also has other uses.

## Changes

- **What**: Nodes flagged as dev_only in the node schema will only appear in search and menus if Dev Mode is on.

## Screenshots (if applicable)

With Dev Mode off:
<img width="2189" height="1003" alt="image" src="https://github.com/user-attachments/assets/a08e1fd7-dca9-4ce1-9964-5f4f3b7b95ac" />

With Dev Mode on:
<img width="2201" height="1066" alt="image" src="https://github.com/user-attachments/assets/7fe6cd1f-f774-4f48-b604-a528e286b584" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8359-feat-support-dev-only-nodes-2f66d73d36508102839ee7cd66a26129) by [Unito](https://www.unito.io)
