### PR TITLE
fix: update PostHog api_host fallback domain

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -81,7 +81,7 @@ describe('PostHogTelemetryProvider', () => {
       await vi.dynamicImportSettled()
 
       expect(hoisted.mockInit).toHaveBeenCalledWith('phc_test_token', {
-        api_host: 'https://ph.comfy.org',
+        api_host: 'https://t.comfy.org',
         autocapture: false,
         capture_pageview: false,
         capture_pageleave: false,

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -101,7 +101,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
             this.posthog = posthogModule.default
             this.posthog!.init(apiKey, {
               api_host:
-                window.__CONFIG__?.posthog_api_host || 'https://ph.comfy.org',
+                window.__CONFIG__?.posthog_api_host || 'https://t.comfy.org',
               autocapture: false,
               capture_pageview: false,
               capture_pageleave: false,


### PR DESCRIPTION
Update the PostHog `api_host` fallback from `ph.comfy.org` to `t.comfy.org`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9733-fix-update-PostHog-api_host-fallback-domain-3206d73d36508107a5d1e1fdfd3ccaec) by [Unito](https://www.unito.io)
