### PR TITLE
fix: Optimize histogramToPath percentile calculation with QuickSelect algorithm (#9109)

### DIFF
--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -84,6 +84,30 @@ export function createMonotoneInterpolator(
   }
 }
 
+function quickSelect(arr: Uint32Array, k: number): number {
+  let lo = 0
+  let hi = arr.length - 1
+  while (lo < hi) {
+    const pivot = arr[hi]
+    let i = lo
+    for (let j = lo; j < hi; j++) {
+      if (arr[j] <= pivot) {
+        const tmp = arr[i]
+        arr[i] = arr[j]
+        arr[j] = tmp
+        i++
+      }
+    }
+    const tmp = arr[i]
+    arr[i] = arr[hi]
+    arr[hi] = tmp
+    if (i === k) return arr[i]
+    else if (i < k) lo = i + 1
+    else hi = i - 1
+  }
+  return arr[lo]
+}
+
 /**
  * Convert a 256-bin histogram into an SVG path string.
  * Normalizes using the 99.5th percentile to avoid outlier spikes.
@@ -91,8 +115,8 @@ export function createMonotoneInterpolator(
 export function histogramToPath(histogram: Uint32Array): string {
   if (!histogram.length) return ''
 
-  const sorted = Array.from(histogram).sort((a, b) => a - b)
-  const max = sorted[Math.floor(255 * 0.995)]
+  const copy = new Uint32Array(histogram)
+  const max = quickSelect(copy, Math.floor(255 * 0.995))
   if (max === 0) return ''
 
   const invMax = 1 / max


### PR DESCRIPTION
Closes #9109

## Summary

The `histogramToPath` function previously used `Array.from(histogram).sort()` to find the 99.5th percentile value for normalization. This performed an O(n log n) full sort when only a single order statistic was needed. For the 256-bin histogram this is called on every render of curve widgets, creating unnecessary overhead.

Replaced the full sort with a QuickSelect algorithm (O(n) average case) that operates on a `Uint32Array` copy instead of converting to a regular `Array`, avoiding both the sorting overhead and the typed-array-to-array conversion cost.

## Changes

- **`src/components/curve/curveUtils.ts`**: Added `quickSelect` function implementing the Lomuto partition scheme to find the k-th smallest element in O(n) average time. Updated `histogramToPath` to use `new Uint32Array(histogram)` + `quickSelect` instead of `Array.from(histogram).sort()`.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9504-fix-Optimize-histogramToPath-percentile-calculation-with-QuickSelect-algorithm-9109-31b6d73d36508196bc60ffb2cb7c6533) by [Unito](https://www.unito.io)
