### PR TITLE
feat: differentiate personal/team pricing table with two-stage team workspace flow

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -559,7 +559,14 @@ onMounted(async () => {
 
   // Open create workspace dialog from URL if present (e.g., ?create_workspace=1)
   if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
-    await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
+    try {
+      await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
+    } catch (error) {
+      console.error(
+        '[GraphCanvas] Failed to load create workspace from URL:',
+        error
+      )
+    }
   }
 
   // Initialize release store to fetch releases from comfy-api (fire-and-forget)

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -191,6 +191,7 @@ import { forEachNode } from '@/utils/graphTraversalUtil'
 import SelectionRectangle from './SelectionRectangle.vue'
 import { isCloud } from '@/platform/distribution/types'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
 import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
 
 const { t } = useI18n()
@@ -434,8 +435,9 @@ useEventListener(
 const comfyAppReady = ref(false)
 const workflowPersistence = useWorkflowPersistence()
 const { flags } = useFeatureFlags()
-// Set up invite loader during setup phase so useRoute/useRouter work correctly
+// Set up URL loaders during setup phase so useRoute/useRouter work correctly
 const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
+const createWorkspaceUrlLoader = isCloud ? useCreateWorkspaceUrlLoader() : null
 useCanvasDrop(canvasRef)
 useLitegraphSettings()
 useNodeBadge()
@@ -553,6 +555,11 @@ onMounted(async () => {
   // WorkspaceAuthGate ensures flag state is resolved before GraphCanvas mounts
   if (inviteUrlLoader && flags.teamWorkspacesEnabled) {
     await inviteUrlLoader.loadInviteFromUrl()
+  }
+
+  // Open create workspace dialog from URL if present (e.g., ?create_workspace=1)
+  if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
+    await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
   }
 
   // Initialize release store to fetch releases from comfy-api (fire-and-forget)

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -3073,7 +3073,6 @@
       "title": "تم إلغاء اشتراكك"
     },
     "changeTo": "تغيير إلى {plan}",
-    "chooseBestPlanWorkspace": "اختر أفضل خطة لمساحة العمل الخاصة بك",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "شعار Comfy Cloud",
     "contactOwnerToSubscribe": "يرجى التواصل مع مالك مساحة العمل للاشتراك",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2586,7 +2586,8 @@
     "roleOwner": "Owner",
     "roleMember": "Member",
     "createWorkspace": "Create new workspace",
-    "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one."
+    "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one.",
+    "failedToSwitch": "Failed to switch workspace"
   },
   "selectionToolbox": {
     "executeButton": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2573,7 +2573,7 @@
   "teamWorkspacesDialog": {
     "title": "Team Workspaces",
     "subtitle": "Switch to an existing one or create a new workspace",
-    "subtitleNoWorkspaces": "Create a new team workspace to collaborate",
+    "subtitleNoWorkspaces": "Create a new team workspace to share credits",
     "confirmCallbackFailed": "Workspace created but setup incomplete",
     "yourTeamWorkspaces": "Your team workspaces",
     "switch": "Switch",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2570,6 +2570,15 @@
       "failedToFetchWorkspaces": "Failed to load workspaces"
     }
   },
+  "teamWorkspacesDialog": {
+    "title": "Team Workspaces",
+    "subtitle": "Switch to an existing one or create a new workspace",
+    "yourTeamWorkspaces": "Your team workspaces",
+    "switch": "Switch",
+    "newWorkspace": "New workspace",
+    "namePlaceholder": "e.g. Marketing Team",
+    "createWorkspace": "Create workspace"
+  },
   "workspaceSwitcher": {
     "switchWorkspace": "Switch workspace",
     "subscribe": "Subscribe",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2573,6 +2573,8 @@
   "teamWorkspacesDialog": {
     "title": "Team Workspaces",
     "subtitle": "Switch to an existing one or create a new workspace",
+    "subtitleNoWorkspaces": "Create a new team workspace to collaborate",
+    "confirmCallbackFailed": "Workspace created but setup incomplete",
     "yourTeamWorkspaces": "Your team workspaces",
     "switch": "Switch",
     "newWorkspace": "New workspace",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2253,7 +2253,6 @@
     "topupTimeout": "Top-up verification timed out"
   },
   "subscription": {
-    "chooseBestPlanWorkspace": "Choose the best plan for your workspace",
     "plansFor": "Plans for",
     "personalWorkspace": "Personal Workspace",
     "teamWorkspace": "Team Workspace",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2253,7 +2253,7 @@
     "topupTimeout": "Top-up verification timed out"
   },
   "subscription": {
-    "plansFor": "Plans for",
+    "plansForWorkspace": "Plans for {workspace}",
     "personalWorkspace": "Personal Workspace",
     "teamWorkspace": "Team Workspace",
     "soloUseOnly": "Solo use only",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2579,7 +2579,8 @@
     "switch": "Switch",
     "newWorkspace": "New workspace",
     "namePlaceholder": "e.g. Marketing Team",
-    "createWorkspace": "Create workspace"
+    "createWorkspace": "Create workspace",
+    "nameValidationError": "Name must be 1–50 characters using letters, numbers, spaces, or common punctuation."
   },
   "workspaceSwitcher": {
     "switchWorkspace": "Switch workspace",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2254,6 +2254,12 @@
   },
   "subscription": {
     "chooseBestPlanWorkspace": "Choose the best plan for your workspace",
+    "plansFor": "Plans for",
+    "personalWorkspace": "Personal Workspace",
+    "teamWorkspace": "Team Workspace",
+    "soloUseOnly": "Solo use only",
+    "needTeamWorkspace": "Need team workspace?",
+    "inviteUpTo": "Invite up to",
     "title": "Subscription",
     "titleUnsubscribed": "Subscribe to Comfy Cloud",
     "comfyCloud": "Comfy Cloud",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -3073,7 +3073,6 @@
       "title": "Tu suscripción ha sido cancelada"
     },
     "changeTo": "Cambiar a {plan}",
-    "chooseBestPlanWorkspace": "Elige el mejor plan para tu espacio de trabajo",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Logo de Comfy Cloud",
     "contactOwnerToSubscribe": "Contacta al propietario del espacio de trabajo para suscribirte",

--- a/src/locales/fa/main.json
+++ b/src/locales/fa/main.json
@@ -3085,7 +3085,6 @@
       "title": "اشتراک شما لغو شده است"
     },
     "changeTo": "تغییر به {plan}",
-    "chooseBestPlanWorkspace": "بهترین طرح را برای فضای کاری خود انتخاب کنید",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "لوگوی Comfy Cloud",
     "contactOwnerToSubscribe": "برای فعال‌سازی اشتراک با مالک محیط کاری تماس بگیرید",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -3073,7 +3073,6 @@
       "title": "Votre abonnement a été annulé"
     },
     "changeTo": "Changer pour {plan}",
-    "chooseBestPlanWorkspace": "Choisissez la meilleure offre pour votre espace de travail",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Logo Comfy Cloud",
     "contactOwnerToSubscribe": "Contactez le propriétaire de l’espace de travail pour vous abonner",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -3073,7 +3073,6 @@
       "title": "サブスクリプションはキャンセルされました"
     },
     "changeTo": "{plan}に変更",
-    "chooseBestPlanWorkspace": "ワークスペースに最適なプランを選択してください",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud ロゴ",
     "contactOwnerToSubscribe": "サブスクリプションのためにワークスペースのオーナーに連絡してください",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -3073,7 +3073,6 @@
       "title": "구독이 취소되었습니다"
     },
     "changeTo": "{plan}로 변경",
-    "chooseBestPlanWorkspace": "워크스페이스에 가장 적합한 플랜을 선택하세요",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud 로고",
     "contactOwnerToSubscribe": "워크스페이스 소유자에게 구독을 요청하세요",

--- a/src/locales/pt-BR/main.json
+++ b/src/locales/pt-BR/main.json
@@ -3085,7 +3085,6 @@
       "title": "Sua assinatura foi cancelada"
     },
     "changeTo": "Mudar para {plan}",
-    "chooseBestPlanWorkspace": "Escolha o melhor plano para seu workspace",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Logo do Comfy Cloud",
     "contactOwnerToSubscribe": "Entre em contato com o proprietário do espaço de trabalho para assinar",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -3073,7 +3073,6 @@
       "title": "Ваша подписка отменена"
     },
     "changeTo": "Перейти на {plan}",
-    "chooseBestPlanWorkspace": "Выберите лучший тариф для вашего рабочего пространства",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Логотип Comfy Cloud",
     "contactOwnerToSubscribe": "Свяжитесь с владельцем рабочего пространства для оформления подписки",

--- a/src/locales/tr/main.json
+++ b/src/locales/tr/main.json
@@ -3073,7 +3073,6 @@
       "title": "Aboneliğiniz iptal edildi"
     },
     "changeTo": "{plan} planına geç",
-    "chooseBestPlanWorkspace": "Çalışma alanınız için en iyi planı seçin",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud Logosu",
     "contactOwnerToSubscribe": "Abone olmak için çalışma alanı sahibiyle iletişime geçin",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -3073,7 +3073,6 @@
       "title": "您的訂閱已取消"
     },
     "changeTo": "切換至 {plan}",
-    "chooseBestPlanWorkspace": "為您的工作區選擇最佳方案",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud 標誌",
     "contactOwnerToSubscribe": "請聯絡工作區擁有者以訂閱",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -3085,7 +3085,6 @@
       "title": "您的订阅已被取消"
     },
     "changeTo": "更改为 {plan}",
-    "chooseBestPlanWorkspace": "为您的工作区选择最佳方案",
     "comfyCloud": "Comfy 云",
     "comfyCloudLogo": "Comfy Cloud Logo",
     "contactOwnerToSubscribe": "请联系工作区所有者进行订阅",

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -107,6 +107,8 @@ const i18n = createI18n({
         videoEstimateHelp: 'How is this calculated?',
         videoEstimateExplanation: 'Based on average usage.',
         videoEstimateTryTemplate: 'Try template',
+        soloUseOnly: 'Solo use only',
+        needTeamWorkspace: 'Need team workspace?',
         maxDuration: {
           standard: '30 min',
           creator: '30 min',

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -298,4 +298,20 @@ describe('PricingTable', () => {
       expect(mockAccessBillingPortal).toHaveBeenCalledWith('standard-yearly')
     })
   })
+
+  describe('team workspace link', () => {
+    it('should emit chooseTeamWorkspace when clicking "Need team workspace?" link', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+
+      const teamLink = wrapper
+        .findAll('button')
+        .find((btn) => btn.text().includes('Need team workspace?'))
+
+      expect(teamLink).toBeDefined()
+      await teamLink?.trigger('click')
+
+      expect(wrapper.emitted('chooseTeamWorkspace')).toHaveLength(1)
+    })
+  })
 })

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -95,6 +95,21 @@
             </div>
           </div>
 
+          <div
+            class="flex h-10 items-center rounded-lg bg-secondary-background px-3"
+          >
+            <span class="text-sm text-muted-foreground">
+              {{ t('subscription.soloUseOnly') }}
+              <span class="mx-1 text-muted-foreground">–</span>
+              <button
+                class="text-primary-foreground cursor-pointer border-none bg-transparent p-0 text-sm font-medium underline hover:text-base-foreground"
+                @click="emit('chooseTeamWorkspace')"
+              >
+                {{ t('subscription.needTeamWorkspace') }}
+              </button>
+            </span>
+          </div>
+
           <div class="flex flex-1 flex-col gap-4 pb-0">
             <div class="flex flex-row items-center justify-between">
               <span
@@ -302,6 +317,10 @@ interface PricingTierConfig {
   customLoRAs: boolean
   isPopular?: boolean
 }
+
+const emit = defineEmits<{
+  chooseTeamWorkspace: []
+}>()
 
 const { t, n } = useI18n()
 

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-8">
+  <div class="flex flex-col gap-6">
     <div class="flex justify-center">
       <SelectButton
         v-model="currentBillingCycle"
@@ -38,7 +38,7 @@
         </template>
       </SelectButton>
     </div>
-    <div class="flex flex-col items-stretch gap-6 xl:flex-row">
+    <div class="flex flex-col items-stretch gap-4 xl:flex-row">
       <div
         v-for="tier in tiers"
         :key="tier.id"
@@ -49,7 +49,7 @@
           )
         "
       >
-        <div class="flex flex-col gap-8 p-8 pb-0">
+        <div class="flex flex-col gap-4 p-6 pb-0">
           <div class="flex flex-row items-center justify-between gap-2">
             <span
               class="font-inter text-base/normal font-bold text-base-foreground"
@@ -67,7 +67,7 @@
             <div class="flex flex-col gap-2">
               <div class="flex flex-row items-baseline gap-2">
                 <span
-                  class="font-inter text-[32px] leading-normal font-semibold text-base-foreground"
+                  class="font-inter text-[28px] leading-normal font-semibold text-base-foreground"
                 >
                   <span
                     v-show="currentBillingCycle === 'yearly'"
@@ -110,7 +110,7 @@
             </span>
           </div>
 
-          <div class="flex flex-1 flex-col gap-4 pb-0">
+          <div class="flex flex-1 flex-col gap-3 pb-0">
             <div class="flex flex-row items-center justify-between">
               <span
                 class="text-foreground font-inter text-sm/normal font-normal"
@@ -194,7 +194,7 @@
             </div>
           </div>
         </div>
-        <div class="flex flex-col p-8">
+        <div class="flex flex-col p-6">
           <Button
             :variant="getButtonSeverity(tier)"
             :disabled="isLoading || isCurrentPlan(tier.key)"

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -96,7 +96,7 @@
           </div>
 
           <div
-            class="flex h-10 items-center rounded-lg bg-secondary-background px-3"
+            class="flex h-10 items-center rounded-lg bg-muted-foreground/30 px-3"
           >
             <span class="text-sm text-muted-foreground">
               {{ t('subscription.soloUseOnly') }}

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -95,20 +95,20 @@
             </div>
           </div>
 
-          <div
-            class="flex h-10 items-center rounded-lg bg-muted-foreground/30 px-3"
+          <p
+            role="note"
+            :aria-label="t('subscription.soloUseOnly')"
+            class="m-0 flex h-10 items-center rounded-lg bg-muted-foreground/30 px-3 text-sm text-muted-foreground"
           >
-            <span class="text-sm text-muted-foreground">
-              {{ t('subscription.soloUseOnly') }}
-              <span class="mx-1 text-muted-foreground">–</span>
-              <button
-                class="text-primary-foreground cursor-pointer border-none bg-transparent p-0 text-sm font-medium underline hover:text-base-foreground"
-                @click="emit('chooseTeamWorkspace')"
-              >
-                {{ t('subscription.needTeamWorkspace') }}
-              </button>
-            </span>
-          </div>
+            {{ t('subscription.soloUseOnly') }}
+            <span class="mx-1 text-muted-foreground">–</span>
+            <button
+              class="text-primary-foreground cursor-pointer border-none bg-transparent p-0 text-sm font-medium underline hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
+              @click="emit('chooseTeamWorkspace')"
+            >
+              {{ t('subscription.needTeamWorkspace') }}
+            </button>
+          </p>
 
           <div class="flex flex-1 flex-col gap-3 pb-0">
             <div class="flex flex-row items-center justify-between">

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -10,7 +10,7 @@
       :aria-label="$t('g.close')"
       @click="handleClose"
     >
-      <i class="pi pi-times text-xl" />
+      <i class="pi pi-times text-xl" aria-hidden="true" />
     </Button>
     <div class="flex flex-col items-center gap-3">
       <div
@@ -70,7 +70,7 @@
       :aria-label="$t('g.close')"
       @click="handleClose"
     >
-      <i class="pi pi-times" />
+      <i class="pi pi-times" aria-hidden="true" />
     </Button>
 
     <div

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -15,6 +15,7 @@
     <div class="flex flex-col items-center gap-3">
       <div
         class="flex size-10 items-center justify-center rounded-xl bg-muted-foreground/30 text-lg font-semibold text-white"
+        aria-hidden="true"
       >
         <!-- Decorative initial for "Personal" workspace icon; not user-facing text -->
         P

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -16,6 +16,7 @@
       <div
         class="flex size-10 items-center justify-center rounded-xl bg-muted-foreground/30 text-lg font-semibold text-white"
       >
+        <!-- Decorative initial for "Personal" workspace icon; not user-facing text -->
         P
       </div>
       <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="showCustomPricingTable"
-    class="relative flex h-full flex-col gap-6 overflow-y-auto! p-4 pt-8 md:px-16 md:py-8"
+    class="relative flex h-full flex-col gap-6 overflow-y-auto p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
       size="icon"

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -13,13 +13,14 @@
       <i class="pi pi-times text-xl" />
     </Button>
     <div class="flex flex-col items-center gap-3">
-      <WorkspaceProfilePic
-        class="size-10 rounded-xl text-lg"
-        workspace-name="Personal"
-      />
-      <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
+      <div
+        class="flex size-10 items-center justify-center rounded-xl bg-muted-foreground/30 text-lg font-semibold text-white"
+      >
+        P
+      </div>
+      <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
         {{ $t('subscription.plansFor') }}
-        <span class="text-primary-foreground">
+        <span class="text-muted-foreground">
           {{ $t('subscription.personalWorkspace') }}
         </span>
       </h2>
@@ -150,7 +151,6 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
-import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 
 const { onClose, reason, onChooseTeam } = defineProps<{
   onClose: () => void

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -20,12 +20,17 @@
         <!-- Decorative initial for "Personal" workspace icon; not user-facing text -->
         P
       </div>
-      <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
-        {{ $t('subscription.plansFor') }}
-        <span class="text-muted-foreground">
-          {{ $t('subscription.personalWorkspace') }}
-        </span>
-      </h2>
+      <i18n-t
+        keypath="subscription.plansForWorkspace"
+        tag="h2"
+        class="m-0 font-inter text-2xl font-semibold text-base-foreground"
+      >
+        <template #workspace>
+          <span class="text-muted-foreground">
+            {{ $t('subscription.personalWorkspace') }}
+          </span>
+        </template>
+      </i18n-t>
     </div>
 
     <PricingTable class="flex-1" @choose-team-workspace="handleChooseTeam" />
@@ -258,7 +263,11 @@ const handleSubscribed = () => {
 
 const handleChooseTeam = () => {
   stopPolling()
-  onChooseTeam?.()
+  if (onChooseTeam) {
+    onChooseTeam()
+  } else {
+    onClose()
+  }
 }
 
 const handleClose = () => {

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -12,13 +12,20 @@
     >
       <i class="pi pi-times text-xl" />
     </Button>
-    <div class="text-center">
+    <div class="flex flex-col items-center gap-4">
+      <WorkspaceProfilePic
+        class="size-12 rounded-xl text-lg"
+        workspace-name="Personal"
+      />
       <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
-        {{ $t('subscription.description') }}
+        {{ $t('subscription.plansFor') }}
+        <span class="text-primary-foreground">
+          {{ $t('subscription.personalWorkspace') }}
+        </span>
       </h2>
     </div>
 
-    <PricingTable class="flex-1" />
+    <PricingTable class="flex-1" @choose-team-workspace="handleChooseTeam" />
 
     <!-- Contact and Enterprise Links -->
     <div class="flex flex-col items-center gap-2">
@@ -143,10 +150,12 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 
-const { onClose, reason } = defineProps<{
+const { onClose, reason, onChooseTeam } = defineProps<{
   onClose: () => void
   reason?: SubscriptionDialogReason
+  onChooseTeam?: () => void
 }>()
 
 const emit = defineEmits<{
@@ -243,6 +252,11 @@ watch(
 
 const handleSubscribed = () => {
   emit('close', true)
+}
+
+const handleChooseTeam = () => {
+  stopPolling()
+  onChooseTeam?.()
 }
 
 const handleClose = () => {

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="showCustomPricingTable"
-    class="relative flex h-full flex-col gap-8 overflow-y-auto! p-4 pt-8 md:p-16"
+    class="relative flex h-full flex-col gap-6 overflow-y-auto! p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
       size="icon"
@@ -12,9 +12,9 @@
     >
       <i class="pi pi-times text-xl" />
     </Button>
-    <div class="flex flex-col items-center gap-4">
+    <div class="flex flex-col items-center gap-3">
       <WorkspaceProfilePic
-        class="size-12 rounded-xl text-lg"
+        class="size-10 rounded-xl text-lg"
         workspace-name="Personal"
       />
       <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -1,6 +1,51 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSubscriptionDialog } from './useSubscriptionDialog'
+
+const mockCloseDialog = vi.fn()
+const mockShowLayoutDialog = vi.fn()
+const mockShowTeamWorkspacesDialog = vi.fn()
+const mockIsInPersonalWorkspace = vi.hoisted(() => ({ value: true }))
+const mockIsFreeTier = vi.hoisted(() => ({ value: false }))
+const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: false }))
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
+
+vi.mock('vue', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    defineAsyncComponent: vi.fn((loader) => loader)
+  }
+})
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: mockCloseDialog
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showLayoutDialog: mockShowLayoutDialog,
+    showTeamWorkspacesDialog: mockShowTeamWorkspacesDialog
+  })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get teamWorkspacesEnabled() {
+        return mockTeamWorkspacesEnabled.value
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
+  useSubscription: () => ({
+    isFreeTier: mockIsFreeTier
+  })
+}))
 
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -8,70 +53,144 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-const mockShowLayoutDialog = vi.fn()
-vi.mock('@/services/dialogService', () => ({
-  useDialogService: vi.fn(() => ({
-    showLayoutDialog: mockShowLayoutDialog
-  }))
-}))
-
-vi.mock('@/stores/dialogStore', () => ({
-  useDialogStore: vi.fn(() => ({
-    closeDialog: vi.fn()
-  }))
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: vi.fn(() => ({
-    flags: { teamWorkspacesEnabled: false }
-  }))
-}))
-
-vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
-  useSubscription: vi.fn(() => ({
-    isFreeTier: { value: false }
-  }))
-}))
-
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: vi.fn(() => ({
-    isInPersonalWorkspace: true
-  }))
-}))
-
-vi.mock('pinia')
-
-vi.mock('firebase/app', () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signOut: vi.fn()
+  useTeamWorkspaceStore: () => ({
+    get isInPersonalWorkspace() {
+      return mockIsInPersonalWorkspace.value
+    }
+  })
 }))
 
 describe('useSubscriptionDialog', () => {
-  it('showPricingTable does not open dialog on non-cloud', async () => {
-    mockIsCloud.value = false
-    const { useSubscriptionDialog } = await import('./useSubscriptionDialog')
-    const dialog = useSubscriptionDialog()
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsCloud.value = true
+    mockIsInPersonalWorkspace.value = true
+    mockIsFreeTier.value = false
+    mockTeamWorkspacesEnabled.value = false
 
-    dialog.showPricingTable()
-
-    expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    try {
+      sessionStorage.clear()
+    } catch {
+      // noop
+    }
   })
 
-  it('showPricingTable opens dialog on cloud', async () => {
-    mockIsCloud.value = true
-    const { useSubscriptionDialog } = await import('./useSubscriptionDialog')
-    const dialog = useSubscriptionDialog()
+  describe('showPricingTable', () => {
+    it('does not open dialog on non-cloud', () => {
+      mockIsCloud.value = false
+      const { showPricingTable } = useSubscriptionDialog()
 
-    dialog.showPricingTable()
+      showPricingTable()
 
-    expect(mockShowLayoutDialog).toHaveBeenCalled()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('opens dialog on cloud', () => {
+      mockIsCloud.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalled()
+    })
+  })
+
+  describe('startTeamWorkspaceUpgradeFlow', () => {
+    it('closes existing dialogs before opening team workspace dialog', () => {
+      mockShowTeamWorkspacesDialog.mockResolvedValue(undefined)
+      const { startTeamWorkspaceUpgradeFlow } = useSubscriptionDialog()
+
+      startTeamWorkspaceUpgradeFlow()
+
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'subscription-required'
+      })
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'free-tier-info'
+      })
+      expect(mockShowTeamWorkspacesDialog).toHaveBeenCalledWith(
+        expect.any(Function)
+      )
+    })
+
+    it('persists resume intent to sessionStorage via onConfirm callback', () => {
+      mockShowTeamWorkspacesDialog.mockResolvedValue(undefined)
+      const { startTeamWorkspaceUpgradeFlow } = useSubscriptionDialog()
+
+      startTeamWorkspaceUpgradeFlow()
+
+      const onConfirm = mockShowTeamWorkspacesDialog.mock.calls[0][0]
+      onConfirm()
+
+      expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBe('1')
+    })
+
+    it('reopens pricing table on dialog rejection', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockShowTeamWorkspacesDialog.mockRejectedValue(new Error('dialog error'))
+
+      const { startTeamWorkspaceUpgradeFlow } = useSubscriptionDialog()
+      startTeamWorkspaceUpgradeFlow()
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          '[useSubscriptionDialog] Failed to open team workspaces dialog:',
+          expect.any(Error)
+        )
+      })
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'subscription-required' })
+      )
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('resumePendingPricingFlow', () => {
+    it('does nothing when no resume intent is stored', () => {
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+
+      resumePendingPricingFlow()
+
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('shows pricing table and clears intent when in team workspace', () => {
+      sessionStorage.setItem('comfy:resume-team-pricing', '1')
+      mockIsInPersonalWorkspace.value = false
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      resumePendingPricingFlow()
+
+      expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'subscription-required' })
+      )
+    })
+
+    it('clears intent but does not show pricing if still in personal workspace', () => {
+      sessionStorage.setItem('comfy:resume-team-pricing', '1')
+      mockIsInPersonalWorkspace.value = true
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      resumePendingPricingFlow()
+
+      expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('consumes intent so second call is a no-op', () => {
+      sessionStorage.setItem('comfy:resume-team-pricing', '1')
+      mockIsInPersonalWorkspace.value = false
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      resumePendingPricingFlow()
+      mockShowLayoutDialog.mockClear()
+
+      resumePendingPricingFlow()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -134,6 +134,7 @@ export const useSubscriptionDialog = () => {
           '[useSubscriptionDialog] Failed to open team workspaces dialog:',
           error
         )
+        showPricingTable()
       })
   }
 

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -114,13 +114,20 @@ export const useSubscriptionDialog = () => {
    */
   function startTeamWorkspaceUpgradeFlow() {
     hide()
-    void dialogService.showTeamWorkspacesDialog(() => {
-      try {
-        sessionStorage.setItem(RESUME_PRICING_KEY, '1')
-      } catch {
-        // sessionStorage may be unavailable
-      }
-    })
+    dialogService
+      .showTeamWorkspacesDialog(() => {
+        try {
+          sessionStorage.setItem(RESUME_PRICING_KEY, '1')
+        } catch {
+          // sessionStorage may be unavailable
+        }
+      })
+      .catch((error) => {
+        console.error(
+          '[useSubscriptionDialog] Failed to open team workspaces dialog:',
+          error
+        )
+      })
   }
 
   /**

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -8,6 +8,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 
 const DIALOG_KEY = 'subscription-required'
 const FREE_TIER_DIALOG_KEY = 'free-tier-info'
+const RESUME_PRICING_KEY = 'comfy:resume-team-pricing'
 
 export type SubscriptionDialogReason =
   | 'subscription_required'
@@ -47,7 +48,8 @@ export const useSubscriptionDialog = () => {
       component,
       props: {
         onClose: hide,
-        reason: options?.reason
+        reason: options?.reason,
+        onChooseTeam: () => startTeamWorkspaceUpgradeFlow()
       },
       dialogComponentProps: {
         style: 'width: min(1328px, 95vw); max-height: 958px;',
@@ -101,9 +103,47 @@ export const useSubscriptionDialog = () => {
     showPricingTable(options)
   }
 
+  /**
+   * Start the two-stage team workspace upgrade flow:
+   * 1. Close the current pricing dialog
+   * 2. Open the create workspace dialog
+   * 3. On successful creation, persist a resume intent so the team pricing
+   *    dialog reopens automatically after the page reload
+   */
+  function startTeamWorkspaceUpgradeFlow() {
+    hide()
+    dialogService.showCreateWorkspaceDialog(() => {
+      try {
+        sessionStorage.setItem(RESUME_PRICING_KEY, '1')
+      } catch {
+        // sessionStorage may be unavailable
+      }
+    })
+  }
+
+  /**
+   * Check for and consume a pending team pricing resume intent.
+   * Call once after workspace initialization on app boot.
+   */
+  function resumePendingPricingFlow() {
+    try {
+      const pending = sessionStorage.getItem(RESUME_PRICING_KEY)
+      if (!pending) return
+      sessionStorage.removeItem(RESUME_PRICING_KEY)
+
+      if (!workspaceStore.isInPersonalWorkspace) {
+        showPricingTable()
+      }
+    } catch {
+      // sessionStorage may be unavailable
+    }
+  }
+
   return {
     show,
     showPricingTable,
-    hide
+    hide,
+    startTeamWorkspaceUpgradeFlow,
+    resumePendingPricingFlow
   }
 }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -43,16 +43,20 @@ export const useSubscriptionDialog = () => {
             import('@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue')
         )
 
+    const personalProps = {
+      onClose: hide,
+      reason: options?.reason,
+      onChooseTeam: () => startTeamWorkspaceUpgradeFlow()
+    }
+    const workspaceProps = {
+      onClose: hide,
+      reason: options?.reason
+    }
+
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
       component,
-      props: {
-        onClose: hide,
-        reason: options?.reason,
-        ...(useWorkspaceVariant
-          ? {}
-          : { onChooseTeam: () => startTeamWorkspaceUpgradeFlow() })
-      },
+      props: useWorkspaceVariant ? workspaceProps : personalProps,
       dialogComponentProps: {
         style: 'width: min(1328px, 95vw); max-height: 958px;',
         pt: {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -114,7 +114,7 @@ export const useSubscriptionDialog = () => {
    */
   function startTeamWorkspaceUpgradeFlow() {
     hide()
-    dialogService.showCreateWorkspaceDialog(() => {
+    void dialogService.showTeamWorkspacesDialog(() => {
       try {
         sessionStorage.setItem(RESUME_PRICING_KEY, '1')
       } catch {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -115,6 +115,9 @@ export const useSubscriptionDialog = () => {
    * 2. Open the create workspace dialog
    * 3. On successful creation, persist a resume intent so the team pricing
    *    dialog reopens automatically after the page reload
+   *
+   * Uses sessionStorage (not a store) because the intent must survive
+   * a full page reload triggered by workspace switching.
    */
   function startTeamWorkspaceUpgradeFlow() {
     hide()

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -49,7 +49,9 @@ export const useSubscriptionDialog = () => {
       props: {
         onClose: hide,
         reason: options?.reason,
-        onChooseTeam: () => startTeamWorkspaceUpgradeFlow()
+        ...(useWorkspaceVariant
+          ? {}
+          : { onChooseTeam: () => startTeamWorkspaceUpgradeFlow() })
       },
       dialogComponentProps: {
         style: 'width: min(1328px, 95vw); max-height: 958px;',

--- a/src/platform/navigation/preservedQueryNamespaces.ts
+++ b/src/platform/navigation/preservedQueryNamespaces.ts
@@ -1,5 +1,6 @@
 export const PRESERVED_QUERY_NAMESPACES = {
   TEMPLATE: 'template',
   INVITE: 'invite',
-  SHARE: 'share'
+  SHARE: 'share',
+  CREATE_WORKSPACE: 'create_workspace'
 } as const

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -51,6 +51,7 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
+const mockResumePendingPricingFlow = vi.fn()
 vi.mock(
   '@/platform/cloud/subscription/composables/useSubscriptionDialog',
   () => ({
@@ -59,7 +60,7 @@ vi.mock(
       showPricingTable: vi.fn(),
       hide: vi.fn(),
       startTeamWorkspaceUpgradeFlow: vi.fn(),
-      resumePendingPricingFlow: vi.fn()
+      resumePendingPricingFlow: mockResumePendingPricingFlow
     })
   })
 )
@@ -153,6 +154,16 @@ describe('WorkspaceAuthGate', () => {
 
       expect(mockWorkspaceStoreInitialize).toHaveBeenCalled()
       expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+    })
+
+    it('calls resumePendingPricingFlow after successful workspace init', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockWorkspaceStoreInitState.value = 'ready'
+
+      mountComponent()
+      await flushPromises()
+
+      expect(mockResumePendingPricingFlow).toHaveBeenCalled()
     })
 
     it('skips workspace init when store is already initialized', async () => {

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -51,6 +51,19 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({
+      show: vi.fn(),
+      showPricingTable: vi.fn(),
+      hide: vi.fn(),
+      startTeamWorkspaceUpgradeFlow: vi.fn(),
+      resumePendingPricingFlow: vi.fn()
+    })
+  })
+)
+
 describe('WorkspaceAuthGate', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -24,6 +24,7 @@ import { onMounted, ref } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
@@ -32,6 +33,7 @@ const FIREBASE_INIT_TIMEOUT_MS = 16_000
 const CONFIG_REFRESH_TIMEOUT_MS = 10_000
 
 const isReady = ref(!isCloud)
+const subscriptionDialog = useSubscriptionDialog()
 
 async function initialize(): Promise<void> {
   if (!isCloud) return
@@ -86,6 +88,9 @@ async function initialize(): Promise<void> {
 
     // Step 5: WORKSPACE MODE - Full initialization
     await initializeWorkspaceMode()
+
+    // Step 6: Resume any pending pricing flow from team workspace creation
+    subscriptionDialog.resumePendingPricingFlow()
   } catch (error) {
     console.error('[WorkspaceAuthGate] Initialization failed:', error)
   } finally {

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -90,7 +90,12 @@ async function initialize(): Promise<void> {
     await initializeWorkspaceMode()
 
     // Step 6: Resume any pending pricing flow from team workspace creation
-    subscriptionDialog.resumePendingPricingFlow()
+    // Only safe after workspace store initialized successfully — the pricing
+    // dialog reads workspace state to decide which variant to show.
+    const workspaceStore = useTeamWorkspaceStore()
+    if (workspaceStore.initState === 'ready') {
+      subscriptionDialog.resumePendingPricingFlow()
+    }
   } catch (error) {
     console.error('[WorkspaceAuthGate] Initialization failed:', error)
   } finally {

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -45,7 +45,7 @@
         :class="
           cn(
             'flex flex-1 flex-col rounded-2xl border border-border-default bg-base-background shadow-[0_0_12px_rgba(0,0,0,0.1)]',
-            tier.isPopular ? 'border-muted-foreground' : ''
+            tier.isPopular ? 'border-emerald-500' : ''
           )
         "
       >

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -99,7 +99,7 @@
             :class="
               cn(
                 'flex h-10 items-center justify-between rounded-lg px-3',
-                getMaxMembers(tier) > 1 ? 'bg-[rgba(0,205,114,0.20)]' : ''
+                getMaxMembers(tier) > 1 ? 'bg-emerald-500/20' : ''
               )
             "
           >

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -99,11 +99,11 @@
             :class="
               cn(
                 'flex h-10 items-center justify-between rounded-lg px-3',
-                getMaxMembers(tier) > 1 ? 'bg-emerald-500/20' : ''
+                maxMembersByTier[tier.key] > 1 ? 'bg-emerald-500/20' : ''
               )
             "
           >
-            <template v-if="getMaxMembers(tier) > 1">
+            <template v-if="maxMembersByTier[tier.key] > 1">
               <div class="flex items-center gap-2">
                 <i class="pi pi-users text-xs text-emerald-400" />
                 <span class="text-sm text-emerald-400">
@@ -111,7 +111,7 @@
                 </span>
               </div>
               <span class="text-sm font-bold text-base-foreground">
-                {{ t('subscription.memberCount', getMaxMembers(tier)) }}
+                {{ t('subscription.memberCount', maxMembersByTier[tier.key]) }}
               </span>
             </template>
           </div>
@@ -138,7 +138,7 @@
               <span
                 class="font-inter text-sm/normal font-bold text-base-foreground"
               >
-                {{ getMaxMembers(tier) }}
+                {{ maxMembersByTier[tier.key] }}
               </span>
             </div>
 
@@ -499,7 +499,13 @@ const getAnnualTotal = (tier: PricingTierConfig): number => {
   return plan ? plan.price_cents / 100 : tier.pricing.yearly * 12
 }
 
-const getMaxMembers = (tier: PricingTierConfig): number => getMaxSeats(tier.key)
+const maxMembersByTier = computed(
+  () =>
+    Object.fromEntries(tiers.map((t) => [t.key, getMaxSeats(t.key)])) as Record<
+      CheckoutTierKey,
+      number
+    >
+)
 
 const getMonthlyCreditsPerMember = (tier: PricingTierConfig): number =>
   tier.pricing.credits

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -96,17 +96,24 @@
           </div>
 
           <div
-            class="flex h-10 items-center justify-between rounded-lg bg-emerald-950/40 px-3"
+            :class="
+              cn(
+                'flex h-10 items-center justify-between rounded-lg px-3',
+                getMaxMembers(tier) > 1 ? 'bg-[rgba(0,205,114,0.20)]' : ''
+              )
+            "
           >
-            <div class="flex items-center gap-2">
-              <i class="pi pi-users text-xs text-emerald-400" />
-              <span class="text-sm text-emerald-400">
-                {{ t('subscription.inviteUpTo') }}
+            <template v-if="getMaxMembers(tier) > 1">
+              <div class="flex items-center gap-2">
+                <i class="pi pi-users text-xs text-emerald-400" />
+                <span class="text-sm text-emerald-400">
+                  {{ t('subscription.inviteUpTo') }}
+                </span>
+              </div>
+              <span class="text-sm font-bold text-base-foreground">
+                {{ t('subscription.memberCount', getMaxMembers(tier)) }}
               </span>
-            </div>
-            <span class="text-sm font-bold text-base-foreground">
-              {{ t('subscription.memberCount', getMaxMembers(tier)) }}
-            </span>
+            </template>
           </div>
 
           <div class="flex flex-1 flex-col gap-3 pb-0">
@@ -208,7 +215,7 @@
                 'h-10 w-full',
                 getButtonTextClass(tier),
                 tier.key === 'creator'
-                  ? 'border-transparent bg-base-foreground hover:bg-inverted-background-hover'
+                  ? 'border-transparent bg-success-background hover:bg-success-background/80'
                   : 'border-transparent bg-secondary-background hover:bg-secondary-background-hover focus:bg-secondary-background-selected'
               )
             "

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-8">
+  <div class="flex flex-col gap-6">
     <div class="flex justify-center">
       <SelectButton
         v-model="currentBillingCycle"
@@ -38,7 +38,7 @@
         </template>
       </SelectButton>
     </div>
-    <div class="flex flex-col items-stretch gap-6 xl:flex-row">
+    <div class="flex flex-col items-stretch gap-4 xl:flex-row">
       <div
         v-for="tier in tiers"
         :key="tier.id"
@@ -49,7 +49,7 @@
           )
         "
       >
-        <div class="flex flex-col gap-8 p-8 pb-0">
+        <div class="flex flex-col gap-4 p-6 pb-0">
           <div class="flex flex-row items-center justify-between gap-2">
             <span
               class="font-inter text-base/normal font-bold text-base-foreground"
@@ -67,7 +67,7 @@
             <div class="flex flex-col gap-2">
               <div class="flex flex-row items-baseline gap-2">
                 <span
-                  class="font-inter text-[32px] leading-normal font-semibold text-base-foreground"
+                  class="font-inter text-[28px] leading-normal font-semibold text-base-foreground"
                 >
                   <span
                     v-show="currentBillingCycle === 'yearly'"
@@ -109,7 +109,7 @@
             </span>
           </div>
 
-          <div class="flex flex-1 flex-col gap-4 pb-0">
+          <div class="flex flex-1 flex-col gap-3 pb-0">
             <div class="flex flex-row items-center justify-between">
               <span class="text-foreground text-sm font-normal">
                 {{ t('subscription.monthlyCreditsPerMemberLabel') }}
@@ -198,7 +198,7 @@
             </div>
           </div>
         </div>
-        <div class="flex flex-col p-8">
+        <div class="flex flex-col p-6">
           <Button
             :variant="getButtonSeverity(tier)"
             :disabled="isButtonDisabled(tier)"

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -114,7 +114,11 @@
                 </span>
               </div>
               <span class="text-sm font-bold text-base-foreground">
-                {{ t('subscription.memberCount', maxMembersByTier[tier.key]) }}
+                {{
+                  t('subscription.memberCount', {
+                    count: maxMembersByTier[tier.key]
+                  })
+                }}
               </span>
             </template>
           </div>

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -105,7 +105,10 @@
           >
             <template v-if="maxMembersByTier[tier.key] > 1">
               <div class="flex items-center gap-2">
-                <i class="pi pi-users text-xs text-emerald-400" />
+                <i
+                  class="pi pi-users text-xs text-emerald-400"
+                  aria-hidden="true"
+                />
                 <span class="text-sm text-emerald-400">
                   {{ t('subscription.inviteUpTo') }}
                 </span>

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="flex flex-col gap-8">
-    <h2 class="m-0 text-center text-xl text-muted-foreground lg:text-2xl">
-      {{ t('subscription.chooseBestPlanWorkspace') }}
-    </h2>
-
     <div class="flex justify-center">
       <SelectButton
         v-model="currentBillingCycle"
@@ -97,6 +93,20 @@
                 </span>
               </div>
             </div>
+          </div>
+
+          <div
+            class="flex h-10 items-center justify-between rounded-lg bg-emerald-950/40 px-3"
+          >
+            <div class="flex items-center gap-2">
+              <i class="pi pi-users text-xs text-emerald-400" />
+              <span class="text-sm text-emerald-400">
+                {{ t('subscription.inviteUpTo') }}
+              </span>
+            </div>
+            <span class="text-sm font-bold text-base-foreground">
+              {{ t('subscription.memberCount', getMaxMembers(tier)) }}
+            </span>
           </div>
 
           <div class="flex flex-1 flex-col gap-4 pb-0">

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -24,8 +24,10 @@
     </Button>
 
     <div class="flex flex-col items-center gap-3">
+      <!-- Decorative initial for "Team" workspace icon; not user-facing text -->
       <div
         class="flex size-10 items-center justify-center rounded-xl bg-primary-background text-lg font-semibold text-white"
+        aria-hidden="true"
       >
         T
       </div>

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -24,11 +24,12 @@
     </Button>
 
     <div class="flex flex-col items-center gap-3">
-      <WorkspaceProfilePic
-        class="size-10 rounded-xl text-lg"
-        :workspace-name="workspaceName"
-      />
-      <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
+      <div
+        class="flex size-10 items-center justify-center rounded-xl bg-primary-background text-lg font-semibold text-white"
+      >
+        T
+      </div>
+      <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
         {{ $t('subscription.plansFor') }}
         <span class="text-emerald-400">
           {{ $t('subscription.teamWorkspace') }}
@@ -97,13 +98,11 @@ import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscript
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 import PricingTableWorkspace from './PricingTableWorkspace.vue'
 import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
-import WorkspaceProfilePic from './WorkspaceProfilePic.vue'
 
 type CheckoutStep = 'pricing' | 'preview'
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
@@ -121,11 +120,6 @@ const { t } = useI18n()
 const toast = useToast()
 const { subscribe, previewSubscribe, plans, fetchStatus, fetchBalance } =
   useBillingContext()
-const workspaceStore = useTeamWorkspaceStore()
-const workspaceName = computed(
-  () => workspaceStore.workspaceName || t('subscription.teamWorkspace')
-)
-
 const billingOperationStore = useBillingOperationStore()
 const isPolling = computed(() => billingOperationStore.hasPendingOperations)
 

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -23,6 +23,19 @@
       <i class="pi pi-times text-xl" />
     </Button>
 
+    <div class="flex flex-col items-center gap-4">
+      <WorkspaceProfilePic
+        class="size-12 rounded-xl text-lg"
+        :workspace-name="workspaceName"
+      />
+      <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
+        {{ $t('subscription.plansFor') }}
+        <span class="text-emerald-400">
+          {{ $t('subscription.teamWorkspace') }}
+        </span>
+      </h2>
+    </div>
+
     <div v-if="reason === 'out_of_credits'" class="text-center">
       <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
         {{ $t('credits.topUp.insufficientTitle') }}
@@ -84,11 +97,13 @@ import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscript
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
 import PricingTableWorkspace from './PricingTableWorkspace.vue'
 import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
+import WorkspaceProfilePic from './WorkspaceProfilePic.vue'
 
 type CheckoutStep = 'pricing' | 'preview'
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
@@ -106,6 +121,10 @@ const { t } = useI18n()
 const toast = useToast()
 const { subscribe, previewSubscribe, plans, fetchStatus, fetchBalance } =
   useBillingContext()
+const workspaceStore = useTeamWorkspaceStore()
+const workspaceName = computed(
+  () => workspaceStore.workspaceName || t('subscription.teamWorkspace')
+)
 
 const billingOperationStore = useBillingOperationStore()
 const isPolling = computed(() => billingOperationStore.hasPendingOperations)

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative flex h-full flex-col gap-8 overflow-y-auto! p-4 pt-8 md:p-16"
+    class="relative flex h-full flex-col gap-6 overflow-y-auto! p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
       v-if="checkoutStep === 'preview'"
@@ -23,9 +23,9 @@
       <i class="pi pi-times text-xl" />
     </Button>
 
-    <div class="flex flex-col items-center gap-4">
+    <div class="flex flex-col items-center gap-3">
       <WorkspaceProfilePic
-        class="size-12 rounded-xl text-lg"
+        class="size-10 rounded-xl text-lg"
         :workspace-name="workspaceName"
       />
       <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative flex h-full flex-col gap-6 overflow-y-auto! p-4 pt-8 md:px-16 md:py-8"
+    class="relative flex h-full flex-col gap-6 overflow-y-auto p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
       v-if="checkoutStep === 'preview'"

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -31,12 +31,17 @@
       >
         T
       </div>
-      <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
-        {{ $t('subscription.plansFor') }}
-        <span class="text-emerald-400">
-          {{ $t('subscription.teamWorkspace') }}
-        </span>
-      </h2>
+      <i18n-t
+        keypath="subscription.plansForWorkspace"
+        tag="h2"
+        class="m-0 font-inter text-2xl font-semibold text-base-foreground"
+      >
+        <template #workspace>
+          <span class="text-emerald-400">
+            {{ $t('subscription.teamWorkspace') }}
+          </span>
+        </template>
+      </i18n-t>
     </div>
 
     <div v-if="reason === 'out_of_credits'" class="text-center">

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -115,6 +115,7 @@ import { useI18n } from 'vue-i18n'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
+import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
 import type {
   SubscriptionTier,
   WorkspaceRole,
@@ -141,27 +142,8 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { switchWorkspace } = useWorkspaceSwitch()
 const { subscription } = useBillingContext()
-
-const tierKeyMap: Record<string, string> = {
-  FREE: 'free',
-  STANDARD: 'standard',
-  CREATOR: 'creator',
-  PRO: 'pro',
-  FOUNDER: 'founder',
-  FOUNDERS_EDITION: 'founder'
-}
-
-function formatTierName(
-  tier: string | null | undefined,
-  isYearly: boolean
-): string {
-  if (!tier) return ''
-  const key = tierKeyMap[tier] ?? 'standard'
-  const baseName = t(`subscription.tiers.${key}.name`)
-  return isYearly
-    ? t('subscription.tierNameYearly', { name: baseName })
-    : baseName
-}
+const { formatTierName, getTierLabel: getStoreTierLabel } =
+  useWorkspaceTierLabel()
 
 const currentSubscriptionTierName = computed(() => {
   const tier = subscription.value?.tier
@@ -203,26 +185,7 @@ function getTierLabel(workspace: AvailableWorkspace): string | null {
     return currentSubscriptionTierName.value || null
   }
 
-  // For non-active workspaces, use cached store data
-  if (!workspace.isSubscribed) return null
-
-  if (workspace.subscriptionTier) {
-    return formatTierName(workspace.subscriptionTier, false)
-  }
-
-  if (!workspace.subscriptionPlan) return null
-
-  // Parse plan slug (format: TIER_DURATION, e.g. "CREATOR_MONTHLY", "PRO_YEARLY")
-  const planSlug = workspace.subscriptionPlan
-
-  // Extract tier from plan slug (e.g., "CREATOR_MONTHLY" -> "CREATOR")
-  const tierMatch = Object.keys(tierKeyMap).find((tier) =>
-    planSlug.startsWith(tier)
-  )
-  if (!tierMatch) return null
-
-  const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
-  return formatTierName(tierMatch, isYearly)
+  return getStoreTierLabel(workspace)
 }
 
 async function handleSelectWorkspace(workspace: AvailableWorkspace) {

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -47,10 +47,10 @@
                       }}
                     </span>
                     <span
-                      v-if="getTierLabel(workspace)"
+                      v-if="resolveTierLabel(workspace)"
                       class="rounded-full bg-base-foreground px-1 py-0.5 text-[10px] font-bold text-base-background uppercase"
                     >
-                      {{ getTierLabel(workspace) }}
+                      {{ resolveTierLabel(workspace) }}
                     </span>
                   </div>
                   <span class="text-xs text-muted-foreground">
@@ -142,8 +142,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { switchWorkspace } = useWorkspaceSwitch()
 const { subscription } = useBillingContext()
-const { formatTierName, getTierLabel: getStoreTierLabel } =
-  useWorkspaceTierLabel()
+const { formatTierName, getTierLabel } = useWorkspaceTierLabel()
 
 const currentSubscriptionTierName = computed(() => {
   const tier = subscription.value?.tier
@@ -178,14 +177,12 @@ function getRoleLabel(role: AvailableWorkspace['role']): string {
   return ''
 }
 
-function getTierLabel(workspace: AvailableWorkspace): string | null {
-  // For the current/active workspace, use billing context directly
-  // This ensures we always have the most up-to-date subscription info
+function resolveTierLabel(workspace: AvailableWorkspace): string | null {
   if (isCurrentWorkspace(workspace)) {
     return currentSubscriptionTierName.value || null
   }
 
-  return getStoreTierLabel(workspace)
+  return getTierLabel(workspace)
 }
 
 async function handleSelectWorkspace(workspace: AvailableWorkspace) {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import { nextTick } from 'vue'
@@ -163,6 +163,7 @@ describe('TeamWorkspacesDialogContent', () => {
 
       const switchButton = wrapper.find('li button')
       await switchButton.trigger('click')
+      await flushPromises()
 
       expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
       expect(mockCloseDialog).toHaveBeenCalledWith({
@@ -177,6 +178,7 @@ describe('TeamWorkspacesDialogContent', () => {
 
       const switchButton = wrapper.find('li button')
       await switchButton.trigger('click')
+      await flushPromises()
 
       expect(mockCloseDialog).not.toHaveBeenCalled()
       expect(mockToastAdd).toHaveBeenCalledWith(
@@ -230,7 +232,7 @@ describe('TeamWorkspacesDialogContent', () => {
       await wrapper.find('#workspace-name-input').setValue(name)
       await nextTick()
       findCreateButton(wrapper).vm.$emit('click')
-      await nextTick()
+      await flushPromises()
     }
 
     it('calls createWorkspace and onConfirm on success', async () => {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -143,7 +143,7 @@ describe('TeamWorkspacesDialogContent', () => {
   })
 
   describe('workspace switching', () => {
-    it('calls switchWorkspace with workspace id', async () => {
+    it('calls switchWorkspace with workspace id and closes dialog on success', async () => {
       mockSwitchWorkspace.mockResolvedValue(true)
       setOwnedWorkspaces()
       const wrapper = mountComponent()
@@ -151,13 +151,13 @@ describe('TeamWorkspacesDialogContent', () => {
       const switchButton = wrapper.find('li button')
       await switchButton.trigger('click')
 
+      expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
       expect(mockCloseDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
-      expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
-    it('shows error toast when switch fails', async () => {
+    it('shows error toast and keeps dialog open when switch fails', async () => {
       mockSwitchWorkspace.mockRejectedValue(new Error('Network error'))
       setOwnedWorkspaces()
       const wrapper = mountComponent()
@@ -165,6 +165,7 @@ describe('TeamWorkspacesDialogContent', () => {
       const switchButton = wrapper.find('li button')
       await switchButton.trigger('click')
 
+      expect(mockCloseDialog).not.toHaveBeenCalled()
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -140,6 +140,19 @@ describe('TeamWorkspacesDialogContent', () => {
       const wrapper = mountComponent()
       expect(wrapper.findAll('li')).toHaveLength(0)
     })
+
+    it('shows create-only subtitle when no owned workspaces', () => {
+      const wrapper = mountComponent()
+      const subtitle = wrapper.find('header p')
+      expect(subtitle.text()).toBe('teamWorkspacesDialog.subtitleNoWorkspaces')
+    })
+
+    it('shows switch-or-create subtitle when owned workspaces exist', () => {
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+      const subtitle = wrapper.find('header p')
+      expect(subtitle.text()).toBe('teamWorkspacesDialog.subtitle')
+    })
   })
 
   describe('workspace switching', () => {
@@ -246,6 +259,36 @@ describe('TeamWorkspacesDialogContent', () => {
           detail: 'Limit reached'
         })
       )
+      expect(mockCloseDialog).not.toHaveBeenCalled()
+    })
+
+    it('shows separate toast when onConfirm fails but still closes dialog', async () => {
+      mockCreateWorkspace.mockResolvedValue({ id: 'new-ws' })
+      const onConfirm = vi.fn().mockRejectedValue(new Error('Setup failed'))
+      const wrapper = mountComponent({ onConfirm })
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(mockCreateWorkspace).toHaveBeenCalledWith('New Team')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'Setup failed'
+        })
+      )
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+
+    it('does not call onConfirm when createWorkspace fails', async () => {
+      mockCreateWorkspace.mockRejectedValue(new Error('Limit reached'))
+      const onConfirm = vi.fn()
+      const wrapper = mountComponent({ onConfirm })
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(onConfirm).not.toHaveBeenCalled()
     })
 
     it('does not call createWorkspace when name is invalid', async () => {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -1,0 +1,270 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { nextTick } from 'vue'
+
+import TeamWorkspacesDialogContent from './TeamWorkspacesDialogContent.vue'
+
+const mockCloseDialog = vi.fn()
+const mockToastAdd = vi.fn()
+const mockSwitchWorkspace = vi.fn()
+const mockCreateWorkspace = vi.fn()
+const mockSharedWorkspaces = vi.hoisted(() => ({
+  value: [] as Array<{
+    id: string
+    name: string
+    role: string
+    isSubscribed: boolean
+    subscriptionPlan: string | null
+    subscriptionTier: string | null
+  }>
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: mockToastAdd
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: mockCloseDialog
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceSwitch', () => ({
+  useWorkspaceSwitch: () => ({
+    switchWorkspace: mockSwitchWorkspace
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceTierLabel', () => ({
+  useWorkspaceTierLabel: () => ({
+    getTierLabel: (w: { subscriptionTier: string | null }) =>
+      w.subscriptionTier === 'PRO' ? 'Pro' : null
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    sharedWorkspaces: mockSharedWorkspaces,
+    createWorkspace: mockCreateWorkspace
+  })
+}))
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const ButtonStub = {
+  name: 'Button',
+  template:
+    '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+  props: ['disabled', 'loading', 'variant', 'size']
+}
+
+function mountComponent(props: Record<string, unknown> = {}) {
+  return mount(TeamWorkspacesDialogContent, {
+    props,
+    shallow: true,
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Button: ButtonStub,
+        WorkspaceProfilePic: true
+      }
+    }
+  })
+}
+
+function findCreateButton(wrapper: ReturnType<typeof mountComponent>) {
+  return wrapper.findComponent(ButtonStub)
+}
+
+function setOwnedWorkspaces() {
+  mockSharedWorkspaces.value = [
+    {
+      id: 'ws-1',
+      name: 'Team Alpha',
+      role: 'owner',
+      isSubscribed: true,
+      subscriptionPlan: null,
+      subscriptionTier: 'PRO'
+    },
+    {
+      id: 'ws-2',
+      name: 'Team Beta',
+      role: 'member',
+      isSubscribed: false,
+      subscriptionPlan: null,
+      subscriptionTier: null
+    }
+  ]
+}
+
+describe('TeamWorkspacesDialogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSharedWorkspaces.value = []
+  })
+
+  describe('workspace listing', () => {
+    it('displays only owned workspaces', () => {
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+      const items = wrapper.findAll('li')
+      expect(items).toHaveLength(1)
+      expect(wrapper.text()).toContain('Team Alpha')
+      expect(wrapper.text()).not.toContain('Team Beta')
+    })
+
+    it('shows tier label for subscribed workspaces', () => {
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+      expect(wrapper.text()).toContain('Pro')
+    })
+
+    it('hides workspace list section when no owned workspaces', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.findAll('li')).toHaveLength(0)
+    })
+  })
+
+  describe('workspace switching', () => {
+    it('calls switchWorkspace with workspace id', async () => {
+      mockSwitchWorkspace.mockResolvedValue(true)
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+
+      const switchButton = wrapper.find('li button')
+      await switchButton.trigger('click')
+
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+      expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
+    })
+
+    it('shows error toast when switch fails', async () => {
+      mockSwitchWorkspace.mockRejectedValue(new Error('Network error'))
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+
+      const switchButton = wrapper.find('li button')
+      await switchButton.trigger('click')
+
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'Network error'
+        })
+      )
+    })
+  })
+
+  describe('name validation', () => {
+    it('disables create button for empty name', () => {
+      const wrapper = mountComponent()
+      expect(findCreateButton(wrapper).props('disabled')).toBe(true)
+    })
+
+    it('enables create button for valid name', async () => {
+      const wrapper = mountComponent()
+      const input = wrapper.find('#workspace-name-input')
+      await input.setValue('My Team')
+      await nextTick()
+
+      expect(findCreateButton(wrapper).props('disabled')).toBe(false)
+    })
+
+    it('disables create button for name with special characters', async () => {
+      const wrapper = mountComponent()
+      const input = wrapper.find('#workspace-name-input')
+      await input.setValue('!@#$%')
+      await nextTick()
+
+      expect(findCreateButton(wrapper).props('disabled')).toBe(true)
+    })
+
+    it('disables create button for name exceeding 50 characters', async () => {
+      const wrapper = mountComponent()
+      const input = wrapper.find('#workspace-name-input')
+      await input.setValue('a'.repeat(51))
+      await nextTick()
+
+      expect(findCreateButton(wrapper).props('disabled')).toBe(true)
+    })
+  })
+
+  describe('workspace creation', () => {
+    async function typeAndCreate(
+      wrapper: ReturnType<typeof mountComponent>,
+      name: string
+    ) {
+      await wrapper.find('#workspace-name-input').setValue(name)
+      await nextTick()
+      findCreateButton(wrapper).vm.$emit('click')
+      await nextTick()
+    }
+
+    it('calls createWorkspace and onConfirm on success', async () => {
+      mockCreateWorkspace.mockResolvedValue({ id: 'new-ws' })
+      const onConfirm = vi.fn()
+      const wrapper = mountComponent({ onConfirm })
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(mockCreateWorkspace).toHaveBeenCalledWith('New Team')
+      expect(onConfirm).toHaveBeenCalledWith('New Team')
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+
+    it('shows error toast when creation fails', async () => {
+      mockCreateWorkspace.mockRejectedValue(new Error('Limit reached'))
+      const wrapper = mountComponent()
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'Limit reached'
+        })
+      )
+    })
+
+    it('does not call createWorkspace when name is invalid', async () => {
+      const wrapper = mountComponent()
+      findCreateButton(wrapper).vm.$emit('click')
+      await nextTick()
+
+      expect(mockCreateWorkspace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('close button', () => {
+    it('closes dialog on close button click', async () => {
+      const wrapper = mountComponent()
+      const closeBtn = wrapper.find('header button')
+      await closeBtn.trigger('click')
+
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+  })
+})

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -99,7 +99,7 @@
           type="text"
           class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
           :placeholder="$t('teamWorkspacesDialog.namePlaceholder')"
-          @keydown.enter="isValidName && onCreate()"
+          @keydown.enter="isValidName && !loading && onCreate()"
         />
       </div>
       <Button
@@ -107,7 +107,7 @@
         size="lg"
         class="w-full"
         :loading
-        :disabled="!isValidName"
+        :disabled="!isValidName || loading"
         @click="onCreate"
       >
         <i class="pi pi-plus text-xs" aria-hidden="true" />
@@ -182,7 +182,7 @@ async function handleSwitch(workspaceId: string) {
 }
 
 async function onCreate() {
-  if (!isValidName.value) return
+  if (!isValidName.value || loading.value) return
   loading.value = true
   try {
     const name = workspaceName.value.trim()

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -27,7 +27,7 @@
         :aria-label="$t('g.close')"
         @click="onCancel"
       >
-        <i class="pi pi-times size-4" />
+        <i class="pi pi-times size-4" aria-hidden="true" />
       </button>
     </header>
 

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -57,10 +57,10 @@
                   {{ workspace.name }}
                 </span>
                 <span
-                  v-if="getTierLabel(workspace)"
+                  v-if="tierLabels.get(workspace.id)"
                   class="shrink-0 rounded-full bg-base-foreground px-1 py-0.5 text-[10px] font-bold text-base-background uppercase"
                 >
-                  {{ getTierLabel(workspace) }}
+                  {{ tierLabels.get(workspace.id) }}
                 </span>
               </div>
             </div>
@@ -150,6 +150,13 @@ const workspaceName = ref('')
 
 const ownedTeamWorkspaces = computed(() =>
   sharedWorkspaces.value.filter((w) => w.role === 'owner')
+)
+
+const tierLabels = computed(
+  () =>
+    new Map(
+      ownedTeamWorkspaces.value.map((w) => [w.id, getTierLabel(w)] as const)
+    )
 )
 
 const isValidName = computed(() => {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -1,0 +1,187 @@
+<template>
+  <section
+    class="flex w-full max-w-[480px] flex-col rounded-2xl border border-border-default bg-base-background"
+  >
+    <!-- Header -->
+    <header class="flex items-start gap-3 p-5 pb-0">
+      <div
+        class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary-background text-white"
+      >
+        <i class="icon-[lucide--users] text-lg" />
+      </div>
+      <div class="flex min-w-0 flex-1 flex-col">
+        <h2 class="m-0 text-lg font-semibold text-base-foreground">
+          {{ $t('teamWorkspacesDialog.title') }}
+        </h2>
+        <p class="m-0 text-sm text-muted-foreground">
+          {{ $t('teamWorkspacesDialog.subtitle') }}
+        </p>
+      </div>
+      <button
+        class="focus-visible:ring-secondary-foreground -mt-1 cursor-pointer rounded-sm border-none bg-transparent p-1 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
+        :aria-label="$t('g.close')"
+        @click="onCancel"
+      >
+        <i class="pi pi-times size-4" />
+      </button>
+    </header>
+
+    <!-- Existing team workspaces -->
+    <section
+      v-if="ownedTeamWorkspaces.length > 0"
+      class="flex flex-col px-5 pt-5"
+    >
+      <h3
+        class="m-0 mb-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase"
+      >
+        {{ $t('teamWorkspacesDialog.yourTeamWorkspaces') }}
+      </h3>
+      <ul
+        class="m-0 flex max-h-52 list-none flex-col gap-2 overflow-y-auto p-0"
+      >
+        <li v-for="workspace in ownedTeamWorkspaces" :key="workspace.id">
+          <button
+            class="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border-default bg-transparent px-4 py-3 transition-colors hover:bg-secondary-background-hover focus-visible:ring-1 focus-visible:outline-none"
+            @click="handleSwitch(workspace.id)"
+          >
+            <WorkspaceProfilePic
+              class="size-9 shrink-0 text-sm"
+              :workspace-name="workspace.name"
+            />
+            <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
+              <div class="flex items-center gap-1.5">
+                <span
+                  class="truncate text-left text-sm font-medium text-base-foreground"
+                >
+                  {{ workspace.name }}
+                </span>
+                <span
+                  v-if="getTierLabel(workspace)"
+                  class="shrink-0 rounded-full bg-base-foreground px-1 py-0.5 text-[10px] font-bold text-base-background uppercase"
+                >
+                  {{ getTierLabel(workspace) }}
+                </span>
+              </div>
+            </div>
+            <span class="text-primary-foreground shrink-0 text-sm font-medium">
+              {{ $t('teamWorkspacesDialog.switch') }}
+              <i class="pi pi-arrow-right text-xs" />
+            </span>
+          </button>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Divider -->
+    <hr
+      v-if="ownedTeamWorkspaces.length > 0"
+      class="mx-5 my-4 border-border-default"
+    />
+
+    <!-- New workspace section -->
+    <section
+      class="flex flex-col gap-3 px-5 pb-5"
+      :class="{ 'pt-5': ownedTeamWorkspaces.length === 0 }"
+    >
+      <h3
+        class="m-0 text-xs font-semibold tracking-wider text-muted-foreground uppercase"
+      >
+        {{ $t('teamWorkspacesDialog.newWorkspace') }}
+      </h3>
+      <div class="flex flex-col gap-2">
+        <label for="workspace-name-input" class="text-sm text-base-foreground">
+          {{ $t('workspacePanel.createWorkspaceDialog.nameLabel') }}
+        </label>
+        <input
+          id="workspace-name-input"
+          v-model="workspaceName"
+          type="text"
+          class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
+          :placeholder="$t('teamWorkspacesDialog.namePlaceholder')"
+          @keydown.enter="isValidName && onCreate()"
+        />
+      </div>
+      <Button
+        variant="secondary"
+        size="lg"
+        class="w-full"
+        :loading
+        :disabled="!isValidName"
+        @click="onCreate"
+      >
+        <i class="pi pi-plus text-xs" />
+        {{ $t('teamWorkspacesDialog.createWorkspace') }}
+      </Button>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useToast } from 'primevue/usetoast'
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
+import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
+import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const { onConfirm } = defineProps<{
+  onConfirm?: (name: string) => void | Promise<void>
+}>()
+
+const DIALOG_KEY = 'team-workspaces'
+
+const { t } = useI18n()
+const dialogStore = useDialogStore()
+const toast = useToast()
+const workspaceStore = useTeamWorkspaceStore()
+const { switchWorkspace } = useWorkspaceSwitch()
+const { getTierLabel } = useWorkspaceTierLabel()
+const { sharedWorkspaces } = storeToRefs(workspaceStore)
+
+const loading = ref(false)
+const workspaceName = ref('')
+
+const ownedTeamWorkspaces = computed(() =>
+  sharedWorkspaces.value.filter((w) => w.role === 'owner')
+)
+
+const isValidName = computed(() => {
+  const name = workspaceName.value.trim()
+  const safeNameRegex = /^[a-zA-Z0-9][a-zA-Z0-9\s\-_'.,()&+]*$/
+  return name.length >= 1 && name.length <= 50 && safeNameRegex.test(name)
+})
+
+function onCancel() {
+  dialogStore.closeDialog({ key: DIALOG_KEY })
+}
+
+async function handleSwitch(workspaceId: string) {
+  dialogStore.closeDialog({ key: DIALOG_KEY })
+  await switchWorkspace(workspaceId)
+}
+
+async function onCreate() {
+  if (!isValidName.value) return
+  loading.value = true
+  try {
+    const name = workspaceName.value.trim()
+    await onConfirm?.(name)
+    dialogStore.closeDialog({ key: DIALOG_KEY })
+    await workspaceStore.createWorkspace(name)
+  } catch (error) {
+    console.error('[TeamWorkspacesDialog] Failed to create workspace:', error)
+    toast.add({
+      severity: 'error',
+      summary: t('workspacePanel.toast.failedToCreateWorkspace'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -103,8 +103,21 @@
           type="text"
           class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
           :placeholder="$t('teamWorkspacesDialog.namePlaceholder')"
+          :aria-invalid="workspaceName.length > 0 && !isValidName"
+          :aria-describedby="
+            workspaceName.length > 0 && !isValidName
+              ? 'workspace-name-error'
+              : undefined
+          "
           @keydown.enter="isValidName && !loading && onCreate()"
         />
+        <p
+          v-if="workspaceName.length > 0 && !isValidName"
+          id="workspace-name-error"
+          class="text-danger m-0 text-xs"
+        >
+          {{ $t('teamWorkspacesDialog.nameValidationError') }}
+        </p>
       </div>
       <Button
         variant="secondary"
@@ -188,30 +201,28 @@ async function handleSwitch(workspaceId: string) {
 async function onCreate() {
   if (!isValidName.value || loading.value) return
   loading.value = true
+  const name = workspaceName.value.trim()
   try {
-    const name = workspaceName.value.trim()
-    try {
-      await workspaceStore.createWorkspace(name)
-    } catch (error) {
-      toast.add({
-        severity: 'error',
-        summary: t('workspacePanel.toast.failedToCreateWorkspace'),
-        detail: error instanceof Error ? error.message : t('g.unknownError')
-      })
-      return
-    }
-    try {
-      await onConfirm?.(name)
-    } catch (error) {
-      toast.add({
-        severity: 'error',
-        summary: t('teamWorkspacesDialog.confirmCallbackFailed'),
-        detail: error instanceof Error ? error.message : t('g.unknownError')
-      })
-    }
-    dialogStore.closeDialog({ key: DIALOG_KEY })
-  } finally {
+    await workspaceStore.createWorkspace(name)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: t('workspacePanel.toast.failedToCreateWorkspace'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
     loading.value = false
+    return
   }
+  try {
+    await onConfirm?.(name)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: t('teamWorkspacesDialog.confirmCallbackFailed'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
+  }
+  dialogStore.closeDialog({ key: DIALOG_KEY })
+  loading.value = false
 }
 </script>

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -66,7 +66,7 @@
             </div>
             <span class="text-primary-foreground shrink-0 text-sm font-medium">
               {{ $t('teamWorkspacesDialog.switch') }}
-              <i class="pi pi-arrow-right text-xs" />
+              <i class="pi pi-arrow-right text-xs" aria-hidden="true" />
             </span>
           </button>
         </li>
@@ -110,7 +110,7 @@
         :disabled="!isValidName"
         @click="onCreate"
       >
-        <i class="pi pi-plus text-xs" />
+        <i class="pi pi-plus text-xs" aria-hidden="true" />
         {{ $t('teamWorkspacesDialog.createWorkspace') }}
       </Button>
     </section>
@@ -170,8 +170,8 @@ function onCancel() {
 
 async function handleSwitch(workspaceId: string) {
   try {
-    dialogStore.closeDialog({ key: DIALOG_KEY })
     await switchWorkspace(workspaceId)
+    dialogStore.closeDialog({ key: DIALOG_KEY })
   } catch (error) {
     toast.add({
       severity: 'error',

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -15,7 +15,11 @@
           {{ $t('teamWorkspacesDialog.title') }}
         </h2>
         <p class="m-0 text-sm text-muted-foreground">
-          {{ $t('teamWorkspacesDialog.subtitle') }}
+          {{
+            ownedTeamWorkspaces.length > 0
+              ? $t('teamWorkspacesDialog.subtitle')
+              : $t('teamWorkspacesDialog.subtitleNoWorkspaces')
+          }}
         </p>
       </div>
       <button
@@ -186,15 +190,26 @@ async function onCreate() {
   loading.value = true
   try {
     const name = workspaceName.value.trim()
-    await workspaceStore.createWorkspace(name)
-    await onConfirm?.(name)
+    try {
+      await workspaceStore.createWorkspace(name)
+    } catch (error) {
+      toast.add({
+        severity: 'error',
+        summary: t('workspacePanel.toast.failedToCreateWorkspace'),
+        detail: error instanceof Error ? error.message : t('g.unknownError')
+      })
+      return
+    }
+    try {
+      await onConfirm?.(name)
+    } catch (error) {
+      toast.add({
+        severity: 'error',
+        summary: t('teamWorkspacesDialog.confirmCallbackFailed'),
+        detail: error instanceof Error ? error.message : t('g.unknownError')
+      })
+    }
     dialogStore.closeDialog({ key: DIALOG_KEY })
-  } catch (error) {
-    toast.add({
-      severity: 'error',
-      summary: t('workspacePanel.toast.failedToCreateWorkspace'),
-      detail: error instanceof Error ? error.message : t('g.unknownError')
-    })
   } finally {
     loading.value = false
   }

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -6,6 +6,7 @@
     <header class="flex items-start gap-3 p-5 pb-0">
       <div
         class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary-background text-white"
+        aria-hidden="true"
       >
         <i class="icon-[lucide--users] text-lg" />
       </div>
@@ -18,7 +19,7 @@
         </p>
       </div>
       <button
-        class="focus-visible:ring-secondary-foreground -mt-1 cursor-pointer rounded-sm border-none bg-transparent p-1 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
+        class="focus-visible:ring-secondary-foreground -mt-1 cursor-pointer rounded-sm border-none bg-transparent p-2 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
         :aria-label="$t('g.close')"
         @click="onCancel"
       >
@@ -41,7 +42,7 @@
       >
         <li v-for="workspace in ownedTeamWorkspaces" :key="workspace.id">
           <button
-            class="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border-default bg-transparent px-4 py-3 transition-colors hover:bg-secondary-background-hover focus-visible:ring-1 focus-visible:outline-none"
+            class="focus-visible:ring-secondary-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border-default bg-transparent px-4 py-3 transition-colors hover:bg-secondary-background-hover focus-visible:ring-1 focus-visible:outline-none"
             @click="handleSwitch(workspace.id)"
           >
             <WorkspaceProfilePic
@@ -134,6 +135,7 @@ const { onConfirm } = defineProps<{
 }>()
 
 const DIALOG_KEY = 'team-workspaces'
+const SAFE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9\s\-_'.,()&+]*$/
 
 const { t } = useI18n()
 const dialogStore = useDialogStore()
@@ -152,8 +154,7 @@ const ownedTeamWorkspaces = computed(() =>
 
 const isValidName = computed(() => {
   const name = workspaceName.value.trim()
-  const safeNameRegex = /^[a-zA-Z0-9][a-zA-Z0-9\s\-_'.,()&+]*$/
-  return name.length >= 1 && name.length <= 50 && safeNameRegex.test(name)
+  return name.length >= 1 && name.length <= 50 && SAFE_NAME_REGEX.test(name)
 })
 
 function onCancel() {
@@ -161,8 +162,16 @@ function onCancel() {
 }
 
 async function handleSwitch(workspaceId: string) {
-  dialogStore.closeDialog({ key: DIALOG_KEY })
-  await switchWorkspace(workspaceId)
+  try {
+    dialogStore.closeDialog({ key: DIALOG_KEY })
+    await switchWorkspace(workspaceId)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: t('workspaceSwitcher.failedToSwitch'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
+  }
 }
 
 async function onCreate() {
@@ -170,11 +179,10 @@ async function onCreate() {
   loading.value = true
   try {
     const name = workspaceName.value.trim()
+    await workspaceStore.createWorkspace(name)
     await onConfirm?.(name)
     dialogStore.closeDialog({ key: DIALOG_KEY })
-    await workspaceStore.createWorkspace(name)
   } catch (error) {
-    console.error('[TeamWorkspacesDialog] Failed to create workspace:', error)
     toast.add({
       severity: 'error',
       summary: t('workspacePanel.toast.failedToCreateWorkspace'),

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
@@ -16,7 +16,7 @@ vi.mock(
 const mockRouteQuery = vi.hoisted(() => ({
   value: {} as Record<string, string>
 }))
-const mockRouterReplace = vi.hoisted(() => vi.fn())
+const mockRouterReplace = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({
@@ -27,7 +27,9 @@ vi.mock('vue-router', () => ({
   })
 }))
 
-const mockShowCreateWorkspaceDialog = vi.hoisted(() => vi.fn())
+const mockShowCreateWorkspaceDialog = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
+)
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCreateWorkspaceUrlLoader } from './useCreateWorkspaceUrlLoader'
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  clearPreservedQuery: vi.fn(),
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn()
+}))
+
+vi.mock(
+  '@/platform/navigation/preservedQueryManager',
+  () => preservedQueryMocks
+)
+
+const mockRouteQuery = vi.hoisted(() => ({
+  value: {} as Record<string, string>
+}))
+const mockRouterReplace = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: mockRouteQuery.value
+  }),
+  useRouter: () => ({
+    replace: mockRouterReplace
+  })
+}))
+
+const mockShowCreateWorkspaceDialog = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showCreateWorkspaceDialog: mockShowCreateWorkspaceDialog
+  })
+}))
+
+describe('useCreateWorkspaceUrlLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('loadCreateWorkspaceFromUrl', () => {
+    it('does nothing when no create_workspace param present', async () => {
+      mockRouteQuery.value = {}
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowCreateWorkspaceDialog).not.toHaveBeenCalled()
+      expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+
+    it('opens create workspace dialog when param is present', async () => {
+      mockRouteQuery.value = { create_workspace: '1' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalledOnce()
+    })
+
+    it('restores preserved query and opens dialog', async () => {
+      mockRouteQuery.value = {}
+      preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+        create_workspace: '1'
+      })
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
+        'create_workspace'
+      )
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        query: { create_workspace: '1' }
+      })
+      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalledOnce()
+    })
+
+    it('cleans up URL after processing', async () => {
+      mockRouteQuery.value = { create_workspace: '1', other: 'param' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        query: { other: 'param' }
+      })
+    })
+
+    it('clears preserved query after processing', async () => {
+      mockRouteQuery.value = { create_workspace: '1' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+        'create_workspace'
+      )
+    })
+
+    it('ignores empty param', async () => {
+      mockRouteQuery.value = { create_workspace: '' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowCreateWorkspaceDialog).not.toHaveBeenCalled()
+    })
+
+    it('ignores non-string param', async () => {
+      mockRouteQuery.value = {
+        create_workspace: ['array'] as unknown as string
+      }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowCreateWorkspaceDialog).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
@@ -27,13 +27,13 @@ vi.mock('vue-router', () => ({
   })
 }))
 
-const mockShowCreateWorkspaceDialog = vi.hoisted(() =>
+const mockShowTeamWorkspacesDialog = vi.hoisted(() =>
   vi.fn().mockResolvedValue(undefined)
 )
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
-    showCreateWorkspaceDialog: mockShowCreateWorkspaceDialog
+    showTeamWorkspacesDialog: mockShowTeamWorkspacesDialog
   })
 }))
 
@@ -55,7 +55,7 @@ describe('useCreateWorkspaceUrlLoader', () => {
       const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
       await loadCreateWorkspaceFromUrl()
 
-      expect(mockShowCreateWorkspaceDialog).not.toHaveBeenCalled()
+      expect(mockShowTeamWorkspacesDialog).not.toHaveBeenCalled()
       expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 
@@ -65,7 +65,7 @@ describe('useCreateWorkspaceUrlLoader', () => {
       const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
       await loadCreateWorkspaceFromUrl()
 
-      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalledOnce()
+      expect(mockShowTeamWorkspacesDialog).toHaveBeenCalledOnce()
     })
 
     it('restores preserved query and opens dialog', async () => {
@@ -83,7 +83,7 @@ describe('useCreateWorkspaceUrlLoader', () => {
       expect(mockRouterReplace).toHaveBeenCalledWith({
         query: { create_workspace: '1' }
       })
-      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalledOnce()
+      expect(mockShowTeamWorkspacesDialog).toHaveBeenCalledOnce()
     })
 
     it('cleans up URL after processing', async () => {
@@ -114,7 +114,7 @@ describe('useCreateWorkspaceUrlLoader', () => {
       const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
       await loadCreateWorkspaceFromUrl()
 
-      expect(mockShowCreateWorkspaceDialog).not.toHaveBeenCalled()
+      expect(mockShowTeamWorkspacesDialog).not.toHaveBeenCalled()
     })
 
     it('ignores non-string param', async () => {
@@ -125,7 +125,7 @@ describe('useCreateWorkspaceUrlLoader', () => {
       const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
       await loadCreateWorkspaceFromUrl()
 
-      expect(mockShowCreateWorkspaceDialog).not.toHaveBeenCalled()
+      expect(mockShowTeamWorkspacesDialog).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
@@ -1,0 +1,68 @@
+import { useRoute, useRouter } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  hydratePreservedQuery,
+  mergePreservedQueryIntoQuery
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { useDialogService } from '@/services/dialogService'
+
+const NAMESPACE = PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE
+
+/**
+ * Composable for opening the create workspace dialog via URL query parameter.
+ *
+ * Supports URLs like:
+ * - /?create_workspace=1 (opens the create workspace dialog)
+ *
+ * The parameter is preserved through login redirects via the
+ * preserved query system (sessionStorage), following the same pattern
+ * as the invite URL loader.
+ */
+export function useCreateWorkspaceUrlLoader() {
+  const route = useRoute()
+  const router = useRouter()
+  const dialogService = useDialogService()
+
+  const ensureQueryFromIntent = async () => {
+    hydratePreservedQuery(NAMESPACE)
+    const mergedQuery = mergePreservedQueryIntoQuery(NAMESPACE, route.query)
+
+    if (mergedQuery) {
+      await router.replace({ query: mergedQuery })
+    }
+
+    return mergedQuery ?? route.query
+  }
+
+  const cleanupUrlParams = () => {
+    const newQuery = { ...route.query }
+    delete newQuery.create_workspace
+    void router.replace({ query: newQuery })
+  }
+
+  /**
+   * Opens the create workspace dialog if `?create_workspace=1` is present.
+   *
+   * Flow:
+   * 1. Restore preserved query (for post-login redirect)
+   * 2. Check for create_workspace param in route.query
+   * 3. Open the create workspace dialog
+   * 4. Clean up URL and preserved query
+   */
+  async function loadCreateWorkspaceFromUrl() {
+    const query = await ensureQueryFromIntent()
+    const param = query.create_workspace
+    if (!param || typeof param !== 'string') return
+
+    cleanupUrlParams()
+    clearPreservedQuery(NAMESPACE)
+
+    dialogService.showCreateWorkspaceDialog()
+  }
+
+  return {
+    loadCreateWorkspaceFromUrl
+  }
+}

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
@@ -25,28 +25,6 @@ export function useCreateWorkspaceUrlLoader() {
   const router = useRouter()
   const dialogService = useDialogService()
 
-  const ensureQueryFromIntent = async () => {
-    hydratePreservedQuery(NAMESPACE)
-    const mergedQuery = mergePreservedQueryIntoQuery(NAMESPACE, route.query)
-
-    if (mergedQuery) {
-      await router.replace({ query: mergedQuery })
-    }
-
-    return mergedQuery ?? route.query
-  }
-
-  const cleanupUrlParams = () => {
-    const newQuery = { ...route.query }
-    delete newQuery.create_workspace
-    router.replace({ query: newQuery }).catch((error) => {
-      console.warn(
-        '[useCreateWorkspaceUrlLoader] Failed to clean URL params:',
-        error
-      )
-    })
-  }
-
   /**
    * Opens the create workspace dialog if `?create_workspace=1` is present.
    *
@@ -57,11 +35,24 @@ export function useCreateWorkspaceUrlLoader() {
    * 4. Clean up URL and preserved query
    */
   async function loadCreateWorkspaceFromUrl() {
-    const query = await ensureQueryFromIntent()
+    hydratePreservedQuery(NAMESPACE)
+    const mergedQuery = mergePreservedQueryIntoQuery(NAMESPACE, route.query)
+    if (mergedQuery) {
+      await router.replace({ query: mergedQuery })
+    }
+
+    const query = mergedQuery ?? route.query
     const param = query.create_workspace
     if (!param || typeof param !== 'string') return
 
-    cleanupUrlParams()
+    const newQuery = { ...route.query }
+    delete newQuery.create_workspace
+    router.replace({ query: newQuery }).catch((error) => {
+      console.warn(
+        '[useCreateWorkspaceUrlLoader] Failed to clean URL params:',
+        error
+      )
+    })
     clearPreservedQuery(NAMESPACE)
 
     try {

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
@@ -11,10 +11,10 @@ import { useDialogService } from '@/services/dialogService'
 const NAMESPACE = PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE
 
 /**
- * Composable for opening the create workspace dialog via URL query parameter.
+ * Composable for opening the team workspaces dialog via URL query parameter.
  *
  * Supports URLs like:
- * - /?create_workspace=1 (opens the create workspace dialog)
+ * - /?create_workspace=1 (opens the team workspaces dialog)
  *
  * The parameter is preserved through login redirects via the
  * preserved query system (sessionStorage), following the same pattern
@@ -26,12 +26,12 @@ export function useCreateWorkspaceUrlLoader() {
   const dialogService = useDialogService()
 
   /**
-   * Opens the create workspace dialog if `?create_workspace=1` is present.
+   * Opens the team workspaces dialog if `?create_workspace=1` is present.
    *
    * Flow:
    * 1. Restore preserved query (for post-login redirect)
    * 2. Check for create_workspace param in route.query
-   * 3. Open the create workspace dialog
+   * 3. Open the team workspaces dialog
    * 4. Clean up URL and preserved query
    */
   async function loadCreateWorkspaceFromUrl() {
@@ -56,7 +56,7 @@ export function useCreateWorkspaceUrlLoader() {
     clearPreservedQuery(NAMESPACE)
 
     try {
-      await dialogService.showCreateWorkspaceDialog()
+      await dialogService.showTeamWorkspacesDialog()
     } catch (error) {
       console.error(
         '[useCreateWorkspaceUrlLoader] Failed to open create workspace dialog:',

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
@@ -39,7 +39,12 @@ export function useCreateWorkspaceUrlLoader() {
   const cleanupUrlParams = () => {
     const newQuery = { ...route.query }
     delete newQuery.create_workspace
-    void router.replace({ query: newQuery })
+    router.replace({ query: newQuery }).catch((error) => {
+      console.warn(
+        '[useCreateWorkspaceUrlLoader] Failed to clean URL params:',
+        error
+      )
+    })
   }
 
   /**
@@ -59,7 +64,14 @@ export function useCreateWorkspaceUrlLoader() {
     cleanupUrlParams()
     clearPreservedQuery(NAMESPACE)
 
-    dialogService.showCreateWorkspaceDialog()
+    try {
+      await dialogService.showCreateWorkspaceDialog()
+    } catch (error) {
+      console.error(
+        '[useCreateWorkspaceUrlLoader] Failed to open create workspace dialog:',
+        error
+      )
+    }
   }
 
   return {

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -138,5 +138,14 @@ describe('useWorkspaceTierLabel', () => {
       })
       expect(result).toBe('Standard Yearly')
     })
+
+    it('parses FOUNDERS_EDITION from plan slug fallback', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'FOUNDERS_EDITION_MONTHLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe("Founder's Edition")
+    })
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -52,8 +52,8 @@ describe('useWorkspaceTierLabel', () => {
       )
     })
 
-    it('falls back to standard for unknown tier', () => {
-      expect(formatTierName('UNKNOWN_TIER', false)).toBe('Standard')
+    it('returns empty string for unknown tier', () => {
+      expect(formatTierName('UNKNOWN_TIER', false)).toBe('')
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -52,8 +52,8 @@ describe('useWorkspaceTierLabel', () => {
       )
     })
 
-    it('returns empty string for unknown tier', () => {
-      expect(formatTierName('UNKNOWN_TIER', false)).toBe('')
+    it('falls back to standard for unknown tier', () => {
+      expect(formatTierName('UNKNOWN_TIER', false)).toBe('Standard')
     })
   })
 
@@ -76,22 +76,13 @@ describe('useWorkspaceTierLabel', () => {
       expect(result).toBe('Creator')
     })
 
-    it('detects yearly plan from subscriptionPlan containing YEARLY', () => {
+    it('ignores plan slug yearly when subscriptionTier is present', () => {
       const result = getTierLabel({
         isSubscribed: true,
         subscriptionPlan: 'PRO_YEARLY',
         subscriptionTier: 'PRO'
       })
-      expect(result).toBe('Pro Yearly')
-    })
-
-    it('detects yearly plan from subscriptionPlan containing ANNUAL', () => {
-      const result = getTierLabel({
-        isSubscribed: true,
-        subscriptionPlan: 'PRO_ANNUAL',
-        subscriptionTier: 'PRO'
-      })
-      expect(result).toBe('Pro Yearly')
+      expect(result).toBe('Pro')
     })
 
     it('falls back to parsing subscriptionPlan when tier is null', () => {

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -53,7 +53,7 @@ describe('useWorkspaceTierLabel', () => {
     })
 
     it('falls back to standard for unknown tier', () => {
-      expect(formatTierName('UNKNOWN_TIER', false)).toBe('Standard')
+      expect(formatTierName('UNKNOWN_TIER', false)).toBe('')
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useWorkspaceTierLabel } from './useWorkspaceTierLabel'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: vi.fn((key: string, params?: Record<string, unknown>) => {
+      if (key === 'subscription.tierNameYearly') return `${params?.name} Yearly`
+
+      const tierNames: Record<string, string> = {
+        'subscription.tiers.free.name': 'Free',
+        'subscription.tiers.standard.name': 'Standard',
+        'subscription.tiers.creator.name': 'Creator',
+        'subscription.tiers.pro.name': 'Pro',
+        'subscription.tiers.founder.name': "Founder's Edition"
+      }
+      return tierNames[key] ?? key
+    })
+  })
+}))
+
+describe('useWorkspaceTierLabel', () => {
+  let formatTierName: ReturnType<typeof useWorkspaceTierLabel>['formatTierName']
+  let getTierLabel: ReturnType<typeof useWorkspaceTierLabel>['getTierLabel']
+
+  beforeEach(() => {
+    const composable = useWorkspaceTierLabel()
+    formatTierName = composable.formatTierName
+    getTierLabel = composable.getTierLabel
+  })
+
+  describe('formatTierName', () => {
+    it('returns empty string for null tier', () => {
+      expect(formatTierName(null, false)).toBe('')
+    })
+
+    it('returns empty string for undefined tier', () => {
+      expect(formatTierName(undefined, false)).toBe('')
+    })
+
+    it('returns base name for monthly plan', () => {
+      expect(formatTierName('PRO', false)).toBe('Pro')
+    })
+
+    it('appends yearly suffix for yearly plan', () => {
+      expect(formatTierName('PRO', true)).toBe('Pro Yearly')
+    })
+
+    it('maps FOUNDERS_EDITION to founder label', () => {
+      expect(formatTierName('FOUNDERS_EDITION', false)).toBe(
+        "Founder's Edition"
+      )
+    })
+
+    it('falls back to standard for unknown tier', () => {
+      expect(formatTierName('UNKNOWN_TIER', false)).toBe('Standard')
+    })
+  })
+
+  describe('getTierLabel', () => {
+    it('returns null when workspace is not subscribed', () => {
+      const result = getTierLabel({
+        isSubscribed: false,
+        subscriptionPlan: 'PRO_MONTHLY',
+        subscriptionTier: 'PRO'
+      })
+      expect(result).toBeNull()
+    })
+
+    it('uses subscriptionTier when available', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: null,
+        subscriptionTier: 'CREATOR'
+      })
+      expect(result).toBe('Creator')
+    })
+
+    it('detects yearly plan from subscriptionPlan containing YEARLY', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'PRO_YEARLY',
+        subscriptionTier: 'PRO'
+      })
+      expect(result).toBe('Pro Yearly')
+    })
+
+    it('detects yearly plan from subscriptionPlan containing ANNUAL', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'PRO_ANNUAL',
+        subscriptionTier: 'PRO'
+      })
+      expect(result).toBe('Pro Yearly')
+    })
+
+    it('falls back to parsing subscriptionPlan when tier is null', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'CREATOR_MONTHLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe('Creator')
+    })
+
+    it('returns null when subscribed but both tier and plan are null', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: null,
+        subscriptionTier: null
+      })
+      expect(result).toBeNull()
+    })
+
+    it('returns null when plan slug does not match any known tier', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'ENTERPRISE_CUSTOM',
+        subscriptionTier: null
+      })
+      expect(result).toBeNull()
+    })
+
+    it('handles FOUNDERS_EDITION tier', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: null,
+        subscriptionTier: 'FOUNDERS_EDITION'
+      })
+      expect(result).toBe("Founder's Edition")
+    })
+
+    it('parses yearly suffix from plan slug fallback', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'STANDARD_YEARLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe('Standard Yearly')
+    })
+  })
+})

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -31,7 +31,8 @@ export function useWorkspaceTierLabel() {
     isYearly: boolean
   ): string {
     if (!tier) return ''
-    const key = TIER_KEY_MAP[tier] ?? 'standard'
+    const key = TIER_KEY_MAP[tier]
+    if (!key) return ''
     const baseName = t(`subscription.tiers.${key}.name`)
     return isYearly
       ? t('subscription.tierNameYearly', { name: baseName })

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -57,10 +57,9 @@ export function useWorkspaceTierLabel() {
     if (!workspace.subscriptionPlan) return null
 
     const planSlug = workspace.subscriptionPlan
-    const planTokens = planSlug.split(/[-_.]/)
-    const tierMatch = Object.keys(TIER_KEY_MAP).find((tier) =>
-      planTokens.includes(tier)
-    )
+    const tierMatch = Object.keys(TIER_KEY_MAP)
+      .sort((a, b) => b.length - a.length)
+      .find((tier) => planSlug.startsWith(tier))
     if (!tierMatch) return null
 
     return formatTierName(tierMatch, isYearlyPlan(planSlug))

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -13,6 +13,10 @@ const TIER_KEY_MAP: Record<string, string> = {
   FOUNDERS_EDITION: 'founder'
 }
 
+const SORTED_TIER_KEYS = Object.keys(TIER_KEY_MAP).sort(
+  (a, b) => b.length - a.length
+)
+
 interface WorkspaceSubscriptionInfo {
   isSubscribed: boolean
   subscriptionPlan: string | null
@@ -57,9 +61,7 @@ export function useWorkspaceTierLabel() {
     if (!workspace.subscriptionPlan) return null
 
     const planSlug = workspace.subscriptionPlan
-    const tierMatch = Object.keys(TIER_KEY_MAP)
-      .sort((a, b) => b.length - a.length)
-      .find((tier) => planSlug.startsWith(tier))
+    const tierMatch = SORTED_TIER_KEYS.find((tier) => planSlug.startsWith(tier))
     if (!tierMatch) return null
 
     return formatTierName(tierMatch, isYearlyPlan(planSlug))

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -57,8 +57,9 @@ export function useWorkspaceTierLabel() {
     if (!workspace.subscriptionPlan) return null
 
     const planSlug = workspace.subscriptionPlan
+    const planTokens = planSlug.split(/[-_.]/)
     const tierMatch = Object.keys(TIER_KEY_MAP).find((tier) =>
-      planSlug.startsWith(tier)
+      planTokens.includes(tier)
     )
     if (!tierMatch) return null
 

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -25,7 +25,8 @@ export function useWorkspaceTierLabel() {
     isYearly: boolean
   ): string {
     if (!tier) return ''
-    const key = tierKeyMap[tier] ?? 'standard'
+    const key = tierKeyMap[tier]
+    if (!key) return ''
     const baseName = t(`subscription.tiers.${key}.name`)
     return isYearly
       ? t('subscription.tierNameYearly', { name: baseName })
@@ -42,9 +43,9 @@ export function useWorkspaceTierLabel() {
     if (!workspace.subscriptionPlan) return null
 
     const planSlug = workspace.subscriptionPlan
-    const tierMatch = Object.keys(tierKeyMap).find((tier) =>
-      planSlug.startsWith(tier)
-    )
+    const tierMatch = Object.keys(tierKeyMap)
+      .sort((a, b) => b.length - a.length)
+      .find((tier) => planSlug === tier || planSlug.startsWith(`${tier}_`))
     if (!tierMatch) return null
 
     const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -2,6 +2,8 @@ import { useI18n } from 'vue-i18n'
 
 import type { SubscriptionTier } from '@/platform/workspace/api/workspaceApi'
 
+// Maps API tier identifiers to i18n key segments.
+// FOUNDERS_EDITION is a legacy alias for FOUNDER — both resolve to the same label.
 const TIER_KEY_MAP: Record<string, string> = {
   FREE: 'free',
   STANDARD: 'standard',
@@ -17,6 +19,10 @@ interface WorkspaceSubscriptionInfo {
   subscriptionTier: SubscriptionTier | null
 }
 
+/**
+ * Provides helpers for deriving human-readable subscription tier labels
+ * from workspace subscription info, with support for yearly plan suffixes.
+ */
 export function useWorkspaceTierLabel() {
   const { t } = useI18n()
 

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -2,9 +2,7 @@ import { useI18n } from 'vue-i18n'
 
 import type { SubscriptionTier } from '@/platform/workspace/api/workspaceApi'
 
-// Maps API tier identifiers to i18n key segments.
-// FOUNDERS_EDITION is a legacy alias for FOUNDER — both resolve to the same label.
-const TIER_KEY_MAP: Record<string, string> = {
+const tierKeyMap: Record<string, string> = {
   FREE: 'free',
   STANDARD: 'standard',
   CREATOR: 'creator',
@@ -13,20 +11,12 @@ const TIER_KEY_MAP: Record<string, string> = {
   FOUNDERS_EDITION: 'founder'
 }
 
-const SORTED_TIER_KEYS = Object.keys(TIER_KEY_MAP).sort(
-  (a, b) => b.length - a.length
-)
-
 interface WorkspaceSubscriptionInfo {
   isSubscribed: boolean
   subscriptionPlan: string | null
   subscriptionTier: SubscriptionTier | null
 }
 
-/**
- * Provides helpers for deriving human-readable subscription tier labels
- * from workspace subscription info, with support for yearly plan suffixes.
- */
 export function useWorkspaceTierLabel() {
   const { t } = useI18n()
 
@@ -35,36 +25,30 @@ export function useWorkspaceTierLabel() {
     isYearly: boolean
   ): string {
     if (!tier) return ''
-    const key = TIER_KEY_MAP[tier]
-    if (!key) return ''
+    const key = tierKeyMap[tier] ?? 'standard'
     const baseName = t(`subscription.tiers.${key}.name`)
     return isYearly
       ? t('subscription.tierNameYearly', { name: baseName })
       : baseName
   }
 
-  function isYearlyPlan(planSlug: string | null): boolean {
-    if (!planSlug) return false
-    return planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
-  }
-
   function getTierLabel(workspace: WorkspaceSubscriptionInfo): string | null {
     if (!workspace.isSubscribed) return null
 
     if (workspace.subscriptionTier) {
-      return formatTierName(
-        workspace.subscriptionTier,
-        isYearlyPlan(workspace.subscriptionPlan)
-      )
+      return formatTierName(workspace.subscriptionTier, false)
     }
 
     if (!workspace.subscriptionPlan) return null
 
     const planSlug = workspace.subscriptionPlan
-    const tierMatch = SORTED_TIER_KEYS.find((tier) => planSlug.startsWith(tier))
+    const tierMatch = Object.keys(tierKeyMap).find((tier) =>
+      planSlug.startsWith(tier)
+    )
     if (!tierMatch) return null
 
-    return formatTierName(tierMatch, isYearlyPlan(planSlug))
+    const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
+    return formatTierName(tierMatch, isYearly)
   }
 
   return { formatTierName, getTierLabel }

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -32,11 +32,19 @@ export function useWorkspaceTierLabel() {
       : baseName
   }
 
+  function isYearlyPlan(planSlug: string | null): boolean {
+    if (!planSlug) return false
+    return planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
+  }
+
   function getTierLabel(workspace: WorkspaceSubscriptionInfo): string | null {
     if (!workspace.isSubscribed) return null
 
     if (workspace.subscriptionTier) {
-      return formatTierName(workspace.subscriptionTier, false)
+      return formatTierName(
+        workspace.subscriptionTier,
+        isYearlyPlan(workspace.subscriptionPlan)
+      )
     }
 
     if (!workspace.subscriptionPlan) return null
@@ -47,8 +55,7 @@ export function useWorkspaceTierLabel() {
     )
     if (!tierMatch) return null
 
-    const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
-    return formatTierName(tierMatch, isYearly)
+    return formatTierName(tierMatch, isYearlyPlan(planSlug))
   }
 
   return { formatTierName, getTierLabel }

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -1,0 +1,55 @@
+import { useI18n } from 'vue-i18n'
+
+import type { SubscriptionTier } from '@/platform/workspace/api/workspaceApi'
+
+const TIER_KEY_MAP: Record<string, string> = {
+  FREE: 'free',
+  STANDARD: 'standard',
+  CREATOR: 'creator',
+  PRO: 'pro',
+  FOUNDER: 'founder',
+  FOUNDERS_EDITION: 'founder'
+}
+
+interface WorkspaceSubscriptionInfo {
+  isSubscribed: boolean
+  subscriptionPlan: string | null
+  subscriptionTier: SubscriptionTier | null
+}
+
+export function useWorkspaceTierLabel() {
+  const { t } = useI18n()
+
+  function formatTierName(
+    tier: string | null | undefined,
+    isYearly: boolean
+  ): string {
+    if (!tier) return ''
+    const key = TIER_KEY_MAP[tier] ?? 'standard'
+    const baseName = t(`subscription.tiers.${key}.name`)
+    return isYearly
+      ? t('subscription.tierNameYearly', { name: baseName })
+      : baseName
+  }
+
+  function getTierLabel(workspace: WorkspaceSubscriptionInfo): string | null {
+    if (!workspace.isSubscribed) return null
+
+    if (workspace.subscriptionTier) {
+      return formatTierName(workspace.subscriptionTier, false)
+    }
+
+    if (!workspace.subscriptionPlan) return null
+
+    const planSlug = workspace.subscriptionPlan
+    const tierMatch = Object.keys(TIER_KEY_MAP).find((tier) =>
+      planSlug.startsWith(tier)
+    )
+    if (!tierMatch) return null
+
+    const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
+    return formatTierName(tierMatch, isYearly)
+  }
+
+  return { formatTierName, getTierLabel }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -106,6 +106,10 @@ installPreservedQueryTracker(router, [
   {
     namespace: PRESERVED_QUERY_NAMESPACES.INVITE,
     keys: ['invite']
+  },
+  {
+    namespace: PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE,
+    keys: ['create_workspace']
   }
 ])
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -454,6 +454,21 @@ export const useDialogService = () => {
     })
   }
 
+  async function showTeamWorkspacesDialog(
+    onConfirm?: (name: string) => void | Promise<void>
+  ) {
+    const { default: component } =
+      await import('@/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue')
+    return dialogStore.showDialog({
+      key: 'team-workspaces',
+      component,
+      props: { onConfirm },
+      dialogComponentProps: {
+        ...workspaceDialogPt
+      }
+    })
+  }
+
   async function showLeaveWorkspaceDialog() {
     const { default: component } =
       await import('@/platform/workspace/components/dialogs/LeaveWorkspaceDialogContent.vue')
@@ -588,6 +603,7 @@ export const useDialogService = () => {
     showSmallLayoutDialog,
     showDeleteWorkspaceDialog,
     showCreateWorkspaceDialog,
+    showTeamWorkspacesDialog,
     showLeaveWorkspaceDialog,
     showEditWorkspaceDialog,
     showRemoveMemberDialog,

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -454,6 +454,10 @@ export const useDialogService = () => {
     })
   }
 
+  /**
+   * Show the team workspaces dialog for creating or switching workspaces.
+   * Optionally calls `onConfirm` after a workspace is successfully created.
+   */
   async function showTeamWorkspacesDialog(
     onConfirm?: (name: string) => void | Promise<void>
   ) {


### PR DESCRIPTION
## Summary

Differentiates the subscription pricing dialog between personal and team workspaces with distinct visual treatments and a two-stage team workspace upgrade flow.

### Changes

- **Personal pricing dialog**: Shows "P" avatar badge, "Plans for Personal Workspace" header, and "Solo use only – Need team workspace?" banner on each tier card
- **Team pricing dialog**: Shows workspace avatar, "Plans for Team Workspace" header (emerald), green "Invite up to X members" badge, and emerald border on Creator card
- **Two-stage upgrade flow**: "Need team workspace?" → closes pricing → opens CreateWorkspaceDialog → sessionStorage flag → page reload → WorkspaceAuthGate auto-opens team pricing dialog
- **Spacing**: Reduced vertical gaps/padding/font sizes so the table fits without scrolling

### Key decisions

- sessionStorage key `comfy:resume-team-pricing` bridges the page reload during workspace creation
- `onChooseTeam` prop is conditionally passed only to the personal variant
- `resumePendingPricingFlow()` is called from WorkspaceAuthGate after workspace initialization

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9901-feat-differentiate-personal-team-pricing-table-with-two-stage-team-workspace-flow-3226d73d365081e7af60dcca86e83673) by [Unito](https://www.unito.io)
