### PR TITLE
feat: download missing model files automatically

### DIFF
--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -47,26 +47,52 @@
   </div>
   <ListBox :options="missingModels" class="comfy-missing-models">
     <template #option="{ option }">
-      <Suspense v-if="isDesktop">
-        <ElectronFileDownload
+      <div class="flex w-full flex-col gap-2">
+        <Suspense v-if="isDesktop">
+          <ElectronFileDownload
+            :url="option.url"
+            :label="option.label"
+            :error="option.error"
+          />
+        </Suspense>
+        <FileDownload
+          v-else
           :url="option.url"
           :label="option.label"
           :error="option.error"
         />
-      </Suspense>
-      <FileDownload
-        v-else
-        :url="option.url"
-        :label="option.label"
-        :error="option.error"
-      />
+        <div
+          v-if="option.downloadStatusLabel || option.downloadProgressLabel"
+          class="flex items-center justify-between text-xs text-muted-foreground"
+        >
+          <div class="flex items-center gap-2">
+            <span>{{ option.downloadStatusLabel }}</span>
+            <Button
+              v-if="option.canCancel"
+              variant="destructive"
+              size="icon-sm"
+              class="size-[20px]"
+              :disabled="option.canceling"
+              :loading="option.canceling"
+              @click.stop="
+                cancelMissingModelDownload(option.name, option.directory)
+              "
+            >
+              <i class="icon-[lucide--x] size-3" />
+            </Button>
+          </div>
+          <span v-if="option.downloadProgressLabel">{{
+            option.downloadProgressLabel
+          }}</span>
+        </div>
+      </div>
     </template>
   </ListBox>
 </template>
 
 <script setup lang="ts">
 import ListBox from 'primevue/listbox'
-import { computed, onBeforeUnmount, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
@@ -77,7 +103,9 @@ import { isDesktop } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { api, type MissingModelDownloadItem } from '@/scripts/api'
+import { api } from '@/scripts/api'
+import type { MissingModelDownloadItem } from '@/scripts/api'
+import type { MissingModelDownloadWsMessage } from '@/schemas/apiSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
 // TODO: Read this from server internal API rather than hardcoding here
@@ -100,11 +128,28 @@ interface ModelInfo {
   directory: string
   directory_invalid?: boolean
   url: string
-  downloading?: boolean
-  completed?: boolean
-  progress?: number
-  error?: string
-  folder_path?: string
+}
+
+type DownloadStatus =
+  | 'idle'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'skipped_existing'
+  | 'blocked'
+  | 'canceled'
+
+interface ModelDownloadInfo {
+  name: string
+  directory: string
+  url: string
+  taskId: string | null
+  status: DownloadStatus
+  canceling: boolean
+  completed: boolean
+  bytesDownloaded: number
+  error: string | null
+  folderPath: string
 }
 
 const props = defineProps<{
@@ -116,67 +161,170 @@ const { t } = useI18n()
 
 const doNotAskAgain = ref(false)
 const isBulkDownloading = ref(false)
+const activeBatchId = ref<string | null>(null)
 
 function openShowMissingModelsSetting() {
   useDialogStore().closeDialog({ key: 'global-missing-models-warning' })
   useSettingsDialog().show(undefined, 'Comfy.Workflow.ShowMissingModelsWarning')
 }
 
-const modelDownloads = ref<Record<string, ModelInfo>>({})
+const modelDownloads = ref<Record<string, ModelDownloadInfo>>({})
+
+function createBatchId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function modelKey(model: Pick<ModelInfo, 'name' | 'directory'>): string {
+  return `${model.directory}::${model.name}`
+}
+
+function getOrCreateDownloadInfo(
+  model: ModelInfo,
+  folderPath: string
+): ModelDownloadInfo {
+  const key = modelKey(model)
+  const existing = modelDownloads.value[key]
+  if (existing) {
+    return existing
+  }
+
+  const created: ModelDownloadInfo = {
+    name: model.name,
+    directory: model.directory,
+    url: model.url,
+    taskId: null,
+    status: 'idle',
+    canceling: false,
+    completed: false,
+    bytesDownloaded: 0,
+    error: null,
+    folderPath
+  }
+  modelDownloads.value[key] = created
+  return created
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const kb = bytes / 1024
+  if (kb < 1024) return `${kb.toFixed(1)} KB`
+  const mb = kb / 1024
+  if (mb < 1024) return `${mb.toFixed(1)} MB`
+  return `${(mb / 1024).toFixed(2)} GB`
+}
+
+function getDownloadStatusLabel(info: ModelDownloadInfo): string {
+  switch (info.status) {
+    case 'running':
+      return t('g.downloading')
+    case 'completed':
+      return t('g.completed')
+    case 'failed':
+      return info.error ? `${t('g.failed')}: ${info.error}` : t('g.failed')
+    case 'blocked':
+      return info.error ? `Blocked: ${info.error}` : 'Blocked'
+    case 'skipped_existing':
+      return 'Skipped (already exists)'
+    case 'canceled':
+      return 'Canceled'
+    default:
+      return ''
+  }
+}
+
+function getDownloadProgressLabel(info: ModelDownloadInfo): string {
+  if (info.bytesDownloaded <= 0) {
+    return ''
+  }
+  return formatBytes(info.bytesDownloaded)
+}
+
+function handleMissingModelDownload(
+  e: CustomEvent<MissingModelDownloadWsMessage>
+) {
+  const data = e.detail
+  if (activeBatchId.value && data.batch_id !== activeBatchId.value) {
+    return
+  }
+
+  const key = modelKey({ name: data.name, directory: data.directory })
+  const existing = modelDownloads.value[key] ?? {
+    name: data.name,
+    directory: data.directory,
+    url: data.url,
+    taskId: null,
+    status: 'idle' as DownloadStatus,
+    canceling: false,
+    completed: false,
+    bytesDownloaded: 0,
+    error: null,
+    folderPath: ''
+  }
+
+  const status = data.status
+  modelDownloads.value[key] = {
+    ...existing,
+    name: data.name,
+    directory: data.directory,
+    url: data.url,
+    taskId: data.task_id,
+    status,
+    canceling: false,
+    completed: status === 'completed' || status === 'skipped_existing',
+    bytesDownloaded: data.bytes_downloaded,
+    error: data.error ?? null
+  }
+}
+
 const missingModels = computed(() => {
   return props.missingModels.map((model) => {
     const paths = props.paths[model.directory]
+    const folderPath = paths?.[0] ?? ''
+    const downloadInfo = getOrCreateDownloadInfo(model, folderPath)
+
     if (model.directory_invalid || !paths) {
       return {
         name: model.name,
         directory: model.directory,
         label: `${model.directory} / ${model.name}`,
         url: model.url,
-        error: 'Invalid directory specified (does this require custom nodes?)'
+        error: 'Invalid directory specified (does this require custom nodes?)',
+        downloading: false,
+        completed: false,
+        downloadStatusLabel: '',
+        downloadProgressLabel: '',
       }
     }
-    const downloadInfo: ModelInfo = modelDownloads.value[model.name] ?? {
-      downloading: false,
-      completed: false,
-      progress: 0,
-      error: null,
-      name: model.name,
-      directory: model.directory,
-      url: model.url,
-      folder_path: paths[0]
-    }
-    modelDownloads.value[model.name] = downloadInfo
+
+    let validationError: string | undefined
     if (!whiteListedUrls.has(model.url)) {
       if (!allowedSources.some((source) => model.url.startsWith(source))) {
-        return {
-          name: model.name,
-          directory: model.directory,
-          label: `${model.directory} / ${model.name}`,
-          url: model.url,
-          error: `Download not allowed from source '${model.url}', only allowed from '${allowedSources.join("', '")}'`
-        }
+        validationError = `Download not allowed from source '${model.url}', only allowed from '${allowedSources.join("', '")}'`
       }
       if (!allowedSuffixes.some((suffix) => model.name.endsWith(suffix))) {
-        return {
-          name: model.name,
-          directory: model.directory,
-          label: `${model.directory} / ${model.name}`,
-          url: model.url,
-          error: `Only allowed suffixes are: '${allowedSuffixes.join("', '")}'`
-        }
+        validationError =
+          validationError ??
+          `Only allowed suffixes are: '${allowedSuffixes.join("', '")}'`
       }
     }
+
     return {
       url: model.url,
       label: `${model.directory} / ${model.name}`,
-      downloading: downloadInfo.downloading,
+      downloading: downloadInfo.status === 'running',
+      canCancel: downloadInfo.status === 'running' && !!downloadInfo.taskId,
+      canceling: downloadInfo.canceling,
       completed: downloadInfo.completed,
-      progress: downloadInfo.progress,
-      error: downloadInfo.error,
+      error: validationError,
+      downloadStatusLabel: getDownloadStatusLabel(downloadInfo),
+      downloadProgressLabel: getDownloadProgressLabel(downloadInfo),
       name: model.name,
       directory: model.directory,
-      paths: paths,
-      folderPath: downloadInfo.folder_path
+      paths,
+      folderPath: downloadInfo.folderPath
     }
   })
 })
@@ -196,9 +344,63 @@ async function downloadAllMissingModels() {
     return
   }
 
+  const batchId = createBatchId()
+  activeBatchId.value = batchId
+
+  for (const model of downloadableModels.value) {
+    const key = modelKey(model)
+    const existing = modelDownloads.value[key] ?? {
+      name: model.name,
+      directory: model.directory,
+      url: model.url,
+      taskId: null,
+      status: 'idle' as DownloadStatus,
+      canceling: false,
+      completed: false,
+      bytesDownloaded: 0,
+      error: null,
+      folderPath: props.paths[model.directory]?.[0] ?? ''
+    }
+
+    modelDownloads.value[key] = {
+      ...existing,
+      taskId: null,
+      status: 'idle',
+      canceling: false,
+      completed: false,
+      bytesDownloaded: 0,
+      error: null
+    }
+  }
+
   isBulkDownloading.value = true
   try {
-    const result = await api.downloadMissingModels(downloadableModels.value)
+    const result = await api.downloadMissingModels(downloadableModels.value, {
+      batchId
+    })
+
+    for (const modelResult of result.results) {
+      const key = modelKey(modelResult)
+      const existing = modelDownloads.value[key]
+      if (!existing) {
+        continue
+      }
+
+      const status: DownloadStatus =
+        modelResult.status === 'downloaded'
+          ? 'completed'
+          : modelResult.status
+      const completed = status === 'completed' || status === 'skipped_existing'
+
+      modelDownloads.value[key] = {
+        ...existing,
+        status,
+        canceling: false,
+        completed,
+        error: modelResult.error ?? null
+      }
+    }
+
     const severity =
       result.failed > 0
         ? result.downloaded + result.skipped > 0
@@ -225,10 +427,46 @@ async function downloadAllMissingModels() {
     })
   } finally {
     isBulkDownloading.value = false
+    activeBatchId.value = null
   }
 }
 
+async function cancelMissingModelDownload(name: string, directory: string) {
+  const key = modelKey({ name, directory })
+  const info = modelDownloads.value[key]
+  if (!info?.taskId || info.status !== 'running' || info.canceling) {
+    return
+  }
+
+  modelDownloads.value[key] = {
+    ...info,
+    canceling: true
+  }
+
+  try {
+    await api.cancelMissingModelDownload(info.taskId, {
+      batchId: activeBatchId.value ?? undefined
+    })
+  } catch {
+    modelDownloads.value[key] = {
+      ...modelDownloads.value[key],
+      canceling: false
+    }
+    useToastStore().add({
+      severity: 'error',
+      summary: t('missingModelsDialog.downloadAll'),
+      detail: 'Failed to cancel download.',
+      life: 3000
+    })
+  }
+}
+
+onMounted(() => {
+  api.addEventListener('missing_model_download', handleMissingModelDownload)
+})
+
 onBeforeUnmount(async () => {
+  api.removeEventListener('missing_model_download', handleMissingModelDownload)
   if (doNotAskAgain.value) {
     await useSettingStore().set(
       'Comfy.Workflow.ShowMissingModelsWarning',

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1702,7 +1702,10 @@
     "reEnableInSettings": "Re-enable in {link}",
     "reEnableInSettingsLink": "Settings",
     "missingModels": "Missing Models",
-    "missingModelsMessage": "When loading the graph, the following models were not found"
+    "missingModelsMessage": "When loading the graph, the following models were not found",
+    "downloadAll": "Download all models",
+    "downloadAllResult": "Models downloaded successfully: {downloaded}, skipped: {skipped}, failed: {failed}",
+    "downloadAllRequestFailed": "Failed to download missing models."
   },
   "versionMismatchWarning": {
     "title": "Version Compatibility Warning",

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -148,6 +148,24 @@ const zAssetDownloadWsMessage = z.object({
   error: z.string().optional()
 })
 
+const zMissingModelDownloadWsMessage = z.object({
+  batch_id: z.string(),
+  task_id: z.string(),
+  name: z.string(),
+  directory: z.string(),
+  url: z.string(),
+  bytes_downloaded: z.number(),
+  status: z.enum([
+    'running',
+    'completed',
+    'failed',
+    'skipped_existing',
+    'blocked',
+    'canceled'
+  ]),
+  error: z.string().optional()
+})
+
 export type StatusWsMessageStatus = z.infer<typeof zStatusWsMessageStatus>
 export type StatusWsMessage = z.infer<typeof zStatusWsMessage>
 export type ProgressWsMessage = z.infer<typeof zProgressWsMessage>
@@ -168,6 +186,9 @@ export type NodeProgressState = z.infer<typeof zNodeProgressState>
 export type ProgressStateWsMessage = z.infer<typeof zProgressStateWsMessage>
 export type FeatureFlagsWsMessage = z.infer<typeof zFeatureFlagsWsMessage>
 export type AssetDownloadWsMessage = z.infer<typeof zAssetDownloadWsMessage>
+export type MissingModelDownloadWsMessage = z.infer<
+  typeof zMissingModelDownloadWsMessage
+>
 // End of ws messages
 
 export type NotificationWsMessage = z.infer<typeof zNotificationWsMessage>

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -172,7 +172,7 @@ interface BackendApiCalls {
 }
 
 /** Dictionary of all api calls */
-interface ApiCalls extends BackendApiCalls, FrontendApiCalls {}
+interface ApiCalls extends BackendApiCalls, FrontendApiCalls { }
 
 /** Used to create a discriminating union on type value. */
 interface ApiMessage<T extends keyof ApiCalls> {
@@ -180,7 +180,7 @@ interface ApiMessage<T extends keyof ApiCalls> {
   data: ApiCalls[T]
 }
 
-export class UnauthorizedError extends Error {}
+export class UnauthorizedError extends Error { }
 
 /** Ensures workers get a fair shake. */
 type Unionize<T> = T[keyof T]
@@ -206,10 +206,10 @@ type AsCustomEvents<T> = {
 /** Handles differing event and API signatures. */
 type ApiToEventType<T = ApiCalls> = {
   [K in keyof T]: K extends 'status'
-    ? StatusWsMessageStatus
-    : K extends 'executing'
-      ? NodeId
-      : T[K]
+  ? StatusWsMessageStatus
+  : K extends 'executing'
+  ? NodeId
+  : T[K]
 }
 
 /** Dictionary of types used in the detail for a custom event */
@@ -241,6 +241,24 @@ export type GlobalSubgraphData = {
     search_aliases?: string[]
   }
   data: string | Promise<string>
+}
+
+export interface MissingModelDownloadItem {
+  name: string
+  directory: string
+  url: string
+}
+
+export interface MissingModelDownloadResult extends MissingModelDownloadItem {
+  status: 'downloaded' | 'skipped_existing' | 'failed' | 'blocked'
+  error?: string
+}
+
+export interface MissingModelDownloadResponse {
+  downloaded: number
+  skipped: number
+  failed: number
+  results: MissingModelDownloadResult[]
 }
 
 function addHeaderEntry(headers: HeadersInit, key: string, value: string) {
@@ -808,8 +826,8 @@ export class ComfyApi extends EventTarget {
         extra_pnginfo: { workflow },
         ...(options?.previewMethod &&
           options.previewMethod !== 'default' && {
-            preview_method: options.previewMethod
-          })
+          preview_method: options.previewMethod
+        })
       }
     }
 
@@ -860,6 +878,21 @@ export class ComfyApi extends EventTarget {
       return []
     }
     return await res.json()
+  }
+
+  /**
+   * Downloads the missing models in the specified folder
+   * @param {MissingModelDownloadItem} models The list of models to download
+   * @returns The models successfully download, skipped, or failed
+   */
+  async downloadMissingModels(
+    models: MissingModelDownloadItem[]
+  ): Promise<MissingModelDownloadResponse> {
+    const response = await axios.post(
+      this.apiURL('/experiment/models/download_missing'),
+      { models }
+    )
+    return response.data
   }
 
   /**
@@ -1091,11 +1124,11 @@ export class ComfyApi extends EventTarget {
       throwOnError?: boolean
       full_info?: boolean
     } = {
-      overwrite: true,
-      stringify: true,
-      throwOnError: true,
-      full_info: false
-    }
+        overwrite: true,
+        stringify: true,
+        throwOnError: true,
+        full_info: false
+      }
   ): Promise<Response> {
     const resp = await this.fetchApi(
       `/userdata/${encodeURIComponent(file)}?overwrite=${options.overwrite}&full_info=${options.full_info}`,


### PR DESCRIPTION
There's currently no way to download all model files automatically. You either need to click on the "Download" button (and then pick the correct directory), or "Copy URL" and download manually in the correct dir.
This PR adds the possibility to download all files directly.

- Adds bulk “Download all missing models” flow for workflow missing-model warnings.
- Adds per-file download state updates (running/completed/failed/skipped/canceled) streamed from backend to frontend.
- Adds per-file cancel support during active downloads.
- Keeps download status visible in the missing-model dialog while downloads are in progress.
- Adds backend endpoint support for canceling individual missing-model download tasks.

The linked PR in the backend: https://github.com/Comfy-Org/ComfyUI/pull/12487

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8909-download-missing-model-files-automatically-3096d73d3650812daa68ec2fe678ea45) by [Unito](https://www.unito.io)
