### PR TITLE
[backport core/1.40] fix(ErrorNodeCard): show error message body in compact (single-node) mode (#9437)

### DIFF
--- a/src/components/rightSidePanel/errors/ErrorNodeCard.vue
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.vue
@@ -47,7 +47,7 @@
       >
         <!-- Error Message -->
         <p
-          v-if="error.message && !compact"
+          v-if="error.message"
           class="m-0 text-sm break-words whitespace-pre-wrap leading-relaxed px-0.5 max-h-[4lh] overflow-y-auto"
         >
           {{ error.message }}


### PR DESCRIPTION
Backport of #9437 to core/1.40.

**Original PR:** https://github.com/Comfy-Org/ComfyUI_frontend/pull/9437
**Pipeline ticket:** 15e1f241-efaa-4fe5-88ca-4ccc7bfb3345