### PR TITLE
fix: use PR_GH_TOKEN in lint/i18n workflows to trigger e2e tests

### DIFF
--- a/.github/workflows/ci-lint-format.yaml
+++ b/.github/workflows/ci-lint-format.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || github.ref }}
+          token: ${{ secrets.PR_GH_TOKEN }}
 
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend

--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PR_GH_TOKEN }}
 
       # Setup playwright environment
       - name: Setup ComfyUI Frontend

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -1,4 +1,4 @@
-import { memoize } from 'es-toolkit/compat'
+import { memoize } from "es-toolkit/compat";
 
 type RGB = { r: number; g: number; b: number }
 export interface HSB {

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -1,4 +1,4 @@
-import { memoize } from "es-toolkit/compat";
+import { memoize } from 'es-toolkit/compat'
 
 type RGB = { r: number; g: number; b: number }
 export interface HSB {


### PR DESCRIPTION
## Summary

Add `PR_GH_TOKEN` to ci-lint-format and i18n-update-core workflows to ensure commits trigger e2e test runs.

## Changes

- Add `token: ${{ secrets.PR_GH_TOKEN }}` to checkout step in `.github/workflows/ci-lint-format.yaml`
- Add `token: ${{ secrets.PR_GH_TOKEN }}` to checkout step in `.github/workflows/i18n-update-core.yaml`

## Context

This matches the pattern used consistently across all other workflows in the repository (release-version-bump, version-bump-desktop-ui, api-update-registry-api-types, i18n-update-nodes, etc.).

Without this token, commits made by these workflows don't trigger downstream e2e tests, which can lead to issues being missed.

## Original Work

Original idea & implementation by @drjkl in commits:
- be3a8d61c - fix: use GitHub App token for lint/i18n workflows to trigger e2e tests
- 50ccb254b - Add github app token action to pinact

This PR simplifies the approach to use the existing `PR_GH_TOKEN` secret instead of GitHub App tokens, for consistency with the rest of the repository.

## Test Plan

- [x] Verify workflows can checkout code successfully
- [x] Confirm commits from these workflows trigger e2e test runs

## It works!
<img width="1075" height="402" alt="image" src="https://github.com/user-attachments/assets/31762d68-a37f-4926-b463-84d184d4309d" />
