### PR TITLE
fix: add text color and increase size for nav badge count

### DIFF
--- a/src/components/widget/nav/NavItem.vue
+++ b/src/components/widget/nav/NavItem.vue
@@ -25,7 +25,7 @@
       :label="String(badge)"
       severity="contrast"
       variant="circle"
-      class="ml-auto"
+      class="ml-auto min-h-5 min-w-5 px-1 text-base-background"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Fix nav sidebar badge count not visible due to missing text color, and increase badge size for better readability.

## Changes

- **What**: Added explicit `text-base-background` color and increased min size (`min-h-5 min-w-5`) with padding to the StatusBadge in NavItem so the count number is visible in dark mode.

## Review Focus

The parent NavItem div sets `text-base-foreground` which was overriding the StatusBadge's contrast severity text color, making the count invisible against the badge background.

## As-is
<img width="1607" height="1076" alt="스크린샷 2026-03-10 오후 9 28 17" src="https://github.com/user-attachments/assets/f34de3fa-8930-4328-ba2b-03990a5e6f22" />

## To-be
<img width="1607" height="1058" alt="스크린샷 2026-03-10 오후 9 34 48" src="https://github.com/user-attachments/assets/e420c359-78b7-4f5d-9d03-a600c51b880c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9713-fix-add-text-color-and-increase-size-for-nav-badge-count-31f6d73d36508114874be2e31627099a) by [Unito](https://www.unito.io)
