### PR TITLE
chore: add deprecation warning for legacy node templates extension

### DIFF
--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -9,7 +9,11 @@ interface ShimResult {
 const SKIP_WARNING_FILES = new Set(['scripts/app', 'scripts/api'])
 
 /** Files that will be removed in v1.34 */
-const DEPRECATED_FILES = ['scripts/ui', 'extensions/core/groupNode'] as const
+const DEPRECATED_FILES = [
+  'scripts/ui',
+  'extensions/core/groupNode',
+  'extensions/core/nodeTemplates'
+] as const
 
 function getWarningMessage(
   fileKey: string,


### PR DESCRIPTION
## Summary

Adds the legacy `nodeTemplates` extension to the `DEPRECATED_FILES` list in the build plugin, causing a console warning when external extensions import from this file.

## Changes

Adds `'extensions/core/nodeTemplates'` to `DEPRECATED_FILES` in `build/plugins/comfyAPIPlugin.ts`.

## Effect

When an external extension imports from `extensions/core/nodeTemplates.js`, they will see:
```
[ComfyUI Deprecated] Importing from "extensions/core/nodeTemplates.js" is deprecated and will be removed in v1.34.
```

## Related

- Follows pattern from PR #6090 (feat: deprecated API alert)
- Related issue: #4056 (Migrate Node Templates to Workflows)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8463-chore-add-deprecation-warning-for-legacy-node-templates-extension-2f86d73d3650811e9f53fa3e5a572332) by [Unito](https://www.unito.io)
