### PR TITLE
[refactor] Rename queueIndex variables to reflect job.priority usage

### DIFF
--- a/src/components/queue/job/JobDetailsPopover.vue
+++ b/src/components/queue/job/JobDetailsPopover.vue
@@ -166,13 +166,13 @@ const queuedAtValue = computed(() =>
     : ''
 )
 
-const currentQueueIndex = computed<number | null>(() => {
+const currentJobPriority = computed<number | null>(() => {
   const task = taskForJob.value
   return task ? Number(task.job.priority) : null
 })
 
 const jobsAhead = computed<number | null>(() => {
-  const idx = currentQueueIndex.value
+  const idx = currentJobPriority.value
   if (idx == null) return null
   const ahead = queueStore.pendingTasks.filter(
     (t: TaskItemImpl) => Number(t.job.priority) < idx

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -271,7 +271,7 @@ describe('useQueueStore', () => {
       expect(store.tasks).toEqual([])
       expect(store.flatTasks).toEqual([])
       expect(store.hasPendingTasks).toBe(false)
-      expect(store.lastHistoryQueueIndex).toBe(-1)
+      expect(store.lastJobHistoryPriority).toBe(-1)
     })
   })
 
@@ -686,7 +686,7 @@ describe('useQueueStore', () => {
       expect(store.hasPendingTasks).toBe(false)
     })
 
-    it('lastHistoryQueueIndex should return highest queue index', async () => {
+    it('lastJobHistoryPriority should return highest job priority', async () => {
       const hist1 = createHistoryJob(10, 'hist-1')
       const hist2 = createHistoryJob(25, 'hist-2')
       const hist3 = createHistoryJob(15, 'hist-3')
@@ -695,15 +695,15 @@ describe('useQueueStore', () => {
       mockGetHistory.mockResolvedValue([hist1, hist2, hist3])
 
       await store.update()
-      expect(store.lastHistoryQueueIndex).toBe(25)
+      expect(store.lastJobHistoryPriority).toBe(25)
     })
 
-    it('lastHistoryQueueIndex should be -1 when no history', async () => {
+    it('lastJobHistoryPriority should be -1 when no history', async () => {
       mockGetQueue.mockResolvedValue({ Running: [], Pending: [] })
       mockGetHistory.mockResolvedValue([])
 
       await store.update()
-      expect(store.lastHistoryQueueIndex).toBe(-1)
+      expect(store.lastJobHistoryPriority).toBe(-1)
     })
   })
 

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -495,7 +495,7 @@ export const useQueueStore = defineStore('queue', () => {
     tasks.value.flatMap((task: TaskItemImpl) => task.flatten())
   )
 
-  const lastHistoryQueueIndex = computed<number>(() =>
+  const lastJobHistoryPriority = computed<number>(() =>
     historyTasks.value.length ? historyTasks.value[0].job.priority : -1
   )
 
@@ -607,7 +607,7 @@ export const useQueueStore = defineStore('queue', () => {
 
     tasks,
     flatTasks,
-    lastHistoryQueueIndex,
+    lastJobHistoryPriority,
     hasPendingTasks,
     activeJobsCount,
 


### PR DESCRIPTION
## Summary
Rename `lastHistoryQueueIndex` → `lastJobHistoryPriority` and `currentQueueIndex` → `currentJobPriority` to reflect that these variables now read `job.priority` directly.

## Changes
- **queueStore.ts**: `lastHistoryQueueIndex` → `lastJobHistoryPriority`
- **JobDetailsPopover.vue**: `currentQueueIndex` → `currentJobPriority`
- **queueStore.test.ts**: Updated references and test descriptions

Fixes #9246

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9258-refactor-Rename-queueIndex-variables-to-reflect-job-priority-usage-3136d73d36508126989dd464f7dad9a1) by [Unito](https://www.unito.io)
