### PR TITLE
fix: properties panel obscures menus in legacy layout

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -960,7 +960,7 @@ body {
   top: 50%;
   right: 0;
   text-align: center;
-  z-index: 999;
+  z-index: 1100;
   width: 190px;
   display: flex;
   flex-direction: column;

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -960,7 +960,7 @@ body {
   top: 50%;
   right: 0;
   text-align: center;
-  z-index: 1100;
+  z-index: 999;
   width: 190px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Fixes overlap issue where the new menu's node properties panel could cover the old floating menu.

## Changes

Hide the properties panel when using the legacy menu, so it doesn't obscure the old menu. The properties panel did not work anyway (empy content).


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8474-fix-increase-z-index-of-legacy-floating-menu-2f86d73d365081a0ab44db24c2ea6357) by [Unito](https://www.unito.io)
