### PR TITLE
fix: make ResizeHandle interface properties readonly

### DIFF
--- a/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.ts
@@ -1,12 +1,12 @@
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
 
 interface ResizeHandle {
-  corner: CompassCorners
-  positionClasses: string
-  cursorClass: string
-  i18nKey: string
-  svgPositionClasses: string
-  svgTransform: string
+  readonly corner: CompassCorners
+  readonly positionClasses: string
+  readonly cursorClass: string
+  readonly i18nKey: string
+  readonly svgPositionClasses: string
+  readonly svgTransform: string
 }
 
 export const RESIZE_HANDLES: ResizeHandle[] = [
@@ -42,4 +42,4 @@ export const RESIZE_HANDLES: ResizeHandle[] = [
     svgPositionClasses: 'bottom-1 right-1',
     svgTransform: 'scale(-1, -1)'
   }
-]
+] as const


### PR DESCRIPTION
## Summary

improve for https://github.com/Comfy-Org/ComfyUI_frontend/pull/8845

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8847-fix-make-ResizeHandle-interface-properties-readonly-3066d73d3650814da6cee7bb955bbeb7) by [Unito](https://www.unito.io)
