### PR TITLE
ci: filter snapshot update job to only run @screenshot tagged tests

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -109,7 +109,7 @@ jobs:
       # Run sharded tests with snapshot updates (browsers pre-installed in container)
       - name: Update snapshots (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         id: playwright-tests
-        run: pnpm exec playwright test --update-snapshots --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: pnpm exec playwright test --update-snapshots --grep @screenshot --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         continue-on-error: true
 
       - name: Stage changed snapshot files


### PR DESCRIPTION
## Summary
- Adds `--grep @screenshot` to the Playwright command in the update-snapshots CI workflow
- Skips ~146 non-screenshot tests that don't produce any snapshot files, reducing CI time and resource usage

## Details
All tests that call `toHaveScreenshot` are already tagged with `@screenshot` (either at the `test.describe` or individual `test` level). The snapshot update job was previously running every test unnecessarily.

The `--grep` CLI flag is ANDed with each project's existing `grep`/`grepInvert` settings, so all projects continue to work correctly:
- `chromium`: `@screenshot` AND NOT `@mobile`
- `chromium-2x`: `@screenshot` AND `@2x`
- `mobile-chrome`: `@screenshot` AND `@mobile`

## Test plan
- [x] Trigger the update-snapshots workflow on a PR with the "New Browser Test Expectations" label and verify only screenshot-tagged tests run
- [x] Verify snapshot files are still correctly updated