### PR TITLE
feat: add dedicated queue tab to assets sidebar

### DIFF
--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    ref="container"
-    class="h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-(--dialog-surface)"
-  >
+  <div ref="container" class="h-full scrollbar-custom">
     <div :style="topSpacerStyle" />
     <div :style="mergedGridStyle">
       <div

--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -1,23 +1,7 @@
 <template>
   <div class="flex h-full flex-col">
-    <!-- Active Jobs Grid -->
-    <div
-      v-if="!isInFolderView && isQueuePanelV2Enabled && activeJobItems.length"
-      class="grid max-h-[50%] scrollbar-custom overflow-y-auto"
-      :style="gridStyle"
-    >
-      <ActiveMediaAssetCard
-        v-for="job in activeJobItems"
-        :key="job.id"
-        :job="job"
-      />
-    </div>
-
     <!-- Assets Header -->
-    <div
-      v-if="assets.length"
-      :class="cn('px-2 2xl:px-4', activeJobItems.length && 'mt-2')"
-    >
+    <div v-if="assets.length" class="px-2 2xl:px-4">
       <div
         class="flex items-center py-2 text-sm font-normal leading-normal text-muted-foreground font-inter"
       >
@@ -59,25 +43,18 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
-import ActiveMediaAssetCard from '@/platform/assets/components/ActiveMediaAssetCard.vue'
-import { useJobList } from '@/composables/queue/useJobList'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { isActiveJobState } from '@/utils/queueUtil'
-import { cn } from '@/utils/tailwindUtil'
-import { useSettingStore } from '@/platform/settings/settingStore'
 
 const {
   assets,
   isSelected,
-  isInFolderView = false,
   assetType = 'output',
   showOutputCount,
   getOutputCount
 } = defineProps<{
   assets: AssetItem[]
   isSelected: (assetId: string) => boolean
-  isInFolderView?: boolean
   assetType?: 'input' | 'output'
   showOutputCount: (asset: AssetItem) => boolean
   getOutputCount: (asset: AssetItem) => number
@@ -92,18 +69,8 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { jobItems } = useJobList()
-const settingStore = useSettingStore()
-
-const isQueuePanelV2Enabled = computed(() =>
-  settingStore.get('Comfy.Queue.QPOV2')
-)
 
 type AssetGridItem = { key: string; asset: AssetItem }
-
-const activeJobItems = computed(() =>
-  jobItems.value.filter((item) => isActiveJobState(item.state)).toReversed()
-)
 
 const assetItems = computed<AssetGridItem[]>(() =>
   assets.map((asset) => ({

--- a/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import AssetsSidebarListView from './AssetsSidebarListView.vue'
 
@@ -10,49 +9,10 @@ vi.mock('vue-i18n', () => ({
   })
 }))
 
-vi.mock('@/composables/queue/useJobActions', () => ({
-  useJobActions: () => ({
-    cancelAction: { variant: 'ghost', label: 'Cancel', icon: 'pi pi-times' },
-    canCancelJob: ref(false),
-    runCancelJob: vi.fn()
-  })
-}))
-
-const mockJobItems = ref<
-  Array<{
-    id: string
-    title: string
-    meta: string
-    state: string
-    createTime?: number
-  }>
->([])
-
-vi.mock('@/composables/queue/useJobList', () => ({
-  useJobList: () => ({
-    jobItems: mockJobItems
-  })
-}))
-
 vi.mock('@/stores/assetsStore', () => ({
   useAssetsStore: () => ({
     isAssetDeleting: () => false
   })
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({
-    get: (key: string) => key === 'Comfy.Queue.QPOV2'
-  })
-}))
-
-vi.mock('@/utils/queueUtil', () => ({
-  isActiveJobState: (state: string) =>
-    state === 'pending' || state === 'running'
-}))
-
-vi.mock('@/utils/queueDisplay', () => ({
-  iconForJobState: () => 'pi pi-spinner'
 }))
 
 vi.mock('@/platform/assets/schemas/assetMetadataSchema', () => ({
@@ -73,7 +33,6 @@ vi.mock('@/utils/formatUtil', () => ({
 describe('AssetsSidebarListView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockJobItems.value = []
   })
 
   const defaultProps = {
@@ -84,67 +43,14 @@ describe('AssetsSidebarListView', () => {
     toggleStack: async () => {}
   }
 
-  it('displays active jobs in oldest-first order (FIFO)', () => {
-    mockJobItems.value = [
-      {
-        id: 'newest',
-        title: 'Newest Job',
-        meta: '',
-        state: 'pending',
-        createTime: 3000
-      },
-      {
-        id: 'middle',
-        title: 'Middle Job',
-        meta: '',
-        state: 'running',
-        createTime: 2000
-      },
-      {
-        id: 'oldest',
-        title: 'Oldest Job',
-        meta: '',
-        state: 'pending',
-        createTime: 1000
-      }
-    ]
-
+  it('renders without errors with empty assets', () => {
     const wrapper = mount(AssetsSidebarListView, {
       props: defaultProps,
       shallow: true
     })
 
-    const jobListItems = wrapper.findAllComponents({ name: 'AssetsListItem' })
-    expect(jobListItems).toHaveLength(3)
-
-    const displayedTitles = jobListItems.map((item) =>
-      item.props('primaryText')
-    )
-    expect(displayedTitles).toEqual(['Oldest Job', 'Middle Job', 'Newest Job'])
-  })
-
-  it('excludes completed and failed jobs from active jobs section', () => {
-    mockJobItems.value = [
-      { id: 'pending', title: 'Pending', meta: '', state: 'pending' },
-      { id: 'completed', title: 'Completed', meta: '', state: 'completed' },
-      { id: 'failed', title: 'Failed', meta: '', state: 'failed' },
-      { id: 'running', title: 'Running', meta: '', state: 'running' }
-    ]
-
-    const wrapper = mount(AssetsSidebarListView, {
-      props: defaultProps,
-      shallow: true
-    })
-
-    const jobListItems = wrapper.findAllComponents({ name: 'AssetsListItem' })
-    expect(jobListItems).toHaveLength(2)
-
-    const displayedTitles = jobListItems.map((item) =>
-      item.props('primaryText')
-    )
-    expect(displayedTitles).toContain('Running')
-    expect(displayedTitles).toContain('Pending')
-    expect(displayedTitles).not.toContain('Completed')
-    expect(displayedTitles).not.toContain('Failed')
+    expect(wrapper.exists()).toBe(true)
+    const listItems = wrapper.findAllComponents({ name: 'AssetsListItem' })
+    expect(listItems).toHaveLength(0)
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarListView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.vue
@@ -122,7 +122,6 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-
 const hoveredAssetId = ref<string | null>(null)
 
 const listGridStyle = {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -71,16 +71,14 @@
         </span>
         <div class="flex items-center gap-2">
           <MediaAssetViewModeToggle v-model:view-mode="viewMode" />
-          <span class="text-sm text-base-foreground">
-            {{ t('sideToolbar.queueProgressOverlay.clearQueueTooltip') }}
-          </span>
           <Button
+            v-tooltip.top="clearQueueTooltip"
             variant="destructive"
             size="icon"
             :aria-label="
               t('sideToolbar.queueProgressOverlay.clearQueueTooltip')
             "
-            :disabled="queuedCount === 0"
+            :disabled="activeJobsCount === 0"
             @click="handleClearQueue"
           >
             <i class="icon-[lucide--list-x] size-4" />
@@ -249,6 +247,7 @@ import ResultGallery from '@/components/sidebar/tabs/queue/ResultGallery.vue'
 import Tab from '@/components/tab/Tab.vue'
 import TabList from '@/components/tab/TabList.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { buildTooltipConfig } from '@/composables/useTooltipConfig'
 import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContextMenu.vue'
 import MediaAssetFilterBar from '@/platform/assets/components/MediaAssetFilterBar.vue'
 import MediaAssetViewModeToggle from '@/platform/assets/components/MediaAssetViewModeToggle.vue'
@@ -327,7 +326,9 @@ const formattedExecutionTime = computed(() => {
   return formatDuration(folderExecutionTime.value * 1000)
 })
 
-const queuedCount = computed(() => queueStore.pendingTasks.length)
+const clearQueueTooltip = computed(() =>
+  buildTooltipConfig(t('sideToolbar.queueProgressOverlay.clearQueueTooltip'))
+)
 const activeJobsLabel = computed(() => {
   const count = activeJobsCount.value
   return t(

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -78,7 +78,7 @@
             :aria-label="
               t('sideToolbar.queueProgressOverlay.clearQueueTooltip')
             "
-            :disabled="activeJobsCount === 0"
+            :disabled="queueStore.pendingTasks.length === 0"
             @click="handleClearQueue"
           >
             <i class="icon-[lucide--list-x] size-4" />

--- a/src/components/sidebar/tabs/QueueAssetView.test.ts
+++ b/src/components/sidebar/tabs/QueueAssetView.test.ts
@@ -1,12 +1,19 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
 import { ref } from 'vue'
 
 import type { JobListItem } from '@/composables/queue/useJobList'
 
 import QueueAssetView from './QueueAssetView.vue'
 
-const mockJobItems = ref<JobListItem[]>([])
+const { mockJobItems } = vi.hoisted<{
+  mockJobItems: Ref<JobListItem[]>
+}>(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: hoistedRef } = require('vue')
+  return { mockJobItems: hoistedRef([]) }
+})
 
 vi.mock('@/composables/queue/useJobList', () => ({
   useJobList: () => ({

--- a/src/components/sidebar/tabs/QueueAssetView.test.ts
+++ b/src/components/sidebar/tabs/QueueAssetView.test.ts
@@ -1,0 +1,91 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { JobListItem } from '@/composables/queue/useJobList'
+
+import QueueAssetView from './QueueAssetView.vue'
+
+const mockJobItems = ref<JobListItem[]>([])
+
+vi.mock('@/composables/queue/useJobList', () => ({
+  useJobList: () => ({
+    jobItems: mockJobItems
+  })
+}))
+
+vi.mock('@/composables/queue/useJobActions', () => ({
+  useJobActions: () => ({
+    cancelAction: { variant: 'ghost', label: 'Cancel', icon: 'pi pi-times' },
+    canCancelJob: ref(false),
+    runCancelJob: vi.fn()
+  })
+}))
+
+vi.mock('@/utils/queueUtil', () => ({
+  isActiveJobState: (state: string) =>
+    state === 'pending' || state === 'running' || state === 'initialization'
+}))
+
+vi.mock('@/utils/queueDisplay', () => ({
+  iconForJobState: () => 'pi pi-spinner'
+}))
+
+function makeJob(overrides: Partial<JobListItem>): JobListItem {
+  return {
+    id: 'job-1',
+    title: 'Job 1',
+    meta: '',
+    state: 'pending',
+    ...overrides
+  }
+}
+
+describe('QueueAssetView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockJobItems.value = []
+  })
+
+  it('displays active jobs in oldest-first order (FIFO)', () => {
+    mockJobItems.value = [
+      makeJob({ id: 'newest', title: 'Newest Job', state: 'pending' }),
+      makeJob({ id: 'middle', title: 'Middle Job', state: 'running' }),
+      makeJob({ id: 'oldest', title: 'Oldest Job', state: 'pending' })
+    ]
+
+    const wrapper = mount(QueueAssetView, {
+      props: { viewMode: 'list' },
+      shallow: true
+    })
+
+    const items = wrapper.findAllComponents({ name: 'AssetsListItem' })
+    expect(items).toHaveLength(3)
+
+    const titles = items.map((item) => item.props('primaryText'))
+    expect(titles).toEqual(['Oldest Job', 'Middle Job', 'Newest Job'])
+  })
+
+  it('excludes completed and failed jobs', () => {
+    mockJobItems.value = [
+      makeJob({ id: 'pending', title: 'Pending', state: 'pending' }),
+      makeJob({ id: 'completed', title: 'Completed', state: 'completed' }),
+      makeJob({ id: 'failed', title: 'Failed', state: 'failed' }),
+      makeJob({ id: 'running', title: 'Running', state: 'running' })
+    ]
+
+    const wrapper = mount(QueueAssetView, {
+      props: { viewMode: 'list' },
+      shallow: true
+    })
+
+    const items = wrapper.findAllComponents({ name: 'AssetsListItem' })
+    expect(items).toHaveLength(2)
+
+    const titles = items.map((item) => item.props('primaryText'))
+    expect(titles).toContain('Running')
+    expect(titles).toContain('Pending')
+    expect(titles).not.toContain('Completed')
+    expect(titles).not.toContain('Failed')
+  })
+})

--- a/src/components/sidebar/tabs/QueueAssetView.vue
+++ b/src/components/sidebar/tabs/QueueAssetView.vue
@@ -92,7 +92,6 @@ const gridStyle = {
   gap: '0.5rem'
 }
 
-// List view hover & cancel logic
 const hoveredJobId = ref<string | null>(null)
 const hoveredJob = computed(() =>
   hoveredJobId.value
@@ -113,11 +112,10 @@ function onJobLeave(jobId: string) {
 }
 
 function getJobIconClass(job: JobListItem): string | undefined {
-  const classes = []
   const iconName = job.iconName ?? iconForJobState(job.state)
   if (!job.iconImageUrl && iconName === iconForJobState('pending')) {
-    classes.push('animate-spin')
+    return 'animate-spin'
   }
-  return classes.length ? classes.join(' ') : undefined
+  return undefined
 }
 </script>

--- a/src/components/sidebar/tabs/QueueAssetView.vue
+++ b/src/components/sidebar/tabs/QueueAssetView.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="flex h-full flex-col">
+    <!-- Grid View -->
+    <VirtualGrid
+      v-if="viewMode === 'grid'"
+      class="flex-1"
+      :items="gridItems"
+      :grid-style="gridStyle"
+    >
+      <template #item="{ item }">
+        <ActiveMediaAssetCard :job="item.job" />
+      </template>
+    </VirtualGrid>
+
+    <!-- List View -->
+    <div
+      v-else
+      class="flex flex-1 scrollbar-custom flex-col gap-2 overflow-y-auto px-2"
+    >
+      <AssetsListItem
+        v-for="job in activeJobItems"
+        :key="job.id"
+        :class="
+          cn(
+            'w-full shrink-0 text-text-primary transition-colors hover:bg-secondary-background-hover',
+            'cursor-default'
+          )
+        "
+        :preview-url="job.iconImageUrl"
+        :preview-alt="job.title"
+        :icon-name="job.iconName"
+        :icon-class="getJobIconClass(job)"
+        :primary-text="job.title"
+        :secondary-text="job.meta"
+        :progress-total-percent="job.progressTotalPercent"
+        :progress-current-percent="job.progressCurrentPercent"
+        @mouseenter="onJobEnter(job.id)"
+        @mouseleave="onJobLeave(job.id)"
+        @click.stop
+      >
+        <template v-if="hoveredJobId === job.id" #actions>
+          <Button
+            v-if="canCancelJob"
+            :variant="cancelAction.variant"
+            size="icon"
+            :aria-label="cancelAction.label"
+            @click.stop="runCancelJob()"
+          >
+            <i :class="cancelAction.icon" class="size-4" />
+          </Button>
+        </template>
+      </AssetsListItem>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import VirtualGrid from '@/components/common/VirtualGrid.vue'
+import Button from '@/components/ui/button/Button.vue'
+import { useJobActions } from '@/composables/queue/useJobActions'
+import type { JobListItem } from '@/composables/queue/useJobList'
+import { useJobList } from '@/composables/queue/useJobList'
+import ActiveMediaAssetCard from '@/platform/assets/components/ActiveMediaAssetCard.vue'
+import AssetsListItem from '@/platform/assets/components/AssetsListItem.vue'
+import { isActiveJobState } from '@/utils/queueUtil'
+import { iconForJobState } from '@/utils/queueDisplay'
+import { cn } from '@/utils/tailwindUtil'
+
+const { viewMode = 'grid' } = defineProps<{
+  viewMode?: 'list' | 'grid'
+}>()
+
+const { jobItems } = useJobList()
+
+const activeJobItems = computed(() =>
+  jobItems.value.filter((item) => isActiveJobState(item.state)).toReversed()
+)
+
+const gridItems = computed(() =>
+  activeJobItems.value.map((job) => ({
+    key: `queue-${job.id}`,
+    job
+  }))
+)
+
+const gridStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+  padding: '0 0.5rem',
+  gap: '0.5rem'
+}
+
+// List view hover & cancel logic
+const hoveredJobId = ref<string | null>(null)
+const hoveredJob = computed(() =>
+  hoveredJobId.value
+    ? (activeJobItems.value.find((job) => job.id === hoveredJobId.value) ??
+      null)
+    : null
+)
+const { cancelAction, canCancelJob, runCancelJob } = useJobActions(hoveredJob)
+
+function onJobEnter(jobId: string) {
+  hoveredJobId.value = jobId
+}
+
+function onJobLeave(jobId: string) {
+  if (hoveredJobId.value === jobId) {
+    hoveredJobId.value = null
+  }
+}
+
+function getJobIconClass(job: JobListItem): string | undefined {
+  const classes = []
+  const iconName = job.iconName ?? iconForJobState(job.state)
+  if (!job.iconImageUrl && iconName === iconForJobState('pending')) {
+    classes.push('animate-spin')
+  }
+  return classes.length ? classes.join(' ') : undefined
+}
+</script>

--- a/src/components/sidebar/tabs/QueueAssetView.vue
+++ b/src/components/sidebar/tabs/QueueAssetView.vue
@@ -75,7 +75,10 @@ const { viewMode = 'grid' } = defineProps<{
 const { jobItems } = useJobList()
 
 const activeJobItems = computed(() =>
-  jobItems.value.filter((item) => isActiveJobState(item.state)).toReversed()
+  jobItems.value
+    .filter((item) => isActiveJobState(item.state))
+    .slice()
+    .reverse()
 )
 
 const gridItems = computed(() =>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -755,6 +755,8 @@
     "noFilesFound": "No files found",
     "noImportedFiles": "No imported files found",
     "noGeneratedFiles": "No generated files found",
+    "noQueueItems": "No active jobs",
+    "noQueueItemsMessage": "Queue a prompt to see active jobs here",
     "generatedAssetsHeader": "Generated assets",
     "importedAssetsHeader": "Imported assets",
     "activeJobStatus": "Active job: {status}",


### PR DESCRIPTION
## Summary

Extract active job display from the generated/imported asset views into a dedicated "Queue" tab in the assets sidebar, providing a cleaner separation of concerns and improved UX.

## Changes

- **What**: Add a new "Queue" tab (gated behind `Comfy.Queue.QPOV2` setting) that shows active jobs in both list and grid views via a new `QueueAssetView` component. Remove inline active-job sections from `AssetsSidebarGridView` and `AssetsSidebarListView`. Add badge showing active job count, view-mode toggle, and clear-queue button to the queue tab header. Hide the filter bar on the queue tab since it only shows live jobs.
- **Dependencies**: None

## Review Focus

- Tab state management: queue tab resets to output if QPOV2 is disabled mid-session
- Empty state messaging for queue tab vs asset tabs
- `QueueAssetView` list/grid view parity with the previously inlined job sections

[screen-capture.webm](https://github.com/user-attachments/assets/59c259c7-31db-4c2e-9fef-f4cde46031fa)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8769-feat-add-dedicated-queue-tab-to-assets-sidebar-3036d73d3650813abaf7c7209832c290) by [Unito](https://www.unito.io)
