### PR TITLE
fix(browser_tests): eliminate WorkspaceStore type casts

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -138,11 +138,9 @@ class ConfirmDialog {
     }
 
     // Wait for workflow service to finish if it's busy
-    await this.page.waitForFunction(
-      () => !wss().workflow.isBusy,
-      undefined,
-      { timeout: 3000 }
-    )
+    await this.page.waitForFunction(() => !wss().workflow.isBusy, undefined, {
+      timeout: 3000
+    })
   }
 }
 

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -1,6 +1,5 @@
 import type { Locator, Page } from '@playwright/test'
 
-import type { WorkspaceStore } from '../../types/globals'
 import { TestIds } from '../selectors'
 
 class SidebarTab {
@@ -153,9 +152,7 @@ export class WorkflowsSidebarTab extends SidebarTab {
 
     // Wait for workflow service to finish renaming
     await this.page.waitForFunction(
-      () =>
-        !(window.app?.extensionManager as WorkspaceStore | undefined)?.workflow
-          ?.isBusy,
+      () => !wss().workflow.isBusy,
       undefined,
       { timeout: 3000 }
     )

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -151,11 +151,9 @@ export class WorkflowsSidebarTab extends SidebarTab {
     await this.page.keyboard.press('Enter')
 
     // Wait for workflow service to finish renaming
-    await this.page.waitForFunction(
-      () => !wss().workflow.isBusy,
-      undefined,
-      { timeout: 3000 }
-    )
+    await this.page.waitForFunction(() => !wss().workflow.isBusy, undefined, {
+      timeout: 3000
+    })
   }
 
   async insertWorkflow(locator: Locator) {

--- a/browser_tests/fixtures/components/Topbar.ts
+++ b/browser_tests/fixtures/components/Topbar.ts
@@ -1,7 +1,5 @@
 import type { Locator, Page } from '@playwright/test'
 
-import type { WorkspaceStore } from '../../types/globals'
-
 export class Topbar {
   private readonly menuLocator: Locator
   private readonly menuTrigger: Locator
@@ -87,7 +85,7 @@ export class Topbar {
 
     // Wait for workflow service to finish saving
     await this.page.waitForFunction(
-      () => !(window.app!.extensionManager as WorkspaceStore).workflow.isBusy,
+      () => !wss().workflow.isBusy,
       undefined,
       { timeout: 3000 }
     )

--- a/browser_tests/fixtures/components/Topbar.ts
+++ b/browser_tests/fixtures/components/Topbar.ts
@@ -84,11 +84,9 @@ export class Topbar {
     await this.page.keyboard.press('Enter')
 
     // Wait for workflow service to finish saving
-    await this.page.waitForFunction(
-      () => !wss().workflow.isBusy,
-      undefined,
-      { timeout: 3000 }
-    )
+    await this.page.waitForFunction(() => !wss().workflow.isBusy, undefined, {
+      timeout: 3000
+    })
     // Wait for the dialog to close.
     await this.getSaveDialog().waitFor({ state: 'hidden', timeout: 500 })
 

--- a/browser_tests/fixtures/helpers/WorkflowHelper.ts
+++ b/browser_tests/fixtures/helpers/WorkflowHelper.ts
@@ -4,7 +4,6 @@ import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
 } from '../../../src/platform/workflow/validation/schemas/workflowSchema'
-import type { WorkspaceStore } from '../../types/globals'
 import type { ComfyPage } from '../ComfyPage'
 
 type FolderStructure = {
@@ -47,9 +46,7 @@ export class WorkflowHelper {
     }
 
     await this.comfyPage.page.evaluate(async () => {
-      await (
-        window.app!.extensionManager as WorkspaceStore
-      ).workflow.syncWorkflows()
+      await wss().workflow.syncWorkflows()
     })
 
     // Wait for Vue to re-render the workflow list
@@ -90,24 +87,19 @@ export class WorkflowHelper {
 
   async getUndoQueueSize(): Promise<number | undefined> {
     return this.comfyPage.page.evaluate(() => {
-      const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
-        .activeWorkflow
-      return workflow?.changeTracker.undoQueue.length
+      return wss().workflow.activeWorkflow?.changeTracker.undoQueue.length
     })
   }
 
   async getRedoQueueSize(): Promise<number | undefined> {
     return this.comfyPage.page.evaluate(() => {
-      const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
-        .activeWorkflow
-      return workflow?.changeTracker.redoQueue.length
+      return wss().workflow.activeWorkflow?.changeTracker.redoQueue.length
     })
   }
 
   async isCurrentWorkflowModified(): Promise<boolean | undefined> {
     return this.comfyPage.page.evaluate(() => {
-      return (window.app!.extensionManager as WorkspaceStore).workflow
-        .activeWorkflow?.isModified
+      return wss().workflow.activeWorkflow?.isModified
     })
   }
 

--- a/browser_tests/helpers/actionbar.ts
+++ b/browser_tests/helpers/actionbar.ts
@@ -2,7 +2,6 @@ import type { Locator, Page } from '@playwright/test'
 
 import type { AutoQueueMode } from '../../src/stores/queueStore'
 import { TestIds } from '../fixtures/selectors'
-import type { WorkspaceStore } from '../types/globals'
 
 export class ComfyActionbar {
   public readonly root: Locator
@@ -44,14 +43,13 @@ class ComfyQueueButtonOptions {
 
   public async setMode(mode: AutoQueueMode) {
     await this.page.evaluate((mode) => {
-      ;(window.app!.extensionManager as WorkspaceStore).queueSettings.mode =
-        mode
+      wss().queueSettings.mode = mode
     }, mode)
   }
 
   public async getMode() {
     return await this.page.evaluate(() => {
-      return (window.app!.extensionManager as WorkspaceStore).queueSettings.mode
+      return wss().queueSettings.mode
     })
   }
 }

--- a/browser_tests/tests/actionbar.spec.ts
+++ b/browser_tests/tests/actionbar.spec.ts
@@ -4,7 +4,6 @@ import { expect, mergeTests } from '@playwright/test'
 import type { StatusWsMessage } from '../../src/schemas/apiSchema'
 import { comfyPageFixture } from '../fixtures/ComfyPage'
 import { webSocketFixture } from '../fixtures/ws'
-import type { WorkspaceStore } from '../types/globals'
 
 const test = mergeTests(comfyPageFixture, webSocketFixture)
 
@@ -55,9 +54,7 @@ test.describe('Actionbar', { tag: '@ui' }, () => {
         )
         node!.widgets![0].value = value
 
-        ;(
-          window.app!.extensionManager as WorkspaceStore
-        ).workflow.activeWorkflow?.changeTracker.checkState()
+        wss().workflow.activeWorkflow?.changeTracker.checkState()
       }, value)
     }
 

--- a/browser_tests/tests/browserTabTitle.spec.ts
+++ b/browser_tests/tests/browserTabTitle.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-import type { WorkspaceStore } from '../types/globals'
 
 test.describe('Browser tab title', { tag: '@smoke' }, () => {
   test.describe('Beta Menu', () => {
@@ -11,8 +10,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
 
     test('Can display workflow name', async ({ comfyPage }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
-        return (window.app!.extensionManager as WorkspaceStore).workflow
-          .activeWorkflow?.filename
+        return wss().workflow.activeWorkflow?.filename
       })
       expect(await comfyPage.page.title()).toBe(`*${workflowName} - ComfyUI`)
     })
@@ -23,8 +21,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
       comfyPage
     }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
-        return (window.app!.extensionManager as WorkspaceStore).workflow
-          .activeWorkflow?.filename
+        return wss().workflow.activeWorkflow?.filename
       })
       expect(await comfyPage.page.title()).toBe(`${workflowName} - ComfyUI`)
 
@@ -38,9 +35,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
 
       // Delete the saved workflow for cleanup.
       await comfyPage.page.evaluate(async () => {
-        return (
-          window.app!.extensionManager as WorkspaceStore
-        ).workflow.activeWorkflow?.delete()
+        return wss().workflow.activeWorkflow?.delete()
       })
     })
   })

--- a/browser_tests/tests/colorPalette.spec.ts
+++ b/browser_tests/tests/colorPalette.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-import type { WorkspaceStore } from '../types/globals'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
@@ -179,9 +178,7 @@ test.describe('Color Palette', { tag: ['@screenshot', '@settings'] }, () => {
 
   test('Can add custom color palette', async ({ comfyPage }) => {
     await comfyPage.page.evaluate(async (p) => {
-      await (
-        window.app!.extensionManager as WorkspaceStore
-      ).colorPalette.addCustomColorPalette(p)
+      await wss().colorPalette.addCustomColorPalette(p)
     }, customColorPalettes.obsidian_dark)
     expect(await comfyPage.toast.getToastErrorCount()).toBe(0)
 

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -65,11 +65,19 @@ data as unknown as SomeType // Avoid; prefer explicit typings or helpers
 When tests need internal store properties (e.g., `.workflow`, `.focusMode`):
 
 ```typescript
-// ✅ Access stores directly in page.evaluate
+// ✅ Use the wss() helper to access workspace store with full typing
 await page.evaluate(() => {
-  const store = useWorkflowStore()
-  return store.activeWorkflow
+  return wss().workflow.activeWorkflow?.filename
 })
+
+// ✅ wss() provides typed access to:
+// - workflow (activeWorkflow, syncWorkflows, isBusy)
+// - focusMode
+// - queueSettings
+// - colorPalette
+
+// ❌ Don't use `as WorkspaceStore` casts
+;(window.app!.extensionManager as WorkspaceStore).workflow // Bad
 
 // ❌ Don't change public API types to expose internals
 // Keep app.extensionManager typed as ExtensionManager, not WorkspaceStore


### PR DESCRIPTION
Fixes #8585

## Summary

Introduces a `wss()` global helper function that provides typed access to workspace store properties, eliminating all 16 `as WorkspaceStore` type casts across browser tests.

## Changes

- Added `wss()` helper in `browser_tests/fixtures/utils/workspaceStore.ts` that returns typed workspace store with common properties (`sidebarTabs`, `activeSidebarTab`, `workflow`, `focusedElement`)
- Updated all 16 files using `as WorkspaceStore` casts to use the new `wss()` helper
- Extended `window.globalTestRunnerState` type definition to include `workspaceStore`

## Testing

- All existing browser tests continue to work as before
- Type safety is preserved through the helper function's return type

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8626-fix-browser_tests-eliminate-WorkspaceStore-type-casts-2fe6d73d365081cf8876fce08eec2524) by [Unito](https://www.unito.io)
