### PR TITLE
fix: refactor: replace two-pass error flag reconciliation with single-pass diff in lastNodeErrors watcher (#9796)

### DIFF
--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -35,42 +35,54 @@ interface MissingNodesError {
   nodeTypes: MissingNodeType[]
 }
 
-function clearAllNodeErrorFlags(rootGraph: LGraph): void {
+function reconcileNodeErrorFlags(
+  rootGraph: LGraph,
+  nodeErrors: Record<NodeId, NodeError> | null
+): void {
+  const errorNodeIds = new Set<LGraphNode>()
+  const errorSlotNames = new Map<LGraphNode, Set<string>>()
+
+  if (nodeErrors) {
+    for (const [executionId, nodeError] of Object.entries(nodeErrors)) {
+      const node = getNodeByExecutionId(rootGraph, executionId)
+      if (!node) continue
+
+      errorNodeIds.add(node)
+
+      for (const error of nodeError.errors) {
+        const slotName = error.extra_info?.input_name
+        if (!slotName) continue
+        let slots = errorSlotNames.get(node)
+        if (!slots) {
+          slots = new Set()
+          errorSlotNames.set(node, slots)
+        }
+        slots.add(slotName)
+      }
+
+      for (const parentId of getParentExecutionIds(executionId)) {
+        const parentNode = getNodeByExecutionId(rootGraph, parentId)
+        if (parentNode) errorNodeIds.add(parentNode)
+      }
+    }
+  }
+
   forEachNode(rootGraph, (node) => {
-    node.has_errors = false
+    const shouldHaveErrors = errorNodeIds.has(node)
+    if (node.has_errors !== shouldHaveErrors) {
+      node.has_errors = shouldHaveErrors
+    }
+
     if (node.inputs) {
+      const slotNames = errorSlotNames.get(node)
       for (const slot of node.inputs) {
-        slot.hasErrors = false
+        const shouldSlotHaveErrors = !!slotNames?.has(slot.name)
+        if (slot.hasErrors !== shouldSlotHaveErrors) {
+          slot.hasErrors = shouldSlotHaveErrors
+        }
       }
     }
   })
-}
-
-function markNodeSlotErrors(node: LGraphNode, nodeError: NodeError): void {
-  if (!node.inputs) return
-  for (const error of nodeError.errors) {
-    const slotName = error.extra_info?.input_name
-    if (!slotName) continue
-    const slot = node.inputs.find((s) => s.name === slotName)
-    if (slot) slot.hasErrors = true
-  }
-}
-
-function applyNodeError(
-  rootGraph: LGraph,
-  executionId: NodeExecutionId,
-  nodeError: NodeError
-): void {
-  const node = getNodeByExecutionId(rootGraph, executionId)
-  if (!node) return
-
-  node.has_errors = true
-  markNodeSlotErrors(node, nodeError)
-
-  for (const parentId of getParentExecutionIds(executionId)) {
-    const parentNode = getNodeByExecutionId(rootGraph, parentId)
-    if (parentNode) parentNode.has_errors = true
-  }
 }
 
 /** Execution error state: node errors, runtime errors, prompt errors, and missing assets. */
@@ -377,17 +389,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
 
   watch(lastNodeErrors, () => {
     if (!app.isGraphReady) return
-    const rootGraph = app.rootGraph
-
-    clearAllNodeErrorFlags(rootGraph)
-
-    if (!lastNodeErrors.value) return
-
-    for (const [executionId, nodeError] of Object.entries(
-      lastNodeErrors.value
-    )) {
-      applyNodeError(rootGraph, executionId, nodeError)
-    }
+    reconcileNodeErrorFlags(app.rootGraph, lastNodeErrors.value)
   })
 
   return {


### PR DESCRIPTION
Closes #9796

## Summary

The `lastNodeErrors` watcher in `executionErrorStore.ts` used a two-pass approach: first clearing all error flags on every node in the graph, then re-applying errors from the new state. This caused unnecessary DOM/reactivity churn by toggling flags on nodes that hadn't changed, and required three separate helper functions (`clearAllNodeErrorFlags`, `markNodeSlotErrors`, `applyNodeError`).

This PR replaces the two-pass clear-then-set approach with a single-pass diff-based reconciliation. The new `reconcileNodeErrorFlags` function first collects which nodes and slots should have errors, then walks all nodes once, only updating flags that actually changed.

## Changes

- **`src/stores/executionErrorStore.ts`**: Replaced `clearAllNodeErrorFlags`, `markNodeSlotErrors`, and `applyNodeError` with a single `reconcileNodeErrorFlags` function that:
  - Pre-computes error node set and per-node error slot names from `nodeErrors`
  - Walks all nodes once via `forEachNode`, only updating `has_errors` and `slot.hasErrors` when the value actually differs
  - Simplified the watcher to a single function call

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9824-fix-refactor-replace-two-pass-error-flag-reconciliation-with-single-pass-diff-in-lastNo-3216d73d36508134bcceff75797ba900) by [Unito](https://www.unito.io)
