### PR TITLE
fix: use getAuthHeader in createCustomer for API key auth support

### DIFF
--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -277,7 +277,7 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
   }
 
   const createCustomer = async (): Promise<CreateCustomerResponse> => {
-    const authHeader = await getFirebaseAuthHeader()
+    const authHeader = await getAuthHeader()
     if (!authHeader) {
       throw new FirebaseAuthStoreError(t('toastMessages.userNotAuthenticated'))
     }


### PR DESCRIPTION
## Summary

Re-apply the fix from PR #8408 that was accidentally reverted by PR #8508 — `createCustomer` must use `getAuthHeader()` (not `getFirebaseAuthHeader()`) so API key authentication works.

## Changes

- **What**: Changed `createCustomer` in `firebaseAuthStore.ts` to use `getAuthHeader()` which falls back through workspace token → Firebase token → API key. Added regression tests covering API key auth, Firebase auth, and no-auth paths.

## Review Focus

This is the same one-line fix from #8408. PR #8508 ("Feat/workspaces 6 billing") overwrote it during merge because it was branched before #8408 landed. The regression test should prevent this from happening again.

Fixes COM-15060

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8983-fix-use-getAuthHeader-in-createCustomer-for-API-key-auth-support-30c6d73d365081c2aab6d5defa5298d6) by [Unito](https://www.unito.io)
