### PR TITLE
fix: align in-app pricing copy with comfy.org/cloud/pricing

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2034,7 +2034,7 @@
       "howManyCredits": "How many credits would you like to add?",
       "usdAmount": "${amount}",
       "videosEstimate": "~{count} videos*",
-      "templateNote": "*Generated with Wan Fun Control template",
+      "templateNote": "*Generated with Wan 2.2 Image-to-Video template",
       "buy": "Buy",
       "purchaseSuccess": "Credits added successfully!",
       "purchaseError": "Purchase Failed",
@@ -2139,7 +2139,7 @@
     "messageSupport": "Message support",
     "invoiceHistory": "Invoice history",
     "benefits": {
-      "benefit1": "$10 in monthly credits for Partner Nodes — top up when needed",
+      "benefit1": "Monthly credits for Partner Nodes — top up when needed",
       "benefit2": "Up to 30 min runtime per job"
     },
     "yearlyDiscount": "20% DISCOUNT",
@@ -2198,7 +2198,7 @@
     "customLoRAsLabel": "Import your own LoRAs",
     "videoEstimateLabel": "Approx. amount of 5s videos generated with Wan 2.2 Image-to-Video template",
     "videoEstimateHelp": "More details on this template",
-    "videoEstimateExplanation": "These estimates are based on the Wan 2.2 Image-to-Video template using default settings (5 seconds, 640x640, 16fps, 4-step sampling).",
+    "videoEstimateExplanation": "These estimates are based on the Wan 2.2 Image-to-Video template using default settings (5 sec, 16fps, 640x640, 4-step sampling).",
     "videoEstimateTryTemplate": "Try this template",
     "videoTemplateBasedCredits": "Videos generated with Wan 2.2 Image to Video",
     "upgradePlan": "Upgrade Plan",

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -226,7 +226,7 @@
           {{ t('subscription.videoEstimateExplanation') }}
         </p>
         <a
-          href="https://cloud.comfy.org/?template=video_wan2_2_14B_fun_camera"
+          href="https://cloud.comfy.org/?template=video_wan2_2_14B_i2v"
           target="_blank"
           rel="noopener noreferrer"
           class="text-sm text-azure-600 hover:text-azure-400 no-underline flex gap-1"

--- a/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
+++ b/src/platform/cloud/subscription/components/PricingTableWorkspace.vue
@@ -235,7 +235,7 @@
           {{ t('subscription.videoEstimateExplanation') }}
         </p>
         <a
-          href="https://cloud.comfy.org/?template=video_wan2_2_14B_fun_camera"
+          href="https://cloud.comfy.org/?template=video_wan2_2_14B_i2v"
           target="_blank"
           rel="noopener noreferrer"
           class="text-sm text-azure-600 hover:text-azure-400 no-underline flex gap-1"

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -19,9 +19,9 @@ export interface TierPricing {
 }
 
 export const TIER_PRICING: Record<Exclude<TierKey, 'founder'>, TierPricing> = {
-  standard: { monthly: 20, yearly: 16, credits: 4200, videoEstimate: 120 },
-  creator: { monthly: 35, yearly: 28, credits: 7400, videoEstimate: 211 },
-  pro: { monthly: 100, yearly: 80, credits: 21100, videoEstimate: 600 }
+  standard: { monthly: 20, yearly: 16, credits: 4200, videoEstimate: 213 },
+  creator: { monthly: 35, yearly: 28, credits: 7400, videoEstimate: 374 },
+  pro: { monthly: 100, yearly: 80, credits: 21100, videoEstimate: 1067 }
 }
 
 interface TierFeatures {

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -19,9 +19,9 @@ export interface TierPricing {
 }
 
 export const TIER_PRICING: Record<Exclude<TierKey, 'founder'>, TierPricing> = {
-  standard: { monthly: 20, yearly: 16, credits: 4200, videoEstimate: 213 },
-  creator: { monthly: 35, yearly: 28, credits: 7400, videoEstimate: 374 },
-  pro: { monthly: 100, yearly: 80, credits: 21100, videoEstimate: 1067 }
+  standard: { monthly: 20, yearly: 16, credits: 4200, videoEstimate: 380 },
+  creator: { monthly: 35, yearly: 28, credits: 7400, videoEstimate: 670 },
+  pro: { monthly: 100, yearly: 80, credits: 21100, videoEstimate: 1915 }
 }
 
 interface TierFeatures {


### PR DESCRIPTION
## Summary

Align stale in-app pricing strings and links with the current comfy.org/cloud/pricing page.

## Changes

- **What**: Update video estimate numbers (standard 120→380, creator 211→670, pro 600→1915), fix template URL (`video_wan2_2_14B_fun_camera` → `video_wan2_2_14B_i2v`), fix `templateNote` to reference Wan 2.2 Image-to-Video, align `videoEstimateExplanation` wording order with website, remove stale "$10" from `benefit1` string.

## Review Focus

Copy-only changes across 4 files — no logic or UI changes. Source of truth: https://www.comfy.org/cloud/pricing

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8725-fix-align-in-app-pricing-copy-with-comfy-org-cloud-pricing-3006d73d3650811faf11c248e6bf27c3) by [Unito](https://www.unito.io)
