### PR TITLE
fix: make custom nodes checkbox optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I am running the latest version of ComfyUI
           required: true
-        - label: I'm using custom nodes
+        - label: This setup includes custom nodes
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -10,8 +10,7 @@ body:
       options:
         - label: I am running the latest version of ComfyUI
           required: true
-        - label: I have tested with all custom nodes disabled ([see how](https://docs.comfy.org/troubleshooting/custom-node-issues#step-1%3A-test-with-all-custom-nodes-disabled))
-          required: true
+        - label: I'm using custom nodes
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I am running the latest version of ComfyUI
           required: true
-        - label: This setup includes custom nodes
+        - label: I have custom nodes enabled
 
   - type: textarea
     id: description


### PR DESCRIPTION
## Summary

Lower the barrier for bug reports by making custom-node info optional rather than a required prerequisite. Many users run custom nodes and can still hit core or interaction bugs that aren't caused by those nodes; even when custom nodes are involved, the issue may still be ours, so this change unblocks reports and feature requests while preserving context.

## Changes

- **What**: Replace the required "tested with all custom nodes disabled" checkbox with a neutral "I'm using custom nodes" checkbox to capture context without blocking submissions.

## Review Focus

Confirm the new checkbox wording captures custom-node context without discouraging reports from users who can't or shouldn't disable custom nodes.

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8546-fix-make-custom-nodes-checkbox-optional-2fb6d73d3650816fa743e355f1877de1) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report issue template to clarify prerequisites: the primary prerequisite remains required, while the custom-nodes option is now optional. This reduces mandatory checklist items and improves guidance on which setup details are essential for effective bug reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->