### PR TITLE
feat: update user-facing 'Simple Mode' terminology to 'App Mode'

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1233,7 +1233,7 @@ export function useCoreCommands(): ComfyCommand[] {
     {
       id: 'Comfy.ToggleLinear',
       icon: 'pi pi-database',
-      label: 'Toggle Simple Mode',
+      label: 'Toggle App Mode',
       function: (metadata?: Record<string, unknown>) => {
         const source =
           typeof metadata?.source === 'string' ? metadata.source : 'keybind'

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "المساعدة في الإصلاح"
   },
   "linearMode": {
-    "beta": "تجريبي - أرسل ملاحظاتك",
+    "beta": "وضع التطبيق تجريبي - أرسل ملاحظاتك",
     "downloadAll": "تنزيل الكل",
     "dragAndDropImage": "اسحب وأسقط صورة",
     "graphMode": "وضع الرسم البياني",
-    "linearMode": "الوضع البسيط",
+    "linearMode": "وضع التطبيق",
     "rerun": "تشغيل مجدد",
     "reuseParameters": "إعادة استخدام المعلمات",
     "runCount": "عدد مرات التشغيل:"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "تبديل لوحة السجلات السفلية",
     "Toggle Queue Panel V2": "تبديل لوحة قائمة الانتظار V2",
     "Toggle Search Box": "تبديل مربع البحث",
-    "Toggle Simple Mode": "تبديل وضع البسيط",
+    "Toggle App Mode": "تبديل وضع التطبيق",
     "Toggle Terminal Bottom Panel": "تبديل لوحة الطرفية السفلية",
     "Toggle Theme (Dark/Light)": "تبديل السمة (داكن/فاتح)",
     "Toggle View Controls Bottom Panel": "تبديل لوحة عناصر التحكم في العرض السفلية",

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -276,7 +276,7 @@
     "label": "Help Center"
   },
   "Comfy_ToggleLinear": {
-    "label": "Toggle Simple Mode"
+    "label": "Toggle App Mode"
   },
   "Comfy_ToggleQPOV2": {
     "label": "Toggle Queue Panel V2"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1243,7 +1243,7 @@
     "Experimental: Enable AssetAPI": "Experimental: Enable AssetAPI",
     "Canvas Performance": "Canvas Performance",
     "Help Center": "Help Center",
-    "Toggle Simple Mode": "Toggle Simple Mode",
+    "Toggle App Mode": "Toggle App Mode",
     "Toggle Queue Panel V2": "Toggle Queue Panel V2",
     "Toggle Theme (Dark/Light)": "Toggle Theme (Dark/Light)",
     "Undo": "Undo",
@@ -2757,8 +2757,8 @@
     "message": "Switch back to Nodes 2.0 anytime from the main menu."
   },
   "linearMode": {
-    "linearMode": "Simple Mode",
-    "beta": "Simple Mode in Beta - Feedback",
+    "linearMode": "App Mode",
+    "beta": "App Mode in Beta - Feedback",
     "graphMode": "Graph Mode",
     "dragAndDropImage": "Click to browse or drag an image",
     "runCount": "Run count:",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "Ayuda a Solucionar Esto"
   },
   "linearMode": {
-    "beta": "Beta - Enviar comentarios",
+    "beta": "Modo App Beta - Enviar comentarios",
     "downloadAll": "Descargar todo",
     "dragAndDropImage": "Arrastra y suelta una imagen",
     "graphMode": "Modo gráfico",
-    "linearMode": "Modo simple",
+    "linearMode": "Modo App",
     "rerun": "Volver a ejecutar",
     "reuseParameters": "Reutilizar parámetros",
     "runCount": "Número de ejecuciones:"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "Alternar panel inferior de registros",
     "Toggle Queue Panel V2": "Alternar panel de cola V2",
     "Toggle Search Box": "Alternar caja de búsqueda",
-    "Toggle Simple Mode": "Alternar modo simple",
+    "Toggle App Mode": "Alternar modo App",
     "Toggle Terminal Bottom Panel": "Alternar panel inferior de terminal",
     "Toggle Theme (Dark/Light)": "Alternar tema (Oscuro/Claro)",
     "Toggle View Controls Bottom Panel": "Alternar panel inferior de controles de vista",

--- a/src/locales/fa/main.json
+++ b/src/locales/fa/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "کمک به رفع این مشکل"
   },
   "linearMode": {
-    "beta": "بتا - ارسال بازخورد",
+    "beta": "حالت برنامه بتا - ارسال بازخورد",
     "downloadAll": "دانلود همه",
     "dragAndDropImage": "تصویر را بکشید و رها کنید",
     "graphMode": "حالت گراف",
-    "linearMode": "حالت ساده",
+    "linearMode": "حالت برنامه",
     "rerun": "اجرای مجدد",
     "reuseParameters": "استفاده مجدد از پارامترها",
     "runCount": "تعداد اجرا: "
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "تغییر وضعیت پنل لاگ پایین",
     "Toggle Queue Panel V2": "تغییر وضعیت پنل صف V2",
     "Toggle Search Box": "تغییر وضعیت جعبه جستجو",
-    "Toggle Simple Mode": "تغییر حالت ساده",
+    "Toggle App Mode": "تغییر حالت برنامه",
     "Toggle Terminal Bottom Panel": "تغییر وضعیت پنل ترمینال پایین",
     "Toggle Theme (Dark/Light)": "تغییر وضعیت تم (تاریک/روشن)",
     "Toggle View Controls Bottom Panel": "تغییر وضعیت کنترل‌های نمای پایین",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "Aidez à résoudre cela"
   },
   "linearMode": {
-    "beta": "Bêta - Donnez votre avis",
+    "beta": "Mode App Bêta - Donnez votre avis",
     "downloadAll": "Tout télécharger",
     "dragAndDropImage": "Glissez-déposez une image",
     "graphMode": "Mode graphique",
-    "linearMode": "Mode simple",
+    "linearMode": "Mode App",
     "rerun": "Relancer",
     "reuseParameters": "Réutiliser les paramètres",
     "runCount": "Nombre d’exécutions :"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "Basculer le panneau inférieur des journaux",
     "Toggle Queue Panel V2": "Basculer le panneau de file d’attente V2",
     "Toggle Search Box": "Basculer la boîte de recherche",
-    "Toggle Simple Mode": "Basculer en mode simple",
+    "Toggle App Mode": "Basculer en mode App",
     "Toggle Terminal Bottom Panel": "Basculer le panneau inférieur du terminal",
     "Toggle Theme (Dark/Light)": "Basculer le thème (Sombre/Clair)",
     "Toggle View Controls Bottom Panel": "Basculer le panneau inférieur des contrôles d’affichage",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "これを修正するのを助ける"
   },
   "linearMode": {
-    "beta": "ベータ版 - フィードバックを送る",
+    "beta": "アプリモード ベータ版 - フィードバックを送る",
     "downloadAll": "すべてダウンロード",
     "dragAndDropImage": "画像をドラッグ＆ドロップ",
     "graphMode": "グラフモード",
-    "linearMode": "シンプルモード",
+    "linearMode": "アプリモード",
     "rerun": "再実行",
     "reuseParameters": "パラメータを再利用",
     "runCount": "実行回数："
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "ログ下部パネルの切り替え",
     "Toggle Queue Panel V2": "キューパネルV2を切り替え",
     "Toggle Search Box": "検索ボックスの切り替え",
-    "Toggle Simple Mode": "シンプルモードを切り替え",
+    "Toggle App Mode": "アプリモードを切り替え",
     "Toggle Terminal Bottom Panel": "ターミナル下部パネルの切り替え",
     "Toggle Theme (Dark/Light)": "テーマを切り替え（ダーク/ライト）",
     "Toggle View Controls Bottom Panel": "ビューコントロール下部パネルの切り替え",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "이 문제 해결에 도움을 주세요"
   },
   "linearMode": {
-    "beta": "베타 - 피드백 보내기",
+    "beta": "앱 모드 베타 - 피드백 보내기",
     "downloadAll": "모두 다운로드",
     "dragAndDropImage": "이미지를 드래그 앤 드롭하세요",
     "graphMode": "그래프 모드",
-    "linearMode": "간단 모드",
+    "linearMode": "앱 모드",
     "rerun": "다시 실행",
     "reuseParameters": "파라미터 재사용",
     "runCount": "실행 횟수:"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "로그 하단 패널 전환",
     "Toggle Queue Panel V2": "대기열 패널 V2 전환",
     "Toggle Search Box": "검색 상자 전환",
-    "Toggle Simple Mode": "간단 모드 전환",
+    "Toggle App Mode": "앱 모드 전환",
     "Toggle Terminal Bottom Panel": "터미널 하단 패널 전환",
     "Toggle Theme (Dark/Light)": "테마 전환 (어두운/밝은)",
     "Toggle View Controls Bottom Panel": "뷰 컨트롤 하단 패널 전환",

--- a/src/locales/pt-BR/main.json
+++ b/src/locales/pt-BR/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "Ajude a Corrigir Isto"
   },
   "linearMode": {
-    "beta": "Beta - Envie seu feedback",
+    "beta": "Modo App Beta - Envie seu feedback",
     "downloadAll": "Baixar tudo",
     "dragAndDropImage": "Arraste e solte uma imagem",
     "graphMode": "Modo Gráfico",
-    "linearMode": "Modo Simples",
+    "linearMode": "Modo App",
     "rerun": "Executar novamente",
     "reuseParameters": "Reutilizar parâmetros",
     "runCount": "Número de execuções:"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "Alternar painel inferior de logs",
     "Toggle Queue Panel V2": "Alternar painel de fila V2",
     "Toggle Search Box": "Alternar caixa de pesquisa",
-    "Toggle Simple Mode": "Alternar Modo Simples",
+    "Toggle App Mode": "Alternar Modo App",
     "Toggle Terminal Bottom Panel": "Alternar painel inferior do terminal",
     "Toggle Theme (Dark/Light)": "Alternar tema (Escuro/Claro)",
     "Toggle View Controls Bottom Panel": "Alternar painel inferior de controles de visualização",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "Помочь исправить это"
   },
   "linearMode": {
-    "beta": "Бета - Оставить отзыв",
+    "beta": "Режим приложения Бета - Оставить отзыв",
     "downloadAll": "Скачать всё",
     "dragAndDropImage": "Перетащите изображение",
     "graphMode": "Графовый режим",
-    "linearMode": "Простой режим",
+    "linearMode": "Режим приложения",
     "rerun": "Перезапустить",
     "reuseParameters": "Повторно использовать параметры",
     "runCount": "Количество запусков:"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "Показать/скрыть нижнюю панель логов",
     "Toggle Queue Panel V2": "Переключить панель очереди V2",
     "Toggle Search Box": "Переключить поисковую панель",
-    "Toggle Simple Mode": "Переключить простой режим",
+    "Toggle App Mode": "Переключить режим приложения",
     "Toggle Terminal Bottom Panel": "Показать/скрыть нижнюю панель терминала",
     "Toggle Theme (Dark/Light)": "Переключение темы (Тёмная/Светлая)",
     "Toggle View Controls Bottom Panel": "Показать/скрыть нижнюю панель элементов управления",

--- a/src/locales/tr/main.json
+++ b/src/locales/tr/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "Bunu Düzeltmeye Yardım Et"
   },
   "linearMode": {
-    "beta": "Beta - Geri Bildirim Verin",
+    "beta": "Uygulama Modu Beta - Geri Bildirim Verin",
     "downloadAll": "Tümünü İndir",
     "dragAndDropImage": "Bir görseli sürükleyip bırakın",
     "graphMode": "Grafik Modu",
-    "linearMode": "Basit Mod",
+    "linearMode": "Uygulama Modu",
     "rerun": "Tekrar Çalıştır",
     "reuseParameters": "Parametreleri Yeniden Kullan",
     "runCount": "Çalıştırma sayısı:"
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "Kayıtlar Alt Panelini Aç/Kapat",
     "Toggle Queue Panel V2": "Kuyruk Paneli V2'yi Aç/Kapat",
     "Toggle Search Box": "Arama Kutusunu Aç/Kapat",
-    "Toggle Simple Mode": "Basit Modu Aç/Kapat",
+    "Toggle App Mode": "Uygulama Modunu Aç/Kapat",
     "Toggle Terminal Bottom Panel": "Terminal Alt Panelini Aç/Kapat",
     "Toggle Theme (Dark/Light)": "Temayı Değiştir (Karanlık/Açık)",
     "Toggle View Controls Bottom Panel": "Görünüm Kontrolleri Alt Panelini Aç/Kapat",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "協助修復此問題"
   },
   "linearMode": {
-    "beta": "Beta - 提供回饋",
+    "beta": "App 模式 Beta - 提供回饋",
     "downloadAll": "全部下載",
     "dragAndDropImage": "拖曳圖片到此",
     "graphMode": "圖形模式",
-    "linearMode": "簡易模式",
+    "linearMode": "App 模式",
     "rerun": "重新執行",
     "reuseParameters": "重用參數",
     "runCount": "執行次數："
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "切換日誌底部面板",
     "Toggle Queue Panel V2": "切換佇列面板 V2",
     "Toggle Search Box": "切換搜尋框",
-    "Toggle Simple Mode": "切換簡易模式",
+    "Toggle App Mode": "切換 App 模式",
     "Toggle Terminal Bottom Panel": "切換終端機底部面板",
     "Toggle Theme (Dark/Light)": "切換主題（深色/淺色）",
     "Toggle View Controls Bottom Panel": "切換檢視控制底部面板",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -1152,11 +1152,11 @@
     "helpFix": "帮助修复这个"
   },
   "linearMode": {
-    "beta": "测试版 - 提供反馈",
+    "beta": "App 模式测试版 - 提供反馈",
     "downloadAll": "全部下载",
     "dragAndDropImage": "拖拽图片到此处",
     "graphMode": "图形模式",
-    "linearMode": "简易模式",
+    "linearMode": "App 模式",
     "rerun": "重新运行",
     "reuseParameters": "复用参数",
     "runCount": "运行次数："
@@ -1648,7 +1648,7 @@
     "Toggle Logs Bottom Panel": "切换日志底部面板",
     "Toggle Queue Panel V2": "切换队列面板 V2",
     "Toggle Search Box": "切换搜索框",
-    "Toggle Simple Mode": "切换简易模式",
+    "Toggle App Mode": "切换 App 模式",
     "Toggle Terminal Bottom Panel": "切换终端底部面板",
     "Toggle Theme (Dark/Light)": "切换主题（暗/亮）",
     "Toggle View Controls Bottom Panel": "切换视图控制底部面板",


### PR DESCRIPTION
## Summary
Updates all user-facing instances of 'Simple Mode' / 'Linear Mode' to 'App Mode' as discussed in PR #8562.

## Changes
- Updated command label in `useCoreCommands.ts`
- Updated `src/locales/en/commands.json`
- Updated all 12 locale `main.json` files with:
  - `linearMode.linearMode` → "App Mode" (translated)
  - `linearMode.beta` → "App Mode in Beta - Feedback" (translated)
  - `Toggle Simple Mode` command → `Toggle App Mode` (translated)

## Languages Updated
en, zh, zh-TW, ja, ko, fr, es, pt-BR, ru, tr, ar, fa

## Notes
Internal variable names (`linearMode`, `canvasStore.linearMode`) remain unchanged to avoid breaking changes.

Fixes #8577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Renamed application terminology from "Simple Mode" to "App Mode" in user interface labels, mode descriptions, and mode toggle command. Updates applied consistently across all 12 supported language translations to ensure consistent terminology throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8590-feat-update-user-facing-Simple-Mode-terminology-to-App-Mode-2fc6d73d36508160a19af70b228b0a7e) by [Unito](https://www.unito.io)
