### PR TITLE
feat: add focusedJobId for concurrent job execution support

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -47,7 +47,9 @@ const config: KnipConfig = {
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
     // Agent review check config, not part of the build
-    '.agents/checks/eslint.strict.config.js'
+    '.agents/checks/eslint.strict.config.js',
+    // Pending integration in stacked PR (concurrent job execution)
+    'src/composables/useConcurrentExecution.ts'
   ],
   compilers: {
     // https://github.com/webpro-nl/knip/issues/1008#issuecomment-3207756199

--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -355,6 +355,17 @@ describe('TopMenuSection', () => {
       configureSettings(pinia, true)
       const executionStore = useExecutionStore(pinia)
       executionStore.activeJobId = 'job-1'
+      executionStore.nodeProgressStatesByJob = {
+        'job-1': {
+          'node-1': {
+            value: 50,
+            max: 100,
+            state: 'running',
+            node_id: 'node-1',
+            prompt_id: 'job-1'
+          }
+        }
+      }
 
       const ComfyActionbarStub = createComfyActionbarStub(actionbarTarget)
 

--- a/src/composables/queue/useJobList.ts
+++ b/src/composables/queue/useJobList.ts
@@ -261,8 +261,11 @@ export function useJobList() {
 
   const jobItems = computed<JobListItem[]>(() => {
     return filteredTaskEntries.value.map(({ task, state }) => {
-      const isActive =
-        String(task.jobId ?? '') === String(executionStore.activeJobId ?? '')
+      const isRunning =
+        executionStore.runningJobIds.includes(String(task.jobId ?? ''))
+      const isFocused =
+        String(task.jobId ?? '') === String(executionStore.focusedJobId ?? '')
+      const isActive = isRunning || isFocused
       const showAddedHint = shouldShowAddedHint(task, state)
       const promptKey = taskIdToKey(task.jobId)
       const promptPreviewUrl =

--- a/src/composables/useBrowserTabTitle.test.ts
+++ b/src/composables/useBrowserTabTitle.test.ts
@@ -26,13 +26,23 @@ const executionStore = reactive<{
       }
     }
   } | null
+  focusedJob: {
+    workflow: {
+      changeTracker: {
+        activeState: {
+          nodes: { id: number; type: string }[]
+        }
+      }
+    }
+  } | null
 }>({
   isIdle: true,
   executionProgress: 0,
   executingNode: null,
   executingNodeProgress: 0,
   nodeProgressStates: {},
-  activeJob: null
+  activeJob: null,
+  focusedJob: null
 })
 vi.mock('@/stores/executionStore', () => ({
   useExecutionStore: () => executionStore
@@ -77,6 +87,7 @@ describe('useBrowserTabTitle', () => {
     executionStore.executingNodeProgress = 0
     executionStore.nodeProgressStates = {}
     executionStore.activeJob = null
+    executionStore.focusedJob = null
 
     // reset setting and workflow stores
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
@@ -188,6 +199,15 @@ describe('useBrowserTabTitle', () => {
       '1': { state: 'running', value: 5, max: 10, node: '1', prompt_id: 'test' }
     }
     executionStore.activeJob = {
+      workflow: {
+        changeTracker: {
+          activeState: {
+            nodes: [{ id: 1, type: 'Foo' }]
+          }
+        }
+      }
+    }
+    executionStore.focusedJob = {
       workflow: {
         changeTracker: {
           activeState: {

--- a/src/composables/useBrowserTabTitle.ts
+++ b/src/composables/useBrowserTabTitle.ts
@@ -77,7 +77,7 @@ export const useBrowserTabTitle = () => {
     const [nodeId, state] = runningNodes[0]
     const progress = Math.round((state.value / state.max) * 100)
     const nodeType =
-      executionStore.activeJob?.workflow?.changeTracker?.activeState.nodes.find(
+      executionStore.focusedJob?.workflow?.changeTracker?.activeState.nodes.find(
         (n) => String(n.id) === nodeId
       )?.type || 'Node'
 

--- a/src/composables/useConcurrentExecution.ts
+++ b/src/composables/useConcurrentExecution.ts
@@ -1,0 +1,51 @@
+import { computed } from 'vue'
+
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+export function useConcurrentExecution() {
+  const settingStore = useSettingStore()
+
+  const isFeatureEnabled = computed(
+    () => remoteConfig.value.concurrent_execution_enabled === true
+  )
+
+  const isUserEnabled = computed(
+    () => settingStore.get('Comfy.Cloud.ConcurrentExecution') === true
+  )
+
+  const isConcurrentExecutionEnabled = computed(
+    () => isFeatureEnabled.value && isUserEnabled.value
+  )
+
+  const maxConcurrentJobs = computed(
+    () => remoteConfig.value.max_concurrent_jobs ?? 1
+  )
+
+  const hasSeenOnboarding = computed(
+    () =>
+      settingStore.get('Comfy.Cloud.ConcurrentExecution.OnboardingSeen') ===
+      true
+  )
+
+  async function setUserEnabled(enabled: boolean) {
+    await settingStore.set('Comfy.Cloud.ConcurrentExecution', enabled)
+  }
+
+  async function markOnboardingSeen() {
+    await settingStore.set(
+      'Comfy.Cloud.ConcurrentExecution.OnboardingSeen',
+      true
+    )
+  }
+
+  return {
+    isFeatureEnabled,
+    isUserEnabled,
+    isConcurrentExecutionEnabled,
+    maxConcurrentJobs,
+    hasSeenOnboarding,
+    setUserEnabled,
+    markOnboardingSeen
+  }
+}

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -315,7 +315,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Interrupt',
       category: 'essentials' as const,
       function: async () => {
-        await api.interrupt(executionStore.activeJobId)
+        await api.interrupt(executionStore.focusedJobId)
         toastStore.add({
           severity: 'info',
           summary: t('g.interrupted'),

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -51,4 +51,6 @@ export type RemoteConfig = {
   workflow_sharing_enabled?: boolean
   comfyhub_upload_enabled?: boolean
   comfyhub_profile_gate_enabled?: boolean
+  max_concurrent_jobs?: number
+  concurrent_execution_enabled?: boolean
 }

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1257,5 +1257,21 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: true,
     experimental: true,
     versionAdded: '1.40.0'
+  },
+  {
+    id: 'Comfy.Cloud.ConcurrentExecution',
+    name: 'Run jobs in parallel',
+    tooltip:
+      'When enabled, multiple workflow runs execute concurrently instead of queuing sequentially.',
+    type: isCloud ? 'boolean' : 'hidden',
+    defaultValue: true,
+    versionAdded: '1.42.0'
+  },
+  {
+    id: 'Comfy.Cloud.ConcurrentExecution.OnboardingSeen',
+    name: 'Concurrent execution onboarding dialog seen',
+    type: 'hidden',
+    defaultValue: false,
+    versionAdded: '1.42.0'
   }
 ]

--- a/src/renderer/extensions/linearMode/linearOutputStore.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.ts
@@ -240,7 +240,7 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
 
   function handleExecuted({ detail }: CustomEvent<ExecutedWsMessage>) {
     const jobId = detail.prompt_id
-    if (jobId !== executionStore.activeJobId) return
+    if (jobId !== executionStore.focusedJobId) return
     onNodeExecuted(jobId, detail)
   }
 
@@ -259,7 +259,7 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
   }
 
   watch(
-    () => executionStore.activeJobId,
+    () => executionStore.focusedJobId,
     (jobId, oldJobId) => {
       if (!isAppMode.value) return
       if (oldJobId && oldJobId !== jobId) {
@@ -275,7 +275,7 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
     () => jobPreviewStore.nodePreviewsByPromptId,
     (previews) => {
       if (!isAppMode.value) return
-      const jobId = executionStore.activeJobId
+      const jobId = executionStore.focusedJobId
       if (!jobId) return
       const preview = previews[jobId]
       if (preview) onLatentPreview(jobId, preview.url, preview.nodeId)

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -463,7 +463,9 @@ const zSettings = z.object({
   'Comfy.VersionCompatibility.DisableWarnings': z.boolean(),
   'Comfy.RightSidePanel.IsOpen': z.boolean(),
   'Comfy.RightSidePanel.ShowErrorsTab': z.boolean(),
-  'Comfy.Node.AlwaysShowAdvancedWidgets': z.boolean()
+  'Comfy.Node.AlwaysShowAdvancedWidgets': z.boolean(),
+  'Comfy.Cloud.ConcurrentExecution': z.boolean(),
+  'Comfy.Cloud.ConcurrentExecution.OnboardingSeen': z.boolean()
 })
 
 export type EmbeddingsResponse = z.infer<typeof zEmbeddingsResponse>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -762,6 +762,14 @@ export class ComfyApp {
         useNodeOutputStore()
       const blobUrl = createSharedObjectUrl(blob)
       useJobPreviewStore().setPreviewUrl(jobId, blobUrl, displayNodeId)
+
+      // Only render preview on canvas if this is the focused job
+      const executionStore = useExecutionStore()
+      if (jobId && executionStore.focusedJobId && jobId !== executionStore.focusedJobId) {
+        releaseSharedObjectUrl(blobUrl)
+        return
+      }
+
       // Ensure clean up if `executing` event is missed.
       revokePreviewsByExecutionId(displayNodeId)
       // Preview cleanup is handled in progress_state event to support multiple concurrent previews

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -178,6 +178,298 @@ describe('useExecutionStore - reconcileInitializingJobs', () => {
   })
 })
 
+describe('useExecutionStore - focusedJobId management', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('should initialize focusedJobId as null', () => {
+    expect(store.focusedJobId).toBeNull()
+  })
+
+  it('should set focusedJobId and update nodeProgressStates via setFocusedJob', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 50,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      },
+      'job-2': {
+        'node-2': {
+          value: 30,
+          max: 100,
+          state: 'running',
+          node_id: 'node-2',
+          prompt_id: 'job-2'
+        }
+      }
+    }
+
+    store.setFocusedJob('job-1')
+    expect(store.focusedJobId).toBe('job-1')
+    expect(store.nodeProgressStates).toEqual({
+      'node-1': {
+        value: 50,
+        max: 100,
+        state: 'running',
+        node_id: 'node-1',
+        prompt_id: 'job-1'
+      }
+    })
+
+    store.setFocusedJob('job-2')
+    expect(store.focusedJobId).toBe('job-2')
+    expect(store.nodeProgressStates).toEqual({
+      'node-2': {
+        value: 30,
+        max: 100,
+        state: 'running',
+        node_id: 'node-2',
+        prompt_id: 'job-2'
+      }
+    })
+  })
+
+  it('should clear nodeProgressStates when setFocusedJob is called with null', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 50,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      }
+    }
+    store.setFocusedJob('job-1')
+    expect(store.nodeProgressStates).not.toEqual({})
+
+    store.setFocusedJob(null)
+    expect(store.focusedJobId).toBeNull()
+    expect(store.nodeProgressStates).toEqual({})
+  })
+
+  it('should return undefined for focusedJob when no job is focused', () => {
+    expect(store.focusedJob).toBeUndefined()
+  })
+
+  it('should return the focused QueuedJob from focusedJob computed', () => {
+    store.queuedJobs = {
+      'job-1': { nodes: { n1: false, n2: true } }
+    }
+    store.setFocusedJob('job-1')
+    expect(store.focusedJob).toEqual({ nodes: { n1: false, n2: true } })
+  })
+})
+
+describe('useExecutionStore - isConcurrentExecutionActive', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('should be false when no jobs are running', () => {
+    expect(store.isConcurrentExecutionActive).toBe(false)
+  })
+
+  it('should be false when only one job is running', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 50,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      }
+    }
+    expect(store.isConcurrentExecutionActive).toBe(false)
+  })
+
+  it('should be true when multiple jobs are running', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 50,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      },
+      'job-2': {
+        'node-2': {
+          value: 30,
+          max: 100,
+          state: 'running',
+          node_id: 'node-2',
+          prompt_id: 'job-2'
+        }
+      }
+    }
+    expect(store.isConcurrentExecutionActive).toBe(true)
+  })
+})
+
+describe('useExecutionStore - isIdle with multi-job', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('should be true when no jobs are running', () => {
+    expect(store.isIdle).toBe(true)
+  })
+
+  it('should be false when at least one job is running', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 0,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      }
+    }
+    expect(store.isIdle).toBe(false)
+  })
+
+  it('should be true when all jobs are finished (not running)', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 100,
+          max: 100,
+          state: 'finished',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      }
+    }
+    expect(store.isIdle).toBe(true)
+  })
+})
+
+describe('useExecutionStore - resetExecutionState auto-advance', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('should set focusedJobId to null when last running job finishes', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 50,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      }
+    }
+    store.activeJobId = 'job-1'
+    store.setFocusedJob('job-1')
+
+    // When the last job finishes, nodeProgressStatesByJob will be empty
+    // and focusedJobId should become null
+    store.nodeProgressStatesByJob = {}
+    store.setFocusedJob(null)
+    expect(store.focusedJobId).toBeNull()
+    expect(store.nodeProgressStates).toEqual({})
+  })
+
+  it('should not change focusedJobId when a non-focused job finishes', () => {
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        'node-1': {
+          value: 50,
+          max: 100,
+          state: 'running',
+          node_id: 'node-1',
+          prompt_id: 'job-1'
+        }
+      },
+      'job-2': {
+        'node-2': {
+          value: 30,
+          max: 100,
+          state: 'running',
+          node_id: 'node-2',
+          prompt_id: 'job-2'
+        }
+      }
+    }
+    store.setFocusedJob('job-1')
+
+    // job-2 finishes — focusedJobId should stay on job-1
+    const updated = { ...store.nodeProgressStatesByJob }
+    delete updated['job-2']
+    store.nodeProgressStatesByJob = updated
+
+    // Focus should still be on job-1
+    expect(store.focusedJobId).toBe('job-1')
+    expect(store.nodeProgressStates).toEqual({
+      'node-1': {
+        value: 50,
+        max: 100,
+        state: 'running',
+        node_id: 'node-1',
+        prompt_id: 'job-1'
+      }
+    })
+  })
+})
+
+describe('useExecutionStore - executionProgress from focusedJob', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('should compute executionProgress from focused job nodes', () => {
+    store.queuedJobs = {
+      'job-1': { nodes: { n1: true, n2: false, n3: false } },
+      'job-2': { nodes: { n4: true, n5: true } }
+    }
+    store.setFocusedJob('job-1')
+    // 1 out of 3 done
+    expect(store.executionProgress).toBeCloseTo(1 / 3)
+
+    store.setFocusedJob('job-2')
+    // 2 out of 2 done
+    expect(store.executionProgress).toBe(1)
+  })
+
+  it('should return 0 when no job is focused', () => {
+    expect(store.executionProgress).toBe(0)
+  })
+})
+
 describe('useExecutionErrorStore - Node Error Lookups', () => {
   let store: ReturnType<typeof useExecutionErrorStore>
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -53,6 +53,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   const clientId = ref<string | null>(null)
   const activeJobId = ref<string | null>(null)
+  const focusedJobId = ref<string | null>(null)
   const queuedJobs = ref<Record<NodeId, QueuedJob>>({})
   // This is the progress of all nodes in the currently executing workflow
   const nodeProgressStates = ref<Record<string, NodeProgressState>>({})
@@ -145,7 +146,7 @@ export const useExecutionStore = defineStore('execution', () => {
   const executingNode = computed<ComfyNode | null>(() => {
     if (!executingNodeId.value) return null
 
-    const workflow: ComfyWorkflow | undefined = activeJob.value?.workflow
+    const workflow: ComfyWorkflow | undefined = focusedJob.value?.workflow
     if (!workflow) return null
 
     const canvasState: ComfyWorkflowJSON | null =
@@ -170,20 +171,28 @@ export const useExecutionStore = defineStore('execution', () => {
     () => queuedJobs.value[activeJobId.value ?? '']
   )
 
+  const focusedJob = computed<QueuedJob | undefined>(
+    () => queuedJobs.value[focusedJobId.value ?? '']
+  )
+
+  const isConcurrentExecutionActive = computed(
+    () => runningJobIds.value.length > 1
+  )
+
   const totalNodesToExecute = computed<number>(() => {
-    if (!activeJob.value) return 0
-    return Object.values(activeJob.value.nodes).length
+    if (!focusedJob.value) return 0
+    return Object.values(focusedJob.value.nodes).length
   })
 
-  const isIdle = computed<boolean>(() => !activeJobId.value)
+  const isIdle = computed<boolean>(() => runningJobIds.value.length === 0)
 
   const nodesExecuted = computed<number>(() => {
-    if (!activeJob.value) return 0
-    return Object.values(activeJob.value.nodes).filter(Boolean).length
+    if (!focusedJob.value) return 0
+    return Object.values(focusedJob.value.nodes).filter(Boolean).length
   })
 
   const executionProgress = computed<number>(() => {
-    if (!activeJob.value) return 0
+    if (!focusedJob.value) return 0
     const total = totalNodesToExecute.value
     const done = nodesExecuted.value
     return total > 0 ? done / total : 0
@@ -224,6 +233,14 @@ export const useExecutionStore = defineStore('execution', () => {
     activeJobId.value = e.detail.prompt_id
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
     clearInitializationByJobId(activeJobId.value)
+
+    // Auto-focus the first job, or if the current focused job is no longer running
+    if (
+      !focusedJobId.value ||
+      !nodeProgressStatesByJob.value[focusedJobId.value]
+    ) {
+      focusedJobId.value = activeJobId.value
+    }
 
     // Ensure path mapping exists — execution_start can arrive via WebSocket
     // before the HTTP response from queuePrompt triggers storeJob.
@@ -300,16 +317,19 @@ export const useExecutionStore = defineStore('execution', () => {
       ...nodeProgressStatesByJob.value,
       [jobId]: nodes
     }
-    nodeProgressStates.value = nodes
 
-    // If we have progress for the currently executing node, update it for backwards compatibility
-    if (executingNodeId.value && nodes[executingNodeId.value]) {
-      const nodeState = nodes[executingNodeId.value]
-      _executingNodeProgress.value = {
-        value: nodeState.value,
-        max: nodeState.max,
-        prompt_id: nodeState.prompt_id,
-        node: nodeState.display_node_id || nodeState.node_id
+    if (jobId === focusedJobId.value) {
+      nodeProgressStates.value = nodes
+
+      // If we have progress for the currently executing node, update it for backwards compatibility
+      if (executingNodeId.value && nodes[executingNodeId.value]) {
+        const nodeState = nodes[executingNodeId.value]
+        _executingNodeProgress.value = {
+          value: nodeState.value,
+          max: nodeState.max,
+          prompt_id: nodeState.prompt_id,
+          node: nodeState.display_node_id || nodeState.node_id
+        }
       }
     }
   }
@@ -437,7 +457,6 @@ export const useExecutionStore = defineStore('execution', () => {
    * Reset execution-related state after a run completes or is stopped.
    */
   function resetExecutionState(jobIdParam?: string | null) {
-    nodeProgressStates.value = {}
     const jobId = jobIdParam ?? activeJobId.value ?? null
     if (jobId) {
       const map = { ...nodeProgressStatesByJob.value }
@@ -445,12 +464,31 @@ export const useExecutionStore = defineStore('execution', () => {
       nodeProgressStatesByJob.value = map
       useJobPreviewStore().clearPreview(jobId)
     }
-    if (activeJobId.value) {
-      delete queuedJobs.value[activeJobId.value]
+    if (jobId === activeJobId.value || !jobIdParam) {
+      if (activeJobId.value) {
+        delete queuedJobs.value[activeJobId.value]
+      }
+      activeJobId.value = null
     }
-    activeJobId.value = null
+    if (jobId === focusedJobId.value || !jobIdParam) {
+      // Auto-advance to next running job, or null
+      focusedJobId.value =
+        runningJobIds.value.find((id) => id !== jobId) ?? null
+      nodeProgressStates.value = focusedJobId.value
+        ? (nodeProgressStatesByJob.value[focusedJobId.value] ?? {})
+        : {}
+    }
     _executingNodeProgress.value = null
     executionErrorStore.clearPromptError()
+  }
+
+  function setFocusedJob(jobId: string | null) {
+    focusedJobId.value = jobId
+    if (jobId) {
+      nodeProgressStates.value = nodeProgressStatesByJob.value[jobId] ?? {}
+    } else {
+      nodeProgressStates.value = {}
+    }
   }
 
   function getNodeIdIfExecuting(nodeId: string | number) {
@@ -557,6 +595,10 @@ export const useExecutionStore = defineStore('execution', () => {
     executingNodeId,
     executingNodeIds,
     activeJob,
+    focusedJobId,
+    focusedJob,
+    isConcurrentExecutionActive,
+    setFocusedJob,
     totalNodesToExecute,
     nodesExecuted,
     executionProgress,


### PR DESCRIPTION
## Summary

Add multi-job focus management to `executionStore`, enabling concurrent job execution where canvas progress tracks a user-selected "focused" job. Cloud-only feature gated by remote config + user setting.

## Changes

- **What**: `focusedJobId` ref + `setFocusedJob` action in executionStore; `handleProgressState` filters by focused job; `resetExecutionState` auto-advances focus; `isIdle` uses `runningJobIds`; `executionProgress`/`executingNode` derive from focused job. Remote config types (`max_concurrent_jobs`, `concurrent_execution_enabled`), settings (`Comfy.Cloud.ConcurrentExecution`), and `useConcurrentExecution` composable for feature gating. 15 new unit tests.

## Review Focus

- `resetExecutionState` now conditionally clears `activeJobId`/`focusedJobId` only when the finishing job matches, instead of unconditionally clearing everything. This is the key behavioral change for multi-job support.
- `isIdle` changed from `!activeJobId` to `runningJobIds.length === 0` — safe for single-job mode since `runningJobIds` is `[]` when idle.
- `nodeProgressStates` is now only updated when the incoming `progress_state` message matches `focusedJobId`, preventing canvas flicker between concurrent jobs.
- Backward compatibility: `activeJob`, `activeJobId` remain unchanged for consumers not yet migrated.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9781-feat-add-focusedJobId-for-concurrent-job-execution-support-3216d73d3650816d8e2be462519ffca5) by [Unito](https://www.unito.io)
