### PR TITLE
fix: use v-show for frequently toggled canvas overlay components

### DIFF
--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="tooltipText"
+    v-show="tooltipText"
     ref="tooltipRef"
     class="node-tooltip"
     :style="{ left, top }"
@@ -34,7 +34,8 @@ const left = ref<string>()
 const top = ref<string>()
 
 function hideTooltip() {
-  return (tooltipText.value = '')
+  if (!tooltipText.value) return
+  tooltipText.value = ''
 }
 
 async function showTooltip(tooltip: string | null | undefined) {

--- a/src/components/graph/SelectionRectangle.vue
+++ b/src/components/graph/SelectionRectangle.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="isVisible"
+    v-show="isVisible"
     class="pointer-events-none absolute z-9999 border border-blue-400 bg-blue-500/20"
     :style="rectangleStyle"
   />


### PR DESCRIPTION
## What
Replace `v-if` with `v-show` on SelectionRectangle and NodeTooltip components.

## Why
Firefox profiler shows 687 Vue `insert` markers from mount/unmount cycling during canvas interaction. These components toggle frequently during drag and mouse move events.

## How
- **SelectionRectangle**: `v-if` → `v-show` (single element, safe to keep in DOM)
- **NodeTooltip**: `v-if` → `v-show` + no-op guard on `hideTooltip()` to skip redundant reactivity triggers

## Perf Impact
Expected reduction: ~687 Vue insert/remove operations per profiling session

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9401-fix-use-v-show-for-frequently-toggled-canvas-overlay-components-31a6d73d365081aba2d7fce079bde7e9) by [Unito](https://www.unito.io)
