### PR TITLE
feat: enable linear mode toggle for nightly builds

### DIFF
--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -1,6 +1,6 @@
 import { computed, reactive, readonly } from 'vue'
 
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isNightly } from '@/platform/distribution/types'
 import {
   isAuthenticatedConfigLoaded,
   remoteConfig
@@ -84,6 +84,8 @@ export function useFeatureFlags() {
       )
     },
     get linearToggleEnabled() {
+      if (isNightly) return true
+
       return (
         remoteConfig.value.linear_toggle_enabled ??
         api.getServerFeature(ServerFeatureFlag.LINEAR_TOGGLE_ENABLED, false)


### PR DESCRIPTION
Enables the linear mode toggle for all nightly build users by short-circuiting the `linearToggleEnabled` feature flag.

## Changes
- Adds `isNightly` check in `linearToggleEnabled` getter  
- Returns `true` for nightly builds, bypassing remote config/server feature checks
- Adds unit tests for the new behavior

## Reviewers
- @AustinMroz (linear mode maintainer)
- @christian-byrne (isNightly author)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8569-feat-enable-linear-mode-toggle-for-nightly-builds-2fc6d73d3650819681f8dcdc23b6eefe) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled linear toggle feature for nightly distribution builds.
  * Feature flag system now respects nightly vs. standard build configurations.

* **Tests**
  * Added test coverage for nightly build feature flag behavior and remote configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->