### PR TITLE
docs: add widget serialization reference (widget.serialize vs widget.options.serialize)

### DIFF
--- a/docs/WIDGET_SERIALIZATION.md
+++ b/docs/WIDGET_SERIALIZATION.md
@@ -1,0 +1,33 @@
+# Widget Serialization: `widget.serialize` vs `widget.options.serialize`
+
+Two properties named `serialize` exist at different levels of a widget object. They control different serialization layers and are checked by completely different code paths.
+
+**`widget.serialize`** — Controls **workflow persistence**. Checked by `LGraphNode.serialize()` and `configure()` when reading/writing `widgets_values` in the workflow JSON. When `false`, the widget is skipped in both serialization and deserialization. Used for UI-only widgets (image previews, progress text, audio players). Typed as `IBaseWidget.serialize` in `src/lib/litegraph/src/types/widgets.ts`.
+
+**`widget.options.serialize`** — Controls **prompt/API serialization**. Checked by `executionUtil.ts` when building the API payload sent to the backend. When `false`, the widget is excluded from prompt inputs. Used for client-side-only controls (`control_after_generate`, combo filter lists) that the server doesn't need. Not currently typed in `IWidgetOptions` — set at runtime via the options bag.
+
+These correspond to the two data formats in `ComfyMetadata` embedded in output files (PNG, GLTF, WebM, AVIF, etc.): `widget.serialize` → `ComfyMetadataTags.WORKFLOW`, `widget.options.serialize` → `ComfyMetadataTags.PROMPT`.
+
+## Permutation table
+
+| `widget.serialize` | `widget.options.serialize` | In workflow? | In prompt? | Examples |
+|---|---|---|---|---|
+| ✅ default | ✅ default | Yes | Yes | seed, cfg, sampler_name |
+| ✅ default | ❌ false | Yes | No | control_after_generate, combo filter list |
+| ❌ false | ✅ default | No | Yes | No current usage (would be a transient value computed at queue time) |
+| ❌ false | ❌ false | No | No | Image/video previews, audio players, progress text |
+
+## Gotchas
+
+- `addWidget('combo', name, value, cb, { serialize: false })` puts `serialize` into `widget.options`, **not** onto `widget` directly. These are different properties consumed by different systems.
+- `LGraphNode.serialize()` checks `widget.serialize === false` (line 967). It does **not** check `widget.options.serialize`. A widget with `options.serialize = false` is still included in `widgets_values`.
+- `LGraphNode.serialize()` only writes `widgets_values` if `this.widgets` is truthy. Nodes that create widgets dynamically (like `PrimitiveNode`) will have no `widgets_values` in serialized output if serialized before widget creation — even if `this.widgets_values` exists on the instance from a prior `configure()` call.
+- `widget.options.serialize` is not typed in `IWidgetOptions`. If you add it to the type definition, update this doc.
+
+## Code references
+
+- `widget.serialize` checked: `src/lib/litegraph/src/LGraphNode.ts` serialize() and configure()
+- `widget.options.serialize` checked: `src/utils/executionUtil.ts`
+- `widget.options.serialize` set: `src/scripts/widgets.ts` addValueControlWidgets()
+- `widget.serialize` set: `src/composables/node/useNodeImage.ts`, `src/extensions/core/previewAny.ts`, etc.
+- Metadata types: `src/types/metadataTypes.ts`

--- a/docs/WIDGET_SERIALIZATION.md
+++ b/docs/WIDGET_SERIALIZATION.md
@@ -10,12 +10,12 @@ These correspond to the two data formats in `ComfyMetadata` embedded in output f
 
 ## Permutation table
 
-| `widget.serialize` | `widget.options.serialize` | In workflow? | In prompt? | Examples |
-|---|---|---|---|---|
-| ✅ default | ✅ default | Yes | Yes | seed, cfg, sampler_name |
-| ✅ default | ❌ false | Yes | No | control_after_generate, combo filter list |
-| ❌ false | ✅ default | No | Yes | No current usage (would be a transient value computed at queue time) |
-| ❌ false | ❌ false | No | No | Image/video previews, audio players, progress text |
+| `widget.serialize` | `widget.options.serialize` | In workflow? | In prompt? | Examples                                                             |
+| ------------------ | -------------------------- | ------------ | ---------- | -------------------------------------------------------------------- |
+| ✅ default         | ✅ default                 | Yes          | Yes        | seed, cfg, sampler_name                                              |
+| ✅ default         | ❌ false                   | Yes          | No         | control_after_generate, combo filter list                            |
+| ❌ false           | ✅ default                 | No           | Yes        | No current usage (would be a transient value computed at queue time) |
+| ❌ false           | ❌ false                   | No           | No         | Image/video previews, audio players, progress text                   |
 
 ## Gotchas
 

--- a/src/lib/litegraph/AGENTS.md
+++ b/src/lib/litegraph/AGENTS.md
@@ -6,6 +6,10 @@
 - Avoid repetition where possible, but not at expense of legibility
 - Prefer running single tests, not the whole suite, for performance
 
+## Widget Serialization
+
+See `docs/WIDGET_SERIALIZATION.md` for the distinction between `widget.serialize` (workflow persistence) and `widget.options.serialize` (API prompt). These are different properties checked by different code paths — a common source of confusion.
+
 ## Code Style
 
 - Prefer single line `if` syntax for concise expressions


### PR DESCRIPTION
Documents the distinction between `widget.serialize` (workflow persistence, checked by `LGraphNode.serialize()`) and `widget.options.serialize` (API prompt, checked by `executionUtil.ts`).

These share a property name but live at different levels of the widget object and are consumed by different code paths — a common source of confusion when debugging serialization bugs.

Includes:
- Explanation of both properties with code references
- Permutation table of the 4 possible combinations with real examples
- Gotchas section covering the `addWidget` options bag behavior and `PrimitiveNode` dynamic widgets
- Reference added to `src/lib/litegraph/AGENTS.md`

Context: discovered while debugging #1757 (PrimitiveNode `control_after_generate` lost on copy-paste).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9102-docs-add-widget-serialization-reference-widget-serialize-vs-widget-options-serialize-30f6d73d365081cd86add44bdaa20d30) by [Unito](https://www.unito.io)
