### PR TITLE
Add prompt_id support to progress_text WS messages

### DIFF
--- a/src/config/clientFeatureFlags.json
+++ b/src/config/clientFeatureFlags.json
@@ -1,4 +1,5 @@
 {
   "supports_preview_metadata": true,
-  "supports_manager_v4_ui": true
+  "supports_manager_v4_ui": true,
+  "supports_progress_text_metadata": true
 }

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -113,7 +113,7 @@ const zExecutionErrorWsMessage = zExecutionWsMessageBase.extend({
 const zProgressTextWsMessage = z.object({
   nodeId: zNodeId,
   text: z.string(),
-  prompt_id: zPromptId.optional()
+  prompt_id: z.string().optional()
 })
 
 const zNotificationWsMessage = z.object({

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -112,7 +112,8 @@ const zExecutionErrorWsMessage = zExecutionWsMessageBase.extend({
 
 const zProgressTextWsMessage = z.object({
   nodeId: zNodeId,
-  text: z.string()
+  text: z.string(),
+  prompt_id: zPromptId.optional()
 })
 
 const zNotificationWsMessage = z.object({

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -631,16 +631,22 @@ export class ComfyApi extends EventTarget {
               let offset = 0
               let promptId: string | undefined
 
-              if (this.getClientFeatureFlags()?.supports_progress_text_metadata) {
+              if (
+                this.getClientFeatureFlags()?.supports_progress_text_metadata
+              ) {
                 const promptIdLength = rawView.getUint32(offset)
                 offset += 4
-                promptId = decoder3.decode(rawData.slice(offset, offset + promptIdLength))
+                promptId = decoder3.decode(
+                  rawData.slice(offset, offset + promptIdLength)
+                )
                 offset += promptIdLength
               }
 
               const nodeIdLength = rawView.getUint32(offset)
               offset += 4
-              const nodeId = decoder3.decode(rawData.slice(offset, offset + nodeIdLength))
+              const nodeId = decoder3.decode(
+                rawData.slice(offset, offset + nodeIdLength)
+              )
               offset += nodeIdLength
               const text = decoder3.decode(rawData.slice(offset))
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -624,37 +624,41 @@ export class ComfyApi extends EventTarget {
           let imageMime
           switch (eventType) {
             case 3: {
-              const decoder3 = new TextDecoder()
-              const rawData = event.data.slice(4)
-              const rawView = new DataView(rawData)
+              try {
+                const decoder3 = new TextDecoder()
+                const rawData = event.data.slice(4)
+                const rawView = new DataView(rawData)
 
-              let offset = 0
-              let promptId: string | undefined
+                let offset = 0
+                let promptId: string | undefined
 
-              if (
-                this.getClientFeatureFlags()?.supports_progress_text_metadata
-              ) {
-                const promptIdLength = rawView.getUint32(offset)
+                if (
+                  this.getClientFeatureFlags()?.supports_progress_text_metadata
+                ) {
+                  const promptIdLength = rawView.getUint32(offset)
+                  offset += 4
+                  promptId = decoder3.decode(
+                    rawData.slice(offset, offset + promptIdLength)
+                  )
+                  offset += promptIdLength
+                }
+
+                const nodeIdLength = rawView.getUint32(offset)
                 offset += 4
-                promptId = decoder3.decode(
-                  rawData.slice(offset, offset + promptIdLength)
+                const nodeId = decoder3.decode(
+                  rawData.slice(offset, offset + nodeIdLength)
                 )
-                offset += promptIdLength
+                offset += nodeIdLength
+                const text = decoder3.decode(rawData.slice(offset))
+
+                this.dispatchCustomEvent('progress_text', {
+                  nodeId,
+                  text,
+                  ...(promptId !== undefined && { prompt_id: promptId })
+                })
+              } catch (e) {
+                console.warn('Failed to parse progress_text binary message', e)
               }
-
-              const nodeIdLength = rawView.getUint32(offset)
-              offset += 4
-              const nodeId = decoder3.decode(
-                rawData.slice(offset, offset + nodeIdLength)
-              )
-              offset += nodeIdLength
-              const text = decoder3.decode(rawData.slice(offset))
-
-              this.dispatchCustomEvent('progress_text', {
-                nodeId,
-                text,
-                ...(promptId !== undefined && { prompt_id: promptId })
-              })
               break
             }
             case 1:

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -623,15 +623,34 @@ export class ComfyApi extends EventTarget {
 
           let imageMime
           switch (eventType) {
-            case 3:
-              const decoder = new TextDecoder()
-              const data = event.data.slice(4)
-              const nodeIdLength = view.getUint32(4)
+            case 3: {
+              const decoder3 = new TextDecoder()
+              const rawData = event.data.slice(4)
+              const rawView = new DataView(rawData)
+
+              let offset = 0
+              let promptId: string | undefined
+
+              if (this.getClientFeatureFlags()?.supports_progress_text_metadata) {
+                const promptIdLength = rawView.getUint32(offset)
+                offset += 4
+                promptId = decoder3.decode(rawData.slice(offset, offset + promptIdLength))
+                offset += promptIdLength
+              }
+
+              const nodeIdLength = rawView.getUint32(offset)
+              offset += 4
+              const nodeId = decoder3.decode(rawData.slice(offset, offset + nodeIdLength))
+              offset += nodeIdLength
+              const text = decoder3.decode(rawData.slice(offset))
+
               this.dispatchCustomEvent('progress_text', {
-                nodeId: decoder.decode(data.slice(4, 4 + nodeIdLength)),
-                text: decoder.decode(data.slice(4 + nodeIdLength))
+                nodeId,
+                text,
+                ...(promptId !== undefined && { prompt_id: promptId })
               })
               break
+            }
             case 1:
               const imageType = view.getUint32(4)
               const imageData = event.data.slice(8)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -517,8 +517,12 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleProgressText(e: CustomEvent<ProgressTextWsMessage>) {
-    const { nodeId, text } = e.detail
+    const { nodeId, text, prompt_id } = e.detail
     if (!text || !nodeId) return
+
+    // Filter: only accept progress for the active prompt
+    if (prompt_id && activePromptId.value && prompt_id !== activePromptId.value)
+      return
 
     // Handle execution node IDs for subgraphs
     const currentId = getNodeIdIfExecuting(nodeId)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -521,11 +521,12 @@ export const useExecutionStore = defineStore('execution', () => {
     if (!text || !nodeId) return
 
     // Filter: only accept progress for the active prompt
-    if (prompt_id && activePromptId.value && prompt_id !== activePromptId.value)
+    if (prompt_id && activeJobId.value && prompt_id !== activeJobId.value)
       return
 
     // Handle execution node IDs for subgraphs
     const currentId = getNodeIdIfExecuting(nodeId)
+    if (!currentId) return
     const node = canvasStore.getCanvas().graph?.getNodeById(currentId)
     if (!node) return
 


### PR DESCRIPTION
## Summary

Add frontend support for `prompt_id` in `progress_text` binary WS messages, enabling parallel workflow execution to route progress text to the correct active prompt.

Backend PR: https://github.com/Comfy-Org/ComfyUI/pull/12540

## Changes

- Advertise `supports_progress_text_metadata` in client feature flags
- Decode `prompt_id` from new binary format when flag is active
- Add optional `prompt_id` to `zProgressTextWsMessage` schema
- Filter `progress_text` events by `activePromptId` — skip messages for non-active prompts

## Deployment

Can be deployed independently in any order — feature flag negotiation ensures graceful degradation.

Part of COM-12671

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9002-Add-prompt_id-support-to-progress_text-WS-messages-30d6d73d365081acabbcdac939e0c751) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress text updates can include optional metadata so richer context is available.
* **Bug Fixes / Improvements**
  * Progress updates are now filtered to show only the currently active prompt, reducing cross-talk from concurrent operations and improving update accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->