### PR TITLE
fix: load API format workflows with missing node types

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1830,7 +1830,6 @@ export class ComfyApp {
     )
     if (missingNodeTypes.length) {
       this.showMissingNodesError(missingNodeTypes.map((t) => t.class_type))
-      return
     }
 
     const ids = Object.keys(apiData)


### PR DESCRIPTION
## Summary

`loadApiJson` early-returns when missing node types are detected, preventing the entire API-format workflow from loading onto the canvas.

## Changes

- **What**: Remove early `return` in `loadApiJson` so missing nodes are skipped while the rest of the workflow loads normally, consistent with how `loadGraphData` handles missing nodes in standard workflow format.

## Review Focus

The existing code already handles missing nodes gracefully:
- `LiteGraph.createNode()` returns `null` for unregistered types
- `if (!node) continue` skips missing nodes during graph construction
- `if (!fromNode) continue` skips connections to missing nodes
- `if (!node) return` skips input processing for missing nodes

The early `return` was unnecessarily preventing the entire load. The warning modal is still shown via `showMissingNodesError`.

## Test workflow & screen recording
[04wan2.2smoothmix图生视频 (3).json](https://github.com/user-attachments/files/25858354/04wan2.2smoothmix.3.json)
[screen-capture.webm](https://github.com/user-attachments/assets/9c396f80-fff1-4d17-882c-35ada86542c1)
