### PR TITLE
fix: disable CodeRabbit high_level_summary to stop PR description auto-updates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,5 +2,6 @@ issue_enrichment:
   auto_enrich:
     enabled: true
 reviews:
+  high_level_summary: false
   auto_review:
     drafts: true


### PR DESCRIPTION
## Summary

Disables the `high_level_summary` feature in CodeRabbit's configuration. This feature automatically modifies the PR description every time a commit is pushed, which was causing frustration for developers.

## Changes

- Set `high_level_summary: false` in `.coderabbit.yaml`

## Context

Discussed in #frontend-code-reviews Slack channel. The team agreed that having PR descriptions automatically modified with every commit push is not desirable behavior.

---

Fixes https://www.notion.so/comfy-org/Ops-Disable-high_level_summary-in-ComfyUI_frontend-coderabbit-yaml-2fd6d73d3650812b9eb8d6680fa11932

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8615-fix-disable-CodeRabbit-high_level_summary-to-stop-PR-description-auto-updates-2fe6d73d36508112ac16f5df51845fcd) by [Unito](https://www.unito.io)
