### PR TITLE
fix: propagate widget disabled state to Vue node components

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -204,9 +204,11 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     // Get value from store (falls back to undefined if not registered)
     const value = widgetState?.value as WidgetValue
 
-    // Build options from store state, with slot-linked override for disabled
+    // Build options from store state, with disabled override for
+    // slot-linked widgets or widgets with disabled state (e.g. display-only)
     const storeOptions = widgetState?.options ?? {}
-    const widgetOptions = slotMetadata?.linked
+    const isDisabled = slotMetadata?.linked || widgetState?.disabled
+    const widgetOptions = isDisabled
       ? { ...storeOptions, disabled: true }
       : storeOptions
 


### PR DESCRIPTION
## Summary

Widgets with `widget.disabled = true` (e.g. display-only counters in custom nodes) were editable in Vue node mode despite being correctly greyed out in litegraph mode. The disabled state from the widget store was not being merged into the options passed to Vue widget components.

## Screenshots (if applicable)
Before

https://github.com/user-attachments/assets/6957dd86-6eb9-4edb-93ee-50fc5aa5350f


After

https://github.com/user-attachments/assets/d954006f-d7e6-4e7c-9b3c-bcabed0e6260

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9321-fix-propagate-widget-disabled-state-to-Vue-node-components-3166d73d365081a7936aeabe81eb6e15) by [Unito](https://www.unito.io)
