### PR TITLE
fix: use merge-multiple for snapshot artifact download

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -180,7 +180,7 @@ jobs:
         with:
           pattern: snapshots-shard-*
           path: ./downloaded-snapshots
-          merge-multiple: false
+          merge-multiple: true
 
       - name: List downloaded files
         run: |
@@ -206,13 +206,13 @@ jobs:
           echo "MERGING CHANGED SNAPSHOTS"
           echo "=========================================="
 
-          # Check if any artifacts were downloaded
+          # Check if any artifacts were downloaded (merge-multiple puts files directly in path)
           if [ ! -d "./downloaded-snapshots" ]; then
             echo "No snapshot artifacts to merge"
             echo "=========================================="
             echo "MERGE COMPLETE"
             echo "=========================================="
-            echo "Shards merged: 0"
+            echo "Files merged: 0"
             exit 0
           fi
 
@@ -222,37 +222,29 @@ jobs:
             exit 1
           fi
 
-          merged_count=0
+          # Count files to merge
+          file_count=$(find ./downloaded-snapshots -type f | wc -l)
 
-          # For each shard's changed files, copy them directly
-          for shard_dir in ./downloaded-snapshots/snapshots-shard-*/; do
-            if [ ! -d "$shard_dir" ]; then
-              continue
-            fi
+          if [ "$file_count" -eq 0 ]; then
+            echo "No snapshot files found in downloaded artifacts"
+            echo "=========================================="
+            echo "MERGE COMPLETE"
+            echo "=========================================="
+            echo "Files merged: 0"
+            exit 0
+          fi
 
-            shard_name=$(basename "$shard_dir")
-            file_count=$(find "$shard_dir" -type f | wc -l)
+          echo "Merging $file_count snapshot file(s)..."
 
-            if [ "$file_count" -eq 0 ]; then
-              echo "  $shard_name: no files"
-              continue
-            fi
+          # Copy all files directly, preserving directory structure
+          # With merge-multiple: true, files are directly in ./downloaded-snapshots/ without shard subdirs
+          cp -v -r ./downloaded-snapshots/* browser_tests/ 2>&1 | sed 's/^/  /'
 
-            echo "Processing $shard_name ($file_count file(s))..."
-
-            # Copy files directly, preserving directory structure
-            # Since files are already in correct structure (no browser_tests/ prefix), just copy them all
-            cp -v -r "$shard_dir"* browser_tests/ 2>&1 | sed 's/^/  /'
-
-            merged_count=$((merged_count + 1))
-            echo "  ✓ Merged"
-            echo ""
-          done
-
+          echo ""
           echo "=========================================="
           echo "MERGE COMPLETE"
           echo "=========================================="
-          echo "Shards merged: $merged_count"
+          echo "Files merged: $file_count"
 
       - name: Show changes
         run: |


### PR DESCRIPTION
## Summary

Fixes the snapshot merge failure introduced by PR #8377 (actions/download-artifact v4→v7 upgrade).

## Root Cause

The v5+ release of `download-artifact` changed behavior: when a `pattern` matches only a **single artifact**, files are extracted directly to `path/` without the artifact name subdirectory. When only one shard had changes, the merge loop couldn't find the expected `snapshots-shard-*/` directories.

## Fix

Use `merge-multiple: true` — the documented pattern for combining sharded artifacts. This merges all matched artifacts directly into the target path, eliminating directory structure assumptions.

## Testing

This fix can be validated by re-running the workflow on [PR #8276](https://github.com/Comfy-Org/ComfyUI_frontend/pull/8276) after merge.

---
- Fixes snapshot update workflow regression from #8377

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8432-fix-use-merge-multiple-for-snapshot-artifact-download-2f76d73d3650810b97fdfe28cd3c7694) by [Unito](https://www.unito.io)
