### PR TITLE
Fix labels on output slots in vue mode

### DIFF
--- a/src/renderer/extensions/vueNodes/components/OutputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.vue
@@ -7,7 +7,11 @@
         v-if="!props.dotOnly && !hasNoLabel"
         class="truncate text-node-component-slot-text"
       >
-        {{ slotData.localized_name || (slotData.name ?? `Output ${index}`) }}
+        {{
+          slotData.label ||
+          slotData.localized_name ||
+          (slotData.name ?? `Output ${index}`)
+        }}
       </span>
     </div>
     <!-- Connection Dot -->


### PR DESCRIPTION
Vue output slots were not respecting the `slot.label`. As a result, a renamed subgraph output slot would still display the original name when in vue mode.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8846-Fix-labels-on-output-slots-in-vue-mode-3066d73d3650811c986cffee03f56ac2) by [Unito](https://www.unito.io)
