### PR TITLE
fix: test(browser): add Playwright test for app startup when initServerCapabilities() fails or times out (#9825)

### DIFF
--- a/browser_tests/tests/serverCapabilities.spec.ts
+++ b/browser_tests/tests/serverCapabilities.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Server Capabilities Resilience', { tag: '@slow' }, () => {
+  test('App starts successfully when /api/features returns 500', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.route('**/api/features**', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Internal Server Error' })
+      })
+    })
+    await comfyPage.setup()
+
+    await expect(comfyPage.canvas).toBeVisible()
+  })
+
+  test('App starts successfully when /api/features network request fails', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.route('**/api/features**', async (route) => {
+      await route.abort('connectionrefused')
+    })
+    await comfyPage.setup()
+
+    await expect(comfyPage.canvas).toBeVisible()
+  })
+})


### PR DESCRIPTION
Closes #9825

## Summary

Issue #9825 reported that the app should gracefully handle failures in `initServerCapabilities()` (the `/api/features` endpoint). This PR adds Playwright E2E tests to verify the app starts successfully even when the server capabilities endpoint fails or is unreachable.

## Changes

- **`browser_tests/tests/serverCapabilities.spec.ts`** (new file): Added two Playwright tests:
  - Verifies app startup when `/api/features` returns HTTP 500
  - Verifies app startup when `/api/features` network request fails (connection refused)
  
  Both tests intercept the route before page setup and assert the canvas becomes visible, confirming the app is resilient to capabilities endpoint failures.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9828-fix-test-browser-add-Playwright-test-for-app-startup-when-initServerCapabilities-fai-3216d73d365081e69635d849283cbd5c) by [Unito](https://www.unito.io)
