### PR TITLE
fix: hide output images for ImageCropV2 node

### DIFF
--- a/src/extensions/core/imageCrop.ts
+++ b/src/extensions/core/imageCrop.ts
@@ -6,6 +6,7 @@ useExtensionService().registerExtension({
   async nodeCreated(node) {
     if (node.constructor.comfyClass !== 'ImageCropV2') return
 
+    node.hideOutputImages = true
     const [oldWidth, oldHeight] = node.size
     node.setSize([Math.max(oldWidth, 300), Math.max(oldHeight, 450)])
   }


### PR DESCRIPTION
## Summary
using the new hideOutputImages flag for image crop.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8873-fix-hide-output-images-for-ImageCropV2-node-3076d73d365081079839dfc9b801606c) by [Unito](https://www.unito.io)
