### PR TITLE
feat: add DropZone Storybook coverage for file upload states

### DIFF
--- a/src/renderer/extensions/linearMode/DropZone.stories.ts
+++ b/src/renderer/extensions/linearMode/DropZone.stories.ts
@@ -1,0 +1,85 @@
+import type {
+  ComponentPropsAndSlots,
+  Meta,
+  StoryObj
+} from '@storybook/vue3-vite'
+
+import DropZone from './DropZone.vue'
+
+type StoryArgs = ComponentPropsAndSlots<typeof DropZone>
+
+const baseIndicator = {
+  label: 'Click to browse or drag an image',
+  iconClass: 'icon-[lucide--image]'
+}
+
+const renderStory = (args: StoryArgs) => ({
+  components: { DropZone },
+  setup() {
+    const onDragOver = () => true
+    const onDragDrop = async () => true
+    return { args, onDragOver, onDragDrop }
+  },
+  template: `
+    <DropZone
+      v-bind="args"
+      :on-drag-over="onDragOver"
+      :on-drag-drop="onDragDrop"
+    />
+  `
+})
+
+const meta: Meta<StoryArgs> = {
+  title: 'Components/LinearMode/DropZone',
+  component: DropZone,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: [
+          'Linear mode drag-and-drop target with a file upload indicator.',
+          'The linked Figma reference defines two states for this element: Default and Hover.',
+          'These stories use `forceHovered` to preview the hover treatment without requiring a live drag event.'
+        ].join(' ')
+      }
+    }
+  },
+  argTypes: {
+    onDragOver: { table: { disable: true } },
+    onDragDrop: { table: { disable: true } },
+    dropIndicator: { control: false },
+    forceHovered: {
+      control: 'boolean',
+      description: 'Preview-only override for the drag-hover visual state.'
+    }
+  },
+  args: {
+    forceHovered: false,
+    dropIndicator: baseIndicator
+  },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: `
+        <div class="w-[440px] rounded-xl bg-component-node-background p-4">
+          <story />
+        </div>
+      `
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: renderStory
+}
+
+export const Hover: Story = {
+  args: {
+    forceHovered: true
+  },
+  render: renderStory
+}

--- a/src/renderer/extensions/linearMode/DropZone.vue
+++ b/src/renderer/extensions/linearMode/DropZone.vue
@@ -1,19 +1,25 @@
 <script setup lang="ts">
 import { useDropZone } from '@vueuse/core'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { cn } from '@/utils/tailwindUtil'
 
-const props = defineProps<{
-  onDragOver?: (e: DragEvent) => boolean
-  onDragDrop?: (e: DragEvent) => Promise<boolean> | boolean
-  dropIndicator?: {
-    iconClass?: string
-    imageUrl?: string
-    label?: string
-    onClick?: (e: MouseEvent) => void
+const props = withDefaults(
+  defineProps<{
+    onDragOver?: (e: DragEvent) => boolean
+    onDragDrop?: (e: DragEvent) => Promise<boolean> | boolean
+    dropIndicator?: {
+      iconClass?: string
+      imageUrl?: string
+      label?: string
+      onClick?: (e: MouseEvent) => void
+    }
+    forceHovered?: boolean
+  }>(),
+  {
+    forceHovered: false
   }
-}>()
+)
 
 const dropZoneRef = ref<HTMLElement | null>(null)
 const canAcceptDrop = ref(false)
@@ -37,39 +43,69 @@ const { isOverDropZone } = useDropZone(dropZoneRef, {
     canAcceptDrop.value = false
   }
 })
+
+const isHovered = computed(
+  () => props.forceHovered || (canAcceptDrop.value && isOverDropZone.value)
+)
+const indicatorTag = computed(() =>
+  props.dropIndicator?.onClick ? 'button' : 'div'
+)
 </script>
 <template>
   <div
     v-if="onDragOver && onDragDrop"
     ref="dropZoneRef"
+    data-slot="drop-zone"
     :class="
       cn(
-        'rounded-lg ring-primary-500 ring-inset',
-        canAcceptDrop && isOverDropZone && 'bg-primary-500/10 ring-4'
+        'rounded-lg transition-colors',
+        isHovered && 'bg-component-node-widget-background-hovered'
       )
     "
   >
     <slot />
-    <div
+    <component
+      :is="indicatorTag"
       v-if="dropIndicator"
+      :type="dropIndicator?.onClick ? 'button' : undefined"
+      data-slot="drop-zone-indicator"
       :class="
         cn(
-          'm-3 flex h-25 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border-subtle py-2',
+          'm-3 block w-[calc(100%-1.5rem)] appearance-none overflow-hidden rounded-lg border border-node-component-border bg-transparent p-1 text-left text-component-node-foreground-secondary transition-colors',
           dropIndicator?.onClick && 'cursor-pointer'
         )
       "
       @click.prevent="dropIndicator?.onClick?.($event)"
     >
-      <img
-        v-if="dropIndicator?.imageUrl"
-        class="h-23"
-        :src="dropIndicator?.imageUrl"
-      />
-      <template v-else>
-        <span v-if="dropIndicator.label" v-text="dropIndicator.label" />
-        <i v-if="dropIndicator.iconClass" :class="dropIndicator.iconClass" />
-      </template>
-    </div>
+      <div
+        :class="
+          cn(
+            'flex min-h-23 w-full flex-col items-center justify-center gap-2 rounded-[7px] p-6 text-center text-sm/tight transition-colors',
+            isHovered &&
+              !dropIndicator?.imageUrl &&
+              'border border-dashed border-component-node-foreground-secondary bg-component-node-widget-background-hovered'
+          )
+        "
+      >
+        <img
+          v-if="dropIndicator?.imageUrl"
+          class="max-h-23 rounded-md object-contain"
+          :src="dropIndicator?.imageUrl"
+        />
+        <template v-else>
+          <span v-if="dropIndicator.label" v-text="dropIndicator.label" />
+          <i
+            v-if="dropIndicator.iconClass"
+            :class="
+              cn(
+                'size-4 text-component-node-foreground-secondary',
+                dropIndicator.iconClass
+              )
+            "
+          />
+        </template>
+      </div>
+    </component>
   </div>
   <slot v-else />
 </template>


### PR DESCRIPTION
## Summary
- align the linear-mode `DropZone` upload indicator with the Figma file upload states
- add a co-located Storybook story for the default and hover variants
- add a `forceHovered` preview prop so Storybook can render the hover state deterministically

## Validation
- `pnpm typecheck` (run in the original workspace with dependencies installed)
- `pnpm lint` (passes with one pre-existing warning in `src/lib/litegraph/src/ContextMenu.ts`)
- Storybook smoke check is currently blocked by an existing workspace issue: `vite-plugin-inspect` fails with `Can not found environment context for client`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9688-feat-add-DropZone-Storybook-coverage-for-file-upload-states-31f6d73d3650816cbf76f89e4223f7c1) by [Unito](https://www.unito.io)
