### PR TITLE
Austin/fix move subgraph input

### DIFF
--- a/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
@@ -73,6 +73,28 @@ describe('LinkConnector SubgraphInput connection validation', () => {
       expect(toTargetNode.onConnectionsChange).toHaveBeenCalledTimes(1)
       expect(fromTargetNode.onConnectionsChange).toHaveBeenCalledTimes(1)
     })
+    it('should allow reconnection to same target', () => {
+      const subgraph = createTestSubgraph({
+        inputs: [{ name: 'number_input', type: 'number' }]
+      })
+
+      const node = new LGraphNode('TargetNode')
+      node.addInput('number_in', 'number')
+      subgraph.add(node)
+
+      const link = subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+
+      const renderLink = new ToInputFromIoNodeLink(
+        subgraph,
+        subgraph.inputNode,
+        subgraph.inputNode.slots[0],
+        undefined,
+        LinkDirection.CENTER,
+        link
+      )
+      renderLink.connectToInput(node, node.inputs[0], connector.events)
+      expect(node.inputs[0].link).not.toBeNull()
+    })
   })
 
   describe('MovingOutputLink validation', () => {

--- a/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
+++ b/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
@@ -58,6 +58,12 @@ export class ToInputFromIoNodeLink implements RenderLink {
     events: CustomEventTarget<LinkConnectorEventMap>
   ) {
     const { fromSlot, fromReroute, existingLink } = this
+    if (
+      existingLink &&
+      node.id === existingLink.target_id &&
+      node.inputs[existingLink.target_slot] === input
+    )
+      return
 
     const newLink = fromSlot.connect(input, node, fromReroute?.id)
 


### PR DESCRIPTION
Previously, moving a subgraph input link and re-attaching to the same input slot would result in an invalid link

![broken-link](https://github.com/user-attachments/assets/085a0a6f-281d-4e06-be58-e5bdc873f1d5)

This occurred because:
- A new link is created to which overwrites the target `input.link`
- The previous link is then disconnected, which clears `input.link`

This is solved by instead returning early if the target is the same as the existing link.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8777-Austin-fix-move-subgraph-input-3036d73d365081318de3cccb926f7fe7) by [Unito](https://www.unito.io)
