### PR TITLE
fix: Add a tooltip to account for assets with really long names.

### DIFF
--- a/src/platform/workflow/sharing/components/AssetSectionList.vue
+++ b/src/platform/workflow/sharing/components/AssetSectionList.vue
@@ -46,7 +46,10 @@
                 onThumbnailError($event.name, $event.previewUrl)
               "
             />
-            <span class="truncate text-xs text-base-foreground">
+            <span
+              v-tooltip="buildTooltipConfig(item.name)"
+              class="truncate text-xs text-base-foreground"
+            >
               {{ item.name }}
             </span>
             <span
@@ -74,6 +77,7 @@ import ShareAssetThumbnail from '@/platform/workflow/sharing/components/ShareAss
 import { useAssetSections } from '@/platform/workflow/sharing/composables/useAssetSections'
 import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@/utils/tailwindUtil'
+import { buildTooltipConfig } from '@/composables/useTooltipConfig'
 
 const { items } = defineProps<{
   items: AssetInfo[]


### PR DESCRIPTION
## Summary

Simple tooltip, default show delay.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9665-fix-Add-a-tooltip-to-account-for-assets-with-really-long-names-31e6d73d3650811f9057d1ec41e761b6) by [Unito](https://www.unito.io)
