### PR TITLE
feat: add model type mappings for cloud custom nodes

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -216,6 +216,26 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
     quickRegister('sams', 'SAMLoader', 'model_name')
     quickRegister('ultralytics', 'UltralyticsDetectorProvider', 'model_name')
 
+    // IP-Adapter models
+    quickRegister('ipadapter', 'IPAdapterModelLoader', 'ipadapter_file')
+
+    // Segformer clothing/fashion segmentation models
+    quickRegister(
+      'segformer_b2_clothes',
+      'LayerMask: SegformerClothesPipelineLoader',
+      'model'
+    )
+    quickRegister(
+      'segformer_b3_clothes',
+      'LayerMask: SegformerClothesPipelineLoader',
+      'model'
+    )
+    quickRegister(
+      'segformer_b3_fashion',
+      'LayerMask: SegformerFashionPipelineLoader',
+      'model'
+    )
+
     // Other specialized models
     quickRegister('nlf', 'LoadNLFModel', 'nlf_model')
   }

--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -198,10 +198,18 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
     quickRegister('SEEDVR2', 'SeedVR2LoadDiTModel', 'model')
 
     // Depth estimation models
-    quickRegister('depthanything', 'DownloadAndLoadDepthAnythingV2Model', 'model')
+    quickRegister(
+      'depthanything',
+      'DownloadAndLoadDepthAnythingV2Model',
+      'model'
+    )
 
     // Latent upscaling models
-    quickRegister('latent_upscale_models', 'LatentUpscaleModelLoader', 'model_name')
+    quickRegister(
+      'latent_upscale_models',
+      'LatentUpscaleModelLoader',
+      'model_name'
+    )
 
     // Segmentation models
     quickRegister('sam2', 'DownloadAndLoadSAM2Model', 'model')

--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -192,6 +192,24 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
       ''
     )
     quickRegister('chatterbox/chatterbox_vc', 'FL_ChatterboxVC', '')
+
+    // Video upscaling models
+    quickRegister('FlashVSR', 'FlashVSRInitPipe', 'model')
+    quickRegister('SEEDVR2', 'SeedVR2LoadDiTModel', 'model')
+
+    // Depth estimation models
+    quickRegister('depthanything', 'DownloadAndLoadDepthAnythingV2Model', 'model')
+
+    // Latent upscaling models
+    quickRegister('latent_upscale_models', 'LatentUpscaleModelLoader', 'model_name')
+
+    // Segmentation models
+    quickRegister('sam2', 'DownloadAndLoadSAM2Model', 'model')
+    quickRegister('sams', 'SAMLoader', 'model_name')
+    quickRegister('ultralytics', 'UltralyticsDetectorProvider', 'model_name')
+
+    // Other specialized models
+    quickRegister('nlf', 'LoadNLFModel', 'nlf_model')
   }
 
   return {


### PR DESCRIPTION
## Summary
Add mappings for model directories used by cloud-deployed custom nodes so the "Use" button works in the model browser.

## Problem
When clicking "Use" on models in certain directories, nothing happens because the frontend doesn't know which node to create.

## Mappings Added

| Model Directory | Node Class | Input Key |
|-----------------|------------|-----------|
| `FlashVSR` | `FlashVSRInitPipe` | `model` |
| `SEEDVR2` | `SeedVR2LoadDiTModel` | `model` |
| `depthanything` | `DownloadAndLoadDepthAnythingV2Model` | `model` |
| `latent_upscale_models` | `LatentUpscaleModelLoader` | `model_name` |
| `sam2` | `DownloadAndLoadSAM2Model` | `model` |
| `sams` | `SAMLoader` | `model_name` |
| `ultralytics` | `UltralyticsDetectorProvider` | `model_name` |
| `ipadapter` | `IPAdapterModelLoader` | `ipadapter_file` |
| `segformer_b2_clothes` | `LayerMask: SegformerClothesPipelineLoader` | `model` |
| `segformer_b3_clothes` | `LayerMask: SegformerClothesPipelineLoader` | `model` |
| `segformer_b3_fashion` | `LayerMask: SegformerFashionPipelineLoader` | `model` |
| `nlf` | `LoadNLFModel` | `nlf_model` |

## Notes
- `FlashVSR-v1.1` falls back to `FlashVSR` mapping via the hierarchical fallback logic
- `ultralytics/bbox` and `ultralytics/segm` fall back to `ultralytics` mapping
- `detection` and `vae_approx` not mapped (detection has multiple model inputs, vae_approx is internal)

## Test plan
- [ ] Verify "Use" button works for models in FlashVSR directory
- [ ] Verify "Use" button works for models in SEEDVR2 directory
- [ ] Verify "Use" button works for ipadapter models
- [ ] Verify segformer model mappings work

🤖 Generated with [Claude Code](https://claude.com/claude-code)