### PR TITLE
fix: open target panel when toggling Docked Job History

### DIFF
--- a/src/components/queue/JobHistoryActionsMenu.vue
+++ b/src/components/queue/JobHistoryActionsMenu.vue
@@ -79,6 +79,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { buildTooltipConfig } from '@/composables/useTooltipConfig'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 const emit = defineEmits<{
   (e: 'clearHistory'): void
@@ -86,6 +87,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const settingStore = useSettingStore()
+const sidebarTabStore = useSidebarTabStore()
 
 const moreTooltipConfig = computed(() => buildTooltipConfig(t('g.more')))
 const isQueuePanelV2Enabled = computed(() =>
@@ -99,6 +101,13 @@ const onClearHistoryFromMenu = (close: () => void) => {
 }
 
 const onToggleDockedJobHistory = async () => {
-  await settingStore.set('Comfy.Queue.QPOV2', !isQueuePanelV2Enabled.value)
+  if (isQueuePanelV2Enabled.value) {
+    await settingStore.set('Comfy.Queue.QPOV2', false)
+    await settingStore.set('Comfy.Queue.History.Expanded', true)
+    return
+  }
+
+  await settingStore.set('Comfy.Queue.QPOV2', true)
+  sidebarTabStore.activeSidebarTabId = 'job-history'
 }
 </script>


### PR DESCRIPTION
## Summary
Make the Docked Job History toggle deterministic so it opens the expected UI target in both directions.

## Changes
- Update `JobHistoryActionsMenu` toggle behavior:
  - When currently docked (`Comfy.Queue.QPOV2=true`), disable docked mode and explicitly open floating QPO (`Comfy.Queue.History.Expanded=true`)
  - When currently floating (`Comfy.Queue.QPOV2=false`), enable docked mode and open the `job-history` sidebar tab
- Add/adjust unit tests in `QueueOverlayHeader.test.ts` to verify both toggle directions and target panel behavior

## Testing
- `pnpm exec eslint src/components/queue/JobHistoryActionsMenu.vue src/components/queue/QueueOverlayHeader.test.ts`
- `pnpm typecheck`
- `pnpm test:unit -- src/components/queue/QueueOverlayHeader.test.ts`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9215-fix-open-target-panel-when-toggling-Docked-Job-History-3126d73d3650810eb409ff38e3a521f3) by [Unito](https://www.unito.io)
