### PR TITLE
refactor: use singleton mock pattern for useDialogStore in escape test

### DIFF
--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -90,9 +90,6 @@ describe('keybindingService - Escape key handling', () => {
   }
 
   it('should execute Escape keybinding when no dialogs are open', async () => {
-    const dialogStore = useDialogStore()
-    dialogStore.dialogStack.length = 0
-
     const event = createKeyboardEvent('Escape')
     await keybindingService.keybindHandler(event)
 

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { reactive } from 'vue'
+import { markRaw, reactive } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CORE_KEYBINDINGS } from '@/platform/keybindings/defaults'
@@ -10,6 +10,21 @@ import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import type { DialogInstance } from '@/stores/dialogStore'
 import { useDialogStore } from '@/stores/dialogStore'
+
+function createTestDialogInstance(
+  key: string,
+  overrides: Partial<DialogInstance> = {}
+): DialogInstance {
+  return {
+    key,
+    visible: true,
+    component: markRaw({ template: '<div />' }),
+    contentProps: {},
+    dialogComponentProps: {},
+    priority: 0,
+    ...overrides
+  }
+}
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn(() => ({
@@ -86,7 +101,7 @@ describe('keybindingService - Escape key handling', () => {
 
   it('should NOT execute Escape keybinding when dialogs are open', async () => {
     const dialogStore = useDialogStore()
-    dialogStore.dialogStack.push({ key: 'test-dialog' } as DialogInstance)
+    dialogStore.dialogStack.push(createTestDialogInstance('test-dialog'))
 
     keybindingService = useKeybindingService()
 
@@ -98,7 +113,7 @@ describe('keybindingService - Escape key handling', () => {
 
   it('should execute Escape keybinding with modifiers regardless of dialog state', async () => {
     const dialogStore = useDialogStore()
-    dialogStore.dialogStack.push({ key: 'test-dialog' } as DialogInstance)
+    dialogStore.dialogStack.push(createTestDialogInstance('test-dialog'))
 
     const keybindingStore = useKeybindingStore()
     keybindingStore.addDefaultKeybinding(


### PR DESCRIPTION
## Summary

Refactors `keybindingService.escape.test.ts` to use the singleton mock pattern with reactive state, following project testing guidance.

## Changes

- **What**: Replaced `vi.fn(() => ({dialogStack: []}))` anti-pattern with `reactive()` array defined inline in `vi.mock()` factory. Tests now use array mutation (`.push()`, `.length = 0`) instead of `mockReturnValue` calls.

## Review Focus

Pattern aligns with docs/testing/unit-testing.md section "Mocking Composables with Reactive State".

Fixes #8467

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8538-refactor-use-singleton-mock-pattern-for-useDialogStore-in-escape-test-2fb6d73d3650812a95c6e223e38d50ad) by [Unito](https://www.unito.io)
