### PR TITLE
feat: add Free subscription tier support

### DIFF
--- a/packages/registry-types/src/comfyRegistryTypes.ts
+++ b/packages/registry-types/src/comfyRegistryTypes.ts
@@ -3952,7 +3952,7 @@ export interface components {
          * @description The subscription tier level
          * @enum {string}
          */
-        SubscriptionTier: "STANDARD" | "CREATOR" | "PRO" | "FOUNDERS_EDITION";
+        SubscriptionTier: "FREE" | "STANDARD" | "CREATOR" | "PRO" | "FOUNDERS_EDITION";
         /**
          * @description The subscription billing duration
          * @enum {string}

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -113,12 +113,13 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
 }))
 
 // Mock the useSubscriptionDialog composable
-const mockSubscriptionDialogShow = vi.fn()
+const mockShowPricingTable = vi.fn()
 vi.mock(
   '@/platform/cloud/subscription/composables/useSubscriptionDialog',
   () => ({
     useSubscriptionDialog: vi.fn(() => ({
-      show: mockSubscriptionDialogShow,
+      show: vi.fn(),
+      showPricingTable: mockShowPricingTable,
       hide: vi.fn()
     }))
   })
@@ -318,8 +319,8 @@ describe('CurrentUserPopoverLegacy', () => {
 
     await plansPricingItem.trigger('click')
 
-    // Verify subscription dialog show was called
-    expect(mockSubscriptionDialogShow).toHaveBeenCalled()
+    // Verify showPricingTable was called
+    expect(mockShowPricingTable).toHaveBeenCalled()
 
     // Verify close event was emitted
     expect(wrapper.emitted('close')).toBeTruthy()

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -46,6 +46,17 @@
         class="icon-[lucide--circle-help] cursor-help text-base text-muted-foreground mr-auto"
       />
       <Button
+        v-if="isFreeTier"
+        variant="secondary"
+        size="sm"
+        class="text-base-foreground"
+        data-testid="upgrade-button"
+        @click="handleOpenPlansAndPricing"
+      >
+        {{ $t('subscription.upgrade') }}
+      </Button>
+      <Button
+        v-else
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -170,6 +181,7 @@ const settingsDialog = useSettingsDialog()
 const dialogService = useDialogService()
 const {
   isActiveSubscription,
+  isFreeTier,
   subscriptionTierName,
   subscriptionTier,
   fetchStatus
@@ -195,7 +207,10 @@ const formattedBalance = computed(() => {
 const canUpgrade = computed(() => {
   const tier = subscriptionTier.value
   return (
-    tier === 'FOUNDERS_EDITION' || tier === 'STANDARD' || tier === 'CREATOR'
+    tier === 'FREE' ||
+    tier === 'FOUNDERS_EDITION' ||
+    tier === 'STANDARD' ||
+    tier === 'CREATOR'
   )
 })
 

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -220,7 +220,7 @@ const handleOpenUserSettings = () => {
 }
 
 const handleOpenPlansAndPricing = () => {
-  subscriptionDialog.show()
+  subscriptionDialog.showPricingTable()
   emit('close')
 }
 

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -46,17 +46,6 @@
         class="icon-[lucide--circle-help] cursor-help text-base text-muted-foreground mr-auto"
       />
       <Button
-        v-if="isFreeTier"
-        variant="secondary"
-        size="sm"
-        class="text-base-foreground"
-        data-testid="upgrade-button"
-        @click="handleOpenPlansAndPricing"
-      >
-        {{ $t('subscription.upgrade') }}
-      </Button>
-      <Button
-        v-else
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -181,7 +170,6 @@ const settingsDialog = useSettingsDialog()
 const dialogService = useDialogService()
 const {
   isActiveSubscription,
-  isFreeTier,
   subscriptionTierName,
   subscriptionTier,
   fetchStatus

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -95,9 +95,12 @@ export const useFirebaseAuthActions = () => {
   )
 
   const purchaseCredits = wrapWithErrorHandlingAsync(async (amount: number) => {
-    const { isActiveSubscription, subscription } = useBillingContext()
-    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE')
+    const { isActiveSubscription, subscription, showSubscriptionDialog } =
+      useBillingContext()
+    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE') {
+      showSubscriptionDialog()
       return
+    }
 
     const response = await authStore.initiateCreditPurchase({
       amount_micros: usdToMicros(amount),

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -99,6 +99,8 @@ export const useFirebaseAuthActions = () => {
     const { isActiveSubscription } = useBillingContext()
     if (!isActiveSubscription.value) return
 
+    // Defense-in-depth: showTopUpCreditsDialog also gates free-tier users,
+    // but purchaseCredits can be called directly from other entry points.
     const { isFreeTier } = useSubscription()
     if (isFreeTier.value) {
       await useDialogService().showSubscriptionRequiredDialog({

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useErrorHandling } from '@/composables/useErrorHandling'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { ErrorRecoveryStrategy } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
@@ -95,10 +96,14 @@ export const useFirebaseAuthActions = () => {
   )
 
   const purchaseCredits = wrapWithErrorHandlingAsync(async (amount: number) => {
-    const { isActiveSubscription, subscription, showSubscriptionDialog } =
-      useBillingContext()
-    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE') {
-      showSubscriptionDialog()
+    const { isActiveSubscription } = useBillingContext()
+    if (!isActiveSubscription.value) return
+
+    const { isFreeTier } = useSubscription()
+    if (isFreeTier.value) {
+      await useDialogService().showSubscriptionRequiredDialog({
+        reason: 'top_up_blocked'
+      })
       return
     }
 

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -4,7 +4,6 @@ import { ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useErrorHandling } from '@/composables/useErrorHandling'
-import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { ErrorRecoveryStrategy } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
@@ -98,16 +97,6 @@ export const useFirebaseAuthActions = () => {
   const purchaseCredits = wrapWithErrorHandlingAsync(async (amount: number) => {
     const { isActiveSubscription } = useBillingContext()
     if (!isActiveSubscription.value) return
-
-    // Defense-in-depth: showTopUpCreditsDialog also gates free-tier users,
-    // but purchaseCredits can be called directly from other entry points.
-    const { isFreeTier } = useSubscription()
-    if (isFreeTier.value) {
-      await useDialogService().showSubscriptionRequiredDialog({
-        reason: 'top_up_blocked'
-      })
-      return
-    }
 
     const response = await authStore.initiateCreditPurchase({
       amount_micros: usdToMicros(amount),

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -95,8 +95,9 @@ export const useFirebaseAuthActions = () => {
   )
 
   const purchaseCredits = wrapWithErrorHandlingAsync(async (amount: number) => {
-    const { isActiveSubscription } = useBillingContext()
-    if (!isActiveSubscription.value) return
+    const { isActiveSubscription, subscription } = useBillingContext()
+    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE')
+      return
 
     const response = await authStore.initiateCreditPurchase({
       amount_micros: usdToMicros(amount),

--- a/src/composables/billing/types.ts
+++ b/src/composables/billing/types.ts
@@ -70,6 +70,11 @@ export interface BillingState {
    * Equivalent to `subscription.value?.isActive ?? false`
    */
   isActiveSubscription: ComputedRef<boolean>
+  /**
+   * Whether the current billing context has a FREE tier subscription.
+   * Workspace-aware: reflects the active workspace's tier, not the user's personal tier.
+   */
+  isFreeTier: ComputedRef<boolean>
 }
 
 export interface BillingContext extends BillingState, BillingActions {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -120,6 +120,8 @@ function useBillingContextInternal(): BillingContext {
     toValue(activeContext.value.isActiveSubscription)
   )
 
+  const isFreeTier = computed(() => subscription.value?.tier === 'FREE')
+
   function getMaxSeats(tierKey: TierKey): number {
     if (type.value === 'legacy') return 1
 
@@ -238,6 +240,7 @@ function useBillingContextInternal(): BillingContext {
     isLoading,
     error,
     isActiveSubscription,
+    isFreeTier,
     getMaxSeats,
 
     initialize,

--- a/src/composables/billing/useLegacyBilling.ts
+++ b/src/composables/billing/useLegacyBilling.ts
@@ -40,6 +40,7 @@ export function useLegacyBilling(): BillingState & BillingActions {
   const error = ref<string | null>(null)
 
   const isActiveSubscription = computed(() => legacyIsActiveSubscription.value)
+  const isFreeTier = computed(() => subscriptionTier.value === 'FREE')
 
   const subscription = computed<SubscriptionInfo | null>(() => {
     if (!legacyIsActiveSubscription.value && !subscriptionTier.value) {
@@ -85,6 +86,10 @@ export function useLegacyBilling(): BillingState & BillingActions {
     error.value = null
     try {
       await Promise.all([fetchStatus(), fetchBalance()])
+      // Re-fetch balance if free tier credits were just lazily granted
+      if (isFreeTier.value && balance.value?.amountMicros === 0) {
+        await fetchBalance()
+      }
       isInitialized.value = true
     } catch (err) {
       error.value =
@@ -173,6 +178,7 @@ export function useLegacyBilling(): BillingState & BillingActions {
     isLoading,
     error,
     isActiveSubscription,
+    isFreeTier,
 
     // Actions
     initialize,

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2262,6 +2262,17 @@
     "haveQuestions": "Have questions or wondering about enterprise?",
     "contactUs": "Contact us",
     "viewEnterprise": "View enterprise",
+    "freeTier": {
+      "title": "You're on the Free plan",
+      "description": "Your free plan includes {credits} credits each month to try Comfy Cloud.",
+      "nextRefresh": "Your credits refresh on {date}.",
+      "subscribeCta": "Subscribe for more",
+      "topUpBlocked": {
+        "title": "Top-ups aren't available on Free",
+        "description": "Adding credits requires a paid subscription. Subscribe to get more monthly credits and the ability to add credits anytime.",
+        "subscribeCta": "View plans"
+      }
+    },
     "partnerNodesCredits": "Partner nodes pricing",
     "plansAndPricing": "Plans & pricing",
     "managePlan": "Manage plan",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1987,7 +1987,7 @@
       "newUser": "New here?",
       "userAvatar": "User Avatar",
       "signUp": "Sign up",
-      "signUpFreeTier": "Sign up to try Cloud for free",
+      "signUpFreeTierPromo": "New here? {signUp} with a Gmail account to get {credits} free credits every month.",
       "emailLabel": "Email",
       "emailPlaceholder": "Enter your email",
       "passwordLabel": "Password",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2221,8 +2221,9 @@
     "messageSupport": "Message support",
     "invoiceHistory": "Invoice history",
     "benefits": {
-      "benefit1": "Monthly credits for Partner Nodes — top up when needed",
-      "benefit2": "Up to 30 min runtime per job"
+      "benefit1": "More monthly credits, top up anytime",
+      "benefit2": "Up to 1 hour runtime per job on Pro",
+      "benefit3": "Bring your own models (Creator & Pro)"
     },
     "yearlyDiscount": "20% DISCOUNT",
     "tiers": {
@@ -2267,11 +2268,14 @@
       "description": "Your free plan includes {credits} credits each month to try Comfy Cloud.",
       "nextRefresh": "Your credits refresh on {date}.",
       "subscribeCta": "Subscribe for more",
+      "outOfCredits": {
+        "title": "You're out of free credits",
+        "subtitle": "Subscribe to unlock top-ups and more"
+      },
       "topUpBlocked": {
-        "title": "Top-ups aren't available on Free",
-        "description": "Adding credits requires a paid subscription. Subscribe to get more monthly credits and the ability to add credits anytime.",
-        "subscribeCta": "View plans"
-      }
+        "title": "Unlock top-ups and more"
+      },
+      "upgradeCta": "View plans"
     },
     "partnerNodesCredits": "Partner nodes pricing",
     "plansAndPricing": "Plans & pricing",
@@ -2290,6 +2294,7 @@
     "maxDurationLabel": "Max run duration",
     "gpuLabel": "RTX 6000 Pro (96GB VRAM)",
     "addCreditsLabel": "Add more credits whenever",
+    "monthlyCreditsIncluded": "{credits} credits / month",
     "customLoRAsLabel": "Import your own LoRAs",
     "videoEstimateLabel": "Approx. amount of 5s videos generated with Wan 2.2 Image-to-Video template",
     "videoEstimateHelp": "More details on this template",
@@ -2300,6 +2305,7 @@
     "upgradeTo": "Upgrade to {plan}",
     "changeTo": "Change to {plan}",
     "maxDuration": {
+      "free": "30 min",
       "standard": "30 min",
       "creator": "30 min",
       "pro": "1 hr",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2011,7 +2011,12 @@
       "failed": "Login failed",
       "insecureContextWarning": "This connection is insecure (HTTP) - your credentials may be intercepted by attackers if you proceed to login.",
       "questionsContactPrefix": "Questions? Contact us at",
-      "noAssociatedUser": "There is no Comfy user associated with the provided API key"
+      "noAssociatedUser": "There is no Comfy user associated with the provided API key",
+      "useEmailInstead": "Use email instead",
+      "freeTierBadge": "Eligible for Free Tier",
+      "freeTierDescription": "Sign up with Google to get {credits} free credits every month. No card needed.",
+      "freeTierDescriptionGeneric": "Sign up with Google and get free credits every month. No card needed.",
+      "backToSocialLogin": "Sign up with Google or Github instead"
     },
     "signup": {
       "title": "Create an account",
@@ -2025,7 +2030,8 @@
       "signUpWithGoogle": "Sign up with Google",
       "signUpWithGithub": "Sign up with Github",
       "regionRestrictionChina": "In accordance with local regulatory requirements, our services are temporarily unavailable to users located in China.",
-      "personalDataConsentLabel": "I agree to the processing of my personal data."
+      "personalDataConsentLabel": "I agree to the processing of my personal data.",
+      "emailNotEligibleForFreeTier": "Email sign-up is not eligible for Free Tier."
     },
     "signOut": {
       "signOut": "Log Out",
@@ -2220,6 +2226,9 @@
     },
     "yearlyDiscount": "20% DISCOUNT",
     "tiers": {
+      "free": {
+        "name": "Free"
+      },
       "founder": {
         "name": "Founder's Edition"
       },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2014,8 +2014,8 @@
       "noAssociatedUser": "There is no Comfy user associated with the provided API key",
       "useEmailInstead": "Use email instead",
       "freeTierBadge": "Eligible for Free Tier",
-      "freeTierDescription": "Sign up with Google to get {credits} free credits every month. No card needed.",
-      "freeTierDescriptionGeneric": "Sign up with Google and get free credits every month. No card needed.",
+      "freeTierDescription": "Sign up to get {credits} free credits every month. No card needed.",
+      "freeTierDescriptionGeneric": "Sign up and get free credits every month. No card needed.",
       "backToSocialLogin": "Sign up with Google or Github instead"
     },
     "signup": {
@@ -2266,6 +2266,7 @@
     "freeTier": {
       "title": "You're on the Free plan",
       "description": "Your free plan includes {credits} credits each month to try Comfy Cloud.",
+      "descriptionGeneric": "Your free plan includes a monthly credit allowance to try Comfy Cloud.",
       "nextRefresh": "Your credits refresh on {date}.",
       "subscribeCta": "Subscribe for more",
       "outOfCredits": {
@@ -2294,7 +2295,6 @@
     "maxDurationLabel": "Max run duration",
     "gpuLabel": "RTX 6000 Pro (96GB VRAM)",
     "addCreditsLabel": "Add more credits whenever",
-    "monthlyCreditsIncluded": "{credits} credits / month",
     "customLoRAsLabel": "Import your own LoRAs",
     "videoEstimateLabel": "Approx. amount of 5s videos generated with Wan 2.2 Image-to-Video template",
     "videoEstimateHelp": "More details on this template",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1987,6 +1987,7 @@
       "newUser": "New here?",
       "userAvatar": "User Avatar",
       "signUp": "Sign up",
+      "signUpFreeTier": "Sign up to try Cloud for free",
       "emailLabel": "Email",
       "emailPlaceholder": "Enter your email",
       "passwordLabel": "Password",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1987,7 +1987,7 @@
       "newUser": "New here?",
       "userAvatar": "User Avatar",
       "signUp": "Sign up",
-      "signUpFreeTierPromo": "New here? {signUp} with a Gmail account to get {credits} free credits every month.",
+      "signUpFreeTierPromo": "New here? {signUp} with Google to get {credits} free credits every month.",
       "emailLabel": "Email",
       "emailPlaceholder": "Enter your email",
       "passwordLabel": "Password",
@@ -2015,8 +2015,8 @@
       "noAssociatedUser": "There is no Comfy user associated with the provided API key",
       "useEmailInstead": "Use email instead",
       "freeTierBadge": "Eligible for Free Tier",
-      "freeTierDescription": "Sign up to get {credits} free credits every month. No card needed.",
-      "freeTierDescriptionGeneric": "Sign up and get free credits every month. No card needed.",
+      "freeTierDescription": "Sign up with Google to get {credits} free credits every month. No card needed.",
+      "freeTierDescriptionGeneric": "Sign up with Google to get free credits every month. No card needed.",
       "backToSocialLogin": "Sign up with Google or Github instead"
     },
     "signup": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2221,7 +2221,8 @@
     "messageSupport": "Message support",
     "invoiceHistory": "Invoice history",
     "benefits": {
-      "benefit1": "More monthly credits, top up anytime",
+      "benefit1": "Monthly credits for Partner Nodes — top up when needed",
+      "benefit1FreeTier": "More monthly credits, top up anytime",
       "benefit2": "Up to 1 hour runtime per job on Pro",
       "benefit3": "Bring your own models (Creator & Pro)"
     },

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -2,7 +2,7 @@
   <div class="flex h-full items-center justify-center p-8">
     <div class="max-w-screen p-2 lg:w-96">
       <!-- Header -->
-      <div class="mt-6 mb-8 flex flex-col gap-4">
+      <div class="mb-8 flex flex-col gap-4">
         <h1 class="my-0 text-xl leading-normal font-medium">
           {{ t('auth.login.title') }}
         </h1>
@@ -23,7 +23,7 @@
       <template v-if="!showEmailForm">
         <p
           v-if="showFreeTierBadge"
-          class="mb-4 text-center text-xs text-muted-foreground"
+          class="mb-4 text-center text-sm text-muted-foreground"
         >
           {{
             freeTierCredits

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -138,7 +138,7 @@ const {
   showFreeTierBadge,
   switchToEmailForm,
   switchToSocialLogin
-} = useFreeTierOnboarding('login')
+} = useFreeTierOnboarding()
 
 const navigateToSignup = async () => {
   await router.push({ name: 'cloud-signup', query: route.query })

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -183,7 +183,9 @@ const signInWithEmail = async (values: SignInData) => {
 
 onMounted(() => {
   if (isCloud) {
-    telemetry?.trackLoginOpened({ free_tier_badge_shown: showFreeTierBadge })
+    telemetry?.trackLoginOpened({
+      free_tier_badge_shown: showFreeTierBadge.value
+    })
   }
 })
 </script>

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -61,29 +61,27 @@
         </div>
 
         <div class="mt-6 text-center">
-          <button
-            class="cursor-pointer border-none bg-transparent text-sm text-muted-foreground underline hover:text-base-foreground"
-            @click="onShowEmailForm"
+          <Button
+            variant="muted-textonly"
+            class="text-sm underline"
+            @click="switchToEmailForm"
           >
             {{ t('auth.login.useEmailInstead') }}
-          </button>
+          </Button>
         </div>
       </template>
 
       <template v-else>
-        <Message severity="warn" class="mb-4">
-          {{ t('auth.signup.emailNotEligibleForFreeTier') }}
-        </Message>
-
         <CloudSignInForm :auth-error="authError" @submit="signInWithEmail" />
 
         <div class="mt-4 text-center">
-          <button
-            class="cursor-pointer border-none bg-transparent text-sm text-muted-foreground underline hover:text-base-foreground"
-            @click="onBackToSocialLogin"
+          <Button
+            variant="muted-textonly"
+            class="text-sm underline"
+            @click="switchToSocialLogin"
           >
             {{ t('auth.login.backToSocialLogin') }}
-          </button>
+          </Button>
         </div>
       </template>
 
@@ -112,16 +110,16 @@
 
 <script setup lang="ts">
 import Message from 'primevue/message'
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
+import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
 import { getSafePreviousFullPath } from '@/platform/cloud/onboarding/utils/previousFullPath'
 import { isCloud } from '@/platform/distribution/types'
-import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { SignInData } from '@/schemas/signInSchema'
@@ -132,21 +130,15 @@ const route = useRoute()
 const authActions = useFirebaseAuthActions()
 const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
-const showEmailForm = ref(false)
-const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
-const showFreeTierBadge = !localStorage.getItem('comfy:hasAccount')
 const toastStore = useToastStore()
 const telemetry = useTelemetry()
-
-const onShowEmailForm = () => {
-  showEmailForm.value = true
-  telemetry?.trackUiButtonClicked({ button_id: 'login_use_email_instead' })
-}
-
-const onBackToSocialLogin = () => {
-  showEmailForm.value = false
-  telemetry?.trackUiButtonClicked({ button_id: 'login_back_to_social_login' })
-}
+const {
+  showEmailForm,
+  freeTierCredits,
+  showFreeTierBadge,
+  switchToEmailForm,
+  switchToSocialLogin
+} = useFreeTierOnboarding('login')
 
 const navigateToSignup = async () => {
   await router.push({ name: 'cloud-signup', query: route.query })

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -6,16 +6,28 @@
         <h1 class="my-0 text-xl leading-normal font-medium">
           {{ t('auth.login.title') }}
         </h1>
-        <p class="my-0 text-base">
-          <span class="text-muted">{{ t('auth.login.newUser') }}</span>
+        <i18n-t
+          v-if="isFreeTierEnabled"
+          keypath="auth.login.signUpFreeTierPromo"
+          tag="p"
+          class="my-0 text-base text-muted"
+          :plural="freeTierCredits ?? undefined"
+        >
+          <template #signUp>
+            <span
+              class="cursor-pointer text-blue-500"
+              @click="navigateToSignup"
+              >{{ t('auth.login.signUp') }}</span
+            >
+          </template>
+          <template #credits>{{ freeTierCredits }}</template>
+        </i18n-t>
+        <p v-else class="my-0 text-base text-muted">
+          {{ t('auth.login.newUser') }}
           <span
-            class="ml-1 cursor-pointer text-blue-500"
+            class="cursor-pointer text-blue-500"
             @click="navigateToSignup"
-            >{{
-              isFreeTierEnabled
-                ? t('auth.login.signUpFreeTier')
-                : t('auth.login.signUp')
-            }}</span
+            >{{ t('auth.login.signUp') }}</span
           >
         </p>
       </div>
@@ -113,7 +125,7 @@ const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
 const toastStore = useToastStore()
 const showEmailForm = ref(false)
-const { isFreeTierEnabled } = useFreeTierOnboarding()
+const { isFreeTierEnabled, freeTierCredits } = useFreeTierOnboarding()
 
 function switchToEmailForm() {
   showEmailForm.value = true

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -11,7 +11,11 @@
           <span
             class="ml-1 cursor-pointer text-blue-500"
             @click="navigateToSignup"
-            >{{ t('auth.login.signUp') }}</span
+            >{{
+              isFreeTierEnabled
+                ? t('auth.login.signUpFreeTier')
+                : t('auth.login.signUp')
+            }}</span
           >
         </p>
       </div>
@@ -21,33 +25,12 @@
       </Message>
 
       <template v-if="!showEmailForm">
-        <p
-          v-if="showFreeTierBadge"
-          class="mb-4 text-center text-sm text-muted-foreground"
-        >
-          {{
-            freeTierCredits
-              ? t('auth.login.freeTierDescription', {
-                  credits: freeTierCredits
-                })
-              : t('auth.login.freeTierDescriptionGeneric')
-          }}
-        </p>
-
         <!-- OAuth Buttons (primary) -->
         <div class="flex flex-col gap-4">
-          <div class="relative">
-            <Button type="button" class="h-10 w-full" @click="signInWithGoogle">
-              <i class="pi pi-google mr-2"></i>
-              {{ t('auth.login.loginWithGoogle') }}
-            </Button>
-            <span
-              v-if="showFreeTierBadge"
-              class="absolute -top-2.5 -right-2.5 rounded-full bg-yellow-400 px-2 py-0.5 text-[10px] font-bold whitespace-nowrap text-gray-900"
-            >
-              {{ t('auth.login.freeTierBadge') }}
-            </span>
-          </div>
+          <Button type="button" class="h-10 w-full" @click="signInWithGoogle">
+            <i class="pi pi-google mr-2"></i>
+            {{ t('auth.login.loginWithGoogle') }}
+          </Button>
 
           <Button
             type="button"
@@ -110,7 +93,7 @@
 
 <script setup lang="ts">
 import Message from 'primevue/message'
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -119,8 +102,6 @@ import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthAction
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
 import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
 import { getSafePreviousFullPath } from '@/platform/cloud/onboarding/utils/previousFullPath'
-import { isCloud } from '@/platform/distribution/types'
-import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { SignInData } from '@/schemas/signInSchema'
 
@@ -131,14 +112,16 @@ const authActions = useFirebaseAuthActions()
 const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
 const toastStore = useToastStore()
-const telemetry = useTelemetry()
-const {
-  showEmailForm,
-  freeTierCredits,
-  showFreeTierBadge,
-  switchToEmailForm,
-  switchToSocialLogin
-} = useFreeTierOnboarding()
+const showEmailForm = ref(false)
+const { isFreeTierEnabled } = useFreeTierOnboarding()
+
+function switchToEmailForm() {
+  showEmailForm.value = true
+}
+
+function switchToSocialLogin() {
+  showEmailForm.value = false
+}
 
 const navigateToSignup = async () => {
   await router.push({ name: 'cloud-signup', query: route.query })
@@ -180,12 +163,4 @@ const signInWithEmail = async (values: SignInData) => {
     await onSuccess()
   }
 }
-
-onMounted(() => {
-  if (isCloud) {
-    telemetry?.trackLoginOpened({
-      free_tier_badge_shown: showFreeTierBadge.value
-    })
-  }
-})
 </script>

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -207,7 +207,9 @@ const signUpWithEmail = async (values: SignUpData) => {
 onMounted(async () => {
   // Track signup screen opened
   if (isCloud) {
-    telemetry?.trackSignupOpened({ free_tier_badge_shown: showFreeTierBadge })
+    telemetry?.trackSignupOpened({
+      free_tier_badge_shown: showFreeTierBadge.value
+    })
   }
 
   userIsInChina.value = await isInChina()

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -63,12 +63,13 @@
         </div>
 
         <div class="mt-6 text-center">
-          <button
-            class="cursor-pointer border-none bg-transparent text-sm text-muted-foreground underline hover:text-base-foreground"
-            @click="onShowEmailForm"
+          <Button
+            variant="muted-textonly"
+            class="text-sm underline"
+            @click="switchToEmailForm"
           >
             {{ t('auth.login.useEmailInstead') }}
-          </button>
+          </Button>
         </div>
       </template>
 
@@ -83,12 +84,13 @@
         <SignUpForm v-else :auth-error="authError" @submit="signUpWithEmail" />
 
         <div class="mt-4 text-center">
-          <button
-            class="cursor-pointer border-none bg-transparent text-sm text-muted-foreground underline hover:text-base-foreground"
-            @click="onBackToSocialLogin"
+          <Button
+            variant="muted-textonly"
+            class="text-sm underline"
+            @click="switchToSocialLogin"
           >
             {{ t('auth.login.backToSocialLogin') }}
-          </button>
+          </Button>
         </div>
       </template>
 
@@ -128,16 +130,16 @@
 
 <script setup lang="ts">
 import Message from 'primevue/message'
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
 import SignUpForm from '@/components/dialog/content/signin/SignUpForm.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useFirebaseAuthActions } from '@/composables/auth/useFirebaseAuthActions'
+import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
 import { getSafePreviousFullPath } from '@/platform/cloud/onboarding/utils/previousFullPath'
 import { isCloud } from '@/platform/distribution/types'
-import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { SignUpData } from '@/schemas/signInSchema'
@@ -149,22 +151,16 @@ const route = useRoute()
 const authActions = useFirebaseAuthActions()
 const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
-const showEmailForm = ref(false)
-const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
-const showFreeTierBadge = !localStorage.getItem('comfy:hasAccount')
 const userIsInChina = ref(false)
 const toastStore = useToastStore()
 const telemetry = useTelemetry()
-
-const onShowEmailForm = () => {
-  showEmailForm.value = true
-  telemetry?.trackUiButtonClicked({ button_id: 'signup_use_email_instead' })
-}
-
-const onBackToSocialLogin = () => {
-  showEmailForm.value = false
-  telemetry?.trackUiButtonClicked({ button_id: 'signup_back_to_social_login' })
-}
+const {
+  showEmailForm,
+  freeTierCredits,
+  showFreeTierBadge,
+  switchToEmailForm,
+  switchToSocialLogin
+} = useFreeTierOnboarding('signup')
 
 const navigateToLogin = async () => {
   await router.push({ name: 'cloud-login', query: route.query })

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -160,7 +160,7 @@ const {
   showFreeTierBadge,
   switchToEmailForm,
   switchToSocialLogin
-} = useFreeTierOnboarding('signup')
+} = useFreeTierOnboarding()
 
 const navigateToLogin = async () => {
   await router.push({ name: 'cloud-login', query: route.query })

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -25,7 +25,7 @@
       <template v-if="!showEmailForm">
         <p
           v-if="showFreeTierBadge"
-          class="mb-4 text-center text-xs text-muted-foreground"
+          class="mb-4 text-center text-sm text-muted-foreground"
         >
           {{
             freeTierCredits
@@ -95,7 +95,7 @@
       </template>
 
       <!-- Terms & Contact -->
-      <div class="mt-5 text-sm text-gray-600">
+      <p class="mt-5 text-sm text-gray-600">
         {{ t('auth.login.termsText') }}
         <a
           href="https://www.comfy.org/terms-of-service"
@@ -106,24 +106,24 @@
         </a>
         {{ t('auth.login.andText') }}
         <a
-          href="/privacy-policy"
+          href="https://www.comfy.org/privacy-policy"
           target="_blank"
           class="cursor-pointer text-blue-400 no-underline"
         >
           {{ t('auth.login.privacyLink') }} </a
         >.
-        <p class="mt-2">
-          {{ t('cloudWaitlist_questionsText') }}
-          <a
-            href="https://support.comfy.org"
-            class="cursor-pointer text-blue-400 no-underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{ t('cloudWaitlist_contactLink') }}</a
-          >.
-        </p>
-      </div>
+      </p>
+      <p class="mt-2 text-sm text-gray-600">
+        {{ t('cloudWaitlist_questionsText') }}
+        <a
+          href="https://support.comfy.org"
+          class="cursor-pointer text-blue-400 no-underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ t('cloudWaitlist_contactLink') }}</a
+        >.
+      </p>
     </div>
   </div>
 </template>

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -74,7 +74,7 @@
       </template>
 
       <template v-else>
-        <Message severity="warn" class="mb-4">
+        <Message v-if="showFreeTierBadge" severity="warn" class="mb-4">
           {{ t('auth.signup.emailNotEligibleForFreeTier') }}
         </Message>
 

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -23,10 +23,7 @@
       </Message>
 
       <template v-if="!showEmailForm">
-        <p
-          v-if="isFreeTierEnabled"
-          class="mb-4 text-center text-sm text-muted-foreground"
-        >
+        <p v-if="isFreeTierEnabled" class="mb-4 text-sm text-muted-foreground">
           {{
             freeTierCredits
               ? t('auth.login.freeTierDescription', {

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -24,7 +24,7 @@
 
       <template v-if="!showEmailForm">
         <p
-          v-if="showFreeTierBadge"
+          v-if="isFreeTierEnabled"
           class="mb-4 text-center text-sm text-muted-foreground"
         >
           {{
@@ -44,7 +44,7 @@
               {{ t('auth.signup.signUpWithGoogle') }}
             </Button>
             <span
-              v-if="showFreeTierBadge"
+              v-if="isFreeTierEnabled"
               class="absolute -top-2.5 -right-2.5 rounded-full bg-yellow-400 px-2 py-0.5 text-[10px] font-bold whitespace-nowrap text-gray-900"
             >
               {{ t('auth.login.freeTierBadge') }}
@@ -74,7 +74,7 @@
       </template>
 
       <template v-else>
-        <Message v-if="showFreeTierBadge" severity="warn" class="mb-4">
+        <Message v-if="isFreeTierEnabled" severity="warn" class="mb-4">
           {{ t('auth.signup.emailNotEligibleForFreeTier') }}
         </Message>
 
@@ -157,7 +157,7 @@ const telemetry = useTelemetry()
 const {
   showEmailForm,
   freeTierCredits,
-  showFreeTierBadge,
+  isFreeTierEnabled,
   switchToEmailForm,
   switchToSocialLogin
 } = useFreeTierOnboarding()
@@ -207,9 +207,7 @@ const signUpWithEmail = async (values: SignUpData) => {
 onMounted(async () => {
   // Track signup screen opened
   if (isCloud) {
-    telemetry?.trackSignupOpened({
-      free_tier_badge_shown: showFreeTierBadge.value
-    })
+    telemetry?.trackSignupOpened({})
   }
 
   userIsInChina.value = await isInChina()

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -204,7 +204,7 @@ const signUpWithEmail = async (values: SignUpData) => {
 onMounted(async () => {
   // Track signup screen opened
   if (isCloud) {
-    telemetry?.trackSignupOpened({})
+    telemetry?.trackSignupOpened()
   }
 
   userIsInChina.value = await isInChina()

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -59,6 +59,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     return
   }
 
+  // Only paid tiers can be checked out via redirect
   const validTierKeys: TierKey[] = ['standard', 'creator', 'pro', 'founder']
   if (!(validTierKeys as string[]).includes(tierKeyParam)) {
     await router.push('/')

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -27,6 +27,7 @@ const selectedTierKey = ref<TierKey | null>(null)
 const tierDisplayName = computed(() => {
   if (!selectedTierKey.value) return ''
   const names: Record<TierKey, string> = {
+    free: t('subscription.tiers.free.name'),
     standard: t('subscription.tiers.standard.name'),
     creator: t('subscription.tiers.creator.name'),
     pro: t('subscription.tiers.pro.name'),

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.test.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
+import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
+
+vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+  remoteConfig: { value: { free_tier_credits: 50 } }
+}))
+
+describe('useFreeTierOnboarding', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('showFreeTierBadge', () => {
+    it('returns true when neither key exists in localStorage', () => {
+      const { showFreeTierBadge } = useFreeTierOnboarding()
+      expect(showFreeTierBadge.value).toBe(true)
+    })
+
+    it('returns false when HAS_ACCOUNT_KEY is set', () => {
+      localStorage.setItem(HAS_ACCOUNT_KEY, '1')
+      const { showFreeTierBadge } = useFreeTierOnboarding()
+      expect(showFreeTierBadge.value).toBe(false)
+    })
+
+    it('returns false when Comfy.PreviousWorkflow is set', () => {
+      localStorage.setItem('Comfy.PreviousWorkflow', 'default.json')
+      const { showFreeTierBadge } = useFreeTierOnboarding()
+      expect(showFreeTierBadge.value).toBe(false)
+    })
+  })
+
+  describe('showEmailForm', () => {
+    it('starts as false', () => {
+      const { showEmailForm } = useFreeTierOnboarding()
+      expect(showEmailForm.value).toBe(false)
+    })
+
+    it('switchToEmailForm sets it to true', () => {
+      const { showEmailForm, switchToEmailForm } = useFreeTierOnboarding()
+      switchToEmailForm()
+      expect(showEmailForm.value).toBe(true)
+    })
+
+    it('switchToSocialLogin sets it back to false', () => {
+      const { showEmailForm, switchToEmailForm, switchToSocialLogin } =
+        useFreeTierOnboarding()
+      switchToEmailForm()
+      switchToSocialLogin()
+      expect(showEmailForm.value).toBe(false)
+    })
+  })
+
+  describe('freeTierCredits', () => {
+    it('returns value from remote config', () => {
+      const { freeTierCredits } = useFreeTierOnboarding()
+      expect(freeTierCredits.value).toBe(50)
+    })
+  })
+})

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.test.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.test.ts
@@ -1,36 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
-import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
+
+const mockRemoteConfig = vi.hoisted(() => ({
+  value: { free_tier_credits: 50 } as Record<string, unknown>
+}))
 
 vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
-  remoteConfig: { value: { free_tier_credits: 50 } }
+  remoteConfig: mockRemoteConfig
 }))
 
 describe('useFreeTierOnboarding', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
-  describe('showFreeTierBadge', () => {
-    it('returns true when neither key exists in localStorage', () => {
-      const { showFreeTierBadge } = useFreeTierOnboarding()
-      expect(showFreeTierBadge.value).toBe(true)
-    })
-
-    it('returns false when HAS_ACCOUNT_KEY is set', () => {
-      localStorage.setItem(HAS_ACCOUNT_KEY, '1')
-      const { showFreeTierBadge } = useFreeTierOnboarding()
-      expect(showFreeTierBadge.value).toBe(false)
-    })
-
-    it('returns false when Comfy.PreviousWorkflow is set', () => {
-      localStorage.setItem('Comfy.PreviousWorkflow', 'default.json')
-      const { showFreeTierBadge } = useFreeTierOnboarding()
-      expect(showFreeTierBadge.value).toBe(false)
-    })
-  })
-
   describe('showEmailForm', () => {
     it('starts as false', () => {
       const { showEmailForm } = useFreeTierOnboarding()
@@ -56,6 +36,26 @@ describe('useFreeTierOnboarding', () => {
     it('returns value from remote config', () => {
       const { freeTierCredits } = useFreeTierOnboarding()
       expect(freeTierCredits.value).toBe(50)
+    })
+  })
+
+  describe('isFreeTierEnabled', () => {
+    it('returns true when remote config says enabled', () => {
+      mockRemoteConfig.value.new_free_tier_subscriptions = true
+      const { isFreeTierEnabled } = useFreeTierOnboarding()
+      expect(isFreeTierEnabled.value).toBe(true)
+    })
+
+    it('returns false when remote config says disabled', () => {
+      mockRemoteConfig.value.new_free_tier_subscriptions = false
+      const { isFreeTierEnabled } = useFreeTierOnboarding()
+      expect(isFreeTierEnabled.value).toBe(false)
+    })
+
+    it('defaults to false when not set in remote config', () => {
+      mockRemoteConfig.value = { free_tier_credits: 50 }
+      const { isFreeTierEnabled } = useFreeTierOnboarding()
+      expect(isFreeTierEnabled.value).toBe(false)
     })
   })
 })

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
@@ -1,10 +1,9 @@
 import { computed, ref } from 'vue'
 
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
-import { useTelemetry } from '@/platform/telemetry'
 import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
 
-export function useFreeTierOnboarding(source: 'login' | 'signup') {
+export function useFreeTierOnboarding() {
   const showEmailForm = ref(false)
   const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
   // Evaluated once at mount — localStorage won't change mid-session
@@ -15,20 +14,13 @@ export function useFreeTierOnboarding(source: 'login' | 'signup') {
       return false
     }
   })()
-  const telemetry = useTelemetry()
 
   function switchToEmailForm() {
     showEmailForm.value = true
-    telemetry?.trackUiButtonClicked({
-      button_id: `${source}_use_email_instead`
-    })
   }
 
   function switchToSocialLogin() {
     showEmailForm.value = false
-    telemetry?.trackUiButtonClicked({
-      button_id: `${source}_back_to_social_login`
-    })
   }
 
   return {

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
@@ -1,12 +1,12 @@
 import { useLocalStorage } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
-import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
 import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
 
 export function useFreeTierOnboarding() {
   const showEmailForm = ref(false)
-  const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
+  const freeTierCredits = computed(() => getTierCredits('free'))
 
   // Returning users are detected by either:
   // - HAS_ACCOUNT_KEY: set by onAuthStateChanged after first login

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
@@ -1,3 +1,4 @@
+import { useLocalStorage } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
@@ -6,14 +7,21 @@ import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
 export function useFreeTierOnboarding() {
   const showEmailForm = ref(false)
   const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
-  // Evaluated once at mount — localStorage won't change mid-session
-  const showFreeTierBadge = (() => {
-    try {
-      return !localStorage.getItem(HAS_ACCOUNT_KEY)
-    } catch {
-      return false
-    }
-  })()
+
+  // Returning users are detected by either:
+  // - HAS_ACCOUNT_KEY: set by onAuthStateChanged after first login
+  // - Comfy.PreviousWorkflow: set on every workflow save (covers existing
+  //   users before HAS_ACCOUNT_KEY was introduced)
+  // Reactive via useLocalStorage so the badge hides if the user signs in
+  // during the current session.
+  const hasAccount = useLocalStorage<string | null>(HAS_ACCOUNT_KEY, null)
+  const previousWorkflow = useLocalStorage<string | null>(
+    'Comfy.PreviousWorkflow',
+    null
+  )
+  const showFreeTierBadge = computed(
+    () => !hasAccount.value && !previousWorkflow.value
+  )
 
   function switchToEmailForm() {
     showEmailForm.value = true

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
@@ -1,0 +1,40 @@
+import { computed, ref } from 'vue'
+
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { useTelemetry } from '@/platform/telemetry'
+import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
+
+export function useFreeTierOnboarding(source: 'login' | 'signup') {
+  const showEmailForm = ref(false)
+  const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
+  const showFreeTierBadge = (() => {
+    try {
+      return !localStorage.getItem(HAS_ACCOUNT_KEY)
+    } catch {
+      return false
+    }
+  })()
+  const telemetry = useTelemetry()
+
+  function switchToEmailForm() {
+    showEmailForm.value = true
+    telemetry?.trackUiButtonClicked({
+      button_id: `${source}_use_email_instead`
+    })
+  }
+
+  function switchToSocialLogin() {
+    showEmailForm.value = false
+    telemetry?.trackUiButtonClicked({
+      button_id: `${source}_back_to_social_login`
+    })
+  }
+
+  return {
+    showEmailForm,
+    freeTierCredits,
+    showFreeTierBadge,
+    switchToEmailForm,
+    switchToSocialLogin
+  }
+}

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
@@ -7,6 +7,7 @@ import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
 export function useFreeTierOnboarding(source: 'login' | 'signup') {
   const showEmailForm = ref(false)
   const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
+  // Evaluated once at mount — localStorage won't change mid-session
   const showFreeTierBadge = (() => {
     try {
       return !localStorage.getItem(HAS_ACCOUNT_KEY)

--- a/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
+++ b/src/platform/cloud/onboarding/composables/useFreeTierOnboarding.ts
@@ -1,26 +1,13 @@
-import { useLocalStorage } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
 import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
-import { HAS_ACCOUNT_KEY } from '@/stores/firebaseAuthStore'
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 
 export function useFreeTierOnboarding() {
   const showEmailForm = ref(false)
   const freeTierCredits = computed(() => getTierCredits('free'))
-
-  // Returning users are detected by either:
-  // - HAS_ACCOUNT_KEY: set by onAuthStateChanged after first login
-  // - Comfy.PreviousWorkflow: set on every workflow save (covers existing
-  //   users before HAS_ACCOUNT_KEY was introduced)
-  // Reactive via useLocalStorage so the badge hides if the user signs in
-  // during the current session.
-  const hasAccount = useLocalStorage<string | null>(HAS_ACCOUNT_KEY, null)
-  const previousWorkflow = useLocalStorage<string | null>(
-    'Comfy.PreviousWorkflow',
-    null
-  )
-  const showFreeTierBadge = computed(
-    () => !hasAccount.value && !previousWorkflow.value
+  const isFreeTierEnabled = computed(
+    () => remoteConfig.value.new_free_tier_subscriptions ?? false
   )
 
   function switchToEmailForm() {
@@ -34,7 +21,7 @@ export function useFreeTierOnboarding() {
   return {
     showEmailForm,
     freeTierCredits,
-    showFreeTierBadge,
+    isFreeTierEnabled,
     switchToEmailForm,
     switchToSocialLogin
   }

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="relative grid h-full grid-cols-5">
+    <!-- Custom close button -->
+    <Button
+      size="icon"
+      variant="muted-textonly"
+      class="rounded-full absolute top-2.5 right-2.5 z-10 h-8 w-8 p-0 text-white hover:bg-white/20"
+      :aria-label="$t('g.close')"
+      @click="$emit('close', false)"
+    >
+      <i class="pi pi-times" />
+    </Button>
+
+    <div
+      class="relative col-span-2 flex items-center justify-center overflow-hidden rounded-sm"
+    >
+      <video
+        autoplay
+        loop
+        muted
+        playsinline
+        class="h-full min-w-[125%] object-cover p-0"
+        style="margin-left: -20%"
+      >
+        <source
+          src="/assets/images/cloud-subscription.webm"
+          type="video/webm"
+        />
+      </video>
+    </div>
+
+    <div class="col-span-3 flex flex-col justify-between p-8">
+      <div>
+        <div class="flex flex-col gap-6">
+          <div class="inline-flex items-center gap-2">
+            <div class="text-sm text-text-primary">
+              {{
+                reason === 'out_of_credits'
+                  ? $t('subscription.freeTier.topUpBlocked.title')
+                  : $t('subscription.freeTier.title')
+              }}
+            </div>
+            <CloudBadge
+              reverse-order
+              no-padding
+              background-color="var(--p-dialog-background)"
+              use-subscription
+            />
+          </div>
+
+          <p class="m-0 text-sm text-text-secondary">
+            {{
+              reason === 'out_of_credits'
+                ? $t('subscription.freeTier.topUpBlocked.description')
+                : $t('subscription.freeTier.description', {
+                    credits: formattedCredits
+                  })
+            }}
+          </p>
+
+          <p
+            v-if="reason !== 'out_of_credits' && formattedRenewalDate"
+            class="m-0 text-sm text-text-secondary"
+          >
+            {{
+              $t('subscription.freeTier.nextRefresh', {
+                date: formattedRenewalDate
+              })
+            }}
+          </p>
+        </div>
+
+        <SubscriptionBenefits class="mt-6 text-muted" />
+      </div>
+
+      <div class="flex flex-col pt-8">
+        <Button
+          variant="primary"
+          class="py-2 px-4 rounded-lg w-full"
+          :pt="{
+            root: {
+              style: 'background: var(--color-accent-blue, #0B8CE9);'
+            },
+            label: {
+              class: 'font-inter font-[700] text-sm'
+            }
+          }"
+          @click="$emit('upgrade')"
+        >
+          {{
+            reason === 'out_of_credits'
+              ? $t('subscription.freeTier.topUpBlocked.subscribeCta')
+              : $t('subscription.freeTier.subscribeCta')
+          }}
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import CloudBadge from '@/components/topbar/CloudBadge.vue'
+import Button from '@/components/ui/button/Button.vue'
+import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { centsToCredits } from '@/base/credits/comfyCredits'
+
+defineProps<{
+  reason?: 'subscription_required' | 'out_of_credits'
+}>()
+
+defineEmits<{
+  close: [subscribed: boolean]
+  upgrade: []
+}>()
+
+const { formattedRenewalDate } = useSubscription()
+
+const FREE_TIER_CENTS = 190
+const formattedCredits = Math.round(
+  centsToCredits(FREE_TIER_CENTS)
+).toLocaleString()
+</script>
+
+<style scoped>
+:deep(.bg-comfy-menu-secondary) {
+  background-color: transparent;
+}
+
+:deep(.p-button) {
+  color: white;
+}
+</style>

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -105,7 +105,7 @@ import Button from '@/components/ui/button/Button.vue'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
-import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
 
 defineProps<{
   reason?: SubscriptionDialogReason
@@ -118,5 +118,5 @@ defineEmits<{
 
 const { formattedRenewalDate } = useSubscription()
 
-const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
+const freeTierCredits = computed(() => getTierCredits('free'))
 </script>

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -56,9 +56,11 @@
             class="m-0 text-sm text-text-secondary"
           >
             {{
-              $t('subscription.freeTier.description', {
-                credits: formattedCredits
-              })
+              freeTierCredits
+                ? $t('subscription.freeTier.description', {
+                    credits: freeTierCredits.toLocaleString()
+                  })
+                : $t('subscription.freeTier.descriptionGeneric')
             }}
           </p>
 
@@ -82,16 +84,7 @@
 
       <div class="flex flex-col pt-8">
         <Button
-          variant="primary"
-          class="py-2 px-4 rounded-lg w-full"
-          :pt="{
-            root: {
-              style: 'background: var(--color-accent-blue, #0B8CE9);'
-            },
-            label: {
-              class: 'font-inter font-[700] text-sm'
-            }
-          }"
+          class="w-full rounded-lg bg-[var(--color-accent-blue,#0B8CE9)] px-4 py-2 font-inter text-sm font-bold text-white hover:bg-[var(--color-accent-blue,#0B8CE9)]/90"
           @click="$emit('upgrade')"
         >
           {{
@@ -109,12 +102,13 @@
 import { computed } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
+import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 
 defineProps<{
-  reason?: 'subscription_required' | 'out_of_credits' | 'top_up_blocked'
+  reason?: SubscriptionDialogReason
 }>()
 
 defineEmits<{
@@ -124,13 +118,5 @@ defineEmits<{
 
 const { formattedRenewalDate } = useSubscription()
 
-const formattedCredits = computed(() =>
-  (remoteConfig.value.free_tier_credits ?? 400).toLocaleString()
-)
+const freeTierCredits = computed(() => remoteConfig.value.free_tier_credits)
 </script>
-
-<style scoped>
-:deep(.p-button) {
-  color: white;
-}
-</style>

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -79,7 +79,7 @@
           </p>
         </div>
 
-        <SubscriptionBenefits class="mt-6 text-muted" />
+        <SubscriptionBenefits is-free-tier class="mt-6 text-muted" />
       </div>
 
       <div class="flex flex-col pt-8">

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -24,6 +24,7 @@ const mockGetCheckoutAttribution = vi.hoisted(() => vi.fn(() => ({})))
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
+    isFreeTier: computed(() => false),
     subscriptionTier: computed(() => mockSubscriptionTier.value),
     isYearlySubscription: computed(() => mockIsYearlySubscription.value),
     subscriptionStatus: ref(null)

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -272,7 +272,7 @@ import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
 import type { components } from '@/types/comfyRegistryTypes'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
-type CheckoutTierKey = Exclude<TierKey, 'founder'>
+type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 type CheckoutTier = CheckoutTierKey | `${CheckoutTierKey}-yearly`
 
 const getCheckoutTier = (

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -344,8 +344,12 @@ const tiers: PricingTierConfig[] = [
     isPopular: false
   }
 ]
-const { isActiveSubscription, subscriptionTier, isYearlySubscription } =
-  useSubscription()
+const {
+  isActiveSubscription,
+  isFreeTier,
+  subscriptionTier,
+  isYearlySubscription
+} = useSubscription()
 const telemetry = useTelemetry()
 const { userId } = storeToRefs(useFirebaseAuthStore())
 const { accessBillingPortal, reportError } = useFirebaseAuthActions()
@@ -355,6 +359,10 @@ const isLoading = ref(false)
 const loadingTier = ref<CheckoutTierKey | null>(null)
 const popover = ref()
 const currentBillingCycle = ref<BillingCycle>('yearly')
+
+const hasPaidSubscription = computed(
+  () => isActiveSubscription.value && !isFreeTier.value
+)
 
 const currentTierKey = computed<TierKey | null>(() =>
   subscriptionTier.value ? TIER_TO_KEY[subscriptionTier.value] : null
@@ -392,7 +400,7 @@ const getButtonLabel = (tier: PricingTierConfig): string => {
       ? t('subscription.tierNameYearly', { name: tier.name })
       : tier.name
 
-  return isActiveSubscription.value
+  return hasPaidSubscription.value
     ? t('subscription.changeTo', { plan: planName })
     : t('subscription.subscribeTo', { plan: planName })
 }
@@ -427,7 +435,7 @@ const handleSubscribe = wrapWithErrorHandlingAsync(
     loadingTier.value = tierKey
 
     try {
-      if (isActiveSubscription.value) {
+      if (hasPaidSubscription.value) {
         const checkoutAttribution = await getCheckoutAttributionForCloud()
         if (userId.value) {
           telemetry?.trackBeginCheckout({

--- a/src/platform/cloud/subscription/components/SubscribeButton.vue
+++ b/src/platform/cloud/subscription/components/SubscribeButton.vue
@@ -24,6 +24,7 @@ import { onBeforeUnmount, ref, watch } from 'vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { isCloud } from '@/platform/distribution/types'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { useTelemetry } from '@/platform/telemetry'
 import { cn } from '@/utils/tailwindUtil'
 
@@ -46,6 +47,7 @@ const emit = defineEmits<{
 }>()
 
 const { isActiveSubscription, showSubscriptionDialog } = useBillingContext()
+const { subscriptionTier } = useSubscription()
 const isAwaitingStripeSubscription = ref(false)
 
 watch(
@@ -60,7 +62,9 @@ watch(
 
 const handleSubscribe = () => {
   if (isCloud) {
-    useTelemetry()?.trackSubscription('subscribe_clicked')
+    useTelemetry()?.trackSubscription('subscribe_clicked', {
+      current_tier: subscriptionTier.value?.toLowerCase()
+    })
   }
   isAwaitingStripeSubscription.value = true
   showSubscriptionDialog()

--- a/src/platform/cloud/subscription/components/SubscriptionBenefits.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionBenefits.vue
@@ -3,7 +3,11 @@
     <div class="flex items-center gap-2 py-2">
       <i class="pi pi-check text-xs text-text-primary" />
       <span class="text-sm text-text-primary">
-        {{ $t('subscription.benefits.benefit1') }}
+        {{
+          isFreeTier
+            ? $t('subscription.benefits.benefit1FreeTier')
+            : $t('subscription.benefits.benefit1')
+        }}
       </span>
     </div>
 
@@ -23,4 +27,8 @@
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+const { isFreeTier = false } = defineProps<{
+  isFreeTier?: boolean
+}>()
+</script>

--- a/src/platform/cloud/subscription/components/SubscriptionBenefits.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionBenefits.vue
@@ -13,6 +13,13 @@
         {{ $t('subscription.benefits.benefit2') }}
       </span>
     </div>
+
+    <div class="flex items-center gap-2 py-2">
+      <i class="pi pi-check text-xs text-text-primary" />
+      <span class="text-sm text-text-primary">
+        {{ $t('subscription.benefits.benefit3') }}
+      </span>
+    </div>
   </div>
 </template>
 

--- a/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
@@ -213,9 +213,10 @@ import {
   DEFAULT_TIER_KEY,
   TIER_TO_KEY,
   getTierCredits,
-  getTierFeatures,
   getTierPrice
 } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefits'
+import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { cn } from '@/utils/tailwindUtil'
 
 const authActions = useFirebaseAuthActions()
@@ -264,6 +265,7 @@ const creditsRemainingLabel = computed(() =>
 
 const planTotalCredits = computed(() => {
   const credits = getTierCredits(tierKey.value)
+  if (credits === null) return '—'
   const total = isYearlySubscription.value ? credits * 12 : credits
   return n(total)
 })
@@ -272,63 +274,9 @@ const includedCreditsDisplay = computed(
   () => `${monthlyBonusCredits.value} / ${planTotalCredits.value}`
 )
 
-// Tier benefits for v-for loop
-type BenefitType = 'metric' | 'feature'
-
-interface Benefit {
-  key: string
-  type: BenefitType
-  label: string
-  value?: string
-}
-
-const tierBenefits = computed((): Benefit[] => {
-  const key = tierKey.value
-
-  const benefits: Benefit[] = []
-
-  const isFreeTierPlan = key === 'free'
-
-  if (isFreeTierPlan) {
-    benefits.push({
-      key: 'monthlyCredits',
-      type: 'metric',
-      value: n(getTierCredits(key)),
-      label: t('subscription.monthlyCreditsLabel')
-    })
-  }
-
-  benefits.push({
-    key: 'maxDuration',
-    type: 'metric',
-    value: t(`subscription.maxDuration.${key}`),
-    label: t('subscription.maxDurationLabel')
-  })
-
-  benefits.push({
-    key: 'gpu',
-    type: 'feature',
-    label: t('subscription.gpuLabel')
-  })
-
-  if (!isFreeTierPlan) {
-    benefits.push({
-      key: 'addCredits',
-      type: 'feature',
-      label: t('subscription.addCreditsLabel')
-    })
-  }
-
-  if (getTierFeatures(key).customLoRAs) {
-    benefits.push({
-      key: 'customLoRAs',
-      type: 'feature',
-      label: t('subscription.customLoRAsLabel')
-    })
-  }
-
-  return benefits
-})
+const tierBenefits = computed((): TierBenefit[] =>
+  getCommonTierBenefits(tierKey.value, t, n)
+)
 
 const { totalCredits, monthlyBonusCredits, prepaidCredits, isLoadingBalance } =
   useSubscriptionCredits()

--- a/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
@@ -33,7 +33,7 @@
           </div>
 
           <Button
-            v-if="isActiveSubscription"
+            v-if="isActiveSubscription && !isFreeTier"
             variant="secondary"
             class="ml-auto rounded-lg px-4 py-2 text-sm font-normal text-text-primary bg-interface-menu-component-surface-selected"
             @click="
@@ -225,6 +225,7 @@ const { t, n } = useI18n()
 const {
   isActiveSubscription,
   isCancelled,
+  isFreeTier,
   formattedRenewalDate,
   formattedEndDate,
   subscriptionTier,

--- a/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
@@ -285,24 +285,39 @@ interface Benefit {
 const tierBenefits = computed((): Benefit[] => {
   const key = tierKey.value
 
-  const benefits: Benefit[] = [
-    {
-      key: 'maxDuration',
+  const benefits: Benefit[] = []
+
+  const isFreeTierPlan = key === 'free'
+
+  if (isFreeTierPlan) {
+    benefits.push({
+      key: 'monthlyCredits',
       type: 'metric',
-      value: t(`subscription.maxDuration.${key}`),
-      label: t('subscription.maxDurationLabel')
-    },
-    {
-      key: 'gpu',
-      type: 'feature',
-      label: t('subscription.gpuLabel')
-    },
-    {
+      value: n(getTierCredits(key)),
+      label: t('subscription.monthlyCreditsLabel')
+    })
+  }
+
+  benefits.push({
+    key: 'maxDuration',
+    type: 'metric',
+    value: t(`subscription.maxDuration.${key}`),
+    label: t('subscription.maxDurationLabel')
+  })
+
+  benefits.push({
+    key: 'gpu',
+    type: 'feature',
+    label: t('subscription.gpuLabel')
+  })
+
+  if (!isFreeTierPlan) {
+    benefits.push({
       key: 'addCredits',
       type: 'feature',
       label: t('subscription.addCreditsLabel')
-    }
-  ]
+    })
+  }
 
   if (getTierFeatures(key).customLoRAs) {
     benefits.push({

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -1,13 +1,6 @@
 <template>
-  <!-- Free tier users: show explanation modal first, upgrade button opens pricing table -->
-  <FreeTierDialogContent
-    v-if="isFreeTier && !showPricingTable"
-    :reason="reason"
-    @close="(subscribed: boolean) => emit('close', subscribed)"
-    @upgrade="showPricingTable = true"
-  />
   <div
-    v-else-if="showCustomPricingTable"
+    v-if="showCustomPricingTable"
     class="relative flex flex-col p-4 pt-8 md:p-16 !overflow-y-auto h-full gap-8"
   >
     <Button
@@ -137,24 +130,22 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, watch } from 'vue'
 
 import CloudBadge from '@/components/topbar/CloudBadge.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { MONTHLY_SUBSCRIPTION_PRICE } from '@/config/subscriptionPricesConfig'
-import FreeTierDialogContent from '@/platform/cloud/subscription/components/FreeTierDialogContent.vue'
 import PricingTable from '@/platform/cloud/subscription/components/PricingTable.vue'
 import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeButton.vue'
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 
 const { onClose, reason } = defineProps<{
   onClose: () => void
-  reason?: 'subscription_required' | 'out_of_credits'
+  reason?: 'subscription_required' | 'out_of_credits' | 'top_up_blocked'
 }>()
 
 const emit = defineEmits<{
@@ -162,13 +153,9 @@ const emit = defineEmits<{
 }>()
 
 const { fetchStatus, isActiveSubscription } = useBillingContext()
-const { isFreeTier } = useSubscription()
 
 const isSubscriptionEnabled = (): boolean =>
   Boolean(isCloud && window.__CONFIG__?.subscription_required)
-
-// Free tier users start on the explanation view; clicking "Subscribe for more" shows pricing
-const showPricingTable = ref(false)
 
 // Legacy price for non-tier flow with locale-aware formatting
 const formattedMonthlyPrice = new Intl.NumberFormat(

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -142,10 +142,11 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
+import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 const { onClose, reason } = defineProps<{
   onClose: () => void
-  reason?: 'subscription_required' | 'out_of_credits' | 'top_up_blocked'
+  reason?: SubscriptionDialogReason
 }>()
 
 const emit = defineEmits<{

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -81,7 +81,11 @@
         <div class="flex flex-col gap-6">
           <div class="inline-flex items-center gap-2">
             <div class="text-sm text-text-primary">
-              {{ $t('subscription.required.title') }}
+              {{
+                reason === 'out_of_credits'
+                  ? $t('credits.topUp.insufficientTitle')
+                  : $t('subscription.required.title')
+              }}
             </div>
             <CloudBadge
               reverse-order
@@ -90,6 +94,13 @@
               use-subscription
             />
           </div>
+
+          <p
+            v-if="reason === 'out_of_credits'"
+            class="m-0 text-sm text-text-secondary"
+          >
+            {{ $t('credits.topUp.insufficientMessage') }}
+          </p>
 
           <div class="flex items-baseline gap-2">
             <span class="text-4xl font-bold">{{ formattedMonthlyPrice }}</span>
@@ -132,8 +143,9 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 
-const props = defineProps<{
+const { onClose, reason } = defineProps<{
   onClose: () => void
+  reason?: 'subscription_required' | 'out_of_credits'
 }>()
 
 const emit = defineEmits<{
@@ -234,7 +246,7 @@ const handleSubscribed = () => {
 
 const handleClose = () => {
   stopPolling()
-  props.onClose()
+  onClose()
 }
 
 const handleContactUs = async () => {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -77,6 +77,8 @@ function useSubscriptionInternal() {
     () => subscriptionStatus.value?.subscription_tier ?? null
   )
 
+  const isFreeTier = computed(() => subscriptionTier.value === 'FREE')
+
   const subscriptionDuration = computed(
     () => subscriptionStatus.value?.subscription_duration ?? null
   )
@@ -278,6 +280,7 @@ function useSubscriptionInternal() {
     formattedRenewalDate,
     formattedEndDate,
     subscriptionTier,
+    isFreeTier,
     subscriptionDuration,
     isYearlySubscription,
     subscriptionTierName,

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -8,6 +8,7 @@ import { getComfyApiBaseUrl, getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { CheckoutAttributionMetadata } from '@/platform/telemetry/types'
 import {
   FirebaseAuthStoreError,
@@ -132,12 +133,17 @@ function useSubscriptionInternal() {
     window.open(response.checkout_url, '_blank')
   }, reportError)
 
-  const showSubscriptionDialog = () => {
+  const showSubscriptionDialog = (options?: {
+    reason?: SubscriptionDialogReason
+  }) => {
     if (isCloud) {
-      useTelemetry()?.trackSubscription('modal_opened')
+      useTelemetry()?.trackSubscription('modal_opened', {
+        current_tier: subscriptionTier.value?.toLowerCase(),
+        reason: options?.reason
+      })
     }
 
-    void showSubscriptionRequiredDialog()
+    void showSubscriptionRequiredDialog(options)
   }
 
   /**

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -22,9 +22,6 @@ export const useSubscriptionDialog = () => {
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
-  }
-
-  function hideFreeTier() {
     dialogStore.closeDialog({ key: FREE_TIER_DIALOG_KEY })
   }
 
@@ -76,9 +73,9 @@ export const useSubscriptionDialog = () => {
         component,
         props: {
           reason: options?.reason,
-          onClose: hideFreeTier,
+          onClose: hide,
           onUpgrade: () => {
-            hideFreeTier()
+            hide()
             showPricingTable(options)
           }
         },

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -6,6 +6,10 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 
 const DIALOG_KEY = 'subscription-required'
 
+export type SubscriptionDialogReason =
+  | 'subscription_required'
+  | 'out_of_credits'
+
 export const useSubscriptionDialog = () => {
   const { flags } = useFeatureFlags()
   const dialogService = useDialogService()
@@ -16,7 +20,7 @@ export const useSubscriptionDialog = () => {
     dialogStore.closeDialog({ key: DIALOG_KEY })
   }
 
-  function show() {
+  function show(options?: { reason?: SubscriptionDialogReason }) {
     const useWorkspaceVariant =
       flags.teamWorkspacesEnabled && !workspaceStore.isInPersonalWorkspace
 
@@ -34,7 +38,8 @@ export const useSubscriptionDialog = () => {
       key: DIALOG_KEY,
       component,
       props: {
-        onClose: hide
+        onClose: hide,
+        reason: options?.reason
       },
       dialogComponentProps: {
         style: 'width: min(1328px, 95vw); max-height: 958px;',

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -2,23 +2,33 @@ import { defineAsyncComponent } from 'vue'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const DIALOG_KEY = 'subscription-required'
+const FREE_TIER_DIALOG_KEY = 'free-tier-info'
 
-type SubscriptionDialogReason = 'subscription_required' | 'out_of_credits'
+type SubscriptionDialogReason =
+  | 'subscription_required'
+  | 'out_of_credits'
+  | 'top_up_blocked'
 
 export const useSubscriptionDialog = () => {
   const { flags } = useFeatureFlags()
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
   const workspaceStore = useTeamWorkspaceStore()
+  const { isFreeTier } = useSubscription()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
   }
 
-  function show(options?: { reason?: SubscriptionDialogReason }) {
+  function hideFreeTier() {
+    dialogStore.closeDialog({ key: FREE_TIER_DIALOG_KEY })
+  }
+
+  function showPricingTable(options?: { reason?: SubscriptionDialogReason }) {
     const useWorkspaceVariant =
       flags.teamWorkspacesEnabled && !workspaceStore.isInPersonalWorkspace
 
@@ -54,8 +64,46 @@ export const useSubscriptionDialog = () => {
     })
   }
 
+  function show(options?: { reason?: SubscriptionDialogReason }) {
+    if (isFreeTier.value) {
+      const component = defineAsyncComponent(
+        () =>
+          import('@/platform/cloud/subscription/components/FreeTierDialogContent.vue')
+      )
+
+      dialogService.showLayoutDialog({
+        key: FREE_TIER_DIALOG_KEY,
+        component,
+        props: {
+          reason: options?.reason,
+          onClose: hideFreeTier,
+          onUpgrade: () => {
+            hideFreeTier()
+            showPricingTable(options)
+          }
+        },
+        dialogComponentProps: {
+          style: 'width: min(640px, 95vw);',
+          pt: {
+            root: {
+              class: 'rounded-2xl bg-transparent'
+            },
+            content: {
+              class:
+                '!p-0 rounded-2xl border border-border-default bg-base-background/60 backdrop-blur-md shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
+            }
+          }
+        }
+      })
+      return
+    }
+
+    showPricingTable(options)
+  }
+
   return {
     show,
+    showPricingTable,
     hide
   }
 }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -8,7 +8,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 const DIALOG_KEY = 'subscription-required'
 const FREE_TIER_DIALOG_KEY = 'free-tier-info'
 
-type SubscriptionDialogReason =
+export type SubscriptionDialogReason =
   | 'subscription_required'
   | 'out_of_credits'
   | 'top_up_blocked'

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -6,9 +6,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 
 const DIALOG_KEY = 'subscription-required'
 
-export type SubscriptionDialogReason =
-  | 'subscription_required'
-  | 'out_of_credits'
+type SubscriptionDialogReason = 'subscription_required' | 'out_of_credits'
 
 export const useSubscriptionDialog = () => {
   const { flags } = useFeatureFlags()

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -62,7 +62,7 @@ export const useSubscriptionDialog = () => {
   }
 
   function show(options?: { reason?: SubscriptionDialogReason }) {
-    if (isFreeTier.value) {
+    if (isFreeTier.value && workspaceStore.isInPersonalWorkspace) {
       const component = defineAsyncComponent(
         () =>
           import('@/platform/cloud/subscription/components/FreeTierDialogContent.vue')

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -2,9 +2,10 @@ import type { components } from '@/types/comfyRegistryTypes'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
 
-export type TierKey = 'standard' | 'creator' | 'pro' | 'founder'
+export type TierKey = 'free' | 'standard' | 'creator' | 'pro' | 'founder'
 
 export const TIER_TO_KEY: Record<SubscriptionTier, TierKey> = {
+  FREE: 'free',
   STANDARD: 'standard',
   CREATOR: 'creator',
   PRO: 'pro',
@@ -12,6 +13,7 @@ export const TIER_TO_KEY: Record<SubscriptionTier, TierKey> = {
 }
 
 export const KEY_TO_TIER: Record<TierKey, SubscriptionTier> = {
+  free: 'FREE',
   standard: 'STANDARD',
   creator: 'CREATOR',
   pro: 'PRO',
@@ -25,7 +27,10 @@ export interface TierPricing {
   videoEstimate: number
 }
 
-export const TIER_PRICING: Record<Exclude<TierKey, 'founder'>, TierPricing> = {
+export const TIER_PRICING: Record<
+  Exclude<TierKey, 'free' | 'founder'>,
+  TierPricing
+> = {
   standard: { monthly: 20, yearly: 16, credits: 4200, videoEstimate: 380 },
   creator: { monthly: 35, yearly: 28, credits: 7400, videoEstimate: 670 },
   pro: { monthly: 100, yearly: 80, credits: 21100, videoEstimate: 1915 }
@@ -37,6 +42,7 @@ interface TierFeatures {
 }
 
 const TIER_FEATURES: Record<TierKey, TierFeatures> = {
+  free: { customLoRAs: false, maxMembers: 1 },
   standard: { customLoRAs: false, maxMembers: 1 },
   creator: { customLoRAs: true, maxMembers: 5 },
   pro: { customLoRAs: true, maxMembers: 20 },
@@ -49,12 +55,14 @@ const FOUNDER_MONTHLY_PRICE = 20
 const FOUNDER_MONTHLY_CREDITS = 5460
 
 export function getTierPrice(tierKey: TierKey, isYearly = false): number {
+  if (tierKey === 'free') return 0
   if (tierKey === 'founder') return FOUNDER_MONTHLY_PRICE
   const pricing = TIER_PRICING[tierKey]
   return isYearly ? pricing.yearly : pricing.monthly
 }
 
 export function getTierCredits(tierKey: TierKey): number {
+  if (tierKey === 'free') return 0
   if (tierKey === 'founder') return FOUNDER_MONTHLY_CREDITS
   return TIER_PRICING[tierKey].credits
 }

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -62,8 +62,11 @@ export function getTierPrice(tierKey: TierKey, isYearly = false): number {
   return isYearly ? pricing.yearly : pricing.monthly
 }
 
-export function getTierCredits(tierKey: TierKey): number {
-  if (tierKey === 'free') return remoteConfig.value.free_tier_credits ?? 400
+export function getTierCredits(tierKey: 'free'): number | null
+export function getTierCredits(tierKey: Exclude<TierKey, 'free'>): number
+export function getTierCredits(tierKey: TierKey): number | null
+export function getTierCredits(tierKey: TierKey): number | null {
+  if (tierKey === 'free') return remoteConfig.value.free_tier_credits ?? null
   if (tierKey === 'founder') return FOUNDER_MONTHLY_CREDITS
   return TIER_PRICING[tierKey].credits
 }

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -1,3 +1,4 @@
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import type { components } from '@/types/comfyRegistryTypes'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
@@ -62,7 +63,7 @@ export function getTierPrice(tierKey: TierKey, isYearly = false): number {
 }
 
 export function getTierCredits(tierKey: TierKey): number {
-  if (tierKey === 'free') return 0
+  if (tierKey === 'free') return remoteConfig.value.free_tier_credits ?? 400
   if (tierKey === 'founder') return FOUNDER_MONTHLY_CREDITS
   return TIER_PRICING[tierKey].credits
 }

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -62,9 +62,6 @@ export function getTierPrice(tierKey: TierKey, isYearly = false): number {
   return isYearly ? pricing.yearly : pricing.monthly
 }
 
-export function getTierCredits(tierKey: 'free'): number | null
-export function getTierCredits(tierKey: Exclude<TierKey, 'free'>): number
-export function getTierCredits(tierKey: TierKey): number | null
 export function getTierCredits(tierKey: TierKey): number | null {
   if (tierKey === 'free') return remoteConfig.value.free_tier_credits ?? null
   if (tierKey === 'founder') return FOUNDER_MONTHLY_CREDITS

--- a/src/platform/cloud/subscription/utils/subscriptionTierRank.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionTierRank.ts
@@ -2,7 +2,7 @@ import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricin
 
 export type BillingCycle = 'monthly' | 'yearly'
 
-type RankedTierKey = Exclude<TierKey, 'founder'>
+type RankedTierKey = Exclude<TierKey, 'founder' | 'free'>
 type RankedPlanKey = `${BillingCycle}-${RankedTierKey}`
 
 interface PlanDescriptor {
@@ -28,7 +28,7 @@ const toRankedPlanKey = (
   tierKey: TierKey,
   billingCycle: BillingCycle
 ): RankedPlanKey | null => {
-  if (tierKey === 'founder') return null
+  if (tierKey === 'founder' || tierKey === 'free') return null
   return `${billingCycle}-${tierKey}` as RankedPlanKey
 }
 

--- a/src/platform/cloud/subscription/utils/tierBenefits.ts
+++ b/src/platform/cloud/subscription/utils/tierBenefits.ts
@@ -1,0 +1,67 @@
+import {
+  getTierCredits,
+  getTierFeatures
+} from '@/platform/cloud/subscription/constants/tierPricing'
+import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+
+type BenefitType = 'metric' | 'feature' | 'icon'
+
+export interface TierBenefit {
+  key: string
+  type: BenefitType
+  label: string
+  value?: string
+  icon?: string
+}
+
+export function getCommonTierBenefits(
+  key: TierKey,
+  t: (key: string, params?: Record<string, unknown>) => string,
+  n: (value: number) => string
+): TierBenefit[] {
+  const benefits: TierBenefit[] = []
+  const isFree = key === 'free'
+
+  if (isFree) {
+    const credits = getTierCredits(key)
+    if (credits !== null) {
+      benefits.push({
+        key: 'monthlyCredits',
+        type: 'metric',
+        value: n(credits),
+        label: t('subscription.monthlyCreditsLabel')
+      })
+    }
+  }
+
+  benefits.push({
+    key: 'maxDuration',
+    type: 'metric',
+    value: t(`subscription.maxDuration.${key}`),
+    label: t('subscription.maxDurationLabel')
+  })
+
+  benefits.push({
+    key: 'gpu',
+    type: 'feature',
+    label: t('subscription.gpuLabel')
+  })
+
+  if (!isFree) {
+    benefits.push({
+      key: 'addCredits',
+      type: 'feature',
+      label: t('subscription.addCreditsLabel')
+    })
+  }
+
+  if (getTierFeatures(key).customLoRAs) {
+    benefits.push({
+      key: 'customLoRAs',
+      type: 'feature',
+      label: t('subscription.customLoRAsLabel')
+    })
+  }
+
+  return benefits
+}

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -44,4 +44,5 @@ export type RemoteConfig = {
   team_workspaces_enabled?: boolean
   user_secrets_enabled?: boolean
   node_library_essentials_enabled?: boolean
+  free_tier_credits?: number
 }

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -45,4 +45,5 @@ export type RemoteConfig = {
   user_secrets_enabled?: boolean
   node_library_essentials_enabled?: boolean
   free_tier_credits?: number
+  new_free_tier_subscriptions?: boolean
 }

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -16,6 +16,7 @@ import type {
   PageVisibilityMetadata,
   SettingChangedMetadata,
   AuthPageOpenedMetadata,
+  SubscriptionMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryDispatcher,
@@ -70,8 +71,11 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackUserLoggedIn?.())
   }
 
-  trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void {
-    this.dispatch((provider) => provider.trackSubscription?.(event))
+  trackSubscription(
+    event: 'modal_opened' | 'subscribe_clicked',
+    metadata?: SubscriptionMetadata
+  ): void {
+    this.dispatch((provider) => provider.trackSubscription?.(event, metadata))
   }
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -15,6 +15,7 @@ import type {
   PageViewMetadata,
   PageVisibilityMetadata,
   SettingChangedMetadata,
+  SignupPageMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryDispatcher,
@@ -53,8 +54,12 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     })
   }
 
-  trackSignupOpened(): void {
-    this.dispatch((provider) => provider.trackSignupOpened?.())
+  trackSignupOpened(metadata?: SignupPageMetadata): void {
+    this.dispatch((provider) => provider.trackSignupOpened?.(metadata))
+  }
+
+  trackLoginOpened(metadata?: SignupPageMetadata): void {
+    this.dispatch((provider) => provider.trackLoginOpened?.(metadata))
   }
 
   trackAuth(metadata: AuthMetadata): void {

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -15,7 +15,7 @@ import type {
   PageViewMetadata,
   PageVisibilityMetadata,
   SettingChangedMetadata,
-  SignupPageMetadata,
+  AuthPageOpenedMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryDispatcher,
@@ -54,11 +54,11 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     })
   }
 
-  trackSignupOpened(metadata?: SignupPageMetadata): void {
+  trackSignupOpened(metadata?: AuthPageOpenedMetadata): void {
     this.dispatch((provider) => provider.trackSignupOpened?.(metadata))
   }
 
-  trackLoginOpened(metadata?: SignupPageMetadata): void {
+  trackLoginOpened(metadata?: AuthPageOpenedMetadata): void {
     this.dispatch((provider) => provider.trackLoginOpened?.(metadata))
   }
 

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -15,7 +15,6 @@ import type {
   PageViewMetadata,
   PageVisibilityMetadata,
   SettingChangedMetadata,
-  AuthPageOpenedMetadata,
   SubscriptionMetadata,
   SurveyResponses,
   TabCountMetadata,
@@ -55,12 +54,8 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     })
   }
 
-  trackSignupOpened(metadata?: AuthPageOpenedMetadata): void {
-    this.dispatch((provider) => provider.trackSignupOpened?.(metadata))
-  }
-
-  trackLoginOpened(metadata?: AuthPageOpenedMetadata): void {
-    this.dispatch((provider) => provider.trackLoginOpened?.(metadata))
+  trackSignupOpened(): void {
+    this.dispatch((provider) => provider.trackSignupOpened?.())
   }
 
   trackAuth(metadata: AuthMetadata): void {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -35,7 +35,6 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
-  AuthPageOpenedMetadata,
   SubscriptionMetadata,
   SurveyResponses,
   TabCountMetadata,
@@ -212,12 +211,8 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     )
   }
 
-  trackSignupOpened(metadata?: AuthPageOpenedMetadata): void {
-    this.trackEvent(TelemetryEvents.USER_SIGN_UP_OPENED, metadata)
-  }
-
-  trackLoginOpened(metadata?: AuthPageOpenedMetadata): void {
-    this.trackEvent(TelemetryEvents.USER_LOGIN_OPENED, metadata)
+  trackSignupOpened(): void {
+    this.trackEvent(TelemetryEvents.USER_SIGN_UP_OPENED)
   }
 
   trackAuth(metadata: AuthMetadata): void {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -35,6 +35,7 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
+  SignupPageMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryEventName,
@@ -210,8 +211,12 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     )
   }
 
-  trackSignupOpened(): void {
-    this.trackEvent(TelemetryEvents.USER_SIGN_UP_OPENED)
+  trackSignupOpened(metadata?: SignupPageMetadata): void {
+    this.trackEvent(TelemetryEvents.USER_SIGN_UP_OPENED, metadata)
+  }
+
+  trackLoginOpened(metadata?: SignupPageMetadata): void {
+    this.trackEvent(TelemetryEvents.USER_LOGIN_OPENED, metadata)
   }
 
   trackAuth(metadata: AuthMetadata): void {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -36,6 +36,7 @@ import type {
   RunButtonProperties,
   SettingChangedMetadata,
   AuthPageOpenedMetadata,
+  SubscriptionMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryEventName,
@@ -227,13 +228,16 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.USER_LOGGED_IN)
   }
 
-  trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void {
+  trackSubscription(
+    event: 'modal_opened' | 'subscribe_clicked',
+    metadata?: SubscriptionMetadata
+  ): void {
     const eventName =
       event === 'modal_opened'
         ? TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED
         : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED
 
-    this.trackEvent(eventName)
+    this.trackEvent(eventName, metadata)
   }
 
   trackAddApiCreditButtonClicked(): void {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -35,7 +35,7 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
-  SignupPageMetadata,
+  AuthPageOpenedMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryEventName,
@@ -211,11 +211,11 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     )
   }
 
-  trackSignupOpened(metadata?: SignupPageMetadata): void {
+  trackSignupOpened(metadata?: AuthPageOpenedMetadata): void {
     this.trackEvent(TelemetryEvents.USER_SIGN_UP_OPENED, metadata)
   }
 
-  trackLoginOpened(metadata?: SignupPageMetadata): void {
+  trackLoginOpened(metadata?: AuthPageOpenedMetadata): void {
     this.trackEvent(TelemetryEvents.USER_LOGIN_OPENED, metadata)
   }
 

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -27,6 +27,14 @@ export interface AuthMetadata {
   utm_source?: string
   utm_medium?: string
   utm_campaign?: string
+  free_tier_badge_shown?: boolean
+}
+
+/**
+ * Metadata for signup/login page opened events
+ */
+export interface SignupPageMetadata {
+  free_tier_badge_shown?: boolean
 }
 
 /**
@@ -316,7 +324,8 @@ export interface BeginCheckoutMetadata
  */
 export interface TelemetryProvider {
   // Authentication flow events
-  trackSignupOpened?(): void
+  trackSignupOpened?(metadata?: SignupPageMetadata): void
+  trackLoginOpened?(metadata?: SignupPageMetadata): void
   trackAuth?(metadata: AuthMetadata): void
   trackUserLoggedIn?(): void
 
@@ -407,6 +416,7 @@ export type TelemetryDispatcher = Required<TelemetryProvider>
 export const TelemetryEvents = {
   // Authentication Flow
   USER_SIGN_UP_OPENED: 'app:user_sign_up_opened',
+  USER_LOGIN_OPENED: 'app:user_login_opened',
   USER_AUTH_COMPLETED: 'app:user_auth_completed',
   USER_LOGGED_IN: 'app:user_logged_in',
 
@@ -512,3 +522,4 @@ export type TelemetryEventProperties =
   | HelpCenterClosedMetadata
   | WorkflowCreatedMetadata
   | EnterLinearMetadata
+  | SignupPageMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -33,7 +33,7 @@ export interface AuthMetadata {
 /**
  * Metadata for signup/login page opened events
  */
-export interface SignupPageMetadata {
+export interface AuthPageOpenedMetadata {
   free_tier_badge_shown?: boolean
 }
 
@@ -324,8 +324,8 @@ export interface BeginCheckoutMetadata
  */
 export interface TelemetryProvider {
   // Authentication flow events
-  trackSignupOpened?(metadata?: SignupPageMetadata): void
-  trackLoginOpened?(metadata?: SignupPageMetadata): void
+  trackSignupOpened?(metadata?: AuthPageOpenedMetadata): void
+  trackLoginOpened?(metadata?: AuthPageOpenedMetadata): void
   trackAuth?(metadata: AuthMetadata): void
   trackUserLoggedIn?(): void
 
@@ -522,4 +522,4 @@ export type TelemetryEventProperties =
   | HelpCenterClosedMetadata
   | WorkflowCreatedMetadata
   | EnterLinearMetadata
-  | SignupPageMetadata
+  | AuthPageOpenedMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -12,6 +12,7 @@
  * 3. Check dist/assets/*.js files contain no tracking code
  */
 
+import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { AuditLog } from '@/services/customerEventsService'
@@ -27,7 +28,6 @@ export interface AuthMetadata {
   utm_source?: string
   utm_medium?: string
   utm_campaign?: string
-  free_tier_badge_shown?: boolean
 }
 
 /**
@@ -309,6 +309,11 @@ export interface CheckoutAttributionMetadata {
   wbraid?: string
 }
 
+export interface SubscriptionMetadata {
+  current_tier?: string
+  reason?: SubscriptionDialogReason
+}
+
 export interface BeginCheckoutMetadata
   extends Record<string, unknown>, CheckoutAttributionMetadata {
   user_id: string
@@ -330,7 +335,10 @@ export interface TelemetryProvider {
   trackUserLoggedIn?(): void
 
   // Subscription flow events
-  trackSubscription?(event: 'modal_opened' | 'subscribe_clicked'): void
+  trackSubscription?(
+    event: 'modal_opened' | 'subscribe_clicked',
+    metadata?: SubscriptionMetadata
+  ): void
   trackBeginCheckout?(metadata: BeginCheckoutMetadata): void
   trackMonthlySubscriptionSucceeded?(): void
   trackMonthlySubscriptionCancelled?(): void
@@ -523,3 +531,4 @@ export type TelemetryEventProperties =
   | WorkflowCreatedMetadata
   | EnterLinearMetadata
   | AuthPageOpenedMetadata
+  | SubscriptionMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -33,9 +33,7 @@ export interface AuthMetadata {
 /**
  * Metadata for signup/login page opened events
  */
-export interface AuthPageOpenedMetadata {
-  free_tier_badge_shown?: boolean
-}
+export interface AuthPageOpenedMetadata {}
 
 /**
  * Survey response data for user profiling

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -31,11 +31,6 @@ export interface AuthMetadata {
 }
 
 /**
- * Metadata for signup/login page opened events
- */
-export interface AuthPageOpenedMetadata {}
-
-/**
  * Survey response data for user profiling
  * Maps 1-to-1 with actual survey fields
  */
@@ -327,8 +322,7 @@ export interface BeginCheckoutMetadata
  */
 export interface TelemetryProvider {
   // Authentication flow events
-  trackSignupOpened?(metadata?: AuthPageOpenedMetadata): void
-  trackLoginOpened?(metadata?: AuthPageOpenedMetadata): void
+  trackSignupOpened?(): void
   trackAuth?(metadata: AuthMetadata): void
   trackUserLoggedIn?(): void
 
@@ -422,7 +416,6 @@ export type TelemetryDispatcher = Required<TelemetryProvider>
 export const TelemetryEvents = {
   // Authentication Flow
   USER_SIGN_UP_OPENED: 'app:user_sign_up_opened',
-  USER_LOGIN_OPENED: 'app:user_login_opened',
   USER_AUTH_COMPLETED: 'app:user_auth_completed',
   USER_LOGGED_IN: 'app:user_logged_in',
 
@@ -528,5 +521,4 @@ export type TelemetryEventProperties =
   | HelpCenterClosedMetadata
   | WorkflowCreatedMetadata
   | EnterLinearMetadata
-  | AuthPageOpenedMetadata
   | SubscriptionMetadata

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -78,6 +78,7 @@ interface ListWorkspacesResponse {
 }
 
 export type SubscriptionTier =
+  | 'FREE'
   | 'STANDARD'
   | 'CREATOR'
   | 'PRO'

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -296,7 +296,7 @@ const handleOpenWorkspaceSettings = () => {
 }
 
 const handleOpenPlansAndPricing = () => {
-  subscriptionDialog.show()
+  subscriptionDialog.showPricingTable()
   emit('close')
 }
 

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -298,7 +298,7 @@ import type { Plan } from '@/platform/workspace/api/workspaceApi'
 import type { components } from '@/types/comfyRegistryTypes'
 
 type SubscriptionTier = components['schemas']['SubscriptionTier']
-type CheckoutTierKey = Exclude<TierKey, 'founder'>
+type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 
 interface Props {
   isLoading?: boolean

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -182,7 +182,7 @@ import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspac
 import { cn } from '@/utils/tailwindUtil'
 
 interface Props {
-  tierKey: Exclude<TierKey, 'founder'>
+  tierKey: Exclude<TierKey, 'free' | 'founder'>
   billingCycle?: BillingCycle
   isLoading?: boolean
   previewData?: PreviewSubscribeResponse | null

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -213,7 +213,7 @@ const displayPrice = computed(() => {
   return getTierPrice(tierKey, billingCycle === 'yearly')
 })
 
-const displayCredits = computed(() => n(getTierCredits(tierKey)))
+const displayCredits = computed(() => n(getTierCredits(tierKey) ?? 0))
 
 const hasCustomLoRAs = computed(() => getTierFeatures(tierKey).customLoRAs)
 const maxDuration = computed(() => t(`subscription.maxDuration.${tierKey}`))

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -156,11 +156,7 @@
                     size="lg"
                     variant="primary"
                     class="rounded-lg px-4 text-sm font-normal text-text-primary"
-                    @click="
-                      isFreeTierPlan
-                        ? showPricingTable()
-                        : showSubscriptionDialog()
-                    "
+                    @click="handleUpgrade"
                   >
                     {{ $t('subscription.upgradePlan') }}
                   </Button>
@@ -463,6 +459,10 @@ const showZeroState = computed(
 // Subscribe workspace - opens the subscription dialog (personal or workspace variant)
 function handleSubscribeWorkspace() {
   showSubscriptionDialog()
+}
+
+function handleUpgrade() {
+  isFreeTierPlan.value ? showPricingTable() : showSubscriptionDialog()
 }
 const subscriptionTier = computed(() => subscription.value?.tier ?? null)
 const { isFreeTier: isFreeTierPlan } = useSubscription()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -144,6 +144,7 @@
                 <!-- Active state: show Manage Payment, Upgrade, and menu -->
                 <template v-else>
                   <Button
+                    v-if="!isFreeTierPlan"
                     size="lg"
                     variant="secondary"
                     class="rounded-lg px-4 text-sm font-normal text-text-primary bg-interface-menu-component-surface-selected"
@@ -155,11 +156,16 @@
                     size="lg"
                     variant="primary"
                     class="rounded-lg px-4 text-sm font-normal text-text-primary"
-                    @click="showSubscriptionDialog"
+                    @click="
+                      isFreeTierPlan
+                        ? showPricingTable()
+                        : showSubscriptionDialog()
+                    "
                   >
                     {{ $t('subscription.upgradePlan') }}
                   </Button>
                   <Button
+                    v-if="!isFreeTierPlan"
                     v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
                     variant="secondary"
                     size="lg"
@@ -369,6 +375,7 @@ import {
   getTierFeatures,
   getTierPrice
 } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@/utils/tailwindUtil'
@@ -394,6 +401,7 @@ const {
 } = useBillingContext()
 
 const { showCancelSubscriptionDialog } = useDialogService()
+const { showPricingTable } = useSubscriptionDialog()
 
 const isResubscribing = ref(false)
 
@@ -455,6 +463,7 @@ function handleSubscribeWorkspace() {
   showSubscriptionDialog()
 }
 const subscriptionTier = computed(() => subscription.value?.tier ?? null)
+const isFreeTierPlan = computed(() => subscriptionTier.value === 'FREE')
 const isYearlySubscription = computed(
   () => subscription.value?.duration === 'ANNUAL'
 )
@@ -567,24 +576,37 @@ const tierBenefits = computed((): Benefit[] => {
     })
   }
 
-  benefits.push(
-    {
-      key: 'maxDuration',
+  const isFreeTierPlan = key === 'free'
+
+  if (isFreeTierPlan) {
+    benefits.push({
+      key: 'monthlyCredits',
       type: 'metric',
-      value: t(`subscription.maxDuration.${key}`),
-      label: t('subscription.maxDurationLabel')
-    },
-    {
-      key: 'gpu',
-      type: 'feature',
-      label: t('subscription.gpuLabel')
-    },
-    {
+      value: n(getTierCredits(key)),
+      label: t('subscription.monthlyCreditsLabel')
+    })
+  }
+
+  benefits.push({
+    key: 'maxDuration',
+    type: 'metric',
+    value: t(`subscription.maxDuration.${key}`),
+    label: t('subscription.maxDurationLabel')
+  })
+
+  benefits.push({
+    key: 'gpu',
+    type: 'feature',
+    label: t('subscription.gpuLabel')
+  })
+
+  if (!isFreeTierPlan) {
+    benefits.push({
       key: 'addCredits',
       type: 'feature',
       label: t('subscription.addCreditsLabel')
-    }
-  )
+    })
+  }
 
   if (getTierFeatures(key).customLoRAs) {
     benefits.push({

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -370,7 +370,6 @@ import {
   getTierCredits,
   getTierPrice
 } from '@/platform/cloud/subscription/constants/tierPricing'
-import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
@@ -390,6 +389,7 @@ const isSettingUp = computed(() => billingOperationStore.isSettingUp)
 
 const {
   isActiveSubscription,
+  isFreeTier: isFreeTierPlan,
   subscription,
   showSubscriptionDialog,
   manageSubscription,
@@ -465,7 +465,6 @@ function handleUpgrade() {
   isFreeTierPlan.value ? showPricingTable() : showSubscriptionDialog()
 }
 const subscriptionTier = computed(() => subscription.value?.tier ?? null)
-const { isFreeTier: isFreeTierPlan } = useSubscription()
 const isYearlySubscription = computed(
   () => subscription.value?.duration === 'ANNUAL'
 )

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -23,6 +23,15 @@
       <i class="pi pi-times text-xl" />
     </Button>
 
+    <div v-if="reason === 'out_of_credits'" class="text-center">
+      <h2 class="text-xl lg:text-2xl text-muted-foreground m-0">
+        {{ $t('credits.topUp.insufficientTitle') }}
+      </h2>
+      <p class="m-0 mt-2 text-sm text-text-secondary">
+        {{ $t('credits.topUp.insufficientMessage') }}
+      </p>
+    </div>
+
     <!-- Pricing Table Step -->
     <PricingTableWorkspace
       v-if="checkoutStep === 'pricing'"
@@ -83,8 +92,9 @@ import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPrev
 type CheckoutStep = 'pricing' | 'preview'
 type CheckoutTierKey = Exclude<TierKey, 'founder'>
 
-const props = defineProps<{
+const { onClose, reason } = defineProps<{
   onClose: () => void
+  reason?: 'subscription_required' | 'out_of_credits'
 }>()
 
 const emit = defineEmits<{
@@ -314,7 +324,7 @@ async function handleResubscribe() {
 }
 
 function handleClose() {
-  props.onClose()
+  onClose()
 }
 </script>
 

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -84,17 +84,18 @@ import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscript
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 import PricingTableWorkspace from './PricingTableWorkspace.vue'
 import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 
 type CheckoutStep = 'pricing' | 'preview'
-type CheckoutTierKey = Exclude<TierKey, 'founder'>
+type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 
 const { onClose, reason } = defineProps<{
   onClose: () => void
-  reason?: 'subscription_required' | 'out_of_credits'
+  reason?: SubscriptionDialogReason
 }>()
 
 const emit = defineEmits<{

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -208,7 +208,7 @@ const currentDisplayCredits = computed(() => {
     | 'standard'
     | 'creator'
     | 'pro'
-  return n(getTierCredits(tierKey))
+  return n(getTierCredits(tierKey) ?? 0)
 })
 
 const newDisplayCredits = computed(() => {
@@ -216,7 +216,7 @@ const newDisplayCredits = computed(() => {
     | 'standard'
     | 'creator'
     | 'pro'
-  return n(getTierCredits(tierKey))
+  return n(getTierCredits(tierKey) ?? 0)
 })
 
 const currentPeriodEndDate = computed(() =>

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -143,6 +143,7 @@ const { switchWithConfirmation } = useWorkspaceSwitch()
 const { subscription } = useBillingContext()
 
 const tierKeyMap: Record<string, string> = {
+  FREE: 'free',
   STANDARD: 'standard',
   CREATOR: 'creator',
   PRO: 'pro',

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -37,6 +37,9 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
   const isActiveSubscription = computed(
     () => statusData.value?.is_active ?? false
   )
+  const isFreeTier = computed(
+    () => statusData.value?.subscription_tier === 'FREE'
+  )
 
   const subscription = computed<SubscriptionInfo | null>(() => {
     const status = statusData.value
@@ -141,6 +144,10 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     error.value = null
     try {
       await Promise.all([fetchStatus(), fetchBalance(), fetchPlans()])
+      // Re-fetch balance if free tier credits were just lazily granted
+      if (isFreeTier.value && balance.value?.amountMicros === 0) {
+        await fetchBalance()
+      }
       isInitialized.value = true
     } catch (err) {
       error.value =
@@ -295,6 +302,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     isLoading,
     error,
     isActiveSubscription,
+    isFreeTier,
 
     // Actions
     initialize,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -51,7 +51,6 @@ import {
   DOMWidgetImpl
 } from '@/scripts/domWidget'
 import { useDialogService } from '@/services/dialogService'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useMissingNodesDialog } from '@/composables/useMissingNodesDialog'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -741,17 +740,9 @@ export class ComfyApp {
           'Payment Required: Please add credits to your account to use this node.'
         )
       ) {
-        const { isActiveSubscription, subscription } = useBillingContext()
-        if (isActiveSubscription.value && subscription.value?.tier !== 'FREE') {
-          useDialogService().showTopUpCreditsDialog({
-            isInsufficientCredits: true
-          })
-        } else {
-          // Free tier users can't top up; take them straight to the subscription CTA.
-          void useDialogService().showSubscriptionRequiredDialog({
-            reason: 'out_of_credits'
-          })
-        }
+        useDialogService().showTopUpCreditsDialog({
+          isInsufficientCredits: true
+        })
       } else if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
         useExecutionErrorStore().showErrorOverlay()
       } else {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -741,14 +741,16 @@ export class ComfyApp {
           'Payment Required: Please add credits to your account to use this node.'
         )
       ) {
-        const { isActiveSubscription, subscription, showSubscriptionDialog } =
-          useBillingContext()
+        const { isActiveSubscription, subscription } = useBillingContext()
         if (isActiveSubscription.value && subscription.value?.tier !== 'FREE') {
           useDialogService().showTopUpCreditsDialog({
             isInsufficientCredits: true
           })
         } else {
-          showSubscriptionDialog()
+          // Free tier users can't top up; take them straight to the subscription CTA.
+          void useDialogService().showSubscriptionRequiredDialog({
+            reason: 'out_of_credits'
+          })
         }
       } else if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
         useExecutionErrorStore().showErrorOverlay()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -741,11 +741,14 @@ export class ComfyApp {
           'Payment Required: Please add credits to your account to use this node.'
         )
       ) {
-        const { isActiveSubscription } = useBillingContext()
-        if (isActiveSubscription.value) {
+        const { isActiveSubscription, subscription, showSubscriptionDialog } =
+          useBillingContext()
+        if (isActiveSubscription.value && subscription.value?.tier !== 'FREE') {
           useDialogService().showTopUpCreditsDialog({
             isInsufficientCredits: true
           })
+        } else {
+          showSubscriptionDialog()
         }
       } else if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
         useExecutionErrorStore().showErrorOverlay()

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -274,8 +274,9 @@ export const useDialogService = () => {
   async function showTopUpCreditsDialog(options?: {
     isInsufficientCredits?: boolean
   }) {
-    const { isActiveSubscription, type } = useBillingContext()
-    if (!isActiveSubscription.value) return
+    const { isActiveSubscription, subscription, type } = useBillingContext()
+    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE')
+      return
 
     const component =
       type.value === 'workspace'

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -277,7 +277,7 @@ export const useDialogService = () => {
     const { isActiveSubscription, subscription, type } = useBillingContext()
     if (!isActiveSubscription.value || subscription.value?.tier === 'FREE') {
       // Free tier users can't top up. Give them a clear upgrade CTA instead.
-      await showSubscriptionRequiredDialog({ reason: 'out_of_credits' })
+      await showSubscriptionRequiredDialog({ reason: 'top_up_blocked' })
       return
     }
 
@@ -397,7 +397,7 @@ export const useDialogService = () => {
   }
 
   async function showSubscriptionRequiredDialog(options?: {
-    reason?: 'subscription_required' | 'out_of_credits'
+    reason?: 'subscription_required' | 'out_of_credits' | 'top_up_blocked'
   }) {
     if (!isCloud) {
       return

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -275,8 +275,11 @@ export const useDialogService = () => {
     isInsufficientCredits?: boolean
   }) {
     const { isActiveSubscription, subscription, type } = useBillingContext()
-    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE')
+    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE') {
+      // Free tier users can't top up. Give them a clear upgrade CTA instead.
+      await showSubscriptionRequiredDialog({ reason: 'out_of_credits' })
       return
+    }
 
     const component =
       type.value === 'workspace'
@@ -393,15 +396,17 @@ export const useDialogService = () => {
     })
   }
 
-  async function showSubscriptionRequiredDialog() {
-    if (!isCloud || !window.__CONFIG__?.subscription_required) {
+  async function showSubscriptionRequiredDialog(options?: {
+    reason?: 'subscription_required' | 'out_of_credits'
+  }) {
+    if (!isCloud) {
       return
     }
 
     const { useSubscriptionDialog } =
       await import('@/platform/cloud/subscription/composables/useSubscriptionDialog')
     const { show } = useSubscriptionDialog()
-    show()
+    show(options)
   }
 
   // Workspace dialogs - dynamically imported to avoid bundling when feature flag is off

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/stores/dialogStore'
 
 import type { ComponentAttrs } from 'vue-component-type-helpers'
+import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 // Lazy loaders for dialogs - components are loaded on first use
 const lazyApiNodesSignInContent = () =>
@@ -276,8 +277,11 @@ export const useDialogService = () => {
   }) {
     const { isActiveSubscription, subscription, type } = useBillingContext()
     if (!isActiveSubscription.value || subscription.value?.tier === 'FREE') {
-      // Free tier users can't top up. Give them a clear upgrade CTA instead.
-      await showSubscriptionRequiredDialog({ reason: 'top_up_blocked' })
+      await showSubscriptionRequiredDialog({
+        reason: options?.isInsufficientCredits
+          ? 'out_of_credits'
+          : 'top_up_blocked'
+      })
       return
     }
 
@@ -397,9 +401,9 @@ export const useDialogService = () => {
   }
 
   async function showSubscriptionRequiredDialog(options?: {
-    reason?: 'subscription_required' | 'out_of_credits' | 'top_up_blocked'
+    reason?: SubscriptionDialogReason
   }) {
-    if (!isCloud) {
+    if (!isCloud || !window.__CONFIG__?.subscription_required) {
       return
     }
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/stores/dialogStore'
 
 import type { ComponentAttrs } from 'vue-component-type-helpers'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 // Lazy loaders for dialogs - components are loaded on first use
@@ -275,8 +276,9 @@ export const useDialogService = () => {
   async function showTopUpCreditsDialog(options?: {
     isInsufficientCredits?: boolean
   }) {
-    const { isActiveSubscription, subscription, type } = useBillingContext()
-    if (!isActiveSubscription.value || subscription.value?.tier === 'FREE') {
+    const { isActiveSubscription, type } = useBillingContext()
+    const { isFreeTier } = useSubscription()
+    if (!isActiveSubscription.value || isFreeTier.value) {
       await showSubscriptionRequiredDialog({
         reason: options?.isInsufficientCredits
           ? 'out_of_credits'

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -17,7 +17,6 @@ import type {
 } from '@/stores/dialogStore'
 
 import type { ComponentAttrs } from 'vue-component-type-helpers'
-import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 // Lazy loaders for dialogs - components are loaded on first use
@@ -276,8 +275,7 @@ export const useDialogService = () => {
   async function showTopUpCreditsDialog(options?: {
     isInsufficientCredits?: boolean
   }) {
-    const { isActiveSubscription, type } = useBillingContext()
-    const { isFreeTier } = useSubscription()
+    const { isActiveSubscription, isFreeTier, type } = useBillingContext()
     if (!isActiveSubscription.value || isFreeTier.value) {
       await showSubscriptionRequiredDialog({
         reason: options?.isInsufficientCredits

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -31,6 +31,7 @@ import type { AuthHeader } from '@/types/authTypes'
 import type { operations } from '@/types/comfyRegistryTypes'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 
+/** Set after first login; used to detect returning users so the sign-in flow can skip the free-tier badge. */
 export const HAS_ACCOUNT_KEY = 'comfy:hasAccount'
 
 type CreditPurchaseResponse =

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -105,9 +105,18 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   // Set persistence to localStorage (works in both browser and Electron)
   void setPersistence(auth, browserLocalPersistence)
 
+  const HAS_ACCOUNT_KEY = 'comfy:hasAccount'
+
   onAuthStateChanged(auth, (user) => {
     currentUser.value = user
     isInitialized.value = true
+    if (user) {
+      try {
+        localStorage.setItem(HAS_ACCOUNT_KEY, '1')
+      } catch {
+        // Ignore localStorage errors (e.g., in private browsing mode)
+      }
+    }
     if (user === null) {
       lastTokenUserId.value = null
 

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -31,6 +31,8 @@ import type { AuthHeader } from '@/types/authTypes'
 import type { operations } from '@/types/comfyRegistryTypes'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 
+export const HAS_ACCOUNT_KEY = 'comfy:hasAccount'
+
 type CreditPurchaseResponse =
   operations['InitiateCreditPurchase']['responses']['201']['content']['application/json']
 type CreditPurchasePayload =
@@ -104,8 +106,6 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   const auth = useFirebaseAuth()!
   // Set persistence to localStorage (works in both browser and Electron)
   void setPersistence(auth, browserLocalPersistence)
-
-  const HAS_ACCOUNT_KEY = 'comfy:hasAccount'
 
   onAuthStateChanged(auth, (user) => {
     currentUser.value = user

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -31,9 +31,6 @@ import type { AuthHeader } from '@/types/authTypes'
 import type { operations } from '@/types/comfyRegistryTypes'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 
-/** Set after first login; used to detect returning users so the sign-in flow can skip the free-tier badge. */
-export const HAS_ACCOUNT_KEY = 'comfy:hasAccount'
-
 type CreditPurchaseResponse =
   operations['InitiateCreditPurchase']['responses']['201']['content']['application/json']
 type CreditPurchasePayload =
@@ -111,13 +108,6 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   onAuthStateChanged(auth, (user) => {
     currentUser.value = user
     isInitialized.value = true
-    if (user) {
-      try {
-        localStorage.setItem(HAS_ACCOUNT_KEY, '1')
-      } catch {
-        // Ignore localStorage errors (e.g., in private browsing mode)
-      }
-    }
     if (user === null) {
       lastTokenUserId.value = null
 


### PR DESCRIPTION
## Summary

Add frontend support for a Free subscription tier — login/signup page restructuring, telemetry instrumentation, and tier-aware billing gating.

## Changes

- **What**: 
  - Restructure login/signup pages: OAuth buttons promoted as primary sign-in method, email login available via progressive disclosure
  - Add Free tier badge on Google sign-up button with dynamic credit count from remote config
  - Add `FREE` subscription tier to type system (tier pricing, tier rank, registry types)
  - Add `isFreeTier` computed to `useSubscription()`
  - Disable credit top-up for Free tier users (dialogService, purchaseCredits, popover CTA)
  - Show subscription/upgrade dialog instead of top-up dialog when Free tier user hits out-of-credits
  - Add funnel telemetry: `trackLoginOpened`, enrich `trackSignupOpened` with `free_tier_badge_shown`, track email toggle clicks

## Review Focus

- Tier gating logic: Free tier users should see "Upgrade" instead of "Add Credits" and never reach the top-up flow
- Telemetry event design for Mixpanel funnel analysis
- Progressive disclosure UX on login/signup pages

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8864-feat-add-Free-subscription-tier-support-3076d73d36508133b84ec5f0a67ccb03) by [Unito](https://www.unito.io)
