### PR TITLE
refactor: improve missing node error handling and add roadmap documen…

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -7,6 +7,7 @@
     "empty": "Empty",
     "noWorkflowsFound": "No workflows found.",
     "comingSoon": "Coming Soon",
+    "inSubgraph": "in subgraph {name}",
     "download": "Download",
     "downloadImage": "Download image",
     "downloadVideo": "Download video",

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -21,6 +21,7 @@ import { useMissingModelsDialog } from '@/composables/useMissingModelsDialog'
 import { useMissingNodesDialog } from '@/composables/useMissingNodesDialog'
 import { useDialogService } from '@/services/dialogService'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { appendJsonExt } from '@/utils/formatUtil'
 
@@ -33,6 +34,7 @@ export const useWorkflowService = () => {
   const missingNodesDialog = useMissingNodesDialog()
   const workflowThumbnail = useWorkflowThumbnail()
   const domWidgetStore = useDomWidgetStore()
+  const executionErrorStore = useExecutionErrorStore()
   const workflowDraftStore = useWorkflowDraftStore()
 
   async function getFilename(defaultName: string): Promise<string | null> {
@@ -472,7 +474,15 @@ export const useWorkflowService = () => {
       settingStore.get('Comfy.Workflow.ShowMissingNodesWarning')
     ) {
       missingNodesDialog.show({ missingNodeTypes })
+
+      // For now, we'll make them coexist.
+      // Once the Node Replacement feature is implemented in TabErrors
+      // we'll remove the modal display and direct users to the error tab.
+      if (settingStore.get('Comfy.RightSidePanel.ShowErrorsTab')) {
+        executionErrorStore.showErrorOverlay()
+      }
     }
+
     if (
       missingModels &&
       settingStore.get('Comfy.Workflow.ShowMissingModelsWarning')

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -547,7 +547,6 @@ export type ComfyApiWorkflow = z.infer<typeof zComfyApiWorkflow>
  * where that definition is instantiated in the workflow.
  *
  * "def-A" → ["5", "10"] for each container node instantiating that subgraph definition.
- * @knipIgnoreUsedByStackedPR
  */
 export function buildSubgraphExecutionPaths(
   rootNodes: ComfyNode[],

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -32,7 +32,8 @@ import {
   type ComfyWorkflowJSON,
   type ModelFile,
   type NodeId,
-  isSubgraphDefinition
+  isSubgraphDefinition,
+  buildSubgraphExecutionPaths
 } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type {
   ExecutionErrorWsMessage,
@@ -1099,6 +1100,15 @@ export class ComfyApp {
   private showMissingNodesError(missingNodeTypes: MissingNodeType[]) {
     if (useSettingStore().get('Comfy.Workflow.ShowMissingNodesWarning')) {
       useMissingNodesDialog().show({ missingNodeTypes })
+
+      // For now, we'll make them coexist.
+      // Once the Node Replacement feature is implemented in TabErrors
+      // we'll remove the modal display and direct users to the error tab.
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.setMissingNodeTypes(missingNodeTypes)
+      if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
+        executionErrorStore.showErrorOverlay()
+      }
     }
   }
 
@@ -1181,12 +1191,13 @@ export class ComfyApp {
 
     const collectMissingNodesAndModels = (
       nodes: ComfyWorkflowJSON['nodes'],
-      path: string = ''
+      pathPrefix: string = '',
+      displayName: string = ''
     ) => {
       if (!Array.isArray(nodes)) {
         console.warn(
           'Workflow nodes data is missing or invalid, skipping node processing',
-          { nodes, path }
+          { nodes, pathPrefix }
         )
         return
       }
@@ -1195,9 +1206,26 @@ export class ComfyApp {
         if (!(n.type in LiteGraph.registered_node_types)) {
           const replacement = nodeReplacementStore.getReplacementFor(n.type)
 
+          // To access missing node information in the error tab
+          // we collect the cnr_id and execution_id here.
+          let cnrId: string | undefined
+          if (typeof n.properties?.cnr_id === 'string') {
+            cnrId = n.properties.cnr_id
+          } else if (typeof n.properties?.aux_id === 'string') {
+            cnrId = n.properties.aux_id
+          }
+
+          const executionId = pathPrefix
+            ? `${pathPrefix}:${n.id}`
+            : String(n.id)
+
           missingNodeTypes.push({
             type: n.type,
-            ...(path && { hint: `in subgraph '${path}'` }),
+            nodeId: executionId,
+            cnrId,
+            ...(displayName && {
+              hint: t('g.inSubgraph', { name: displayName })
+            }),
             isReplaceable: replacement !== null,
             replacement: replacement ?? undefined
           })
@@ -1216,14 +1244,25 @@ export class ComfyApp {
     // Process nodes at the top level
     collectMissingNodesAndModels(graphData.nodes)
 
+    // Build map: subgraph definition UUID → full execution path prefix.
+    // Handles arbitrary nesting depth (e.g. root node 11 → "11", node 14 in sg 11 → "11:14").
+    const subgraphContainerIdMap = buildSubgraphExecutionPaths(
+      graphData.nodes,
+      graphData.definitions?.subgraphs ?? []
+    )
+
     // Process nodes in subgraphs
     if (graphData.definitions?.subgraphs) {
       for (const subgraph of graphData.definitions.subgraphs) {
         if (isSubgraphDefinition(subgraph)) {
-          collectMissingNodesAndModels(
-            subgraph.nodes,
-            subgraph.name || subgraph.id
-          )
+          const paths = subgraphContainerIdMap.get(subgraph.id) ?? []
+          for (const pathPrefix of paths) {
+            collectMissingNodesAndModels(
+              subgraph.nodes,
+              pathPrefix,
+              subgraph.name || subgraph.id
+            )
+          }
         }
       }
     }

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 
+import { st } from '@/i18n'
+import { isCloud } from '@/platform/distribution/types'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { app } from '@/scripts/app'
@@ -10,8 +12,13 @@ import type {
   PromptError
 } from '@/schemas/apiSchema'
 import type { NodeId } from '@/platform/workflow/validation/schemas/workflowSchema'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  getAncestorExecutionIds,
+  getParentExecutionIds
+} from '@/types/nodeIdentification'
 import type { NodeExecutionId, NodeLocatorId } from '@/types/nodeIdentification'
+import type { MissingNodeType } from '@/types/comfy'
 import {
   executionIdToNodeLocatorId,
   forEachNode,
@@ -20,12 +27,52 @@ import {
 } from '@/utils/graphTraversalUtil'
 
 /**
- * Store dedicated to execution error state management.
- *
- * Extracted from executionStore to separate error-related concerns
- * (state, computed properties, graph flag propagation, overlay UI)
- * from execution flow management (progress, queuing, events).
+ * @knipIgnoreUsedByStackedPR
  */
+interface MissingNodesError {
+  message: string
+  nodeTypes: MissingNodeType[]
+}
+
+function clearAllNodeErrorFlags(rootGraph: LGraph): void {
+  forEachNode(rootGraph, (node) => {
+    node.has_errors = false
+    if (node.inputs) {
+      for (const slot of node.inputs) {
+        slot.hasErrors = false
+      }
+    }
+  })
+}
+
+function markNodeSlotErrors(node: LGraphNode, nodeError: NodeError): void {
+  if (!node.inputs) return
+  for (const error of nodeError.errors) {
+    const slotName = error.extra_info?.input_name
+    if (!slotName) continue
+    const slot = node.inputs.find((s) => s.name === slotName)
+    if (slot) slot.hasErrors = true
+  }
+}
+
+function applyNodeError(
+  rootGraph: LGraph,
+  executionId: NodeExecutionId,
+  nodeError: NodeError
+): void {
+  const node = getNodeByExecutionId(rootGraph, executionId)
+  if (!node) return
+
+  node.has_errors = true
+  markNodeSlotErrors(node, nodeError)
+
+  for (const parentId of getParentExecutionIds(executionId)) {
+    const parentNode = getNodeByExecutionId(rootGraph, parentId)
+    if (parentNode) parentNode.has_errors = true
+  }
+}
+
+/** Execution error state: node errors, runtime errors, prompt errors, and missing nodes. */
 export const useExecutionErrorStore = defineStore('executionError', () => {
   const workflowStore = useWorkflowStore()
   const canvasStore = useCanvasStore()
@@ -33,6 +80,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   const lastNodeErrors = ref<Record<NodeId, NodeError> | null>(null)
   const lastExecutionError = ref<ExecutionErrorWsMessage | null>(null)
   const lastPromptError = ref<PromptError | null>(null)
+  const missingNodesError = ref<MissingNodesError | null>(null)
 
   const isErrorOverlayOpen = ref(false)
 
@@ -49,12 +97,47 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     lastExecutionError.value = null
     lastPromptError.value = null
     lastNodeErrors.value = null
+    missingNodesError.value = null
     isErrorOverlayOpen.value = false
   }
 
   /** Clear only prompt-level errors. Called during resetExecutionState. */
   function clearPromptError() {
     lastPromptError.value = null
+  }
+
+  function setMissingNodeTypes(types: MissingNodeType[]) {
+    if (!types.length) {
+      missingNodesError.value = null
+      return
+    }
+    const seen = new Set<string>()
+    const uniqueTypes = types.filter((node) => {
+      // For string entries (group nodes), deduplicate by the string itself.
+      // For object entries, prefer nodeId so multiple instances of the same
+      // type are kept as separate rows; fall back to type if nodeId is absent.
+      const isString = typeof node === 'string'
+      let key: string
+      if (isString) {
+        key = node
+      } else if (node.nodeId != null) {
+        key = String(node.nodeId)
+      } else {
+        key = node.type
+      }
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    missingNodesError.value = {
+      message: isCloud
+        ? st(
+            'rightSidePanel.missingNodePacks.unsupportedTitle',
+            'Unsupported Node Packs'
+          )
+        : st('rightSidePanel.missingNodePacks.title', 'Missing Node Packs'),
+      nodeTypes: uniqueTypes
+    }
   }
 
   const lastExecutionErrorNodeLocatorId = computed(() => {
@@ -81,9 +164,18 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     () => !!lastNodeErrors.value && Object.keys(lastNodeErrors.value).length > 0
   )
 
-  /** Whether any error (node validation, runtime execution, or prompt-level) is present */
+  /** Whether any missing node types are present in the current workflow
+   * @knipIgnoreUsedByStackedPR
+   */
+  const hasMissingNodes = computed(() => !!missingNodesError.value)
+
+  /** Whether any error (node validation, runtime execution, prompt-level, or missing nodes) is present */
   const hasAnyError = computed(
-    () => hasExecutionError.value || hasPromptError.value || hasNodeError.value
+    () =>
+      hasExecutionError.value ||
+      hasPromptError.value ||
+      hasNodeError.value ||
+      hasMissingNodes.value
   )
 
   const allErrorExecutionIds = computed<string[]>(() => {
@@ -116,13 +208,19 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   /** Count of runtime execution errors (0 or 1) */
   const executionErrorCount = computed(() => (lastExecutionError.value ? 1 : 0))
 
+  /** Count of missing node errors (0 or 1) */
+  const missingNodeCount = computed(() => (missingNodesError.value ? 1 : 0))
+
   /** Total count of all individual errors */
   const totalErrorCount = computed(
     () =>
-      promptErrorCount.value + nodeErrorCount.value + executionErrorCount.value
+      promptErrorCount.value +
+      nodeErrorCount.value +
+      executionErrorCount.value +
+      missingNodeCount.value
   )
 
-  /** Pre-computed Set of graph node IDs (as strings) that have errors in the current graph scope. */
+  /** Graph node IDs (as strings) that have errors in the current graph scope. */
   const activeGraphErrorNodeIds = computed<Set<string>>(() => {
     const ids = new Set<string>()
     if (!app.rootGraph) return ids
@@ -142,6 +240,44 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     if (lastExecutionError.value) {
       const execNodeId = String(lastExecutionError.value.node_id)
       const graphNode = getNodeByExecutionId(app.rootGraph, execNodeId)
+      if (graphNode?.graph === activeGraph) {
+        ids.add(String(graphNode.id))
+      }
+    }
+
+    return ids
+  })
+
+  /**
+   * Set of all execution ID prefixes derived from missing node execution IDs,
+   * including the missing nodes themselves.
+   *
+   * Example: missing node at "65:70:63" → Set { "65", "65:70", "65:70:63" }
+   */
+  const missingAncestorExecutionIds = computed<Set<NodeExecutionId>>(() => {
+    const ids = new Set<NodeExecutionId>()
+    const error = missingNodesError.value
+    if (!error) return ids
+
+    for (const nodeType of error.nodeTypes) {
+      if (typeof nodeType === 'string') continue
+      if (nodeType.nodeId == null) continue
+      for (const id of getAncestorExecutionIds(String(nodeType.nodeId))) {
+        ids.add(id)
+      }
+    }
+
+    return ids
+  })
+
+  const activeMissingNodeGraphIds = computed<Set<string>>(() => {
+    const ids = new Set<string>()
+    if (!app.rootGraph) return ids
+
+    const activeGraph = canvasStore.currentGraph ?? app.rootGraph
+
+    for (const executionId of missingAncestorExecutionIds.value) {
+      const graphNode = getNodeByExecutionId(app.rootGraph, executionId)
       if (graphNode?.graph === activeGraph) {
         ids.add(String(graphNode.id))
       }
@@ -196,15 +332,11 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
    */
   const errorAncestorExecutionIds = computed<Set<NodeExecutionId>>(() => {
     const ids = new Set<NodeExecutionId>()
-
     for (const executionId of allErrorExecutionIds.value) {
-      const parts = executionId.split(':')
-      // Add every prefix including the full ID (error leaf node itself)
-      for (let i = 1; i <= parts.length; i++) {
-        ids.add(parts.slice(0, i).join(':'))
+      for (const id of getAncestorExecutionIds(executionId)) {
+        ids.add(id)
       }
     }
-
     return ids
   })
 
@@ -216,59 +348,28 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     return errorAncestorExecutionIds.value.has(execId)
   }
 
-  /**
-   * Update node and slot error flags when validation errors change.
-   * Propagates errors up subgraph chains.
+  /** True if the node has a missing node inside it at any nesting depth.
+   * @knipIgnoreUsedByStackedPR
    */
-  watch(lastNodeErrors, () => {
-    if (!app.rootGraph) return
+  function isContainerWithMissingNode(node: LGraphNode): boolean {
+    if (!app.rootGraph) return false
+    const execId = getExecutionIdByNode(app.rootGraph, node)
+    if (!execId) return false
+    return missingAncestorExecutionIds.value.has(execId)
+  }
 
-    // Clear all error flags
-    forEachNode(app.rootGraph, (node) => {
-      node.has_errors = false
-      if (node.inputs) {
-        for (const slot of node.inputs) {
-          slot.hasErrors = false
-        }
-      }
-    })
+  watch(lastNodeErrors, () => {
+    const rootGraph = app.rootGraph
+    if (!rootGraph) return
+
+    clearAllNodeErrorFlags(rootGraph)
 
     if (!lastNodeErrors.value) return
 
-    // Set error flags on nodes and slots
     for (const [executionId, nodeError] of Object.entries(
       lastNodeErrors.value
     )) {
-      const node = getNodeByExecutionId(app.rootGraph, executionId)
-      if (!node) continue
-
-      node.has_errors = true
-
-      // Mark input slots with errors
-      if (node.inputs) {
-        for (const error of nodeError.errors) {
-          const slotName = error.extra_info?.input_name
-          if (!slotName) continue
-
-          const slot = node.inputs.find((s) => s.name === slotName)
-          if (slot) {
-            slot.hasErrors = true
-          }
-        }
-      }
-
-      // Propagate errors to parent subgraph nodes
-      const parts = executionId.split(':')
-      for (let i = parts.length - 1; i > 0; i--) {
-        const parentExecutionId = parts.slice(0, i).join(':')
-        const parentNode = getNodeByExecutionId(
-          app.rootGraph,
-          parentExecutionId
-        )
-        if (parentNode) {
-          parentNode.has_errors = true
-        }
-      }
+      applyNodeError(rootGraph, executionId, nodeError)
     }
   })
 
@@ -277,6 +378,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     lastNodeErrors,
     lastExecutionError,
     lastPromptError,
+    missingNodesError,
 
     // Clearing
     clearAllErrors,
@@ -291,16 +393,21 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     hasExecutionError,
     hasPromptError,
     hasNodeError,
+    hasMissingNodes,
     hasAnyError,
     allErrorExecutionIds,
     totalErrorCount,
     lastExecutionErrorNodeId,
     activeGraphErrorNodeIds,
+    activeMissingNodeGraphIds,
+
+    // Missing node actions
+    setMissingNodeTypes,
 
     // Lookup helpers
     getNodeErrors,
     slotHasError,
-    errorAncestorExecutionIds,
-    isContainerWithInternalError
+    isContainerWithInternalError,
+    isContainerWithMissingNode
   }
 })

--- a/src/types/comfy.ts
+++ b/src/types/comfy.ts
@@ -90,6 +90,8 @@ export type MissingNodeType =
   // Primarily used by group nodes.
   | {
       type: string
+      nodeId?: string | number
+      cnrId?: string
       hint?: string
       action?: {
         text: string

--- a/src/types/nodeIdentification.ts
+++ b/src/types/nodeIdentification.ts
@@ -126,7 +126,6 @@ export function createNodeExecutionId(nodeIds: NodeId[]): NodeExecutionId {
  * Returns all ancestor execution IDs for a given execution ID, including itself.
  *
  * Example: "65:70:63" → ["65", "65:70", "65:70:63"]
- * @knipIgnoreUsedByStackedPR
  */
 export function getAncestorExecutionIds(
   executionId: string | NodeExecutionId
@@ -141,7 +140,6 @@ export function getAncestorExecutionIds(
  * Returns all ancestor execution IDs for a given execution ID, excluding itself.
  *
  * Example: "65:70:63" → ["65", "65:70"]
- * @knipIgnoreUsedByStackedPR
  */
 export function getParentExecutionIds(
   executionId: string | NodeExecutionId


### PR DESCRIPTION
## Summary

This PR refactors missing node error handling to provide better context for the upcoming Errors Tab integration and documents the roadmap for deprecating the standalone Missing Nodes Modal.

## Changes

- **What**: 
  - Added roadmap documentation in `app.ts` and `workflowService.ts` explaining that the Missing Nodes Modal currently coexists with the Errors Tab, but will be removed once the Node Replacement feature is fully implemented in the Errors Tab.
  - Enhanced error handling logic to collect `cnr_id` and `execution_id` when processing missing nodes, which provides sufficient context for the Errors Tab to function correctly.
  - Enforced strict `NodeExecutionId` typing in `applyNodeError` within the `executionErrorStore`.
  - Cleaned up obsolete comments and reorganized imports across error stores and the app script.
  - Added `@knipIgnoreUsedByStackedPR` to the `hasMissingNodes` property to prevent unused export warnings while waiting for dependent PRs.

## Review Focus

- **Roadmap Verification**: Please review the newly added roadmap comments to ensure they accurately reflect the planned direction for the Missing Nodes Modal and Errors Tab integration.
- **Context Collection**: Verify that extracting `cnr_id` and `execution_id` appropriately prepares the missing node objects for the Node Replacement feature in the Errors Tab.
- **Type Safety**: Ensure the transition to strict `NodeExecutionId` typing in the error store doesn't introduce typing issues.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9203-refactor-improve-missing-node-error-handling-and-add-roadmap-documen-3126d73d365081baacd3fc25e9ee929a) by [Unito](https://www.unito.io)
