### PR TITLE
fix: prevent middle-click paste on graph canvas

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -394,6 +394,21 @@ useEventListener(
   { passive: true }
 )
 
+// Prevent middle-click paste on Linux systems
+// On Linux, middle mouse button triggers paste from PRIMARY clipboard,
+// which can cause unwanted workflow duplication during canvas panning
+// See: https://github.com/Comfy-Org/ComfyUI_frontend/issues/4464
+useEventListener(
+  canvasRef,
+  'auxclick',
+  (e: MouseEvent) => {
+    if (e.button === 1) {
+      e.preventDefault()
+    }
+  },
+  { capture: true }
+)
+
 const comfyAppReady = ref(false)
 const workflowPersistence = useWorkflowPersistence()
 const { flags } = useFeatureFlags()


### PR DESCRIPTION
## Summary
This PR fixes #4464 where middle mouse button pan duplicates entire workflow on Linux systems.

## Problem
On Linux systems, middle mouse button triggers paste from the PRIMARY clipboard. When panning the canvas using middle-click drag, releasing the button fires an `auxclick` event that pastes clipboard contents, duplicating the workflow.

## Solution
Added an `auxclick` event listener on the canvas that prevents the default behavior for middle mouse button (button === 1) clicks while preserving the pan functionality.

## Changes
- Added event listener in `GraphCanvas.vue` using the existing `useEventListener` pattern
- Uses capture phase to intercept before other handlers
- Only prevents middle mouse button, doesn't affect other buttons

## Testing
- [x] Middle drag panning still works correctly
- [x] Middle button release no longer pastes clipboard content
- [x] Other mouse interactions remain unaffected

Fixes #4464

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8526-fix-prevent-middle-click-paste-on-graph-canvas-2fa6d73d365081eda8b7c565bc86b5eb) by [Unito](https://www.unito.io)
