### PR TITLE
feat: add model-to-node mappings for new custom node packs

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -346,6 +346,44 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
 
     // Detection models (vitpose, yolo)
     quickRegister('detection', 'OnnxDetectionModelLoader', 'yolo_model')
+
+    // HunyuanVideo text encoders (ComfyUI-HunyuanVideoWrapper)
+    quickRegister(
+      'LLM/llava-llama-3-8b-text-encoder-tokenizer',
+      'DownloadAndLoadHyVideoTextEncoder',
+      'llm_model'
+    )
+    quickRegister(
+      'LLM/llava-llama-3-8b-v1_1-transformers',
+      'DownloadAndLoadHyVideoTextEncoder',
+      'llm_model'
+    )
+
+    // CogVideoX models (comfyui-cogvideoxwrapper)
+    quickRegister('CogVideo/GGUF', 'DownloadAndLoadCogVideoGGUFModel', 'model')
+    quickRegister(
+      'CogVideo/ControlNet',
+      'DownloadAndLoadCogVideoControlNet',
+      'model'
+    )
+
+    // DynamiCrafter models (ComfyUI-DynamiCrafterWrapper)
+    quickRegister(
+      'checkpoints/dynamicrafter',
+      'DownloadAndLoadDynamiCrafterModel',
+      'model'
+    )
+    quickRegister(
+      'checkpoints/dynamicrafter/controlnet',
+      'DownloadAndLoadDynamiCrafterCNModel',
+      'model'
+    )
+
+    // LayerStyle models (ComfyUI_LayerStyle_Advance)
+    quickRegister('BEN', 'LS_LoadBenModel', 'model')
+    quickRegister('BiRefNet/pth', 'LS_LoadBiRefNetModel', 'model')
+    quickRegister('onnx/human-parts', 'LS_HumanPartsUltra', '')
+    quickRegister('lama', 'LaMa', 'lama_model')
   }
 
   return {


### PR DESCRIPTION
## Summary
- Add `quickRegister()` mappings so the "Use" button works in the model browser for new node packs

## Mappings added

| Node Pack | Model Directories | Loader Node |
|-----------|-------------------|-------------|
| ComfyUI-HunyuanVideoWrapper | `LLM/llava-llama-3-8b-*` | `DownloadAndLoadHyVideoTextEncoder` |
| comfyui-cogvideoxwrapper | `CogVideo/GGUF`, `CogVideo/ControlNet` | `DownloadAndLoadCogVideoGGUFModel`, `DownloadAndLoadCogVideoControlNet` |
| ComfyUI-DynamiCrafterWrapper | `checkpoints/dynamicrafter{,/controlnet}` | `DownloadAndLoadDynamiCrafterModel`, `DownloadAndLoadDynamiCrafterCNModel` |
| ComfyUI_LayerStyle_Advance | `BEN`, `BiRefNet/pth`, `onnx/human-parts`, `lama` | `LS_LoadBenModel`, `LS_LoadBiRefNetModel`, `LS_HumanPartsUltra`, `LaMa` |

## Safe to merge early

Unknown node classes are silently skipped by `registerNodeProvider()` — the mapping becomes a no-op until the node pack is available. Zero risk.

## Test plan
- [ ] Verify no runtime errors on load (unknown classes are skipped gracefully)
- [ ] After node packs are available, verify "Use" button creates correct node for each model type

🤖 Generated with [Claude Code](https://claude.com/claude-code)