### PR TITLE
Fix badges to bottom of node

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -119,7 +119,7 @@
           v-if="shouldShowPreviewImg"
           :image-url="latestPreviewUrl"
         />
-        <NodeBadges v-bind="badges" :pricing="undefined" />
+        <NodeBadges v-bind="badges" :pricing="undefined" class="mt-auto" />
       </div>
     </template>
     <Button


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/75171909-829e-49c0-9d94-3d5588f28f05"  /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/1ee438c7-8231-4d8f-abea-f901a682dfa3"/>|

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9033-Fix-badges-to-bottom-of-node-30d6d73d365081a584b1ca925980e59a) by [Unito](https://www.unito.io)
