### PR TITLE
feat: wire renewal_date from cloud billing status

### DIFF
--- a/src/composables/billing/useWorkspaceBilling.ts
+++ b/src/composables/billing/useWorkspaceBilling.ts
@@ -47,7 +47,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       tier: status.subscription_tier ?? null,
       duration: status.subscription_duration ?? null,
       planSlug: status.plan_slug ?? null,
-      renewalDate: null, // Workspace billing uses cancel_at for end date
+      renewalDate: status.renewal_date ?? null,
       endDate: status.cancel_at ?? null,
       isCancelled: status.subscription_status === 'canceled',
       hasFunds: status.has_funds

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -211,6 +211,7 @@ export interface BillingStatusResponse {
   billing_status?: BillingStatus
   has_funds: boolean
   cancel_at?: string
+  renewal_date?: string
 }
 
 export interface BillingBalanceResponse {


### PR DESCRIPTION
## Summary

Wire `renewal_date` from the cloud `/billing/status` response into the workspace subscription UI so users can see when their subscription renews.

## Problem

The workspace billing adapter hardcoded `renewalDate: null` because the cloud billing status endpoint didn't return a renewal date. The `SubscriptionPanelContentWorkspace` component already has UI for displaying it — it just had no data.

Personal Workspace (existing `cloud-subscription-status`):
<img width="181" height="112" alt="Screenshot 2026-02-08 at 7 54 53 PM" src="https://github.com/user-attachments/assets/a96ba2cd-10d0-442a-ae72-dbc663a9e52b" />

Current missing data from `/billing/status`:
<img width="240" height="124" alt="Screenshot 2026-02-08 at 7 55 38 PM" src="https://github.com/user-attachments/assets/a3f51ce3-6663-43e1-97ed-d012a6a8a5ba" />

## Solution

- Add `renewal_date?: string` to `BillingStatusResponse` interface
- Use `status.renewal_date ?? null` instead of hardcoded `null` in `useWorkspaceBilling`

### Related
- Cloud PR: Comfy-Org/cloud#2370 (adds `renewal_date` to the endpoint)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8754-feat-wire-renewal_date-from-cloud-billing-status-3026d73d365081c7ae51d79ef0633a1d) by [Unito](https://www.unito.io)
