### PR TITLE
fix: Optimize histogramToPath performance in curveUtils (#9117)

### DIFF
--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -96,11 +96,14 @@ export function histogramToPath(histogram: Uint32Array): string {
   if (max === 0) return ''
 
   const invMax = 1 / max
+  const step = 1 / 255
+  const round = (v: number) => Math.round(v * 10000) / 10000
   const parts: string[] = ['M0,1']
+  let x = 0
   for (let i = 0; i < 256; i++) {
-    const x = i / 255
-    const y = 1 - Math.min(1, histogram[i] * invMax)
-    parts.push(`L${x},${y}`)
+    const y = round(1 - Math.min(1, histogram[i] * invMax))
+    parts.push(`L${round(x)},${y}`)
+    x += step
   }
   parts.push('L1,1 Z')
   return parts.join(' ')


### PR DESCRIPTION
Closes #9117

## Summary

The `histogramToPath` function in `curveUtils.ts` generated excessively long SVG path strings due to unrounded floating-point coordinates. This caused performance issues when rendering histogram overlays, as the browser had to parse and render paths with unnecessarily high precision.

## Changes

- **`src/components/curve/curveUtils.ts`** — `histogramToPath`:
  - Added a `round()` helper that limits coordinate precision to 4 decimal places, significantly reducing SVG path string length
  - Pre-computed `step = 1/255` and use incremental x accumulation instead of per-iteration division
  - Pre-computed `invMax = 1/max` (already existed) for multiplication instead of division in the loop

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9494-fix-Optimize-histogramToPath-performance-in-curveUtils-9117-31b6d73d365081f7a3d0c5bbfd5b42ff) by [Unito](https://www.unito.io)
