### PR TITLE
fix: show all QwenVL models in asset browser dropdown

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -237,68 +237,10 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
     quickRegister('SEEDVR2', 'SeedVR2LoadDiTModel', 'model')
 
     // Qwen VL vision-language models (comfyui-qwen-vl)
-    // Register each specific path to avoid LLM fallback catching unrelated models
-    // (e.g., LLM/llava-* should NOT map to AILab_QwenVL)
-    quickRegister(
-      'LLM/Qwen-VL/Qwen2.5-VL-3B-Instruct',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen2.5-VL-7B-Instruct',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-2B-Instruct',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-2B-Thinking',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-4B-Instruct',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-4B-Thinking',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-8B-Instruct',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-8B-Thinking',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-32B-Instruct',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-VL-32B-Thinking',
-      'AILab_QwenVL',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-0.6B',
-      'AILab_QwenVL_PromptEnhancer',
-      'model_name'
-    )
-    quickRegister(
-      'LLM/Qwen-VL/Qwen3-4B-Instruct-2507',
-      'AILab_QwenVL_PromptEnhancer',
-      'model_name'
-    )
+    // Use parent path so getCategoryForNodeType returns a single category that
+    // includes all subdirectory models via hierarchical fallback in the asset API
+    quickRegister('LLM/Qwen-VL', 'AILab_QwenVL', 'model_name')
+    quickRegister('LLM/Qwen-VL', 'AILab_QwenVL_PromptEnhancer', 'model_name')
     quickRegister('LLM/checkpoints', 'LoadChatGLM3', 'chatglm3_checkpoint')
 
     // Qwen3 TTS speech models (ComfyUI-FunBox)


### PR DESCRIPTION
## Summary
- QwenVL model dropdown only showed the 3B model instead of all available models (3B, 7B, 2B, 4B, 8B, 32B variants)
- Root cause: each model was registered with its full subdirectory path (e.g., `LLM/Qwen-VL/Qwen3-VL-8B-Instruct`), but `getCategoryForNodeType()` only returns the **first** registered category per node type
- The asset browser then fetched models for only that first category (`LLM/Qwen-VL/Qwen2.5-VL-3B-Instruct`), showing just the 3B model
- Fix: register with the parent path `LLM/Qwen-VL` so all subdirectory models are included via the existing hierarchical fallback in the asset API

## Test plan
- [ ] Verify AILab_QwenVL node shows all model variants (Qwen2.5-VL-3B, 7B; Qwen3-VL-2B, 4B, 8B, 32B) in the dropdown
- [ ] Verify AILab_QwenVL_PromptEnhancer node shows both Qwen3-0.6B and Qwen3-4B models
- [ ] Verify other LLM nodes (e.g., llava-llama, LoadChatGLM3) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9737-fix-show-all-QwenVL-models-in-asset-browser-dropdown-3206d73d3650816a8effd930fb13daa4) by [Unito](https://www.unito.io)
