### PR TITLE
fix(ErrorNodeCard): show error message body in compact (single-node) mode

### DIFF
--- a/src/components/rightSidePanel/errors/ErrorNodeCard.vue
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.vue
@@ -49,7 +49,7 @@
       >
         <!-- Error Message -->
         <p
-          v-if="error.message && !compact"
+          v-if="error.message"
           class="m-0 text-sm break-words whitespace-pre-wrap leading-relaxed px-0.5 max-h-[4lh] overflow-y-auto"
         >
           {{ error.message }}

--- a/src/components/rightSidePanel/errors/MissingNodeCard.vue
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.vue
@@ -21,13 +21,13 @@
     >
       <template #pipCmd>
         <code
-          class="px-1 py-0.5 rounded text-xs font-mono bg-comfy-menu-bg text-comfy-input-foreground"
+          class="px-1 py-0.5 rounded-sm text-xs font-mono bg-comfy-menu-bg text-comfy-input-foreground"
           >pip install -U --pre comfyui-manager</code
         >
       </template>
       <template #flag>
         <code
-          class="px-1 py-0.5 rounded text-xs font-mono bg-comfy-menu-bg text-comfy-input-foreground"
+          class="px-1 py-0.5 rounded-sm text-xs font-mono bg-comfy-menu-bg text-comfy-input-foreground"
           >--enable-manager</code
         >
       </template>


### PR DESCRIPTION
## Summary
Remove the `!compact` condition that was preventing the error message body from being displayed in compact (single-node error) mode.

## Changes
- **What**: Removed `&& !compact` guard from `v-if="error.message && !compact"` in `ErrorNodeCard.vue` so the error message body is always shown when present, regardless of display mode

<img width="1209" height="605" alt="image" src="https://github.com/user-attachments/assets/b720c9fa-2789-441d-aa4b-7850fe370436" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9437-fix-ErrorNodeCard-show-error-message-body-in-compact-single-node-mode-31a6d73d3650814683f7e6983534a4ad) by [Unito](https://www.unito.io)
