### PR TITLE
refactor(changeTracker): use shared clone util and centralize nodeOutputs snapshot

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -77,7 +77,7 @@ export class ChangeTracker {
       scale: app.canvas.ds.scale,
       offset: [app.canvas.ds.offset[0], app.canvas.ds.offset[1]]
     }
-    this.nodeOutputs = clone(app.nodeOutputs)
+    this.nodeOutputs = useNodeOutputStore().snapshotOutputs()
     const navigation = useSubgraphNavigationStore().exportState()
     // Always store the navigation state, even if empty (root level)
     this.subgraphState = { navigation }

--- a/src/stores/imagePreviewStore.ts
+++ b/src/stores/imagePreviewStore.ts
@@ -13,6 +13,7 @@ import type {
 import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import { clone } from '@/scripts/utils'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { parseFilePath } from '@/utils/formatUtil'
 import { isAnimatedOutput, isVideoNode } from '@/utils/litegraphUtil'
@@ -365,6 +366,10 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     return hadOutputs
   }
 
+  function snapshotOutputs(): Record<string, ExecutedWsMessage['output']> {
+    return clone(app.nodeOutputs)
+  }
+
   function restoreOutputs(
     outputs: Record<string, ExecutedWsMessage['output']>
   ) {
@@ -455,6 +460,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     revokeAllPreviews,
     revokeSubgraphPreviews,
     removeNodeOutputs,
+    snapshotOutputs,
     restoreOutputs,
     resetAllOutputsAndPreviews,
 


### PR DESCRIPTION
## Summary

Follow-up to #9380. Replaces local `clone()` with shared util and centralizes output snapshotting.

## Changes

- **What**: Replaced local `JSON.parse(JSON.stringify)` clone in `changeTracker.ts` with shared `clone()` from `@/scripts/utils` (prefers `structuredClone` with JSON fallback). Added `snapshotOutputs()` to `useNodeOutputStore` as symmetric counterpart to existing `restoreOutputs()`, and wired `changeTracker.store()` to use it.
- **Breaking**: None

## Review Focus

Symmetry between `snapshotOutputs()` and `restoreOutputs()` in the node output store.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9387-refactor-changeTracker-use-shared-clone-util-and-centralize-nodeOutputs-snapshot-3196d73d365081a289c3cb414f57929e) by [Unito](https://www.unito.io)
