### PR TITLE
fix: exclude transient image URLs from ImageCompare workflow serialization

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageCompareWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageCompareWidget.ts
@@ -15,6 +15,10 @@ export const useImageCompareWidget = (): ComfyWidgetConstructorV2 => {
       ...options
     }) as IImageCompareWidget
 
+    // widget.serialize controls workflow persistence; widget.options.serialize
+    // controls prompt (API) serialization — only disable the former.
+    widget.serialize = false
+
     return widget
   }
 }


### PR DESCRIPTION
## Summary
Image URLs set by onExecuted are execution results that don't exist on other machines. Disable workflow persistence (widget.serialize) while keeping prompt serialization (widget.options.serialize) so compare_view is still sent to the backend.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8715-fix-exclude-transient-image-URLs-from-ImageCompare-workflow-serialization-3006d73d365081b8aa87c7e05cb25f2f) by [Unito](https://www.unito.io)
