### PR TITLE
test: use createTestingPinia instead of createPinia

### DIFF
--- a/docs/testing/store-testing.md
+++ b/docs/testing/store-testing.md
@@ -18,7 +18,8 @@ Basic setup for testing Pinia stores:
 
 ```typescript
 // Example from: tests-ui/tests/store/workflowStore.test.ts
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useWorkflowStore } from '@/domains/workflow/ui/stores/workflowStore'
@@ -27,8 +28,8 @@ describe('useWorkflowStore', () => {
   let store: ReturnType<typeof useWorkflowStore>
 
   beforeEach(() => {
-    // Create a fresh pinia and activate it for each test
-    setActivePinia(createPinia())
+    // Create a fresh testing pinia and activate it for each test
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     // Initialize the store
     store = useWorkflowStore()

--- a/src/platform/cloud/subscription/composables/useSubscriptionCredits.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCredits.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as VueI18nModule from 'vue-i18n'
 
@@ -79,7 +80,7 @@ describe('useSubscriptionCredits', () => {
   let authStore: ReturnType<typeof useFirebaseAuthStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     authStore = useFirebaseAuthStore()
     vi.clearAllMocks()
   })

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -1,5 +1,6 @@
 import { until } from '@vueuse/core'
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -40,7 +41,7 @@ describe('useVersionCompatibilityStore', () => {
   let mockSettingStore: { get: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     // Clear the mock dismissal storage
     mockDismissalStorage.value = {}

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -66,7 +67,7 @@ describe('useWorkflowStore', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useWorkflowStore()
     bookmarkStore = useWorkflowBookmarkStore()
     vi.clearAllMocks()

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistence.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistence.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as I18n from 'vue-i18n'
 
@@ -108,7 +109,7 @@ describe('useWorkflowPersistence', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-01-01T00:00:00Z'))
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()
     sessionStorage.clear()
     vi.clearAllMocks()

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useTeamWorkspaceStore } from './teamWorkspaceStore'
@@ -111,7 +112,7 @@ const mockMemberWorkspace = {
 
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     vi.stubGlobal('localStorage', mockLocalStorage)
     sessionStorage.clear()

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -15,7 +16,7 @@ vi.mock('@/stores/workspace/colorPaletteStore', () => ({
 
 describe('useMinimapSettings', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
   })
 

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
@@ -1,5 +1,6 @@
+import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
-import { createPinia, setActivePinia } from 'pinia'
+import { setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import { describe, expect, it, vi } from 'vitest'
@@ -29,7 +30,7 @@ const makeNodeData = (overrides: Partial<VueNodeData> = {}): VueNodeData => ({
 })
 
 const setupMockStores = () => {
-  const pinia = createPinia()
+  const pinia = createTestingPinia({ stubActions: false })
   setActivePinia(pinia)
 
   const settingStore = useSettingStore()

--- a/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable vue/one-component-per-file */
+import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
-import { createPinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import { defineComponent } from 'vue'
 import type { PropType } from 'vue'
@@ -84,7 +84,7 @@ const mountSlots = (nodeData: VueNodeData, readonly = false) => {
   })
   return mount(NodeSlots, {
     global: {
-      plugins: [i18n, createPinia()],
+      plugins: [i18n, createTestingPinia({ stubActions: false })],
       stubs: {
         InputSlot: InputSlotStub,
         OutputSlot: OutputSlotStub

--- a/src/services/keybindingService.escape.test.ts
+++ b/src/services/keybindingService.escape.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CORE_KEYBINDINGS } from '@/constants/coreKeybindings'
@@ -30,7 +31,7 @@ describe('keybindingService - Escape key handling', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     // Mock command store execute
     const commandStore = useCommandStore()

--- a/src/services/keybindingService.forwarding.test.ts
+++ b/src/services/keybindingService.forwarding.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { app } from '@/scripts/app'
@@ -68,7 +69,7 @@ describe('keybindingService - Event Forwarding', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     // Mock command store execute
     const commandStore = useCommandStore()

--- a/src/stores/comfyRegistryStore.test.ts
+++ b/src/stores/comfyRegistryStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -83,7 +84,7 @@ describe('useComfyRegistryStore', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     mockRegistryService = {
       isLoading: ref(false),

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent } from 'vue'
 
@@ -11,7 +12,7 @@ const MockComponent = defineComponent({
 
 describe('dialogStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   describe('priority system', () => {

--- a/src/stores/domWidgetStore.test.ts
+++ b/src/stores/domWidgetStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
@@ -30,7 +31,7 @@ describe('domWidgetStore', () => {
   let store: ReturnType<typeof useDomWidgetStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useDomWidgetStore()
   })
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { app } from '@/scripts/app'
@@ -59,7 +60,7 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
     mockNodeIdToNodeLocatorId.mockReset()
     mockNodeLocatorIdToNodeExecutionId.mockReset()
 
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
   })
 
@@ -137,7 +138,7 @@ describe('useExecutionStore - Node Error Lookups', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
   })
 

--- a/src/stores/firebaseAuthStore.test.ts
+++ b/src/stores/firebaseAuthStore.test.ts
@@ -1,6 +1,7 @@
 import { FirebaseError } from 'firebase/app'
 import * as firebaseAuth from 'firebase/auth'
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
@@ -153,7 +154,7 @@ describe('useFirebaseAuthStore', () => {
     })
 
     // Initialize Pinia
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useFirebaseAuthStore()
 
     // Reset and set up getIdToken mock
@@ -175,7 +176,7 @@ describe('useFirebaseAuthStore', () => {
 
       vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(mockAuth as any)
 
-      setActivePinia(createPinia())
+      setActivePinia(createTestingPinia({ stubActions: false }))
       store = useFirebaseAuthStore()
     })
 

--- a/src/stores/imagePreviewStore.test.ts
+++ b/src/stores/imagePreviewStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -30,7 +31,7 @@ const createMockOutputs = (
 
 describe('imagePreviewStore getPreviewParam', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     vi.mocked(litegraphUtil.isVideoNode).mockReturnValue(false)
   })

--- a/src/stores/keybindingStore.test.ts
+++ b/src/stores/keybindingStore.test.ts
@@ -1,11 +1,12 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { KeybindingImpl, useKeybindingStore } from '@/stores/keybindingStore'
 
 describe('useKeybindingStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   it('should add and retrieve default keybindings', () => {

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assetService } from '@/platform/assets/services/assetService'
@@ -89,7 +90,7 @@ describe('useModelStore', () => {
   let store: ReturnType<typeof useModelStore>
 
   beforeEach(async () => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.resetAllMocks()
   })
 

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
@@ -82,7 +83,7 @@ vi.mock('@/stores/nodeDefStore', async (importOriginal) => {
 
 describe('useModelToNodeStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
   })
 
@@ -330,7 +331,7 @@ describe('useModelToNodeStore', () => {
 
     it('should not register when nodeDefStore is empty', () => {
       // Create fresh Pinia for this test to avoid state persistence
-      setActivePinia(createPinia())
+      setActivePinia(createTestingPinia({ stubActions: false }))
 
       vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
         nodeDefsByName: {}
@@ -355,7 +356,7 @@ describe('useModelToNodeStore', () => {
 
     it('should return empty Record when nodeDefStore is empty', () => {
       // Create fresh Pinia for this test to avoid state persistence
-      setActivePinia(createPinia())
+      setActivePinia(createTestingPinia({ stubActions: false }))
 
       vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
         nodeDefsByName: {}

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
@@ -9,7 +10,7 @@ describe('useNodeDefStore', () => {
   let store: ReturnType<typeof useNodeDefStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useNodeDefStore()
   })
 

--- a/src/stores/queueStore.loadWorkflow.test.ts
+++ b/src/stores/queueStore.loadWorkflow.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -71,7 +72,7 @@ describe('TaskItemImpl.loadWorkflow - workflow fetching', () => {
   let mockFetchApi: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
 
     mockFetchApi = vi.fn()

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
@@ -240,7 +241,7 @@ describe('useQueueStore', () => {
   let store: ReturnType<typeof useQueueStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useQueueStore()
     vi.clearAllMocks()
   })

--- a/src/stores/serverConfigStore.test.ts
+++ b/src/stores/serverConfigStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ServerConfig } from '@/constants/serverConfig'
@@ -14,7 +15,7 @@ describe('useServerConfigStore', () => {
   let store: ReturnType<typeof useServerConfigStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useServerConfigStore()
   })
 

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -47,7 +48,7 @@ vi.mock('@/utils/graphTraversalUtil', () => ({
 
 describe('useSubgraphNavigationStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   it('should not clear navigation stack when workflow internal state changes', async () => {

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -46,7 +47,7 @@ const mockCanvas = app.canvas as any
 
 describe('useSubgraphNavigationStore - Viewport Persistence', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     // Reset canvas state
     mockCanvas.ds.scale = 1
     mockCanvas.ds.offset = [0, 0]

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
@@ -78,7 +79,7 @@ describe('useSubgraphStore', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useSubgraphStore()
     vi.clearAllMocks()
   })

--- a/src/stores/systemStatsStore.test.ts
+++ b/src/stores/systemStatsStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
@@ -25,7 +26,7 @@ describe('useSystemStatsStore', () => {
   beforeEach(() => {
     // Mock API to prevent automatic fetch on store creation
     vi.mocked(api.getSystemStats).mockResolvedValue(null as any)
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useSystemStatsStore()
     vi.clearAllMocks()
   })

--- a/src/stores/templateRankingStore.test.ts
+++ b/src/stores/templateRankingStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useTemplateRankingStore } from '@/stores/templateRankingStore'
@@ -12,7 +13,7 @@ vi.mock('axios', () => ({
 
 describe('templateRankingStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
   })
 

--- a/src/stores/userFileStore.test.ts
+++ b/src/stores/userFileStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
@@ -19,7 +20,7 @@ describe('useUserFileStore', () => {
   let store: ReturnType<typeof useUserFileStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useUserFileStore()
     vi.resetAllMocks()
   })

--- a/src/stores/workspace/bottomPanelStore.test.ts
+++ b/src/stores/workspace/bottomPanelStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
@@ -53,7 +54,7 @@ vi.mock('@/utils/envUtil', () => ({
 
 describe('useBottomPanelStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   it('should initialize with empty panels', () => {

--- a/src/stores/workspace/nodeHelpStore.test.ts
+++ b/src/stores/workspace/nodeHelpStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useNodeHelpStore } from '@/stores/workspace/nodeHelpStore'
@@ -14,7 +15,7 @@ describe('nodeHelpStore', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   it('should initialize with empty state', () => {

--- a/src/stores/workspace/searchBoxStore.test.ts
+++ b/src/stores/workspace/searchBoxStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
@@ -34,7 +35,7 @@ function createMockSettingStore(): ReturnType<typeof useSettingStore> {
 
 describe('useSearchBoxStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     vi.restoreAllMocks()
   })

--- a/src/workbench/extensions/manager/components/manager/NodeConflictDialogContent.test.ts
+++ b/src/workbench/extensions/manager/components/manager/NodeConflictDialogContent.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import Button from '@/components/ui/button/Button.vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
@@ -44,11 +45,11 @@ vi.mock(
 )
 
 describe('NodeConflictDialogContent', () => {
-  let pinia: ReturnType<typeof createPinia>
+  let pinia: ReturnType<typeof createTestingPinia>
 
   beforeEach(() => {
     vi.clearAllMocks()
-    pinia = createPinia()
+    pinia = createTestingPinia({ stubActions: false })
     setActivePinia(pinia)
     // Reset mock data
     mockConflictData.value = []

--- a/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { createPinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -89,7 +89,7 @@ describe('PackVersionBadge', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createPinia(), i18n],
+        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
         directives: {
           tooltip: Tooltip
         },

--- a/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { createPinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
 import Button from '@/components/ui/button/Button.vue'
 import PrimeVue from 'primevue/config'
 import Listbox from 'primevue/listbox'
@@ -115,7 +115,7 @@ describe('PackVersionSelectorPopover', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createPinia(), i18n],
+        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
         components: {
           Listbox,
           VerifiedIcon,

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { createPinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -81,7 +81,7 @@ describe('PackEnableToggle', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createPinia(), i18n]
+        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n]
       }
     })
   }

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { createPinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -73,7 +73,7 @@ describe('PackCardFooter', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createPinia(), i18n],
+        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
         provide: {
           [IsInstallingKey]: ref(false)
         }

--- a/src/workbench/extensions/manager/components/manager/skeleton/PackCardGridSkeleton.test.ts
+++ b/src/workbench/extensions/manager/components/manager/skeleton/PackCardGridSkeleton.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { createPinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
@@ -32,7 +32,7 @@ describe('GridSkeleton', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createPinia(), i18n],
+        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
         stubs: {
           PackCardSkeleton: true
         }

--- a/src/workbench/extensions/manager/composables/nodePack/usePacksSelection.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePacksSelection.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -36,7 +37,7 @@ describe('usePacksSelection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    const pinia = createPinia()
+    const pinia = createTestingPinia({ stubActions: false })
     setActivePinia(pinia)
 
     managerStore = useComfyManagerStore()

--- a/src/workbench/extensions/manager/composables/nodePack/usePacksStatus.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePacksStatus.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -48,7 +49,7 @@ describe('usePacksStatus', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     conflictDetectionStore = useConflictDetectionStore()
   })
 

--- a/src/workbench/extensions/manager/composables/useConflictAcknowledgment.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictAcknowledgment.test.ts
@@ -1,10 +1,11 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useConflictAcknowledgment', () => {
   beforeEach(() => {
     // Set up Pinia for each test
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     // Clear localStorage before each test
     localStorage.clear()
     // Reset modules to ensure fresh state

--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 
@@ -114,7 +115,7 @@ vi.mock('@/workbench/extensions/manager/composables/useManagerState', () => ({
 }))
 
 describe('useConflictDetection', () => {
-  let pinia: ReturnType<typeof createPinia>
+  let pinia: ReturnType<typeof createTestingPinia>
 
   const mockComfyManagerService = {
     getImportFailInfoBulk: vi.fn(),
@@ -221,7 +222,7 @@ describe('useConflictDetection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    pinia = createPinia()
+    pinia = createTestingPinia({ stubActions: false })
     setActivePinia(pinia)
 
     // Setup mocks

--- a/src/workbench/extensions/manager/composables/useImportFailedDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useImportFailedDetection.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 
@@ -31,7 +32,7 @@ describe('useImportFailedDetection', () => {
   let mockDialogService: ReturnType<typeof dialogService.useDialogService>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     mockComfyManagerStore = {
       isPackInstalled: vi.fn()

--- a/src/workbench/extensions/manager/stores/comfyManagerStore.test.ts
+++ b/src/workbench/extensions/manager/stores/comfyManagerStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -72,7 +73,7 @@ describe('useComfyManagerStore', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     mockManagerService = {
       isLoading: ref(false),

--- a/src/workbench/extensions/manager/stores/conflictDetectionStore.test.ts
+++ b/src/workbench/extensions/manager/stores/conflictDetectionStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores/conflictDetectionStore'
@@ -6,7 +7,7 @@ import type { ConflictDetectionResult } from '@/workbench/extensions/manager/typ
 
 describe('useConflictDetectionStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   const mockConflictedPackages: ConflictDetectionResult[] = [


### PR DESCRIPTION
Replace \createPinia\ with \createTestingPinia({ stubActions: false })\ from \@pinia/testing\ across 45 test files for proper test isolation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8376-test-use-createTestingPinia-instead-of-createPinia-2f66d73d36508137a9f0daffcddc86f7) by [Unito](https://www.unito.io)
