### PR TITLE
fix: resolve errors when converting ImageCrop node to subgraph

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -965,8 +965,12 @@ export class LGraphNode
       o.widgets_values = []
       for (const [i, widget] of widgets.entries()) {
         if (widget.serialize === false) continue
-        // @ts-expect-error #595 No-null
-        o.widgets_values[i] = widget ? widget.value : null
+        const val = widget?.value
+        // Ensure object values are plain (not reactive proxies) for structuredClone compatibility.
+        o.widgets_values[i] =
+          val != null && typeof val === 'object'
+            ? JSON.parse(JSON.stringify(val))
+            : (val ?? null)
       }
     }
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.ts
@@ -45,7 +45,15 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
       widgetType,
       name,
       { ...defaultValue },
-      null,
+      () => {
+        for (let i = 0; i < fields.length; i++) {
+          const field = fields[i]
+          const subWidget = subWidgets[i]
+          if (subWidget) {
+            subWidget.value = widget.value[field]
+          }
+        }
+      },
       {
         serialize: true,
         canvasOnly: false
@@ -57,16 +65,6 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
     }
 
     const widget = rawWidget
-
-    widget.callback = () => {
-      for (let i = 0; i < fields.length; i++) {
-        const field = fields[i]
-        const subWidget = subWidgets[i]
-        if (subWidget) {
-          subWidget.value = widget.value[field]
-        }
-      }
-    }
 
     for (const field of fields) {
       const subWidget = node.addWidget(


### PR DESCRIPTION
## Summary

- Pass callback directly to addWidget instead of null to eliminate 'addWidget without a callback or property assigned' warning
- Serialize object widget values as plain objects in LGraphNode.serialize to prevent DataCloneError when structuredClone encounters Vue reactive proxies

## Screenshots (if applicable)
before
https://github.com/user-attachments/assets/af20bd84-3e0e-4eca-b095-eaf4d5bb6884

after

https://github.com/user-attachments/assets/5a17772e-04bc-4f3e-abec-78c540e0efa3

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8898-fix-resolve-errors-when-converting-ImageCrop-node-to-subgraph-3086d73d365081b2ae34db31225683ad) by [Unito](https://www.unito.io)
