### PR TITLE
docs: audit and update litegraph documentation

### DIFF
--- a/src/lib/litegraph/AGENTS.md
+++ b/src/lib/litegraph/AGENTS.md
@@ -34,7 +34,7 @@ import { LGraph } from '@/lib/litegraph/src/LGraph'
 import {
   createTestSubgraph,
   createTestSubgraphNode
-} from './fixtures/subgraphHelpers'
+} from './__fixtures__/subgraphHelpers'
 
 function createTestSetup() {
   const subgraph = createTestSubgraph()

--- a/src/lib/litegraph/API.md
+++ b/src/lib/litegraph/API.md
@@ -191,7 +191,6 @@ if (canvas.state.hoveringOver & CanvasItem.ResizeSe) element.style.cursor = 'se-
 All are unused and incomplete. Have bugs beyond just typescript typing, and are (currently) not worth maintaining. If any of these features are desired down the track, they can be reimplemented.
 
 - Live mode
-- Subgraph
 - `dragged_node`
 
 ## LiteGraph

--- a/src/lib/litegraph/CONTRIBUTING.md
+++ b/src/lib/litegraph/CONTRIBUTING.md
@@ -1,9 +1,0 @@
-# Contribution Rules
-
-There are some simple rules that everyone should follow:
-
-### Do not commit files from build folder
-
-> I usually have horrible merge conflicts when I upload the build version that take me too much time to solve, but I want to keep the build version in the repo, so I guess it would be better if only one of us does the built, which would be me.
-> https://github.com/jagenjo/litegraph.js/pull/155#issuecomment-656602861
-> Those files will be updated by owner.

--- a/src/lib/litegraph/README.md
+++ b/src/lib/litegraph/README.md
@@ -144,18 +144,7 @@ Litegraph has no runtime dependencies. The build tooling has been tested on Node
 
 ## Releasing
 
-Use GitHub actions to release normal versions.
-
-1. Run the `Release a New Version` action, selecting the version increment type
-1. Merge the resolution PR
-1. A GitHub release is automatically published on merge
-
-### Pre-release
-
-The action directly translates `Version increment type` to the pnpm version command. `Pre-release ID (suffix)` is the option for the `--preid` argument.
-
-e.g. Use `prerelease` increment type to automatically bump the patch version and create a pre-release version. Subsequent runs of prerelease will update the prerelease version only.
-Use `patch` when ready to remove the pre-release suffix.
+This library is embedded via git subtree in ComfyUI_frontend. Releases are managed through the parent repository's release process.
 
 ## Contributors
 

--- a/src/lib/litegraph/src/subgraph/__fixtures__/README.md
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/README.md
@@ -18,8 +18,8 @@ A subgraph in LiteGraph is a graph-within-a-graph that can be reused as a single
 import {
   createTestSubgraph,
   assertSubgraphStructure
-} from './fixtures/subgraphHelpers'
-import { subgraphTest } from './fixtures/subgraphFixtures'
+} from './__fixtures__/subgraphHelpers'
+import { subgraphTest } from './__fixtures__/subgraphFixtures'
 
 // Option 1: Create a subgraph manually
 it('should do something', () => {


### PR DESCRIPTION
## Summary

Audits and updates litegraph documentation files that came from the old litegraph.js repo merged via git subtree (per #8341 discussion).

## Changes

- **Delete** `CONTRIBUTING.md` - completely outdated, referenced original jagenjo/litegraph.js from 2020
- **Fix** `API.md` - remove Subgraph from "Removed public interfaces" (actively used in 25+ files)
- **Update** `README.md` - replace standalone releasing instructions with note about embedded subtree workflow
- **Fix** `AGENTS.md` and `__fixtures__/README.md` - correct import path typos (`./fixtures/` → `./__fixtures__/`)

Fixes #8347

cc @DrJKL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated release information to clarify that the library is embedded via git subtree and managed through the parent repository's release process
* Removed contribution guidelines documentation file
* Updated API documentation by removing Subgraph from the list of removed public interfaces
* Updated documentation examples to align with current project structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8588-docs-audit-and-update-litegraph-documentation-2fc6d73d365081fca335c78ce8493d3e) by [Unito](https://www.unito.io)
