### PR TITLE
fix: add GLSLShader to toolkit node telemetry tracking

### DIFF
--- a/src/constants/toolkitNodes.ts
+++ b/src/constants/toolkitNodes.ts
@@ -25,7 +25,10 @@ export const TOOLKIT_NODE_NAMES: ReadonlySet<string> = new Set([
   // API Nodes
   'RecraftRemoveBackgroundNode',
   'RecraftVectorizeImageNode',
-  'KlingOmniProEditVideoNode'
+  'KlingOmniProEditVideoNode',
+
+  // Shader Nodes
+  'GLSLShader'
 ])
 
 /**


### PR DESCRIPTION
## Summary

Add `GLSLShader` to `TOOLKIT_NODE_NAMES` so Mixpanel telemetry tracks GLSL shader node usage alongside other toolkit nodes.

## Changes

- Add `'GLSLShader'` to the `TOOLKIT_NODE_NAMES` set in `src/constants/toolkitNodes.ts`

## Context

The Toolkit Nodes PRD defines success metrics that require tracking "% of workflows using one of these nodes" and "how often each node is used." GLSLShader was missing from the tracking list, so no GLSL-specific telemetry was being collected despite 12 GLSL blueprints shipping in prod (BlueprintsVersion 0.9.1).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9197-fix-add-GLSLShader-to-toolkit-node-telemetry-tracking-3126d73d3650814dad05fa78382d5064) by [Unito](https://www.unito.io)
