### PR TITLE
fix: use useI18n() instead of direct i18n import in PricingTableWorkspace

### DIFF
--- a/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
+++ b/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
@@ -285,7 +285,6 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { t } from '@/i18n'
 import {
   TIER_PRICING,
   TIER_TO_KEY
@@ -332,6 +331,8 @@ interface PricingTierConfig {
   isPopular?: boolean
 }
 
+const { t, n } = useI18n()
+
 const billingCycleOptions: BillingCycleOption[] = [
   { label: t('subscription.yearly'), value: 'yearly' },
   { label: t('subscription.monthly'), value: 'monthly' }
@@ -369,8 +370,6 @@ const tiers: PricingTierConfig[] = [
     isPopular: false
   }
 ]
-
-const { n } = useI18n()
 const {
   plans: apiPlans,
   currentPlanSlug,


### PR DESCRIPTION
## Summary
Replace restricted `import { t } from '@/i18n'` with `const { t, n } = useI18n()` to comply with no-restricted-imports lint rule for Vue components.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8716-fix-use-useI18n-instead-of-direct-i18n-import-in-PricingTableWorkspace-3006d73d3650815db563f345ba86fe54) by [Unito](https://www.unito.io)
