### PR TITLE
feat: wrap CURVE widget value with typed format

### DIFF
--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -109,7 +109,7 @@ export const graphToPrompt = async (
         // execution.
         inputs[widget.name] = Array.isArray(widgetValue)
           ? widget.type === 'curve'
-            ? { __type: 'CURVE', value: widgetValue }
+            ? { __type__: 'CURVE', __value__: widgetValue }
             : { __value__: widgetValue }
           : widgetValue
       }

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -108,9 +108,9 @@ export const graphToPrompt = async (
         // The backend automatically unwraps the object to an array during
         // execution.
         inputs[widget.name] = Array.isArray(widgetValue)
-          ? {
-              __value__: widgetValue
-            }
+          ? widget.type === 'curve'
+            ? { __type: 'CURVE', value: widgetValue }
+            : { __value__: widgetValue }
           : widgetValue
       }
     }


### PR DESCRIPTION
## Summary
Send CURVE values as { __type: 'CURVE', value: [...] } instead of { __value__: [...] } to avoid ambiguity with link detection and enable external tools to identify the data type.

change requested by @guill

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9294-feat-wrap-CURVE-widget-value-with-typed-format-3156d73d365081bf8e5de59527e2d3ce) by [Unito](https://www.unito.io)
