### PR TITLE
Redirect authenticated users from signup page to cloud

### DIFF
--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -31,7 +31,19 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         path: 'signup',
         name: 'cloud-signup',
         component: () =>
-          import('@/platform/cloud/onboarding/CloudSignupView.vue')
+          import('@/platform/cloud/onboarding/CloudSignupView.vue'),
+        beforeEnter: async (to, _from, next) => {
+          if (!to.query.switchAccount) {
+            const { useCurrentUser } =
+              await import('@/composables/auth/useCurrentUser')
+            const { isLoggedIn } = useCurrentUser()
+
+            if (isLoggedIn.value) {
+              return next({ name: 'cloud-user-check' })
+            }
+          }
+          next()
+        }
       },
       {
         path: 'forgot-password',


### PR DESCRIPTION
## Summary

When a logged-in user navigates to `/cloud/signup`, they are now redirected to `cloud-user-check` (which handles survey or main page routing).

This mirrors the existing `beforeEnter` guard on the `cloud-login` route. The `switchAccount` query param bypass is preserved for consistency.

## Changes

- Added `beforeEnter` guard to the `cloud-signup` route in `onboardingCloudRoutes.ts`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9691-Redirect-authenticated-users-from-signup-page-to-cloud-31f6d73d365081e08cb5c3360a862a37) by [Unito](https://www.unito.io)
