### PR TITLE
fix: show skeleton loading state in asset folder view

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -406,6 +406,7 @@ const skeletonCount = computed(() =>
 const {
   state: folderAssets,
   isLoading: folderLoading,
+  error: folderError,
   execute: loadFolderAssets
 } = useAsyncState(
   (metadata: OutputAssetMetadata, options: { createdAt?: string } = {}) =>
@@ -450,9 +451,13 @@ const isBulkMode = computed(
   () => hasSelection.value && selectedAssets.value.length > 1
 )
 
+const isFolderLoading = computed(
+  () => isInFolderView.value && folderLoading.value
+)
+
 const showLoadingState = computed(
   () =>
-    (loading.value || folderLoading.value) &&
+    (loading.value || isFolderLoading.value) &&
     displayAssets.value.length === 0 &&
     activeJobsCount.value === 0
 )
@@ -460,7 +465,7 @@ const showLoadingState = computed(
 const showEmptyState = computed(
   () =>
     !loading.value &&
-    !folderLoading.value &&
+    !isFolderLoading.value &&
     displayAssets.value.length === 0 &&
     activeJobsCount.value === 0
 )
@@ -639,6 +644,16 @@ const enterFolderView = async (asset: AssetItem) => {
   expectedFolderCount.value = metadata.outputCount ?? 0
 
   await loadFolderAssets(0, metadata, { createdAt: asset.created_at })
+
+  if (folderError.value) {
+    toast.add({
+      severity: 'error',
+      summary: t('sideToolbar.folderView.errorSummary'),
+      detail: t('sideToolbar.folderView.errorDetail'),
+      life: 5000
+    })
+    exitFolderView()
+  }
 }
 
 const exitFolderView = () => {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -81,8 +81,7 @@
     <template #body>
       <div
         v-if="showLoadingState"
-        class="grid gap-2 px-2"
-        :style="skeletonGridStyle"
+        class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2 px-2"
       >
         <div
           v-for="n in skeletonCount"
@@ -393,9 +392,6 @@ const mediaAssets = computed(() => currentAssets.value.media.value)
 const galleryActiveIndex = ref(-1)
 const currentGalleryAssetId = ref<string | null>(null)
 
-const skeletonGridStyle = {
-  gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))'
-}
 const DEFAULT_SKELETON_COUNT = 6
 const skeletonCount = computed(() =>
   expectedFolderCount.value > 0

--- a/src/components/ui/skeleton/Skeleton.vue
+++ b/src/components/ui/skeleton/Skeleton.vue
@@ -9,5 +9,7 @@ const { class: className } = defineProps<{
 </script>
 
 <template>
-  <div :class="cn('animate-pulse rounded-md bg-primary/10', className)" />
+  <div
+    :class="cn('animate-pulse rounded-md bg-secondary-background', className)"
+  />
 </template>

--- a/src/components/ui/skeleton/Skeleton.vue
+++ b/src/components/ui/skeleton/Skeleton.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/utils/tailwindUtil'
+
+const { class: className } = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div :class="cn('animate-pulse rounded-md bg-primary/10', className)" />
+</template>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -743,6 +743,10 @@
       "filterText": "Text"
     },
     "backToAssets": "Back to all assets",
+    "folderView": {
+      "errorSummary": "Failed to load outputs",
+      "errorDetail": "Could not retrieve outputs for this job. Please try again."
+    },
     "searchAssets": "Search Assets",
     "labels": {
       "queue": "Queue",


### PR DESCRIPTION
## Description

When clicking a multi-output job to enter folder view, `resolveOutputAssetItems` fetches job details asynchronously. During this fetch, the panel showed "No generated files found" because there was no loading state for the folder resolution—only the media list fetch had one.

This replaces the empty state flash with skeleton cards that match the asset grid layout, using the known output count from metadata to render the correct number of placeholders.

Supersedes #8960.

### Changes

- **Add shadcn/vue `Skeleton` component** (`src/components/ui/skeleton/Skeleton.vue`)
- **Use `useAsyncState`** from VueUse to track folder asset resolution, providing `isLoading` automatically
- **Wire `folderLoading`** into `showLoadingState` and `showEmptyState` computeds
- **Replace `ProgressSpinner`** with a skeleton grid that mirrors the asset card layout
- **Use `metadata.outputCount`** to predict skeleton count; falls back to 6

### Before / After

| Before | After |
|--------|-------|
| "No generated files found" flash | Skeleton cards matching grid layout |

## Checklist

- [x] Code follows project conventions
- [x] No `any` types introduced
- [x] Lint and typecheck pass

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8979-fix-show-skeleton-loading-state-in-asset-folder-view-30c6d73d365081fa9809f616204ed234) by [Unito](https://www.unito.io)
