### PR TITLE
fix: Eliminate WorkspaceStore type casts in browser tests (#8585)

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -35,7 +35,6 @@ import { SubgraphHelper } from './helpers/SubgraphHelper'
 import { ToastHelper } from './helpers/ToastHelper'
 import { WorkflowHelper } from './helpers/WorkflowHelper'
 import type { NodeReference } from './utils/litegraphUtils'
-import type { WorkspaceStore } from '../types/globals'
 
 dotenv.config()
 
@@ -142,8 +141,7 @@ class ConfirmDialog {
     // Wait for workflow service to finish if it's busy
     await this.page.waitForFunction(
       () =>
-        (window.app?.extensionManager as WorkspaceStore | undefined)?.workflow
-          ?.isBusy === false,
+        window.app?.extensionManager?.workflow?.isBusy === false,
       undefined,
       { timeout: 3000 }
     )
@@ -391,7 +389,7 @@ export class ComfyPage {
 
   async setFocusMode(focusMode: boolean) {
     await this.page.evaluate((focusMode) => {
-      ;(window.app!.extensionManager as WorkspaceStore).focusMode = focusMode
+      window.app!.extensionManager.focusMode = focusMode
     }, focusMode)
     await this.nextFrame()
   }

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -140,8 +140,7 @@ class ConfirmDialog {
 
     // Wait for workflow service to finish if it's busy
     await this.page.waitForFunction(
-      () =>
-        window.app?.extensionManager?.workflow?.isBusy === false,
+      () => window.app?.extensionManager?.workflow?.isBusy === false,
       undefined,
       { timeout: 3000 }
     )

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -152,8 +152,7 @@ export class WorkflowsSidebarTab extends SidebarTab {
 
     // Wait for workflow service to finish renaming
     await this.page.waitForFunction(
-      () =>
-        !window.app?.extensionManager?.workflow?.isBusy,
+      () => !window.app?.extensionManager?.workflow?.isBusy,
       undefined,
       { timeout: 3000 }
     )

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -1,6 +1,5 @@
 import type { Locator, Page } from '@playwright/test'
 
-import type { WorkspaceStore } from '../../types/globals'
 import { TestIds } from '../selectors'
 
 class SidebarTab {
@@ -154,8 +153,7 @@ export class WorkflowsSidebarTab extends SidebarTab {
     // Wait for workflow service to finish renaming
     await this.page.waitForFunction(
       () =>
-        !(window.app?.extensionManager as WorkspaceStore | undefined)?.workflow
-          ?.isBusy,
+        !window.app?.extensionManager?.workflow?.isBusy,
       undefined,
       { timeout: 3000 }
     )

--- a/browser_tests/fixtures/components/Topbar.ts
+++ b/browser_tests/fixtures/components/Topbar.ts
@@ -1,7 +1,5 @@
 import type { Locator, Page } from '@playwright/test'
 
-import type { WorkspaceStore } from '../../types/globals'
-
 export class Topbar {
   private readonly menuLocator: Locator
   private readonly menuTrigger: Locator
@@ -87,7 +85,7 @@ export class Topbar {
 
     // Wait for workflow service to finish saving
     await this.page.waitForFunction(
-      () => !(window.app!.extensionManager as WorkspaceStore).workflow.isBusy,
+      () => !window.app!.extensionManager.workflow.isBusy,
       undefined,
       { timeout: 3000 }
     )

--- a/browser_tests/fixtures/helpers/WorkflowHelper.ts
+++ b/browser_tests/fixtures/helpers/WorkflowHelper.ts
@@ -4,7 +4,6 @@ import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
 } from '../../../src/platform/workflow/validation/schemas/workflowSchema'
-import type { WorkspaceStore } from '../../types/globals'
 import type { ComfyPage } from '../ComfyPage'
 
 type FolderStructure = {
@@ -47,9 +46,7 @@ export class WorkflowHelper {
     }
 
     await this.comfyPage.page.evaluate(async () => {
-      await (
-        window.app!.extensionManager as WorkspaceStore
-      ).workflow.syncWorkflows()
+      await window.app!.extensionManager.workflow.syncWorkflows()
     })
 
     // Wait for Vue to re-render the workflow list
@@ -90,24 +87,21 @@ export class WorkflowHelper {
 
   async getUndoQueueSize(): Promise<number | undefined> {
     return this.comfyPage.page.evaluate(() => {
-      const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
-        .activeWorkflow
+      const workflow = window.app!.extensionManager.workflow.activeWorkflow
       return workflow?.changeTracker.undoQueue.length
     })
   }
 
   async getRedoQueueSize(): Promise<number | undefined> {
     return this.comfyPage.page.evaluate(() => {
-      const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
-        .activeWorkflow
+      const workflow = window.app!.extensionManager.workflow.activeWorkflow
       return workflow?.changeTracker.redoQueue.length
     })
   }
 
   async isCurrentWorkflowModified(): Promise<boolean | undefined> {
     return this.comfyPage.page.evaluate(() => {
-      return (window.app!.extensionManager as WorkspaceStore).workflow
-        .activeWorkflow?.isModified
+      return window.app!.extensionManager.workflow.activeWorkflow?.isModified
     })
   }
 

--- a/browser_tests/helpers/actionbar.ts
+++ b/browser_tests/helpers/actionbar.ts
@@ -2,7 +2,6 @@ import type { Locator, Page } from '@playwright/test'
 
 import type { AutoQueueMode } from '../../src/stores/queueStore'
 import { TestIds } from '../fixtures/selectors'
-import type { WorkspaceStore } from '../types/globals'
 
 export class ComfyActionbar {
   public readonly root: Locator
@@ -46,14 +45,13 @@ class ComfyQueueButtonOptions {
 
   public async setMode(mode: AutoQueueMode) {
     await this.page.evaluate((mode) => {
-      ;(window.app!.extensionManager as WorkspaceStore).queueSettings.mode =
-        mode
+      window.app!.extensionManager.queueSettings.mode = mode
     }, mode)
   }
 
   public async getMode() {
     return await this.page.evaluate(() => {
-      return (window.app!.extensionManager as WorkspaceStore).queueSettings.mode
+      return window.app!.extensionManager.queueSettings.mode
     })
   }
 }

--- a/browser_tests/tests/actionbar.spec.ts
+++ b/browser_tests/tests/actionbar.spec.ts
@@ -4,7 +4,6 @@ import { expect, mergeTests } from '@playwright/test'
 import type { StatusWsMessage } from '../../src/schemas/apiSchema'
 import { comfyPageFixture } from '../fixtures/ComfyPage'
 import { webSocketFixture } from '../fixtures/ws'
-import type { WorkspaceStore } from '../types/globals'
 
 const test = mergeTests(comfyPageFixture, webSocketFixture)
 
@@ -55,9 +54,7 @@ test.describe('Actionbar', { tag: '@ui' }, () => {
         )
         node!.widgets![0].value = value
 
-        ;(
-          window.app!.extensionManager as WorkspaceStore
-        ).workflow.activeWorkflow?.changeTracker.checkState()
+        window.app!.extensionManager.workflow.activeWorkflow?.changeTracker.checkState()
       }, value)
     }
 

--- a/browser_tests/tests/browserTabTitle.spec.ts
+++ b/browser_tests/tests/browserTabTitle.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-import type { WorkspaceStore } from '../types/globals'
 
 test.describe('Browser tab title', { tag: '@smoke' }, () => {
   test.describe('Beta Menu', () => {
@@ -11,7 +10,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
 
     test('Can display workflow name', async ({ comfyPage }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
-        return (window.app!.extensionManager as WorkspaceStore).workflow
+        return window.app!.extensionManager.workflow
           .activeWorkflow?.filename
       })
       await expect
@@ -25,7 +24,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
       comfyPage
     }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
-        return (window.app!.extensionManager as WorkspaceStore).workflow
+        return window.app!.extensionManager.workflow
           .activeWorkflow?.filename
       })
       expect(await comfyPage.page.title()).toBe(`${workflowName} - ComfyUI`)
@@ -40,9 +39,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
 
       // Delete the saved workflow for cleanup.
       await comfyPage.page.evaluate(async () => {
-        return (
-          window.app!.extensionManager as WorkspaceStore
-        ).workflow.activeWorkflow?.delete()
+        return window.app!.extensionManager.workflow.activeWorkflow?.delete()
       })
     })
   })

--- a/browser_tests/tests/browserTabTitle.spec.ts
+++ b/browser_tests/tests/browserTabTitle.spec.ts
@@ -10,8 +10,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
 
     test('Can display workflow name', async ({ comfyPage }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
-        return window.app!.extensionManager.workflow
-          .activeWorkflow?.filename
+        return window.app!.extensionManager.workflow.activeWorkflow?.filename
       })
       await expect
         .poll(() => comfyPage.page.title())
@@ -24,8 +23,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
       comfyPage
     }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
-        return window.app!.extensionManager.workflow
-          .activeWorkflow?.filename
+        return window.app!.extensionManager.workflow.activeWorkflow?.filename
       })
       expect(await comfyPage.page.title()).toBe(`${workflowName} - ComfyUI`)
 

--- a/browser_tests/tests/colorPalette.spec.ts
+++ b/browser_tests/tests/colorPalette.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-import type { WorkspaceStore } from '../types/globals'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
@@ -179,9 +178,7 @@ test.describe('Color Palette', { tag: ['@screenshot', '@settings'] }, () => {
 
   test('Can add custom color palette', async ({ comfyPage }) => {
     await comfyPage.page.evaluate(async (p) => {
-      await (
-        window.app!.extensionManager as WorkspaceStore
-      ).colorPalette.addCustomColorPalette(p)
+      await window.app!.extensionManager.colorPalette.addCustomColorPalette(p)
     }, customColorPalettes.obsidian_dark)
     expect(await comfyPage.toast.getToastErrorCount()).toBe(0)
 

--- a/browser_tests/types/extensionManager.d.ts
+++ b/browser_tests/types/extensionManager.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Module augmentation that extends the public ExtensionManager interface
+ * with internal properties exposed by the WorkspaceStore.
+ *
+ * This augmentation is scoped to browser_tests (via browser_tests/tsconfig.json)
+ * and allows tests to access store internals without type casts.
+ */
+import type { useColorPaletteService } from '@/services/colorPaletteService'
+import type { useQueueSettingsStore } from '@/stores/queueStore'
+import type { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+declare module '@/types/extensionTypes' {
+  interface ExtensionManager {
+    workflow: ReturnType<typeof useWorkflowStore>
+    queueSettings: ReturnType<typeof useQueueSettingsStore>
+    colorPalette: ReturnType<typeof useColorPaletteService>
+    focusMode: boolean
+  }
+}

--- a/browser_tests/types/globals.d.ts
+++ b/browser_tests/types/globals.d.ts
@@ -53,4 +53,3 @@ declare global {
   const LiteGraph: LiteGraphGlobal | undefined
   const LGraphBadge: typeof LGraphBadge | undefined
 }
-

--- a/browser_tests/types/globals.d.ts
+++ b/browser_tests/types/globals.d.ts
@@ -4,7 +4,6 @@ import type { LGraphBadge } from '@/lib/litegraph/src/LGraphBadge'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { LiteGraphGlobal } from '@/lib/litegraph/src/LiteGraphGlobal'
 import type { ComfyApp } from '@/scripts/app'
-import type { useWorkspaceStore } from '@/stores/workspaceStore'
 
 /**
  * Helper type for accessing nodes by ID in browser tests.
@@ -55,15 +54,3 @@ declare global {
   const LGraphBadge: typeof LGraphBadge | undefined
 }
 
-/**
- * Internal store type for browser test access.
- * Used to access properties not exposed via the public ExtensionManager interface.
- *
- * @example
- * ```ts
- * await page.evaluate(() => {
- *   ;(window.app!.extensionManager as WorkspaceStore).workflow.syncWorkflows()
- * })
- * ```
- */
-export type WorkspaceStore = ReturnType<typeof useWorkspaceStore>


### PR DESCRIPTION
Closes #8585

## Summary

Browser tests used `as WorkspaceStore` type casts to access internal store properties (workflow, queueSettings, colorPalette, focusMode) on `window.app.extensionManager`. This bypassed type safety and was fragile. Instead of casting, this PR uses TypeScript module augmentation to extend the `ExtensionManager` interface with the internal properties, scoped only to browser tests.

## Changes

- **`browser_tests/types/extensionManager.d.ts`** (new): Module augmentation that extends `ExtensionManager` from `@/types/extensionTypes` with `workflow`, `queueSettings`, `colorPalette`, and `focusMode` properties using their actual store return types.
- **`browser_tests/types/globals.d.ts`**: Removed the `WorkspaceStore` type alias and its import, as it is no longer needed.
- **`browser_tests/fixtures/ComfyPage.ts`**: Removed `WorkspaceStore` import and all `as WorkspaceStore` casts.
- **`browser_tests/fixtures/components/SidebarTab.ts`**: Removed `WorkspaceStore` import and cast.
- **`browser_tests/fixtures/components/Topbar.ts`**: Removed `WorkspaceStore` import and cast.
- **`browser_tests/fixtures/helpers/WorkflowHelper.ts`**: Removed `WorkspaceStore` import and all casts.
- **`browser_tests/helpers/actionbar.ts`**: Removed `WorkspaceStore` import and casts.
- **`browser_tests/tests/actionbar.spec.ts`**: Removed `WorkspaceStore` import and cast.
- **`browser_tests/tests/browserTabTitle.spec.ts`**: Removed `WorkspaceStore` import and casts.
- **`browser_tests/tests/colorPalette.spec.ts`**: Removed `WorkspaceStore` import and cast.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9661-fix-Eliminate-WorkspaceStore-type-casts-in-browser-tests-8585-31e6d73d3650810db7dfce8b519185a7) by [Unito](https://www.unito.io)
