### PR TITLE
fix: update FormDropdown filteredItems when items prop changes

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
@@ -1,0 +1,124 @@
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { createI18n } from 'vue-i18n'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+
+import FormDropdown from './FormDropdown.vue'
+import type { FormDropdownItem } from './types'
+
+function createItem(id: string, name: string): FormDropdownItem {
+  return { id, preview_url: '', name, label: name }
+}
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({
+    addAlert: vi.fn()
+  })
+}))
+
+const MockFormDropdownMenu = defineComponent({
+  name: 'FormDropdownMenu',
+  props: {
+    items: { type: Array as () => FormDropdownItem[], default: () => [] },
+    updateKey: { type: null, default: undefined },
+    searcher: { type: Function, default: undefined },
+    isSelected: { type: Function, default: undefined },
+    filterOptions: { type: Array, default: () => [] },
+    sortOptions: { type: Array, default: () => [] },
+    maxSelectable: { type: Number, default: 1 },
+    disabled: { type: Boolean, default: false },
+    showOwnershipFilter: { type: Boolean, default: false },
+    ownershipOptions: { type: Array, default: () => [] },
+    showBaseModelFilter: { type: Boolean, default: false },
+    baseModelOptions: { type: Array, default: () => [] }
+  },
+  setup() {
+    return () => h('div', { class: 'mock-menu' })
+  }
+})
+
+function mountDropdown(items: FormDropdownItem[]) {
+  return mount(FormDropdown, {
+    props: { items },
+    global: {
+      plugins: [PrimeVue, i18n],
+      stubs: {
+        FormDropdownInput: true,
+        Popover: { template: '<div><slot /></div>' },
+        FormDropdownMenu: MockFormDropdownMenu
+      }
+    }
+  })
+}
+
+function getMenuItems(
+  wrapper: ReturnType<typeof mountDropdown>
+): FormDropdownItem[] {
+  return wrapper
+    .findComponent(MockFormDropdownMenu)
+    .props('items') as FormDropdownItem[]
+}
+
+describe('FormDropdown', () => {
+  describe('filteredItems updates when items prop changes', () => {
+    it('updates displayed items when items prop changes', async () => {
+      const wrapper = mountDropdown([
+        createItem('input-0', 'video1.mp4'),
+        createItem('input-1', 'video2.mp4')
+      ])
+      await nextTick()
+      await nextTick()
+
+      expect(getMenuItems(wrapper)).toHaveLength(2)
+
+      await wrapper.setProps({
+        items: [
+          createItem('output-0', 'rendered1.mp4'),
+          createItem('output-1', 'rendered2.mp4')
+        ]
+      })
+      await nextTick()
+      await nextTick()
+
+      const menuItems = getMenuItems(wrapper)
+      expect(menuItems).toHaveLength(2)
+      expect(menuItems[0].name).toBe('rendered1.mp4')
+    })
+
+    it('updates when items change but IDs stay the same', async () => {
+      const wrapper = mountDropdown([createItem('1', 'alpha')])
+      await nextTick()
+      await nextTick()
+
+      await wrapper.setProps({ items: [createItem('1', 'beta')] })
+      await nextTick()
+      await nextTick()
+
+      expect(getMenuItems(wrapper)[0].name).toBe('beta')
+    })
+
+    it('updates when switching between empty and non-empty items', async () => {
+      const wrapper = mountDropdown([])
+      await nextTick()
+      await nextTick()
+
+      expect(getMenuItems(wrapper)).toHaveLength(0)
+
+      await wrapper.setProps({ items: [createItem('1', 'video.mp4')] })
+      await nextTick()
+      await nextTick()
+
+      expect(getMenuItems(wrapper)).toHaveLength(1)
+      expect(getMenuItems(wrapper)[0].name).toBe('video.mp4')
+
+      await wrapper.setProps({ items: [] })
+      await nextTick()
+      await nextTick()
+
+      expect(getMenuItems(wrapper)).toHaveLength(0)
+    })
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import Popover from 'primevue/popover'
-import { computed, ref, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -101,9 +101,23 @@ const maxSelectable = computed(() => {
   return 1
 })
 
-const itemsKey = computed(() => items.map((item) => item.id).join('|'))
+const itemsKey = ref<symbol>(Symbol())
 
 const filteredItems = ref<FormDropdownItem[]>([])
+
+watch(
+  () => items,
+  async (newItems, _old, onCleanup) => {
+    itemsKey.value = Symbol()
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    const results = await searcher(searchQuery.value, newItems, () => {})
+    if (!cancelled) filteredItems.value = results
+  },
+  { immediate: true }
+)
 
 const defaultSorter = computed<SortOption['sorter']>(() => {
   const sorter = sortOptions.find((option) => option.id === 'default')?.sorter

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -110,10 +110,16 @@ watch(
   async (newItems, _old, onCleanup) => {
     itemsKey.value = Symbol()
     let cancelled = false
+    let cleanupFn: (() => void) | undefined
     onCleanup(() => {
       cancelled = true
+      cleanupFn?.()
     })
-    const results = await searcher(searchQuery.value, newItems, () => {})
+    const results = await searcher(
+      searchQuery.value,
+      newItems,
+      (cb) => (cleanupFn = cb)
+    )
     if (!cancelled) filteredItems.value = results
   },
   { immediate: true }


### PR DESCRIPTION
## Problem

The Load Video node's Media Assets panel dropdown didn't show videos when switching between asset types. The `filteredItems` ref stayed stale because the update chain relied on a computed `itemsKey` (string of IDs) — if the key didn't change (e.g., switching between two empty arrays or identical item sets), the watcher never fired.

## Solution

- Replace computed `itemsKey` with a `Symbol` ref that always produces a unique value on change
- Add a `watch` on the `items` prop that immediately re-runs the searcher with cancellation support
- Add unit tests covering prop changes with same IDs, different names, and empty↔non-empty transitions

## Testing

- `pnpm test:unit -- FormDropdown.test.ts` — 3/3 pass
- All quality gates pass (format, lint, typecheck)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9551-fix-update-FormDropdown-filteredItems-when-items-prop-changes-31d6d73d3650812bb325e5c31036a5a0) by [Unito](https://www.unito.io)
