### PR TITLE
fix: prevent white flash when opening mask editor

### DIFF
--- a/src/components/maskeditor/MaskEditorContent.vue
+++ b/src/components/maskeditor/MaskEditorContent.vue
@@ -35,7 +35,14 @@
           'z-40': store.activeLayer === 'mask'
         }"
       />
-      <div ref="canvasBackgroundRef" class="size-full bg-white" />
+      <div ref="canvasBackgroundRef" class="size-full" />
+    </div>
+
+    <div
+      v-if="!initialized"
+      class="absolute inset-0 z-50 flex items-center justify-center"
+    >
+      <span class="mask-editor-spinner" />
     </div>
 
     <div class="maskEditor-ui-container flex min-h-0 flex-1 flex-col">
@@ -227,5 +234,20 @@ onBeforeUnmount(() => {
   width: 100%;
   height: 100%;
   z-index: 0;
+}
+
+.mask-editor-spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgb(255 255 255 / 20%);
+  border-top-color: rgb(255 255 255 / 80%);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/src/components/maskeditor/MaskEditorContent.vue
+++ b/src/components/maskeditor/MaskEditorContent.vue
@@ -38,12 +38,7 @@
       <div ref="canvasBackgroundRef" class="size-full" />
     </div>
 
-    <div
-      v-if="!initialized"
-      class="absolute inset-0 z-50 flex items-center justify-center"
-    >
-      <span class="mask-editor-spinner" />
-    </div>
+    <LoadingOverlay :loading="!initialized" size="sm" />
 
     <div class="maskEditor-ui-container flex min-h-0 flex-1 flex-col">
       <div class="flex min-h-0 flex-1 overflow-hidden">
@@ -83,6 +78,8 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
+
+import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 
 import BrushCursor from './BrushCursor.vue'
 import PointerZone from './PointerZone.vue'
@@ -234,20 +231,5 @@ onBeforeUnmount(() => {
   width: 100%;
   height: 100%;
   z-index: 0;
-}
-
-.mask-editor-spinner {
-  width: 36px;
-  height: 36px;
-  border: 3px solid rgb(255 255 255 / 20%);
-  border-top-color: rgb(255 255 255 / 80%);
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 </style>


### PR DESCRIPTION
## Summary

- Remove hardcoded `bg-white` from mask editor canvas background div to prevent white flash on dialog open
- Add a loading spinner while the mask editor initializes (image loading, canvas setup, GPU resources)
- Background color is set dynamically by `setCanvasBackground()` after initialization

Fixes #9852


### AS IS

https://github.com/user-attachments/assets/7da61e32-671b-4056-b5ec-8cb246fc7689



### TO BE 
https://github.com/user-attachments/assets/bfdedc69-f690-42c5-8591-619623c04f55



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9860-fix-prevent-white-flash-when-opening-mask-editor-3226d73d365081de9b7ad4622438e6ed) by [Unito](https://www.unito.io)
