### PR TITLE
feat: migrate 13 priority events from Mixpanel-only to GA4 via GTM

### DIFF
--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -2,6 +2,16 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { GtmTelemetryProvider } from './GtmTelemetryProvider'
 
+function createInitializedProvider(): GtmTelemetryProvider {
+  window.__CONFIG__ = { gtm_container_id: 'GTM-TEST123' }
+  return new GtmTelemetryProvider()
+}
+
+function lastDataLayerEntry(): Record<string, unknown> | undefined {
+  const dl = window.dataLayer as unknown[] | undefined
+  return dl?.[dl.length - 1] as Record<string, unknown> | undefined
+}
+
 describe('GtmTelemetryProvider', () => {
   beforeEach(() => {
     window.__CONFIG__ = {}
@@ -65,5 +75,158 @@ describe('GtmTelemetryProvider', () => {
     )
 
     expect(gtagScripts).toHaveLength(1)
+  })
+
+  describe('event dispatch', () => {
+    it('pushes subscription modal as view_promotion', () => {
+      const provider = createInitializedProvider()
+      provider.trackSubscription('modal_opened')
+      expect(lastDataLayerEntry()).toMatchObject({ event: 'view_promotion' })
+    })
+
+    it('pushes subscribe click as select_promotion', () => {
+      const provider = createInitializedProvider()
+      provider.trackSubscription('subscribe_clicked')
+      expect(lastDataLayerEntry()).toMatchObject({ event: 'select_promotion' })
+    })
+
+    it('pushes run_workflow with trigger_source', () => {
+      const provider = createInitializedProvider()
+      provider.trackRunButton({ trigger_source: 'button' })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'run_workflow',
+        trigger_source: 'button',
+        subscribe_to_run: false
+      })
+    })
+
+    it('pushes execution_error with truncated error', () => {
+      const provider = createInitializedProvider()
+      const longError = 'x'.repeat(200)
+      provider.trackExecutionError({
+        jobId: 'job-1',
+        nodeType: 'KSampler',
+        error: longError
+      })
+      const entry = lastDataLayerEntry()
+      expect(entry).toMatchObject({
+        event: 'execution_error',
+        node_type: 'KSampler'
+      })
+      expect((entry?.error as string).length).toBe(100)
+    })
+
+    it('pushes select_content for template events', () => {
+      const provider = createInitializedProvider()
+      provider.trackTemplate({
+        workflow_name: 'flux-dev',
+        template_category: 'image-gen'
+      })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'select_content',
+        content_type: 'template',
+        workflow_name: 'flux-dev',
+        template_category: 'image-gen'
+      })
+    })
+
+    it('pushes survey_opened for survey opened stage', () => {
+      const provider = createInitializedProvider()
+      provider.trackSurvey('opened')
+      expect(lastDataLayerEntry()).toMatchObject({ event: 'survey_opened' })
+    })
+
+    it('pushes survey_submitted with responses', () => {
+      const provider = createInitializedProvider()
+      provider.trackSurvey('submitted', {
+        familiarity: 'expert',
+        industry: 'gaming'
+      })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'survey_submitted',
+        familiarity: 'expert',
+        industry: 'gaming'
+      })
+    })
+
+    it('pushes email_verify_opened for opened stage', () => {
+      const provider = createInitializedProvider()
+      provider.trackEmailVerification('opened')
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'email_verify_opened'
+      })
+    })
+
+    it('pushes email_verify_completed for completed stage', () => {
+      const provider = createInitializedProvider()
+      provider.trackEmailVerification('completed')
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'email_verify_completed'
+      })
+    })
+
+    it('pushes search for node search (GA4 recommended)', () => {
+      const provider = createInitializedProvider()
+      provider.trackNodeSearch({ query: 'KSampler' })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'search',
+        search_term: 'KSampler'
+      })
+    })
+
+    it('pushes select_item for node search result (GA4 recommended)', () => {
+      const provider = createInitializedProvider()
+      provider.trackNodeSearchResultSelected({
+        node_type: 'KSampler',
+        last_query: 'sampler'
+      })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'select_item',
+        item_id: 'KSampler',
+        search_term: 'sampler'
+      })
+    })
+
+    it('pushes setting_changed with setting_id', () => {
+      const provider = createInitializedProvider()
+      provider.trackSettingChanged({ setting_id: 'theme' })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'setting_changed',
+        setting_id: 'theme'
+      })
+    })
+
+    it('pushes workflow_created with metadata', () => {
+      const provider = createInitializedProvider()
+      provider.trackWorkflowCreated({
+        workflow_type: 'blank',
+        previous_workflow_had_nodes: true
+      })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'workflow_created',
+        workflow_type: 'blank',
+        previous_workflow_had_nodes: true
+      })
+    })
+
+    it('pushes share_flow with step and source', () => {
+      const provider = createInitializedProvider()
+      provider.trackShareFlow({
+        step: 'link_copied',
+        source: 'app_mode'
+      })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'share_flow',
+        step: 'link_copied',
+        source: 'app_mode'
+      })
+    })
+
+    it('does not push events when not initialized', () => {
+      window.__CONFIG__ = {}
+      const provider = new GtmTelemetryProvider()
+      provider.trackSubscription('modal_opened')
+      expect(window.dataLayer).toBeUndefined()
+    })
   })
 })

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -108,9 +108,22 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     gtag('config', measurementId, { send_page_view: false })
   }
 
+  private sanitizeProperties(
+    properties?: Record<string, unknown>
+  ): Record<string, unknown> | undefined {
+    if (!properties) return undefined
+
+    return Object.fromEntries(
+      Object.entries(properties).map(([key, value]) => [
+        key,
+        typeof value === 'string' ? value.slice(0, 100) : value
+      ])
+    )
+  }
+
   private pushEvent(event: string, properties?: Record<string, unknown>): void {
     if (!this.initialized) return
-    window.dataLayer?.push({ event, ...properties })
+    window.dataLayer?.push({ event, ...this.sanitizeProperties(properties) })
   }
 
   trackPageView(pageName: string, properties?: PageViewMetadata): void {
@@ -169,7 +182,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
   trackExecutionError(metadata: ExecutionErrorMetadata): void {
     this.pushEvent('execution_error', {
       node_type: metadata.nodeType,
-      error: metadata.error?.slice(0, 100)
+      error: metadata.error
     })
   }
 

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -1,8 +1,32 @@
 import type {
   AuthMetadata,
   BeginCheckoutMetadata,
+  DefaultViewSetMetadata,
+  EnterLinearMetadata,
+  ExecutionErrorMetadata,
+  ExecutionSuccessMetadata,
+  ExecutionTriggerSource,
+  HelpCenterClosedMetadata,
+  HelpCenterOpenedMetadata,
+  HelpResourceClickedMetadata,
+  NodeSearchMetadata,
+  NodeSearchResultMetadata,
   PageViewMetadata,
-  TelemetryProvider
+  PageVisibilityMetadata,
+  SettingChangedMetadata,
+  ShareFlowMetadata,
+  SubscriptionMetadata,
+  SurveyResponses,
+  TabCountMetadata,
+  TelemetryProvider,
+  TemplateFilterMetadata,
+  TemplateLibraryClosedMetadata,
+  TemplateLibraryMetadata,
+  TemplateMetadata,
+  UiButtonClickMetadata,
+  WorkflowCreatedMetadata,
+  WorkflowImportMetadata,
+  WorkflowSavedMetadata
 } from '../../types'
 
 /**
@@ -113,5 +137,208 @@ export class GtmTelemetryProvider implements TelemetryProvider {
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {
     this.pushEvent('begin_checkout', metadata)
+  }
+
+  trackSubscription(
+    event: 'modal_opened' | 'subscribe_clicked',
+    metadata?: SubscriptionMetadata
+  ): void {
+    const ga4EventName =
+      event === 'modal_opened' ? 'view_promotion' : 'select_promotion'
+    this.pushEvent(ga4EventName, metadata ? { ...metadata } : undefined)
+  }
+
+  trackSignupOpened(): void {
+    this.pushEvent('signup_opened')
+  }
+
+  trackRunButton(options?: {
+    subscribe_to_run?: boolean
+    trigger_source?: ExecutionTriggerSource
+  }): void {
+    this.pushEvent('run_workflow', {
+      subscribe_to_run: options?.subscribe_to_run ?? false,
+      trigger_source: options?.trigger_source ?? 'unknown'
+    })
+  }
+
+  trackWorkflowExecution(): void {
+    this.pushEvent('execution_start')
+  }
+
+  trackExecutionError(metadata: ExecutionErrorMetadata): void {
+    this.pushEvent('execution_error', {
+      node_type: metadata.nodeType,
+      error: metadata.error?.slice(0, 100)
+    })
+  }
+
+  trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
+    this.pushEvent('execution_success', {
+      job_id: metadata.jobId
+    })
+  }
+
+  trackTemplate(metadata: TemplateMetadata): void {
+    this.pushEvent('select_content', {
+      content_type: 'template',
+      workflow_name: metadata.workflow_name,
+      template_category: metadata.template_category
+    })
+  }
+
+  trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void {
+    this.pushEvent('template_library_opened', {
+      source: metadata.source
+    })
+  }
+
+  trackTemplateLibraryClosed(metadata: TemplateLibraryClosedMetadata): void {
+    this.pushEvent('template_library_closed', {
+      template_selected: metadata.template_selected,
+      time_spent_seconds: metadata.time_spent_seconds
+    })
+  }
+
+  trackWorkflowImported(metadata: WorkflowImportMetadata): void {
+    this.pushEvent('workflow_import', {
+      missing_node_count: metadata.missing_node_count,
+      open_source: metadata.open_source
+    })
+  }
+
+  trackUserLoggedIn(): void {
+    this.pushEvent('login')
+  }
+
+  trackSurvey(stage: 'opened' | 'submitted', responses?: SurveyResponses): void {
+    const ga4EventName =
+      stage === 'opened' ? 'survey_opened' : 'survey_submitted'
+    this.pushEvent(ga4EventName, responses ? { ...responses } : undefined)
+  }
+
+  trackEmailVerification(stage: 'opened' | 'requested' | 'completed'): void {
+    const eventMap = {
+      opened: 'email_verify_opened',
+      requested: 'email_verify_requested',
+      completed: 'email_verify_completed'
+    } as const
+    this.pushEvent(eventMap[stage])
+  }
+
+  trackWorkflowOpened(metadata: WorkflowImportMetadata): void {
+    this.pushEvent('workflow_opened', {
+      missing_node_count: metadata.missing_node_count,
+      open_source: metadata.open_source
+    })
+  }
+
+  trackWorkflowSaved(metadata: WorkflowSavedMetadata): void {
+    this.pushEvent('workflow_saved', {
+      is_app: metadata.is_app,
+      is_new: metadata.is_new
+    })
+  }
+
+  trackDefaultViewSet(metadata: DefaultViewSetMetadata): void {
+    this.pushEvent('default_view_set', {
+      default_view: metadata.default_view
+    })
+  }
+
+  trackEnterLinear(metadata: EnterLinearMetadata): void {
+    this.pushEvent('app_mode_opened', {
+      source: metadata.source
+    })
+  }
+
+  trackShareFlow(metadata: ShareFlowMetadata): void {
+    this.pushEvent('share_flow', {
+      step: metadata.step,
+      source: metadata.source
+    })
+  }
+
+  trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void {
+    this.pushEvent('page_visibility', {
+      visibility_state: metadata.visibility_state
+    })
+  }
+
+  trackTabCount(metadata: TabCountMetadata): void {
+    this.pushEvent('tab_count', {
+      tab_count: metadata.tab_count
+    })
+  }
+
+  trackNodeSearch(metadata: NodeSearchMetadata): void {
+    this.pushEvent('search', {
+      search_term: metadata.query
+    })
+  }
+
+  trackNodeSearchResultSelected(metadata: NodeSearchResultMetadata): void {
+    this.pushEvent('select_item', {
+      item_id: metadata.node_type,
+      search_term: metadata.last_query
+    })
+  }
+
+  trackTemplateFilterChanged(metadata: TemplateFilterMetadata): void {
+    this.pushEvent('template_filter', {
+      search_query: metadata.search_query,
+      sort_by: metadata.sort_by,
+      filtered_count: metadata.filtered_count,
+      total_count: metadata.total_count
+    })
+  }
+
+  trackSettingChanged(metadata: SettingChangedMetadata): void {
+    this.pushEvent('setting_changed', {
+      setting_id: metadata.setting_id
+    })
+  }
+
+  trackUiButtonClicked(metadata: UiButtonClickMetadata): void {
+    this.pushEvent('ui_button_click', {
+      button_id: metadata.button_id
+    })
+  }
+
+  trackHelpCenterOpened(metadata: HelpCenterOpenedMetadata): void {
+    this.pushEvent('help_center_opened', {
+      source: metadata.source
+    })
+  }
+
+  trackHelpResourceClicked(metadata: HelpResourceClickedMetadata): void {
+    this.pushEvent('help_resource_click', {
+      resource_type: metadata.resource_type,
+      is_external: metadata.is_external,
+      source: metadata.source
+    })
+  }
+
+  trackHelpCenterClosed(metadata: HelpCenterClosedMetadata): void {
+    this.pushEvent('help_center_closed', {
+      time_spent_seconds: metadata.time_spent_seconds
+    })
+  }
+
+  trackWorkflowCreated(metadata: WorkflowCreatedMetadata): void {
+    this.pushEvent('workflow_created', {
+      workflow_type: metadata.workflow_type,
+      previous_workflow_had_nodes: metadata.previous_workflow_had_nodes
+    })
+  }
+
+  trackAddApiCreditButtonClicked(): void {
+    this.pushEvent('add_credit_clicked')
+  }
+
+  trackApiCreditTopupButtonPurchaseClicked(amount: number): void {
+    this.pushEvent('credit_topup_clicked', {
+      credit_amount: amount
+    })
   }
 }

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -221,7 +221,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
   }
 
   trackUserLoggedIn(): void {
-    this.pushEvent('login')
+    this.pushEvent('user_logged_in')
   }
 
   trackSurvey(

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -211,7 +211,10 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     this.pushEvent('login')
   }
 
-  trackSurvey(stage: 'opened' | 'submitted', responses?: SurveyResponses): void {
+  trackSurvey(
+    stage: 'opened' | 'submitted',
+    responses?: SurveyResponses
+  ): void {
     const ga4EventName =
       stage === 'opened' ? 'survey_opened' : 'survey_submitted'
     this.pushEvent(ga4EventName, responses ? { ...responses } : undefined)


### PR DESCRIPTION
## Summary

Migrate all client-side telemetry events to GA4 via the GtmTelemetryProvider, completing the dual-write setup alongside Mixpanel.

## Changes

- Add all client-side Mixpanel events to GtmTelemetryProvider for GA4 dual-write
- Map events to GA4 recommended names where applicable (search, select_item, login, sign_up)
- Exclude server-side payment events (subscription success/cancel, credit topup succeeded) - those belong in comfy-api via Measurement Protocol
- Truncate error strings to 100 chars to respect GA4 parameter limits
- Keep event parameter counts under GA4 25-param limit

## Events Added

### GA4 Recommended Events
- sign_up / login (auth flow)
- begin_checkout (checkout flow)
- search (node search)
- select_item (node search result selected)
- select_content (template opened)
- view_promotion / select_promotion (subscription modal)

### Custom Events
- Survey, email verification, workflow lifecycle (opened/imported/created/saved)
- Execution lifecycle (start/error/success)
- Template library, help center, settings, UI interactions
- App mode, share flow, page visibility, tab count

### Excluded (Server-Side Only)
- subscription_success -> comfy-api Stripe webhook
- subscription_cancel -> comfy-api Stripe webhook
- credit_topup_succeeded -> comfy-api Stripe webhook

## Testing
- Unit tests cover initialization, event dispatch, GA4 event name mapping, and parameter handling
- Verified typecheck and lint pass