### PR TITLE
fix: use widget.options.hidden to hide painter widgets in Vue renderer

### DIFF
--- a/src/extensions/core/painter.ts
+++ b/src/extensions/core/painter.ts
@@ -15,7 +15,7 @@ useExtensionService().registerExtension({
 
     for (const widget of node.widgets ?? []) {
       if (HIDDEN_WIDGETS.has(widget.name)) {
-        widget.hidden = true
+        widget.options.hidden = true
       }
     }
   }


### PR DESCRIPTION
## Summary

The Vue node renderer checks widget.options.hidden, not widget.hidden. This was previously masked by the backend sending hidden: true via extra_dict, but is now needed as the backend switches to io.Color.Input.

BE change is in https://github.com/Comfy-Org/ComfyUI/pull/12294

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9337-fix-use-widget-options-hidden-to-hide-painter-widgets-in-Vue-renderer-3176d73d3650815cad4beb8f9f35f7e6) by [Unito](https://www.unito.io)
