### PR TITLE
fix: set queue job filter tabs to 32px

### DIFF
--- a/src/components/queue/job/JobFilterTabs.vue
+++ b/src/components/queue/job/JobFilterTabs.vue
@@ -5,7 +5,7 @@
         v-for="tab in visibleJobTabs"
         :key="tab"
         :variant="selectedJobTab === tab ? 'secondary' : 'muted-textonly'"
-        size="sm"
+        size="md"
         @click="$emit('update:selectedJobTab', tab)"
       >
         {{ tabLabel(tab) }}


### PR DESCRIPTION
## Summary
- Increase queue job filter tab button height from `sm` to `md` (`32px` equivalent).
- Apply consistently to both floating Queue Progress Overlay and docked Job History sidebar, since both use `JobFilterTabs`.

## Design
- https://www.figma.com/board/R9eN9DHmDgX3qEJXsRKiRr/QA-Feedback--Alex-?node-id=273-111&t=OUCBdoZhwrOMsxXE-4

## Testing
- `pnpm typecheck`
- `pnpm lint` (passes with existing repo warnings only)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9217-fix-set-queue-job-filter-tabs-to-32px-3126d73d36508106a9c8e3786ab77aa5) by [Unito](https://www.unito.io)
