### PR TITLE
fix: test(changeTracker): add regression test for multilineOrOptions forwarding in wrapped prompt (#9418)

### DIFF
--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+
+import { ChangeTracker } from './changeTracker'
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: vi.fn(() => ({
+    activeWorkflow: null
+  })),
+  ComfyWorkflow: vi.fn()
+}))
+
+vi.mock('./api', () => ({
+  api: {
+    addEventListener: vi.fn(),
+    apiURL: vi.fn((path: string) => path)
+  }
+}))
+
+vi.mock('./app', () => ({
+  app: {
+    ui: { autoQueueEnabled: false, autoQueueMode: 'instant' },
+    canvas: { ds: { scale: 1, offset: [0, 0] } },
+    constructor: { maskeditor_is_opended: undefined }
+  },
+  ComfyApp: vi.fn()
+}))
+
+describe('ChangeTracker.init', () => {
+  it('forwards multiline argument to original prompt', () => {
+    const originalPrompt = vi.fn()
+    LGraphCanvas.prototype.prompt = originalPrompt
+
+    ChangeTracker.init()
+
+    const wrappedPrompt = LGraphCanvas.prototype.prompt
+    expect(wrappedPrompt).not.toBe(originalPrompt)
+
+    const mockCallback = vi.fn()
+    const mockEvent = {} as CanvasPointerEvent
+    const multilineValue = true
+
+    wrappedPrompt.call(
+      {} as LGraphCanvas,
+      'Title',
+      'value',
+      mockCallback,
+      mockEvent,
+      multilineValue
+    )
+
+    expect(originalPrompt).toHaveBeenCalledWith(
+      'Title',
+      'value',
+      expect.any(Function),
+      mockEvent,
+      true
+    )
+  })
+})

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -307,14 +307,21 @@ export class ChangeTracker {
       title: string,
       value: string | number,
       callback: (v: string) => void,
-      event: CanvasPointerEvent
+      event: CanvasPointerEvent,
+      multiline?: boolean
     ) {
       const extendedCallback = (v: string) => {
         callback(v)
         checkState()
       }
       logger.debug('checkState on prompt')
-      return prompt.apply(this, [title, value, extendedCallback, event])
+      return prompt.apply(this, [
+        title,
+        value,
+        extendedCallback,
+        event,
+        multiline
+      ])
     }
 
     // Handle litegraph context menu for COMBO widgets


### PR DESCRIPTION
Closes #9418

## Summary

The `ChangeTracker.init()` method wraps `LGraphCanvas.prototype.prompt` to inject change-tracking into the callback, but the wrapper was not forwarding the `multiline` (5th) parameter to the original function. This caused text widgets with `options.multiline` to render as single-line inputs instead of textareas.

The fix adds the `multiline` parameter to the wrapper's signature and forwards it through `prompt.apply()`. A regression test verifies the parameter is correctly passed through.

## Changes

- **`src/scripts/changeTracker.ts`**: Added `multiline?: boolean` parameter to the wrapped `prompt` function and included it in the `prompt.apply()` arguments array.
- **`src/scripts/changeTracker.test.ts`**: New test file with a regression test that verifies the `multiline` argument is forwarded from the wrapper to the original `LGraphCanvas.prototype.prompt`.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9475-fix-test-changeTracker-add-regression-test-for-multilineOrOptions-forwarding-in-wrappe-31b6d73d3650814f845dd8d213199900) by [Unito](https://www.unito.io)
