### PR TITLE
use getLoad3dAsync

### DIFF
--- a/src/components/load3d/Load3dViewerContent.vue
+++ b/src/components/load3d/Load3dViewerContent.vue
@@ -141,7 +141,7 @@ onMounted(async () => {
   if (isStandaloneMode && props.modelUrl) {
     await viewer.initializeStandaloneViewer(containerRef.value, props.modelUrl)
   } else if (props.node) {
-    const source = useLoad3dService().getLoad3d(props.node)
+    const source = await useLoad3dService().getLoad3dAsync(props.node)
     if (source) {
       await viewer.initializeViewer(containerRef.value, source)
     }


### PR DESCRIPTION
## Summary

Applying `useLoad3dService().getLoad3dAsync` to fix the broken 3D viewer scene.

Fix https://github.com/Comfy-Org/ComfyUI_frontend/issues/9495

## Screenshots 

before

<img width="3456" height="2168" alt="665d1b83bf8b23a9ddde1411a34c8df9" src="https://github.com/user-attachments/assets/6cb190f4-ef13-4fd3-a0c5-2360f056da55" />


after

<img width="5120" height="2638" alt="image" src="https://github.com/user-attachments/assets/154b1a98-bd71-41e2-839d-f0f1f7e5e72e" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9520-use-getLoad3dAsync-31c6d73d365081cf8c24cd89b545ccb4) by [Unito](https://www.unito.io)
