### PR TITLE
fix: Optimize sorting performance in useCurveEditor composable (#9115)

### DIFF
--- a/src/composables/useCurveEditor.ts
+++ b/src/composables/useCurveEditor.ts
@@ -9,6 +9,21 @@ interface UseCurveEditorOptions {
   modelValue: Ref<CurvePoint[]>
 }
 
+function insertSorted(
+  points: CurvePoint[],
+  point: CurvePoint
+): [CurvePoint[], number] {
+  let lo = 0
+  let hi = points.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (points[mid][0] < point[0]) lo = mid + 1
+    else hi = mid
+  }
+  const result = [...points.slice(0, lo), point, ...points.slice(lo)]
+  return [result, lo]
+}
+
 export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
   const dragIndex = ref(-1)
   let cleanupDrag: (() => void) | null = null
@@ -77,11 +92,10 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
     if (e.ctrlKey) return
 
     const newPoint: CurvePoint = [x, y]
-    const newPoints: CurvePoint[] = [...modelValue.value, newPoint]
-    newPoints.sort((a, b) => a[0] - b[0])
+    const [newPoints, insertIndex] = insertSorted(modelValue.value, newPoint)
     modelValue.value = newPoints
 
-    startDrag(newPoints.indexOf(newPoint), e)
+    startDrag(insertIndex, e)
   }
 
   function startDrag(index: number, e: PointerEvent) {
@@ -106,11 +120,10 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
       if (dragIndex.value < 0) return
       const [x, y] = svgCoords(ev)
       const movedPoint: CurvePoint = [x, y]
-      const newPoints = [...modelValue.value]
-      newPoints[dragIndex.value] = movedPoint
-      newPoints.sort((a, b) => a[0] - b[0])
+      const remaining = modelValue.value.filter((_, i) => i !== dragIndex.value)
+      const [newPoints, newIndex] = insertSorted(remaining, movedPoint)
       modelValue.value = newPoints
-      dragIndex.value = newPoints.indexOf(movedPoint)
+      dragIndex.value = newIndex
     }
 
     const endDrag = () => {


### PR DESCRIPTION
Closes #9115

## Summary

The `useCurveEditor` composable used `Array.sort()` after every point insertion and drag move, resulting in O(n log n) sorting on each operation. Since the points array is always maintained in sorted order, we can use binary search (O(log n)) to find the correct insertion position instead.

Additionally, `indexOf` was used to track the dragged point index after sorting, which could return incorrect results if multiple points shared the same coordinates. The new approach returns the insertion index directly from the binary search, eliminating this ambiguity.

## Changes

- **`src/composables/useCurveEditor.ts`**: 
  - Added `insertSorted()` helper using binary search to insert a point into an already-sorted array and return both the new array and the insertion index
  - Replaced `sort()` + `indexOf()` in `handleSvgPointerDown` with `insertSorted()`
  - Replaced `sort()` + `indexOf()` in the drag `onMove` handler with `filter()` + `insertSorted()`, removing the dragged point first then reinserting at the correct position

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9496-fix-Optimize-sorting-performance-in-useCurveEditor-composable-9115-31b6d73d365081e7bd2bc0f2390a5b87) by [Unito](https://www.unito.io)
