### PR TITLE
fix: resolve empty combo options for promoted subgraph widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -215,13 +215,15 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     // Get value from store (falls back to undefined if not registered)
     const value = widgetState?.value as WidgetValue
 
-    // Build options from store state, with disabled override for
-    // slot-linked widgets or widgets with disabled state (e.g. display-only)
-    const storeOptions = widgetState?.options ?? {}
+    // PromotedWidgetView is not a BaseWidget and never registers in the
+    // widgetValueStore, so read options from the widget directly.
+    const baseOptions = isPromotedView
+      ? (widget.options ?? {})
+      : (widgetState?.options ?? {})
     const isDisabled = slotMetadata?.linked || widgetState?.disabled
     const widgetOptions = isDisabled
-      ? { ...storeOptions, disabled: true }
-      : storeOptions
+      ? { ...baseOptions, disabled: true }
+      : baseOptions
 
     const borderStyle =
       graphId &&


### PR DESCRIPTION
## Summary

Investigating subgraph combo/dropdown showing "No available options" when exposed via SubgraphInput socket.

## Changes

- **What**: Read widget options directly from `widget.options` for promoted views instead of from the store
- **Status**: **Needs runtime verification** — initial analysis found that `SafeWidgetData.options` strips `values` from widget options (only keeps `canvasOnly`, `advanced`, `hidden`, `read_only`). The actual combo `values` should come from `widgetValueStore` via concrete widget lookup. Need to verify whether the store lookup is finding the correct concrete widget state.
- **Root cause (under investigation)**: PR #9282 replaced the old `proxyWidget.ts` shallow-copy with `PromotedWidgetView`. The promoted widget resolves its store key via `${subgraphId}:${sourceNodeId}` + `sourceWidgetName`. If this key doesn't match the key used when the concrete widget called `BaseWidget.setNodeId()`, the store lookup returns `undefined` → options = `{}` → empty combo values.
- **Broken since**: v1.40.8 (PR #9282)
- **Working in**: v1.40.0

## Review Focus

- Need to verify runtime behavior: does `widgetValueStore.getWidget()` find the correct concrete widget state for promoted combo widgets?
- If the store lookup works, the original `widgetState?.options` already contains `values` (registered via `BaseWidget.setNodeId` with Proxy-wrapped options). In that case, a different fix path is needed.

Fixes #9012

## Reproduction

1. Add a node with a combo widget (e.g. KSampler with `sampler_name` dropdown)
2. Convert it to a subgraph
3. Inside the subgraph, expose the combo widget via SubgraphInput socket
4. Navigate to parent graph → promoted combo shows "No available options"