### PR TITLE
fix: make queue button tooltip reflect current mode

### DIFF
--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -361,7 +361,13 @@ const cancelJobTooltipConfig = computed(() =>
   buildTooltipConfig(t('menu.interrupt'))
 )
 const queueHistoryTooltipConfig = computed(() =>
-  buildTooltipConfig(t('sideToolbar.queueProgressOverlay.viewJobHistory'))
+  buildTooltipConfig(
+    t(
+      isQueuePanelV2Enabled.value
+        ? 'sideToolbar.queueProgressOverlay.viewJobHistory'
+        : 'sideToolbar.queueProgressOverlay.expandCollapsedQueue'
+    )
+  )
 )
 const activeJobsLabel = computed(() => {
   const count = activeJobsCount.value


### PR DESCRIPTION
## Summary

Make queue button tooltip mode-aware so it shows the correct action text based on whether QPOV2 is enabled.

## Changes

- **What**: Update `queueHistoryTooltipConfig` in `ComfyActionbar.vue` to conditionally show "View Job History" (QPOV2 enabled) or "Expand/Collapse Queue" (QPOV2 disabled) instead of always showing "View Job History"

## Review Focus

Straightforward conditional using existing `isQueuePanelV2Enabled` computed and existing i18n keys.

Fixes #9278

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9350-fix-make-queue-button-tooltip-reflect-current-mode-3186d73d36508122b198e5fbb0226221) by [Unito](https://www.unito.io)
