### PR TITLE
fix: show stop state for active instant run button

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
@@ -120,7 +120,7 @@ describe('ComfyQueueButton', () => {
     const wrapper = createWrapper()
     const queueSettingsStore = useQueueSettingsStore()
 
-    queueSettingsStore.mode = 'instant'
+    queueSettingsStore.mode = 'instant-idle'
     await nextTick()
 
     const splitButton = wrapper.get('[data-testid="queue-button"]')
@@ -135,8 +135,7 @@ describe('ComfyQueueButton', () => {
     const queueSettingsStore = useQueueSettingsStore()
     const queueStore = useQueueStore()
 
-    queueSettingsStore.mode = 'instant'
-    queueSettingsStore.instantAutoQueueActive = true
+    queueSettingsStore.mode = 'instant-running'
     queueStore.runningTasks = [createTask('run-1', 'in_progress')]
     await nextTick()
 
@@ -153,8 +152,7 @@ describe('ComfyQueueButton', () => {
     const queueStore = useQueueStore()
     const commandStore = useCommandStore()
 
-    queueSettingsStore.mode = 'instant'
-    queueSettingsStore.instantAutoQueueActive = true
+    queueSettingsStore.mode = 'instant-running'
     queueStore.runningTasks = [createTask('run-1', 'in_progress')]
     await nextTick()
 
@@ -163,8 +161,7 @@ describe('ComfyQueueButton', () => {
       .trigger('click')
     await nextTick()
 
-    expect(queueSettingsStore.mode).toBe('instant')
-    expect(queueSettingsStore.instantAutoQueueActive).toBe(false)
+    expect(queueSettingsStore.mode).toBe('instant-idle')
     const splitButtonWhileStopping = wrapper.get('[data-testid="queue-button"]')
     expect(splitButtonWhileStopping.attributes('data-label')).toBe(
       'Run (Instant)'
@@ -184,26 +181,24 @@ describe('ComfyQueueButton', () => {
     )
 
     const splitButton = wrapper.get('[data-testid="queue-button"]')
-    expect(queueSettingsStore.mode).toBe('instant')
-    expect(queueSettingsStore.instantAutoQueueActive).toBe(false)
+    expect(queueSettingsStore.mode).toBe('instant-idle')
     expect(splitButton.attributes('data-label')).toBe('Run (Instant)')
     expect(splitButton.attributes('data-severity')).toBe('primary')
     expect(wrapper.find('.icon-\\[lucide--fast-forward\\]').exists()).toBe(true)
   })
 
-  it('activates instant auto queue when queueing again', async () => {
+  it('activates instant running mode when queueing again', async () => {
     const wrapper = createWrapper()
     const queueSettingsStore = useQueueSettingsStore()
     const commandStore = useCommandStore()
 
-    queueSettingsStore.mode = 'instant'
-    queueSettingsStore.instantAutoQueueActive = false
+    queueSettingsStore.mode = 'instant-idle'
     await nextTick()
 
     await wrapper.get('[data-testid="queue-button"]').trigger('click')
     await nextTick()
 
-    expect(queueSettingsStore.instantAutoQueueActive).toBe(true)
+    expect(queueSettingsStore.mode).toBe('instant-running')
     expect(commandStore.execute).toHaveBeenCalledWith('Comfy.QueuePrompt', {
       metadata: {
         subscribe_to_run: false,

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
@@ -1,0 +1,168 @@
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type {
+  JobListItem,
+  JobStatus
+} from '@/platform/remote/comfyui/jobs/jobTypes'
+import { useCommandStore } from '@/stores/commandStore'
+import {
+  TaskItemImpl,
+  useQueueSettingsStore,
+  useQueueStore
+} from '@/stores/queueStore'
+
+import ComfyQueueButton from './ComfyQueueButton.vue'
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => null
+}))
+
+vi.mock('@/workbench/extensions/manager/utils/graphHasMissingNodes', () => ({
+  graphHasMissingNodes: () => false
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    rootGraph: {}
+  }
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => ({
+    shiftDown: false
+  })
+}))
+
+const SplitButtonStub = defineComponent({
+  name: 'SplitButton',
+  props: {
+    label: {
+      type: String,
+      default: ''
+    },
+    severity: {
+      type: String,
+      default: 'primary'
+    }
+  },
+  template: `
+    <button
+      data-testid="split-button"
+      :data-label="label"
+      :data-severity="severity"
+    >
+      <slot name="icon" />
+    </button>
+  `
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      menu: {
+        run: 'Run',
+        disabledTooltip: 'Disabled tooltip',
+        onChange: 'On Change',
+        onChangeTooltip: 'On change tooltip',
+        instant: 'Instant',
+        instantTooltip: 'Instant tooltip',
+        stopRunInstant: 'Stop Run (Instant)',
+        stopRunInstantTooltip:
+          'Stop instant auto queue and cancel the current run',
+        runWorkflow: 'Run workflow',
+        runWorkflowFront: 'Run workflow front',
+        runWorkflowDisabled: 'Run workflow disabled'
+      }
+    }
+  }
+})
+
+function createTask(id: string, status: JobStatus): TaskItemImpl {
+  const job: JobListItem = {
+    id,
+    status,
+    create_time: Date.now(),
+    priority: 1
+  }
+
+  return new TaskItemImpl(job)
+}
+
+function createWrapper() {
+  const pinia = createTestingPinia({ createSpy: vi.fn })
+
+  return mount(ComfyQueueButton, {
+    global: {
+      plugins: [pinia, i18n],
+      directives: {
+        tooltip: () => {}
+      },
+      stubs: {
+        SplitButton: SplitButtonStub,
+        BatchCountEdit: true
+      }
+    }
+  })
+}
+
+describe('ComfyQueueButton', () => {
+  it('keeps the run instant presentation while idle', async () => {
+    const wrapper = createWrapper()
+    const queueSettingsStore = useQueueSettingsStore()
+
+    queueSettingsStore.mode = 'instant'
+    await nextTick()
+
+    const splitButton = wrapper.get('[data-testid="queue-button"]')
+
+    expect(splitButton.attributes('data-label')).toBe('Run (Instant)')
+    expect(splitButton.attributes('data-severity')).toBe('primary')
+    expect(wrapper.find('.icon-\\[lucide--fast-forward\\]').exists()).toBe(true)
+  })
+
+  it('switches to stop presentation for active instant auto queue', async () => {
+    const wrapper = createWrapper()
+    const queueSettingsStore = useQueueSettingsStore()
+    const queueStore = useQueueStore()
+
+    queueSettingsStore.mode = 'instant'
+    queueStore.runningTasks = [createTask('run-1', 'in_progress')]
+    await nextTick()
+
+    const splitButton = wrapper.get('[data-testid="queue-button"]')
+
+    expect(splitButton.attributes('data-label')).toBe('Stop Run (Instant)')
+    expect(splitButton.attributes('data-severity')).toBe('danger')
+    expect(wrapper.find('.icon-\\[lucide--square\\]').exists()).toBe(true)
+  })
+
+  it('stops instant mode instead of queueing a new prompt when clicked in stop state', async () => {
+    const wrapper = createWrapper()
+    const queueSettingsStore = useQueueSettingsStore()
+    const queueStore = useQueueStore()
+    const commandStore = useCommandStore()
+
+    queueSettingsStore.mode = 'instant'
+    queueStore.runningTasks = [createTask('run-1', 'in_progress')]
+    await nextTick()
+
+    await wrapper.get('[data-testid="queue-button"]').trigger('click')
+
+    expect(commandStore.execute).toHaveBeenCalledWith('Comfy.Interrupt')
+    expect(commandStore.execute).not.toHaveBeenCalledWith(
+      'Comfy.QueuePrompt',
+      expect.anything()
+    )
+    expect(queueSettingsStore.mode).toBe('disabled')
+  })
+})

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
@@ -162,6 +162,12 @@ describe('ComfyQueueButton', () => {
     await nextTick()
 
     expect(queueSettingsStore.mode).toBe('disabled')
+    const splitButtonWhileStopping = wrapper.get('[data-testid="queue-button"]')
+    expect(splitButtonWhileStopping.attributes('data-label')).toBe(
+      'Stop Run (Instant)'
+    )
+    expect(splitButtonWhileStopping.attributes('data-severity')).toBe('danger')
+    expect(wrapper.find('.icon-\\[lucide--square\\]').exists()).toBe(true)
 
     queueStore.runningTasks = []
     await nextTick()

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -173,7 +173,7 @@ const queuePrompt = async (e: Event) => {
       await until(activeJobsCount).toBe(0, { timeout: 5000 })
     }
 
-    if (queueMode.value === 'disabled') {
+    if (queueMode.value === 'disabled' && activeJobsCount.value === 0) {
       queueMode.value = 'instant'
     }
     return

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -51,8 +51,7 @@ import { useNodeDefStore } from '@/stores/nodeDefStore'
 import {
   isInstantMode,
   isInstantRunningMode,
-  useQueueSettingsStore,
-  useQueueStore
+  useQueueSettingsStore
 } from '@/stores/queueStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { graphHasMissingNodes } from '@/workbench/extensions/manager/utils/graphHasMissingNodes'
@@ -61,7 +60,6 @@ import BatchCountEdit from '../BatchCountEdit.vue'
 
 const workspaceStore = useWorkspaceStore()
 const { mode: queueMode, batchCount } = storeToRefs(useQueueSettingsStore())
-const { activeJobsCount } = storeToRefs(useQueueStore())
 
 const nodeDefStore = useNodeDefStore()
 const hasMissingNodes = computed(() =>
@@ -124,8 +122,8 @@ const queueModeMenuItems = computed(() =>
   Object.values(queueModeMenuItemLookup.value)
 )
 
-const isStopInstantAction = computed(
-  () => isInstantRunningMode(queueMode.value) && activeJobsCount.value > 0
+const isStopInstantAction = computed(() =>
+  isInstantRunningMode(queueMode.value)
 )
 
 const queueButtonLabel = computed(() =>
@@ -177,7 +175,6 @@ const commandStore = useCommandStore()
 const queuePrompt = async (e: Event) => {
   if (isStopInstantAction.value) {
     queueMode.value = 'instant-idle'
-    await commandStore.execute('Comfy.Interrupt')
     return
   }
 

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -36,6 +36,7 @@
 </template>
 
 <script setup lang="ts">
+import { until } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import type { MenuItem } from 'primevue/menuitem'
 import SplitButton from 'primevue/splitbutton'
@@ -167,6 +168,14 @@ const queuePrompt = async (e: Event) => {
   if (isInstantAutoQueueActive.value) {
     queueMode.value = 'disabled'
     await commandStore.execute('Comfy.Interrupt')
+
+    if (activeJobsCount.value > 0) {
+      await until(activeJobsCount).toBe(0, { timeout: 5000 })
+    }
+
+    if (queueMode.value === 'disabled') {
+      queueMode.value = 'instant'
+    }
     return
   }
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -894,6 +894,8 @@
     "runWorkflowFront": "Run workflow (Queue at front)",
     "runWorkflowDisabled": "Workflow contains unsupported nodes (highlighted red). Remove these to run the workflow.",
     "run": "Run",
+    "stopRunInstant": "Stop Run (Instant)",
+    "stopRunInstantTooltip": "Stop running",
     "execute": "Execute",
     "interrupt": "Cancel current run",
     "refresh": "Refresh node definitions",

--- a/src/services/autoQueueService.ts
+++ b/src/services/autoQueueService.ts
@@ -1,6 +1,7 @@
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import {
+  isInstantRunningMode,
   useQueuePendingTaskCountStore,
   useQueueSettingsStore
 } from '@/stores/queueStore'
@@ -29,8 +30,7 @@ export function setupAutoQueueHandler() {
       internalCount = queueCountStore.count
       if (!internalCount && !app.lastExecutionError) {
         if (
-          (queueSettingsStore.mode === 'instant' &&
-            queueSettingsStore.instantAutoQueueActive) ||
+          isInstantRunningMode(queueSettingsStore.mode) ||
           (queueSettingsStore.mode === 'change' && graphHasChanged)
         ) {
           graphHasChanged = false

--- a/src/services/autoQueueService.ts
+++ b/src/services/autoQueueService.ts
@@ -29,7 +29,8 @@ export function setupAutoQueueHandler() {
       internalCount = queueCountStore.count
       if (!internalCount && !app.lastExecutionError) {
         if (
-          queueSettingsStore.mode === 'instant' ||
+          (queueSettingsStore.mode === 'instant' &&
+            queueSettingsStore.instantAutoQueueActive) ||
           (queueSettingsStore.mode === 'change' && graphHasChanged)
         ) {
           graphHasChanged = false

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -620,7 +620,8 @@ export type AutoQueueMode = 'disabled' | 'instant' | 'change'
 export const useQueueSettingsStore = defineStore('queueSettingsStore', {
   state: () => ({
     mode: 'disabled' as AutoQueueMode,
-    batchCount: 1
+    batchCount: 1,
+    instantAutoQueueActive: false
   })
 })
 

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -615,13 +615,25 @@ export const useQueuePendingTaskCountStore = defineStore(
   }
 )
 
-export type AutoQueueMode = 'disabled' | 'instant' | 'change'
+export type AutoQueueMode =
+  | 'disabled'
+  | 'change'
+  | 'instant-idle'
+  | 'instant-running'
+
+export const isInstantMode = (
+  mode: AutoQueueMode
+): mode is 'instant-idle' | 'instant-running' =>
+  mode === 'instant-idle' || mode === 'instant-running'
+
+export const isInstantRunningMode = (
+  mode: AutoQueueMode
+): mode is 'instant-running' => mode === 'instant-running'
 
 export const useQueueSettingsStore = defineStore('queueSettingsStore', {
   state: () => ({
     mode: 'disabled' as AutoQueueMode,
-    batchCount: 1,
-    instantAutoQueueActive: false
+    batchCount: 1
   })
 })
 


### PR DESCRIPTION
Switch the Run (Instant) actionbar button into a stop-state while instant auto-queue is actively running, so users can explicitly stop that mode from the same control.

Figma context: https://www.figma.com/design/LVilZgHGk5RwWOkVN6yCEK/Queue-Progress-Modal?node-id=3381-6181&m=dev

## Screenshots (if applicable)


https://github.com/user-attachments/assets/a4aca6ab-eb0c-41a2-9f05-3af7ecf2bedd

