### PR TITLE
fix: correct over-escaped node -e payload in .claude/settings.json (#9801)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpx vitest run --testPathPattern=\"draftCacheV2.test\")",
+      "Bash(pnpx vitest run \"draftCacheV2.test\")",
+      "Bash(node -e \"const fc = require('fast-check'); console.log(Object.keys(fc).filter((k) => k.includes('string')).join(', '))\")"
+    ]
+  }
+}


### PR DESCRIPTION
Closes #9801

## Summary

The `node -e` permission entry in `.claude/settings.json` was over-escaped, containing literal `\(` backslash-escaped parentheses and doubled single quotes like `''fast-check''`. This made the JavaScript payload invalid — Node.js would reject it with a syntax error when Claude attempted to run the command.

## Changes

- **`.claude/settings.json`**: Fixed the `node -e` Bash permission entry by removing extraneous backslash escapes before parentheses and replacing doubled single quotes with standard single quotes, producing valid JavaScript syntax.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9821-fix-correct-over-escaped-node-e-payload-in-claude-settings-json-9801-3216d73d365081aa9d11c8fb75b7bd14) by [Unito](https://www.unito.io)
