### PR TITLE
fix: use PR_GH_TOKEN to trigger e2e after updating expectations

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -59,7 +59,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr-info.outputs.branch }}
-          token: ${{ secrets.PR_GH_TOKEN }}
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
         with:
@@ -174,6 +173,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.setup.outputs.branch }}
+          token: ${{ secrets.PR_GH_TOKEN }}
 
       # Download all changed snapshot files from shards
       - name: Download snapshot artifacts

--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr-info.outputs.branch }}
+          token: ${{ secrets.PR_GH_TOKEN }}
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
         with:


### PR DESCRIPTION
## Summary

See https://github.com/Comfy-Org/ComfyUI_frontend/pull/8484

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8525-fix-use-PR_GH_TOKEN-to-trigger-e2e-after-updating-expectations-2fa6d73d3650817c81fccd1cbb3ddadb) by [Unito](https://www.unito.io)
