### PR TITLE
fix: app mode widgets disappear after hard refresh

### DIFF
--- a/src/renderer/extensions/linearMode/LinearControls.vue
+++ b/src/renderer/extensions/linearMode/LinearControls.vue
@@ -64,6 +64,7 @@ useEventListener(
 )
 
 const mappedSelections = computed(() => {
+  void graphNodes.value
   let unprocessedInputs = appModeStore.selectedInputs.flatMap(
     ([nodeId, widgetName]) => {
       const [node, widget] = resolveNodeWidget(nodeId, widgetName)

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -247,10 +247,7 @@ describe('appModeStore', () => {
 
       // Initially nodes are not resolvable — pruning removes them
       mockResolveNode.mockReturnValue(undefined)
-      workflowStore.activeWorkflow = workflowWithLinearData(
-        [[1, 'seed']],
-        [1]
-      )
+      workflowStore.activeWorkflow = workflowWithLinearData([[1, 'seed']], [1])
       await nextTick()
       expect(store.selectedInputs).toEqual([])
       expect(store.selectedOutputs).toEqual([])

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -25,7 +25,7 @@ const mockEmptyWorkflowDialog = vi.hoisted(() => {
 
 vi.mock('@/scripts/app', () => ({
   app: {
-    rootGraph: { extra: {}, nodes: [{ id: 1 }] }
+    rootGraph: { extra: {}, nodes: [{ id: 1 }], events: new EventTarget() }
   }
 }))
 
@@ -242,50 +242,30 @@ describe('appModeStore', () => {
       expect(store.selectedOutputs).toEqual([1])
     })
 
-    it('preserves inputs during graph loading when nodes are not yet available', async () => {
-      // Simulate the race condition: graph is loading, nodes don't exist yet
+    it('reloads selections on configured event', async () => {
+      const node1 = mockNode(1)
+
+      // Initially nodes are not resolvable — pruning removes them
       mockResolveNode.mockReturnValue(undefined)
-
-      const { ChangeTracker } = await import('@/scripts/changeTracker')
-      ChangeTracker.isLoadingGraph = true
-      try {
-        workflowStore.activeWorkflow = workflowWithLinearData(
-          [
-            [1, 'seed'],
-            [2, 'prompt']
-          ],
-          [3]
-        )
-        await nextTick()
-
-        // Inputs and outputs should NOT be pruned during loading
-        expect(store.selectedInputs).toEqual([
-          [1, 'seed'],
-          [2, 'prompt']
-        ])
-        expect(store.selectedOutputs).toEqual([3])
-      } finally {
-        ChangeTracker.isLoadingGraph = false
-      }
-    })
-
-    it('prunes inputs when graph is not loading and nodes are missing', async () => {
-      const { ChangeTracker } = await import('@/scripts/changeTracker')
-      expect(ChangeTracker.isLoadingGraph).toBe(false)
-
-      mockResolveNode.mockReturnValue(undefined)
-
       workflowStore.activeWorkflow = workflowWithLinearData(
-        [
-          [1, 'seed'],
-          [2, 'prompt']
-        ],
-        [3]
+        [[1, 'seed']],
+        [1]
+      )
+      await nextTick()
+      expect(store.selectedInputs).toEqual([])
+      expect(store.selectedOutputs).toEqual([])
+
+      // After graph configures, nodes become resolvable
+      mockResolveNode.mockImplementation((id) =>
+        id == 1 ? (node1 as unknown as LGraphNode) : undefined
+      )
+      ;(app.rootGraph.events as EventTarget).dispatchEvent(
+        new Event('configured')
       )
       await nextTick()
 
-      expect(store.selectedInputs).toEqual([])
-      expect(store.selectedOutputs).toEqual([])
+      expect(store.selectedInputs).toEqual([[1, 'seed']])
+      expect(store.selectedOutputs).toEqual([1])
     })
 
     it('hasOutputs is false when all output nodes are deleted', async () => {

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -242,6 +242,52 @@ describe('appModeStore', () => {
       expect(store.selectedOutputs).toEqual([1])
     })
 
+    it('preserves inputs during graph loading when nodes are not yet available', async () => {
+      // Simulate the race condition: graph is loading, nodes don't exist yet
+      mockResolveNode.mockReturnValue(undefined)
+
+      const { ChangeTracker } = await import('@/scripts/changeTracker')
+      ChangeTracker.isLoadingGraph = true
+      try {
+        workflowStore.activeWorkflow = workflowWithLinearData(
+          [
+            [1, 'seed'],
+            [2, 'prompt']
+          ],
+          [3]
+        )
+        await nextTick()
+
+        // Inputs and outputs should NOT be pruned during loading
+        expect(store.selectedInputs).toEqual([
+          [1, 'seed'],
+          [2, 'prompt']
+        ])
+        expect(store.selectedOutputs).toEqual([3])
+      } finally {
+        ChangeTracker.isLoadingGraph = false
+      }
+    })
+
+    it('prunes inputs when graph is not loading and nodes are missing', async () => {
+      const { ChangeTracker } = await import('@/scripts/changeTracker')
+      expect(ChangeTracker.isLoadingGraph).toBe(false)
+
+      mockResolveNode.mockReturnValue(undefined)
+
+      workflowStore.activeWorkflow = workflowWithLinearData(
+        [
+          [1, 'seed'],
+          [2, 'prompt']
+        ],
+        [3]
+      )
+      await nextTick()
+
+      expect(store.selectedInputs).toEqual([])
+      expect(store.selectedOutputs).toEqual([])
+    })
+
     it('hasOutputs is false when all output nodes are deleted', async () => {
       mockResolveNode.mockReturnValue(undefined)
 

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { reactive, computed, watch } from 'vue'
+import { useEventListener } from '@vueuse/core'
 
 import { useEmptyWorkflowDialog } from '@/components/builder/useEmptyWorkflowDialog'
 import { useAppMode } from '@/composables/useAppMode'
@@ -39,13 +40,11 @@ export const useAppModeStore = defineStore('appMode', () => {
     const rawInputs = data?.inputs ?? []
     const rawOutputs = data?.outputs ?? []
 
-    const canPrune = app.rootGraph && !ChangeTracker.isLoadingGraph
-
     return {
-      inputs: canPrune
+      inputs: app.rootGraph
         ? rawInputs.filter(([nodeId]) => resolveNode(nodeId))
         : rawInputs,
-      outputs: canPrune
+      outputs: app.rootGraph
         ? rawOutputs.filter((nodeId) => resolveNode(nodeId))
         : rawOutputs
     }
@@ -76,6 +75,12 @@ export const useAppModeStore = defineStore('appMode', () => {
       }
     },
     { immediate: true }
+  )
+
+  useEventListener(
+    () => app.rootGraph?.events,
+    'configured',
+    resetSelectedToWorkflow
   )
 
   watch(

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -39,11 +39,13 @@ export const useAppModeStore = defineStore('appMode', () => {
     const rawInputs = data?.inputs ?? []
     const rawOutputs = data?.outputs ?? []
 
+    const canPrune = app.rootGraph && !ChangeTracker.isLoadingGraph
+
     return {
-      inputs: app.rootGraph
+      inputs: canPrune
         ? rawInputs.filter(([nodeId]) => resolveNode(nodeId))
         : rawInputs,
-      outputs: app.rootGraph
+      outputs: canPrune
         ? rawOutputs.filter((nodeId) => resolveNode(nodeId))
         : rawOutputs
     }


### PR DESCRIPTION
## Summary

Fix all app mode widgets (including seed) disappearing after hard refresh due to a race condition in `pruneLinearData` and a missing reactivity dependency in `mappedSelections`.

## Changes

- **What**: Guard `pruneLinearData` with `!ChangeTracker.isLoadingGraph` so inputs are preserved while `rootGraph.configure()` hasn't populated nodes yet. Add `graphNodes` dependency to `mappedSelections` computed in `LinearControls.vue` so it re-evaluates when the graph finishes configuring.

## Review Focus

The core fix is a one-line guard change: `app.rootGraph && !ChangeTracker.isLoadingGraph` instead of just `app.rootGraph`. The previous guard failed because `rootGraph` exists as an empty graph during loading — `resolveNode()` returns `undefined` for all nodes and everything gets filtered out.

Fixes COM-16193

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9621-fix-app-mode-widgets-disappear-after-hard-refresh-31d6d73d3650811193f5e1bc8f3c15c8) by [Unito](https://www.unito.io)
