### PR TITLE
ci: deploy Storybook to fixed production URL on main merge

### DIFF
--- a/.github/workflows/ci-tests-storybook.yaml
+++ b/.github/workflows/ci-tests-storybook.yaml
@@ -143,7 +143,7 @@ jobs:
   # Deploy Storybook to production URL on main branch push
   deploy-production:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci-tests-storybook.yaml
+++ b/.github/workflows/ci-tests-storybook.yaml
@@ -143,7 +143,7 @@ jobs:
   # Deploy Storybook to production URL on main branch push
   deploy-production:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci-tests-storybook.yaml
+++ b/.github/workflows/ci-tests-storybook.yaml
@@ -4,6 +4,8 @@ name: 'CI: Tests Storybook'
 on:
   workflow_dispatch: # Allow manual triggering
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   # Post starting comment for non-forked PRs
@@ -137,6 +139,32 @@ jobs:
             "${{ github.event.pull_request.number }}" \
             "${{ github.head_ref }}" \
             "completed"
+
+  # Deploy Storybook to production URL on main branch push
+  deploy-production:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Build Storybook
+        run: pnpm build-storybook
+
+      - name: Install wrangler
+        run: npm install -g wrangler@^4.0.0
+
+      - name: Deploy to Cloudflare Pages (production)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler pages deploy storybook-static \
+            --project-name=comfy-storybook \
+            --branch=main
 
   # Update comment with Chromatic URLs for version-bump branches
   update-comment-with-chromatic:

--- a/.github/workflows/ci-tests-storybook.yaml
+++ b/.github/workflows/ci-tests-storybook.yaml
@@ -154,15 +154,12 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
 
-      - name: Install wrangler
-        run: npm install -g wrangler@^4.0.0
-
       - name: Deploy to Cloudflare Pages (production)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          wrangler pages deploy storybook-static \
+          npx wrangler@^4.0.0 pages deploy storybook-static \
             --project-name=comfy-storybook \
             --branch=main
 


### PR DESCRIPTION
## Summary
- Add `deploy-production` job to Storybook CI workflow
- Triggers on push to `main` branch
- Deploys to fixed Cloudflare Pages URL: `https://comfy-storybook.pages.dev`
- PR preview deployments remain unchanged

## Linked Issues
- Notion: [COM-15826](https://www.notion.so/Deploy-Storybook-to-fixed-production-URL-on-main-branch-merge-3196d73d36508159a875d42694a619d1)

## Test Plan
- [ ] Merge to main and verify `deploy-production` job runs in GitHub Actions
- [ ] Confirm `https://comfy-storybook.pages.dev` serves latest Storybook
- [ ] Verify existing PR preview deployments still work
- [ ] Verify other jobs (comment, chromatic) are not affected by the new trigger

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9373-ci-deploy-Storybook-to-fixed-production-URL-on-main-merge-3196d73d3650816795ead1a5b839a571) by [Unito](https://www.unito.io)
