### PR TITLE
feat: add batch image navigation to ImageCompare node

### DIFF
--- a/src/extensions/core/imageCompare.ts
+++ b/src/extensions/core/imageCompare.ts
@@ -26,22 +26,18 @@ useExtensionService().registerExtension({
       const { a_images: aImages, b_images: bImages } = output
       const rand = app.getRandParam()
 
-      const beforeUrl =
-        aImages && aImages.length > 0
-          ? api.apiURL(`/view?${new URLSearchParams(aImages[0])}${rand}`)
-          : ''
-      const afterUrl =
-        bImages && bImages.length > 0
-          ? api.apiURL(`/view?${new URLSearchParams(bImages[0])}${rand}`)
-          : ''
+      const toUrl = (params: Record<string, string>) =>
+        api.apiURL(`/view?${new URLSearchParams(params)}${rand}`)
+
+      const beforeImages =
+        aImages && aImages.length > 0 ? aImages.map(toUrl) : []
+      const afterImages =
+        bImages && bImages.length > 0 ? bImages.map(toUrl) : []
 
       const widget = node.widgets?.find((w) => w.type === 'imagecompare')
 
       if (widget) {
-        widget.value = {
-          before: beforeUrl,
-          after: afterUrl
-        }
+        widget.value = { beforeImages, afterImages }
         widget.callback?.(widget.value)
       }
     }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1796,7 +1796,12 @@
     "errorNotSupported": "Clipboard API not supported in your browser"
   },
   "imageCompare": {
-    "noImages": "No images to compare"
+    "noImages": "No images to compare",
+    "batchLabelA": "A:",
+    "batchLabelB": "B:"
+  },
+  "batch": {
+    "index": "{current} / {total}"
   },
   "load3d": {
     "switchCamera": "Switch Camera",

--- a/src/renderer/extensions/vueNodes/widgets/components/BatchNavigation.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/BatchNavigation.vue
@@ -1,0 +1,38 @@
+<template>
+  <div v-if="count > 1" class="flex items-center gap-1">
+    <span class="mr-1 text-muted-foreground">
+      <slot name="label" />
+    </span>
+    <Button
+      variant="muted-textonly"
+      size="icon-sm"
+      :disabled="index === 0"
+      data-testid="batch-prev"
+      @click="index--"
+    >
+      <i class="icon-[lucide--chevron-left]" />
+    </Button>
+    <span data-testid="batch-counter">
+      {{ $t('batch.index', { current: index + 1, total: count }) }}
+    </span>
+    <Button
+      variant="muted-textonly"
+      size="icon-sm"
+      :disabled="index === count - 1"
+      data-testid="batch-next"
+      @click="index++"
+    >
+      <i class="icon-[lucide--chevron-right]" />
+    </Button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+const index = defineModel<number>({ required: true })
+
+defineProps<{
+  count: number
+}>()
+</script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetImageCompare.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetImageCompare.vue
@@ -1,6 +1,33 @@
 <template>
-  <div ref="containerRef" class="relative size-full min-h-32 overflow-hidden">
-    <div v-if="beforeImage || afterImage" class="relative size-full">
+  <div class="flex size-full min-h-32 flex-col overflow-hidden">
+    <div
+      v-if="showBatchNav"
+      class="flex shrink-0 justify-between px-2 py-1 text-xs"
+      data-testid="batch-nav"
+    >
+      <BatchNavigation
+        v-model="beforeIndex"
+        :count="beforeBatchCount"
+        data-testid="before-batch"
+      >
+        <template #label>{{ $t('imageCompare.batchLabelA') }}</template>
+      </BatchNavigation>
+      <div v-if="beforeBatchCount <= 1" />
+
+      <BatchNavigation
+        v-model="afterIndex"
+        :count="afterBatchCount"
+        data-testid="after-batch"
+      >
+        <template #label>{{ $t('imageCompare.batchLabelB') }}</template>
+      </BatchNavigation>
+    </div>
+
+    <div
+      v-if="beforeImage || afterImage"
+      ref="containerRef"
+      class="relative min-h-0 flex-1"
+    >
       <img
         v-if="afterImage"
         :src="afterImage"
@@ -25,7 +52,7 @@
       />
     </div>
 
-    <div v-else class="flex size-full items-center justify-center">
+    <div v-else class="flex min-h-0 flex-1 items-center justify-center">
       {{ $t('imageCompare.noImages') }}
     </div>
   </div>
@@ -37,9 +64,11 @@ import { computed, ref, watch } from 'vue'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
+import BatchNavigation from './BatchNavigation.vue'
+
 export interface ImageCompareValue {
-  before: string
-  after: string
+  beforeImages?: string[]
+  afterImages?: string[]
   beforeAlt?: string
   afterAlt?: string
   initialPosition?: number
@@ -52,6 +81,8 @@ const props = defineProps<{
 
 const containerRef = ref<HTMLElement | null>(null)
 const sliderPosition = ref(50)
+const beforeIndex = ref(0)
+const afterIndex = ref(0)
 
 const { elementX, elementWidth, isOutside } = useMouseInElement(containerRef)
 
@@ -61,14 +92,48 @@ watch([elementX, elementWidth, isOutside], ([x, width, outside]) => {
   }
 })
 
+const parsedValue = computed(() => {
+  const value = props.widget.value
+  return typeof value === 'string' ? null : value
+})
+
+const beforeBatchCount = computed(
+  () => parsedValue.value?.beforeImages?.length ?? 0
+)
+
+const afterBatchCount = computed(
+  () => parsedValue.value?.afterImages?.length ?? 0
+)
+
+const showBatchNav = computed(
+  () => beforeBatchCount.value > 1 || afterBatchCount.value > 1
+)
+
+// Reset indices when batch data changes
+watch(
+  () => parsedValue.value?.beforeImages,
+  () => {
+    beforeIndex.value = 0
+  }
+)
+
+watch(
+  () => parsedValue.value?.afterImages,
+  () => {
+    afterIndex.value = 0
+  }
+)
+
 const beforeImage = computed(() => {
   const value = props.widget.value
-  return typeof value === 'string' ? value : value?.before || ''
+  if (typeof value === 'string') return value
+  return value?.beforeImages?.[beforeIndex.value] ?? ''
 })
 
 const afterImage = computed(() => {
   const value = props.widget.value
-  return typeof value === 'string' ? '' : value?.after || ''
+  if (typeof value === 'string') return ''
+  return value?.afterImages?.[afterIndex.value] ?? ''
 })
 
 const beforeAlt = computed(() => {


### PR DESCRIPTION
## Summary

Add batch image navigation to the ImageCompare node so users can browse all images in a batch instead of only seeing the first one.                                                    
                                                                                                                                                                                         
## Changes
The backend already returns all batch images in a_images/b_images arrays, but the frontend only used index [0]. Now all images are mapped to URLs and a navigation bar with prev/next controls appears above the comparison slider when either side has more than one image. A/B sides navigate independently. Extracted a reusable BatchNavigation component for the index selector UI.

fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/9098

## Screenshots (if applicable)

https://github.com/user-attachments/assets/a801cc96-9182-4b0d-a342-4e6107290f47

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9151-feat-add-batch-image-navigation-to-ImageCompare-node-3116d73d365081498be6d401773619a3) by [Unito](https://www.unito.io)
