### PR TITLE
fix: skip loading drafts when Comfy.Workflow.Persist is disabled

### DIFF
--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -62,8 +62,11 @@ export class ComfyWorkflow extends UserFile {
   > {
     const { useWorkflowDraftStore } =
       await import('@/platform/workflow/persistence/stores/workflowDraftStore')
+    const { useSettingStore } = await import('@/platform/settings/settingStore')
     const draftStore = useWorkflowDraftStore()
-    let draft = !force ? draftStore.getDraft(this.path) : undefined
+    const persistEnabled = useSettingStore().get('Comfy.Workflow.Persist')
+    let draft =
+      !force && persistEnabled ? draftStore.getDraft(this.path) : undefined
     let draftState: ComfyWorkflowJSON | null = null
     let draftContent: string | null = null
 

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistence.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistence.ts
@@ -53,6 +53,13 @@ export function useWorkflowPersistence() {
 
   const lastSavedJsonByPath = ref<Record<string, string>>({})
 
+  watch(workflowPersistenceEnabled, (enabled) => {
+    if (!enabled) {
+      workflowDraftStore.reset()
+      lastSavedJsonByPath.value = {}
+    }
+  })
+
   const persistCurrentWorkflow = () => {
     if (!workflowPersistenceEnabled.value) return
     const activeWorkflow = workflowStore.activeWorkflow


### PR DESCRIPTION
## Summary

Skip draft loading and clear stored drafts when `Comfy.Workflow.Persist` is disabled, preventing unsaved changes from reappearing.

## Changes

- **What**: Guard draft loading in `ComfyWorkflow.load()` with `Comfy.Workflow.Persist` setting check. Clear all localStorage drafts when Persist is toggled from true to false.

## Review Focus

`ComfyWorkflow.load()` previously read drafts unconditionally regardless of the Persist setting. This meant that after disabling Persist, previously stored drafts would still be applied when opening a saved workflow. The fix adds a guard in two places:
1. `comfyWorkflow.ts`: `load()` now checks `Comfy.Workflow.Persist` before calling `getDraft()`
2. `useWorkflowPersistence.ts`: A `watch` on the Persist setting calls `draftStore.reset()` when disabled

Fixes Comfy-Org/ComfyUI#12323

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8851-fix-skip-loading-drafts-when-Comfy-Workflow-Persist-is-disabled-3066d73d36508119ac2ce13564e18c01) by [Unito](https://www.unito.io)
