### PR TITLE
fix: followup: add `once` option to subscription tier watcher in PostHogTelemetryProvider (#9835)

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -222,7 +222,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
           this.posthog.people.set({ subscription_tier: tier })
         }
       },
-      { immediate: true }
+      { immediate: true, once: true }
     )
   }
 


### PR DESCRIPTION
Closes #9835

## Summary

The `setSubscriptionProperties` method in `PostHogTelemetryProvider` used a `watch` with `{ immediate: true }` to observe `subscriptionTier` and set it as a PostHog user property. This watcher remained active indefinitely, re-setting the property on every tier change — which is unnecessary since the goal is to capture the user's subscription tier once at identification time.

## Changes

- **`src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts`**: Added `once: true` to the `watch` options in `setSubscriptionProperties()`, so the watcher fires only once when the tier is resolved, then automatically stops.

---
Automated by coderabbit-fixer

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9837-fix-followup-add-once-option-to-subscription-tier-watcher-in-PostHogTelemetryProvider-3216d73d36508104a7d2f2a21808e0f2) by [Unito](https://www.unito.io)
