### PR TITLE
fix(queue): address follow-up review comments from #8740

### DIFF
--- a/src/components/queue/QueueNotificationBanner.stories.ts
+++ b/src/components/queue/QueueNotificationBanner.stories.ts
@@ -52,7 +52,7 @@ export const Completed: Story = {
   args: args({
     type: 'completed',
     count: 1,
-    thumbnailUrl: thumbnail('4dabf7')
+    thumbnailUrls: [thumbnail('4dabf7')]
   })
 }
 
@@ -97,7 +97,7 @@ export const Gallery: Story = {
       const completed = args({
         type: 'completed',
         count: 1,
-        thumbnailUrl: thumbnail('ff6b6b')
+        thumbnailUrls: [thumbnail('ff6b6b')]
       })
       const completedMultiple = args({
         type: 'completed',

--- a/src/components/queue/QueueNotificationBanner.vue
+++ b/src/components/queue/QueueNotificationBanner.vue
@@ -71,11 +71,6 @@ const thumbnailUrls = computed(() => {
   if (notification.type !== 'completed') {
     return []
   }
-  if (typeof notification.thumbnailUrl === 'string') {
-    return notification.thumbnailUrl.length > 0
-      ? [notification.thumbnailUrl]
-      : []
-  }
   return notification.thumbnailUrls?.slice(0, 2) ?? []
 })
 

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -23,7 +23,6 @@ type QueueQueuedNotification = {
 type QueueCompletedNotification = {
   type: 'completed'
   count: number
-  thumbnailUrl?: string
   thumbnailUrls?: string[]
 }
 

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -38,7 +38,7 @@ export type QueueNotificationBanner =
   | QueueFailedNotification
 
 const sanitizeCount = (value: number | undefined) => {
-  if (value === undefined || Number.isNaN(value) || value <= 0) {
+  if (!(typeof value === 'number' && value > 0)) {
     return 1
   }
   return Math.floor(value)


### PR DESCRIPTION
## Summary
Address follow-up review feedback from #8740 by consolidating completed-banner thumbnail fields and tightening queue count sanitization.

## Changes
- **What**:
  - Consolidated completed notification thumbnail data to `thumbnailUrls` only by removing legacy `thumbnailUrl` support from the queue banner notification type and renderer.
  - Updated queue notification banner stories to use `thumbnailUrls` consistently.
  - Simplified `sanitizeCount` to treat any non-positive or non-number value as the fallback count (`1`).

## Review Focus
Confirm the completed notification payload shape is now consistently `thumbnailUrls` and no consumer relies on `thumbnailUrl`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8880-fix-queue-address-follow-up-review-comments-from-8740-3076d73d365081719a70d860691c5f05) by [Unito](https://www.unito.io)
