### PR TITLE
feat: dispatch cloud build when preview label is added to PR

### DIFF
--- a/.github/workflows/cloud-dispatch-build.yaml
+++ b/.github/workflows/cloud-dispatch-build.yaml
@@ -13,6 +13,8 @@ on:
     branches:
       - 'cloud/*'
       - 'main'
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
 
 permissions: {}
@@ -23,16 +25,27 @@ concurrency:
 
 jobs:
   dispatch:
-    # Fork guard: prevent forks from dispatching to the cloud repo
-    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
+    # Fork guard: prevent forks from dispatching to the cloud repo.
+    # For pull_request events, only dispatch when the 'preview' label is added.
+    if: >
+      github.repository == 'Comfy-Org/ComfyUI_frontend' &&
+      (github.event_name != 'pull_request' ||
+       github.event.label.name == 'preview')
     runs-on: ubuntu-latest
     steps:
       - name: Build client payload
         id: payload
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            REF="${{ github.event.pull_request.head.sha }}"
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          else
+            REF="${GITHUB_SHA}"
+            BRANCH="${GITHUB_REF_NAME}"
+          fi
           payload="$(jq -nc \
-            --arg ref "${GITHUB_SHA}" \
-            --arg branch "${GITHUB_REF_NAME}" \
+            --arg ref "${REF}" \
+            --arg branch "${BRANCH}" \
             '{ref: $ref, branch: $branch}')"
           echo "json=${payload}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/cloud-dispatch-build.yaml
+++ b/.github/workflows/cloud-dispatch-build.yaml
@@ -35,10 +35,14 @@ jobs:
     steps:
       - name: Build client payload
         id: payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            REF="${{ github.event.pull_request.head.sha }}"
-            BRANCH="${{ github.event.pull_request.head.ref }}"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            REF="${PR_HEAD_SHA}"
+            BRANCH="${PR_HEAD_REF}"
           else
             REF="${GITHUB_SHA}"
             BRANCH="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary

Dispatch a `frontend-asset-build` event to the cloud repo when the `preview` label is added to a PR, so cloud can build preview assets.

## Changes

- **What**: Extended `cloud-dispatch-build.yaml` to trigger on `pull_request` `labeled` events filtered to the `preview` label. The payload sends the PR head SHA and branch.

## Review Focus

- The `pull_request` trigger gives a read-only `GITHUB_TOKEN`, but the dispatch step uses `CLOUD_DISPATCH_TOKEN` so this is fine.
- Fork PRs are blocked by the existing `github.repository` guard.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9518-feat-dispatch-cloud-build-when-preview-label-is-added-to-PR-31c6d73d365081a8aab6f585960977f6) by [Unito](https://www.unito.io)
