### PR TITLE
fix: prevent blueprint cache corruption on repeated placement

### DIFF
--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -155,6 +155,16 @@ describe('useSubgraphStore', () => {
     } as ComfyNodeDefV1)
     expect(res).toBeTruthy()
   })
+  it('should return a deep copy from getBlueprint so mutations do not corrupt the cache', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    const first = store.getBlueprint(store.typePrefix + 'test')
+    first.nodes[0].id = -1
+    first.definitions!.subgraphs![0].id = 'corrupted'
+
+    const second = store.getBlueprint(store.typePrefix + 'test')
+    expect(second.nodes[0].id).not.toBe(-1)
+    expect(second.definitions!.subgraphs![0].id).toBe('123')
+  })
   it('should identify user blueprints as non-global', async () => {
     await mockFetch({ 'test.json': mockGraph })
     expect(store.isGlobalBlueprint('test')).toBe(false)

--- a/src/stores/subgraphStore.ts
+++ b/src/stores/subgraphStore.ts
@@ -392,7 +392,7 @@ export const useSubgraphStore = defineStore('subgraph', () => {
     if (!(name in subgraphCache))
       //As loading is blocked on in startup, this can likely be changed to invalid type
       throw new Error('not yet loaded')
-    return subgraphCache[name].changeTracker.initialState
+    return structuredClone(subgraphCache[name].changeTracker.initialState)
   }
   async function deleteBlueprint(nodeType: string) {
     const name = nodeType.slice(typePrefix.length)


### PR DESCRIPTION
Add `structuredClone()` in `getBlueprint()` so `_deserializeItems()` mutations (node IDs, subgraph UUIDs) don't corrupt cached data.

Includes regression test verifying cache immutability.

Fixes COM-16026

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9897-fix-prevent-blueprint-cache-corruption-on-repeated-placement-3226d73d3650815c8594fa8d266e680f) by [Unito](https://www.unito.io)
