### PR TITLE
feat: add Copy, Paste, Select All commands to Edit menu

### DIFF
--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -319,30 +319,30 @@ describe('useCoreCommands', () => {
       vi.mocked(app.canvas.selectItems).mockClear()
     })
 
-    it('should copy selected items when selection exists', () => {
+    it('should copy selected items when selection exists', async () => {
       app.canvas.selectedItems = new Set([
         {}
       ]) as typeof app.canvas.selectedItems
 
-      findCommand('Comfy.Canvas.CopySelected').function()
+      await findCommand('Comfy.Canvas.CopySelected').function()
 
       expect(app.canvas.copyToClipboard).toHaveBeenCalledWith()
     })
 
-    it('should not copy when no items are selected', () => {
-      findCommand('Comfy.Canvas.CopySelected').function()
+    it('should not copy when no items are selected', async () => {
+      await findCommand('Comfy.Canvas.CopySelected').function()
 
       expect(app.canvas.copyToClipboard).not.toHaveBeenCalled()
     })
 
-    it('should paste from clipboard', () => {
-      findCommand('Comfy.Canvas.PasteFromClipboard').function()
+    it('should paste from clipboard', async () => {
+      await findCommand('Comfy.Canvas.PasteFromClipboard').function()
 
       expect(app.canvas.pasteFromClipboard).toHaveBeenCalledWith()
     })
 
-    it('should select all items', () => {
-      findCommand('Comfy.Canvas.SelectAll').function()
+    it('should select all items', async () => {
+      await findCommand('Comfy.Canvas.SelectAll').function()
 
       // No arguments means "select all items on canvas"
       expect(app.canvas.selectItems).toHaveBeenCalledWith()

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -326,7 +326,7 @@ describe('useCoreCommands', () => {
 
       findCommand('Comfy.Canvas.CopySelected').function()
 
-      expect(app.canvas.copyToClipboard).toHaveBeenCalled()
+      expect(app.canvas.copyToClipboard).toHaveBeenCalledWith()
     })
 
     it('should not copy when no items are selected', () => {
@@ -338,13 +338,14 @@ describe('useCoreCommands', () => {
     it('should paste from clipboard', () => {
       findCommand('Comfy.Canvas.PasteFromClipboard').function()
 
-      expect(app.canvas.pasteFromClipboard).toHaveBeenCalled()
+      expect(app.canvas.pasteFromClipboard).toHaveBeenCalledWith()
     })
 
     it('should select all items', () => {
       findCommand('Comfy.Canvas.SelectAll').function()
 
-      expect(app.canvas.selectItems).toHaveBeenCalled()
+      // No arguments means "select all items on canvas"
+      expect(app.canvas.selectItems).toHaveBeenCalledWith()
     })
   })
 

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -23,7 +23,13 @@ vi.mock('vue-i18n', async () => {
 
 vi.mock('@/scripts/app', () => {
   const mockGraphClear = vi.fn()
-  const mockCanvas = { subgraph: undefined }
+  const mockCanvas = {
+    subgraph: undefined,
+    selectedItems: new Set(),
+    copyToClipboard: vi.fn(),
+    pasteFromClipboard: vi.fn(),
+    selectItems: vi.fn()
+  }
 
   return {
     app: {
@@ -105,7 +111,8 @@ vi.mock('@/stores/subgraphStore', () => ({
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: vi.fn(() => ({
-    getCanvas: () => app.canvas
+    getCanvas: () => app.canvas,
+    canvas: app.canvas
   })),
   useTitleEditorStore: vi.fn(() => ({
     titleEditorTarget: null
@@ -297,6 +304,47 @@ describe('useCoreCommands', () => {
       expect(app.clean).not.toHaveBeenCalled()
       expect(app.rootGraph.clear).not.toHaveBeenCalled()
       expect(api.dispatchCustomEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Canvas clipboard commands', () => {
+    function findCommand(id: string) {
+      return useCoreCommands().find((cmd) => cmd.id === id)!
+    }
+
+    beforeEach(() => {
+      app.canvas.selectedItems = new Set()
+      vi.mocked(app.canvas.copyToClipboard).mockClear()
+      vi.mocked(app.canvas.pasteFromClipboard).mockClear()
+      vi.mocked(app.canvas.selectItems).mockClear()
+    })
+
+    it('should copy selected items when selection exists', () => {
+      app.canvas.selectedItems = new Set([
+        {}
+      ]) as typeof app.canvas.selectedItems
+
+      findCommand('Comfy.Canvas.CopySelected').function()
+
+      expect(app.canvas.copyToClipboard).toHaveBeenCalled()
+    })
+
+    it('should not copy when no items are selected', () => {
+      findCommand('Comfy.Canvas.CopySelected').function()
+
+      expect(app.canvas.copyToClipboard).not.toHaveBeenCalled()
+    })
+
+    it('should paste from clipboard', () => {
+      findCommand('Comfy.Canvas.PasteFromClipboard').function()
+
+      expect(app.canvas.pasteFromClipboard).toHaveBeenCalled()
+    })
+
+    it('should select all items', () => {
+      findCommand('Comfy.Canvas.SelectAll').function()
+
+      expect(app.canvas.selectItems).toHaveBeenCalled()
     })
   })
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -885,6 +885,39 @@ export function useCoreCommands(): ComfyCommand[] {
       }
     },
     {
+      id: 'Comfy.Canvas.CopySelected',
+      icon: 'pi pi-copy',
+      label: 'Copy',
+      function: () => {
+        const canvas = canvasStore.canvas
+        if (canvas?.selectedItems?.size) {
+          canvas.copyToClipboard()
+        }
+      }
+    },
+    {
+      id: 'Comfy.Canvas.PasteFromClipboard',
+      icon: 'pi pi-clipboard',
+      label: 'Paste',
+      function: () => {
+        const canvas = canvasStore.canvas
+        if (canvas) {
+          canvas.pasteFromClipboard()
+        }
+      }
+    },
+    {
+      id: 'Comfy.Canvas.SelectAll',
+      icon: 'pi pi-check-square',
+      label: 'Select All',
+      function: () => {
+        const canvas = canvasStore.canvas
+        if (canvas) {
+          canvas.selectItems()
+        }
+      }
+    },
+    {
       id: 'Comfy.Canvas.DeleteSelectedItems',
       icon: 'pi pi-trash',
       label: 'Delete Selected Items',

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -886,35 +886,28 @@ export function useCoreCommands(): ComfyCommand[] {
     },
     {
       id: 'Comfy.Canvas.CopySelected',
-      icon: 'pi pi-copy',
+      icon: 'icon-[lucide--copy]',
       label: 'Copy',
       function: () => {
-        const canvas = canvasStore.canvas
-        if (canvas?.selectedItems?.size) {
-          canvas.copyToClipboard()
+        if (app.canvas.selectedItems?.size) {
+          app.canvas.copyToClipboard()
         }
       }
     },
     {
       id: 'Comfy.Canvas.PasteFromClipboard',
-      icon: 'pi pi-clipboard',
+      icon: 'icon-[lucide--clipboard-paste]',
       label: 'Paste',
       function: () => {
-        const canvas = canvasStore.canvas
-        if (canvas) {
-          canvas.pasteFromClipboard()
-        }
+        app.canvas.pasteFromClipboard()
       }
     },
     {
       id: 'Comfy.Canvas.SelectAll',
-      icon: 'pi pi-check-square',
+      icon: 'icon-[lucide--lasso-select]',
       label: 'Select All',
       function: () => {
-        const canvas = canvasStore.canvas
-        if (canvas) {
-          canvas.selectItems()
-        }
+        app.canvas.selectItems()
       }
     },
     {

--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -14,6 +14,14 @@ export const CORE_MENU_COMMANDS = [
     ]
   ],
   [['Edit'], ['Comfy.Undo', 'Comfy.Redo']],
+  [
+    ['Edit'],
+    [
+      'Comfy.Canvas.CopySelected',
+      'Comfy.Canvas.PasteFromClipboard',
+      'Comfy.Canvas.SelectAll'
+    ]
+  ],
   [['Edit'], ['Comfy.ClearWorkflow']],
   [['Edit'], ['Comfy.OpenClipspace']],
   [


### PR DESCRIPTION
## Summary

- Add Copy, Paste, and Select All commands to the Edit menu for mobile/touch users and accessibility
- Menu-based copy uses LiteGraph internal clipboard; existing Ctrl+C/V behavior is unchanged

## Changes

- `useCoreCommands.ts`: Register three new commands (`CopySelected`, `PasteFromClipboard`, `SelectAll`)
- `coreMenuCommands.ts`: Add menu entries under Edit (between Undo/Redo and Clear Workflow)
- `useCoreCommands.test.ts`: Add unit tests for the new commands

### AS IS
<img width="260" height="176" alt="스크린샷 2026-02-18 오후 5 44 14" src="https://github.com/user-attachments/assets/8c9c86e1-55cc-411b-9d42-429001e04630" />


### TO BE
<img width="516" height="497" alt="스크린샷 2026-02-19 오후 5 07 28" src="https://github.com/user-attachments/assets/a2047541-582f-4520-a08f-98c6e532d29f" />


## Test plan

- [x] Verify Copy/Paste/Select All appear in Edit menu
- [x] Select nodes → Edit > Copy → Edit > Paste → nodes duplicated
- [x] Edit > Select All → all canvas items selected
- [x] Copy with no selection → no-op (no error)
- [x] Existing Ctrl+C/V keyboard shortcuts still work

Fixes #2892

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8954-feat-add-Copy-Paste-Select-All-commands-to-Edit-menu-30b6d73d365081ec9270ed2a562eaf0b) by [Unito](https://www.unito.io)
