### PR TITLE
Fix Help Center display in linear mode

### DIFF
--- a/src/components/helpcenter/HelpCenterPopups.vue
+++ b/src/components/helpcenter/HelpCenterPopups.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Help Center Popup positioned within canvas area -->
-  <Teleport to="#graph-canvas-container">
+  <Teleport to="body">
     <div
       v-if="isHelpCenterVisible"
       class="help-center-popup"


### PR DESCRIPTION
The Help Center popover wasn't working in linear mode because the `#graph-canvas-container` is hidden. This is fixed by instead setting the target to body. This matches the [default behaviour used by portals in rekai-ui](https://github.com/unovue/reka-ui/blob/v2/packages/core/src/Teleport/Teleport.vue)
<img width="476" height="677" alt="image" src="https://github.com/user-attachments/assets/cca46648-3bce-4b72-a5be-3727e2358217" />

I've got a working branch for moving the Help Center to our reka-ui Popover component, but that'll require a much larger surface area of code changes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8438-Fix-Help-Center-display-in-linear-mode-2f76d73d36508112abedf1160f7c3a90) by [Unito](https://www.unito.io)
