### PR TITLE
fix: Optimize SVG coordinate transform during CurveEditor drag operations (#9113)

### DIFF
--- a/src/composables/useCurveEditor.ts
+++ b/src/composables/useCurveEditor.ts
@@ -12,6 +12,7 @@ interface UseCurveEditorOptions {
 export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
   const dragIndex = ref(-1)
   let cleanupDrag: (() => void) | null = null
+  let cachedInverseCTM: DOMMatrix | null = null
 
   const curvePath = computed(() => {
     const points = modelValue.value
@@ -31,16 +32,14 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
     return parts.join('')
   })
 
-  function svgCoords(e: PointerEvent): [number, number] {
-    const svg = svgRef.value
-    if (!svg) return [0, 0]
+  function svgCoords(
+    e: PointerEvent,
+    inverseCTM?: DOMMatrix | null
+  ): [number, number] {
+    const inv = inverseCTM ?? svgRef.value?.getScreenCTM()?.inverse()
+    if (!inv) return [0, 0]
 
-    const ctm = svg.getScreenCTM()
-    if (!ctm) return [0, 0]
-
-    const svgPt = new DOMPoint(e.clientX, e.clientY).matrixTransform(
-      ctm.inverse()
-    )
+    const svgPt = new DOMPoint(e.clientX, e.clientY).matrixTransform(inv)
     return [
       Math.max(0, Math.min(1, svgPt.x)),
       Math.max(0, Math.min(1, 1 - svgPt.y))
@@ -100,11 +99,12 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
     const svg = svgRef.value
     if (!svg) return
 
+    cachedInverseCTM = svg.getScreenCTM()?.inverse() ?? null
     svg.setPointerCapture(e.pointerId)
 
     const onMove = (ev: PointerEvent) => {
       if (dragIndex.value < 0) return
-      const [x, y] = svgCoords(ev)
+      const [x, y] = svgCoords(ev, cachedInverseCTM)
       const movedPoint: CurvePoint = [x, y]
       const newPoints = [...modelValue.value]
       newPoints[dragIndex.value] = movedPoint
@@ -116,6 +116,7 @@ export function useCurveEditor({ svgRef, modelValue }: UseCurveEditorOptions) {
     const endDrag = () => {
       if (dragIndex.value < 0) return
       dragIndex.value = -1
+      cachedInverseCTM = null
       svg.removeEventListener('pointermove', onMove)
       svg.removeEventListener('pointerup', endDrag)
       svg.removeEventListener('lostpointercapture', endDrag)


### PR DESCRIPTION
Closes #9113

## Summary

The CurveEditor was calling `svg.getScreenCTM().inverse()` on every `pointermove` event during drag operations. Since the SVG element's position doesn't change during a drag, this repeated computation was unnecessary and caused performance overhead. The fix caches the inverse CTM matrix at drag start and reuses it throughout the drag operation.

## Changes

- **`src/composables/useCurveEditor.ts`**: 
  - Added `cachedInverseCTM` variable to store the inverse screen CTM matrix
  - Cache the inverse CTM once in `startDrag()` when a drag begins
  - Pass the cached matrix to `svgCoords()` during `pointermove` events
  - Clear the cache in `endDrag()` when the drag ends
  - Updated `svgCoords()` to accept an optional pre-computed inverse CTM parameter, falling back to computing it on demand for non-drag calls

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9500-fix-Optimize-SVG-coordinate-transform-during-CurveEditor-drag-operations-9113-31b6d73d36508150af5edf2c79e59d69) by [Unito](https://www.unito.io)
