### PR TITLE
Prevent serialization of progress text to prompt

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
@@ -55,6 +55,7 @@ export function useTextPreviewWidget(
               typeof value === 'string' ? value : String(value)
         },
         getMinHeight: () => options.minHeight ?? 42 + PADDING,
+        serialize: false,
         read_only: true
       },
       type: inputSpec.type


### PR DESCRIPTION
#8625 fixed a bug where `ProgressTextWidget`s would be serialized to workflow data and, under rare circumstances, clobber over other widget values on restore.

I was mistaken that the `serialize: false` being sent to options does serve a purpose: preventing the widget value from being serialized to the (api) prompt which is sent to the backend. This PR reverts the removal so now both forms of disabling serialization apply.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9221-Prevent-serialization-of-progress-text-to-prompt-3126d73d365081c5b9ecc560f0a248d5) by [Unito](https://www.unito.io)
