### PR TITLE
fix: use Ctrl+Shift modifier for sidebar toggle shortcuts

### DIFF
--- a/src/platform/keybindings/defaults.test.ts
+++ b/src/platform/keybindings/defaults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
+
+import { CORE_KEYBINDINGS } from './defaults'
+
+function findKeybinding(commandId: string) {
+  return CORE_KEYBINDINGS.find((kb) => kb.commandId === commandId)
+}
+
+describe('CORE_KEYBINDINGS', () => {
+  describe('sidebar toggle shortcuts use Ctrl+Shift modifier', () => {
+    const sidebarCommands = [
+      {
+        commandId: 'Workspace.ToggleSidebarTab.workflows',
+        expectedKey: 'w'
+      },
+      {
+        commandId: 'Workspace.ToggleSidebarTab.node-library',
+        expectedKey: 'n'
+      },
+      {
+        commandId: 'Workspace.ToggleSidebarTab.model-library',
+        expectedKey: 'm'
+      },
+      {
+        commandId: 'Workspace.ToggleSidebarTab.assets',
+        expectedKey: 'a'
+      }
+    ]
+
+    it.each(sidebarCommands)(
+      '$commandId is bound to Ctrl+Shift+$expectedKey',
+      ({ commandId, expectedKey }) => {
+        const kb = findKeybinding(commandId)
+        expect(kb).toBeDefined()
+        expect(kb!.combo).toEqual(
+          expect.objectContaining({
+            ctrl: true,
+            shift: true,
+            key: expectedKey
+          })
+        )
+      }
+    )
+
+    it.each(sidebarCommands)(
+      '$commandId is not reserved by text input',
+      ({ commandId }) => {
+        const kb = findKeybinding(commandId)
+        const combo = new KeyComboImpl(kb!.combo)
+        expect(combo.isReservedByTextInput).toBe(false)
+      }
+    )
+  })
+
+  it('Comfy.ToggleLinear is bound to Ctrl+Shift+D', () => {
+    const kb = findKeybinding('Comfy.ToggleLinear')
+    expect(kb).toBeDefined()
+    expect(kb!.combo).toEqual(
+      expect.objectContaining({
+        ctrl: true,
+        shift: true,
+        key: 'd'
+      })
+    )
+  })
+
+  it('no keybinding uses Ctrl+Shift+A for ToggleLinear', () => {
+    const toggleLinear = findKeybinding('Comfy.ToggleLinear')
+    expect(toggleLinear!.combo.key).not.toBe('a')
+  })
+})

--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -32,24 +32,32 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
+      ctrl: true,
+      shift: true,
       key: 'w'
     },
     commandId: 'Workspace.ToggleSidebarTab.workflows'
   },
   {
     combo: {
+      ctrl: true,
+      shift: true,
       key: 'n'
     },
     commandId: 'Workspace.ToggleSidebarTab.node-library'
   },
   {
     combo: {
+      ctrl: true,
+      shift: true,
       key: 'm'
     },
     commandId: 'Workspace.ToggleSidebarTab.model-library'
   },
   {
     combo: {
+      ctrl: true,
+      shift: true,
       key: 'a'
     },
     commandId: 'Workspace.ToggleSidebarTab.assets'
@@ -58,7 +66,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
     combo: {
       ctrl: true,
       shift: true,
-      key: 'a'
+      key: 'd'
     },
     commandId: 'Comfy.ToggleLinear'
   },


### PR DESCRIPTION
## Summary

Sidebar toggle shortcuts (`w`, `n`, `m`, `a`) fire correctly on first press but become inert once the sidebar opens and its search box gains focus, because plain-key combos have `isReservedByTextInput = true`. This changes them to `Ctrl+Shift+<letter>` (VS Code-style) so `isReservedByTextInput = false` and the handler fires regardless of input focus.

## Changes

- **What**: Change sidebar toggle keybindings from plain keys to `Ctrl+Shift+W/N/M/A`. Relocate `Comfy.ToggleLinear` from `Ctrl+Shift+A` to `Ctrl+Shift+D` to resolve the conflict.
- Add `defaults.test.ts` verifying modifier presence and `isReservedByTextInput` behavior.

## Review Focus

Confirm the new `Ctrl+Shift+D` binding for ToggleLinear doesn't conflict with any other shortcut.

Fixes #7653

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9357-fix-use-Ctrl-Shift-modifier-for-sidebar-toggle-shortcuts-3186d73d3650819a83c9fcf0e0ee5de0) by [Unito](https://www.unito.io)
