### PR TITLE
refactor: move cancellable states to module-level constant

### DIFF
--- a/src/composables/queue/useJobActions.ts
+++ b/src/composables/queue/useJobActions.ts
@@ -13,6 +13,8 @@ export type JobAction = {
   variant: 'destructive' | 'secondary' | 'textonly'
 }
 
+const CANCELLABLE_STATES: JobState[] = ['pending', 'initialization', 'running']
+
 export function useJobActions(
   job: MaybeRefOrGetter<JobListItem | null | undefined>
 ) {
@@ -26,8 +28,6 @@ export function useJobActions(
     variant: 'destructive'
   }
 
-  const cancellableStates: JobState[] = ['pending', 'initialization', 'running']
-
   const jobRef = computed(() => toValue(job) ?? null)
 
   const canCancelJob = computed(() => {
@@ -38,7 +38,7 @@ export function useJobActions(
 
     return (
       currentJob.showClear !== false &&
-      cancellableStates.includes(currentJob.state)
+      CANCELLABLE_STATES.includes(currentJob.state)
     )
   })
 


### PR DESCRIPTION
## Summary

Moves static data outside the `useJobActions` composable to module-level.

## Changes

- **What**: Extracted `cancellableStates` array to a module-level `CANCELLABLE_STATES` constant. The `cancelAction` object remains inside the composable because it depends on `t()` for i18n reactivity.

## Review Focus

This is a pure refactor with no behavior change - the constant is now allocated once per module instead of per-composable-call.

Fixes #7946

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8570-refactor-move-cancellable-states-to-module-level-constant-2fc6d73d3650814fa1fefa172f7ace2f) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code refactoring to improve maintainability of job cancellation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->