### PR TITLE
feat: add essentials_category field to node schema

### DIFF
--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -287,10 +287,10 @@ export const zComfyNodeDef = z.object({
    */
   price_badge: zPriceBadge.optional(),
   /**
-   * Optional category for the Essentials tab in the node library.
-   * Path-based like category field (e.g., 'Basic', 'Image Tools/Editing').
+   * Optional main category for top-level tabs in the node library
+   * (e.g., 'Basic', 'Image Tools', 'Partner Nodes').
    */
-  essentials_category: z.string().optional()
+  main_category: z.string().optional()
 })
 
 export const zAutogrowOptions = z.object({

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -285,7 +285,12 @@ export const zComfyNodeDef = z.object({
    * Contains a JSONata expression to calculate pricing based on widget values
    * and input connectivity.
    */
-  price_badge: zPriceBadge.optional()
+  price_badge: zPriceBadge.optional(),
+  /**
+   * Optional category for the Essentials tab in the node library.
+   * Path-based like category field (e.g., 'Basic', 'Image Tools/Editing').
+   */
+  essentials_category: z.string().optional()
 })
 
 export const zAutogrowOptions = z.object({


### PR DESCRIPTION
Adds `essentials_category` field to the frontend node definition schema to support the Essentials tab in the redesigned node library.

Depends on: Comfy-Org/ComfyUI#12291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes now support an optional "main category" designation, allowing improved classification and organization of node types for clearer browsing and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8616-feat-add-essentials_category-field-to-node-schema-2fe6d73d365081c48374e77efccdd80a) by [Unito](https://www.unito.io)
