### PR TITLE
fix: skip node replacement API call when feature is disabled

### DIFF
--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -22,7 +22,8 @@ function mockSettingStore(enabled: boolean) {
         return enabled
       }
       return false
-    })
+    }),
+    load: vi.fn().mockResolvedValue(undefined)
   })
 }
 
@@ -225,6 +226,16 @@ describe('useNodeReplacementStore', () => {
       expect(store.isLoaded).toBe(false)
 
       consoleErrorSpy.mockRestore()
+    })
+
+    it('should not fetch when feature is disabled', async () => {
+      vi.mocked(fetchNodeReplacements).mockResolvedValue({})
+      store = createStore(false)
+
+      await store.load()
+
+      expect(fetchNodeReplacements).not.toHaveBeenCalled()
+      expect(store.isLoaded).toBe(false)
     })
 
     it('should not re-fetch when called twice', async () => {

--- a/src/platform/nodeReplacement/nodeReplacementStore.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.ts
@@ -15,7 +15,7 @@ export const useNodeReplacementStore = defineStore('nodeReplacement', () => {
   )
 
   async function load() {
-    if (isLoaded.value) return
+    if (isLoaded.value || !isEnabled.value) return
 
     try {
       replacements.value = await fetchNodeReplacements()

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1198,7 +1198,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'When enabled, missing nodes can be automatically replaced with their newer equivalents if a replacement mapping exists.',
     type: 'boolean',
-    defaultValue: true,
+    defaultValue: false,
     experimental: true,
     versionAdded: '1.40.0'
   }


### PR DESCRIPTION
## Summary
Node replacement API (`/node_replacements`) was called unconditionally at startup, ignoring the `Comfy.NodeReplacement.Enabled` setting. Default was also incorrectly set to `true`.

## Changes
- **Default OFF**: `Comfy.NodeReplacement.Enabled` default changed from `true` to `false`
- **Guard `load()`**: Skip `/node_replacements` fetch when `isEnabled` is `false`
- **Test**: Added test for disabled-state behavior

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8618-fix-skip-node-replacement-API-call-when-feature-is-disabled-2fe6d73d3650811faf33d7bd12d8bfa2) by [Unito](https://www.unito.io)
