### PR TITLE
fix: compact bundle size report to single-line header

### DIFF
--- a/scripts/size-report.js
+++ b/scripts/size-report.js
@@ -175,15 +175,9 @@ async function buildBundleReport() {
  * @returns {string}
  */
 function renderReport(report) {
-  const parts = ['## Bundle Size Report\n']
-
-  parts.push(renderSummary(report))
+  const parts = [renderCompactHeader(report)]
 
   if (report.categories.length > 0) {
-    const glance = renderCategoryGlance(report)
-    if (glance) {
-      parts.push('\n' + glance)
-    }
     parts.push('\n' + renderCategoryDetails(report))
   }
 
@@ -193,6 +187,24 @@ function renderReport(report) {
       .replace(/\n{3,}/g, '\n\n')
       .trimEnd() + '\n'
   )
+}
+
+/**
+ * Render compact single-line header with key metrics
+ * @param {BundleReport} report
+ * @returns {string}
+ */
+function renderCompactHeader(report) {
+  const { overall, hasBaseline } = report
+
+  const gzipSize = prettyBytes(overall.metrics.current.gzip)
+  let header = `## 📦 Bundle: ${gzipSize} gzip`
+
+  if (hasBaseline) {
+    header += ` ${formatDiffIndicator(overall.metrics.diff.gzip)}`
+  }
+
+  return header
 }
 
 /**
@@ -310,7 +322,16 @@ function renderCategoryGlance(report) {
  * @returns {string}
  */
 function renderCategoryDetails(report) {
-  const lines = ['<details>', '<summary>Per-category breakdown</summary>', '']
+  const lines = ['<details>', '<summary>Details</summary>', '']
+
+  lines.push(renderSummary(report))
+  lines.push('')
+
+  const glance = renderCategoryGlance(report)
+  if (glance) {
+    lines.push(glance)
+    lines.push('')
+  }
 
   for (const category of report.categories) {
     lines.push(renderCategoryBlock(category, report.hasBaseline))


### PR DESCRIPTION
## Summary
Reduces bundle size report noise by:
- Single-line header: `## 📦 Bundle: 1.2 MB gzip :green_circle: -5 kB`
- Moves detailed metrics (raw, gzip, brotli, bundle counts) into collapsible Details section
- Category glance and per-file breakdowns remain available on expand

**Before:** Multi-line summary always visible
**After:** One-line header, details collapsed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8677-fix-compact-bundle-size-report-to-single-line-header-2ff6d73d365081a6a1b1dce4e942bc83) by [Unito](https://www.unito.io)
