### PR TITLE
feat: support accumulate toggle for SaveImage/PreviewImage nodes

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -717,11 +717,15 @@ export class ComfyApp {
       const nodeOutputStore = useNodeOutputStore()
       const executionId = String(detail.display_node || detail.node)
 
+      const node = getNodeByExecutionId(this.rootGraph, executionId)
+      const accumulate = node?.widgets?.find(
+        (w) => w.name === 'accumulate'
+      )?.value
+
       nodeOutputStore.setNodeOutputsByExecutionId(executionId, detail.output, {
-        merge: detail.merge
+        merge: detail.merge || !!accumulate
       })
 
-      const node = getNodeByExecutionId(this.rootGraph, executionId)
       if (node && node.onExecuted) {
         node.onExecuted(detail.output)
       }


### PR DESCRIPTION
Read the `accumulate` widget value in the `executed` event handler and pass `merge: true` to the output store when enabled.

Depends on backend PR: https://github.com/Comfy-Org/ComfyUI/pull/12647

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9239-feat-support-accumulate-toggle-for-SaveImage-PreviewImage-nodes-3136d73d365081c0af9ac612956fd4d8) by [Unito](https://www.unito.io)
