### PR TITLE
Defer vue node layout calculations on hidden browser tabs

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
@@ -69,7 +69,6 @@ document.addEventListener('visibilitychange', () => {
   // Re-observe deferred elements to trigger fresh measurements
   for (const element of deferredElements) {
     if (element.isConnected) {
-      resizeObserver.unobserve(element)
       resizeObserver.observe(element)
     }
   }
@@ -85,6 +84,7 @@ const resizeObserver = new ResizeObserver((entries) => {
     for (const entry of entries) {
       if (entry.target instanceof HTMLElement) {
         deferredElements.add(entry.target)
+        resizeObserver.unobserve(entry.target)
       }
     }
     return


### PR DESCRIPTION
## Summary

If you load the window in Nodes 2.0, then switch tabs while it is still loading, the position of the nodes is calculated incorrectly due to useElementBounding returning left=0, top=0 for the canvas element in a hidden tab, causing clientPosToCanvasPos to miscalculate node positions from the ResizeObserver measurements

## Changes

- **What**: 
- Store observed elements while document is in hidden state
- Re-observe when tab becomes visible

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8805-Defer-vue-node-layout-calculations-on-hidden-browser-tabs-3046d73d365081019ae6c403c0ac6d1a) by [Unito](https://www.unito.io)
