### PR TITLE
fix: align BOUNDING_BOX type with backend and target ImageCropV2 node

### DIFF
--- a/src/extensions/core/imageCrop.ts
+++ b/src/extensions/core/imageCrop.ts
@@ -4,7 +4,7 @@ useExtensionService().registerExtension({
   name: 'Comfy.ImageCrop',
 
   async nodeCreated(node) {
-    if (node.constructor.comfyClass !== 'ImageCrop') return
+    if (node.constructor.comfyClass !== 'ImageCropV2') return
 
     const [oldWidth, oldHeight] = node.size
     node.setSize([Math.max(oldWidth, 300), Math.max(oldHeight, 450)])

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -172,7 +172,7 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     'boundingbox',
     {
       component: WidgetBoundingBox,
-      aliases: ['BOUNDINGBOX'],
+      aliases: ['BOUNDING_BOX'],
       essential: false
     }
   ]

--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -65,7 +65,7 @@ const zImageCompareInputSpec = zBaseInputOptions.extend({
 })
 
 const zBoundingBoxInputSpec = zBaseInputOptions.extend({
-  type: z.literal('BOUNDINGBOX'),
+  type: z.literal('BOUNDING_BOX'),
   name: z.string(),
   isOptional: z.boolean().optional(),
   component: z.enum(['ImageCrop']).optional(),

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -302,7 +302,7 @@ export const ComfyWidgets = {
   IMAGEUPLOAD: useImageUploadWidget(),
   COLOR: transformWidgetConstructorV2ToV1(useColorWidget()),
   IMAGECOMPARE: transformWidgetConstructorV2ToV1(useImageCompareWidget()),
-  BOUNDINGBOX: transformWidgetConstructorV2ToV1(useBoundingBoxWidget()),
+  BOUNDING_BOX: transformWidgetConstructorV2ToV1(useBoundingBoxWidget()),
   CHART: transformWidgetConstructorV2ToV1(useChartWidget()),
   GALLERIA: transformWidgetConstructorV2ToV1(useGalleriaWidget()),
   TEXTAREA: transformWidgetConstructorV2ToV1(useTextareaWidget()),


### PR DESCRIPTION
## Summary
- Update imageCrop extension to target new ImageCropV2 comfyClass
- Fix BOUNDING_BOX io_type mismatch (was BOUNDINGBOX, backend sends BOUNDING_BOX)
- Keep old ImageCrop node_id unchanged for backward compatibility

BE Changes is https://github.com/Comfy-Org/ComfyUI/pull/11594

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8531-fix-align-BOUNDING_BOX-type-with-backend-and-target-ImageCropV2-node-2fa6d73d36508160a06ad06108b8a15e) by [Unito](https://www.unito.io)
