### PR TITLE
Fix primitve assets on cloud

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -6,7 +6,6 @@ import { reactiveComputed } from '@vueuse/core'
 import { customRef, reactive, shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import { isProxyWidget } from '@/core/graph/subgraph/proxyWidget'
 import type {
   INodeInputSlot,
   INodeOutputSlot
@@ -51,7 +50,6 @@ export interface SafeWidgetData {
   hasLayoutSize?: boolean
   isDOMWidget?: boolean
   label?: string
-  nodeType?: string
   options?: IWidgetOptions
   spec?: InputSpec
   slotMetadata?: WidgetSlotMetadata
@@ -123,12 +121,6 @@ function getControlWidget(widget: IBaseWidget): SafeControlWidget | undefined {
   }
 }
 
-function getNodeType(node: LGraphNode, widget: IBaseWidget) {
-  if (!node.isSubgraphNode() || !isProxyWidget(widget)) return undefined
-  const subNode = node.subgraph.getNodeById(widget._overlay.nodeId)
-  return subNode?.type
-}
-
 /**
  * Shared widget enhancements used by both safeWidgetMapper and Right Side Panel
  */
@@ -139,8 +131,6 @@ interface SharedWidgetEnhancements {
   controlWidget?: SafeControlWidget
   /** Input specification from node definition */
   spec?: InputSpec
-  /** Node type (for subgraph promoted widgets) */
-  nodeType?: string
   /** Border style for promoted/advanced widgets */
   borderStyle?: string
   /** Widget label */
@@ -164,7 +154,6 @@ export function getSharedWidgetEnhancements(
     value: useReactiveWidgetValue(widget),
     controlWidget: getControlWidget(widget),
     spec: nodeDefStore.getInputSpecForWidget(node, widget.name),
-    nodeType: getNodeType(node, widget),
     borderStyle: widget.promoted
       ? 'ring ring-component-node-widget-promoted'
       : widget.advanced

--- a/src/platform/assets/utils/createAssetWidget.ts
+++ b/src/platform/assets/utils/createAssetWidget.ts
@@ -105,7 +105,10 @@ export function createAssetWidget(
     })
   }
 
-  const options: IWidgetAssetOptions = { openModal }
+  const options: IWidgetAssetOptions = {
+    openModal,
+    nodeType: nodeTypeForBrowser
+  }
 
   return node.addWidget('asset', widgetName, displayLabel, () => {}, options)
 }

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -184,7 +184,6 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       callback: widget.callback,
       controlWidget: widget.controlWidget,
       label: widget.label,
-      nodeType: widget.nodeType,
       options: widgetOptions,
       spec: widget.spec
     }


### PR DESCRIPTION
THIS IS A PR DIRECTLY INTO `cloud/1.39`

#8598 made primitve widgets connected to an asset have the asset type, but the `nodeType` parameter required to actually resolve valid models wasn't getting passed correctly.

This `nodeType`, introduced by me back in #7576, was a mistake. I'm pulling it out now and instead passing nodeType as an option. Of note: code changes are only required to pass the option, not to utilize it.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/f1abfbd1-2502-4b82-841c-7ef697b3a431" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/099cd511-0101-496c-b24e-ee2c19f23384"/>|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8878-Fix-primitve-assets-on-cloud-3076d73d365081f5a3a7f8b632ba3f3f) by [Unito](https://www.unito.io)
