### PR TITLE
A heavy-handed fix for middlemouse pan

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -60,6 +60,9 @@
     v-if="shouldRenderVueNodes && comfyApp.canvas && comfyAppReady"
     :canvas="comfyApp.canvas"
     @wheel.capture="canvasInteractions.forwardEventToCanvas"
+    @pointerdown.capture="forwardPanEvent"
+    @pointerup.capture="forwardPanEvent"
+    @pointermove.capture="forwardPanEvent"
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <LGraphNode
@@ -154,12 +157,14 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import TransformPane from '@/renderer/core/layout/transform/TransformPane.vue'
 import MiniMap from '@/renderer/extensions/minimap/MiniMap.vue'
 import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
+import { forwardMiddlePointerIfNeeded } from '@/renderer/extensions/vueNodes/composables/useNodePointerInteractions'
 import { UnauthorizedError } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import { IS_CONTROL_WIDGET, updateControlWidgetLabel } from '@/scripts/widgets'
 import { useColorPaletteService } from '@/services/colorPaletteService'
 import { useNewUserService } from '@/services/useNewUserService'
+import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
 import { storeToRefs } from 'pinia'
 
 import { useBootstrapStore } from '@/stores/bootstrapStore'
@@ -540,4 +545,9 @@ onMounted(async () => {
 onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
+function forwardPanEvent(e: PointerEvent) {
+  if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
+    return
+  forwardMiddlePointerIfNeeded(e)
+}
 </script>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -117,6 +117,7 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { isMiddlePointerInput } from '@/base/pointerUtils'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import TopMenuSection from '@/components/TopMenuSection.vue'
 import BottomPanel from '@/components/bottomPanel/BottomPanel.vue'
@@ -157,7 +158,6 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import TransformPane from '@/renderer/core/layout/transform/TransformPane.vue'
 import MiniMap from '@/renderer/extensions/minimap/MiniMap.vue'
 import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
-import { forwardMiddlePointerIfNeeded } from '@/renderer/extensions/vueNodes/composables/useNodePointerInteractions'
 import { UnauthorizedError } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { ChangeTracker } from '@/scripts/changeTracker'
@@ -546,8 +546,12 @@ onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
 function forwardPanEvent(e: PointerEvent) {
-  if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
+  if (
+    (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target) ||
+    !isMiddlePointerInput(e)
+  )
     return
-  forwardMiddlePointerIfNeeded(e)
+
+  canvasInteractions.forwardEventToCanvas(e)
 }
 </script>

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -9,23 +9,22 @@ import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables
 import { isMultiSelectKey } from '@/renderer/extensions/vueNodes/utils/selectionUtils'
 import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
 
-const { forwardEventToCanvas, shouldHandleNodePointerEvents } =
-  useCanvasInteractions()
-
-export const forwardMiddlePointerIfNeeded = (event: PointerEvent) => {
-  if (!isMiddlePointerInput(event)) return false
-  forwardEventToCanvas(event)
-  return true
-}
-
 export function useNodePointerInteractions(
   nodeIdRef: MaybeRefOrGetter<string>
 ) {
   const { startDrag, endDrag, handleDrag } = useNodeDrag()
   // Use canvas interactions for proper wheel event handling and pointer event capture control
+  const { forwardEventToCanvas, shouldHandleNodePointerEvents } =
+    useCanvasInteractions()
   const { handleNodeSelect, toggleNodeSelectionAfterPointerUp } =
     useNodeEventHandlers()
   const { nodeManager } = useVueNodeLifecycle()
+
+  const forwardMiddlePointerIfNeeded = (event: PointerEvent) => {
+    if (!isMiddlePointerInput(event)) return false
+    forwardEventToCanvas(event)
+    return true
+  }
 
   let hasDraggingStarted = false
 

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -9,22 +9,23 @@ import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables
 import { isMultiSelectKey } from '@/renderer/extensions/vueNodes/utils/selectionUtils'
 import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
 
+const { forwardEventToCanvas, shouldHandleNodePointerEvents } =
+  useCanvasInteractions()
+
+export const forwardMiddlePointerIfNeeded = (event: PointerEvent) => {
+  if (!isMiddlePointerInput(event)) return false
+  forwardEventToCanvas(event)
+  return true
+}
+
 export function useNodePointerInteractions(
   nodeIdRef: MaybeRefOrGetter<string>
 ) {
   const { startDrag, endDrag, handleDrag } = useNodeDrag()
   // Use canvas interactions for proper wheel event handling and pointer event capture control
-  const { forwardEventToCanvas, shouldHandleNodePointerEvents } =
-    useCanvasInteractions()
   const { handleNodeSelect, toggleNodeSelectionAfterPointerUp } =
     useNodeEventHandlers()
   const { nodeManager } = useVueNodeLifecycle()
-
-  const forwardMiddlePointerIfNeeded = (event: PointerEvent) => {
-    if (!isMiddlePointerInput(event)) return false
-    forwardEventToCanvas(event)
-    return true
-  }
 
   let hasDraggingStarted = false
 


### PR DESCRIPTION
Sometimes, middle mouse clicks would fail to initiate a canvas pan, depending on the target of the initial pan. This PR adds a capturing event handler to the transform pane that forwards the pointer event to canvas if
- It is a middle mouse click
- The target element is not a focused text element

Resolves #6911

While testing this, I encountered infrequent cases of "some nodes unintentionally translating continually to the left". Reproduction was too unreliable to properly track down, but did appear unrelated to this PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8865-A-heavy-handed-fix-for-middlemouse-pan-3076d73d365081ea9a4ddd5786fc647a) by [Unito](https://www.unito.io)
