### PR TITLE
refactor: replace type catch-all with generic ComponentAttrs in showLayoutDialog

### DIFF
--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -459,7 +459,7 @@ export const useDialogService = () => {
   function showLayoutDialog<C extends Component>(options: {
     key: string
     component: C
-    props: ComponentAttrs<C> & { onClose: () => void }
+    props: ComponentAttrs<C>
     dialogComponentProps?: DialogComponentProps
   }) {
     const layoutDefaultProps: DialogComponentProps = {

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -456,10 +456,10 @@ export const useDialogService = () => {
     }
   }
 
-  function showLayoutDialog(options: {
+  function showLayoutDialog<C extends Component>(options: {
     key: string
-    component: Component
-    props: { onClose: () => void } & Record<string, unknown>
+    component: C
+    props: ComponentAttrs<C> & { onClose: () => void }
     dialogComponentProps?: DialogComponentProps
   }) {
     const layoutDefaultProps: DialogComponentProps = {


### PR DESCRIPTION
## Summary

Replaces `Record<string, unknown>` catch-all with properly typed generic props in `showLayoutDialog`, improving type safety.

## Changes

- Made `showLayoutDialog` generic over component type `C extends Component`
- Changed props type from `{ onClose: () => void } & Record<string, unknown>` to `ComponentAttrs<C> & { onClose: () => void }`

This matches existing patterns used elsewhere in `dialogService.ts` (e.g., `showLoadWorkflowWarning`, `showMissingModelsWarning`).

Fixes #8102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dialog handling updated to infer props per component, resulting in more consistent and reliable dialog behavior and fewer runtime prop mismatches when opening dialogs. Developers will have clearer, safer dialog configuration, while end users should experience steadier dialog interactions. No visible UI changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8571-fix-replace-type-catch-all-with-generic-ComponentAttrs-in-showLayoutDialog-2fc6d73d36508104bf60d27c9b94af69) by [Unito](https://www.unito.io)
