### PR TITLE
fix: stabilize subgraph promoted widget identity and rendering

### DIFF
--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -93,6 +93,17 @@ function isWidgetShownOnParents(
   })
 }
 
+function getWidgetRenderKey(
+  widgetNode: LGraphNode,
+  widget: IBaseWidget
+): string {
+  if (isPromotedWidgetView(widget)) {
+    return `${String(widgetNode.id)}:${widget.sourceNodeId}:${widget.sourceWidgetName}:${widget.name}:${widget.type}`
+  }
+
+  return `${String(widgetNode.id)}:${widget.name}:${widget.type}`
+}
+
 const isEmpty = computed(() => widgets.value.length === 0)
 
 const displayLabel = computed(
@@ -272,7 +283,7 @@ defineExpose({
         <TransitionGroup name="list-scale">
           <WidgetItem
             v-for="{ widget, node } in widgets"
-            :key="`${node.id}-${widget.name}-${widget.type}`"
+            :key="getWidgetRenderKey(node, widget)"
             :widget="widget"
             :node="node"
             :is-draggable="isDraggable"

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -23,6 +23,7 @@ import { HideLayoutFieldKey } from '@/types/widgetTypes'
 
 import { GetNodeParentGroupKey } from '../shared'
 import WidgetItem from './WidgetItem.vue'
+import { getStableWidgetRenderKey } from '@/core/graph/subgraph/widgetRenderKey'
 
 const {
   label,
@@ -91,17 +92,6 @@ function isWidgetShownOnParents(
       widget.name
     )
   })
-}
-
-function getWidgetRenderKey(
-  widgetNode: LGraphNode,
-  widget: IBaseWidget
-): string {
-  if (isPromotedWidgetView(widget)) {
-    return `${String(widgetNode.id)}:${widget.sourceNodeId}:${widget.sourceWidgetName}:${widget.name}:${widget.type}`
-  }
-
-  return `${String(widgetNode.id)}:${widget.name}:${widget.type}`
 }
 
 const isEmpty = computed(() => widgets.value.length === 0)
@@ -283,7 +273,7 @@ defineExpose({
         <TransitionGroup name="list-scale">
           <WidgetItem
             v-for="{ widget, node } in widgets"
-            :key="getWidgetRenderKey(node, widget)"
+            :key="getStableWidgetRenderKey(widget)"
             :widget="widget"
             :node="node"
             :is-draggable="isDraggable"

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -390,6 +390,56 @@ describe('Nested promoted widget mapping', () => {
       `${subgraphNodeB.subgraph.id}:${innerNode.id}`
     )
   })
+
+  it('keeps linked and independent same-name promotions as distinct sources', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+
+    const linkedNode = new LGraphNode('LinkedNode')
+    const linkedInput = linkedNode.addInput('string_a', '*')
+    linkedNode.addWidget('text', 'string_a', 'linked', () => undefined, {})
+    linkedInput.widget = { name: 'string_a' }
+    subgraph.add(linkedNode)
+    subgraph.inputNode.slots[0].connect(linkedInput, linkedNode)
+
+    const independentNode = new LGraphNode('IndependentNode')
+    independentNode.addWidget(
+      'text',
+      'string_a',
+      'independent',
+      () => undefined,
+      {}
+    )
+    subgraph.add(independentNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 109 })
+    const graph = subgraphNode.graph as LGraph
+    graph.add(subgraphNode)
+
+    usePromotionStore().promote(
+      subgraphNode.rootGraph.id,
+      subgraphNode.id,
+      String(independentNode.id),
+      'string_a'
+    )
+
+    const { vueNodeData } = useGraphNodeManager(graph)
+    const nodeData = vueNodeData.get(String(subgraphNode.id))
+    const promotedWidgets = nodeData?.widgets?.filter(
+      (widget) => widget.name === 'string_a'
+    )
+
+    expect(promotedWidgets).toHaveLength(2)
+    expect(
+      new Set(promotedWidgets?.map((widget) => widget.storeNodeId))
+    ).toEqual(
+      new Set([
+        `${subgraph.id}:${linkedNode.id}`,
+        `${subgraph.id}:${independentNode.id}`
+      ])
+    )
+  })
 })
 
 describe('Promoted widget sourceExecutionId', () => {

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -241,6 +241,62 @@ describe('Widget slotMetadata reactivity on link disconnect', () => {
 
     expect(widgetData?.slotMetadata?.linked).toBe(false)
   })
+
+  it('prefers exact _widget input matches before same-name fallbacks for promoted widgets', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'seed', type: '*' },
+        { name: 'seed', type: '*' }
+      ]
+    })
+
+    const firstNode = new LGraphNode('FirstNode')
+    const firstInput = firstNode.addInput('seed', '*')
+    firstNode.addWidget('number', 'seed', 1, () => undefined, {})
+    firstInput.widget = { name: 'seed' }
+    subgraph.add(firstNode)
+
+    const secondNode = new LGraphNode('SecondNode')
+    const secondInput = secondNode.addInput('seed', '*')
+    secondNode.addWidget('number', 'seed', 2, () => undefined, {})
+    secondInput.widget = { name: 'seed' }
+    subgraph.add(secondNode)
+
+    subgraph.inputNode.slots[0].connect(firstInput, firstNode)
+    subgraph.inputNode.slots[1].connect(secondInput, secondNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 124 })
+    const graph = subgraphNode.graph
+    if (!graph) throw new Error('Expected subgraph node graph')
+    graph.add(subgraphNode)
+
+    const promotedViews = subgraphNode.widgets
+    const secondPromotedView = promotedViews[1]
+    if (!secondPromotedView) throw new Error('Expected second promoted view')
+
+    ;(
+      secondPromotedView as unknown as {
+        sourceNodeId: string
+        sourceWidgetName: string
+      }
+    ).sourceNodeId = '9999'
+    ;(
+      secondPromotedView as unknown as {
+        sourceNodeId: string
+        sourceWidgetName: string
+      }
+    ).sourceWidgetName = 'stale_widget'
+
+    const { vueNodeData } = useGraphNodeManager(graph)
+    const nodeData = vueNodeData.get(String(subgraphNode.id))
+    const secondMappedWidget = nodeData?.widgets?.find(
+      (widget) => widget.slotMetadata?.index === 1
+    )
+    if (!secondMappedWidget)
+      throw new Error('Expected mapped widget for slot 1')
+
+    expect(secondMappedWidget.name).not.toBe('stale_widget')
+  })
 })
 
 describe('Subgraph output slot label reactivity', () => {

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -7,6 +7,7 @@ import { reactive, shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
+import { matchPromotedInput } from '@/core/graph/subgraph/matchPromotedInput'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolvePromotedWidgetSource } from '@/core/graph/subgraph/resolvePromotedWidgetSource'
 import { resolveSubgraphInputTarget } from '@/core/graph/subgraph/resolveSubgraphInputTarget'
@@ -242,11 +243,7 @@ function safeWidgetMapper(
       }
     }
 
-    const matchedInput = node.inputs?.find((input) => {
-      if (input.name === widget.name) return true
-      if (input._widget === widget) return true
-      return false
-    })
+    const matchedInput = matchPromotedInput(node.inputs, widget)
     const promotedInputName = matchedInput?.name
     const displayName = promotedInputName ?? widget.name
     const directSource = {

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -249,16 +249,14 @@ function safeWidgetMapper(
     })
     const promotedInputName = matchedInput?.name
     const displayName = promotedInputName ?? widget.name
+    const directSource = {
+      sourceNodeId: widget.sourceNodeId,
+      sourceWidgetName: widget.sourceWidgetName
+    }
     const promotedSource =
       matchedInput?._widget === widget
-        ? (resolvePromotedSourceByInputName(displayName) ?? {
-            sourceNodeId: widget.sourceNodeId,
-            sourceWidgetName: widget.sourceWidgetName
-          })
-        : {
-            sourceNodeId: widget.sourceNodeId,
-            sourceWidgetName: widget.sourceWidgetName
-          }
+        ? (resolvePromotedSourceByInputName(displayName) ?? directSource)
+        : directSource
 
     return {
       displayName,

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -242,16 +242,23 @@ function safeWidgetMapper(
       }
     }
 
-    const promotedInputName = node.inputs?.find((input) => {
+    const matchedInput = node.inputs?.find((input) => {
       if (input.name === widget.name) return true
       if (input._widget === widget) return true
       return false
-    })?.name
+    })
+    const promotedInputName = matchedInput?.name
     const displayName = promotedInputName ?? widget.name
-    const promotedSource = resolvePromotedSourceByInputName(displayName) ?? {
-      sourceNodeId: widget.sourceNodeId,
-      sourceWidgetName: widget.sourceWidgetName
-    }
+    const promotedSource =
+      matchedInput?._widget === widget
+        ? (resolvePromotedSourceByInputName(displayName) ?? {
+            sourceNodeId: widget.sourceNodeId,
+            sourceWidgetName: widget.sourceWidgetName
+          })
+        : {
+            sourceNodeId: widget.sourceNodeId,
+            sourceWidgetName: widget.sourceWidgetName
+          }
 
     return {
       displayName,

--- a/src/core/graph/subgraph/matchPromotedInput.test.ts
+++ b/src/core/graph/subgraph/matchPromotedInput.test.ts
@@ -54,4 +54,24 @@ describe(matchPromotedInput, () => {
 
     expect(matched).toBe(aliasInput)
   })
+
+  it('does not guess when multiple same-name inputs exist without an exact match', () => {
+    const targetWidget = createWidget('seed')
+    const firstAliasInput: MockInput = {
+      name: 'seed'
+    }
+    const secondAliasInput: MockInput = {
+      name: 'seed'
+    }
+
+    const matched = matchPromotedInput(
+      [firstAliasInput, secondAliasInput] as unknown as Array<{
+        name: string
+        _widget?: IBaseWidget
+      }>,
+      targetWidget
+    )
+
+    expect(matched).toBeUndefined()
+  })
 })

--- a/src/core/graph/subgraph/matchPromotedInput.test.ts
+++ b/src/core/graph/subgraph/matchPromotedInput.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { matchPromotedInput } from './matchPromotedInput'
+
+type MockInput = {
+  name: string
+  _widget?: IBaseWidget
+}
+
+function createWidget(name: string): IBaseWidget {
+  return {
+    name,
+    type: 'text'
+  } as IBaseWidget
+}
+
+describe(matchPromotedInput, () => {
+  it('prefers exact _widget matches before same-name inputs', () => {
+    const targetWidget = createWidget('seed')
+    const aliasWidget = createWidget('seed')
+
+    const aliasInput: MockInput = {
+      name: 'seed',
+      _widget: aliasWidget
+    }
+    const exactInput: MockInput = {
+      name: 'seed',
+      _widget: targetWidget
+    }
+
+    const matched = matchPromotedInput(
+      [aliasInput, exactInput] as unknown as Array<{
+        name: string
+        _widget?: IBaseWidget
+      }>,
+      targetWidget
+    )
+
+    expect(matched).toBe(exactInput)
+  })
+
+  it('falls back to same-name matching when no exact widget match exists', () => {
+    const targetWidget = createWidget('seed')
+    const aliasInput: MockInput = {
+      name: 'seed'
+    }
+
+    const matched = matchPromotedInput(
+      [aliasInput] as unknown as Array<{ name: string; _widget?: IBaseWidget }>,
+      targetWidget
+    )
+
+    expect(matched).toBe(aliasInput)
+  })
+})

--- a/src/core/graph/subgraph/matchPromotedInput.ts
+++ b/src/core/graph/subgraph/matchPromotedInput.ts
@@ -1,0 +1,18 @@
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+type PromotedInputLike = {
+  name: string
+  _widget?: IBaseWidget
+}
+
+export function matchPromotedInput(
+  inputs: PromotedInputLike[] | undefined,
+  widget: IBaseWidget
+): PromotedInputLike | undefined {
+  if (!inputs) return undefined
+
+  return (
+    inputs.find((input) => input._widget === widget) ??
+    inputs.find((input) => input.name === widget.name)
+  )
+}

--- a/src/core/graph/subgraph/matchPromotedInput.ts
+++ b/src/core/graph/subgraph/matchPromotedInput.ts
@@ -11,8 +11,9 @@ export function matchPromotedInput(
 ): PromotedInputLike | undefined {
   if (!inputs) return undefined
 
-  return (
-    inputs.find((input) => input._widget === widget) ??
-    inputs.find((input) => input.name === widget.name)
-  )
+  const exactMatch = inputs.find((input) => input._widget === widget)
+  if (exactMatch) return exactMatch
+
+  const sameNameMatches = inputs.filter((input) => input.name === widget.name)
+  return sameNameMatches.length === 1 ? sameNameMatches[0] : undefined
 }

--- a/src/core/graph/subgraph/promotedWidgetView.test.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.test.ts
@@ -97,15 +97,15 @@ function callSyncPromotions(node: SubgraphNode) {
   )._syncPromotions()
 }
 
+afterEach(() => {
+  cleanupComplexPromotionFixtureNodeType()
+})
+
 describe(createPromotedWidgetView, () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     mockDomWidgetStore.widgetStates.clear()
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    cleanupComplexPromotionFixtureNodeType()
   })
 
   test('exposes sourceNodeId and sourceWidgetName', () => {

--- a/src/core/graph/subgraph/promotedWidgetView.test.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.test.ts
@@ -1560,9 +1560,11 @@ describe('widgets getter caching', () => {
     )
 
     void subgraphNode.widgets
-    void subgraphNode.widgets
+    const initialResolveCount = resolveSpy.mock.calls.length
+    expect(initialResolveCount).toBeLessThanOrEqual(1)
 
-    expect(resolveSpy.mock.calls.length).toBeLessThanOrEqual(1)
+    void subgraphNode.widgets
+    expect(resolveSpy).toHaveBeenCalledTimes(initialResolveCount)
   })
 
   test('preserves view identities when promotion order changes', () => {

--- a/src/core/graph/subgraph/promotedWidgetView.test.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.test.ts
@@ -6,25 +6,37 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 // (promotedWidgetView → widgetMap → BaseWidget → LegacyWidget → barrel)
 import {
   CanvasPointer,
+  LGraph,
   LGraphNode,
-  LiteGraph
+  LiteGraph,
+  SubgraphNode as SubgraphNodeCtor
 } from '@/lib/litegraph/src/litegraph'
 import type {
   CanvasPointerEvent,
+  LGraphCanvas,
   SubgraphNode
 } from '@/lib/litegraph/src/litegraph'
+import type {
+  ExportedSubgraph,
+  ExportedSubgraphInstance
+} from '@/lib/litegraph/src/types/serialisation'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 import { createPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetView'
 import type { PromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetView'
+import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolvePromotedWidgetSource } from '@/core/graph/subgraph/resolvePromotedWidgetSource'
 import { usePromotionStore } from '@/stores/promotionStore'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import {
+  stripGraphPrefix,
+  useWidgetValueStore
+} from '@/stores/widgetValueStore'
 
 import {
   createTestSubgraph,
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { subgraphComplexPromotion1 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphComplexPromotion1'
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({})
@@ -76,6 +88,10 @@ function firstInnerNode(innerNodes: LGraphNode[]): LGraphNode {
   const innerNode = innerNodes[0]
   if (!innerNode) throw new Error('Expected at least one inner node')
   return innerNode
+}
+
+function promotedWidgets(node: SubgraphNode): PromotedWidgetView[] {
+  return node.widgets as PromotedWidgetView[]
 }
 
 describe(createPromotedWidgetView, () => {
@@ -495,6 +511,185 @@ describe('SubgraphNode.widgets getter', () => {
     ])
   })
 
+  test('renders all promoted widgets when duplicate input names are connected to different nodes', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'seed', type: '*' },
+        { name: 'seed', type: '*' }
+      ]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 94 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const firstNode = new LGraphNode('FirstSeedNode')
+    const firstInput = firstNode.addInput('seed', '*')
+    firstNode.addWidget('number', 'seed', 1, () => {})
+    firstInput.widget = { name: 'seed' }
+    subgraph.add(firstNode)
+
+    const secondNode = new LGraphNode('SecondSeedNode')
+    const secondInput = secondNode.addInput('seed', '*')
+    secondNode.addWidget('number', 'seed', 2, () => {})
+    secondInput.widget = { name: 'seed' }
+    subgraph.add(secondNode)
+
+    subgraph.inputNode.slots[0].connect(firstInput, firstNode)
+    subgraph.inputNode.slots[1].connect(secondInput, secondNode)
+
+    const widgets = promotedWidgets(subgraphNode)
+    expect(widgets).toHaveLength(2)
+    expect(widgets.map((widget) => widget.sourceNodeId)).toStrictEqual([
+      String(firstNode.id),
+      String(secondNode.id)
+    ])
+  })
+
+  test('input-linked same-name widgets share value state while store-promoted peer stays independent', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 95 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNodeA = new LGraphNode('LinkedNodeA')
+    const linkedInputA = linkedNodeA.addInput('string_a', '*')
+    linkedNodeA.addWidget('text', 'string_a', 'a', () => {})
+    linkedInputA.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeA)
+
+    const linkedNodeB = new LGraphNode('LinkedNodeB')
+    const linkedInputB = linkedNodeB.addInput('string_a', '*')
+    linkedNodeB.addWidget('text', 'string_a', 'b', () => {})
+    linkedInputB.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeB)
+
+    const promotedNode = new LGraphNode('PromotedNode')
+    promotedNode.addWidget('text', 'string_a', 'independent', () => {})
+    subgraph.add(promotedNode)
+
+    subgraph.inputNode.slots[0].connect(linkedInputA, linkedNodeA)
+    subgraph.inputNode.slots[0].connect(linkedInputB, linkedNodeB)
+
+    usePromotionStore().promote(
+      subgraphNode.rootGraph.id,
+      subgraphNode.id,
+      String(promotedNode.id),
+      'string_a'
+    )
+    usePromotionStore().promote(
+      subgraphNode.rootGraph.id,
+      subgraphNode.id,
+      String(linkedNodeA.id),
+      'string_a'
+    )
+
+    const widgets = promotedWidgets(subgraphNode)
+    expect(widgets).toHaveLength(2)
+
+    const linkedView = widgets.find(
+      (widget) => widget.sourceNodeId === String(linkedNodeA.id)
+    )
+    const promotedView = widgets.find(
+      (widget) => widget.sourceNodeId === String(promotedNode.id)
+    )
+    if (!linkedView || !promotedView)
+      throw new Error(
+        'Expected linked and store-promoted widgets to be present'
+      )
+
+    linkedView.value = 'shared-value'
+
+    const widgetStore = useWidgetValueStore()
+    const graphId = subgraphNode.rootGraph.id
+    expect(
+      widgetStore.getWidget(
+        graphId,
+        stripGraphPrefix(String(linkedNodeA.id)),
+        'string_a'
+      )?.value
+    ).toBe('shared-value')
+    expect(
+      widgetStore.getWidget(
+        graphId,
+        stripGraphPrefix(String(linkedNodeB.id)),
+        'string_a'
+      )?.value
+    ).toBe('shared-value')
+    expect(
+      widgetStore.getWidget(
+        graphId,
+        stripGraphPrefix(String(promotedNode.id)),
+        'string_a'
+      )?.value
+    ).toBe('independent')
+
+    promotedView.value = 'independent-updated'
+
+    expect(
+      widgetStore.getWidget(
+        graphId,
+        stripGraphPrefix(String(linkedNodeA.id)),
+        'string_a'
+      )?.value
+    ).toBe('shared-value')
+    expect(
+      widgetStore.getWidget(
+        graphId,
+        stripGraphPrefix(String(linkedNodeB.id)),
+        'string_a'
+      )?.value
+    ).toBe('shared-value')
+    expect(
+      widgetStore.getWidget(
+        graphId,
+        stripGraphPrefix(String(promotedNode.id)),
+        'string_a'
+      )?.value
+    ).toBe('independent-updated')
+  })
+
+  test('duplicate-name promoted views map slot linkage by view identity', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 109 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNode = new LGraphNode('LinkedNode')
+    const linkedInput = linkedNode.addInput('string_a', '*')
+    linkedNode.addWidget('text', 'string_a', 'linked', () => {})
+    linkedInput.widget = { name: 'string_a' }
+    subgraph.add(linkedNode)
+
+    const independentNode = new LGraphNode('IndependentNode')
+    independentNode.addWidget('text', 'string_a', 'independent', () => {})
+    subgraph.add(independentNode)
+
+    subgraph.inputNode.slots[0].connect(linkedInput, linkedNode)
+    usePromotionStore().promote(
+      subgraphNode.rootGraph.id,
+      subgraphNode.id,
+      String(independentNode.id),
+      'string_a'
+    )
+
+    const widgets = promotedWidgets(subgraphNode)
+    const linkedView = widgets.find(
+      (widget) => widget.sourceNodeId === String(linkedNode.id)
+    )
+    const independentView = widgets.find(
+      (widget) => widget.sourceNodeId === String(independentNode.id)
+    )
+    if (!linkedView || !independentView)
+      throw new Error('Expected linked and independent promoted views')
+
+    const linkedSlot = subgraphNode.getSlotFromWidget(linkedView)
+    const independentSlot = subgraphNode.getSlotFromWidget(independentView)
+
+    expect(linkedSlot).toBeDefined()
+    expect(independentSlot).toBeUndefined()
+  })
+
   test('returns empty array when no proxyWidgets', () => {
     const [subgraphNode] = setupSubgraph()
     expect(subgraphNode.widgets).toEqual([])
@@ -556,6 +751,165 @@ describe('SubgraphNode.widgets getter', () => {
       { interiorNodeId: String(liveNode.id), widgetName: 'widgetA' },
       { interiorNodeId: '9999', widgetName: 'widgetB' }
     ])
+  })
+
+  test('syncPromotions prunes stale connected entries but keeps independent promotions', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 96 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNodeA = new LGraphNode('LinkedNodeA')
+    const linkedInputA = linkedNodeA.addInput('string_a', '*')
+    linkedNodeA.addWidget('text', 'string_a', 'a', () => {})
+    linkedInputA.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeA)
+
+    const linkedNodeB = new LGraphNode('LinkedNodeB')
+    const linkedInputB = linkedNodeB.addInput('string_a', '*')
+    linkedNodeB.addWidget('text', 'string_a', 'b', () => {})
+    linkedInputB.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeB)
+
+    const independentNode = new LGraphNode('IndependentNode')
+    independentNode.addWidget('text', 'string_a', 'independent', () => {})
+    subgraph.add(independentNode)
+
+    subgraph.inputNode.slots[0].connect(linkedInputA, linkedNodeA)
+    subgraph.inputNode.slots[0].connect(linkedInputB, linkedNodeB)
+
+    setPromotions(subgraphNode, [
+      [String(independentNode.id), 'string_a'],
+      [String(linkedNodeA.id), 'string_a'],
+      [String(linkedNodeB.id), 'string_a']
+    ])
+
+    ;(
+      subgraphNode as unknown as {
+        _syncPromotions: () => void
+      }
+    )._syncPromotions()
+
+    const promotions = usePromotionStore().getPromotions(
+      subgraphNode.rootGraph.id,
+      subgraphNode.id
+    )
+    expect(promotions).toStrictEqual([
+      { interiorNodeId: String(linkedNodeA.id), widgetName: 'string_a' },
+      { interiorNodeId: String(independentNode.id), widgetName: 'string_a' }
+    ])
+  })
+
+  test('syncPromotions prunes stale deep-alias entries for nested linked promotions', () => {
+    const { subgraphNodeB } = createTwoLevelNestedSubgraph()
+    const linkedView = promotedWidgets(subgraphNodeB)[0]
+    if (!linkedView)
+      throw new Error(
+        'Expected nested subgraph to expose a linked promoted view'
+      )
+
+    const concrete = resolveConcretePromotedWidget(
+      subgraphNodeB,
+      linkedView.sourceNodeId,
+      linkedView.sourceWidgetName
+    )
+    if (concrete.status !== 'resolved')
+      throw new Error(
+        'Expected nested promoted view to resolve to concrete widget'
+      )
+
+    const linkedEntry = [
+      linkedView.sourceNodeId,
+      linkedView.sourceWidgetName
+    ] as [string, string]
+    const deepAliasEntry = [
+      String(concrete.resolved.node.id),
+      concrete.resolved.widget.name
+    ] as [string, string]
+
+    // Guardrail: this test specifically validates host/deep alias cleanup.
+    expect(deepAliasEntry).not.toStrictEqual(linkedEntry)
+
+    setPromotions(subgraphNodeB, [linkedEntry, deepAliasEntry])
+
+    ;(
+      subgraphNodeB as unknown as {
+        _syncPromotions: () => void
+      }
+    )._syncPromotions()
+
+    const promotions = usePromotionStore().getPromotions(
+      subgraphNodeB.rootGraph.id,
+      subgraphNodeB.id
+    )
+    expect(promotions).toStrictEqual([
+      {
+        interiorNodeId: linkedEntry[0],
+        widgetName: linkedEntry[1]
+      }
+    ])
+  })
+
+  test('configure prunes stale disconnected host aliases that resolve to the active linked concrete widget', () => {
+    const nestedSubgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+
+    const concreteNode = new LGraphNode('ConcreteNode')
+    const concreteInput = concreteNode.addInput('string_a', '*')
+    concreteNode.addWidget('text', 'string_a', 'value', () => {})
+    concreteInput.widget = { name: 'string_a' }
+    nestedSubgraph.add(concreteNode)
+    nestedSubgraph.inputNode.slots[0].connect(concreteInput, concreteNode)
+
+    const hostSubgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+
+    const activeAliasNode = createTestSubgraphNode(nestedSubgraph, { id: 118 })
+    const staleAliasNode = createTestSubgraphNode(nestedSubgraph, { id: 119 })
+    hostSubgraph.add(activeAliasNode)
+    hostSubgraph.add(staleAliasNode)
+
+    activeAliasNode._internalConfigureAfterSlots()
+    staleAliasNode._internalConfigureAfterSlots()
+    hostSubgraph.inputNode.slots[0].connect(
+      activeAliasNode.inputs[0],
+      activeAliasNode
+    )
+
+    const hostSubgraphNode = createTestSubgraphNode(hostSubgraph, { id: 120 })
+    hostSubgraphNode.graph?.add(hostSubgraphNode)
+
+    setPromotions(hostSubgraphNode, [
+      [String(activeAliasNode.id), 'string_a'],
+      [String(staleAliasNode.id), 'string_a']
+    ])
+
+    const serialized = hostSubgraphNode.serialize()
+    const restoredNode = createTestSubgraphNode(hostSubgraph, { id: 121 })
+    restoredNode.configure({
+      ...serialized,
+      id: restoredNode.id,
+      type: hostSubgraph.id,
+      inputs: []
+    })
+
+    const restoredPromotions = usePromotionStore().getPromotions(
+      restoredNode.rootGraph.id,
+      restoredNode.id
+    )
+    expect(restoredPromotions).toStrictEqual([
+      {
+        interiorNodeId: String(activeAliasNode.id),
+        widgetName: 'string_a'
+      }
+    ])
+
+    const restoredWidgets = promotedWidgets(restoredNode)
+    expect(restoredWidgets).toHaveLength(1)
+    expect(restoredWidgets[0].sourceNodeId).toBe(String(activeAliasNode.id))
   })
 
   test('caches view objects across getter calls (stable references)', () => {
@@ -701,6 +1055,356 @@ describe('SubgraphNode.widgets getter', () => {
     ])
   })
 
+  test('configure with empty serialized inputs keeps linked filtering active', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 97 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNodeA = new LGraphNode('LinkedNodeA')
+    const linkedInputA = linkedNodeA.addInput('string_a', '*')
+    linkedNodeA.addWidget('text', 'string_a', 'a', () => {})
+    linkedInputA.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeA)
+
+    const linkedNodeB = new LGraphNode('LinkedNodeB')
+    const linkedInputB = linkedNodeB.addInput('string_a', '*')
+    linkedNodeB.addWidget('text', 'string_a', 'b', () => {})
+    linkedInputB.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeB)
+
+    const storeOnlyNode = new LGraphNode('StoreOnlyNode')
+    storeOnlyNode.addWidget('text', 'string_a', 'independent', () => {})
+    subgraph.add(storeOnlyNode)
+
+    subgraph.inputNode.slots[0].connect(linkedInputA, linkedNodeA)
+    subgraph.inputNode.slots[0].connect(linkedInputB, linkedNodeB)
+
+    setPromotions(subgraphNode, [
+      [String(linkedNodeA.id), 'string_a'],
+      [String(linkedNodeB.id), 'string_a'],
+      [String(storeOnlyNode.id), 'string_a']
+    ])
+
+    const serialized = subgraphNode.serialize()
+    const restoredNode = createTestSubgraphNode(subgraph, { id: 98 })
+    restoredNode.configure({
+      ...serialized,
+      id: restoredNode.id,
+      type: subgraph.id,
+      inputs: []
+    })
+
+    const restoredWidgets = promotedWidgets(restoredNode)
+    expect(restoredWidgets).toHaveLength(2)
+
+    const linkedViewCount = restoredWidgets.filter((widget) =>
+      [String(linkedNodeA.id), String(linkedNodeB.id)].includes(
+        widget.sourceNodeId
+      )
+    ).length
+    expect(linkedViewCount).toBe(1)
+    expect(
+      restoredWidgets.some(
+        (widget) => widget.sourceNodeId === String(storeOnlyNode.id)
+      )
+    ).toBe(true)
+  })
+
+  test('configure with serialized inputs rebinds subgraph slots for linked filtering', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 107 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNodeA = new LGraphNode('LinkedNodeA')
+    const linkedInputA = linkedNodeA.addInput('string_a', '*')
+    linkedNodeA.addWidget('text', 'string_a', 'a', () => {})
+    linkedInputA.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeA)
+
+    const linkedNodeB = new LGraphNode('LinkedNodeB')
+    const linkedInputB = linkedNodeB.addInput('string_a', '*')
+    linkedNodeB.addWidget('text', 'string_a', 'b', () => {})
+    linkedInputB.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeB)
+
+    const storeOnlyNode = new LGraphNode('StoreOnlyNode')
+    storeOnlyNode.addWidget('text', 'string_a', 'independent', () => {})
+    subgraph.add(storeOnlyNode)
+
+    subgraph.inputNode.slots[0].connect(linkedInputA, linkedNodeA)
+    subgraph.inputNode.slots[0].connect(linkedInputB, linkedNodeB)
+
+    setPromotions(subgraphNode, [
+      [String(linkedNodeA.id), 'string_a'],
+      [String(linkedNodeB.id), 'string_a'],
+      [String(storeOnlyNode.id), 'string_a']
+    ])
+
+    const serialized = subgraphNode.serialize()
+    const restoredNode = createTestSubgraphNode(subgraph, { id: 108 })
+    restoredNode.configure({
+      ...serialized,
+      id: restoredNode.id,
+      type: subgraph.id,
+      inputs: [
+        {
+          name: 'string_a',
+          type: '*',
+          link: null
+        }
+      ]
+    })
+
+    const restoredWidgets = promotedWidgets(restoredNode)
+    expect(restoredWidgets).toHaveLength(2)
+
+    const linkedViewCount = restoredWidgets.filter((widget) =>
+      [String(linkedNodeA.id), String(linkedNodeB.id)].includes(
+        widget.sourceNodeId
+      )
+    ).length
+    expect(linkedViewCount).toBe(1)
+    expect(
+      restoredWidgets.some(
+        (widget) => widget.sourceNodeId === String(storeOnlyNode.id)
+      )
+    ).toBe(true)
+  })
+
+  test('fixture keeps earliest linked representative and independent promotion only', () => {
+    const fixture = structuredClone(subgraphComplexPromotion1)
+    const subgraphData = fixture.definitions?.subgraphs?.[0]
+    if (!subgraphData)
+      throw new Error('Expected fixture to contain one subgraph definition')
+
+    const fixtureStringConcatType = 'Fixture/StringConcatenate'
+    class FixtureStringConcatenateNode extends LGraphNode {
+      constructor() {
+        super('StringConcatenate')
+        const input = this.addInput('string_a', 'STRING')
+        input.widget = { name: 'string_a' }
+        this.addOutput('STRING', 'STRING')
+        this.addWidget('text', 'string_a', '', () => {})
+        this.addWidget('text', 'string_b', '', () => {})
+        this.addWidget('text', 'delimiter', '', () => {})
+      }
+    }
+    LiteGraph.registerNodeType(
+      fixtureStringConcatType,
+      FixtureStringConcatenateNode
+    )
+
+    for (const node of subgraphData.nodes as Array<{ type: string }>) {
+      if (node.type === 'StringConcatenate') node.type = fixtureStringConcatType
+    }
+
+    const hostNodeData = fixture.nodes.find((node) => node.id === 21)
+    if (!hostNodeData)
+      throw new Error(
+        'Expected fixture to contain subgraph instance node id 21'
+      )
+
+    const graph = new LGraph()
+    const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
+    subgraph.configure(subgraphData as ExportedSubgraph)
+    const hostNode = new SubgraphNodeCtor(
+      graph,
+      subgraph,
+      hostNodeData as ExportedSubgraphInstance
+    )
+    graph.add(hostNode)
+
+    const hostWidgets = promotedWidgets(hostNode)
+    expect(hostWidgets).toHaveLength(2)
+    expect(hostWidgets.map((widget) => widget.sourceNodeId)).toStrictEqual([
+      '20',
+      '19'
+    ])
+
+    const promotions = usePromotionStore().getPromotions(graph.id, hostNode.id)
+    expect(promotions).toStrictEqual([
+      { interiorNodeId: '20', widgetName: 'string_a' },
+      { interiorNodeId: '19', widgetName: 'string_a' }
+    ])
+
+    const linkedView = hostWidgets[0]
+    const independentView = hostWidgets[1]
+    if (!linkedView || !independentView)
+      throw new Error('Expected linked and independent promoted widgets')
+
+    independentView.value = 'independent-value'
+    linkedView.value = 'shared-linked'
+
+    const widgetStore = useWidgetValueStore()
+    const getValue = (nodeId: string) =>
+      widgetStore.getWidget(graph.id, stripGraphPrefix(nodeId), 'string_a')
+        ?.value
+
+    expect(getValue('20')).toBe('shared-linked')
+    expect(getValue('18')).toBe('shared-linked')
+    expect(getValue('19')).toBe('independent-value')
+  })
+
+  test('fixture refreshes duplicate fallback after linked representative recovers', () => {
+    const fixture = structuredClone(subgraphComplexPromotion1)
+    const subgraphData = fixture.definitions?.subgraphs?.[0]
+    if (!subgraphData)
+      throw new Error('Expected fixture to contain one subgraph definition')
+
+    const fixtureStringConcatType = 'Fixture/StringConcatenate'
+    class FixtureStringConcatenateNode extends LGraphNode {
+      constructor() {
+        super('StringConcatenate')
+        const input = this.addInput('string_a', 'STRING')
+        input.widget = { name: 'string_a' }
+        this.addOutput('STRING', 'STRING')
+        this.addWidget('text', 'string_a', '', () => {})
+        this.addWidget('text', 'string_b', '', () => {})
+        this.addWidget('text', 'delimiter', '', () => {})
+      }
+    }
+    LiteGraph.registerNodeType(
+      fixtureStringConcatType,
+      FixtureStringConcatenateNode
+    )
+
+    for (const node of subgraphData.nodes as Array<{ type: string }>) {
+      if (node.type === 'StringConcatenate') node.type = fixtureStringConcatType
+    }
+
+    const hostNodeData = fixture.nodes.find((node) => node.id === 21)
+    if (!hostNodeData)
+      throw new Error(
+        'Expected fixture to contain subgraph instance node id 21'
+      )
+
+    const graph = new LGraph()
+    const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
+    subgraph.configure(subgraphData as ExportedSubgraph)
+    const hostNode = new SubgraphNodeCtor(
+      graph,
+      subgraph,
+      hostNodeData as ExportedSubgraphInstance
+    )
+    graph.add(hostNode)
+
+    const earliestLinkedNode = subgraph.getNodeById(20)
+    if (!earliestLinkedNode?.widgets)
+      throw new Error('Expected fixture to contain node 20 with widgets')
+
+    const originalWidgets = earliestLinkedNode.widgets
+    earliestLinkedNode.widgets = originalWidgets.filter(
+      (widget) => widget.name !== 'string_a'
+    )
+
+    const unresolvedWidgets = promotedWidgets(hostNode)
+    expect(
+      unresolvedWidgets.map((widget) => widget.sourceNodeId)
+    ).toStrictEqual(['18', '20', '19'])
+
+    earliestLinkedNode.widgets = originalWidgets
+
+    const restoredWidgets = promotedWidgets(hostNode)
+    expect(restoredWidgets.map((widget) => widget.sourceNodeId)).toStrictEqual([
+      '20',
+      '19'
+    ])
+  })
+
+  test('fixture converges external widgets and keeps rendered value isolation after transient linked fallback churn', () => {
+    const fixture = structuredClone(subgraphComplexPromotion1)
+    const subgraphData = fixture.definitions?.subgraphs?.[0]
+    if (!subgraphData)
+      throw new Error('Expected fixture to contain one subgraph definition')
+
+    const fixtureStringConcatType = 'Fixture/StringConcatenate'
+    class FixtureStringConcatenateNode extends LGraphNode {
+      constructor() {
+        super('StringConcatenate')
+        const input = this.addInput('string_a', 'STRING')
+        input.widget = { name: 'string_a' }
+        this.addOutput('STRING', 'STRING')
+        this.addWidget('text', 'string_a', '', () => {})
+        this.addWidget('text', 'string_b', '', () => {})
+        this.addWidget('text', 'delimiter', '', () => {})
+      }
+    }
+    LiteGraph.registerNodeType(
+      fixtureStringConcatType,
+      FixtureStringConcatenateNode
+    )
+
+    for (const node of subgraphData.nodes as Array<{ type: string }>) {
+      if (node.type === 'StringConcatenate') node.type = fixtureStringConcatType
+    }
+
+    const hostNodeData = fixture.nodes.find((node) => node.id === 21)
+    if (!hostNodeData)
+      throw new Error(
+        'Expected fixture to contain subgraph instance node id 21'
+      )
+
+    const graph = new LGraph()
+    const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
+    subgraph.configure(subgraphData as ExportedSubgraph)
+    const hostNode = new SubgraphNodeCtor(
+      graph,
+      subgraph,
+      hostNodeData as ExportedSubgraphInstance
+    )
+    graph.add(hostNode)
+
+    const initialWidgets = promotedWidgets(hostNode)
+    expect(initialWidgets.map((widget) => widget.sourceNodeId)).toStrictEqual([
+      '20',
+      '19'
+    ])
+
+    const earliestLinkedNode = subgraph.getNodeById(20)
+    if (!earliestLinkedNode?.widgets)
+      throw new Error('Expected fixture to contain node 20 with widgets')
+
+    const originalWidgets = earliestLinkedNode.widgets
+    earliestLinkedNode.widgets = originalWidgets.filter(
+      (widget) => widget.name !== 'string_a'
+    )
+
+    const transientWidgets = promotedWidgets(hostNode)
+    expect(transientWidgets.map((widget) => widget.sourceNodeId)).toStrictEqual(
+      ['18', '20', '19']
+    )
+
+    earliestLinkedNode.widgets = originalWidgets
+
+    const finalWidgets = promotedWidgets(hostNode)
+    expect(finalWidgets).toHaveLength(2)
+    expect(finalWidgets.map((widget) => widget.sourceNodeId)).toStrictEqual([
+      '20',
+      '19'
+    ])
+
+    const finalLinkedView = finalWidgets.find(
+      (widget) => widget.sourceNodeId === '20'
+    )
+    const finalIndependentView = finalWidgets.find(
+      (widget) => widget.sourceNodeId === '19'
+    )
+    if (!finalLinkedView || !finalIndependentView)
+      throw new Error('Expected final rendered linked and independent views')
+
+    finalIndependentView.value = 'independent-final'
+    expect(finalIndependentView.value).toBe('independent-final')
+    expect(finalLinkedView.value).not.toBe('independent-final')
+
+    finalLinkedView.value = 'linked-final'
+    expect(finalLinkedView.value).toBe('linked-final')
+    expect(finalIndependentView.value).toBe('independent-final')
+  })
+
   test('clone output preserves proxyWidgets for promotion hydration', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)
     const innerNode = firstInnerNode(innerNodes)
@@ -749,6 +1453,101 @@ describe('SubgraphNode.widgets getter', () => {
 describe('widgets getter caching', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  test('reconciles at most once per canvas frame across repeated widgets reads', () => {
+    const [subgraphNode, innerNodes] = setupSubgraph(1)
+    innerNodes[0].addWidget('text', 'widgetA', 'a', () => {})
+    setPromotions(subgraphNode, [['1', 'widgetA']])
+
+    const fakeCanvas = { frame: 12 } as Pick<LGraphCanvas, 'frame'>
+    subgraphNode.rootGraph.primaryCanvas = fakeCanvas as LGraphCanvas
+
+    const reconcileSpy = vi.spyOn(
+      subgraphNode as unknown as {
+        _buildPromotionReconcileState: (
+          entries: Array<{ interiorNodeId: string; widgetName: string }>,
+          linkedEntries: Array<{
+            inputName: string
+            inputKey: string
+            interiorNodeId: string
+            widgetName: string
+          }>
+        ) => unknown
+      },
+      '_buildPromotionReconcileState'
+    )
+
+    void subgraphNode.widgets
+    void subgraphNode.widgets
+    void subgraphNode.widgets
+
+    expect(reconcileSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not re-run reconciliation when only canvas frame advances', () => {
+    const [subgraphNode, innerNodes] = setupSubgraph(1)
+    innerNodes[0].addWidget('text', 'widgetA', 'a', () => {})
+    setPromotions(subgraphNode, [['1', 'widgetA']])
+
+    const fakeCanvas = { frame: 24 } as Pick<LGraphCanvas, 'frame'>
+    subgraphNode.rootGraph.primaryCanvas = fakeCanvas as LGraphCanvas
+
+    const reconcileSpy = vi.spyOn(
+      subgraphNode as unknown as {
+        _buildPromotionReconcileState: (
+          entries: Array<{ interiorNodeId: string; widgetName: string }>,
+          linkedEntries: Array<{
+            inputName: string
+            inputKey: string
+            interiorNodeId: string
+            widgetName: string
+          }>
+        ) => unknown
+      },
+      '_buildPromotionReconcileState'
+    )
+
+    void subgraphNode.widgets
+    fakeCanvas.frame += 1
+    void subgraphNode.widgets
+
+    expect(reconcileSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not re-resolve linked entries when linked input state is unchanged', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 97 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNodeA = new LGraphNode('LinkedNodeA')
+    const linkedInputA = linkedNodeA.addInput('string_a', '*')
+    linkedNodeA.addWidget('text', 'string_a', 'a', () => {})
+    linkedInputA.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeA)
+
+    const linkedNodeB = new LGraphNode('LinkedNodeB')
+    const linkedInputB = linkedNodeB.addInput('string_a', '*')
+    linkedNodeB.addWidget('text', 'string_a', 'b', () => {})
+    linkedInputB.widget = { name: 'string_a' }
+    subgraph.add(linkedNodeB)
+
+    subgraph.inputNode.slots[0].connect(linkedInputA, linkedNodeA)
+    subgraph.inputNode.slots[0].connect(linkedInputB, linkedNodeB)
+
+    const resolveSpy = vi.spyOn(
+      subgraphNode as unknown as {
+        _resolveLinkedPromotionBySubgraphInput: (...args: unknown[]) => unknown
+      },
+      '_resolveLinkedPromotionBySubgraphInput'
+    )
+
+    void subgraphNode.widgets
+    void subgraphNode.widgets
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
   })
 
   test('preserves view identities when promotion order changes', () => {

--- a/src/core/graph/subgraph/promotedWidgetView.test.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.test.ts
@@ -6,20 +6,14 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 // (promotedWidgetView → widgetMap → BaseWidget → LegacyWidget → barrel)
 import {
   CanvasPointer,
-  LGraph,
   LGraphNode,
-  LiteGraph,
-  SubgraphNode as SubgraphNodeCtor
+  LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import type {
   CanvasPointerEvent,
   LGraphCanvas,
   SubgraphNode
 } from '@/lib/litegraph/src/litegraph'
-import type {
-  ExportedSubgraph,
-  ExportedSubgraphInstance
-} from '@/lib/litegraph/src/types/serialisation'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 import { createPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetView'
@@ -34,9 +28,9 @@ import {
 
 import {
   createTestSubgraph,
-  createTestSubgraphNode
+  createTestSubgraphNode,
+  setupComplexPromotionFixture
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
-import { subgraphComplexPromotion1 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphComplexPromotion1'
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({})
@@ -92,6 +86,14 @@ function firstInnerNode(innerNodes: LGraphNode[]): LGraphNode {
 
 function promotedWidgets(node: SubgraphNode): PromotedWidgetView[] {
   return node.widgets as PromotedWidgetView[]
+}
+
+function callSyncPromotions(node: SubgraphNode) {
+  ;(
+    node as unknown as {
+      _syncPromotions: () => void
+    }
+  )._syncPromotions()
 }
 
 describe(createPromotedWidgetView, () => {
@@ -785,11 +787,7 @@ describe('SubgraphNode.widgets getter', () => {
       [String(linkedNodeB.id), 'string_a']
     ])
 
-    ;(
-      subgraphNode as unknown as {
-        _syncPromotions: () => void
-      }
-    )._syncPromotions()
+    callSyncPromotions(subgraphNode)
 
     const promotions = usePromotionStore().getPromotions(
       subgraphNode.rootGraph.id,
@@ -833,11 +831,7 @@ describe('SubgraphNode.widgets getter', () => {
 
     setPromotions(subgraphNodeB, [linkedEntry, deepAliasEntry])
 
-    ;(
-      subgraphNodeB as unknown as {
-        _syncPromotions: () => void
-      }
-    )._syncPromotions()
+    callSyncPromotions(subgraphNodeB)
 
     const promotions = usePromotionStore().getPromotions(
       subgraphNodeB.rootGraph.id,
@@ -1176,47 +1170,7 @@ describe('SubgraphNode.widgets getter', () => {
   })
 
   test('fixture keeps earliest linked representative and independent promotion only', () => {
-    const fixture = structuredClone(subgraphComplexPromotion1)
-    const subgraphData = fixture.definitions?.subgraphs?.[0]
-    if (!subgraphData)
-      throw new Error('Expected fixture to contain one subgraph definition')
-
-    const fixtureStringConcatType = 'Fixture/StringConcatenate'
-    class FixtureStringConcatenateNode extends LGraphNode {
-      constructor() {
-        super('StringConcatenate')
-        const input = this.addInput('string_a', 'STRING')
-        input.widget = { name: 'string_a' }
-        this.addOutput('STRING', 'STRING')
-        this.addWidget('text', 'string_a', '', () => {})
-        this.addWidget('text', 'string_b', '', () => {})
-        this.addWidget('text', 'delimiter', '', () => {})
-      }
-    }
-    LiteGraph.registerNodeType(
-      fixtureStringConcatType,
-      FixtureStringConcatenateNode
-    )
-
-    for (const node of subgraphData.nodes as Array<{ type: string }>) {
-      if (node.type === 'StringConcatenate') node.type = fixtureStringConcatType
-    }
-
-    const hostNodeData = fixture.nodes.find((node) => node.id === 21)
-    if (!hostNodeData)
-      throw new Error(
-        'Expected fixture to contain subgraph instance node id 21'
-      )
-
-    const graph = new LGraph()
-    const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
-    subgraph.configure(subgraphData as ExportedSubgraph)
-    const hostNode = new SubgraphNodeCtor(
-      graph,
-      subgraph,
-      hostNodeData as ExportedSubgraphInstance
-    )
-    graph.add(hostNode)
+    const { graph, hostNode } = setupComplexPromotionFixture()
 
     const hostWidgets = promotedWidgets(hostNode)
     expect(hostWidgets).toHaveLength(2)
@@ -1250,47 +1204,7 @@ describe('SubgraphNode.widgets getter', () => {
   })
 
   test('fixture refreshes duplicate fallback after linked representative recovers', () => {
-    const fixture = structuredClone(subgraphComplexPromotion1)
-    const subgraphData = fixture.definitions?.subgraphs?.[0]
-    if (!subgraphData)
-      throw new Error('Expected fixture to contain one subgraph definition')
-
-    const fixtureStringConcatType = 'Fixture/StringConcatenate'
-    class FixtureStringConcatenateNode extends LGraphNode {
-      constructor() {
-        super('StringConcatenate')
-        const input = this.addInput('string_a', 'STRING')
-        input.widget = { name: 'string_a' }
-        this.addOutput('STRING', 'STRING')
-        this.addWidget('text', 'string_a', '', () => {})
-        this.addWidget('text', 'string_b', '', () => {})
-        this.addWidget('text', 'delimiter', '', () => {})
-      }
-    }
-    LiteGraph.registerNodeType(
-      fixtureStringConcatType,
-      FixtureStringConcatenateNode
-    )
-
-    for (const node of subgraphData.nodes as Array<{ type: string }>) {
-      if (node.type === 'StringConcatenate') node.type = fixtureStringConcatType
-    }
-
-    const hostNodeData = fixture.nodes.find((node) => node.id === 21)
-    if (!hostNodeData)
-      throw new Error(
-        'Expected fixture to contain subgraph instance node id 21'
-      )
-
-    const graph = new LGraph()
-    const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
-    subgraph.configure(subgraphData as ExportedSubgraph)
-    const hostNode = new SubgraphNodeCtor(
-      graph,
-      subgraph,
-      hostNodeData as ExportedSubgraphInstance
-    )
-    graph.add(hostNode)
+    const { subgraph, hostNode } = setupComplexPromotionFixture()
 
     const earliestLinkedNode = subgraph.getNodeById(20)
     if (!earliestLinkedNode?.widgets)
@@ -1316,47 +1230,7 @@ describe('SubgraphNode.widgets getter', () => {
   })
 
   test('fixture converges external widgets and keeps rendered value isolation after transient linked fallback churn', () => {
-    const fixture = structuredClone(subgraphComplexPromotion1)
-    const subgraphData = fixture.definitions?.subgraphs?.[0]
-    if (!subgraphData)
-      throw new Error('Expected fixture to contain one subgraph definition')
-
-    const fixtureStringConcatType = 'Fixture/StringConcatenate'
-    class FixtureStringConcatenateNode extends LGraphNode {
-      constructor() {
-        super('StringConcatenate')
-        const input = this.addInput('string_a', 'STRING')
-        input.widget = { name: 'string_a' }
-        this.addOutput('STRING', 'STRING')
-        this.addWidget('text', 'string_a', '', () => {})
-        this.addWidget('text', 'string_b', '', () => {})
-        this.addWidget('text', 'delimiter', '', () => {})
-      }
-    }
-    LiteGraph.registerNodeType(
-      fixtureStringConcatType,
-      FixtureStringConcatenateNode
-    )
-
-    for (const node of subgraphData.nodes as Array<{ type: string }>) {
-      if (node.type === 'StringConcatenate') node.type = fixtureStringConcatType
-    }
-
-    const hostNodeData = fixture.nodes.find((node) => node.id === 21)
-    if (!hostNodeData)
-      throw new Error(
-        'Expected fixture to contain subgraph instance node id 21'
-      )
-
-    const graph = new LGraph()
-    const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
-    subgraph.configure(subgraphData as ExportedSubgraph)
-    const hostNode = new SubgraphNodeCtor(
-      graph,
-      subgraph,
-      hostNodeData as ExportedSubgraphInstance
-    )
-    graph.add(hostNode)
+    const { subgraph, hostNode } = setupComplexPromotionFixture()
 
     const initialWidgets = promotedWidgets(hostNode)
     expect(initialWidgets.map((widget) => widget.sourceNodeId)).toStrictEqual([
@@ -1547,7 +1421,7 @@ describe('widgets getter caching', () => {
     void subgraphNode.widgets
     void subgraphNode.widgets
 
-    expect(resolveSpy).toHaveBeenCalledTimes(1)
+    expect(resolveSpy.mock.calls.length).toBeLessThanOrEqual(1)
   })
 
   test('preserves view identities when promotion order changes', () => {

--- a/src/core/graph/subgraph/promotedWidgetView.test.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.test.ts
@@ -281,6 +281,31 @@ describe(createPromotedWidgetView, () => {
     expect(fallbackWidget.value).toBe('updated')
   })
 
+  test('value setter falls back to host widget when linked states are unavailable', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'string_a', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 124 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNode = new LGraphNode('LinkedNode')
+    const linkedInput = linkedNode.addInput('string_a', '*')
+    linkedNode.addWidget('text', 'string_a', 'initial', () => {})
+    linkedInput.widget = { name: 'string_a' }
+    subgraph.add(linkedNode)
+    subgraph.inputNode.slots[0].connect(linkedInput, linkedNode)
+
+    const linkedView = promotedWidgets(subgraphNode)[0]
+    if (!linkedView) throw new Error('Expected a linked promoted widget')
+
+    const widgetValueStore = useWidgetValueStore()
+    vi.spyOn(widgetValueStore, 'getWidget').mockReturnValue(undefined)
+
+    linkedView.value = 'updated'
+
+    expect(linkedNode.widgets?.[0].value).toBe('updated')
+  })
+
   test('label falls back to displayName then widgetName', () => {
     const [subgraphNode, innerNodes] = setupSubgraph(1)
     const innerNode = firstInnerNode(innerNodes)
@@ -755,6 +780,52 @@ describe('SubgraphNode.widgets getter', () => {
     ])
   })
 
+  test('full linked coverage does not prune unresolved independent fallback promotions', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'widgetA', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 125 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const liveNode = new LGraphNode('LiveNode')
+    const liveInput = liveNode.addInput('widgetA', '*')
+    liveNode.addWidget('text', 'widgetA', 'a', () => {})
+    liveInput.widget = { name: 'widgetA' }
+    subgraph.add(liveNode)
+    subgraph.inputNode.slots[0].connect(liveInput, liveNode)
+
+    setPromotions(subgraphNode, [
+      [String(liveNode.id), 'widgetA'],
+      ['9999', 'widgetA']
+    ])
+
+    callSyncPromotions(subgraphNode)
+
+    const promotions = usePromotionStore().getPromotions(
+      subgraphNode.rootGraph.id,
+      subgraphNode.id
+    )
+    expect(promotions).toStrictEqual([
+      { interiorNodeId: String(liveNode.id), widgetName: 'widgetA' },
+      { interiorNodeId: '9999', widgetName: 'widgetA' }
+    ])
+  })
+
+  test('input-added existing-input path tolerates missing link metadata', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'widgetA', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 126 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const existingSlot = subgraph.inputNode.slots[0]
+    if (!existingSlot) throw new Error('Expected subgraph input slot')
+
+    expect(() => {
+      subgraph.events.dispatch('input-added', { input: existingSlot })
+    }).not.toThrow()
+  })
+
   test('syncPromotions prunes stale connected entries but keeps independent promotions', () => {
     const subgraph = createTestSubgraph({
       inputs: [{ name: 'string_a', type: '*' }]
@@ -904,6 +975,76 @@ describe('SubgraphNode.widgets getter', () => {
     const restoredWidgets = promotedWidgets(restoredNode)
     expect(restoredWidgets).toHaveLength(1)
     expect(restoredWidgets[0].sourceNodeId).toBe(String(activeAliasNode.id))
+  })
+
+  test('serialize syncs duplicate-name linked inputs by subgraph slot identity', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'seed', type: '*' },
+        { name: 'seed', type: '*' }
+      ]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 127 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const firstNode = new LGraphNode('FirstNode')
+    const firstInput = firstNode.addInput('seed', '*')
+    firstNode.addWidget('text', 'seed', 'first-initial', () => {})
+    firstInput.widget = { name: 'seed' }
+    subgraph.add(firstNode)
+
+    const secondNode = new LGraphNode('SecondNode')
+    const secondInput = secondNode.addInput('seed', '*')
+    secondNode.addWidget('text', 'seed', 'second-initial', () => {})
+    secondInput.widget = { name: 'seed' }
+    subgraph.add(secondNode)
+
+    subgraph.inputNode.slots[0].connect(firstInput, firstNode)
+    subgraph.inputNode.slots[1].connect(secondInput, secondNode)
+
+    const widgets = promotedWidgets(subgraphNode)
+    const firstView = widgets[0]
+    const secondView = widgets[1]
+    if (!firstView || !secondView)
+      throw new Error('Expected two linked promoted views')
+
+    firstView.value = 'first-updated'
+    secondView.value = 'second-updated'
+
+    expect(firstNode.widgets?.[0].value).toBe('first-updated')
+    expect(secondNode.widgets?.[0].value).toBe('second-updated')
+
+    subgraphNode.serialize()
+
+    expect(firstNode.widgets?.[0].value).toBe('first-updated')
+    expect(secondNode.widgets?.[0].value).toBe('second-updated')
+  })
+
+  test('renaming an input updates linked promoted view display names', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'seed', type: '*' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 128 })
+    subgraphNode.graph?.add(subgraphNode)
+
+    const linkedNode = new LGraphNode('LinkedNode')
+    const linkedInput = linkedNode.addInput('seed', '*')
+    linkedNode.addWidget('text', 'seed', 'value', () => {})
+    linkedInput.widget = { name: 'seed' }
+    subgraph.add(linkedNode)
+    subgraph.inputNode.slots[0].connect(linkedInput, linkedNode)
+
+    const beforeRename = promotedWidgets(subgraphNode)[0]
+    if (!beforeRename) throw new Error('Expected linked promoted view')
+    expect(beforeRename.name).toBe('seed')
+
+    const inputToRename = subgraph.inputs[0]
+    if (!inputToRename) throw new Error('Expected input to rename')
+    subgraph.renameInput(inputToRename, 'seed_renamed')
+
+    const afterRename = promotedWidgets(subgraphNode)[0]
+    if (!afterRename) throw new Error('Expected linked promoted view')
+    expect(afterRename.name).toBe('seed_renamed')
   })
 
   test('caches view objects across getter calls (stable references)', () => {

--- a/src/core/graph/subgraph/promotedWidgetView.test.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 // Barrel import must come first to avoid circular dependency
 // (promotedWidgetView → widgetMap → BaseWidget → LegacyWidget → barrel)
@@ -27,6 +27,7 @@ import {
 } from '@/stores/widgetValueStore'
 
 import {
+  cleanupComplexPromotionFixtureNodeType,
   createTestSubgraph,
   createTestSubgraphNode,
   setupComplexPromotionFixture
@@ -101,6 +102,10 @@ describe(createPromotedWidgetView, () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     mockDomWidgetStore.widgetStates.clear()
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanupComplexPromotionFixtureNodeType()
   })
 
   test('exposes sourceNodeId and sourceWidgetName', () => {

--- a/src/core/graph/subgraph/promotedWidgetView.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.ts
@@ -136,13 +136,17 @@ class PromotedWidgetView implements IPromotedWidgetView {
     const linkedWidgets = this.getLinkedInputWidgets()
     if (linkedWidgets.length > 0) {
       const widgetStore = useWidgetValueStore()
+      let didUpdateState = false
       for (const linkedWidget of linkedWidgets) {
         const state = widgetStore.getWidget(
           this.graphId,
           linkedWidget.nodeId,
           linkedWidget.widgetName
         )
-        if (state) state.value = value
+        if (state) {
+          state.value = value
+          didUpdateState = true
+        }
       }
 
       const resolved = this.resolveDeepest()
@@ -152,10 +156,13 @@ class PromotedWidgetView implements IPromotedWidgetView {
           stripGraphPrefix(String(resolved.node.id)),
           resolved.widget.name
         )
-        if (resolvedState) resolvedState.value = value
+        if (resolvedState) {
+          resolvedState.value = value
+          didUpdateState = true
+        }
       }
 
-      return
+      if (didUpdateState) return
     }
 
     const state = this.getWidgetState()

--- a/src/core/graph/subgraph/promotedWidgetView.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.ts
@@ -1,4 +1,4 @@
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
 import type { Point } from '@/lib/litegraph/src/interfaces'
@@ -13,6 +13,7 @@ import {
   stripGraphPrefix,
   useWidgetValueStore
 } from '@/stores/widgetValueStore'
+import type { WidgetState } from '@/stores/widgetValueStore'
 import {
   resolveConcretePromotedWidget,
   resolvePromotedWidgetAtHost
@@ -37,6 +38,12 @@ type LegacyMouseWidget = IBaseWidget & {
 
 function hasLegacyMouse(widget: IBaseWidget): widget is LegacyMouseWidget {
   return 'mouse' in widget && typeof widget.mouse === 'function'
+}
+
+function hasWidgetNode(
+  widget: IBaseWidget
+): widget is IBaseWidget & { node: LGraphNode } {
+  return 'node' in widget && !!widget.node
 }
 
 const designTokenCache = new Map<string, string>()
@@ -125,12 +132,31 @@ class PromotedWidgetView implements IPromotedWidgetView {
   }
 
   get value(): IBaseWidget['value'] {
+    const linkedState = this.getLinkedInputWidgetStates()[0]
+    if (linkedState && isWidgetValue(linkedState.value))
+      return linkedState.value
+
     const state = this.getWidgetState()
     if (state && isWidgetValue(state.value)) return state.value
     return this.resolveAtHost()?.widget.value
   }
 
   set value(value: IBaseWidget['value']) {
+    const linkedWidgets = this.getLinkedInputWidgets()
+    if (linkedWidgets.length > 0) {
+      const widgetStore = useWidgetValueStore()
+      for (const linkedWidget of linkedWidgets) {
+        const state = widgetStore.getWidget(
+          this.graphId,
+          linkedWidget.nodeId,
+          linkedWidget.widgetName
+        )
+        if (state) state.value = value
+        if (isWidgetValue(value)) linkedWidget.widget.value = value
+      }
+      return
+    }
+
     const state = this.getWidgetState()
     if (state) {
       state.value = value
@@ -278,6 +304,9 @@ class PromotedWidgetView implements IPromotedWidgetView {
   }
 
   private getWidgetState() {
+    const linkedState = this.getLinkedInputWidgetStates()[0]
+    if (linkedState) return linkedState
+
     const resolved = this.resolveDeepest()
     if (!resolved) return undefined
     return useWidgetValueStore().getWidget(
@@ -285,6 +314,37 @@ class PromotedWidgetView implements IPromotedWidgetView {
       stripGraphPrefix(String(resolved.node.id)),
       resolved.widget.name
     )
+  }
+
+  private getLinkedInputWidgets(): Array<{
+    nodeId: NodeId
+    widgetName: string
+    widget: IBaseWidget
+  }> {
+    const linkedInputSlot = this.subgraphNode.inputs.find(
+      (input) => input._widget === this && input._subgraphSlot
+    )
+    const linkedInput = linkedInputSlot?._subgraphSlot
+    if (!linkedInput) return []
+
+    return linkedInput
+      .getConnectedWidgets()
+      .filter(hasWidgetNode)
+      .map((widget) => ({
+        nodeId: stripGraphPrefix(String(widget.node.id)),
+        widgetName: widget.name,
+        widget
+      }))
+  }
+
+  private getLinkedInputWidgetStates(): WidgetState[] {
+    const widgetStore = useWidgetValueStore()
+
+    return this.getLinkedInputWidgets()
+      .map(({ nodeId, widgetName }) =>
+        widgetStore.getWidget(this.graphId, nodeId, widgetName)
+      )
+      .filter((state): state is WidgetState => state !== undefined)
   }
 
   private getProjectedWidget(resolved: {

--- a/src/core/graph/subgraph/promotedWidgetView.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.ts
@@ -18,6 +18,7 @@ import {
   resolveConcretePromotedWidget,
   resolvePromotedWidgetAtHost
 } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
+import { hasWidgetNode } from '@/core/graph/subgraph/widgetNodeTypeGuard'
 
 import type { PromotedWidgetView as IPromotedWidgetView } from './promotedWidgetTypes'
 
@@ -38,12 +39,6 @@ type LegacyMouseWidget = IBaseWidget & {
 
 function hasLegacyMouse(widget: IBaseWidget): widget is LegacyMouseWidget {
   return 'mouse' in widget && typeof widget.mouse === 'function'
-}
-
-function hasWidgetNode(
-  widget: IBaseWidget
-): widget is IBaseWidget & { node: LGraphNode } {
-  return 'node' in widget && !!widget.node
 }
 
 const designTokenCache = new Map<string, string>()
@@ -132,10 +127,6 @@ class PromotedWidgetView implements IPromotedWidgetView {
   }
 
   get value(): IBaseWidget['value'] {
-    const linkedState = this.getLinkedInputWidgetStates()[0]
-    if (linkedState && isWidgetValue(linkedState.value))
-      return linkedState.value
-
     const state = this.getWidgetState()
     if (state && isWidgetValue(state.value)) return state.value
     return this.resolveAtHost()?.widget.value
@@ -152,8 +143,18 @@ class PromotedWidgetView implements IPromotedWidgetView {
           linkedWidget.widgetName
         )
         if (state) state.value = value
-        if (isWidgetValue(value)) linkedWidget.widget.value = value
       }
+
+      const resolved = this.resolveDeepest()
+      if (resolved) {
+        const resolvedState = widgetStore.getWidget(
+          this.graphId,
+          stripGraphPrefix(String(resolved.node.id)),
+          resolved.widget.name
+        )
+        if (resolvedState) resolvedState.value = value
+      }
+
       return
     }
 

--- a/src/core/graph/subgraph/promotedWidgetView.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.ts
@@ -18,8 +18,10 @@ import {
   resolveConcretePromotedWidget,
   resolvePromotedWidgetAtHost
 } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
+import { matchPromotedInput } from '@/core/graph/subgraph/matchPromotedInput'
 import { hasWidgetNode } from '@/core/graph/subgraph/widgetNodeTypeGuard'
 
+import { isPromotedWidgetView } from './promotedWidgetTypes'
 import type { PromotedWidgetView as IPromotedWidgetView } from './promotedWidgetTypes'
 
 export type { PromotedWidgetView } from './promotedWidgetTypes'
@@ -329,9 +331,29 @@ class PromotedWidgetView implements IPromotedWidgetView {
     widgetName: string
     widget: IBaseWidget
   }> {
-    const linkedInputSlot = this.subgraphNode.inputs.find(
-      (input) => input._widget === this && input._subgraphSlot
-    )
+    const linkedInputSlot = this.subgraphNode.inputs.find((input) => {
+      if (!input._subgraphSlot) return false
+      if (matchPromotedInput([input], this) !== input) return false
+
+      const boundWidget = input._widget
+      if (boundWidget === this) return true
+
+      if (boundWidget && isPromotedWidgetView(boundWidget)) {
+        return (
+          boundWidget.sourceNodeId === this.sourceNodeId &&
+          boundWidget.sourceWidgetName === this.sourceWidgetName
+        )
+      }
+
+      return input._subgraphSlot
+        .getConnectedWidgets()
+        .filter(hasWidgetNode)
+        .some(
+          (widget) =>
+            String(widget.node.id) === this.sourceNodeId &&
+            widget.name === this.sourceWidgetName
+        )
+    })
     const linkedInput = linkedInputSlot?._subgraphSlot
     if (!linkedInput) return []
 

--- a/src/core/graph/subgraph/widgetNodeTypeGuard.ts
+++ b/src/core/graph/subgraph/widgetNodeTypeGuard.ts
@@ -1,0 +1,8 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+export function hasWidgetNode(
+  widget: IBaseWidget
+): widget is IBaseWidget & { node: LGraphNode } {
+  return 'node' in widget && !!widget.node
+}

--- a/src/core/graph/subgraph/widgetRenderKey.test.ts
+++ b/src/core/graph/subgraph/widgetRenderKey.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { getStableWidgetRenderKey } from './widgetRenderKey'
+
+function createWidget(overrides: Partial<IBaseWidget> = {}): IBaseWidget {
+  return {
+    name: 'seed',
+    type: 'number',
+    ...overrides
+  } as IBaseWidget
+}
+
+describe(getStableWidgetRenderKey, () => {
+  it('returns a stable key for the same widget instance', () => {
+    const widget = createWidget()
+
+    const first = getStableWidgetRenderKey(widget)
+    const second = getStableWidgetRenderKey(widget)
+
+    expect(second).toBe(first)
+  })
+
+  it('returns distinct keys for distinct widget instances', () => {
+    const firstWidget = createWidget()
+    const secondWidget = createWidget()
+
+    const firstKey = getStableWidgetRenderKey(firstWidget)
+    const secondKey = getStableWidgetRenderKey(secondWidget)
+
+    expect(secondKey).not.toBe(firstKey)
+  })
+})

--- a/src/core/graph/subgraph/widgetRenderKey.ts
+++ b/src/core/graph/subgraph/widgetRenderKey.ts
@@ -1,0 +1,17 @@
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
+
+const widgetRenderKeys = new WeakMap<IBaseWidget, string>()
+let nextWidgetRenderKeyId = 0
+
+export function getStableWidgetRenderKey(widget: IBaseWidget): string {
+  const cachedKey = widgetRenderKeys.get(widget)
+  if (cachedKey) return cachedKey
+
+  const prefix = isPromotedWidgetView(widget) ? 'promoted' : 'widget'
+  const key = `${prefix}:${nextWidgetRenderKeyId++}`
+
+  widgetRenderKeys.set(widget, key)
+  return key
+}

--- a/src/lib/litegraph/src/strings.ts
+++ b/src/lib/litegraph/src/strings.ts
@@ -12,6 +12,9 @@ export function parseSlotTypes(type: ISlotType): string[] {
  * @param name The name to make unique
  * @param existingNames The names that already exist. Default: an empty array
  * @returns The name, or a unique name if it already exists.
+ * @remark Used by SubgraphInputNode to deduplicate input names when promoting
+ * the same widget name from multiple node instances (e.g. `seed` → `seed_1`).
+ * Extensions matching by slot name should account for the `_N` suffix.
  */
 export function nextUniqueName(
   name: string,

--- a/src/lib/litegraph/src/subgraph/SubgraphIO.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIO.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { ToInputFromIoNodeLink } from '@/lib/litegraph/src/canvas/ToInputFromIoNodeLink'
 import { LinkDirection } from '@/lib/litegraph/src//types/globalEnums'
+import { usePromotionStore } from '@/stores/promotionStore'
 
 import { subgraphTest } from './__fixtures__/subgraphFixtures'
 import {
@@ -454,6 +455,52 @@ describe('SubgraphIO - Empty Slot Connection', () => {
       expect(link.target_slot).toBe(0)
       expect(link.origin_id).toBe(subgraph.inputNode.id)
       expect(link.origin_slot).toBe(1) // Should be the second slot
+    }
+  )
+
+  subgraphTest(
+    'creates distinct named inputs when promoting same widget name from multiple node instances',
+    ({ subgraphWithNode }) => {
+      const { subgraph, subgraphNode } = subgraphWithNode
+
+      const firstNode = new LGraphNode('First Seed Node')
+      const firstInput = firstNode.addInput('seed', 'number')
+      firstNode.addWidget('number', 'seed', 1, () => undefined)
+      firstInput.widget = { name: 'seed' }
+      subgraph.add(firstNode)
+
+      const secondNode = new LGraphNode('Second Seed Node')
+      const secondInput = secondNode.addInput('seed', 'number')
+      secondNode.addWidget('number', 'seed', 2, () => undefined)
+      secondInput.widget = { name: 'seed' }
+      subgraph.add(secondNode)
+
+      subgraph.inputNode.connectByType(-1, firstNode, 'number')
+      subgraph.inputNode.connectByType(-1, secondNode, 'number')
+
+      expect(subgraph.inputs.map((input) => input.name)).toStrictEqual([
+        'input',
+        'seed',
+        'seed_1'
+      ])
+      expect(subgraphNode.inputs.map((input) => input.name)).toStrictEqual([
+        'input',
+        'seed',
+        'seed_1'
+      ])
+      expect(subgraphNode.widgets.map((widget) => widget.name)).toStrictEqual([
+        'seed',
+        'seed_1'
+      ])
+      expect(
+        usePromotionStore().getPromotions(
+          subgraphNode.rootGraph.id,
+          subgraphNode.id
+        )
+      ).toStrictEqual([
+        { interiorNodeId: String(firstNode.id), widgetName: 'seed' },
+        { interiorNodeId: String(secondNode.id), widgetName: 'seed' }
+      ])
     }
   )
 })

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -15,6 +15,7 @@ import type { NodeLike } from '@/lib/litegraph/src/types/NodeLike'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import { findFreeSlotOfType } from '@/lib/litegraph/src/utils/collections'
+import { nextUniqueName } from '@/lib/litegraph/src/strings'
 
 import { EmptySubgraphInput } from './EmptySubgraphInput'
 import { SubgraphIONodeBase } from './SubgraphIONodeBase'
@@ -130,8 +131,10 @@ export class SubgraphInputNode
     if (slot === -1) {
       // This indicates a connection is being made from the "Empty" slot.
       // We need to create a new, concrete input on the subgraph that matches the target.
+      const existingNames = this.subgraph.inputs.map((input) => input.name)
+      const uniqueName = nextUniqueName(inputSlot.slot.name, existingNames)
       const newSubgraphInput = this.subgraph.addInput(
-        inputSlot.slot.name,
+        uniqueName,
         String(inputSlot.slot.type ?? '')
       )
       const newSlotIndex = this.slots.indexOf(newSubgraphInput)

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -6,6 +6,8 @@
  * IO synchronization, and edge cases.
  */
 import { describe, expect, it, vi } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 
 import type { SubgraphNode } from '@/lib/litegraph/src/litegraph'
 import { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -613,5 +615,37 @@ describe.skip('SubgraphNode Cleanup', () => {
     // Verify abort was called on each controller
     expect(abortSpy1).toHaveBeenCalledTimes(1)
     expect(abortSpy2).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SubgraphNode promotion view keys', () => {
+  it('distinguishes tuples that differ only by colon placement', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    const nodeWithKeyBuilder = subgraphNode as unknown as {
+      _makePromotionViewKey: (
+        inputKey: string,
+        interiorNodeId: string,
+        widgetName: string,
+        inputName?: string
+      ) => string
+    }
+
+    const firstKey = nodeWithKeyBuilder._makePromotionViewKey(
+      '65',
+      '18',
+      'a:b',
+      'c'
+    )
+    const secondKey = nodeWithKeyBuilder._makePromotionViewKey(
+      '65',
+      '18',
+      'a',
+      'b:c'
+    )
+
+    expect(firstKey).not.toBe(secondKey)
   })
 })

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -622,13 +622,15 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
           if (!link) return
 
           const { inputNode, input } = link.resolve(subgraph)
-          const widget = inputNode?.widgets?.find?.((w) => w.name === name)
-          if (widget && inputNode)
+          if (!inputNode || !input) return
+
+          const widget = inputNode.getWidgetFromSlot(input)
+          if (widget)
             this._setWidget(
               subgraphInput,
               existingInput,
               widget,
-              input?.widget,
+              input.widget,
               inputNode
             )
           return
@@ -1295,6 +1297,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     this._promotedViewManager.remove(view.sourceNodeId, view.sourceWidgetName)
     for (const input of this.inputs) {
       if (input._widget !== view || !input._subgraphSlot) continue
+      const inputName = input.label ?? input.name
 
       this._promotedViewManager.removeByViewKey(
         view.sourceNodeId,
@@ -1302,22 +1305,11 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         this._makePromotionViewKey(
           String(input._subgraphSlot.id),
           view.sourceNodeId,
-          view.sourceWidgetName
+          view.sourceWidgetName,
+          inputName
         )
       )
     }
-
-    // Reconciled views can also be keyed by inputName-scoped view keys.
-    // Remove both key shapes to avoid stale cache entries across promote/rebind flows.
-    this._promotedViewManager.removeByViewKey(
-      view.sourceNodeId,
-      view.sourceWidgetName,
-      this._makePromotionViewKey(
-        view.name,
-        view.sourceNodeId,
-        view.sourceWidgetName
-      )
-    )
   }
 
   override removeWidget(widget: IBaseWidget): void {

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -553,7 +553,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     widgetName: string,
     inputName = ''
   ): string {
-    return `${inputKey}:${interiorNodeId}:${widgetName}:${inputName}`
+    return JSON.stringify([inputKey, interiorNodeId, widgetName, inputName])
   }
 
   private _resolveLegacyEntry(

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -35,6 +35,7 @@ import {
   isPromotedWidgetView
 } from '@/core/graph/subgraph/promotedWidgetView'
 import type { PromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetView'
+import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolveSubgraphInputTarget } from '@/core/graph/subgraph/resolveSubgraphInputTarget'
 import { parseProxyWidgets } from '@/core/schemas/promotionSchema'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
@@ -52,12 +53,24 @@ workflowSvg.src =
 
 type LinkedPromotionEntry = {
   inputName: string
+  inputKey: string
+  interiorNodeId: string
+  widgetName: string
+}
+
+type PromotionEntry = {
   interiorNodeId: string
   widgetName: string
 }
 // Pre-rasterize the SVG to a bitmap canvas to avoid Firefox re-processing
 // the SVG's internal stylesheet on every ctx.drawImage() call per frame.
 const workflowBitmapCache = createBitmapCache(workflowSvg, 32)
+
+function hasWidgetNode(
+  widget: IBaseWidget
+): widget is IBaseWidget & { node: LGraphNode } {
+  return 'node' in widget && !!widget.node
+}
 
 /**
  * An instance of a {@link Subgraph}, displayed as a node on the containing (parent) graph.
@@ -95,40 +108,80 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     interiorNodeId: string
     widgetName: string
   }> = []
+  private _linkedPromotionEntriesCache?: {
+    stateSignature: string
+    entries: LinkedPromotionEntry[]
+  }
+  private _promotedViewsCache?: {
+    entriesSignature: string
+    linkedEntriesSignature: string
+    views: PromotedWidgetView[]
+  }
 
   // Declared as accessor via Object.defineProperty in constructor.
   // TypeScript doesn't allow overriding a property with get/set syntax,
   // so we use declare + defineProperty instead.
   declare widgets: IBaseWidget[]
 
-  private _resolveLinkedPromotionByInputName(
-    inputName: string
+  private _resolveLinkedPromotionBySubgraphInput(
+    subgraphInput: SubgraphInput
   ): { interiorNodeId: string; widgetName: string } | undefined {
-    const resolvedTarget = resolveSubgraphInputTarget(this, inputName)
-    if (!resolvedTarget) return undefined
+    // Preserve deterministic representative selection for multi-linked inputs:
+    // the first connected source remains the promoted linked view.
+    for (const linkId of subgraphInput.linkIds) {
+      const link = this.subgraph.getLink(linkId)
+      if (!link) continue
 
-    return {
-      interiorNodeId: resolvedTarget.nodeId,
-      widgetName: resolvedTarget.widgetName
+      const { inputNode } = link.resolve(this.subgraph)
+      if (!inputNode || !Array.isArray(inputNode.inputs)) continue
+
+      const targetInput = inputNode.inputs.find(
+        (entry) => entry.link === linkId
+      )
+      if (!targetInput) continue
+
+      const targetWidget = inputNode.getWidgetFromSlot(targetInput)
+      if (!targetWidget) continue
+
+      if (inputNode.isSubgraphNode())
+        return {
+          interiorNodeId: String(inputNode.id),
+          widgetName: targetInput.name
+        }
+
+      return {
+        interiorNodeId: String(inputNode.id),
+        widgetName: targetWidget.name
+      }
     }
   }
 
   private _getLinkedPromotionEntries(): LinkedPromotionEntry[] {
+    const stateSignature = this._makeLinkedPromotionEntriesStateSignature()
+    const cached = this._linkedPromotionEntriesCache
+    if (cached?.stateSignature === stateSignature) return cached.entries
+
     const linkedEntries: LinkedPromotionEntry[] = []
 
-    // TODO(pr9282): Optimization target. This path runs on widgets getter reads
-    // and resolves each input link chain eagerly.
     for (const input of this.inputs) {
-      const resolved = this._resolveLinkedPromotionByInputName(input.name)
+      const subgraphInput = input._subgraphSlot
+      if (!subgraphInput) continue
+
+      const resolved =
+        this._resolveLinkedPromotionBySubgraphInput(subgraphInput)
       if (!resolved) continue
 
-      linkedEntries.push({ inputName: input.name, ...resolved })
+      linkedEntries.push({
+        inputName: input.name,
+        inputKey: String(subgraphInput.id),
+        ...resolved
+      })
     }
 
     const seenEntryKeys = new Set<string>()
     const deduplicatedEntries = linkedEntries.filter((entry) => {
       const entryKey = this._makePromotionViewKey(
-        entry.inputName,
+        entry.inputKey,
         entry.interiorNodeId,
         entry.widgetName
       )
@@ -138,24 +191,125 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       return true
     })
 
+    this._linkedPromotionEntriesCache = {
+      stateSignature,
+      entries: deduplicatedEntries
+    }
+
     return deduplicatedEntries
+  }
+
+  private _makeLinkedPromotionEntriesStateSignature(): string {
+    return this.inputs
+      .map((input) => {
+        const subgraphInput = input._subgraphSlot
+        if (!subgraphInput) return `${input.name}:no-subgraph-slot`
+
+        const linkIdsSignature = subgraphInput.linkIds.join(',')
+        const boundWidget =
+          input._widget && isPromotedWidgetView(input._widget)
+            ? input._widget
+            : undefined
+        if (!boundWidget) {
+          const connectedWidgetSignature = subgraphInput
+            .getConnectedWidgets()
+            .filter(hasWidgetNode)
+            .map((widget) => `${String(widget.node.id)}:${widget.name}`)
+            .join(',')
+          return `${String(subgraphInput.id)}:${linkIdsSignature}:unbound:${connectedWidgetSignature}`
+        }
+
+        const boundNode = this.subgraph.getNodeById(boundWidget.sourceNodeId)
+        const hasBoundSourceWidget =
+          boundNode?.widgets?.some(
+            (widget) => widget.name === boundWidget.sourceWidgetName
+          ) === true
+
+        return `${String(subgraphInput.id)}:${linkIdsSignature}:${boundWidget.sourceNodeId}:${boundWidget.sourceWidgetName}:${hasBoundSourceWidget ? '1' : '0'}`
+      })
+      .join('|')
   }
 
   private _getPromotedViews(): PromotedWidgetView[] {
     const store = usePromotionStore()
     const entries = store.getPromotionsRef(this.rootGraph.id, this.id)
     const linkedEntries = this._getLinkedPromotionEntries()
+    const cachedViews = this._readPromotedViewsCache(entries, linkedEntries)
+    if (cachedViews) return cachedViews
+
     const { displayNameByViewKey, reconcileEntries } =
       this._buildPromotionReconcileState(entries, linkedEntries)
 
-    return this._promotedViewManager.reconcile(reconcileEntries, (entry) =>
-      createPromotedWidgetView(
-        this,
-        entry.interiorNodeId,
-        entry.widgetName,
-        entry.viewKey ? displayNameByViewKey.get(entry.viewKey) : undefined
-      )
+    const views = this._promotedViewManager.reconcile(
+      reconcileEntries,
+      (entry) =>
+        createPromotedWidgetView(
+          this,
+          entry.interiorNodeId,
+          entry.widgetName,
+          entry.viewKey ? displayNameByViewKey.get(entry.viewKey) : undefined
+        )
     )
+
+    this._writePromotedViewsCache(entries, linkedEntries, views)
+    return views
+  }
+
+  private _invalidatePromotedViewsCache(): void {
+    this._linkedPromotionEntriesCache = undefined
+    this._promotedViewsCache = undefined
+  }
+
+  private _readPromotedViewsCache(
+    entries: PromotionEntry[],
+    linkedEntries: LinkedPromotionEntry[]
+  ): PromotedWidgetView[] | undefined {
+    const entriesSignature = this._makePromotedEntriesSignature(entries)
+    const linkedEntriesSignature =
+      this._makeLinkedEntriesSignature(linkedEntries)
+    const cache = this._promotedViewsCache
+    if (
+      !cache ||
+      cache.entriesSignature !== entriesSignature ||
+      cache.linkedEntriesSignature !== linkedEntriesSignature
+    )
+      return undefined
+
+    return cache.views
+  }
+
+  private _writePromotedViewsCache(
+    entries: PromotionEntry[],
+    linkedEntries: LinkedPromotionEntry[],
+    views: PromotedWidgetView[]
+  ): void {
+    this._promotedViewsCache = {
+      entriesSignature: this._makePromotedEntriesSignature(entries),
+      linkedEntriesSignature: this._makeLinkedEntriesSignature(linkedEntries),
+      views
+    }
+  }
+
+  private _makePromotedEntriesSignature(entries: PromotionEntry[]): string {
+    return entries
+      .map((entry) =>
+        this._makePromotionEntryKey(entry.interiorNodeId, entry.widgetName)
+      )
+      .join('|')
+  }
+
+  private _makeLinkedEntriesSignature(
+    linkedEntries: LinkedPromotionEntry[]
+  ): string {
+    return linkedEntries
+      .map((entry) =>
+        this._makePromotionViewKey(
+          entry.inputKey,
+          entry.interiorNodeId,
+          entry.widgetName
+        )
+      )
+      .join('|')
   }
 
   private _syncPromotions(): void {
@@ -164,9 +318,10 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     const store = usePromotionStore()
     const entries = store.getPromotionsRef(this.rootGraph.id, this.id)
     const linkedEntries = this._getLinkedPromotionEntries()
-    const { mergedEntries, shouldPersistLinkedOnly } =
-      this._buildPromotionPersistenceState(entries, linkedEntries)
-    if (!shouldPersistLinkedOnly) return
+    const { mergedEntries } = this._buildPromotionPersistenceState(
+      entries,
+      linkedEntries
+    )
 
     const hasChanged =
       mergedEntries.length !== entries.length ||
@@ -181,7 +336,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   private _buildPromotionReconcileState(
-    entries: Array<{ interiorNodeId: string; widgetName: string }>,
+    entries: PromotionEntry[],
     linkedEntries: LinkedPromotionEntry[]
   ): {
     displayNameByViewKey: Map<string, string>
@@ -197,26 +352,33 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     )
     const linkedReconcileEntries =
       this._buildLinkedReconcileEntries(linkedEntries)
-    const shouldPersistLinkedOnly = this._shouldPersistLinkedOnly(linkedEntries)
+    const shouldPersistLinkedOnly = this._shouldPersistLinkedOnly(
+      linkedEntries,
+      fallbackStoredEntries
+    )
+    const reconcileEntries = shouldPersistLinkedOnly
+      ? linkedReconcileEntries
+      : [...linkedReconcileEntries, ...fallbackStoredEntries]
 
     return {
       displayNameByViewKey: this._buildDisplayNameByViewKey(linkedEntries),
-      reconcileEntries: shouldPersistLinkedOnly
-        ? linkedReconcileEntries
-        : [...linkedReconcileEntries, ...fallbackStoredEntries]
+      reconcileEntries
     }
   }
 
   private _buildPromotionPersistenceState(
-    entries: Array<{ interiorNodeId: string; widgetName: string }>,
+    entries: PromotionEntry[],
     linkedEntries: LinkedPromotionEntry[]
   ): {
-    mergedEntries: Array<{ interiorNodeId: string; widgetName: string }>
+    mergedEntries: PromotionEntry[]
     shouldPersistLinkedOnly: boolean
   } {
     const { linkedPromotionEntries, fallbackStoredEntries } =
       this._collectLinkedAndFallbackEntries(entries, linkedEntries)
-    const shouldPersistLinkedOnly = this._shouldPersistLinkedOnly(linkedEntries)
+    const shouldPersistLinkedOnly = this._shouldPersistLinkedOnly(
+      linkedEntries,
+      fallbackStoredEntries
+    )
 
     return {
       mergedEntries: shouldPersistLinkedOnly
@@ -227,18 +389,29 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   private _collectLinkedAndFallbackEntries(
-    entries: Array<{ interiorNodeId: string; widgetName: string }>,
+    entries: PromotionEntry[],
     linkedEntries: LinkedPromotionEntry[]
   ): {
-    linkedPromotionEntries: Array<{
-      interiorNodeId: string
-      widgetName: string
-    }>
-    fallbackStoredEntries: Array<{ interiorNodeId: string; widgetName: string }>
+    linkedPromotionEntries: PromotionEntry[]
+    fallbackStoredEntries: PromotionEntry[]
   } {
     const linkedPromotionEntries = this._toPromotionEntries(linkedEntries)
-    const fallbackStoredEntries = this._getFallbackStoredEntries(
+    const excludedEntryKeys = new Set(
+      linkedPromotionEntries.map((entry) =>
+        this._makePromotionEntryKey(entry.interiorNodeId, entry.widgetName)
+      )
+    )
+    const connectedEntryKeys = this._getConnectedPromotionEntryKeys()
+    for (const key of connectedEntryKeys) {
+      excludedEntryKeys.add(key)
+    }
+
+    const prePruneFallbackStoredEntries = this._getFallbackStoredEntries(
       entries,
+      excludedEntryKeys
+    )
+    const fallbackStoredEntries = this._pruneStaleAliasFallbackEntries(
+      prePruneFallbackStoredEntries,
       linkedPromotionEntries
     )
 
@@ -249,14 +422,26 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   private _shouldPersistLinkedOnly(
-    linkedEntries: LinkedPromotionEntry[]
+    linkedEntries: LinkedPromotionEntry[],
+    fallbackStoredEntries: PromotionEntry[]
   ): boolean {
-    return this.inputs.length > 0 && linkedEntries.length === this.inputs.length
+    if (
+      !(this.inputs.length > 0 && linkedEntries.length === this.inputs.length)
+    )
+      return false
+
+    return !fallbackStoredEntries.some((entry) => {
+      const sourceNode = this.subgraph.getNodeById(entry.interiorNodeId)
+      if (!sourceNode) return false
+      return !!sourceNode.widgets?.some(
+        (widget) => widget.name === entry.widgetName
+      )
+    })
   }
 
   private _toPromotionEntries(
     linkedEntries: LinkedPromotionEntry[]
-  ): Array<{ interiorNodeId: string; widgetName: string }> {
+  ): PromotionEntry[] {
     return linkedEntries.map(({ interiorNodeId, widgetName }) => ({
       interiorNodeId,
       widgetName
@@ -264,32 +449,92 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   private _getFallbackStoredEntries(
-    entries: Array<{ interiorNodeId: string; widgetName: string }>,
-    linkedPromotionEntries: Array<{
-      interiorNodeId: string
-      widgetName: string
-    }>
-  ): Array<{ interiorNodeId: string; widgetName: string }> {
-    const linkedKeys = new Set(
-      linkedPromotionEntries.map((entry) =>
-        this._makePromotionEntryKey(entry.interiorNodeId, entry.widgetName)
-      )
-    )
+    entries: PromotionEntry[],
+    excludedEntryKeys: Set<string>
+  ): PromotionEntry[] {
     return entries.filter(
       (entry) =>
-        !linkedKeys.has(
+        !excludedEntryKeys.has(
           this._makePromotionEntryKey(entry.interiorNodeId, entry.widgetName)
         )
     )
   }
 
+  private _pruneStaleAliasFallbackEntries(
+    fallbackStoredEntries: PromotionEntry[],
+    linkedPromotionEntries: PromotionEntry[]
+  ): PromotionEntry[] {
+    if (
+      fallbackStoredEntries.length === 0 ||
+      linkedPromotionEntries.length === 0
+    )
+      return fallbackStoredEntries
+
+    const linkedConcreteKeys = new Set(
+      linkedPromotionEntries
+        .map((entry) => this._resolveConcretePromotionEntryKey(entry))
+        .filter((key): key is string => key !== undefined)
+    )
+    if (linkedConcreteKeys.size === 0) return fallbackStoredEntries
+
+    const prunedEntries: PromotionEntry[] = []
+
+    for (const entry of fallbackStoredEntries) {
+      const concreteKey = this._resolveConcretePromotionEntryKey(entry)
+      if (concreteKey && linkedConcreteKeys.has(concreteKey)) continue
+
+      prunedEntries.push(entry)
+    }
+
+    return prunedEntries
+  }
+
+  private _resolveConcretePromotionEntryKey(
+    entry: PromotionEntry
+  ): string | undefined {
+    const result = resolveConcretePromotedWidget(
+      this,
+      entry.interiorNodeId,
+      entry.widgetName
+    )
+    if (result.status !== 'resolved') return undefined
+
+    return this._makePromotionEntryKey(
+      String(result.resolved.node.id),
+      result.resolved.widget.name
+    )
+  }
+
+  private _getConnectedPromotionEntryKeys(): Set<string> {
+    const connectedEntryKeys = new Set<string>()
+
+    for (const input of this.inputs) {
+      const subgraphInput = input._subgraphSlot
+      if (!subgraphInput) continue
+
+      const connectedWidgets = subgraphInput.getConnectedWidgets()
+
+      for (const widget of connectedWidgets) {
+        const hasNodeRef = hasWidgetNode(widget)
+        const widgetNodeId = hasNodeRef ? String(widget.node.id) : undefined
+        if (!widgetNodeId) continue
+
+        connectedEntryKeys.add(
+          this._makePromotionEntryKey(widgetNodeId, widget.name)
+        )
+      }
+    }
+
+    return connectedEntryKeys
+  }
+
   private _buildLinkedReconcileEntries(
     linkedEntries: LinkedPromotionEntry[]
   ): Array<{ interiorNodeId: string; widgetName: string; viewKey: string }> {
-    return linkedEntries.map(({ inputName, interiorNodeId, widgetName }) => ({
+    return linkedEntries.map(({ inputKey, interiorNodeId, widgetName }) => ({
       interiorNodeId,
       widgetName,
-      viewKey: this._makePromotionViewKey(inputName, interiorNodeId, widgetName)
+      viewKey: this._makePromotionViewKey(inputKey, interiorNodeId, widgetName)
     }))
   }
 
@@ -299,7 +544,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     return new Map(
       linkedEntries.map((entry) => [
         this._makePromotionViewKey(
-          entry.inputName,
+          entry.inputKey,
           entry.interiorNodeId,
           entry.widgetName
         ),
@@ -316,11 +561,11 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   private _makePromotionViewKey(
-    inputName: string,
+    inputKey: string,
     interiorNodeId: string,
     widgetName: string
   ): string {
-    return `${inputName}:${interiorNodeId}:${widgetName}`
+    return `${inputKey}:${interiorNodeId}:${widgetName}`
   }
 
   private _resolveLegacyEntry(
@@ -378,7 +623,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       (e) => {
         const subgraphInput = e.detail.input
         const { name, type } = subgraphInput
-        const existingInput = this.inputs.find((i) => i.name === name)
+        const existingInput = this.inputs.find(
+          (input) => input._subgraphSlot === subgraphInput
+        )
         if (existingInput) {
           const linkId = subgraphInput.linkIds[0]
           const { inputNode, input } = subgraph.links[linkId].resolve(subgraph)
@@ -393,7 +640,10 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
             )
           return
         }
-        const input = this.addInput(name, type)
+        const input = this.addInput(name, type, {
+          _subgraphSlot: subgraphInput
+        })
+        this._invalidatePromotedViewsCache()
 
         this._addSubgraphInputListeners(subgraphInput, input)
       },
@@ -407,6 +657,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         if (widget) this.ensureWidgetRemoved(widget)
 
         this.removeInput(e.detail.index)
+        this._invalidatePromotedViewsCache()
         this._syncPromotions()
         this.setDirtyCanvas(true, true)
       },
@@ -493,6 +744,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     subgraphInput: SubgraphInput,
     input: INodeInputSlot & Partial<ISubgraphInput>
   ) {
+    input._subgraphSlot = subgraphInput
+
     if (
       input._listenerController &&
       typeof input._listenerController.abort === 'function'
@@ -505,36 +758,39 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     subgraphInput.events.addEventListener(
       'input-connected',
       (e) => {
-        const widget = subgraphInput._widget
-        if (!widget) return
+        this._invalidatePromotedViewsCache()
 
-        // If this widget is already promoted, demote it first
-        // so it transitions cleanly to being linked via SubgraphInput.
+        // `SubgraphInput.connect()` dispatches before appending to `linkIds`,
+        // so resolve by current links would miss this new connection.
+        // Keep the earliest bound view once present, and only bind from event
+        // payload when this input has no representative yet.
         const nodeId = String(e.detail.node.id)
         if (
           usePromotionStore().isPromoted(
             this.rootGraph.id,
             this.id,
             nodeId,
-            widget.name
+            e.detail.widget.name
           )
         ) {
           usePromotionStore().demote(
             this.rootGraph.id,
             this.id,
             nodeId,
-            widget.name
+            e.detail.widget.name
           )
         }
 
-        const widgetLocator = e.detail.input.widget
-        this._setWidget(
-          subgraphInput,
-          input,
-          widget,
-          widgetLocator,
-          e.detail.node
-        )
+        const didSetWidgetFromEvent = !input._widget
+        if (didSetWidgetFromEvent)
+          this._setWidget(
+            subgraphInput,
+            input,
+            e.detail.widget,
+            e.detail.input.widget,
+            e.detail.node
+          )
+
         this._syncPromotions()
       },
       { signal }
@@ -543,9 +799,15 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     subgraphInput.events.addEventListener(
       'input-disconnected',
       () => {
-        // If the input is connected to more than one widget, don't remove the widget
+        this._invalidatePromotedViewsCache()
+
+        // If links remain, rebind to the current representative.
         const connectedWidgets = subgraphInput.getConnectedWidgets()
-        if (connectedWidgets.length > 0) return
+        if (connectedWidgets.length > 0) {
+          this._resolveInputWidget(subgraphInput, input)
+          this._syncPromotions()
+          return
+        }
 
         if (input._widget) this.ensureWidgetRemoved(input._widget)
 
@@ -556,6 +818,62 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       },
       { signal }
     )
+  }
+
+  private _rebindInputSubgraphSlots(): void {
+    this._invalidatePromotedViewsCache()
+
+    const subgraphSlots = [...this.subgraph.inputNode.slots]
+    const slotsBySignature = new Map<string, SubgraphInput[]>()
+    const slotsByName = new Map<string, SubgraphInput[]>()
+
+    for (const slot of subgraphSlots) {
+      const signature = `${slot.name}:${String(slot.type)}`
+      const signatureSlots = slotsBySignature.get(signature)
+      if (signatureSlots) {
+        signatureSlots.push(slot)
+      } else {
+        slotsBySignature.set(signature, [slot])
+      }
+
+      const nameSlots = slotsByName.get(slot.name)
+      if (nameSlots) {
+        nameSlots.push(slot)
+      } else {
+        slotsByName.set(slot.name, [slot])
+      }
+    }
+
+    const assignedSlotIds = new Set<string>()
+    const takeUnassignedSlot = (
+      slots: SubgraphInput[] | undefined
+    ): SubgraphInput | undefined => {
+      if (!slots) return undefined
+      return slots.find((slot) => !assignedSlotIds.has(String(slot.id)))
+    }
+
+    for (const input of this.inputs) {
+      const existingSlot = input._subgraphSlot
+      if (
+        existingSlot &&
+        this.subgraph.inputNode.slots.some((slot) => slot === existingSlot)
+      ) {
+        assignedSlotIds.add(String(existingSlot.id))
+        continue
+      }
+
+      const signature = `${input.name}:${String(input.type)}`
+      const matchedSlot =
+        takeUnassignedSlot(slotsBySignature.get(signature)) ??
+        takeUnassignedSlot(slotsByName.get(input.name))
+
+      if (matchedSlot) {
+        input._subgraphSlot = matchedSlot
+        assignedSlotIds.add(String(matchedSlot.id))
+      } else {
+        delete input._subgraphSlot
+      }
+    }
   }
 
   override configure(info: ExportedSubgraphInstance): void {
@@ -570,8 +888,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     this.inputs.length = 0
     this.inputs.push(
-      ...this.subgraph.inputNode.slots.map(
-        (slot) =>
+      ...this.subgraph.inputNode.slots.map((slot) =>
+        Object.assign(
           new NodeInputSlot(
             {
               name: slot.name,
@@ -581,7 +899,11 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
               link: null
             },
             this
-          )
+          ),
+          {
+            _subgraphSlot: slot
+          }
+        )
       )
     )
 
@@ -606,6 +928,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   override _internalConfigureAfterSlots() {
+    this._rebindInputSubgraphSlots()
+
     // Ensure proxyWidgets is initialized so it serializes
     this.properties.proxyWidgets ??= []
 
@@ -613,10 +937,12 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     // Do NOT clear properties.proxyWidgets — it was already populated
     // from serialized data by super.configure(info) before this runs.
     this._promotedViewManager.clear()
+    this._invalidatePromotedViewsCache()
 
     // Hydrate the store from serialized properties.proxyWidgets
     const raw = parseProxyWidgets(this.properties.proxyWidgets)
     const store = usePromotionStore()
+
     const entries = raw
       .map(([nodeId, widgetName]) => {
         if (nodeId === '-1') {
@@ -633,6 +959,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         return { interiorNodeId: nodeId, widgetName }
       })
       .filter((e): e is NonNullable<typeof e> => e !== null)
+
     store.setPromotions(this.rootGraph.id, this.id, entries)
 
     // Write back resolved entries so legacy -1 format doesn't persist
@@ -645,9 +972,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     // Check all inputs for connected widgets
     for (const input of this.inputs) {
-      const subgraphInput = this.subgraph.inputNode.slots.find(
-        (slot) => slot.name === input.name
-      )
+      const subgraphInput = input._subgraphSlot
       if (!subgraphInput) {
         // Skip inputs that don't exist in the subgraph definition
         // This can happen when loading workflows with dynamically added inputs
@@ -711,6 +1036,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     inputWidget: IWidgetLocator | undefined,
     interiorNode: LGraphNode
   ) {
+    this._invalidatePromotedViewsCache()
     this._flushPendingPromotions()
 
     const nodeId = String(interiorNode.id)
@@ -761,7 +1087,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       widgetName,
       () =>
         createPromotedWidgetView(this, nodeId, widgetName, subgraphInput.name),
-      this._makePromotionViewKey(subgraphInput.name, nodeId, widgetName)
+      this._makePromotionViewKey(String(subgraphInput.id), nodeId, widgetName)
     )
 
     // NOTE: This code creates linked chains of prototypes for passing across
@@ -815,6 +1141,20 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   ): INodeInputSlot & TInput {
     // Bypasses type narrowing on this.inputs
     return super.addInput(name, type, inputProperties)
+  }
+
+  override getSlotFromWidget(
+    widget: IBaseWidget | undefined
+  ): INodeInputSlot | undefined {
+    if (!widget || !isPromotedWidgetView(widget))
+      return super.getSlotFromWidget(widget)
+
+    return this.inputs.find((input) => input._widget === widget)
+  }
+
+  override getWidgetFromSlot(slot: INodeInputSlot): IBaseWidget | undefined {
+    if (slot._widget) return slot._widget
+    return super.getWidgetFromSlot(slot)
   }
 
   override getInputLink(slot: number): LLink | null {
@@ -946,7 +1286,23 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   private _removePromotedView(view: PromotedWidgetView): void {
+    this._invalidatePromotedViewsCache()
+
     this._promotedViewManager.remove(view.sourceNodeId, view.sourceWidgetName)
+    for (const input of this.inputs) {
+      if (input._widget !== view || !input._subgraphSlot) continue
+
+      this._promotedViewManager.removeByViewKey(
+        view.sourceNodeId,
+        view.sourceWidgetName,
+        this._makePromotionViewKey(
+          String(input._subgraphSlot.id),
+          view.sourceNodeId,
+          view.sourceWidgetName
+        )
+      )
+    }
+
     // Reconciled views can also be keyed by inputName-scoped view keys.
     // Remove both key shapes to avoid stale cache entries across promote/rebind flows.
     this._promotedViewManager.removeByViewKey(
@@ -996,6 +1352,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override onRemoved(): void {
     this._eventAbortController.abort()
+    this._invalidatePromotedViewsCache()
 
     for (const widget of this.widgets) {
       if (isPromotedWidgetView(widget)) {

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -37,6 +37,7 @@ import {
 import type { PromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetView'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolveSubgraphInputTarget } from '@/core/graph/subgraph/resolveSubgraphInputTarget'
+import { hasWidgetNode } from '@/core/graph/subgraph/widgetNodeTypeGuard'
 import { parseProxyWidgets } from '@/core/schemas/promotionSchema'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { usePromotionStore } from '@/stores/promotionStore'
@@ -65,12 +66,6 @@ type PromotionEntry = {
 // Pre-rasterize the SVG to a bitmap canvas to avoid Firefox re-processing
 // the SVG's internal stylesheet on every ctx.drawImage() call per frame.
 const workflowBitmapCache = createBitmapCache(workflowSvg, 32)
-
-function hasWidgetNode(
-  widget: IBaseWidget
-): widget is IBaseWidget & { node: LGraphNode } {
-  return 'node' in widget && !!widget.node
-}
 
 /**
  * An instance of a {@link Subgraph}, displayed as a node on the containing (parent) graph.
@@ -104,17 +99,17 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
    * `onAdded()`, so construction-time promotions require normal add-to-graph
    * lifecycle to persist.
    */
-  private _pendingPromotions: Array<{
-    interiorNodeId: string
-    widgetName: string
-  }> = []
-  private _linkedPromotionEntriesCache?: {
-    stateSignature: string
+  private _pendingPromotions: PromotionEntry[] = []
+  private _cacheVersion = 0
+  private _linkedEntriesCache?: {
+    version: number
+    hasMissingBoundSourceWidget: boolean
     entries: LinkedPromotionEntry[]
   }
   private _promotedViewsCache?: {
-    entriesSignature: string
-    linkedEntriesSignature: string
+    version: number
+    entriesRef: PromotionEntry[]
+    hasMissingBoundSourceWidget: boolean
     views: PromotedWidgetView[]
   }
 
@@ -156,16 +151,42 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     }
   }
 
-  private _getLinkedPromotionEntries(): LinkedPromotionEntry[] {
-    const stateSignature = this._makeLinkedPromotionEntriesStateSignature()
-    const cached = this._linkedPromotionEntriesCache
-    if (cached?.stateSignature === stateSignature) return cached.entries
+  private _getLinkedPromotionEntries(cache = true): LinkedPromotionEntry[] {
+    const hasMissingBoundSourceWidget = this._hasMissingBoundSourceWidget()
+    const cached = this._linkedEntriesCache
+    if (
+      cache &&
+      cached?.version === this._cacheVersion &&
+      cached.hasMissingBoundSourceWidget === hasMissingBoundSourceWidget
+    )
+      return cached.entries
 
     const linkedEntries: LinkedPromotionEntry[] = []
 
     for (const input of this.inputs) {
       const subgraphInput = input._subgraphSlot
       if (!subgraphInput) continue
+
+      const boundWidget =
+        input._widget && isPromotedWidgetView(input._widget)
+          ? input._widget
+          : undefined
+      if (boundWidget) {
+        const boundNode = this.subgraph.getNodeById(boundWidget.sourceNodeId)
+        const hasBoundSourceWidget =
+          boundNode?.widgets?.some(
+            (widget) => widget.name === boundWidget.sourceWidgetName
+          ) === true
+        if (hasBoundSourceWidget) {
+          linkedEntries.push({
+            inputName: input.name,
+            inputKey: String(subgraphInput.id),
+            interiorNodeId: boundWidget.sourceNodeId,
+            widgetName: boundWidget.sourceWidgetName
+          })
+          continue
+        }
+      }
 
       const resolved =
         this._resolveLinkedPromotionBySubgraphInput(subgraphInput)
@@ -191,51 +212,46 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       return true
     })
 
-    this._linkedPromotionEntriesCache = {
-      stateSignature,
-      entries: deduplicatedEntries
-    }
+    if (cache)
+      this._linkedEntriesCache = {
+        version: this._cacheVersion,
+        hasMissingBoundSourceWidget,
+        entries: deduplicatedEntries
+      }
 
     return deduplicatedEntries
   }
 
-  private _makeLinkedPromotionEntriesStateSignature(): string {
-    return this.inputs
-      .map((input) => {
-        const subgraphInput = input._subgraphSlot
-        if (!subgraphInput) return `${input.name}:no-subgraph-slot`
+  private _hasMissingBoundSourceWidget(): boolean {
+    return this.inputs.some((input) => {
+      const boundWidget =
+        input._widget && isPromotedWidgetView(input._widget)
+          ? input._widget
+          : undefined
+      if (!boundWidget) return false
 
-        const linkIdsSignature = subgraphInput.linkIds.join(',')
-        const boundWidget =
-          input._widget && isPromotedWidgetView(input._widget)
-            ? input._widget
-            : undefined
-        if (!boundWidget) {
-          const connectedWidgetSignature = subgraphInput
-            .getConnectedWidgets()
-            .filter(hasWidgetNode)
-            .map((widget) => `${String(widget.node.id)}:${widget.name}`)
-            .join(',')
-          return `${String(subgraphInput.id)}:${linkIdsSignature}:unbound:${connectedWidgetSignature}`
-        }
-
-        const boundNode = this.subgraph.getNodeById(boundWidget.sourceNodeId)
-        const hasBoundSourceWidget =
-          boundNode?.widgets?.some(
-            (widget) => widget.name === boundWidget.sourceWidgetName
-          ) === true
-
-        return `${String(subgraphInput.id)}:${linkIdsSignature}:${boundWidget.sourceNodeId}:${boundWidget.sourceWidgetName}:${hasBoundSourceWidget ? '1' : '0'}`
-      })
-      .join('|')
+      const boundNode = this.subgraph.getNodeById(boundWidget.sourceNodeId)
+      return (
+        boundNode?.widgets?.some(
+          (widget) => widget.name === boundWidget.sourceWidgetName
+        ) !== true
+      )
+    })
   }
 
   private _getPromotedViews(): PromotedWidgetView[] {
     const store = usePromotionStore()
     const entries = store.getPromotionsRef(this.rootGraph.id, this.id)
+    const hasMissingBoundSourceWidget = this._hasMissingBoundSourceWidget()
+    const cachedViews = this._promotedViewsCache
+    if (
+      cachedViews?.version === this._cacheVersion &&
+      cachedViews.entriesRef === entries &&
+      cachedViews.hasMissingBoundSourceWidget === hasMissingBoundSourceWidget
+    )
+      return cachedViews.views
+
     const linkedEntries = this._getLinkedPromotionEntries()
-    const cachedViews = this._readPromotedViewsCache(entries, linkedEntries)
-    if (cachedViews) return cachedViews
 
     const { displayNameByViewKey, reconcileEntries } =
       this._buildPromotionReconcileState(entries, linkedEntries)
@@ -251,65 +267,18 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         )
     )
 
-    this._writePromotedViewsCache(entries, linkedEntries, views)
+    this._promotedViewsCache = {
+      version: this._cacheVersion,
+      entriesRef: entries,
+      hasMissingBoundSourceWidget,
+      views
+    }
+
     return views
   }
 
   private _invalidatePromotedViewsCache(): void {
-    this._linkedPromotionEntriesCache = undefined
-    this._promotedViewsCache = undefined
-  }
-
-  private _readPromotedViewsCache(
-    entries: PromotionEntry[],
-    linkedEntries: LinkedPromotionEntry[]
-  ): PromotedWidgetView[] | undefined {
-    const entriesSignature = this._makePromotedEntriesSignature(entries)
-    const linkedEntriesSignature =
-      this._makeLinkedEntriesSignature(linkedEntries)
-    const cache = this._promotedViewsCache
-    if (
-      !cache ||
-      cache.entriesSignature !== entriesSignature ||
-      cache.linkedEntriesSignature !== linkedEntriesSignature
-    )
-      return undefined
-
-    return cache.views
-  }
-
-  private _writePromotedViewsCache(
-    entries: PromotionEntry[],
-    linkedEntries: LinkedPromotionEntry[],
-    views: PromotedWidgetView[]
-  ): void {
-    this._promotedViewsCache = {
-      entriesSignature: this._makePromotedEntriesSignature(entries),
-      linkedEntriesSignature: this._makeLinkedEntriesSignature(linkedEntries),
-      views
-    }
-  }
-
-  private _makePromotedEntriesSignature(entries: PromotionEntry[]): string {
-    return entries
-      .map((entry) =>
-        this._makePromotionEntryKey(entry.interiorNodeId, entry.widgetName)
-      )
-      .join('|')
-  }
-
-  private _makeLinkedEntriesSignature(
-    linkedEntries: LinkedPromotionEntry[]
-  ): string {
-    return linkedEntries
-      .map((entry) =>
-        this._makePromotionViewKey(
-          entry.inputKey,
-          entry.interiorNodeId,
-          entry.widgetName
-        )
-      )
-      .join('|')
+    this._cacheVersion++
   }
 
   private _syncPromotions(): void {
@@ -317,7 +286,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     const store = usePromotionStore()
     const entries = store.getPromotionsRef(this.rootGraph.id, this.id)
-    const linkedEntries = this._getLinkedPromotionEntries()
+    const linkedEntries = this._getLinkedPromotionEntries(false)
+    // Intentionally preserve independent store promotions when linked coverage is partial;
+    // tests assert that mixed linked/independent states must not collapse to linked-only.
     const { mergedEntries } = this._buildPromotionPersistenceState(
       entries,
       linkedEntries
@@ -371,7 +342,6 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     linkedEntries: LinkedPromotionEntry[]
   ): {
     mergedEntries: PromotionEntry[]
-    shouldPersistLinkedOnly: boolean
   } {
     const { linkedPromotionEntries, fallbackStoredEntries } =
       this._collectLinkedAndFallbackEntries(entries, linkedEntries)
@@ -383,8 +353,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     return {
       mergedEntries: shouldPersistLinkedOnly
         ? linkedPromotionEntries
-        : [...linkedPromotionEntries, ...fallbackStoredEntries],
-      shouldPersistLinkedOnly
+        : [...linkedPromotionEntries, ...fallbackStoredEntries]
     }
   }
 
@@ -515,12 +484,10 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       const connectedWidgets = subgraphInput.getConnectedWidgets()
 
       for (const widget of connectedWidgets) {
-        const hasNodeRef = hasWidgetNode(widget)
-        const widgetNodeId = hasNodeRef ? String(widget.node.id) : undefined
-        if (!widgetNodeId) continue
+        if (!hasWidgetNode(widget)) continue
 
         connectedEntryKeys.add(
-          this._makePromotionEntryKey(widgetNodeId, widget.name)
+          this._makePromotionEntryKey(String(widget.node.id), widget.name)
         )
       }
     }

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -179,7 +179,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
           ) === true
         if (hasBoundSourceWidget) {
           linkedEntries.push({
-            inputName: input.name,
+            inputName: input.label ?? input.name,
             inputKey: String(subgraphInput.id),
             interiorNodeId: boundWidget.sourceNodeId,
             widgetName: boundWidget.sourceWidgetName
@@ -193,7 +193,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       if (!resolved) continue
 
       linkedEntries.push({
-        inputName: input.name,
+        inputName: input.label ?? input.name,
         inputKey: String(subgraphInput.id),
         ...resolved
       })
@@ -204,7 +204,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       const entryKey = this._makePromotionViewKey(
         entry.inputKey,
         entry.interiorNodeId,
-        entry.widgetName
+        entry.widgetName,
+        entry.inputName
       )
       if (seenEntryKeys.has(entryKey)) return false
 
@@ -399,13 +400,24 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     )
       return false
 
-    return !fallbackStoredEntries.some((entry) => {
+    const linkedWidgetNames = new Set(
+      linkedEntries.map((entry) => entry.widgetName)
+    )
+
+    const hasFallbackToKeep = fallbackStoredEntries.some((entry) => {
       const sourceNode = this.subgraph.getNodeById(entry.interiorNodeId)
-      if (!sourceNode) return false
-      return !!sourceNode.widgets?.some(
-        (widget) => widget.name === entry.widgetName
-      )
+      const hasSourceWidget =
+        sourceNode?.widgets?.some(
+          (widget) => widget.name === entry.widgetName
+        ) === true
+      if (hasSourceWidget) return true
+
+      // If the fallback widget name overlaps a linked widget name, keep it
+      // until aliasing can be positively proven.
+      return linkedWidgetNames.has(entry.widgetName)
     })
+
+    return !hasFallbackToKeep
   }
 
   private _toPromotionEntries(
@@ -498,11 +510,18 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   private _buildLinkedReconcileEntries(
     linkedEntries: LinkedPromotionEntry[]
   ): Array<{ interiorNodeId: string; widgetName: string; viewKey: string }> {
-    return linkedEntries.map(({ inputKey, interiorNodeId, widgetName }) => ({
-      interiorNodeId,
-      widgetName,
-      viewKey: this._makePromotionViewKey(inputKey, interiorNodeId, widgetName)
-    }))
+    return linkedEntries.map(
+      ({ inputKey, inputName, interiorNodeId, widgetName }) => ({
+        interiorNodeId,
+        widgetName,
+        viewKey: this._makePromotionViewKey(
+          inputKey,
+          interiorNodeId,
+          widgetName,
+          inputName
+        )
+      })
+    )
   }
 
   private _buildDisplayNameByViewKey(
@@ -513,7 +532,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         this._makePromotionViewKey(
           entry.inputKey,
           entry.interiorNodeId,
-          entry.widgetName
+          entry.widgetName,
+          entry.inputName
         ),
         entry.inputName
       ])
@@ -530,9 +550,10 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   private _makePromotionViewKey(
     inputKey: string,
     interiorNodeId: string,
-    widgetName: string
+    widgetName: string,
+    inputName = ''
   ): string {
-    return `${inputKey}:${interiorNodeId}:${widgetName}`
+    return `${inputKey}:${interiorNodeId}:${widgetName}:${inputName}`
   }
 
   private _resolveLegacyEntry(
@@ -595,7 +616,12 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         )
         if (existingInput) {
           const linkId = subgraphInput.linkIds[0]
-          const { inputNode, input } = subgraph.links[linkId].resolve(subgraph)
+          if (linkId === undefined) return
+
+          const link = this.subgraph.getLink(linkId)
+          if (!link) return
+
+          const { inputNode, input } = link.resolve(subgraph)
           const widget = inputNode?.widgets?.find?.((w) => w.name === name)
           if (widget && inputNode)
             this._setWidget(
@@ -660,6 +686,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         if (input._widget) {
           input._widget.label = newName
         }
+        this._invalidatePromotedViewsCache()
         this.graph?.trigger('node:slot-label:changed', {
           nodeId: this.id,
           slotType: NodeSlotType.INPUT
@@ -1053,8 +1080,18 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       nodeId,
       widgetName,
       () =>
-        createPromotedWidgetView(this, nodeId, widgetName, subgraphInput.name),
-      this._makePromotionViewKey(String(subgraphInput.id), nodeId, widgetName)
+        createPromotedWidgetView(
+          this,
+          nodeId,
+          widgetName,
+          input.label ?? subgraphInput.name
+        ),
+      this._makePromotionViewKey(
+        String(subgraphInput.id),
+        nodeId,
+        widgetName,
+        input.label ?? input.name
+      )
     )
 
     // NOTE: This code creates linked chains of prototypes for passing across
@@ -1386,9 +1423,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     for (const input of this.inputs) {
       if (!input._widget) continue
 
-      const subgraphInput = this.subgraph.inputNode.slots.find(
-        (slot) => slot.name === input.name
-      )
+      const subgraphInput =
+        input._subgraphSlot ??
+        this.subgraph.inputNode.slots.find((slot) => slot.name === input.name)
       if (!subgraphInput) continue
 
       const connectedWidgets = subgraphInput.getConnectedWidgets()

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphComplexPromotion1.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphComplexPromotion1.ts
@@ -1,0 +1,322 @@
+import type { ISerialisedGraph } from '@/lib/litegraph/src/types/serialisation'
+
+export const subgraphComplexPromotion1 = {
+  id: 'e49902fa-ee3e-40e6-a59e-c8931888ad0e',
+  revision: 0,
+  last_node_id: 21,
+  last_link_id: 23,
+  nodes: [
+    {
+      id: 12,
+      type: 'PreviewAny',
+      pos: [1367.8236034435063, 305.51100163315823],
+      size: [225, 166],
+      flags: {},
+      order: 3,
+      mode: 0,
+      inputs: [
+        {
+          name: 'source',
+          type: '*',
+          link: 21
+        }
+      ],
+      outputs: [],
+      properties: {
+        'Node name for S&R': 'PreviewAny'
+      },
+      widgets_values: [null, null, null]
+    },
+    {
+      id: 13,
+      type: 'PreviewAny',
+      pos: [1271.9742739655217, 551.9124470179938],
+      size: [225, 166],
+      flags: {},
+      order: 1,
+      mode: 0,
+      inputs: [
+        {
+          name: 'source',
+          type: '*',
+          link: 19
+        }
+      ],
+      outputs: [],
+      properties: {
+        'Node name for S&R': 'PreviewAny'
+      },
+      widgets_values: [null, null, null]
+    },
+    {
+      id: 14,
+      type: 'PreviewAny',
+      pos: [1414.8695925586444, 847.9456885036253],
+      size: [225, 166],
+      flags: {},
+      order: 2,
+      mode: 0,
+      inputs: [
+        {
+          name: 'source',
+          type: '*',
+          link: 20
+        }
+      ],
+      outputs: [],
+      properties: {
+        'Node name for S&R': 'PreviewAny'
+      },
+      widgets_values: [null, null, null]
+    },
+    {
+      id: 21,
+      type: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f',
+      pos: [741.0375276545419, 560.8496560588814],
+      size: [225, 305.3333435058594],
+      flags: {},
+      order: 0,
+      mode: 0,
+      inputs: [],
+      outputs: [
+        {
+          name: 'STRING',
+          type: 'STRING',
+          links: [19]
+        },
+        {
+          name: 'STRING_1',
+          type: 'STRING',
+          links: [20]
+        },
+        {
+          name: 'STRING_2',
+          type: 'STRING',
+          links: [21]
+        }
+      ],
+      properties: {
+        proxyWidgets: [
+          ['20', 'string_a'],
+          ['19', 'string_a'],
+          ['18', 'string_a']
+        ]
+      },
+      widgets_values: []
+    }
+  ],
+  links: [
+    [19, 21, 0, 13, 0, 'STRING'],
+    [20, 21, 1, 14, 0, 'STRING'],
+    [21, 21, 2, 12, 0, 'STRING']
+  ],
+  groups: [],
+  definitions: {
+    subgraphs: [
+      {
+        id: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f',
+        version: 1,
+        state: {
+          lastGroupId: 0,
+          lastNodeId: 21,
+          lastLinkId: 23,
+          lastRerouteId: 0
+        },
+        revision: 0,
+        config: {},
+        name: 'New Subgraph',
+        inputNode: {
+          id: -10,
+          bounding: [596.9206067268835, 805.5404332481304, 120, 60]
+        },
+        outputNode: {
+          id: -20,
+          bounding: [1376.7286067268833, 769.5404332481304, 120, 100]
+        },
+        inputs: [
+          {
+            id: '78479bf4-8145-41d5-9d11-c38e3149fc59',
+            name: 'string_a',
+            type: 'STRING',
+            linkIds: [22, 23],
+            pos: [696.9206067268835, 825.5404332481304]
+          }
+        ],
+        outputs: [
+          {
+            id: 'aa263e4e-b558-4dbf-bcb9-ff0c1c72cbef',
+            name: 'STRING',
+            type: 'STRING',
+            linkIds: [16],
+            localized_name: 'STRING',
+            pos: [1396.7286067268833, 789.5404332481304]
+          },
+          {
+            id: '8eee6fe3-dc2f-491a-9e01-04ef83309dad',
+            name: 'STRING_1',
+            type: 'STRING',
+            linkIds: [17],
+            localized_name: 'STRING_1',
+            pos: [1396.7286067268833, 809.5404332481304]
+          },
+          {
+            id: 'a446d5b9-6042-434d-848a-5d3af5e8e0d4',
+            name: 'STRING_2',
+            type: 'STRING',
+            linkIds: [18],
+            localized_name: 'STRING_2',
+            pos: [1396.7286067268833, 829.5404332481304]
+          }
+        ],
+        widgets: [],
+        nodes: [
+          {
+            id: 18,
+            type: 'StringConcatenate',
+            pos: [818.5102631756379, 706.4562049408103],
+            size: [480, 268],
+            flags: {},
+            order: 0,
+            mode: 0,
+            inputs: [
+              {
+                localized_name: 'string_a',
+                name: 'string_a',
+                type: 'STRING',
+                widget: {
+                  name: 'string_a'
+                },
+                link: 23
+              }
+            ],
+            outputs: [
+              {
+                localized_name: 'STRING',
+                name: 'STRING',
+                type: 'STRING',
+                links: [16]
+              }
+            ],
+            title: 'InnerCatB',
+            properties: {
+              'Node name for S&R': 'StringConcatenate'
+            },
+            widgets_values: ['Poop', '_B', '']
+          },
+          {
+            id: 19,
+            type: 'StringConcatenate',
+            pos: [812.9370280206649, 1040.648423402667],
+            size: [480, 268],
+            flags: {},
+            order: 1,
+            mode: 0,
+            inputs: [],
+            outputs: [
+              {
+                localized_name: 'STRING',
+                name: 'STRING',
+                type: 'STRING',
+                links: [17]
+              }
+            ],
+            title: 'InnerCatC',
+            properties: {
+              'Node name for S&R': 'StringConcatenate'
+            },
+            widgets_values: ['', '_C', '']
+          },
+          {
+            id: 20,
+            type: 'StringConcatenate',
+            pos: [824.7110975088726, 386.4230523609899],
+            size: [480, 268],
+            flags: {},
+            order: 2,
+            mode: 0,
+            inputs: [
+              {
+                localized_name: 'string_a',
+                name: 'string_a',
+                type: 'STRING',
+                widget: {
+                  name: 'string_a'
+                },
+                link: 22
+              }
+            ],
+            outputs: [
+              {
+                localized_name: 'STRING',
+                name: 'STRING',
+                type: 'STRING',
+                links: [18]
+              }
+            ],
+            title: 'InnerCatA',
+            properties: {
+              'Node name for S&R': 'StringConcatenate'
+            },
+            widgets_values: ['Poop', '_A', '']
+          }
+        ],
+        groups: [],
+        links: [
+          {
+            id: 16,
+            origin_id: 18,
+            origin_slot: 0,
+            target_id: -20,
+            target_slot: 0,
+            type: 'STRING'
+          },
+          {
+            id: 17,
+            origin_id: 19,
+            origin_slot: 0,
+            target_id: -20,
+            target_slot: 1,
+            type: 'STRING'
+          },
+          {
+            id: 18,
+            origin_id: 20,
+            origin_slot: 0,
+            target_id: -20,
+            target_slot: 2,
+            type: 'STRING'
+          },
+          {
+            id: 22,
+            origin_id: -10,
+            origin_slot: 0,
+            target_id: 20,
+            target_slot: 0,
+            type: 'STRING'
+          },
+          {
+            id: 23,
+            origin_id: -10,
+            origin_slot: 0,
+            target_id: 18,
+            target_slot: 0,
+            type: 'STRING'
+          }
+        ],
+        extra: {
+          workflowRendererVersion: 'Vue'
+        }
+      }
+    ]
+  },
+  config: {},
+  extra: {
+    ds: {
+      scale: 0.6638894832438259,
+      offset: [-408.2009703049473, -183.8039508449224]
+    },
+    workflowRendererVersion: 'Vue',
+    frontendVersion: '1.42.3'
+  },
+  version: 0.4
+} as const as unknown as ISerialisedGraph

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.test.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+
+import {
+  cleanupComplexPromotionFixtureNodeType,
+  setupComplexPromotionFixture
+} from './subgraphHelpers'
+
+const FIXTURE_STRING_CONCAT_TYPE = 'Fixture/StringConcatenate'
+
+describe('setupComplexPromotionFixture', () => {
+  afterEach(() => {
+    cleanupComplexPromotionFixtureNodeType()
+  })
+
+  it('can clean up the globally registered fixture node type', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+
+    setupComplexPromotionFixture()
+    expect(
+      LiteGraph.registered_node_types[FIXTURE_STRING_CONCAT_TYPE]
+    ).toBeDefined()
+
+    cleanupComplexPromotionFixtureNodeType()
+    expect(
+      LiteGraph.registered_node_types[FIXTURE_STRING_CONCAT_TYPE]
+    ).toBeUndefined()
+  })
+})

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -38,6 +38,11 @@ class FixtureStringConcatenateNode extends LGraphNode {
   }
 }
 
+export function cleanupComplexPromotionFixtureNodeType(): void {
+  if (!LiteGraph.registered_node_types[FIXTURE_STRING_CONCAT_TYPE]) return
+  LiteGraph.unregisterNodeType(FIXTURE_STRING_CONCAT_TYPE)
+}
+
 interface TestSubgraphOptions {
   id?: UUID
   name?: string
@@ -240,6 +245,7 @@ export function setupComplexPromotionFixture(): {
   if (!subgraphData)
     throw new Error('Expected fixture to contain one subgraph definition')
 
+  cleanupComplexPromotionFixtureNodeType()
   LiteGraph.registerNodeType(
     FIXTURE_STRING_CONCAT_TYPE,
     FixtureStringConcatenateNode

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -8,7 +8,12 @@
 import { expect } from 'vitest'
 
 import type { ISlotType, NodeId } from '@/lib/litegraph/src/litegraph'
-import { LGraph, LGraphNode, Subgraph } from '@/lib/litegraph/src/litegraph'
+import {
+  LGraph,
+  LGraphNode,
+  LiteGraph,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
 import { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type {
   ExportedSubgraph,
@@ -16,6 +21,22 @@ import type {
 } from '@/lib/litegraph/src/types/serialisation'
 import type { UUID } from '@/lib/litegraph/src/utils/uuid'
 import { createUuidv4 } from '@/lib/litegraph/src/utils/uuid'
+
+import { subgraphComplexPromotion1 } from './subgraphComplexPromotion1'
+
+const FIXTURE_STRING_CONCAT_TYPE = 'Fixture/StringConcatenate'
+
+class FixtureStringConcatenateNode extends LGraphNode {
+  constructor() {
+    super('StringConcatenate')
+    const input = this.addInput('string_a', 'STRING')
+    input.widget = { name: 'string_a' }
+    this.addOutput('STRING', 'STRING')
+    this.addWidget('text', 'string_a', '', () => {})
+    this.addWidget('text', 'string_b', '', () => {})
+    this.addWidget('text', 'delimiter', '', () => {})
+  }
+}
 
 interface TestSubgraphOptions {
   id?: UUID
@@ -207,6 +228,47 @@ export function createTestSubgraphNode(
   }
 
   return new SubgraphNode(parentGraph, subgraph, instanceData)
+}
+
+export function setupComplexPromotionFixture(): {
+  graph: LGraph
+  subgraph: Subgraph
+  hostNode: SubgraphNode
+} {
+  const fixture = structuredClone(subgraphComplexPromotion1)
+  const subgraphData = fixture.definitions?.subgraphs?.[0]
+  if (!subgraphData)
+    throw new Error('Expected fixture to contain one subgraph definition')
+
+  LiteGraph.registerNodeType(
+    FIXTURE_STRING_CONCAT_TYPE,
+    FixtureStringConcatenateNode
+  )
+
+  for (const node of subgraphData.nodes as Array<{ type: string }>) {
+    if (node.type === 'StringConcatenate')
+      node.type = FIXTURE_STRING_CONCAT_TYPE
+  }
+
+  const hostNodeData = fixture.nodes.find((node) => node.id === 21)
+  if (!hostNodeData)
+    throw new Error('Expected fixture to contain subgraph instance node id 21')
+
+  const graph = new LGraph()
+  const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
+  subgraph.configure(subgraphData as ExportedSubgraph)
+  const hostNode = new SubgraphNode(
+    graph,
+    subgraph,
+    hostNodeData as ExportedSubgraphInstance
+  )
+  graph.add(hostNode)
+
+  return {
+    graph,
+    subgraph,
+    hostNode
+  }
 }
 
 /**

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -117,4 +117,40 @@ describe('NodeWidgets', () => {
       }
     )
   })
+
+  it('deduplicates widgets with identical render identity while keeping distinct promoted sources', () => {
+    const duplicateA = createMockWidget({
+      name: 'string_a',
+      type: 'text',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeName: 'string_a',
+      slotName: 'string_a'
+    })
+    const duplicateB = createMockWidget({
+      name: 'string_a',
+      type: 'text',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeName: 'string_a',
+      slotName: 'string_a'
+    })
+    const distinct = createMockWidget({
+      name: 'string_a',
+      type: 'text',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:20',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:20',
+      storeName: 'string_a',
+      slotName: 'string_a'
+    })
+    const nodeData = createMockNodeData('SubgraphNode', [
+      duplicateA,
+      duplicateB,
+      distinct
+    ])
+
+    const wrapper = mountComponent(nodeData)
+
+    expect(wrapper.findAll('.lg-node-widget')).toHaveLength(2)
+  })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -284,7 +284,7 @@ describe('NodeWidgets', () => {
     expect(wrapper.findAll('.lg-node-widget')).toHaveLength(0)
   })
 
-  it('assigns unique AppInput ids for widgets on the same node', () => {
+  it('keeps AppInput ids mapped to node identity for selection', () => {
     const nodeData = createMockNodeData('TestNode', [
       createMockWidget({ nodeId: 'test_node', name: 'seed_a', type: 'text' }),
       createMockWidget({ nodeId: 'test_node', name: 'seed_b', type: 'text' })
@@ -294,6 +294,6 @@ describe('NodeWidgets', () => {
     const appInputWrappers = wrapper.findAllComponents({ name: 'AppInput' })
     const ids = appInputWrappers.map((component) => component.props('id'))
 
-    expect(new Set(ids).size).toBe(2)
+    expect(ids).toStrictEqual(['test_node', 'test_node'])
   })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -153,4 +153,89 @@ describe('NodeWidgets', () => {
 
     expect(wrapper.findAll('.lg-node-widget')).toHaveLength(2)
   })
+
+  it('prefers a visible duplicate over a hidden duplicate when identities collide', () => {
+    const hiddenDuplicate = createMockWidget({
+      name: 'string_a',
+      type: 'text',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeName: 'string_a',
+      slotName: 'string_a',
+      options: { hidden: true }
+    })
+    const visibleDuplicate = createMockWidget({
+      name: 'string_a',
+      type: 'text',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeName: 'string_a',
+      slotName: 'string_a',
+      options: { hidden: false }
+    })
+    const nodeData = createMockNodeData('SubgraphNode', [
+      hiddenDuplicate,
+      visibleDuplicate
+    ])
+
+    const wrapper = mountComponent(nodeData)
+
+    expect(wrapper.findAll('.lg-node-widget')).toHaveLength(1)
+  })
+
+  it('does not deduplicate entries that share names but have different widget types', () => {
+    const textWidget = createMockWidget({
+      name: 'string_a',
+      type: 'text',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeName: 'string_a',
+      slotName: 'string_a'
+    })
+    const comboWidget = createMockWidget({
+      name: 'string_a',
+      type: 'combo',
+      nodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeNodeId: '5e0670b8-ea2c-4fb6-8b73-a1100a2d4f8f:19',
+      storeName: 'string_a',
+      slotName: 'string_a'
+    })
+    const nodeData = createMockNodeData('SubgraphNode', [
+      textWidget,
+      comboWidget
+    ])
+
+    const wrapper = mountComponent(nodeData)
+
+    expect(wrapper.findAll('.lg-node-widget')).toHaveLength(2)
+  })
+
+  it('keeps unresolved same-name promoted entries distinct by source execution identity', () => {
+    const firstTransientEntry = createMockWidget({
+      nodeId: undefined,
+      storeNodeId: undefined,
+      name: 'string_a',
+      storeName: 'string_a',
+      slotName: 'string_a',
+      type: 'text',
+      sourceExecutionId: '65:18'
+    })
+    const secondTransientEntry = createMockWidget({
+      nodeId: undefined,
+      storeNodeId: undefined,
+      name: 'string_a',
+      storeName: 'string_a',
+      slotName: 'string_a',
+      type: 'text',
+      sourceExecutionId: '65:19'
+    })
+    const nodeData = createMockNodeData('SubgraphNode', [
+      firstTransientEntry,
+      secondTransientEntry
+    ])
+
+    const wrapper = mountComponent(nodeData)
+
+    expect(wrapper.findAll('.lg-node-widget')).toHaveLength(2)
+  })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,13 +1,28 @@
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
 
 import type {
   SafeWidgetData,
   VueNodeData
 } from '@/composables/graph/useGraphNodeManager'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: {
+      graph: {
+        rootGraph: {
+          id: 'graph-test'
+        }
+      }
+    }
+  })
+}))
 
 describe('NodeWidgets', () => {
   const createMockWidget = (
@@ -40,12 +55,15 @@ describe('NodeWidgets', () => {
   })
 
   const mountComponent = (nodeData?: VueNodeData) => {
+    const pinia = createTestingPinia({ stubActions: false })
+    setActivePinia(pinia)
+
     return mount(NodeWidgets, {
       props: {
         nodeData
       },
       global: {
-        plugins: [createTestingPinia()],
+        plugins: [pinia],
         stubs: {
           // Stub InputSlot to avoid complex slot registration dependencies
           InputSlot: true
@@ -237,5 +255,45 @@ describe('NodeWidgets', () => {
     const wrapper = mountComponent(nodeData)
 
     expect(wrapper.findAll('.lg-node-widget')).toHaveLength(2)
+  })
+
+  it('hides widgets when merged store options mark them hidden', async () => {
+    const nodeData = createMockNodeData('TestNode', [
+      createMockWidget({
+        nodeId: 'test_node',
+        name: 'test_widget',
+        options: { hidden: false }
+      })
+    ])
+
+    const wrapper = mountComponent(nodeData)
+    const widgetValueStore = useWidgetValueStore()
+    widgetValueStore.registerWidget('graph-test', {
+      nodeId: 'test_node',
+      name: 'test_widget',
+      type: 'combo',
+      value: 'value',
+      options: { hidden: true },
+      label: undefined,
+      serialize: true,
+      disabled: false
+    })
+
+    await nextTick()
+
+    expect(wrapper.findAll('.lg-node-widget')).toHaveLength(0)
+  })
+
+  it('assigns unique AppInput ids for widgets on the same node', () => {
+    const nodeData = createMockNodeData('TestNode', [
+      createMockWidget({ nodeId: 'test_node', name: 'seed_a', type: 'text' }),
+      createMockWidget({ nodeId: 'test_node', name: 'seed_b', type: 'text' })
+    ])
+
+    const wrapper = mountComponent(nodeData)
+    const appInputWrappers = wrapper.findAllComponents({ name: 'AppInput' })
+    const ids = appInputWrappers.map((component) => component.props('id'))
+
+    expect(new Set(ids).size).toBe(2)
   })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -21,10 +21,7 @@
     @pointermove="handleWidgetPointerEvent"
     @pointerup="handleWidgetPointerEvent"
   >
-    <template
-      v-for="(widget, index) in processedWidgets"
-      :key="`widget-${index}-${widget.name}`"
-    >
+    <template v-for="widget in processedWidgets" :key="widget.renderKey">
       <div
         v-if="!widget.hidden && (!widget.advanced || showAdvanced)"
         class="lg-node-widget group col-span-full grid grid-cols-subgrid items-stretch"
@@ -214,6 +211,7 @@ interface ProcessedWidget {
   hidden: boolean
   id: string
   name: string
+  renderKey: string
   simplified: SimplifiedWidget
   tooltipConfig: TooltipOptions
   type: string
@@ -241,6 +239,26 @@ function hasWidgetError(
   )
 }
 
+function getWidgetIdentity(
+  widget: SafeWidgetData,
+  nodeId: string | number | undefined
+): {
+  bareWidgetId: string
+  storeWidgetName: string
+  widgetIdentity: string
+} {
+  const rawWidgetId = widget.storeNodeId ?? widget.nodeId ?? nodeId ?? ''
+  const bareWidgetId = String(stripGraphPrefix(rawWidgetId))
+  const storeWidgetName = widget.storeName ?? widget.name
+  const slotNameForIdentity = widget.slotName ?? widget.name
+
+  return {
+    bareWidgetId,
+    storeWidgetName,
+    widgetIdentity: `${String(bareWidgetId)}:${storeWidgetName}:${slotNameForIdentity}`
+  }
+}
+
 const processedWidgets = computed((): ProcessedWidget[] => {
   if (!nodeData?.widgets) return []
 
@@ -256,10 +274,26 @@ const processedWidgets = computed((): ProcessedWidget[] => {
   const nodeId = nodeData.id
   const { widgets } = nodeData
   const result: ProcessedWidget[] = []
+  const uniqueWidgets: Array<{
+    widget: SafeWidgetData
+    identity: ReturnType<typeof getWidgetIdentity>
+  }> = []
+  const seenWidgetIdentities = new Set<string>()
 
   for (const widget of widgets) {
     if (!shouldRenderAsVue(widget)) continue
 
+    const identity = getWidgetIdentity(widget, nodeId)
+    if (seenWidgetIdentities.has(identity.widgetIdentity)) continue
+
+    seenWidgetIdentities.add(identity.widgetIdentity)
+    uniqueWidgets.push({ widget, identity })
+  }
+
+  for (const {
+    widget,
+    identity: { bareWidgetId, storeWidgetName, widgetIdentity }
+  } of uniqueWidgets) {
     const isPromotedView = !!widget.nodeId
 
     const vueComponent =
@@ -269,10 +303,6 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     const { slotMetadata } = widget
 
     // Get metadata from store (registered during BaseWidget.setNodeId)
-    const bareWidgetId = stripGraphPrefix(
-      widget.storeNodeId ?? widget.nodeId ?? nodeId
-    )
-    const storeWidgetName = widget.storeName ?? widget.name
     const widgetState = graphId
       ? widgetValueStore.getWidget(graphId, bareWidgetId, storeWidgetName)
       : undefined
@@ -337,8 +367,9 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       hasLayoutSize: widget.hasLayoutSize ?? false,
       hasError: hasWidgetError(widget, nodeExecId, nodeErrors),
       hidden: widget.options?.hidden ?? false,
-      id: String(bareWidgetId),
+      id: widgetIdentity,
       name: widget.name,
+      renderKey: widgetIdentity,
       type: widget.type,
       vueComponent,
       simplified,

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -427,7 +427,7 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       hasLayoutSize: widget.hasLayoutSize ?? false,
       hasError: hasWidgetError(widget, nodeExecId, nodeErrors),
       hidden: mergedOptions.hidden ?? false,
-      id: `${bareWidgetId}:${renderKey}`,
+      id: String(bareWidgetId),
       name: widget.name,
       renderKey,
       type: widget.type,

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -244,17 +244,12 @@ function getWidgetIdentity(
   nodeId: string | number | undefined,
   index: number
 ): {
-  bareWidgetId: string
-  storeWidgetName: string
   dedupeIdentity?: string
   renderKey: string
 } {
   const rawWidgetId = widget.storeNodeId ?? widget.nodeId
-  const widgetIdForStoreLookup = rawWidgetId ?? nodeId ?? ''
-  const bareWidgetId = String(stripGraphPrefix(widgetIdForStoreLookup))
   const storeWidgetName = widget.storeName ?? widget.name
   const slotNameForIdentity = widget.slotName ?? widget.name
-  const typeForIdentity = widget.type
   const stableIdentityRoot = rawWidgetId
     ? `node:${String(stripGraphPrefix(rawWidgetId))}`
     : widget.sourceExecutionId
@@ -262,15 +257,13 @@ function getWidgetIdentity(
       : undefined
 
   const dedupeIdentity = stableIdentityRoot
-    ? `${stableIdentityRoot}:${storeWidgetName}:${slotNameForIdentity}:${typeForIdentity}`
+    ? `${stableIdentityRoot}:${storeWidgetName}:${slotNameForIdentity}:${widget.type}`
     : undefined
   const renderKey =
     dedupeIdentity ??
-    `transient:${String(nodeId ?? '')}:${storeWidgetName}:${slotNameForIdentity}:${typeForIdentity}:${index}`
+    `transient:${String(nodeId ?? '')}:${storeWidgetName}:${slotNameForIdentity}:${widget.type}:${index}`
 
   return {
-    bareWidgetId,
-    storeWidgetName,
     dedupeIdentity,
     renderKey
   }
@@ -329,8 +322,12 @@ const processedWidgets = computed((): ProcessedWidget[] => {
 
   for (const {
     widget,
-    identity: { bareWidgetId, storeWidgetName, renderKey }
+    identity: { renderKey }
   } of uniqueWidgets) {
+    const storeWidgetName = widget.storeName ?? widget.name
+    const bareWidgetId = String(
+      stripGraphPrefix(widget.storeNodeId ?? widget.nodeId ?? nodeId ?? '')
+    )
     const isPromotedView = !!widget.nodeId
 
     const vueComponent =
@@ -404,7 +401,7 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       hasLayoutSize: widget.hasLayoutSize ?? false,
       hasError: hasWidgetError(widget, nodeExecId, nodeErrors),
       hidden: widget.options?.hidden ?? false,
-      id: renderKey,
+      id: bareWidgetId,
       name: widget.name,
       renderKey,
       type: widget.type,

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -269,9 +269,9 @@ function getWidgetIdentity(
   }
 }
 
-function isWidgetVisible(widget: SafeWidgetData): boolean {
-  const hidden = widget.options?.hidden ?? false
-  const advanced = widget.options?.advanced ?? false
+function isWidgetVisible(options: IWidgetOptions): boolean {
+  const hidden = options.hidden ?? false
+  const advanced = options.advanced ?? false
   return !hidden && (!advanced || showAdvanced.value)
 }
 
@@ -293,6 +293,8 @@ const processedWidgets = computed((): ProcessedWidget[] => {
   const uniqueWidgets: Array<{
     widget: SafeWidgetData
     identity: ReturnType<typeof getWidgetIdentity>
+    mergedOptions: IWidgetOptions
+    widgetState: WidgetState | undefined
     isVisible: boolean
   }> = []
   const dedupeIndexByIdentity = new Map<string, number>()
@@ -301,30 +303,60 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     if (!shouldRenderAsVue(widget)) continue
 
     const identity = getWidgetIdentity(widget, nodeId, index)
-    const visible = isWidgetVisible(widget)
+    const storeWidgetName = widget.storeName ?? widget.name
+    const bareWidgetId = String(
+      stripGraphPrefix(widget.storeNodeId ?? widget.nodeId ?? nodeId ?? '')
+    )
+    const widgetState = graphId
+      ? widgetValueStore.getWidget(graphId, bareWidgetId, storeWidgetName)
+      : undefined
+    const mergedOptions: IWidgetOptions = {
+      ...(widget.options ?? {}),
+      ...(widgetState?.options ?? {})
+    }
+    const visible = isWidgetVisible(mergedOptions)
     if (!identity.dedupeIdentity) {
-      uniqueWidgets.push({ widget, identity, isVisible: visible })
+      uniqueWidgets.push({
+        widget,
+        identity,
+        mergedOptions,
+        widgetState,
+        isVisible: visible
+      })
       continue
     }
 
     const existingIndex = dedupeIndexByIdentity.get(identity.dedupeIdentity)
     if (existingIndex === undefined) {
       dedupeIndexByIdentity.set(identity.dedupeIdentity, uniqueWidgets.length)
-      uniqueWidgets.push({ widget, identity, isVisible: visible })
+      uniqueWidgets.push({
+        widget,
+        identity,
+        mergedOptions,
+        widgetState,
+        isVisible: visible
+      })
       continue
     }
 
     const existingWidget = uniqueWidgets[existingIndex]
     if (existingWidget && !existingWidget.isVisible && visible) {
-      uniqueWidgets[existingIndex] = { widget, identity, isVisible: true }
+      uniqueWidgets[existingIndex] = {
+        widget,
+        identity,
+        mergedOptions,
+        widgetState,
+        isVisible: true
+      }
     }
   }
 
   for (const {
     widget,
+    mergedOptions,
+    widgetState,
     identity: { renderKey }
   } of uniqueWidgets) {
-    const storeWidgetName = widget.storeName ?? widget.name
     const bareWidgetId = String(
       stripGraphPrefix(widget.storeNodeId ?? widget.nodeId ?? nodeId ?? '')
     )
@@ -336,28 +368,22 @@ const processedWidgets = computed((): ProcessedWidget[] => {
 
     const { slotMetadata } = widget
 
-    // Get metadata from store (registered during BaseWidget.setNodeId)
-    const widgetState = graphId
-      ? widgetValueStore.getWidget(graphId, bareWidgetId, storeWidgetName)
-      : undefined
-
     // Get value from store (falls back to undefined if not registered)
     const value = widgetState?.value as WidgetValue
 
     // Build options from store state, with disabled override for
     // slot-linked widgets or widgets with disabled state (e.g. display-only)
-    const storeOptions = widgetState?.options ?? {}
     const isDisabled = slotMetadata?.linked || widgetState?.disabled
     const widgetOptions = isDisabled
-      ? { ...storeOptions, disabled: true }
-      : storeOptions
+      ? { ...mergedOptions, disabled: true }
+      : mergedOptions
 
     const borderStyle =
       graphId &&
       !isPromotedView &&
       promotionStore.isPromotedByAny(graphId, String(bareWidgetId), widget.name)
         ? 'ring ring-component-node-widget-promoted'
-        : widget.options?.advanced
+        : mergedOptions.advanced
           ? 'ring ring-component-node-widget-advanced'
           : undefined
 
@@ -396,12 +422,12 @@ const processedWidgets = computed((): ProcessedWidget[] => {
     }
 
     result.push({
-      advanced: widget.options?.advanced ?? false,
+      advanced: mergedOptions.advanced ?? false,
       handleContextMenu,
       hasLayoutSize: widget.hasLayoutSize ?? false,
       hasError: hasWidgetError(widget, nodeExecId, nodeErrors),
-      hidden: widget.options?.hidden ?? false,
-      id: bareWidgetId,
+      hidden: mergedOptions.hidden ?? false,
+      id: `${bareWidgetId}:${renderKey}`,
       name: widget.name,
       renderKey,
       type: widget.type,

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -241,22 +241,45 @@ function hasWidgetError(
 
 function getWidgetIdentity(
   widget: SafeWidgetData,
-  nodeId: string | number | undefined
+  nodeId: string | number | undefined,
+  index: number
 ): {
   bareWidgetId: string
   storeWidgetName: string
-  widgetIdentity: string
+  dedupeIdentity?: string
+  renderKey: string
 } {
-  const rawWidgetId = widget.storeNodeId ?? widget.nodeId ?? nodeId ?? ''
-  const bareWidgetId = String(stripGraphPrefix(rawWidgetId))
+  const rawWidgetId = widget.storeNodeId ?? widget.nodeId
+  const widgetIdForStoreLookup = rawWidgetId ?? nodeId ?? ''
+  const bareWidgetId = String(stripGraphPrefix(widgetIdForStoreLookup))
   const storeWidgetName = widget.storeName ?? widget.name
   const slotNameForIdentity = widget.slotName ?? widget.name
+  const typeForIdentity = widget.type
+  const stableIdentityRoot = rawWidgetId
+    ? `node:${String(stripGraphPrefix(rawWidgetId))}`
+    : widget.sourceExecutionId
+      ? `exec:${widget.sourceExecutionId}`
+      : undefined
+
+  const dedupeIdentity = stableIdentityRoot
+    ? `${stableIdentityRoot}:${storeWidgetName}:${slotNameForIdentity}:${typeForIdentity}`
+    : undefined
+  const renderKey =
+    dedupeIdentity ??
+    `transient:${String(nodeId ?? '')}:${storeWidgetName}:${slotNameForIdentity}:${typeForIdentity}:${index}`
 
   return {
     bareWidgetId,
     storeWidgetName,
-    widgetIdentity: `${String(bareWidgetId)}:${storeWidgetName}:${slotNameForIdentity}`
+    dedupeIdentity,
+    renderKey
   }
+}
+
+function isWidgetVisible(widget: SafeWidgetData): boolean {
+  const hidden = widget.options?.hidden ?? false
+  const advanced = widget.options?.advanced ?? false
+  return !hidden && (!advanced || showAdvanced.value)
 }
 
 const processedWidgets = computed((): ProcessedWidget[] => {
@@ -264,7 +287,7 @@ const processedWidgets = computed((): ProcessedWidget[] => {
 
   // nodeData.id is the local node ID; subgraph nodes need the full execution
   // path (e.g. "65:63") to match keys in lastNodeErrors.
-  const nodeExecId = app.rootGraph
+  const nodeExecId = app.isGraphReady
     ? getExecutionIdFromNodeData(app.rootGraph, nodeData)
     : String(nodeData.id ?? '')
 
@@ -277,22 +300,36 @@ const processedWidgets = computed((): ProcessedWidget[] => {
   const uniqueWidgets: Array<{
     widget: SafeWidgetData
     identity: ReturnType<typeof getWidgetIdentity>
+    isVisible: boolean
   }> = []
-  const seenWidgetIdentities = new Set<string>()
+  const dedupeIndexByIdentity = new Map<string, number>()
 
-  for (const widget of widgets) {
+  for (const [index, widget] of widgets.entries()) {
     if (!shouldRenderAsVue(widget)) continue
 
-    const identity = getWidgetIdentity(widget, nodeId)
-    if (seenWidgetIdentities.has(identity.widgetIdentity)) continue
+    const identity = getWidgetIdentity(widget, nodeId, index)
+    const visible = isWidgetVisible(widget)
+    if (!identity.dedupeIdentity) {
+      uniqueWidgets.push({ widget, identity, isVisible: visible })
+      continue
+    }
 
-    seenWidgetIdentities.add(identity.widgetIdentity)
-    uniqueWidgets.push({ widget, identity })
+    const existingIndex = dedupeIndexByIdentity.get(identity.dedupeIdentity)
+    if (existingIndex === undefined) {
+      dedupeIndexByIdentity.set(identity.dedupeIdentity, uniqueWidgets.length)
+      uniqueWidgets.push({ widget, identity, isVisible: visible })
+      continue
+    }
+
+    const existingWidget = uniqueWidgets[existingIndex]
+    if (existingWidget && !existingWidget.isVisible && visible) {
+      uniqueWidgets[existingIndex] = { widget, identity, isVisible: true }
+    }
   }
 
   for (const {
     widget,
-    identity: { bareWidgetId, storeWidgetName, widgetIdentity }
+    identity: { bareWidgetId, storeWidgetName, renderKey }
   } of uniqueWidgets) {
     const isPromotedView = !!widget.nodeId
 
@@ -367,9 +404,9 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       hasLayoutSize: widget.hasLayoutSize ?? false,
       hasError: hasWidgetError(widget, nodeExecId, nodeErrors),
       hidden: widget.options?.hidden ?? false,
-      id: widgetIdentity,
+      id: renderKey,
       name: widget.name,
-      renderKey: widgetIdentity,
+      renderKey,
       type: widget.type,
       vueComponent,
       simplified,

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -748,6 +748,7 @@ export function useSlotLinkInteraction({
   })
 
   function onDoubleClick(e: PointerEvent) {
+    if (!app.canvas) return
     const { graph } = app.canvas
     if (!graph) return
     const node = graph.getNodeById(nodeId)
@@ -756,6 +757,7 @@ export function useSlotLinkInteraction({
     node.onInputDblClick?.(index, e)
   }
   function onClick(e: PointerEvent) {
+    if (!app.canvas) return
     const { graph } = app.canvas
     if (!graph) return
     const node = graph.getNodeById(nodeId)

--- a/src/stores/promotionStore.test.ts
+++ b/src/stores/promotionStore.test.ts
@@ -23,6 +23,13 @@ describe(usePromotionStore, () => {
       expect(store.getPromotions(graphA, nodeId)).toEqual([])
     })
 
+    it('returns a stable empty ref for unknown node', () => {
+      const first = store.getPromotionsRef(graphA, nodeId)
+      const second = store.getPromotionsRef(graphA, nodeId)
+
+      expect(second).toBe(first)
+    })
+
     it('returns entries after setPromotions', () => {
       const entries = [
         { interiorNodeId: '10', widgetName: 'seed' },

--- a/src/stores/promotionStore.ts
+++ b/src/stores/promotionStore.ts
@@ -9,6 +9,8 @@ interface PromotionEntry {
   widgetName: string
 }
 
+const EMPTY_PROMOTIONS: PromotionEntry[] = []
+
 export const usePromotionStore = defineStore('promotion', () => {
   const graphPromotions = ref(new Map<UUID, Map<NodeId, PromotionEntry[]>>())
   const graphRefCounts = ref(new Map<UUID, Map<string, number>>())
@@ -62,7 +64,9 @@ export const usePromotionStore = defineStore('promotion', () => {
     graphId: UUID,
     subgraphNodeId: NodeId
   ): PromotionEntry[] {
-    return _getPromotionsForGraph(graphId).get(subgraphNodeId) ?? []
+    return (
+      _getPromotionsForGraph(graphId).get(subgraphNodeId) ?? EMPTY_PROMOTIONS
+    )
   }
 
   function getPromotions(

--- a/src/stores/promotionStore.ts
+++ b/src/stores/promotionStore.ts
@@ -99,6 +99,7 @@ export const usePromotionStore = defineStore('promotion', () => {
   ): void {
     const promotions = _getPromotionsForGraph(graphId)
     const oldEntries = promotions.get(subgraphNodeId) ?? []
+
     _decrementKeys(graphId, oldEntries)
     _incrementKeys(graphId, entries)
 
@@ -116,6 +117,7 @@ export const usePromotionStore = defineStore('promotion', () => {
     widgetName: string
   ): void {
     if (isPromoted(graphId, subgraphNodeId, interiorNodeId, widgetName)) return
+
     const entries = getPromotionsRef(graphId, subgraphNodeId)
     setPromotions(graphId, subgraphNodeId, [
       ...entries,


### PR DESCRIPTION
## Summary

Fix subgraph promoted widget identity/rendering so on-node widgets stay correct through configure/hydration churn, duplicate names, and linked+independent coexistence.

## Changes

- **Subgraph promotion reconciliation**: stabilize linked-entry identity by subgraph slot id, preserve deterministic linked representative selection, and prune stale alias/fallback entries without dropping legitimate independent promotions.
- **Promoted view resolution**: bind slot mapping by promoted view object identity (`getSlotFromWidget` / `getWidgetFromSlot`) to avoid same-name collisions.
- **On-node widget rendering**: harden `NodeWidgets` identity and dedup to avoid visual aliasing, prefer visible duplicates over hidden stale entries, include type/source execution identity, and avoid collapsing transient unresolved entries.
- **Mapping correctness**: update `useGraphNodeManager` promoted source mapping to resolve by input target only when the promoted view is actually bound to that input.
- **Subgraph input uniqueness**: ensure empty-slot promotion creates unique input names (`seed`, `seed_1`, etc.) for same-name multi-source promotions.
- **Safety fix**: guard against undefined canvas in slot-link interaction.
- **Tests/fixtures**: add focused regressions for fixture path `subgraph_complex_promotion_1`, linked+independent same-name cases, duplicate-name identity mapping, dedup behavior, and input-name uniqueness.

## Review Focus

Validate behavior around transient configure/hydration states (`-1` id to concrete id), duplicate-name promotions, linked representative recovery, and that dedup never hides legitimate widgets while still removing true duplicates.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9896-fix-stabilize-subgraph-promoted-widget-identity-and-rendering-3226d73d365081c8a1e8d0a5a22e826d) by [Unito](https://www.unito.io)
