### PR TITLE
Enable CodeRabbit issue enrichment

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+issue_enrichment:
+  auto_enrich:
+    enabled: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -10,8 +10,6 @@ body:
       options:
         - label: I am running the latest version of ComfyUI
           required: true
-        - label: I have searched existing issues to make sure this isn't a duplicate
-          required: true
         - label: I have tested with all custom nodes disabled ([see how](https://docs.comfy.org/troubleshooting/custom-node-issues#step-1%3A-test-with-all-custom-nodes-disabled))
           required: true
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -4,13 +4,6 @@ labels: []
 type: Feature
 
 body:
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the problem you're experiencing, and that it's not addressed in a recent build/commit.
-      options:
-        - label: I have searched the existing issues and checked the recent builds/commits
-          required: true
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
## Summary

Enable CodeRabbit issue enrichment and remove duplicate-check requirements to lower the barrier for reporting problems.

## Changes

- **What**: Add `.coderabbit.yaml` enabling issue enrichment; remove dedupe checkboxes from bug and feature issue templates.

## Review Focus

Confirm we want CodeRabbit/Dosu to handle deduplication so users aren’t blocked by a mandatory “search for duplicates” step.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8543-Enable-CodeRabbit-issue-enrichment-2fb6d73d36508132947acf5f01c9cb22) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic issue enrichment to enhance issue tracking.
  * Streamlined issue submission forms by removing prerequisite verification steps from bug report and feature request templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->