### PR TITLE
Revert matchtype slot reactivity on cloud/1.38

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -1,5 +1,4 @@
 import { remove } from 'es-toolkit'
-import { shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type {
@@ -345,7 +344,6 @@ function applyMatchType(node: LGraphNode, inputSpec: InputSpecV2) {
   requestAnimationFrame(() => {
     const input = node.inputs[index]
     if (!input) return
-    node.inputs[index] = shallowReactive(input)
     node.onConnectionsChange?.(
       LiteGraph.INPUT,
       index,


### PR DESCRIPTION
Fixes a bug where canvas functionality is lost if a multitype input (like the native switch) is added to the graph in litegraph mode.

This issue is properly fixed by #8440, but this single revision is easier and safer to backport

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8477-Revert-matchtype-slot-reactivity-on-cloud-1-38-2f86d73d365081279285e6d86ded9e43) by [Unito](https://www.unito.io)
