### PR TITLE
feat: add model-to-node mappings for CogVideo, inpaint, and LayerDiffuse

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -384,6 +384,15 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
     quickRegister('BiRefNet/pth', 'LS_LoadBiRefNetModel', 'model')
     quickRegister('onnx/human-parts', 'LS_HumanPartsUltra', '')
     quickRegister('lama', 'LaMa', 'lama_model')
+
+    // CogVideoX video generation models (comfyui-cogvideoxwrapper)
+    quickRegister('CogVideo', 'DownloadAndLoadCogVideoModel', 'model')
+
+    // Inpaint models (comfyui-inpaint-nodes)
+    quickRegister('inpaint', 'INPAINT_LoadInpaintModel', 'model_name')
+
+    // LayerDiffuse transparent image generation (comfyui-layerdiffuse)
+    quickRegister('layer_model', 'LayeredDiffusionApply', 'config')
   }
 
   return {


### PR DESCRIPTION
## Summary
- Add `quickRegister()` entries for 3 model directories missing UI backlinks:
  - `CogVideo` → `DownloadAndLoadCogVideoModel` (covers CogVideo, CogVideo/ControlNet/*, CogVideo/VAE)
  - `inpaint` → `INPAINT_LoadInpaintModel`
  - `layer_model` → `LayeredDiffusionApply`

These mappings ensure the "Use" button in the model browser correctly creates
the appropriate loader node when users click on models from these node packs.

## Test plan
- [ ] Verify "Use" button works for CogVideo models in model browser
- [ ] Verify "Use" button works for inpaint models (fooocus, lama, MAT)
- [ ] Verify "Use" button works for LayerDiffuse models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9890-feat-add-model-to-node-mappings-for-CogVideo-inpaint-and-LayerDiffuse-3226d73d3650816ea547fbcdf3a20c35) by [Unito](https://www.unito.io)
