### PR TITLE
feat: identify and locate node from execution errors (#6447)

### DIFF
--- a/src/components/dialog/content/ErrorDialogContent.vue
+++ b/src/components/dialog/content/ErrorDialogContent.vue
@@ -110,20 +110,12 @@ const showReport = () => {
 const toast = useToast()
 const { t } = useI18n()
 const systemStatsStore = useSystemStatsStore()
-const canvasStore = useCanvasStore()
-const telemetry = useTelemetry()
-const dialogStore = useDialogStore()
-
-/**
- * Locate the node on the canvas.
- */
 function handleLocateNode() {
   if (!error.nodeId || !canvasStore.canvas) return
 
   const graphNode = canvasStore.canvas.graph?.getNodeById(error.nodeId)
-  if (graphNode) {
-    canvasStore.canvas.animateToBounds(graphNode.boundingRect)
-  }
+  if (!graphNode) return
+  canvasStore.canvas.animateToBounds(graphNode.boundingRect)
   dialogStore.closeDialog()
 }
 

--- a/src/components/dialog/content/ErrorDialogContent.vue
+++ b/src/components/dialog/content/ErrorDialogContent.vue
@@ -110,6 +110,13 @@ const showReport = () => {
 const toast = useToast()
 const { t } = useI18n()
 const systemStatsStore = useSystemStatsStore()
+const canvasStore = useCanvasStore()
+const telemetry = useTelemetry()
+const dialogStore = useDialogStore()
+
+/**
+ * Locate the node on the canvas.
+ */
 function handleLocateNode() {
   if (!error.nodeId || !canvasStore.canvas) return
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1702,7 +1702,8 @@
     "loadWorkflowTitle": "Loading aborted due to error reloading workflow data",
     "noStackTrace": "No stacktrace available",
     "extensionFileHint": "This may be due to the following script",
-    "promptExecutionError": "Prompt execution failed"
+    "promptExecutionError": "Prompt execution failed",
+    "locateNode": "Locate node on canvas"
   },
   "apiNodesSignInDialog": {
     "title": "Sign In Required to Use API Nodes",

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -203,6 +203,34 @@ export const useDialogService = () => {
     })
   }
 
+  function showPromptExecutionErrorDialog(
+    executionError: ExecutionErrorDialogInput
+  ) {
+    const props: ComponentAttrs<typeof ErrorDialogContent> = {
+      error: {
+        exceptionType: t('errorDialog.promptExecutionError'),
+        exceptionMessage: executionError.exception_message,
+        nodeId: executionError.node_id?.toString(),
+        nodeType: executionError.node_type,
+        traceback: executionError.traceback.join('\n'),
+        reportType: 'promptExecutionError'
+      }
+    }
+
+    dialogStore.showDialog({
+      key: 'global-error',
+      component: ErrorDialogContent,
+      props,
+      dialogComponentProps: {
+        onClose: () => {
+          useTelemetry()?.trackUiButtonClicked({
+            button_id: 'error_dialog_closed'
+          })
+        }
+      }
+    })
+  }
+
   function parseError(error: Error) {
     const filename =
       'fileName' in error
@@ -735,6 +763,7 @@ export const useDialogService = () => {
     showSettingsDialog,
     showAboutDialog,
     showExecutionErrorDialog,
+    showPromptExecutionErrorDialog,
     showApiNodesSignInDialog,
     showSignInDialog,
     showSubscriptionRequiredDialog,


### PR DESCRIPTION
- Extract node IDs from prompt_outputs_failed_validation errors
- Integrate showPromptExecutionErrorDialog in dialogService
- Display nodeType/ID in error dialog and locate node on canvas upon clicking
- Add i18n keys for node navigation feature

## Summary

This PR enhances the error handling experience by allowing users to directly identify and navigate to nodes causing errors on the canvas from the error dialog.

## Changes

- **What**: 
  - Improved error ID extraction for `prompt_outputs_failed_validation` errors in `app.ts`.
  - Added a dedicated `showPromptExecutionErrorDialog` in `dialogService.ts` for better error context.
  - Updated `ErrorDialogContent.vue` to include a navigation button in the top-right corner that displays the dynamic `nodeType` and `nodeId`.
  - Clicking this button performs the "Locate node on canvas" action, focusing the target node and automatically closing the dialog.
  - Added new i18n translation key `locateNode` for the button's tooltip/accessible label.

## Review Focus

- The reliability of node ID extraction from the `node_errors` response in `app.ts`.
- The UX of automatically closing the error dialog after navigating to the node on the canvas to ensure a smooth transition back to the workflow.

Fixes #6447

## Screenshots (if applicable)
<img width="1229" height="1578" alt="image" src="https://github.com/user-attachments/assets/beb936ec-f804-40bc-a44d-81da1b25423a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Locate Node" button in error dialogs to jump to the problematic node on the canvas.
  * Error handling now surfaces per-node validation details for prompt execution errors, improving diagnostic context.
  * Added a dedicated dialog flow to display prompt execution errors with node-specific info.

* **Localization**
  * Added a localized string for "Locate node on canvas".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8605-feat-identify-and-locate-node-from-execution-errors-6447-2fd6d73d365081488c17f2d3822cf2a3) by [Unito](https://www.unito.io)
