### PR TITLE
feat: add reset parameters option to right side panel

### DIFF
--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -63,18 +63,21 @@ const { t } = useI18n()
 
 const getNodeParentGroup = inject(GetNodeParentGroupKey, null)
 
+function writeWidgetValue(widget: IBaseWidget, value: WidgetValue) {
+  widget.value = value
+  widget.callback?.(value)
+  canvasStore.canvas?.setDirty(true, true)
+}
+
 function handleResetAllWidgets() {
   for (const { widget, node: widgetNode } of widgetsProp) {
     const spec = nodeDefStore.getInputSpecForWidget(widgetNode, widget.name)
     const defaultValue = getWidgetDefaultValue(spec)
     if (defaultValue !== undefined) {
-      // Ensure Vue reactivity is set up for this widget before updating
       getSharedWidgetEnhancements(widgetNode, widget)
-      widget.value = defaultValue
-      widget.callback?.(defaultValue)
+      writeWidgetValue(widget, defaultValue)
     }
   }
-  canvasStore.canvas?.setDirty(true, true)
 }
 
 function isWidgetShownOnParents(
@@ -136,9 +139,7 @@ function handleLocateNode() {
 
 function handleWidgetValueUpdate(widget: IBaseWidget, newValue: WidgetValue) {
   if (newValue === undefined) return
-  widget.value = newValue
-  widget.callback?.(newValue)
-  canvasStore.canvas?.setDirty(true, true)
+  writeWidgetValue(widget, newValue)
 }
 
 function handleWidgetReset(
@@ -147,9 +148,7 @@ function handleWidgetReset(
   newValue: WidgetValue
 ) {
   getSharedWidgetEnhancements(widgetNode, widget)
-  widget.value = newValue
-  widget.callback?.(newValue)
-  canvasStore.canvas?.setDirty(true, true)
+  writeWidgetValue(widget, newValue)
 }
 
 defineExpose({
@@ -183,7 +182,7 @@ defineExpose({
             </span>
           </span>
           <Button
-            v-if="canShowLocateButton"
+            v-if="!isEmpty"
             variant="textonly"
             size="icon-sm"
             class="subbutton shrink-0 size-8 cursor-pointer text-muted-foreground hover:text-base-foreground"

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -3,6 +3,7 @@ import { computed, inject, provide, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
+import { getSharedWidgetEnhancements } from '@/composables/graph/useGraphNodeManager'
 import { isProxyWidget } from '@/core/graph/subgraph/proxyWidget'
 import { parseProxyWidgets } from '@/core/schemas/proxyWidget'
 import type {
@@ -67,6 +68,8 @@ function handleResetAllWidgets() {
     const spec = nodeDefStore.getInputSpecForWidget(widgetNode, widget.name)
     const defaultValue = getWidgetDefaultValue(spec)
     if (defaultValue !== undefined) {
+      // Ensure Vue reactivity is set up for this widget before updating
+      getSharedWidgetEnhancements(widgetNode, widget)
       widget.value = defaultValue
       widget.callback?.(defaultValue)
     }

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -141,6 +141,17 @@ function handleWidgetValueUpdate(widget: IBaseWidget, newValue: WidgetValue) {
   canvasStore.canvas?.setDirty(true, true)
 }
 
+function handleWidgetReset(
+  widgetNode: LGraphNode,
+  widget: IBaseWidget,
+  newValue: WidgetValue
+) {
+  getSharedWidgetEnhancements(widgetNode, widget)
+  widget.value = newValue
+  widget.callback?.(newValue)
+  canvasStore.canvas?.setDirty(true, true)
+}
+
 defineExpose({
   widgetsContainer,
   rootElement
@@ -214,7 +225,7 @@ defineExpose({
             :parents="parents"
             :is-shown-on-parents="isWidgetShownOnParents(node, widget)"
             @update:widget-value="handleWidgetValueUpdate(widget, $event)"
-            @reset-to-default="handleWidgetValueUpdate(widget, $event)"
+            @reset-to-default="handleWidgetReset(node, widget, $event)"
           />
         </TransitionGroup>
       </div>

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -9,7 +9,9 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 import WidgetActions from './WidgetActions.vue'
 
-const mockGetInputSpecForWidget = vi.fn()
+const { mockGetInputSpecForWidget } = vi.hoisted(() => ({
+  mockGetInputSpecForWidget: vi.fn()
+}))
 
 vi.mock('@/stores/nodeDefStore', () => ({
   useNodeDefStore: () => ({
@@ -75,15 +77,17 @@ describe('WidgetActions', () => {
       type: 'number',
       value,
       label: 'Test Widget',
+      options: {},
+      y: 0,
       callback
-    } as unknown as IBaseWidget
+    } as IBaseWidget
   }
 
-  function createMockNode() {
+  function createMockNode(): LGraphNode {
     return {
       id: 1,
       type: 'TestNode'
-    } as unknown as LGraphNode
+    } as LGraphNode
   }
 
   function mountWidgetActions(widget: IBaseWidget, node: LGraphNode) {
@@ -94,12 +98,7 @@ describe('WidgetActions', () => {
         label: 'Test Widget'
       },
       global: {
-        plugins: [i18n],
-        stubs: {
-          MoreButton: {
-            template: '<div><slot :close="() => {}" /></div>'
-          }
-        }
+        plugins: [i18n]
       }
     })
   }

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -1,0 +1,203 @@
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import WidgetActions from './WidgetActions.vue'
+
+const mockGetInputSpecForWidget = vi.fn()
+
+vi.mock('@/stores/nodeDefStore', () => ({
+  useNodeDefStore: () => ({
+    getInputSpecForWidget: mockGetInputSpecForWidget
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: { setDirty: vi.fn() }
+  })
+}))
+
+vi.mock('@/stores/workspace/favoritedWidgetsStore', () => ({
+  useFavoritedWidgetsStore: () => ({
+    isFavorited: vi.fn().mockReturnValue(false),
+    toggleFavorite: vi.fn()
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    prompt: vi.fn()
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: {
+        rename: 'Rename',
+        enterNewName: 'Enter new name'
+      },
+      rightSidePanel: {
+        hideInput: 'Hide input',
+        showInput: 'Show input',
+        addFavorite: 'Favorite',
+        removeFavorite: 'Unfavorite',
+        resetToDefault: 'Reset to default'
+      }
+    }
+  }
+})
+
+describe('WidgetActions', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.resetAllMocks()
+    mockGetInputSpecForWidget.mockReturnValue({
+      type: 'INT',
+      default: 42
+    })
+  })
+
+  function createMockWidget(
+    value: number = 100,
+    callback?: () => void
+  ): IBaseWidget {
+    return {
+      name: 'test_widget',
+      type: 'number',
+      value,
+      label: 'Test Widget',
+      callback
+    } as unknown as IBaseWidget
+  }
+
+  function createMockNode() {
+    return {
+      id: 1,
+      type: 'TestNode'
+    } as unknown as LGraphNode
+  }
+
+  function mountWidgetActions(widget: IBaseWidget, node: LGraphNode) {
+    return mount(WidgetActions, {
+      props: {
+        widget,
+        node,
+        label: 'Test Widget'
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          MoreButton: {
+            template: '<div><slot :close="() => {}" /></div>'
+          }
+        }
+      }
+    })
+  }
+
+  it('shows reset button when widget has default value', () => {
+    const widget = createMockWidget()
+    const node = createMockNode()
+
+    const wrapper = mountWidgetActions(widget, node)
+
+    const resetButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Reset'))
+    expect(resetButton).toBeDefined()
+  })
+
+  it('emits resetToDefault with default value when reset button clicked', async () => {
+    const widget = createMockWidget(100)
+    const node = createMockNode()
+
+    const wrapper = mountWidgetActions(widget, node)
+
+    const resetButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Reset'))
+
+    await resetButton?.trigger('click')
+
+    expect(wrapper.emitted('resetToDefault')).toHaveLength(1)
+    expect(wrapper.emitted('resetToDefault')![0]).toEqual([42])
+  })
+
+  it('disables reset button when value equals default', () => {
+    const widget = createMockWidget(42)
+    const node = createMockNode()
+
+    const wrapper = mountWidgetActions(widget, node)
+
+    const resetButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Reset'))
+
+    expect(resetButton?.attributes('disabled')).toBeDefined()
+  })
+
+  it('does not show reset button when no default value exists', () => {
+    mockGetInputSpecForWidget.mockReturnValue({
+      type: 'CUSTOM'
+    })
+
+    const widget = createMockWidget(100)
+    const node = createMockNode()
+
+    const wrapper = mountWidgetActions(widget, node)
+
+    const resetButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Reset'))
+
+    expect(resetButton).toBeUndefined()
+  })
+
+  it('uses fallback default for INT type without explicit default', async () => {
+    mockGetInputSpecForWidget.mockReturnValue({
+      type: 'INT'
+    })
+
+    const widget = createMockWidget(100)
+    const node = createMockNode()
+
+    const wrapper = mountWidgetActions(widget, node)
+
+    const resetButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Reset'))
+
+    await resetButton?.trigger('click')
+
+    expect(wrapper.emitted('resetToDefault')![0]).toEqual([0])
+  })
+
+  it('uses first option as default for combo without explicit default', async () => {
+    mockGetInputSpecForWidget.mockReturnValue({
+      type: 'COMBO',
+      options: ['option1', 'option2', 'option3']
+    })
+
+    const widget = createMockWidget(100)
+    const node = createMockNode()
+
+    const wrapper = mountWidgetActions(widget, node)
+
+    const resetButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Reset'))
+
+    await resetButton?.trigger('click')
+
+    expect(wrapper.emitted('resetToDefault')![0]).toEqual(['option1'])
+  })
+})

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -1,6 +1,8 @@
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
 import { setActivePinia } from 'pinia'
+import type { Slots } from 'vue'
+import { h } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -36,6 +38,11 @@ vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
     prompt: vi.fn()
   })
+}))
+
+vi.mock('@/components/button/MoreButton.vue', () => ({
+  default: (_: unknown, { slots }: { slots: Slots }) =>
+    h('div', slots.default?.({ close: () => {} }))
 }))
 
 const i18n = createI18n({

--- a/src/components/rightSidePanel/parameters/WidgetActions.vue
+++ b/src/components/rightSidePanel/parameters/WidgetActions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import _ from 'es-toolkit/compat'
+import { isEqual } from 'es-toolkit'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -62,7 +62,7 @@ const hasDefault = computed(() => defaultValue.value !== undefined)
 
 const isCurrentValueDefault = computed(() => {
   if (!hasDefault.value) return true
-  return _.isEqual(widget.value, defaultValue.value)
+  return isEqual(widget.value, defaultValue.value)
 })
 
 async function handleRename() {

--- a/src/components/rightSidePanel/parameters/WidgetActions.vue
+++ b/src/components/rightSidePanel/parameters/WidgetActions.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
+import _ from 'es-toolkit/compat'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -61,7 +62,7 @@ const hasDefault = computed(() => defaultValue.value !== undefined)
 
 const isCurrentValueDefault = computed(() => {
   if (!hasDefault.value) return true
-  return widget.value === defaultValue.value
+  return _.isEqual(widget.value, defaultValue.value)
 })
 
 async function handleRename() {

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -20,6 +20,7 @@ import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
 import { resolveNodeDisplayName } from '@/utils/nodeTitleUtil'
 import { cn } from '@/utils/tailwindUtil'
 import { renameWidget } from '@/utils/widgetUtil'
+import type { WidgetValue } from '@/utils/widgetUtil'
 
 import WidgetActions from './WidgetActions.vue'
 
@@ -42,8 +43,8 @@ const {
 }>()
 
 const emit = defineEmits<{
-  'update:widgetValue': [value: string | number | boolean | object]
-  resetToDefault: [value: string | number | boolean | object | undefined]
+  'update:widgetValue': [value: WidgetValue]
+  resetToDefault: [value: WidgetValue]
 }>()
 
 const { t } = useI18n()

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -43,6 +43,7 @@ const {
 
 const emit = defineEmits<{
   'update:widgetValue': [value: string | number | boolean | object]
+  resetToDefault: [value: string | number | boolean | object | undefined]
 }>()
 
 const { t } = useI18n()
@@ -156,6 +157,7 @@ const displayLabel = customRef((track, trigger) => {
           :node="node"
           :parents="parents"
           :is-shown-on-parents="isShownOnParents"
+          @reset-to-default="emit('resetToDefault', $event)"
         />
       </div>
     </div>

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -88,7 +88,7 @@ const widgetValue = computed({
     widget.vueTrack?.()
     return widget.value
   },
-  set: (newValue: string | number | boolean | object) => {
+  set: (newValue: WidgetValue) => {
     emit('update:widgetValue', newValue)
   }
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2831,6 +2831,8 @@
     "removeFavorite": "Unfavorite",
     "hideInput": "Hide input",
     "showInput": "Show input",
+    "resetToDefault": "Reset to default",
+    "resetAllParameters": "Reset all parameters",
     "locateNode": "Locate node on canvas",
     "favorites": "FAVORITED INPUTS",
     "favoritesNone": "NO FAVORITED INPUTS",

--- a/src/utils/widgetUtil.test.ts
+++ b/src/utils/widgetUtil.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+import { getWidgetDefaultValue } from '@/utils/widgetUtil'
+
+describe('getWidgetDefaultValue', () => {
+  it('returns undefined for undefined spec', () => {
+    expect(getWidgetDefaultValue(undefined)).toBeUndefined()
+  })
+
+  it('returns explicit default when provided', () => {
+    const spec = { type: 'INT', default: 42 } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBe(42)
+  })
+
+  it('returns 0 for INT type without default', () => {
+    const spec = { type: 'INT' } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBe(0)
+  })
+
+  it('returns 0 for FLOAT type without default', () => {
+    const spec = { type: 'FLOAT' } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBe(0)
+  })
+
+  it('returns false for BOOLEAN type without default', () => {
+    const spec = { type: 'BOOLEAN' } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBe(false)
+  })
+
+  it('returns empty string for STRING type without default', () => {
+    const spec = { type: 'STRING' } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBe('')
+  })
+
+  it('returns first option for array options without default', () => {
+    const spec = { type: 'COMBO', options: ['a', 'b', 'c'] } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBe('a')
+  })
+
+  it('returns undefined for unknown type without options', () => {
+    const spec = { type: 'CUSTOM' } as InputSpec
+    expect(getWidgetDefaultValue(spec)).toBeUndefined()
+  })
+})

--- a/src/utils/widgetUtil.ts
+++ b/src/utils/widgetUtil.ts
@@ -2,6 +2,37 @@ import { isProxyWidget } from '@/core/graph/subgraph/proxyWidget'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+export type WidgetValue = boolean | number | string | object | undefined
+
+/**
+ * Gets the default value for a widget based on its input spec.
+ * Returns the explicit default if defined, otherwise returns a sensible
+ * default based on the input type.
+ */
+export function getWidgetDefaultValue(
+  spec: InputSpec | undefined
+): WidgetValue {
+  if (!spec) return undefined
+
+  if (spec.default !== undefined) return spec.default as WidgetValue
+
+  switch (spec.type) {
+    case 'INT':
+    case 'FLOAT':
+      return 0
+    case 'BOOLEAN':
+      return false
+    case 'STRING':
+      return ''
+    default:
+      if (Array.isArray(spec.options) && spec.options.length > 0) {
+        return spec.options[0] as WidgetValue
+      }
+      return undefined
+  }
+}
 
 /**
  * Renames a widget and its corresponding input.


### PR DESCRIPTION
## Summary

Add reset parameters functionality to the right side panel, allowing users to reset widget values to their defaults.

## Changes

- **Per-widget reset**: "Reset to default" button in WidgetActions dropdown menu
- **Per-node reset**: "Reset all parameters" button in SectionWidgets header (next to "Locate Node")
- **Shared utility**: `getWidgetDefaultValue` function in `widgetUtil.ts` with fallback defaults (INT/FLOAT=0, BOOLEAN=false, STRING='', COMBO=first option)
- **Unit tests**: 6 tests covering reset functionality edge cases

## Review Focus

- Event emission pattern: WidgetActions emits `resetToDefault` which flows through WidgetItem to SectionWidgets
- Default value resolution uses `nodeDefStore.getInputSpecForWidget()` for accurate defaults

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8591-feat-add-reset-parameters-option-to-right-side-panel-2fc6d73d3650819da925e9bca5a2ea48) by [Unito](https://www.unito.io)