### PR TITLE
fix: refresh image previews on media upload nodes when refreshing node definitions

### DIFF
--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -2,26 +2,12 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import {
   type ComfyNodeDef,
   type InputSpec,
-  isComboInputSpecV1
+  isMediaUploadComboInput
 } from '@/schemas/nodeDefSchema'
 
 import { app } from '../../scripts/app'
 
 // Adds an upload button to the nodes
-
-const isMediaUploadComboInput = (inputSpec: InputSpec) => {
-  const [inputName, inputOptions] = inputSpec
-  if (!inputOptions) return false
-
-  const isUploadInput =
-    inputOptions['image_upload'] === true ||
-    inputOptions['video_upload'] === true ||
-    inputOptions['animated_image_upload'] === true
-
-  return (
-    isUploadInput && (isComboInputSpecV1(inputSpec) || inputName === 'COMBO')
-  )
-}
 
 const createUploadInput = (
   imageInputName: string,

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -158,6 +158,20 @@ export function isComboInputSpec(
   return isComboInputSpecV1(inputSpec) || isComboInputSpecV2(inputSpec)
 }
 
+export function isMediaUploadComboInput(inputSpec: InputSpec): boolean {
+  const [inputName, inputOptions] = inputSpec
+  if (!inputOptions) return false
+
+  const isUploadInput =
+    inputOptions['image_upload'] === true ||
+    inputOptions['video_upload'] === true ||
+    inputOptions['animated_image_upload'] === true
+
+  return (
+    isUploadInput && (isComboInputSpecV1(inputSpec) || inputName === 'COMBO')
+  )
+}
+
 /**
  * Get the type of an input spec.
  *

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -43,7 +43,8 @@ import type {
 import {
   type ComfyNodeDef as ComfyNodeDefV1,
   isComboInputSpecV1,
-  isComboInputSpecV2
+  isComboInputSpecV2,
+  isMediaUploadComboInput
 } from '@/schemas/nodeDefSchema'
 import {
   type BaseDOMWidget,
@@ -1822,6 +1823,7 @@ export class ComfyApp {
       this.registerNodeDef(nodeId, defs[nodeId])
     }
     // Refresh combo widgets in all nodes including those in subgraphs
+    const nodeOutputStore = useNodeOutputStore()
     forEachNode(this.rootGraph, (node) => {
       const def = defs[node.type]
       // Allow primitive nodes to handle refresh
@@ -1853,6 +1855,18 @@ export class ComfyApp {
             }
           }
         }
+      }
+
+      // Re-trigger previews on media upload nodes (e.g. LoadImage)
+      // to bust browser cache when files are edited externally
+      const hasMediaUpload = Object.values(def.input.required ?? {}).some(
+        isMediaUploadComboInput
+      )
+      if (hasMediaUpload && nodeOutputStore.getNodeOutputs(node)) {
+        const comboWidget = node.widgets?.find(
+          (w) => w.type === 'combo' && w.callback
+        )
+        comboWidget?.callback?.(comboWidget.value)
       }
     })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -43,8 +43,7 @@ import type {
 import {
   type ComfyNodeDef as ComfyNodeDefV1,
   isComboInputSpecV1,
-  isComboInputSpecV2,
-  isMediaUploadComboInput
+  isComboInputSpecV2
 } from '@/schemas/nodeDefSchema'
 import {
   type BaseDOMWidget,
@@ -90,7 +89,8 @@ import {
   executeWidgetsCallback,
   createNode,
   fixLinkInputSlots,
-  isImageNode
+  isImageNode,
+  isVideoNode
 } from '@/utils/litegraphUtil'
 import {
   createSharedObjectUrl,
@@ -1857,16 +1857,10 @@ export class ComfyApp {
         }
       }
 
-      // Re-trigger previews on media upload nodes (e.g. LoadImage)
+      // Re-trigger previews on media nodes (e.g. LoadImage)
       // to bust browser cache when files are edited externally
-      const hasMediaUpload = Object.values(def.input.required ?? {}).some(
-        isMediaUploadComboInput
-      )
-      if (hasMediaUpload && nodeOutputStore.getNodeOutputs(node)) {
-        const comboWidget = node.widgets?.find(
-          (w) => w.type === 'combo' && w.callback
-        )
-        comboWidget?.callback?.(comboWidget.value)
+      if (isImageNode(node) || isVideoNode(node)) {
+        nodeOutputStore.refreshNodeOutputs(node)
       }
     })
 

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -388,6 +388,16 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     }
   }
 
+  function refreshNodeOutputs(node: LGraphNode) {
+    const locatorId = nodeToNodeLocatorId(node)
+    if (!locatorId) return
+
+    const outputs = app.nodeOutputs[locatorId]
+    if (!outputs) return
+
+    nodeOutputs.value[locatorId] = { ...outputs }
+  }
+
   function resetAllOutputsAndPreviews() {
     app.nodeOutputs = {}
     nodeOutputs.value = {}
@@ -433,6 +443,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     setNodePreviewsByExecutionId,
     setNodePreviewsByNodeId,
     updateNodeImages,
+    refreshNodeOutputs,
     syncLegacyNodeImgs,
 
     // Cleanup


### PR DESCRIPTION
## Summary
- When pressing `R` to refresh node definitions, image previews on LoadImage/LoadVideo nodes now update to reflect external file changes
- Re-triggers the combo widget callback to regenerate preview URLs with a fresh cache-busting `&rand=` parameter
- Extracts `isMediaUploadComboInput` from `uploadImage.ts` to `nodeDefSchema.ts` as a shared utility

- Fixes #2082


https://github.com/user-attachments/assets/d18d69ae-6ecd-448d-8d7c-76b2c49fdea5



## Test plan
- [ ] Open a workflow with a LoadImage node and select an image
- [ ] Edit and save the image externally (e.g. in an image editor)
- [ ] Press `R` to refresh node definitions
- [ ] Verify the preview updates to show the edited image