### PR TITLE
fix: intercept window.open in zendesk test to avoid external network dependency

### DIFF
--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -340,17 +340,21 @@ test.describe('Support', () => {
     comfyPage
   }) => {
     await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-    const pagePromise = comfyPage.page.context().waitForEvent('page')
+
+    // Prevent loading the external page
+    await comfyPage.page.context().route('https://support.comfy.org/**', (route) =>
+      route.fulfill({ body: '<html></html>', contentType: 'text/html' })
+    )
+
+    const popupPromise = comfyPage.page.waitForEvent('popup')
     await comfyPage.menu.topbar.triggerTopbarCommand(['Help', 'Support'])
-    const newPage = await pagePromise
+    const popup = await popupPromise
 
-    await newPage.waitForLoadState('networkidle')
-    await expect(newPage).toHaveURL(/.*support\.comfy\.org.*/)
-
-    const url = new URL(newPage.url())
+    const url = new URL(popup.url())
+    expect(url.hostname).toBe('support.comfy.org')
     expect(url.searchParams.get('tf_42243568391700')).toBe('oss')
 
-    await newPage.close()
+    await popup.close()
   })
 })
 

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -342,9 +342,11 @@ test.describe('Support', () => {
     await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
 
     // Prevent loading the external page
-    await comfyPage.page.context().route('https://support.comfy.org/**', (route) =>
-      route.fulfill({ body: '<html></html>', contentType: 'text/html' })
-    )
+    await comfyPage.page
+      .context()
+      .route('https://support.comfy.org/**', (route) =>
+        route.fulfill({ body: '<html></html>', contentType: 'text/html' })
+      )
 
     const popupPromise = comfyPage.page.waitForEvent('popup')
     await comfyPage.menu.topbar.triggerTopbarCommand(['Help', 'Support'])


### PR DESCRIPTION
The zendesk support test was flaky because it waited for `networkidle` on an external Zendesk page (`support.comfy.org`). External network requests in CI are unreliable — they can timeout, be slow, or redirect.

**Fix:** Intercept `window.open` to capture the URL that would be opened, without actually navigating to the external page. This makes the test deterministic and fast.

- Fixes flaky test: `[chromium] › browser_tests/tests/dialog.spec.ts:339:3 › Support › Should open external zendesk link with OSS tag`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9035-fix-intercept-window-open-in-zendesk-test-to-avoid-external-network-dependency-30e6d73d365081c2a021edd816b8c1d0) by [Unito](https://www.unito.io)
