### PR TITLE
feat: add server-side PostHog config overrides

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -35,7 +35,7 @@ interface Window {
     mixpanel_token?: string
     posthog_project_token?: string
     posthog_api_host?: string
-    posthog_debug?: boolean
+    posthog_config?: Record<string, unknown>
     require_whitelist?: boolean
     subscription_required?: boolean
     max_upload_size?: number

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -1,3 +1,5 @@
+import type { PostHogConfig } from 'posthog-js'
+
 import type { TelemetryEventName } from '@/platform/telemetry/types'
 
 /**
@@ -31,7 +33,7 @@ export type RemoteConfig = {
   mixpanel_token?: string
   posthog_project_token?: string
   posthog_api_host?: string
-  posthog_debug?: boolean
+  posthog_config?: Partial<PostHogConfig>
   subscription_required?: boolean
   server_health_alert?: ServerHealthAlert
   max_upload_size?: number

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -40,8 +40,12 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
   })
 }))
 
+const mockRemoteConfig = vi.hoisted(
+  () => ({ value: null }) as { value: Record<string, unknown> | null }
+)
+
 vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
-  remoteConfig: { value: null }
+  remoteConfig: mockRemoteConfig
 }))
 
 vi.mock('posthog-js', () => hoisted.mockPosthog)
@@ -61,6 +65,7 @@ function createProvider(
 describe('PostHogTelemetryProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockRemoteConfig.value = null
     window.__CONFIG__ = {
       posthog_project_token: 'phc_test_token'
     } as typeof window.__CONFIG__
@@ -76,7 +81,7 @@ describe('PostHogTelemetryProvider', () => {
       expect(hoisted.mockCapture).not.toHaveBeenCalled()
     })
 
-    it('calls posthog.init with the token and default api_host', async () => {
+    it('calls posthog.init with the token and default config', async () => {
       createProvider()
       await vi.dynamicImportSettled()
 
@@ -93,17 +98,22 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
-    it('enables debug mode when posthog_debug is true in config', async () => {
-      window.__CONFIG__ = {
-        posthog_project_token: 'phc_test_token',
-        posthog_debug: true
-      } as typeof window.__CONFIG__
-      new PostHogTelemetryProvider()
+    it('applies posthog_config overrides from remote config', async () => {
+      mockRemoteConfig.value = {
+        posthog_config: {
+          debug: true,
+          api_host: 'https://custom.host.com'
+        }
+      }
+      createProvider()
       await vi.dynamicImportSettled()
 
       expect(hoisted.mockInit).toHaveBeenCalledWith(
         'phc_test_token',
-        expect.objectContaining({ debug: true })
+        expect.objectContaining({
+          debug: true,
+          api_host: 'https://custom.host.com'
+        })
       )
     })
 

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -101,6 +101,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
         void import('posthog-js')
           .then((posthogModule) => {
             this.posthog = posthogModule.default
+            const serverConfig = remoteConfig.value?.posthog_config ?? {}
             this.posthog!.init(apiKey, {
               api_host:
                 window.__CONFIG__?.posthog_api_host || 'https://t.comfy.org',
@@ -109,9 +110,8 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
               capture_pageview: false,
               capture_pageleave: false,
               persistence: 'localStorage+cookie',
-              debug:
-                window.__CONFIG__?.posthog_debug ??
-                import.meta.env.VITE_POSTHOG_DEBUG === 'true'
+              debug: import.meta.env.VITE_POSTHOG_DEBUG === 'true',
+              ...serverConfig
             })
             this.isInitialized = true
             this.flushEventQueue()


### PR DESCRIPTION
Add posthog_config to RemoteConfig so any PostHog init parameter can be overridden via /api/features. Client-side defaults are applied first, then server config is spread on top.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9758-feat-add-server-side-PostHog-config-overrides-3206d73d36508123ad82c31187e69e49) by [Unito](https://www.unito.io)
