### PR TITLE
Temporarily remove VRAM sort option

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -729,10 +729,11 @@ const sortOptions = computed(() => [
     value: 'popular'
   },
   { name: t('templateWorkflows.sort.newest', 'Newest'), value: 'newest' },
-  {
-    name: t('templateWorkflows.sort.vramLowToHigh', 'VRAM Usage (Low to High)'),
-    value: 'vram-low-to-high'
-  },
+  // TODO: Uncomment when we have a way to get the real VRAM usage
+  // {
+  //   name: t('templateWorkflows.sort.vramLowToHigh', 'VRAM Usage (Low to High)'),
+  //   value: 'vram-low-to-high'
+  // },
   {
     name: t(
       'templateWorkflows.sort.modelSizeLowToHigh',


### PR DESCRIPTION
Since I can't get the actual VRAM usage data, let's hide the VRAM usage sorting until we can.