### PR TITLE
fix: raise graphdialog z-index above menu bars

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -1192,7 +1192,7 @@ button.comfy-queue-btn {
 .graphdialog {
   min-height: 1em;
   background-color: var(--comfy-menu-bg);
-  z-index: 41; /* z-index is set to 41 here in order to appear over selection-overlay-container which should have a z-index of 40 */
+  z-index: 1500;
 }
 
 .graphdialog .name {


### PR DESCRIPTION

## Summary

- Raise `.graphdialog` z-index from 41 to 1500 so the widget prompt dialog is no longer hidden behind menu bars when a node is near the top of the screen.

### Why 1500 instead of 10000?

The issue suggested 10000, but that would place the dialog **above** context menus (9999) and at the same level as toasts (10000). A value of 1500 is sufficient to sit above the top menu bar (1001) and actionbar (1300), while staying **below** popovers (1700), context menus (9999), and toasts (10000).

| Element | z-index |
|---------|---------|
| `.comfyui-body-top` (top menu) | 1001 |
| Actionbar | 1300 |
| **`.graphdialog` (this PR)** | **1500** |
| Popover | 1700 |
| Context menus / search box | 9999 |
| Toast | 10000 |

- Fixes #4573
### test

#### AS IS
<img width="534" height="120" alt="스크린샷 2026-02-21 오후 1 27 56" src="https://github.com/user-attachments/assets/e58922b4-ae3f-4083-a0e1-06c27efb64af" />

#### TO BE
<img width="659" height="140" alt="스크린샷 2026-02-21 오후 1 47 09" src="https://github.com/user-attachments/assets/980334f4-b5d2-43f5-a237-d7c2a7dfb6c9" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9049-fix-raise-graphdialog-z-index-above-menu-bars-30e6d73d36508172b9b3c728c3628477) by [Unito](https://www.unito.io)
