### PR TITLE
fix: remove false 'invalid directory' errors when asset API is enabled

### DIFF
--- a/src/components/dialog/content/MissingModelsWarning.vue
+++ b/src/components/dialog/content/MissingModelsWarning.vue
@@ -85,7 +85,6 @@ const whiteListedUrls = new Set([
 interface ModelInfo {
   name: string
   directory: string
-  directory_invalid?: boolean
   url: string
   downloading?: boolean
   completed?: boolean
@@ -112,7 +111,7 @@ const modelDownloads = ref<Record<string, ModelInfo>>({})
 const missingModels = computed(() => {
   return props.missingModels.map((model) => {
     const paths = props.paths[model.directory]
-    if (model.directory_invalid || !paths) {
+    if (!paths) {
       return {
         label: `${model.directory} / ${model.name}`,
         url: model.url,

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -40,8 +40,7 @@ const zModelFile = z.object({
   url: z.string().url(),
   hash: z.string().optional(),
   hash_type: z.string().optional(),
-  directory: z.string(),
-  directory_invalid: z.boolean().optional()
+  directory: z.string()
 })
 
 const zGraphState = z

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -40,7 +40,8 @@ const zModelFile = z.object({
   url: z.string().url(),
   hash: z.string().optional(),
   hash_type: z.string().optional(),
-  directory: z.string()
+  directory: z.string(),
+  directory_invalid: z.boolean().optional()
 })
 
 const zGraphState = z

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1205,23 +1205,16 @@ export class ComfyApp {
 
     const getModelKey = (model: ModelFile) => model.url || model.hash
     const validModels = embeddedModels.filter(getModelKey)
-    const uniqueModels: ModelFile[] = _.uniqBy(validModels, getModelKey)
+    const uniqueModels = _.uniqBy(validModels, getModelKey)
 
-    let folderPaths: Record<string, string[]> | undefined
     if (
       uniqueModels.length &&
       useSettingStore().get('Comfy.Workflow.ShowMissingModelsWarning')
     ) {
       const modelStore = useModelStore()
-      const [, paths] = await Promise.all([
-        modelStore.loadModelFolders(),
-        api.getFolderPaths()
-      ])
-      folderPaths = paths
+      await modelStore.loadModelFolders()
       for (const m of uniqueModels) {
         const modelFolder = await modelStore.getLoadedModelFolder(m.directory)
-        m.directory_invalid = !modelFolder && !folderPaths?.[m.directory]
-
         const modelsAvailable = modelFolder?.models
         const modelExists =
           modelsAvailable &&
@@ -1363,7 +1356,7 @@ export class ComfyApp {
         warnings.missingNodeTypes = missingNodeTypes
       }
       if (missingModels.length && showMissingModelsDialog) {
-        const paths = folderPaths ?? (await api.getFolderPaths())
+        const paths = await api.getFolderPaths()
         warnings.missingModels = { missingModels: missingModels, paths }
       }
       if (warnings.missingNodeTypes || warnings.missingModels) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1205,7 +1205,7 @@ export class ComfyApp {
 
     const getModelKey = (model: ModelFile) => model.url || model.hash
     const validModels = embeddedModels.filter(getModelKey)
-    const uniqueModels = _.uniqBy(validModels, getModelKey)
+    const uniqueModels: ModelFile[] = _.uniqBy(validModels, getModelKey)
 
     let folderPaths: Record<string, string[]> | undefined
     if (
@@ -1220,9 +1220,7 @@ export class ComfyApp {
       folderPaths = paths
       for (const m of uniqueModels) {
         const modelFolder = await modelStore.getLoadedModelFolder(m.directory)
-        if (!modelFolder && !folderPaths?.[m.directory])
-          (m as ModelFile & { directory_invalid?: boolean }).directory_invalid =
-            true
+        m.directory_invalid = !modelFolder && !folderPaths?.[m.directory]
 
         const modelsAvailable = modelFolder?.models
         const modelExists =


### PR DESCRIPTION
## Summary
- When `Comfy.Assets.UseAssetAPI` is enabled, `getAssetModelFolders()` only discovers folders containing assets. Empty folders (e.g. `text_encoders`, `vae`) were falsely flagged as invalid, showing "Invalid directory specified" on every missing model dialog.
- Removes the `directory_invalid` concept entirely — the existing `!paths` check via `getFolderPaths()` already correctly validates all registered directories including empty ones, making `directory_invalid` redundant.

## Before
<img width="1841" height="954" alt="Screenshot 2026-02-18 at 21 09 55" src="https://github.com/user-attachments/assets/09cf4f28-5175-4ff6-aa9d-916568c6d9b3" />


## After
<img width="1134" height="738" alt="Screenshot 2026-02-18 at 21 23 29" src="https://github.com/user-attachments/assets/578d2fa5-3fb8-401a-beee-0fd74667f08b" />

## Test plan
- [ ] Enable `Comfy.Assets.UseAssetAPI` setting
- [ ] Open a template referencing models in empty folders (e.g. "Image Editing (New)")
- [ ] Verify the missing models dialog shows download buttons instead of "Invalid directory specified" error
- [ ] Disable `Comfy.Assets.UseAssetAPI` and verify behavior is unchanged

Fixes #8583