### PR TITLE
fix: reorder forwardPanEvent conditions to skip expensive hasTextSelection on non-middle-button events

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -563,10 +563,8 @@ onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
 function forwardPanEvent(e: PointerEvent) {
-  if (
-    (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target) ||
-    !isMiddlePointerInput(e)
-  )
+  if (!isMiddlePointerInput(e)) return
+  if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
     return
 
   canvasInteractions.forwardEventToCanvas(e)


### PR DESCRIPTION
## Summary

Reorder condition checks in `forwardPanEvent` so the cheap `isMiddlePointerInput()` check runs first, avoiding expensive `hasTextSelection()` → `window.getSelection().toString().trim()` on every pointermove event.

## Changes

- **What**: `forwardPanEvent` now early-returns on `!isMiddlePointerInput(e)` before calling `shouldIgnoreCopyPaste`, which internally calls `hasTextSelection()`. Since most pointermove events are not middle-button, this skips the expensive `toString()` call entirely.

## Review Focus

Semantic equivalence: the original condition was `(A && B) || C → return`. Rewritten as two guards: `if (C) return; if (A && B) return;`. The logic is equivalent — if `C` (`!isMiddlePointerInput`) is true, we return regardless of `A && B`. If `C` is false (middle button), we check `A && B` (`shouldIgnoreCopyPaste && activeElement`).

## Evidence

Backlog item #19. rizumu's Chrome DevTools profiling (Mar 2026) of a 245-node workflow showed `toString()` in `hasTextSelection` called on every pointermove. Source: Slack `#C095BJSFV24` thread `p1772823346206479`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9892-fix-reorder-forwardPanEvent-conditions-to-skip-expensive-hasTextSelection-on-non-middle--3226d73d365081d38b89c8bb1dde3693) by [Unito](https://www.unito.io)
