### PR TITLE
refactor: remove redundant `= false` defaults on boolean props

### DIFF
--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -78,7 +78,7 @@ interface Props {
   isActive?: boolean
 }
 
-const { item, isActive = false } = defineProps<Props>()
+const { item, isActive } = defineProps<Props>()
 
 const nodeDefStore = useNodeDefStore()
 const hasMissingNodes = computed(() =>

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -75,7 +75,7 @@ import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 type OverlayState = 'hidden' | 'active' | 'expanded'
 
-const { expanded, menuHovered = false } = defineProps<{
+const { expanded, menuHovered } = defineProps<{
   expanded?: boolean
   menuHovered?: boolean
 }>()

--- a/src/components/topbar/CloudBadge.vue
+++ b/src/components/topbar/CloudBadge.vue
@@ -18,8 +18,8 @@ import TopbarBadge from './TopbarBadge.vue'
 
 const {
   displayMode = 'full',
-  reverseOrder = false,
-  noPadding = false,
+  reverseOrder,
+  noPadding,
   backgroundColor = 'var(--comfy-menu-bg)'
 } = defineProps<{
   displayMode?: 'full' | 'compact' | 'icon-only'

--- a/src/components/topbar/TopbarBadge.vue
+++ b/src/components/topbar/TopbarBadge.vue
@@ -132,8 +132,8 @@ import { cn } from '@/utils/tailwindUtil'
 const {
   badge,
   displayMode = 'full',
-  reverseOrder = false,
-  noPadding = false,
+  reverseOrder,
+  noPadding,
   backgroundColor = 'var(--comfy-menu-bg)'
 } = defineProps<{
   badge: TopbarBadge

--- a/src/components/topbar/TopbarBadges.vue
+++ b/src/components/topbar/TopbarBadges.vue
@@ -19,7 +19,7 @@ import { useTopbarBadgeStore } from '@/stores/topbarBadgeStore'
 
 import TopbarBadge from './TopbarBadge.vue'
 
-const { reverseOrder = false, noPadding = false } = defineProps<{
+const { reverseOrder, noPadding } = defineProps<{
   reverseOrder?: boolean
   noPadding?: boolean
 }>()

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -305,7 +305,7 @@ interface Props {
   loadingTier?: CheckoutTierKey | null
 }
 
-const { isLoading = false, loadingTier = null } = defineProps<Props>()
+const { isLoading, loadingTier = null } = defineProps<Props>()
 
 const emit = defineEmits<{
   subscribe: [payload: { tierKey: CheckoutTierKey; billingCycle: BillingCycle }]

--- a/src/renderer/extensions/vueNodes/widgets/components/form/FormSelectButton.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/FormSelectButton.vue
@@ -63,7 +63,7 @@ const {
   options,
   optionLabel = 'label',
   optionValue = 'value',
-  disabled = false
+  disabled
 } = defineProps<Props>()
 
 const emit = defineEmits<Emits>()

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const {
-  isOpen = false,
+  isOpen,
   placeholder = 'Select...',
   items,
   displayItems,


### PR DESCRIPTION
## Summary

Remove redundant `= false` defaults from destructured `defineProps` on boolean props, since Vue's [Boolean casting](https://vuejs.org/guide/components/props.html#boolean-casting) already defaults absent boolean props to `false`.

## Changes

- **What**: Remove 10 unnecessary `= false` default values across 8 components

## Review Focus

Vue compiles `defineProps<{ myBool?: boolean }>()` to `{ myBool: { type: Boolean, required: false } }`. Boolean casting means absent boolean props are already `false` — the explicit `= false` in JS destructuring defaults never triggers.

Follow-up to #9150.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9155-refactor-remove-redundant-false-defaults-on-boolean-props-3116d73d36508196af0bcba53257720a) by [Unito](https://www.unito.io)
