### PR TITLE
fix: skip CodeRabbit reviews on bot and release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,3 +11,4 @@ reviews:
     ignore_usernames:
       - comfy-pr-bot
       - github-actions
+      - github-actions[bot]

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,3 +5,9 @@ reviews:
   high_level_summary: false
   auto_review:
     drafts: true
+    ignore_title_keywords:
+      - '[release]'
+      - '[backport'
+    ignore_usernames:
+      - comfy-pr-bot
+      - github-actions


### PR DESCRIPTION
## Problem

CodeRabbit is reviewing release and backport PRs created by bots (e.g. [#9264](https://github.com/Comfy-Org/ComfyUI_frontend/pull/9264)), leaving unnecessary review comments.

## Solution

Add ignore rules to `.coderabbit.yaml`:

- **`ignore_usernames`**: `comfy-pr-bot`, `github-actions` — skips reviews on PRs authored by these bot accounts
- **`ignore_title_keywords`**: `[release]`, `[backport` — skips reviews on release and backport PRs by title

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9279-fix-skip-CodeRabbit-reviews-on-bot-and-release-PRs-3146d73d3650814c9ebae0d08acbafd6) by [Unito](https://www.unito.io)
