### PR TITLE
fix: Implement atomic workflow overwrite via persistence-level flag (#9355)

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -99,7 +99,9 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 vi.mock('@/renderer/core/thumbnail/useWorkflowThumbnail', () => ({
   useWorkflowThumbnail: () => ({
     storeThumbnail: vi.fn(),
-    getThumbnail: vi.fn()
+    getThumbnail: vi.fn(),
+    clearThumbnail: vi.fn(),
+    moveWorkflowThumbnail: vi.fn()
   })
 }))
 
@@ -853,12 +855,13 @@ describe('useWorkflowService', () => {
 
       const existing = createSaveableWorkflow('workflows/test.app.json')
       vi.spyOn(workflowStore, 'getWorkflowByPath').mockReturnValue(existing)
-      vi.spyOn(workflowStore, 'deleteWorkflow').mockResolvedValue()
+      vi.spyOn(workflowStore, 'removeWorkflowEntry').mockResolvedValue()
       mockConfirm.mockResolvedValue(true)
 
       await service.saveWorkflow(workflow)
 
       expect(mockConfirm).toHaveBeenCalled()
+      expect(workflowStore.removeWorkflowEntry).toHaveBeenCalledWith(existing)
       expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
         workflow,
         'workflows/test.app.json'

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -130,11 +130,20 @@ export const useWorkflowService = () => {
 
     if (existingWorkflow && !existingWorkflow.isTemporary) {
       if ((await confirmOverwrite(newPath)) !== true) return false
+    }
 
-      if (!isSelfOverwrite) {
-        const deleted = await deleteWorkflow(existingWorkflow, true)
-        if (!deleted) return false
+    const needsOverwrite =
+      !!existingWorkflow && !existingWorkflow.isTemporary && !isSelfOverwrite
+
+    // Close and remove the old workflow entry before saving the new content.
+    // The file on disk is intentionally kept so that a save failure does not
+    // cause data loss.  The subsequent save with overwrite: true will
+    // atomically replace it.
+    if (needsOverwrite) {
+      if (workflowStore.isOpen(existingWorkflow)) {
+        await closeWorkflow(existingWorkflow, { warnIfUnsaved: false })
       }
+      await workflowStore.removeWorkflowEntry(existingWorkflow)
     }
 
     workflow.changeTracker?.checkState()
@@ -143,11 +152,19 @@ export const useWorkflowService = () => {
       await saveWorkflow(workflow)
     } else if (workflow.isTemporary) {
       await renameWorkflow(workflow, newPath)
-      await workflowStore.saveWorkflow(workflow)
+      if (needsOverwrite) {
+        await workflowStore.saveWorkflow(workflow, { overwrite: true })
+      } else {
+        await workflowStore.saveWorkflow(workflow)
+      }
     } else {
       const tempWorkflow = workflowStore.saveAs(workflow, newPath)
       await openWorkflow(tempWorkflow)
-      await workflowStore.saveWorkflow(tempWorkflow)
+      if (needsOverwrite) {
+        await workflowStore.saveWorkflow(tempWorkflow, { overwrite: true })
+      } else {
+        await workflowStore.saveWorkflow(tempWorkflow)
+      }
     }
     return true
   }
@@ -174,7 +191,12 @@ export const useWorkflowService = () => {
             await workflowStore.saveWorkflow(workflow)
             return
           }
-          await deleteWorkflow(existing, true)
+          // Remove the old entry without deleting the file; the rename
+          // will atomically replace it, preventing data loss on failure.
+          if (workflowStore.isOpen(existing)) {
+            await closeWorkflow(existing, { warnIfUnsaved: false })
+          }
+          await workflowStore.removeWorkflowEntry(existing)
         }
         await renameWorkflow(workflow, expectedPath)
         toastStore.add({

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -151,14 +151,16 @@ export class ComfyWorkflow extends UserFile {
     super.unload()
   }
 
-  override async save() {
+  override async save({
+    overwrite
+  }: { force?: boolean; overwrite?: boolean } = {}) {
     const { useWorkflowDraftStore } =
       await import('@/platform/workflow/persistence/stores/workflowDraftStore')
     const draftStore = useWorkflowDraftStore()
     this.content = JSON.stringify(this.activeState)
     // Force save to ensure the content is updated in remote storage incase
     // the isModified state is screwed by changeTracker.
-    const ret = await super.save({ force: true })
+    const ret = await super.save({ force: true, overwrite })
     this.changeTracker?.reset()
     this.isModified = false
     draftStore.removeDraft(this.path)

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -63,7 +63,11 @@ interface WorkflowStore {
   ) => ComfyWorkflow
   renameWorkflow: (workflow: ComfyWorkflow, newPath: string) => Promise<void>
   deleteWorkflow: (workflow: ComfyWorkflow) => Promise<void>
-  saveWorkflow: (workflow: ComfyWorkflow) => Promise<void>
+  removeWorkflowEntry: (workflow: ComfyWorkflow) => Promise<void>
+  saveWorkflow: (
+    workflow: ComfyWorkflow,
+    options?: { overwrite?: boolean }
+  ) => Promise<void>
 
   workflows: ComfyWorkflow[]
   bookmarkedWorkflows: ComfyWorkflow[]
@@ -540,13 +544,31 @@ export const useWorkflowStore = defineStore('workflow', () => {
   }
 
   /**
+   * Remove a workflow entry from the store without deleting the file on disk.
+   * Used during atomic overwrite to clear the old entry before saving the new
+   * content, so that the save can use overwrite: true to replace the file.
+   */
+  const removeWorkflowEntry = async (workflow: ComfyWorkflow) => {
+    useWorkflowDraftStore().removeDraft(workflow.path)
+    if (bookmarkStore.isBookmarked(workflow.path)) {
+      await bookmarkStore.setBookmarked(workflow.path, false)
+    }
+    clearThumbnail(workflow.key)
+    delete workflowLookup.value[workflow.path]
+  }
+
+  /**
    * Save a workflow.
    * @param workflow The workflow to save.
+   * @param options.overwrite Force overwrite of existing file at the path.
    */
-  const saveWorkflow = async (workflow: ComfyWorkflow) => {
+  const saveWorkflow = async (
+    workflow: ComfyWorkflow,
+    options?: { overwrite?: boolean }
+  ) => {
     isBusy.value = true
     try {
-      await workflow.save()
+      await workflow.save({ overwrite: options?.overwrite })
       // Synchronously detach and re-attach to force refresh the tree objects
       // without an async gap that would cause the tab to disappear.
       const openIndex = detachWorkflow(workflow)
@@ -774,6 +796,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     createNewTemporary,
     renameWorkflow,
     deleteWorkflow,
+    removeWorkflowEntry,
     saveAs,
     saveWorkflow,
     reorderWorkflows,

--- a/src/stores/userFileStore.ts
+++ b/src/stores/userFileStore.ts
@@ -140,11 +140,14 @@ export class UserFile {
    * Saves the file to the remote storage.
    * @param force Whether to force the save even if the file is not modified.
    */
-  async save({ force = false }: { force?: boolean } = {}): Promise<UserFile> {
+  async save({
+    force = false,
+    overwrite
+  }: { force?: boolean; overwrite?: boolean } = {}): Promise<UserFile> {
     if (this.isPersisted && !this.isModified && !force) return this
 
     const resp = await api.storeUserData(this.path, this.content, {
-      overwrite: this.isPersisted,
+      overwrite: overwrite ?? this.isPersisted,
       throwOnError: true,
       full_info: true
     })


### PR DESCRIPTION
Closes #9355

## Summary

When saving a workflow with "Save As" to overwrite an existing file, the old workflow was deleted from disk before the new content was saved. If the save failed (e.g. network error), the user lost both the old and new versions of the workflow, causing data loss.

This fix replaces the delete-then-save pattern with an atomic overwrite approach: instead of deleting the file on disk, we only remove the old workflow entry from the store, then save the new content with an explicit `overwrite: true` flag passed down to the persistence layer. This ensures the file on disk is only replaced when the new content is successfully written.

## Changes

- **`src/stores/userFileStore.ts`**: Added `overwrite` option to `UserFile.save()` that allows callers to explicitly control the `overwrite` flag sent to the API, decoupling it from the `isPersisted` state.
- **`src/platform/workflow/management/stores/comfyWorkflow.ts`**: Updated `ComfyWorkflow.save()` to accept and forward the `overwrite` option to the parent `UserFile.save()`.
- **`src/platform/workflow/management/stores/workflowStore.ts`**: Added `removeWorkflowEntry()` to remove a workflow from the store without deleting the file on disk. Updated `saveWorkflow()` to accept and forward `{ overwrite }` options.
- **`src/platform/workflow/core/services/workflowService.ts`**: Replaced `deleteWorkflow()` calls during overwrite with `removeWorkflowEntry()` + save with `overwrite: true`, both in `saveWorkflowAs` and `saveWorkflow` rename paths.
- **`src/platform/workflow/core/services/workflowService.test.ts`**: Updated tests to use `removeWorkflowEntry` instead of `deleteWorkflow` and added missing mock functions.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9481-fix-Implement-atomic-workflow-overwrite-via-persistence-level-flag-9355-31b6d73d365081548c4ae5e57cd72350) by [Unito](https://www.unito.io)
