### PR TITLE
fix: standardize execution time metadata handling to milliseconds

### DIFF
--- a/src/components/queue/job/useQueueEstimates.ts
+++ b/src/components/queue/job/useQueueEstimates.ts
@@ -30,10 +30,8 @@ export const formatElapsedTime = (ms: number): string => {
 const pickRecentDurations = (queueStore: QueueStore) =>
   queueStore.historyTasks
     .map((task: TaskItemImpl) => Number(task.executionTimeInSeconds))
-    .filter(
-      (value: number | undefined) =>
-        typeof value === 'number' && !Number.isNaN(value)
-    ) as number[]
+    .filter((value: number) => Number.isFinite(value) && value >= 0)
+    .map((durationMilliseconds: number) => durationMilliseconds / 1000)
 
 export const useQueueEstimates = ({
   queueStore,

--- a/src/components/sidebar/tabs/AssetsSidebarListView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.vue
@@ -153,7 +153,7 @@ function getAssetPreviewUrl(asset: AssetItem): string {
 function getAssetSecondaryText(asset: AssetItem): string {
   const metadata = getOutputAssetMetadata(asset.user_metadata)
   if (typeof metadata?.executionTimeInSeconds === 'number') {
-    return `${metadata.executionTimeInSeconds.toFixed(2)}s`
+    return formatDuration(metadata.executionTimeInSeconds)
   }
 
   const duration = asset.user_metadata?.duration

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -293,7 +293,7 @@ const shouldShowOutputCount = (item: AssetItem): boolean => {
 
 const formattedExecutionTime = computed(() => {
   if (!folderExecutionTime.value) return ''
-  return formatDuration(folderExecutionTime.value * 1000)
+  return formatDuration(folderExecutionTime.value)
 })
 
 const toast = useToast()

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -255,7 +255,7 @@ const formattedDuration = computed(() => {
   // Check for execution time first (from history API)
   const executionTime = asset?.user_metadata?.executionTimeInSeconds
   if (executionTime !== undefined && executionTime !== null) {
-    return `${Number(executionTime).toFixed(2)}s`
+    return formatDuration(Number(executionTime))
   }
 
   // Fall back to duration for media files

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -391,9 +391,7 @@ export class TaskItemImpl {
   }
 
   get executionTimeInSeconds() {
-    return this.executionTime !== undefined
-      ? this.executionTime / 1000
-      : undefined
+    return this.executionTime
   }
 
   /**

--- a/src/utils/queueDisplay.ts
+++ b/src/utils/queueDisplay.ts
@@ -139,7 +139,7 @@ export const buildJobDisplay = (
       iconName: iconForJobState(state),
       iconImageUrl,
       primary,
-      secondary: time !== undefined ? `${time.toFixed(2)}s` : '',
+      secondary: time !== undefined ? formatDuration(time) : '',
       showClear: false
     }
   }


### PR DESCRIPTION
### Motivation
- The backend now returns execution durations as milliseconds while the API typing (`executionTimeInSeconds`) remains unchanged, so the frontend must interpret that value consistently as milliseconds.

### Description
- Updated `TaskItemImpl.executionTimeInSeconds` to return the raw millisecond duration instead of dividing by 1000 so the property reflects backend milliseconds.
- Replaced ad-hoc seconds formatting and conversions with `formatDuration(...)` at UI surfaces so durations are rendered correctly from millisecond values.
- Applied changes in the queue display and asset UI: `src/stores/queueStore.ts`, `src/utils/queueDisplay.ts`, `src/components/sidebar/tabs/AssetsSidebarTab.vue`, `src/components/sidebar/tabs/AssetsSidebarListView.vue`, and `src/platform/assets/components/MediaAssetCard.vue`.

### Testing
- Ran linting with `pnpm lint`; lint completed successfully with unrelated repository warnings but no errors.
- Ran type checking with `pnpm typecheck` (`vue-tsc --noEmit`) and it succeeded.
- No new automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaca7d2a0833094ba4c61caa88f8f)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9090-fix-standardize-execution-time-metadata-handling-to-milliseconds-30f6d73d365081ebbe0bdde8f8aae1d4) by [Unito](https://www.unito.io)
