### PR TITLE
fix: resolve 3D nodes missing after page refresh

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -985,9 +985,11 @@ export class ComfyApp {
     await useExtensionService().invokeExtensionsAsync('addCustomNodeDefs', defs)
 
     // Register a node for each definition
-    for (const nodeId in defs) {
-      this.registerNodeDef(nodeId, defs[nodeId])
-    }
+    await Promise.all(
+      Object.keys(defs).map((nodeId) =>
+        this.registerNodeDef(nodeId, defs[nodeId])
+      )
+    )
   }
 
   loadTemplateData(templateData: {


### PR DESCRIPTION
## Summary
Await all registerNodeDef calls in registerNodesFromDefs to prevent race condition where lazy-loaded 3D node types (Load3D, Preview3D, SaveGLB) are not registered in LiteGraph before workflow loading.

Replay lazily loaded extensions' beforeRegisterNodeDef hooks so that input type modifications (e.g. Preview3D → PREVIEW_3D) are applied correctly despite the extensions being registered mid-invocation.

Fixes the issue introduced by code splitting (#8542) where THREE.js lazy import caused node registration to complete after workflow load.

## Screenshots (if applicable)
before
https://github.com/user-attachments/assets/370545dc-4081-4164-83ed-331a092fc690

after
https://github.com/user-attachments/assets/bf9dc887-0076-41fe-93ad-ab0bb984c5ce

