### PR TITLE
feat: add executionIdToNodeLocatorId call counter behind feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-frontend",
-  "version": "1.41.6",
+  "version": "1.42.0",
   "private": true,
   "description": "Official front-end implementation of ComfyUI",
   "homepage": "https://comfy.org",

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -31,6 +31,7 @@ import { useNodeOutputStore } from '@/stores/imagePreviewStore'
 import { useJobPreviewStore } from '@/stores/jobPreviewStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 import { classifyCloudValidationError } from '@/utils/executionErrorUtil'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
 
@@ -66,6 +67,16 @@ export const useExecutionStore = defineStore('execution', () => {
   const jobIdToWorkflowId = ref<Map<string, string>>(new Map())
 
   const initializingJobIds = ref<Set<string>>(new Set())
+
+  let executionIdToLocatorCallCount = 0
+
+  function isLocatorCacheCounterEnabled(): boolean {
+    return (
+      getDevOverride<boolean>(
+        'expose_executionId_to_node_locator_id_cache_counters'
+      ) ?? false
+    )
+  }
 
   const mergeExecutionProgressStates = (
     currentState: NodeProgressState | undefined,
@@ -106,6 +117,9 @@ export const useExecutionStore = defineStore('execution', () => {
       const parts = String(state.display_node_id).split(':')
       for (let i = 0; i < parts.length; i++) {
         const executionId = parts.slice(0, i + 1).join(':')
+        if (isLocatorCacheCounterEnabled()) {
+          executionIdToLocatorCallCount++
+        }
         const locatorId = executionIdToNodeLocatorId(app.rootGraph, executionId)
         if (!locatorId) continue
 
@@ -424,6 +438,12 @@ export const useExecutionStore = defineStore('execution', () => {
    * Reset execution-related state after a run completes or is stopped.
    */
   function resetExecutionState(jobIdParam?: string | null) {
+    if (isLocatorCacheCounterEnabled() && executionIdToLocatorCallCount > 0) {
+      console.warn(
+        `[executionStore] executionIdToNodeLocatorId calls this run: ${executionIdToLocatorCallCount}`
+      )
+      executionIdToLocatorCallCount = 0
+    }
     nodeProgressStates.value = {}
     const jobId = jobIdParam ?? activeJobId.value ?? null
     if (jobId) {


### PR DESCRIPTION
## Summary

Add dev-only instrumentation to count how many times executionIdToNodeLocatorId is called per execution run, providing a baseline measurement for evaluating the impact of caching this function's results, in a later PR.

- **What**: Minor, just adds a feature flagged log and two counters
- **Breaking**: Nothing
- **Dependencies**: None

Gated behind the feature flag `ff:expose_executionId_to_node_locator_id_cache_counters`.  Enable in your browser console:

```js
  localStorage.setItem(
    'ff:expose_executionId_to_node_locator_id_cache_counters',
    'true'
  )
```

On execution completion, logs the total call count to console.warn. No reload needed to toggle.

**feat**: Allow measurement of caching impact, behind a flag

**impact**: None unless activated, then just some logging

## Changes

- **What**: <!-- Core functionality added/modified -->
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

## Review Focus

Trivial, just set the flag and look at some workflow with subgraphs

## Screenshots

Login problems due to cross-opener policy are preventing me from taking screenshots from a local dev build at this time

## Thread

There isn't one.  I don't have access to AmpCode or Unito.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9243-feat-add-executionIdToNodeLocatorId-call-counter-behind-feature-flag-3136d73d3650814593e3fdc7e5ad1f73) by [Unito](https://www.unito.io)
