### PR TITLE
fix: prevent node drag when selecting text in InputText widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
@@ -3,7 +3,7 @@ import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import type { InputTextProps } from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -175,6 +175,54 @@ describe('WidgetInputText Value Binding', () => {
       const emitted = wrapper.emitted('update:modelValue')
       expect(emitted).toBeDefined()
       expect(emitted![0]).toContain(unicodeText)
+    })
+  })
+
+  describe('Pointer Event Propagation', () => {
+    it('stops pointerdown propagation to prevent node drag during text selection', async () => {
+      const widget = createMockWidget('test text')
+      const wrapper = mountComponent(widget, 'test text')
+
+      const input = wrapper.find('input[type="text"]')
+      expect(input.exists()).toBe(true)
+
+      const parentPointerdownHandler = vi.fn()
+      const wrapperEl = wrapper.element as HTMLElement
+      wrapperEl.addEventListener('pointerdown', parentPointerdownHandler)
+
+      await input.trigger('pointerdown')
+
+      expect(parentPointerdownHandler).not.toHaveBeenCalled()
+    })
+
+    it('stops pointermove propagation during text selection', async () => {
+      const widget = createMockWidget('test text')
+      const wrapper = mountComponent(widget, 'test text')
+
+      const input = wrapper.find('input[type="text"]')
+
+      const parentPointermoveHandler = vi.fn()
+      const wrapperEl = wrapper.element as HTMLElement
+      wrapperEl.addEventListener('pointermove', parentPointermoveHandler)
+
+      await input.trigger('pointermove')
+
+      expect(parentPointermoveHandler).not.toHaveBeenCalled()
+    })
+
+    it('stops pointerup propagation after text selection', async () => {
+      const widget = createMockWidget('test text')
+      const wrapper = mountComponent(widget, 'test text')
+
+      const input = wrapper.find('input[type="text"]')
+
+      const parentPointerupHandler = vi.fn()
+      const wrapperEl = wrapper.element as HTMLElement
+      wrapperEl.addEventListener('pointerup', parentPointerupHandler)
+
+      await input.trigger('pointerup')
+
+      expect(parentPointerupHandler).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -7,6 +7,9 @@
       :aria-label="widget.name"
       size="small"
       :pt="{ root: 'truncate min-w-[4ch]' }"
+      @pointerdown.capture.stop
+      @pointermove.capture.stop
+      @pointerup.capture.stop
     />
   </WidgetLayoutField>
 </template>


### PR DESCRIPTION
## Summary

Fixes a bug where attempting to select text inside Vue node InputText widgets causes the node to drag instead of text being selected.

**Affected Versions**: FE 1.35.9 (cloud and local), FE 1.37.3

## Root Cause

`WidgetInputText.vue` lacked capture-phase pointer event modifiers. When users click/drag to select text:
1. `pointerdown` event fires on input element
2. Event bubbles up to `LGraphNode.vue` which initiates node drag via `useNodePointerInteractions.ts`
3. After 3px movement, `setPointerCapture()` hijacks all pointer events away from the input

## Solution

Add `@pointerdown.capture.stop`, `@pointermove.capture.stop`, and `@pointerup.capture.stop` modifiers to the InputText component, matching the existing pattern in `WidgetTextarea.vue` (lines 22-24).

## Blast Radius Analysis

- `NodeWidgets.handleBringToFront` still fires (capture phase on parent fires before child)
- Custom widget handlers in `WidgetLegacy.vue` and `WidgetDOM.vue` unaffected (already use `.stop`)
- Pattern identical to `WidgetTextarea.vue` which has been in production

## Testing

- Added 3 new unit tests for pointer event propagation
- All 13 tests pass
- `pnpm typecheck` passes
- `pnpm lint` passes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8405-fix-prevent-node-drag-when-selecting-text-in-InputText-widgets-2f76d73d365081c48ee9c5344c4e52bb) by [Unito](https://www.unito.io)
