### PR TITLE
fix: use distribution flags for desktop detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "collect-i18n": "pnpm exec playwright test --config=playwright.i18n.config.ts",
     "dev:cloud": "cross-env DEV_SERVER_COMFYUI_URL='https://testcloud.comfy.org/' nx serve",
     "dev:desktop": "nx dev @comfyorg/desktop-ui",
-    "dev:electron": "nx serve --config vite.electron.config.mts",
+    "dev:electron": "cross-env DISTRIBUTION=desktop nx serve --config vite.electron.config.mts",
     "dev:no-vue": "cross-env DISABLE_VUE_PLUGINS=true nx serve",
     "dev": "nx serve",
     "devtools:pycheck": "python3 -m compileall -q tools/devtools",

--- a/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
+++ b/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
@@ -285,7 +285,6 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { t } from '@/i18n'
 import {
   TIER_PRICING,
   TIER_TO_KEY
@@ -315,6 +314,7 @@ const emit = defineEmits<{
   subscribe: [payload: { tierKey: CheckoutTierKey; billingCycle: BillingCycle }]
   resubscribe: []
 }>()
+const { t, n } = useI18n()
 
 interface BillingCycleOption {
   label: string
@@ -369,8 +369,6 @@ const tiers: PricingTierConfig[] = [
     isPopular: false
   }
 ]
-
-const { n } = useI18n()
 const {
   plans: apiPlans,
   currentPlanSlug,

--- a/src/platform/distribution/types.ts
+++ b/src/platform/distribution/types.ts
@@ -1,5 +1,3 @@
-import { isElectron } from '@/utils/envUtil'
-
 /**
  * Distribution types and compile-time constants for managing
  * multi-distribution builds (Desktop, Localhost, Cloud)
@@ -16,7 +14,7 @@ declare global {
 const DISTRIBUTION: Distribution = __DISTRIBUTION__
 
 /** Distribution type checks */
-export const isDesktop = DISTRIBUTION === 'desktop' || isElectron() // TODO: replace with build var
+export const isDesktop = DISTRIBUTION === 'desktop'
 export const isCloud = DISTRIBUTION === 'cloud'
 // export const isLocalhost = DISTRIBUTION === 'localhost' || (!isDesktop && !isCloud)
 


### PR DESCRIPTION
## Summary

Use distribution flags as the sole source of desktop detection so environment checks are deterministic across builds and local dev.

## Changes

- **What**: Remove runtime Electron fallback from `isDesktop` and rely only on the desktop distribution flag (`DISTRIBUTION`).
- **What**: Update `dev:electron` to set `DISTRIBUTION=desktop` so local Electron dev preserves desktop behavior.

## Review Focus

- Confirm desktop-only paths still behave correctly in Electron dev and production builds.
- Confirm no code path still depends on `isElectron()` for desktop detection.

## Screenshots (if applicable)

N/A (no UI changes)