### PR TITLE
feat: route all billing through cloud server

### DIFF
--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -83,13 +83,11 @@ function useBillingContextInternal(): BillingContext {
   /**
    * Determines which billing type to use:
    * - If team workspaces feature is disabled: always use legacy (/customers)
-   * - If team workspaces feature is enabled:
-   *   - Personal workspace: use legacy (/customers)
-   *   - Team workspace: use workspace (/billing)
+   * - If team workspaces feature is enabled: always use workspace (/billing)
    */
   const type = computed<BillingType>(() => {
     if (!flags.teamWorkspacesEnabled) return 'legacy'
-    return store.isInPersonalWorkspace ? 'legacy' : 'workspace'
+    return 'workspace'
   })
 
   const activeContext = computed(() =>
@@ -121,7 +119,7 @@ function useBillingContextInternal(): BillingContext {
   watch(
     subscription,
     (sub) => {
-      if (!sub || store.isInPersonalWorkspace) return
+      if (!sub) return
 
       store.updateActiveWorkspace({
         isSubscribed: sub.isActive && !sub.isCancelled,

--- a/src/config/comfyApi.ts
+++ b/src/config/comfyApi.ts
@@ -23,11 +23,9 @@ export function getComfyApiBaseUrl(): string {
     return BUILD_TIME_API_BASE_URL
   }
 
-  return configValueOrDefault(
-    remoteConfig.value,
-    'comfy_api_base_url',
-    BUILD_TIME_API_BASE_URL
-  )
+  // In cloud mode, proxy all comfy-api requests through the cloud server
+  // instead of calling api.comfy.org directly
+  return ''
 }
 
 export function getComfyPlatformBaseUrl(): string {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -2,7 +2,6 @@ import { defineAsyncComponent } from 'vue'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const DIALOG_KEY = 'subscription-required'
 
@@ -10,15 +9,13 @@ export const useSubscriptionDialog = () => {
   const { flags } = useFeatureFlags()
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
-  const workspaceStore = useTeamWorkspaceStore()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
   }
 
   function show() {
-    const useWorkspaceVariant =
-      flags.teamWorkspacesEnabled && !workspaceStore.isInPersonalWorkspace
+    const useWorkspaceVariant = flags.teamWorkspacesEnabled
 
     const component = useWorkspaceVariant
       ? defineAsyncComponent(

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -4,11 +4,10 @@ import { ref } from 'vue'
 
 import type { components, operations } from '@/types/comfyRegistryTypes'
 import { isAbortError } from '@/utils/typeGuardUtil'
-
-const API_BASE_URL = 'https://api.comfy.org'
+import { getComfyApiBaseUrl } from '@/config/comfyApi'
 
 const registryApiClient = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: getComfyApiBaseUrl(),
   headers: {
     'Content-Type': 'application/json'
   },

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -340,10 +340,8 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     email: string,
     password: string
   ): Promise<UserCredential> => {
-    const result = await executeAuthAction(
-      (authInstance) =>
-        signInWithEmailAndPassword(authInstance, email, password),
-      { createCustomer: true }
+    const result = await executeAuthAction((authInstance) =>
+      signInWithEmailAndPassword(authInstance, email, password)
     )
 
     if (isCloud) {
@@ -361,10 +359,8 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     email: string,
     password: string
   ): Promise<UserCredential> => {
-    const result = await executeAuthAction(
-      (authInstance) =>
-        createUserWithEmailAndPassword(authInstance, email, password),
-      { createCustomer: true }
+    const result = await executeAuthAction((authInstance) =>
+      createUserWithEmailAndPassword(authInstance, email, password)
     )
 
     if (isCloud) {
@@ -379,9 +375,8 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   }
 
   const loginWithGoogle = async (): Promise<UserCredential> => {
-    const result = await executeAuthAction(
-      (authInstance) => signInWithPopup(authInstance, googleProvider),
-      { createCustomer: true }
+    const result = await executeAuthAction((authInstance) =>
+      signInWithPopup(authInstance, googleProvider)
     )
 
     if (isCloud) {
@@ -398,9 +393,8 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   }
 
   const loginWithGithub = async (): Promise<UserCredential> => {
-    const result = await executeAuthAction(
-      (authInstance) => signInWithPopup(authInstance, githubProvider),
-      { createCustomer: true }
+    const result = await executeAuthAction((authInstance) =>
+      signInWithPopup(authInstance, githubProvider)
     )
 
     if (isCloud) {


### PR DESCRIPTION
## Summary

Route all billing and comfy-api requests through the cloud server instead of calling api.comfy.org directly. Personal workspaces now use the same Metronome-based billing as team workspaces.

## Changes

- **useBillingContext.ts**: Always returns `'workspace'` billing type when teamWorkspacesEnabled (removed personal workspace special case)
- **comfyApi.ts**: `getComfyApiBaseUrl()` returns `''` in cloud mode, proxying all requests through cloud
- **comfyRegistryService.ts**: Uses `getComfyApiBaseUrl()` instead of hardcoded `https://api.comfy.org`
- **firebaseAuthStore.ts**: Removed `{ createCustomer: true }` from all auth actions (no legacy Stripe customers for new signups)
- **useSubscriptionDialog.ts**: Simplified to just `teamWorkspacesEnabled` flag
- **useBillingContext.test.ts**: Updated tests to match new behavior

## Related

- Cloud PR: Comfy-Org/cloud (same branch name)
- Feature-gated behind `teamWorkspacesEnabled` flag

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8743-feat-route-all-billing-through-cloud-server-3016d73d3650815b8098e3ab36be1802) by [Unito](https://www.unito.io)
