### PR TITLE
[bugfix] Fix workspace dialog pt override losing base styles

### DIFF
--- a/src/platform/workspace/components/dialogs/EditWorkspaceDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/EditWorkspaceDialogContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex w-full max-w-[400px] flex-col rounded-2xl border border-border-default bg-base-background"
+    class="flex w-full min-w-[400px] flex-col rounded-2xl border border-border-default bg-base-background"
   >
     <!-- Header -->
     <div

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -437,11 +437,7 @@ export const useDialogService = () => {
       component,
       props: { onConfirm },
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[400px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -463,11 +459,7 @@ export const useDialogService = () => {
       key: 'edit-workspace',
       component,
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[400px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -490,11 +482,7 @@ export const useDialogService = () => {
       key: 'invite-member',
       component,
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[512px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -506,11 +494,7 @@ export const useDialogService = () => {
       key: 'invite-member-upsell',
       component,
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[512px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -552,11 +536,7 @@ export const useDialogService = () => {
       component,
       props: { cancelAt },
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[400px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }


### PR DESCRIPTION
## Summary
Workspace dialog `pt` overrides were spreading `workspaceDialogPt` then replacing `pt.root`, which discarded other `pt` properties from the base config. This fix removes the redundant overrides so all workspace dialogs consistently use `workspaceDialogPt` as-is.

## Changes
- **What**: Remove incorrect `pt` spread-and-override pattern in 5 workspace dialog calls
- **Why**: The override replaced the entire `pt` object, losing styles like `header: { class: 'p-0! hidden' }`

## Review Focus
- Verify that the removed `max-w-[400px]` / `max-w-[512px]` constraints are either unnecessary or already handled by `workspaceDialogPt` or the dialog components themselves

<img width="709" height="357" alt="스크린샷 2026-02-25 오후 12 16 08" src="https://github.com/user-attachments/assets/5020664d-1a8c-478b-a16a-14f59bcf0dde" />
<img width="784" height="390" alt="스크린샷 2026-02-25 오후 12 16 03" src="https://github.com/user-attachments/assets/041dc09d-5639-4880-a95d-a8a6e29e303e" />
<img width="551" height="392" alt="스크린샷 2026-02-25 오후 12 15 56" src="https://github.com/user-attachments/assets/b9769a9d-c0fa-4400-b6d7-0358ba806eaa" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9188-bugfix-Fix-workspace-dialog-pt-override-losing-base-styles-3126d73d365081b8a73ffc681ccb52a6) by [Unito](https://www.unito.io)
