### PR TITLE
fix: remove redundant canvas save/restore and add error logging

### DIFF
--- a/src/components/queue/JobHistoryActionsMenu.vue
+++ b/src/components/queue/JobHistoryActionsMenu.vue
@@ -114,8 +114,8 @@ const onToggleDockedJobHistory = async (close: () => void) => {
 
     sidebarTabStore.activeSidebarTabId = 'job-history'
     await settingStore.set('Comfy.Queue.QPOV2', true)
-  } catch {
-    return
+  } catch (error) {
+    console.warn('[JobHistory] Failed to toggle docked job history:', error)
   }
 }
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.ts
@@ -60,14 +60,12 @@ function renderUploadSpinner(
   const radius = 16
   const angle = ((Date.now() % 1000) / 1000) * TWO_PI
 
-  ctx.save()
   ctx.strokeStyle = LiteGraph.NODE_TEXT_COLOR
   ctx.lineWidth = 3
   ctx.lineCap = 'round'
   ctx.beginPath()
   ctx.arc(centerX, centerY, radius, angle, angle + SPINNER_ARC_LENGTH)
   ctx.stroke()
-  ctx.restore()
 
   // Schedule next frame to keep spinner animating continuously.
   // Only runs while node.isUploading is true (checked by caller).


### PR DESCRIPTION
## Summary

Minor code quality fixes addressing CodeRabbit review feedback on two files.

## Changes

- **What**: Remove redundant `ctx.save()`/`ctx.restore()` in `renderUploadSpinner` (parent `drawFrontCanvas` already handles canvas state cleanup). Add error logging in `JobHistoryActionsMenu` catch block instead of silently swallowing errors.

## Review Focus

Straightforward cleanup, no behavioral changes expected.

Fixes #9233
Fixes #9268

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9351-fix-remove-redundant-canvas-save-restore-and-add-error-logging-3186d73d36508156b362fdd9afa8fe0a) by [Unito](https://www.unito.io)
