### PR TITLE
fix: remove beta labeling from comfy cloud badges

### DIFF
--- a/src/components/topbar/CloudBadge.vue
+++ b/src/components/topbar/CloudBadge.vue
@@ -28,6 +28,7 @@ const {
 }>()
 
 const cloudBadge = computed<TopbarBadgeType>(() => ({
+  icon: 'pi pi-cloud',
   text: 'Comfy Cloud'
 }))
 </script>

--- a/src/components/topbar/CloudBadge.vue
+++ b/src/components/topbar/CloudBadge.vue
@@ -10,7 +10,6 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import type { TopbarBadge as TopbarBadgeType } from '@/types/comfy'
 
@@ -28,10 +27,7 @@ const {
   backgroundColor?: string
 }>()
 
-const { t } = useI18n()
-
 const cloudBadge = computed<TopbarBadgeType>(() => ({
-  label: t('g.beta'),
   text: 'Comfy Cloud'
 }))
 </script>

--- a/src/components/topbar/CloudBadge.vue
+++ b/src/components/topbar/CloudBadge.vue
@@ -28,7 +28,7 @@ const {
 }>()
 
 const cloudBadge = computed<TopbarBadgeType>(() => ({
-  icon: 'pi pi-cloud',
+  icon: 'icon-[lucide--cloud]',
   text: 'Comfy Cloud'
 }))
 </script>

--- a/src/extensions/core/cloudBadges.ts
+++ b/src/extensions/core/cloudBadges.ts
@@ -20,6 +20,7 @@ const badges = computed<TopbarBadge[]>(() => {
 
   // Always add cloud badge last (furthest right)
   result.push({
+    icon: 'pi pi-cloud',
     text: 'Comfy Cloud'
   })
 

--- a/src/extensions/core/cloudBadges.ts
+++ b/src/extensions/core/cloudBadges.ts
@@ -1,7 +1,6 @@
 import { computed } from 'vue'
 
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
-import { t } from '@/i18n'
 import { useExtensionService } from '@/services/extensionService'
 import type { TopbarBadge } from '@/types/comfy'
 
@@ -21,7 +20,6 @@ const badges = computed<TopbarBadge[]>(() => {
 
   // Always add cloud badge last (furthest right)
   result.push({
-    label: t('g.beta'),
     text: 'Comfy Cloud'
   })
 

--- a/src/extensions/core/cloudBadges.ts
+++ b/src/extensions/core/cloudBadges.ts
@@ -20,7 +20,7 @@ const badges = computed<TopbarBadge[]>(() => {
 
   // Always add cloud badge last (furthest right)
   result.push({
-    icon: 'pi pi-cloud',
+    icon: 'icon-[lucide--cloud]',
     text: 'Comfy Cloud'
   })
 


### PR DESCRIPTION
Remove the BETA label from Comfy Cloud badges while keeping the `Comfy Cloud` text.

This updates both paths that render Comfy Cloud badge content:
- `src/extensions/core/cloudBadges.ts` (topbar extension badge path)
- `src/components/topbar/CloudBadge.vue` (reusable cloud badge used in subscription UI)

<img width="479" height="106" alt="image" src="https://github.com/user-attachments/assets/a73e0607-e747-4335-b09e-cf45b5016ff5" />

Reasoning:
https://comfy-organization.slack.com/archives/C08V9NDB3B4/p1771981530055409?thread_ts=1771978875.127499&cid=C08V9NDB3B4

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9184-fix-remove-beta-labeling-from-comfy-cloud-badges-3126d73d365081e993aac651993010e7) by [Unito](https://www.unito.io)
