### PR TITLE
Add Mixpanel detection to telemetry tree-shaking validation

### DIFF
--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -34,10 +34,13 @@ jobs:
 
       - name: Build project
         run: pnpm build
+        env:
+          DISTRIBUTION: localhost
 
-      - name: Scan dist for telemetry references
+      - name: Scan dist for GTM telemetry references
         run: |
           set -euo pipefail
+          echo '🔍 Scanning for Google Tag Manager references...'
           if rg --no-ignore -n \
             -g '*.html' \
             -g '*.js' \
@@ -46,7 +49,34 @@ jobs:
             -e '(?i)googletagmanager\.com/gtm\.js\\?id=' \
             -e '(?i)googletagmanager\.com/ns\.html\\?id=' \
             dist; then
-            echo 'Telemetry references found in dist assets.'
+            echo '❌ ERROR: Google Tag Manager references found in dist assets!'
+            echo 'GTM must be properly tree-shaken from OSS builds.'
             exit 1
           fi
-          echo 'No telemetry references found in dist assets.'
+          echo '✅ No GTM references found'
+
+      - name: Scan dist for Mixpanel telemetry references
+        run: |
+          set -euo pipefail
+          echo '🔍 Scanning for Mixpanel references...'
+          if rg --no-ignore -n \
+            -g '*.html' \
+            -g '*.js' \
+            -g '!*.map' \
+            -e '(?i)mixpanel\.init' \
+            -e '(?i)mixpanel\.identify' \
+            -e 'MixpanelTelemetryProvider' \
+            -e 'mp\.comfy\.org' \
+            -e 'mixpanel-browser' \
+            -e '(?i)mixpanel\.track\(' \
+            dist; then
+            echo '❌ ERROR: Mixpanel references found in dist assets!'
+            echo 'Mixpanel must be properly tree-shaken from OSS builds.'
+            echo ''
+            echo 'To fix this:'
+            echo '1. Use the TelemetryProvider pattern (see src/platform/telemetry/)'
+            echo '2. Call telemetry via useTelemetry() hook'
+            echo '3. Use conditional dynamic imports behind isCloud checks'
+            exit 1
+          fi
+          echo '✅ No Mixpanel references found'

--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -62,7 +62,6 @@ jobs:
           if rg --no-ignore -n \
             -g '*.html' \
             -g '*.js' \
-            -g '!*.map' \
             -e '(?i)mixpanel\.init' \
             -e '(?i)mixpanel\.identify' \
             -e 'MixpanelTelemetryProvider' \


### PR DESCRIPTION
## Summary
Enhances the existing CI telemetry scan workflow to also detect Mixpanel code in dist files, ensuring it's properly tree-shaken from OSS builds.

## Context
- Extends existing `ci-dist-telemetry-scan.yaml` (added in PR #8354)
- Based on analysis in closed PR #6777 (split into focused PRs)
- Complements GTM detection already in place
- Part of comprehensive OSS compliance effort

## Implementation
- Adds separate Mixpanel check step with specific patterns:
  - `mixpanel.init`
  - `mixpanel.identify` 
  - `MixpanelTelemetryProvider`
  - `mp.comfy.org`
  - `mixpanel-browser`
  - `mixpanel.track(`
- Separates GTM and Mixpanel checks for clarity
- Adds `DISTRIBUTION=localhost` env var to build step
- Excludes source maps from scanning

## Related
- Supersedes part of closed PR #6777
- Complements existing GTM check from PR #8354
- Related to PR #8623 (GTM-focused, may be redundant)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8826-Add-Mixpanel-detection-to-telemetry-tree-shaking-validation-3056d73d36508153bab5f55d4bb17658) by [Unito](https://www.unito.io)
