### PR TITLE
fix: use previewable output count for asset sidebar badge

### DIFF
--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -70,7 +70,7 @@ function mapHistoryToAssets(historyItems: JobListItem[]): AssetItem[] {
 
     assetItem.user_metadata = {
       ...assetItem.user_metadata,
-      outputCount: job.outputs_count,
+      outputCount: task.previewableOutputs.length,
       allOutputs: task.previewableOutputs
     }
 


### PR DESCRIPTION
## Summary

Fix asset sidebar badge showing inflated output count by using previewable outputs length instead of raw server count.

## Changes

- **What**: Changed `outputCount` in `mapHistoryToAssets` from `job.outputs_count` (includes all output types: text, JSON, custom data) to `task.previewableOutputs.length` (only image, video, audio, 3D). The badge now matches what users actually see in the expanded view.

## Review Focus

One-line change. The `task.previewableOutputs` array is already computed on the line immediately below and used for `allOutputs`, so this introduces no new computation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9535-fix-use-previewable-output-count-for-asset-sidebar-badge-31c6d73d365081c49161caec64cf3921) by [Unito](https://www.unito.io)
