### PR TITLE
fix: resolve ImageCrop input image through subgraph nodes

### DIFF
--- a/src/composables/useImageCrop.ts
+++ b/src/composables/useImageCrop.ts
@@ -155,11 +155,18 @@ export function useImageCrop(nodeId: NodeId, options: UseImageCropOptions) {
   const getInputImageUrl = (): string | null => {
     if (!node.value) return null
 
-    const inputNode = node.value.getInputNode(0)
+    let sourceNode = node.value.getInputNode(0)
+    if (!sourceNode) return null
 
-    if (!inputNode) return null
+    if (sourceNode.isSubgraphNode()) {
+      const link = node.value.getInputLink(0)
+      if (!link) return null
+      const resolved = sourceNode.resolveSubgraphOutputLink(link.origin_slot)
+      sourceNode = resolved?.outputNode ?? null
+      if (!sourceNode) return null
+    }
 
-    const urls = nodeOutputStore.getNodeImageUrls(inputNode)
+    const urls = nodeOutputStore.getNodeImageUrls(sourceNode)
 
     if (urls?.length) {
       return urls[0]

--- a/src/composables/useImageCrop.ts
+++ b/src/composables/useImageCrop.ts
@@ -569,7 +569,10 @@ export function useImageCrop(nodeId: NodeId, options: UseImageCropOptions) {
 
   const initialize = () => {
     if (nodeId != null) {
-      node.value = app.rootGraph?.getNodeById(nodeId) || null
+      node.value =
+        app.canvas?.graph?.getNodeById(nodeId) ||
+        app.rootGraph?.getNodeById(nodeId) ||
+        null
     }
 
     updateImageUrl()


### PR DESCRIPTION
## Summary
When ImageCrop's input comes from a subgraph node, getInputNode returns the subgraph node itself which has no image outputs. 
Use resolveSubgraphOutputLink to trace through to the actual source node (e.g. LoadImage) inside the subgraph.

Use canvas.graph (the currently active graph/subgraph) as the primary lookup, falling back to rootGraph. When the ImageCrop node is inside a subgraph, rootGraph cannot find it since it only contains root-level nodes.

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/c3995f7c-6bcd-41fe-bc41-cfd87f9be94a


after

https://github.com/user-attachments/assets/ac660f58-6e6a-46ad-a441-84c7b88d28e2

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8899-fix-resolve-ImageCrop-input-image-through-subgraph-nodes-3086d73d36508172a759d7747190591f) by [Unito](https://www.unito.io)
