### PR TITLE
fix: update loadWorkflowInMedia test to only assert upload request URL

### DIFF
--- a/browser_tests/tests/loadWorkflowInMedia.spec.ts
+++ b/browser_tests/tests/loadWorkflowInMedia.spec.ts
@@ -41,20 +41,15 @@ test.describe(
               req.url().includes('/upload/')
             )
           : null
-        const viewRequestPromise = shouldUpload
-          ? comfyPage.page.waitForRequest((req) => req.url().includes('/view'))
-          : null
 
         await comfyPage.dragDrop.dragAndDropFile(`workflowInMedia/${fileName}`)
 
         if (uploadRequestPromise) {
           const request = await uploadRequestPromise
           expect(request.url()).toContain('/upload/')
+        } else {
+          await expect(comfyPage.canvas).toHaveScreenshot(`${fileName}.png`)
         }
-        if (viewRequestPromise) {
-          await viewRequestPromise
-        }
-        await expect(comfyPage.canvas).toHaveScreenshot(`${fileName}.png`)
       })
     })
 

--- a/browser_tests/tests/loadWorkflowInMedia.spec.ts
+++ b/browser_tests/tests/loadWorkflowInMedia.spec.ts
@@ -35,16 +35,24 @@ test.describe(
       test(`Load workflow in ${fileName} (drop from filesystem)`, async ({
         comfyPage
       }) => {
-        const waitForUpload = filesWithUpload.has(fileName)
-        await comfyPage.dragDrop.dragAndDropFile(
-          `workflowInMedia/${fileName}`,
-          { waitForUpload }
-        )
-        if (waitForUpload) {
-          await comfyPage.page.waitForResponse(
-            (resp) => resp.url().includes('/view') && resp.status() !== 0,
-            { timeout: 10000 }
-          )
+        const shouldUpload = filesWithUpload.has(fileName)
+        const uploadRequestPromise = shouldUpload
+          ? comfyPage.page.waitForRequest((req) =>
+              req.url().includes('/upload/')
+            )
+          : null
+        const viewRequestPromise = shouldUpload
+          ? comfyPage.page.waitForRequest((req) => req.url().includes('/view'))
+          : null
+
+        await comfyPage.dragDrop.dragAndDropFile(`workflowInMedia/${fileName}`)
+
+        if (uploadRequestPromise) {
+          const request = await uploadRequestPromise
+          expect(request.url()).toContain('/upload/')
+        }
+        if (viewRequestPromise) {
+          await viewRequestPromise
         }
         await expect(comfyPage.canvas).toHaveScreenshot(`${fileName}.png`)
       })


### PR DESCRIPTION
## Summary

Fixes flakey test to only assert that the upload request is made with the correct URL

## Changes

- **What**
- Replace waitForResponse with waitForRequest for the no_workflow.webp upload test to only assert the request is initiated with the correct URL
- Move request listener setup before the drag-drop action to avoid race conditions                                                                
- Remove screenshot assertion for the upload case since the upload may not complete before the screenshot is taken

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9488-fix-update-loadWorkflowInMedia-test-to-only-assert-upload-request-URL-31b6d73d365081f69a9aeb1095da7d60) by [Unito](https://www.unito.io)
