### PR TITLE
fix: reduce minimap per-frame allocations and O(N) link serialization

### DIFF
--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -37,8 +37,11 @@ describe('useMinimapGraph', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    const linksMap = new Map([[1, createMockLLink({ id: 1 })]])
     mockGraph = createMockLGraph({
       id: 'test-graph-123',
+      _version: 0,
+      _links: linksMap,
       _nodes: [
         createMockLGraphNode({ id: '1', pos: [100, 100], size: [150, 80] }),
         createMockLGraphNode({ id: '2', pos: [300, 200], size: [120, 60] })
@@ -199,22 +202,51 @@ describe('useMinimapGraph', () => {
     expect(graphManager.updateFlags.value.nodes).toBe(true)
   })
 
-  it('should detect connection changes', () => {
+  it('should detect connection changes via graph version', () => {
     const graphRef = ref(mockGraph) as Ref<LGraph | null>
     const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
 
     // Cache initial state
     graphManager.checkForChanges()
 
-    // Change connections
-    mockGraph.links = createMockLinks([
-      createMockLLink({ id: 1 }),
-      createMockLLink({ id: 2 })
-    ])
+    // Increment graph version (simulates add/remove node/link)
+    mockGraph._version++
 
     const hasChanges = graphManager.checkForChanges()
     expect(hasChanges).toBe(true)
     expect(graphManager.updateFlags.value.connections).toBe(true)
+  })
+
+  it('should detect connection changes via link count', () => {
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+
+    // Cache initial state
+    graphManager.checkForChanges()
+
+    // Add a link to the backing Map
+    const newLink = createMockLLink({ id: 2 })
+    mockGraph._links.set(2, newLink)
+
+    const hasChanges = graphManager.checkForChanges()
+    expect(hasChanges).toBe(true)
+    expect(graphManager.updateFlags.value.connections).toBe(true)
+  })
+
+  it('should not detect connection changes when version and count unchanged', () => {
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+
+    // Cache initial state
+    graphManager.checkForChanges()
+
+    // Reset flags
+    graphManager.updateFlags.value.connections = false
+
+    // No changes to version or link count
+    const hasChanges = graphManager.checkForChanges()
+    expect(hasChanges).toBe(false)
+    expect(graphManager.updateFlags.value.connections).toBe(false)
   })
 
   it('should handle node removal in callbacks', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -12,7 +12,7 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { api } from '@/scripts/api'
 
 import { MinimapDataSourceFactory } from '../data/MinimapDataSourceFactory'
-import type { UpdateFlags } from '../types'
+import type { IMinimapDataSource, UpdateFlags } from '../types'
 
 interface GraphCallbacks {
   onNodeAdded?: (node: LGraphNode) => void
@@ -26,7 +26,8 @@ export function useMinimapGraph(
   onGraphChanged: () => void
 ) {
   const nodeStatesCache = new Map<NodeId, string>()
-  const linksCache = ref<string>('')
+  let lastLinkCount = 0
+  let lastGraphVersion = -1
   const lastNodeCount = ref(0)
   const updateFlags = ref<UpdateFlags>({
     bounds: false,
@@ -34,6 +35,13 @@ export function useMinimapGraph(
     connections: false,
     viewport: false
   })
+
+  // Reusable Set for node ID cleanup (avoids allocation per frame)
+  const currentNodeIds = new Set<NodeId>()
+
+  // Cached data source instance — invalidated when graph changes
+  let cachedDataSource: IMinimapDataSource | null = null
+  let cachedDataSourceGraph: LGraph | null = null
 
   // Track LayoutStore version for change detection
   const layoutStoreVersion = layoutStore.getVersion()
@@ -114,6 +122,15 @@ export function useMinimapGraph(
     originalCallbacksMap.delete(g.id)
   }
 
+  function getDataSource(g: LGraph): IMinimapDataSource {
+    if (cachedDataSource && cachedDataSourceGraph === g) {
+      return cachedDataSource
+    }
+    cachedDataSource = MinimapDataSourceFactory.create(g)
+    cachedDataSourceGraph = g
+    return cachedDataSource
+  }
+
   const checkForChangesInternal = () => {
     const g = graph.value
     if (!g) return false
@@ -122,8 +139,7 @@ export function useMinimapGraph(
     let positionChanged = false
     let connectionChanged = false
 
-    // Use unified data source for change detection
-    const dataSource = MinimapDataSourceFactory.create(g)
+    const dataSource = getDataSource(g)
 
     // Check for node count changes
     const currentNodeCount = dataSource.getNodeCount()
@@ -144,8 +160,11 @@ export function useMinimapGraph(
       }
     }
 
-    // Clean up removed nodes from cache
-    const currentNodeIds = new Set(nodes.map((n) => n.id))
+    // Clean up removed nodes from cache (reuse Set to avoid allocation)
+    currentNodeIds.clear()
+    for (const node of nodes) {
+      currentNodeIds.add(node.id)
+    }
     for (const [nodeId] of nodeStatesCache) {
       if (!currentNodeIds.has(nodeId)) {
         nodeStatesCache.delete(nodeId)
@@ -153,11 +172,17 @@ export function useMinimapGraph(
       }
     }
 
-    // TODO: update when Layoutstore tracks links
-    const currentLinks = JSON.stringify(g.links || {})
-    if (currentLinks !== linksCache.value) {
+    // Detect connection changes via graph version + link count
+    // (avoids JSON.stringify of all links every frame)
+    const currentVersion = g._version
+    const currentLinkCount = g._links?.size ?? 0
+    if (
+      currentVersion !== lastGraphVersion ||
+      currentLinkCount !== lastLinkCount
+    ) {
       connectionChanged = true
-      linksCache.value = currentLinks
+      lastGraphVersion = currentVersion
+      lastLinkCount = currentLinkCount
     }
 
     if (structureChanged || positionChanged) {
@@ -184,13 +209,17 @@ export function useMinimapGraph(
   const destroy = () => {
     cleanupEventListeners()
     api.removeEventListener('graphChanged', handleGraphChangedThrottled)
-    nodeStatesCache.clear()
+    clearCache()
   }
 
   const clearCache = () => {
     nodeStatesCache.clear()
-    linksCache.value = ''
+    currentNodeIds.clear()
+    lastLinkCount = 0
+    lastGraphVersion = -1
     lastNodeCount.value = 0
+    cachedDataSource = null
+    cachedDataSourceGraph = null
   }
 
   return {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -126,6 +126,11 @@ export function useMinimapGraph(
     if (cachedDataSource && cachedDataSourceGraph === g) {
       return cachedDataSource
     }
+    nodeStatesCache.clear()
+    currentNodeIds.clear()
+    lastNodeCount.value = 0
+    lastLinkCount = 0
+    lastGraphVersion = -1
     cachedDataSource = MinimapDataSourceFactory.create(g)
     cachedDataSourceGraph = g
     return cachedDataSource


### PR DESCRIPTION
## Summary

Eliminates per-frame allocations and O(N) serialization in minimap change detection (backlog #20).

## Changes

- **What**: `checkForChanges()` ran every animation frame. It was calling `JSON.stringify(g.links)` (O(N) on all links), allocating a new `Set` + `.map()` array for node ID cleanup, and creating a new `MinimapDataSourceFactory` instance — all per frame. Replaced with O(1) version+size check, reusable hoisted Set, and cached data source.
- **Breaking**: None

## Review Focus

- The version check uses `g._version` (incremented on structural graph changes) + `g._links.size` to detect connection changes without serialization.
- The hoisted `currentNodeIds` Set is cleared and reused each frame instead of allocating new Set+map.
- The cached data source is invalidated only when the graph reference changes.

Backlog: docs/perf/BACKLOG.md #20

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9912-fix-reduce-minimap-per-frame-allocations-and-O-N-link-serialization-3236d73d365081639bf1cf048511c784) by [Unito](https://www.unito.io)
