### PR TITLE
style: scale down node previews in manager info panel

### DIFF
--- a/src/workbench/extensions/manager/components/manager/infoPanel/tabs/NodesTabPanel.vue
+++ b/src/workbench/extensions/manager/components/manager/infoPanel/tabs/NodesTabPanel.vue
@@ -1,8 +1,14 @@
 <template>
   <div class="flex flex-col gap-1 text-sm">
     <template v-if="mappedNodeDefs?.length">
-      <div v-for="nodeDef in mappedNodeDefs" :key="createNodeDefKey(nodeDef)">
-        <NodePreview :node-def="nodeDef" class="min-w-full!" />
+      <div class="flex flex-col gap-2">
+        <div
+          v-for="nodeDef in mappedNodeDefs"
+          :key="createNodeDefKey(nodeDef)"
+          class="scale-75"
+        >
+          <NodePreview :node-def="nodeDef" class="min-w-full!" />
+        </div>
       </div>
     </template>
     <template v-else-if="isLoading">


### PR DESCRIPTION
## Summary
Scale down node previews in the manager info panel to 75% for better visual fit.

## Changes
- Add 75% scale to node preview items in NodesTabPanel
- Add gap between scaled items for better spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual layout of node items in the manager panel with improved spacing and individual item scaling for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8579-style-scale-down-node-previews-in-manager-info-panel-2fc6d73d36508176a307d980cd3b9329) by [Unito](https://www.unito.io)
