### PR TITLE
fix: restore native copy/paste events for image paste support

### DIFF
--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -220,22 +220,6 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   {
     combo: {
       ctrl: true,
-      key: 'c'
-    },
-    commandId: 'Comfy.Canvas.CopySelected',
-    targetElementId: 'graph-canvas-container'
-  },
-  {
-    combo: {
-      ctrl: true,
-      key: 'v'
-    },
-    commandId: 'Comfy.Canvas.PasteFromClipboard',
-    targetElementId: 'graph-canvas-container'
-  },
-  {
-    combo: {
-      ctrl: true,
       shift: true,
       key: 'v'
     },

--- a/src/platform/keybindings/keybindingService.canvas.test.ts
+++ b/src/platform/keybindings/keybindingService.canvas.test.ts
@@ -141,7 +141,7 @@ describe('keybindingService - Canvas Keybindings', () => {
     )
   })
 
-  it('should execute CopySelected for Ctrl+C on canvas', async () => {
+  it('should not intercept Ctrl+C to allow native copy event', async () => {
     const event = createTestKeyboardEvent('c', {
       ctrlKey: true,
       target: canvasChild
@@ -149,12 +149,10 @@ describe('keybindingService - Canvas Keybindings', () => {
 
     await keybindingService.keybindHandler(event)
 
-    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
-      'Comfy.Canvas.CopySelected'
-    )
+    expect(vi.mocked(useCommandStore().execute)).not.toHaveBeenCalled()
   })
 
-  it('should execute PasteFromClipboard for Ctrl+V on canvas', async () => {
+  it('should not intercept Ctrl+V to allow native paste event', async () => {
     const event = createTestKeyboardEvent('v', {
       ctrlKey: true,
       target: canvasChild
@@ -162,9 +160,7 @@ describe('keybindingService - Canvas Keybindings', () => {
 
     await keybindingService.keybindHandler(event)
 
-    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
-      'Comfy.Canvas.PasteFromClipboard'
-    )
+    expect(vi.mocked(useCommandStore().execute)).not.toHaveBeenCalled()
   })
 
   it('should execute PasteFromClipboardWithConnect for Ctrl+Shift+V on canvas', async () => {


### PR DESCRIPTION
## Summary

- Remove Ctrl+C and Ctrl+V keybindings from the keybinding service defaults so native browser copy/paste events fire
- This restores image paste into LoadImage nodes, which broke after #9459

## Problem

PR #9459 moved Ctrl+C/V into the keybinding service, which calls `event.preventDefault()` on keydown. This prevents the browser `paste` event from firing, so `usePaste` (which detects images in the clipboard) never runs. The `PasteFromClipboard` command only reads from localStorage, completely bypassing image detection.

**Repro:** Copy a node → copy an image externally → try to paste the image into a LoadImage node → gets old node data from localStorage instead.

## Fix

Remove Ctrl+C and Ctrl+V from `CORE_KEYBINDINGS` in `defaults.ts`. The native browser events now fire as before, and `useCopy`/`usePaste` handle them correctly. Ctrl+Shift+V, Ctrl+A, Delete, and Backspace keybindings remain in the keybinding service.

Fixes #9459 (regression)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9914-fix-restore-native-copy-paste-events-for-image-paste-support-3236d73d365081c7ac53f983f316e10f) by [Unito](https://www.unito.io)
