### PR TITLE
feat: display original image dimensions in cloud mode

### DIFF
--- a/src/platform/assets/components/MediaImageTop.vue
+++ b/src/platform/assets/components/MediaImageTop.vue
@@ -20,6 +20,9 @@
 
 <script setup lang="ts">
 import { useImage, whenever } from '@vueuse/core'
+import { ref } from 'vue'
+
+import { isCloud } from '@/platform/distribution/types'
 
 import type { AssetMeta } from '../schemas/mediaAssetSchema'
 import { getAssetDisplayName } from '../utils/assetMetadataUtils'
@@ -33,6 +36,19 @@ const emit = defineEmits<{
   view: []
 }>()
 
+const originalDimensions = ref<{ width: number; height: number }>()
+
+if (isCloud && asset.src) {
+  fetch(asset.src).then((resp) => {
+    const w = Number(resp.headers.get('X-Original-Width'))
+    const h = Number(resp.headers.get('X-Original-Height'))
+    if (w > 0 && h > 0) {
+      originalDimensions.value = { width: w, height: h }
+      emit('image-loaded', w, h)
+    }
+  })
+}
+
 const { state, error, isReady } = useImage({
   src: asset.src ?? '',
   alt: getAssetDisplayName(asset)
@@ -40,7 +56,10 @@ const { state, error, isReady } = useImage({
 
 whenever(
   () =>
-    isReady.value && state.value?.naturalWidth && state.value?.naturalHeight,
+    isReady.value &&
+    state.value?.naturalWidth &&
+    state.value?.naturalHeight &&
+    !originalDimensions.value,
   () =>
     emit('image-loaded', state.value!.naturalWidth, state.value!.naturalHeight)
 )


### PR DESCRIPTION
## Summary

In cloud mode, the Assets panel shows 512px thumbnail dimensions instead of the original image size because `/api/view` uses `res=512`.

This reads `X-Original-Width` and `X-Original-Height` response headers (added in Comfy-Org/cloud#2830) to display accurate original dimensions.

## Changes

- **`MediaImageTop.vue`**: In cloud mode, fetch the image URL and read original dimension headers before falling back to `naturalWidth`/`naturalHeight`.

## Dependencies

- Comfy-Org/cloud#2830 (backend: include original image dimensions in resized view response headers)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9858-feat-display-original-image-dimensions-in-cloud-mode-3226d73d36508195a1f0c68c43f707c9) by [Unito](https://www.unito.io)
