### PR TITLE
feat: add visual indicators for widget slot drag hover and connected state

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -286,6 +286,7 @@
   --component-node-widget-background-highlighted: var(--color-ash-500);
   --component-node-widget-promoted: var(--color-purple-700);
   --component-node-widget-advanced: var(--color-azure-400);
+  --component-node-widget-linked: var(--color-azure-400);
 
   /* Default UI element color palette variables */
   --palette-contrast-mix-color: #fff;
@@ -450,6 +451,7 @@
   --component-node-widget-background-highlighted: var(--color-graphite-400);
   --component-node-widget-promoted: var(--color-purple-700);
   --component-node-widget-advanced: var(--color-azure-600);
+  --component-node-widget-linked: var(--color-azure-600);
 
   --modal-card-background: var(--secondary-background);
   --modal-card-background-hovered: var(--secondary-background-hover);
@@ -573,6 +575,7 @@
   );
   --color-component-node-widget-promoted: var(--component-node-widget-promoted);
   --color-component-node-widget-advanced: var(--component-node-widget-advanced);
+  --color-component-node-widget-linked: var(--component-node-widget-linked);
 
   /* Semantic tokens */
   --color-base-foreground: var(--base-foreground);

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -258,6 +258,7 @@
   --component-node-widget-background-highlighted: var(--color-smoke-800);
   --component-node-widget-promoted: var(--color-purple-700);
   --component-node-widget-advanced: var(--color-azure-400);
+  --component-node-widget-linked: var(--color-azure-400);
 
   --video-trim-selection-background: var(--color-datatype-CLIP, #ffd500);
   --video-trim-playhead-background: #f0513b;
@@ -413,6 +414,7 @@
   --component-node-widget-background-highlighted: var(--color-smoke-800);
   --component-node-widget-promoted: var(--color-purple-700);
   --component-node-widget-advanced: var(--color-azure-600);
+  --component-node-widget-linked: var(--color-azure-600);
 
   --modal-card-background: var(--secondary-background);
   --modal-card-background-hovered: var(--secondary-background-hover);
@@ -547,6 +549,7 @@
   );
   --color-component-node-widget-promoted: var(--component-node-widget-promoted);
   --color-component-node-widget-advanced: var(--component-node-widget-advanced);
+  --color-component-node-widget-linked: var(--component-node-widget-linked);
   --color-video-trim-selection-background: var(
     --video-trim-selection-background
   );

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -294,4 +294,56 @@ describe('NodeWidgets', () => {
       expect(widgetEl.classes()).not.toContain('border-l-2')
     })
   })
+
+  describe('slot dot visibility during drag', () => {
+    it('shows slot dots when drag is active', () => {
+      const widget = createMockWidget({
+        slotMetadata: { index: 0, linked: false }
+      })
+      const nodeData = createMockNodeData('TestNode', [widget])
+
+      mockDragState.active = true
+
+      const wrapper = mountComponent(nodeData)
+      const dotContainer = wrapper.find('.lg-node-widget > div:first-child')
+      expect(dotContainer.classes()).toContain('opacity-100')
+      expect(dotContainer.classes()).not.toContain('opacity-0')
+    })
+
+    it('hides slot dots when no drag is active and not linked', () => {
+      const widget = createMockWidget({
+        slotMetadata: { index: 0, linked: false }
+      })
+      const nodeData = createMockNodeData('TestNode', [widget])
+      const wrapper = mountComponent(nodeData)
+      const dotContainer = wrapper.find('.lg-node-widget > div:first-child')
+      expect(dotContainer.classes()).toContain('opacity-0')
+    })
+
+    it('shows slot dots when linked even without drag', () => {
+      const widget = createMockWidget({
+        slotMetadata: { index: 0, linked: true }
+      })
+      const nodeData = createMockNodeData('TestNode', [widget])
+      const wrapper = mountComponent(nodeData)
+      const dotContainer = wrapper.find('.lg-node-widget > div:first-child')
+      expect(dotContainer.classes()).toContain('opacity-100')
+      expect(dotContainer.classes()).not.toContain('opacity-0')
+    })
+  })
+
+  describe('pointer-events during drag', () => {
+    it('enables pointer-events on widget container during drag', () => {
+      const widget = createMockWidget({
+        slotMetadata: { index: 0, linked: false }
+      })
+      const nodeData = createMockNodeData('TestNode', [widget])
+
+      mockDragState.active = true
+
+      const wrapper = mountComponent(nodeData)
+      const container = wrapper.find('.lg-node-widgets')
+      expect(container.classes()).toContain('pointer-events-auto')
+    })
+  })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,6 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
-import { reactive } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -10,16 +9,26 @@ import type {
 
 import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
 
-const mockDragState = reactive({
-  active: false,
-  pointerId: null as number | null,
-  source: null,
-  pointer: { client: { x: 0, y: 0 }, canvas: { x: 0, y: 0 } },
-  candidate: null as {
-    layout: { nodeId: string; index: number; type: string }
-    compatible: boolean
-  } | null,
-  compatible: new Map<string, boolean>()
+const { mockDragState, resetDragState } = vi.hoisted(() => {
+  const mockDragState = {
+    active: false,
+    pointerId: null as number | null,
+    source: null,
+    pointer: { client: { x: 0, y: 0 }, canvas: { x: 0, y: 0 } },
+    candidate: null as {
+      layout: { nodeId: string; index: number; type: string }
+      compatible: boolean
+    } | null,
+    compatible: new Map<string, boolean>()
+  }
+
+  function resetDragState() {
+    mockDragState.active = false
+    mockDragState.candidate = null
+    mockDragState.compatible.clear()
+  }
+
+  return { mockDragState, resetDragState }
 })
 
 vi.mock('@/renderer/core/canvas/links/slotLinkDragUIState', () => ({
@@ -65,12 +74,6 @@ describe('NodeWidgets', () => {
     inputs: [],
     outputs: []
   })
-
-  function resetDragState() {
-    mockDragState.active = false
-    mockDragState.candidate = null
-    mockDragState.compatible.clear()
-  }
 
   afterEach(() => {
     resetDragState()

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
 import { createTestingPinia } from '@pinia/testing'
-import { render } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeState } from '@/types/nodeState'
 import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
@@ -16,6 +16,20 @@ import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-test'
+
+const { mockDragState, resetDragState } = vi.hoisted(() => {
+  const mockDragState = { active: false }
+  return {
+    mockDragState,
+    resetDragState: () => {
+      mockDragState.active = false
+    }
+  }
+})
+
+vi.mock('@/renderer/core/canvas/links/slotLinkDragUIState', () => ({
+  useSlotLinkDragUIState: () => ({ state: mockDragState })
+}))
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({
@@ -111,6 +125,8 @@ function renderComponent({
 }
 
 describe('NodeWidgets', () => {
+  afterEach(resetDragState)
+
   describe('node-type prop passing', () => {
     it('passes node type to widget components', () => {
       const id = widgetId(GRAPH_ID, toNodeId(1), 'test_widget')
@@ -266,6 +282,21 @@ describe('NodeWidgets', () => {
     expect(container.querySelector('.widget-stub')).toHaveAttribute(
       'aria-invalid',
       'true'
+    )
+  })
+
+  it('enables widget pointer events while a link drag is active', () => {
+    mockDragState.active = true
+
+    renderComponent({
+      nodeData: createMockNodeData()
+    })
+
+    expect(screen.getByTestId('node-widgets')).toHaveClass(
+      'pointer-events-auto'
+    )
+    expect(screen.getByTestId('node-widgets')).not.toHaveClass(
+      'pointer-events-none'
     )
   })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -7,7 +7,7 @@
     :class="
       cn(
         'lg-node-widgets grid grid-cols-[min-content_minmax(80px,min-content)_minmax(125px,1fr)] gap-y-1 pr-3',
-        shouldHandleNodePointerEvents
+        shouldHandleNodePointerEvents || dragState.active
           ? 'pointer-events-auto'
           : 'pointer-events-none'
       )
@@ -43,8 +43,10 @@
         <div
           :class="
             cn(
-              'z-10 w-3 opacity-0 transition-opacity duration-150 group-hover:opacity-100 flex items-stretch',
-              widget.slotMetadata?.linked && 'opacity-100'
+              'z-10 w-3 transition-opacity duration-150 flex items-stretch',
+              dragState.active || widget.slotMetadata?.linked
+                ? 'opacity-100'
+                : 'opacity-0 group-hover:opacity-100'
             )
           "
         >

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -9,7 +9,7 @@
     :can-select-inputs
     :node-id="nodeData?.id"
     :class="
-      shouldHandleNodePointerEvents
+      shouldHandleNodePointerEvents || dragState.active
         ? 'pointer-events-auto'
         : 'pointer-events-none'
     "
@@ -27,6 +27,7 @@ import type { NodeState } from '@/types/nodeState'
 import type { WidgetId } from '@/types/widgetId'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { st } from '@/i18n'
+import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import WidgetGrid from '@/renderer/extensions/vueNodes/components/WidgetGrid.vue'
 import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
@@ -42,6 +43,7 @@ const { nodeData, widgetIds } = defineProps<NodeWidgetsProps>()
 const { shouldHandleNodePointerEvents, forwardEventToCanvas } =
   useCanvasInteractions()
 const { bringNodeToFront } = useNodeZIndex()
+const { state: dragState } = useSlotLinkDragUIState()
 
 function handleWidgetPointerEvent(event: PointerEvent) {
   if (shouldHandleNodePointerEvents.value) return

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -157,15 +157,23 @@ describe('WidgetGrid', () => {
     )
   })
 
-  it.each([
+  const nonTargetCases = [
     ['inactive drag', false, 'input', '1', 0, true],
     ['incompatible candidate', true, 'input', '1', 0, false],
     ['output candidate', true, 'output', '1', 0, true],
     ['different node', true, 'input', '2', 0, true],
     ['different slot', true, 'input', '1', 1, true]
-  ])(
-    'does not highlight for %s',
-    (_, active, type, nodeId, index, compatible) => {
+  ] as const
+
+  for (const [
+    name,
+    active,
+    type,
+    nodeId,
+    index,
+    compatible
+  ] of nonTargetCases) {
+    it(`does not highlight for ${name}`, () => {
       mockDragState.active = active
       mockDragState.candidate = {
         layout: { nodeId, index, type },
@@ -185,8 +193,8 @@ describe('WidgetGrid', () => {
       })
 
       expect(screen.getByTestId('node-widget')).not.toHaveClass('ring')
-    }
-  )
+    })
+  }
 
   it('marks linked widgets when they are not a drag target', () => {
     const linkedWidget = widget('seed', 'number', 0)

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -1,10 +1,32 @@
 import { render, screen } from '@testing-library/vue'
 import { defineComponent, markRaw } from 'vue'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import WidgetGrid from '@/renderer/extensions/vueNodes/components/WidgetGrid.vue'
 import type { WidgetGridItem } from '@/renderer/extensions/vueNodes/types/widgetGrid'
 import { toNodeId } from '@/types/nodeId'
+
+const { mockDragState, resetDragState } = vi.hoisted(() => {
+  const mockDragState = {
+    active: false,
+    candidate: null as {
+      layout: { nodeId: string; index: number; type: string }
+      compatible: boolean
+    } | null
+  }
+
+  return {
+    mockDragState,
+    resetDragState: () => {
+      mockDragState.active = false
+      mockDragState.candidate = null
+    }
+  }
+})
+
+vi.mock('@/renderer/core/canvas/links/slotLinkDragUIState', () => ({
+  useSlotLinkDragUIState: () => ({ state: mockDragState })
+}))
 
 const WidgetStub = markRaw(
   defineComponent({
@@ -47,6 +69,8 @@ function widget(name: string, type: string, index: number): WidgetGridItem {
 }
 
 describe('WidgetGrid', () => {
+  afterEach(resetDragState)
+
   it('renders hidden converted widgets as input sockets without controls', () => {
     render(WidgetGrid, {
       props: {
@@ -106,5 +130,108 @@ describe('WidgetGrid', () => {
       'true'
     )
     expect(screen.getByTestId('app-input')).not.toHaveAttribute('aria-invalid')
+  })
+
+  it('highlights the compatible widget targeted by a link drag', () => {
+    mockDragState.active = true
+    mockDragState.candidate = {
+      layout: { nodeId: '1', index: 0, type: 'input' },
+      compatible: true
+    }
+
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [widget('seed', 'number', 0)]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+      }
+    })
+
+    expect(screen.getByTestId('node-widget')).toHaveClass(
+      'ring',
+      'ring-component-node-widget-linked'
+    )
+  })
+
+  it.each([
+    ['inactive drag', false, 'input', '1', 0, true],
+    ['incompatible candidate', true, 'input', '1', 0, false],
+    ['output candidate', true, 'output', '1', 0, true],
+    ['different node', true, 'input', '2', 0, true],
+    ['different slot', true, 'input', '1', 1, true]
+  ])(
+    'does not highlight for %s',
+    (_, active, type, nodeId, index, compatible) => {
+      mockDragState.active = active
+      mockDragState.candidate = {
+        layout: { nodeId, index, type },
+        compatible
+      }
+
+      render(WidgetGrid, {
+        props: {
+          nodeId: toNodeId(1),
+          nodeType: 'TestNode',
+          processedWidgets: [widget('seed', 'number', 0)]
+        },
+        global: {
+          directives: { tooltip: {} },
+          stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+        }
+      })
+
+      expect(screen.getByTestId('node-widget')).not.toHaveClass('ring')
+    }
+  )
+
+  it('marks linked widgets when they are not a drag target', () => {
+    const linkedWidget = widget('seed', 'number', 0)
+    linkedWidget.slotMetadata!.linked = true
+
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [linkedWidget]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+      }
+    })
+
+    expect(screen.getByTestId('node-widget')).toHaveClass(
+      'border-l-2',
+      'border-component-node-widget-linked'
+    )
+  })
+
+  it('prefers drag highlighting over the linked border', () => {
+    const linkedWidget = widget('seed', 'number', 0)
+    linkedWidget.slotMetadata!.linked = true
+    mockDragState.active = true
+    mockDragState.candidate = {
+      layout: { nodeId: '1', index: 0, type: 'input' },
+      compatible: true
+    }
+
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [linkedWidget]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+      }
+    })
+
+    expect(screen.getByTestId('node-widget')).toHaveClass('ring')
+    expect(screen.getByTestId('node-widget')).not.toHaveClass('border-l-2')
   })
 })

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -234,4 +234,67 @@ describe('WidgetGrid', () => {
     expect(screen.getByTestId('node-widget')).toHaveClass('ring')
     expect(screen.getByTestId('node-widget')).not.toHaveClass('border-l-2')
   })
+
+  it('shows widget slots while a link drag is active', () => {
+    mockDragState.active = true
+
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [widget('seed', 'number', 0)]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+      }
+    })
+
+    expect(screen.getByTestId('widget-slot-container')).toHaveClass(
+      'opacity-100'
+    )
+    expect(screen.getByTestId('widget-slot-container')).not.toHaveClass(
+      'opacity-0'
+    )
+  })
+
+  it('hides an unlinked widget slot when no link drag is active', () => {
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [widget('seed', 'number', 0)]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+      }
+    })
+
+    expect(screen.getByTestId('widget-slot-container')).toHaveClass(
+      'opacity-0',
+      'group-hover:opacity-100'
+    )
+  })
+
+  it('shows a linked widget slot without a link drag', () => {
+    const linkedWidget = widget('seed', 'number', 0)
+    linkedWidget.slotMetadata!.linked = true
+
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [linkedWidget]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub, InputSlot: InputSlotStub }
+      }
+    })
+
+    expect(screen.getByTestId('widget-slot-container')).toHaveClass(
+      'opacity-100'
+    )
+  })
 })

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -157,28 +157,31 @@ describe('WidgetGrid', () => {
     )
   })
 
-  const nonTargetCases = [
-    ['inactive drag', false, 'input', '1', 0, true],
-    ['incompatible candidate', true, 'input', '1', 0, false],
-    ['output candidate', true, 'output', '1', 0, true],
-    ['different node', true, 'input', '2', 0, true],
-    ['different slot', true, 'input', '1', 1, true]
-  ] as const
-
-  for (const [
-    name,
-    active,
-    type,
-    nodeId,
-    index,
+  const candidate = (
+    type: string,
+    nodeId: string,
+    index: number,
+    compatible: boolean
+  ): NonNullable<typeof mockDragState.candidate> => ({
+    layout: { nodeId, index, type },
     compatible
-  ] of nonTargetCases) {
+  })
+
+  const nonTargetCases: ReadonlyArray<
+    readonly [string, boolean, typeof mockDragState.candidate]
+  > = [
+    ['inactive drag', false, candidate('input', '1', 0, true)],
+    ['incompatible candidate', true, candidate('input', '1', 0, false)],
+    ['output candidate', true, candidate('output', '1', 0, true)],
+    ['different node', true, candidate('input', '2', 0, true)],
+    ['different slot', true, candidate('input', '1', 1, true)],
+    ['cleared candidate', true, null]
+  ]
+
+  for (const [name, active, dragCandidate] of nonTargetCases) {
     it(`does not highlight for ${name}`, () => {
       mockDragState.active = active
-      mockDragState.candidate = {
-        layout: { nodeId, index, type },
-        compatible
-      }
+      mockDragState.candidate = dragCandidate
 
       render(WidgetGrid, {
         props: {
@@ -193,6 +196,9 @@ describe('WidgetGrid', () => {
       })
 
       expect(screen.getByTestId('node-widget')).not.toHaveClass('ring')
+      expect(screen.getByTestId('node-widget')).not.toHaveClass(
+        'ring-component-node-widget-linked'
+      )
     })
   }
 

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
@@ -25,10 +25,13 @@
         "
       >
         <div
+          data-testid="widget-slot-container"
           :class="
             cn(
-              'z-10 flex w-3 items-stretch opacity-0 transition-opacity duration-150 group-hover:opacity-100',
-              widget.slotMetadata?.linked && 'opacity-100'
+              'z-10 flex w-3 items-stretch transition-opacity duration-150',
+              dragState.active || widget.slotMetadata?.linked
+                ? 'opacity-100'
+                : 'opacity-0 group-hover:opacity-100'
             )
           "
         >

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
@@ -15,7 +15,12 @@
         :class="
           cn(
             'group col-span-full grid grid-cols-subgrid items-stretch',
-            !isConvertedWidget(widget) && 'lg-node-widget'
+            !isConvertedWidget(widget) && 'lg-node-widget',
+            isDragHoverTarget(widget) &&
+              'ring ring-component-node-widget-linked',
+            !isDragHoverTarget(widget) &&
+              widget.slotMetadata?.linked &&
+              'border-l-2 border-component-node-widget-linked'
           )
         "
       >
@@ -84,6 +89,7 @@ import type { WidgetGridItem } from '@/renderer/extensions/vueNodes/types/widget
 import { shouldExpand } from '@/renderer/extensions/vueNodes/widgets/registry/widgetRegistry'
 import type { NodeId } from '@/types/nodeId'
 import { cn } from '@comfyorg/tailwind-utils'
+import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 
 import InputSlot from './InputSlot.vue'
 
@@ -98,6 +104,19 @@ const isConvertedWidget = (widget: WidgetGridItem) =>
 
 const shouldRenderRow = (widget: WidgetGridItem) =>
   isConvertedWidget(widget) ? !!widget.slotMetadata : widget.visible
+
+const { state: dragState } = useSlotLinkDragUIState()
+
+const isDragHoverTarget = (widget: WidgetGridItem) => {
+  const candidate = dragState.candidate
+  return (
+    dragState.active &&
+    candidate?.compatible === true &&
+    candidate.layout.type === 'input' &&
+    String(candidate.layout.nodeId) === String(nodeId) &&
+    candidate.layout.index === widget.slotMetadata?.index
+  )
+}
 
 const {
   processedWidgets,


### PR DESCRIPTION
## Summary

Add ring highlight when dragging a compatible link over a widget input slot, and a left border when a widget has an active link connected.

## Changes

- **What**: Two visual indicators on node widgets: (1) `ring ring-component-node-widget-linked` during compatible drag hover, (2) `border-l-2 border-component-node-widget-linked` for connected slots. Drag hover takes priority to avoid visual conflict.
- **Design token**: `--component-node-widget-linked` added in light (azure-400) and dark (azure-600) themes
- **Files**: `style.css` (token), `NodeWidgets.vue` (logic + classes), `NodeWidgets.test.ts` (6 new tests)

## Review Focus

- `isDragHoverTarget()` logic in `processedWidgets` computed — checks `dragState.active`, `candidate.compatible`, matching `nodeId`/`index`/`type`
- Conditional class priority: drag hover ring suppresses connected border via template ordering

Fixes COM-15052

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8994-feat-add-visual-indicators-for-widget-slot-drag-hover-and-connected-state-30d6d73d3650810f88d0cfa08010c85e) by [Unito](https://www.unito.io)
