### PR TITLE
fix: Add explicit wait for queue size in 'shows selection toolbox' screenshot test (#9703)

### DIFF
--- a/browser_tests/tests/selectionToolbox.spec.ts
+++ b/browser_tests/tests/selectionToolbox.spec.ts
@@ -40,6 +40,8 @@ test.describe('Selection Toolbox', { tag: ['@screenshot', '@ui'] }, () => {
 
     // Selection toolbox should be visible with multiple nodes selected
     await expect(comfyPage.selectionToolbox).toBeVisible()
+    // Wait for the canvas render queue to settle before taking the screenshot
+    await comfyPage.nextFrame()
     // Border is now drawn on canvas, check via screenshot
     await expect(comfyPage.canvas).toHaveScreenshot(
       'selection-toolbox-multiple-nodes-border.png'


### PR DESCRIPTION
Closes #9703

## Summary

The `shows selection toolbox` Playwright screenshot test was flaky because the canvas screenshot was taken before the render queue had fully settled after selecting multiple nodes. This caused intermittent differences in the captured screenshot.

## Changes

- **`browser_tests/tests/selectionToolbox.spec.ts`**: Added `await comfyPage.nextFrame()` call after confirming the selection toolbox is visible and before taking the canvas screenshot. This ensures the canvas render queue has settled, producing consistent screenshots.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9709-fix-Add-explicit-wait-for-queue-size-in-shows-selection-toolbox-screenshot-test-9703-31f6d73d365081fba379ce421d3ea078) by [Unito](https://www.unito.io)
