### PR TITLE
refactor: use muted-textonly variant for SectionWidgets icon buttons

### DIFF
--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -217,9 +217,9 @@ defineExpose({
           </Button>
           <Button
             v-if="!isEmpty"
-            variant="textonly"
+            variant="muted-textonly"
             size="icon-sm"
-            class="subbutton shrink-0 size-8 cursor-pointer text-muted-foreground hover:text-base-foreground"
+            class="subbutton shrink-0 size-8 hover:text-base-foreground"
             :title="t('rightSidePanel.resetAllParameters')"
             :aria-label="t('rightSidePanel.resetAllParameters')"
             @click.stop="handleResetAllWidgets"
@@ -228,9 +228,9 @@ defineExpose({
           </Button>
           <Button
             v-if="canShowLocateButton"
-            variant="textonly"
+            variant="muted-textonly"
             size="icon-sm"
-            class="subbutton shrink-0 mr-3 size-8 cursor-pointer text-muted-foreground hover:text-base-foreground"
+            class="subbutton shrink-0 mr-3 size-8 hover:text-base-foreground"
             :title="t('rightSidePanel.locateNode')"
             :aria-label="t('rightSidePanel.locateNode')"
             @click.stop="handleLocateNode"


### PR DESCRIPTION
Fixes #8890

Switches the Reset All and Locate Node buttons from `variant="textonly"`
with manual text color overrides to `variant="muted-textonly"`, which
already provides the muted text color. Removes redundant `cursor-pointer`
and `text-muted-foreground` classes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8972-refactor-use-muted-textonly-variant-for-SectionWidgets-icon-buttons-30c6d73d3650819abca7e4ca5be77f15) by [Unito](https://www.unito.io)
