### PR TITLE
fix: refactor(litegraph): localize hardcoded 'Value' prompt titles in NumberWidget.ts via vue-i18n (#9389)

### DIFF
--- a/src/lib/litegraph/src/widgets/NumberWidget.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.ts
@@ -1,3 +1,4 @@
+import { t } from '@/i18n'
 import type { INumericWidget } from '@/lib/litegraph/src/types/widgets'
 import { evaluateInput, getWidgetStep } from '@/lib/litegraph/src/utils/widget'
 
@@ -65,7 +66,7 @@ export class NumberWidget
 
     // Handle center click - show prompt
     canvas.prompt(
-      'Value',
+      t('widgets.valuePromptTitle'),
       this.value,
       (v: string) => {
         const parsed = evaluateInput(v)

--- a/src/lib/litegraph/src/widgets/TextWidget.ts
+++ b/src/lib/litegraph/src/widgets/TextWidget.ts
@@ -1,3 +1,4 @@
+import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IStringWidget } from '@/lib/litegraph/src/types/widgets'
 
@@ -40,7 +41,7 @@ export class TextWidget
   override onClick({ e, node, canvas }: WidgetEventOptions) {
     // Show prompt dialog for text input
     canvas.prompt(
-      'Value',
+      t('widgets.valuePromptTitle'),
       this.value,
       (v: string) => {
         if (v !== null) {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2545,6 +2545,7 @@
     },
     "node2only": "Node 2.0 only",
     "selectModel": "Select model",
+    "valuePromptTitle": "Value",
     "uploadSelect": {
       "placeholder": "Select...",
       "placeholderImage": "Select image...",


### PR DESCRIPTION
Closes #9389

## Summary

The `NumberWidget.ts` and `TextWidget.ts` files in litegraph had hardcoded `'Value'` strings used as prompt titles when users click to edit widget values. These strings were not localized through vue-i18n, making them untranslatable for non-English users.

## Changes

- **`src/lib/litegraph/src/widgets/NumberWidget.ts`**: Replaced hardcoded `'Value'` prompt title with `t('widgets.valuePromptTitle')` using the `@/i18n` module.
- **`src/lib/litegraph/src/widgets/TextWidget.ts`**: Same localization change for the text widget prompt title.
- **`src/locales/en/main.json`**: Added `widgets.valuePromptTitle` translation key with value `"Value"`.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9480-fix-refactor-litegraph-localize-hardcoded-Value-prompt-titles-in-NumberWidget-ts-via-31b6d73d365081ffa5b5e08fcf924690) by [Unito](https://www.unito.io)
