### PR TITLE
fix: App builder menu change "Save app" to just "Save"

### DIFF
--- a/src/components/builder/BuilderMenu.vue
+++ b/src/components/builder/BuilderMenu.vue
@@ -32,7 +32,7 @@
         @click="onSave(close)"
       >
         <i class="icon-[lucide--save] size-4" />
-        {{ t('builderMenu.saveApp') }}
+        {{ t('g.save') }}
       </button>
       <div class="my-1 border-t border-border-default" />
       <button

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3371,7 +3371,6 @@
     "viewApp": "View app"
   },
   "builderMenu": {
-    "saveApp": "Save app",
     "exitAppBuilder": "Exit app builder"
   }
 }


### PR DESCRIPTION
## Summary

Changes "Save app" to just "Save" as you are saving the whole workflow as normal

## Screenshots (if applicable)

<img width="293" height="247" alt="image" src="https://github.com/user-attachments/assets/c5aea772-12cf-4b0e-8336-8d72ef55be98" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9356-fix-App-builder-menu-change-Save-app-to-just-Save-3186d73d36508119a7c0e8e00155e0b0) by [Unito](https://www.unito.io)
