### PR TITLE
fix: Design clean public API for extension authors to integrate custom widgets with widgetValueStore (#9296)

### DIFF
--- a/src/composables/element/useDomValueBridge.test.ts
+++ b/src/composables/element/useDomValueBridge.test.ts
@@ -1,0 +1,78 @@
+import { nextTick } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import { useDomValueBridge } from './useDomValueBridge'
+
+function createInput(initialValue = ''): HTMLInputElement {
+  const el = document.createElement('input')
+  el.value = initialValue
+  return el
+}
+
+function createTextarea(initialValue = ''): HTMLTextAreaElement {
+  const el = document.createElement('textarea')
+  el.value = initialValue
+  return el
+}
+
+describe('useDomValueBridge', () => {
+  it('initializes the ref with the current element value', () => {
+    const el = createInput('hello')
+    const bridged = useDomValueBridge(el)
+    expect(bridged.value).toBe('hello')
+  })
+
+  it('updates the ref when element.value is set programmatically', () => {
+    const el = createInput('')
+    const bridged = useDomValueBridge(el)
+
+    el.value = 'updated'
+    expect(bridged.value).toBe('updated')
+  })
+
+  it('updates the ref on user input events', () => {
+    const el = createInput('')
+    const bridged = useDomValueBridge(el)
+
+    // Simulate user typing by using the original descriptor to set value,
+    // then dispatching an input event
+    const proto = Object.getPrototypeOf(el)
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value')
+    desc?.set?.call(el, 'typed')
+    el.dispatchEvent(new Event('input'))
+
+    expect(bridged.value).toBe('typed')
+  })
+
+  it('updates the DOM element when the ref is written to', async () => {
+    const el = createInput('initial')
+    const bridged = useDomValueBridge(el)
+
+    bridged.value = 'from-ref'
+    await nextTick()
+
+    expect(el.value).toBe('from-ref')
+  })
+
+  it('works with textarea elements', () => {
+    const el = createTextarea('initial')
+    const bridged = useDomValueBridge(el)
+
+    expect(bridged.value).toBe('initial')
+    el.value = 'new text'
+    expect(bridged.value).toBe('new text')
+  })
+
+  it('reads element value through the intercepted getter', async () => {
+    const el = createInput('start')
+    const bridged = useDomValueBridge(el)
+
+    // The getter on element.value should still work
+    expect(el.value).toBe('start')
+
+    bridged.value = 'changed'
+    await nextTick()
+    // The element getter should reflect the latest set
+    expect(el.value).toBe('changed')
+  })
+})

--- a/src/composables/element/useDomValueBridge.ts
+++ b/src/composables/element/useDomValueBridge.ts
@@ -1,0 +1,79 @@
+import { ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+type ValueElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+
+/**
+ * Bridges a DOM element's `.value` property to a Vue reactive ref.
+ *
+ * This composable provides a clean, public API for extension authors to
+ * synchronize DOM widget values with Vue reactivity (and by extension, the
+ * `widgetValueStore`). It works by:
+ *
+ * 1. Intercepting programmatic `.value` writes via `Object.defineProperty`
+ * 2. Listening for user-driven `input` events on the element
+ * 3. Exposing a reactive `Ref<string>` that stays in sync with the DOM
+ *
+ * When the returned ref is written to, the DOM element's value is updated.
+ * When the DOM element's value changes (programmatically or via user input),
+ * the ref is updated.
+ *
+ * @param element - The DOM element to bridge (input, textarea, or select)
+ * @returns A reactive ref that stays in sync with the element's value
+ *
+ * @example
+ * ```ts
+ * // In a custom widget's getValue/setValue:
+ * const bridgedValue = useDomValueBridge(inputEl)
+ * const widget = node.addDOMWidget(name, type, inputEl, {
+ *   getValue: () => bridgedValue.value,
+ *   setValue: (v) => { bridgedValue.value = v }
+ * })
+ * ```
+ */
+export function useDomValueBridge(element: ValueElement): Ref<string> {
+  const bridgedValue = ref(element.value)
+
+  // Capture the original property descriptor so we can chain through it
+  const proto = Object.getPrototypeOf(element)
+  const originalDescriptor =
+    Object.getOwnPropertyDescriptor(element, 'value') ??
+    Object.getOwnPropertyDescriptor(proto, 'value')
+
+  // Intercept programmatic .value writes on the element
+  // This catches cases where extensions or libraries set element.value directly
+  try {
+    Object.defineProperty(element, 'value', {
+      get() {
+        return originalDescriptor?.get?.call(this) ?? bridgedValue.value
+      },
+      set(newValue: string) {
+        originalDescriptor?.set?.call(this, newValue)
+        bridgedValue.value = newValue
+      },
+      configurable: true,
+      enumerable: true
+    })
+  } catch {
+    // If the descriptor is non-configurable, fall back to polling-free sync
+    // via input events only
+  }
+
+  // Listen for user-driven input events
+  element.addEventListener('input', () => {
+    // Read through the original descriptor to avoid infinite loops
+    const currentValue = originalDescriptor?.get?.call(element) ?? element.value
+    bridgedValue.value = currentValue
+  })
+
+  // When the ref is written to externally, update the DOM element
+  watch(bridgedValue, (newValue) => {
+    const currentDomValue =
+      originalDescriptor?.get?.call(element) ?? element.value
+    if (currentDomValue !== newValue) {
+      originalDescriptor?.set?.call(element, newValue)
+    }
+  })
+
+  return bridgedValue
+}

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -1,6 +1,7 @@
 import _ from 'es-toolkit/compat'
 import { type Component, toRaw } from 'vue'
 
+import { useDomValueBridge } from '@/composables/element/useDomValueBridge'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import {
   LGraphNode,
@@ -379,6 +380,16 @@ export const addWidget = <W extends BaseDOMWidget<object | string>>(
   })
 }
 
+function isValueElement(
+  el: HTMLElement
+): el is HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
+  return (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement
+  )
+}
+
 LGraphNode.prototype.addDOMWidget = function <
   T extends HTMLElement,
   V extends object | string
@@ -389,6 +400,19 @@ LGraphNode.prototype.addDOMWidget = function <
   element: T,
   options: DOMWidgetOptions<V> = {}
 ): DOMWidget<T, V> {
+  // Auto-bridge value-bearing elements when no getValue/setValue provided.
+  // This gives extension authors automatic widgetValueStore integration.
+  if (!options.getValue && !options.setValue && isValueElement(element)) {
+    const bridgedValue = useDomValueBridge(element)
+    options = {
+      ...options,
+      getValue: (() => bridgedValue.value) as () => V,
+      setValue: ((v: V) => {
+        bridgedValue.value = String(v)
+      }) as (v: V) => void
+    }
+  }
+
   const widget = new DOMWidgetImpl({
     node: this,
     name,


### PR DESCRIPTION
Closes #9296

## Summary

Extension authors lacked a clean, documented way to integrate custom DOM widgets with the `widgetValueStore`. The existing value-descriptor pattern was an implementation detail rather than a stable public API. This PR introduces `useDomValueBridge`, a composable that provides a proper public API for bridging DOM element values to Vue reactivity, and auto-wires it into `addDOMWidget` for value-bearing elements (input, textarea, select) when no `getValue`/`setValue` options are provided.

## Changes

- **`src/composables/element/useDomValueBridge.ts`** (new): Composable that synchronizes a DOM element's `.value` property with a Vue `Ref<string>` via `Object.defineProperty` interception and `input` event listening. Extension authors can use this directly for explicit control.
- **`src/composables/element/useDomValueBridge.test.ts`** (new): Unit tests covering initialization, programmatic writes, user input events, ref-to-DOM sync, and textarea support.
- **`src/scripts/domWidget.ts`**: Auto-bridges value-bearing elements in `addDOMWidget` when no `getValue`/`setValue` callbacks are provided, giving extensions automatic `widgetValueStore` integration without any code changes.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9484-fix-Design-clean-public-API-for-extension-authors-to-integrate-custom-widgets-with-widge-31b6d73d365081b28f33cbae81b7ff28) by [Unito](https://www.unito.io)
