### PR TITLE
fix: add security params to Contact Support window.open call

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -862,7 +862,7 @@ export function useCoreCommands(): ComfyCommand[] {
           userEmail: userEmail.value,
           userId: resolvedUserInfo.value?.id
         })
-        window.open(supportUrl, '_blank')
+        window.open(supportUrl, '_blank', 'noopener,noreferrer')
       }
     },
     {


### PR DESCRIPTION
## Summary

Adds `'noopener,noreferrer'` to the `window.open()` call in `Comfy.ContactSupport` command, aligning with the established codebase pattern for external links.

## Changes

- Updated `src/composables/useCoreCommands.ts` line 865 to include security parameters

## Testing

- [x] Typecheck passes
- [x] Lint passes

## Related

- Fixes COM-13631
- Notion: https://www.notion.so/2ee6d73d365081328ae5cc7bce64b310

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8470-fix-add-security-params-to-Contact-Support-window-open-call-2f86d73d365081e38ea1c1ea9c9883f5) by [Unito](https://www.unito.io)
