### PR TITLE
feat: make invalid URL error message more actionable

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2544,7 +2544,7 @@
     "tagsPlaceholder": "e.g., models, checkpoint",
     "tryAdjustingFilters": "Try adjusting your search or filters",
     "unknown": "Unknown",
-    "unsupportedUrlSource": "Only URLs from {sources} are supported",
+    "unsupportedUrlSource": "This URL is not supported. Use a direct model link from {sources}. See the how-to videos below for help.",
     "upgradeFeatureDescription": "This feature is only available with Creator or Pro plans.",
     "upgradeToUnlockFeature": "Upgrade to unlock this feature",
     "upload": "Import",


### PR DESCRIPTION
## Summary

Updates the error message shown when users enter an unsupported URL in the BYOM (Bring Your Own Model) upload dialog.

**Before:** "Only URLs from Civitai, Hugging Face are supported"
**After:** "Please check the link format. Only URLs from Civitai, Hugging Face are supported."

This provides more actionable guidance by suggesting users verify their link format before listing the supported sources.

## Changes

- Updated `unsupportedUrlSource` i18n key in `src/locales/en/main.json`

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Manual: Enter invalid URL (e.g., `https://example.com/model.safetensors`) in model upload dialog

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8368-feat-make-invalid-URL-error-message-more-actionable-2f66d73d3650810bbcc1e9fa3d1cd962) by [Unito](https://www.unito.io)
