### PR TITLE
fix: suppress link rendering during slot sync after graph reconfigure

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5614,6 +5614,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     this.renderedPaths.clear()
     if (this.links_render_mode === LinkRenderType.HIDDEN_LINK) return
 
+    // Skip link rendering while waiting for slot positions to sync after reconfigure
+    if (LiteGraph.vueNodesMode && layoutStore.pendingSlotSync) return
+
     const { graph, subgraph } = this
     if (!graph) throw new NullGraphError()
 

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5615,7 +5615,10 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     if (this.links_render_mode === LinkRenderType.HIDDEN_LINK) return
 
     // Skip link rendering while waiting for slot positions to sync after reconfigure
-    if (LiteGraph.vueNodesMode && layoutStore.pendingSlotSync) return
+    if (LiteGraph.vueNodesMode && layoutStore.pendingSlotSync) {
+      this.#visibleReroutes.clear()
+      return
+    }
 
     const { graph, subgraph } = this
     if (!graph) throw new NullGraphError()

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -141,6 +141,20 @@ class LayoutStoreImpl implements LayoutStore {
   // Vue resizing state to prevent drag from activating during resize
   public isResizingVueNodes = ref(false)
 
+  /**
+   * Flag indicating slot positions are pending sync after graph reconfiguration.
+   * When true, link rendering should be skipped to avoid drawing with stale positions.
+   */
+  private _pendingSlotSync = false
+
+  get pendingSlotSync(): boolean {
+    return this._pendingSlotSync
+  }
+
+  setPendingSlotSync(value: boolean): void {
+    this._pendingSlotSync = value
+  }
+
   constructor() {
     // Initialize Yjs data structures
     this.ynodes = this.ydoc.getMap('nodes')

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -36,9 +36,9 @@ function scheduleSlotLayoutSync(nodeId: string) {
 
 export function flushScheduledSlotLayoutSync() {
   if (pendingNodes.size === 0) {
-    // No pending nodes - don't clear the flag here as late mounts may still
-    // call scheduleSlotLayoutSync. The RAF callback will clear it after
-    // processing actual nodes.
+    // No pending nodes and no RAF scheduled - clear the flag to avoid
+    // permanently suppressing link rendering (e.g., workflows without Vue nodes)
+    layoutStore.setPendingSlotSync(false)
     return
   }
   const conv = useSharedCanvasPositionConversion()

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -37,8 +37,15 @@ function scheduleSlotLayoutSync(nodeId: string) {
 
 export function flushScheduledSlotLayoutSync() {
   if (pendingNodes.size === 0) {
-    // No pending nodes and no RAF scheduled - clear the flag to avoid
-    // permanently suppressing link rendering (e.g., workflows without Vue nodes)
+    // No pending nodes - check if we should wait for Vue components to mount
+    const graph = app.canvas?.graph
+    const hasNodes = graph && graph._nodes && graph._nodes.length > 0
+    if (hasNodes) {
+      // Graph has nodes but Vue hasn't mounted them yet - keep flag set
+      // so late mounts can re-assert it via scheduleSlotLayoutSync()
+      return
+    }
+    // No nodes in graph - safe to clear the flag (no Vue components will mount)
     layoutStore.setPendingSlotSync(false)
     app.canvas?.setDirty(true, true)
     return

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -12,6 +12,7 @@ import { useSharedCanvasPositionConversion } from '@/composables/element/useCanv
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { app } from '@/scripts/app'
 import type { SlotLayout } from '@/renderer/core/layout/types'
 import {
   isPointEqual,
@@ -39,6 +40,7 @@ export function flushScheduledSlotLayoutSync() {
     // No pending nodes and no RAF scheduled - clear the flag to avoid
     // permanently suppressing link rendering (e.g., workflows without Vue nodes)
     layoutStore.setPendingSlotSync(false)
+    app.canvas?.setDirty(true, true)
     return
   }
   const conv = useSharedCanvasPositionConversion()
@@ -48,6 +50,8 @@ export function flushScheduledSlotLayoutSync() {
   }
   // Clear the pending sync flag - slots are now synced
   layoutStore.setPendingSlotSync(false)
+  // Trigger canvas redraw now that links can render with correct positions
+  app.canvas?.setDirty(true, true)
 }
 
 export function syncNodeSlotLayoutsFromDOM(

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -31,13 +31,19 @@ function scheduleSlotLayoutSync(nodeId: string) {
   raf.schedule()
 }
 
-function flushScheduledSlotLayoutSync() {
-  if (pendingNodes.size === 0) return
+export function flushScheduledSlotLayoutSync() {
+  if (pendingNodes.size === 0) {
+    // Even if no pending nodes, clear the flag (e.g., graph with no nodes)
+    layoutStore.setPendingSlotSync(false)
+    return
+  }
   const conv = useSharedCanvasPositionConversion()
   for (const nodeId of Array.from(pendingNodes)) {
     pendingNodes.delete(nodeId)
     syncNodeSlotLayoutsFromDOM(nodeId, conv)
   }
+  // Clear the pending sync flag - slots are now synced
+  layoutStore.setPendingSlotSync(false)
 }
 
 export function syncNodeSlotLayoutsFromDOM(

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -737,23 +737,26 @@ export class ComfyApp {
         layoutStore.setPendingSlotSync(true)
       }
 
-      fixLinkInputSlots(this)
+      try {
+        fixLinkInputSlots(this)
 
-      // Fire callbacks before the onConfigure, this is used by widget inputs to setup the config
-      triggerCallbackOnAllNodes(this, 'onGraphConfigured')
+        // Fire callbacks before the onConfigure, this is used by widget inputs to setup the config
+        triggerCallbackOnAllNodes(this, 'onGraphConfigured')
 
-      const r = onConfigure?.apply(this, args)
+        const r = onConfigure?.apply(this, args)
 
-      // Fire after onConfigure, used by primitives to generate widget using input nodes config
-      triggerCallbackOnAllNodes(this, 'onAfterGraphConfigured')
+        // Fire after onConfigure, used by primitives to generate widget using input nodes config
+        triggerCallbackOnAllNodes(this, 'onAfterGraphConfigured')
 
-      // Flush pending slot layout syncs to fix link alignment after undo/redo
-      if (LiteGraph.vueNodesMode) {
-        flushScheduledSlotLayoutSync()
-        app.canvas?.setDirty(true, true)
+        return r
+      } finally {
+        // Flush pending slot layout syncs to fix link alignment after undo/redo
+        // Using finally ensures links aren't permanently suppressed if an error occurs
+        if (LiteGraph.vueNodesMode) {
+          flushScheduledSlotLayoutSync()
+          app.canvas?.setDirty(true, true)
+        }
       }
-
-      return r
     }
   }
 


### PR DESCRIPTION
## Description

Fixes link alignment issues after undo/redo operations in Vue Nodes 2.0. When multiple connections exist from the same output to different nodes, performing an undo would cause the connections to become misaligned with their inputs.

## Root Cause

When undo triggers `loadGraphData`, the graph is reconfigured and Vue node components are destroyed and recreated. The new slot elements mount and schedule RAF-batched position syncs via `scheduleSlotLayoutSync`. However, links are drawn **before** the RAF batch completes, causing `getSlotPosition()` to return stale/missing positions.

## Solution

- Export a new `flushPendingSlotLayoutSyncs()` function from `useSlotElementTracking.ts`
- Create a `useGraphConfigureSlotSync` composable that flushes pending syncs after graph configuration
- Integrate the flush into `addAfterConfigureHandler` in `app.ts`, called after `onAfterGraphConfigured`
- Force canvas redraw after flushing to render links with correct positions

## Testing

- Added unit tests for `flushPendingSlotLayoutSyncs`
- Added unit tests for `useGraphConfigureSlotSync` composable
- Manual verification: connections now align correctly after undo/redo operations

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8367-fix-flush-pending-slot-layout-syncs-after-graph-configure-2f66d73d365081a3a564fac96c44a048) by [Unito](https://www.unito.io)
