### PR TITLE
[bugfix] Show active job count in assets sidebar badge

### DIFF
--- a/src/composables/sidebarTabs/useAssetsSidebarTab.test.ts
+++ b/src/composables/sidebarTabs/useAssetsSidebarTab.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useAssetsSidebarTab } from '@/composables/sidebarTabs/useAssetsSidebarTab'
 
-const { mockGetSetting, mockPendingTasks } = vi.hoisted(() => ({
+const { mockGetSetting, mockActiveJobsCount } = vi.hoisted(() => ({
   mockGetSetting: vi.fn(),
-  mockPendingTasks: [] as unknown[]
+  mockActiveJobsCount: { value: 0 }
 }))
 
 vi.mock('@/platform/settings/settingStore', () => ({
@@ -19,14 +19,14 @@ vi.mock('@/components/sidebar/tabs/AssetsSidebarTab.vue', () => ({
 
 vi.mock('@/stores/queueStore', () => ({
   useQueueStore: () => ({
-    pendingTasks: mockPendingTasks
+    activeJobsCount: mockActiveJobsCount.value
   })
 }))
 
 describe('useAssetsSidebarTab', () => {
   it('hides icon badge when QPO V2 is disabled', () => {
     mockGetSetting.mockReturnValue(false)
-    mockPendingTasks.splice(0, mockPendingTasks.length, {}, {})
+    mockActiveJobsCount.value = 3
 
     const sidebarTab = useAssetsSidebarTab()
 
@@ -34,13 +34,22 @@ describe('useAssetsSidebarTab', () => {
     expect((sidebarTab.iconBadge as () => string | null)()).toBeNull()
   })
 
-  it('shows pending task count when QPO V2 is enabled', () => {
+  it('shows active job count when QPO V2 is enabled', () => {
     mockGetSetting.mockReturnValue(true)
-    mockPendingTasks.splice(0, mockPendingTasks.length, {}, {}, {})
+    mockActiveJobsCount.value = 3
 
     const sidebarTab = useAssetsSidebarTab()
 
     expect(typeof sidebarTab.iconBadge).toBe('function')
     expect((sidebarTab.iconBadge as () => string | null)()).toBe('3')
+  })
+
+  it('hides badge when no active jobs', () => {
+    mockGetSetting.mockReturnValue(true)
+    mockActiveJobsCount.value = 0
+
+    const sidebarTab = useAssetsSidebarTab()
+
+    expect((sidebarTab.iconBadge as () => string | null)()).toBeNull()
   })
 })

--- a/src/composables/sidebarTabs/useAssetsSidebarTab.ts
+++ b/src/composables/sidebarTabs/useAssetsSidebarTab.ts
@@ -22,9 +22,8 @@ export const useAssetsSidebarTab = (): SidebarTabExtension => {
       }
 
       const queueStore = useQueueStore()
-      return queueStore.pendingTasks.length > 0
-        ? queueStore.pendingTasks.length.toString()
-        : null
+      const count = queueStore.activeJobsCount
+      return count > 0 ? count.toString() : null
     }
   }
 }


### PR DESCRIPTION
## Summary
Assets sidebar badge now shows total active jobs (pending + running) instead of only pending jobs, making it consistent with the "X active jobs" label inside the panel.

## Changes
- **What**: Changed `iconBadge` in `useAssetsSidebarTab` from `pendingTasks.length` to `activeJobsCount` (pending + running)
- Badge still hidden when QPO V2 is disabled (legacy queue)

## Review Focus
- Whether `activeJobsCount` (pending + running) is the correct metric for the badge

<img width="1718" height="1327" alt="스크린샷 2026-02-20 오후 7 46 40(2)" src="https://github.com/user-attachments/assets/4d0d2bed-8be9-44d7-bd62-4dd8c075d265" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9015-bugfix-Show-active-job-count-in-assets-sidebar-badge-30d6d73d365081c287a6ce9bc0a60244) by [Unito](https://www.unito.io)
