### PR TITLE
fix: update copy on cloud login and profile popover

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2025,7 +2025,7 @@
       "whitelistInfo": "About non-whitelisted sites"
     },
     "login": {
-      "title": "Log in to your account",
+      "title": "Welcome back! Log in to your account",
       "useApiKey": "Comfy API Key",
       "signInOrSignUp": "Sign In / Sign Up",
       "forgotPasswordError": "Failed to send password reset email",
@@ -2082,7 +2082,7 @@
       "emailNotEligibleForFreeTier": "Email sign-up is not eligible for Free Tier."
     },
     "signOut": {
-      "signOut": "Log Out",
+      "signOut": "Sign Out",
       "success": "Signed out successfully",
       "successDetail": "You have been signed out of your account.",
       "unsavedChangesTitle": "Unsaved Changes",


### PR DESCRIPTION
- Updated cloud login title: 'Log in to your account' → 'Welcome back! Log in to your account'
- Updated profile popover sign out: 'Log Out' → 'Sign Out'

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9517-fix-update-copy-on-cloud-login-and-profile-popover-31c6d73d36508103b197d4dcd4e56525) by [Unito](https://www.unito.io)
