### PR TITLE
fix: allow cursor positioning in painter opacity input

### DIFF
--- a/src/components/painter/WidgetPainter.vue
+++ b/src/components/painter/WidgetPainter.vue
@@ -141,7 +141,7 @@
               max="100"
               step="1"
               class="w-7 appearance-none border-0 bg-transparent text-right text-xs text-node-text-muted outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
-              @click.prevent
+              @click.stop
               @change="
                 (e) => {
                   const val = Math.min(


### PR DESCRIPTION
## Summary

Change `@click.prevent` to `@click.stop` on the painter opacity number input so users can click to position the text cursor.

## Changes

- **What**: Replace `@click.prevent` with `@click.stop` on the opacity `<input>` in `WidgetPainter.vue`. `preventDefault` blocks native input click behavior (cursor positioning), while `stopPropagation` correctly prevents event bubbling without interfering with the input.

## Review Focus

Single-line event modifier change. Verify that click events no longer bubble to parent canvas handlers while cursor positioning works normally.

Fixes #9234

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9348-fix-allow-cursor-positioning-in-painter-opacity-input-3186d73d365081e699b8ddeac83a55bf) by [Unito](https://www.unito.io)
