### PR TITLE
deprecate: add warning for unsupported widgets_up property

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -393,6 +393,10 @@ export class LGraphNode
   action_call?: string
   execute_triggered?: number
   action_triggered?: number
+  /**
+   * @deprecated This property is unsupported and will be removed in a future release.
+   * Use `widgets_start_y` or a custom `arrange()` override instead.
+   */
   widgets_up?: boolean
   widgets_start_y?: number
   lostFocusAt?: number
@@ -892,6 +896,14 @@ export class LGraphNode
 
     // Sync the state of this.resizable.
     if (this.pinned) this.resizable = false
+
+    if (this.widgets_up) {
+      console.warn(
+        `[LiteGraph] Node type "${this.type}" uses deprecated property "widgets_up". ` +
+          'This property is unsupported and will be removed. ' +
+          'Use "widgets_start_y" or a custom arrange() override instead.'
+      )
+    }
 
     this.onConfigure?.(info)
   }


### PR DESCRIPTION
## Summary
Adds deprecation warning for the `widgets_up` property which has known layout bugs and is not officially supported.

## Changes
- Added `@deprecated` JSDoc comment on `widgets_up` property
- Added console warning during configure path
- Warning directs users to use `widgets_start_y` or custom `arrange()` override instead

## Context
The `widgets_up` property is an undocumented legacy LiteGraph feature that positions widgets at the top of nodes. However, the `arrange()` method doesn't properly handle slot positioning when this is enabled, causing widgets and slots to overlap (see #7878).

Rather than fix this edge case in an unsupported feature, we're formally deprecating it with a warning.

- Closes #7878

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8541-deprecate-add-warning-for-unsupported-widgets_up-property-2fb6d73d365081a89bb6e41038d94455) by [Unito](https://www.unito.io)
