### PR TITLE
fix: show user-friendly message for network errors

### DIFF
--- a/src/composables/useErrorHandling.ts
+++ b/src/composables/useErrorHandling.ts
@@ -52,10 +52,17 @@ export interface ErrorRecoveryStrategy<
 export function useErrorHandling() {
   const toast = useToastStore()
   const toastErrorHandler = (error: unknown) => {
+    const isNetworkError =
+      error instanceof TypeError && error.message === 'Failed to fetch'
+    const message = isNetworkError
+      ? t('g.disconnectedFromBackend')
+      : error instanceof Error
+        ? error.message
+        : t('g.unknownError')
     toast.add({
       severity: 'error',
       summary: t('g.error'),
-      detail: error instanceof Error ? error.message : t('g.unknownError')
+      detail: message
     })
     console.error(error)
   }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -95,6 +95,7 @@
     "imageFailedToLoad": "Image failed to load",
     "reconnecting": "Reconnecting",
     "reconnected": "Reconnected",
+    "disconnectedFromBackend": "Disconnected from backend. Check if the server is running.",
     "delete": "Delete",
     "rename": "Rename",
     "save": "Save",


### PR DESCRIPTION
## Summary

Replaces cryptic "Failed to fetch" error messages with user-friendly "Disconnected from backend" messages.

## Changes

- **What**: Detect network fetch errors in the central toast error handler and display a helpful message with suggested action ("Check if the server is running")

## Review Focus

The fix is intentionally minimal—only the central `toastErrorHandler` is modified since all user-facing API errors flow through it.

Fixes COM-1839

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8748-fix-show-user-friendly-message-for-network-errors-3016d73d365081b3869bf19550c9af93) by [Unito](https://www.unito.io)
