### PR TITLE
fix: prevent scroll event leak in TextPreviewWidget

### DIFF
--- a/src/components/graph/widgets/TextPreviewWidget.vue
+++ b/src/components/graph/widgets/TextPreviewWidget.vue
@@ -1,6 +1,8 @@
 <template>
   <div
+    ref="containerRef"
     class="relative max-h-[200px] min-h-[28px] w-full overflow-y-auto rounded-lg px-4 py-2 text-xs"
+    @wheel="handleWheel"
   >
     <div class="flex items-center gap-2">
       <div class="flex flex-1 items-center gap-2 break-all">
@@ -13,7 +15,7 @@
 
 <script setup lang="ts">
 import Skeleton from 'primevue/skeleton'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import type { NodeId } from '@/lib/litegraph/src/litegraph'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -23,6 +25,28 @@ const modelValue = defineModel<string>({ required: true })
 const props = defineProps<{
   nodeId: NodeId
 }>()
+
+const containerRef = useTemplateRef<HTMLElement>('containerRef')
+
+function handleWheel(event: WheelEvent) {
+  const container = containerRef.value
+  if (!container) return
+
+  const isScrollable = container.scrollHeight > container.clientHeight
+  if (!isScrollable) return
+
+  const { scrollTop, scrollHeight, clientHeight } = container
+  const isScrollingUp = event.deltaY < 0
+  const isScrollingDown = event.deltaY > 0
+
+  const scrollTolerance = 1
+  const isAtTop = Math.abs(scrollTop) <= scrollTolerance
+  const isAtBottom = scrollTop + clientHeight >= scrollHeight - scrollTolerance
+
+  if ((isScrollingUp && !isAtTop) || (isScrollingDown && !isAtBottom)) {
+    event.stopPropagation()
+  }
+}
 
 const executionStore = useExecutionStore()
 const isParentNodeExecuting = ref(true)


### PR DESCRIPTION
hey! noticed this issue was causing some annoying behavior when scrolling through text widgets.

## what was happening
when you'd scroll to the top or bottom of a text preview widget, the scroll event would leak through to the canvas layer and cause unwanted zooming/panning. pretty frustrating when you're just trying to read some text.

## the fix
added a wheel event handler that's a bit smarter about when to stop propagation:
- if the text is scrollable and you're scrolling within bounds → stops the event from reaching canvas
- if you're at the top/bottom and keep scrolling → lets it through so canvas zoom still works
- if there's not enough text to scroll → events pass through normally

tested it out and it feels much more natural now. you can scroll through your text without the canvas freaking out, but you can still zoom the canvas when you need to.

closes #3990

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8877-fix-prevent-scroll-event-leak-in-TextPreviewWidget-3076d73d36508143ae96d564006e12bc) by [Unito](https://www.unito.io)
