### PR TITLE
feat: add category support for blueprints and protect global blueprints

### DIFF
--- a/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
@@ -128,8 +128,12 @@ const editBlueprint = async () => {
   await useSubgraphStore().editBlueprint(props.node.data.name)
 }
 const menu = ref<InstanceType<typeof ContextMenu> | null>(null)
+const subgraphStore = useSubgraphStore()
 const menuItems = computed<MenuItem[]>(() => {
-  const items: MenuItem[] = [
+  const name = nodeDef.value.name.slice(subgraphStore.typePrefix.length)
+  if (subgraphStore.isGlobalBlueprint(name)) return []
+
+  return [
     {
       label: t('g.delete'),
       icon: 'pi pi-trash',
@@ -137,7 +141,6 @@ const menuItems = computed<MenuItem[]>(() => {
       command: deleteBlueprint
     }
   ]
-  return items
 })
 function handleContextMenu(event: Event) {
   if (!nodeDef.value.name.startsWith(useSubgraphStore().typePrefix)) return

--- a/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
@@ -13,10 +13,7 @@
           severity="danger"
         />
       </template>
-      <template
-        v-if="nodeDef.name.startsWith(useSubgraphStore().typePrefix)"
-        #actions
-      >
+      <template v-if="isUserBlueprint" #actions>
         <Button
           variant="destructive"
           size="icon-sm"
@@ -129,6 +126,11 @@ const editBlueprint = async () => {
 }
 const menu = ref<InstanceType<typeof ContextMenu> | null>(null)
 const subgraphStore = useSubgraphStore()
+const isUserBlueprint = computed(() => {
+  const name = nodeDef.value.name
+  if (!name.startsWith(subgraphStore.typePrefix)) return false
+  return !subgraphStore.isGlobalBlueprint(name.slice(subgraphStore.typePrefix.length))
+})
 const menuItems = computed<MenuItem[]>(() => {
   const name = nodeDef.value.name.slice(subgraphStore.typePrefix.length)
   if (subgraphStore.isGlobalBlueprint(name)) return []
@@ -143,12 +145,12 @@ const menuItems = computed<MenuItem[]>(() => {
   ]
 })
 function handleContextMenu(event: Event) {
-  if (!nodeDef.value.name.startsWith(useSubgraphStore().typePrefix)) return
+  if (!isUserBlueprint.value) return
   menu.value?.show(event)
 }
 function deleteBlueprint() {
   if (!props.node.data) return
-  void useSubgraphStore().deleteBlueprint(props.node.data.name)
+  void subgraphStore.deleteBlueprint(props.node.data.name)
 }
 
 const nodePreviewStyle = ref<CSSProperties>({

--- a/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
@@ -129,7 +129,9 @@ const subgraphStore = useSubgraphStore()
 const isUserBlueprint = computed(() => {
   const name = nodeDef.value.name
   if (!name.startsWith(subgraphStore.typePrefix)) return false
-  return !subgraphStore.isGlobalBlueprint(name.slice(subgraphStore.typePrefix.length))
+  return !subgraphStore.isGlobalBlueprint(
+    name.slice(subgraphStore.typePrefix.length)
+  )
 })
 const menuItems = computed<MenuItem[]>(() => {
   const name = nodeDef.value.name.slice(subgraphStore.typePrefix.length)

--- a/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
@@ -134,8 +134,7 @@ const isUserBlueprint = computed(() => {
   )
 })
 const menuItems = computed<MenuItem[]>(() => {
-  const name = nodeDef.value.name.slice(subgraphStore.typePrefix.length)
-  if (subgraphStore.isGlobalBlueprint(name)) return []
+  if (!isUserBlueprint.value) return []
 
   return [
     {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -993,7 +993,8 @@
     "showAll": "Show all",
     "hidden": "Hidden / nested parameters",
     "hideAll": "Hide all",
-    "showRecommended": "Show recommended widgets"
+    "showRecommended": "Show recommended widgets",
+    "cannotDeleteGlobal": "Cannot delete installed blueprints"
   },
   "electronFileDownload": {
     "inProgress": "In Progress",

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -394,6 +394,7 @@ interface SubgraphDefinitionBase<
   id: string
   revision: number
   name: string
+  category?: string
 
   inputNode: T extends ComfyWorkflow1BaseInput
     ? z.input<typeof zExportedSubgraphIONode>
@@ -425,6 +426,7 @@ const zSubgraphDefinition = zComfyWorkflow1
     id: z.string().uuid(),
     revision: z.number(),
     name: z.string(),
+    category: z.string().optional(),
     inputNode: zExportedSubgraphIONode,
     outputNode: zExportedSubgraphIONode,
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -231,7 +231,10 @@ type ComplexApiEvents = keyof NeverNever<ApiEventTypes>
 
 export type GlobalSubgraphData = {
   name: string
-  info: { node_pack: string }
+  info: {
+    node_pack: string
+    category?: string
+  }
   data: string | Promise<string>
 }
 

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -60,7 +60,7 @@ const mockGraph = {
 
 describe('useSubgraphStore', () => {
   let store: ReturnType<typeof useSubgraphStore>
-  const mockFetch = async (
+  async function mockFetch(
     filenames: Record<string, unknown>,
     globalSubgraphs: Record<
       string,
@@ -70,7 +70,7 @@ describe('useSubgraphStore', () => {
         data: string
       }
     > = {}
-  ) => {
+  ) {
     vi.mocked(api.listUserDataFullInfo).mockResolvedValue(
       Object.keys(filenames).map((filename) => ({
         path: filename,

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -113,7 +113,7 @@ describe('useSubgraphStore', () => {
     await mockFetch({ 'test.json': mockGraph })
     expect(
       useNodeDefStore().nodeDefs.filter(
-        (d) => d.category == 'Subgraph Blueprints'
+        (d) => d.category === 'Subgraph Blueprints/User'
       )
     ).toHaveLength(1)
   })
@@ -130,5 +130,19 @@ describe('useSubgraphStore', () => {
       name: 'SubgraphBlueprint.test'
     } as ComfyNodeDefV1)
     expect(res).toBeTruthy()
+  })
+  it('should identify user blueprints as non-global', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    expect(store.isGlobalBlueprint('test')).toBe(false)
+  })
+  it('should identify blueprints with non-blueprint python_module as global', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    const nodeDef = store.subgraphBlueprints.find(
+      (d) => d.name === 'SubgraphBlueprint.test'
+    )
+    if (nodeDef) {
+      ;(nodeDef as any).python_module = 'comfy_essentials'
+    }
+    expect(store.isGlobalBlueprint('test')).toBe(true)
   })
 })

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -64,7 +64,11 @@ describe('useSubgraphStore', () => {
     filenames: Record<string, unknown>,
     globalSubgraphs: Record<
       string,
-      { name: string; info: { node_pack: string; category?: string }; data: string }
+      {
+        name: string
+        info: { node_pack: string; category?: string }
+        data: string
+      }
     > = {}
   ) => {
     vi.mocked(api.listUserDataFullInfo).mockResolvedValue(
@@ -143,13 +147,16 @@ describe('useSubgraphStore', () => {
     expect(store.isGlobalBlueprint('test')).toBe(false)
   })
   it('should identify global blueprints loaded from getGlobalSubgraphs', async () => {
-    await mockFetch({}, {
-      global_test: {
-        name: 'Global Test Blueprint',
-        info: { node_pack: 'comfy_essentials' },
-        data: JSON.stringify(mockGraph)
+    await mockFetch(
+      {},
+      {
+        global_test: {
+          name: 'Global Test Blueprint',
+          info: { node_pack: 'comfy_essentials' },
+          data: JSON.stringify(mockGraph)
+        }
       }
-    })
+    )
     expect(store.isGlobalBlueprint('global_test')).toBe(true)
   })
   it('should return false for non-existent blueprints', async () => {

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import type { GlobalSubgraphData } from '@/scripts/api'
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -62,14 +63,7 @@ describe('useSubgraphStore', () => {
   let store: ReturnType<typeof useSubgraphStore>
   async function mockFetch(
     filenames: Record<string, unknown>,
-    globalSubgraphs: Record<
-      string,
-      {
-        name: string
-        info: { node_pack: string; category?: string }
-        data: string
-      }
-    > = {}
+    globalSubgraphs: Record<string, GlobalSubgraphData> = {}
   ) {
     vi.mocked(api.listUserDataFullInfo).mockResolvedValue(
       Object.keys(filenames).map((filename) => ({

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -319,8 +319,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
   }
   async function deleteBlueprint(nodeType: string) {
     const name = nodeType.slice(typePrefix.length)
-    if (!(name in subgraphCache))
-      throw new Error('not yet loaded')
+    if (!(name in subgraphCache)) throw new Error('not yet loaded')
 
     if (isGlobalBlueprint(name)) {
       useToastStore().add({

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -96,7 +96,9 @@ export const useSubgraphStore = defineStore('subgraph', () => {
         this.hasPromptedSave = true
       }
       const ret = await super.save()
-      useSubgraphStore().updateDef(await this.load())
+      useSubgraphStore().registerNodeDef(await this.load(), {
+        category: 'Subgraph Blueprints/User'
+      })
       return ret
     }
 
@@ -104,7 +106,9 @@ export const useSubgraphStore = defineStore('subgraph', () => {
       this.validateSubgraph()
       this.hasPromptedSave = true
       const ret = await super.saveAs(path)
-      useSubgraphStore().updateDef(await this.load())
+      useSubgraphStore().registerNodeDef(await this.load(), {
+        category: 'Subgraph Blueprints/User'
+      })
       return ret
     }
     override async load({ force = false }: { force?: boolean } = {}): Promise<
@@ -288,16 +292,12 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     await workflow.save()
     //add to files list?
     useWorkflowStore().attachWorkflow(loadedWorkflow)
-    registerNodeDef(loadedWorkflow)
     useToastStore().add({
       severity: 'success',
       summary: t('subgraphStore.publishSuccess'),
       detail: t('subgraphStore.publishSuccessMessage'),
       life: 4000
     })
-  }
-  function updateDef(blueprint: LoadedComfyWorkflow) {
-    registerNodeDef(blueprint)
   }
   async function editBlueprint(nodeType: string) {
     const name = nodeType.slice(typePrefix.length)
@@ -365,6 +365,6 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     publishSubgraph,
     subgraphBlueprints,
     typePrefix,
-    updateDef
+    registerNodeDef
   }
 })

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -96,7 +96,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
         this.hasPromptedSave = true
       }
       const ret = await super.save()
-      useSubgraphStore().registerNodeDef(await this.load(), {
+      registerNodeDef(await this.load(), {
         category: 'Subgraph Blueprints/User'
       })
       return ret
@@ -106,7 +106,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
       this.validateSubgraph()
       this.hasPromptedSave = true
       const ret = await super.saveAs(path)
-      useSubgraphStore().registerNodeDef(await this.load(), {
+      registerNodeDef(await this.load(), {
         category: 'Subgraph Blueprints/User'
       })
       return ret
@@ -364,7 +364,6 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     isSubgraphBlueprint,
     publishSubgraph,
     subgraphBlueprints,
-    typePrefix,
-    registerNodeDef
+    typePrefix
   }
 })

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -352,7 +352,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
 
   function isGlobalBlueprint(name: string): boolean {
     const nodeDef = subgraphDefCache.value.get(name)
-    return nodeDef?.python_module !== 'blueprint'
+    return nodeDef !== undefined && nodeDef.python_module !== 'blueprint'
   }
 
   return {


### PR DESCRIPTION
## Summary

This PR adds two related features for subgraph blueprints:

### 1. Protect Global Blueprints from Deletion
- Added `isGlobalBlueprint()` helper that distinguishes blueprints by `python_module` field
- User blueprints have `python_module: 'blueprint'`
- Global (installed) blueprints have `python_module` set to the node pack name
- Guarded `deleteBlueprint()` to show a warning toast for global blueprints
- Hidden delete menu in node library for global blueprints

### 2. Category Support for Blueprints
- User blueprints now use category `Subgraph Blueprints/User`
- Global blueprints use `Subgraph Blueprints/{category}` if category is provided, otherwise `Subgraph Blueprints`
- Extended `GlobalSubgraphData.info` type with optional `category` field
- Added `category` to `zSubgraphDefinition` schema

## Files Changed
- `src/stores/subgraphStore.ts` - Core logic for both features
- `src/stores/subgraphStore.test.ts` - Tests for `isGlobalBlueprint`
- `src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue` - Hide delete menu for global blueprints
- `src/scripts/api.ts` - Extended `GlobalSubgraphData` type
- `src/platform/workflow/validation/schemas/workflowSchema.ts` - Added category to schema
- `src/locales/en/main.json` - Added translation key

## Testing
- ✅ `pnpm typecheck` passed
- ✅ `pnpm lint` passed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8378-feat-add-category-support-for-blueprints-and-protect-global-blueprints-2f66d73d36508137aa67c2d88c358b69) by [Unito](https://www.unito.io)
