### PR TITLE
feat: remove client-side cache-busting query parameters

### DIFF
--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -59,10 +59,7 @@ function mkFileUrl(props: { ref: ImageRef; preview?: boolean }): string {
   }
 
   const pathPlusQueryParams = api.apiURL(
-    '/view?' +
-      params.toString() +
-      app.getPreviewFormatParam() +
-      app.getRandParam()
+    '/view?' + params.toString() + app.getPreviewFormatParam()
   )
   const imageElement = new Image()
   imageElement.crossOrigin = 'anonymous'

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -73,10 +73,7 @@ function mkFileUrl(props: { ref: ImageRef; preview?: boolean }): string {
   }
 
   const pathPlusQueryParams = api.apiURL(
-    '/view?' +
-      params.toString() +
-      app.getPreviewFormatParam() +
-      app.getRandParam()
+    '/view?' + params.toString() + app.getPreviewFormatParam()
   )
   const imageElement = new Image()
   imageElement.crossOrigin = 'anonymous'

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -17,7 +17,7 @@ type MockTask = {
   executionEndTimestamp?: number
   previewOutput?: {
     isImage: boolean
-    urlWithTimestamp: string
+    url: string
   }
 }
 
@@ -94,7 +94,7 @@ describe(useQueueNotificationBanners, () => {
     if (previewUrl) {
       task.previewOutput = {
         isImage,
-        urlWithTimestamp: previewUrl
+        url: previewUrl
       }
     }
 

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -231,7 +231,7 @@ export const useQueueNotificationBanners = () => {
         completedCount++
         const preview = task.previewOutput
         if (preview?.isImage) {
-          imagePreviews.push(preview.urlWithTimestamp)
+          imagePreviews.push(preview.url)
         }
       } else if (state === 'failed') {
         failedCount++

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -265,7 +265,7 @@ export const useQueueNotificationBanners = () => {
         completedCount++
         const preview = task.previewOutput
         if (preview?.isImage) {
-          imagePreviews.push(preview.urlWithTimestamp)
+          imagePreviews.push(preview.url)
         }
       } else if (state === 'failed') {
         failedCount++

--- a/src/extensions/core/imageCompare.ts
+++ b/src/extensions/core/imageCompare.ts
@@ -1,7 +1,6 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { NodeOutputWith } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
-import { app } from '@/scripts/app'
 import { useExtensionService } from '@/services/extensionService'
 
 type ImageCompareOutput = NodeOutputWith<{
@@ -24,11 +23,10 @@ useExtensionService().registerExtension({
       onExecuted?.call(this, output)
 
       const { a_images: aImages, b_images: bImages } = output
-      const rand = app.getRandParam()
 
       const toUrl = (record: Record<string, string>) => {
         const params = new URLSearchParams(record)
-        return api.apiURL(`/view?${params}${rand}`)
+        return api.apiURL(`/view?${params}`)
       }
 
       const beforeImages =

--- a/src/extensions/core/load3d/Load3dUtils.ts
+++ b/src/extensions/core/load3d/Load3dUtils.ts
@@ -2,7 +2,6 @@ import type Load3d from '@/extensions/core/load3d/Load3d'
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
-import { app } from '@/scripts/app'
 
 class Load3dUtils {
   static async generateThumbnailIfNeeded(
@@ -133,8 +132,7 @@ class Load3dUtils {
     const params = [
       'filename=' + encodeURIComponent(filename),
       'type=' + type,
-      'subfolder=' + subfolder,
-      app.getRandParam().substring(1)
+      'subfolder=' + subfolder
     ].join('&')
 
     return `/view?${params}`

--- a/src/extensions/core/load3d/Load3dUtils.ts
+++ b/src/extensions/core/load3d/Load3dUtils.ts
@@ -1,7 +1,6 @@
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
-import { app } from '@/scripts/app'
 
 class Load3dUtils {
   static async uploadTempImage(
@@ -117,8 +116,7 @@ class Load3dUtils {
     const params = [
       'filename=' + encodeURIComponent(filename),
       'type=' + type,
-      'subfolder=' + subfolder,
-      app.getRandParam().substring(1)
+      'subfolder=' + subfolder
     ].join('&')
 
     return `/view?${params}`

--- a/src/renderer/extensions/vueNodes/widgets/utils/audioUtils.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/audioUtils.ts
@@ -1,5 +1,4 @@
 import type { ResultItemType } from '@/schemas/apiSchema'
-import { app } from '@/scripts/app'
 
 /**
  * Format time in MM:SS format
@@ -20,8 +19,7 @@ export function getResourceURL(
   const params = [
     'filename=' + encodeURIComponent(filename),
     'type=' + type,
-    'subfolder=' + subfolder,
-    app.getRandParam().substring(1)
+    'subfolder=' + subfolder
   ].join('&')
 
   return `/view?${params}`

--- a/src/renderer/extensions/vueNodes/widgets/utils/audioUtils.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/audioUtils.ts
@@ -1,5 +1,4 @@
 import type { ResultItemType } from '@/schemas/apiSchema'
-import { app } from '@/scripts/app'
 
 export function getResourceURL(
   subfolder: string,
@@ -9,8 +8,7 @@ export function getResourceURL(
   const params = [
     'filename=' + encodeURIComponent(filename),
     'type=' + type,
-    'subfolder=' + subfolder,
-    app.getRandParam().substring(1)
+    'subfolder=' + subfolder
   ].join('&')
 
   return `/view?${params}`

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -382,11 +382,6 @@ export class ComfyApp {
     else return ''
   }
 
-  getRandParam() {
-    if (isCloud) return ''
-    return '&rand=' + Math.random()
-  }
-
   static onClipspaceEditorSave() {
     if (ComfyApp.clipspace_return_node) {
       ComfyApp.pasteFromClipspace(ComfyApp.clipspace_return_node)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -520,11 +520,6 @@ export class ComfyApp {
     else return ''
   }
 
-  getRandParam() {
-    if (isCloud) return ''
-    return '&rand=' + Math.random()
-  }
-
   static onClipspaceEditorSave() {
     if (ComfyApp.clipspace_return_node) {
       ComfyApp.pasteFromClipspace(ComfyApp.clipspace_return_node)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -367,6 +367,12 @@ export class ComfyApp {
   get configuringGraph() {
     return this.configuringGraphLevel > 0
   }
+
+  getRandParam() {
+    if (isCloud) return ''
+    return '&rand=' + Math.random()
+  }
+
   ctx!: CanvasRenderingContext2D
   bodyTop: HTMLElement
   bodyLeft: HTMLElement

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -25,6 +25,7 @@ const mockGetNodeById = vi.fn()
 
 vi.mock('@/scripts/app', () => ({
   app: {
+    getRandParam: vi.fn(() => '&rand=0.5'),
     getPreviewFormatParam: vi.fn(() => '&format=test_webp'),
     rootGraph: {
       getNodeById: (...args: unknown[]) => mockGetNodeById(...args)
@@ -533,6 +534,30 @@ describe('nodeOutputStore getPreviewParam', () => {
     ])
     expect(store.getPreviewParam(node, outputs)).toBe('&format=test_webp')
     expect(vi.mocked(app).getPreviewFormatParam).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('nodeOutputStore cache compatibility', () => {
+  beforeEach(() => {
+    app.nodeOutputs = {}
+    app.nodePreviewImages = {}
+    vi.mocked(litegraphUtil.isAnimatedOutput).mockReturnValue(false)
+    vi.mocked(litegraphUtil.isVideoNode).mockReturnValue(false)
+  })
+
+  it('keeps cache busting on node output URLs for legacy backends', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode({ id: 5 })
+    store.setNodeOutputsByExecutionId(
+      createNodeExecutionId([toNodeId(5)]),
+      createMockOutputs([
+        { filename: 'output.png', subfolder: '', type: 'output' }
+      ])
+    )
+
+    expect(store.getNodeImageUrls(node)).toEqual([
+      '/api/view?filename=output.png&subfolder=&type=output&format=test_webp&rand=0.5'
+    ])
   })
 })
 

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -117,12 +117,11 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     const outputs = getNodeOutputs(node)
     if (!outputs?.images?.length) return
 
-    const rand = app.getRandParam()
     const previewParam = getPreviewParam(node, outputs)
 
     return outputs.images.map((image) => {
       const params = new URLSearchParams(image)
-      return api.apiURL(`/view?${params}${previewParam}${rand}`)
+      return api.apiURL(`/view?${params}${previewParam}`)
     })
   }
 

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -124,13 +124,14 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
   ): string[] | undefined {
     if (!outputs?.images?.length) return
 
+    const rand = app.getRandParam()
     const previewParam = getPreviewParam(node, outputs)
 
     return outputs.images
       .filter((image) => image != null)
       .map((image) => {
         const params = new URLSearchParams(image)
-        return api.apiURL(`/view?${params}${previewParam}`)
+        return api.apiURL(`/view?${params}${previewParam}${rand}`)
       })
   }
 

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -124,14 +124,13 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
   ): string[] | undefined {
     if (!outputs?.images?.length) return
 
-    const rand = app.getRandParam()
     const previewParam = getPreviewParam(node, outputs)
 
     return outputs.images
       .filter((image) => image != null)
       .map((image) => {
         const params = new URLSearchParams(image)
-        return api.apiURL(`/view?${params}${previewParam}${rand}`)
+        return api.apiURL(`/view?${params}${previewParam}`)
       })
   }
 

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -104,10 +104,6 @@ export class ResultItemImpl {
     return api.apiURL('/view?' + params)
   }
 
-  get urlWithTimestamp(): string {
-    return `${this.url}&t=${+new Date()}`
-  }
-
   get isVhsFormat(): boolean {
     return !!this.format && !!this.frame_rate
   }

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -115,10 +115,6 @@ export class ResultItemImpl {
     return api.apiURL('/view?' + params)
   }
 
-  get urlWithTimestamp(): string {
-    return `${this.url}&t=${+new Date()}`
-  }
-
   get isVhsFormat(): boolean {
     return !!this.format && !!this.frame_rate
   }


### PR DESCRIPTION
## Summary

Remove `getRandParam()` and `urlWithTimestamp` that added cache-busting query params (`&rand=...` and `&t=...`) to output URLs.

This is now handled by the backend generating unique filenames with timestamps.

## Changes

- `app.ts`: removed `getRandParam()` method
- `queueStore.ts`: removed `urlWithTimestamp` getter; kept `previewUrl` getter for cloud asset thumbnail URLs
- `useQueueNotificationBanners.ts`/`.test.ts`: use `.url` instead of `.urlWithTimestamp`
- `useCompletionSummary.ts`: use `.url` instead of `.urlWithTimestamp`
- `imageCompare.ts`, `useMaskEditorLoader.ts`, `audioUtils.ts`, `Load3dUtils.ts`: removed `getRandParam()` usage
- `nodeOutputStore.ts`: removed rand param from image URL generation

## Related

Depends on backend PR: Comfy-Org/ComfyUI#12200 (adds timestamps to output filenames)

> **Backwards compatibility**: Without the backend update, the PR is safe — URLs just won't have the rand params, which may allow browser caching. The backend PR improves correctness for self-hosted instances.