### PR TITLE
test: mark failing Vue Nodes Image Preview browser tests as fixme

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
@@ -29,7 +29,9 @@ test.describe('Vue Nodes Image Preview', () => {
     return imagePreview
   }
 
-  test.fixme('opens mask editor from image preview button', async ({ comfyPage }) => {
+  test.fixme('opens mask editor from image preview button', async ({
+    comfyPage
+  }) => {
     const imagePreview = await loadImageOnNode(comfyPage)
 
     await imagePreview.locator('[role="img"]').hover()

--- a/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
@@ -29,7 +29,7 @@ test.describe('Vue Nodes Image Preview', () => {
     return imagePreview
   }
 
-  test('opens mask editor from image preview button', async ({ comfyPage }) => {
+  test.fixme('opens mask editor from image preview button', async ({ comfyPage }) => {
     const imagePreview = await loadImageOnNode(comfyPage)
 
     await imagePreview.locator('[role="img"]').hover()
@@ -38,7 +38,7 @@ test.describe('Vue Nodes Image Preview', () => {
     await expect(comfyPage.page.locator('.mask-editor-dialog')).toBeVisible()
   })
 
-  test('shows image context menu options', async ({ comfyPage }) => {
+  test.fixme('shows image context menu options', async ({ comfyPage }) => {
     await loadImageOnNode(comfyPage)
 
     const nodeHeader = comfyPage.vueNodes.getNodeByTitle('Load Image')


### PR DESCRIPTION
Mark the two browser tests added in #8143 as `test.fixme` — they are failing on main.

- `opens mask editor from image preview button`
- `shows image context menu options`

- Fixes #8143 (browser test failures)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8980-test-mark-failing-Vue-Nodes-Image-Preview-browser-tests-as-fixme-30c6d73d36508103bcadf9ce1dd21ae9) by [Unito](https://www.unito.io)
