### PR TITLE
Fix storybook build again

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -100,7 +100,8 @@ const config: StorybookConfig = {
         rolldownOptions: {
           treeshake: false,
           output: {
-            keepNames: true
+            keepNames: true,
+            strictExecutionOrder: true
           },
           onwarn: (warning, warn) => {
             // Suppress specific warnings


### PR DESCRIPTION
## Summary
This flag was removed again which breaks the storybook build action

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8907-Fix-storybook-build-again-3096d73d3650811b9a6ce31f8d872982) by [Unito](https://www.unito.io)
