### PR TITLE
[bugfix] Fix manager missing node tab with shared composable

### DIFF
--- a/src/workbench/extensions/manager/composables/nodePack/useWorkflowPacks.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/useWorkflowPacks.ts
@@ -1,3 +1,4 @@
+import { createSharedComposable } from '@vueuse/core'
 import { computed, onUnmounted, ref } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -9,7 +10,6 @@ import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { components } from '@/types/comfyRegistryTypes'
 import { mapAllNodes } from '@/utils/graphTraversalUtil'
 import { useNodePacks } from '@/workbench/extensions/manager/composables/nodePack/useNodePacks'
-import type { UseNodePacksOptions } from '@/workbench/extensions/manager/types/comfyManagerTypes'
 
 type WorkflowPack = {
   id:
@@ -22,9 +22,10 @@ const CORE_NODES_PACK_NAME = 'comfy-core'
 
 /**
  * Handles parsing node pack metadata from nodes on the graph and fetching the
- * associated node packs from the registry
+ * associated node packs from the registry.
+ * This is a shared singleton composable - all components use the same instance.
  */
-export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
+const _useWorkflowPacks = () => {
   const nodeDefStore = useNodeDefStore()
   const systemStatsStore = useSystemStatsStore()
   const { inferPackFromNodeName } = useComfyRegistryStore()
@@ -129,7 +130,7 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
   )
 
   const { startFetch, cleanup, error, isLoading, nodePacks, isReady } =
-    useNodePacks(workflowPacksIds, options)
+    useNodePacks(workflowPacksIds)
 
   const isIdInWorkflow = (packId: string) =>
     workflowPacksIds.value.includes(packId)
@@ -153,3 +154,5 @@ export const useWorkflowPacks = (options: UseNodePacksOptions = {}) => {
     filterWorkflowPack
   }
 }
+
+export const useWorkflowPacks = createSharedComposable(_useWorkflowPacks)


### PR DESCRIPTION
## Summary
Fix the manager missing nodes tab by converting `useWorkflowPacks` to a shared singleton composable using `createSharedComposable` from VueUse.

## Changes
- **What**: Wrap `useWorkflowPacks` with `createSharedComposable` to ensure all components share the same instance
- **Why**: Multiple instances were causing the missing nodes tab to not work correctly

## Technical Details
- Removed unused `UseNodePacksOptions` parameter since the shared composable pattern doesn't support per-call options
- All components now share the same workflow packs state and data fetching

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8409-bugfix-Fix-manager-missing-node-tab-with-shared-composable-2f76d73d365081e682acfa3a7450cdd6) by [Unito](https://www.unito.io)
