### PR TITLE
fix: release webcam stream when WebcamCapture node is removed

### DIFF
--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -24,9 +24,11 @@ app.registerExtension({
         const video = document.createElement('video')
         video.style.height = video.style.width = '100%'
 
+        let stream: MediaStream | null = null
+
         const loadVideo = async () => {
           try {
-            const stream = await navigator.mediaDevices.getUserMedia({
+            stream = await navigator.mediaDevices.getUserMedia({
               video: true,
               audio: false
             })
@@ -59,6 +61,13 @@ app.registerExtension({
 
             container.replaceChildren(label)
           }
+        }
+
+        const originalOnRemoved = node.onRemoved
+        node.onRemoved = function () {
+          stream?.getTracks().forEach((track) => track.stop())
+          stream = null
+          originalOnRemoved?.call(this)
         }
 
         loadVideo()


### PR DESCRIPTION
## Summary

The MediaStream was not stopped on node removal, keeping the camera active. Hoist the stream reference and stop all tracks in onRemoved.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9330-fix-release-webcam-stream-when-WebcamCapture-node-is-removed-3176d73d365081d2ae66e938ee58b713) by [Unito](https://www.unito.io)
