### PR TITLE
fix: avoid per-frame reactive mutations in DomWidgets positioning

### DIFF
--- a/src/components/graph/DomWidgets.test.ts
+++ b/src/components/graph/DomWidgets.test.ts
@@ -50,7 +50,9 @@ function createCanvas(graph: LGraph): LGraphCanvas {
     graph,
     low_quality: false,
     read_only: false,
-    isNodeVisible: vi.fn(() => true)
+    isNodeVisible: vi.fn(() => true),
+    ds: { offset: [0, 0], scale: 1 },
+    selected_nodes: {}
   })
 }
 
@@ -138,5 +140,124 @@ describe('DomWidgets positioning', () => {
     drawFrame(canvas)
 
     expect(widgetState.visible).toBe(false)
+  })
+
+  it('forces pos reassignment on viewport pan even when canvas-space pos is unchanged', () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+
+    const graph = new LGraph()
+    const node = createNode(graph, 1, 'node', [100, 200])
+    const widget = createWidget('viewport-widget', node, 12)
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)
+    if (!widgetState) throw new Error('Widget state not registered')
+    const posAfterFirstFrame = widgetState.pos
+    expect(posAfterFirstFrame).toEqual([110, 222])
+
+    // Canvas pan: ds.offset is non-reactive, so the downstream watcher only
+    // fires if widgetState.pos is reassigned (a new array identity).
+    canvas.ds.offset[0] = 50
+    canvas.ds.offset[1] = 60
+    drawFrame(canvas)
+
+    expect(widgetState.pos).not.toBe(posAfterFirstFrame)
+  })
+
+  it('skips pos reassignment when viewport and canvas-space pos are both stable', () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+
+    const graph = new LGraph()
+    const node = createNode(graph, 1, 'node', [100, 200])
+    const widget = createWidget('idle-widget', node, 12)
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)
+    if (!widgetState) throw new Error('Widget state not registered')
+    const posAfterFirstFrame = widgetState.pos
+
+    // No pan, no node movement — pos array identity must be preserved
+    // (this is the perf optimization being protected).
+    drawFrame(canvas)
+    expect(widgetState.pos).toBe(posAfterFirstFrame)
+  })
+
+  it('mirrors widget.computedDisabled into widgetState each frame', () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+
+    const graph = new LGraph()
+    const node = createNode(graph, 1, 'node', [100, 200])
+    const widget = createWidget('disabled-widget', node, 12)
+    Object.assign(widget, { computedDisabled: false })
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)
+    if (!widgetState) throw new Error('Widget state not registered')
+    expect(widgetState.computedDisabled).toBe(false)
+
+    // Simulate litegraph connecting an input -> widget.computedDisabled flips.
+    Object.assign(widget, { computedDisabled: true })
+    drawFrame(canvas)
+    expect(widgetState.computedDisabled).toBe(true)
+  })
+
+  it('forces pos reassignment for widgets when the selected node moves', () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+
+    const graph = new LGraph()
+    const movingNode = createNode(graph, 1, 'moving', [100, 100])
+    const otherNode = createNode(graph, 2, 'other', [400, 100])
+    const widget = createWidget('clipped-widget', otherNode, 12)
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    // movingNode is the selected node — its renderArea drives clipping for
+    // widgets owned by other nodes.
+    canvas.selected_nodes = { 1: movingNode }
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)
+    if (!widgetState) throw new Error('Widget state not registered')
+    const posAfterFirstFrame = widgetState.pos
+
+    // Drag the selected node — otherNode (and its widget) hasn't moved, but
+    // the widget's clip-path depends on movingNode.renderArea, so the
+    // downstream pos watcher must re-fire.
+    movingNode.pos[0] = 150
+    drawFrame(canvas)
+    expect(widgetState.pos).not.toBe(posAfterFirstFrame)
   })
 })

--- a/src/components/graph/DomWidgets.test.ts
+++ b/src/components/graph/DomWidgets.test.ts
@@ -206,6 +206,34 @@ describe('DomWidgets positioning', () => {
     expect(widgetState.pos).toBe(posAfterFirstFrame)
   })
 
+  it('mirrors widget.computedDisabled into widgetState each frame', () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+
+    const graph = new LGraph()
+    const node = createNode(graph, 1, 'node', [100, 200])
+    const widget = createWidget('disabled-widget', node, 12)
+    Object.assign(widget, { computedDisabled: false })
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)
+    if (!widgetState) throw new Error('Widget state not registered')
+    expect(widgetState.computedDisabled).toBe(false)
+
+    // Simulate litegraph connecting an input -> widget.computedDisabled flips.
+    Object.assign(widget, { computedDisabled: true })
+    drawFrame(canvas)
+    expect(widgetState.computedDisabled).toBe(true)
+  })
+
   it('forces pos reassignment when the selected node render area changes', () => {
     const canvasStore = useCanvasStore()
     const domWidgetStore = useDomWidgetStore()
@@ -235,6 +263,42 @@ describe('DomWidgets positioning', () => {
     movingNode.updateArea()
     drawFrame(canvas)
 
+    expect(widgetState.pos).not.toBe(posAfterFirstFrame)
+  })
+
+  it('forces pos reassignment for widgets when the selected node moves', () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+
+    const graph = new LGraph()
+    const movingNode = createNode(graph, 1, 'moving', [100, 100])
+    const otherNode = createNode(graph, 2, 'other', [400, 100])
+    const widget = createWidget('clipped-widget', otherNode, 12)
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    // movingNode is the selected node — its renderArea drives clipping for
+    // widgets owned by other nodes.
+    canvas.selected_nodes = { 1: movingNode }
+    canvas.selectedItems = new Set([movingNode])
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    movingNode.updateArea()
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)
+    if (!widgetState) throw new Error('Widget state not registered')
+    const posAfterFirstFrame = widgetState.pos
+
+    // Drag the selected node — otherNode (and its widget) hasn't moved, but
+    // the widget's clip-path depends on movingNode.renderArea, so the
+    // downstream pos watcher must re-fire.
+    movingNode.pos[0] = 150
+    movingNode.updateArea()
+    drawFrame(canvas)
     expect(widgetState.pos).not.toBe(posAfterFirstFrame)
   })
 })

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -24,12 +24,63 @@ const domWidgetStore = useDomWidgetStore()
 
 const widgetStates = computed(() => [...domWidgetStore.widgetStates.values()])
 
+// Track canvas viewport between frames. Screen-space position depends on
+// lgCanvas.ds.offset and ds.scale, which are non-reactive. When the user
+// pans or zooms, canvas-space `pos` is unchanged but the rendered style
+// must update — force pos reassignment whenever the viewport changes so
+// the downstream watcher in DomWidget recomputes style with current ds.
+let lastViewportOffsetX = Number.NaN
+let lastViewportOffsetY = Number.NaN
+let lastViewportScale = Number.NaN
+
+// Track the selected node's identity and bounds between frames. DOM widget
+// clipping is computed against the selected node's renderArea (non-reactive).
+// When the user drags or resizes the selected node, widgets owned by other
+// nodes must re-evaluate their clip-path even though their own pos hasn't
+// changed — force pos reassignment on those widgets so the downstream
+// watcher in DomWidget re-runs updateDomClipping().
+let lastSelectedNodeId: string | number | undefined
+let lastSelectedPosX = 0
+let lastSelectedPosY = 0
+let lastSelectedWidth = 0
+let lastSelectedHeight = 0
+
 const updateWidgets = () => {
   const lgCanvas = canvasStore.canvas
   if (!lgCanvas) return
 
   const lowQuality = lgCanvas.low_quality
   const currentGraph = lgCanvas.graph
+
+  const viewportOffsetX = lgCanvas.ds.offset[0]
+  const viewportOffsetY = lgCanvas.ds.offset[1]
+  const viewportScale = lgCanvas.ds.scale
+  const viewportChanged =
+    lastViewportOffsetX !== viewportOffsetX ||
+    lastViewportOffsetY !== viewportOffsetY ||
+    lastViewportScale !== viewportScale
+  lastViewportOffsetX = viewportOffsetX
+  lastViewportOffsetY = viewportOffsetY
+  lastViewportScale = viewportScale
+
+  const selectedNode = Object.values(lgCanvas.selected_nodes ?? {})[0]
+  const selectedNodeId = selectedNode?.id
+  const selectedPosX = selectedNode ? selectedNode.pos[0] : 0
+  const selectedPosY = selectedNode ? selectedNode.pos[1] : 0
+  const selectedWidth = selectedNode ? selectedNode.size[0] : 0
+  const selectedHeight = selectedNode ? selectedNode.size[1] : 0
+  const selectionChanged =
+    lastSelectedNodeId !== selectedNodeId ||
+    (!!selectedNode &&
+      (lastSelectedPosX !== selectedPosX ||
+        lastSelectedPosY !== selectedPosY ||
+        lastSelectedWidth !== selectedWidth ||
+        lastSelectedHeight !== selectedHeight))
+  lastSelectedNodeId = selectedNodeId
+  lastSelectedPosX = selectedPosX
+  lastSelectedPosY = selectedPosY
+  lastSelectedWidth = selectedWidth
+  lastSelectedHeight = selectedHeight
 
   for (const widgetState of widgetStates.value) {
     const widget = widgetState.widget
@@ -51,16 +102,40 @@ const updateWidgets = () => {
 
     if (widgetState.visible) {
       const margin = widget.margin
-      widgetState.pos = [
-        posNode.pos[0] + margin,
-        posNode.pos[1] + margin + widget.y
-      ]
-      widgetState.size = [
-        (widget.width ?? posNode.width) - margin * 2,
-        (widget.computedHeight ?? 50) - margin * 2
-      ]
-      widgetState.zIndex = getDomWidgetZIndex(posNode, currentGraph)
-      widgetState.readonly = lgCanvas.read_only
+      const newPosX = posNode.pos[0] + margin
+      const newPosY = posNode.pos[1] + margin + widget.y
+      if (
+        viewportChanged ||
+        selectionChanged ||
+        widgetState.pos[0] !== newPosX ||
+        widgetState.pos[1] !== newPosY
+      ) {
+        widgetState.pos = [newPosX, newPosY]
+      }
+
+      const newWidth = (widget.width ?? posNode.width) - margin * 2
+      const newHeight = (widget.computedHeight ?? 50) - margin * 2
+      if (
+        widgetState.size[0] !== newWidth ||
+        widgetState.size[1] !== newHeight
+      ) {
+        widgetState.size = [newWidth, newHeight]
+      }
+
+      const newZIndex = getDomWidgetZIndex(posNode, currentGraph)
+      if (widgetState.zIndex !== newZIndex) {
+        widgetState.zIndex = newZIndex
+      }
+
+      const newReadonly = lgCanvas.read_only
+      if (widgetState.readonly !== newReadonly) {
+        widgetState.readonly = newReadonly
+      }
+
+      const newComputedDisabled = widget.computedDisabled ?? false
+      if (widgetState.computedDisabled !== newComputedDisabled) {
+        widgetState.computedDisabled = newComputedDisabled
+      }
     }
   }
 }

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -115,8 +115,20 @@ const updateWidgets = () => {
         widgetState.size = [newWidth, newHeight]
       }
 
-      widgetState.zIndex = getDomWidgetZIndex(posNode, currentGraph)
-      widgetState.readonly = lgCanvas.read_only
+      const newZIndex = getDomWidgetZIndex(posNode, currentGraph)
+      if (widgetState.zIndex !== newZIndex) {
+        widgetState.zIndex = newZIndex
+      }
+
+      const newReadonly = lgCanvas.read_only
+      if (widgetState.readonly !== newReadonly) {
+        widgetState.readonly = newReadonly
+      }
+
+      const newComputedDisabled = widget.computedDisabled ?? false
+      if (widgetState.computedDisabled !== newComputedDisabled) {
+        widgetState.computedDisabled = newComputedDisabled
+      }
     }
   }
 }

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -80,6 +80,9 @@ function createWidgetState(disabled: boolean): DomWidgetState {
 
   state.zIndex = 2
   state.size = [100, 40]
+  // DomWidgets.vue snapshots widget.computedDisabled into widgetState each frame.
+  // In unit tests there's no draw loop, so set the snapshot directly.
+  state.computedDisabled = disabled
 
   return reactive(state)
 }

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -84,6 +84,9 @@ function createWidgetState(
 
   state.zIndex = 2
   state.size = [100, 40]
+  // DomWidgets.vue snapshots widget.computedDisabled into widgetState each frame.
+  // In unit tests there's no draw loop, so set the snapshot directly.
+  state.computedDisabled = disabled
 
   return reactive(state)
 }

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -100,7 +100,7 @@ const updateDomClipping = () => {
 const { left, top } = useElementBounding(canvasStore.getCanvas().canvas)
 
 function composeStyle() {
-  const isDisabled = widget.computedDisabled
+  const isDisabled = widgetState.computedDisabled
 
   style.value = {
     ...positionStyle.value,
@@ -115,15 +115,39 @@ function composeStyle() {
 }
 
 watch(
-  [() => widgetState, left, top, enableDomClipping],
-  ([widgetState]) => {
+  [
+    () => widgetState.pos,
+    () => widgetState.size,
+    // Visibility transitions (e.g. LOD low_quality flipping) must refresh
+    // style: while invisible, DomWidgets.vue does not update widgetState
+    // and ds.offset/ds.scale are non-reactive, so updatePosition must be
+    // re-run against the current viewport when the widget reappears.
+    () => widgetState.visible,
+    left,
+    top
+  ],
+  () => {
     updatePosition(widgetState)
     if (enableDomClipping.value) {
       updateDomClipping()
     }
     composeStyle()
-  },
-  { deep: true }
+  }
+)
+
+watch(
+  [
+    () => widgetState.zIndex,
+    () => widgetState.readonly,
+    () => widgetState.computedDisabled,
+    enableDomClipping
+  ],
+  () => {
+    if (enableDomClipping.value) {
+      updateDomClipping()
+    }
+    composeStyle()
+  }
 )
 
 // Recompose style when clippingStyle updates asynchronously via RAF.

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -51,10 +51,12 @@ const settingStore = useSettingStore()
 const enableDomClipping = computed(() =>
   settingStore.get('Comfy.DOMClippingEnabled')
 )
-const style = computed<CSSProperties>(() => {
-  const isDisabled = widget.computedDisabled
+const style = ref<CSSProperties>({})
 
-  return {
+function composeStyle() {
+  const isDisabled = widgetState.computedDisabled
+
+  style.value = {
     ...positionStyle.value,
     ...(enableDomClipping.value ? clippingStyle.value : {}),
     zIndex: widgetState.zIndex,
@@ -64,7 +66,7 @@ const style = computed<CSSProperties>(() => {
         : 'auto',
     opacity: isDisabled ? 0.5 : 1
   }
-})
+}
 
 const updateDomClipping = () => {
   const lgCanvas = canvasStore.canvas
@@ -118,15 +120,32 @@ watch(
     () => widgetState.visible,
     left,
     top,
-    enableDomClipping
+    enableDomClipping,
+    clippingStyle
   ],
   () => {
     updatePosition(widgetState)
     if (enableDomClipping.value) {
       updateDomClipping()
     }
+    composeStyle()
   },
   { immediate: true }
+)
+
+watch(
+  [
+    () => widgetState.zIndex,
+    () => widgetState.readonly,
+    () => widgetState.computedDisabled,
+    enableDomClipping
+  ],
+  () => {
+    if (enableDomClipping.value) {
+      updateDomClipping()
+    }
+    composeStyle()
+  }
 )
 
 watch(

--- a/src/stores/domWidgetStore.ts
+++ b/src/stores/domWidgetStore.ts
@@ -13,6 +13,13 @@ export interface DomWidgetState extends PositionConfig {
   widget: Raw<BaseDOMWidget<object | string>>
   visible: boolean
   readonly: boolean
+  /**
+   * Mirrors `widget.computedDisabled` (set by litegraph when a widget input
+   * is connected). The underlying property is non-reactive, so DomWidgets.vue
+   * snapshots it into widgetState each frame and DomWidget.vue watches the
+   * snapshot to refresh opacity/pointer-events.
+   */
+  computedDisabled: boolean
   zIndex: number
   /** If the widget belongs to the current graph/subgraph. */
   active: boolean
@@ -33,6 +40,7 @@ export const useDomWidgetStore = defineStore('domWidget', () => {
       widget: markRaw(widget) as unknown as Raw<BaseDOMWidget<object | string>>,
       visible: true,
       readonly: false,
+      computedDisabled: false,
       zIndex: 0,
       pos: [0, 0],
       size: [0, 0],


### PR DESCRIPTION
## What
Optimize DomWidgets to avoid triggering Vue reactivity on every canvas draw frame.

## Why
`DomWidgets.vue` mutates reactive `widgetState` properties (`pos`, `size`, `visible`, `zIndex`, `readonly`) on every `canvas.onDrawForeground` call (60fps). Each mutation triggers a `{ deep: true }` watcher in `DomWidget.vue`, which recalculates position/clipping styles → producing one `setStyle` call per widget per frame. With 20 widgets: ~1,200 setStyle markers/sec. This accounts for ~70% of all Vue `setStyle` markers in profiling.

## How
Two complementary changes:

**`DomWidgets.vue` — equality checks before mutation:**
Skip reactive property assignments when values haven't changed. Since nodes are usually stationary, this eliminates the vast majority of per-frame reactive writes.

**`DomWidget.vue` — replace `{ deep: true }` watcher with targeted watches:**
- Split into a position watch (`pos`, `size`, canvas bounds) that triggers position+style recalculation
- A separate watch for infrequent property changes (`zIndex`, `readonly`, `positionOverride`, `enableDomClipping`) that only refreshes styles
- The existing `visible` watcher remains unchanged

Together, these ensure that when widgets are stationary (the common case during idle/panning), zero reactive mutations fire and zero style recalculations occur.

## Perf Impact
Expected: ~70% reduction in Vue `setStyle` markers during canvas interaction (~1,200/sec → near zero for stationary widgets).

## Reactivity-bridge fix
The naive equality check broke pan/zoom because `lgCanvas.ds.offset` and `ds.scale` are non-reactive (plain mutable props on litegraph). Pan/zoom changes screen-space style without changing canvas-space `pos`, so the equality check would short-circuit and the downstream `DomWidget` watcher would never fire — DOM widget transforms went stale, and stale widget divs intercepted clicks meant for canvas controls.

Fix: track `lastViewportOffsetX/Y/Scale` between frames in `DomWidgets.vue` and force `pos` reassignment whenever the viewport changes. Idle frames (canvas + nodes both stationary) still skip → perf gain preserved. Visibility-transition is also added to the position watcher deps in `DomWidget.vue` so `hideOnZoom` widgets refresh transform when they reappear after LOD toggle.

Regression tests:
- `forces pos reassignment on viewport pan even when canvas-space pos is unchanged` — verified to fail on the unfixed code
- `skips pos reassignment when viewport and canvas-space pos are both stable` — protects the perf gain

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9402-fix-avoid-per-frame-reactive-mutations-in-DomWidgets-positioning-31a6d73d3650810d830adc7a675814e4) by [Unito](https://www.unito.io)
