### PR TITLE
fix: clear combo widget value when removing image preview

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -243,7 +243,15 @@ const handleDownload = () => {
 
 const handleRemove = () => {
   if (!props.nodeId) return
+  const node = app.rootGraph?.getNodeById(Number(props.nodeId))
   nodeOutputStore.removeNodeOutputs(props.nodeId)
+  if (node) {
+    node.imgs = undefined
+    const imageWidget = node.widgets?.find((w) => w.name === 'image')
+    if (imageWidget) {
+      imageWidget.value = ''
+    }
+  }
 }
 
 const setCurrentIndex = (index: number) => {


### PR DESCRIPTION
## Summary
The X button on image preview in VueNodes mode only cleared the stored outputs but left the combo widget value intact, causing the old image to persist across workflow runs and page refreshes.

## Screenshots (if applicable)
Before
https://github.com/user-attachments/assets/e2146ed1-5d79-41d6-946c-b30667ffac6a

After

https://github.com/user-attachments/assets/359b81fa-acc9-4711-9cee-62c230086f0c

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9323-fix-clear-combo-widget-value-when-removing-image-preview-3166d73d3650816db867eba49b8aeb6c) by [Unito](https://www.unito.io)
