### PR TITLE
fix: use useI18n() instead of @/i18n import in PricingTableWorkspace

### DIFF
--- a/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
+++ b/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
@@ -285,7 +285,6 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { t } from '@/i18n'
 import {
   TIER_PRICING,
   TIER_TO_KEY
@@ -332,6 +331,8 @@ interface PricingTierConfig {
   isPopular?: boolean
 }
 
+const { t, n } = useI18n()
+
 const billingCycleOptions: BillingCycleOption[] = [
   { label: t('subscription.yearly'), value: 'yearly' },
   { label: t('subscription.monthly'), value: 'monthly' }
@@ -369,8 +370,6 @@ const tiers: PricingTierConfig[] = [
     isPopular: false
   }
 ]
-
-const { n } = useI18n()
 const {
   plans: apiPlans,
   currentPlanSlug,


### PR DESCRIPTION
## Summary

PricingTableWorkspace.vue was missed in #8704 which migrated all Vue components from `import { t } from '@/i18n'` to `useI18n()` and upgraded the lint rule to `error`. This breaks `pnpm lint` on main.

## Changes

- **What**: Removed `import { t } from '@/i18n'` and destructured `t` from the existing `useI18n()` call. Moved `useI18n()` above static initializers that reference `t`.

## Review Focus

The `billingCycleOptions` and `tiers` arrays call `t()` at module init time — this is fine in `<script setup>` since `useI18n()` is called first in the same synchronous scope.