### PR TITLE
fix: make docked job history toggle persistence-safe

### DIFF
--- a/src/components/queue/JobHistoryActionsMenu.vue
+++ b/src/components/queue/JobHistoryActionsMenu.vue
@@ -20,7 +20,7 @@
             class="w-full justify-between text-sm font-light"
             variant="textonly"
             size="sm"
-            @click="onToggleDockedJobHistory"
+            @click="onToggleDockedJobHistory(close)"
           >
             <span class="flex items-center gap-2">
               <i
@@ -100,14 +100,22 @@ const onClearHistoryFromMenu = (close: () => void) => {
   emit('clearHistory')
 }
 
-const onToggleDockedJobHistory = async () => {
-  if (isQueuePanelV2Enabled.value) {
-    await settingStore.set('Comfy.Queue.QPOV2', false)
-    await settingStore.set('Comfy.Queue.History.Expanded', true)
+const onToggleDockedJobHistory = async (close: () => void) => {
+  close()
+
+  try {
+    if (isQueuePanelV2Enabled.value) {
+      await settingStore.setMany({
+        'Comfy.Queue.QPOV2': false,
+        'Comfy.Queue.History.Expanded': true
+      })
+      return
+    }
+
+    sidebarTabStore.activeSidebarTabId = 'job-history'
+    await settingStore.set('Comfy.Queue.QPOV2', true)
+  } catch {
     return
   }
-
-  await settingStore.set('Comfy.Queue.QPOV2', true)
-  sidebarTabStore.activeSidebarTabId = 'job-history'
 }
 </script>


### PR DESCRIPTION
## Summary
Follow-up to #9215 to keep Docked Job History toggle behavior deterministic even when settings persistence fails.

## Changes
- Close the actions popover immediately when toggling Docked Job History.
- Use settingStore.setMany(...) when switching from docked to floating mode.
- Set sidebarTabStore.activeSidebarTabId = 'job-history' before persisting when switching from floating to docked mode.
- Wrap persistence calls in try/catch without rollback so locally-applied UI state remains deterministic.
- Expand QueueOverlayHeader tests to cover setMany, popover close behavior, and persistence-failure paths.

## Testing
- pnpm test:unit -- src/components/queue/QueueOverlayHeader.test.ts
- pnpm typecheck
- pnpm exec eslint src/components/queue/JobHistoryActionsMenu.vue src/components/queue/QueueOverlayHeader.test.ts
- pnpm lint (fails in this branch due pre-existing stylelint errors in generated apps/desktop-ui/dist/**/*.css files, unrelated to this change)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9265-fix-make-docked-job-history-toggle-persistence-safe-3146d73d3650818f86c4dfdd57669abd) by [Unito](https://www.unito.io)
