### PR TITLE
fix: Add tests for nested promoted widget resolution paths in safeWidgetMapper (#9292)

### DIFF
--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -278,7 +278,7 @@ describe('Nested promoted widget mapping', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it('maps store identity to deepest concrete widget for two-layer promotions', () => {
+  function createTwoLayerPromotionSetup() {
     const subgraphA = createTestSubgraph({
       inputs: [{ name: 'a_input', type: '*' }]
     })
@@ -308,11 +308,30 @@ describe('Nested promoted widget mapping', () => {
     const nodeData = vueNodeData.get(String(subgraphNodeB.id))
     const mappedWidget = nodeData?.widgets?.[0]
 
+    return { innerNode, subgraphNodeB, mappedWidget }
+  }
+
+  it('resolves storeNodeId to the deepest concrete node for two-layer promotions', () => {
+    const { innerNode, subgraphNodeB, mappedWidget } =
+      createTwoLayerPromotionSetup()
+
     expect(mappedWidget).toBeDefined()
-    expect(mappedWidget?.type).toBe('combo')
-    expect(mappedWidget?.storeName).toBe('picker')
     expect(mappedWidget?.storeNodeId).toBe(
       `${subgraphNodeB.subgraph.id}:${innerNode.id}`
     )
+  })
+
+  it('resolves storeName to the deepest concrete widget name for two-layer promotions', () => {
+    const { mappedWidget } = createTwoLayerPromotionSetup()
+
+    expect(mappedWidget).toBeDefined()
+    expect(mappedWidget?.storeName).toBe('picker')
+  })
+
+  it('resolves effectiveWidget type to the deepest concrete widget type for two-layer promotions', () => {
+    const { mappedWidget } = createTwoLayerPromotionSetup()
+
+    expect(mappedWidget).toBeDefined()
+    expect(mappedWidget?.type).toBe('combo')
   })
 })


### PR DESCRIPTION
Closes #9292

## Summary

Issue #9292 identified that the `safeWidgetMapper` lacked test coverage for nested promoted widget resolution paths — specifically verifying that `storeNodeId`, `storeName`, and widget `type` correctly resolve through multiple layers of subgraph promotion.

The existing test combined all three assertions into a single test case. This change splits them into focused, independent tests and extracts the shared setup into a reusable helper function.

## Changes

- **`src/composables/graph/useGraphNodeManager.test.ts`**: Refactored the `Nested promoted widget mapping` describe block:
  - Extracted `createTwoLayerPromotionSetup()` helper for shared two-layer subgraph setup
  - Split monolithic test into three focused tests:
    - `storeNodeId` resolves to the deepest concrete node
    - `storeName` resolves to the deepest concrete widget name
    - Widget `type` resolves to the deepest concrete widget type

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9486-fix-Add-tests-for-nested-promoted-widget-resolution-paths-in-safeWidgetMapper-9292-31b6d73d365081d5aa9ec941f2e9c205) by [Unito](https://www.unito.io)
