### PR TITLE
Revert matchtype slot reactivity on core/1.38

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -1,5 +1,4 @@
 import { remove } from 'es-toolkit'
-import { shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type {
@@ -345,7 +344,6 @@ function applyMatchType(node: LGraphNode, inputSpec: InputSpecV2) {
   requestAnimationFrame(() => {
     const input = node.inputs[index]
     if (!input) return
-    node.inputs[index] = shallowReactive(input)
     node.onConnectionsChange?.(
       LiteGraph.INPUT,
       index,


### PR DESCRIPTION
Fixes a bug where canvas functionality is lost if a multitype input (like the native switch) is added to the graph in litegraph mode.

See also #8477

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8481-Revert-matchtype-slot-reactivity-on-core-1-38-2f86d73d365081ac8e0aeb5ce96fe685) by [Unito](https://www.unito.io)
