### PR TITLE
feat: deduplicate subgraph node IDs on workflow load (experimental)

### DIFF
--- a/browser_tests/assets/subgraphs/subgraph-nested-duplicate-ids.json
+++ b/browser_tests/assets/subgraphs/subgraph-nested-duplicate-ids.json
@@ -7,14 +7,8 @@
     {
       "id": 5,
       "type": "1e38d8ea-45e1-48a5-aa20-966584201867",
-      "pos": [
-        788,
-        433.5
-      ],
-      "size": [
-        210,
-        108
-      ],
+      "pos": [788, 433.5],
+      "size": [210, 108],
       "flags": {},
       "order": 1,
       "mode": 0,
@@ -32,34 +26,19 @@
         {
           "name": "STRING",
           "type": "STRING",
-          "links": [
-            5
-          ]
+          "links": [5]
         }
       ],
       "properties": {
-        "proxyWidgets": [
-          [
-            "-1",
-            "string_a"
-          ]
-        ]
+        "proxyWidgets": [["-1", "string_a"]]
       },
-      "widgets_values": [
-        ""
-      ]
+      "widgets_values": [""]
     },
     {
       "id": 2,
       "type": "PreviewAny",
-      "pos": [
-        1135,
-        429
-      ],
-      "size": [
-        250,
-        145.5
-      ],
+      "pos": [1135, 429],
+      "size": [250, 145.5],
       "flags": {},
       "order": 2,
       "mode": 0,
@@ -74,23 +53,13 @@
       "properties": {
         "Node name for S&R": "PreviewAny"
       },
-      "widgets_values": [
-        null,
-        null,
-        false
-      ]
+      "widgets_values": [null, null, false]
     },
     {
       "id": 1,
       "type": "PrimitiveStringMultiline",
-      "pos": [
-        456,
-        450
-      ],
-      "size": [
-        225,
-        121.5
-      ],
+      "pos": [456, 450],
+      "size": [225, 121.5],
       "flags": {},
       "order": 0,
       "mode": 0,
@@ -99,36 +68,18 @@
         {
           "name": "STRING",
           "type": "STRING",
-          "links": [
-            4
-          ]
+          "links": [4]
         }
       ],
       "properties": {
         "Node name for S&R": "PrimitiveStringMultiline"
       },
-      "widgets_values": [
-        "Outer\n"
-      ]
+      "widgets_values": ["Outer\n"]
     }
   ],
   "links": [
-    [
-      4,
-      1,
-      0,
-      5,
-      0,
-      "STRING"
-    ],
-    [
-      5,
-      5,
-      0,
-      2,
-      0,
-      "STRING"
-    ]
+    [4, 1, 0, 5, 0, "STRING"],
+    [5, 5, 0, 2, 0, "STRING"]
   ],
   "groups": [],
   "definitions": {
@@ -147,35 +98,20 @@
         "name": "New Subgraph",
         "inputNode": {
           "id": -10,
-          "bounding": [
-            351,
-            432.5,
-            120,
-            60
-          ]
+          "bounding": [351, 432.5, 120, 60]
         },
         "outputNode": {
           "id": -20,
-          "bounding": [
-            1315,
-            432.5,
-            120,
-            60
-          ]
+          "bounding": [1315, 432.5, 120, 60]
         },
         "inputs": [
           {
             "id": "7bf3e1d4-0521-4b5c-92f5-47ca598b7eb4",
             "name": "string_a",
             "type": "STRING",
-            "linkIds": [
-              1
-            ],
+            "linkIds": [1],
             "localized_name": "string_a",
-            "pos": [
-              451,
-              452.5
-            ]
+            "pos": [451, 452.5]
           }
         ],
         "outputs": [
@@ -183,14 +119,9 @@
             "id": "fbe975ba-d7c2-471e-a99a-a1e2c6ab466d",
             "name": "STRING",
             "type": "STRING",
-            "linkIds": [
-              9
-            ],
+            "linkIds": [9],
             "localized_name": "STRING",
-            "pos": [
-              1335,
-              452.5
-            ]
+            "pos": [1335, 452.5]
           }
         ],
         "widgets": [],
@@ -198,14 +129,8 @@
           {
             "id": 3,
             "type": "StringConcatenate",
-            "pos": [
-              815,
-              373
-            ],
-            "size": [
-              347,
-              231
-            ],
+            "pos": [815, 373],
+            "size": [347, 231],
             "flags": {},
             "order": 2,
             "mode": 0,
@@ -234,31 +159,19 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  7
-                ]
+                "links": [7]
               }
             ],
             "properties": {
               "Node name for S&R": "StringConcatenate"
             },
-            "widgets_values": [
-              "",
-              "",
-              ""
-            ]
+            "widgets_values": ["", "", ""]
           },
           {
             "id": 6,
             "type": "9be42452-056b-4c99-9f9f-7381d11c4454",
-            "pos": [
-              955,
-              775
-            ],
-            "size": [
-              210,
-              88
-            ],
+            "pos": [955, 775],
+            "size": [210, 88],
             "flags": {},
             "order": 1,
             "mode": 0,
@@ -278,34 +191,19 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  9
-                ]
+                "links": [9]
               }
             ],
             "properties": {
-              "proxyWidgets": [
-                [
-                  "-1",
-                  "string_a"
-                ]
-              ]
+              "proxyWidgets": [["-1", "string_a"]]
             },
-            "widgets_values": [
-              ""
-            ]
+            "widgets_values": [""]
           },
           {
             "id": 4,
             "type": "PrimitiveStringMultiline",
-            "pos": [
-              313,
-              685
-            ],
-            "size": [
-              325,
-              109
-            ],
+            "pos": [313, 685],
+            "size": [325, 109],
             "flags": {},
             "order": 0,
             "mode": 0,
@@ -315,17 +213,13 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  2
-                ]
+                "links": [2]
               }
             ],
             "properties": {
               "Node name for S&R": "PrimitiveStringMultiline"
             },
-            "widgets_values": [
-              "Inner 1\n"
-            ]
+            "widgets_values": ["Inner 1\n"]
           }
         ],
         "groups": [],
@@ -387,35 +281,20 @@
         "name": "New Subgraph",
         "inputNode": {
           "id": -10,
-          "bounding": [
-            680,
-            774,
-            120,
-            60
-          ]
+          "bounding": [680, 774, 120, 60]
         },
         "outputNode": {
           "id": -20,
-          "bounding": [
-            1320,
-            774,
-            120,
-            60
-          ]
+          "bounding": [1320, 774, 120, 60]
         },
         "inputs": [
           {
             "id": "01c05c51-86b5-4bad-b32f-9c911683a13d",
             "name": "string_a",
             "type": "STRING",
-            "linkIds": [
-              4
-            ],
+            "linkIds": [4],
             "localized_name": "string_a",
-            "pos": [
-              780,
-              794
-            ]
+            "pos": [780, 794]
           }
         ],
         "outputs": [
@@ -423,14 +302,9 @@
             "id": "a8bcf3bf-a66a-4c71-8d92-17a2a4d03686",
             "name": "STRING",
             "type": "STRING",
-            "linkIds": [
-              12
-            ],
+            "linkIds": [12],
             "localized_name": "STRING",
-            "pos": [
-              1340,
-              794
-            ]
+            "pos": [1340, 794]
           }
         ],
         "widgets": [],
@@ -438,14 +312,8 @@
           {
             "id": 5,
             "type": "StringConcatenate",
-            "pos": [
-              860,
-              719
-            ],
-            "size": [
-              400,
-              200
-            ],
+            "pos": [860, 719],
+            "size": [400, 200],
             "flags": {},
             "order": 2,
             "mode": 0,
@@ -474,31 +342,19 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  11
-                ]
+                "links": [11]
               }
             ],
             "properties": {
               "Node name for S&R": "StringConcatenate"
             },
-            "widgets_values": [
-              "",
-              "",
-              ""
-            ]
+            "widgets_values": ["", "", ""]
           },
           {
             "id": 6,
             "type": "PrimitiveStringMultiline",
-            "pos": [
-              401,
-              973
-            ],
-            "size": [
-              400,
-              200
-            ],
+            "pos": [401, 973],
+            "size": [400, 200],
             "flags": {},
             "order": 0,
             "mode": 0,
@@ -508,29 +364,19 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  7
-                ]
+                "links": [7]
               }
             ],
             "properties": {
               "Node name for S&R": "PrimitiveStringMultiline"
             },
-            "widgets_values": [
-              "Inner 2\n"
-            ]
+            "widgets_values": ["Inner 2\n"]
           },
           {
             "id": 9,
             "type": "7c2915a5-5eb8-4958-a8fd-4beb30f370ce",
-            "pos": [
-              1046,
-              985
-            ],
-            "size": [
-              210,
-              88
-            ],
+            "pos": [1046, 985],
+            "size": [210, 88],
             "flags": {},
             "order": 1,
             "mode": 0,
@@ -550,22 +396,13 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  12
-                ]
+                "links": [12]
               }
             ],
             "properties": {
-              "proxyWidgets": [
-                [
-                  "-1",
-                  "string_a"
-                ]
-              ]
+              "proxyWidgets": [["-1", "string_a"]]
             },
-            "widgets_values": [
-              ""
-            ]
+            "widgets_values": [""]
           }
         ],
         "groups": [],
@@ -627,35 +464,20 @@
         "name": "New Subgraph",
         "inputNode": {
           "id": -10,
-          "bounding": [
-            262,
-            1222,
-            120,
-            60
-          ]
+          "bounding": [262, 1222, 120, 60]
         },
         "outputNode": {
           "id": -20,
-          "bounding": [
-            1330,
-            1222,
-            120,
-            60
-          ]
+          "bounding": [1330, 1222, 120, 60]
         },
         "inputs": [
           {
             "id": "934a8baa-d79c-428c-8ec9-814ad437d7c7",
             "name": "string_a",
             "type": "STRING",
-            "linkIds": [
-              9
-            ],
+            "linkIds": [9],
             "localized_name": "string_a",
-            "pos": [
-              362,
-              1242
-            ]
+            "pos": [362, 1242]
           }
         ],
         "outputs": [
@@ -663,14 +485,9 @@
             "id": "4c3d243b-9ff6-4dcd-9dbf-e4ec8e1fc879",
             "name": "STRING",
             "type": "STRING",
-            "linkIds": [
-              10
-            ],
+            "linkIds": [10],
             "localized_name": "STRING",
-            "pos": [
-              1350,
-              1242
-            ]
+            "pos": [1350, 1242]
           }
         ],
         "widgets": [],
@@ -678,14 +495,8 @@
           {
             "id": 7,
             "type": "StringConcatenate",
-            "pos": [
-              870,
-              1038
-            ],
-            "size": [
-              400,
-              200
-            ],
+            "pos": [870, 1038],
+            "size": [400, 200],
             "flags": {},
             "order": 1,
             "mode": 0,
@@ -714,31 +525,19 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  10
-                ]
+                "links": [10]
               }
             ],
             "properties": {
               "Node name for S&R": "StringConcatenate"
             },
-            "widgets_values": [
-              "",
-              "",
-              ""
-            ]
+            "widgets_values": ["", "", ""]
           },
           {
             "id": 8,
             "type": "PrimitiveStringMultiline",
-            "pos": [
-              442,
-              1296
-            ],
-            "size": [
-              400,
-              200
-            ],
+            "pos": [442, 1296],
+            "size": [400, 200],
             "flags": {},
             "order": 0,
             "mode": 0,
@@ -748,17 +547,13 @@
                 "localized_name": "STRING",
                 "name": "STRING",
                 "type": "STRING",
-                "links": [
-                  8
-                ]
+                "links": [8]
               }
             ],
             "properties": {
               "Node name for S&R": "PrimitiveStringMultiline"
             },
-            "widgets_values": [
-              "Inner 3\n"
-            ]
+            "widgets_values": ["Inner 3\n"]
           }
         ],
         "groups": [],
@@ -796,10 +591,7 @@
   "extra": {
     "ds": {
       "scale": 1,
-      "offset": [
-        -7,
-        144
-      ]
+      "offset": [-7, 144]
     },
     "frontendVersion": "1.38.13"
   },

--- a/browser_tests/assets/subgraphs/subgraph-nested-duplicate-ids.json
+++ b/browser_tests/assets/subgraphs/subgraph-nested-duplicate-ids.json
@@ -1,0 +1,807 @@
+{
+  "id": "9a37f747-e96b-4304-9212-7abcaad7bdac",
+  "revision": 0,
+  "last_node_id": 5,
+  "last_link_id": 5,
+  "nodes": [
+    {
+      "id": 5,
+      "type": "1e38d8ea-45e1-48a5-aa20-966584201867",
+      "pos": [
+        788,
+        433.5
+      ],
+      "size": [
+        210,
+        108
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "string_a",
+          "type": "STRING",
+          "widget": {
+            "name": "string_a"
+          },
+          "link": 4
+        }
+      ],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            5
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "-1",
+            "string_a"
+          ]
+        ]
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 2,
+      "type": "PreviewAny",
+      "pos": [
+        1135,
+        429
+      ],
+      "size": [
+        250,
+        145.5
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 5
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [
+        null,
+        null,
+        false
+      ]
+    },
+    {
+      "id": 1,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        456,
+        450
+      ],
+      "size": [
+        225,
+        121.5
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            4
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PrimitiveStringMultiline"
+      },
+      "widgets_values": [
+        "Outer\n"
+      ]
+    }
+  ],
+  "links": [
+    [
+      4,
+      1,
+      0,
+      5,
+      0,
+      "STRING"
+    ],
+    [
+      5,
+      5,
+      0,
+      2,
+      0,
+      "STRING"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "1e38d8ea-45e1-48a5-aa20-966584201867",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 6,
+          "lastLinkId": 9,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "New Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            351,
+            432.5,
+            120,
+            60
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1315,
+            432.5,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "7bf3e1d4-0521-4b5c-92f5-47ca598b7eb4",
+            "name": "string_a",
+            "type": "STRING",
+            "linkIds": [
+              1
+            ],
+            "localized_name": "string_a",
+            "pos": [
+              451,
+              452.5
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "fbe975ba-d7c2-471e-a99a-a1e2c6ab466d",
+            "name": "STRING",
+            "type": "STRING",
+            "linkIds": [
+              9
+            ],
+            "localized_name": "STRING",
+            "pos": [
+              1335,
+              452.5
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 3,
+            "type": "StringConcatenate",
+            "pos": [
+              815,
+              373
+            ],
+            "size": [
+              347,
+              231
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 1
+              },
+              {
+                "localized_name": "string_b",
+                "name": "string_b",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_b"
+                },
+                "link": 2
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  7
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringConcatenate"
+            },
+            "widgets_values": [
+              "",
+              "",
+              ""
+            ]
+          },
+          {
+            "id": 6,
+            "type": "9be42452-056b-4c99-9f9f-7381d11c4454",
+            "pos": [
+              955,
+              775
+            ],
+            "size": [
+              210,
+              88
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 7
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  9
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "-1",
+                  "string_a"
+                ]
+              ]
+            },
+            "widgets_values": [
+              ""
+            ]
+          },
+          {
+            "id": 4,
+            "type": "PrimitiveStringMultiline",
+            "pos": [
+              313,
+              685
+            ],
+            "size": [
+              325,
+              109
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  2
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": [
+              "Inner 1\n"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 2,
+            "origin_id": 4,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 7,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 6,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 9,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          }
+        ],
+        "extra": {}
+      },
+      {
+        "id": "9be42452-056b-4c99-9f9f-7381d11c4454",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 9,
+          "lastLinkId": 12,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "New Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            680,
+            774,
+            120,
+            60
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1320,
+            774,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "01c05c51-86b5-4bad-b32f-9c911683a13d",
+            "name": "string_a",
+            "type": "STRING",
+            "linkIds": [
+              4
+            ],
+            "localized_name": "string_a",
+            "pos": [
+              780,
+              794
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "a8bcf3bf-a66a-4c71-8d92-17a2a4d03686",
+            "name": "STRING",
+            "type": "STRING",
+            "linkIds": [
+              12
+            ],
+            "localized_name": "STRING",
+            "pos": [
+              1340,
+              794
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 5,
+            "type": "StringConcatenate",
+            "pos": [
+              860,
+              719
+            ],
+            "size": [
+              400,
+              200
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 4
+              },
+              {
+                "localized_name": "string_b",
+                "name": "string_b",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_b"
+                },
+                "link": 7
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  11
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringConcatenate"
+            },
+            "widgets_values": [
+              "",
+              "",
+              ""
+            ]
+          },
+          {
+            "id": 6,
+            "type": "PrimitiveStringMultiline",
+            "pos": [
+              401,
+              973
+            ],
+            "size": [
+              400,
+              200
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  7
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": [
+              "Inner 2\n"
+            ]
+          },
+          {
+            "id": 9,
+            "type": "7c2915a5-5eb8-4958-a8fd-4beb30f370ce",
+            "pos": [
+              1046,
+              985
+            ],
+            "size": [
+              210,
+              88
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 11
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  12
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "-1",
+                  "string_a"
+                ]
+              ]
+            },
+            "widgets_values": [
+              ""
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 4,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 5,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 7,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 5,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 11,
+            "origin_id": 5,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 10,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 12,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          }
+        ],
+        "extra": {}
+      },
+      {
+        "id": "7c2915a5-5eb8-4958-a8fd-4beb30f370ce",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 8,
+          "lastLinkId": 10,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "New Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            262,
+            1222,
+            120,
+            60
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1330,
+            1222,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "934a8baa-d79c-428c-8ec9-814ad437d7c7",
+            "name": "string_a",
+            "type": "STRING",
+            "linkIds": [
+              9
+            ],
+            "localized_name": "string_a",
+            "pos": [
+              362,
+              1242
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "4c3d243b-9ff6-4dcd-9dbf-e4ec8e1fc879",
+            "name": "STRING",
+            "type": "STRING",
+            "linkIds": [
+              10
+            ],
+            "localized_name": "STRING",
+            "pos": [
+              1350,
+              1242
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 7,
+            "type": "StringConcatenate",
+            "pos": [
+              870,
+              1038
+            ],
+            "size": [
+              400,
+              200
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 9
+              },
+              {
+                "localized_name": "string_b",
+                "name": "string_b",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_b"
+                },
+                "link": 8
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  10
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringConcatenate"
+            },
+            "widgets_values": [
+              "",
+              "",
+              ""
+            ]
+          },
+          {
+            "id": 8,
+            "type": "PrimitiveStringMultiline",
+            "pos": [
+              442,
+              1296
+            ],
+            "size": [
+              400,
+              200
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  8
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": [
+              "Inner 3\n"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 8,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": 7,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 9,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 10,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [
+        -7,
+        144
+      ]
+    },
+    "frontendVersion": "1.38.13"
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/subgraph-duplicate-ids.spec.ts
+++ b/browser_tests/tests/subgraph-duplicate-ids.spec.ts
@@ -5,6 +5,13 @@ import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 test.describe('Subgraph duplicate ID remapping', { tag: ['@subgraph'] }, () => {
   const WORKFLOW = 'subgraphs/subgraph-nested-duplicate-ids'
 
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting(
+      'Comfy.Graph.DeduplicateSubgraphNodeIds',
+      true
+    )
+  })
+
   test('All node IDs are globally unique after loading', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/subgraph-duplicate-ids.spec.ts
+++ b/browser_tests/tests/subgraph-duplicate-ids.spec.ts
@@ -85,18 +85,16 @@ test.describe('Subgraph duplicate ID remapping', { tag: ['@subgraph'] }, () => {
     const subgraphNode = await comfyPage.nodeOps.getNodeRefById('5')
     await subgraphNode.navigateIntoSubgraph()
 
-    // TODO: Expose isSubgraph property on LGraph/Subgraph
-    const inSubgraph = await comfyPage.page.evaluate(() => {
-      return window.app!.canvas.graph?.constructor?.name === 'Subgraph'
-    })
-    expect(inSubgraph).toBe(true)
+    const isInSubgraph = () =>
+      comfyPage.page.evaluate(
+        () => window.app!.canvas.graph?.isRootGraph === false
+      )
+
+    expect(await isInSubgraph()).toBe(true)
 
     await comfyPage.page.keyboard.press('Escape')
     await comfyPage.nextFrame()
 
-    const backToRoot = await comfyPage.page.evaluate(() => {
-      return window.app!.canvas.graph?.constructor?.name !== 'Subgraph'
-    })
-    expect(backToRoot).toBe(true)
+    expect(await isInSubgraph()).toBe(false)
   })
 })

--- a/browser_tests/tests/subgraph-duplicate-ids.spec.ts
+++ b/browser_tests/tests/subgraph-duplicate-ids.spec.ts
@@ -1,0 +1,102 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Subgraph duplicate ID remapping', { tag: ['@subgraph'] }, () => {
+  const WORKFLOW = 'subgraphs/subgraph-nested-duplicate-ids'
+
+  test('All node IDs are globally unique after loading', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      // TODO: Extract allGraphs accessor (root + subgraphs) into LGraph
+      // TODO: Extract allNodeIds accessor into LGraph
+      const allGraphs = [graph, ...graph.subgraphs.values()]
+      const allIds = allGraphs
+        .flatMap((g) => g._nodes)
+        .map((n) => n.id)
+        .filter((id): id is number => typeof id === 'number')
+
+      return { allIds, uniqueCount: new Set(allIds).size }
+    })
+
+    expect(result.uniqueCount).toBe(result.allIds.length)
+    expect(result.allIds.length).toBeGreaterThanOrEqual(10)
+  })
+
+  test('Root graph node IDs are preserved as canonical', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+    const rootIds = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      return graph._nodes
+        .map((n) => n.id)
+        .filter((id): id is number => typeof id === 'number')
+        .sort((a, b) => a - b)
+    })
+
+    expect(rootIds).toEqual([1, 2, 5])
+  })
+
+  test('All links reference valid nodes in their graph', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+    const invalidLinks = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const labeledGraphs: [string, typeof graph][] = [
+        ['root', graph],
+        ...[...graph.subgraphs.entries()].map(
+          ([id, sg]) => [`subgraph:${id}`, sg] as [string, typeof graph]
+        )
+      ]
+
+      const isNonNegative = (id: number | string) =>
+        typeof id === 'number' && id >= 0
+
+      return labeledGraphs.flatMap(([label, g]) =>
+        [...g._links.values()].flatMap((link) =>
+          [
+            isNonNegative(link.origin_id) &&
+              !g._nodes_by_id[link.origin_id] &&
+              `${label}: origin_id ${link.origin_id} not found`,
+            isNonNegative(link.target_id) &&
+              !g._nodes_by_id[link.target_id] &&
+              `${label}: target_id ${link.target_id} not found`
+          ].filter(Boolean)
+        )
+      )
+    })
+
+    expect(invalidLinks).toEqual([])
+  })
+
+  test('Subgraph navigation works after ID remapping', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+    const subgraphNode = await comfyPage.nodeOps.getNodeRefById('5')
+    await subgraphNode.navigateIntoSubgraph()
+
+    // TODO: Expose isSubgraph property on LGraph/Subgraph
+    const inSubgraph = await comfyPage.page.evaluate(() => {
+      return window.app!.canvas.graph?.constructor?.name === 'Subgraph'
+    })
+    expect(inSubgraph).toBe(true)
+
+    await comfyPage.page.keyboard.press('Escape')
+    await comfyPage.nextFrame()
+
+    const backToRoot = await comfyPage.page.evaluate(() => {
+      return window.app!.canvas.graph?.constructor?.name !== 'Subgraph'
+    })
+    expect(backToRoot).toBe(true)
+  })
+})

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -439,6 +439,21 @@ describe('ensureGlobalIdUniqueness', () => {
     expect(link.origin_id).not.toBe(rootNode.id)
   })
 
+  it('detects collisions with reserved (not-yet-created) node IDs', () => {
+    const rootGraph = new LGraph()
+    const subgraph = createSubgraphOnGraph(rootGraph)
+
+    const subNode = new DummyNode()
+    subNode.id = 42
+    subgraph._nodes.push(subNode)
+    subgraph._nodes_by_id[subNode.id] = subNode
+
+    rootGraph.ensureGlobalIdUniqueness([42])
+
+    expect(subNode.id).not.toBe(42)
+    expect(subgraph._nodes_by_id[subNode.id]).toBe(subNode)
+  })
+
   it('is a no-op when there are no collisions', () => {
     const rootGraph = new LGraph()
     const subgraph = createSubgraphOnGraph(rootGraph)

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2436,6 +2436,13 @@ export class LGraph
           this.subgraphs.get(subgraph.id)?.configure(subgraph)
       }
 
+      if (this.isRootGraph) {
+        const reservedNodeIds = nodesData
+          ?.map((n) => n.id)
+          .filter((id): id is number => typeof id === 'number')
+        this.ensureGlobalIdUniqueness(reservedNodeIds)
+      }
+
       let error = false
       const nodeDataMap = new Map<NodeId, ISerialisedNode>()
 
@@ -2521,8 +2528,6 @@ export class LGraph
         }
       }
 
-      if (this.isRootGraph) this.ensureGlobalIdUniqueness()
-
       this.setDirtyCanvas(true, true)
       return error
     } finally {
@@ -2536,12 +2541,12 @@ export class LGraph
    * root graph IDs as canonical. Updates link references (`origin_id`,
    * `target_id`) within the affected graph to match the new node IDs.
    */
-  ensureGlobalIdUniqueness(): void {
+  ensureGlobalIdUniqueness(reservedNodeIds?: Iterable<number>): void {
     const { state } = this
 
     const allGraphs: LGraph[] = [this, ...this._subgraphs.values()]
 
-    const usedNodeIds = new Set<number>()
+    const usedNodeIds = new Set<number>(reservedNodeIds)
     for (const graph of allGraphs) {
       const remappedIds = new Map<NodeId, NodeId>()
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2555,18 +2555,21 @@ export class LGraph
 
         if (usedNodeIds.has(node.id)) {
           const oldId = node.id
-          const newId = ++state.lastNodeId
+          while (usedNodeIds.has(++state.lastNodeId));
+          const newId = state.lastNodeId
           delete graph._nodes_by_id[oldId]
           node.id = newId
           graph._nodes_by_id[newId] = node
+          usedNodeIds.add(newId)
           remappedIds.set(oldId, newId)
           console.warn(
             `LiteGraph: duplicate node ID ${oldId} reassigned to ${newId} in graph ${graph.id}`
           )
+        } else {
+          usedNodeIds.add(node.id as number)
+          if ((node.id as number) > state.lastNodeId)
+            state.lastNodeId = node.id as number
         }
-        usedNodeIds.add(node.id as number)
-        if ((node.id as number) > state.lastNodeId)
-          state.lastNodeId = node.id as number
       }
 
       if (remappedIds.size > 0) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2564,7 +2564,10 @@ export class LGraph
           state.lastNodeId = node.id as number
       }
 
-      if (remappedIds.size > 0) patchLinkNodeIds(graph._links, remappedIds)
+      if (remappedIds.size > 0) {
+        patchLinkNodeIds(graph._links, remappedIds)
+        patchLinkNodeIds(graph.floatingLinksInternal, remappedIds)
+      }
     }
   }
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -158,6 +158,7 @@ export class LGraph
 
   static STATUS_STOPPED = 1
   static STATUS_RUNNING = 2
+  static deduplicateSubgraphIds = false
 
   /** List of LGraph properties that are manually handled by {@link LGraph.configure}. */
   static readonly ConfigureProperties = new Set([
@@ -2436,7 +2437,7 @@ export class LGraph
           this.subgraphs.get(subgraph.id)?.configure(subgraph)
       }
 
-      if (this.isRootGraph) {
+      if (this.isRootGraph && LGraph.deduplicateSubgraphIds) {
         const reservedNodeIds = nodesData
           ?.map((n) => n.id)
           .filter((id): id is number => typeof id === 'number')

--- a/src/platform/settings/composables/useLitegraphSettings.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.ts
@@ -2,6 +2,7 @@ import { watchEffect } from 'vue'
 
 import {
   CanvasPointer,
+  LGraph,
   LGraphNode,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
@@ -160,6 +161,12 @@ export const useLitegraphSettings = () => {
   watchEffect(() => {
     LiteGraph.saveViewportWithGraph = settingStore.get(
       'Comfy.EnableWorkflowViewRestore'
+    )
+  })
+
+  watchEffect(() => {
+    LGraph.deduplicateSubgraphIds = settingStore.get(
+      'Comfy.Graph.DeduplicateSubgraphNodeIds'
     )
   })
 }

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1201,5 +1201,16 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: false,
     experimental: true,
     versionAdded: '1.40.0'
+  },
+  {
+    id: 'Comfy.Graph.DeduplicateSubgraphNodeIds',
+    category: ['Comfy', 'Graph', 'Subgraph'],
+    name: 'Deduplicate subgraph node IDs',
+    tooltip:
+      'Automatically reassign duplicate node IDs in subgraphs when loading a workflow.',
+    type: 'boolean',
+    defaultValue: false,
+    experimental: true,
+    versionAdded: '1.41.0'
   }
 ]

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1211,6 +1211,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'boolean',
     defaultValue: false,
     experimental: true,
-    versionAdded: '1.41.0'
+    versionAdded: '1.40.0'
   }
 ]

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -288,6 +288,7 @@ const zSettings = z.object({
   'Comfy.Graph.CanvasInfo': z.boolean(),
   'Comfy.Graph.CanvasMenu': z.boolean(),
   'Comfy.Graph.CtrlShiftZoom': z.boolean(),
+  'Comfy.Graph.DeduplicateSubgraphNodeIds': z.boolean(),
   'Comfy.Graph.LiveSelection': z.boolean(),
   'Comfy.Graph.LinkMarkers': z.nativeEnum(LinkMarkerShape),
   'Comfy.Graph.ZoomSpeed': z.number(),


### PR DESCRIPTION
## Summary

Add `ensureGlobalIdUniqueness` to reassign duplicate node IDs across subgraphs when loading workflows, gated behind an experimental setting.

## Changes

- **What**: Shared `LGraphState` between root graph and subgraphs so ID counters are global. Added `ensureGlobalIdUniqueness()` method that detects and remaps colliding node IDs in subgraphs, preserving root graph IDs as canonical and patching link references. Gated behind `Comfy.Graph.DeduplicateSubgraphNodeIds` (experimental, default `false`).
- **Dependencies**: None

## Review Focus

- Shared state override on `Subgraph` (getter delegates to root, setter is no-op) — verify no existing code sets `subgraph.state` directly.
- `Math.max` state merging in `configure()` prevents ID counter regression when loading subgraph definitions.
- Feature flag wiring: static property on `LGraph`, synced from settings via `useLitegraphSettings`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8762-feat-deduplicate-subgraph-node-IDs-on-workflow-load-experimental-3036d73d36508184b6cee5876dc4d935) by [Unito](https://www.unito.io)
