### PR TITLE
fix: remove cloud guard for clear history menu

### DIFF
--- a/src/components/queue/QueueOverlayHeader.vue
+++ b/src/components/queue/QueueOverlayHeader.vue
@@ -36,7 +36,7 @@
         <i class="icon-[lucide--list-x] size-4" />
       </Button>
     </div>
-    <div v-if="!isCloud" class="flex items-center gap-1">
+    <div class="flex items-center gap-1">
       <Button
         v-tooltip.top="moreTooltipConfig"
         variant="textonly"
@@ -91,7 +91,6 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { buildTooltipConfig } from '@/composables/useTooltipConfig'
-import { isCloud } from '@/platform/distribution/types'
 
 defineProps<{
   headerTitle: string


### PR DESCRIPTION
## Summary
- remove the cloud-only visibility guard for the queue overlay clear-history (`...`) menu
- keep existing clear-history behavior unchanged; this only affects menu visibility

This was added a long time ago when there was a bug where the clear history items call actually deleted the assets. After asset updates in recent times, this is now safe as purely a history deletion, while keeping the asset.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8955-fix-remove-cloud-guard-for-clear-history-menu-30b6d73d3650815992abf3daabc6f32c) by [Unito](https://www.unito.io)
