### PR TITLE
fix: restore backend outputs_count for asset sidebar multi-output badge

### DIFF
--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -70,7 +70,7 @@ function mapHistoryToAssets(historyItems: JobListItem[]): AssetItem[] {
 
     assetItem.user_metadata = {
       ...assetItem.user_metadata,
-      outputCount: task.previewableOutputs.length,
+      outputCount: task.outputsCount ?? task.previewableOutputs.length,
       allOutputs: task.previewableOutputs
     }
 


### PR DESCRIPTION
## Summary

Fix regression from PR #9535 where the multi-output count badge stopped appearing in the asset sidebar.

## Root Cause

PR #9535 changed `outputCount` in `mapHistoryToAssets` from `job.outputs_count` (backend-provided total) to `task.previewableOutputs.length`. However, `TaskItemImpl` constructed from a job listing only has the single `preview_output`, so `previewableOutputs.length` is always **1** — the multi-output badge never appears.

## Fix

Use the backend-provided `outputs_count` (via `task.outputsCount`) with fallback to `task.previewableOutputs.length` when unavailable. This restores the correct count while preserving the fallback for jobs that don't have `outputs_count` from the server.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9627-fix-restore-backend-outputs_count-for-asset-sidebar-multi-output-badge-31d6d73d36508160b93fd03af4a01aa3) by [Unito](https://www.unito.io)
