### PR TITLE
CI: Add formatting after generating locales.

### DIFF
--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           PLAYWRIGHT_TEST_URL: http://localhost:5173
       - name: Update translations
-        run: pnpm locale
+        run: pnpm locale && pnpm format
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: Commit updated locales


### PR DESCRIPTION
## Summary

Hopefully prevent thrashing from formatting disagreements.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8360-CI-Add-formatting-after-generating-locales-2f66d73d36508143a2f6d5ba90056110) by [Unito](https://www.unito.io)
