### PR TITLE
[backport core/1.40] fix: remove beta labeling from comfy cloud badges (#9184)

### DIFF
--- a/src/components/topbar/CloudBadge.vue
+++ b/src/components/topbar/CloudBadge.vue
@@ -10,7 +10,6 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import type { TopbarBadge as TopbarBadgeType } from '@/types/comfy'
 
@@ -31,10 +30,8 @@ withDefaults(
   }
 )
 
-const { t } = useI18n()
-
 const cloudBadge = computed<TopbarBadgeType>(() => ({
-  label: t('g.beta'),
+  icon: 'icon-[lucide--cloud]',
   text: 'Comfy Cloud'
 }))
 </script>

--- a/src/extensions/core/cloudBadges.ts
+++ b/src/extensions/core/cloudBadges.ts
@@ -1,7 +1,6 @@
 import { computed } from 'vue'
 
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
-import { t } from '@/i18n'
 import { useExtensionService } from '@/services/extensionService'
 import type { TopbarBadge } from '@/types/comfy'
 
@@ -21,7 +20,7 @@ const badges = computed<TopbarBadge[]>(() => {
 
   // Always add cloud badge last (furthest right)
   result.push({
-    label: t('g.beta'),
+    icon: 'icon-[lucide--cloud]',
     text: 'Comfy Cloud'
   })
 


### PR DESCRIPTION
Backport of #9184 to core/1.40.

**Original PR:** https://github.com/Comfy-Org/ComfyUI_frontend/pull/9184
**Pipeline ticket:** 15e1f241-efaa-4fe5-88ca-4ccc7bfb3345