### PR TITLE
fix: show credit balance for unsubscribed personal workspaces

### DIFF
--- a/src/components/topbar/CurrentUserPopoverWorkspace.vue
+++ b/src/components/topbar/CurrentUserPopoverWorkspace.vue
@@ -254,9 +254,6 @@ const isLoadingBalance = isLoading
 
 const displayedCredits = computed(() => {
   if (initState.value !== 'ready') return ''
-  // Wait for subscription to load
-  if (subscription.value === null) return ''
-  if (!isActiveSubscription.value) return '0'
 
   // API field is named _micros but contains cents (naming inconsistency)
   const cents =
@@ -343,9 +340,7 @@ const toggleWorkspaceSwitcher = (event: MouseEvent) => {
 }
 
 const refreshBalance = () => {
-  if (isActiveSubscription.value) {
-    void fetchBalance()
-  }
+  void fetchBalance()
 }
 
 defineExpose({ refreshBalance })


### PR DESCRIPTION
## Summary

Credit balance was not displayed in the user popover for personal workspace users without an active subscription. The `displayedCredits` computed returned `"0"` and `refreshBalance` skipped the API call when there was no active subscription, hiding any existing balance.

## Changes

- **What**: Remove subscription-gated guards in `CurrentUserPopoverWorkspace.vue`:
  - `displayedCredits`: no longer returns early `""` / `"0"` when subscription is null or inactive — always reads from the balance API response
  - `refreshBalance`: always fetches balance on popover open regardless of subscription status

## Review Focus

The credits section visibility is already gated by `showCreditsSection` (personal workspace or owner role). This change only affects what value is displayed and whether the balance API is called — it does not change who sees the section.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8719-fix-show-credit-balance-for-unsubscribed-personal-workspaces-3006d73d3650812e9d70e5a8629c5f60) by [Unito](https://www.unito.io)
