### PR TITLE
feat: wire high-priority GA4 events in GtmTelemetryProvider

### DIFF
--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -66,4 +66,89 @@ describe('GtmTelemetryProvider', () => {
 
     expect(gtagScripts).toHaveLength(1)
   })
+
+  describe('GA4 event methods', () => {
+    let provider: GtmTelemetryProvider
+
+    beforeEach(() => {
+      window.__CONFIG__ = { gtm_container_id: 'GTM-TEST123' }
+      provider = new GtmTelemetryProvider()
+    })
+
+    it('pushes subscription_change event', () => {
+      provider.trackSubscription('subscribe_clicked')
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({
+          event: 'subscription_change',
+          action: 'subscribe_clicked'
+        })
+      )
+    })
+
+    it('pushes subscription_success event', () => {
+      provider.trackMonthlySubscriptionSucceeded()
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({ event: 'subscription_success' })
+      )
+    })
+
+    it('pushes run_workflow event with trigger source', () => {
+      provider.trackRunButton({
+        subscribe_to_run: true,
+        trigger_source: 'button'
+      })
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({
+          event: 'run_workflow',
+          subscribe_to_run: true,
+          trigger_source: 'button'
+        })
+      )
+    })
+
+    it('pushes workflow_execution event', () => {
+      provider.trackWorkflowExecution()
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({ event: 'workflow_execution' })
+      )
+    })
+
+    it('pushes execution_error event', () => {
+      provider.trackExecutionError({
+        jobId: 'job-1',
+        nodeType: 'KSampler',
+        error: 'OOM'
+      })
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({
+          event: 'execution_error',
+          node_type: 'KSampler',
+          error: 'OOM'
+        })
+      )
+    })
+
+    it('pushes add_credit_clicked event', () => {
+      provider.trackAddApiCreditButtonClicked()
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({ event: 'add_credit_clicked' })
+      )
+    })
+
+    it('pushes template_used event', () => {
+      provider.trackTemplate({
+        workflow_name: 'SDXL Basic',
+        template_source: 'library',
+        template_category: 'image_generation'
+      })
+      expect(window.dataLayer).toContainEqual(
+        expect.objectContaining({
+          event: 'template_used',
+          workflow_name: 'SDXL Basic',
+          template_source: 'library',
+          template_category: 'image_generation'
+        })
+      )
+    })
+  })
 })

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -1,7 +1,10 @@
 import type {
   AuthMetadata,
   BeginCheckoutMetadata,
+  ExecutionErrorMetadata,
+  ExecutionTriggerSource,
   PageViewMetadata,
+  TemplateMetadata,
   TelemetryProvider
 } from '../../types'
 
@@ -113,5 +116,46 @@ export class GtmTelemetryProvider implements TelemetryProvider {
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {
     this.pushEvent('begin_checkout', metadata)
+  }
+
+  trackSubscription(event: 'modal_opened' | 'subscribe_clicked'): void {
+    this.pushEvent('subscription_change', { action: event })
+  }
+
+  trackMonthlySubscriptionSucceeded(): void {
+    this.pushEvent('subscription_success')
+  }
+
+  trackRunButton(options?: {
+    subscribe_to_run?: boolean
+    trigger_source?: ExecutionTriggerSource
+  }): void {
+    this.pushEvent('run_workflow', {
+      subscribe_to_run: options?.subscribe_to_run,
+      trigger_source: options?.trigger_source
+    })
+  }
+
+  trackWorkflowExecution(): void {
+    this.pushEvent('workflow_execution')
+  }
+
+  trackExecutionError(metadata: ExecutionErrorMetadata): void {
+    this.pushEvent('execution_error', {
+      node_type: metadata.nodeType,
+      error: metadata.error
+    })
+  }
+
+  trackAddApiCreditButtonClicked(): void {
+    this.pushEvent('add_credit_clicked')
+  }
+
+  trackTemplate(metadata: TemplateMetadata): void {
+    this.pushEvent('template_used', {
+      workflow_name: metadata.workflow_name,
+      template_source: metadata.template_source,
+      template_category: metadata.template_category
+    })
   }
 }


### PR DESCRIPTION
## Summary

Wire 7 high-priority events from the TelemetryProvider interface to GA4 via GTM dataLayer pushes in `GtmTelemetryProvider`. These events were previously only tracked by Mixpanel.

## Events Added

| Method | GA4 Event Name | Priority | Purpose |
|---|---|---|---|
| `trackSubscription` | `subscription_change` | High | Track modal opens and subscribe clicks |
| `trackMonthlySubscriptionSucceeded` | `subscription_success` | High | Frontend conversion complement |
| `trackRunButton` | `run_workflow` | High | Core product engagement metric |
| `trackWorkflowExecution` | `workflow_execution` | Medium | Engagement depth |
| `trackExecutionError` | `execution_error` | Medium | Product quality signal |
| `trackAddApiCreditButtonClicked` | `add_credit_clicked` | Medium | Purchase intent signal |
| `trackTemplate` | `template_used` | Low | Content engagement |

## GTM Setup Required

Each new event needs a corresponding GA4 Event tag in GTM container `GTM-NP9JM6K7` following the pattern in the GA4 tracking docs. Without the GTM tags, events will be in the dataLayer but won't reach GA4.

## Testing

- 10 unit tests pass (3 existing + 7 new covering each event method)
- TypeScript typecheck clean

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9783-feat-wire-high-priority-GA4-events-in-GtmTelemetryProvider-3216d73d36508104953eea2f604550b5) by [Unito](https://www.unito.io)
