### PR TITLE
fix(cloud): disable legacy node templates feature on cloud

### DIFF
--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -13,7 +13,9 @@ import './imageCompare'
 import './imageCrop'
 import './load3d'
 import './maskeditor'
-import './nodeTemplates'
+if (!isCloud) {
+  await import('./nodeTemplates')
+}
 import './noteNode'
 import './previewAny'
 import './rerouteNode'


### PR DESCRIPTION
## Summary

Disables the legacy "node templates" feature on ComfyUI Cloud. This feature is accessed via right-clicking on the canvas and is distinct from both subgraphs and workflow templates.

## Problem

The legacy node templates feature presents false-positive errors on cloud:
- Errors appear when no existing templates exist initially
- After refresh, workflow progress is lost from workflow tabs
- Node templates fail to delete (except the first one)

## Solution

Conditionally load the `nodeTemplates` extension only for non-cloud builds by wrapping the import in `if (!isCloud)`.

## Testing

- [ ] Verify right-click canvas menu no longer shows "Node Templates" submenu on cloud
- [ ] Verify right-click canvas menu no longer shows "Save Selected as Template" on cloud
- [ ] Verify the feature still works on desktop/OSS builds

## Related

- Refs: COM-14105
- Related issue: #4056 (Migrate Node Templates to Workflows)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8462-fix-cloud-disable-legacy-node-templates-feature-on-cloud-2f86d73d36508162948cc897d4c7ef5e) by [Unito](https://www.unito.io)
