### PR TITLE
feat: add default keybindings for toggle mode and assets panel

### DIFF
--- a/src/components/sidebar/ModeToggle.vue
+++ b/src/components/sidebar/ModeToggle.vue
@@ -1,10 +1,21 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import Button from '@/components/ui/button/Button.vue'
 import { t } from '@/i18n'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCommandStore } from '@/stores/commandStore'
 
 const canvasStore = useCanvasStore()
+const keybindingStore = useKeybindingStore()
+
+const keybindingSuffix = computed(() => {
+  const keybinding =
+    keybindingStore.getKeybindingByCommandId('Comfy.ToggleLinear')
+  return keybinding ? ` (${keybinding.combo.toString()})` : ''
+})
+
 function toggleLinearMode() {
   useCommandStore().execute('Comfy.ToggleLinear', {
     metadata: { source: 'button' }
@@ -15,7 +26,7 @@ function toggleLinearMode() {
   <div class="p-1 bg-secondary-background rounded-lg w-10">
     <Button
       v-tooltip="{
-        value: t('linearMode.linearMode'),
+        value: t('linearMode.linearMode') + keybindingSuffix,
         showDelay: 300,
         hideDelay: 300
       }"
@@ -27,7 +38,7 @@ function toggleLinearMode() {
     </Button>
     <Button
       v-tooltip="{
-        value: t('linearMode.graphMode'),
+        value: t('linearMode.graphMode') + keybindingSuffix,
         showDelay: 300,
         hideDelay: 300
       }"

--- a/src/components/sidebar/ModeToggle.vue
+++ b/src/components/sidebar/ModeToggle.vue
@@ -11,8 +11,9 @@ const canvasStore = useCanvasStore()
 const keybindingStore = useKeybindingStore()
 
 const keybindingSuffix = computed(() => {
-  const shortcut =
-    keybindingStore.getKeybindingByCommandId('Comfy.ToggleLinear')?.combo.toString()
+  const shortcut = keybindingStore
+    .getKeybindingByCommandId('Comfy.ToggleLinear')
+    ?.combo.toString()
   return shortcut ? t('g.shortcutSuffix', { shortcut }) : ''
 })
 

--- a/src/components/sidebar/ModeToggle.vue
+++ b/src/components/sidebar/ModeToggle.vue
@@ -11,9 +11,9 @@ const canvasStore = useCanvasStore()
 const keybindingStore = useKeybindingStore()
 
 const keybindingSuffix = computed(() => {
-  const keybinding =
-    keybindingStore.getKeybindingByCommandId('Comfy.ToggleLinear')
-  return keybinding ? ` (${keybinding.combo.toString()})` : ''
+  const shortcut =
+    keybindingStore.getKeybindingByCommandId('Comfy.ToggleLinear')?.combo.toString()
+  return shortcut ? t('g.shortcutSuffix', { shortcut }) : ''
 })
 
 function toggleLinearMode() {

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -65,6 +65,7 @@ import SidebarBottomPanelToggleButton from '@/components/sidebar/SidebarBottomPa
 import SidebarSettingsButton from '@/components/sidebar/SidebarSettingsButton.vue'
 import SidebarShortcutsToggleButton from '@/components/sidebar/SidebarShortcutsToggleButton.vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
@@ -150,10 +151,10 @@ const onTabClick = async (item: SidebarTabExtension) => {
 
 const keybindingStore = useKeybindingStore()
 const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
-  const keybinding = keybindingStore.getKeybindingByCommandId(
+  const shortcut = keybindingStore.getKeybindingByCommandId(
     `Workspace.ToggleSidebarTab.${tab.id}`
-  )
-  return keybinding ? ` (${keybinding.combo.toString()})` : ''
+  )?.combo.toString()
+  return shortcut ? t('g.shortcutSuffix', { shortcut }) : ''
 }
 
 const isOverflowing = ref(false)

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -151,9 +151,9 @@ const onTabClick = async (item: SidebarTabExtension) => {
 
 const keybindingStore = useKeybindingStore()
 const getTabTooltipSuffix = (tab: SidebarTabExtension) => {
-  const shortcut = keybindingStore.getKeybindingByCommandId(
-    `Workspace.ToggleSidebarTab.${tab.id}`
-  )?.combo.toString()
+  const shortcut = keybindingStore
+    .getKeybindingByCommandId(`Workspace.ToggleSidebarTab.${tab.id}`)
+    ?.combo.toString()
   return shortcut ? t('g.shortcutSuffix', { shortcut }) : ''
 }
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1,5 +1,6 @@
 {
   "g": {
+    "shortcutSuffix": " ({shortcut})",
     "user": "User",
     "you": "You",
     "currentUser": "Current user",

--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -50,6 +50,20 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
+      key: 'a'
+    },
+    commandId: 'Workspace.ToggleSidebarTab.assets'
+  },
+  {
+    combo: {
+      ctrl: true,
+      shift: true,
+      key: 'a'
+    },
+    commandId: 'Comfy.ToggleLinear'
+  },
+  {
+    combo: {
       key: 's',
       ctrl: true
     },


### PR DESCRIPTION
## Summary
Add default keyboard shortcuts for mode toggle and assets panel access.

## Changes
- **Ctrl+Shift+A**: Toggle between Simple Mode and Graph Mode (`Comfy.ToggleLinear`)
- **A**: Open/toggle assets panel (`Workspace.ToggleSidebarTab.assets`)
- Show keybinding in ModeToggle button tooltip (e.g. "Simple Mode (Ctrl+Shift+A)")

## Keybinding Rationale
- `A` follows the existing pattern: `w` (workflows), `n` (node-lib), `m` (model-lib)
- `Ctrl+Shift+A` chosen because:
  - Ctrl+Shift is the standard modifier pattern for toggle commands
  - "A" mnemonic for "App mode"
  - Does not conflict with existing keybindings

## Testing
- Verified typecheck passes
- Verified lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltips now show dynamic keyboard shortcut suffixes for mode and tab controls.
  * Added keyboard shortcut: A — toggles the assets sidebar.
  * Added keyboard shortcut: Ctrl+Shift+A — toggles linear mode.

* **Localization**
  * Added a localized shortcut suffix template so displayed shortcuts respect translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8593-feat-add-default-keybindings-for-toggle-mode-and-assets-panel-2fc6d73d36508172bd6ed3378f43de55) by [Unito](https://www.unito.io)
