### PR TITLE
fix: handle non-string serverLogs in error report

### DIFF
--- a/src/utils/errorReportUtil.ts
+++ b/src/utils/errorReportUtil.ts
@@ -66,7 +66,7 @@ ${systemStats.devices
   .join('\n')}
 ## Logs
 \`\`\`
-${error.serverLogs}
+${typeof error.serverLogs === 'string' ? error.serverLogs : JSON.stringify(error.serverLogs, null, 2)}
 \`\`\`
 ## Attached Workflow
 Please make sure that workflow does not contain any sensitive information such as API keys or passwords.


### PR DESCRIPTION
## Summary
- Fix `[object Object]` display in error report logs section

## Changes
- Add runtime type check for `serverLogs` in error report template
- JSON stringify object logs with proper formatting

## Test plan
- [x] Verify string logs still display correctly
- [x] Verify object logs are properly stringified instead of showing `[object Object]`

Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/8463

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8460-fix-handle-non-string-serverLogs-in-error-report-2f86d73d36508179af5afcdeec025a75) by [Unito](https://www.unito.io)
