### PR TITLE
fix: hide all painter labels in compact mode consistently

### DIFF
--- a/src/components/painter/WidgetPainter.vue
+++ b/src/components/painter/WidgetPainter.vue
@@ -116,6 +116,7 @@
 
       <template v-if="tool === PAINTER_TOOLS.BRUSH">
         <div
+          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.color') }}
@@ -158,6 +159,7 @@
         </div>
 
         <div
+          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.hardness') }}
@@ -183,6 +185,7 @@
 
       <template v-if="!isImageInputConnected">
         <div
+          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.width') }}
@@ -204,6 +207,7 @@
         </div>
 
         <div
+          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.height') }}
@@ -225,6 +229,7 @@
         </div>
 
         <div
+          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.background') }}


### PR DESCRIPTION
## Summary

Add missing `v-if="!compact"` guards to painter label divs so all labels are hidden consistently in compact mode.

## Changes

- **What**: Added `v-if="!compact"` to the Color, Hardness, Width, Height, and Background label divs in `WidgetPainter.vue`, matching the existing guards on Tool and Size labels.

## Review Focus

Straightforward consistency fix — all 7 label divs now use the same compact-mode guard.

Fixes #9235

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9397-fix-hide-all-painter-labels-in-compact-mode-consistently-31a6d73d3650811a9d3af8dd290e2bca) by [Unito](https://www.unito.io)
