### PR TITLE
fix: resolve desktop-ui build failure from icon path cwd mismatch

### DIFF
--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -61,8 +61,7 @@
           "^build"
         ],
         "options": {
-          "cwd": "apps/desktop-ui",
-          "command": "vite build --config vite.config.mts"
+          "command": "vite build --config apps/desktop-ui/vite.config.mts"
         },
         "outputs": [
           "{projectRoot}/dist"


### PR DESCRIPTION
## Summary
Desktop UI production builds were failing in distribution due to an icon path being resolved from the wrong working directory.

## Problem
`@comfyorg/desktop-ui:build` runs with `cwd: apps/desktop-ui`, but design-system CSS config includes:
`from-folder(comfy, './packages/design-system/src/icons')`

That relative path only exists from workspace root, so desktop builds errored with:
`ENOENT: no such file or directory, scandir './packages/design-system/src/icons/'`

## Fix
Update the desktop build target to run Vite from workspace root by removing the app-local `cwd` and using a root-relative config path:
- from: `vite build --config vite.config.mts` with `cwd: apps/desktop-ui`
- to: `vite build --config apps/desktop-ui/vite.config.mts`

This keeps the icon path resolvable while preserving the same desktop build config.

## Validation
- `pnpm nx run @comfyorg/desktop-ui:build --skip-nx-cache` ✅
- `pnpm build:desktop --skip-nx-cache` ✅

(Separate pre-existing issues remain in `@comfyorg/desktop-ui:typecheck` and `@comfyorg/desktop-ui:lint`; unchanged by this PR.)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9185-fix-resolve-desktop-ui-build-failure-from-icon-path-cwd-mismatch-3126d73d3650813c94cae25a9240f9b7) by [Unito](https://www.unito.io)
