### PR TITLE
fix: RAF-batch WebSocket progress events

### DIFF
--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1,8 +1,9 @@
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { app } from '@/scripts/app'
+import { api } from '@/scripts/api'
 import { MAX_PROGRESS_JOBS, useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
@@ -460,14 +461,21 @@ describe('useExecutionStore - nodeProgressStatesByJob eviction', () => {
     handler(
       new CustomEvent('progress_state', { detail: { nodes, prompt_id: jobId } })
     )
+    // Flush the RAF so the batched update is applied immediately
+    vi.advanceTimersByTime(16)
   }
 
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     apiEventHandlers.clear()
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
     store.bindExecutionEvents()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('should retain entries below the limit', () => {
@@ -1478,6 +1486,312 @@ describe('useMissingNodesErrorStore - setMissingNodeTypes', () => {
   })
 })
 
+describe('useExecutionStore - RAF batching', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  function getRegisteredHandler(eventName: string) {
+    const calls = vi.mocked(api.addEventListener).mock.calls
+    const call = calls.find(([name]) => name === eventName)
+    return call?.[1] as (e: CustomEvent) => void
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+    store.bindExecutionEvents()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('handleProgress', () => {
+    function makeProgressEvent(value: number, max: number): CustomEvent {
+      return new CustomEvent('progress', {
+        detail: { value, max, prompt_id: 'job-1', node: '1' }
+      })
+    }
+
+    it('batches multiple progress events into one reactive update per frame', () => {
+      const handler = getRegisteredHandler('progress')
+
+      handler(makeProgressEvent(1, 10))
+      handler(makeProgressEvent(5, 10))
+      handler(makeProgressEvent(9, 10))
+
+      expect(store._executingNodeProgress).toBeNull()
+
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toEqual({
+        value: 9,
+        max: 10,
+        prompt_id: 'job-1',
+        node: '1'
+      })
+    })
+
+    it('does not update reactive state before RAF fires', () => {
+      const handler = getRegisteredHandler('progress')
+
+      handler(makeProgressEvent(3, 10))
+
+      expect(store._executingNodeProgress).toBeNull()
+    })
+
+    it('allows a new batch after the previous RAF fires', () => {
+      const handler = getRegisteredHandler('progress')
+
+      handler(makeProgressEvent(1, 10))
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toEqual(
+        expect.objectContaining({ value: 1 })
+      )
+
+      handler(makeProgressEvent(7, 10))
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toEqual(
+        expect.objectContaining({ value: 7 })
+      )
+    })
+  })
+
+  describe('handleProgressState', () => {
+    function makeProgressStateEvent(
+      nodeId: string,
+      state: string,
+      value = 0,
+      max = 10
+    ): CustomEvent {
+      return new CustomEvent('progress_state', {
+        detail: {
+          prompt_id: 'job-1',
+          nodes: {
+            [nodeId]: {
+              value,
+              max,
+              state,
+              node_id: nodeId,
+              prompt_id: 'job-1',
+              display_node_id: nodeId
+            }
+          }
+        }
+      })
+    }
+
+    it('batches multiple progress_state events into one reactive update per frame', () => {
+      const handler = getRegisteredHandler('progress_state')
+
+      handler(makeProgressStateEvent('1', 'running', 1))
+      handler(makeProgressStateEvent('1', 'running', 5))
+      handler(makeProgressStateEvent('1', 'running', 9))
+
+      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+
+      vi.advanceTimersByTime(16)
+
+      expect(store.nodeProgressStates['1']).toEqual(
+        expect.objectContaining({ value: 9, state: 'running' })
+      )
+    })
+
+    it('does not update reactive state before RAF fires', () => {
+      const handler = getRegisteredHandler('progress_state')
+
+      handler(makeProgressStateEvent('1', 'running'))
+
+      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+    })
+  })
+
+  describe('pending RAF is discarded when execution completes', () => {
+    it('discards pending progress RAF on execution_success', () => {
+      const progressHandler = getRegisteredHandler('progress')
+      const startHandler = getRegisteredHandler('execution_start')
+      const successHandler = getRegisteredHandler('execution_success')
+
+      startHandler(
+        new CustomEvent('execution_start', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
+
+      progressHandler(
+        new CustomEvent('progress', {
+          detail: { value: 5, max: 10, prompt_id: 'job-1', node: '1' }
+        })
+      )
+
+      successHandler(
+        new CustomEvent('execution_success', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
+
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toBeNull()
+    })
+
+    it('discards pending progress_state RAF on execution_success', () => {
+      const progressStateHandler = getRegisteredHandler('progress_state')
+      const startHandler = getRegisteredHandler('execution_start')
+      const successHandler = getRegisteredHandler('execution_success')
+
+      startHandler(
+        new CustomEvent('execution_start', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
+
+      progressStateHandler(
+        new CustomEvent('progress_state', {
+          detail: {
+            prompt_id: 'job-1',
+            nodes: {
+              '1': {
+                value: 5,
+                max: 10,
+                state: 'running',
+                node_id: '1',
+                prompt_id: 'job-1',
+                display_node_id: '1'
+              }
+            }
+          }
+        })
+      )
+
+      successHandler(
+        new CustomEvent('execution_success', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
+
+      vi.advanceTimersByTime(16)
+
+      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+    })
+
+    it('discards pending progress RAF on execution_error', () => {
+      const progressHandler = getRegisteredHandler('progress')
+      const startHandler = getRegisteredHandler('execution_start')
+      const errorHandler = getRegisteredHandler('execution_error')
+
+      startHandler(
+        new CustomEvent('execution_start', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
+
+      progressHandler(
+        new CustomEvent('progress', {
+          detail: { value: 5, max: 10, prompt_id: 'job-1', node: '1' }
+        })
+      )
+
+      errorHandler(
+        new CustomEvent('execution_error', {
+          detail: {
+            prompt_id: 'job-1',
+            node_id: '1',
+            node_type: 'TestNode',
+            exception_message: 'error',
+            exception_type: 'RuntimeError',
+            traceback: []
+          }
+        })
+      )
+
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toBeNull()
+    })
+
+    it('discards pending progress RAF on execution_interrupted', () => {
+      const progressHandler = getRegisteredHandler('progress')
+      const startHandler = getRegisteredHandler('execution_start')
+      const interruptedHandler = getRegisteredHandler('execution_interrupted')
+
+      startHandler(
+        new CustomEvent('execution_start', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
+
+      progressHandler(
+        new CustomEvent('progress', {
+          detail: { value: 5, max: 10, prompt_id: 'job-1', node: '1' }
+        })
+      )
+
+      interruptedHandler(
+        new CustomEvent('execution_interrupted', {
+          detail: {
+            prompt_id: 'job-1',
+            node_id: '1',
+            node_type: 'TestNode',
+            executed: []
+          }
+        })
+      )
+
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toBeNull()
+    })
+  })
+
+  describe('unbindExecutionEvents cancels pending RAFs', () => {
+    it('cancels pending progress RAF on unbind', () => {
+      const handler = getRegisteredHandler('progress')
+
+      handler(
+        new CustomEvent('progress', {
+          detail: { value: 5, max: 10, prompt_id: 'job-1', node: '1' }
+        })
+      )
+
+      store.unbindExecutionEvents()
+      vi.advanceTimersByTime(16)
+
+      expect(store._executingNodeProgress).toBeNull()
+    })
+
+    it('cancels pending progress_state RAF on unbind', () => {
+      const handler = getRegisteredHandler('progress_state')
+
+      handler(
+        new CustomEvent('progress_state', {
+          detail: {
+            prompt_id: 'job-1',
+            nodes: {
+              '1': {
+                value: 0,
+                max: 10,
+                state: 'running',
+                node_id: '1',
+                prompt_id: 'job-1',
+                display_node_id: '1'
+              }
+            }
+          }
+        })
+      )
+
+      store.unbindExecutionEvents()
+      vi.advanceTimersByTime(16)
+
+      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+    })
+  })
+})
+
 describe('useExecutionStore - WebSocket event handlers', () => {
   let store: ReturnType<typeof useExecutionStore>
 
@@ -1774,12 +2088,21 @@ describe('useExecutionStore - WebSocket event handlers', () => {
   })
 
   describe('progress', () => {
-    it('sets _executingNodeProgress from the event payload', () => {
-      const payload = { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' }
+    it('sets _executingNodeProgress from the event payload (RAF-batched)', () => {
+      vi.useFakeTimers()
+      try {
+        const payload = { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' }
 
-      fire('progress', payload)
+        fire('progress', payload)
+        // RAF-batched: not applied synchronously
+        expect(store._executingNodeProgress).toBeNull()
 
-      expect(store._executingNodeProgress).toEqual(payload)
+        vi.advanceTimersByTime(16)
+
+        expect(store._executingNodeProgress).toEqual(payload)
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -2085,6 +2085,20 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       expect(store.activeJobId).toBe('job-1')
       expect(store.queuedJobs['job-1']).toBeDefined()
     })
+
+    it('discards a progress update still queued when the next node starts', () => {
+      vi.useFakeTimers()
+      try {
+        fire('progress', { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' })
+
+        fire('executing', 'n2')
+        vi.advanceTimersToNextFrame()
+
+        expect(store._executingNodeProgress).toBeNull()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('progress', () => {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1534,6 +1534,7 @@ describe('useExecutionStore - RAF batching', () => {
     })
 
     it('does not update reactive state before RAF fires', () => {
+      expect.assertions(1)
       const handler = getRegisteredHandler('progress')
 
       handler(makeProgressEvent(3, 10))
@@ -1601,6 +1602,7 @@ describe('useExecutionStore - RAF batching', () => {
     })
 
     it('does not update reactive state before RAF fires', () => {
+      expect.assertions(1)
       const handler = getRegisteredHandler('progress_state')
 
       handler(makeProgressStateEvent('1', 'running'))
@@ -1611,6 +1613,7 @@ describe('useExecutionStore - RAF batching', () => {
 
   describe('pending RAF is discarded when execution completes', () => {
     it('discards pending progress RAF on execution_success', () => {
+      expect.assertions(1)
       const progressHandler = getRegisteredHandler('progress')
       const startHandler = getRegisteredHandler('execution_start')
       const successHandler = getRegisteredHandler('execution_success')
@@ -1639,6 +1642,7 @@ describe('useExecutionStore - RAF batching', () => {
     })
 
     it('discards pending progress_state RAF on execution_success', () => {
+      expect.assertions(1)
       const progressStateHandler = getRegisteredHandler('progress_state')
       const startHandler = getRegisteredHandler('execution_start')
       const successHandler = getRegisteredHandler('execution_success')
@@ -1679,6 +1683,7 @@ describe('useExecutionStore - RAF batching', () => {
     })
 
     it('discards pending progress RAF on execution_error', () => {
+      expect.assertions(1)
       const progressHandler = getRegisteredHandler('progress')
       const startHandler = getRegisteredHandler('execution_start')
       const errorHandler = getRegisteredHandler('execution_error')
@@ -1714,6 +1719,7 @@ describe('useExecutionStore - RAF batching', () => {
     })
 
     it('discards pending progress RAF on execution_interrupted', () => {
+      expect.assertions(1)
       const progressHandler = getRegisteredHandler('progress')
       const startHandler = getRegisteredHandler('execution_start')
       const interruptedHandler = getRegisteredHandler('execution_interrupted')
@@ -1749,6 +1755,7 @@ describe('useExecutionStore - RAF batching', () => {
 
   describe('unbindExecutionEvents cancels pending RAFs', () => {
     it('cancels pending progress RAF on unbind', () => {
+      expect.assertions(1)
       const handler = getRegisteredHandler('progress')
 
       handler(
@@ -1764,6 +1771,7 @@ describe('useExecutionStore - RAF batching', () => {
     })
 
     it('cancels pending progress_state RAF on unbind', () => {
+      expect.assertions(1)
       const handler = getRegisteredHandler('progress_state')
 
       handler(
@@ -1788,6 +1796,77 @@ describe('useExecutionStore - RAF batching', () => {
       vi.advanceTimersToNextFrame()
 
       expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+    })
+  })
+
+  describe('executing cancels both coalescers', () => {
+    it('discards pending progress_state RAF when a new node starts executing', () => {
+      expect.assertions(1)
+      const progressStateHandler = getRegisteredHandler('progress_state')
+      const executingHandler = getRegisteredHandler('executing')
+
+      progressStateHandler(
+        new CustomEvent('progress_state', {
+          detail: {
+            prompt_id: 'job-1',
+            nodes: {
+              '1': {
+                value: 5,
+                max: 10,
+                state: 'running',
+                node_id: '1',
+                prompt_id: 'job-1',
+                display_node_id: '1'
+              }
+            }
+          }
+        })
+      )
+
+      executingHandler(new CustomEvent('executing', { detail: '2' }))
+      vi.advanceTimersToNextFrame()
+
+      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+    })
+  })
+
+  describe('concurrent progress and progress_state in the same frame', () => {
+    it('applies both coalesced updates when RAFs fire in the same tick', () => {
+      expect.assertions(2)
+      const progressHandler = getRegisteredHandler('progress')
+      const progressStateHandler = getRegisteredHandler('progress_state')
+
+      progressHandler(
+        new CustomEvent('progress', {
+          detail: { value: 7, max: 10, prompt_id: 'job-1', node: '1' }
+        })
+      )
+      progressStateHandler(
+        new CustomEvent('progress_state', {
+          detail: {
+            prompt_id: 'job-1',
+            nodes: {
+              '1': {
+                value: 7,
+                max: 10,
+                state: 'running',
+                node_id: '1',
+                prompt_id: 'job-1',
+                display_node_id: '1'
+              }
+            }
+          }
+        })
+      )
+
+      vi.advanceTimersToNextFrame()
+
+      expect(store._executingNodeProgress).toEqual(
+        expect.objectContaining({ value: 7 })
+      )
+      expect(store.nodeProgressStates['1']).toEqual(
+        expect.objectContaining({ value: 7, state: 'running' })
+      )
     })
   })
 })

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -462,7 +462,7 @@ describe('useExecutionStore - nodeProgressStatesByJob eviction', () => {
       new CustomEvent('progress_state', { detail: { nodes, prompt_id: jobId } })
     )
     // Flush the RAF so the batched update is applied immediately
-    vi.advanceTimersByTime(16)
+    vi.advanceTimersToNextFrame()
   }
 
   beforeEach(() => {
@@ -1523,7 +1523,7 @@ describe('useExecutionStore - RAF batching', () => {
 
       expect(store._executingNodeProgress).toBeNull()
 
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toEqual({
         value: 9,
@@ -1545,14 +1545,14 @@ describe('useExecutionStore - RAF batching', () => {
       const handler = getRegisteredHandler('progress')
 
       handler(makeProgressEvent(1, 10))
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toEqual(
         expect.objectContaining({ value: 1 })
       )
 
       handler(makeProgressEvent(7, 10))
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toEqual(
         expect.objectContaining({ value: 7 })
@@ -1593,7 +1593,7 @@ describe('useExecutionStore - RAF batching', () => {
 
       expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
 
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store.nodeProgressStates['1']).toEqual(
         expect.objectContaining({ value: 9, state: 'running' })
@@ -1633,7 +1633,7 @@ describe('useExecutionStore - RAF batching', () => {
         })
       )
 
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toBeNull()
     })
@@ -1673,7 +1673,7 @@ describe('useExecutionStore - RAF batching', () => {
         })
       )
 
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
     })
@@ -1708,7 +1708,7 @@ describe('useExecutionStore - RAF batching', () => {
         })
       )
 
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toBeNull()
     })
@@ -1741,7 +1741,7 @@ describe('useExecutionStore - RAF batching', () => {
         })
       )
 
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toBeNull()
     })
@@ -1758,7 +1758,7 @@ describe('useExecutionStore - RAF batching', () => {
       )
 
       store.unbindExecutionEvents()
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(store._executingNodeProgress).toBeNull()
     })
@@ -1785,7 +1785,7 @@ describe('useExecutionStore - RAF batching', () => {
       )
 
       store.unbindExecutionEvents()
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersToNextFrame()
 
       expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
     })
@@ -2097,7 +2097,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         // RAF-batched: not applied synchronously
         expect(store._executingNodeProgress).toBeNull()
 
-        vi.advanceTimersByTime(16)
+        vi.advanceTimersToNextFrame()
 
         expect(store._executingNodeProgress).toEqual(payload)
       } finally {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1492,7 +1492,7 @@ describe('useExecutionStore - RAF batching', () => {
   function getRegisteredHandler(eventName: string) {
     const calls = vi.mocked(api.addEventListener).mock.calls
     const call = calls.find(([name]) => name === eventName)
-    return call?.[1] as (e: CustomEvent) => void
+    return call![1]!
   }
 
   beforeEach(() => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -527,7 +527,6 @@ export const useExecutionStore = defineStore('execution', () => {
   function handleExecuting(e: CustomEvent<string | number | null>): void {
     progressCoalescer.cancel()
 
-
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -40,10 +40,11 @@ import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
 import { parseNodeId } from '@/types/nodeId'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
-import { classifyCloudValidationError } from '@/utils/executionErrorUtil'
-import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
 import type { AppMode } from '@/utils/appMode'
 import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
+import { classifyCloudValidationError } from '@/utils/executionErrorUtil'
+import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
+import { createRafCoalescer } from '@/utils/rafBatch'
 
 interface ExecutionNodeInfo {
   title?: string | null
@@ -447,6 +448,8 @@ export const useExecutionStore = defineStore('execution', () => {
     if (workflowStatus.value.size > 0) workflowStatus.value = new Map()
     pendingWorkflowStatusByJobId.clear()
     jobIdToWorkflow.clear()
+
+    cancelPendingProgressUpdates()
   }
 
   function handleExecutionStart(e: CustomEvent<ExecutionStartWsMessage>) {
@@ -522,6 +525,9 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecuting(e: CustomEvent<string | number | null>): void {
+    progressCoalescer.cancel()
+
+
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
 
@@ -561,8 +567,15 @@ export const useExecutionStore = defineStore('execution', () => {
     nodeProgressStatesByJob.value = pruned
   }
 
+  const progressStateCoalescer =
+    createRafCoalescer<ProgressStateWsMessage>(_applyProgressState)
+
   function handleProgressState(e: CustomEvent<ProgressStateWsMessage>) {
-    const { nodes, prompt_id: jobId } = e.detail
+    progressStateCoalescer.push(e.detail)
+  }
+
+  function _applyProgressState(detail: ProgressStateWsMessage) {
+    const { nodes, prompt_id: jobId } = detail
 
     // Revoke previews for nodes that are starting to execute
     const previousForJob = nodeProgressStatesByJob.value[jobId] || {}
@@ -599,8 +612,17 @@ export const useExecutionStore = defineStore('execution', () => {
     }
   }
 
+  const progressCoalescer = createRafCoalescer<ProgressWsMessage>((detail) => {
+    _executingNodeProgress.value = detail
+  })
+
   function handleProgress(e: CustomEvent<ProgressWsMessage>) {
-    _executingNodeProgress.value = e.detail
+    progressCoalescer.push(e.detail)
+  }
+
+  function cancelPendingProgressUpdates() {
+    progressCoalescer.cancel()
+    progressStateCoalescer.cancel()
   }
 
   function handleStatus() {
@@ -765,6 +787,8 @@ export const useExecutionStore = defineStore('execution', () => {
    * Reset execution-related state after a run completes or is stopped.
    */
   function resetExecutionState(jobIdParam?: JobId | null) {
+    cancelPendingProgressUpdates()
+
     executionIdToLocatorCache.clear()
     nodeProgressStates.value = {}
     const jobId = jobIdParam ?? activeJobId.value ?? null

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -525,7 +525,7 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecuting(e: CustomEvent<string | number | null>): void {
-    progressCoalescer.cancel()
+    cancelPendingProgressUpdates()
 
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
@@ -566,14 +566,16 @@ export const useExecutionStore = defineStore('execution', () => {
     nodeProgressStatesByJob.value = pruned
   }
 
-  const progressStateCoalescer =
-    createRafCoalescer<ProgressStateWsMessage>(_applyProgressState)
+  const progressStateCoalescer = createRafCoalescer<ProgressStateWsMessage>(
+    applyProgressState,
+    'raf:progress_state'
+  )
 
   function handleProgressState(e: CustomEvent<ProgressStateWsMessage>) {
     progressStateCoalescer.push(e.detail)
   }
 
-  function _applyProgressState(detail: ProgressStateWsMessage) {
+  function applyProgressState(detail: ProgressStateWsMessage) {
     const { nodes, prompt_id: jobId } = detail
 
     // Revoke previews for nodes that are starting to execute
@@ -613,7 +615,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   const progressCoalescer = createRafCoalescer<ProgressWsMessage>((detail) => {
     _executingNodeProgress.value = detail
-  })
+  }, 'raf:progress')
 
   function handleProgress(e: CustomEvent<ProgressWsMessage>) {
     progressCoalescer.push(e.detail)

--- a/src/utils/rafBatch.test.ts
+++ b/src/utils/rafBatch.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createRafCoalescer } from '@/utils/rafBatch'
+
+describe('createRafCoalescer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('applies the latest pushed value on the next frame', () => {
+    const apply = vi.fn()
+    const coalescer = createRafCoalescer<number>(apply)
+
+    coalescer.push(1)
+    coalescer.push(2)
+    coalescer.push(3)
+
+    expect(apply).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(16)
+
+    expect(apply).toHaveBeenCalledOnce()
+    expect(apply).toHaveBeenCalledWith(3)
+  })
+
+  it('does not apply after cancel', () => {
+    const apply = vi.fn()
+    const coalescer = createRafCoalescer<number>(apply)
+
+    coalescer.push(42)
+    coalescer.cancel()
+
+    vi.advanceTimersByTime(16)
+
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('applies immediately on flush', () => {
+    const apply = vi.fn()
+    const coalescer = createRafCoalescer<number>(apply)
+
+    coalescer.push(99)
+    coalescer.flush()
+
+    expect(apply).toHaveBeenCalledOnce()
+    expect(apply).toHaveBeenCalledWith(99)
+  })
+
+  it('does nothing on flush when no value is pending', () => {
+    const apply = vi.fn()
+    const coalescer = createRafCoalescer<number>(apply)
+
+    coalescer.flush()
+
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('does not double-apply after flush', () => {
+    const apply = vi.fn()
+    const coalescer = createRafCoalescer<number>(apply)
+
+    coalescer.push(1)
+    coalescer.flush()
+
+    vi.advanceTimersByTime(16)
+
+    expect(apply).toHaveBeenCalledOnce()
+  })
+
+  it('reports scheduled state correctly', () => {
+    const coalescer = createRafCoalescer<number>(vi.fn())
+
+    expect(coalescer.isScheduled()).toBe(false)
+
+    coalescer.push(1)
+    expect(coalescer.isScheduled()).toBe(true)
+
+    vi.advanceTimersByTime(16)
+    expect(coalescer.isScheduled()).toBe(false)
+  })
+})

--- a/src/utils/rafBatch.test.ts
+++ b/src/utils/rafBatch.test.ts
@@ -21,7 +21,7 @@ describe('createRafCoalescer', () => {
 
     expect(apply).not.toHaveBeenCalled()
 
-    vi.advanceTimersByTime(16)
+    vi.advanceTimersToNextFrame()
 
     expect(apply).toHaveBeenCalledOnce()
     expect(apply).toHaveBeenCalledWith(3)
@@ -34,7 +34,7 @@ describe('createRafCoalescer', () => {
     coalescer.push(42)
     coalescer.cancel()
 
-    vi.advanceTimersByTime(16)
+    vi.advanceTimersToNextFrame()
 
     expect(apply).not.toHaveBeenCalled()
   })
@@ -66,7 +66,7 @@ describe('createRafCoalescer', () => {
     coalescer.push(1)
     coalescer.flush()
 
-    vi.advanceTimersByTime(16)
+    vi.advanceTimersToNextFrame()
 
     expect(apply).toHaveBeenCalledOnce()
   })
@@ -79,7 +79,7 @@ describe('createRafCoalescer', () => {
     coalescer.push(1)
     expect(coalescer.isScheduled()).toBe(true)
 
-    vi.advanceTimersByTime(16)
+    vi.advanceTimersToNextFrame()
     expect(coalescer.isScheduled()).toBe(false)
   })
 })

--- a/src/utils/rafBatch.test.ts
+++ b/src/utils/rafBatch.test.ts
@@ -39,38 +39,6 @@ describe('createRafCoalescer', () => {
     expect(apply).not.toHaveBeenCalled()
   })
 
-  it('applies immediately on flush', () => {
-    const apply = vi.fn()
-    const coalescer = createRafCoalescer<number>(apply)
-
-    coalescer.push(99)
-    coalescer.flush()
-
-    expect(apply).toHaveBeenCalledOnce()
-    expect(apply).toHaveBeenCalledWith(99)
-  })
-
-  it('does nothing on flush when no value is pending', () => {
-    const apply = vi.fn()
-    const coalescer = createRafCoalescer<number>(apply)
-
-    coalescer.flush()
-
-    expect(apply).not.toHaveBeenCalled()
-  })
-
-  it('does not double-apply after flush', () => {
-    const apply = vi.fn()
-    const coalescer = createRafCoalescer<number>(apply)
-
-    coalescer.push(1)
-    coalescer.flush()
-
-    vi.advanceTimersToNextFrame()
-
-    expect(apply).toHaveBeenCalledOnce()
-  })
-
   it('reports scheduled state correctly', () => {
     const coalescer = createRafCoalescer<number>(vi.fn())
 

--- a/src/utils/rafBatch.ts
+++ b/src/utils/rafBatch.ts
@@ -27,3 +27,40 @@ export function createRafBatch(run: () => void) {
 
   return { schedule, cancel, flush, isScheduled }
 }
+
+/**
+ * Last-write-wins RAF coalescer. Buffers the latest value and applies it
+ * on the next animation frame, coalescing multiple pushes into a single
+ * reactive update.
+ */
+export function createRafCoalescer<T>(apply: (value: T) => void) {
+  let hasPending = false
+  let pendingValue: T | undefined
+
+  const batch = createRafBatch(() => {
+    if (!hasPending) return
+    const value = pendingValue as T
+    hasPending = false
+    pendingValue = undefined
+    apply(value)
+  })
+
+  const push = (value: T) => {
+    pendingValue = value
+    hasPending = true
+    batch.schedule()
+  }
+
+  const cancel = () => {
+    hasPending = false
+    pendingValue = undefined
+    batch.cancel()
+  }
+
+  const flush = () => {
+    if (!hasPending) return
+    batch.flush()
+  }
+
+  return { push, cancel, flush, isScheduled: batch.isScheduled }
+}

--- a/src/utils/rafBatch.ts
+++ b/src/utils/rafBatch.ts
@@ -32,35 +32,45 @@ export function createRafBatch(run: () => void) {
  * Last-write-wins RAF coalescer. Buffers the latest value and applies it
  * on the next animation frame, coalescing multiple pushes into a single
  * reactive update.
+ *
+ * Pass a `label` to emit `performance.mark` events in dev mode so the
+ * batching benefit is visible in the browser profiler under that name.
  */
-export function createRafCoalescer<T>(apply: (value: T) => void) {
+export function createRafCoalescer<T>(
+  apply: (value: T) => void,
+  label?: string
+) {
   let hasPending = false
   let pendingValue: T | undefined
+  let droppedCount = 0
 
   const batch = createRafBatch(() => {
     if (!hasPending) return
     const value = pendingValue as T
+    if (import.meta.env.DEV && label) {
+      performance.mark(`${label}:apply`, {
+        detail: { dropped: droppedCount }
+      })
+    }
+    droppedCount = 0
     hasPending = false
     pendingValue = undefined
     apply(value)
   })
 
   const push = (value: T) => {
+    if (hasPending) droppedCount++
     pendingValue = value
     hasPending = true
     batch.schedule()
   }
 
   const cancel = () => {
+    droppedCount = 0
     hasPending = false
     pendingValue = undefined
     batch.cancel()
   }
 
-  const flush = () => {
-    if (!hasPending) return
-    batch.flush()
-  }
-
-  return { push, cancel, flush, isScheduled: batch.isScheduled }
+  return { push, cancel, isScheduled: batch.isScheduled }
 }


### PR DESCRIPTION
## What

RAF-batch WebSocket `progress` and `progress_state` events to coalesce multiple updates per animation frame.

## Why

Each WebSocket progress message immediately updates reactive state, triggering Vue re-renders. Profiler shows 339 markers from `onProgressUpdate`. During rapid execution, multiple progress events per frame cause redundant reactive update → watcher → setDirty cycles.

## How

Defer reactive state updates to `requestAnimationFrame` callbacks. Multiple progress events within the same frame are coalesced — only the latest value is applied. Pending RAFs are cancelled on `unbindExecutionEvents`.

## Verification

- [x] Unit tests verifying RAF batching behavior (7 new tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

## Perf Impact

Reduces per-frame reactive updates during workflow execution from N (one per WebSocket message) to 1.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9303-fix-RAF-batch-WebSocket-progress-events-3156d73d365081959d93e85a4b8d38c4) by [Unito](https://www.unito.io)
