### PR TITLE
fix: make chart colors reactive to theme changes (#9806)

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.vue
@@ -13,6 +13,7 @@
 
 <script setup lang="ts">
 import type { ChartData } from 'chart.js'
+import { useCssVar } from '@vueuse/core'
 import Chart from 'primevue/chart'
 import { computed } from 'vue'
 
@@ -33,50 +34,58 @@ const chartType = computed(() => props.widget.options?.type ?? 'line')
 
 const chartData = computed(() => value.value || { labels: [], datasets: [] })
 
-const chartOptions = computed(() => ({
-  responsive: true,
-  maintainAspectRatio: false,
-  plugins: {
-    legend: {
-      labels: {
-        color: '#FFF',
-        usePointStyle: true,
-        pointStyle: 'circle'
-      }
-    }
-  },
-  scales: {
-    x: {
-      ticks: {
-        color: '#9FA2BD'
-      },
-      grid: {
-        display: true,
-        color: '#9FA2BD',
-        drawTicks: false,
-        drawOnChartArea: true,
-        drawBorder: false
-      },
-      border: {
-        display: true,
-        color: '#9FA2BD'
+const baseForeground = useCssVar('--color-base-foreground')
+const mutedForeground = useCssVar('--color-muted-foreground')
+
+const chartOptions = computed(() => {
+  const legendColor = baseForeground.value || '#FFF'
+  const axisColor = mutedForeground.value || '#9FA2BD'
+
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        labels: {
+          color: legendColor,
+          usePointStyle: true,
+          pointStyle: 'circle'
+        }
       }
     },
-    y: {
-      ticks: {
-        color: '#9FA2BD'
+    scales: {
+      x: {
+        ticks: {
+          color: axisColor
+        },
+        grid: {
+          display: true,
+          color: axisColor,
+          drawTicks: false,
+          drawOnChartArea: true,
+          drawBorder: false
+        },
+        border: {
+          display: true,
+          color: axisColor
+        }
       },
-      grid: {
-        display: false,
-        drawTicks: false,
-        drawOnChartArea: false,
-        drawBorder: false
-      },
-      border: {
-        display: true,
-        color: '#9FA2BD'
+      y: {
+        ticks: {
+          color: axisColor
+        },
+        grid: {
+          display: false,
+          drawTicks: false,
+          drawOnChartArea: false,
+          drawBorder: false
+        },
+        border: {
+          display: true,
+          color: axisColor
+        }
       }
     }
   }
-}))
+})
 </script>


### PR DESCRIPTION
Closes #9806

## Summary

The chart widget (`WidgetChart.vue`) used hardcoded color values (`#FFF` for legend text, `#9FA2BD` for axes) that did not adapt when the application theme changed. This made the chart unreadable in light themes and inconsistent with the rest of the UI.

## Changes

- **`src/renderer/extensions/vueNodes/widgets/components/WidgetChart.vue`**: Replaced hardcoded color strings with reactive CSS variable references using `useCssVar` from VueUse. Legend text now uses `--color-base-foreground` and axis/grid colors use `--color-muted-foreground`, with the original values as fallbacks. The `chartOptions` computed property automatically updates when the theme changes.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9812-fix-make-chart-colors-reactive-to-theme-changes-9806-3216d73d365081139b26f8106bb9b40c) by [Unito](https://www.unito.io)
