### PR TITLE
feat: separate Sentry DSN for stage/prod environments

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -38,7 +38,11 @@ TEST_COMFYUI_DIR=/home/ComfyUI
 ALGOLIA_APP_ID=4E0RO38HS8
 ALGOLIA_API_KEY=684d998c36b67a9a9fce8fc2d8860579
 
-# Sentry ENV vars replace with real ones for debugging
+# Sentry ENV vars — replace with real values for debugging.
+# Stage DSN/project are used by default; prod variants are selected when USE_PROD_CONFIG=true.
 # SENTRY_AUTH_TOKEN=private-token # get from sentry
 # SENTRY_ORG=comfy-org
+# SENTRY_DSN=https://stage-dsn@sentry.io/stage-project-id
 # SENTRY_PROJECT=cloud-frontend-staging
+# SENTRY_DSN_PROD=https://prod-dsn@sentry.io/prod-project-id
+# SENTRY_PROJECT_PROD=cloud-frontend-prod

--- a/.github/workflows/release-draft-create.yaml
+++ b/.github/workflows/release-draft-create.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Build project
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_DSN_PROD: ${{ secrets.SENTRY_DSN_PROD }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           ENABLE_MINIFY: 'true'

--- a/.github/workflows/release-pypi-dev.yaml
+++ b/.github/workflows/release-pypi-dev.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Build project
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_DSN_PROD: ${{ secrets.SENTRY_DSN_PROD }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           ENABLE_MINIFY: 'true'

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -59,12 +59,12 @@ const IS_PROD_CONFIG = process.env.USE_PROD_CONFIG === 'true'
 // Select the correct Sentry DSN and project based on environment.
 // Prod uses SENTRY_DSN_PROD / SENTRY_PROJECT_PROD; stage falls back to SENTRY_DSN / SENTRY_PROJECT.
 const SENTRY_DSN = IS_PROD_CONFIG
-  ? (process.env.SENTRY_DSN_PROD || process.env.SENTRY_DSN || '')
-  : (process.env.SENTRY_DSN || '')
+  ? process.env.SENTRY_DSN_PROD || process.env.SENTRY_DSN || ''
+  : process.env.SENTRY_DSN || ''
 
 const SENTRY_PROJECT = IS_PROD_CONFIG
-  ? (process.env.SENTRY_PROJECT_PROD || process.env.SENTRY_PROJECT || '')
-  : (process.env.SENTRY_PROJECT || '')
+  ? process.env.SENTRY_PROJECT_PROD || process.env.SENTRY_PROJECT || ''
+  : process.env.SENTRY_PROJECT || ''
 
 // Disable Vue DevTools for production cloud distribution
 const DISABLE_VUE_PLUGINS =

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -54,6 +54,17 @@ const DISTRIBUTION: 'desktop' | 'localhost' | 'cloud' =
 // Nightly builds are from main branch; RC/stable builds are from core/* branches
 // Can be overridden via IS_NIGHTLY env var for testing
 const IS_NIGHTLY = process.env.IS_NIGHTLY === 'true'
+const IS_PROD_CONFIG = process.env.USE_PROD_CONFIG === 'true'
+
+// Select the correct Sentry DSN and project based on environment.
+// Prod uses SENTRY_DSN_PROD / SENTRY_PROJECT_PROD; stage falls back to SENTRY_DSN / SENTRY_PROJECT.
+const SENTRY_DSN = IS_PROD_CONFIG
+  ? (process.env.SENTRY_DSN_PROD || process.env.SENTRY_DSN || '')
+  : (process.env.SENTRY_DSN || '')
+
+const SENTRY_PROJECT = IS_PROD_CONFIG
+  ? (process.env.SENTRY_PROJECT_PROD || process.env.SENTRY_PROJECT || '')
+  : (process.env.SENTRY_PROJECT || '')
 
 // Disable Vue DevTools for production cloud distribution
 const DISABLE_VUE_PLUGINS =
@@ -413,12 +424,12 @@ export default defineConfig({
     ...(DISTRIBUTION === 'cloud' &&
     process.env.SENTRY_AUTH_TOKEN &&
     process.env.SENTRY_ORG &&
-    process.env.SENTRY_PROJECT &&
+    SENTRY_PROJECT &&
     !IS_DEV
       ? [
           sentryVitePlugin({
             org: process.env.SENTRY_ORG,
-            project: process.env.SENTRY_PROJECT,
+            project: SENTRY_PROJECT,
             authToken: process.env.SENTRY_AUTH_TOKEN,
             sourcemaps: {
               // Delete source maps after upload to prevent public access
@@ -587,9 +598,9 @@ export default defineConfig({
       process.env.npm_package_version
     ),
     __SENTRY_ENABLED__: JSON.stringify(
-      !(process.env.NODE_ENV === 'development' || !process.env.SENTRY_DSN)
+      !(process.env.NODE_ENV === 'development' || !SENTRY_DSN)
     ),
-    __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
+    __SENTRY_DSN__: JSON.stringify(SENTRY_DSN),
     __ALGOLIA_APP_ID__: JSON.stringify(process.env.ALGOLIA_APP_ID || ''),
     __ALGOLIA_API_KEY__: JSON.stringify(process.env.ALGOLIA_API_KEY || ''),
     __USE_PROD_CONFIG__: process.env.USE_PROD_CONFIG === 'true',


### PR DESCRIPTION
## Summary
- Split Sentry DSN and project selection based on `USE_PROD_CONFIG`, following the same pattern as `comfyApi.ts` and `firebase.ts`
- When `USE_PROD_CONFIG=true`, uses `SENTRY_DSN_PROD` / `SENTRY_PROJECT_PROD` env vars; falls back to `SENTRY_DSN` / `SENTRY_PROJECT` for stage
- Pass `SENTRY_DSN_PROD` secret in release CI workflows

## Test plan
- [ ] Verify stage cloud build uses `SENTRY_DSN` (no `USE_PROD_CONFIG` or `USE_PROD_CONFIG=false`)
- [ ] Verify prod cloud build uses `SENTRY_DSN_PROD` (`USE_PROD_CONFIG=true`)
- [ ] Verify sourcemap uploads target correct Sentry project per environment
- [ ] Verify desktop/localhost builds are unaffected (no Sentry DSN change)
- [ ] Add `SENTRY_DSN_PROD` and `SENTRY_PROJECT_PROD` to GitHub Secrets and cloud CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9347-feat-separate-Sentry-DSN-for-stage-prod-environments-3186d73d365081aea4baf480a4c870f6) by [Unito](https://www.unito.io)
