### PR TITLE
[do not merge] Prototype: proxy /customers/* calls through cloud

### DIFF
--- a/src/config/comfyApi.ts
+++ b/src/config/comfyApi.ts
@@ -30,6 +30,19 @@ export function getComfyApiBaseUrl(): string {
   )
 }
 
+/**
+ * Base URL for /customers/* API calls.
+ * In cloud mode, routes through the cloud proxy (same-origin).
+ * In non-cloud mode, calls api.comfy.org directly.
+ */
+export function getCustomerApiBaseUrl(): string {
+  if (isCloud) {
+    return '/api/proxy/registry'
+  }
+
+  return getComfyApiBaseUrl()
+}
+
 export function getComfyPlatformBaseUrl(): string {
   if (!isCloud) {
     return BUILD_TIME_PLATFORM_BASE_URL

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -4,7 +4,10 @@ import { createSharedComposable } from '@vueuse/core'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
-import { getComfyApiBaseUrl, getComfyPlatformBaseUrl } from '@/config/comfyApi'
+import {
+  getComfyPlatformBaseUrl,
+  getCustomerApiBaseUrl
+} from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
@@ -96,7 +99,7 @@ function useSubscriptionInternal() {
   })
 
   function buildApiUrl(path: string): string {
-    return `${getComfyApiBaseUrl()}${path}`
+    return `${getCustomerApiBaseUrl()}${path}`
   }
 
   const getCheckoutAttributionForCloud =

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
@@ -1,6 +1,6 @@
 import { storeToRefs } from 'pinia'
 
-import { getComfyApiBaseUrl } from '@/config/comfyApi'
+import { getCustomerApiBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
@@ -73,7 +73,7 @@ export async function performSubscriptionCheckout(
   const checkoutPayload = { ...checkoutAttribution }
 
   const response = await fetch(
-    `${getComfyApiBaseUrl()}/customers/cloud-subscription-checkout/${checkoutTier}`,
+    `${getCustomerApiBaseUrl()}/customers/cloud-subscription-checkout/${checkoutTier}`,
     {
       method: 'POST',
       headers: { ...authHeader, 'Content-Type': 'application/json' },

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -2,7 +2,7 @@ import type { AxiosError, AxiosResponse } from 'axios'
 import axios from 'axios'
 import { ref, watch } from 'vue'
 
-import { getComfyApiBaseUrl } from '@/config/comfyApi'
+import { getCustomerApiBaseUrl } from '@/config/comfyApi'
 import { d } from '@/i18n'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import type { components, operations } from '@/types/comfyRegistryTypes'
@@ -24,7 +24,7 @@ type CustomerEventsResponseQuery =
 export type AuditLog = components['schemas']['AuditLog']
 
 const customerApiClient = axios.create({
-  baseURL: getComfyApiBaseUrl(),
+  baseURL: getCustomerApiBaseUrl(),
   headers: {
     'Content-Type': 'application/json'
   }
@@ -35,7 +35,7 @@ export const useCustomerEventsService = () => {
   const error = ref<string | null>(null)
 
   watch(
-    () => getComfyApiBaseUrl(),
+    () => getCustomerApiBaseUrl(),
     (url) => {
       customerApiClient.defaults.baseURL = url
     }

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -20,7 +20,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useFirebaseAuth } from 'vuefire'
 
-import { getComfyApiBaseUrl } from '@/config/comfyApi'
+import { getCustomerApiBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/auth/workspace/workspaceConstants'
 import { isCloud } from '@/platform/distribution/types'
@@ -78,7 +78,7 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
    */
   const lastTokenUserId = ref<string | null>(null)
 
-  const buildApiUrl = (path: string) => `${getComfyApiBaseUrl()}${path}`
+  const buildApiUrl = (path: string) => `${getCustomerApiBaseUrl()}${path}`
 
   // Providers
   const googleProvider = new GoogleAuthProvider()


### PR DESCRIPTION
Experimental prototype for proxying frontend `/customers/*` API calls through the cloud server instead of calling `api.comfy.org` directly in cloud mode.

## Changes
- Add `getCustomerApiBaseUrl()` in `comfyApi.ts` — returns `/api/proxy/registry` (same-origin) in cloud mode, `getComfyApiBaseUrl()` otherwise
- Update 4 consumer files (`firebaseAuthStore`, `customerEventsService`, `useSubscription`, `subscriptionCheckoutUtil`) to use it for `/customers/*` endpoints
- Non-cloud (desktop) builds are unchanged

Related cloud PR: Comfy-Org/cloud (free-tier-work branch)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8855-do-not-merge-Prototype-proxy-customers-calls-through-cloud-3066d73d365081e3b4aaf6cddb922dd9) by [Unito](https://www.unito.io)
