### PR TITLE
fix: textarea stays disabled after link disconnect on promoted widgets

### DIFF
--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -69,6 +69,12 @@ export interface SafeWidgetData {
   spec?: InputSpec
   /** Input slot metadata (index and link status) */
   slotMetadata?: WidgetSlotMetadata
+  /**
+   * Original LiteGraph widget name used for slot metadata matching.
+   * For promoted widgets, `name` is `sourceWidgetName` (interior widget name)
+   * which differs from the subgraph node's input slot widget name.
+   */
+  slotName?: string
 }
 
 export interface VueNodeData {
@@ -238,7 +244,8 @@ function safeWidgetMapper(
         options: isPromotedPseudoWidget
           ? { ...options, canvasOnly: true }
           : options,
-        slotMetadata: slotInfo
+        slotMetadata: slotInfo,
+        slotName: name !== widget.name ? widget.name : undefined
       }
     } catch (error) {
       return {
@@ -376,7 +383,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
     // Update only widgets with new slot metadata, keeping other widget data intact
     for (const widget of currentData.widgets ?? []) {
-      const slotInfo = slotMetadata.get(widget.name)
+      const slotInfo = slotMetadata.get(widget.slotName ?? widget.name)
       if (slotInfo) widget.slotMetadata = slotInfo
     }
   }


### PR DESCRIPTION
## Summary

Fix textarea widgets staying disabled after disconnecting a link on promoted widgets in subgraphs.

## Changes

- **What**: `refreshNodeSlots` used `SafeWidgetData.name` for slot metadata lookups, but for promoted widgets this is `sourceWidgetName` (the interior widget name), which doesn't match the subgraph node's input slot widget name. Added `slotName` field to `SafeWidgetData` to track the original LiteGraph widget name, and updated `refreshNodeSlots` to use `slotName ?? name` for correct matching.

## Review Focus

The key change is the `slotName` field on `SafeWidgetData` — it's only populated when `name !== widget.name` (i.e., for promoted widgets). The `refreshNodeSlots` function now uses `widget.slotName ?? widget.name` to look up slot metadata, ensuring promoted widgets correctly update their `linked` state on disconnect.

Fixes #8818

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9199-fix-textarea-stays-disabled-after-link-disconnect-on-promoted-widgets-3126d73d3650813db499c227e6587aca) by [Unito](https://www.unito.io)
