### PR TITLE
Remove confirmation from builder exit

### DIFF
--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -2,11 +2,9 @@ import { defineStore } from 'pinia'
 import { reactive, computed, watch } from 'vue'
 
 import { useAppMode } from '@/composables/useAppMode'
-import { t } from '@/i18n'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { LinearData } from '@/platform/workflow/management/stores/comfyWorkflow'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { useDialogService } from '@/services/dialogService'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 
 export const useAppModeStore = defineStore('appMode', () => {
@@ -69,14 +67,6 @@ export const useAppModeStore = defineStore('appMode', () => {
   )
 
   async function exitBuilder() {
-    if (
-      !(await useDialogService().confirm({
-        title: t('linearMode.builder.exitConfirmTitle'),
-        message: t('linearMode.builder.exitConfirmMessage')
-      }))
-    )
-      return
-
     const workflow = workflowStore.activeWorkflow
     if (workflow) workflow.dirtyLinearData = null
     resetSelectedToWorkflow()


### PR DESCRIPTION
With the move to always storing builder selection changes, the confirmation dialogue on builder exit is no longer needed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9286-Remove-confirmation-from-builder-exit-3146d73d3650815aa1c1dcfb491cc963) by [Unito](https://www.unito.io)
