### PR TITLE
fix: clear draft on workflow close to prevent stale state on reopen

### DIFF
--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -215,6 +215,8 @@ export const useWorkflowService = () => {
       }
     }
 
+    workflowDraftStore.removeDraft(workflow.path)
+
     // If this is the last workflow, create a new default temporary workflow
     if (workflowStore.openWorkflows.length === 1) {
       await loadDefaultWorkflow()

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -320,11 +320,9 @@ export const useWorkflowStore = defineStore('workflow', () => {
     openWorkflowPaths.value = openWorkflowPaths.value.filter(
       (path) => path !== workflow.path
     )
+    useWorkflowDraftStore().removeDraft(workflow.path)
     if (workflow.isTemporary) {
-      // Clear thumbnail when temporary workflow is closed
       clearThumbnail(workflow.key)
-      // Clear draft when unsaved workflow tab is closed
-      useWorkflowDraftStore().removeDraft(workflow.path)
       delete workflowLookup.value[workflow.path]
     } else {
       workflow.unload()


### PR DESCRIPTION
## Summary

Clear the workflow draft from localStorage when any workflow tab is closed, preventing stale cached state from being served when the workflow is re-opened.

## Changes

- **What**: `closeWorkflow()` in `workflowStore.ts` now calls `removeDraft()` for all workflows, not just temporary ones. `closeWorkflow()` in `workflowService.ts` removes the draft before switching tabs, preventing `beforeLoadNewGraph()` from re-saving it.

## Review Focus

- Draft is removed before the tab switch in `workflowService.closeWorkflow()` to prevent `beforeLoadNewGraph()` from re-saving it during the switch
- Crash recovery is preserved: drafts are only cleared on explicit close, not on unload/crash
- Tab restore on restart is unaffected: drafts for intentionally-open tabs are saved on graph change events, not on close

Fixes #8778
Fixes https://github.com/Comfy-Org/ComfyUI/issues/12323

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8854-fix-clear-draft-on-workflow-close-to-prevent-stale-state-on-reopen-3066d73d365081a2a633c9b352d0b0d1) by [Unito](https://www.unito.io)
