### PR TITLE
fix: sync subgraph name on double-click title rename

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.ts
@@ -93,6 +93,11 @@ function useNodeEventHandlersIndividual() {
 
     // Update the node title in LiteGraph for persistence
     node.title = newTitle
+
+    // If this is a subgraph node, sync the subgraph name for breadcrumb reactivity
+    if (node.isSubgraphNode?.()) {
+      node.subgraph.name = newTitle
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
The Vue renderer's title editing path (NodeHeader → useNodeEventHandlers) only updated node.title but not subgraph.name, so the breadcrumb didn't reflect the new name when entering the subgraph.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9353-fix-sync-subgraph-name-on-double-click-title-rename-3186d73d365081e2bc54f19ecd421ac0) by [Unito](https://www.unito.io)
