### PR TITLE
feat: default Vue Nodes (Nodes 2.0) to enabled for new cloud installs

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1148,6 +1148,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'Modern: DOM-based rendering with enhanced interactivity, native browser features, and updated visual design. Classic: Traditional canvas rendering.',
     defaultValue: false,
+    defaultsByInstallVersion: { '1.41.0': isCloud },
     sortOrder: 100,
     experimental: true,
     versionAdded: '1.27.1'


### PR DESCRIPTION
## Summary

Default Nodes 2.0 (`Comfy.VueNodes.Enabled`) to `true` for new cloud installs (≥1.41.0).

## Changes

- **What**: Add `defaultsByInstallVersion: { '1.41.0': isCloud }` to the `Comfy.VueNodes.Enabled` setting. Since `isCloud` is a compile-time constant, cloud builds get `{ '1.41.0': true }` while local builds get `{ '1.41.0': false }` (tree-shaken away).

## Review Focus

- Version threshold `1.41.0` — should this match a specific upcoming release?
- Existing users (installed before 1.41.0) and non-cloud builds are unaffected — they keep the `defaultValue: false` fallback.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9009-feat-default-Vue-Nodes-Nodes-2-0-to-enabled-for-new-cloud-installs-30d6d73d365081268337f7ee72c24d98) by [Unito](https://www.unito.io)
