### PR TITLE
fix: Refactor: Normalize graph-canvas targetElementId at keybinding registration time (#9497)

### DIFF
--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -96,7 +96,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetElementId: 'graph-canvas'
+    targetElementId: 'graph-canvas-container'
   },
   {
     combo: {
@@ -105,7 +105,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       shift: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetElementId: 'graph-canvas'
+    targetElementId: 'graph-canvas-container'
   },
   {
     combo: {
@@ -113,7 +113,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomIn',
-    targetElementId: 'graph-canvas'
+    targetElementId: 'graph-canvas-container'
   },
   {
     combo: {
@@ -121,7 +121,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       alt: true
     },
     commandId: 'Comfy.Canvas.ZoomOut',
-    targetElementId: 'graph-canvas'
+    targetElementId: 'graph-canvas-container'
   },
   {
     combo: {

--- a/src/platform/keybindings/keybinding.ts
+++ b/src/platform/keybindings/keybinding.ts
@@ -11,7 +11,10 @@ export class KeybindingImpl implements Keybinding {
   constructor(obj: Keybinding) {
     this.commandId = obj.commandId
     this.combo = new KeyComboImpl(obj.combo)
-    this.targetElementId = obj.targetElementId
+    this.targetElementId =
+      obj.targetElementId === 'graph-canvas'
+        ? 'graph-canvas-container'
+        : obj.targetElementId
   }
 
   equals(other: unknown): boolean {

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -34,12 +34,8 @@ export function useKeybindingService() {
 
     const keybinding = keybindingStore.getKeybinding(keyCombo)
     if (keybinding) {
-      const targetElementId =
-        keybinding.targetElementId === 'graph-canvas'
-          ? 'graph-canvas-container'
-          : keybinding.targetElementId
-      if (targetElementId) {
-        const container = document.getElementById(targetElementId)
+      if (keybinding.targetElementId) {
+        const container = document.getElementById(keybinding.targetElementId)
         if (!container?.contains(target)) {
           return
         }


### PR DESCRIPTION
Closes #9497

## Summary

The `graph-canvas` element ID was renamed to `graph-canvas-container` but keybindings still referenced the old ID. The previous fix normalized `graph-canvas` to `graph-canvas-container` at event-handling time in `keybindingService.ts`. This refactor moves that normalization to registration time in `KeybindingImpl`'s constructor, so that all keybindings are stored with the correct `targetElementId` from the start.

## Changes

- **`src/platform/keybindings/keybinding.ts`**: Added normalization logic in `KeybindingImpl` constructor to map `graph-canvas` → `graph-canvas-container`, handling both core and user-defined keybindings at registration time.
- **`src/platform/keybindings/defaults.ts`**: Updated 4 hardcoded `targetElementId` values from `graph-canvas` to `graph-canvas-container` for consistency.
- **`src/platform/keybindings/keybindingService.ts`**: Removed the runtime normalization logic from `keybindHandler`, since it's now handled at registration time.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9659-fix-Refactor-Normalize-graph-canvas-targetElementId-at-keybinding-registration-time-9-31e6d73d365081b49b65e71ea958faab) by [Unito](https://www.unito.io)
