### PR TITLE
feat: add serverCapabilities module for static REST-based feature fetching

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,12 +14,15 @@ import { VueFire, VueFireAuth } from 'vuefire'
 import { getFirebaseConfig } from '@/config/firebase'
 import '@/lib/litegraph/public/css/litegraph.css'
 import router from '@/router'
+import { initServerCapabilities } from '@/services/serverCapabilities'
 import { useBootstrapStore } from '@/stores/bootstrapStore'
 
 import App from './App.vue'
 // Intentionally relative import to ensure the CSS is loaded in the right order (after litegraph.css)
 import './assets/css/style.css'
 import { i18n } from './i18n'
+
+await initServerCapabilities()
 
 /**
  * CRITICAL: Load remote config FIRST for cloud builds to ensure

--- a/src/services/serverCapabilities.test.ts
+++ b/src/services/serverCapabilities.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getServerCapability,
+  initServerCapabilities
+} from '@/services/serverCapabilities'
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false
+}))
+
+describe('serverCapabilities', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            supports_preview_metadata: true,
+            max_upload_size: 104857600,
+            node_replacements: false,
+            extension: { manager: { supports_v4: true } }
+          })
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  describe('initServerCapabilities', () => {
+    it('fetches and freezes capabilities on success', async () => {
+      await initServerCapabilities()
+
+      expect(getServerCapability('supports_preview_metadata')).toBe(true)
+      expect(getServerCapability('max_upload_size')).toBe(104857600)
+    })
+
+    it('retries and falls back to empty object on persistent failure', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await initServerCapabilities()
+
+      expect(fetch).toHaveBeenCalledTimes(3)
+      expect(getServerCapability('supports_preview_metadata')).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to fetch server capabilities after retries'
+      )
+    })
+
+    it('succeeds on retry after initial failure', async () => {
+      vi.mocked(fetch)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ supports_preview_metadata: true })
+        } as Response)
+
+      await initServerCapabilities()
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(getServerCapability('supports_preview_metadata')).toBe(true)
+    })
+
+    it('falls back to empty object on persistent non-ok response', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({})
+      } as Response)
+
+      await initServerCapabilities()
+
+      expect(fetch).toHaveBeenCalledTimes(3)
+      expect(getServerCapability('supports_preview_metadata')).toBeUndefined()
+    })
+  })
+
+  describe('getServerCapability', () => {
+    it('returns default value when called before init', () => {
+      expect(getServerCapability('some_key', 'fallback')).toBe('fallback')
+    })
+
+    beforeEach(async () => {
+      await initServerCapabilities()
+    })
+
+    it('returns value for existing key', () => {
+      expect(getServerCapability('supports_preview_metadata')).toBe(true)
+    })
+
+    it('returns default value for missing key', () => {
+      expect(getServerCapability('non_existent', 'fallback')).toBe('fallback')
+    })
+
+    it('supports dot notation for nested values', () => {
+      expect(getServerCapability('extension.manager.supports_v4')).toBe(true)
+    })
+
+    it('returns undefined for missing key with no default', () => {
+      expect(getServerCapability('missing_key')).toBeUndefined()
+    })
+  })
+
+  describe('dev override via localStorage', () => {
+    beforeEach(async () => {
+      await initServerCapabilities()
+    })
+
+    afterEach(() => {
+      localStorage.clear()
+    })
+
+    it('returns localStorage override over server value', () => {
+      localStorage.setItem('ff:supports_preview_metadata', 'false')
+      expect(getServerCapability('supports_preview_metadata')).toBe(false)
+    })
+
+    it('falls through to server value when no override is set', () => {
+      expect(getServerCapability('supports_preview_metadata')).toBe(true)
+    })
+
+    it('override works with numeric values', () => {
+      localStorage.setItem('ff:max_upload_size', '999')
+      expect(getServerCapability('max_upload_size')).toBe(999)
+    })
+  })
+})

--- a/src/services/serverCapabilities.ts
+++ b/src/services/serverCapabilities.ts
@@ -1,0 +1,41 @@
+import { get } from 'es-toolkit/compat'
+
+import { isCloud } from '@/platform/distribution/types'
+import { getDevOverride } from '@/utils/devFeatureFlagOverride'
+
+const EMPTY: Readonly<Record<string, unknown>> = Object.freeze({})
+const MAX_RETRIES = 2
+
+let capabilities: Readonly<Record<string, unknown>> = EMPTY
+
+function getApiBase(): string {
+  return isCloud ? '' : location.pathname.split('/').slice(0, -1).join('/')
+}
+
+export async function initServerCapabilities(): Promise<void> {
+  const url = `${getApiBase()}/api/features`
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' })
+      if (res.ok) {
+        capabilities = Object.freeze(await res.json())
+        return
+      }
+    } catch {
+      // Retry on network errors
+    }
+  }
+
+  console.warn('Failed to fetch server capabilities after retries')
+  capabilities = EMPTY
+}
+
+export function getServerCapability<T = unknown>(
+  key: string,
+  defaultValue?: T
+): T {
+  const override = getDevOverride<T>(key)
+  if (override !== undefined) return override
+  return get(capabilities, key, defaultValue) as T
+}


### PR DESCRIPTION
## Summary
- Introduces `src/services/serverCapabilities.ts` — fetches server capabilities via `GET /api/features` before app mount with retry logic (3 attempts)
- `initServerCapabilities()` called in `main.ts` before `app.mount()` so capabilities are available immediately
- `getServerCapability(key, default)` provides dot-notation access with dev override support
- Static, one-shot fetch + `Object.freeze()` — no reactivity needed

**Part 1 of 3** for #9079 (additive only, no existing code modified except `main.ts` init call)

## Test plan
- [x] 12 unit tests covering: fetch success, retry on failure, non-ok response, dot notation, dev override via localStorage
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm knip` clean

Fixes #9079

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9093-feat-add-serverCapabilities-module-for-static-REST-based-feature-fetching-30f6d73d365081bb87e9c89799a450a7) by [Unito](https://www.unito.io)
