### PR TITLE
fix: load 3D dialog content with defineAsyncComponent

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -202,13 +202,22 @@ import {
 } from '@vueuse/core'
 import Divider from 'primevue/divider'
 import { useToast } from 'primevue/usetoast'
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 // Lazy-loaded to avoid pulling THREE.js into the main bundle
-const Load3dViewerContent = () =>
-  import('@/components/load3d/Load3dViewerContent.vue')
+const Load3dViewerContent = defineAsyncComponent(
+  () => import('@/components/load3d/Load3dViewerContent.vue')
+)
 import AssetsSidebarGridView from '@/components/sidebar/tabs/AssetsSidebarGridView.vue'
 import AssetsSidebarListView from '@/components/sidebar/tabs/AssetsSidebarListView.vue'
 import SidebarTabTemplate from '@/components/sidebar/tabs/SidebarTabTemplate.vue'


### PR DESCRIPTION
## Summary
Fix 3D inspect dialog rendering by wrapping `Load3dViewerContent` with `defineAsyncComponent` before passing it to `dialogStore.showDialog`.

## Changes
- Update `AssetsSidebarTab` to lazy-load `Load3dViewerContent` via `defineAsyncComponent(() => import(...))`.

## Why
Passing a raw `() => import(...)` loader to the dialog store can render `[object Promise]` instead of the component in this path.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8990-fix-load-3D-dialog-content-with-defineAsyncComponent-30c6d73d365081e7ba82cc8282943756) by [Unito](https://www.unito.io)
