### PR TITLE
fix: promoted textarea widgets in subgraphs no longer permanently read-only

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -192,19 +192,23 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     // Get value from store (falls back to undefined if not registered)
     const value = widgetState?.value as WidgetValue
 
-    // Build options from store state, with slot-linked override for disabled
+    // Build options from store state, with slot-linked override for disabled.
+    // Promoted widgets inside a subgraph are always linked to SubgraphInput,
+    // but should remain interactive — skip the disabled override for them.
     const storeOptions = widgetState?.options ?? {}
-    const widgetOptions = slotMetadata?.linked
-      ? { ...storeOptions, disabled: true }
-      : storeOptions
+    const isPromotedOnOwningNode =
+      widgetState?.promoted && String(widgetState?.nodeId) === String(nodeId)
+    const widgetOptions =
+      slotMetadata?.linked && !isPromotedOnOwningNode
+        ? { ...storeOptions, disabled: true }
+        : storeOptions
 
     // Derive border style from store metadata
-    const borderStyle =
-      widgetState?.promoted && String(widgetState?.nodeId) === String(nodeId)
-        ? 'ring ring-component-node-widget-promoted'
-        : widget.options?.advanced
-          ? 'ring ring-component-node-widget-advanced'
-          : undefined
+    const borderStyle = isPromotedOnOwningNode
+      ? 'ring ring-component-node-widget-promoted'
+      : widget.options?.advanced
+        ? 'ring ring-component-node-widget-advanced'
+        : undefined
 
     const simplified: SimplifiedWidget = {
       name: widget.name,

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts
@@ -22,14 +22,12 @@ function createMockWidget(
 function mountComponent(
   widget: SimplifiedWidget<string>,
   modelValue: string,
-  readonly = false,
   placeholder?: string
 ) {
   return mount(WidgetTextarea, {
     props: {
       widget,
       modelValue,
-      readonly,
       placeholder
     }
   })
@@ -179,15 +177,36 @@ describe('WidgetTextarea Value Binding', () => {
 
     it('uses provided placeholder when specified', () => {
       const widget = createMockWidget('test')
-      const wrapper = mountComponent(
-        widget,
-        'test',
-        false,
-        'Custom placeholder'
-      )
+      const wrapper = mountComponent(widget, 'test', 'Custom placeholder')
 
       const textarea = wrapper.find('textarea')
       expect(textarea.attributes('placeholder')).toBe('Custom placeholder')
+    })
+  })
+
+  describe('Read-Only Behavior', () => {
+    it('is readonly when options.read_only is true', () => {
+      const widget = createMockWidget('test', { read_only: true })
+      const wrapper = mountComponent(widget, 'test')
+      expect(wrapper.find('textarea').attributes('readonly')).toBeDefined()
+    })
+
+    it('is readonly when options.disabled is true', () => {
+      const widget = createMockWidget('test', { disabled: true })
+      const wrapper = mountComponent(widget, 'test')
+      expect(wrapper.find('textarea').attributes('readonly')).toBeDefined()
+    })
+
+    it('is editable when neither read_only nor disabled is set', () => {
+      const widget = createMockWidget('test', {})
+      const wrapper = mountComponent(widget, 'test')
+      expect(wrapper.find('textarea').attributes('readonly')).toBeUndefined()
+    })
+
+    it('is editable when disabled is explicitly false', () => {
+      const widget = createMockWidget('test', { disabled: false })
+      const wrapper = mountComponent(widget, 'test')
+      expect(wrapper.find('textarea').attributes('readonly')).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Summary

Promoted textarea widgets inside subgraphs were permanently read-only because `disabled: true` was unconditionally injected when the widget's input slot was linked.

## Changes

- **What**: In `NodeWidgets.vue`, extract `isPromotedOnOwningNode` check and skip the `disabled: true` override for promoted widgets whose slot is internally linked to a SubgraphInput node. Reuse the same variable for the existing `borderStyle` condition (was duplicated). Add 4 unit tests for `WidgetTextarea` read-only behavior. Remove dead `readonly` prop parameter from test helper.

## Review Focus

The `isPromotedOnOwningNode` guard uses a `nodeId` comparison (`String(widgetState?.nodeId) === String(nodeId)`) to distinguish promoted widgets on their owning node (should be interactive) from proxy widgets on the SubgraphNode (should remain disabled). This fix benefits all promoted widget types (combos, numbers, etc.), not just textareas.

Fixes #8818

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9124-fix-promoted-textarea-widgets-in-subgraphs-no-longer-permanently-read-only-3106d73d3650816b8c08e417c7d10464) by [Unito](https://www.unito.io)
