### PR TITLE
test: add browser test for node replacement classification

### DIFF
--- a/browser_tests/assets/missing/replaceable_nodes.json
+++ b/browser_tests/assets/missing/replaceable_nodes.json
@@ -33,9 +33,7 @@
         { "name": "image1", "type": "IMAGE", "link": null },
         { "name": "image2", "type": "IMAGE", "link": null }
       ],
-      "outputs": [
-        { "name": "IMAGE", "type": "IMAGE", "links": [1] }
-      ],
+      "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [1] }],
       "properties": { "Node name for S&R": "ImageBatch" }
     },
     {
@@ -46,18 +44,12 @@
       "flags": {},
       "order": 2,
       "mode": 0,
-      "inputs": [
-        { "name": "image", "type": "IMAGE", "link": 1 }
-      ],
-      "outputs": [
-        { "name": "IMAGE", "type": "IMAGE", "links": null }
-      ],
+      "inputs": [{ "name": "image", "type": "IMAGE", "link": 1 }],
+      "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": null }],
       "properties": { "Node name for S&R": "UNKNOWN_NO_REPLACEMENT" }
     }
   ],
-  "links": [
-    [1, 2, 0, 3, 0, "IMAGE"]
-  ],
+  "links": [[1, 2, 0, 3, 0, "IMAGE"]],
   "groups": [],
   "config": {},
   "extra": {

--- a/browser_tests/assets/missing/replaceable_nodes.json
+++ b/browser_tests/assets/missing/replaceable_nodes.json
@@ -1,0 +1,67 @@
+{
+  "last_node_id": 3,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "T2IAdapterLoader",
+      "pos": [100, 100],
+      "size": { "0": 300, "1": 58 },
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONTROL_NET",
+          "type": "CONTROL_NET",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "T2IAdapterLoader" },
+      "widgets_values": ["t2iadapter_model.safetensors"]
+    },
+    {
+      "id": 2,
+      "type": "ImageBatch",
+      "pos": [100, 200],
+      "size": { "0": 210, "1": 46 },
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        { "name": "image1", "type": "IMAGE", "link": null },
+        { "name": "image2", "type": "IMAGE", "link": null }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [1] }
+      ],
+      "properties": { "Node name for S&R": "ImageBatch" }
+    },
+    {
+      "id": 3,
+      "type": "UNKNOWN_NO_REPLACEMENT",
+      "pos": [100, 300],
+      "size": { "0": 210, "1": 46 },
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        { "name": "image", "type": "IMAGE", "link": 1 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": null }
+      ],
+      "properties": { "Node name for S&R": "UNKNOWN_NO_REPLACEMENT" }
+    }
+  ],
+  "links": [
+    [1, 2, 0, 3, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": { "scale": 1, "offset": [0, 0] }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Adds a browser test that verifies the missing node classification by replacement availability feature.

## Test Coverage

- Loads a workflow with nodes that have registered replacements (`T2IAdapterLoader`, `ImageBatch`) and one without (`UNKNOWN_NO_REPLACEMENT`)
- Verifies console logs show `isReplaceable: true` for replaceable nodes
- Verifies console logs show `isReplaceable: false` for non-replaceable nodes

## Test Fixture

Added `browser_tests/assets/missing/replaceable_nodes.json` with:
- 2 deprecated nodes with replacements
- 1 unknown node without replacement

---

Targets PR #8483