### PR TITLE
fix: set audio widget value after file upload

### DIFF
--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -71,6 +71,7 @@ async function uploadFile(
           api.apiURL(getResourceURL(...splitFilePath(path)))
         )
 
+        audioWidget.value = path
         // Manually trigger the callback to update VueNodes
         audioWidget.callback?.(path)
       }


### PR DESCRIPTION
## Summary

Set `audioWidget.value` after uploading an audio file so the combo dropdown reflects the newly uploaded file.

## Changes

- **What**: Added `audioWidget.value = path` in the `uploadFile` function before the callback call, matching the pattern used by the image upload widget.

## Review Focus

One-line fix. The image upload widget already does this correctly in `useImageUploadWidget.ts:86`. Without this line, the file uploads but the dropdown doesn't update to show the selection.

Fixes #8800

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8814-fix-set-audio-widget-value-after-file-upload-3056d73d365081a0af90d4e096eb4975) by [Unito](https://www.unito.io)
