### PR TITLE
[Bug] Node preview images are lost when switching between multiple workflow tabs

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -77,7 +77,7 @@ export class ChangeTracker {
       scale: app.canvas.ds.scale,
       offset: [app.canvas.ds.offset[0], app.canvas.ds.offset[1]]
     }
-    this.nodeOutputs = { ...app.nodeOutputs }
+    this.nodeOutputs = clone(app.nodeOutputs)
     const navigation = useSubgraphNavigationStore().exportState()
     // Always store the navigation state, even if empty (root level)
     this.subgraphState = { navigation }

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -77,6 +77,7 @@ export class ChangeTracker {
       scale: app.canvas.ds.scale,
       offset: [app.canvas.ds.offset[0], app.canvas.ds.offset[1]]
     }
+    this.nodeOutputs = { ...app.nodeOutputs }
     const navigation = useSubgraphNavigationStore().exportState()
     // Always store the navigation state, even if empty (root level)
     this.subgraphState = { navigation }


### PR DESCRIPTION
## Summary

When working with multiple workflow tabs, the internal preview (image thumbnail) of nodes like Load Image disappears after navigating away from and back to a tab. This affects all active tabs once the switch occurs.

## Screenshot
before

https://github.com/user-attachments/assets/99466123-37db-406f-9e17-0a9ff22311c3



after



https://github.com/user-attachments/assets/bdad0ef1-72b7-46c7-aa61-0a557688e55e



