### PR TITLE
fix: fix error overlay and TabErrors filtering for nested subgraphs

### DIFF
--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -106,7 +106,7 @@ const hasContainerInternalError = computed(() => {
   if (allErrorExecutionIds.value.length === 0) return false
   return selectedNodes.value.some((node) => {
     if (!(node instanceof SubgraphNode || isGroupNode(node))) return false
-    return executionErrorStore.hasInternalErrorForNode(node.id)
+    return executionErrorStore.isContainerWithInternalError(node)
   })
 })
 

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -121,7 +121,7 @@ const hasContainerInternalError = computed(() => {
     targetNode.value instanceof SubgraphNode || isGroupNode(targetNode.value)
   if (!isContainer) return false
 
-  return executionErrorStore.hasInternalErrorForNode(targetNode.value.id)
+  return executionErrorStore.isContainerWithInternalError(targetNode.value)
 })
 
 const nodeHasError = computed(() => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -342,7 +342,9 @@ const hasAnyError = computed((): boolean => {
     hasExecutionError.value ||
     nodeData.hasErrors ||
     error ||
-    (executionErrorStore.lastNodeErrors?.[nodeData.id]?.errors.length ?? 0) > 0
+    executionErrorStore.getNodeErrors(nodeLocatorId.value) ||
+    (lgraphNode.value &&
+      executionErrorStore.isContainerWithInternalError(lgraphNode.value))
   )
 })
 

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -332,6 +332,35 @@ export function getNodeByExecutionId(
 }
 
 /**
+ * Returns the execution ID for a node relative to the root graph.
+ *
+ * Root-level nodes return their ID directly (e.g. "42").
+ * Nodes inside subgraphs return a colon-separated chain (e.g. "65:70:63").
+ *
+ * @param rootGraph - The root graph to resolve from
+ * @param node - The node whose execution ID to compute
+ * @returns The execution ID string, or null if the node has no graph
+ */
+export function getExecutionIdByNode(
+  rootGraph: LGraph,
+  node: LGraphNode
+): NodeExecutionId | null {
+  if (!node.graph) return null
+
+  if (node.graph === rootGraph || node.graph.isRootGraph) {
+    return String(node.id)
+  }
+
+  const parentPath = findPartialExecutionPathToGraph(
+    node.graph as LGraph,
+    rootGraph
+  )
+  if (parentPath === undefined) return null
+
+  return `${parentPath}:${node.id}`
+}
+
+/**
  * Get a node by its locator ID from anywhere in the graph hierarchy.
  * Locator IDs use UUID format like "uuid:nodeId" for subgraph nodes.
  *


### PR DESCRIPTION
## Summary

Fix error overlays not showing on subgraph container nodes and nested error cards not appearing in the Errors tab when a node inside a subgraph fails.

## Changes

- **What**: Error overlay and Errors tab filtering now use full hierarchical execution IDs (e.g. `65:70`) instead of local node IDs, enabling correct ancestor detection at any nesting depth
- Added `getExecutionIdByNode` to [graphTraversalUtil.ts](src/utils/graphTraversalUtil.ts) to compute a node's full execution ID chain from the root graph
- Added `errorAncestorExecutionIds` computed set and `isContainerWithInternalError(node)` helper to [executionErrorStore.ts](src/stores/executionErrorStore.ts) for O(1) container checks
- Updated `hasAnyError` in [LGraphNode.vue](src/extensions/vueNodes/components/LGraphNode.vue) to use the new store helper
- Fixed `isErrorInSelection` in [useErrorGroups.ts](src/components/rightSidePanel/errors/useErrorGroups.ts) to use full execution IDs for selected containers

## Review Focus

- `errorAncestorExecutionIds` is rebuilt reactively whenever the active errors change — confirm this is efficient enough given typical error counts
- `getExecutionIdByNode` walks up the graph hierarchy; verify the base case (root graph, no parent) is handled correctly

## Screenshots

https://github.com/user-attachments/assets/b5be5892-80a9-4e5e-8b6f-fe754b4ebc4e


https://github.com/user-attachments/assets/92ff12b3-3bc9-4f02-ba4a-e2c7384bafe5


https://github.com/user-attachments/assets/be8e95be-ac8c-4699-9be9-b11902294bda



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9129-fix-fix-error-overlay-and-TabErrors-filtering-for-nested-subgraphs-3106d73d365081c1875bc1a3c89eae29) by [Unito](https://www.unito.io)
