### PR TITLE
[bugfix] Asset widget search matches display label

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/shared.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/shared.test.ts
@@ -51,6 +51,31 @@ describe('defaultSearcher', () => {
     const result = await defaultSearcher('xyz', items)
     expect(result).toHaveLength(0)
   })
+
+  it('matches against label when provided', async () => {
+    const itemsWithLabels = [
+      createItem('model_v1.safetensors', 'My Cool Model'),
+      createItem('lora_v2.safetensors', 'Style Transfer LoRA'),
+      createItem('checkpoint.ckpt', 'Realistic Vision')
+    ]
+    const result = await defaultSearcher('cool', itemsWithLabels)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('model_v1.safetensors')
+  })
+
+  it('matches by label case-insensitively', async () => {
+    const itemsWithLabels = [createItem('file.safetensors', 'My Cool Model')]
+    const result = await defaultSearcher('MY COOL', itemsWithLabels)
+    expect(result).toHaveLength(1)
+  })
+
+  it('matches when word is in name or label', async () => {
+    const itemsWithLabels = [
+      createItem('sd_v15.safetensors', 'Stable Diffusion 1.5')
+    ]
+    const result = await defaultSearcher('stable', itemsWithLabels)
+    expect(result).toHaveLength(1)
+  })
 })
 
 describe('getDefaultSortOptions', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/shared.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/shared.ts
@@ -12,7 +12,8 @@ export async function defaultSearcher(
   const words = query.trim().toLowerCase().split(' ')
   return items.filter((item) => {
     const name = item.name.toLowerCase()
-    return words.every((word) => name.includes(word))
+    const label = item.label?.toLowerCase() ?? ''
+    return words.every((word) => name.includes(word) || label.includes(word))
   })
 }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
@@ -33,7 +33,7 @@ const hideLayoutField = useHideLayoutField()
       <div
         :class="
           cn(
-            'cursor-default min-w-0 rounded-lg has-[:focus-visible]:ring has-[:focus-visible]:ring-component-node-widget-background-highlighted transition-all',
+            'min-w-0 cursor-default rounded-lg transition-all has-focus-visible:ring has-focus-visible:ring-component-node-widget-background-highlighted',
             widget.borderStyle
           )
         "


### PR DESCRIPTION
## Summary
Asset widget dropdown search only matched against `item.name` (filename), but users see `item.label` (display name). Now searches both fields so filtering matches what is visually displayed.

## Changes
- **What**: `defaultSearcher` in `FormDropdown` now matches against both `name` and `label` fields
- Added 3 unit tests covering label-based search scenarios

## Review Focus
- The change only affects cloud asset mode where `name` (filename) and `label` (display name) differ. In local mode, `label` is either `undefined` or identical to `name`, so behavior is unchanged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9774-bugfix-Asset-widget-search-matches-display-label-3216d73d365081ca8befdf7260c66a26) by [Unito](https://www.unito.io)
