### PR TITLE
Fix hover state on collapsed bottom button

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -126,8 +126,9 @@
       variant="textonly"
       :class="
         cn(
-          'w-full h-12 rounded-b-2xl -mt-5 pt-7 pb-2 -z-1 text-xs',
-          hasAnyError && 'hover:bg-destructive-background-hover'
+          'w-full h-7 rounded-b-2xl py-2 -z-1 text-xs rounded-t-none',
+          hasAnyError && 'hover:bg-destructive-background-hover',
+          !isCollapsed && '-mt-5 pt-7 h-12'
         )
       "
       as-child


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/0de0790a-e9f0-432c-9501-eae633e341b6" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/588221b0-b34a-4d35-8393-1bc1ec36c285" />|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8837-Fix-hover-state-on-collapsed-bottom-button-3056d73d36508139919fc1d750c6b135) by [Unito](https://www.unito.io)
