### PR TITLE
Fix paste-with-links breaking autogrow connections

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -557,7 +557,7 @@ function withComfyAutogrow(node: LGraphNode): asserts node is AutogrowNode {
       if (!autogrowGroup) return
       if (app.configuringGraph && input.widget)
         ensureWidgetForInput(node, input)
-      if (iscon && linf) {
+      if (iscon) {
         if (swappingConnection || !linf) return
         autogrowInputConnected(slot, this)
       } else {


### PR DESCRIPTION
The extra `linf` check was made in 878c8c0f39. I'm no longer able to replicate the cloning bug the check was introduced for.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8442-Fix-paste-with-links-breaking-autogrow-connections-2f76d73d3650817aa99cc3b9e4e6412c) by [Unito](https://www.unito.io)
