### PR TITLE
fix: update workspace creation modal phrasing for credit pool clarity

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2505,7 +2505,7 @@
     },
     "createWorkspaceDialog": {
       "title": "Create a new workspace",
-      "message": "Workspaces let members share a single credits pool. You'll become the owner after creating this.",
+      "message": "Workspaces create a new credit pool that can be shared among members. You'll become the owner after creating this.",
       "nameLabel": "Workspace name*",
       "namePlaceholder": "Enter workspace name",
       "create": "Create"


### PR DESCRIPTION
## Summary

Update workspace creation modal copy to clarify that creating a workspace establishes a **new** credit pool, rather than sharing from the owner's existing credits.

## Changes

- **What**: Changed i18n message from "Workspaces let members share a single credits pool" to "Workspaces create a new credit pool that can be shared among members"

## Review Focus

Copy change only — single i18n string update in `src/locales/en/main.json`.

Fixes COM-16521

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9811-fix-update-workspace-creation-modal-phrasing-for-credit-pool-clarity-3216d73d36508186850ac5a8ad97461d) by [Unito](https://www.unito.io)
