### PR TITLE
fix: restore strictExecutionOrder for Storybook Chromatic builds

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -100,7 +100,8 @@ const config: StorybookConfig = {
         rolldownOptions: {
           treeshake: false,
           output: {
-            keepNames: true
+            keepNames: true,
+            strictExecutionOrder: true
           },
           onwarn: (warning, warn) => {
             // Suppress specific warnings


### PR DESCRIPTION
## Summary

Restore `strictExecutionOrder: true` in `.storybook/main.ts` rolldownOptions, accidentally removed in #8834 as a merge artifact.

## Problem

Chromatic visual regression tests fail on `version-bump-*` release branches with:
```
Error: __STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__ is not defined
```

Rolldown without `strictExecutionOrder` doesn't guarantee module execution order. Storybook's internal module system defines `__STORYBOOK_MODULE_*` globals during initialization — without strict ordering, downstream code references them before they're defined.

Only `version-bump-*` branches are affected because the `chromatic-deployment` CI job (which actually loads and extracts stories at runtime) is gated to those branches.

## Changes

- Restore `strictExecutionOrder: true` in `.storybook/main.ts` rolldownOptions output config

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9038-fix-restore-strictExecutionOrder-for-Storybook-Chromatic-builds-30e6d73d365081489c53cea131b97a2f) by [Unito](https://www.unito.io)
