### PR TITLE
fix: rename docked queue panel setting

### DIFF
--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -349,7 +349,7 @@
   },
   "Comfy_Queue_QPOV2": {
     "name": "Docked job history/queue panel",
-    "tooltip": "Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout."
+    "tooltip": "Replaces the floating job queue panel with an equivalent job queue embedded in the job history side panel. You can disable this to return to the floating panel layout."
   },
   "Comfy_QueueButton_BatchCountLimit": {
     "name": "Batch count limit",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -348,7 +348,7 @@
     "tooltip": "The maximum number of tasks that show in the queue history."
   },
   "Comfy_Queue_QPOV2": {
-    "name": "Use the unified job queue in the Assets side panel",
+    "name": "Docked job history/queue panel",
     "tooltip": "Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout."
   },
   "Comfy_QueueButton_BatchCountLimit": {

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1201,7 +1201,7 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Queue.QPOV2',
     category: ['Comfy', 'Queue', 'Layout'],
-    name: 'Use the unified job queue in the Assets side panel',
+    name: 'Docked job history/queue panel',
     type: 'boolean',
     tooltip:
       'Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout.',

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1204,7 +1204,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     name: 'Docked job history/queue panel',
     type: 'boolean',
     tooltip:
-      'Replaces the floating job queue panel with an equivalent job queue embedded in the Assets side panel. You can disable this to return to the floating panel layout.',
+      'Replaces the floating job queue panel with an equivalent job queue embedded in the job history side panel. You can disable this to return to the floating panel layout.',
     defaultValue: false,
     experimental: true
   },


### PR DESCRIPTION
## Summary

Rename the `Comfy.Queue.QPOV2` settings label to `Docked job history/queue panel` to improve searchability/discoverability in the settings UI.

## Changes

- **What**: Updated the visible setting name in the core settings definition and the English locale string.

## Review Focus

The change is intentionally limited to the display label. The persisted setting key remains `Comfy.Queue.QPOV2`, so existing user configuration is preserved.

## Screenshots (if applicable)

Not applicable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9620-fix-rename-docked-queue-panel-setting-31d6d73d36508189a2d1d3a621739a22) by [Unito](https://www.unito.io)
