### PR TITLE
fix: address CodeRabbit issue #9451

### DIFF
--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue
@@ -280,13 +280,13 @@ const publishButtonLabel = computed(() => {
     : t('shareWorkflow.createLinkButton')
 })
 
-function stripJsonExtension(filename: string): string {
-  return filename.replace(/\.json$/i, '')
+function stripWorkflowExtension(filename: string): string {
+  return filename.replace(/\.app\.json$/i, '').replace(/\.json$/i, '')
 }
 
 function buildWorkflowPath(directory: string, filename: string): string {
   const normalizedDirectory = directory.replace(/\/+$/, '')
-  const normalizedFilename = appendJsonExt(stripJsonExtension(filename))
+  const normalizedFilename = appendJsonExt(stripWorkflowExtension(filename))
 
   return normalizedDirectory
     ? `${normalizedDirectory}/${normalizedFilename}`
@@ -299,7 +299,7 @@ async function refreshDialogState() {
   if (!workflow || workflow.isTemporary || workflow.isModified) {
     dialogState.value = 'unsaved'
     if (workflow) {
-      workflowName.value = stripJsonExtension(workflow.filename)
+      workflowName.value = stripWorkflowExtension(workflow.filename)
     }
     return
   }


### PR DESCRIPTION
Closes #9451
                                                                                             
  ## Summary

The `stripJsonExtension` helper in `src/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue` currently only strips the `.json` extension. It should also handle `.app.json` (and potentially other compound extensions) to correctly derive workflow names.

## Suggested approach

Either extend `stripJsonExtension` to also strip `.app.json`, or introduce a dedicated helper (e.g. `stripWorkflowExtension`) that handles all known workflow file extensions.

```ts
// Current
function stripJsonExtension(filename: string): string {
  return filename.replace(/\.json$/i, '')
}

// Proposed
function stripWorkflowExtension(filename: string): string {
  return filename.replace(/\.app\.json$/i, '').replace(/\.json$/i, '')
}
```    
                                                                                             
  ---
  Automated by coderabbit-fixer