### PR TITLE
[backport core/1.40] [bugfix] Fix workspace dialog pt override losing base styles (#9188)

### DIFF
--- a/src/platform/workspace/components/dialogs/EditWorkspaceDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/EditWorkspaceDialogContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex w-full max-w-[400px] flex-col rounded-2xl border border-border-default bg-base-background"
+    class="flex w-full min-w-[400px] flex-col rounded-2xl border border-border-default bg-base-background"
   >
     <!-- Header -->
     <div

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -437,11 +437,7 @@ export const useDialogService = () => {
       component,
       props: { onConfirm },
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[400px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -463,11 +459,7 @@ export const useDialogService = () => {
       key: 'edit-workspace',
       component,
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[400px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -490,11 +482,7 @@ export const useDialogService = () => {
       key: 'invite-member',
       component,
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[512px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -506,11 +494,7 @@ export const useDialogService = () => {
       key: 'invite-member-upsell',
       component,
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[512px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }
@@ -552,11 +536,7 @@ export const useDialogService = () => {
       component,
       props: { cancelAt },
       dialogComponentProps: {
-        ...workspaceDialogPt,
-        pt: {
-          ...workspaceDialogPt.pt,
-          root: { class: 'rounded-2xl max-w-[400px] w-full' }
-        }
+        ...workspaceDialogPt
       }
     })
   }


### PR DESCRIPTION
Backport of #9188 to core/1.40.

**Original PR:** https://github.com/Comfy-Org/ComfyUI_frontend/pull/9188
**Pipeline ticket:** 15e1f241-efaa-4fe5-88ca-4ccc7bfb3345