### PR TITLE
[backport cloud/1.40] fix: sync DOM widget values to widgetValueStore on registration

### DIFF
--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -7,12 +7,14 @@ import {
   LegacyWidget,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
+import type { NodeId } from '@/lib/litegraph/src/litegraph'
 import type {
   IBaseWidget,
   IWidgetOptions
 } from '@/lib/litegraph/src/types/widgets'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { generateUUID } from '@/utils/formatUtil'
 
 export interface BaseDOMWidget<
@@ -146,6 +148,18 @@ abstract class BaseDOMWidgetImpl<V extends object | string>
   override set value(v: V) {
     this.options.setValue?.(v)
     this.callback?.(this.value)
+  }
+
+  override setNodeId(nodeId: NodeId): void {
+    // Capture the DOM-resolved value before registration, since the base class
+    // registers _state.value which is undefined for DOM widgets (their value
+    // lives in the DOM element / options.getValue).
+    const resolvedValue = this.value
+    super.setNodeId(nodeId)
+    const graphId = this.node.graph?.rootGraph.id
+    if (!graphId) return
+    const state = useWidgetValueStore().getWidget(nodeId, this.name)
+    if (state) state.value = resolvedValue
   }
 
   get margin(): number {

--- a/src/scripts/domWidgetStore.test.ts
+++ b/src/scripts/domWidgetStore.test.ts
@@ -1,0 +1,48 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { DOMWidgetImpl } from '@/scripts/domWidget'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+
+describe('DOMWidgetImpl store integration', () => {
+  let graph: LGraph
+  let node: LGraphNode
+  let store: ReturnType<typeof useWidgetValueStore>
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useWidgetValueStore()
+    graph = new LGraph()
+    node = new LGraphNode('TestNode')
+    node.id = 1
+    graph.add(node)
+  })
+
+  it('registers DOM-resolved value in store via setNodeId', () => {
+    const defaultValue = 'You are an expert image-generation engine.'
+    const element = document.createElement('textarea')
+    element.value = defaultValue
+
+    const widget = new DOMWidgetImpl({
+      node,
+      name: 'system_prompt',
+      type: 'customtext',
+      element,
+      options: {
+        getValue: () => element.value as string,
+        setValue: (v: string) => {
+          element.value = v
+          const state = store.getWidget(node.id, 'system_prompt')
+          if (state) state.value = v
+        }
+      }
+    })
+
+    widget.setNodeId(node.id)
+
+    const state = store.getWidget(node.id, 'system_prompt')
+    expect(state?.value).toBe(defaultValue)
+  })
+})


### PR DESCRIPTION
Backport of #9166 to cloud/1.40

Manually created.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9174-backport-cloud-1-40-fix-sync-DOM-widget-values-to-widgetValueStore-on-registration-3116d73d36508173a24ccd01037803a8) by [Unito](https://www.unito.io)
