### PR TITLE
Fix localization on share and hide entry

### DIFF
--- a/src/composables/useWorkflowActionsMenu.ts
+++ b/src/composables/useWorkflowActionsMenu.ts
@@ -189,11 +189,10 @@ export function useWorkflowActionsMenu(
 
     addItem({
       id: 'share',
-      label: t('menuLabels.Share'),
+      label: t('breadcrumbsMenu.share'),
       icon: 'icon-[comfy--send]',
       command: async () => {},
-      disabled: true,
-      visible: isRoot
+      visible: false
     })
 
     addItem({

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2600,7 +2600,8 @@
     "deleteWorkflow": "Delete Workflow",
     "deleteBlueprint": "Delete Blueprint",
     "enterNewName": "Enter new name",
-    "missingNodesWarning": "Workflow contains unsupported nodes (highlighted red)."
+    "missingNodesWarning": "Workflow contains unsupported nodes (highlighted red).",
+    "share": "Share"
   },
   "shortcuts": {
     "shortcuts": "Shortcuts",


### PR DESCRIPTION
A placeholder share entry was added in #9368, but the localization for this share label was then removed in #9361.

This localization is re-added in a location that is less likely to be overwritten and the menu item is set to hidden. I'll manually connect it to the workflow sharing feature flag in a followup PR after that has been merged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9395-Fix-localization-on-share-and-hide-entry-3196d73d36508146a343f625a5327bdd) by [Unito](https://www.unito.io)
