### PR TITLE
feat: add provider logo overlays to workflow template thumbnails

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -254,7 +254,7 @@
                     <LogoOverlay
                       v-if="template.logos?.length"
                       :logos="template.logos"
-                      :get-logo-url="getLogoUrl"
+                      :get-logo-url="workflowTemplatesStore.getLogoUrl"
                     />
                     <ProgressSpinner
                       v-if="loadingTemplate === template.name"
@@ -478,8 +478,7 @@ const {
   loadWorkflowTemplate,
   getTemplateThumbnailUrl,
   getTemplateTitle,
-  getTemplateDescription,
-  getLogoUrl
+  getTemplateDescription
 } = useTemplateWorkflows()
 
 const getEffectiveSourceModule = (template: TemplateInfo) =>

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -251,6 +251,11 @@
                         "
                       />
                     </template>
+                    <LogoOverlay
+                      v-if="template.logos?.length"
+                      :logos="template.logos"
+                      :get-logo-url="getLogoUrl"
+                    />
                     <ProgressSpinner
                       v-if="loadingTemplate === template.name"
                       class="absolute inset-0 z-10 m-auto h-12 w-12"
@@ -392,6 +397,7 @@ import AudioThumbnail from '@/components/templates/thumbnails/AudioThumbnail.vue
 import CompareSliderThumbnail from '@/components/templates/thumbnails/CompareSliderThumbnail.vue'
 import DefaultThumbnail from '@/components/templates/thumbnails/DefaultThumbnail.vue'
 import HoverDissolveThumbnail from '@/components/templates/thumbnails/HoverDissolveThumbnail.vue'
+import LogoOverlay from '@/components/templates/thumbnails/LogoOverlay.vue'
 import Button from '@/components/ui/button/Button.vue'
 import BaseModalLayout from '@/components/widget/layout/BaseModalLayout.vue'
 import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
@@ -472,7 +478,8 @@ const {
   loadWorkflowTemplate,
   getTemplateThumbnailUrl,
   getTemplateTitle,
-  getTemplateDescription
+  getTemplateDescription,
+  getLogoUrl
 } = useTemplateWorkflows()
 
 const getEffectiveSourceModule = (template: TemplateInfo) =>

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -9,7 +9,7 @@ describe('LogoOverlay', () => {
     return `/logos/${provider}.png`
   }
 
-  const mountOverlay = (logos: LogoInfo[], props = {}) => {
+  function mountOverlay(logos: LogoInfo[], props = {}) {
     return mount(LogoOverlay, {
       props: {
         logos,
@@ -24,14 +24,14 @@ describe('LogoOverlay', () => {
     expect(wrapper.findAll('img')).toHaveLength(0)
   })
 
-  it('renders a logo with correct src and alt', () => {
+  it('renders a single logo with correct src and alt', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
     const img = wrapper.find('img')
     expect(img.attributes('src')).toBe('/logos/Google.png')
     expect(img.attributes('alt')).toBe('Google')
   })
 
-  it('renders multiple logos', () => {
+  it('renders multiple separate logo entries', () => {
     const wrapper = mountOverlay([
       { provider: 'Google' },
       { provider: 'OpenAI' },
@@ -40,7 +40,7 @@ describe('LogoOverlay', () => {
     expect(wrapper.findAll('img')).toHaveLength(3)
   })
 
-  it('displays provider name in pill', () => {
+  it('displays provider name as label for single provider', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
     const span = wrapper.find('span')
     expect(span.text()).toBe('Google')
@@ -53,8 +53,9 @@ describe('LogoOverlay', () => {
   })
 
   it('filters out logos with empty URLs', () => {
-    const getLogoUrl = (provider: string) =>
-      provider === 'Google' ? '/logos/Google.png' : ''
+    function getLogoUrl(provider: string) {
+      return provider === 'Google' ? '/logos/Google.png' : ''
+    }
     const wrapper = mount(LogoOverlay, {
       props: {
         logos: [{ provider: 'Google' }, { provider: 'Unknown' }],
@@ -70,5 +71,78 @@ describe('LogoOverlay', () => {
       { provider: 'OpenAI' }
     ])
     expect(wrapper.findAll('img')).toHaveLength(2)
+  })
+
+  describe('stacked logos', () => {
+    it('renders multiple providers as stacked overlapping logos', () => {
+      const wrapper = mountOverlay([{ provider: ['WaveSpeed', 'Hunyuan'] }])
+      const images = wrapper.findAll('img')
+      expect(images).toHaveLength(2)
+      expect(images[0].attributes('alt')).toBe('WaveSpeed')
+      expect(images[1].attributes('alt')).toBe('Hunyuan')
+    })
+
+    it('joins provider names with ampersand for default label', () => {
+      const wrapper = mountOverlay([{ provider: ['WaveSpeed', 'Hunyuan'] }])
+      const span = wrapper.find('span')
+      expect(span.text()).toBe('WaveSpeed & Hunyuan')
+    })
+
+    it('uses custom label when provided', () => {
+      const wrapper = mountOverlay([
+        { provider: ['WaveSpeed', 'Hunyuan'], label: 'Custom Label' }
+      ])
+      const span = wrapper.find('span')
+      expect(span.text()).toBe('Custom Label')
+    })
+
+    it('applies negative gap for overlap effect', () => {
+      const wrapper = mountOverlay([
+        { provider: ['WaveSpeed', 'Hunyuan'], gap: -8 }
+      ])
+      const images = wrapper.findAll('img')
+      expect(images[1].attributes('style')).toContain('margin-left: -8px')
+    })
+
+    it('applies default gap when not specified', () => {
+      const wrapper = mountOverlay([{ provider: ['WaveSpeed', 'Hunyuan'] }])
+      const images = wrapper.findAll('img')
+      expect(images[1].attributes('style')).toContain('margin-left: -6px')
+    })
+
+    it('filters out invalid providers from stacked logos', () => {
+      function getLogoUrl(provider: string) {
+        return provider === 'WaveSpeed' ? '/logos/WaveSpeed.png' : ''
+      }
+      const wrapper = mount(LogoOverlay, {
+        props: {
+          logos: [{ provider: ['WaveSpeed', 'Unknown'] }],
+          getLogoUrl
+        }
+      })
+      expect(wrapper.findAll('img')).toHaveLength(1)
+      expect(wrapper.find('span').text()).toBe('WaveSpeed')
+    })
+  })
+
+  describe('styling', () => {
+    it('applies default opacity of 0.85', () => {
+      const wrapper = mountOverlay([{ provider: 'Google' }])
+      const pill = wrapper.find('.rounded-full')
+      expect(pill.attributes('style')).toContain('opacity: 0.85')
+    })
+
+    it('applies custom opacity', () => {
+      const wrapper = mountOverlay([{ provider: 'Google', opacity: 0.5 }])
+      const pill = wrapper.find('.rounded-full')
+      expect(pill.attributes('style')).toContain('opacity: 0.5')
+    })
+
+    it('logos have white border for stacking visibility', () => {
+      const wrapper = mountOverlay([{ provider: 'Google' }])
+      const img = wrapper.find('img')
+      expect(img.classes()).toContain('border-2')
+      expect(img.classes()).toContain('border-white')
+    })
   })
 })

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -41,8 +41,8 @@ describe('LogoOverlay', () => {
   it('applies default position when not specified', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
     const container = wrapper.find('div')
-    expect(container.classes()).toContain('bottom-2')
-    expect(container.classes()).toContain('right-2')
+    expect(container.classes()).toContain('top-2')
+    expect(container.classes()).toContain('left-2')
   })
 
   it('applies custom position from logo config', () => {
@@ -54,37 +54,37 @@ describe('LogoOverlay', () => {
     expect(container.classes()).toContain('left-2')
   })
 
-  it('applies default medium size class', () => {
+  it('renders logo with fixed size and circular shape', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
     const img = wrapper.find('img')
-    expect(img.classes()).toContain('h-8')
-    expect(img.classes()).toContain('w-8')
+    expect(img.classes()).toContain('h-5')
+    expect(img.classes()).toContain('w-5')
+    expect(img.classes()).toContain('rounded-[50%]')
   })
 
-  it('applies small size class', () => {
-    const wrapper = mountOverlay([{ provider: 'Google', size: 'sm' }])
-    const img = wrapper.find('img')
-    expect(img.classes()).toContain('h-6')
-    expect(img.classes()).toContain('w-6')
-  })
-
-  it('applies large size class', () => {
-    const wrapper = mountOverlay([{ provider: 'Google', size: 'lg' }])
-    const img = wrapper.find('img')
-    expect(img.classes()).toContain('h-12')
-    expect(img.classes()).toContain('w-12')
-  })
-
-  it('applies default opacity', () => {
+  it('renders pill container with correct styling', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
-    const container = wrapper.find('div')
-    expect(container.attributes('style')).toContain('opacity: 0.9')
+    const pill = wrapper.find('.rounded-full')
+    expect(pill.exists()).toBe(true)
+    expect(pill.classes()).toContain('bg-black/20')
+  })
+
+  it('displays provider name in pill', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const span = wrapper.find('span')
+    expect(span.text()).toBe('Google')
+  })
+
+  it('applies default opacity of 1', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const pill = wrapper.find('.rounded-full')
+    expect(pill.attributes('style')).toContain('opacity: 1')
   })
 
   it('applies custom opacity', () => {
     const wrapper = mountOverlay([{ provider: 'Google', opacity: 0.5 }])
-    const container = wrapper.find('div')
-    expect(container.attributes('style')).toContain('opacity: 0.5')
+    const pill = wrapper.find('.rounded-full')
+    expect(pill.attributes('style')).toContain('opacity: 0.5')
   })
 
   it('images are not draggable', () => {

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -5,7 +5,9 @@ import LogoOverlay from '@/components/templates/thumbnails/LogoOverlay.vue'
 import type { LogoInfo } from '@/platform/workflow/templates/types/template'
 
 describe('LogoOverlay', () => {
-  const mockGetLogoUrl = (provider: string) => `/logos/${provider}.png`
+  function mockGetLogoUrl(provider: string) {
+    return `/logos/${provider}.png`
+  }
 
   const mountOverlay = (logos: LogoInfo[], props = {}) => {
     return mount(LogoOverlay, {

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -64,12 +64,11 @@ describe('LogoOverlay', () => {
     expect(wrapper.findAll('img')).toHaveLength(1)
   })
 
-  it('uses provider as unique key for each logo', () => {
+  it('renders one logo per unique provider', () => {
     const wrapper = mountOverlay([
       { provider: 'Google' },
       { provider: 'OpenAI' }
     ])
-    const containers = wrapper.findAll('[class*="absolute"]')
-    expect(containers).toHaveLength(2)
+    expect(wrapper.findAll('img')).toHaveLength(2)
   })
 })

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -1,16 +1,22 @@
 import { mount } from '@vue/test-utils'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { nextTick } from 'vue'
 import { describe, expect, it } from 'vitest'
 
 import LogoOverlay from '@/components/templates/thumbnails/LogoOverlay.vue'
 import type { LogoInfo } from '@/platform/workflow/templates/types/template'
 
+type LogoOverlayProps = ComponentProps<typeof LogoOverlay>
+
 describe('LogoOverlay', () => {
   function mockGetLogoUrl(provider: string) {
     return `/logos/${provider}.png`
   }
 
-  function mountOverlay(logos: LogoInfo[], props = {}) {
+  function mountOverlay(
+    logos: LogoInfo[],
+    props: Partial<LogoOverlayProps> = {}
+  ) {
     return mount(LogoOverlay, {
       props: {
         logos,
@@ -83,10 +89,10 @@ describe('LogoOverlay', () => {
       expect(images[1].attributes('alt')).toBe('Hunyuan')
     })
 
-    it('joins provider names with ampersand for default label', () => {
+    it('joins provider names with locale-aware conjunction for default label', () => {
       const wrapper = mountOverlay([{ provider: ['WaveSpeed', 'Hunyuan'] }])
       const span = wrapper.find('span')
-      expect(span.text()).toBe('WaveSpeed & Hunyuan')
+      expect(span.text()).toBe('WaveSpeed and Hunyuan')
     })
 
     it('uses custom label when provided', () => {

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -38,58 +38,36 @@ describe('LogoOverlay', () => {
     expect(wrapper.findAll('img')).toHaveLength(3)
   })
 
-  it('applies default position when not specified', () => {
-    const wrapper = mountOverlay([{ provider: 'Google' }])
-    const container = wrapper.find('div')
-    expect(container.classes()).toContain('top-2')
-    expect(container.classes()).toContain('left-2')
-  })
-
-  it('applies custom position from logo config', () => {
-    const wrapper = mountOverlay([
-      { provider: 'Google', position: 'top-2 left-2' }
-    ])
-    const container = wrapper.find('div')
-    expect(container.classes()).toContain('top-2')
-    expect(container.classes()).toContain('left-2')
-  })
-
-  it('renders logo with fixed size and circular shape', () => {
-    const wrapper = mountOverlay([{ provider: 'Google' }])
-    const img = wrapper.find('img')
-    expect(img.classes()).toContain('h-5')
-    expect(img.classes()).toContain('w-5')
-    expect(img.classes()).toContain('rounded-[50%]')
-  })
-
-  it('renders pill container with correct styling', () => {
-    const wrapper = mountOverlay([{ provider: 'Google' }])
-    const pill = wrapper.find('.rounded-full')
-    expect(pill.exists()).toBe(true)
-    expect(pill.classes()).toContain('bg-black/20')
-  })
-
   it('displays provider name in pill', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
     const span = wrapper.find('span')
     expect(span.text()).toBe('Google')
   })
 
-  it('applies default opacity of 1', () => {
-    const wrapper = mountOverlay([{ provider: 'Google' }])
-    const pill = wrapper.find('.rounded-full')
-    expect(pill.attributes('style')).toContain('opacity: 1')
-  })
-
-  it('applies custom opacity', () => {
-    const wrapper = mountOverlay([{ provider: 'Google', opacity: 0.5 }])
-    const pill = wrapper.find('.rounded-full')
-    expect(pill.attributes('style')).toContain('opacity: 0.5')
-  })
-
   it('images are not draggable', () => {
     const wrapper = mountOverlay([{ provider: 'Google' }])
     const img = wrapper.find('img')
     expect(img.attributes('draggable')).toBe('false')
+  })
+
+  it('filters out logos with empty URLs', () => {
+    const getLogoUrl = (provider: string) =>
+      provider === 'Google' ? '/logos/Google.png' : ''
+    const wrapper = mount(LogoOverlay, {
+      props: {
+        logos: [{ provider: 'Google' }, { provider: 'Unknown' }],
+        getLogoUrl
+      }
+    })
+    expect(wrapper.findAll('img')).toHaveLength(1)
+  })
+
+  it('uses provider as unique key for each logo', () => {
+    const wrapper = mountOverlay([
+      { provider: 'Google' },
+      { provider: 'OpenAI' }
+    ])
+    const containers = wrapper.findAll('[class*="absolute"]')
+    expect(containers).toHaveLength(2)
   })
 })

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import { describe, expect, it } from 'vitest'
 
 import LogoOverlay from '@/components/templates/thumbnails/LogoOverlay.vue'
@@ -122,6 +123,26 @@ describe('LogoOverlay', () => {
       })
       expect(wrapper.findAll('img')).toHaveLength(1)
       expect(wrapper.find('span').text()).toBe('WaveSpeed')
+    })
+  })
+
+  describe('error handling', () => {
+    it('hides logo pill when all provider images fail to load', async () => {
+      const wrapper = mountOverlay([{ provider: 'Google' }])
+      const img = wrapper.find('[data-testid="logo-img"]')
+      await img.trigger('error')
+      await nextTick()
+      const pill = wrapper.find('[data-testid="logo-pill"]')
+      expect(pill.attributes('style')).toContain('display: none')
+    })
+
+    it('keeps logo visible when only some images fail in stacked logos', async () => {
+      const wrapper = mountOverlay([{ provider: ['Google', 'OpenAI'] }])
+      const images = wrapper.findAll('[data-testid="logo-img"]')
+      await images[0].trigger('error')
+      await nextTick()
+      const pill = wrapper.find('[data-testid="logo-pill"]')
+      expect(pill.attributes('style')).not.toContain('display: none')
     })
   })
 

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -128,21 +128,20 @@ describe('LogoOverlay', () => {
   describe('styling', () => {
     it('applies default opacity of 0.85', () => {
       const wrapper = mountOverlay([{ provider: 'Google' }])
-      const pill = wrapper.find('.rounded-full')
+      const pill = wrapper.find('[data-testid="logo-pill"]')
       expect(pill.attributes('style')).toContain('opacity: 0.85')
     })
 
     it('applies custom opacity', () => {
       const wrapper = mountOverlay([{ provider: 'Google', opacity: 0.5 }])
-      const pill = wrapper.find('.rounded-full')
+      const pill = wrapper.find('[data-testid="logo-pill"]')
       expect(pill.attributes('style')).toContain('opacity: 0.5')
     })
 
-    it('logos have white border for stacking visibility', () => {
+    it('logos have border styling for stacking visibility', () => {
       const wrapper = mountOverlay([{ provider: 'Google' }])
-      const img = wrapper.find('img')
-      expect(img.classes()).toContain('border-2')
-      expect(img.classes()).toContain('border-white')
+      const img = wrapper.find('[data-testid="logo-img"]')
+      expect(img.exists()).toBe(true)
     })
   })
 })

--- a/src/components/templates/thumbnails/LogoOverlay.test.ts
+++ b/src/components/templates/thumbnails/LogoOverlay.test.ts
@@ -1,0 +1,95 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import LogoOverlay from '@/components/templates/thumbnails/LogoOverlay.vue'
+import type { LogoInfo } from '@/platform/workflow/templates/types/template'
+
+describe('LogoOverlay', () => {
+  const mockGetLogoUrl = (provider: string) => `/logos/${provider}.png`
+
+  const mountOverlay = (logos: LogoInfo[], props = {}) => {
+    return mount(LogoOverlay, {
+      props: {
+        logos,
+        getLogoUrl: mockGetLogoUrl,
+        ...props
+      }
+    })
+  }
+
+  it('renders nothing when logos array is empty', () => {
+    const wrapper = mountOverlay([])
+    expect(wrapper.findAll('img')).toHaveLength(0)
+  })
+
+  it('renders a logo with correct src and alt', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const img = wrapper.find('img')
+    expect(img.attributes('src')).toBe('/logos/Google.png')
+    expect(img.attributes('alt')).toBe('Google')
+  })
+
+  it('renders multiple logos', () => {
+    const wrapper = mountOverlay([
+      { provider: 'Google' },
+      { provider: 'OpenAI' },
+      { provider: 'Stability' }
+    ])
+    expect(wrapper.findAll('img')).toHaveLength(3)
+  })
+
+  it('applies default position when not specified', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const container = wrapper.find('div')
+    expect(container.classes()).toContain('bottom-2')
+    expect(container.classes()).toContain('right-2')
+  })
+
+  it('applies custom position from logo config', () => {
+    const wrapper = mountOverlay([
+      { provider: 'Google', position: 'top-2 left-2' }
+    ])
+    const container = wrapper.find('div')
+    expect(container.classes()).toContain('top-2')
+    expect(container.classes()).toContain('left-2')
+  })
+
+  it('applies default medium size class', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const img = wrapper.find('img')
+    expect(img.classes()).toContain('h-8')
+    expect(img.classes()).toContain('w-8')
+  })
+
+  it('applies small size class', () => {
+    const wrapper = mountOverlay([{ provider: 'Google', size: 'sm' }])
+    const img = wrapper.find('img')
+    expect(img.classes()).toContain('h-6')
+    expect(img.classes()).toContain('w-6')
+  })
+
+  it('applies large size class', () => {
+    const wrapper = mountOverlay([{ provider: 'Google', size: 'lg' }])
+    const img = wrapper.find('img')
+    expect(img.classes()).toContain('h-12')
+    expect(img.classes()).toContain('w-12')
+  })
+
+  it('applies default opacity', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const container = wrapper.find('div')
+    expect(container.attributes('style')).toContain('opacity: 0.9')
+  })
+
+  it('applies custom opacity', () => {
+    const wrapper = mountOverlay([{ provider: 'Google', opacity: 0.5 }])
+    const container = wrapper.find('div')
+    expect(container.attributes('style')).toContain('opacity: 0.5')
+  })
+
+  it('images are not draggable', () => {
+    const wrapper = mountOverlay([{ provider: 'Google' }])
+    const img = wrapper.find('img')
+    expect(img.attributes('draggable')).toBe('false')
+  })
+})

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -1,25 +1,33 @@
 <template>
   <div
     v-for="logo in validLogos"
-    :key="logo.provider"
+    :key="logo.key"
     :class="
       cn('pointer-events-none absolute z-10', logo.position ?? defaultPosition)
     "
   >
     <div
-      v-show="!failedLogos.has(logo.provider)"
-      class="flex items-center gap-1.5 rounded-full bg-black/20 px-2 py-1"
-      :style="{ opacity: logo.opacity ?? 1 }"
+      v-show="!hasAllFailed(logo.providers)"
+      class="flex items-center gap-1.5 rounded-full bg-black/20 py-1 pr-2"
+      :style="{ opacity: logo.opacity ?? 0.85 }"
     >
-      <img
-        :src="logo.url"
-        :alt="logo.provider"
-        class="h-5 w-5 rounded-[50%]"
-        draggable="false"
-        @error="onImageError(logo.provider)"
-      />
+      <div class="flex items-center" :style="{ marginLeft: '2px' }">
+        <img
+          v-for="(provider, providerIndex) in logo.providers"
+          :key="provider"
+          :src="logo.urls[providerIndex]"
+          :alt="provider"
+          class="h-6 w-6 rounded-full border-2 border-white object-cover"
+          :class="{ relative: providerIndex > 0 }"
+          :style="
+            providerIndex > 0 ? { marginLeft: `${logo.gap ?? -6}px` } : {}
+          "
+          draggable="false"
+          @error="onImageError(provider)"
+        />
+      </div>
       <span class="text-sm font-medium text-white">
-        {{ logo.provider }}
+        {{ logo.label }}
       </span>
     </div>
   </div>
@@ -43,16 +51,48 @@ const {
 
 const failedLogos = ref(new Set<string>())
 
-const onImageError = (provider: string) => {
+function onImageError(provider: string) {
   failedLogos.value = new Set([...failedLogos.value, provider])
 }
 
-const validLogos = computed(() =>
-  logos
-    .map((logo) => ({
-      ...logo,
-      url: getLogoUrl(logo.provider)
-    }))
-    .filter((logo) => logo.url)
-)
+function hasAllFailed(providers: string[]): boolean {
+  return providers.every((p) => failedLogos.value.has(p))
+}
+
+interface ValidatedLogo {
+  key: string
+  providers: string[]
+  urls: string[]
+  label: string
+  position: string | undefined
+  opacity: number | undefined
+  gap: number | undefined
+}
+
+const validLogos = computed<ValidatedLogo[]>(() => {
+  const result: ValidatedLogo[] = []
+
+  logos.forEach((logo, index) => {
+    const providers = Array.isArray(logo.provider)
+      ? logo.provider
+      : [logo.provider]
+    const urls = providers.map((p) => getLogoUrl(p))
+    const validProviders = providers.filter((_, i) => urls[i])
+    const validUrls = urls.filter((url) => url)
+
+    if (validProviders.length === 0) return
+
+    result.push({
+      key: validProviders.join('-') || `logo-${index}`,
+      providers: validProviders,
+      urls: validUrls,
+      label: logo.label ?? validProviders.join(' & '),
+      position: logo.position,
+      opacity: logo.opacity,
+      gap: logo.gap
+    })
+  })
+
+  return result
+})
 </script>

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -1,0 +1,39 @@
+<template>
+  <div
+    v-for="(logo, index) in logos"
+    :key="index"
+    :class="
+      cn('pointer-events-none absolute', logo.position ?? defaultPosition)
+    "
+    :style="{ opacity: logo.opacity ?? 0.9 }"
+  >
+    <img
+      :src="getLogoUrl(logo.provider)"
+      :alt="logo.provider"
+      :class="sizeClasses[logo.size ?? 'md']"
+      class="drop-shadow-md"
+      draggable="false"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { LogoInfo } from '@/platform/workflow/templates/types/template'
+import { cn } from '@/utils/tailwindUtil'
+
+const {
+  logos,
+  getLogoUrl,
+  defaultPosition = 'bottom-2 right-2'
+} = defineProps<{
+  logos: LogoInfo[]
+  getLogoUrl: (provider: string) => string
+  defaultPosition?: string
+}>()
+
+const sizeClasses: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'h-6 w-6',
+  md: 'h-8 w-8',
+  lg: 'h-12 w-12'
+}
+</script>

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -1,39 +1,58 @@
 <template>
   <div
-    v-for="(logo, index) in logos"
+    v-for="(logo, index) in validLogos"
     :key="index"
     :class="
-      cn('pointer-events-none absolute', logo.position ?? defaultPosition)
+      cn('pointer-events-none absolute z-10', logo.position ?? defaultPosition)
     "
-    :style="{ opacity: logo.opacity ?? 0.9 }"
   >
-    <img
-      :src="getLogoUrl(logo.provider)"
-      :alt="logo.provider"
-      :class="sizeClasses[logo.size ?? 'md']"
-      class="drop-shadow-md"
-      draggable="false"
-    />
+    <div
+      v-show="!failedLogos.has(logo.provider)"
+      class="flex items-center gap-1.5 rounded-full bg-black/20 px-2 py-1"
+      :style="{ opacity: logo.opacity ?? 1 }"
+    >
+      <img
+        :src="logo.url"
+        :alt="logo.provider"
+        class="h-5 w-5 rounded-[50%]"
+        draggable="false"
+        @error="onImageError(logo.provider)"
+      />
+      <span class="text-sm font-medium text-white">
+        {{ logo.provider }}
+      </span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue'
+
 import type { LogoInfo } from '@/platform/workflow/templates/types/template'
 import { cn } from '@/utils/tailwindUtil'
 
 const {
   logos,
   getLogoUrl,
-  defaultPosition = 'bottom-2 right-2'
+  defaultPosition = 'top-2 left-2'
 } = defineProps<{
   logos: LogoInfo[]
   getLogoUrl: (provider: string) => string
   defaultPosition?: string
 }>()
 
-const sizeClasses: Record<'sm' | 'md' | 'lg', string> = {
-  sm: 'h-6 w-6',
-  md: 'h-8 w-8',
-  lg: 'h-12 w-12'
+const failedLogos = ref(new Set<string>())
+
+const onImageError = (provider: string) => {
+  failedLogos.value = new Set([...failedLogos.value, provider])
 }
+
+const validLogos = computed(() =>
+  logos
+    .map((logo) => ({
+      ...logo,
+      url: getLogoUrl(logo.provider)
+    }))
+    .filter((logo) => logo.url)
+)
 </script>

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -12,7 +12,7 @@
       class="flex items-center gap-1.5 rounded-full bg-black/20 py-1 pr-2"
       :style="{ opacity: logo.opacity ?? 0.85 }"
     >
-      <div class="flex items-center" :style="{ marginLeft: '2px' }">
+      <div class="ml-0.5 flex items-center">
         <img
           v-for="(provider, providerIndex) in logo.providers"
           :key="provider"

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -38,8 +38,21 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import { i18n } from '@/i18n'
 import type { LogoInfo } from '@/platform/workflow/templates/types/template'
 import { cn } from '@/utils/tailwindUtil'
+
+function formatProviderList(providers: string[]): string {
+  const locale = String(i18n.global.locale.value)
+  try {
+    return new Intl.ListFormat(locale, {
+      style: 'long',
+      type: 'conjunction'
+    }).format(providers)
+  } catch {
+    return providers.join(' & ')
+  }
+}
 
 const {
   logos,
@@ -88,7 +101,7 @@ const validLogos = computed<ValidatedLogo[]>(() => {
       key: validProviders.join('-') || `logo-${index}`,
       providers: validProviders,
       urls: validUrls,
-      label: logo.label ?? validProviders.join(' & '),
+      label: logo.label ?? formatProviderList(validProviders),
       position: logo.position,
       opacity: logo.opacity,
       gap: logo.gap

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -8,6 +8,7 @@
   >
     <div
       v-show="!hasAllFailed(logo.providers)"
+      data-testid="logo-pill"
       class="flex items-center gap-1.5 rounded-full bg-black/20 py-1 pr-2"
       :style="{ opacity: logo.opacity ?? 0.85 }"
     >
@@ -15,6 +16,7 @@
         <img
           v-for="(provider, providerIndex) in logo.providers"
           :key="provider"
+          data-testid="logo-img"
           :src="logo.urls[providerIndex]"
           :alt="provider"
           class="h-6 w-6 rounded-full border-2 border-white object-cover"

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    v-for="(logo, index) in validLogos"
-    :key="index"
+    v-for="logo in validLogos"
+    :key="logo.provider"
     :class="
       cn('pointer-events-none absolute z-10', logo.position ?? defaultPosition)
     "

--- a/src/components/templates/thumbnails/LogoOverlay.vue
+++ b/src/components/templates/thumbnails/LogoOverlay.vue
@@ -37,20 +37,22 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-import { i18n } from '@/i18n'
 import type { LogoInfo } from '@/platform/workflow/templates/types/template'
 import { cn } from '@/utils/tailwindUtil'
 
+const { t, locale } = useI18n()
+
 function formatProviderList(providers: string[]): string {
-  const locale = String(i18n.global.locale.value)
+  const localeValue = String(locale.value)
   try {
-    return new Intl.ListFormat(locale, {
+    return new Intl.ListFormat(localeValue, {
       style: 'long',
       type: 'conjunction'
     }).format(providers)
   } catch {
-    return providers.join(' & ')
+    return providers.join(t('templates.logoProviderSeparator'))
   }
 }
 
@@ -97,8 +99,10 @@ const validLogos = computed<ValidatedLogo[]>(() => {
 
     if (validProviders.length === 0) return
 
+    const providerKey = validProviders.join('-')
+    const layoutKey = `${logo.position ?? ''}-${logo.opacity ?? ''}-${logo.gap ?? ''}`
     result.push({
-      key: validProviders.join('-') || `logo-${index}`,
+      key: providerKey ? `${providerKey}-${layoutKey}` : `logo-${index}`,
       providers: validProviders,
       urls: validUrls,
       label: logo.label ?? formatProviderList(validProviders),

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -942,6 +942,9 @@
       "searchPlaceholder": "Search..."
     }
   },
+  "templates": {
+    "logoProviderSeparator": " & "
+  },
   "graphCanvasMenu": {
     "zoomIn": "Zoom In",
     "zoomOut": "Zoom Out",

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -158,6 +158,7 @@ export function useTemplateWorkflows() {
    */
   const fetchTemplateJson = async (id: string, sourceModule: string) => {
     if (sourceModule === 'default') {
+      // Default templates provided by frontend are served on this separate endpoint
       return fetch(api.fileURL(`/templates/${id}.json`)).then((r) => r.json())
     } else {
       return fetch(

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -182,7 +182,6 @@ export function useTemplateWorkflows() {
     getTemplateThumbnailUrl,
     getTemplateTitle,
     getTemplateDescription,
-    loadWorkflowTemplate,
-    getLogoUrl: workflowTemplatesStore.getLogoUrl
+    loadWorkflowTemplate
   }
 }

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -158,13 +158,19 @@ export function useTemplateWorkflows() {
    */
   const fetchTemplateJson = async (id: string, sourceModule: string) => {
     if (sourceModule === 'default') {
-      // Default templates provided by frontend are served on this separate endpoint
       return fetch(api.fileURL(`/templates/${id}.json`)).then((r) => r.json())
     } else {
       return fetch(
         api.apiURL(`/workflow_templates/${sourceModule}/${id}.json`)
       ).then((r) => r.json())
     }
+  }
+
+  /**
+   * Gets logo URL for a provider name
+   */
+  const getLogoUrl = (provider: string): string => {
+    return workflowTemplatesStore.getLogoUrl(provider)
   }
 
   return {
@@ -183,6 +189,7 @@ export function useTemplateWorkflows() {
     getTemplateThumbnailUrl,
     getTemplateTitle,
     getTemplateDescription,
-    loadWorkflowTemplate
+    loadWorkflowTemplate,
+    getLogoUrl
   }
 }

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -166,13 +166,6 @@ export function useTemplateWorkflows() {
     }
   }
 
-  /**
-   * Gets logo URL for a provider name
-   */
-  const getLogoUrl = (provider: string): string => {
-    return workflowTemplatesStore.getLogoUrl(provider)
-  }
-
   return {
     // State
     selectedTemplate,
@@ -190,6 +183,6 @@ export function useTemplateWorkflows() {
     getTemplateTitle,
     getTemplateDescription,
     loadWorkflowTemplate,
-    getLogoUrl
+    getLogoUrl: workflowTemplatesStore.getLogoUrl
   }
 }

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -519,6 +519,17 @@ export const useWorkflowTemplatesStore = defineStore(
     function getLogoUrl(provider: string): string {
       const logoPath = logoIndex.value[provider]
       if (!logoPath) return ''
+
+      // Validate path to prevent directory traversal and ensure safe file extensions
+      const safePathPattern = /^[a-zA-Z0-9_\-./]+\.(png|jpg|jpeg|svg|webp)$/i
+      if (
+        !safePathPattern.test(logoPath) ||
+        logoPath.includes('..') ||
+        logoPath.startsWith('/')
+      ) {
+        return ''
+      }
+
       return api.fileURL(`/templates/${logoPath}`)
     }
 

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -515,7 +515,15 @@ export const useWorkflowTemplatesStore = defineStore(
 
     function getLogoUrl(provider: string): string {
       const logoPath = logoIndex.value[provider]
-      if (!logoPath) return ''
+      if (
+        !logoPath ||
+        logoPath.includes('..') ||
+        logoPath.startsWith('/') ||
+        !logoPath.startsWith('logo/') ||
+        !/\.(png|svg|jpg|jpeg)$/i.test(logoPath)
+      ) {
+        return ''
+      }
       return api.fileURL(`/templates/${logoPath}`)
     }
 

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -504,13 +504,21 @@ export const useWorkflowTemplatesStore = defineStore(
       }
     }
 
+    function isValidLogoIndex(data: unknown): data is LogoIndex {
+      if (typeof data !== 'object' || data === null) return false
+      return Object.entries(data).every(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string'
+      )
+    }
+
     async function fetchLogoIndex(): Promise<LogoIndex> {
       try {
-        const response = await axios.get(
+        const response = await axios.get<LogoIndex>(
           api.fileURL('/templates/index_logo.json')
         )
         const contentType = response.headers['content-type']
-        return contentType?.includes('application/json') ? response.data : {}
+        if (!contentType?.includes('application/json')) return {}
+        return isValidLogoIndex(response.data) ? response.data : {}
       } catch {
         return {}
       }

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -9,8 +9,9 @@ import type { NavGroupData, NavItemData } from '@/types/navTypes'
 import { generateCategoryId, getCategoryIcon } from '@/utils/categoryUtil'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
+import { zLogoIndex } from '../schemas/templateSchema'
+import type { LogoIndex } from '../schemas/templateSchema'
 import type {
-  LogoIndex,
   TemplateGroup,
   TemplateInfo,
   WorkflowTemplates
@@ -504,21 +505,15 @@ export const useWorkflowTemplatesStore = defineStore(
       }
     }
 
-    function isValidLogoIndex(data: unknown): data is LogoIndex {
-      if (typeof data !== 'object' || data === null) return false
-      return Object.entries(data).every(
-        ([key, value]) => typeof key === 'string' && typeof value === 'string'
-      )
-    }
-
     async function fetchLogoIndex(): Promise<LogoIndex> {
       try {
-        const response = await axios.get<LogoIndex>(
+        const response = await axios.get(
           api.fileURL('/templates/index_logo.json')
         )
         const contentType = response.headers['content-type']
         if (!contentType?.includes('application/json')) return {}
-        return isValidLogoIndex(response.data) ? response.data : {}
+        const result = zLogoIndex.safeParse(response.data)
+        return result.success ? result.data : {}
       } catch {
         return {}
       }

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -515,15 +515,7 @@ export const useWorkflowTemplatesStore = defineStore(
 
     function getLogoUrl(provider: string): string {
       const logoPath = logoIndex.value[provider]
-      if (
-        !logoPath ||
-        logoPath.includes('..') ||
-        logoPath.startsWith('/') ||
-        !logoPath.startsWith('logo/') ||
-        !/\.(png|svg|jpg|jpeg)$/i.test(logoPath)
-      ) {
-        return ''
-      }
+      if (!logoPath) return ''
       return api.fileURL(`/templates/${logoPath}`)
     }
 

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
@@ -507,12 +506,11 @@ export const useWorkflowTemplatesStore = defineStore(
 
     async function fetchLogoIndex(): Promise<LogoIndex> {
       try {
-        const response = await axios.get(
-          api.fileURL('/templates/index_logo.json')
-        )
-        const contentType = response.headers['content-type']
+        const response = await api.fetchApi('/templates/index_logo.json')
+        const contentType = response.headers.get('content-type')
         if (!contentType?.includes('application/json')) return {}
-        const result = zLogoIndex.safeParse(response.data)
+        const data = await response.json()
+        const result = zLogoIndex.safeParse(data)
         return result.success ? result.data : {}
       } catch {
         return {}

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
@@ -505,9 +506,11 @@ export const useWorkflowTemplatesStore = defineStore(
 
     async function fetchLogoIndex(): Promise<LogoIndex> {
       try {
-        const response = await fetch(api.fileURL('/templates/index_logo.json'))
-        if (!response.ok) return {}
-        return await response.json()
+        const response = await axios.get(
+          api.fileURL('/templates/index_logo.json')
+        )
+        const contentType = response.headers['content-type']
+        return contentType?.includes('application/json') ? response.data : {}
       } catch {
         return {}
       }

--- a/src/platform/workflow/templates/schemas/templateSchema.ts
+++ b/src/platform/workflow/templates/schemas/templateSchema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const zLogoIndex = z.record(z.string(), z.string())
+
+export type LogoIndex = z.infer<typeof zLogoIndex>

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -1,3 +1,16 @@
+export interface LogoInfo {
+  /** Provider name matching index_logo.json */
+  provider: string
+  /** Tailwind positioning classes */
+  position?: string
+  /** Size: 'sm' (24px), 'md' (32px), 'lg' (48px) */
+  size?: 'sm' | 'md' | 'lg'
+  /** Opacity 0-1, default 0.9 */
+  opacity?: number
+}
+
+export type LogoIndex = Record<string, string>
+
 export interface TemplateInfo {
   name: string
   /**
@@ -47,6 +60,10 @@ export interface TemplateInfo {
    * If not specified, the template will be included on all distributions.
    */
   includeOnDistributions?: TemplateIncludeOnDistributionEnum[]
+  /**
+   * Logo overlays to display on the template thumbnail.
+   */
+  logos?: LogoInfo[]
 }
 
 export enum TemplateIncludeOnDistributionEnum {

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -11,8 +11,6 @@ export interface LogoInfo {
   opacity?: number
 }
 
-export type LogoIndex = Record<string, string>
-
 export interface TemplateInfo {
   name: string
   /**

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -1,11 +1,13 @@
 export interface LogoInfo {
-  /** Provider name matching index_logo.json */
-  provider: string
+  /** Provider name(s) matching index_logo.json. String for single, array for stacked logos. */
+  provider: string | string[]
+  /** Custom label text. If omitted, defaults to provider names joined with " & " */
+  label?: string
+  /** Gap between stacked logos in pixels. Negative for overlap effect. Default: -6 */
+  gap?: number
   /** Tailwind positioning classes */
   position?: string
-  /** Size: 'sm' (24px), 'md' (32px), 'lg' (48px) */
-  size?: 'sm' | 'md' | 'lg'
-  /** Opacity 0-1, default 0.9 */
+  /** Opacity 0-1, default 0.85 */
   opacity?: number
 }
 


### PR DESCRIPTION
## Summary

Add support for overlaying provider logos on workflow template thumbnails at runtime.

## Changes

- **What**: 
  - Add `LogoInfo` interface and `logos` field to `TemplateInfo` type
  - Create `LogoOverlay.vue` component for rendering positioned logos
  - Fetch logo index from `templates/index_logo.json` in store
  - Add `getLogoUrl` helper to `useTemplateWorkflows` composable
  - Integrate `LogoOverlay` into `WorkflowTemplateSelectorDialog`

## Review Focus

- Logo positioning uses Tailwind classes (e.g. `absolute bottom-2 right-2`)
- Supports multiple logos per template with configurable size/opacity
- Gracefully handles missing logos (returns empty string, renders nothing)
- Templates must explicitly declare logos - no magic inference from models

## Dependencies

Requires separate PR in workflow_templates repo to:
1. Update `index.schema.json` with logos definition
2. Add `logos` field to templates in `index.json`

## Screenshots (if applicable)

<img width="869" height="719" alt="image" src="https://github.com/user-attachments/assets/65ed1ee4-fbb4-42c9-95d4-7e37813b3655" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8365-feat-add-provider-logo-overlays-to-workflow-template-thumbnails-2f66d73d365081309236c6b991cb6f7b) by [Unito](https://www.unito.io)
