### PR TITLE
fix: Optimize monotone interpolator by precomputing segment constants (#9111)

### DIFF
--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -51,6 +51,17 @@ export function createMonotoneInterpolator(
     }
   }
 
+  const segCount = n - 1
+  const segDx = new Float64Array(segCount)
+  const segM0dx = new Float64Array(segCount)
+  const segM1dx = new Float64Array(segCount)
+  for (let i = 0; i < segCount; i++) {
+    const dx = xs[i + 1] - xs[i]
+    segDx[i] = dx
+    segM0dx[i] = slopes[i] * dx
+    segM1dx[i] = slopes[i + 1] * dx
+  }
+
   return (x: number): number => {
     if (x <= xs[0]) return ys[0]
     if (x >= xs[n - 1]) return ys[n - 1]
@@ -63,7 +74,7 @@ export function createMonotoneInterpolator(
       else hi = mid
     }
 
-    const dx = xs[hi] - xs[lo]
+    const dx = segDx[lo]
     if (dx === 0) return ys[lo]
 
     const t = (x - xs[lo]) / dx
@@ -75,12 +86,7 @@ export function createMonotoneInterpolator(
     const h01 = -2 * t3 + 3 * t2
     const h11 = t3 - t2
 
-    return (
-      h00 * ys[lo] +
-      h10 * dx * slopes[lo] +
-      h01 * ys[hi] +
-      h11 * dx * slopes[hi]
-    )
+    return h00 * ys[lo] + h10 * segM0dx[lo] + h01 * ys[hi] + h11 * segM1dx[lo]
   }
 }
 


### PR DESCRIPTION
Closes #9111

## Summary

The `createMonotoneInterpolator` function in `curveUtils.ts` was recomputing segment dx values and `slopes[i] * dx` products on every call to the returned interpolation function. Since these values are constant after initialization, this caused unnecessary repeated arithmetic during high-frequency LUT generation (256 evaluations per call to `curvesToLUT`).

This fix precomputes the per-segment constants (`dx`, `slopes[i] * dx`, `slopes[i+1] * dx`) into `Float64Array` typed arrays during interpolator construction, so the hot interpolation path only performs lookups instead of recomputation.

## Changes

- **`src/components/curve/curveUtils.ts`** (`createMonotoneInterpolator`): Added precomputed `segDx`, `segM0dx`, and `segM1dx` Float64Array buffers built once during construction. Updated the returned closure to use these precomputed values instead of recalculating `dx` and `slopes * dx` on each evaluation.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9502-fix-Optimize-monotone-interpolator-by-precomputing-segment-constants-9111-31b6d73d3650813ba58afd0c0d81cc5c) by [Unito](https://www.unito.io)
