### PR TITLE
fix: keep begin_checkout user_id reactive in subscription flows

### DIFF
--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -207,7 +207,7 @@ describe('PricingTable', () => {
     it('should use the latest userId value when it changes after mount', async () => {
       mockIsActiveSubscription.value = true
       mockSubscriptionTier.value = 'STANDARD'
-      mockUserId.value = undefined
+      mockUserId.value = 'user-early'
 
       const wrapper = createWrapper()
       await flushPromises()
@@ -221,6 +221,7 @@ describe('PricingTable', () => {
       await creatorButton?.trigger('click')
       await flushPromises()
 
+      expect(mockTrackBeginCheckout).toHaveBeenCalledTimes(1)
       expect(mockTrackBeginCheckout).toHaveBeenCalledWith({
         user_id: 'user-late',
         tier: 'creator',

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -243,6 +243,7 @@
 
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
+import { storeToRefs } from 'pinia'
 import Popover from 'primevue/popover'
 import SelectButton from 'primevue/selectbutton'
 import type { ToggleButtonPassThroughMethodOptions } from 'primevue/togglebutton'
@@ -333,7 +334,7 @@ const tiers: PricingTierConfig[] = [
 const { isActiveSubscription, subscriptionTier, isYearlySubscription } =
   useSubscription()
 const telemetry = useTelemetry()
-const { userId } = useFirebaseAuthStore()
+const { userId } = storeToRefs(useFirebaseAuthStore())
 const { accessBillingPortal, reportError } = useFirebaseAuthActions()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
 
@@ -415,9 +416,9 @@ const handleSubscribe = wrapWithErrorHandlingAsync(
     try {
       if (isActiveSubscription.value) {
         const checkoutAttribution = getCheckoutAttribution()
-        if (userId) {
+        if (userId.value) {
           telemetry?.trackBeginCheckout({
-            user_id: userId,
+            user_id: userId.value,
             tier: tierKey,
             cycle: currentBillingCycle.value,
             checkout_type: 'change',

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -121,7 +121,7 @@ describe('performSubscriptionCheckout', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     const authHeader = createDeferred<{ Authorization: string }>()
 
-    mockUserId.value = undefined
+    mockUserId.value = 'user-early'
     mockGetAuthHeader.mockImplementationOnce(() => authHeader.promise)
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -135,6 +135,7 @@ describe('performSubscriptionCheckout', () => {
 
     await checkoutPromise
 
+    expect(mockTelemetry.trackBeginCheckout).toHaveBeenCalledTimes(1)
     expect(mockTelemetry.trackBeginCheckout).toHaveBeenCalledWith(
       expect.objectContaining({
         user_id: 'user-late',

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
@@ -1,3 +1,5 @@
+import { storeToRefs } from 'pinia'
+
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
@@ -37,9 +39,10 @@ export async function performSubscriptionCheckout(
 ): Promise<void> {
   if (!isCloud) return
 
-  const { getFirebaseAuthHeader, userId } = useFirebaseAuthStore()
+  const firebaseAuthStore = useFirebaseAuthStore()
+  const { userId } = storeToRefs(firebaseAuthStore)
   const telemetry = useTelemetry()
-  const authHeader = await getFirebaseAuthHeader()
+  const authHeader = await firebaseAuthStore.getFirebaseAuthHeader()
 
   if (!authHeader) {
     throw new FirebaseAuthStoreError(t('toastMessages.userNotAuthenticated'))
@@ -84,9 +87,9 @@ export async function performSubscriptionCheckout(
   const data = await response.json()
 
   if (data.checkout_url) {
-    if (userId) {
+    if (userId.value) {
       telemetry?.trackBeginCheckout({
-        user_id: userId,
+        user_id: userId.value,
         tier: tierKey,
         cycle: currentBillingCycle,
         checkout_type: 'new',


### PR DESCRIPTION
## Summary

Use reactive `userId` reads for `begin_checkout` telemetry so delayed auth state updates are reflected at event time instead of using a stale snapshot.

## Changes

- **What**: switched subscription checkout telemetry paths to `storeToRefs(useFirebaseAuthStore())` and read `userId.value` when dispatching `trackBeginCheckout`.
- **What**: added regression tests that mutate `userId` after setup / after checkout starts and assert telemetry uses the updated ID.

## Review Focus

- Verify `PricingTable` and `performSubscriptionCheckout` still emit exactly one `begin_checkout` event per action, with `checkout_type: change` and `checkout_type: new` in their respective paths.
- Verify the new tests would fail with stale store destructuring (manually validated during development).

## Screenshots (if applicable)

N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8726-fix-keep-begin_checkout-user_id-reactive-in-subscription-flows-3006d73d365081888c84c0335ab52e09) by [Unito](https://www.unito.io)
