### PR TITLE
fix: terminal tabs fail to register due to useI18n() after await

### DIFF
--- a/src/composables/bottomPanelTabs/useTerminalTabs.ts
+++ b/src/composables/bottomPanelTabs/useTerminalTabs.ts
@@ -1,15 +1,13 @@
 import { markRaw } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import LogsTerminal from '@/components/bottomPanel/tabs/terminal/LogsTerminal.vue'
 import CommandTerminal from '@/components/bottomPanel/tabs/terminal/CommandTerminal.vue'
 import type { BottomPanelExtension } from '@/types/extensionTypes'
 
 export function useLogsTerminalTab(): BottomPanelExtension {
-  const { t } = useI18n()
   return {
     id: 'logs-terminal',
-    title: t('g.logs'),
+    title: 'Logs',
     titleKey: 'g.logs',
     component: markRaw(LogsTerminal),
     type: 'vue'
@@ -17,10 +15,9 @@ export function useLogsTerminalTab(): BottomPanelExtension {
 }
 
 export function useCommandTerminalTab(): BottomPanelExtension {
-  const { t } = useI18n()
   return {
     id: 'command-terminal',
-    title: t('g.terminal'),
+    title: 'Terminal',
     titleKey: 'g.terminal',
     component: markRaw(CommandTerminal),
     type: 'vue'


### PR DESCRIPTION
## Summary
useI18n() requires an active Vue component instance via getCurrentInstance(), which returns null after an await in the setup
context. Since terminal tabs are loaded via dynamic import (await), useI18n() was silently failing, preventing terminal tab registration.

Replace useI18n() calls with static English strings for the title field, which is only used in command labels. The titleKey field already handles reactive i18n in the UI via BottomPanel.vue's getTabDisplayTitle().

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/8624

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/44e0118e-5566-4299-84cf-72b63d85521a


after

https://github.com/user-attachments/assets/3e99fb81-7a81-4065-a889-3ab5a393d8cf

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8717-fix-terminal-tabs-fail-to-register-due-to-useI18n-after-await-3006d73d3650810fb011c08862434bd5) by [Unito](https://www.unito.io)
