### PR TITLE
fix: increase queue header actions menu item size

### DIFF
--- a/src/components/queue/JobHistoryActionsMenu.vue
+++ b/src/components/queue/JobHistoryActionsMenu.vue
@@ -19,7 +19,7 @@
             data-testid="docked-job-history-action"
             class="w-full justify-between text-sm font-light"
             variant="textonly"
-            size="sm"
+            size="md"
             @click="onToggleDockedJobHistory"
           >
             <span class="flex items-center gap-2">
@@ -39,7 +39,7 @@
             data-testid="show-run-progress-bar-action"
             class="w-full justify-between text-sm font-light"
             variant="textonly"
-            size="sm"
+            size="md"
             @click="onToggleRunProgressBar"
           >
             <span class="flex items-center gap-2">
@@ -58,9 +58,9 @@
             <div class="my-1 border-t border-interface-stroke" />
             <Button
               data-testid="clear-history-action"
-              class="h-auto min-h-0 w-full items-start justify-start whitespace-normal"
+              class="h-auto min-h-8 w-full items-start justify-start whitespace-normal"
               variant="textonly"
-              size="sm"
+              size="md"
               @click="onClearHistoryFromMenu(close)"
             >
               <i


### PR DESCRIPTION
Summary
- Increase row height in the shared `JobHistoryActionsMenu` from `sm` to `md` for `Docked Job History` and `Show run progress bar`.
- Increase `Clear history` row baseline size to `md` and set `min-h-8` for multiline spacing.
- Align all list items to the same 32px-equivalent baseline so the menu no longer feels cramped.

From
<img width="518" height="336" alt="image" src="https://github.com/user-attachments/assets/c8457b94-782f-4635-92c6-009cbd1e2852" />

To
<img width="441" height="331" alt="image" src="https://github.com/user-attachments/assets/f4c4df8a-03c6-476b-a8f7-85bdc13951de" />


Stacked on
- #9176

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9216-fix-increase-queue-header-actions-menu-item-size-3126d73d3650818bbaaad472f4065780) by [Unito](https://www.unito.io)
