### PR TITLE
fix: Add Storybook stories for Vue node components (#8731)

### DIFF
--- a/src/renderer/extensions/vueNodes/components/InputSlot.stories.ts
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.stories.ts
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { INodeSlot } from '@/lib/litegraph/src/interfaces'
+
+import InputSlot from './InputSlot.vue'
+
+function createSlotData(
+  overrides: Partial<INodeSlot> = {}
+): INodeSlot {
+  return {
+    name: 'image',
+    type: 'IMAGE',
+    boundingRect: [0, 0, 0, 0] as const,
+    ...overrides
+  }
+}
+
+const meta: Meta<typeof InputSlot> = {
+  title: 'VueNodes/InputSlot',
+  component: InputSlot,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: '<div class="w-48 bg-node-component-surface p-2"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    slotData: createSlotData({ name: 'image' }),
+    index: 0
+  }
+}
+
+export const WithLocalizedName: Story = {
+  args: {
+    slotData: createSlotData({
+      name: 'image',
+      localized_name: 'Imagen'
+    }),
+    index: 0
+  }
+}
+
+export const WithLabel: Story = {
+  args: {
+    slotData: createSlotData({
+      name: 'image',
+      label: 'Custom Label'
+    }),
+    index: 0
+  }
+}
+
+export const Connected: Story = {
+  args: {
+    slotData: createSlotData({ name: 'model' }),
+    index: 0,
+    connected: true
+  }
+}
+
+export const Compatible: Story = {
+  args: {
+    slotData: createSlotData({ name: 'model' }),
+    index: 0,
+    compatible: true
+  }
+}
+
+export const WithError: Story = {
+  args: {
+    slotData: createSlotData({ name: 'image' }),
+    index: 0,
+    hasError: true
+  }
+}
+
+export const DotOnlyProp: Story = {
+  args: {
+    slotData: createSlotData({ name: 'image' }),
+    index: 0,
+    dotOnly: true
+  }
+}
+
+export const DotOnlyDerived: Story = {
+  name: 'Dot Only (empty name - reroute)',
+  args: {
+    slotData: createSlotData({ name: '' }),
+    index: 0
+  }
+}
+
+export const DotOnlyNoLocalizedName: Story = {
+  name: 'Dot Only (empty name, no localized_name)',
+  args: {
+    slotData: createSlotData({
+      name: '',
+      localized_name: undefined
+    }),
+    index: 0
+  }
+}
+
+export const DifferentTypes: Story = {
+  render: () => ({
+    components: { InputSlot },
+    setup() {
+      const slots = [
+        createSlotData({ name: 'model', type: 'MODEL' }),
+        createSlotData({ name: 'clip', type: 'CLIP' }),
+        createSlotData({ name: 'vae', type: 'VAE' }),
+        createSlotData({ name: 'latent', type: 'LATENT' }),
+        createSlotData({ name: 'anything', type: '*' })
+      ]
+      return { slots }
+    },
+    template: `
+      <div class="flex flex-col gap-1">
+        <InputSlot
+          v-for="(slot, i) in slots"
+          :key="i"
+          :slot-data="slot"
+          :index="i"
+        />
+      </div>
+    `
+  })
+}

--- a/src/renderer/extensions/vueNodes/components/InputSlot.stories.ts
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.stories.ts
@@ -4,9 +4,7 @@ import type { INodeSlot } from '@/lib/litegraph/src/interfaces'
 
 import InputSlot from './InputSlot.vue'
 
-function createSlotData(
-  overrides: Partial<INodeSlot> = {}
-): INodeSlot {
+function createSlotData(overrides: Partial<INodeSlot> = {}): INodeSlot {
   return {
     name: 'image',
     type: 'IMAGE',
@@ -23,7 +21,8 @@ const meta: Meta<typeof InputSlot> = {
   decorators: [
     (story) => ({
       components: { story },
-      template: '<div class="w-48 bg-node-component-surface p-2"><story /></div>'
+      template:
+        '<div class="w-48 bg-node-component-surface p-2"><story /></div>'
     })
   ]
 }

--- a/src/renderer/extensions/vueNodes/components/OutputSlot.stories.ts
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.stories.ts
@@ -4,9 +4,7 @@ import type { INodeSlot } from '@/lib/litegraph/src/interfaces'
 
 import OutputSlot from './OutputSlot.vue'
 
-function createSlotData(
-  overrides: Partial<INodeSlot> = {}
-): INodeSlot {
+function createSlotData(overrides: Partial<INodeSlot> = {}): INodeSlot {
   return {
     name: 'IMAGE',
     type: 'IMAGE',
@@ -23,7 +21,8 @@ const meta: Meta<typeof OutputSlot> = {
   decorators: [
     (story) => ({
       components: { story },
-      template: '<div class="w-48 bg-node-component-surface p-2"><story /></div>'
+      template:
+        '<div class="w-48 bg-node-component-surface p-2"><story /></div>'
     })
   ]
 }

--- a/src/renderer/extensions/vueNodes/components/OutputSlot.stories.ts
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.stories.ts
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { INodeSlot } from '@/lib/litegraph/src/interfaces'
+
+import OutputSlot from './OutputSlot.vue'
+
+function createSlotData(
+  overrides: Partial<INodeSlot> = {}
+): INodeSlot {
+  return {
+    name: 'IMAGE',
+    type: 'IMAGE',
+    boundingRect: [0, 0, 0, 0] as const,
+    ...overrides
+  }
+}
+
+const meta: Meta<typeof OutputSlot> = {
+  title: 'VueNodes/OutputSlot',
+  component: OutputSlot,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: '<div class="w-48 bg-node-component-surface p-2"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    slotData: createSlotData({ name: 'IMAGE' }),
+    index: 0
+  }
+}
+
+export const WithLocalizedName: Story = {
+  args: {
+    slotData: createSlotData({
+      name: 'IMAGE',
+      localized_name: 'Imagen'
+    }),
+    index: 0
+  }
+}
+
+export const WithLabel: Story = {
+  args: {
+    slotData: createSlotData({
+      name: 'IMAGE',
+      label: 'Custom Output'
+    }),
+    index: 0
+  }
+}
+
+export const Connected: Story = {
+  args: {
+    slotData: createSlotData({ name: 'IMAGE' }),
+    index: 0,
+    connected: true
+  }
+}
+
+export const Compatible: Story = {
+  args: {
+    slotData: createSlotData({ name: 'IMAGE' }),
+    index: 0,
+    compatible: true
+  }
+}
+
+export const DotOnlyProp: Story = {
+  args: {
+    slotData: createSlotData({ name: 'IMAGE' }),
+    index: 0,
+    dotOnly: true
+  }
+}
+
+export const DotOnlyDerived: Story = {
+  name: 'Dot Only (empty name - reroute)',
+  args: {
+    slotData: createSlotData({ name: '' }),
+    index: 0
+  }
+}
+
+export const DotOnlyNoLocalizedName: Story = {
+  name: 'Dot Only (empty name, no localized_name)',
+  args: {
+    slotData: createSlotData({
+      name: '',
+      localized_name: undefined
+    }),
+    index: 0
+  }
+}
+
+export const DifferentTypes: Story = {
+  render: () => ({
+    components: { OutputSlot },
+    setup() {
+      const slots = [
+        createSlotData({ name: 'IMAGE', type: 'IMAGE' }),
+        createSlotData({ name: 'MODEL', type: 'MODEL' }),
+        createSlotData({ name: 'CLIP', type: 'CLIP' }),
+        createSlotData({ name: 'VAE', type: 'VAE' }),
+        createSlotData({ name: 'LATENT', type: 'LATENT' }),
+        createSlotData({ name: '*', type: '*' })
+      ]
+      return { slots }
+    },
+    template: `
+      <div class="flex flex-col gap-1">
+        <OutputSlot
+          v-for="(slot, i) in slots"
+          :key="i"
+          :slot-data="slot"
+          :index="i"
+        />
+      </div>
+    `
+  })
+}


### PR DESCRIPTION
Closes #8731

## Summary

Issue #8731 requested Storybook stories for the Vue node slot components (`InputSlot` and `OutputSlot`). These components lacked visual documentation and interactive testing coverage in Storybook.

## Changes

- **`src/renderer/extensions/vueNodes/components/InputSlot.stories.ts`** — Added Storybook stories covering default, localized name, label, connected, compatible, error, dot-only (prop and derived), and multiple slot type variants
- **`src/renderer/extensions/vueNodes/components/OutputSlot.stories.ts`** — Added Storybook stories covering default, localized name, label, connected, compatible, dot-only (prop and derived), and multiple slot type variants

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9660-fix-Add-Storybook-stories-for-Vue-node-components-8731-31e6d73d365081509450f809b9667874) by [Unito](https://www.unito.io)
