### PR TITLE
refactor: use emit events pattern instead of mutating props in widget components

### DIFF
--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -8,6 +8,7 @@ import Tab from '@/components/tab/Tab.vue'
 import TabList from '@/components/tab/TabList.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useGraphHierarchy } from '@/composables/graph/useGraphHierarchy'
+import type { ProxyWidgetsProperty } from '@/core/schemas/proxyWidget'
 import { st } from '@/i18n'
 import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -190,6 +191,12 @@ function handleTitleEdit(newTitle: string) {
 function handleTitleCancel() {
   isEditing.value = false
 }
+
+function handleProxyWidgetsUpdate(value: ProxyWidgetsProperty) {
+  if (!selectedSingleNode.value) return
+  ;(selectedSingleNode.value as SubgraphNode).properties.proxyWidgets = value
+  canvasStore.canvas?.setDirty(true, true)
+}
 </script>
 
 <template>
@@ -283,6 +290,7 @@ function handleTitleCancel() {
         <TabSubgraphInputs
           v-if="activeTab === 'parameters' && isSingleSubgraphNode"
           :node="selectedSingleNode as SubgraphNode"
+          @update:proxy-widgets="handleProxyWidgetsUpdate"
         />
         <TabNormalInputs
           v-else-if="activeTab === 'parameters'"

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -118,6 +118,15 @@ function handleLocateNode() {
   }
 }
 
+function handleWidgetValueUpdate(
+  widget: IBaseWidget,
+  newValue: string | number | boolean | object
+) {
+  widget.value = newValue
+  widget.callback?.(newValue)
+  canvasStore.canvas?.setDirty(true, true)
+}
+
 defineExpose({
   widgetsContainer,
   rootElement
@@ -179,6 +188,7 @@ defineExpose({
             :show-node-name="showNodeName"
             :parents="parents"
             :is-shown-on-parents="isWidgetShownOnParents(node, widget)"
+            @update:widget-value="handleWidgetValueUpdate(widget, $event)"
           />
         </TransitionGroup>
       </div>

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -32,6 +32,10 @@ const { node } = defineProps<{
   node: SubgraphNode
 }>()
 
+const emit = defineEmits<{
+  'update:proxyWidgets': [value: ProxyWidgetsProperty]
+}>()
+
 const { t } = useI18n()
 const canvasStore = useCanvasStore()
 const rightSidePanelStore = useRightSidePanelStore()
@@ -51,8 +55,7 @@ const proxyWidgets = customRef<ProxyWidgetsProperty>((track, trigger) => ({
   set(value?: ProxyWidgetsProperty) {
     trigger()
     if (!value) return
-    // eslint-disable-next-line vue/no-mutating-props
-    node.properties.proxyWidgets = value
+    emit('update:proxyWidgets', value)
   }
 }))
 

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -41,6 +41,10 @@ const {
   isShownOnParents?: boolean
 }>()
 
+const emit = defineEmits<{
+  'update:widgetValue': [value: string | number | boolean | object]
+}>()
+
 const { t } = useI18n()
 const canvasStore = useCanvasStore()
 const favoritedWidgetsStore = useFavoritedWidgetsStore()
@@ -83,10 +87,7 @@ const widgetValue = computed({
     return widget.value
   },
   set: (newValue: string | number | boolean | object) => {
-    // eslint-disable-next-line vue/no-mutating-props
-    widget.value = newValue
-    widget.callback?.(newValue)
-    canvasStore.canvas?.setDirty(true, true)
+    emit('update:widgetValue', newValue)
   }
 })
 


### PR DESCRIPTION
## Summary

Refactors widget components to use Vue's emit events pattern instead of directly mutating props, fixing `vue/no-mutating-props` lint violations.

### Changes

- `TabSubgraphInputs`: Emits `update:proxyWidgets` event instead of mutating `node.properties.proxyWidgets`
- `WidgetItem`: Emits `update:widgetValue` event instead of mutating `widget.value`
- `RightSidePanel`: Handles `update:proxyWidgets` event from TabSubgraphInputs
- `SectionWidgets`: Handles `update:widgetValue` event from WidgetItem
- Removed `// eslint-disable-next-line vue/no-mutating-props` comments

### Why this change?

The previous implementation directly mutated props and used ESLint disable comments to suppress warnings. While functional, this approach:
- Violated Vue's one-way data flow principle
- Made data flow less explicit and harder to trace
- Required ESLint suppressions to bypass proper linting

The emit events pattern is the idiomatic Vue 3 approach and makes parent-child communication explicit.

### Important Note

**This refactor does NOT fix the underlying unified state management issues with widget values across the application.** It only addresses the immediate lint violations by following proper Vue patterns. Widget state management still requires a more comprehensive architectural solution to ensure consistency across the application.

## Test plan

- Build passes
- Lint passes (no more `vue/no-mutating-props` errors or suppressions needed)
- Typecheck passes
- Widget interactions in the right side panel should work as before

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8549-refactor-use-emit-events-pattern-instead-of-mutating-props-in-widget-components-2fb6d73d365081dc8048c61523ea9810) by [Unito](https://www.unito.io)
