### PR TITLE
refactor: change asset cache from nodeType-keyed to category-keyed

### DIFF
--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -581,14 +581,19 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       expect(assets.map((a) => a.id)).toContain('new-asset')
     })
 
-    it('should return cached array on subsequent getAssets calls', () => {
+    it('should return cached array on subsequent getAssets calls', async () => {
       const store = useAssetsStore()
-      const nodeType = 'TestLoader'
+      const nodeType = 'CheckpointLoaderSimple'
+      const assets = [createMockAsset('cache-test-1')]
+
+      vi.mocked(assetService.getAssetsForNodeType).mockResolvedValue(assets)
+      await store.updateModelsForNodeType(nodeType)
 
       const firstCall = store.getAssets(nodeType)
       const secondCall = store.getAssets(nodeType)
 
       expect(secondCall).toBe(firstCall)
+      expect(firstCall).toHaveLength(1)
     })
   })
 

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -279,20 +279,22 @@ export const useAssetsStore = defineStore('assets', () => {
   }
 
   /**
-   * Model assets cached by node type (e.g., 'CheckpointLoaderSimple', 'LoraLoader')
-   * Used by multiple loader nodes to avoid duplicate fetches
+   * Model assets cached by category (e.g., 'checkpoints', 'loras')
+   * Multiple node types sharing the same category share the same cache entry.
+   * Public API accepts nodeType for backwards compatibility but translates
+   * to category internally using modelToNodeStore.getCategoryForNodeType().
    * Cloud-only feature - empty Maps in desktop builds
    */
   const getModelState = () => {
     if (isCloud) {
-      const modelStateByKey = ref(new Map<string, ModelPaginationState>())
+      const modelStateByCategory = ref(new Map<string, ModelPaginationState>())
 
       const assetsArrayCache = new Map<
         string,
         { source: Map<string, AssetItem>; array: AssetItem[] }
       >()
 
-      const pendingRequestByKey = new Map<string, ModelPaginationState>()
+      const pendingRequestByCategory = new Map<string, ModelPaginationState>()
 
       function createState(
         existingAssets?: Map<string, AssetItem>
@@ -306,64 +308,95 @@ export const useAssetsStore = defineStore('assets', () => {
         })
       }
 
-      function isStale(key: string, state: ModelPaginationState): boolean {
-        const committed = modelStateByKey.value.get(key)
-        const pending = pendingRequestByKey.get(key)
+      function isStale(
+        category: string,
+        state: ModelPaginationState
+      ): boolean {
+        const committed = modelStateByCategory.value.get(category)
+        const pending = pendingRequestByCategory.get(category)
         return committed !== state && pending !== state
       }
 
       const EMPTY_ASSETS: AssetItem[] = []
 
+      /**
+       * Resolve a key to a category. Handles both nodeType and tag:xxx formats.
+       * @param key Either a nodeType (e.g., 'CheckpointLoaderSimple') or tag key (e.g., 'tag:models')
+       * @returns The category or undefined if not resolvable
+       */
+      function resolveCategory(key: string): string | undefined {
+        if (key.startsWith('tag:')) {
+          return key
+        }
+        return modelToNodeStore.getCategoryForNodeType(key)
+      }
+
+      /**
+       * Get assets by nodeType or tag key.
+       * Translates nodeType to category internally for cache lookup.
+       * @param key Either a nodeType (e.g., 'CheckpointLoaderSimple') or tag key (e.g., 'tag:models')
+       */
       function getAssets(key: string): AssetItem[] {
-        const state = modelStateByKey.value.get(key)
+        const category = resolveCategory(key)
+        if (!category) return EMPTY_ASSETS
+
+        const state = modelStateByCategory.value.get(category)
         const assetsMap = state?.assets
         if (!assetsMap) return EMPTY_ASSETS
 
-        const cached = assetsArrayCache.get(key)
+        const cached = assetsArrayCache.get(category)
         if (cached && cached.source === assetsMap) {
           return cached.array
         }
 
         const array = Array.from(assetsMap.values())
-        assetsArrayCache.set(key, { source: assetsMap, array })
+        assetsArrayCache.set(category, { source: assetsMap, array })
         return array
       }
 
       function isLoading(key: string): boolean {
-        return modelStateByKey.value.get(key)?.isLoading ?? false
+        const category = resolveCategory(key)
+        if (!category) return false
+        return modelStateByCategory.value.get(category)?.isLoading ?? false
       }
 
       function getError(key: string): Error | undefined {
-        return modelStateByKey.value.get(key)?.error
+        const category = resolveCategory(key)
+        if (!category) return undefined
+        return modelStateByCategory.value.get(category)?.error
       }
 
       function hasMore(key: string): boolean {
-        return modelStateByKey.value.get(key)?.hasMore ?? false
+        const category = resolveCategory(key)
+        if (!category) return false
+        return modelStateByCategory.value.get(category)?.hasMore ?? false
       }
 
       function hasAssetKey(key: string): boolean {
-        return modelStateByKey.value.has(key)
+        const category = resolveCategory(key)
+        if (!category) return false
+        return modelStateByCategory.value.has(category)
       }
 
       /**
-       * Internal helper to fetch and cache assets with a given key and fetcher.
+       * Internal helper to fetch and cache assets for a category.
        * Loads first batch immediately, then progressively loads remaining batches.
        * Keeps existing data visible until new data is successfully fetched.
        */
-      async function updateModelsForKey(
-        key: string,
+      async function updateModelsForCategory(
+        category: string,
         fetcher: (options: PaginationOptions) => Promise<AssetItem[]>
       ): Promise<void> {
-        const existingState = modelStateByKey.value.get(key)
+        const existingState = modelStateByCategory.value.get(category)
         const state = createState(existingState?.assets)
 
         const seenIds = new Set<string>()
 
-        const hasExistingData = modelStateByKey.value.has(key)
+        const hasExistingData = modelStateByCategory.value.has(category)
         if (hasExistingData) {
-          pendingRequestByKey.set(key, state)
+          pendingRequestByCategory.set(category, state)
         } else {
-          modelStateByKey.value.set(key, state)
+          modelStateByCategory.value.set(category, state)
         }
 
         async function loadBatches(): Promise<void> {
@@ -374,14 +407,14 @@ export const useAssetsStore = defineStore('assets', () => {
                 offset: state.offset
               })
 
-              if (isStale(key, state)) return
+              if (isStale(category, state)) return
 
               const isFirstBatch = state.offset === 0
               if (isFirstBatch) {
-                assetsArrayCache.delete(key)
+                assetsArrayCache.delete(category)
                 if (hasExistingData) {
-                  pendingRequestByKey.delete(key)
-                  modelStateByKey.value.set(key, state)
+                  pendingRequestByCategory.delete(category)
+                  modelStateByCategory.value.set(category, state)
                 }
               }
 
@@ -403,13 +436,13 @@ export const useAssetsStore = defineStore('assets', () => {
                 await new Promise((resolve) => setTimeout(resolve, 50))
               }
             } catch (err) {
-              if (isStale(key, state)) return
-              console.error(`Error loading batch for ${key}:`, err)
+              if (isStale(category, state)) return
+              console.error(`Error loading batch for ${category}:`, err)
 
               state.error = err instanceof Error ? err : new Error(String(err))
               state.hasMore = false
               state.isLoading = false
-              pendingRequestByKey.delete(key)
+              pendingRequestByCategory.delete(category)
 
               return
             }
@@ -421,18 +454,24 @@ export const useAssetsStore = defineStore('assets', () => {
           for (const id of staleIds) {
             state.assets.delete(id)
           }
-          assetsArrayCache.delete(key)
+          assetsArrayCache.delete(category)
         }
 
         await loadBatches()
       }
 
       /**
-       * Fetch and cache model assets for a specific node type
+       * Fetch and cache model assets for a specific node type.
+       * Translates nodeType to category internally - multiple node types
+       * sharing the same category will share the same cache entry.
        * @param nodeType The node type to fetch assets for (e.g., 'CheckpointLoaderSimple')
        */
       async function updateModelsForNodeType(nodeType: string): Promise<void> {
-        await updateModelsForKey(nodeType, (opts) =>
+        const category = modelToNodeStore.getCategoryForNodeType(nodeType)
+        if (!category) return
+
+        // Use category as cache key but fetch using nodeType for API compatibility
+        await updateModelsForCategory(category, (opts) =>
           assetService.getAssetsForNodeType(nodeType, opts)
         )
       }
@@ -442,10 +481,21 @@ export const useAssetsStore = defineStore('assets', () => {
        * @param tag The tag to fetch assets for (e.g., 'models')
        */
       async function updateModelsForTag(tag: string): Promise<void> {
-        const key = `tag:${tag}`
-        await updateModelsForKey(key, (opts) =>
+        const category = `tag:${tag}`
+        await updateModelsForCategory(category, (opts) =>
           assetService.getAssetsByTag(tag, true, opts)
         )
+      }
+
+      /**
+       * Invalidate the cache for a specific category.
+       * Forces a refetch on next access.
+       * @param category The category to invalidate (e.g., 'checkpoints', 'loras')
+       */
+      function invalidateCategory(category: string): void {
+        modelStateByCategory.value.delete(category)
+        assetsArrayCache.delete(category)
+        pendingRequestByCategory.delete(category)
       }
 
       /**
@@ -459,19 +509,21 @@ export const useAssetsStore = defineStore('assets', () => {
         updates: Partial<AssetItem>,
         cacheKey?: string
       ) {
-        const keysToCheck = cacheKey
-          ? [cacheKey]
-          : Array.from(modelStateByKey.value.keys())
+        const category = cacheKey ? resolveCategory(cacheKey) : undefined
+        const categoriesToCheck = category
+          ? [category]
+          : Array.from(modelStateByCategory.value.keys())
 
-        for (const key of keysToCheck) {
-          const state = modelStateByKey.value.get(key)
+        for (const cat of categoriesToCheck) {
+          if (!cat) continue
+          const state = modelStateByCategory.value.get(cat)
           if (!state?.assets) continue
 
           const existingAsset = state.assets.get(assetId)
           if (existingAsset) {
             const updatedAsset = { ...existingAsset, ...updates }
             state.assets.set(assetId, updatedAsset)
-            assetsArrayCache.delete(key)
+            assetsArrayCache.delete(cat)
             if (cacheKey) return
           }
         }
@@ -554,6 +606,7 @@ export const useAssetsStore = defineStore('assets', () => {
         hasAssetKey,
         updateModelsForNodeType,
         updateModelsForTag,
+        invalidateCategory,
         updateAssetMetadata,
         updateAssetTags
       }
@@ -567,6 +620,7 @@ export const useAssetsStore = defineStore('assets', () => {
       hasMore: () => false,
       hasAssetKey: () => false,
       updateModelsForNodeType: async () => {},
+      invalidateCategory: () => {},
       updateModelsForTag: async () => {},
       updateAssetMetadata: async () => {},
       updateAssetTags: async () => {}
@@ -581,6 +635,7 @@ export const useAssetsStore = defineStore('assets', () => {
     hasAssetKey,
     updateModelsForNodeType,
     updateModelsForTag,
+    invalidateCategory,
     updateAssetMetadata,
     updateAssetTags
   } = getModelState()
@@ -657,6 +712,7 @@ export const useAssetsStore = defineStore('assets', () => {
     // Model assets - actions
     updateModelsForNodeType,
     updateModelsForTag,
+    invalidateCategory,
     updateAssetMetadata,
     updateAssetTags
   }

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -308,10 +308,7 @@ export const useAssetsStore = defineStore('assets', () => {
         })
       }
 
-      function isStale(
-        category: string,
-        state: ModelPaginationState
-      ): boolean {
+      function isStale(category: string, state: ModelPaginationState): boolean {
         const committed = modelStateByCategory.value.get(category)
         const pending = pendingRequestByCategory.get(category)
         return committed !== state && pending !== state

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -507,12 +507,13 @@ export const useAssetsStore = defineStore('assets', () => {
         cacheKey?: string
       ) {
         const category = cacheKey ? resolveCategory(cacheKey) : undefined
+        if (cacheKey && !category) return
+
         const categoriesToCheck = category
           ? [category]
           : Array.from(modelStateByCategory.value.keys())
 
         for (const cat of categoriesToCheck) {
-          if (!cat) continue
           const state = modelStateByCategory.value.get(cat)
           if (!state?.assets) continue
 


### PR DESCRIPTION
## Summary

Refactors the model assets cache in `assetsStore.ts` to be keyed by category (e.g., 'checkpoints', 'loras') instead of nodeType (e.g., 'CheckpointLoaderSimple').

## Changes

- Rename `modelStateByKey` to `modelStateByCategory`
- Add `resolveCategory()` helper to translate nodeType to category for cache lookup
- Multiple node types sharing the same category now share one cache entry
- Add `invalidateCategory()` method for cache invalidation
- Maintain backwards-compatible public API accepting nodeType
- Update tests for new category-keyed behavior

## Benefits

1. **Deduplication**: Same category = same cache entry = single API call
2. **Simple invalidation**: Delete asset with tag 'checkpoints' then invalidate cache
3. **Cleaner mental model**: Store to View reactive flow works naturally

## Testing

- All existing tests pass with updates
- Added new tests for category-keyed cache sharing, invalidateCategory, and unknown node type handling

## Part of Stack

This is **PR 1 of 2** in a stacked PR series:
1. **This PR**: Refactor asset cache to category-keyed (architectural improvement)
2. **[PR 2 #8434](https://github.com/Comfy-Org/ComfyUI_frontend/pull/8434)**: Fix deletion invalidation

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8433-refactor-change-asset-cache-from-nodeType-keyed-to-category-keyed-2f76d73d365081999b7fda12c9706ab5) by [Unito](https://www.unito.io)
