### PR TITLE
fix: Add unit tests for resolveSubgraphInputLink (#9293)

### DIFF
--- a/src/core/graph/subgraph/resolveSubgraphInputLink.test.ts
+++ b/src/core/graph/subgraph/resolveSubgraphInputLink.test.ts
@@ -121,6 +121,68 @@ describe('resolveSubgraphInputLink', () => {
     expect(result).toBe('seed_input')
   })
 
+  test('skips broken links where getLink returns undefined', () => {
+    const { subgraph, subgraphNode } = createSubgraphSetup('prompt')
+    addLinkedInteriorInput(subgraph, 'prompt', 'valid_input', 'valid')
+    const broken = addLinkedInteriorInput(
+      subgraph,
+      'prompt',
+      'broken_input',
+      'broken'
+    )
+
+    const originalGetLink = subgraph.getLink.bind(subgraph)
+    vi.spyOn(subgraph, 'getLink').mockImplementation((linkId) => {
+      if (typeof linkId !== 'number') return originalGetLink(linkId)
+      if (linkId === broken.linkId) return undefined
+      return originalGetLink(linkId)
+    })
+
+    const result = resolveSubgraphInputLink(
+      subgraphNode,
+      'prompt',
+      ({ targetInput }) => targetInput.name
+    )
+
+    expect(result).toBe('valid_input')
+  })
+
+  test('returns result from latest connection when multiple links resolve', () => {
+    const { subgraph, subgraphNode } = createSubgraphSetup('prompt')
+    addLinkedInteriorInput(subgraph, 'prompt', 'older_input', 'older')
+    addLinkedInteriorInput(subgraph, 'prompt', 'newer_input', 'newer')
+
+    const result = resolveSubgraphInputLink(
+      subgraphNode,
+      'prompt',
+      ({ targetInput }) => targetInput.name
+    )
+
+    expect(result).toBe('newer_input')
+  })
+
+  test('falls back to earlier link when latest resolve callback returns undefined', () => {
+    const { subgraph, subgraphNode } = createSubgraphSetup('prompt')
+    addLinkedInteriorInput(subgraph, 'prompt', 'fallback_input', 'fallback')
+    const newer = addLinkedInteriorInput(
+      subgraph,
+      'prompt',
+      'skipped_input',
+      'skipped'
+    )
+
+    const result = resolveSubgraphInputLink(
+      subgraphNode,
+      'prompt',
+      ({ targetInput }) => {
+        if (targetInput.link === newer.linkId) return undefined
+        return targetInput.name
+      }
+    )
+
+    expect(result).toBe('fallback_input')
+  })
+
   test('caches getTargetWidget result within the same callback evaluation', () => {
     const { subgraph, subgraphNode } = createSubgraphSetup('model')
     const linked = addLinkedInteriorInput(


### PR DESCRIPTION
Closes #9293

## Summary

Issue #9293 identified missing test coverage for `resolveSubgraphInputLink`, specifically for edge cases like broken/null links, multiple connections resolving, and fallback behavior when the resolve callback returns undefined.

## Changes

- **`src/core/graph/subgraph/resolveSubgraphInputLink.test.ts`**: Added 3 new unit tests:
  - `skips broken links where getLink returns undefined` — verifies that the function gracefully skips links when `getLink` returns undefined and falls back to the next valid link
  - `returns result from latest connection when multiple links resolve` — confirms newest-to-oldest iteration order so the latest connection wins
  - `falls back to earlier link when latest resolve callback returns undefined` — tests the fallback behavior when the resolve callback returns undefined for the newest link

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9485-fix-Add-unit-tests-for-resolveSubgraphInputLink-9293-31b6d73d3650811596c6c9d86fb691ad) by [Unito](https://www.unito.io)
