### PR TITLE
[bugfix] Fix node replacements not loading due to feature flag timing

### DIFF
--- a/src/platform/nodeReplacement/nodeReplacementStore.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.ts
@@ -3,8 +3,9 @@ import type { NodeReplacement, NodeReplacementResponse } from './types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { ServerFeatureFlag } from '@/composables/useFeatureFlags'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
 import { fetchNodeReplacements } from './nodeReplacementService'
 
 export const useNodeReplacementStore = defineStore('nodeReplacement', () => {
@@ -15,11 +16,10 @@ export const useNodeReplacementStore = defineStore('nodeReplacement', () => {
     settingStore.get('Comfy.NodeReplacement.Enabled')
   )
 
-  const { flags } = useFeatureFlags()
-
   async function load() {
     if (!isEnabled.value || isLoaded.value) return
-    if (!flags.nodeReplacementsEnabled) return
+    if (!api.getServerFeature(ServerFeatureFlag.NODE_REPLACEMENTS, false))
+      return
 
     try {
       replacements.value = await fetchNodeReplacements()
@@ -42,8 +42,8 @@ export const useNodeReplacementStore = defineStore('nodeReplacement', () => {
   return {
     replacements,
     isLoaded,
-    load,
     isEnabled,
+    load,
     getReplacementFor,
     hasReplacement
   }

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -700,6 +700,7 @@ export class ComfyApi extends EventTarget {
                 'Server feature flags received:',
                 this.serverFeatureFlags
               )
+              this.dispatchCustomEvent('feature_flags', msg.data)
               break
             default:
               if (this._registered.has(msg.type)) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -739,6 +739,10 @@ export class ComfyApp {
       releaseSharedObjectUrl(blobUrl)
     })
 
+    api.addEventListener('feature_flags', () => {
+      void useNodeReplacementStore().load()
+    })
+
     api.init()
   }
 
@@ -802,7 +806,6 @@ export class ComfyApp {
     await useWorkspaceStore().workflow.syncWorkflows()
     //Doesn't need to block. Blueprints will load async
     void useSubgraphStore().fetchSubgraphs()
-    await useNodeReplacementStore().load()
     await useExtensionService().loadExtensions()
 
     this.addProcessKeyHandler()


### PR DESCRIPTION
## Summary
- Node replacements were never loaded because `useNodeReplacementStore().load()` was called before `api.init()`, meaning `serverFeatureFlags` was always empty at that point
- Dispatch `feature_flags` as a custom event from `api.ts` and trigger `load()` in response within `addApiUpdateHandlers()`

## Changes
- **`api.ts`**: Dispatch `feature_flags` custom event after storing server feature flags (already typed in `BackendApiCalls`)
- **`app.ts`**: Replace eager `load()` call with `feature_flags` event listener inside `addApiUpdateHandlers()`, consistent with other API event handlers
- **`nodeReplacementStore.ts`**: Use `api.getServerFeature()` directly instead of `useFeatureFlags` composable; remove side effects from store setup
- **`nodeReplacementStore.test.ts`**: Update mocks to match new `api.getServerFeature` usage

## Review Focus
- Initialization ordering: listener registered before `api.init()` ensures no missed events

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9036-bugfix-Fix-node-replacements-not-loading-due-to-feature-flag-timing-30e6d73d365081a89df4c801f299a655) by [Unito](https://www.unito.io)
