### PR TITLE
fix: test(assetsStore): improve test comprehensiveness and avoid inline type redefinition (#9728)

### DIFF
--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -71,46 +71,15 @@ vi.mock('@/stores/modelToNodeStore', () => ({
   })
 }))
 
-// Mock TaskItemImpl
-vi.mock('@/stores/queueStore', () => ({
-  TaskItemImpl: class {
-    public flatOutputs: Array<{
-      supportsPreview: boolean
-      filename: string
-      subfolder: string
-      type: string
-      url: string
-    }>
-    public previewOutput:
-      | {
-          supportsPreview: boolean
-          filename: string
-          subfolder: string
-          type: string
-          url: string
-        }
-      | undefined
-    public jobId: string
-
-    constructor(public job: JobListItem) {
-      this.jobId = job.id
-      this.flatOutputs = [
-        {
-          supportsPreview: true,
-          filename: 'test.png',
-          subfolder: '',
-          type: 'output',
-          url: 'http://test.com/test.png'
-        }
-      ]
-      this.previewOutput = this.flatOutputs[0]
-    }
-
-    get previewableOutputs() {
-      return this.flatOutputs.filter((o) => o.supportsPreview)
-    }
+// Use the real TaskItemImpl and ResultItemImpl from queueStore
+// to avoid redefining types and filtering logic inline.
+vi.mock('@/stores/queueStore', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return {
+    TaskItemImpl: original.TaskItemImpl,
+    ResultItemImpl: original.ResultItemImpl
   }
-}))
+})
 
 // Mock asset mappers - add unique timestamps
 vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
@@ -140,20 +109,29 @@ describe('assetsStore - Refactored (Option A)', () => {
   let store: ReturnType<typeof useAssetsStore>
 
   // Helper function to create mock job items
-  const createMockJobItem = (index: number): JobListItem => ({
+  const createMockJobItem = (
+    index: number,
+    overrides?: {
+      status?: JobListItem['status']
+      preview_output?: JobListItem['preview_output'] | null
+    }
+  ): JobListItem => ({
     id: `prompt_${index}`,
-    status: 'completed',
+    status: overrides?.status ?? 'completed',
     create_time: 1000 + index,
     update_time: 1000 + index,
     last_state_update: 1000 + index,
     priority: 1000 + index,
-    preview_output: {
-      filename: `output_${index}.png`,
-      subfolder: '',
-      type: 'output',
-      nodeId: 'node_1',
-      mediaType: 'images'
-    }
+    preview_output:
+      overrides?.preview_output === null
+        ? undefined
+        : (overrides?.preview_output ?? {
+            filename: `output_${index}.png`,
+            subfolder: '',
+            type: 'output',
+            nodeId: 'node_1',
+            mediaType: 'images'
+          })
   })
 
   beforeEach(() => {
@@ -492,6 +470,140 @@ describe('assetsStore - Refactored (Option A)', () => {
       expect(asset.user_metadata).toHaveProperty('outputCount')
       expect(asset.user_metadata).toHaveProperty('allOutputs')
       expect(Array.isArray(asset.user_metadata!.allOutputs)).toBe(true)
+    })
+  })
+
+  describe('Media Type Filtering', () => {
+    it('should include image outputs as previewable', async () => {
+      const mockHistory = [
+        createMockJobItem(0, {
+          preview_output: {
+            filename: 'photo.png',
+            subfolder: '',
+            type: 'output',
+            nodeId: 'node_1',
+            mediaType: 'images'
+          }
+        })
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(1)
+    })
+
+    it('should include video outputs as previewable', async () => {
+      const mockHistory = [
+        createMockJobItem(0, {
+          preview_output: {
+            filename: 'clip.mp4',
+            subfolder: '',
+            type: 'output',
+            nodeId: 'node_1',
+            mediaType: 'video'
+          }
+        })
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(1)
+    })
+
+    it('should include audio outputs as previewable', async () => {
+      const mockHistory = [
+        createMockJobItem(0, {
+          preview_output: {
+            filename: 'sound.mp3',
+            subfolder: '',
+            type: 'output',
+            nodeId: 'node_1',
+            mediaType: 'audio'
+          }
+        })
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(1)
+    })
+
+    it('should include 3D outputs as previewable', async () => {
+      const mockHistory = [
+        createMockJobItem(0, {
+          preview_output: {
+            filename: 'model.glb',
+            subfolder: '',
+            type: 'output',
+            nodeId: 'node_1',
+            mediaType: '3d'
+          }
+        })
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(1)
+    })
+
+    it('should skip non-previewable outputs (e.g., text files)', async () => {
+      const mockHistory = [
+        createMockJobItem(0, {
+          preview_output: {
+            filename: 'data.txt',
+            subfolder: '',
+            type: 'output',
+            nodeId: 'node_1',
+            mediaType: 'text'
+          }
+        })
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(0)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should skip jobs without preview_output', async () => {
+      const mockHistory = [
+        createMockJobItem(0, { preview_output: null }),
+        createMockJobItem(1)
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(1)
+    })
+
+    it('should skip non-completed jobs', async () => {
+      const mockHistory = [
+        createMockJobItem(0, { status: 'failed' }),
+        createMockJobItem(1, { status: 'cancelled' }),
+        createMockJobItem(2, { status: 'pending' }),
+        createMockJobItem(3)
+      ]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(1)
+    })
+
+    it('should handle empty history response', async () => {
+      vi.mocked(api.getHistory).mockResolvedValue([])
+
+      await store.updateHistory()
+
+      expect(store.historyAssets).toHaveLength(0)
+      expect(store.hasMoreHistory).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Closes #9728

## Summary

The `assetsStore.test.ts` file contained an inline redefinition of `TaskItemImpl` in the mock that duplicated types and filtering logic from the real implementation. This caused the tests to diverge from actual behavior and made them fragile to changes in the source. The tests also lacked coverage for edge cases like non-completed jobs, missing preview outputs, and different media type filtering.

## Changes

- **`src/stores/assetsStore.test.ts`**: Replaced the inline `TaskItemImpl` mock class with an async `importOriginal()` call that imports the real `TaskItemImpl` and `ResultItemImpl` from `queueStore`, eliminating type redefinition and keeping tests aligned with production behavior.
- **`src/stores/assetsStore.test.ts`**: Extended `createMockJobItem` helper to accept `status` and `preview_output` overrides for more flexible test scenarios.
- **`src/stores/assetsStore.test.ts`**: Added new test sections:
  - **Media Type Filtering**: Tests for images, video, audio, 3D, and non-previewable outputs.
  - **Edge Cases**: Tests for jobs without preview output, non-completed job statuses, and empty history responses.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9731-fix-test-assetsStore-improve-test-comprehensiveness-and-avoid-inline-type-redefinition-3206d73d365081dc87acdd028cc1af86) by [Unito](https://www.unito.io)
