### PR TITLE
feat: add remote config support for PostHog debug mode

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -35,6 +35,7 @@ interface Window {
     mixpanel_token?: string
     posthog_project_token?: string
     posthog_api_host?: string
+    posthog_debug?: boolean
     require_whitelist?: boolean
     subscription_required?: boolean
     max_upload_size?: number

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -31,6 +31,7 @@ export type RemoteConfig = {
   mixpanel_token?: string
   posthog_project_token?: string
   posthog_api_host?: string
+  posthog_debug?: boolean
   subscription_required?: boolean
   server_health_alert?: ServerHealthAlert
   max_upload_size?: number

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -80,28 +80,30 @@ describe('PostHogTelemetryProvider', () => {
       createProvider()
       await vi.dynamicImportSettled()
 
-      expect(hoisted.mockInit).toHaveBeenCalledWith('phc_test_token', {
-        api_host: 'https://t.comfy.org',
-        ui_host: 'https://us.posthog.com',
-        autocapture: false,
-        capture_pageview: false,
-        capture_pageleave: false,
-        persistence: 'localStorage+cookie',
-        debug: false
-      })
+      expect(hoisted.mockInit).toHaveBeenCalledWith(
+        'phc_test_token',
+        expect.objectContaining({
+          api_host: 'https://t.comfy.org',
+          ui_host: 'https://us.posthog.com',
+          autocapture: false,
+          capture_pageview: false,
+          capture_pageleave: false,
+          persistence: 'localStorage+cookie'
+        })
+      )
     })
 
-    it('uses custom api_host from config when provided', async () => {
+    it('enables debug mode when posthog_debug is true in config', async () => {
       window.__CONFIG__ = {
         posthog_project_token: 'phc_test_token',
-        posthog_api_host: 'https://custom.host.com'
+        posthog_debug: true
       } as typeof window.__CONFIG__
       new PostHogTelemetryProvider()
       await vi.dynamicImportSettled()
 
       expect(hoisted.mockInit).toHaveBeenCalledWith(
         'phc_test_token',
-        expect.objectContaining({ api_host: 'https://custom.host.com' })
+        expect.objectContaining({ debug: true })
       )
     })
 

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -109,7 +109,9 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
               capture_pageview: false,
               capture_pageleave: false,
               persistence: 'localStorage+cookie',
-              debug: import.meta.env.VITE_POSTHOG_DEBUG === 'true'
+              debug:
+                window.__CONFIG__?.posthog_debug ??
+                import.meta.env.VITE_POSTHOG_DEBUG === 'true'
             })
             this.isInitialized = true
             this.flushEventQueue()


### PR DESCRIPTION
Allow PostHog debug mode to be toggled at runtime via the `/api/features` endpoint (`posthog_debug`), falling back to `VITE_POSTHOG_DEBUG` env var.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9755-feat-add-remote-config-support-for-PostHog-debug-mode-3206d73d365081fca3afd4cfef117eb1) by [Unito](https://www.unito.io)
