### PR TITLE
fix: handle failed global subgraph blueprint loading gracefully

### DIFF
--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -106,8 +106,13 @@ export class ComfyWorkflow extends UserFile {
     await super.load({ force })
     if (!force && this.isLoaded) return this as this & LoadedComfyWorkflow
 
-    if (!this.originalContent) {
-      throw new Error('[ASSERT] Workflow content should be loaded')
+    if (this.originalContent == null) {
+      throw new Error(
+        `[ASSERT] Workflow content should be loaded for '${this.path}'`
+      )
+    }
+    if (this.originalContent.trim().length === 0) {
+      throw new Error(`Workflow content is empty for '${this.path}'`)
     }
 
     const initialState = JSON.parse(this.originalContent)

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1181,9 +1181,16 @@ export class ComfyApi extends EventTarget {
 
   async getGlobalSubgraphData(id: string): Promise<string> {
     const resp = await api.fetchApi('/global_subgraphs/' + id)
-    if (resp.status !== 200) return ''
+    if (resp.status !== 200) {
+      throw new Error(
+        `Failed to fetch global subgraph '${id}': ${resp.status} ${resp.statusText}`
+      )
+    }
     const subgraph: GlobalSubgraphData = await resp.json()
-    return subgraph?.data ?? ''
+    if (!subgraph?.data) {
+      throw new Error(`Global subgraph '${id}' returned empty data`)
+    }
+    return subgraph.data as string
   }
   async getGlobalSubgraphs(): Promise<Record<string, GlobalSubgraphData>> {
     const resp = await api.fetchApi('/global_subgraphs')


### PR DESCRIPTION
## Summary

Fix "Failed to load subgraph blueprints Error: [ASSERT] Workflow content should be loaded" error occurring on cloud.

## Changes

- **What**: `getGlobalSubgraphData` now throws on API failure instead of returning empty string, global blueprint data is validated before loading, and individual global blueprint errors are properly propagated to the toast/console reporting instead of being silently swallowed.

## Review Focus

Two root causes were fixed:
1. `getGlobalSubgraphData` returned `""` on failure — this empty string was set as `originalContent`, which is falsy, triggering the assertion in `ComfyWorkflow.load()`.
2. `loadInstalledBlueprints` used an internal `Promise.allSettled` whose results were discarded, so individual global blueprint failures never reached the error reporting in `fetchSubgraphs`.

Fixes COM-15199

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9063-fix-handle-failed-global-subgraph-blueprint-loading-gracefully-30e6d73d3650818d9cc8ecf81cd0264e) by [Unito](https://www.unito.io)
