### PR TITLE
Support keeping value across dynamic combo options

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -95,7 +95,9 @@ function dynamicComboWidget(
     const newSpec = value ? options[value] : undefined
 
     const removedInputs = remove(node.inputs, isInGroup)
-    for (const widget of remove(node.widgets, isInGroup)) widget.onRemove?.()
+
+    const removedWidgets = remove(node.widgets, isInGroup)
+    for (const widget of removedWidgets) widget.onRemove?.()
 
     if (!newSpec) return
 
@@ -173,6 +175,18 @@ function dynamicComboWidget(
           node.inputs[inputIndex]
         )
       }
+    }
+    for (const widget of removedWidgets) {
+      const newMatchingWidget = addedWidgets.find((w) => w.name === widget.name)
+      if (!newMatchingWidget || newMatchingWidget.type !== widget.type) continue
+
+      const nameSegment = widget.name.slice(widget.name.lastIndexOf('.') + 1)
+      const spec =
+        newSpec.required?.[nameSegment] ?? newSpec.optional?.[nameSegment]
+      if (spec?.[1] && 'default' in spec?.[1]) continue
+
+      newMatchingWidget.value = widget.value
+      newMatchingWidget.callback?.(widget.value)
     }
 
     node.size[1] = node.computeSize([...node.size])[1]

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
@@ -24,6 +24,10 @@ function onValueChange(this: INumericWidget, v: number) {
     // Round to nearest step, accounting for offset
     this.value = Math.round((v - offset) / step) * step + offset
   }
+  if (this.options.min !== undefined && this.value < this.options.min)
+    this.value = this.options.min
+  if (this.options.max !== undefined && this.value > this.options.max)
+    this.value = this.options.max
 }
 
 export const _for_testing = {


### PR DESCRIPTION
Dynamic Combos will sometimes have options with a level of overlap, either because they differ in options (min/max) or they're only common on a portion of the Dynamic Combo options. This PR provides a means for these shared widgets to maintain there value across option group selections.

TODO
- Currently, the filtering of when updates should apply isn't the greatest. Ideally, value is kept if the defaults of the old and new spec are equal (including if both are undefined), but the default of a widget is not kept after initialization and there is not currently code in place to resolve the input spec of the removed widget.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8721-Support-keeping-value-across-dynamic-combo-options-3006d73d3650817b8d7ae20f68b11b5b) by [Unito](https://www.unito.io)
