### PR TITLE
fix: resolve 'No inner node DTO found' error when muting subgraphs

### DIFF
--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   LGraph,
+  LGraphEventMode,
   LGraphNode,
   ExecutableNodeDTO
 } from '@/lib/litegraph/src/litegraph'
@@ -475,5 +476,122 @@ describe.skip('ExecutableNodeDTO Scale Testing', () => {
       const dto = new ExecutableNodeDTO(node, path, new Map(), undefined)
       expect(dto.id).toBe(testCase.expectedId)
     }
+  })
+})
+
+describe('Muted node output resolution', () => {
+  it('returns undefined when node mode is NEVER', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Muted Node')
+    node.addOutput('out', 'number')
+    node.mode = LGraphEventMode.NEVER
+    graph.add(node)
+
+    const dto = new ExecutableNodeDTO(node, [], new Map(), undefined)
+    const result = dto.resolveOutput(0, 'number', new Set())
+    expect(result).toBeUndefined()
+  })
+
+  it('does not throw when inner nodes are not registered for muted subgraph', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Muted Subgraph')
+    node.addOutput('out', 'number')
+    graph.add(node)
+    node.mode = LGraphEventMode.NEVER
+    // Simulate a subgraph node that would throw if _resolveSubgraphOutput ran
+    vi.spyOn(node, 'isSubgraphNode').mockReturnValue(true)
+
+    const dto = new ExecutableNodeDTO(node, [], new Map(), undefined)
+    expect(() => dto.resolveOutput(0, 'number', new Set())).not.toThrow()
+    expect(dto.resolveOutput(0, 'number', new Set())).toBeUndefined()
+  })
+
+  it('resolveInput to a muted upstream node resolves undefined', () => {
+    const graph = new LGraph()
+
+    const upstream = new LGraphNode('Upstream')
+    upstream.addOutput('out', 'number')
+    upstream.mode = LGraphEventMode.NEVER
+    graph.add(upstream)
+
+    const downstream = new LGraphNode('Downstream')
+    downstream.addInput('in', 'number')
+    graph.add(downstream)
+
+    downstream.connect(0, upstream, 0)
+
+    const nodesByExecutionId = new Map()
+    const upstreamDto = new ExecutableNodeDTO(
+      upstream,
+      [],
+      nodesByExecutionId,
+      undefined
+    )
+    const downstreamDto = new ExecutableNodeDTO(
+      downstream,
+      [],
+      nodesByExecutionId,
+      undefined
+    )
+    nodesByExecutionId.set(upstreamDto.id, upstreamDto)
+    nodesByExecutionId.set(downstreamDto.id, downstreamDto)
+
+    const result = downstreamDto.resolveInput(0)
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('Bypass node output resolution', () => {
+  it('bypasses through matching input when mode is BYPASS', () => {
+    const graph = new LGraph()
+
+    const source = new LGraphNode('Source')
+    source.addOutput('out', 'number')
+    graph.add(source)
+
+    const bypass = new LGraphNode('Bypass')
+    bypass.addInput('in', 'number')
+    bypass.addOutput('out', 'number')
+    bypass.mode = LGraphEventMode.BYPASS
+    graph.add(bypass)
+
+    source.connect(0, bypass, 0)
+
+    const nodesByExecutionId = new Map()
+    const sourceDto = new ExecutableNodeDTO(
+      source,
+      [],
+      nodesByExecutionId,
+      undefined
+    )
+    const bypassDto = new ExecutableNodeDTO(
+      bypass,
+      [],
+      nodesByExecutionId,
+      undefined
+    )
+    nodesByExecutionId.set(sourceDto.id, sourceDto)
+    nodesByExecutionId.set(bypassDto.id, bypassDto)
+
+    const result = bypassDto.resolveOutput(0, 'number', new Set())
+    expect(result).toBeDefined()
+    expect(result?.node).toBe(sourceDto)
+  })
+})
+
+describe('ALWAYS mode node output resolution', () => {
+  it('resolves to itself when mode is ALWAYS', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Normal Node')
+    node.addOutput('out', 'number')
+    node.mode = LGraphEventMode.ALWAYS
+    graph.add(node)
+
+    const dto = new ExecutableNodeDTO(node, [], new Map(), undefined)
+    const result = dto.resolveOutput(0, 'number', new Set())
+    expect(result).toBeDefined()
+    expect(result?.node).toBe(dto)
+    expect(result?.origin_id).toBe(dto.id)
+    expect(result?.origin_slot).toBe(0)
   })
 })

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -266,6 +266,9 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
     }
     visited.add(uniqueId)
 
+    // Muted nodes produce no output
+    if (this.mode === LGraphEventMode.NEVER) return
+
     // Upstreamed: Bypass nodes are bypassed using the first input with matching type
     if (this.mode === LGraphEventMode.BYPASS) {
       // Bypass nodes by finding first input with matching type

--- a/src/utils/executableGroupNodeDto.test.ts
+++ b/src/utils/executableGroupNodeDto.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  LGraph,
+  LGraphEventMode,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+
+import { ExecutableGroupNodeDTO } from './executableGroupNodeDto'
+
+describe('ExecutableGroupNodeDTO muted output resolution', () => {
+  it('returns undefined when node mode is NEVER', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Muted Group')
+    node.addOutput('out', 'number')
+    node.mode = LGraphEventMode.NEVER
+    graph.add(node)
+
+    const dto = new ExecutableGroupNodeDTO(node, [], new Map(), undefined)
+    const result = dto.resolveOutput(0, 'number', new Set())
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/utils/executableGroupNodeDto.ts
+++ b/src/utils/executableGroupNodeDto.ts
@@ -24,6 +24,9 @@ export class ExecutableGroupNodeDTO extends ExecutableNodeDTO {
   }
 
   override resolveOutput(slot: number, type: ISlotType, visited: Set<string>) {
+    // Muted nodes produce no output
+    if (this.mode === LGraphEventMode.NEVER) return
+
     // Temporary duplication: Bypass nodes are bypassed using the first input with matching type
     if (this.mode === LGraphEventMode.BYPASS) {
       const { inputs } = this


### PR DESCRIPTION
## Summary

Fix "No inner node DTO found for id [X:Y:Z]" error that occurs when executing a workflow containing muted subgraphs or group nodes. This is a regression from v1.39.2 → v1.39.3 that blocks workflow execution for many users relying on muted subgraphs.

## Symptoms

- Red popup error: `"No inner node DTO found for id [outer:inner]"` when queueing a prompt
- Workflow fails to execute entirely
- Triggered when a muted (mode=NEVER) subgraph/group node has outputs connected to downstream nodes (e.g. context switch nodes)
- Workaround: using bypass instead of mute, or downgrading to frontend v1.39.2
- Affects custom nodes like rgthree context/context-switch, but is not limited to any specific custom node

## Root Cause

In `executionUtil.ts` (lines 68-73), `graphToPrompt` correctly skips registering inner nodes of muted subgraphs — muted nodes shouldn't execute, so their inner node DTOs are intentionally not added to `nodeDtoMap`:

```typescript
if (node.mode === LGraphEventMode.NEVER || node.mode === LGraphEventMode.BYPASS) {
  continue  // skips dto.getInnerNodes() registration
}
```

However, when a downstream node's input is connected to the muted node's output, `resolveOutput()` still tries to resolve into those inner nodes:
- `ExecutableNodeDTO._resolveSubgraphOutput()` looks up the inner node DTO in `nodesByExecutionId` → not found → throws at line 399
- `ExecutableGroupNodeDTO.resolveOutput()` calls `getInnerNodes()` → fails similarly at line 62

The fix adds an early return for NEVER mode in `resolveOutput()` of both classes, matching the existing pattern used for BYPASS mode. Muted nodes return `undefined` (no output), which is the correct semantic — they produce nothing.

## Changes

- **What**: Add `if (this.mode === LGraphEventMode.NEVER) return` early exit in `resolveOutput()` for both `ExecutableNodeDTO` and `ExecutableGroupNodeDTO`

## Review Focus

The fix mirrors how BYPASS mode is already handled — both short-circuit before reaching inner-node resolution. The only difference is that BYPASS delegates to `resolveInput()` (pass-through), while NEVER returns `undefined` (no output).

Fixes #8986