### PR TITLE
feat: increase allowed batch count (on Run button) on cloud (from 4 to 32)

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -603,7 +603,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'The maximum number of tasks added to the queue at one button click',
     type: 'number',
-    defaultValue: isCloud ? 4 : 100,
+    defaultValue: isCloud ? 32 : 100,
     versionAdded: '1.3.5'
   },
   {


### PR DESCRIPTION
## Summary

cloud.comfy.org now suports up to 100 queued jobs at a time ([details](https://x.com/ComfyUI/status/2016622139722572032?s=20)). We can increase the batch count limit to 32. Possible downside is cloud having to reject larger number of jobs over the 100 limit if someone go to 32 and clicks 4+ times. This setting was configurable anyway before, so this is mostly a QoL change.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8436-feat-increase-allowed-batch-count-on-Run-button-on-cloud-from-4-to-32-2f76d73d365081728650fabefc394046) by [Unito](https://www.unito.io)
