### PR TITLE
Fix storybook build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -100,7 +100,8 @@ const config: StorybookConfig = {
         rolldownOptions: {
           treeshake: false,
           output: {
-            keepNames: true
+            keepNames: true,
+            strictExecutionOrder: true
           },
           onwarn: (warning, warn) => {
             // Suppress specific warnings


### PR DESCRIPTION
## Summary

The strictExecutionOrder looks to have accidently been removed.
This breaks the storybook build: https://github.com/vitejs/rolldown-vite/issues/182#issuecomment-3035289157
https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/21979369339/job/63498007630?pr=8842

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8849-Fix-storybook-build-3066d73d365081aa82ecc61bb7696a8e) by [Unito](https://www.unito.io)
