### PR TITLE
fix: use getAuthHeader in createCustomer to support API key auth

### DIFF
--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -278,7 +278,7 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   }
 
   const createCustomer = async (): Promise<CreateCustomerResponse> => {
-    const authHeader = await getFirebaseAuthHeader()
+    const authHeader = await getAuthHeader()
     if (!authHeader) {
       throw new FirebaseAuthStoreError(t('toastMessages.userNotAuthenticated'))
     }


### PR DESCRIPTION
## Summary

Fixes authentication failure when using API key authentication on staging server after frontend update to 1.33.10.

<img width="1160" height="709" alt="image" src="https://github.com/user-attachments/assets/fe56866d-1819-419e-9f53-35a123d764c3" />


## Changes

- **What**: Changed `createCustomer()` to use `getAuthHeader()` instead of `getFirebaseAuthHeader()`, allowing API key users to authenticate successfully

## Review Focus

- Verify `getAuthHeader()` correctly falls back to API key when no Firebase token exists
- Backend `/customers` endpoint supports `X-API-KEY` header (per cloud PR #1766)

Fixes COM-12398

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8408-fix-use-getAuthHeader-in-createCustomer-to-support-API-key-auth-2f76d73d3650819994e3e6d3ed9f3dfa) by [Unito](https://www.unito.io)
