### PR TITLE
fix: use fileURL for static template logo index path

### DIFF
--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -506,7 +506,7 @@ export const useWorkflowTemplatesStore = defineStore(
 
     async function fetchLogoIndex(): Promise<LogoIndex> {
       try {
-        const response = await api.fetchApi('/templates/index_logo.json')
+        const response = await fetch(api.fileURL('/templates/index_logo.json'))
         const contentType = response.headers.get('content-type')
         if (!contentType?.includes('application/json')) return {}
         const data = await response.json()


### PR DESCRIPTION
## Summary

Fix template logo loading by using `api.fileURL()` instead of `api.fetchApi()` for the static logo index file.

## Problem

`fetchLogoIndex()` was using `api.fetchApi('/templates/index_logo.json')` which adds an `/api` prefix to URLs, resulting in requests to `/api/templates/index_logo.json` instead of `/templates/index_logo.json`.

Since `/templates/index_logo.json` is a static asset file (not an API endpoint), it should use `api.fileURL()` which doesn't add the `/api` prefix.

## Changes

- Change `api.fetchApi('/templates/index_logo.json')` to `fetch(api.fileURL('/templates/index_logo.json'))`

## Testing

- Template logos should now load correctly in the workflow template selector dialog

Fixes COM-14279

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8539-fix-use-fileURL-for-static-template-logo-index-path-2fb6d73d365081178788dc0cf196ada4) by [Unito](https://www.unito.io)
