### PR TITLE
Fix: Widgets Column sizing and ProgressText Widget

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -6,7 +6,7 @@
     v-else
     :class="
       cn(
-        'lg-node-widgets grid grid-cols-[min-content_minmax(80px,max-content)_minmax(125px,auto)] gap-y-1 pr-3',
+        'lg-node-widgets grid grid-cols-[min-content_minmax(80px,min-content)_minmax(125px,1fr)] gap-y-1 pr-3',
         shouldHandleNodePointerEvents
           ? 'pointer-events-auto'
           : 'pointer-events-none'

--- a/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
@@ -1,5 +1,3 @@
-import { ref } from 'vue'
-
 import TextPreviewWidget from '@/components/graph/widgets/TextPreviewWidget.vue'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -7,6 +5,7 @@ import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
 import type { ComponentWidgetStandardProps } from '@/scripts/domWidget'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 type TextPreviewCustomProps = Omit<
   InstanceType<typeof TextPreviewWidget>['$props'],
@@ -24,7 +23,6 @@ export function useTextPreviewWidget(
     node: LGraphNode,
     inputSpec: InputSpec
   ): IBaseWidget {
-    const widgetValue = ref<string>('')
     const widget = new ComponentWidgetImpl<
       string | object,
       TextPreviewCustomProps
@@ -37,9 +35,16 @@ export function useTextPreviewWidget(
         nodeId: node.id
       },
       options: {
-        getValue: () => widgetValue.value,
+        getValue: () =>
+          useWidgetValueStore().getWidget(node.id, inputSpec.name)?.value ?? '',
         setValue: (value: string | object) => {
-          widgetValue.value = typeof value === 'string' ? value : String(value)
+          const widgetState = useWidgetValueStore().getWidget(
+            node.id,
+            inputSpec.name
+          )
+          if (widgetState)
+            widgetState.value =
+              typeof value === 'string' ? value : String(value)
         },
         getMinHeight: () => options.minHeight ?? 42 + PADDING,
         read_only: true


### PR DESCRIPTION
## Summary

Fixes an issue where the label/control columns for widgets were dependent on the contents of the progress text display widget.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8817-Fix-Widgets-Column-sizing-and-ProgressText-Widget-3056d73d36508141a714fe342c386eef) by [Unito](https://www.unito.io)
