### PR TITLE
fix: restore widget.inputEl backward compatibility for custom nodes

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -40,6 +40,7 @@ function addMultilineWidget(
   })
 
   widget.element = inputEl
+  widget.inputEl = inputEl
   widget.options.minNodeSize = [400, 200]
 
   inputEl.addEventListener('input', (event) => {


### PR DESCRIPTION

<img width="791" height="453" alt="스크린샷 2026-03-12 오전 9 55 12" src="https://github.com/user-attachments/assets/7e403cd3-4b2c-4f07-be1d-e80136754b8d" />

See [issue](https://github.com/Comfy-Org/ComfyUI/issues/12893#issuecomment-4043141962) for reproduce 
## Summary

Restores `widget.inputEl` assignment on STRING multiline widgets that was removed in commit a7c211516 (PR #8594) when it was renamed to `widget.element`.

### Root cause

In PR #8594 (`WidgetValueStore`), the multiline STRING widget changed `widget.inputEl = inputEl` to `widget.element = inputEl`. This removed a property that custom node extensions treat as a de facto public API.

### Impact

[ComfyUI-Custom-Scripts](https://github.com/pythongosssss/ComfyUI-Custom-Scripts) (~3k stars, one of the most widely used custom node packs) patches `ComfyWidgets.STRING` globally to attach `TextAreaAutoComplete` to every STRING widget. The autocomplete setup accesses `widget.inputEl` to call `addEventListener` and set `readOnly`. Since the property is now `undefined`, this causes:

- `TypeError: Cannot read properties of undefined (reading 'addEventListener')`
- `TypeError: Cannot set properties of undefined (setting 'readOnly')`

Because the extension patches the **global** `ComfyWidgets.STRING` constructor, **all workflows fail to load** — including stock ComfyUI workflows — as long as the extension is installed. Users do not need to use any custom nodes in their workflow to be affected.

- Fixes Comfy-Org/ComfyUI#12893

## Test plan

- Install comfyui-custom-scripts and verify workflows with multiline STRING widgets load correctly
- Verify `widget.element` still works as before
- Verify `widget.inputEl` is accessible for backward compatibility