### PR TITLE
docs: add Vite preload error handling documentation comment

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,8 @@ onMounted(() => {
     document.addEventListener('contextmenu', showContextMenu)
   }
 
+  // Handle preload errors that occur during dynamic imports (e.g., stale chunks after deployment)
+  // See: https://vite.dev/guide/build#load-error-handling
   window.addEventListener('vite:preloadError', (event) => {
     event.preventDefault()
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
## Summary

Add documentation comment explaining the Vite preload error handler with a link to official documentation.

## Changes

- **What**: Added a 2-line comment above the `vite:preloadError` event listener in App.vue explaining its purpose and linking to https://vite.dev/guide/build#load-error-handling

Fixes COM-14132

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8475-docs-add-Vite-preload-error-handling-documentation-comment-2f86d73d3650815f9731f30bd9c5eb57) by [Unito](https://www.unito.io)
