### PR TITLE
fix: address review nits in load3d

### DIFF
--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -219,22 +219,15 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         return modelPath
       }
 
-      let cleanPath = modelPath.trim()
-      let forcedType: 'output' | 'input' | undefined
-
-      if (cleanPath.endsWith('[output]')) {
-        cleanPath = cleanPath.replace(/\s*\[output\]$/, '').trim()
-        forcedType = 'output'
-      }
+      const trimmed = modelPath.trim()
+      const hasOutputSuffix = trimmed.endsWith('[output]')
+      const cleanPath = hasOutputSuffix
+        ? trimmed.replace(/\s*\[output\]$/, '')
+        : trimmed
+      const type = hasOutputSuffix || isPreview.value ? 'output' : 'input'
 
       const [subfolder, filename] = Load3dUtils.splitFilePath(cleanPath)
-      return api.apiURL(
-        Load3dUtils.getResourceURL(
-          subfolder,
-          filename,
-          forcedType ?? (isPreview.value ? 'output' : 'input')
-        )
-      )
+      return api.apiURL(Load3dUtils.getResourceURL(subfolder, filename, type))
     } catch (error) {
       console.error('Failed to construct model URL:', error)
       return null

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2387,6 +2387,7 @@
       "placeholderImage": "Select image...",
       "placeholderAudio": "Select audio...",
       "placeholderVideo": "Select video...",
+      "placeholderMesh": "Select mesh...",
       "placeholderModel": "Select model...",
       "placeholderUnknown": "Select media..."
     },


### PR DESCRIPTION
## Summary
- Refactor getModelUrl to use const instead of let
- add missing language key

improve for https://github.com/Comfy-Org/ComfyUI_frontend/pull/8765

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8779-fix-address-review-nits-in-load3d-3036d73d36508183af11c5e9bc545650) by [Unito](https://www.unito.io)
