### PR TITLE
[bugfix] Disable install button when already installed version is selected

### DIFF
--- a/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
@@ -55,6 +55,8 @@ const mockNodePack = {
 const mockGetPackVersions = vi.fn()
 const mockInstallPack = vi.fn().mockResolvedValue(undefined)
 const mockCheckNodeCompatibility = vi.fn()
+const mockIsPackInstalled = vi.fn(() => false)
+const mockGetInstalledPackVersion = vi.fn(() => undefined)
 
 // Mock the registry service
 vi.mock('@/services/comfyRegistryService', () => ({
@@ -70,8 +72,8 @@ vi.mock('@/workbench/extensions/manager/stores/comfyManagerStore', () => ({
       call: mockInstallPack,
       clear: vi.fn()
     },
-    isPackInstalled: vi.fn(() => false),
-    getInstalledPackVersion: vi.fn(() => undefined)
+    isPackInstalled: mockIsPackInstalled,
+    getInstalledPackVersion: mockGetInstalledPackVersion
   }))
 }))
 
@@ -98,6 +100,8 @@ describe('PackVersionSelectorPopover', () => {
     mockCheckNodeCompatibility
       .mockReset()
       .mockReturnValue({ hasConflict: false, conflicts: [] })
+    mockIsPackInstalled.mockReset().mockReturnValue(false)
+    mockGetInstalledPackVersion.mockReset().mockReturnValue(undefined)
   })
 
   const mountComponent = ({


### PR DESCRIPTION
## Summary
Prevent re-installing an already installed version by disabling the Install button and the version option in the selector.

## Changes
- Add `isVersionInstalled()` function to check if a version is already installed
- Add `isInstallDisabled` computed to disable Install button when selected version is installed
- Add `option-disabled="isInstalled"` to Listbox to prevent selecting installed versions

Fixes the issue where users could trigger duplicate install operations by selecting the currently installed version.

🤖 Generated with [Claude Code](https://claude.ai/code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8412-bugfix-Disable-install-button-when-already-installed-version-is-selected-2f76d73d365081cb859ff98a3d1c64e6) by [Unito](https://www.unito.io)
