### PR TITLE
fix: update queue tooltip copy to include right-click hint

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -812,7 +812,7 @@
       "activeJobsSuffix": "active jobs",
       "jobQueue": "Job Queue",
       "expandCollapsedQueue": "Expand job queue",
-      "viewJobHistory": "View job history",
+      "viewJobHistory": "View active jobs (right-click to clear queue)",
       "noActiveJobs": "No active jobs",
       "stubClipTextEncode": "CLIP Text Encode:",
       "jobsCompleted": "{count} job completed | {count} jobs completed",


### PR DESCRIPTION
### Motivation
- Update the run-menu queue tooltip to include the right-click-to-clear-queue hint so the UI copy matches the requested product wording.

### Description
- Replaced `sideToolbar.queueProgressOverlay.viewJobHistory` value in `src/locales/en/main.json` with `View active jobs (right-click to clear queue)`.

### Testing
- Ran `pnpm lint` and `pnpm typecheck`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ee702bdc8330ad0d58f0b014c262)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8733-fix-update-queue-tooltip-copy-to-include-right-click-hint-3016d73d365081c09fa7f582ee51c6c2) by [Unito](https://www.unito.io)
