### PR TITLE
test: add mock for useFeatureFlags in nodeReplacementStore tests

### DIFF
--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -15,6 +15,18 @@ vi.mock('./nodeReplacementService', () => ({
   fetchNodeReplacements: vi.fn()
 }))
 
+const mockNodeReplacementsEnabled = vi.hoisted(() => ({ value: true }))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(() => ({
+    flags: {
+      get nodeReplacementsEnabled() {
+        return mockNodeReplacementsEnabled.value
+      }
+    }
+  }))
+}))
+
 function mockSettingStore(enabled: boolean) {
   vi.mocked(useSettingStore, { partial: true }).mockReturnValue({
     get: vi.fn().mockImplementation((key: string) => {
@@ -27,9 +39,10 @@ function mockSettingStore(enabled: boolean) {
   })
 }
 
-function createStore(enabled = true) {
+function createStore(enabled = true, featureEnabled = true) {
   setActivePinia(createPinia())
   mockSettingStore(enabled)
+  mockNodeReplacementsEnabled.value = featureEnabled
   return useNodeReplacementStore()
 }
 
@@ -38,6 +51,7 @@ describe('useNodeReplacementStore', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNodeReplacementsEnabled.value = true
     store = createStore(true)
   })
 
@@ -251,6 +265,16 @@ describe('useNodeReplacementStore', () => {
     it('should not call API when setting is disabled', async () => {
       vi.mocked(fetchNodeReplacements).mockResolvedValue(mockReplacements)
       store = createStore(false)
+
+      await store.load()
+
+      expect(fetchNodeReplacements).not.toHaveBeenCalled()
+      expect(store.isLoaded).toBe(false)
+    })
+
+    it('should not call API when server feature flag is disabled', async () => {
+      vi.mocked(fetchNodeReplacements).mockResolvedValue(mockReplacements)
+      store = createStore(true, false)
 
       await store.load()
 


### PR DESCRIPTION
The PR added a feature flag check using useFeatureFlags() which wasn't being mocked in tests. This caused load() tests to fail because flags.nodeReplacementsEnabled defaults to false when not mocked.

- Added vi.mock for @/composables/useFeatureFlags
- Used vi.hoisted to allow per-test control of the mock value
- Added test case for when server feature flag is disabled

https://claude.ai/code/session_01FQBAU6qx93aq5dyZne8cyr
