### PR TITLE
fix: support Firefox and Safari network error messages

### DIFF
--- a/src/composables/useErrorHandling.ts
+++ b/src/composables/useErrorHandling.ts
@@ -53,7 +53,8 @@ export function useErrorHandling() {
   const toast = useToastStore()
   const toastErrorHandler = (error: unknown) => {
     const isNetworkError =
-      error instanceof TypeError && error.message === 'Failed to fetch'
+      error instanceof TypeError &&
+      /failed to fetch|networkerror|load failed/i.test(error.message)
     const message = isNetworkError
       ? t('g.disconnectedFromBackend')
       : error instanceof Error


### PR DESCRIPTION
Fixes #8912

The `isNetworkError` check in `useErrorHandling.ts` only matched Chrome/Edge's `"Failed to fetch"` message, causing Firefox and Safari users to see raw error text instead of the user-friendly `disconnectedFromBackend` toast.

Updated the check to use a case-insensitive regex matching all three browser variants:
- Chrome/Edge: `Failed to fetch`
- Firefox: `NetworkError when attempting to fetch resource.`
- Safari: `Load failed`

Added parameterized tests covering all three browsers plus a negative case ensuring non-`TypeError` errors are not misclassified.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8949-fix-support-Firefox-and-Safari-network-error-messages-30b6d73d36508185b2cbd6b5447d3795) by [Unito](https://www.unito.io)
