### PR TITLE
Fix primitive assets

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -54,8 +54,6 @@ export interface SafeWidgetData {
   hasLayoutSize?: boolean
   /** Whether widget is a DOM widget */
   isDOMWidget?: boolean
-  /** Node type (for subgraph promoted widgets) */
-  nodeType?: string
   /**
    * Widget options needed for render decisions.
    * Note: Most metadata should be accessed via widgetValueStore.getWidget().
@@ -121,12 +119,6 @@ function getControlWidget(widget: IBaseWidget): SafeControlWidget | undefined {
   }
 }
 
-function getNodeType(node: LGraphNode, widget: IBaseWidget) {
-  if (!node.isSubgraphNode() || !isProxyWidget(widget)) return undefined
-  const subNode = node.subgraph.getNodeById(widget._overlay.nodeId)
-  return subNode?.type
-}
-
 /**
  * Shared widget enhancements used by both safeWidgetMapper and Right Side Panel
  */
@@ -135,8 +127,6 @@ interface SharedWidgetEnhancements {
   controlWidget?: SafeControlWidget
   /** Input specification from node definition */
   spec?: InputSpec
-  /** Node type (for subgraph promoted widgets) */
-  nodeType?: string
 }
 
 /**
@@ -152,8 +142,7 @@ export function getSharedWidgetEnhancements(
 
   return {
     controlWidget: getControlWidget(widget),
-    spec: nodeDefStore.getInputSpecForWidget(node, widget.name),
-    nodeType: getNodeType(node, widget)
+    spec: nodeDefStore.getInputSpecForWidget(node, widget.name)
   }
 }
 

--- a/src/platform/assets/utils/createAssetWidget.ts
+++ b/src/platform/assets/utils/createAssetWidget.ts
@@ -105,7 +105,10 @@ export function createAssetWidget(
     })
   }
 
-  const options: IWidgetAssetOptions = { openModal }
+  const options: IWidgetAssetOptions = {
+    openModal,
+    nodeType: nodeTypeForBrowser
+  }
 
   return node.addWidget('asset', widgetName, displayLabel, () => {}, options)
 }

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -214,7 +214,6 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       callback: widget.callback,
       controlWidget: widget.controlWidget,
       label: widgetState?.label,
-      nodeType: widget.nodeType,
       options: widgetOptions,
       spec: widget.spec
     }


### PR DESCRIPTION
#8598 made primitve widgets connected to an asset have the asset type, but the `nodeType` parameter required to actually resolve valid models wasn't getting passed correctly.

This `nodeType`, introduced by me back in #7576, was a mistake. I'm pulling it out now and instead passing nodeType as an option. Of note: code changes are only required to pass the option, not to utilize it.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/f1abfbd1-2502-4b82-841c-7ef697b3a431" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/099cd511-0101-496c-b24e-ee2c19f23384"/>|

The backport PR was made first in #8878. Fixing the bug was time sensitive and backport would not be clean due to the `widget.value` changes. Changes were still simpler than expected. I probably should have made this PR first and then backported, but I misjudged the complexity of conflict resolution.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8879-Fix-primitive-assets-3076d73d365081b89ed4e6400dbf8e74) by [Unito](https://www.unito.io)
