### PR TITLE
fix: lint-format CI failing on fork PRs due to missing secret

### DIFF
--- a/.github/workflows/ci-lint-format.yaml
+++ b/.github/workflows/ci-lint-format.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || github.ref }}
-          token: ${{ secrets.PR_GH_TOKEN }}
+          token: ${{ !github.event.pull_request.head.repo.fork && secrets.PR_GH_TOKEN || github.token }}
 
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend


### PR DESCRIPTION
## Summary

Fall back to `github.token` when `PR_GH_TOKEN` secret is unavailable on fork PRs, fixing checkout failure.

## Changes

- **What**: The `ci-lint-format` workflow uses `secrets.PR_GH_TOKEN` for checkout. Repository secrets are not available to workflows triggered by fork PRs, causing `Input required and not supplied: token` errors (e.g. [run 22124451916](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/22124451916)). The fix uses `github.token` as a fallback for fork PRs — this is always available with read-only access, which is sufficient since the workflow already skips commit/push for forks.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8948-fix-lint-format-CI-failing-on-fork-PRs-due-to-missing-secret-30b6d73d365081dfb78cf05362a6653c) by [Unito](https://www.unito.io)
