### PR TITLE
fix: Unify UserAvatar compact class to size-full to prevent width shift when toggling workspaces (#9689)

### DIFF
--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -30,7 +30,7 @@
         <UserAvatar
           v-else
           :photo-url="photoURL"
-          :class="compact && 'h-full w-auto'"
+          :class="compact && 'size-full'"
         />
 
         <i v-if="showArrow" class="icon-[lucide--chevron-down] size-4 px-1" />


### PR DESCRIPTION
Closes #9689

## Summary

When toggling between workspace mode and user avatar mode in the topbar, the `UserAvatar` component used `h-full w-auto` for its compact class while the wrapper `div` and `WorkspaceProfilePic` both used `size-full`. The `w-auto` caused a width shift during the toggle because the avatar's width wasn't constrained to match its container, unlike the other elements.

## Changes

- **`src/components/topbar/CurrentUserButton.vue`**: Changed the `UserAvatar` compact class from `h-full w-auto` to `size-full` to match the consistent sizing used by the wrapper div and `WorkspaceProfilePic`, preventing the width shift on toggle.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9692-fix-Unify-UserAvatar-compact-class-to-size-full-to-prevent-width-shift-when-toggling-wor-31f6d73d36508137bc71cf0ed70f7101) by [Unito](https://www.unito.io)
