### PR TITLE
fix: restore mouse-wheel scrolling in preview-as-text outputs

### DIFF
--- a/src/extensions/core/previewAny.ts
+++ b/src/extensions/core/previewAny.ts
@@ -53,7 +53,6 @@ useExtensionService().registerExtension({
         showValueWidget.options.hidden = true
         showValueWidget.options.read_only = true
         showValueWidget.element.readOnly = true
-        showValueWidget.element.disabled = true
         showValueWidget.serialize = false
 
         showValueWidgetPlain.label = 'Preview'
@@ -61,7 +60,6 @@ useExtensionService().registerExtension({
         showValueWidgetPlain.options.hidden = false
         showValueWidgetPlain.options.read_only = true
         showValueWidgetPlain.element.readOnly = true
-        showValueWidgetPlain.element.disabled = true
         showValueWidgetPlain.serialize = false
       }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -4,6 +4,8 @@
     <div
       class="comfy-markdown-content size-full min-h-[60px] overflow-y-auto rounded-lg text-sm"
       :class="isEditing === false ? 'visible' : 'invisible'"
+      tabindex="0"
+      data-capture-wheel="true"
       v-html="renderedHtml"
     />
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -16,7 +16,6 @@
       :class="cn(WidgetInputBaseClass, 'size-full text-xs resize-none')"
       :placeholder
       :readonly="isReadOnly"
-      :disabled="isReadOnly"
       fluid
       data-capture-wheel="true"
       @pointerdown.capture.stop


### PR DESCRIPTION
## Summary

Restore mouse-wheel scrolling for read-only preview widgets (PreviewAny plaintext and markdown modes), broken by the focus-gated wheel capture in #6597.

## Changes

- **What**: Remove `disabled` attribute from read-only textareas (keep `readonly`) so they can receive focus and capture wheel events. Add `data-capture-wheel` and `tabindex` to WidgetMarkdown display div.
- **Root cause**: `disabled` elements cannot receive focus in browsers. The focus-gated `wheelCapturedByFocusedElement()` from #6597 always evaluated to false for disabled textareas, forwarding all wheel events to the canvas.

## Review Focus

- Verify that removing `disabled` while keeping `readonly` does not allow unintended editing
- Confirm `tabindex="0"` on the markdown display div does not cause unexpected tab-order issues
- Ensure trackpad panning over unfocused widgets (#6523) still works correctly

Fixes COM-14812

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8863-fix-restore-mouse-wheel-scrolling-in-preview-as-text-outputs-3076d73d365081719bf5e453235bb2b5) by [Unito](https://www.unito.io)
