### PR TITLE
fix: Optimize CurveEditor drag performance with requestAnimationFrame batching (#9114)

### DIFF
--- a/src/composables/useCurveEditor.ts
+++ b/src/composables/useCurveEditor.ts
@@ -102,8 +102,13 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
 
     svg.setPointerCapture(e.pointerId)
 
-    const onMove = (ev: PointerEvent) => {
-      if (dragIndex.value < 0) return
+    let rafId: number | null = null
+    let latestPointerEvent: PointerEvent | null = null
+
+    const applyMove = () => {
+      rafId = null
+      const ev = latestPointerEvent
+      if (!ev || dragIndex.value < 0) return
       const [x, y] = svgCoords(ev)
       const movedPoint: CurvePoint = [x, y]
       const newPoints = [...modelValue.value]
@@ -113,7 +118,20 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
       dragIndex.value = newPoints.indexOf(movedPoint)
     }
 
+    const onMove = (ev: PointerEvent) => {
+      if (dragIndex.value < 0) return
+      latestPointerEvent = ev
+      if (rafId === null) {
+        rafId = requestAnimationFrame(applyMove)
+      }
+    }
+
     const endDrag = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+        applyMove()
+      }
       if (dragIndex.value < 0) return
       dragIndex.value = -1
       svg.removeEventListener('pointermove', onMove)


### PR DESCRIPTION
Closes #9114

## Summary

The CurveEditor's drag handler was processing every `pointermove` event synchronously, causing excessive reactive updates and re-renders during fast pointer movement. This led to janky/laggy drag behavior, especially on lower-end devices.

This fix introduces `requestAnimationFrame` batching so that only the latest pointer position is applied once per frame, reducing unnecessary intermediate updates while keeping the final position accurate.

## Changes

- **`src/composables/useCurveEditor.ts`**: Refactored `startDrag` to batch `pointermove` events using `requestAnimationFrame`. The `onMove` handler now stores the latest `PointerEvent` and schedules a single rAF callback (`applyMove`) that processes only the most recent position. On drag end, any pending rAF is cancelled and the last queued move is flushed to avoid dropping the final pointer position.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9499-fix-Optimize-CurveEditor-drag-performance-with-requestAnimationFrame-batching-9114-31b6d73d3650816d925dff50573446bd) by [Unito](https://www.unito.io)
