### PR TITLE
fix: promoted widget labels show widgetName instead of "nodeId: widgetName"

### DIFF
--- a/src/core/graph/subgraph/proxyWidget.test.ts
+++ b/src/core/graph/subgraph/proxyWidget.test.ts
@@ -135,7 +135,21 @@ describe('Subgraph proxyWidgets', () => {
     expect(proxyWidget.name).toBe('1: seed')
   })
 
-  test('Proxy widget label reflects user rename', () => {
+  test('Proxy widget label reflects linked widget label', () => {
+    const [subgraphNode, innerNodes] = setupSubgraph(1)
+    innerNodes[0].addWidget('text', 'seed', 'value', () => {})
+    subgraphNode.properties.proxyWidgets = [['1', 'seed']]
+
+    const proxyWidget = subgraphNode.widgets[0]
+    expect(proxyWidget.label).toBe('seed')
+
+    innerNodes[0].widgets![0].label = 'My Inner Label'
+    // Trigger re-resolve of linked widget
+    proxyWidget.computedHeight = 10
+    expect(proxyWidget.label).toBe('My Inner Label')
+  })
+
+  test('Proxy widget user rename takes priority over linked widget label', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)
     innerNodes[0].addWidget('text', 'seed', 'value', () => {})
     subgraphNode.properties.proxyWidgets = [['1', 'seed']]
@@ -143,6 +157,25 @@ describe('Subgraph proxyWidgets', () => {
     const proxyWidget = subgraphNode.widgets[0]
     proxyWidget.label = 'My Custom Seed'
     expect(proxyWidget.label).toBe('My Custom Seed')
+
+    innerNodes[0].widgets![0].label = 'Inner Override'
+    proxyWidget.computedHeight = 10
+    expect(proxyWidget.label).toBe('My Custom Seed')
+  })
+
+  test('Proxy widget label resets to linked widget on undefined', () => {
+    const [subgraphNode, innerNodes] = setupSubgraph(1)
+    innerNodes[0].addWidget('text', 'seed', 'value', () => {})
+    subgraphNode.properties.proxyWidgets = [['1', 'seed']]
+
+    const proxyWidget = subgraphNode.widgets[0]
+    proxyWidget.label = 'Custom'
+    expect(proxyWidget.label).toBe('Custom')
+
+    proxyWidget.label = undefined
+    innerNodes[0].widgets![0].label = 'Inner Label'
+    proxyWidget.computedHeight = 10
+    expect(proxyWidget.label).toBe('Inner Label')
   })
 
   test('Proxy widget labels are correct when loaded from serialized data', () => {

--- a/src/core/graph/subgraph/proxyWidget.test.ts
+++ b/src/core/graph/subgraph/proxyWidget.test.ts
@@ -179,6 +179,8 @@ describe('Subgraph proxyWidgets', () => {
   })
 
   test('Proxy widget labels are correct when loaded from serialized data', () => {
+    // Intentionally constructs SubgraphNode via constructor (not setupSubgraph)
+    // to exercise the deserialization/onConfigure path from blueprint JSON.
     const subgraph = createTestSubgraph()
     const innerNode = new LGraphNode('InnerNode')
     subgraph.add(innerNode)

--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -154,7 +154,6 @@ function newProxyWidget(
     computedHeight: undefined,
     isProxyWidget: true,
     last_y: undefined,
-    label: widgetName,
     name,
     node: subgraphNode,
     onRemove: undefined,
@@ -202,12 +201,15 @@ function newProxyFromOverlay(subgraphNode: SubgraphNode, overlay: Overlay) {
    *   and the value used as 'this' if property is a get/set method
    * @param {unknown} value - only used on set calls. The thing being assigned
    */
+  let userLabel: string | undefined
   const handler = {
     get(_t: IBaseWidget, property: string, receiver: object) {
       let redirectedTarget: object = backingWidget
       let redirectedReceiver = receiver
       if (property == '_overlay') return overlay
       else if (property == 'value') redirectedReceiver = backingWidget
+      else if (property == 'label')
+        return userLabel ?? linkedWidget?.label ?? overlay.widgetName
       if (Object.prototype.hasOwnProperty.call(overlay, property)) {
         redirectedTarget = overlay
         redirectedReceiver = overlay
@@ -215,6 +217,10 @@ function newProxyFromOverlay(subgraphNode: SubgraphNode, overlay: Overlay) {
       return Reflect.get(redirectedTarget, property, redirectedReceiver)
     },
     set(_t: IBaseWidget, property: string, value: unknown) {
+      if (property == 'label') {
+        userLabel = value as string | undefined
+        return true
+      }
       let redirectedTarget: object = backingWidget
       if (property == 'computedHeight') {
         if (overlay.widgetName.startsWith('$$') && linkedNode) {

--- a/src/core/graph/subgraph/proxyWidget.ts
+++ b/src/core/graph/subgraph/proxyWidget.ts
@@ -154,7 +154,7 @@ function newProxyWidget(
     computedHeight: undefined,
     isProxyWidget: true,
     last_y: undefined,
-    label: name,
+    label: widgetName,
     name,
     node: subgraphNode,
     onRemove: undefined,


### PR DESCRIPTION
## Summary

Promoted/proxied widgets on subgraph nodes showed generic "nodeId: widgetName" labels (e.g., "3: seed") in the LiteGraph renderer. Now they correctly show just the widget name (e.g., "seed").

## Changes

- **What**: Set proxy widget overlay `label` to `widgetName` instead of `name` (which contains the unique `"nodeId: widgetName"` format). The overlay `name` still retains the unique format for internal identification.
- Added 2 tests verifying proxy widget label defaults and user rename behavior.

## Review Focus

- The one-line fix in `proxyWidget.ts` line 157: `label: widgetName` instead of `label: name`
- The overlay `name` property is unchanged — only `label` (used for display) is affected
- No code parses the label string for identification; all lookups use `_overlay.nodeId` and `_overlay.widgetName` directly

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9013-fix-promoted-widget-labels-show-widgetName-instead-of-nodeId-widgetName-30d6d73d365081ca8d2feb68585fc187) by [Unito](https://www.unito.io)
