### PR TITLE
fix: widgets disappear when reordering in SubgraphEditor properties panel

### DIFF
--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -196,7 +196,7 @@ function setDraggableState() {
     '.draggable-item'
   )
   draggableList.value.applyNewItemsOrder = function () {
-    const reorderedItems = []
+    const reorderedItems: HTMLElement[] = []
 
     let oldPosition = -1
     this.getAllItems().forEach((item, index) => {
@@ -212,17 +212,27 @@ function setDraggableState() {
       reorderedItems[newIndex] = item
     })
 
+    if (oldPosition === -1) {
+      console.error('[SubgraphEditor] draggableItem not found in items')
+      return
+    }
+
     for (let index = 0; index < this.getAllItems().length; index++) {
       const item = reorderedItems[index]
       if (typeof item === 'undefined') {
-        reorderedItems[index] = this.draggableItem
+        reorderedItems[index] = this.draggableItem as HTMLElement
       }
     }
-    const newPosition = reorderedItems.indexOf(this.draggableItem)
-    const aw = activeWidgets.value
-    const [w] = aw.splice(oldPosition, 1)
-    aw.splice(newPosition, 0, w)
-    activeWidgets.value = aw
+
+    const newPosition = reorderedItems.indexOf(
+      this.draggableItem as HTMLElement
+    )
+
+    const pw = proxyWidgets.value
+    const [w] = pw.splice(oldPosition, 1)
+    pw.splice(newPosition, 0, w)
+    proxyWidgets.value = pw
+    triggerRef(proxyWidgets)
   }
 }
 watch(filteredActive, () => {

--- a/src/core/graph/subgraph/proxyWidget.test.ts
+++ b/src/core/graph/subgraph/proxyWidget.test.ts
@@ -125,6 +125,88 @@ describe('Subgraph proxyWidgets', () => {
     subgraphNode.widgets[0].computedHeight = 10
     expect(subgraphNode.widgets[0].value).toBe('value')
   })
+  describe('proxyWidgets reordering', () => {
+    test('reordering proxyWidgets directly preserves all entries', () => {
+      const [subgraphNode, innerNodes] = setupSubgraph(2)
+      innerNodes[0].addWidget('text', 'widgetA', 'valueA', () => {})
+      innerNodes[1].addWidget('text', 'widgetB', 'valueB', () => {})
+
+      subgraphNode.properties.proxyWidgets = [
+        ['1', 'widgetA'],
+        ['2', 'widgetB']
+      ]
+      expect(subgraphNode.widgets).toHaveLength(2)
+
+      const proxyWidgets = parseProxyWidgets(
+        subgraphNode.properties.proxyWidgets
+      )
+      const [first, second] = proxyWidgets
+      subgraphNode.properties.proxyWidgets = [second, first]
+
+      expect(subgraphNode.properties.proxyWidgets).toStrictEqual([
+        ['2', 'widgetB'],
+        ['1', 'widgetA']
+      ])
+      expect(subgraphNode.widgets).toHaveLength(2)
+    })
+
+    test('reordering maintains correct widget references after swap', () => {
+      const [subgraphNode, innerNodes] = setupSubgraph(2)
+      innerNodes[0].addWidget('text', 'widgetA', 'valueA', () => {})
+      innerNodes[1].addWidget('text', 'widgetB', 'valueB', () => {})
+
+      subgraphNode.properties.proxyWidgets = [
+        ['1', 'widgetA'],
+        ['2', 'widgetB']
+      ]
+      expect(subgraphNode.widgets[0].value).toBe('valueA')
+      expect(subgraphNode.widgets[1].value).toBe('valueB')
+
+      const proxyWidgets = parseProxyWidgets(
+        subgraphNode.properties.proxyWidgets
+      )
+      subgraphNode.properties.proxyWidgets = [proxyWidgets[1], proxyWidgets[0]]
+
+      expect(subgraphNode.widgets[0].value).toBe('valueB')
+      expect(subgraphNode.widgets[1].value).toBe('valueA')
+    })
+
+    test('activeWidgets round-trip drops unresolvable widgets', () => {
+      const [subgraphNode, innerNodes] = setupSubgraph(2)
+      innerNodes[0].addWidget('text', 'widgetA', 'valueA', () => {})
+      innerNodes[1].addWidget('text', 'widgetB', 'valueB', () => {})
+
+      subgraphNode.properties.proxyWidgets = [
+        ['1', 'widgetA'],
+        ['2', 'widgetB']
+      ]
+      expect(subgraphNode.widgets).toHaveLength(2)
+
+      // Simulate the lossy activeWidgets getter: resolving [nodeId, widgetName]
+      // tuples by looking up nodes/widgets. If a node is missing, it returns [].
+      const subgraph = subgraphNode.subgraph
+      function mapWidgets([id, name]: [string, string]) {
+        const wNode = subgraph._nodes_by_id[id]
+        if (!wNode?.widgets) return []
+        const widget = wNode.widgets.find((w) => w.name === name)
+        if (!widget) return []
+        return [[wNode, widget]]
+      }
+
+      // Remove a node to make it unresolvable
+      subgraph.remove(innerNodes[0])
+
+      const proxyWidgets = parseProxyWidgets(
+        subgraphNode.properties.proxyWidgets
+      )
+      const resolved = proxyWidgets.flatMap(mapWidgets)
+
+      // The lossy round-trip drops the entry for the removed node
+      expect(resolved).toHaveLength(1)
+      expect(proxyWidgets).toHaveLength(2)
+    })
+  })
+
   test('Prevents duplicate promotion', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)
     innerNodes[0].addWidget('text', 'stringWidget', 'value', () => {})


### PR DESCRIPTION
## Summary

Fix widgets disappearing when reordering in the SubgraphEditor properties panel (opened from the floating toolbox/toolbar).

## Changes

- **What**: Change `SubgraphEditor.vue`'s `applyNewItemsOrder` to reorder `proxyWidgets.value` directly (raw `[nodeId, widgetName]` tuples) instead of going through `activeWidgets` (a lossy computed that resolves widget items then converts back, dropping entries when nodes/widgets can't be resolved). This matches how `TabSubgraphInputs.vue` already handles reordering correctly.

## Review Focus

The root cause: `activeWidgets.get()` uses `flatMap(mapWidgets)` which returns `[]` for unresolvable nodes, silently dropping entries. The setter then writes this shorter array back. By reordering `proxyWidgets` directly, we skip the lossy resolve→convert round-trip entirely.

This was a day-one bug from PR #6952 (Dec 2025), not a recent regression.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8997-fix-widgets-disappear-when-reordering-in-SubgraphEditor-properties-panel-30d6d73d365081478fb8f02977681b77) by [Unito](https://www.unito.io)
