### PR TITLE
Fix 3D asset context menu inspect and workflow insertion

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -164,7 +164,6 @@
     ref="contextMenuRef"
     :asset="contextMenuAsset"
     :asset-type="contextMenuAssetType"
-    :file-kind="contextMenuFileKind"
     :show-delete-button="shouldShowDeleteButton"
     :selected-assets="selectedAssets"
     :is-bulk-mode="isBulkMode"
@@ -213,7 +212,6 @@ import { useMediaAssetFiltering } from '@/platform/assets/composables/useMediaAs
 import { useOutputStacks } from '@/platform/assets/composables/useOutputStacks'
 import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import type { MediaKind } from '@/platform/assets/schemas/mediaAssetSchema'
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import { isCloud } from '@/platform/distribution/types'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -245,10 +243,6 @@ const shouldShowDeleteButton = computed(() => {
 
 const contextMenuAssetType = computed(() =>
   contextMenuAsset.value ? getAssetType(contextMenuAsset.value.tags) : 'input'
-)
-
-const contextMenuFileKind = computed<MediaKind>(() =>
-  getMediaTypeFromFilename(contextMenuAsset.value?.name ?? '')
 )
 
 const shouldShowOutputCount = (item: AssetItem): boolean => {

--- a/src/composables/queue/useJobMenu.test.ts
+++ b/src/composables/queue/useJobMenu.test.ts
@@ -207,7 +207,8 @@ describe('useJobMenu', () => {
     nodeDefStoreMock.nodeDefsByName = {
       LoadImage: { name: 'LoadImage' },
       LoadVideo: { name: 'LoadVideo' },
-      LoadAudio: { name: 'LoadAudio' }
+      LoadAudio: { name: 'LoadAudio' },
+      Load3D: { name: 'Load3D' }
     }
     // Default: no workflow available via lazy loading
     getJobWorkflowMock.mockResolvedValue(undefined)
@@ -415,6 +416,12 @@ describe('useJobMenu', () => {
       flags: { isAudio: true },
       expectedNode: 'LoadAudio',
       widget: 'audio'
+    },
+    {
+      label: '3D',
+      flags: { is3D: true },
+      expectedNode: 'Load3D',
+      widget: 'model_file'
     }
   ] as const
 

--- a/src/composables/queue/useJobMenu.ts
+++ b/src/composables/queue/useJobMenu.ts
@@ -122,8 +122,9 @@ export function useJobMenu(
     const result: ResultItemImpl | undefined = item.taskRef?.previewOutput
     if (!result) return
 
-    let nodeType: 'LoadImage' | 'LoadVideo' | 'LoadAudio' | null = null
-    let widgetName: 'image' | 'file' | 'audio' | null = null
+    let nodeType: 'LoadImage' | 'LoadVideo' | 'LoadAudio' | 'Load3D' | null =
+      null
+    let widgetName: 'image' | 'file' | 'audio' | 'model_file' | null = null
     if (result.isImage) {
       nodeType = 'LoadImage'
       widgetName = 'image'
@@ -133,6 +134,9 @@ export function useJobMenu(
     } else if (result.isAudio) {
       nodeType = 'LoadAudio'
       widgetName = 'audio'
+    } else if (result.is3D) {
+      nodeType = 'Load3D'
+      widgetName = 'model_file'
     }
     if (!nodeType || !widgetName) return
 

--- a/src/composables/queue/useResultGallery.ts
+++ b/src/composables/queue/useResultGallery.ts
@@ -2,7 +2,11 @@ import { ref, shallowRef } from 'vue'
 
 import type { JobListItem } from '@/composables/queue/useJobList'
 import { findActiveIndex, getOutputsForTask } from '@/services/jobOutputCache'
+import { useDialogStore } from '@/stores/dialogStore'
 import type { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
+
+const Load3dViewerContent = () =>
+  import('@/components/load3d/Load3dViewerContent.vue')
 
 /**
  * Manages result gallery state and activation for queue items.
@@ -10,6 +14,7 @@ import type { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
 export function useResultGallery(getFilteredTasks: () => TaskItemImpl[]) {
   const galleryActiveIndex = ref(-1)
   const galleryItems = shallowRef<ResultItemImpl[]>([])
+  const dialogStore = useDialogStore()
 
   async function onViewItem(item: JobListItem) {
     const tasks = getFilteredTasks()
@@ -22,6 +27,23 @@ export function useResultGallery(getFilteredTasks: () => TaskItemImpl[]) {
 
     // Request was superseded by a newer one
     if (targetOutputs === null && targetTask) return
+
+    const previewOutput = targetTask?.previewOutput
+    if (previewOutput?.is3D) {
+      dialogStore.showDialog({
+        key: 'queue-asset-3d-viewer',
+        title: previewOutput.filename,
+        component: Load3dViewerContent,
+        props: {
+          modelUrl: previewOutput.url
+        },
+        dialogComponentProps: {
+          style: 'width: 80vw; height: 80vh;',
+          maximizable: true
+        }
+      })
+      return
+    }
 
     // Use target's outputs if available, otherwise fall back to all previews
     const items = targetOutputs?.length

--- a/src/platform/assets/components/MediaAssetContextMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetContextMenu.test.ts
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContextMenu.vue'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+const actionMocks = vi.hoisted(() => ({
+  addWorkflow: vi.fn(),
+  copyJobId: vi.fn(),
+  deleteAssets: vi.fn(),
+  downloadAsset: vi.fn(),
+  exportWorkflow: vi.fn(),
+  openWorkflow: vi.fn()
+}))
+
+vi.mock('primevue/contextmenu', () => ({
+  default: {
+    name: 'ContextMenu',
+    props: ['model', 'pt'],
+    emits: ['hide'],
+    template: '<div data-testid="context-menu" />'
+  }
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+vi.mock('@/platform/assets/composables/useMediaAssetActions', () => ({
+  useMediaAssetActions: () => actionMocks
+}))
+
+type MenuItemLike = {
+  label?: string
+  command?: () => void
+}
+
+function createAsset(name: string): AssetItem {
+  return {
+    id: 'asset-1',
+    name,
+    tags: []
+  }
+}
+
+describe('MediaAssetContextMenu', () => {
+  it('includes inspect action for 3D assets and emits zoom when triggered', () => {
+    const wrapper = mount(MediaAssetContextMenu, {
+      props: {
+        asset: createAsset('model.glb'),
+        assetType: 'output'
+      }
+    })
+
+    const model = wrapper
+      .findComponent({ name: 'ContextMenu' })
+      .props('model') as MenuItemLike[]
+    const inspectItem = model.find(
+      (item) => item.label === 'mediaAsset.actions.inspect'
+    )
+
+    expect(inspectItem).toBeDefined()
+    inspectItem?.command?.()
+    expect(wrapper.emitted('zoom')).toHaveLength(1)
+  })
+})

--- a/src/platform/assets/components/MediaAssetContextMenu.vue
+++ b/src/platform/assets/components/MediaAssetContextMenu.vue
@@ -44,23 +44,16 @@ import { cn } from '@/utils/tailwindUtil'
 
 import { useMediaAssetActions } from '../composables/useMediaAssetActions'
 import type { AssetItem } from '../schemas/assetSchema'
-import type { AssetContext, MediaKind } from '../schemas/mediaAssetSchema'
+import type { AssetContext } from '../schemas/mediaAssetSchema'
 
-const {
-  asset,
-  assetType,
-  fileKind,
-  showDeleteButton,
-  selectedAssets,
-  isBulkMode
-} = defineProps<{
-  asset: AssetItem
-  assetType: AssetContext['type']
-  fileKind: MediaKind
-  showDeleteButton?: boolean
-  selectedAssets?: AssetItem[]
-  isBulkMode?: boolean
-}>()
+const { asset, assetType, showDeleteButton, selectedAssets, isBulkMode } =
+  defineProps<{
+    asset: AssetItem
+    assetType: AssetContext['type']
+    showDeleteButton?: boolean
+    selectedAssets?: AssetItem[]
+    isBulkMode?: boolean
+  }>()
 
 const emit = defineEmits<{
   zoom: []
@@ -193,14 +186,12 @@ const contextMenuItems = computed<MenuItem[]>(() => {
 
   // Individual mode: Show all menu options
 
-  // Inspect (if not 3D)
-  if (fileKind !== '3D') {
-    items.push({
-      label: t('mediaAsset.actions.inspect'),
-      icon: 'icon-[lucide--zoom-in]',
-      command: () => emit('zoom')
-    })
-  }
+  // Inspect
+  items.push({
+    label: t('mediaAsset.actions.inspect'),
+    icon: 'icon-[lucide--zoom-in]',
+    command: () => emit('zoom')
+  })
 
   // Add to workflow (conditional)
   if (showAddToWorkflow.value) {

--- a/src/utils/loaderNodeUtil.test.ts
+++ b/src/utils/loaderNodeUtil.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getMediaTypeFromFilename } from '@comfyorg/shared-frontend-utils/formatUtil'
+import { detectNodeTypeFromFilename } from '@/utils/loaderNodeUtil'
+
+vi.mock('@comfyorg/shared-frontend-utils/formatUtil', () => ({
+  getMediaTypeFromFilename: vi.fn()
+}))
+
+const mockGetMediaTypeFromFilename = vi.mocked(getMediaTypeFromFilename)
+
+describe('loaderNodeUtil', () => {
+  beforeEach(() => {
+    mockGetMediaTypeFromFilename.mockReset()
+  })
+
+  describe('detectNodeTypeFromFilename', () => {
+    it('maps image files to LoadImage', () => {
+      mockGetMediaTypeFromFilename.mockReturnValue('image')
+
+      expect(detectNodeTypeFromFilename('image.png')).toEqual({
+        nodeType: 'LoadImage',
+        widgetName: 'image'
+      })
+    })
+
+    it('maps video files to LoadVideo', () => {
+      mockGetMediaTypeFromFilename.mockReturnValue('video')
+
+      expect(detectNodeTypeFromFilename('video.mp4')).toEqual({
+        nodeType: 'LoadVideo',
+        widgetName: 'file'
+      })
+    })
+
+    it('maps audio files to LoadAudio', () => {
+      mockGetMediaTypeFromFilename.mockReturnValue('audio')
+
+      expect(detectNodeTypeFromFilename('audio.mp3')).toEqual({
+        nodeType: 'LoadAudio',
+        widgetName: 'audio'
+      })
+    })
+
+    it('maps 3D files to Load3D', () => {
+      mockGetMediaTypeFromFilename.mockReturnValue('3D')
+
+      expect(detectNodeTypeFromFilename('model.glb')).toEqual({
+        nodeType: 'Load3D',
+        widgetName: 'model_file'
+      })
+    })
+
+    it('returns null node mapping for unsupported files', () => {
+      mockGetMediaTypeFromFilename.mockReturnValue('unknown' as never)
+
+      expect(detectNodeTypeFromFilename('document.txt')).toEqual({
+        nodeType: null,
+        widgetName: null
+      })
+    })
+  })
+})

--- a/src/utils/loaderNodeUtil.ts
+++ b/src/utils/loaderNodeUtil.ts
@@ -17,10 +17,11 @@ import { getMediaTypeFromFilename } from '@comfyorg/shared-frontend-utils/format
  * detectNodeTypeFromFilename('image.png') // { nodeType: 'LoadImage', widgetName: 'image' }
  * detectNodeTypeFromFilename('video.mp4') // { nodeType: 'LoadVideo', widgetName: 'file' }
  * detectNodeTypeFromFilename('audio.mp3') // { nodeType: 'LoadAudio', widgetName: 'audio' }
+ * detectNodeTypeFromFilename('model.glb') // { nodeType: 'Load3D', widgetName: 'model_file' }
  */
 export function detectNodeTypeFromFilename(filename: string): {
-  nodeType: 'LoadImage' | 'LoadVideo' | 'LoadAudio' | null
-  widgetName: 'image' | 'file' | 'audio' | null
+  nodeType: 'LoadImage' | 'LoadVideo' | 'LoadAudio' | 'Load3D' | null
+  widgetName: 'image' | 'file' | 'audio' | 'model_file' | null
 } {
   const mediaType = getMediaTypeFromFilename(filename)
 
@@ -31,8 +32,10 @@ export function detectNodeTypeFromFilename(filename: string): {
       return { nodeType: 'LoadVideo', widgetName: 'file' }
     case 'audio':
       return { nodeType: 'LoadAudio', widgetName: 'audio' }
+    case '3D':
+      return { nodeType: 'Load3D', widgetName: 'model_file' }
     default:
-      // 3D and other types don't have loader nodes
+      // Other unsupported media types don't have loader nodes
       return { nodeType: null, widgetName: null }
   }
 }


### PR DESCRIPTION
## Summary
- always show `Inspect asset` in `MediaAssetContextMenu` (3D assets were incorrectly excluded)
- add 3D loader-node mapping in `detectNodeTypeFromFilename` (`Load3D` + `model_file`) so Assets sidebar "Add asset to workflow" works for 3D assets
- fix Job History / Queue inspect flow by opening the standalone 3D viewer for 3D outputs in `useResultGallery` instead of routing to image/video/audio galleria
- fix Job History / Queue "Add to current workflow" by mapping 3D outputs to `Load3D` + `model_file` in `useJobMenu`
- add regression tests for queue/gallery and loader-node detection 3D behavior

## Testing
- `pnpm vitest src/utils/loaderNodeUtil.test.ts src/platform/assets/components/MediaAssetContextMenu.test.ts`
- `pnpm vitest src/composables/queue/useResultGallery.test.ts src/composables/queue/useJobMenu.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`