### PR TITLE
test: refactor widgetUtil tests to use it.for parameterization

### DIFF
--- a/src/utils/widgetUtil.test.ts
+++ b/src/utils/widgetUtil.test.ts
@@ -14,25 +14,18 @@ describe('getWidgetDefaultValue', () => {
     expect(getWidgetDefaultValue(spec)).toBe(42)
   })
 
-  it('returns 0 for INT type without default', () => {
-    const spec = { type: 'INT' } as InputSpec
-    expect(getWidgetDefaultValue(spec)).toBe(0)
-  })
-
-  it('returns 0 for FLOAT type without default', () => {
-    const spec = { type: 'FLOAT' } as InputSpec
-    expect(getWidgetDefaultValue(spec)).toBe(0)
-  })
-
-  it('returns false for BOOLEAN type without default', () => {
-    const spec = { type: 'BOOLEAN' } as InputSpec
-    expect(getWidgetDefaultValue(spec)).toBe(false)
-  })
-
-  it('returns empty string for STRING type without default', () => {
-    const spec = { type: 'STRING' } as InputSpec
-    expect(getWidgetDefaultValue(spec)).toBe('')
-  })
+  it.for([
+    { type: 'INT', expected: 0 },
+    { type: 'FLOAT', expected: 0 },
+    { type: 'BOOLEAN', expected: false },
+    { type: 'STRING', expected: '' }
+  ])(
+    'returns $expected for $type type without default',
+    ({ type, expected }) => {
+      const spec = { type } as InputSpec
+      expect(getWidgetDefaultValue(spec)).toBe(expected)
+    }
+  )
 
   it('returns first option for array options without default', () => {
     const spec = { type: 'COMBO', options: ['a', 'b', 'c'] } as InputSpec


### PR DESCRIPTION
Fixes #8888

Refactors repetitive test cases in `widgetUtil.test.ts` to use Vitest's
`it.for` syntax for parameterized testing. Tests that follow the same
"returns default for type" pattern are consolidated while keeping unique
test cases separate.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8971-test-refactor-widgetUtil-tests-to-use-it-for-parameterization-30c6d73d365081a48e2ecf52bb7b0f98) by [Unito](https://www.unito.io)
