### PR TITLE
fix: refactor: create rename-aware detach/attach helper in workflowStore to avoid duplicate mutation paths (#9407)

### DIFF
--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -103,14 +103,16 @@ export const useWorkflowStore = defineStore('workflow', () => {
   /**
    * Detach the workflow from the store. lightweight helper function.
    * @param workflow The workflow to detach.
+   * @param oldPath Optional previous path to detach from (used during rename when workflow.path has already changed).
    * @returns The index of the workflow in the openWorkflowPaths array, or -1 if the workflow was not open.
    */
-  const detachWorkflow = (workflow: ComfyWorkflow) => {
-    delete workflowLookup.value[workflow.path]
-    const index = openWorkflowPaths.value.indexOf(workflow.path)
+  const detachWorkflow = (workflow: ComfyWorkflow, oldPath?: string) => {
+    const path = oldPath ?? workflow.path
+    delete workflowLookup.value[path]
+    const index = openWorkflowPaths.value.indexOf(path)
     if (index !== -1) {
       openWorkflowPaths.value = openWorkflowPaths.value.filter(
-        (path) => path !== workflow.path
+        (p) => p !== path
       )
     }
     return index
@@ -501,12 +503,8 @@ export const useWorkflowStore = defineStore('workflow', () => {
 
       // Synchronously swap old path for new path in lookup and open paths
       // to avoid a tab flicker caused by an async gap between detach/attach.
-      delete workflowLookup.value[oldPath]
-      workflowLookup.value[workflow.path] = workflow
-      const openIndex = openWorkflowPaths.value.indexOf(oldPath)
-      if (openIndex !== -1) {
-        openWorkflowPaths.value.splice(openIndex, 1, workflow.path)
-      }
+      const openIndex = detachWorkflow(workflow, oldPath)
+      attachWorkflow(workflow, openIndex)
 
       draftStore.moveDraft(oldPath, newPath, workflow.key)
 


### PR DESCRIPTION
Closes #9407

## Summary

The `renameWorkflow` function in `workflowStore.ts` had inline logic for swapping old/new paths in the workflow lookup and open paths array, duplicating the mutation patterns already encapsulated in `detachWorkflow` and `attachWorkflow` helpers. This made the code harder to maintain and risked the two paths diverging.

## Changes

- **`src/platform/workflow/management/stores/workflowStore.ts`**: Added optional `oldPath` parameter to `detachWorkflow` so it can detach by a previous path (used during rename when `workflow.path` has already changed). Replaced the inline swap logic in `renameWorkflow` with calls to `detachWorkflow(workflow, oldPath)` and `attachWorkflow(workflow, openIndex)`.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9477-fix-refactor-create-rename-aware-detach-attach-helper-in-workflowStore-to-avoid-duplica-31b6d73d365081eb8a9bebc9aab3b5b3) by [Unito](https://www.unito.io)
