### PR TITLE
fix(vueNodes): propagate height to DOM widget children

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
@@ -34,5 +34,11 @@ onMounted(() => {
 whenever(() => !canvasStore.linearMode, mountWidgetElement)
 </script>
 <template>
-  <div ref="domEl" @pointerdown.stop @pointermove.stop @pointerup.stop />
+  <div
+    ref="domEl"
+    class="flex flex-col [&>*]:flex-1"
+    @pointerdown.stop
+    @pointermove.stop
+    @pointerup.stop
+  />
 </template>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -555,7 +555,7 @@ export class ComfyApp {
         try {
           workspace.spinner = true
           if (fileMaybe instanceof File) {
-              await this.handleFile(fileMaybe, 'file_drop')
+            await this.handleFile(fileMaybe, 'file_drop')
           }
 
           if (fileMaybe instanceof FileList) {
@@ -1575,7 +1575,6 @@ export class ComfyApp {
     this.showErrorOnFileLoad(file)
   }
 
-
   /**
    * Loads multiple files, connects to a batch node, and selects them
    * @param {FileList} fileList
@@ -1602,19 +1601,19 @@ export class ComfyApp {
    */
   positionBatchNodes(nodes: LGraphNode[], batchNode: LGraphNode): void {
     const [x, y, width] = nodes[0].getBounding()
-    batchNode.pos = [ x + width + 100, y + 30 ]
+    batchNode.pos = [x + width + 100, y + 30]
 
     // Retrieving Node Height is inconsistent
-    let height = 0;
+    let height = 0
     if (nodes[0].type === 'LoadImage') {
       height = 344
     }
 
     nodes.forEach((node, index) => {
       if (index > 0) {
-        node.pos = [ x, y + (height * index) + (25 * (index + 1)) ]
+        node.pos = [x, y + height * index + 25 * (index + 1)]
       }
-    });
+    })
 
     this.canvas.graph?.change()
   }


### PR DESCRIPTION
## Summary
DOM widgets using CSS background-image (e.g. KJNodes FastPreview) collapsed to 0px height in vueNodes mode because background-image doesn't contribute to intrinsic element size. Make WidgetDOM a flex column container so mounted extension elements fill the available grid row space.

## Screenshots (if applicable)
before 


https://github.com/user-attachments/assets/85de0295-1f7c-4142-ac15-1e813c823e3f


after

https://github.com/user-attachments/assets/824ab662-14cb-412d-93dd-97c0f549f992

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8821-fix-vueNodes-propagate-height-to-DOM-widget-children-3056d73d36508134926dc67336fd0d70) by [Unito](https://www.unito.io)
