### PR TITLE
fix: preserve autogrow links on copy/paste for multi-spec nodes

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -210,4 +210,41 @@ describe('Autogrow', () => {
       'aa'
     ])
   })
+
+  test('Multi-spec autogrow recreates shim widgets on configure', () => {
+    const graph = new LGraph()
+    const node = testNode()
+    graph.add(node)
+    const multiInputsSpec = {
+      required: { value: ['IMAGE', {}], mask: ['IMAGE', {}] }
+    }
+    addAutogrow(node, { min: 1, input: multiInputsSpec })
+
+    // Multi-spec autogrow creates shim widgets via ensureWidgetForInput
+    const shimWidgets = node.widgets.filter((w) => w.type === 'shim')
+    expect(shimWidgets.length).toBe(2)
+
+    // Connect the last slot to trigger growth
+    connectInput(node, 0, graph)
+    expect(node.inputs.length).toBe(4)
+
+    // Simulate paste: manually add a serialized autogrow input with widget ref
+    // but missing its shim widget (reproducing the paste bug)
+    const shimsBefore = node.widgets.filter((w) => w.type === 'shim').length
+    const lastInput = node.inputs.at(-1)!
+    expect(lastInput.widget).toBeDefined()
+
+    // Remove all shim widgets to simulate paste (shim has serialize: false)
+    node.widgets = node.widgets.filter((w) => w.type !== 'shim')
+    expect(node.widgets.filter((w) => w.type === 'shim').length).toBe(0)
+
+    // Re-trigger onConnectionsChange for each input (simulates configure())
+    for (const [i, input] of node.inputs.entries()) {
+      node.onConnectionsChange?.(1, i, true, null, input)
+    }
+
+    // Shim widgets should be recreated
+    const shimsAfter = node.widgets.filter((w) => w.type === 'shim').length
+    expect(shimsAfter).toBe(shimsBefore)
+  })
 })

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -557,8 +557,7 @@ function withComfyAutogrow(node: LGraphNode): asserts node is AutogrowNode {
       const key = input.name.slice(0, input.name.lastIndexOf('.'))
       const autogrowGroup = this.comfyDynamic.autogrow[key]
       if (!autogrowGroup) return
-      if (app.configuringGraph && input.widget)
-        ensureWidgetForInput(node, input)
+      if (input.widget) ensureWidgetForInput(node, input)
       if (iscon) {
         if (swappingConnection || !linf) return
         autogrowInputConnected(slot, this)


### PR DESCRIPTION
## Summary

- Remove overly restrictive `app.configuringGraph` guard from `ensureWidgetForInput` call in autogrow `onConnectionsChange` callback
- During paste, `configuringGraph` is false, so shim widgets (which have `serialize: false`) were not recreated for multi-spec autogrow inputs
- `onGraphConfigured` then removed those inputs (no matching widget found), breaking restored links
- `ensureWidgetForInput` is idempotent — safe to call unconditionally

## Root Cause

Multi-spec autogrow groups (e.g., GLSL Shader, Math Expression) use `ensureWidgetForInput` to create shim widgets with `serialize: false`. On paste:

1. `createNode()` creates min autogrow slots with shim widgets
2. `configure()` restores serialized inputs (including extra autogrow slots with `widget` refs)
3. `onConnectionsChange` fires but skips `ensureWidgetForInput` because `app.configuringGraph` is false
4. `onGraphConfigured` removes inputs whose `widget` has no matching widget in `widgets[]`
5. Links to those removed inputs are lost

Single-spec autogrow (Batch Images) is unaffected because `ensureWidgetForInput` is never called for them, so `input.widget` is never set.

## Test plan

- [x] Unit test: multi-spec autogrow shim widgets are recreated during configure
- [x] All existing autogrow tests pass
- [ ] Manual: copy/paste GLSL Shader or Math Expression nodes with connected autogrow inputs

Fixes #9779

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9861-fix-preserve-autogrow-links-on-copy-paste-for-multi-spec-nodes-3226d73d3650812fad89f6448e8d3e0a) by [Unito](https://www.unito.io)
