### PR TITLE
fix: default frontend preview variant to cpu

### DIFF
--- a/.github/workflows/cloud-dispatch-build.yaml
+++ b/.github/workflows/cloud-dispatch-build.yaml
@@ -55,14 +55,9 @@ jobs:
             REF="${PR_HEAD_SHA}"
             BRANCH="${PR_HEAD_REF}"
 
-            # Derive variant from labels
-            VARIANT="gpu"
-            if [ "${ACTION}" = "labeled" ]; then
-              [ "${LABEL_NAME}" = "preview-cpu" ] && VARIANT="cpu"
-            else
-              # synchronize — check existing labels on the PR
-              echo "${PR_LABELS}" | grep -q '"preview-cpu"' && VARIANT="cpu"
-            fi
+            # Derive variant from all PR labels (default to cpu for frontend-only previews)
+            VARIANT="cpu"
+            echo "${PR_LABELS}" | grep -q '"preview-gpu"' && VARIANT="gpu"
           else
             REF="${GITHUB_SHA}"
             BRANCH="${GITHUB_REF_NAME}"


### PR DESCRIPTION
Frontend previews don't need GPU resources. Default to cpu variant and only use gpu when the `preview-gpu` label is explicitly added.

The plain `preview` label now deploys a cpu-only ephemeral env.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9718-fix-default-frontend-preview-variant-to-cpu-31f6d73d3650811f878cd5dd5ad3881c) by [Unito](https://www.unito.io)
