### PR TITLE
fix: float label on Nodes 2.0 textarea widget obscures text

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -5,6 +5,7 @@
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',
+        '[&_label]:bg-transparent [&_label]:text-component-node-foreground-secondary [&_label]:text-xs',
         widget.borderStyle
       )
     "

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -1,7 +1,8 @@
 <template>
   <FloatLabel
     variant="on"
-    :unstyled="true"
+    :unstyled="hideLayoutField"
+    :pt="{ root: { class: '[&_label]:!bg-transparent [&_label]:!text-[color:var(--p-text-color)]' } }"
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -1,6 +1,6 @@
 <template>
   <FloatLabel
-    variant="in"
+    variant="on"
     :unstyled="hideLayoutField"
     :class="
       cn(

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -2,7 +2,11 @@
   <FloatLabel
     variant="on"
     :unstyled="hideLayoutField"
-    :pt="{ root: { class: '[&_label]:!bg-transparent [&_label]:!text-muted-foreground' } }"
+    :pt="{
+      root: {
+        class: '[&_label]:!bg-transparent [&_label]:!text-muted-foreground'
+      }
+    }"
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -2,7 +2,12 @@
   <FloatLabel
     variant="on"
     :unstyled="hideLayoutField"
-    :pt="{ root: { class: '[&_label]:!bg-transparent [&_label]:!text-[color:var(--p-text-color)]' } }"
+    :pt="{
+      root: {
+        class:
+          '[&_label]:!bg-transparent [&_label]:!text-[color:var(--p-text-color)]'
+      }
+    }"
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -5,7 +5,7 @@
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',
-        '[&_label]:bg-transparent [&_label]:text-component-node-foreground-secondary [&_label]:text-xs',
+        '[&_label]:bg-transparent [&_label]:text-component-node-foreground [&_label]:text-xs',
         widget.borderStyle
       )
     "

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -1,11 +1,10 @@
 <template>
   <FloatLabel
     variant="on"
-    :unstyled="hideLayoutField"
+    :unstyled="true"
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',
-        '[&_label]:bg-transparent [&_label]:text-component-node-foreground [&_label]:text-xs',
         widget.borderStyle
       )
     "

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -2,12 +2,7 @@
   <FloatLabel
     variant="on"
     :unstyled="hideLayoutField"
-    :pt="{
-      root: {
-        class:
-          '[&_label]:!bg-transparent [&_label]:!text-[color:var(--p-text-color)]'
-      }
-    }"
+    :pt="{ root: { class: '[&_label]:!bg-transparent [&_label]:!text-muted-foreground' } }"
     :class="
       cn(
         'rounded-lg space-y-1 focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -4,7 +4,8 @@
     :unstyled="hideLayoutField"
     :pt="{
       root: {
-        class: '[&_label]:!bg-transparent [&_label]:!text-muted-foreground'
+        class:
+          '[&_label]:!bg-component-node-widget-background [&_label]:!text-muted-foreground [&_label]:px-1'
       }
     }"
     :class="


### PR DESCRIPTION
Solves issue where the float label covers the text when the Nodes 2.0 multiline text widget (textarea) has enough lines of content to fill the visible space. Uses variant defined in https://primevue.org/floatlabel/.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8536-Update-WidgetTextarea-vue-2fb6d73d3650819b94fce5e12784f48a) by [Unito](https://www.unito.io)
