### PR TITLE
fix: upgrade @lobehub/i18n-cli to fix 3D API nodes i18n

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^4.1.0
       version: 4.1.0
     '@lobehub/i18n-cli':
-      specifier: ^1.25.1
-      version: 1.25.1
+      specifier: ^1.26.1
+      version: 1.26.1
     '@nx/eslint':
       specifier: 22.2.6
       version: 22.2.6
@@ -521,7 +521,7 @@ importers:
         version: 4.1.0(eslint@9.39.1(jiti@2.6.1))(jsonc-eslint-parser@2.4.0)(vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.6.1)))(yaml-eslint-parser@1.3.0)
       '@lobehub/i18n-cli':
         specifier: 'catalog:'
-        version: 1.25.1(@types/react@19.1.9)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(ws@8.18.3)(zod@3.24.1)
+        version: 1.26.1(@types/react@19.1.9)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(ws@8.18.3)(zod@3.24.1)
       '@nx/eslint':
         specifier: 'catalog:'
         version: 22.2.6(@babel/traverse@7.28.5)(@zkochan/js-yaml@0.0.7)(eslint@9.39.1(jiti@2.6.1))(nx@22.2.6)
@@ -2268,8 +2268,8 @@ packages:
     resolution: {integrity: sha512-7kXm84dc6yiniEFb/KRZv5H4g43n+xKTSpKSczlv54DY3tHSuZjBARyI/UDxFVgn7ezWYAIFuphzs0hSdhs6hw==}
     engines: {node: '>=18'}
 
-  '@lobehub/i18n-cli@1.25.1':
-    resolution: {integrity: sha512-LQSLcU7l5Wfnsq7hMydVmjJ2d4GZKKKEbsQ1EKzYU+S5jTJYAtbNY2f3mg1llJZ+RLOlgKdfkPZhPc41TacA1A==}
+  '@lobehub/i18n-cli@1.26.1':
+    resolution: {integrity: sha512-/LEKOY25KZ5yvBZ9OFy6lXvWURghSkLcVFQF5Us/7o9awzzO65d7VOP59QI0ddThE1ynVFdVhYhAu4tJ0WkTQA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10173,7 +10173,7 @@ snapshots:
       - react-devtools-core
       - utf-8-validate
 
-  '@lobehub/i18n-cli@1.25.1(@types/react@19.1.9)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(ws@8.18.3)(zod@3.24.1)':
+  '@lobehub/i18n-cli@1.26.1(@types/react@19.1.9)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(ws@8.18.3)(zod@3.24.1)':
     dependencies:
       '@lobehub/cli-ui': 1.13.0(@types/react@19.1.9)
       '@yutengjing/eld': 0.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   '@iconify/json': ^2.2.380
   '@iconify/tailwind4': ^1.2.0
   '@intlify/eslint-plugin-vue-i18n': ^4.1.0
-  '@lobehub/i18n-cli': ^1.25.1
+  '@lobehub/i18n-cli': ^1.26.1
   '@nx/eslint': 22.2.6
   '@nx/playwright': 22.2.6
   '@nx/storybook': 22.2.4

--- a/src/locales/ar/nodeDefs.json
+++ b/src/locales/ar/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "الفهرس",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/ar/nodeDefs.json
+++ b/src/locales/ar/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "إجمالي الثواني"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "نطاق الخطوات الزمنية",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "الفهرس",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "تحميل نموذج ControlNet (فرق)",
@@ -3394,17 +3394,17 @@
         "name": "صورة"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "يستخرج جميع المكونات من الفيديو: الإطارات، الصوت، ومعدل الإطارات.",
@@ -3636,14 +3636,14 @@
         "name": "مخرج_clip_الرؤية"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2التكييف متعدد الرؤى",
@@ -3661,14 +3661,14 @@
         "name": "الأيمن"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "Hunyuan صورة إلى فيديو",
@@ -6612,26 +6612,26 @@
         "name": "العرض"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "تحميل الصوت",
@@ -6896,11 +6896,11 @@
         "tooltip": "مدى قوة تعديل نموذج الانتشار. يمكن أن تكون هذه القيمة سالبة."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "استخراج وحفظ LoRA",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: من صورة إلى نموذج",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: من صور متعددة إلى نموذج",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "تحسين نموذج أولي تم إنشاؤه مسبقًا.",
@@ -7726,18 +7726,18 @@
         "tooltip": "أدخل نصًا لتوجيه عملية الإكساء. الحد الأقصى ٦٠٠ حرف. لا يمكن استخدامه مع 'texture_image' في نفس الوقت."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "يوفر شخصية مجهزة بالحركة بصيغ قياسية. التجهيز التلقائي غير مناسب حاليًا للنماذج غير المكسوة، أو الأصول غير البشرية، أو الأصول البشرية ذات البنية غير الواضحة للأطراف والجسم.",
@@ -7755,18 +7755,18 @@
         "tooltip": "صورة الإكساء الأساسية (UV-unwrapped) للنموذج."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: تحويل النص إلى نموذج",
@@ -7805,18 +7805,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: نموذج النسيج",
@@ -7843,18 +7843,18 @@
         "tooltip": "صف نمط النسيج المطلوب للكائن باستخدام النص. الحد الأقصى ٦٠٠ حرف. لا يمكن استخدامه مع 'image_style' في نفس الوقت."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "ينشئ مقاطع فيديو من المُوجِّه، مع إطار أول اختياري باستخدام نموذج MiniMax Hailuo-02 الجديد.",
@@ -12047,13 +12047,13 @@
         "name": "البذرة"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "توليد أصول ثلاثية الأبعاد باستخدام واجهة برمجة تطبيقات رودين",
@@ -12075,13 +12075,13 @@
         "name": "وضعية_TAP"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "توليد أصول ثلاثية الأبعاد باستخدام واجهة برمجة تطبيقات رودين",
@@ -12100,13 +12100,13 @@
         "name": "البذرة"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "توليد أصول ثلاثية الأبعاد باستخدام واجهة برمجة تطبيقات رودين",
@@ -12119,13 +12119,13 @@
         "name": "البذرة"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "توليد أصول ثلاثية الأبعاد باستخدام واجهة برمجة تطبيقات رودين",
@@ -12144,13 +12144,13 @@
         "name": "البذرة"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "قم برفع الإطارات الرئيسية الأولى والأخيرة، واكتب موجهًا، وقم بتوليد فيديو. قد تستفيد التحولات الأكثر تعقيدًا، مثل الحالات التي يختلف فيها الإطار الأخير تمامًا عن الإطار الأول، من المدة الأطول البالغة 10 ثوانٍ. سيمنح هذا التوليد مزيدًا من الوقت للانتقال بسلاسة بين المدخلين. قبل البدء، راجع أفضل الممارسات هذه لضمان أن اختياراتك للمدخلات ستؤدي إلى نجاح التوليد: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "سيغما"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "المُعين المخصص المتقدم",
@@ -12472,14 +12472,14 @@
         "name": "سيغما"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "المُعين DPM التكيفي",
@@ -12777,11 +12777,11 @@
         "name": "نسبة أخذ العينات"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "حفظ PNG متحرك",
@@ -13336,14 +13336,14 @@
         "name": "صوت"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "فصل الصورة مع ألفا",
@@ -13371,14 +13371,14 @@
         "name": "الخطوة"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "فصل Sigmas إزالة التشويش",
@@ -13390,14 +13390,14 @@
         "name": "Sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "يحول جزءًا من عينة الصوت الحالية باستخدام تعليمات نصية.",
@@ -14135,17 +14135,17 @@
         "tooltip": "البذرة تتحكم فيما إذا كان يجب إعادة تشغيل العقدة؛ النتائج غير حتمية بغض النظر عن البذرة."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: من نص إلى نموذج (احترافي)",
@@ -14175,17 +14175,17 @@
         "tooltip": "البذرة تتحكم فيما إذا كان يجب إعادة تشغيل العقدة؛ النتائج غير حتمية بغض النظر عن البذرة."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "نوع البيانات المستخدم في التدريب."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "نموذج مع LoRA مطبق"
       },
-      {
+      "1": {
         "tooltip": "أوزان LoRA"
       },
-      {
+      "2": {
         "tooltip": "سجل الخسارة"
       },
-      {
+      "3": {
         "tooltip": "إجمالي خطوات التدريب"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "قص موتر الصوت إلى النطاق الزمني المختار.",
@@ -14831,14 +14831,14 @@
         "name": "بذرة النسيج"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: متعدد المناظر إلى نموذج",
@@ -14890,14 +14890,14 @@
         "name": "بذرة_الملمس"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "تحسين نموذج مسود تم إنشاؤه بواسطة نماذج Tripo الإصدار 1.4 فقط.",
@@ -14908,14 +14908,14 @@
         "tooltip": "يجب أن يكون نموذج Tripo الإصدار 1.4"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: إعادة توجيه النموذج المجهز",
@@ -14927,14 +14927,14 @@
         "name": "معرف_مهمة_النموذج_الأصلي"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: تجهيز النموذج",
@@ -14943,14 +14943,14 @@
         "name": "معرف_مهمة_النموذج_الأصلي"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: النص إلى نموذج",
@@ -14995,14 +14995,14 @@
         "name": "بذرة_الملمس"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: نموذج الملمس",
@@ -15026,14 +15026,14 @@
         "name": "بذرة_الملمس"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "اقتطاع النص",

--- a/src/locales/es/nodeDefs.json
+++ b/src/locales/es/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "ÍNDICE",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/es/nodeDefs.json
+++ b/src/locales/es/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "segundos_total"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "Rango de Pasos de Tiempo",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "ÍNDICE",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "Cargar Modelo ControlNet (diff)",
@@ -3394,17 +3394,17 @@
         "name": "imagen"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "Extrae todos los componentes de un video: fotogramas, audio y velocidad de fotogramas.",
@@ -3636,14 +3636,14 @@
         "name": "salida_vision_clip"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ConditioningMultiView",
@@ -3661,14 +3661,14 @@
         "name": "derecha"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanImageToVideo",
@@ -6612,26 +6612,26 @@
         "name": "ancho"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "CargarAudio",
@@ -6896,11 +6896,11 @@
         "tooltip": "Qué tan fuerte modificar el modelo de difusión. Este valor puede ser negativo."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "Extraer y Guardar Lora",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: Imagen a Modelo",
@@ -7633,18 +7633,18 @@
         "name": "modo de simetría"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: Multi-Imagen a Modelo",
@@ -7690,18 +7690,18 @@
         "name": "modo de simetría"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "Refina un modelo borrador previamente creado.",
@@ -7726,18 +7726,18 @@
         "tooltip": "Proporcione un texto para guiar el proceso de texturizado. Máximo 600 caracteres. No se puede usar al mismo tiempo que 'texture_image'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "Proporciona un personaje riggeado en formatos estándar. El auto-rigging actualmente no es adecuado para mallas sin textura, activos no humanoides o activos humanoides con estructura de extremidades y cuerpo poco clara.",
@@ -7755,18 +7755,18 @@
         "tooltip": "Imagen de textura de color base UV-desplegada del modelo."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: Texto a Modelo",
@@ -7805,18 +7805,18 @@
         "name": "modo_simetría"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: Modelo de Textura",
@@ -7843,18 +7843,18 @@
         "tooltip": "Describe el estilo de textura deseado para el objeto usando texto. Máximo 600 caracteres. No se puede usar al mismo tiempo que 'image_style'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "Genera videos a partir de un prompt, con opción de usar un fotograma inicial utilizando el nuevo modelo MiniMax Hailuo-02.",
@@ -12047,13 +12047,13 @@
         "name": "Semilla"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Generar activos 3D usando la API de Rodin",
@@ -12075,13 +12075,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Generar activos 3D usando la API de Rodin",
@@ -12100,13 +12100,13 @@
         "name": "Semilla"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Generar activos 3D usando la API de Rodin",
@@ -12119,13 +12119,13 @@
         "name": "Semilla"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Generar activos 3D usando la API de Rodin",
@@ -12144,13 +12144,13 @@
         "name": "Semilla"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "Sube los primeros y últimos fotogramas clave, redacta un prompt y genera un video. Las transiciones más complejas, como casos donde el último fotograma es completamente diferente del primero, pueden beneficiarse de la duración más larga de 10s. Esto le daría a la generación más tiempo para transicionar suavemente entre las dos entradas. Antes de comenzar, revisa estas mejores prácticas para asegurar que tus selecciones de entrada preparen tu generación para el éxito: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "SamplerCustomAdvanced",
@@ -12472,14 +12472,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "SamplerDPMAdaptative",
@@ -12777,11 +12777,11 @@
         "name": "porcentaje_muestreo"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "GuardarPNGAnimado",
@@ -13336,14 +13336,14 @@
         "name": "audio"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "Dividir Imagen con Alfa",
@@ -13371,14 +13371,14 @@
         "name": "paso"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "SplitSigmasDenoise",
@@ -13390,14 +13390,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "Transforma parte de una muestra de audio existente usando instrucciones de texto.",
@@ -14135,17 +14135,17 @@
         "tooltip": "La semilla controla si el nodo debe volver a ejecutarse; los resultados son no deterministas independientemente de la semilla."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: Texto a Modelo (Pro)",
@@ -14175,17 +14175,17 @@
         "tooltip": "La semilla controla si el nodo debe volver a ejecutarse; los resultados son no deterministas independientemente de la semilla."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "El tipo de datos a usar para el entrenamiento."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "Modelo con LoRA aplicado"
       },
-      {
+      "1": {
         "tooltip": "Pesos de LoRA"
       },
-      {
+      "2": {
         "tooltip": "Historial de pérdida"
       },
-      {
+      "3": {
         "tooltip": "Total de pasos de entrenamiento"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "Recortar tensor de audio al rango de tiempo elegido.",
@@ -14831,14 +14831,14 @@
         "name": "semilla_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: Multivista a Modelo",
@@ -14890,14 +14890,14 @@
         "name": "semilla_de_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "Refina un modelo borrador creado únicamente por modelos Tripo v1.4.",
@@ -14908,14 +14908,14 @@
         "tooltip": "Debe ser un modelo Tripo v1.4"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: Redireccionar modelo con rig",
@@ -14927,14 +14927,14 @@
         "name": "ID_de_tarea_del_modelo_original"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: Modelo con rig",
@@ -14943,14 +14943,14 @@
         "name": "ID_de_tarea_del_modelo_original"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: Texto a Modelo",
@@ -14995,14 +14995,14 @@
         "name": "semilla_de_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: Modelo de textura",
@@ -15026,14 +15026,14 @@
         "name": "semilla_de_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "Truncar texto",

--- a/src/locales/fa/nodeDefs.json
+++ b/src/locales/fa/nodeDefs.json
@@ -2090,13 +2090,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "INDEX",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "بارگذاری مدل ControlNet (diff)",
@@ -6621,18 +6621,18 @@
         "name": "عرض"
       }
     },
-    "outputs": [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": null,
+      "3": null,
+      "4": null,
+      "5": null,
+      "6": {
         "name": "مدل_۳بعدی",
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "بارگذاری صوت",
@@ -7579,17 +7579,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: تصویر به مدل",
@@ -7635,18 +7635,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: چند تصویر به مدل",
@@ -7692,18 +7692,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "یک مدل پیش‌نویس ایجادشده قبلی را بهبود دهید.",
@@ -7728,18 +7728,18 @@
         "tooltip": "یک متن راهنما برای هدایت فرایند بافت‌دهی وارد کنید. حداکثر ۶۰۰ کاراکتر. نمی‌توان همزمان با 'texture_image' استفاده کرد."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "یک کاراکتر ریگ‌شده در فرمت‌های استاندارد ارائه می‌دهد. ریگ خودکار در حال حاضر برای مش‌های بدون بافت، دارایی‌های غیرانسان‌نما یا دارایی‌های انسان‌نمایی که ساختار اندام و بدن آن‌ها نامشخص است، مناسب نیست.",
@@ -7757,18 +7757,18 @@
         "tooltip": "تصویر بافت رنگ پایه مدل با UV باز شده."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: متن به مدل",
@@ -7807,18 +7807,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: مدل بافت",
@@ -7845,18 +7845,18 @@
         "tooltip": "سبک بافت مورد نظر شیء را با استفاده از متن توصیف کنید. حداکثر ۶۰۰ کاراکتر. نمی‌توان همزمان با 'image_style' استفاده کرد."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "تولید ویدئو از طریق پرامپت، با امکان استفاده از فریم ابتدایی با مدل جدید MiniMax Hailuo-02.",
@@ -12049,13 +12049,13 @@
         "name": "Seed"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "تولید دارایی‌های سه‌بعدی با استفاده از Rodin API",
@@ -12077,13 +12077,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "تولید دارایی‌های سه‌بعدی با استفاده از Rodin API",
@@ -12102,13 +12102,13 @@
         "name": "Seed"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "تولید دارایی‌های سه‌بعدی با استفاده از Rodin API",
@@ -12121,13 +12121,13 @@
         "name": "Seed"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "تولید دارایی‌های سه‌بعدی با استفاده از Rodin API",
@@ -12146,13 +12146,13 @@
         "name": "Seed"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "اولین و آخرین فریم کلیدی را بارگذاری کنید، یک پرامپت بنویسید و ویدیو تولید کنید. انتقال‌های پیچیده‌تر، مانند زمانی که فریم آخر کاملاً با فریم اول متفاوت است، ممکن است از مدت زمان طولانی‌تر ۱۰ ثانیه‌ای بهره‌مند شوند. این کار به تولید اجازه می‌دهد تا زمان بیشتری برای انتقال روان بین دو ورودی داشته باشد. پیش از شروع، این نکات کلیدی را مرور کنید تا مطمئن شوید انتخاب‌های ورودی شما باعث موفقیت تولید خواهد شد: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -14148,17 +14148,17 @@
         "tooltip": "seed تعیین می‌کند که node باید دوباره اجرا شود یا خیر؛ نتایج صرف‌نظر از seed غیرقطعی هستند."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: تبدیل متن به مدل (پیشرفته)",
@@ -14188,17 +14188,17 @@
         "tooltip": "seed تعیین می‌کند که node باید دوباره اجرا شود یا خیر؛ نتایج صرف‌نظر از seed غیرقطعی هستند."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14844,14 +14844,14 @@
         "name": "بذر تکسچر"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: چندنما به مدل",
@@ -14903,14 +14903,14 @@
         "name": "بذر تکسچر"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "بهبود یک مدل پیش‌نویس که فقط توسط مدل‌های Tripo نسخه ۱.۴ ایجاد شده است.",
@@ -14921,14 +14921,14 @@
         "tooltip": "باید یک مدل Tripo نسخه ۱.۴ باشد"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: هدف‌گذاری مجدد مدل ریگ‌شده",
@@ -14940,14 +14940,14 @@
         "name": "شناسه وظیفه مدل اصلی"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: ریگ مدل",
@@ -14956,14 +14956,14 @@
         "name": "شناسه وظیفه مدل اصلی"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: متن به مدل",
@@ -15008,14 +15008,14 @@
         "name": "بذر تکسچر"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: مدل بافت",
@@ -15039,14 +15039,14 @@
         "name": "بذر بافت"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "کوتاه‌سازی متن",

--- a/src/locales/fa/nodeDefs.json
+++ b/src/locales/fa/nodeDefs.json
@@ -2091,7 +2091,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "INDEX",
         "tooltip": null
@@ -6622,12 +6621,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
-      "2": null,
-      "3": null,
-      "4": null,
-      "5": null,
       "6": {
         "name": "مدل_۳بعدی",
         "tooltip": null
@@ -7580,7 +7573,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7636,8 +7628,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7693,8 +7683,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7729,8 +7717,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7758,8 +7744,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7808,8 +7792,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7846,8 +7828,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12050,7 +12030,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12078,7 +12057,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12103,7 +12081,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12122,7 +12099,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12147,7 +12123,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14149,7 +14124,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14189,7 +14163,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14845,8 +14818,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14904,8 +14875,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14922,8 +14891,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14941,8 +14908,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14957,8 +14922,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15009,8 +14972,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15040,8 +15001,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/fr/nodeDefs.json
+++ b/src/locales/fr/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "secondes_total"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "Plage de pas de temps",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "INDEX",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "Charger le modèle ControlNet (diff)",
@@ -3394,17 +3394,17 @@
         "name": "image"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "Extrait tous les composants d'une vidéo : images, audio et fréquence d’images.",
@@ -3636,14 +3636,14 @@
         "name": "sortie_vision_clip"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ConditioningMultiView",
@@ -3661,14 +3661,14 @@
         "name": "droite"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanImageToVideo",
@@ -6612,26 +6612,26 @@
         "name": "largeur"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "ChargerAudio",
@@ -6896,11 +6896,11 @@
         "tooltip": "Intensité de modification du modèle de diffusion. Cette valeur peut être négative."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "Extraire et Sauvegarder Lora",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy : Image vers modèle",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy : Multi-image vers modèle",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "Affinez un modèle brouillon précédemment créé.",
@@ -7726,18 +7726,18 @@
         "tooltip": "Fournissez une invite textuelle pour guider le processus de texturage. Maximum 600 caractères. Ne peut pas être utilisé en même temps que 'texture_image'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "Fournit un personnage riggé dans des formats standards. L’auto-rigging n’est actuellement pas adapté aux maillages non texturés, aux assets non humanoïdes ou aux assets humanoïdes avec une structure de membres et de corps peu claire.",
@@ -7755,18 +7755,18 @@
         "tooltip": "L’image de texture couleur de base UV-dépliée du modèle."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy : Texte vers modèle",
@@ -7805,18 +7805,18 @@
         "name": "mode_symétrie"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy : Modèle de texture",
@@ -7843,18 +7843,18 @@
         "tooltip": "Décrivez le style de texture souhaité pour l’objet en utilisant du texte. 600 caractères maximum. Ne peut pas être utilisé en même temps que « image_style »."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "Génère des vidéos à partir d'un prompt, avec option d'image de départ utilisant le nouveau modèle MiniMax Hailuo-02.",
@@ -12047,13 +12047,13 @@
         "name": "Graine"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Générer des actifs 3D en utilisant l'API Rodin",
@@ -12075,13 +12075,13 @@
         "name": "PoseTAP"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Générer des actifs 3D en utilisant l'API Rodin",
@@ -12100,13 +12100,13 @@
         "name": "Graine"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Générer des actifs 3D en utilisant l'API Rodin",
@@ -12119,13 +12119,13 @@
         "name": "Graine"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Générer des ressources 3D avec l'API Rodin",
@@ -12144,13 +12144,13 @@
         "name": "Graine"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "Téléchargez les premières et dernières images clés, rédigez un prompt et générez une vidéo. Les transitions plus complexes, comme lorsque la dernière image est complètement différente de la première, peuvent bénéficier de la durée plus longue de 10s. Cela donnerait à la génération plus de temps pour effectuer une transition fluide entre les deux entrées. Avant de commencer, consultez ces bonnes pratiques pour vous assurer que vos sélections d'entrée permettront à votre génération de réussir : https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "ÉchantillonneurPersonnaliséAvancé",
@@ -12472,14 +12472,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "SamplerDPMAdaptative",
@@ -12777,11 +12777,11 @@
         "name": "pourcent_échantillonnage"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "EnregistrerPNGAnimé",
@@ -13336,14 +13336,14 @@
         "name": "audio"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "Diviser l'image avec Alpha",
@@ -13371,14 +13371,14 @@
         "name": "étape"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "SplitSigmasDenoise",
@@ -13390,14 +13390,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "Transforme une partie d'un échantillon audio existant en utilisant des instructions textuelles.",
@@ -14135,17 +14135,17 @@
         "tooltip": "La graine contrôle si le nœud doit être relancé ; les résultats restent non déterministes quelle que soit la graine."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D : Texte vers Modèle (Pro)",
@@ -14175,17 +14175,17 @@
         "tooltip": "La graine contrôle si le nœud doit être relancé ; les résultats restent non déterministes quelle que soit la graine."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "Le type de données à utiliser pour l'entraînement."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "Modèle avec LoRA appliqué"
       },
-      {
+      "1": {
         "tooltip": "Poids LoRA"
       },
-      {
+      "2": {
         "tooltip": "Historique de la perte"
       },
-      {
+      "3": {
         "tooltip": "Nombre total d’étapes d’entraînement"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "Tronquer le tenseur audio dans la plage de temps choisie.",
@@ -14831,14 +14831,14 @@
         "name": "graine_texture"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo : Multivue vers Modèle",
@@ -14890,14 +14890,14 @@
         "name": "graine_texture"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "Affinez un modèle d'ébauche créé uniquement par les modèles Tripo v1.4.",
@@ -14908,14 +14908,14 @@
         "tooltip": "Doit être un modèle Tripo v1.4"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo : Modèle squeletté redirigé",
@@ -14927,14 +14927,14 @@
         "name": "ID_tâche_modèle_original"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo : Modèle squeletté",
@@ -14943,14 +14943,14 @@
         "name": "ID_tâche_modèle_original"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo : Texte vers Modèle",
@@ -14995,14 +14995,14 @@
         "name": "texture_graine"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo : Modèle de texture",
@@ -15026,14 +15026,14 @@
         "name": "texture_graine"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "Tronquer le texte",

--- a/src/locales/fr/nodeDefs.json
+++ b/src/locales/fr/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "INDEX",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/ja/nodeDefs.json
+++ b/src/locales/ja/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "秒_合計"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "タイムステップ範囲",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "インデックス",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "ControlNetモデルを読み込む（diff）",
@@ -3394,17 +3394,17 @@
         "name": "画像"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "ビデオからすべてのコンポーネント（フレーム、オーディオ、フレームレート）を抽出します。",
@@ -3636,14 +3636,14 @@
         "name": "clip_vision_output"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ConditioningMultiView",
@@ -3661,14 +3661,14 @@
         "name": "右"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanImageToVideo",
@@ -6612,26 +6612,26 @@
         "name": "幅"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "音声を読み込む",
@@ -6896,11 +6896,11 @@
         "tooltip": "拡散モデルを変更する強度。この値は負の値も可能です。"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "LoRAを抽出して保存",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy：画像からモデルへ",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy：複数画像からモデルへ",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "以前に作成したドラフトモデルをリファインします。",
@@ -7726,18 +7726,18 @@
         "tooltip": "テクスチャリングプロセスをガイドするテキストプロンプトを入力してください。最大600文字。「texture_image」と同時に使用することはできません。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "標準フォーマットでリギング済みキャラクターを提供します。自動リギングは、テクスチャのないメッシュ、非ヒューマノイドアセット、または手足や体の構造が不明瞭なヒューマノイドアセットには適していません。",
@@ -7755,18 +7755,18 @@
         "tooltip": "モデルのUV展開されたベースカラーテクスチャ画像です。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy：テキストからモデル生成",
@@ -7805,18 +7805,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy：テクスチャモデル",
@@ -7843,18 +7843,18 @@
         "tooltip": "オブジェクトの希望するテクスチャスタイルをテキストで説明してください。最大600文字。'image_style'と同時に使用することはできません。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "新しいMiniMax Hailuo-02モデルを使用して、プロンプトから動画を生成します（開始フレームはオプション）。",
@@ -12047,13 +12047,13 @@
         "name": "シード"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Rodin APIを使用して3Dアセットを生成",
@@ -12075,13 +12075,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Rodin APIを使用して3Dアセットを生成",
@@ -12100,13 +12100,13 @@
         "name": "シード"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Rodin APIを使用して3Dアセットを生成",
@@ -12119,13 +12119,13 @@
         "name": "シード"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Rodin APIを使用して3Dアセットを生成",
@@ -12144,13 +12144,13 @@
         "name": "シード"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "最初と最後のキーフレームをアップロードし、プロンプトを作成して動画を生成します。最後のフレームが最初のフレームと完全に異なる場合など、より複雑な遷移では、長い10秒の期間が効果的です。これにより、2つの入力間を滑らかに遷移するための時間がより多く確保されます。始める前に、これらのベストプラクティスを確認して、入力選択が生成を成功に導くようにしてください: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "シグマ"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "カスタムサンプラー（高度）",
@@ -12472,14 +12472,14 @@
         "name": "シグマ"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "サンプラーDPM適応",
@@ -12777,11 +12777,11 @@
         "name": "sampling_percent"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "アニメーションPNGを保存",
@@ -13336,14 +13336,14 @@
         "name": "オーディオ"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "アルファで画像を分割",
@@ -13371,14 +13371,14 @@
         "name": "ステップ"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "シグマを分割してノイズ除去",
@@ -13390,14 +13390,14 @@
         "name": "シグマ"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "テキスト指示を使用して既存のオーディオサンプルの一部を変換します。",
@@ -14135,17 +14135,17 @@
         "tooltip": "シードはノードの再実行を制御しますが、シードに関わらず結果は非決定的です。"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: テキストからモデルへ (Pro)",
@@ -14175,17 +14175,17 @@
         "tooltip": "シードはノードの再実行を制御しますが、シードに関わらず結果は非決定的です。"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "トレーニングに使用するデータ型。"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "LoRA適用済みモデル"
       },
-      {
+      "1": {
         "tooltip": "LoRA重み"
       },
-      {
+      "2": {
         "tooltip": "損失履歴"
       },
-      {
+      "3": {
         "tooltip": "総トレーニングステップ数"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "オーディオテンソルを選択した時間範囲でトリミングします。",
@@ -14831,14 +14831,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: マルチビューからモデル",
@@ -14890,14 +14890,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "v1.4 Tripoモデルでのみ作成されたドラフトモデルをリファインします。",
@@ -14908,14 +14908,14 @@
         "tooltip": "v1.4 Tripoモデルである必要があります"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: リグ付きモデルのリターゲット",
@@ -14927,14 +14927,14 @@
         "name": "original_model_task_id"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: モデルのリグ設定",
@@ -14943,14 +14943,14 @@
         "name": "original_model_task_id"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: テキストからモデル生成",
@@ -14995,14 +14995,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: モデルのテクスチャリング",
@@ -15026,14 +15026,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "テキストを切り詰める",

--- a/src/locales/ja/nodeDefs.json
+++ b/src/locales/ja/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "インデックス",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/ko/nodeDefs.json
+++ b/src/locales/ko/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "INDEX",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/ko/nodeDefs.json
+++ b/src/locales/ko/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "전체(초)"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "조건 (타임스텝 범위)",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "INDEX",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "컨트롤넷 모델 로드 (차이)",
@@ -3394,17 +3394,17 @@
         "name": "이미지"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "비디오에서 모든 컴포넌트(프레임, 오디오, 프레임레이트)를 추출합니다.",
@@ -3636,14 +3636,14 @@
         "name": "clip_vision_output"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ConditioningMultiView",
@@ -3661,14 +3661,14 @@
         "name": "오른쪽"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanImageToVideo",
@@ -6612,26 +6612,26 @@
         "name": "너비"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "오디오 로드",
@@ -6896,11 +6896,11 @@
         "tooltip": "디퓨전 모델을 수정하는 강도입니다. 이 값은 음수일 수 있습니다."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "LoRA 추출 및 저장",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: 이미지 → 모델",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: 다중 이미지 → 모델",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "이전에 생성된 초안 모델을 다듬습니다.",
@@ -7726,18 +7726,18 @@
         "tooltip": "텍스처링 과정을 안내할 텍스트 프롬프트를 입력하세요. 최대 600자. 'texture_image'와 동시에 사용할 수 없습니다."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "표준 포맷으로 리깅된 캐릭터를 제공합니다. 자동 리깅은 텍스처가 없는 메시, 비휴머노이드 자산, 또는 팔다리와 신체 구조가 불분명한 휴머노이드 자산에는 적합하지 않습니다.",
@@ -7755,18 +7755,18 @@
         "tooltip": "모델의 UV 언랩된 기본 색상 텍스처 이미지입니다."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: 텍스트 → 모델",
@@ -7805,18 +7805,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: 텍스처 모델",
@@ -7843,18 +7843,18 @@
         "tooltip": "오브젝트의 원하는 텍스처 스타일을 텍스트로 설명하세요. 최대 600자까지 입력할 수 있습니다. 'image_style'과 동시에 사용할 수 없습니다."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "새로운 MiniMax Hailuo-02 모델을 사용하여 프롬프트로 비디오를 생성하며, 선택적으로 시작 프레임을 사용할 수 있습니다.",
@@ -12047,13 +12047,13 @@
         "name": "시드"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Rodin API를 사용하여 3D 에셋 생성",
@@ -12075,13 +12075,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Rodin API를 사용하여 3D 에셋 생성",
@@ -12100,13 +12100,13 @@
         "name": "시드"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Rodin API를 사용하여 3D 에셋 생성",
@@ -12119,13 +12119,13 @@
         "name": "시드"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Rodin API를 사용하여 3D 에셋 생성",
@@ -12144,13 +12144,13 @@
         "name": "시드"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "첫 번째와 마지막 키프레임을 업로드하고 프롬프트를 작성하여 비디오를 생성합니다. 마지막 프레임이 첫 번째 프레임과 완전히 다른 경우와 같은 복잡한 전환은 10초의 긴 지속 시간을 사용하는 것이 좋습니다. 이렇게 하면 두 입력 사이를 부드럽게 전환할 수 있는 시간이 더 주어집니다. 시작하기 전에 입력 선택이 생성 성공을 보장할 수 있도록 다음 모범 사례를 검토하세요: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "시그마 배열"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "고급 사용자 정의 샘플러",
@@ -12472,14 +12472,14 @@
         "name": "시그마 배열"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "DPMAdaptive 샘플러",
@@ -12777,11 +12777,11 @@
         "name": "샘플링 백분율"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "애니메이션 PNG 저장",
@@ -13336,14 +13336,14 @@
         "name": "오디오"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "이미지와 알파채널 분리",
@@ -13371,14 +13371,14 @@
         "name": "분할 스텝"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "시그마 배열 분할 (노이즈 제거양)",
@@ -13390,14 +13390,14 @@
         "name": "시그마 배열"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "텍스트 지침을 사용하여 기존 오디오 샘플의 일부를 변환합니다.",
@@ -14135,17 +14135,17 @@
         "tooltip": "시드는 노드가 다시 실행될지 여부를 제어합니다. 시드와 관계없이 결과는 비결정적입니다."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: 텍스트 → 모델 (Pro)",
@@ -14175,17 +14175,17 @@
         "tooltip": "시드는 노드가 다시 실행될지 여부를 제어합니다. 시드와 관계없이 결과는 비결정적입니다."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "훈련에 사용할 데이터 타입입니다."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "LoRA가 적용된 모델"
       },
-      {
+      "1": {
         "tooltip": "LoRA 가중치"
       },
-      {
+      "2": {
         "tooltip": "손실 기록"
       },
-      {
+      "3": {
         "tooltip": "총 학습 스텝"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "오디오 텐서를 선택한 시간 범위로 자릅니다.",
@@ -14831,14 +14831,14 @@
         "name": "텍스처 시드"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: 다중 뷰에서 모델 생성",
@@ -14890,14 +14890,14 @@
         "name": "텍스처 시드"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "v1.4 Tripo 모델로 생성된 드래프트 모델만 정제합니다.",
@@ -14908,14 +14908,14 @@
         "tooltip": "v1.4 Tripo 모델이어야 합니다"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: 리깅된 모델 리타겟",
@@ -14927,14 +14927,14 @@
         "name": "원본 모델 작업 ID"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: 모델 리깅",
@@ -14943,14 +14943,14 @@
         "name": "원본 모델 작업 ID"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: 텍스트에서 모델 생성",
@@ -14995,14 +14995,14 @@
         "name": "텍스처 시드"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: 텍스처 모델",
@@ -15026,14 +15026,14 @@
         "name": "텍스처 시드"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "텍스트 자르기",

--- a/src/locales/pt-BR/nodeDefs.json
+++ b/src/locales/pt-BR/nodeDefs.json
@@ -2091,7 +2091,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "ÍNDICE",
         "tooltip": null
@@ -6622,12 +6621,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
-      "2": null,
-      "3": null,
-      "4": null,
-      "5": null,
       "6": {
         "name": "model_3d",
         "tooltip": null
@@ -7580,7 +7573,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7636,8 +7628,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7693,8 +7683,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7729,8 +7717,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7758,8 +7744,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7808,8 +7792,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7846,8 +7828,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12050,7 +12030,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12078,7 +12057,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12103,7 +12081,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12122,7 +12099,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12147,7 +12123,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14149,7 +14124,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14189,7 +14163,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14845,8 +14818,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14904,8 +14875,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14922,8 +14891,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14941,8 +14908,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14957,8 +14922,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15009,8 +14972,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15040,8 +15001,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/pt-BR/nodeDefs.json
+++ b/src/locales/pt-BR/nodeDefs.json
@@ -2090,13 +2090,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "ÍNDICE",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "Carregar Modelo ControlNet (diff)",
@@ -6621,18 +6621,18 @@
         "name": "largura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": null,
+      "3": null,
+      "4": null,
+      "5": null,
+      "6": {
         "name": "model_3d",
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "Carregar Áudio",
@@ -7579,17 +7579,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: Imagem para Modelo",
@@ -7635,18 +7635,18 @@
         "name": "modo_de_simetria"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: Múltiplas Imagens para Modelo",
@@ -7692,18 +7692,18 @@
         "name": "modo_de_simetria"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "Refine um modelo rascunho criado anteriormente.",
@@ -7728,18 +7728,18 @@
         "tooltip": "Forneça um prompt de texto para orientar o processo de texturização. Máximo de 600 caracteres. Não pode ser usado ao mesmo tempo que 'texture_image'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "Fornece um personagem com rig em formatos padrão. O auto-rigging atualmente não é adequado para malhas sem textura, ativos não humanóides ou ativos humanóides com estrutura de membros e corpo indefinida.",
@@ -7757,18 +7757,18 @@
         "tooltip": "Imagem de textura de cor base UV-desdobrada do modelo."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: Texto para Modelo",
@@ -7807,18 +7807,18 @@
         "name": "modo_de_simetria"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: Modelo de Textura",
@@ -7845,18 +7845,18 @@
         "tooltip": "Descreva o estilo de textura desejado para o objeto usando texto. Máximo de 600 caracteres. Não pode ser usado ao mesmo tempo que 'image_style'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "Gera vídeos a partir do prompt, com quadro inicial opcional usando o novo modelo MiniMax Hailuo-02.",
@@ -12049,13 +12049,13 @@
         "name": "Semente"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Gerar ativos 3D usando a API Rodin",
@@ -12077,13 +12077,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Gerar ativos 3D usando a API Rodin",
@@ -12102,13 +12102,13 @@
         "name": "Semente"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Gerar ativos 3D usando a API Rodin",
@@ -12121,13 +12121,13 @@
         "name": "Semente"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Gerar ativos 3D usando a API Rodin",
@@ -12146,13 +12146,13 @@
         "name": "Semente"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "Envie os quadros-chave inicial e final, escreva um prompt e gere um vídeo. Transições mais complexas, como casos em que o quadro final é completamente diferente do inicial, podem se beneficiar da duração mais longa de 10s. Isso dará mais tempo para a geração fazer uma transição suave entre as duas entradas. Antes de começar, revise estas melhores práticas para garantir que suas seleções de entrada ajudarão no sucesso da geração: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -14148,17 +14148,17 @@
         "tooltip": "A semente controla se o nó deve ser executado novamente; os resultados são não determinísticos independentemente da semente."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: Texto para Modelo (Pro)",
@@ -14188,17 +14188,17 @@
         "tooltip": "A semente controla se o nó deve ser executado novamente; os resultados são não determinísticos independentemente da semente."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14844,14 +14844,14 @@
         "name": "semente_da_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: Multiview para Modelo",
@@ -14903,14 +14903,14 @@
         "name": "semente_da_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "Refine um modelo rascunho criado apenas por modelos Tripo v1.4.",
@@ -14921,14 +14921,14 @@
         "tooltip": "Deve ser um modelo Tripo v1.4"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: Retarget para modelo com rig",
@@ -14940,14 +14940,14 @@
         "name": "id_da_tarefa_do_modelo_original"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: Rig no modelo",
@@ -14956,14 +14956,14 @@
         "name": "id_da_tarefa_do_modelo_original"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: Texto para Modelo",
@@ -15008,14 +15008,14 @@
         "name": "semente_da_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: Modelo de Textura",
@@ -15039,14 +15039,14 @@
         "name": "semente_textura"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "Truncar Texto",

--- a/src/locales/ru/nodeDefs.json
+++ b/src/locales/ru/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "ИНДЕКС",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/ru/nodeDefs.json
+++ b/src/locales/ru/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "всего_секунд"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "Диапазон временных шагов",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "ИНДЕКС",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "Загрузить модель ControlNet (дифф)",
@@ -3394,17 +3394,17 @@
         "name": "изображение"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "Извлекает все компоненты из видео: кадры, аудио и частоту кадров.",
@@ -3636,14 +3636,14 @@
         "name": "выход_clip_vision"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ConditioningMultiView",
@@ -3661,14 +3661,14 @@
         "name": "справа"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanImageToVideo",
@@ -6612,26 +6612,26 @@
         "name": "ширина"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "Загрузить аудио",
@@ -6896,11 +6896,11 @@
         "tooltip": "Степень модификации диффузионной модели. Это значение может быть отрицательным."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "Извлечь и сохранить LoRA",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: Изображение в модель",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: Мульти-изображение в модель",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "Улучшить ранее созданную черновую модель.",
@@ -7726,18 +7726,18 @@
         "tooltip": "Введите текстовый запрос для управления процессом текстурирования. Максимум 600 символов. Не может использоваться одновременно с 'texture_image'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "Предоставляет персонажа с риггингом в стандартных форматах. Автоматический риггинг в настоящее время не подходит для моделей без текстур, не-гуманоидных объектов или гуманоидов с нечеткой структурой конечностей и тела.",
@@ -7755,18 +7755,18 @@
         "tooltip": "UV-развернутая текстура базового цвета модели."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: Текст в Модель",
@@ -7805,18 +7805,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: Модель текстуры",
@@ -7843,18 +7843,18 @@
         "tooltip": "Опишите желаемый стиль текстуры объекта с помощью текста. Максимум 600 символов. Нельзя использовать одновременно с 'image_style'."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "Создает видео из промпта с возможностью использования начального кадра с помощью новой модели MiniMax Hailuo-02.",
@@ -12047,13 +12047,13 @@
         "name": "Сид"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Создание 3D-объектов с помощью Rodin API",
@@ -12075,13 +12075,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Создание 3D-объектов с помощью Rodin API",
@@ -12100,13 +12100,13 @@
         "name": "Сид"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Создание 3D-объектов с помощью Rodin API",
@@ -12119,13 +12119,13 @@
         "name": "Сид"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Создание 3D-объектов с помощью Rodin API",
@@ -12144,13 +12144,13 @@
         "name": "Сид"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "Загрузите первый и последний ключевые кадры, составьте промпт и создайте видео. Более сложные переходы, например, когда последний кадр полностью отличается от первого, могут выиграть от более длительной продолжительности в 10 секунд. Это даст генерации больше времени для плавного перехода между двумя входными данными. Прежде чем начать, ознакомьтесь с лучшими практиками, чтобы убедиться, что ваши входные данные обеспечат успешный результат: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "сигмы"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "Пользовательский сэмплер (Расширенный)",
@@ -12472,14 +12472,14 @@
         "name": "сигмы"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "Адаптивный сэмплер DPM",
@@ -12777,11 +12777,11 @@
         "name": "процент_дискретизации"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "Сохранить анимированный PNG",
@@ -13336,14 +13336,14 @@
         "name": "аудио"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "Разделить изображение с альфа-каналом",
@@ -13371,14 +13371,14 @@
         "name": "шаг"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "Разделить сигмы для удаления шума",
@@ -13390,14 +13390,14 @@
         "name": "сигмы"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "Преобразует часть существующего аудиосэмпла с использованием текстовых инструкций.",
@@ -14135,17 +14135,17 @@
         "tooltip": "Seed управляет тем, будет ли узел запускаться повторно; результаты всегда недетерминированы, независимо от seed."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: Текст в модель (Pro)",
@@ -14175,17 +14175,17 @@
         "tooltip": "Seed управляет тем, будет ли узел запускаться повторно; результаты всегда недетерминированы, независимо от seed."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "Тип данных, используемый для обучения."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "Модель с применённой LoRA"
       },
-      {
+      "1": {
         "tooltip": "Веса LoRA"
       },
-      {
+      "2": {
         "tooltip": "История потерь"
       },
-      {
+      "3": {
         "tooltip": "Всего шагов обучения"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "Обрезать аудио тензор в выбранном временном диапазоне.",
@@ -14831,14 +14831,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: Мультивью в модель",
@@ -14890,14 +14890,14 @@
         "name": "сид_текстуры"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "Уточнение черновой модели, созданной только моделями Tripo v1.4.",
@@ -14908,14 +14908,14 @@
         "tooltip": "Должна быть модель Tripo v1.4"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: Перепривязка ригнутой модели",
@@ -14927,14 +14927,14 @@
         "name": "идентификатор_задачи_исходной_модели"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: Риггинг модели",
@@ -14943,14 +14943,14 @@
         "name": "идентификатор_задачи_исходной_модели"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: Текст в модель",
@@ -14995,14 +14995,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: Модель текстур",
@@ -15026,14 +15026,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "Обрезать текст",

--- a/src/locales/tr/nodeDefs.json
+++ b/src/locales/tr/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "saniye_toplam"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "Zaman Adımları Aralığı",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "INDEX",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "ControlNet Modelini Yükle (fark)",
@@ -3394,17 +3394,17 @@
         "name": "image"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "Bir videodan tüm bileşenleri çıkarır: kareler, ses ve kare hızı.",
@@ -3636,14 +3636,14 @@
         "name": "clip_görü_çıktısı"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ÇokluGörünümKoşullandırma",
@@ -3661,14 +3661,14 @@
         "name": "sağ"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanGörüntüdenVideoya",
@@ -6612,26 +6612,26 @@
         "name": "genişlik"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "Ses Yükle",
@@ -6896,11 +6896,11 @@
         "tooltip": "Difüzyon modelinin ne kadar güçlü bir şekilde değiştirileceği. Bu değer negatif olabilir."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "Lora'yı Çıkar ve Kaydet",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy: Görüntüden Modele",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy: Çoklu Görüntüden Modele",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "Önceden oluşturulmuş bir taslak modeli iyileştirir.",
@@ -7726,18 +7726,18 @@
         "tooltip": "Kaplama sürecini yönlendirmek için bir metin istemi girin. Maksimum 600 karakter. 'texture_image' ile aynı anda kullanılamaz."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "Standart formatlarda riglenmiş bir karakter sağlar. Otomatik rigleme, şu anda dokusuz meshler, insan olmayan varlıklar veya uzuv ve vücut yapısı belirsiz olan insan benzeri varlıklar için uygun değildir.",
@@ -7755,18 +7755,18 @@
         "tooltip": "Modelin UV-unwrap edilmiş temel renk doku görseli."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy: Metinden Modele",
@@ -7805,18 +7805,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy: Doku Modeli",
@@ -7843,18 +7843,18 @@
         "tooltip": "Nesnenin istediğiniz doku stilini metinle tanımlayın. En fazla 600 karakter. 'image_style' ile aynı anda kullanılamaz."
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "Yeni MiniMax Hailuo-02 modelini kullanarak prompt'tan video oluşturur, isteğe bağlı başlangıç karesi ile.",
@@ -12047,13 +12047,13 @@
         "name": "Tohum"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "Rodin API kullanarak 3D Varlıklar Oluştur",
@@ -12075,13 +12075,13 @@
         "name": "TAPoz"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "Rodin API kullanarak 3D Varlıklar Oluştur",
@@ -12100,13 +12100,13 @@
         "name": "Tohum"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "Rodin API kullanarak 3D Varlıklar Oluştur",
@@ -12119,13 +12119,13 @@
         "name": "Tohum"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "Rodin API kullanarak 3D Varlıklar Oluştur",
@@ -12144,13 +12144,13 @@
         "name": "Tohum"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "İlk ve son anahtar kareleri yükleyin, bir prompt taslağı oluşturun ve video üretin. Son karenin İlk kareden tamamen farklı olduğu durumlar gibi daha karmaşık geçişler, daha uzun 10 saniyelik süreden faydalanabilir. Bu, üretimin iki girdi arasında daha pürüzsüz geçiş yapması için daha fazla zaman tanır. Başlamadan önce, girdi seçimlerinizin üretiminizi başarıya ulaştıracağından emin olmak için bu en iyi uygulamaları gözden geçirin: https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3.",
@@ -12444,14 +12444,14 @@
         "name": "sigmalar"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "GelişmişÖzelÖrnekleyici",
@@ -12472,14 +12472,14 @@
         "name": "sigmalar"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "UyarlanabilirDPMÖrnekleyici",
@@ -12777,11 +12777,11 @@
         "name": "örnekleme_yüzdesi"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "Animasyonlu PNG Kaydet",
@@ -13336,14 +13336,14 @@
         "name": "ses"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "Görüntüyü Alfa ile Böl",
@@ -13371,14 +13371,14 @@
         "name": "adım"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "SigmalarıGürültüAzaltmaBöl",
@@ -13390,14 +13390,14 @@
         "name": "sigmalar"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "Mevcut ses örneğinin bir bölümünü metin talimatları kullanarak dönüştürür.",
@@ -14135,17 +14135,17 @@
         "tooltip": "Tohum, düğümün tekrar çalıştırılıp çalıştırılmayacağını kontrol eder; sonuçlar tohumdan bağımsız olarak deterministik değildir."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D: Metinden Modele (Pro)",
@@ -14175,17 +14175,17 @@
         "tooltip": "Tohum, düğümün tekrar çalıştırılıp çalıştırılmayacağını kontrol eder; sonuçlar tohumdan bağımsız olarak deterministik değildir."
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "Eğitim için kullanılacak veri tipi."
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "LoRA uygulanmış model"
       },
-      {
+      "1": {
         "tooltip": "LoRA ağırlıkları"
       },
-      {
+      "2": {
         "tooltip": "Kayıp geçmişi"
       },
-      {
+      "3": {
         "tooltip": "Toplam eğitim adımı"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "Ses tensörünü seçilen zaman aralığına kırp.",
@@ -14831,14 +14831,14 @@
         "name": "doku_tohumu"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo: Çok Bakışlıdan Modele",
@@ -14890,14 +14890,14 @@
         "name": "doku_tohumu"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "Sadece v1.4 Tripo modelleri tarafından oluşturulan taslak bir modeli iyileştirir.",
@@ -14908,14 +14908,14 @@
         "tooltip": "Bir v1.4 Tripo modeli olmalı"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: Riglenmiş Modeli Yeniden Hedefle",
@@ -14927,14 +14927,14 @@
         "name": "orijinal_model_görev_id"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: Modeli Rigle",
@@ -14943,14 +14943,14 @@
         "name": "orijinal_model_görev_id"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: Metinden Modele",
@@ -14995,14 +14995,14 @@
         "name": "doku_tohumu"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: Doku modeli",
@@ -15026,14 +15026,14 @@
         "name": "doku_tohumu"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "Metni Kısalt",

--- a/src/locales/tr/nodeDefs.json
+++ b/src/locales/tr/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "INDEX",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/zh-TW/nodeDefs.json
+++ b/src/locales/zh-TW/nodeDefs.json
@@ -1590,14 +1590,14 @@
         "name": "總秒數"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "ConditioningTimestepsRange": {
     "display_name": "步驟範圍",
@@ -2088,13 +2088,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "INDEX",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "載入 ControlNet 模型（diff）",
@@ -3394,17 +3394,17 @@
         "name": "圖片"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       }
-    ]
+    }
   },
   "GetVideoComponents": {
     "description": "從影片中提取所有元件：影格、音訊與影格率。",
@@ -3636,14 +3636,14 @@
         "name": "clip_vision_output"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "Hunyuan3Dv2ConditioningMultiView": {
     "display_name": "Hunyuan3Dv2ConditioningMultiView",
@@ -3661,14 +3661,14 @@
         "name": "右視圖"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "HunyuanImageToVideo": {
     "display_name": "HunyuanImageToVideo",
@@ -6612,26 +6612,26 @@
         "name": "寬度"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       },
-      {
+      "2": {
         "tooltip": null
       },
-      {
+      "3": {
         "tooltip": null
       },
-      {
+      "4": {
         "tooltip": null
       },
-      {
+      "5": {
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "載入音訊",
@@ -6896,11 +6896,11 @@
         "tooltip": "修改擴散模型的強度。此值可以為負數。"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "name": "model"
       }
-    ]
+    }
   },
   "LoraSave": {
     "display_name": "提取並儲存Lora",
@@ -7577,17 +7577,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy：圖片轉模型",
@@ -7633,18 +7633,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy：多圖轉模型",
@@ -7690,18 +7690,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "精修先前建立的草稿模型。",
@@ -7726,18 +7726,18 @@
         "tooltip": "提供文字提示以引導材質製作。最多 600 字元。不可與「texture_image」同時使用。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "提供標準格式的骨架綁定角色。目前自動綁定不適用於無材質網格、非人形資產，或肢體結構不明確的人形資產。",
@@ -7755,18 +7755,18 @@
         "tooltip": "模型 UV 展開後的基礎色彩貼圖。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy：文字生成模型",
@@ -7805,18 +7805,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy：材質模型",
@@ -7843,18 +7843,18 @@
         "tooltip": "用文字描述你想要的物件材質風格。最多600字。不能與「image_style」同時使用。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "使用新的 MiniMax 海螺-02 模型，從提示詞生成影片，可選起始幀。",
@@ -12047,13 +12047,13 @@
         "name": "種子值"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "使用 Rodin API 生成 3D 資源",
@@ -12075,13 +12075,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "使用 Rodin API 生成 3D 資源",
@@ -12100,13 +12100,13 @@
         "name": "種子值"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "使用 Rodin API 生成 3D 資源",
@@ -12119,13 +12119,13 @@
         "name": "種子值"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "使用 Rodin API 生成 3D 資源",
@@ -12144,13 +12144,13 @@
         "name": "種子值"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "上傳首尾關鍵幀，草擬提示詞，並生成影片。對於較複雜的轉場（例如最後一幀與第一幀完全不同的情況），較長的 10 秒持續時間可能更有利，這能讓生成過程有更多時間在兩個輸入之間平滑過渡。開始前，請先閱讀這些最佳實踐指南，確保您的輸入選擇能為生成成功奠定基礎：https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3。",
@@ -12444,14 +12444,14 @@
         "name": "Sigma 值"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerCustomAdvanced": {
     "display_name": "SamplerCustomAdvanced",
@@ -12472,14 +12472,14 @@
         "name": "Sigma 值"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SamplerDPMAdaptative": {
     "display_name": "SamplerDPMAdaptative",
@@ -12777,11 +12777,11 @@
         "name": "sampling_percent"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SaveAnimatedPNG": {
     "display_name": "SaveAnimatedPNG",
@@ -13336,14 +13336,14 @@
         "name": "音訊"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitImageWithAlpha": {
     "display_name": "以 Alpha 通道分割影像",
@@ -13371,14 +13371,14 @@
         "name": "步驟"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "SplitSigmasDenoise": {
     "display_name": "分割 Sigmas（去噪）",
@@ -13390,14 +13390,14 @@
         "name": "sigmas"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": null
       },
-      {
+      "1": {
         "tooltip": null
       }
-    ]
+    }
   },
   "StabilityAudioInpaint": {
     "description": "使用文字指令轉換現有音訊樣本的部分內容。",
@@ -14135,17 +14135,17 @@
         "tooltip": "種子控制節點是否重新執行；無論種子如何，結果皆為非確定性。"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D：文字轉模型（專業版）",
@@ -14175,17 +14175,17 @@
         "tooltip": "種子控制節點是否重新執行；無論種子如何，結果皆為非確定性。"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "TextEncodeAceStepAudio",
@@ -14652,20 +14652,20 @@
         "tooltip": "訓練時使用的資料類型。"
       }
     },
-    "outputs": [
-      {
+    "outputs": {
+      "0": {
         "tooltip": "已套用 LoRA 的模型"
       },
-      {
+      "1": {
         "tooltip": "LoRA 權重"
       },
-      {
+      "2": {
         "tooltip": "損失歷史"
       },
-      {
+      "3": {
         "tooltip": "總訓練步數"
       }
-    ]
+    }
   },
   "TrimAudioDuration": {
     "description": "將音訊張量修剪至選定的時間範圍。",
@@ -14831,14 +14831,14 @@
         "name": "紋理種子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo：多視角轉模型",
@@ -14890,14 +14890,14 @@
         "name": "texture_seed"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "僅精修由 v1.4 Tripo 模型建立的草稿模型。",
@@ -14908,14 +14908,14 @@
         "tooltip": "必須是 v1.4 Tripo 模型"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: 重新定位骨架模型",
@@ -14927,14 +14927,14 @@
         "name": "original_model_task_id"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: 骨架模型",
@@ -14943,14 +14943,14 @@
         "name": "原始模型任務ID"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo：文字轉模型",
@@ -14995,14 +14995,14 @@
         "name": "紋理種子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo：紋理模型",
@@ -15026,14 +15026,14 @@
         "name": "紋理種子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "截斷文字",

--- a/src/locales/zh-TW/nodeDefs.json
+++ b/src/locales/zh-TW/nodeDefs.json
@@ -2089,7 +2089,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "INDEX",
         "tooltip": null
@@ -7578,7 +7577,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7634,8 +7632,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7691,8 +7687,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7727,8 +7721,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7756,8 +7748,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7806,8 +7796,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7844,8 +7832,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12048,7 +12034,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12076,7 +12061,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12101,7 +12085,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12120,7 +12103,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12145,7 +12127,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14136,7 +14117,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14176,7 +14156,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14832,8 +14811,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14891,8 +14868,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14909,8 +14884,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14928,8 +14901,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14944,8 +14915,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14996,8 +14965,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15027,8 +14994,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -2090,13 +2090,13 @@
       "index": {},
       "option1": {}
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "索引",
         "tooltip": null
       }
-    ]
+    }
   },
   "DiffControlNetLoader": {
     "display_name": "加载ControlNet模型（diff）",
@@ -6621,18 +6621,18 @@
         "name": "宽度"
       }
     },
-    "outputs": [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": null,
+      "3": null,
+      "4": null,
+      "5": null,
+      "6": {
         "name": "model_3d",
         "tooltip": null
       }
-    ]
+    }
   },
   "LoadAudio": {
     "display_name": "加载音频",
@@ -7579,17 +7579,17 @@
         "name": "rig_task_id"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyImageToModelNode": {
     "display_name": "Meshy：图像转模型",
@@ -7635,18 +7635,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyMultiImageToModelNode": {
     "display_name": "Meshy：多图像转模型",
@@ -7692,18 +7692,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRefineNode": {
     "description": "对先前创建的草稿模型进行精细化处理。",
@@ -7728,18 +7728,18 @@
         "tooltip": "提供文本提示以引导材质生成。最多600个字符。不能与'texture_image'同时使用。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyRigModelNode": {
     "description": "以标准格式提供带骨骼的角色模型。自动骨骼绑定目前不适用于无贴图网格、非类人资产或肢体结构不清晰的类人资产。",
@@ -7757,18 +7757,18 @@
         "tooltip": "模型的UV展开基础色贴图。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextToModelNode": {
     "display_name": "Meshy：文本生成模型",
@@ -7807,18 +7807,18 @@
         "name": "symmetry_mode"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MeshyTextureNode": {
     "display_name": "Meshy：纹理模型",
@@ -7845,18 +7845,18 @@
         "tooltip": "用文本描述你想要的物体纹理风格。最多600个字符。不能与“image_style”同时使用。"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "3": {
         "name": "FBX",
         "tooltip": null
       }
-    ]
+    }
   },
   "MinimaxHailuoVideoNode": {
     "description": "使用新的 MiniMax Hailuo-02 模型从提示词生成视频，可选择起始帧。",
@@ -12049,13 +12049,13 @@
         "name": "种子"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Gen2": {
     "description": "使用Rodin API生成3D资源",
@@ -12077,13 +12077,13 @@
         "name": "TAPose"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Regular": {
     "description": "使用Rodin API生成3D资源",
@@ -12102,13 +12102,13 @@
         "name": "种子"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Sketch": {
     "description": "使用Rodin API生成3D资源",
@@ -12121,13 +12121,13 @@
         "name": "种子"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "Rodin3D_Smooth": {
     "description": "使用Rodin API生成3D资源",
@@ -12146,13 +12146,13 @@
         "name": "种子"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "RunwayFirstLastFrameNode": {
     "description": "上传首尾关键帧，草拟提示词，生成视频。对于更复杂的过渡（例如尾帧与首帧完全不同的情况），较长的10秒时长可能更有利，这能为生成过程提供更多时间在两个输入之间平滑过渡。开始前，请查看这些最佳实践以确保您的输入选择能为生成成功奠定基础：https://help.runwayml.com/hc/en-us/articles/34170748696595-Creating-with-Keyframes-on-Gen-3。",
@@ -14148,17 +14148,17 @@
         "tooltip": "种子控制节点是否重新运行；无论种子如何，结果都是非确定性的。"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TencentTextToModelNode": {
     "display_name": "Hunyuan3D：文本转模型（专业版）",
@@ -14188,17 +14188,17 @@
         "tooltip": "种子控制节点是否重新运行；无论种子如何，结果都是非确定性的。"
       }
     },
-    "outputs": [
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": {
         "name": "GLB",
         "tooltip": null
       },
-      {
+      "2": {
         "name": "OBJ",
         "tooltip": null
       }
-    ]
+    }
   },
   "TextEncodeAceStepAudio": {
     "display_name": "文本音频编码（AceStep）",
@@ -14844,14 +14844,14 @@
         "name": "纹理种子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoMultiviewToModelNode": {
     "display_name": "Tripo：多视图转模型",
@@ -14903,14 +14903,14 @@
         "name": "纹理种子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRefineNode": {
     "description": "仅精修由v1.4 Tripo模型创建的草稿模型。",
@@ -14921,14 +14921,14 @@
         "tooltip": "必须是v1.4 Tripo模型"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRetargetNode": {
     "display_name": "Tripo: 重定向绑定模型",
@@ -14940,14 +14940,14 @@
         "name": "原始模型任务ID"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoRigNode": {
     "display_name": "Tripo: 绑定模型",
@@ -14956,14 +14956,14 @@
         "name": "原始模型任务ID"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextToModelNode": {
     "display_name": "Tripo: 文本转模型",
@@ -15008,14 +15008,14 @@
         "name": "纹理种子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TripoTextureNode": {
     "display_name": "Tripo: 纹理化模型",
@@ -15039,14 +15039,14 @@
         "name": "纹理种子"
       }
     },
-    "outputs": [
-      null,
-      null,
-      {
+    "outputs": {
+      "0": null,
+      "1": null,
+      "2": {
         "name": "GLB",
         "tooltip": null
       }
-    ]
+    }
   },
   "TruncateText": {
     "display_name": "截断文本",

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -2091,7 +2091,6 @@
       "option1": {}
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "索引",
         "tooltip": null
@@ -6622,12 +6621,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
-      "2": null,
-      "3": null,
-      "4": null,
-      "5": null,
       "6": {
         "name": "model_3d",
         "tooltip": null
@@ -7580,7 +7573,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -7636,8 +7628,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7693,8 +7683,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7729,8 +7717,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7758,8 +7744,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7808,8 +7792,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -7846,8 +7828,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -12050,7 +12030,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12078,7 +12057,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12103,7 +12081,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12122,7 +12099,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -12147,7 +12123,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14149,7 +14124,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14189,7 +14163,6 @@
       }
     },
     "outputs": {
-      "0": null,
       "1": {
         "name": "GLB",
         "tooltip": null
@@ -14845,8 +14818,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14904,8 +14875,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14922,8 +14891,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14941,8 +14908,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -14957,8 +14922,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15009,8 +14972,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null
@@ -15040,8 +15001,6 @@
       }
     },
     "outputs": {
-      "0": null,
-      "1": null,
       "2": {
         "name": "GLB",
         "tooltip": null


### PR DESCRIPTION
## Summary

Upgrade `@lobehub/i18n-cli` to v1.26.1 and fix corrupted locale files that caused 3D API nodes to break in non-English locales.

## Changes

- **What**: Upgrade `@lobehub/i18n-cli` from `^1.25.1` to `^1.26.1` — v1.26.1 fixes numeric string keys (e.g. `"0"`, `"1"` in node outputs) being incorrectly serialized as JSON arrays instead of objects. Fix all 11 non-English locale `nodeDefs.json` files where this corruption already existed (23-35 entries per locale).
- **Dependencies**: `@lobehub/i18n-cli` `^1.25.1` → `^1.26.1`

## Review Focus

The locale file diffs are mechanical array→object conversions. The key change is in `pnpm-workspace.yaml` (version bump). After this fix, running `pnpm locale` will no longer re-corrupt numeric-keyed outputs.

Affected nodes include: `Load3D`, `Preview3D`, `MeshyImageToModelNode`, `Hunyuan3Dv2Conditioning`, `SV3D_Conditioning`, `ConditioningStableAudio`, `GetImageSize`, and ~30 others across all non-English locales.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8977-fix-upgrade-lobehub-i18n-cli-to-fix-3D-API-nodes-i18n-30c6d73d365081b79f98e17e13652996) by [Unito](https://www.unito.io)
