### PR TITLE
fix: cloud login page stuck on splash loader for unauthenticated users

### DIFF
--- a/src/platform/cloud/onboarding/components/CloudLayoutView.vue
+++ b/src/platform/cloud/onboarding/components/CloudLayoutView.vue
@@ -8,9 +8,14 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 
 import GlobalToast from '@/components/toast/GlobalToast.vue'
 
 import CloudTemplate from './CloudTemplate.vue'
+
+onMounted(() => {
+  document.getElementById('splash-loader')?.remove()
+})
 </script>


### PR DESCRIPTION
## Summary

Fix cloud login page showing only the splash loader (wave SVG) instead of the login form when the user is not authenticated.

## Changes

- **What**: Remove splash loader on `CloudLayoutView` mount. Cloud onboarding pages do not use workspace initialization, so the `workspaceStore.spinner` transition (`true→false`) that normally removes the splash never occurs — leaving it visible indefinitely.