### PR TITLE
App builder item - cap max width and truncate

### DIFF
--- a/src/components/builder/IoItem.vue
+++ b/src/components/builder/IoItem.vue
@@ -32,9 +32,12 @@ const entries = computed(() => {
 })
 </script>
 <template>
-  <div class="p-2 my-2 rounded-lg flex items-center-safe">
-    <span class="mr-auto" v-text="title" />
-    <span class="text-muted-foreground mr-2 text-end" v-text="subTitle" />
+  <div class="p-2 my-2 rounded-lg flex items-center-safe min-w-0 gap-0.5">
+    <span class="max-w-3/4 truncate mr-auto" v-text="title" />
+    <span
+      class="text-muted-foreground mr-2 text-end truncate"
+      v-text="subTitle"
+    />
     <Popover :entries>
       <template #button>
         <Button variant="muted-textonly">

--- a/src/components/builder/IoItem.vue
+++ b/src/components/builder/IoItem.vue
@@ -33,9 +33,12 @@ const entries = computed(() => {
 </script>
 <template>
   <div class="p-2 my-2 rounded-lg flex items-center-safe gap-2">
-    <span class="max-w-3/5 truncate mr-auto shrink" v-text="title" />
     <span
-      class="text-muted-foreground mr-2 text-end truncate grow basis-0"
+      class="mr-auto flex-[3_1_0%] max-w-max min-w-0 truncate"
+      v-text="title"
+    />
+    <span
+      class="flex-[2_1_0%] max-w-max min-w-0 truncate text-muted-foreground text-end"
       v-text="subTitle"
     />
     <Popover :entries>

--- a/src/components/builder/IoItem.vue
+++ b/src/components/builder/IoItem.vue
@@ -34,7 +34,7 @@ const entries = computed(() => {
 <template>
   <div class="p-2 my-2 rounded-lg flex items-center-safe gap-2">
     <span
-      class="mr-auto flex-[3_1_0%] max-w-max min-w-0 truncate"
+      class="mr-auto flex-[4_1_0%] max-w-max min-w-0 truncate"
       v-text="title"
     />
     <span


### PR DESCRIPTION
## Summary

Currently they overflow, this adds truncation

## Screenshots (if applicable)

<img width="325" height="459" alt="image" src="https://github.com/user-attachments/assets/92600c14-da31-4a96-af3c-aeac928243c4" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9335-App-builder-item-cap-max-width-and-truncate-3176d73d365081d1b461cf2758b04ec2) by [Unito](https://www.unito.io)
