### PR TITLE
fix: Optimize CurveEditor with typed arrays for better JIT performance (#9110)

### DIFF
--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -15,25 +15,30 @@ export function createMonotoneInterpolator(
 
   const sorted = [...points].sort((a, b) => a[0] - b[0])
   const n = sorted.length
-  const xs = sorted.map((p) => p[0])
-  const ys = sorted.map((p) => p[1])
+  const xs = new Float64Array(n)
+  const ys = new Float64Array(n)
 
-  const deltas: number[] = []
-  const slopes: number[] = []
+  for (let i = 0; i < n; i++) {
+    xs[i] = sorted[i][0]
+    ys[i] = sorted[i][1]
+  }
+
+  const deltas = new Float64Array(n - 1)
+  const slopes = new Float64Array(n)
   for (let i = 0; i < n - 1; i++) {
     const dx = xs[i + 1] - xs[i]
-    deltas.push(dx === 0 ? 0 : (ys[i + 1] - ys[i]) / dx)
+    deltas[i] = dx === 0 ? 0 : (ys[i + 1] - ys[i]) / dx
   }
 
-  slopes.push(deltas[0] ?? 0)
+  slopes[0] = deltas[0] ?? 0
   for (let i = 1; i < n - 1; i++) {
     if (deltas[i - 1] * deltas[i] <= 0) {
-      slopes.push(0)
+      slopes[i] = 0
     } else {
-      slopes.push((deltas[i - 1] + deltas[i]) / 2)
+      slopes[i] = (deltas[i - 1] + deltas[i]) / 2
     }
   }
-  slopes.push(deltas[n - 2] ?? 0)
+  slopes[n - 1] = deltas[n - 2] ?? 0
 
   for (let i = 0; i < n - 1; i++) {
     if (deltas[i] === 0) {


### PR DESCRIPTION
Closes #9110

## Summary

The CurveEditor's monotone cubic Hermite interpolation used regular JavaScript arrays for numeric data (`xs`, `ys`, `deltas`, `slopes`), which prevents V8's JIT compiler from applying typed-array optimizations. This caused unnecessary overhead in a hot path that runs on every curve evaluation.

Replaced all four numeric arrays with `Float64Array` typed arrays, enabling the JIT to generate more efficient machine code with predictable memory layout and no type-check overhead.

## Changes

- **`src/components/curve/curveUtils.ts`** (`createMonotoneInterpolator`): Converted `xs`, `ys`, `deltas`, and `slopes` from `number[]` to `Float64Array`. Replaced `.push()` calls with direct index assignment to match typed array semantics.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9503-fix-Optimize-CurveEditor-with-typed-arrays-for-better-JIT-performance-9110-31b6d73d365081fbbab8d7fbdb6bbec0) by [Unito](https://www.unito.io)
