### PR TITLE
fix: refactor: Use real composable implementations in ComfyHubPublishDialog tests instead of heavy mocks (#9449)

### DIFF
--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -1,59 +1,79 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import ComfyHubPublishDialog from '@/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue'
+import type { ComfyHubProfile } from '@/schemas/apiSchema'
 
-const mockFetchProfile = vi.hoisted(() => vi.fn())
-const mockGoToStep = vi.hoisted(() => vi.fn())
-const mockGoNext = vi.hoisted(() => vi.fn())
-const mockGoBack = vi.hoisted(() => vi.fn())
-const mockOpenProfileCreationStep = vi.hoisted(() => vi.fn())
-const mockCloseProfileCreationStep = vi.hoisted(() => vi.fn())
+const mockFetchApi = vi.hoisted(() => vi.fn())
+const mockToastErrorHandler = vi.hoisted(() => vi.fn())
+const mockResolvedUserInfo = vi.hoisted(() => ({
+  value: { id: 'user-a' }
+}))
 
-vi.mock(
-  '@/platform/workflow/sharing/composables/useComfyHubProfileGate',
-  () => ({
-    useComfyHubProfileGate: () => ({
-      fetchProfile: mockFetchProfile
-    })
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: mockFetchApi
+  }
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    resolvedUserInfo: mockResolvedUserInfo
   })
-)
+}))
 
-vi.mock(
-  '@/platform/workflow/sharing/composables/useComfyHubPublishWizard',
-  () => ({
-    useComfyHubPublishWizard: () => ({
-      currentStep: ref('finish'),
-      formData: ref({
-        name: '',
-        description: '',
-        workflowType: '',
-        tags: [],
-        thumbnailType: 'image',
-        thumbnailFile: null,
-        comparisonBeforeFile: null,
-        comparisonAfterFile: null,
-        exampleImages: [],
-        selectedExampleIds: []
-      }),
-      isFirstStep: ref(false),
-      isLastStep: ref(true),
-      goToStep: mockGoToStep,
-      goNext: mockGoNext,
-      goBack: mockGoBack,
-      openProfileCreationStep: mockOpenProfileCreationStep,
-      closeProfileCreationStep: mockCloseProfileCreationStep
-    })
+vi.mock('@/composables/useErrorHandling', () => ({
+  useErrorHandling: () => ({
+    toastErrorHandler: mockToastErrorHandler
   })
-)
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    activeWorkflow: { filename: 'test-workflow' }
+  })
+}))
+
+const mockProfile: ComfyHubProfile = {
+  username: 'testuser',
+  name: 'Test User',
+  description: 'A test profile'
+}
+
+function mockSuccessResponse(data?: unknown) {
+  return {
+    ok: true,
+    json: async () => data ?? mockProfile
+  } as Response
+}
+
+function mockErrorResponse(status = 404) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ message: 'Not found' })
+  } as Response
+}
+
+// Reset module-level singleton state in useComfyHubProfileGate between tests
+async function resetProfileGateSingleton() {
+  const { useComfyHubProfileGate } =
+    await import('@/platform/workflow/sharing/composables/useComfyHubProfileGate')
+  const gate = useComfyHubProfileGate()
+  gate.hasProfile.value = null
+  gate.profile.value = null
+  gate.isCheckingProfile.value = false
+  gate.isFetchingProfile.value = false
+}
 
 describe('ComfyHubPublishDialog', () => {
   const onClose = vi.fn()
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
-    mockFetchProfile.mockResolvedValue(null)
+    mockResolvedUserInfo.value = { id: 'user-a' }
+    mockFetchApi.mockResolvedValue(mockErrorResponse())
+    await resetProfileGateSingleton()
   })
 
   function createWrapper() {
@@ -78,7 +98,7 @@ describe('ComfyHubPublishDialog', () => {
           },
           ComfyHubPublishWizardContent: {
             template:
-              '<div><button data-testid="require-profile" @click="$props.onRequireProfile()" /><button data-testid="gate-complete" @click="$props.onGateComplete()" /><button data-testid="gate-close" @click="$props.onGateClose()" /></div>',
+              '<div><button data-testid="require-profile" @click="$props.onRequireProfile()" /><button data-testid="gate-complete" @click="$props.onGateComplete()" /><button data-testid="gate-close" @click="$props.onGateClose()" /><span data-testid="current-step">{{ $props.currentStep }}</span></div>',
             props: [
               'currentStep',
               'formData',
@@ -88,7 +108,9 @@ describe('ComfyHubPublishDialog', () => {
               'onGoBack',
               'onRequireProfile',
               'onGateComplete',
-              'onGateClose'
+              'onGateClose',
+              'onUpdateFormData',
+              'onPublish'
             ]
           }
         }
@@ -96,44 +118,62 @@ describe('ComfyHubPublishDialog', () => {
     })
   }
 
-  it('starts in publish wizard mode and prefetches profile asynchronously', async () => {
+  it('prefetches profile on mount via real composable', async () => {
     createWrapper()
     await flushPromises()
 
-    expect(mockFetchProfile).toHaveBeenCalledWith()
+    expect(mockFetchApi).toHaveBeenCalledWith('/hub/profile')
   })
 
-  it('switches to profile creation step when final-step publish requires profile', async () => {
+  it('starts on the describe step with real wizard composable', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="current-step"]').text()).toBe('describe')
+  })
+
+  it('switches to profileCreation step when require-profile is triggered', async () => {
     const wrapper = createWrapper()
     await flushPromises()
 
     await wrapper.find('[data-testid="require-profile"]').trigger('click')
 
-    expect(mockOpenProfileCreationStep).toHaveBeenCalledOnce()
+    expect(wrapper.find('[data-testid="current-step"]').text()).toBe(
+      'profileCreation'
+    )
   })
 
-  it('returns to finish state after gate complete and does not auto-close', async () => {
+  it('returns to finish step and re-fetches profile after gate complete', async () => {
+    mockFetchApi.mockResolvedValue(mockSuccessResponse())
     const wrapper = createWrapper()
     await flushPromises()
 
     await wrapper.find('[data-testid="require-profile"]').trigger('click')
+    expect(wrapper.find('[data-testid="current-step"]').text()).toBe(
+      'profileCreation'
+    )
+
     await wrapper.find('[data-testid="gate-complete"]').trigger('click')
+    await flushPromises()
 
-    expect(mockOpenProfileCreationStep).toHaveBeenCalledOnce()
-    expect(mockCloseProfileCreationStep).toHaveBeenCalledOnce()
-    expect(mockFetchProfile).toHaveBeenCalledWith({ force: true })
+    expect(wrapper.find('[data-testid="current-step"]').text()).toBe('finish')
+    // Initial prefetch + force re-fetch after gate complete
+    expect(mockFetchApi).toHaveBeenCalledTimes(2)
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('returns to finish state when profile gate is closed', async () => {
+  it('returns to finish step when profile gate is closed', async () => {
     const wrapper = createWrapper()
     await flushPromises()
 
     await wrapper.find('[data-testid="require-profile"]').trigger('click')
+    expect(wrapper.find('[data-testid="current-step"]').text()).toBe(
+      'profileCreation'
+    )
+
     await wrapper.find('[data-testid="gate-close"]').trigger('click')
 
-    expect(mockOpenProfileCreationStep).toHaveBeenCalledOnce()
-    expect(mockCloseProfileCreationStep).toHaveBeenCalledOnce()
+    expect(wrapper.find('[data-testid="current-step"]').text()).toBe('finish')
     expect(onClose).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #9449

## Summary

The `ComfyHubPublishDialog.test.ts` tests were mocking `useComfyHubProfileGate` and `useComfyHubPublishWizard` composables entirely, replacing them with fake return values. This meant the tests were validating mock behavior rather than real component integration. The issue requested replacing these heavy mocks with real composable implementations, mocking only at the boundary layer (API calls, auth, stores).

## Changes

- **`src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts`**:
  - Removed `vi.mock` of `useComfyHubProfileGate` and `useComfyHubPublishWizard` composables
  - Added boundary-level mocks for `@/scripts/api` (fetchApi), `@/composables/auth/useCurrentUser`, `@/composables/useErrorHandling`, and `@/platform/workflow/management/stores/workflowStore`
  - Added `resetProfileGateSingleton()` helper to reset module-level singleton state between tests
  - Updated test assertions to verify real behavior (actual step names rendered via stub, actual API calls) instead of checking mock function calls
  - Added a new test verifying the wizard starts on the `describe` step
  - Updated stub component to expose `currentStep` for assertion and accept `onUpdateFormData`/`onPublish` props

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9472-fix-refactor-Use-real-composable-implementations-in-ComfyHubPublishDialog-tests-instead-31b6d73d365081ffa999c7329a30f659) by [Unito](https://www.unito.io)
