### PR TITLE
test: preview env smoke test

### DIFF
--- a/.github/workflows/cloud-dispatch-build.yaml
+++ b/.github/workflows/cloud-dispatch-build.yaml
@@ -55,13 +55,13 @@ jobs:
             REF="${PR_HEAD_SHA}"
             BRANCH="${PR_HEAD_REF}"
 
-            # Derive variant from labels
-            VARIANT="gpu"
+            # Derive variant from labels (default to cpu for frontend-only previews)
+            VARIANT="cpu"
             if [ "${ACTION}" = "labeled" ]; then
-              [ "${LABEL_NAME}" = "preview-cpu" ] && VARIANT="cpu"
+              [ "${LABEL_NAME}" = "preview-gpu" ] && VARIANT="gpu"
             else
               # synchronize — check existing labels on the PR
-              echo "${PR_LABELS}" | grep -q '"preview-cpu"' && VARIANT="cpu"
+              echo "${PR_LABELS}" | grep -q '"preview-gpu"' && VARIANT="gpu"
             fi
           else
             REF="${GITHUB_SHA}"

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>ComfyUI</title>
+    <title>ComfyUI (Preview Environment Test)</title>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, user-scalable=no"

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>ComfyUI (Preview Environment Test)</title>
+    <title>ComfyUI (Preview v2)</title>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, user-scalable=no"


### PR DESCRIPTION
Smoke test for preview environments. Changes the page title to include '(Preview Environment Test)' — should be visible in the browser tab at fe-pr-{N}.testenvs.comfy.org once deployed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9716-test-preview-env-smoke-test-31f6d73d36508154af11f6de2aa654c3) by [Unito](https://www.unito.io)
