### PR TITLE
feat: add base model filter to FormDropdown

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2506,6 +2506,7 @@
     "imported": "Imported",
     "assetCollection": "Asset collection",
     "assets": "Assets",
+    "baseModel": "Base model",
     "baseModels": "Base models",
     "browseAssets": "Browse Assets",
     "checkpoints": "Checkpoints",

--- a/src/platform/assets/types/filterTypes.ts
+++ b/src/platform/assets/types/filterTypes.ts
@@ -4,16 +4,11 @@
  */
 
 /**
- * Generic option identifier type
- */
-export type OptionId = string
-
-/**
  * Generic filter/select option used across components
  * Compatible with both SelectOption (name/value) and FilterOption (id/name) patterns
  */
 export interface FilterOption {
-  id: OptionId
+  id: string
   name: string
 }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -7,7 +7,6 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type {
   FilterOption,
-  OptionId,
   OwnershipFilterOption,
   OwnershipOption
 } from '@/platform/assets/types/filterTypes'
@@ -33,8 +32,10 @@ interface Props {
   sortOptions?: SortOption[]
   showOwnershipFilter?: boolean
   ownershipOptions?: OwnershipFilterOption[]
+  showBaseModelFilter?: boolean
+  baseModelOptions?: FilterOption[]
   isSelected?: (
-    selected: Set<OptionId>,
+    selected: Set<string>,
     item: FormDropdownItem,
     index: number
   ) => boolean
@@ -56,11 +57,11 @@ const props = withDefaults(defineProps<Props>(), {
   searcher: defaultSearcher
 })
 
-const selected = defineModel<Set<OptionId>>('selected', {
+const selected = defineModel<Set<string>>('selected', {
   default: new Set()
 })
-const filterSelected = defineModel<OptionId>('filterSelected', { default: '' })
-const sortSelected = defineModel<OptionId>('sortSelected', {
+const filterSelected = defineModel<string>('filterSelected', { default: '' })
+const sortSelected = defineModel<string>('sortSelected', {
   default: 'default'
 })
 const layoutMode = defineModel<LayoutMode>('layoutMode', {
@@ -70,6 +71,9 @@ const files = defineModel<File[]>('files', { default: [] })
 const searchQuery = defineModel<string>('searchQuery', { default: '' })
 const ownershipSelected = defineModel<OwnershipOption>('ownershipSelected', {
   default: 'all'
+})
+const baseModelSelected = defineModel<Set<string>>('baseModelSelected', {
+  default: new Set()
 })
 
 const toastStore = useToastStore()
@@ -210,10 +214,13 @@ async function customSearcher(
         v-model:sort-selected="sortSelected"
         v-model:search-query="searchQuery"
         v-model:ownership-selected="ownershipSelected"
+        v-model:base-model-selected="baseModelSelected"
         :filter-options
         :sort-options
         :show-ownership-filter
         :ownership-options
+        :show-base-model-filter
+        :base-model-options
         :disabled
         :searcher="customSearcher"
         :items="sortedItems"

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-import type { OptionId } from '@/platform/assets/types/filterTypes'
 import { cn } from '@/utils/tailwindUtil'
 
 import { WidgetInputBaseClass } from '../../layout'
@@ -11,7 +10,7 @@ interface Props {
   isOpen?: boolean
   placeholder?: string
   items: FormDropdownItem[]
-  selected: Set<OptionId>
+  selected: Set<string>
   maxSelectable: number
   uploadable: boolean
   disabled: boolean

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -5,7 +5,6 @@ import { cn } from '@/utils/tailwindUtil'
 
 import type {
   FilterOption,
-  OptionId,
   OwnershipFilterOption,
   OwnershipOption
 } from '@/platform/assets/types/filterTypes'
@@ -27,6 +26,8 @@ interface Props {
   updateKey?: MaybeRefOrGetter<unknown>
   showOwnershipFilter?: boolean
   ownershipOptions?: OwnershipFilterOption[]
+  showBaseModelFilter?: boolean
+  baseModelOptions?: FilterOption[]
 }
 
 defineProps<Props>()
@@ -34,11 +35,12 @@ const emit = defineEmits<{
   (e: 'item-click', item: FormDropdownItem, index: number): void
 }>()
 
-const filterSelected = defineModel<OptionId>('filterSelected')
+const filterSelected = defineModel<string>('filterSelected')
 const layoutMode = defineModel<LayoutMode>('layoutMode')
-const sortSelected = defineModel<OptionId>('sortSelected')
+const sortSelected = defineModel<string>('sortSelected')
 const searchQuery = defineModel<string>('searchQuery')
 const ownershipSelected = defineModel<OwnershipOption>('ownershipSelected')
+const baseModelSelected = defineModel<Set<string>>('baseModelSelected')
 </script>
 
 <template>
@@ -55,11 +57,14 @@ const ownershipSelected = defineModel<OwnershipOption>('ownershipSelected')
       v-model:sort-selected="sortSelected"
       v-model:search-query="searchQuery"
       v-model:ownership-selected="ownershipSelected"
+      v-model:base-model-selected="baseModelSelected"
       :sort-options
       :searcher
       :update-key
       :show-ownership-filter
       :ownership-options
+      :show-base-model-filter
+      :base-model-options
     />
     <div class="relative flex h-full mt-2 overflow-y-scroll">
       <div

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
@@ -5,6 +5,7 @@ import Popover from 'primevue/popover'
 import { ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import type {
   FilterOption,
   OwnershipFilterOption,
@@ -44,8 +45,6 @@ const actionButtonStyle = cn(
   'h-8 bg-zinc-500/20 rounded-lg outline outline-1 outline-offset-[-1px] outline-node-component-border transition-all duration-150'
 )
 
-const resetInputStyle = 'bg-transparent border-0 outline-0 ring-0 text-left'
-
 const layoutSwitchItemStyle =
   'size-6 flex justify-center items-center rounded-sm cursor-pointer transition-all duration-150 hover:scale-108 hover:text-base-foreground active:scale-95'
 
@@ -56,7 +55,7 @@ const isSortPopoverOpen = ref(false)
 function toggleSortPopover(event: Event) {
   if (!sortPopoverRef.value || !sortTriggerRef.value) return
   isSortPopoverOpen.value = !isSortPopoverOpen.value
-  sortPopoverRef.value.toggle(event, sortTriggerRef.value)
+  sortPopoverRef.value.toggle(event, sortTriggerRef.value.$el)
 }
 function closeSortPopover() {
   isSortPopoverOpen.value = false
@@ -75,7 +74,7 @@ const isOwnershipPopoverOpen = ref(false)
 function toggleOwnershipPopover(event: Event) {
   if (!ownershipPopoverRef.value || !ownershipTriggerRef.value) return
   isOwnershipPopoverOpen.value = !isOwnershipPopoverOpen.value
-  ownershipPopoverRef.value.toggle(event, ownershipTriggerRef.value)
+  ownershipPopoverRef.value.toggle(event, ownershipTriggerRef.value.$el)
 }
 function closeOwnershipPopover() {
   isOwnershipPopoverOpen.value = false
@@ -94,7 +93,7 @@ const isBaseModelPopoverOpen = ref(false)
 function toggleBaseModelPopover(event: Event) {
   if (!baseModelPopoverRef.value || !baseModelTriggerRef.value) return
   isBaseModelPopoverOpen.value = !isBaseModelPopoverOpen.value
-  baseModelPopoverRef.value.toggle(event, baseModelTriggerRef.value)
+  baseModelPopoverRef.value.toggle(event, baseModelTriggerRef.value.$el)
 }
 
 function toggleBaseModelSelection(item: FilterOption) {
@@ -123,15 +122,14 @@ function toggleBaseModelSelection(item: FilterOption) {
       "
     />
 
-    <button
+    <Button
       ref="sortTriggerRef"
+      variant="textonly"
+      size="icon"
       :class="
         cn(
-          resetInputStyle,
           actionButtonStyle,
-          'relative w-8 flex justify-center items-center cursor-pointer',
-          'hover:outline-component-node-widget-background-highlighted',
-          'active:!scale-95'
+          'relative w-8 hover:outline-component-node-widget-background-highlighted active:scale-95'
         )
       "
       @click="toggleSortPopover"
@@ -141,7 +139,7 @@ function toggleBaseModelSelection(item: FilterOption) {
         class="absolute top-[-2px] left-[-2px] size-2 rounded-full bg-component-node-widget-background-highlighted"
       />
       <i class="icon-[lucide--arrow-up-down] size-4" />
-    </button>
+    </Button>
     <Popover
       ref="sortPopoverRef"
       :dismissable="true"
@@ -166,16 +164,12 @@ function toggleBaseModelSelection(item: FilterOption) {
           )
         "
       >
-        <button
+        <Button
           v-for="item of sortOptions"
           :key="item.name"
-          :class="
-            cn(
-              resetInputStyle,
-              'flex justify-between items-center h-6 cursor-pointer',
-              'hover:!text-blue-500'
-            )
-          "
+          variant="textonly"
+          size="unset"
+          :class="cn('flex justify-between items-center h-6 text-left')"
           @click="handleSortSelected(item)"
         >
           <span>{{ item.name }}</span>
@@ -183,22 +177,21 @@ function toggleBaseModelSelection(item: FilterOption) {
             v-if="sortSelected === item.id"
             class="icon-[lucide--check] size-4"
           />
-        </button>
+        </Button>
       </div>
     </Popover>
 
-    <button
+    <Button
       v-if="showOwnershipFilter && ownershipOptions?.length"
       ref="ownershipTriggerRef"
       :aria-label="t('assetBrowser.ownership')"
       :title="t('assetBrowser.ownership')"
+      variant="textonly"
+      size="icon"
       :class="
         cn(
-          resetInputStyle,
           actionButtonStyle,
-          'relative w-8 flex justify-center items-center cursor-pointer',
-          'hover:outline-component-node-widget-background-highlighted',
-          'active:!scale-95'
+          'relative w-8 hover:outline-component-node-widget-background-highlighted active:scale-95'
         )
       "
       @click="toggleOwnershipPopover"
@@ -208,7 +201,7 @@ function toggleBaseModelSelection(item: FilterOption) {
         class="absolute top-[-2px] left-[-2px] size-2 rounded-full bg-component-node-widget-background-highlighted"
       />
       <i class="icon-[lucide--user] size-4" />
-    </button>
+    </Button>
     <Popover
       ref="ownershipPopoverRef"
       :dismissable="true"
@@ -233,16 +226,12 @@ function toggleBaseModelSelection(item: FilterOption) {
           )
         "
       >
-        <button
+        <Button
           v-for="item of ownershipOptions"
           :key="item.id"
-          :class="
-            cn(
-              resetInputStyle,
-              'flex justify-between items-center h-6 cursor-pointer',
-              'hover:!text-blue-500'
-            )
-          "
+          variant="textonly"
+          size="unset"
+          :class="cn('flex justify-between items-center h-6 text-left')"
           @click="handleOwnershipSelected(item)"
         >
           <span>{{ item.name }}</span>
@@ -250,22 +239,21 @@ function toggleBaseModelSelection(item: FilterOption) {
             v-if="ownershipSelected === item.id"
             class="icon-[lucide--check] size-4"
           />
-        </button>
+        </Button>
       </div>
     </Popover>
 
-    <button
+    <Button
       v-if="showBaseModelFilter && baseModelOptions?.length"
       ref="baseModelTriggerRef"
       :aria-label="t('assetBrowser.baseModel')"
       :title="t('assetBrowser.baseModel')"
+      variant="textonly"
+      size="icon"
       :class="
         cn(
-          resetInputStyle,
           actionButtonStyle,
-          'relative w-8 flex justify-center items-center cursor-pointer',
-          'hover:outline-component-node-widget-background-highlighted',
-          'active:!scale-95'
+          'relative w-8 hover:outline-component-node-widget-background-highlighted active:scale-95'
         )
       "
       @click="toggleBaseModelPopover"
@@ -275,7 +263,7 @@ function toggleBaseModelSelection(item: FilterOption) {
         class="absolute top-[-2px] left-[-2px] size-2 rounded-full bg-component-node-widget-background-highlighted"
       />
       <i class="icon-[comfy--ai-model] size-4" />
-    </button>
+    </Button>
     <Popover
       ref="baseModelPopoverRef"
       :dismissable="true"
@@ -300,16 +288,12 @@ function toggleBaseModelSelection(item: FilterOption) {
           )
         "
       >
-        <button
+        <Button
           v-for="item of baseModelOptions"
           :key="item.id"
-          :class="
-            cn(
-              resetInputStyle,
-              'flex justify-between items-center h-6 cursor-pointer',
-              'hover:!text-blue-500'
-            )
-          "
+          variant="textonly"
+          size="unset"
+          :class="cn('flex justify-between items-center h-6 text-left')"
           @click="toggleBaseModelSelection(item)"
         >
           <span>{{ item.name }}</span>
@@ -317,7 +301,7 @@ function toggleBaseModelSelection(item: FilterOption) {
             v-if="baseModelSelected.has(item.id)"
             class="icon-[lucide--check] size-4"
           />
-        </button>
+        </Button>
       </div>
     </Popover>
 
@@ -329,34 +313,32 @@ function toggleBaseModelSelection(item: FilterOption) {
         )
       "
     >
-      <button
+      <Button
+        variant="textonly"
+        size="unset"
         :class="
           cn(
-            resetInputStyle,
             layoutSwitchItemStyle,
-            layoutMode === 'list'
-              ? 'bg-neutral-500/50 text-base-foreground'
-              : ''
+            layoutMode === 'list' && 'bg-neutral-500/50 text-base-foreground'
           )
         "
         @click="layoutMode = 'list'"
       >
         <i class="icon-[lucide--list] size-4" />
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="textonly"
+        size="unset"
         :class="
           cn(
-            resetInputStyle,
             layoutSwitchItemStyle,
-            layoutMode === 'grid'
-              ? 'bg-neutral-500/50 text-base-foreground'
-              : ''
+            layoutMode === 'grid' && 'bg-neutral-500/50 text-base-foreground'
           )
         "
         @click="layoutMode = 'grid'"
       >
         <i class="icon-[lucide--layout-grid] size-4" />
-      </button>
+      </Button>
     </div>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
@@ -302,6 +302,15 @@ function toggleBaseModelSelection(item: FilterOption) {
             class="icon-[lucide--check] size-4"
           />
         </Button>
+        <span class="h-0 w-full border-b border-border-default" />
+        <Button
+          variant="textonly"
+          size="unset"
+          :class="cn('flex justify-between items-center h-6 text-left')"
+          @click="baseModelSelected = new Set()"
+        >
+          {{ t('g.clearFilters') }}
+        </Button>
       </div>
     </Popover>
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.vue
@@ -3,17 +3,14 @@ import { computed } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
-import type {
-  FilterOption,
-  OptionId
-} from '@/platform/assets/types/filterTypes'
+import type { FilterOption } from '@/platform/assets/types/filterTypes'
 import { cn } from '@/utils/tailwindUtil'
 
 const { filterOptions } = defineProps<{
   filterOptions: FilterOption[]
 }>()
 
-const filterSelected = defineModel<OptionId>('filterSelected')
+const filterSelected = defineModel<string>('filterSelected')
 
 const { isUploadButtonEnabled, showUploadDialog } = useModelUpload()
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/types.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/types.ts
@@ -1,6 +1,5 @@
 import type { ComputedRef, InjectionKey } from 'vue'
 
-import type { OptionId } from '@/platform/assets/types/filterTypes'
 import type { AssetKind } from '@/types/widgetTypes'
 
 /**
@@ -8,7 +7,7 @@ import type { AssetKind } from '@/types/widgetTypes'
  * Both AssetItem (from cloud API) and local file items satisfy this contract.
  */
 export interface FormDropdownItem {
-  id: OptionId
+  id: string
   /** Display name shown in the dropdown */
   name: string
   /** Original/alternate label (e.g., original filename) */
@@ -17,9 +16,11 @@ export interface FormDropdownItem {
   preview_url?: string
   /** Whether the item is immutable (public model) - used for ownership filtering */
   is_immutable?: boolean
+  /** Base models this item is compatible with - used for base model filtering */
+  base_models?: string[]
 }
 
-export interface SortOption<TId extends OptionId = OptionId> {
+export interface SortOption<TId extends string = string> {
   id: TId
   name: string
   sorter: (ctx: { items: readonly FormDropdownItem[] }) => FormDropdownItem[]


### PR DESCRIPTION
## Summary

Adds a base model filter to the FormDropdown component, allowing users to filter dropdown options by base model type.

## Changes

- **Base model filter**: New filter popover in FormDropdownMenuActions that lets users select one or more base models to filter by
- **Clear Filters button**: Added to the base model filter popover for quick reset
- **Button component refactor**: Replaced native `<button>` elements with the `Button` component for consistent styling
- **New i18n key**: Added `assets.baseModel` translation

## Files Changed

- `FormDropdownMenuActions.vue` - Main implementation of base model filter UI
- `WidgetSelectDropdown.vue` - Passes base model options to the dropdown
- `FormDropdown.vue`, `FormDropdownMenu.vue`, `FormDropdownMenuFilter.vue` - Prop threading
- `filterTypes.ts`, `types.ts` - Type definitions for filter options

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8501-feat-add-base-model-filter-to-FormDropdown-2f96d73d3650813c994debb06070c7dd) by [Unito](https://www.unito.io)
