### PR TITLE
fix: prevent blueprint cache corruption on repeated placement

### DIFF
--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
@@ -31,7 +31,7 @@
     </template>
 
     <template v-else-if="error">
-      <main class="flex flex-col items-center gap-4 px-8 py-8">
+      <main class="flex flex-col items-center gap-4 p-8">
         <i
           class="icon-[lucide--circle-alert] size-8 text-warning-background"
           aria-hidden="true"

--- a/src/platform/workflow/sharing/components/profile/ComfyHubCreateProfileForm.vue
+++ b/src/platform/workflow/sharing/components/profile/ComfyHubCreateProfileForm.vue
@@ -24,7 +24,7 @@
           {{ $t('comfyHubProfile.chooseProfilePicture') }}
         </label>
         <label
-          class="flex size-13 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-gradient-to-b from-green-600/50 to-green-900"
+          class="flex size-13 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-linear-to-b from-green-600/50 to-green-900"
         >
           <input
             id="profile-picture"

--- a/src/platform/workflow/sharing/components/publish/ComfyHubExamplesStep.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubExamplesStep.vue
@@ -57,7 +57,7 @@
         <img
           :src="image.url"
           :alt="$t('comfyHubPublish.exampleImage', { index: index + 1 })"
-          class="h-full w-full object-cover"
+          class="size-full object-cover"
         />
         <div
           v-if="isSelected(image.id)"

--- a/src/platform/workflow/sharing/components/publish/ComfyHubThumbnailStep.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubThumbnailStep.vue
@@ -50,12 +50,12 @@
             <img
               :src="comparisonPreviewUrls.after!"
               :alt="$t('comfyHubPublish.uploadComparisonAfterPrompt')"
-              class="h-full w-full object-contain"
+              class="size-full object-contain"
             />
             <img
               :src="comparisonPreviewUrls.before!"
               :alt="$t('comfyHubPublish.uploadComparisonBeforePrompt')"
-              class="absolute inset-0 h-full w-full object-contain"
+              class="absolute inset-0 size-full object-contain"
               :style="{
                 clipPath: `inset(0 ${100 - previewSliderPosition}% 0 0)`
               }"

--- a/src/renderer/extensions/vueNodes/VideoPreview.vue
+++ b/src/renderer/extensions/vueNodes/VideoPreview.vue
@@ -247,7 +247,7 @@ const handleFocusOut = (event: FocusEvent) => {
 
 const getNavigationDotClass = (index: number) =>
   cn(
-    'w-2 h-2 rounded-full transition-all duration-200 border-0 cursor-pointer',
+    'size-2 rounded-full transition-all duration-200 border-0 cursor-pointer',
     index === currentIndex.value
       ? 'bg-base-foreground'
       : 'bg-base-foreground/50 hover:bg-base-foreground/80'

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -155,6 +155,16 @@ describe('useSubgraphStore', () => {
     } as ComfyNodeDefV1)
     expect(res).toBeTruthy()
   })
+  it('should return a deep copy from getBlueprint so mutations do not corrupt the cache', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    const first = store.getBlueprint(store.typePrefix + 'test')
+    first.nodes[0].id = -1
+    first.definitions!.subgraphs![0].id = 'corrupted'
+
+    const second = store.getBlueprint(store.typePrefix + 'test')
+    expect(second.nodes[0].id).not.toBe(-1)
+    expect(second.definitions!.subgraphs![0].id).toBe('123')
+  })
   it('should identify user blueprints as non-global', async () => {
     await mockFetch({ 'test.json': mockGraph })
     expect(store.isGlobalBlueprint('test')).toBe(false)

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -393,7 +393,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     if (!(name in subgraphCache))
       //As loading is blocked on in startup, this can likely be changed to invalid type
       throw new Error('not yet loaded')
-    return subgraphCache[name].changeTracker.initialState
+    return structuredClone(subgraphCache[name].changeTracker.initialState)
   }
   async function deleteBlueprint(nodeType: string) {
     const name = nodeType.slice(typePrefix.length)


### PR DESCRIPTION
Add `structuredClone()` in `getBlueprint()` so `_deserializeItems()` mutations (node IDs, subgraph UUIDs) don't corrupt cached data.

Includes regression test verifying cache immutability.

Fixes COM-16026

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9895-fix-prevent-blueprint-cache-corruption-on-repeated-placement-3226d73d365081c2953ce91a98f74e23) by [Unito](https://www.unito.io)
