### PR TITLE
fix: address CodeRabbit issue #9448

### DIFF
--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -255,6 +255,11 @@ export const useWorkflowStore = defineStore('workflow', () => {
     return workflow
   }
 
+  /**
+   * Ensures the workflow data has a stable `id` field for sharing.
+   * If no `id` is present, a new UUID is generated and injected.
+   * Returns a deep copy of the input (or the default graph if none provided).
+   */
   const ensureWorkflowId = (
     workflowData?: ComfyWorkflowJSON
   ): ComfyWorkflowJSON => {
@@ -291,7 +296,12 @@ export const useWorkflowStore = defineStore('workflow', () => {
   }
 
   /**
-   * Create a temporary workflow, attempting to reuse an existing workflow if conditions match
+   * Create a temporary workflow, attempting to reuse an existing workflow
+   * if conditions match.
+   *
+   * Note: A UUID `id` field is injected into the workflow data via
+   * {@link ensureWorkflowId} if one is not already present. The serialized
+   * workflow content will always contain an `id` field.
    */
   const createTemporary = (path?: string, workflowData?: ComfyWorkflowJSON) => {
     const fullPath = getUnconflictedPath(
@@ -323,7 +333,12 @@ export const useWorkflowStore = defineStore('workflow', () => {
   }
 
   /**
-   * Create a new temporary workflow without attempting to reuse existing workflows
+   * Create a new temporary workflow without attempting to reuse existing
+   * workflows.
+   *
+   * Note: A UUID `id` field is injected into the workflow data via
+   * {@link ensureWorkflowId} if one is not already present. The serialized
+   * workflow content will always contain an `id` field.
    */
   const createNewTemporary = (
     path?: string,


### PR DESCRIPTION
Automated fix for #9448

## Summary

`createTemporary()` and `createNewTemporary()` in `src/platform/workflow/management/stores/workflowStore.ts` now silently inject a UUID `id` field into workflow data via `ensureWorkflowId()`. This was introduced as part of the workflow sharing feature (PR #8951) to give workflows a stable identity for sharing.

## Why this matters

Extensions or consumers that rely on the serialized workflow content matching their original input may silently break, since the returned workflow content will now always contain an `id` field even if none was provided.

## Follow-up tasks

- Add JSDoc to `createTemporary()`, `createNewTemporary()`, and `ensureWorkflowId()` documenting the UUID injection behavior.
- Consider adding a note in the changelog or migration guide for extension authors.
- Evaluate whether to expose this behavior in any public-facing API docs.

## References

- PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/8951
- Comment: https://github.com/Comfy-Org/ComfyUI_frontend/pull/8951#discussion_r2887572236
- Requested by: @christian-byrne

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9469-fix-address-CodeRabbit-issue-9448-31b6d73d365081939aafe29d01702f3b) by [Unito](https://www.unito.io)
