### PR TITLE
feat: make custom nodes checkbox informational

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -12,8 +12,7 @@ body:
           required: true
         - label: I have searched existing issues to make sure this isn't a duplicate
           required: true
-        - label: I have tested with all custom nodes disabled ([see how](https://docs.comfy.org/troubleshooting/custom-node-issues#step-1%3A-test-with-all-custom-nodes-disabled))
-          required: true
+        - label: I'm using custom nodes
 
   - type: textarea
     id: description


### PR DESCRIPTION
## Summary

Make the custom nodes checkbox informational so bug reports aren’t blocked.

## Changes

- **What**: Replace the required “tested with all custom nodes disabled” checkbox with an optional “I’m using custom nodes.”

## Review Focus

This lowers the barrier to file bugs and keeps the custom‑nodes signal so we can triage both cases. It also helps surface issues that only appear with custom nodes, which can still be valuable to investigate.

## Testing

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`

## Screenshots (if applicable)

