### PR TITLE
fix: prevent auth errors for API key users on local/desktop

### DIFF
--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -57,7 +57,8 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
     userPhotoUrl: 'https://example.com/avatar.jpg',
     userDisplayName: 'Test User',
     userEmail: 'test@example.com',
-    handleSignOut: mockHandleSignOut
+    handleSignOut: mockHandleSignOut,
+    isApiKeyLogin: { value: false }
   }))
 }))
 

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -162,8 +162,13 @@ const emit = defineEmits<{
 
 const { buildDocsUrl, docsPaths } = useExternalLink()
 
-const { userDisplayName, userEmail, userPhotoUrl, handleSignOut } =
-  useCurrentUser()
+const {
+  userDisplayName,
+  userEmail,
+  userPhotoUrl,
+  handleSignOut,
+  isApiKeyLogin
+} = useCurrentUser()
 const authActions = useFirebaseAuthActions()
 const authStore = useFirebaseAuthStore()
 const settingsDialog = useSettingsDialog()
@@ -244,6 +249,8 @@ const handleSubscribed = async () => {
 }
 
 onMounted(() => {
-  void authActions.fetchBalance()
+  if (!isApiKeyLogin.value) {
+    void authActions.fetchBalance()
+  }
 })
 </script>

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -237,6 +237,21 @@ describe('useSubscription', () => {
   })
 
   describe('fetchStatus', () => {
+    it('should not auto-fetch subscription status when not on cloud', async () => {
+      mockIsCloud.value = false
+      mockIsLoggedIn.value = true
+
+      const { isInitialized } = useSubscriptionWithScope()
+
+      // Wait for the watcher to process
+      await vi.waitFor(() => {
+        expect(isInitialized.value).toBe(true)
+      })
+
+      // Should not have tried to fetch subscription status
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
     it('should fetch subscription status successfully', async () => {
       const mockStatus = {
         is_active: true,

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -217,7 +217,7 @@ function useSubscriptionInternal() {
   watch(
     () => isLoggedIn.value,
     async (loggedIn) => {
-      if (loggedIn) {
+      if (loggedIn && isCloud) {
         try {
           await fetchSubscriptionStatus()
         } catch (error) {


### PR DESCRIPTION
- Guard subscription status auto-fetch with isCloud check in useSubscription.ts to prevent Firebase auth errors on local/desktop
- Guard fetchBalance call in CurrentUserPopoverLegacy.vue for API key users since fetchBalance requires Firebase auth
- Add test to verify subscription status is not fetched when not on cloud
- Update CurrentUserPopoverLegacy test mock to include isApiKeyLogin

Fixes API key authentication showing "User not authenticated" errors when users click profile icon or try to refresh balance on local/desktop versions.

Slack: https://comfy-organization.slack.com/archives/C0A4XMHANP3/p1771896736700429?thread_ts=1771289819.003239&cid=C0A4XMHANP3

https://claude.ai/code/session_012jjZuGQbnnfcciowSwb4dc

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9144-fix-prevent-auth-errors-for-API-key-users-on-local-desktop-3116d73d365081b68095e405e24fa7f1) by [Unito](https://www.unito.io)
