### PR TITLE
fix: show completion summary banner when QPOV2 is enabled

### DIFF
--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -161,7 +161,7 @@ describe('TopMenuSection', () => {
     expect(queueButton.text()).toContain('3 active')
   })
 
-  it('hides queue progress overlay when QPO V2 is enabled', async () => {
+  it('renders queue progress overlay when QPO V2 is enabled with no active jobs', async () => {
     const pinia = createTestingPinia({ createSpy: vi.fn })
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
@@ -176,7 +176,52 @@ describe('TopMenuSection', () => {
     )
     expect(
       wrapper.findComponent({ name: 'QueueProgressOverlay' }).exists()
-    ).toBe(false)
+    ).toBe(true)
+  })
+
+  it('renders queue progress overlay when QPO V2 is enabled and jobs are active', async () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const settingStore = useSettingStore(pinia)
+    vi.mocked(settingStore.get).mockImplementation((key) =>
+      key === 'Comfy.Queue.QPOV2' ? true : undefined
+    )
+    const wrapper = createWrapper({ pinia })
+    const queueStore = useQueueStore(pinia)
+    queueStore.pendingTasks = [createTask('pending-1', 'pending')]
+
+    await nextTick()
+
+    expect(
+      wrapper.findComponent({ name: 'QueueProgressOverlay' }).exists()
+    ).toBe(true)
+  })
+
+  it('passes completion summary only mode to queue progress overlay when QPO V2 is enabled', async () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const settingStore = useSettingStore(pinia)
+    vi.mocked(settingStore.get).mockImplementation((key) =>
+      key === 'Comfy.Queue.QPOV2' ? true : undefined
+    )
+
+    const wrapper = createWrapper({
+      pinia,
+      stubs: {
+        QueueProgressOverlay: {
+          name: 'QueueProgressOverlay',
+          props: ['completionSummaryOnly'],
+          template:
+            '<div data-testid="queue-progress-overlay-prop" :data-completion-summary-only="completionSummaryOnly ? \'true\' : \'false\'" />'
+        }
+      }
+    })
+
+    await nextTick()
+
+    expect(
+      wrapper
+        .get('[data-testid="queue-progress-overlay-prop"]')
+        .attributes('data-completion-summary-only')
+    ).toBe('true')
   })
 
   it('toggles the queue progress overlay when QPO V2 is disabled', async () => {

--- a/src/components/TopMenuSection.vue
+++ b/src/components/TopMenuSection.vue
@@ -54,9 +54,7 @@
               :aria-pressed="
                 isQueuePanelV2Enabled
                   ? activeSidebarTabId === 'assets'
-                  : isQueueProgressOverlayEnabled
-                    ? isQueueOverlayExpanded
-                    : undefined
+                  : isQueueOverlayExpanded
               "
               class="px-3"
               data-testid="queue-overlay-toggle"
@@ -96,9 +94,9 @@
           </div>
         </div>
         <QueueProgressOverlay
-          v-if="isQueueProgressOverlayEnabled"
           v-model:expanded="isQueueOverlayExpanded"
           :menu-hovered="isTopMenuHovered"
+          :completion-summary-only="isQueuePanelV2Enabled"
         />
       </div>
     </div>
@@ -199,9 +197,6 @@ const isIntegratedTabBar = computed(
 )
 const isQueuePanelV2Enabled = computed(() =>
   settingStore.get('Comfy.Queue.QPOV2')
-)
-const isQueueProgressOverlayEnabled = computed(
-  () => !isQueuePanelV2Enabled.value
 )
 const shouldShowInlineProgressSummary = computed(
   () => isQueuePanelV2Enabled.value && isActionbarEnabled.value

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -90,9 +90,11 @@ const props = withDefaults(
   defineProps<{
     expanded?: boolean
     menuHovered?: boolean
+    completionSummaryOnly?: boolean
   }>(),
   {
-    menuHovered: false
+    menuHovered: false,
+    completionSummaryOnly: false
   }
 )
 
@@ -140,6 +142,10 @@ const hasActiveJob = computed(() => runningCount.value > 0 || isExecuting.value)
 const activeJobsCount = computed(() => runningCount.value + queuedCount.value)
 
 const overlayState = computed<OverlayState>(() => {
+  if (props.completionSummaryOnly) {
+    if (hasCompletionSummary.value) return 'empty'
+    return 'hidden'
+  }
   if (isExpanded.value) return 'expanded'
   if (hasActiveJob.value) return 'active'
   if (hasCompletionSummary.value) return 'empty'
@@ -231,6 +237,10 @@ const setExpanded = (expanded: boolean) => {
 }
 
 const openExpandedFromEmpty = () => {
+  if (props.completionSummaryOnly) {
+    openAssetsSidebar()
+    return
+  }
   setExpanded(true)
 }
 


### PR DESCRIPTION
## Summary

Restore the queue completion summary banner behavior when QPOV2 is enabled, while keeping QPOV2 scoped to completion-summary UI rather than active-job overlay UI.

## Changes

- **What**: Added a `completionSummaryOnly` mode to `QueueProgressOverlay` and wired `TopMenuSection` to use it under QPOV2. Simplified top-menu queue overlay rendering/pressed-state logic by removing tautological legacy guards. Updated `TopMenuSection` tests to cover QPOV2 overlay rendering and prop wiring.

## Review Focus

Confirm that with QPOV2 enabled, only completion summary banner behavior is surfaced (no active job overlay state), and that legacy overlay behavior remains unchanged when QPOV2 is disabled.

## Screenshots (if applicable)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8732-fix-show-completion-summary-banner-when-QPOV2-is-enabled-3016d73d3650819c8ce6f36010b0208c) by [Unito](https://www.unito.io)
