### PR TITLE
fix: space bar panning over Vue nodes in standard nav mode

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -27,6 +27,37 @@ test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
     }
   )
 
+  test.describe('spacebar panning', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.Canvas.NavigationMode',
+        'standard'
+      )
+      await comfyPage.workflow.loadWorkflow('vueNodes/simple-triple')
+    })
+
+    test('Space + left-drag on a Vue node pans canvas', async ({
+      comfyPage,
+      comfyMouse
+    }) => {
+      const node = comfyPage.vueNodes.getNodeByTitle('KSampler')
+      const offsetBefore = await comfyPage.canvasOps.getOffset()
+
+      await comfyPage.canvas.focus()
+      await comfyPage.page.keyboard.down('Space')
+      await expect.poll(() => comfyPage.canvasOps.isReadOnly()).toBe(true)
+      try {
+        await comfyMouse.dragElementBy(node, { x: 140, y: 90 })
+      } finally {
+        await comfyPage.page.keyboard.up('Space')
+      }
+
+      await expect
+        .poll(() => comfyPage.canvasOps.getOffset())
+        .not.toEqual(offsetBefore)
+    })
+  })
+
   test(
     '@mobile Can pan with touch',
     { tag: '@screenshot' },

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1270,3 +1270,38 @@ test(
     })
   }
 )
+
+test('Spacebar pan', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
+  const initialOffset = await comfyPage.canvasOps.getOffset()
+
+  await test.step('Setup link drag', async () => {
+    await comfyPage.searchBoxV2.addNode('Load Diffusion')
+    const loadNode = await comfyPage.vueNodes.getFixtureByTitle('Load Diff')
+    const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+
+    await loadNode.getSlot('MODEL').hover()
+    await comfyPage.page.mouse.down()
+    await ksampler.getSlot('model').hover()
+    expect(await comfyPage.canvasOps.getOffset()).toEqual(initialOffset)
+  })
+
+  await test.step('Holding space initiates a pan', async () => {
+    await comfyPage.page.keyboard.down(' ')
+    await comfyPage.page.mouse.move(100, 100)
+    await comfyPage.page.keyboard.up(' ')
+    await expect
+      .poll(() => comfyPage.canvasOps.getOffset())
+      .not.toEqual(initialOffset)
+  })
+
+  await test.step('Mouse remains over model after pan', async () => {
+    await comfyPage.page.mouse.up()
+    await expect
+      .poll(() =>
+        comfyPage.page.evaluate(
+          () => graph?.nodes?.at(-1)?.outputs?.[0]?.links?.length === 1
+        )
+      )
+      .toBe(true)
+  })
+})

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1271,37 +1271,48 @@ test(
   }
 )
 
-test('Spacebar pan', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
-  const initialOffset = await comfyPage.canvasOps.getOffset()
-
-  await test.step('Setup link drag', async () => {
-    await comfyPage.searchBoxV2.addNode('Load Diffusion')
-    const loadNode = await comfyPage.vueNodes.getFixtureByTitle('Load Diff')
-    const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
-
-    await loadNode.getSlot('MODEL').hover()
-    await comfyPage.page.mouse.down()
-    await ksampler.getSlot('model').hover()
-    expect(await comfyPage.canvasOps.getOffset()).toEqual(initialOffset)
+test.describe('Vue link drag panning', { tag: '@vue-nodes' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+    await comfyPage.workflow.loadWorkflow('vueNodes/simple-triple')
+    await fitToViewInstant(comfyPage)
   })
 
-  await test.step('Holding space initiates a pan', async () => {
-    await comfyPage.page.keyboard.down(' ')
-    await comfyPage.page.mouse.move(100, 100)
-    await comfyPage.page.keyboard.up(' ')
-    await expect
-      .poll(() => comfyPage.canvasOps.getOffset())
-      .not.toEqual(initialOffset)
-  })
+  test('spacebar pans during link drag', async ({ comfyPage }) => {
+    const initialOffset = await comfyPage.canvasOps.getOffset()
 
-  await test.step('Mouse remains over model after pan', async () => {
-    await comfyPage.page.mouse.up()
-    await expect
-      .poll(() =>
-        comfyPage.page.evaluate(
-          () => graph?.nodes?.at(-1)?.outputs?.[0]?.links?.length === 1
+    await test.step('Setup link drag', async () => {
+      await comfyPage.searchBoxV2.addNode('Load Diffusion')
+      const loadNode = await comfyPage.vueNodes.getFixtureByTitle('Load Diff')
+      const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+
+      await loadNode.getSlot('MODEL').hover()
+      await comfyPage.page.mouse.down()
+      await ksampler.getSlot('model').hover()
+      expect(
+        await comfyPage.canvasOps.getOffset(),
+        'starting the link drag should not pan the canvas'
+      ).toEqual(initialOffset)
+    })
+
+    await test.step('Holding space initiates a pan', async () => {
+      await comfyPage.page.keyboard.down(' ')
+      await comfyPage.page.mouse.move(100, 100)
+      await comfyPage.page.keyboard.up(' ')
+      await expect
+        .poll(() => comfyPage.canvasOps.getOffset())
+        .not.toEqual(initialOffset)
+    })
+
+    await test.step('Mouse remains over model after pan', async () => {
+      await comfyPage.page.mouse.up()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(
+            () => graph?.nodes?.at(-1)?.outputs?.[0]?.links?.length === 1
+          )
         )
-      )
-      .toBe(true)
+        .toBe(true)
+    })
   })
 })

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/scripts/app', () => {
     copyToClipboard: vi.fn(),
     pasteFromClipboard: vi.fn(),
     selectItems: vi.fn(),
+    read_only: false,
     ds: mockDs,
     setDirty: vi.fn()
   }
@@ -575,6 +576,22 @@ describe('useCoreCommands', () => {
       )
       expect(app.canvas.setDirty).toHaveBeenCalledWith(true, true)
     })
+
+    it.for([
+      { id: 'Comfy.Canvas.Lock', from: false, to: true },
+      { id: 'Comfy.Canvas.Unlock', from: true, to: false },
+      { id: 'Comfy.Canvas.ToggleLock', from: false, to: true },
+      { id: 'Comfy.Canvas.ToggleLock', from: true, to: false }
+    ] as const)(
+      '$id changes read-only state from $from to $to',
+      async ({ id, from, to }) => {
+        app.canvas.read_only = from
+
+        await findCmd(id).function()
+
+        expect(app.canvas.read_only).toBe(to)
+      }
+    )
   })
 
   describe('Workflow lifecycle commands', () => {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -414,7 +414,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Canvas Toggle Lock',
       category: 'view-controls' as const,
       function: () => {
-        app.canvas.state.readOnly = !app.canvas.state.readOnly
+        app.canvas.read_only = !app.canvas.read_only
       }
     },
     {
@@ -423,7 +423,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Lock Canvas',
       category: 'view-controls' as const,
       function: () => {
-        app.canvas.state.readOnly = true
+        app.canvas.read_only = true
       }
     },
     {
@@ -431,7 +431,7 @@ export function useCoreCommands(): ComfyCommand[] {
       icon: 'pi pi-lock-open',
       label: 'Unlock Canvas',
       function: () => {
-        app.canvas.state.readOnly = false
+        app.canvas.read_only = false
       }
     },
     {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -415,9 +415,13 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   }
 
   set read_only(value: boolean) {
+    const changed = this.state.readOnly !== value
     this.state.readOnly = value
     this._updateCursorStyle()
+    if (changed) this.onReadOnlyChanged?.(value)
   }
+
+  onReadOnlyChanged?: (readOnly: boolean) => void
 
   get isDragging(): boolean {
     return this.state.draggingItems

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -418,10 +418,10 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     const changed = this.state.readOnly !== value
     this.state.readOnly = value
     this._updateCursorStyle()
-    if (changed) this.onReadOnlyChanged?.(value)
+    if (changed) {
+      this.dispatchEvent('litegraph:read-only-changed', { readOnly: value })
+    }
   }
-
-  onReadOnlyChanged?: (readOnly: boolean) => void
 
   get isDragging(): boolean {
     return this.state.draggingItems

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3985,7 +3985,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         if (this._previously_dragging_canvas === null) {
           this._previously_dragging_canvas = this.dragging_canvas
         }
-        this.dragging_canvas = this.pointer.isDown
+        this.dragging_canvas =
+          this.pointer.isDown || !!this.linkConnector.renderLinks.length
         block_default = true
       } else if (e.key === 'Escape') {
         // esc

--- a/src/lib/litegraph/src/infrastructure/LGraphCanvasEventMap.ts
+++ b/src/lib/litegraph/src/infrastructure/LGraphCanvasEventMap.ts
@@ -60,4 +60,9 @@ export interface LGraphCanvasEventMap {
     active: boolean
     nodeId: SerializedNodeId
   }
+
+  /** The canvas read-only state has changed. */
+  'litegraph:read-only-changed': {
+    readOnly: boolean
+  }
 }

--- a/src/renderer/core/canvas/canvasStore.test.ts
+++ b/src/renderer/core/canvas/canvasStore.test.ts
@@ -44,23 +44,6 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
-vi.mock('@vueuse/core', async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...(actual as Record<string, unknown>),
-    useEventListener: vi.fn(
-      (
-        target: EventTarget,
-        event: string,
-        handler: EventListenerOrEventListenerObject
-      ) => {
-        target.addEventListener(event, handler)
-        return () => target.removeEventListener(event, handler)
-      }
-    )
-  }
-})
-
 function createMockCanvas(readOnly = false): LGraphCanvas {
   return {
     read_only: readOnly,

--- a/src/renderer/core/canvas/canvasStore.test.ts
+++ b/src/renderer/core/canvas/canvasStore.test.ts
@@ -4,9 +4,9 @@ import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
 import type { LGraphCanvas, Positionable } from '@/lib/litegraph/src/litegraph'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 const { appModeState } = vi.hoisted(() => ({
@@ -43,6 +43,26 @@ vi.mock('@/scripts/app', () => ({
     }
   }
 }))
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as Record<string, unknown>),
+    useEventListener: vi.fn()
+  }
+})
+
+function createMockCanvas(
+  readOnly = false
+): LGraphCanvas & { onReadOnlyChanged?: (v: boolean) => void } {
+  return {
+    read_only: readOnly,
+    canvas: document.createElement('canvas'),
+    onReadOnlyChanged: undefined
+  } as unknown as LGraphCanvas & {
+    onReadOnlyChanged?: (v: boolean) => void
+  }
+}
 
 describe('useCanvasStore', () => {
   let store: ReturnType<typeof useCanvasStore>
@@ -134,5 +154,45 @@ describe('useCanvasStore', () => {
     store.selectedItems = [new LGraphGroup()]
 
     expect(store.selectedNodeIds).toHaveLength(0)
+  })
+
+  describe('isReadOnly', () => {
+    it('syncs initial read_only value when canvas is set', async () => {
+      const mockCanvas = createMockCanvas(true)
+
+      store.canvas = mockCanvas as unknown as LGraphCanvas
+      await nextTick()
+
+      expect(store.isReadOnly).toBe(true)
+    })
+
+    it('updates isReadOnly when onReadOnlyChanged callback fires', async () => {
+      const mockCanvas = createMockCanvas(false)
+
+      store.canvas = mockCanvas as unknown as LGraphCanvas
+      await nextTick()
+
+      expect(store.isReadOnly).toBe(false)
+
+      // Simulate space key press → LGraphCanvas sets read_only = true
+      mockCanvas.onReadOnlyChanged?.(true)
+
+      expect(store.isReadOnly).toBe(true)
+
+      // Simulate space key release
+      mockCanvas.onReadOnlyChanged?.(false)
+
+      expect(store.isReadOnly).toBe(false)
+    })
+
+    it('registers onReadOnlyChanged callback on the canvas', async () => {
+      const mockCanvas = createMockCanvas(false)
+
+      store.canvas = mockCanvas as unknown as LGraphCanvas
+      await nextTick()
+
+      expect(mockCanvas.onReadOnlyChanged).toBeDefined()
+      expect(typeof mockCanvas.onReadOnlyChanged).toBe('function')
+    })
   })
 })

--- a/src/renderer/core/canvas/canvasStore.test.ts
+++ b/src/renderer/core/canvas/canvasStore.test.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
@@ -45,10 +46,10 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 function createMockCanvas(readOnly = false): LGraphCanvas {
-  return {
+  return fromPartial<LGraphCanvas>({
     read_only: readOnly,
     canvas: document.createElement('canvas')
-  } as unknown as LGraphCanvas
+  })
 }
 
 describe('useCanvasStore', () => {
@@ -147,7 +148,7 @@ describe('useCanvasStore', () => {
     it('syncs initial read_only value when canvas is set', async () => {
       const mockCanvas = createMockCanvas(true)
 
-      store.canvas = mockCanvas as unknown as LGraphCanvas
+      store.canvas = mockCanvas
       await nextTick()
 
       expect(store.isReadOnly).toBe(true)
@@ -156,12 +157,11 @@ describe('useCanvasStore', () => {
     it('updates isReadOnly when litegraph:read-only-changed event fires', async () => {
       const mockCanvas = createMockCanvas(false)
 
-      store.canvas = mockCanvas as unknown as LGraphCanvas
+      store.canvas = mockCanvas
       await nextTick()
 
       expect(store.isReadOnly).toBe(false)
 
-      // Simulate space key press → LGraphCanvas sets read_only = true
       mockCanvas.canvas.dispatchEvent(
         new CustomEvent('litegraph:read-only-changed', {
           detail: { readOnly: true }
@@ -170,7 +170,6 @@ describe('useCanvasStore', () => {
 
       expect(store.isReadOnly).toBe(true)
 
-      // Simulate space key release
       mockCanvas.canvas.dispatchEvent(
         new CustomEvent('litegraph:read-only-changed', {
           detail: { readOnly: false }

--- a/src/renderer/core/canvas/canvasStore.test.ts
+++ b/src/renderer/core/canvas/canvasStore.test.ts
@@ -48,20 +48,24 @@ vi.mock('@vueuse/core', async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...(actual as Record<string, unknown>),
-    useEventListener: vi.fn()
+    useEventListener: vi.fn(
+      (
+        target: EventTarget,
+        event: string,
+        handler: EventListenerOrEventListenerObject
+      ) => {
+        target.addEventListener(event, handler)
+        return () => target.removeEventListener(event, handler)
+      }
+    )
   }
 })
 
-function createMockCanvas(
-  readOnly = false
-): LGraphCanvas & { onReadOnlyChanged?: (v: boolean) => void } {
+function createMockCanvas(readOnly = false): LGraphCanvas {
   return {
     read_only: readOnly,
-    canvas: document.createElement('canvas'),
-    onReadOnlyChanged: undefined
-  } as unknown as LGraphCanvas & {
-    onReadOnlyChanged?: (v: boolean) => void
-  }
+    canvas: document.createElement('canvas')
+  } as unknown as LGraphCanvas
 }
 
 describe('useCanvasStore', () => {
@@ -166,7 +170,7 @@ describe('useCanvasStore', () => {
       expect(store.isReadOnly).toBe(true)
     })
 
-    it('updates isReadOnly when onReadOnlyChanged callback fires', async () => {
+    it('updates isReadOnly when litegraph:read-only-changed event fires', async () => {
       const mockCanvas = createMockCanvas(false)
 
       store.canvas = mockCanvas as unknown as LGraphCanvas
@@ -175,24 +179,22 @@ describe('useCanvasStore', () => {
       expect(store.isReadOnly).toBe(false)
 
       // Simulate space key press → LGraphCanvas sets read_only = true
-      mockCanvas.onReadOnlyChanged?.(true)
+      mockCanvas.canvas.dispatchEvent(
+        new CustomEvent('litegraph:read-only-changed', {
+          detail: { readOnly: true }
+        })
+      )
 
       expect(store.isReadOnly).toBe(true)
 
       // Simulate space key release
-      mockCanvas.onReadOnlyChanged?.(false)
+      mockCanvas.canvas.dispatchEvent(
+        new CustomEvent('litegraph:read-only-changed', {
+          detail: { readOnly: false }
+        })
+      )
 
       expect(store.isReadOnly).toBe(false)
-    })
-
-    it('registers onReadOnlyChanged callback on the canvas', async () => {
-      const mockCanvas = createMockCanvas(false)
-
-      store.canvas = mockCanvas as unknown as LGraphCanvas
-      await nextTick()
-
-      expect(mockCanvas.onReadOnlyChanged).toBeDefined()
-      expect(typeof mockCanvas.onReadOnlyChanged).toBe('function')
     })
   })
 })

--- a/src/renderer/core/canvas/canvasStore.ts
+++ b/src/renderer/core/canvas/canvasStore.ts
@@ -56,6 +56,7 @@ export const useCanvasStore = defineStore('canvas', () => {
       setMode(val ? 'app' : 'graph')
     }
   })
+  const isReadOnly = ref(false)
 
   // Set up scale synchronization when canvas is available
   let originalOnChanged: ((scale: number, offset: Point) => void) | undefined =
@@ -139,6 +140,11 @@ export const useCanvasStore = defineStore('canvas', () => {
         }
       )
 
+      isReadOnly.value = newCanvas.read_only
+      newCanvas.onReadOnlyChanged = (value: boolean) => {
+        isReadOnly.value = value
+      }
+
       useEventListener(
         newCanvas.canvas,
         'litegraph:set-graph',
@@ -184,6 +190,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     rerouteSelected,
     appScalePercentage,
     linearMode,
+    isReadOnly,
     updateSelectedItems,
     getCanvas,
     setAppZoomFromPercentage,

--- a/src/renderer/core/canvas/canvasStore.ts
+++ b/src/renderer/core/canvas/canvasStore.ts
@@ -141,9 +141,14 @@ export const useCanvasStore = defineStore('canvas', () => {
       )
 
       isReadOnly.value = newCanvas.read_only
-      newCanvas.onReadOnlyChanged = (value: boolean) => {
-        isReadOnly.value = value
-      }
+
+      useEventListener(
+        newCanvas.canvas,
+        'litegraph:read-only-changed',
+        (event: CustomEvent<{ readOnly: boolean }>) => {
+          isReadOnly.value = event.detail.readOnly
+        }
+      )
 
       useEventListener(
         newCanvas.canvas,

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -13,7 +13,8 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => {
   return {
     useCanvasStore: vi.fn(() => ({
       getCanvas,
-      setCursorStyle
+      setCursorStyle,
+      isReadOnly: false
     }))
   }
 })

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -27,9 +27,7 @@ export function useCanvasInteractions() {
    * Whether Vue node components should handle pointer events.
    * Returns false when canvas is in read-only/panning mode (e.g., space key held for panning).
    */
-  const shouldHandleNodePointerEvents = computed(
-    () => !(canvasStore.canvas?.read_only ?? false)
-  )
+  const shouldHandleNodePointerEvents = computed(() => !canvasStore.isReadOnly)
 
   /**
    * Returns true if the wheel event target is inside an element that should

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -54,6 +54,10 @@ vi.mock('@/renderer/core/canvas/useAutoPan', () => ({
   }
 }))
 
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ isReadOnly: false })
+}))
+
 vi.mock('@/scripts/app', () => ({
   app: {
     canvas: {

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -23,6 +23,7 @@ import {
   resolveNodeSurfaceSlotCandidate,
   resolveSlotTargetCandidate
 } from '@/renderer/core/canvas/links/linkDropOrchestrator'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import type { SlotDropCandidate } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
@@ -124,6 +125,7 @@ export function useSlotLinkInteraction({
     setCompatibleForKey,
     clearCompatible
   } = useSlotLinkDragUIState()
+  const canvasStore = useCanvasStore()
   const conversion = useSharedCanvasPositionConversion()
   const pointerSession = createPointerSession()
   let activeAdapter: LinkConnectorAdapter | null = null
@@ -419,9 +421,11 @@ export function useSlotLinkInteraction({
   const canvas = app.canvas
   const node = nodeId && canvas ? canvas.graph?.getNodeById(nodeId) : null
   const handlePointerMove = (event: PointerEvent) => {
-    if (!pointerSession.matches(event)) return
+    if (!pointerSession.matches(event) || canvasStore.isReadOnly) return
+
     event.stopPropagation()
 
+    app.canvas.last_mouse = [event.clientX, event.clientY]
     autoPan?.updatePointer(event.clientX, event.clientY)
 
     if (canvas?.subgraph && node) {

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -230,14 +230,13 @@ export const useAppModeStore = defineStore('appMode', () => {
 
   let unwatchReadOnly: (() => void) | undefined
   function enforceReadOnly(inSelect: boolean) {
-    const { state } = getCanvas()
-    if (!state) return
-    state.readOnly = inSelect
+    const canvas = getCanvas()
+    canvas.read_only = inSelect
     unwatchReadOnly?.()
     if (inSelect)
       unwatchReadOnly = watch(
-        () => state.readOnly,
-        () => (state.readOnly = true)
+        () => canvas.read_only,
+        () => (canvas.read_only = true)
       )
   }
 


### PR DESCRIPTION
## Summary

Fix spacebar panning over Vue nodes in standard navigation mode, including while dragging a Vue-node link.

## Changes

- **What**: Dispatch a typed `litegraph:read-only-changed` event when `LGraphCanvas.read_only` changes, mirror it in `canvasStore.isReadOnly`, and use that reactive state to disable Vue node pointer handling while the canvas owns the pan gesture.
- Route canvas lock commands and app-mode writes through the `read_only` setter so they cannot bypass reactive synchronization.
- Preserve an active Vue link drag while spacebar panning by letting `LGraphCanvas` enter dragging mode and pausing Vue link pointer processing until panning ends.
- Add focused unit coverage plus browser regressions for space-dragging directly on a Vue node and space-panning during a link drag.

## Review Focus

- The event fires only when read-only state changes; cursor refresh behavior remains unchanged.
- `canvasStore.isReadOnly` is the reactive bridge because the `LGraphCanvas` instance itself is held in a `shallowRef`.
- Link dragging resumes after the pan and still connects to the intended slot.

Fixes #7806

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-8998-fix-space-bar-panning-over-Vue-nodes-in-standard-nav-mode-30d6d73d36508185a25be9ce89f5b86e) by [Unito](https://www.unito.io)
