### PR TITLE
App mode - store - 1

### DIFF
--- a/src/renderer/core/canvas/canvasStore.ts
+++ b/src/renderer/core/canvas/canvasStore.ts
@@ -43,9 +43,9 @@ export const useCanvasStore = defineStore('canvas', () => {
   const appScalePercentage = ref(100)
 
   const linearMode = computed({
-    get: () => useAppModeStore().isApp,
+    get: () => useAppModeStore().isAppMode,
     set: (val: boolean) => {
-      useAppModeStore().view = val ? 'app' : 'graph'
+      useAppModeStore().setMode(val ? 'app' : 'graph')
     }
   })
 

--- a/src/renderer/core/canvas/canvasStore.ts
+++ b/src/renderer/core/canvas/canvasStore.ts
@@ -3,6 +3,8 @@ import { defineStore } from 'pinia'
 import { computed, markRaw, ref, shallowRef } from 'vue'
 import type { Raw } from 'vue'
 
+import { useAppModeStore } from '@/stores/appModeStore'
+
 import type { Point, Positionable } from '@/lib/litegraph/src/interfaces'
 import type {
   LGraph,
@@ -40,7 +42,12 @@ export const useCanvasStore = defineStore('canvas', () => {
   // Reactive scale percentage that syncs with app.canvas.ds.scale
   const appScalePercentage = ref(100)
 
-  const linearMode = ref(false)
+  const linearMode = computed({
+    get: () => useAppModeStore().isApp,
+    set: (val: boolean) => {
+      useAppModeStore().view = val ? 'app' : 'graph'
+    }
+  })
 
   // Set up scale synchronization when canvas is available
   let originalOnChanged: ((scale: number, offset: Point) => void) | undefined =

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -6,12 +6,17 @@ export type AppMode = 'graph' | 'app' | 'builder:select' | 'builder:arrange'
 export const useAppModeStore = defineStore('appMode', () => {
   const mode = ref<AppMode>('graph')
   const builderSaving = ref(false)
+  const hasOutputs = ref(true)
 
   const isBuilderMode = computed(
     () => mode.value === 'builder:select' || mode.value === 'builder:arrange'
   )
-  const isAppMode = computed(() => mode.value === 'app')
-  const isGraphMode = computed(() => mode.value === 'graph')
+  const isAppMode = computed(
+    () => mode.value === 'app' || mode.value === 'builder:arrange'
+  )
+  const isGraphMode = computed(
+    () => mode.value === 'graph' || mode.value === 'builder:select'
+  )
   const isBuilderSaving = computed(
     () => builderSaving.value && isBuilderMode.value
   )
@@ -22,6 +27,11 @@ export const useAppModeStore = defineStore('appMode', () => {
     isAppMode,
     isGraphMode,
     isBuilderSaving,
+    hasOutputs,
+    setBuilderSaving: (newBuilderSaving: boolean) => {
+      if (!isBuilderMode.value) return
+      builderSaving.value = newBuilderSaving
+    },
     setMode: (newMode: AppMode) => {
       if (newMode === mode.value) return
       mode.value = newMode

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -1,26 +1,30 @@
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { readonly, computed, ref } from 'vue'
 
-export type AppView = 'graph' | 'app'
-export type BuilderStep = 'select' | 'arrange'
+export type AppMode = 'graph' | 'app' | 'builder:select' | 'builder:arrange'
 
 export const useAppModeStore = defineStore('appMode', () => {
-  const view = ref<AppView>('graph')
-  const builderStep = ref<BuilderStep>('select')
-  const builderMode = ref(false)
+  const mode = ref<AppMode>('graph')
   const builderSaving = ref(false)
-  const hasOutputs = ref(false)
 
-  const isApp = computed(() => view.value === 'app')
-  const isGraph = computed(() => view.value === 'graph')
+  const isBuilderMode = computed(
+    () => mode.value === 'builder:select' || mode.value === 'builder:arrange'
+  )
+  const isAppMode = computed(() => mode.value === 'app')
+  const isGraphMode = computed(() => mode.value === 'graph')
+  const isBuilderSaving = computed(
+    () => builderSaving.value && isBuilderMode.value
+  )
 
   return {
-    view,
-    builderStep,
-    builderMode,
-    builderSaving,
-    hasOutputs,
-    isApp,
-    isGraph
+    mode: readonly(mode),
+    isBuilderMode,
+    isAppMode,
+    isGraphMode,
+    isBuilderSaving,
+    setMode: (newMode: AppMode) => {
+      if (newMode === mode.value) return
+      mode.value = newMode
+    }
   }
 })

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export type AppView = 'graph' | 'app'
+export type BuilderStep = 'select' | 'arrange' | 'save'
+
+export const useAppModeStore = defineStore('appMode', () => {
+  const view = ref<AppView>('graph')
+  const builderStep = ref<BuilderStep>('select')
+
+  const isApp = computed(() => view.value === 'app')
+  const isGraph = computed(() => view.value === 'graph')
+
+  return { view, builderStep, isApp, isGraph }
+})

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -2,14 +2,25 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
 export type AppView = 'graph' | 'app'
-export type BuilderStep = 'select' | 'arrange' | 'save'
+export type BuilderStep = 'select' | 'arrange'
 
 export const useAppModeStore = defineStore('appMode', () => {
   const view = ref<AppView>('graph')
   const builderStep = ref<BuilderStep>('select')
+  const builderMode = ref(false)
+  const builderSaving = ref(false)
+  const hasOutputs = ref(false)
 
   const isApp = computed(() => view.value === 'app')
   const isGraph = computed(() => view.value === 'graph')
 
-  return { view, builderStep, isApp, isGraph }
+  return {
+    view,
+    builderStep,
+    builderMode,
+    builderSaving,
+    hasOutputs,
+    isApp,
+    isGraph
+  }
 })

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { readonly, computed, ref } from 'vue'
 
-export type AppMode = 'graph' | 'app' | 'builder:select' | 'builder:arrange'
+type AppMode = 'graph' | 'app' | 'builder:select' | 'builder:arrange'
 
 export const useAppModeStore = defineStore('appMode', () => {
   const mode = ref<AppMode>('graph')


### PR DESCRIPTION
## Summary

Adds a store to control the mode the app is in (app, graph, builder)
Changes the existing linearMode in canvasStore to update new store

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9022-App-mode-store-1-30d6d73d365081498df1c1192c9860f0) by [Unito](https://www.unito.io)
