### PR TITLE
fix: stop pointer events on audio widgets to prevent node drag

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div class="relative" @pointerdown.stop>
     <div class="mb-4">
       <Button
         class="text-base-foreground w-full border-0 bg-secondary-background hover:bg-secondary-background-hover"

--- a/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div class="relative" @pointerdown.stop>
     <div
       v-if="!hideWhenEmpty || modelValue"
       class="bg-component-node-widget-background box-border flex gap-4 items-center justify-start relative rounded-lg w-full h-16 px-4 py-0"


### PR DESCRIPTION
## Summary

Audio player and record widgets were missing @pointerdown.stop, causing node drag when interacting with the timeline or controls.

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/061a9ad2-0cc2-45f8-aea0-d45e3a2912b9


after

https://github.com/user-attachments/assets/a510c50a-65b8-4944-9480-b53cbe61c7da

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9329-fix-stop-pointer-events-on-audio-widgets-to-prevent-node-drag-3176d73d36508140b236c61e83954f5c) by [Unito](https://www.unito.io)
