### PR TITLE
fix: enable QPOV2 job right-click context menus

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarGridView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.test.ts
@@ -1,0 +1,100 @@
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { JobListItem } from '@/composables/queue/useJobList'
+
+const { jobItems, settingGetMock } = vi.hoisted(() => ({
+  jobItems: [] as JobListItem[],
+  settingGetMock: vi.fn()
+}))
+
+vi.mock('@/composables/queue/useJobList', () => ({
+  useJobList: () => ({
+    jobItems: {
+      get value() {
+        return jobItems
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: settingGetMock
+  })
+}))
+
+vi.mock('@/platform/assets/components/MediaAssetCard.vue', () => ({
+  default: {
+    name: 'MediaAssetCard',
+    template: '<div class="media-asset-card-stub" />'
+  }
+}))
+
+vi.mock('@/platform/assets/components/ActiveMediaAssetCard.vue', () => ({
+  default: {
+    name: 'ActiveMediaAssetCard',
+    emits: ['context-menu'],
+    template:
+      '<div class="active-media-asset-card-stub" @contextmenu="$emit(\'context-menu\', $event)" />'
+  }
+}))
+
+import AssetsSidebarGridView from '@/components/sidebar/tabs/AssetsSidebarGridView.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
+const VirtualGridStub = {
+  name: 'VirtualGrid',
+  props: {
+    items: { type: Array, required: true }
+  },
+  template:
+    '<div><div v-for="item in items" :key="item.key"><slot name="item" :item="item" /></div></div>'
+}
+
+const createJobItem = (overrides: Partial<JobListItem> = {}): JobListItem => ({
+  id: 'job-1',
+  title: 'Active job',
+  meta: 'In progress',
+  state: 'running',
+  ...overrides
+})
+
+describe('AssetsSidebarGridView', () => {
+  beforeEach(() => {
+    jobItems.splice(0, jobItems.length)
+    settingGetMock.mockReset()
+    settingGetMock.mockReturnValue(true)
+  })
+
+  it('emits job context menu for active job cards in QPOV2', async () => {
+    const activeJob = createJobItem()
+    jobItems.push(activeJob)
+
+    const wrapper = mount(AssetsSidebarGridView, {
+      props: {
+        assets: [],
+        isSelected: () => false,
+        showOutputCount: () => false,
+        getOutputCount: () => 0
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          VirtualGrid: VirtualGridStub
+        }
+      }
+    })
+
+    await wrapper.get('.active-media-asset-card-stub').trigger('contextmenu')
+
+    expect(wrapper.emitted('job-context-menu')).toHaveLength(1)
+    expect(wrapper.emitted('job-context-menu')?.[0]?.[1]).toEqual(activeJob)
+  })
+})

--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -10,6 +10,7 @@
         v-for="job in activeJobItems"
         :key="job.id"
         :job="job"
+        @context-menu="emit('job-context-menu', $event, job)"
       />
     </div>
 
@@ -60,6 +61,7 @@ import { useI18n } from 'vue-i18n'
 
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import ActiveMediaAssetCard from '@/platform/assets/components/ActiveMediaAssetCard.vue'
+import type { JobListItem } from '@/composables/queue/useJobList'
 import { useJobList } from '@/composables/queue/useJobList'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
@@ -84,6 +86,7 @@ const {
 const emit = defineEmits<{
   (e: 'select-asset', asset: AssetItem): void
   (e: 'context-menu', event: MouseEvent, asset: AssetItem): void
+  (e: 'job-context-menu', event: MouseEvent, job: JobListItem): void
   (e: 'approach-end'): void
   (e: 'zoom', asset: AssetItem): void
   (e: 'output-count-click', asset: AssetItem): void

--- a/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
@@ -1,0 +1,113 @@
+import { mount } from '@vue/test-utils'
+import { computed } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { JobListItem } from '@/composables/queue/useJobList'
+
+const { jobItems, settingGetMock } = vi.hoisted(() => ({
+  jobItems: [] as JobListItem[],
+  settingGetMock: vi.fn()
+}))
+
+vi.mock('@/composables/queue/useJobList', () => ({
+  useJobList: () => ({
+    jobItems: {
+      get value() {
+        return jobItems
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: settingGetMock
+  })
+}))
+
+vi.mock('@/stores/assetsStore', () => ({
+  useAssetsStore: () => ({
+    isAssetDeleting: () => false
+  })
+}))
+
+vi.mock('@/composables/queue/useJobActions', () => ({
+  useJobActions: () => ({
+    cancelAction: {
+      icon: 'icon-[lucide--x]',
+      label: 'Cancel',
+      variant: 'destructive'
+    },
+    canCancelJob: computed(() => true),
+    runCancelJob: vi.fn()
+  })
+}))
+
+import AssetsSidebarListView from '@/components/sidebar/tabs/AssetsSidebarListView.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
+const VirtualGridStub = {
+  name: 'VirtualGrid',
+  props: {
+    items: { type: Array, required: true }
+  },
+  template:
+    '<div><div v-for="item in items" :key="item.key"><slot name="item" :item="item" /></div></div>'
+}
+
+const AssetsListItemStub = {
+  name: 'AssetsListItem',
+  emits: ['contextmenu'],
+  template:
+    '<div class="assets-list-item-stub" @contextmenu="$emit(\'contextmenu\', $event)"><slot name="actions" /></div>'
+}
+
+const createJobItem = (overrides: Partial<JobListItem> = {}): JobListItem => ({
+  id: 'job-1',
+  title: 'Active job',
+  meta: 'In progress',
+  state: 'running',
+  ...overrides
+})
+
+describe('AssetsSidebarListView', () => {
+  beforeEach(() => {
+    jobItems.splice(0, jobItems.length)
+    settingGetMock.mockReset()
+    settingGetMock.mockReturnValue(true)
+  })
+
+  it('emits job context menu for active jobs in QPOV2 list mode', async () => {
+    const activeJob = createJobItem()
+    jobItems.push(activeJob)
+
+    const wrapper = mount(AssetsSidebarListView, {
+      props: {
+        assets: [],
+        isSelected: () => false
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          VirtualGrid: VirtualGridStub,
+          AssetsListItem: AssetsListItemStub,
+          Button: true,
+          LoadingOverlay: true
+        }
+      }
+    })
+
+    wrapper
+      .findComponent(AssetsListItemStub)
+      .vm.$emit('contextmenu', new MouseEvent('contextmenu'))
+
+    expect(wrapper.emitted('job-context-menu')).toHaveLength(1)
+    expect(wrapper.emitted('job-context-menu')?.[0]?.[1]).toEqual(activeJob)
+  })
+})

--- a/src/components/sidebar/tabs/AssetsSidebarListView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.vue
@@ -23,6 +23,7 @@
         :progress-current-percent="job.progressCurrentPercent"
         @mouseenter="onJobEnter(job.id)"
         @mouseleave="onJobLeave(job.id)"
+        @contextmenu.prevent.stop="emit('job-context-menu', $event, job)"
         @click.stop
       >
         <template v-if="hoveredJobId === job.id" #actions>
@@ -150,6 +151,7 @@ const assetsStore = useAssetsStore()
 const emit = defineEmits<{
   (e: 'select-asset', asset: AssetItem): void
   (e: 'context-menu', event: MouseEvent, asset: AssetItem): void
+  (e: 'job-context-menu', event: MouseEvent, job: JobListItem): void
   (e: 'approach-end'): void
 }>()
 

--- a/src/platform/assets/components/ActiveMediaAssetCard.vue
+++ b/src/platform/assets/components/ActiveMediaAssetCard.vue
@@ -4,6 +4,7 @@
     tabindex="0"
     :aria-label="t('sideToolbar.activeJobStatus', { status: statusText })"
     class="flex flex-col gap-2 p-2 rounded-lg"
+    @contextmenu.stop.prevent="emit('context-menu', $event)"
     @mouseenter="hovered = true"
     @mouseleave="hovered = false"
     @focusin="hovered = true"
@@ -86,6 +87,9 @@ import type { JobListItem } from '@/composables/queue/useJobList'
 import { useProgressBarBackground } from '@/composables/useProgressBarBackground'
 
 const { job } = defineProps<{ job: JobListItem }>()
+const emit = defineEmits<{
+  (e: 'context-menu', event: MouseEvent): void
+}>()
 
 const { t } = useI18n()
 const hovered = ref(false)


### PR DESCRIPTION
## Summary

Enable right-click context menus for QPOV2 active job items in Assets tab list/grid views, using the same state-aware queue job menu actions as the queue overlay.

## Changes

- **What**: Added `job-context-menu` event wiring for active job rows/cards in QPOV2 list/grid, added a shared `JobContextMenu` host in `AssetsSidebarTab`, and reused `useJobMenu` for menu content/actions.
- **What**: Added targeted unit tests for QPOV2 active job context-menu event propagation in both list and grid views.

## Review Focus

Validate that right-click and "..." parity is preserved for active job actions across pending/running/failed/completed states in the Assets sidebar QPOV2 path.

## Screenshots (if applicable)

N/A (behavioral change)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8741-fix-enable-QPOV2-job-right-click-context-menus-3016d73d36508162a235d0467e406302) by [Unito](https://www.unito.io)
