### PR TITLE
fix: use NodeId for output key parts

### DIFF
--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -1,5 +1,6 @@
 import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import type { NodeId } from '@/platform/workflow/validation/schemas/workflowSchema'
 import {
   getJobDetail,
   getPreviewableOutputsFromJobDetail
@@ -21,7 +22,7 @@ type ResolveOutputAssetItemsOptions = {
 }
 
 type OutputKeyParts = {
-  nodeId?: string | number | null
+  nodeId?: NodeId | null
   subfolder?: string | null
   filename?: string | null
 }


### PR DESCRIPTION
## Summary

Use the shared NodeId type for output asset key construction to keep node id typing consistent across assets and workflow schemas.

## Changes

- **What**: replace the local `string | number` nodeId type in output key parts with the shared `NodeId` alias

## Review Focus

Type consistency for `nodeId` used in output asset key generation.

## Screenshots (if applicable)

N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8547-fix-use-NodeId-for-output-key-parts-2fb6d73d36508127a022cc6052e5f59e) by [Unito](https://www.unito.io)
