### PR TITLE
fix: rename "Manage Extensions" label to "Extensions"

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -897,7 +897,7 @@
     "theme": "Theme",
     "dark": "Dark",
     "light": "Light",
-    "manageExtensions": "Manage Extensions",
+    "manageExtensions": "Extensions",
     "customNodesManager": "Custom Nodes Manager",
     "settings": "Settings",
     "help": "Help",
@@ -1101,7 +1101,7 @@
     "theme": "Theme",
     "dark": "Dark",
     "light": "Light",
-    "manageExtensions": "Manage Extensions",
+    "manageExtensions": "Extensions",
     "settings": "Settings",
     "help": "Help",
     "queue": "Queue Panel"


### PR DESCRIPTION
## Summary

Rename the manager button label from "Manage Extensions" to "Extensions" in both the `menu` and `commands` i18n sections.

## Changes

Updated `manageExtensions` value in `src/locales/en/main.json` (both `menu` and `commands` sections).

- Fixes follow-up from #8644

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8681-fix-rename-Manage-Extensions-label-to-Extensions-2ff6d73d365081c9aef5c94f745299f6) by [Unito](https://www.unito.io)
