### PR TITLE
feat: add clear pending tasks button in actionbar2

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -42,6 +42,17 @@
         >
           <i class="icon-[lucide--x] size-4" />
         </Button>
+        <Button
+          v-if="showClearPendingTasksButton"
+          v-tooltip.bottom="clearPendingTasksTooltipConfig"
+          variant="destructive"
+          size="icon"
+          :disabled="!hasPendingTasks"
+          :aria-label="$t('menuLabels.Clear Pending Tasks')"
+          @click="() => commandStore.execute('Comfy.ClearPendingTasks')"
+        >
+          <i class="icon-[lucide--list-x] size-4" />
+        </Button>
       </div>
     </Panel>
 
@@ -77,6 +88,7 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
+import { useQueueStore } from '@/stores/queueStore'
 import { cn } from '@/utils/tailwindUtil'
 
 import ComfyRunButton from './ComfyRunButton'
@@ -92,11 +104,15 @@ const emit = defineEmits<{
 
 const settingsStore = useSettingStore()
 const commandStore = useCommandStore()
+const { hasPendingTasks } = storeToRefs(useQueueStore())
 const { t } = useI18n()
 const { isIdle: isExecutionIdle } = storeToRefs(useExecutionStore())
 
 const position = computed(() => settingsStore.get('Comfy.UseNewMenu'))
 const visible = computed(() => position.value !== 'Disabled')
+const showClearPendingTasksButton = computed(() =>
+  settingsStore.get('Comfy.Queue.ShowClearPendingTasksButton')
+)
 const isQueuePanelV2Enabled = computed(() =>
   settingsStore.get('Comfy.Queue.QPOV2')
 )
@@ -320,6 +336,10 @@ const cancelCurrentJob = async () => {
   if (isExecutionIdle.value) return
   await commandStore.execute('Comfy.Interrupt')
 }
+
+const clearPendingTasksTooltipConfig = computed(() =>
+  buildTooltipConfig(t('menuLabels.Clear Pending Tasks'))
+)
 
 const actionbarClass = computed(() =>
   cn(

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -346,6 +346,10 @@
     "name": "Use the unified job queue in the Assets side panel",
     "tooltip": "Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout."
   },
+  "Comfy_Queue_ShowClearPendingTasksButton": {
+    "name": "Show clear pending tasks button in action bar",
+    "tooltip": "Adds a clear pending tasks button to the action bar."
+  },
   "Comfy_QueueButton_BatchCountLimit": {
     "name": "Batch count limit",
     "tooltip": "The maximum number of tasks added to the queue at one button click"

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -842,6 +842,14 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.37.0'
   },
   {
+    id: 'Comfy.Queue.ShowClearPendingTasksButton',
+    category: ['Comfy', 'Queue', 'ShowClearPendingTasksButton'],
+    defaultValue: false,
+    name: 'Show clear pending tasks button in action bar',
+    type: 'boolean',
+    tooltip: 'Adds a clear pending tasks button to the action bar.'
+  },
+  {
     id: 'Comfy.Execution.PreviewMethod',
     category: ['Comfy', 'Execution', 'PreviewMethod'],
     name: 'Live preview method',

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -346,6 +346,7 @@ const zSettings = z.object({
   'Comfy.QueueButton.BatchCountLimit': z.number(),
   'Comfy.Queue.MaxHistoryItems': z.number(),
   'Comfy.Queue.History.Expanded': z.boolean(),
+  'Comfy.Queue.ShowClearPendingTasksButton': z.boolean(),
   'Comfy.Keybinding.UnsetBindings': z.array(zKeybinding),
   'Comfy.Keybinding.NewBindings': z.array(zKeybinding),
   'Comfy.Extension.Disabled': z.array(z.string()),


### PR DESCRIPTION
I was told to resend the PR (I think? message was a bit cryptic...) so here it is.

Original PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/7617

## Summary

This PR brings back the Clear Pending Tasks button in the actionbar. (Setting in Queue, defaults to false)

## Changes

- **What**:  Clear Pending Tasks button added in the actionbar.

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/7319 https://github.com/Comfy-Org/ComfyUI_frontend/issues/7282 https://github.com/Comfy-Org/ComfyUI_frontend/issues/7133

## Screenshots (if applicable)

<img width="323" height="121" alt="image" src="https://github.com/user-attachments/assets/ced889cb-22fd-48de-a8c5-c912ffc43ab5" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8806-feat-add-clear-pending-tasks-button-in-actionbar2-3046d73d365081099ee2c7acbc9c8d05) by [Unito](https://www.unito.io)
