### PR TITLE
Update control_after_generate schema

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -74,10 +74,14 @@ const addMultiSelectWidget = (
   // TODO: Add remote support to multi-select widget
   // https://github.com/Comfy-Org/ComfyUI_frontend/issues/3003
   if (inputSpec.control_after_generate) {
+    const defaultType =
+      typeof inputSpec.control_after_generate === 'string'
+        ? inputSpec.control_after_generate
+        : 'fixed'
     widget.linkedWidgets = addValueControlWidgets(
       node,
       widget,
-      'fixed',
+      defaultType,
       undefined,
       transformInputSpecV2ToV1(inputSpec)
     )
@@ -209,10 +213,14 @@ const createInputMappingWidget = (
     if (!isComboWidget(widget)) {
       throw new Error(`Expected combo widget but received ${widget.type}`)
     }
+    const defaultType =
+      typeof inputSpec.control_after_generate === 'string'
+        ? inputSpec.control_after_generate
+        : 'randomize'
     widget.linkedWidgets = addValueControlWidgets(
       node,
       widget,
-      undefined,
+      defaultType,
       undefined,
       transformInputSpecV2ToV1(inputSpec)
     )
@@ -284,10 +292,14 @@ const addComboWidget = (
       throw new Error(`Expected combo widget but received ${widget.type}`)
     }
 
+    const defaultType =
+      typeof inputSpec.control_after_generate === 'string'
+        ? inputSpec.control_after_generate
+        : 'randomize'
     widget.linkedWidgets = addValueControlWidgets(
       node,
       widget,
-      undefined,
+      defaultType,
       undefined,
       transformInputSpecV2ToV1(inputSpec)
     )

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
@@ -72,10 +72,14 @@ export const useIntWidget = () => {
       ['seed', 'noise_seed'].includes(inputSpec.name)
 
     if (controlAfterGenerate) {
+      const defaultType =
+        typeof inputSpec.control_after_generate === 'string'
+          ? inputSpec.control_after_generate
+          : 'randomize'
       const controlWidget = addValueControlWidget(
         node,
         widget,
-        'randomize',
+        defaultType,
         undefined,
         undefined,
         transformInputSpecV2ToV1(inputSpec)

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import { resultItemType } from '@/schemas/apiSchema'
+import { CONTROL_OPTIONS } from '@/types/simplifiedWidget'
 
 const zComboOption = z.union([z.string(), z.number()])
 const zRemoteWidgetConfig = z.object({
@@ -50,7 +51,9 @@ export const zIntInputOptions = zNumericInputOptions.extend({
    * If true, a linked widget will be added to the node to select the mode
    * of `control_after_generate`.
    */
-  control_after_generate: z.boolean().optional()
+  control_after_generate: z
+    .union([z.boolean(), z.enum(CONTROL_OPTIONS)])
+    .optional()
 })
 
 export const zFloatInputOptions = zNumericInputOptions.extend({
@@ -74,7 +77,9 @@ export const zStringInputOptions = zBaseInputOptions.extend({
 })
 
 export const zComboInputOptions = zBaseInputOptions.extend({
-  control_after_generate: z.boolean().optional(),
+  control_after_generate: z
+    .union([z.boolean(), z.enum(CONTROL_OPTIONS)])
+    .optional(),
   image_upload: z.boolean().optional(),
   image_folder: resultItemType.optional(),
   allow_batch: z.boolean().optional(),

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -15,7 +15,7 @@ export type WidgetValue =
   | void
   | File[]
 
-const CONTROL_OPTIONS = [
+export const CONTROL_OPTIONS = [
   'fixed',
   'increment',
   'decrement',


### PR DESCRIPTION
Updates `control_after_generate` in the schema to support specifying the default control value as a string

See Comfy-Org/ComfyUI#12187

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8505-Update-control_after_generate-schema-2f96d73d365081f9bf73c804072bb415) by [Unito](https://www.unito.io)
