### PR TITLE
feat: add Storybook stories for WidgetInputText and WidgetTextarea

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
@@ -1,26 +1,35 @@
-import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { ref } from 'vue'
+import type {
+  ComponentPropsAndSlots,
+  Meta,
+  StoryObj
+} from '@storybook/vue3-vite'
+import { computed, ref, toRefs } from 'vue'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 import WidgetInputText from './WidgetInputText.vue'
 
-function createWidget(
-  overrides: Partial<SimplifiedWidget<string>> = {}
-): SimplifiedWidget<string> {
-  return {
-    name: 'prompt',
-    type: 'STRING',
-    value: '',
-    ...overrides
-  }
+interface StoryArgs extends ComponentPropsAndSlots<typeof WidgetInputText> {
+  readOnly: boolean
+  disabled: boolean
+  placeholder: string
 }
 
-const meta: Meta<typeof WidgetInputText> = {
+const meta: Meta<StoryArgs> = {
   title: 'Widgets/WidgetInputText',
   component: WidgetInputText,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    readOnly: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' }
+  },
+  args: {
+    readOnly: false,
+    disabled: false,
+    placeholder: ''
+  },
   decorators: [
     (story) => ({
       components: { story },
@@ -34,41 +43,21 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  render: () => ({
+  render: (args) => ({
     components: { WidgetInputText },
     setup() {
+      const { readOnly, disabled, placeholder } = toRefs(args)
       const value = ref('Hello world')
-      const widget = createWidget({ name: 'text' })
-      return { value, widget }
-    },
-    template: '<WidgetInputText :widget="widget" v-model="value" />'
-  })
-}
-
-export const WithPlaceholder: Story = {
-  render: () => ({
-    components: { WidgetInputText },
-    setup() {
-      const value = ref('')
-      const widget = createWidget({
-        name: 'prompt',
-        options: { placeholder: 'Enter your prompt here...' }
-      })
-      return { value, widget }
-    },
-    template: '<WidgetInputText :widget="widget" v-model="value" />'
-  })
-}
-
-export const ReadOnly: Story = {
-  render: () => ({
-    components: { WidgetInputText },
-    setup() {
-      const value = ref('This text cannot be edited')
-      const widget = createWidget({
-        name: 'output',
-        options: { read_only: true }
-      })
+      const widget = computed<SimplifiedWidget<string>>(() => ({
+        name: 'text',
+        type: 'STRING',
+        value: '',
+        options: {
+          read_only: readOnly.value,
+          disabled: disabled.value,
+          ...(placeholder.value ? { placeholder: placeholder.value } : {})
+        }
+      }))
       return { value, widget }
     },
     template: '<WidgetInputText :widget="widget" v-model="value" />'
@@ -76,14 +65,39 @@ export const ReadOnly: Story = {
 }
 
 export const Disabled: Story = {
-  render: () => ({
+  args: { disabled: true },
+  render: (args) => ({
     components: { WidgetInputText },
     setup() {
+      const { disabled } = toRefs(args)
       const value = ref('This text is disabled')
-      const widget = createWidget({
+      const widget = computed<SimplifiedWidget<string>>(() => ({
         name: 'locked',
-        options: { disabled: true }
-      })
+        type: 'STRING',
+        value: '',
+        options: { disabled: disabled.value }
+      }))
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}
+
+export const WithPlaceholder: Story = {
+  args: { placeholder: 'Enter your prompt here...' },
+  render: (args) => ({
+    components: { WidgetInputText },
+    setup() {
+      const { placeholder } = toRefs(args)
+      const value = ref('')
+      const widget = computed<SimplifiedWidget<string>>(() => ({
+        name: 'prompt',
+        type: 'STRING',
+        value: '',
+        options: {
+          ...(placeholder.value ? { placeholder: placeholder.value } : {})
+        }
+      }))
       return { value, widget }
     },
     template: '<WidgetInputText :widget="widget" v-model="value" />'
@@ -95,10 +109,12 @@ export const WithLabel: Story = {
     components: { WidgetInputText },
     setup() {
       const value = ref('Some value')
-      const widget = createWidget({
+      const widget: SimplifiedWidget<string> = {
         name: 'seed',
+        type: 'STRING',
+        value: '',
         label: 'Random Seed'
-      })
+      }
       return { value, widget }
     },
     template: '<WidgetInputText :widget="widget" v-model="value" />'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
+
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetInputText from './WidgetInputText.vue'
+
+function createWidget(
+  overrides: Partial<SimplifiedWidget<string>> = {}
+): SimplifiedWidget<string> {
+  return {
+    name: 'prompt',
+    type: 'STRING',
+    value: '',
+    ...overrides
+  }
+}
+
+const meta: Meta<typeof WidgetInputText> = {
+  title: 'Widgets/WidgetInputText',
+  component: WidgetInputText,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template:
+        '<div class="grid grid-cols-[auto_1fr] gap-1 w-80"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { WidgetInputText },
+    setup() {
+      const value = ref('Hello world')
+      const widget = createWidget({ name: 'text' })
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}
+
+export const WithPlaceholder: Story = {
+  render: () => ({
+    components: { WidgetInputText },
+    setup() {
+      const value = ref('')
+      const widget = createWidget({
+        name: 'prompt',
+        options: { placeholder: 'Enter your prompt here...' }
+      })
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}
+
+export const ReadOnly: Story = {
+  render: () => ({
+    components: { WidgetInputText },
+    setup() {
+      const value = ref('This text cannot be edited')
+      const widget = createWidget({
+        name: 'output',
+        options: { read_only: true }
+      })
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}
+
+export const WithLabel: Story = {
+  render: () => ({
+    components: { WidgetInputText },
+    setup() {
+      const value = ref('Some value')
+      const widget = createWidget({
+        name: 'seed',
+        label: 'Random Seed'
+      })
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
@@ -75,6 +75,21 @@ export const ReadOnly: Story = {
   })
 }
 
+export const Disabled: Story = {
+  render: () => ({
+    components: { WidgetInputText },
+    setup() {
+      const value = ref('This text is disabled')
+      const widget = createWidget({
+        name: 'locked',
+        options: { disabled: true }
+      })
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}
+
 export const WithLabel: Story = {
   render: () => ({
     components: { WidgetInputText },

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
@@ -12,6 +12,7 @@ import WidgetInputText from './WidgetInputText.vue'
 interface StoryArgs extends ComponentPropsAndSlots<typeof WidgetInputText> {
   readOnly: boolean
   disabled: boolean
+  invalid: boolean
   placeholder: string
 }
 
@@ -23,11 +24,13 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     readOnly: { control: 'boolean' },
     disabled: { control: 'boolean' },
+    invalid: { control: 'boolean' },
     placeholder: { control: 'text' }
   },
   args: {
     readOnly: false,
     disabled: false,
+    invalid: false,
     placeholder: ''
   },
   decorators: [
@@ -46,12 +49,15 @@ export const Default: Story = {
   render: (args) => ({
     components: { WidgetInputText },
     setup() {
-      const { readOnly, disabled, placeholder } = toRefs(args)
+      const { readOnly, disabled, invalid, placeholder } = toRefs(args)
       const value = ref('Hello world')
       const widget = computed<SimplifiedWidget<string>>(() => ({
         name: 'text',
         type: 'STRING',
         value: '',
+        borderStyle: invalid.value
+          ? 'border border-destructive-background'
+          : undefined,
         options: {
           read_only: readOnly.value,
           disabled: disabled.value,
@@ -76,6 +82,27 @@ export const Disabled: Story = {
         type: 'STRING',
         value: '',
         options: { disabled: disabled.value }
+      }))
+      return { value, widget }
+    },
+    template: '<WidgetInputText :widget="widget" v-model="value" />'
+  })
+}
+
+export const Invalid: Story = {
+  args: { invalid: true },
+  render: (args) => ({
+    components: { WidgetInputText },
+    setup() {
+      const { invalid } = toRefs(args)
+      const value = ref('Invalid input value')
+      const widget = computed<SimplifiedWidget<string>>(() => ({
+        name: 'text',
+        type: 'STRING',
+        value: '',
+        borderStyle: invalid.value
+          ? 'border border-destructive-background'
+          : undefined
       }))
       return { value, widget }
     },

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.stories.ts
@@ -22,15 +22,22 @@ const meta: Meta<StoryArgs> = {
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
   argTypes: {
+    size: {
+      control: 'select',
+      options: ['medium', 'large']
+    },
     readOnly: { control: 'boolean' },
     disabled: { control: 'boolean' },
     invalid: { control: 'boolean' },
+    loading: { control: 'boolean' },
     placeholder: { control: 'text' }
   },
   args: {
+    size: 'medium',
     readOnly: false,
     disabled: false,
     invalid: false,
+    loading: false,
     placeholder: ''
   },
   decorators: [
@@ -49,24 +56,23 @@ export const Default: Story = {
   render: (args) => ({
     components: { WidgetInputText },
     setup() {
-      const { readOnly, disabled, invalid, placeholder } = toRefs(args)
+      const { size, readOnly, disabled, invalid, loading, placeholder } =
+        toRefs(args)
       const value = ref('Hello world')
       const widget = computed<SimplifiedWidget<string>>(() => ({
         name: 'text',
         type: 'STRING',
         value: '',
-        borderStyle: invalid.value
-          ? 'border border-destructive-background'
-          : undefined,
         options: {
           read_only: readOnly.value,
           disabled: disabled.value,
           ...(placeholder.value ? { placeholder: placeholder.value } : {})
         }
       }))
-      return { value, widget }
+      return { value, widget, size, invalid, loading }
     },
-    template: '<WidgetInputText :widget="widget" v-model="value" />'
+    template:
+      '<WidgetInputText :widget="widget" :size="size" :invalid="invalid" :loading="loading" v-model="value" />'
   })
 }
 
@@ -96,17 +102,34 @@ export const Invalid: Story = {
     setup() {
       const { invalid } = toRefs(args)
       const value = ref('Invalid input value')
-      const widget = computed<SimplifiedWidget<string>>(() => ({
+      const widget: SimplifiedWidget<string> = {
         name: 'text',
         type: 'STRING',
-        value: '',
-        borderStyle: invalid.value
-          ? 'border border-destructive-background'
-          : undefined
-      }))
-      return { value, widget }
+        value: ''
+      }
+      return { value, widget, invalid }
     },
-    template: '<WidgetInputText :widget="widget" v-model="value" />'
+    template:
+      '<WidgetInputText :widget="widget" :invalid="invalid" v-model="value" />'
+  })
+}
+
+export const Status: Story = {
+  args: { loading: true },
+  render: (args) => ({
+    components: { WidgetInputText },
+    setup() {
+      const { loading } = toRefs(args)
+      const value = ref('Loading...')
+      const widget: SimplifiedWidget<string> = {
+        name: 'text',
+        type: 'STRING',
+        value: ''
+      }
+      return { value, widget, loading }
+    },
+    template:
+      '<WidgetInputText :widget="widget" :loading="loading" v-model="value" />'
   })
 }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -1,9 +1,10 @@
 <template>
   <WidgetLayoutField :widget="layoutWidget">
     <div class="relative">
-      <i
+      <Loader
         v-if="loading"
-        class="icon-[lucide--loader-circle] absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 animate-spin text-component-node-foreground"
+        size="sm"
+        class="absolute left-3 top-1/2 z-10 -translate-y-1/2 text-component-node-foreground"
       />
       <InputText
         v-model="modelValue"
@@ -18,7 +19,7 @@
         "
         :aria-label="widget.name"
         :readonly="isReadOnly"
-        :size="size === 'large' ? undefined : 'small'"
+        size="small"
         :pt="{ root: 'truncate min-w-[4ch]' }"
       />
     </div>
@@ -29,6 +30,7 @@
 import InputText from 'primevue/inputtext'
 import { computed } from 'vue'
 
+import Loader from '@/components/common/Loader.vue'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { cn } from '@/utils/tailwindUtil'
 import {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -3,7 +3,12 @@
     <InputText
       v-model="modelValue"
       v-bind="filteredProps"
-      :class="cn(WidgetInputBaseClass, 'w-full text-xs py-2 px-4')"
+      :class="
+        cn(
+          WidgetInputBaseClass,
+          'w-full text-xs py-2 px-4 hover:bg-component-node-widget-background-hovered'
+        )
+      "
       :aria-label="widget.name"
       size="small"
       :pt="{ root: 'truncate min-w-[4ch]' }"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -10,6 +10,7 @@
         )
       "
       :aria-label="widget.name"
+      :readonly="isReadOnly"
       size="small"
       :pt="{ root: 'truncate min-w-[4ch]' }"
     />
@@ -30,13 +31,17 @@ import {
 import { WidgetInputBaseClass } from './layout'
 import WidgetLayoutField from './layout/WidgetLayoutField.vue'
 
-const props = defineProps<{
+const { widget } = defineProps<{
   widget: SimplifiedWidget<string>
 }>()
 
 const modelValue = defineModel<string>({ default: '' })
 
 const filteredProps = computed(() =>
-  filterWidgetProps(props.widget.options, INPUT_EXCLUDED_PROPS)
+  filterWidgetProps(widget.options, INPUT_EXCLUDED_PROPS)
+)
+
+const isReadOnly = computed(
+  () => widget.options?.read_only ?? widget.options?.disabled ?? false
 )
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -1,19 +1,27 @@
 <template>
-  <WidgetLayoutField :widget="widget">
-    <InputText
-      v-model="modelValue"
-      v-bind="filteredProps"
-      :class="
-        cn(
-          WidgetInputBaseClass,
-          'w-full text-xs py-2 px-4 hover:bg-component-node-widget-background-hovered'
-        )
-      "
-      :aria-label="widget.name"
-      :readonly="isReadOnly"
-      size="small"
-      :pt="{ root: 'truncate min-w-[4ch]' }"
-    />
+  <WidgetLayoutField :widget="layoutWidget">
+    <div class="relative">
+      <i
+        v-if="loading"
+        class="icon-[lucide--loader-circle] absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 animate-spin text-component-node-foreground"
+      />
+      <InputText
+        v-model="modelValue"
+        v-bind="filteredProps"
+        :class="
+          cn(
+            WidgetInputBaseClass,
+            'w-full px-4 hover:bg-component-node-widget-background-hovered',
+            size === 'large' ? 'text-sm py-3' : 'text-xs py-2',
+            loading && 'pl-9'
+          )
+        "
+        :aria-label="widget.name"
+        :readonly="isReadOnly"
+        :size="size === 'large' ? undefined : 'small'"
+        :pt="{ root: 'truncate min-w-[4ch]' }"
+      />
+    </div>
   </WidgetLayoutField>
 </template>
 
@@ -31,8 +39,16 @@ import {
 import { WidgetInputBaseClass } from './layout'
 import WidgetLayoutField from './layout/WidgetLayoutField.vue'
 
-const { widget } = defineProps<{
+const {
+  widget,
+  size = 'medium',
+  invalid = false,
+  loading = false
+} = defineProps<{
   widget: SimplifiedWidget<string>
+  size?: 'medium' | 'large'
+  invalid?: boolean
+  loading?: boolean
 }>()
 
 const modelValue = defineModel<string>({ default: '' })
@@ -44,4 +60,13 @@ const filteredProps = computed(() =>
 const isReadOnly = computed(
   () => widget.options?.read_only ?? widget.options?.disabled ?? false
 )
+
+const layoutWidget = computed(() => ({
+  name: widget.name,
+  label: widget.label,
+  borderStyle: cn(
+    widget.borderStyle,
+    invalid && 'border border-destructive-background'
+  )
+}))
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -57,8 +57,8 @@ const filteredProps = computed(() =>
   filterWidgetProps(widget.options, INPUT_EXCLUDED_PROPS)
 )
 
-const isReadOnly = computed(
-  () => widget.options?.read_only ?? widget.options?.disabled ?? false
+const isReadOnly = computed(() =>
+  Boolean(widget.options?.read_only || widget.options?.disabled)
 )
 
 const layoutWidget = computed(() => ({

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
@@ -1,23 +1,21 @@
-import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { provide, ref } from 'vue'
+import type {
+  ComponentPropsAndSlots,
+  Meta,
+  StoryObj
+} from '@storybook/vue3-vite'
+import { computed, provide, ref, toRefs } from 'vue'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { HideLayoutFieldKey } from '@/types/widgetTypes'
 
 import WidgetTextarea from './WidgetTextarea.vue'
 
-function createWidget(
-  overrides: Partial<SimplifiedWidget<string>> = {}
-): SimplifiedWidget<string> {
-  return {
-    name: 'text',
-    type: 'STRING',
-    value: '',
-    ...overrides
-  }
+interface StoryArgs extends ComponentPropsAndSlots<typeof WidgetTextarea> {
+  readOnly: boolean
+  disabled: boolean
 }
 
-const meta: Meta<typeof WidgetTextarea> = {
+const meta: Meta<StoryArgs> = {
   title: 'Widgets/WidgetTextarea',
   component: WidgetTextarea,
   tags: ['autodocs'],
@@ -33,6 +31,14 @@ const meta: Meta<typeof WidgetTextarea> = {
       }
     }
   },
+  argTypes: {
+    readOnly: { control: 'boolean' },
+    disabled: { control: 'boolean' }
+  },
+  args: {
+    readOnly: false,
+    disabled: false
+  },
   decorators: [
     (story) => ({
       components: { story },
@@ -45,11 +51,21 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  render: () => ({
+  render: (args) => ({
     components: { WidgetTextarea },
     setup() {
+      const { readOnly, disabled } = toRefs(args)
       const value = ref('A multi-line text area for entering prompts.')
-      const widget = createWidget({ name: 'prompt', label: 'Prompt' })
+      const widget = computed<SimplifiedWidget<string>>(() => ({
+        name: 'prompt',
+        type: 'STRING',
+        value: '',
+        label: 'Prompt',
+        options: {
+          read_only: readOnly.value,
+          disabled: disabled.value
+        }
+      }))
       return { value, widget }
     },
     template:
@@ -57,15 +73,20 @@ export const Default: Story = {
   })
 }
 
-export const WithLabelVisible: Story = {
-  render: () => ({
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: (args) => ({
     components: { WidgetTextarea },
     setup() {
-      const value = ref('beautiful landscape, mountains, sunset, 4k, detailed')
-      const widget = createWidget({
-        name: 'positive',
-        label: 'Positive Prompt'
-      })
+      const { disabled } = toRefs(args)
+      const value = ref('This textarea is disabled via widget options.')
+      const widget = computed<SimplifiedWidget<string>>(() => ({
+        name: 'locked',
+        type: 'STRING',
+        value: '',
+        label: 'Locked Field',
+        options: { disabled: disabled.value }
+      }))
       return { value, widget }
     },
     template: '<WidgetTextarea :widget="widget" v-model="value" />'
@@ -78,47 +99,12 @@ export const HiddenLabel: Story = {
     setup() {
       provide(HideLayoutFieldKey, true)
       const value = ref('Label is hidden via HideLayoutFieldKey injection.')
-      const widget = createWidget({ name: 'notes', label: 'Notes' })
-      return { value, widget }
-    },
-    template: '<WidgetTextarea :widget="widget" v-model="value" />'
-  })
-}
-
-export const ReadOnly: Story = {
-  render: () => ({
-    components: { WidgetTextarea },
-    setup() {
-      const value = ref('This text is read-only. Hover to see the copy button.')
-      const widget = createWidget({
-        name: 'output',
-        label: 'Output',
-        options: { read_only: true }
-      })
-      return { value, widget }
-    },
-    template: '<WidgetTextarea :widget="widget" v-model="value" />'
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'A copy-to-clipboard button appears on hover in the top-right corner.'
+      const widget: SimplifiedWidget<string> = {
+        name: 'notes',
+        type: 'STRING',
+        value: '',
+        label: 'Notes'
       }
-    }
-  }
-}
-
-export const Disabled: Story = {
-  render: () => ({
-    components: { WidgetTextarea },
-    setup() {
-      const value = ref('This textarea is disabled via widget options.')
-      const widget = createWidget({
-        name: 'locked',
-        label: 'Locked Field',
-        options: { disabled: true }
-      })
       return { value, widget }
     },
     template: '<WidgetTextarea :widget="widget" v-model="value" />'
@@ -130,10 +116,12 @@ export const WithPlaceholder: Story = {
     components: { WidgetTextarea },
     setup() {
       const value = ref('')
-      const widget = createWidget({
+      const widget: SimplifiedWidget<string> = {
         name: 'negative',
+        type: 'STRING',
+        value: '',
         label: 'Negative Prompt'
-      })
+      }
       return { value, widget }
     },
     template:

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { provide, ref } from 'vue'
+
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { HideLayoutFieldKey } from '@/types/widgetTypes'
+
+import WidgetTextarea from './WidgetTextarea.vue'
+
+function createWidget(
+  overrides: Partial<SimplifiedWidget<string>> = {}
+): SimplifiedWidget<string> {
+  return {
+    name: 'text',
+    type: 'STRING',
+    value: '',
+    ...overrides
+  }
+}
+
+const meta: Meta<typeof WidgetTextarea> = {
+  title: 'Widgets/WidgetTextarea',
+  component: WidgetTextarea,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: [
+          'Multi-line text input with optional label.',
+          'Captures wheel, pointer, and context menu events to prevent canvas interference.',
+          'Shows a copy-to-clipboard button on hover when in read-only mode.'
+        ].join(' ')
+      }
+    }
+  },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: '<div class="w-80 h-40"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { WidgetTextarea },
+    setup() {
+      const value = ref('A multi-line text area for entering prompts.')
+      const widget = createWidget({ name: 'prompt', label: 'Prompt' })
+      return { value, widget }
+    },
+    template:
+      '<WidgetTextarea :widget="widget" v-model="value" placeholder="Enter prompt..." />'
+  })
+}
+
+export const WithLabelVisible: Story = {
+  render: () => ({
+    components: { WidgetTextarea },
+    setup() {
+      const value = ref('beautiful landscape, mountains, sunset, 4k, detailed')
+      const widget = createWidget({
+        name: 'positive',
+        label: 'Positive Prompt'
+      })
+      return { value, widget }
+    },
+    template: '<WidgetTextarea :widget="widget" v-model="value" />'
+  })
+}
+
+export const HiddenLabel: Story = {
+  render: () => ({
+    components: { WidgetTextarea },
+    setup() {
+      provide(HideLayoutFieldKey, true)
+      const value = ref('Label is hidden via HideLayoutFieldKey injection.')
+      const widget = createWidget({ name: 'notes', label: 'Notes' })
+      return { value, widget }
+    },
+    template: '<WidgetTextarea :widget="widget" v-model="value" />'
+  })
+}
+
+export const ReadOnly: Story = {
+  render: () => ({
+    components: { WidgetTextarea },
+    setup() {
+      const value = ref('This text is read-only. Hover to see the copy button.')
+      const widget = createWidget({
+        name: 'output',
+        label: 'Output',
+        options: { read_only: true }
+      })
+      return { value, widget }
+    },
+    template: '<WidgetTextarea :widget="widget" v-model="value" />'
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When read-only, a copy-to-clipboard button appears on hover in the top-right corner.'
+      }
+    }
+  }
+}
+
+export const Disabled: Story = {
+  render: () => ({
+    components: { WidgetTextarea },
+    setup() {
+      const value = ref('This textarea is disabled via widget options.')
+      const widget = createWidget({
+        name: 'locked',
+        label: 'Locked Field',
+        options: { disabled: true }
+      })
+      return { value, widget }
+    },
+    template: '<WidgetTextarea :widget="widget" v-model="value" />'
+  })
+}
+
+export const WithPlaceholder: Story = {
+  render: () => ({
+    components: { WidgetTextarea },
+    setup() {
+      const value = ref('')
+      const widget = createWidget({
+        name: 'negative',
+        label: 'Negative Prompt'
+      })
+      return { value, widget }
+    },
+    template:
+      '<WidgetTextarea :widget="widget" v-model="value" placeholder="Describe what to avoid..." />'
+  })
+}

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
@@ -13,7 +13,6 @@ import WidgetTextarea from './WidgetTextarea.vue'
 interface StoryArgs extends ComponentPropsAndSlots<typeof WidgetTextarea> {
   readOnly: boolean
   disabled: boolean
-  invalid: boolean
 }
 
 const meta: Meta<StoryArgs> = {
@@ -34,13 +33,11 @@ const meta: Meta<StoryArgs> = {
   },
   argTypes: {
     readOnly: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    invalid: { control: 'boolean' }
+    disabled: { control: 'boolean' }
   },
   args: {
     readOnly: false,
-    disabled: false,
-    invalid: false
+    disabled: false
   },
   decorators: [
     (story) => ({
@@ -57,16 +54,13 @@ export const Default: Story = {
   render: (args) => ({
     components: { WidgetTextarea },
     setup() {
-      const { readOnly, disabled, invalid } = toRefs(args)
+      const { readOnly, disabled } = toRefs(args)
       const value = ref('A multi-line text area for entering prompts.')
       const widget = computed<SimplifiedWidget<string>>(() => ({
         name: 'prompt',
         type: 'STRING',
         value: '',
         label: 'Prompt',
-        borderStyle: invalid.value
-          ? 'border border-destructive-background'
-          : undefined,
         options: {
           read_only: readOnly.value,
           disabled: disabled.value
@@ -92,28 +86,6 @@ export const Disabled: Story = {
         value: '',
         label: 'Locked Field',
         options: { disabled: disabled.value }
-      }))
-      return { value, widget }
-    },
-    template: '<WidgetTextarea :widget="widget" v-model="value" />'
-  })
-}
-
-export const Invalid: Story = {
-  args: { invalid: true },
-  render: (args) => ({
-    components: { WidgetTextarea },
-    setup() {
-      const { invalid } = toRefs(args)
-      const value = ref('Invalid textarea content.')
-      const widget = computed<SimplifiedWidget<string>>(() => ({
-        name: 'prompt',
-        type: 'STRING',
-        value: '',
-        label: 'Prompt',
-        borderStyle: invalid.value
-          ? 'border border-destructive-background'
-          : undefined
       }))
       return { value, widget }
     },

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
@@ -13,6 +13,7 @@ import WidgetTextarea from './WidgetTextarea.vue'
 interface StoryArgs extends ComponentPropsAndSlots<typeof WidgetTextarea> {
   readOnly: boolean
   disabled: boolean
+  invalid: boolean
 }
 
 const meta: Meta<StoryArgs> = {
@@ -33,11 +34,13 @@ const meta: Meta<StoryArgs> = {
   },
   argTypes: {
     readOnly: { control: 'boolean' },
-    disabled: { control: 'boolean' }
+    disabled: { control: 'boolean' },
+    invalid: { control: 'boolean' }
   },
   args: {
     readOnly: false,
-    disabled: false
+    disabled: false,
+    invalid: false
   },
   decorators: [
     (story) => ({
@@ -54,13 +57,16 @@ export const Default: Story = {
   render: (args) => ({
     components: { WidgetTextarea },
     setup() {
-      const { readOnly, disabled } = toRefs(args)
+      const { readOnly, disabled, invalid } = toRefs(args)
       const value = ref('A multi-line text area for entering prompts.')
       const widget = computed<SimplifiedWidget<string>>(() => ({
         name: 'prompt',
         type: 'STRING',
         value: '',
         label: 'Prompt',
+        borderStyle: invalid.value
+          ? 'border border-destructive-background'
+          : undefined,
         options: {
           read_only: readOnly.value,
           disabled: disabled.value
@@ -86,6 +92,28 @@ export const Disabled: Story = {
         value: '',
         label: 'Locked Field',
         options: { disabled: disabled.value }
+      }))
+      return { value, widget }
+    },
+    template: '<WidgetTextarea :widget="widget" v-model="value" />'
+  })
+}
+
+export const Invalid: Story = {
+  args: { invalid: true },
+  render: (args) => ({
+    components: { WidgetTextarea },
+    setup() {
+      const { invalid } = toRefs(args)
+      const value = ref('Invalid textarea content.')
+      const widget = computed<SimplifiedWidget<string>>(() => ({
+        name: 'prompt',
+        type: 'STRING',
+        value: '',
+        label: 'Prompt',
+        borderStyle: invalid.value
+          ? 'border border-destructive-background'
+          : undefined
       }))
       return { value, widget }
     },

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.stories.ts
@@ -28,7 +28,7 @@ const meta: Meta<typeof WidgetTextarea> = {
         component: [
           'Multi-line text input with optional label.',
           'Captures wheel, pointer, and context menu events to prevent canvas interference.',
-          'Shows a copy-to-clipboard button on hover when in read-only mode.'
+          'Shows a copy-to-clipboard button on hover.'
         ].join(' ')
       }
     }
@@ -103,7 +103,7 @@ export const ReadOnly: Story = {
     docs: {
       description: {
         story:
-          'When read-only, a copy-to-clipboard button appears on hover in the top-right corner.'
+          'A copy-to-clipboard button appears on hover in the top-right corner.'
       }
     }
   }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -2,7 +2,7 @@
   <div
     :class="
       cn(
-        'group relative rounded-lg focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',
+        'group relative rounded-lg hover:bg-component-node-widget-background-hovered focus-within:ring focus-within:ring-component-node-widget-background-highlighted transition-all',
         widget.borderStyle
       )
     "
@@ -34,7 +34,6 @@
       @contextmenu.capture.stop
     />
     <Button
-      v-if="isReadOnly"
       variant="textonly"
       size="icon"
       class="invisible absolute top-1.5 right-1.5 z-10 hover:bg-base-foreground/10 group-hover:visible"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -36,13 +36,13 @@
     <Button
       variant="textonly"
       size="icon"
-      class="invisible absolute top-1.5 right-1.5 z-10 text-component-node-foreground hover:bg-base-foreground/10 group-hover:visible"
+      class="invisible absolute top-1.5 right-1.5 z-10 hover:bg-base-foreground/10 group-hover:visible"
       :title="$t('g.copyToClipboard')"
       :aria-label="$t('g.copyToClipboard')"
       @click="handleCopy"
       @pointerdown.capture.stop
     >
-      <i class="icon-[lucide--copy] size-4" />
+      <i class="icon-[lucide--copy] size-4 text-component-node-foreground" />
     </Button>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -34,6 +34,7 @@
       @contextmenu.capture.stop
     />
     <Button
+      v-if="isReadOnly"
       variant="textonly"
       size="icon"
       class="invisible absolute top-1.5 right-1.5 z-10 hover:bg-base-foreground/10 group-hover:visible group-focus-within:visible"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -80,8 +80,8 @@ const filteredProps = computed(() =>
 const displayName = computed(() => widget.label || widget.name)
 const id = useId()
 
-const isReadOnly = computed(
-  () => widget.options?.read_only ?? widget.options?.disabled ?? false
+const isReadOnly = computed(() =>
+  Boolean(widget.options?.read_only || widget.options?.disabled)
 )
 
 function handleCopy() {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -36,7 +36,7 @@
     <Button
       variant="textonly"
       size="icon"
-      class="invisible absolute top-1.5 right-1.5 z-10 hover:bg-base-foreground/10 group-hover:visible"
+      class="invisible absolute top-1.5 right-1.5 z-10 text-component-node-foreground hover:bg-base-foreground/10 group-hover:visible"
       :title="$t('g.copyToClipboard')"
       :aria-label="$t('g.copyToClipboard')"
       @click="handleCopy"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -36,7 +36,7 @@
     <Button
       variant="textonly"
       size="icon"
-      class="invisible absolute top-1.5 right-1.5 z-10 hover:bg-base-foreground/10 group-hover:visible"
+      class="invisible absolute top-1.5 right-1.5 z-10 hover:bg-base-foreground/10 group-hover:visible group-focus-within:visible"
       :title="$t('g.copyToClipboard')"
       :aria-label="$t('g.copyToClipboard')"
       @click="handleCopy"

--- a/src/utils/widgetPropFilter.ts
+++ b/src/utils/widgetPropFilter.ts
@@ -17,7 +17,8 @@ export const STANDARD_EXCLUDED_PROPS = [
 export const INPUT_EXCLUDED_PROPS = [
   ...STANDARD_EXCLUDED_PROPS,
   'inputClass',
-  'inputStyle'
+  'inputStyle',
+  'read_only'
 ] as const
 
 export const PANEL_EXCLUDED_PROPS = [


### PR DESCRIPTION
Add Storybook stories for WidgetInputText and WidgetTextarea, aligned with the Figma Design System spec.

Task: COM-15821

## Summary

Add comprehensive Storybook stories for text widget components and implement missing Figma design system variants for WidgetInputText.

## Changes

- **WidgetInputText component enhancements**:
  - Add `size` prop (`medium` | `large`) matching Figma size variants (32px / 40px)
  - Add `invalid` prop with destructive border style per Figma Invalid state
  - Add `loading` prop showing spinning loader icon per Figma Status state
  - Add hover background (`bg-component-node-widget-background-hovered`)
  - Fix `readonly` not being applied from `widget.options.read_only`
- **WidgetTextarea component fixes**:
  - Show copy button on hover for all states (not just read-only)
  - Apply `text-component-node-foreground` token to copy icon
  - Add hover background to wrapper
- **Storybook stories**:
  - WidgetInputText: Default, Disabled, Invalid, Status, WithPlaceholder, WithLabel stories
  - WidgetTextarea: Default, Disabled, HiddenLabel, WithPlaceholder stories
  - Interactive controls for size, readOnly, disabled, invalid, loading

## Review Focus

- Figma alignment: size/invalid/loading/status variants for WidgetInputText
- Copy icon color token (`text-component-node-foreground`) for light/dark theme support
- `layoutWidget` computed pattern to merge `borderStyle` with invalid state

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->