### PR TITLE
Custom nodes example workflows index

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -489,14 +489,17 @@ const {
 const getEffectiveSourceModule = (template: TemplateInfo) =>
   template.sourceModule || 'default'
 
+const usesTwoThumbnails = (template: TemplateInfo) =>
+  template.thumbnailVariant === 'compareSlider' || template.thumbnailVariant === 'hoverDissolve'
+
 const getBaseThumbnailSrc = (template: TemplateInfo) => {
   const sm = getEffectiveSourceModule(template)
-  return getTemplateThumbnailUrl(template, sm, sm === 'default' ? '1' : '')
+  return getTemplateThumbnailUrl(template, sm, sm === 'default' || usesTwoThumbnails(template) ? '1' : null)
 }
 
 const getOverlayThumbnailSrc = (template: TemplateInfo) => {
   const sm = getEffectiveSourceModule(template)
-  return getTemplateThumbnailUrl(template, sm, sm === 'default' ? '2' : '')
+  return getTemplateThumbnailUrl(template, sm, sm === 'default' || usesTwoThumbnails(template) ? '2' : null)
 }
 
 // Open tutorial in new tab

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -62,14 +62,14 @@ export function useTemplateWorkflows() {
   const getTemplateThumbnailUrl = (
     template: TemplateInfo,
     sourceModule: string,
-    index = '1'
+    index: string | null = null
   ) => {
     const basePath =
       sourceModule === 'default'
         ? api.fileURL(`/templates/${template.name}`)
         : api.apiURL(`/workflow_templates/${sourceModule}/${template.name}`)
 
-    const indexSuffix = sourceModule === 'default' && index ? `-${index}` : ''
+    const indexSuffix = index ? `-${index}` : ''
     return `${basePath}${indexSuffix}.${template.mediaSubtype}`
   }
 

--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.ts
@@ -31,11 +31,39 @@ export const useWorkflowTemplatesStore = defineStore(
   'workflowTemplates',
   () => {
     const customTemplates = shallowRef<{ [moduleName: string]: string[] }>({})
+    const customNodesIndexedTemplates = shallowRef<{ [moduleName: string]: WorkflowTemplates }>({})
     const coreTemplates = shallowRef<WorkflowTemplates[]>([])
     const englishTemplates = shallowRef<WorkflowTemplates[]>([])
     const logoIndex = shallowRef<LogoIndex>({})
     const isLoaded = ref(false)
     const knownTemplateNames = ref(new Set<string>())
+
+    /**
+     * Complete custom template info from customNodesIndexedTemplates
+     */
+    function getCustomTemplateInfo(moduleName: string, name: string) {
+      const indexed = customNodesIndexedTemplates.value[moduleName]
+      if (indexed && Array.isArray(indexed.templates)) {
+        const enhanced = indexed.templates.find((t) => t.name === name)
+        if (enhanced) {
+          return {
+            name,
+            mediaType: 'image',
+            mediaSubtype: enhanced.mediaSubtype ?? 'jpg',
+            description: enhanced.description ?? name,
+            thumbnailVariant: enhanced.thumbnailVariant,
+            sourceModule: moduleName
+          }
+        }
+      }
+      return {
+        name,
+        mediaType: 'image',
+        mediaSubtype: 'jpg',
+        description: name,
+        sourceModule: moduleName
+      }
+    }
 
     const getTemplateByName = (name: string): EnhancedTemplate | undefined => {
       return enhancedTemplates.value.find((template) => template.name === name)
@@ -116,13 +144,7 @@ export const useWorkflowTemplatesStore = defineStore(
       const customTemplatesWithSourceModule = Object.entries(
         customTemplates.value
       ).flatMap(([moduleName, templates]) =>
-        templates.map((name) => ({
-          name,
-          mediaType: 'image',
-          mediaSubtype: 'jpg',
-          description: name,
-          sourceModule: moduleName
-        }))
+        templates.map((name) => getCustomTemplateInfo(moduleName, name))
       )
 
       return {
@@ -144,20 +166,18 @@ export const useWorkflowTemplatesStore = defineStore(
       const allTemplates = [
         ...coreTemplates.value.map(localizeTemplateCategory),
         ...Object.entries(customTemplates.value).map(
-          ([moduleName, templates]) => ({
-            moduleName,
-            title: moduleName,
-            localizedTitle: st(
-              `templateWorkflows.category.${normalizeI18nKey(moduleName)}`,
-              moduleName
-            ),
-            templates: templates.map((name) => ({
-              name,
-              mediaType: 'image',
-              mediaSubtype: 'jpg',
-              description: name
-            }))
-          })
+          ([moduleName, templates]) => {
+            const moduleTemplates = templates.map((name) => getCustomTemplateInfo(moduleName, name))
+            return {
+              moduleName,
+              title: moduleName,
+              localizedTitle: st(
+                `templateWorkflows.category.${normalizeI18nKey(moduleName)}`,
+                moduleName
+              ),
+              templates: moduleTemplates
+            }
+          }
         )
       ]
 
@@ -223,12 +243,18 @@ export const useWorkflowTemplatesStore = defineStore(
       Object.entries(customTemplates.value).forEach(
         ([moduleName, templates]) => {
           templates.forEach((name) => {
+            const indexed = customNodesIndexedTemplates.value[moduleName]
+            let indexedData: TemplateInfo | undefined
+            if (indexed && Array.isArray(indexed.templates)) {
+              indexedData = indexed.templates.find((t) => t.name === name)
+            }
             const enhancedTemplate: EnhancedTemplate = {
               name,
-              title: name,
-              description: name,
+              title: indexedData?.title || name,
+              description: indexedData?.description || name,
               mediaType: 'image',
-              mediaSubtype: 'jpg',
+              mediaSubtype: indexedData?.mediaSubtype || 'jpg',
+              thumbnailVariant: indexedData?.thumbnailVariant,
               sourceModule: moduleName,
               category: 'Extensions',
               categoryType: 'extension',
@@ -472,6 +498,31 @@ export const useWorkflowTemplatesStore = defineStore(
       return items
     })
 
+    /**
+    * Fetch the customization data for this module example workflows from it's index.json if existing.
+    * Will remove the index workflow in that case.
+    */
+    async function fetchIndexedCustomTemplates(customTemplatesObj: { [moduleName: string]: string[] }) {
+      const locale = i18n.global.locale.value
+      const customIndexedTemplates: { [moduleName: string]: WorkflowTemplates } = {}
+      const updatedCustomTemplates: { [moduleName: string]: string[] } = { ...customTemplatesObj }
+      const modulesWithIndex = Object.entries(customTemplatesObj)
+      .filter(([, workflowsList]) => workflowsList.includes('index'))
+
+      const results = await Promise.all(
+        modulesWithIndex.map(async ([customNodeName, workflowsList]) => {
+          const indexed = await api.getCustomIndexWorkflowTemplates(customNodeName, locale)
+          return { customNodeName, indexed, filtered: workflowsList.filter(name => name !== 'index') }
+        })
+      )
+
+      for (const { customNodeName, indexed, filtered } of results) {
+        customIndexedTemplates[customNodeName] = indexed
+        updatedCustomTemplates[customNodeName] = filtered
+      }
+      return { customIndexedTemplates, updatedCustomTemplates }
+    }
+
     async function fetchCoreTemplates() {
       const locale = i18n.global.locale.value
       const [coreResult, englishResult, logoIndexResult] = await Promise.all([
@@ -496,7 +547,10 @@ export const useWorkflowTemplatesStore = defineStore(
     async function loadWorkflowTemplates() {
       try {
         if (!isLoaded.value) {
-          customTemplates.value = await api.getWorkflowTemplates()
+          const fetchedCustomTemplates = await api.getWorkflowTemplates()
+          const { customIndexedTemplates, updatedCustomTemplates } = await fetchIndexedCustomTemplates(fetchedCustomTemplates)
+          customNodesIndexedTemplates.value = customIndexedTemplates
+          customTemplates.value = updatedCustomTemplates
           await fetchCoreTemplates()
           isLoaded.value = true
         }

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -767,13 +767,36 @@ export class ComfyApi extends EventTarget {
 
   /**
    * Gets the index of custom nodes workflow templates supporting it.
-   * supported in the index: icon, Title (to confirm ?) templates
-   * templates: name, title, description, mediaSubType ? date, models, requiresCustomNodes, tags, thumbnailVariant
+   * supported in the index: description, templates
+   * templates supported keys: name, title, description, mediaSubType, thumbnailVariant.
    */
-  async getCustomIndexWorkflowTemplates(customNodeName: string): Promise<WorkflowTemplates[]> {
-    const res = await axios.get(this.fileURL(`/workflow_templates/${customNodeName}/index.json`))
-    const contentType = res.headers['content-type']
-    return contentType?.includes('application/json') ? res.data : []
+  async getCustomIndexWorkflowTemplates(
+    customNodeName: string,
+    locale?: string,
+  ): Promise<WorkflowTemplates> {
+    const fallback: WorkflowTemplates = {
+      moduleName: customNodeName,
+      title: customNodeName,
+      templates: [],
+    };
+    const fileName =
+      locale && locale !== "en" ? `index.${locale}.json` : "index.json";
+    try {
+      const res = await axios.get(
+        this.fileURL(
+          `/api/workflow_templates/${encodeURIComponent(customNodeName)}/${fileName}`,
+        ),
+      );
+      const contentType = res.headers["content-type"];
+      return contentType?.includes("application/json") ? res.data : fallback;
+    } catch (error) {
+      console.warn(
+        "Failed to load custom workflow template index:",
+        customNodeName,
+        error,
+      );
+      return fallback;
+    }
   }
 
   /**

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -766,6 +766,17 @@ export class ComfyApi extends EventTarget {
   }
 
   /**
+   * Gets the index of custom nodes workflow templates supporting it.
+   * supported in the index: icon, Title (to confirm ?) templates
+   * templates: name, title, description, mediaSubType ? date, models, requiresCustomNodes, tags, thumbnailVariant
+   */
+  async getCustomIndexWorkflowTemplates(customNodeName: string): Promise<WorkflowTemplates[]> {
+    const res = await axios.get(this.fileURL(`/workflow_templates/${customNodeName}/index.json`))
+    const contentType = res.headers['content-type']
+    return contentType?.includes('application/json') ? res.data : []
+  }
+
+  /**
    * Gets the index of core workflow templates.
    * @param locale Optional locale code (e.g., 'en', 'fr', 'zh') to load localized templates
    */


### PR DESCRIPTION
## Summary

Follow up from previous [Merge Request](https://github.com/Comfy-Org/ComfyUI_frontend/pull/3682) taking into account the blocked status and feedback comment:
Cf https://github.com/Comfy-Org/ComfyUI_frontend/issues/3684
I am allowing custom nodes to add an index.json file with a format similar to the core workflows to defined the workflows description, title, mediaSubtype and thumbnailVariant

## Changes

- **What**: Handling index.json in custom node example workflows if any
- **Breaking**: should not break anything but prevents custom nodes from calling a workflow `index.json`

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->
Went initially for a lean change, cf https://github.com/Comfy-Org/ComfyUI_frontend/pull/3682
Trying now to make a unification change making custom nodes work like the core workflows
Was helped by AI to understand the project structure and change it.

<!-- Fixes #3684 -->
<!-- Fixes #4155 -->

## Screenshots (if applicable)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9284-Custom-nodes-example-workflows-index-3146d73d365081c7a4d8f2b6244aa1b1) by [Unito](https://www.unito.io)
