### PR TITLE
ci: skip unit and e2e tests for markdown-only changes

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -4,8 +4,10 @@ name: 'CI: Tests E2E'
 on:
   push:
     branches: [main, master, core/*, desktop/*]
+    paths-ignore: ['**/*.md']
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
+    paths-ignore: ['**/*.md']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -4,8 +4,10 @@ name: 'CI: Tests Unit'
 on:
   push:
     branches: [main, master, dev*, core/*, desktop/*]
+    paths-ignore: ['**/*.md']
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
+    paths-ignore: ['**/*.md']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Skip unit and e2e tests when PRs only contain markdown file changes.

## Changes

- Add `paths-ignore: ['**/*.md']` to `push` and `pull_request` triggers in ci-tests-unit.yaml and ci-tests-e2e.yaml
- Manual `workflow_dispatch` trigger preserved for e2e tests

## Testing

Create a PR with only `.md` changes to verify both test workflows are skipped.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9125-ci-skip-unit-and-e2e-tests-for-markdown-only-changes-3106d73d365081bea0dcc06b608a87fc) by [Unito](https://www.unito.io)
