### PR TITLE
fix: undo breaking Vue node image preview reactivity

### DIFF
--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -365,7 +365,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     outputs: Record<string, ExecutedWsMessage['output']>
   ) {
     app.nodeOutputs = outputs
-    nodeOutputs.value = outputs
+    nodeOutputs.value = { ...outputs }
   }
 
   function updateNodeImages(node: LGraphNode) {


### PR DESCRIPTION
## Summary
restoreOutputs was assigning the same object reference to both app.nodeOutputs and the Pinia reactive ref. This caused subsequent writes via setOutputsByLocatorId to mutate the reactive proxy's target through the raw reference before the proxy write, making Vue detect no change and skip reactivity updates permanently.

Shallow-copy the outputs when assigning to the reactive ref so the proxy target remains a separate object from app.nodeOutputs.

## Screenshots
before

https://github.com/user-attachments/assets/98f2b17c-87b9-41e7-9caa-238e36c3c032


after

https://github.com/user-attachments/assets/cb6e1d25-bd2e-41ed-a536-7b8250f858ec

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8839-fix-undo-breaking-Vue-node-image-preview-reactivity-3056d73d365081d2a1c7d4d9553f30e0) by [Unito](https://www.unito.io)
