### PR TITLE
[backport cloud/1.40] fix: add GLSLShader to toolkit node telemetry tracking

### DIFF
--- a/src/constants/toolkitNodes.ts
+++ b/src/constants/toolkitNodes.ts
@@ -1,0 +1,41 @@
+/**
+ * Toolkit (Essentials) node detection constants.
+ *
+ * Used by telemetry to track toolkit node adoption and popularity.
+ * Only novel nodes — basic nodes (LoadImage, SaveImage, etc.) are excluded.
+ *
+ * Source: https://www.notion.so/comfy-org/2fe6d73d365080d0a951d14cdf540778
+ */
+
+/**
+ * Canonical node type names for individual toolkit nodes.
+ */
+export const TOOLKIT_NODE_NAMES: ReadonlySet<string> = new Set([
+  // Image Tools
+  'ImageCrop',
+  'ImageRotate',
+  'ImageBlur',
+  'ImageInvert',
+  'ImageCompare',
+  'Canny',
+
+  // Video Tools
+  'Video Slice',
+
+  // API Nodes
+  'RecraftRemoveBackgroundNode',
+  'RecraftVectorizeImageNode',
+  'KlingOmniProEditVideoNode',
+
+  // Shader Nodes
+  'GLSLShader'
+])
+
+/**
+ * python_module values that identify toolkit blueprint nodes.
+ * Essentials blueprints are registered with node_pack 'comfy_essentials',
+ * which maps to python_module on the node def.
+ */
+export const TOOLKIT_BLUEPRINT_MODULES: ReadonlySet<string> = new Set([
+  'comfy_essentials'
+])


### PR DESCRIPTION
## Backport of #9197

Cherry-pick of merge commit 6034be9a6f261104a1fd33ba2abb24c5dbe858b1 onto cloud/1.40.

### Conflict resolution

- `src/constants/toolkitNodes.ts`: modify/delete conflict — file didn't exist in cloud/1.40 (parent PR #9073 was never backported). Accepted the PR version to add the file.

### Original PR

> Add `GLSLShader` to `TOOLKIT_NODE_NAMES` so Mixpanel telemetry tracks GLSL shader node usage alongside other toolkit nodes.