### PR TITLE
refactor: extract input widget resolution from SubgraphNode configure

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -649,47 +649,50 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       }
 
       this._addSubgraphInputListeners(subgraphInput, input)
-
-      // Find the first widget that this slot is connected to
-      for (const linkId of subgraphInput.linkIds) {
-        const link = this.subgraph.getLink(linkId)
-        if (!link) {
-          console.warn(
-            `[SubgraphNode.configure] No link found for link ID ${linkId}`,
-            this
-          )
-          continue
-        }
-
-        const { inputNode } = link.resolve(this.subgraph)
-        if (!inputNode) {
-          console.warn('Failed to resolve inputNode', link, this)
-          continue
-        }
-
-        //Manually find input since target_slot can't be trusted
-        const targetInput = inputNode.inputs.find((inp) => inp.link === linkId)
-        if (!targetInput) {
-          console.warn('Failed to find corresponding input', link, inputNode)
-          continue
-        }
-
-        // No widget - ignore this link
-        const widget = inputNode.getWidgetFromSlot(targetInput)
-        if (!widget) continue
-
-        this._setWidget(
-          subgraphInput,
-          input,
-          widget,
-          targetInput.widget,
-          inputNode
-        )
-        break
-      }
+      this._resolveInputWidget(subgraphInput, input)
     }
 
     this._syncPromotions()
+  }
+
+  private _resolveInputWidget(
+    subgraphInput: SubgraphInput,
+    input: INodeInputSlot
+  ) {
+    for (const linkId of subgraphInput.linkIds) {
+      const link = this.subgraph.getLink(linkId)
+      if (!link) {
+        console.warn(
+          `[SubgraphNode.configure] No link found for link ID ${linkId}`,
+          this
+        )
+        continue
+      }
+
+      const { inputNode } = link.resolve(this.subgraph)
+      if (!inputNode) {
+        console.warn('Failed to resolve inputNode', link, this)
+        continue
+      }
+
+      const targetInput = inputNode.inputs.find((inp) => inp.link === linkId)
+      if (!targetInput) {
+        console.warn('Failed to find corresponding input', link, inputNode)
+        continue
+      }
+
+      const widget = inputNode.getWidgetFromSlot(targetInput)
+      if (!widget) continue
+
+      this._setWidget(
+        subgraphInput,
+        input,
+        widget,
+        targetInput.widget,
+        inputNode
+      )
+      break
+    }
   }
 
   private _setWidget(


### PR DESCRIPTION
## Summary

Extract the inner link-resolution loop from `_internalConfigureAfterSlots` into a private `_resolveInputWidget` method to reduce cognitive complexity below the sonarjs threshold of 15.

## Changes

- **What**: Extract nested loop body (lines 654-689) into `_resolveInputWidget` private method in `SubgraphNode.ts`
- Pure refactoring with no behavioral changes

## Review Focus

Straightforward extract-method refactoring. The new method contains the exact same logic that was previously inline.

Fixes #9297

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9383-refactor-extract-input-widget-resolution-from-SubgraphNode-configure-3196d73d365081ba9124cfd0d312fcb0) by [Unito](https://www.unito.io)
