### PR TITLE
fix: dedupe queueStore.update() to prevent race conditions

### DIFF
--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -49,6 +49,9 @@ const createTaskOutput = (
   }
 })
 
+type QueueResponse = { Running: JobListItem[]; Pending: JobListItem[] }
+type QueueResolver = (value: QueueResponse) => void
+
 // Mock API
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -805,25 +808,13 @@ describe('useQueueStore', () => {
 
   describe('update deduplication', () => {
     it('should discard stale responses when newer request completes first', async () => {
-      let resolveFirst: (value: {
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }) => void
-      let resolveSecond: (value: {
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }) => void
+      let resolveFirst: QueueResolver
+      let resolveSecond: QueueResolver
 
-      const firstQueuePromise = new Promise<{
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }>((resolve) => {
+      const firstQueuePromise = new Promise<QueueResponse>((resolve) => {
         resolveFirst = resolve
       })
-      const secondQueuePromise = new Promise<{
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }>((resolve) => {
+      const secondQueuePromise = new Promise<QueueResponse>((resolve) => {
         resolveSecond = resolve
       })
 
@@ -853,25 +844,13 @@ describe('useQueueStore', () => {
     })
 
     it('should set isLoading to false only for the latest request', async () => {
-      let resolveFirst: (value: {
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }) => void
-      let resolveSecond: (value: {
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }) => void
+      let resolveFirst: QueueResolver
+      let resolveSecond: QueueResolver
 
-      const firstQueuePromise = new Promise<{
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }>((resolve) => {
+      const firstQueuePromise = new Promise<QueueResponse>((resolve) => {
         resolveFirst = resolve
       })
-      const secondQueuePromise = new Promise<{
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }>((resolve) => {
+      const secondQueuePromise = new Promise<QueueResponse>((resolve) => {
         resolveSecond = resolve
       })
 
@@ -899,15 +878,9 @@ describe('useQueueStore', () => {
     })
 
     it('should handle stale request failure without affecting latest state', async () => {
-      let resolveSecond: (value: {
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }) => void
+      let resolveSecond: QueueResolver
 
-      const secondQueuePromise = new Promise<{
-        Running: JobListItem[]
-        Pending: JobListItem[]
-      }>((resolve) => {
+      const secondQueuePromise = new Promise<QueueResponse>((resolve) => {
         resolveSecond = resolve
       })
 

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -475,6 +475,7 @@ export const useQueueStore = defineStore('queue', () => {
   const maxHistoryItems = ref(64)
   const isLoading = ref(false)
 
+  // Scoped per-store instance; incremented to dedupe concurrent update() calls
   let updateRequestId = 0
 
   const tasks = computed<TaskItemImpl[]>(

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -551,6 +551,9 @@ export const useQueueStore = defineStore('queue', () => {
         return existing
       })
     } finally {
+      // Only clear loading if this is the latest request.
+      // A stale request completing (success or error) should not touch loading state
+      // since a newer request is responsible for it.
       if (requestId === updateRequestId) {
         isLoading.value = false
       }


### PR DESCRIPTION
## Summary

Prevents stale API responses from overwriting fresh queue state during rapid consecutive `update()` calls.

## Problem

When `queueStore.update()` is called multiple times in quick succession (e.g., during websocket reconnection), responses could resolve out-of-order. A stale response resolving after a fresh one would overwrite the current state with outdated data.

## Solution

Added request ID tracking that:
1. Increments a counter on each `update()` call
2. Guards all state mutations with a staleness check
3. Only sets `isLoading=false` for the latest request

This pattern matches the existing approach in `jobOutputCache.ts`.

## Changes

- `src/stores/queueStore.ts`: Added `updateRequestId` counter and staleness guards
- `src/stores/queueStore.test.ts`: Added tests for deduplication behavior

## Testing

- All 49 existing tests pass
- Added 3 new tests for race condition handling:
  - Stale responses are discarded
  - isLoading state is correctly managed
  - Stale request failures don't affect latest state

## Fixes COM-12784

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8523-fix-dedupe-queueStore-update-to-prevent-race-conditions-2fa6d73d3650810daa0dc63af359e1ea) by [Unito](https://www.unito.io)
