### PR TITLE
fix: backport load 3D dialog defineAsyncComponent to cloud/1.40

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -204,13 +204,22 @@ import {
 } from '@vueuse/core'
 import Divider from 'primevue/divider'
 import { useToast } from 'primevue/usetoast'
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import NoResultsPlaceholder from '@/components/common/NoResultsPlaceholder.vue'
 // Lazy-loaded to avoid pulling THREE.js into the main bundle
-const Load3dViewerContent = () =>
-  import('@/components/load3d/Load3dViewerContent.vue')
+const Load3dViewerContent = defineAsyncComponent(
+  () => import('@/components/load3d/Load3dViewerContent.vue')
+)
 import AssetsSidebarGridView from '@/components/sidebar/tabs/AssetsSidebarGridView.vue'
 import AssetsSidebarListView from '@/components/sidebar/tabs/AssetsSidebarListView.vue'
 import SidebarTabTemplate from '@/components/sidebar/tabs/SidebarTabTemplate.vue'


### PR DESCRIPTION
## Summary
Backport the `defineAsyncComponent` fix from #8990 to `cloud/1.40` so the 3D inspect dialog renders the component instead of a promise payload.

## Changes
- Add `defineAsyncComponent` import in `AssetsSidebarTab.vue`
- Wrap `Load3dViewerContent` lazy import with `defineAsyncComponent(...)`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- pre-push hook (`pnpm knip --cache`) ran during `git push`

Backports #8990.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9092-fix-backport-load-3D-dialog-defineAsyncComponent-to-cloud-1-40-30f6d73d365081eb9ea6f2d771cbd762) by [Unito](https://www.unito.io)
