### PR TITLE
feat: add manager enable hint for OSS local users

### DIFF
--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -57,6 +57,8 @@ const i18n = createI18n({
         missingNodePacks: {
           ossMessage: 'Missing node packs detected. Install them.',
           cloudMessage: 'Unsupported node packs detected.',
+          ossManagerDisabledHint:
+            'To install missing nodes, first run {pipCmd} in your Python environment to install Node Manager, then restart ComfyUI with the {flag} flag.',
           applyChanges: 'Apply Changes'
         }
       }
@@ -143,6 +145,27 @@ describe('MissingNodeCard', () => {
       const row = wrapper.findComponent({ name: 'MissingPackGroupRow' })
       expect(row.props('showInfoButton')).toBe(true)
       expect(row.props('showNodeIdBadge')).toBe(true)
+    })
+  })
+
+  describe('Manager Disabled Hint', () => {
+    it('shows hint when OSS and manager is disabled (showInfoButton false)', () => {
+      mockIsCloud.value = false
+      const wrapper = mountCard({ showInfoButton: false })
+      expect(wrapper.text()).toContain('pip install -U --pre comfyui-manager')
+      expect(wrapper.text()).toContain('--enable-manager')
+    })
+
+    it('hides hint when manager is enabled (showInfoButton true)', () => {
+      mockIsCloud.value = false
+      const wrapper = mountCard({ showInfoButton: true })
+      expect(wrapper.text()).not.toContain('--enable-manager')
+    })
+
+    it('hides hint on Cloud even when showInfoButton is false', () => {
+      mockIsCloud.value = true
+      const wrapper = mountCard({ showInfoButton: false })
+      expect(wrapper.text()).not.toContain('--enable-manager')
     })
   })
 

--- a/src/components/rightSidePanel/errors/MissingNodeCard.vue
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.vue
@@ -1,13 +1,37 @@
 <template>
   <div class="px-4 pb-2">
     <!-- Sub-label: cloud or OSS message shown above all pack groups -->
-    <p class="m-0 pb-5 text-sm text-muted-foreground leading-relaxed">
+    <p
+      class="m-0 text-sm text-muted-foreground leading-relaxed"
+      :class="showManagerHint ? 'pb-3' : 'pb-5'"
+    >
       {{
         isCloud
           ? t('rightSidePanel.missingNodePacks.cloudMessage')
           : t('rightSidePanel.missingNodePacks.ossMessage')
       }}
     </p>
+
+    <!-- Manager disabled hint: shown on OSS when manager is not active -->
+    <i18n-t
+      v-if="showManagerHint"
+      keypath="rightSidePanel.missingNodePacks.ossManagerDisabledHint"
+      tag="p"
+      class="m-0 pb-5 text-sm text-muted-foreground leading-relaxed"
+    >
+      <template #pipCmd>
+        <code
+          class="px-1 py-0.5 rounded text-xs font-mono bg-comfy-menu-bg text-comfy-input-foreground"
+          >pip install -U --pre comfyui-manager</code
+        >
+      </template>
+      <template #flag>
+        <code
+          class="px-1 py-0.5 rounded text-xs font-mono bg-comfy-menu-bg text-comfy-input-foreground"
+          >--enable-manager</code
+        >
+      </template>
+    </i18n-t>
     <MissingPackGroupRow
       v-for="group in missingPackGroups"
       :key="group.packId ?? '__unknown__'"
@@ -65,6 +89,13 @@ const { t } = useI18n()
 const comfyManagerStore = useComfyManagerStore()
 const { isRestarting, applyChanges } = useApplyChanges()
 const { shouldShowManagerButtons } = useManagerState()
+
+/**
+ * Show the --enable-manager hint when:
+ * - Not on Cloud (OSS/local only)
+ * - Manager is disabled (showInfoButton is false)
+ */
+const showManagerHint = computed(() => !isCloud && !props.showInfoButton)
 
 /**
  * Show Apply Changes when any pack from the error group is already installed

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3199,6 +3199,7 @@
       "unsupportedTitle": "Unsupported Node Packs",
       "cloudMessage": "This workflow requires custom nodes not yet available on Comfy Cloud.",
       "ossMessage": "This workflow uses custom nodes you haven't installed yet.",
+      "ossManagerDisabledHint": "To install missing nodes, first run {pipCmd} in your Python environment to install Node Manager, then restart ComfyUI with the {flag} flag.",
       "installAll": "Install All",
       "installNodePack": "Install node pack",
       "unknownPack": "Unknown pack",


### PR DESCRIPTION
## Summary

When ComfyUI Manager is disabled, OSS local users see a hint in the Missing Nodes panel explaining how to install and enable it.

## Changes

- **What**: Added an inline hint in `MissingNodeCard` that renders when the user is on OSS (non-Cloud) and Manager is not active (`showInfoButton` is false). The hint shows the pip install command and the `--enable-manager` startup flag, formatted as inline `<code>` snippets via `i18n-t` interpolation.

## Review Focus

- The `showManagerHint` computed is intentionally simple: `!isCloud && !props.showInfoButton`. `showInfoButton` is the existing signal for whether Manager is available/enabled.
- Styling uses existing semantic tokens (`bg-comfy-menu-bg`, `text-comfy-input-foreground`) to match the rest of the panel.

## Screenshot
<img width="642" height="452" alt="image" src="https://github.com/user-attachments/assets/d08280d3-b4a0-4613-b092-1baa49f0b091" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9377-feat-add-manager-enable-hint-for-OSS-local-users-3196d73d365081a19037c8f55f11d1eb) by [Unito](https://www.unito.io)
