### PR TITLE
fix: refactor(changeTracker): replace local clone() with shared clone util from @/scripts/utils (#9414)

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -17,10 +17,7 @@ import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { api } from './api'
 import type { ComfyApp } from './app'
 import { app } from './app'
-
-function clone<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj))
-}
+import { clone } from './utils'
 
 const logger = log.getLogger('ChangeTracker')
 // Change to debug for more verbose logging


### PR DESCRIPTION
Closes #9414

## Summary

The `changeTracker.ts` file defined its own local `clone()` function (`JSON.parse(JSON.stringify(obj))`) that duplicated the identical utility already exported from `@/scripts/utils`. This fix removes the local definition and imports the shared `clone` utility instead.

## Changes

- **`src/scripts/changeTracker.ts`**: Removed the local `clone<T>()` function and replaced it with `import { clone } from './utils'` to use the shared utility, eliminating code duplication.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9476-fix-refactor-changeTracker-replace-local-clone-with-shared-clone-util-from-scripts-31b6d73d36508110be1ec50bfe955761) by [Unito](https://www.unito.io)
