### PR TITLE
Track node search usage for nightly survey

### DIFF
--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -63,6 +63,7 @@ import type { LiteGraphCanvasEvent } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTracking'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -84,6 +85,7 @@ let disconnectOnReset = false
 const settingStore = useSettingStore()
 const searchBoxStore = useSearchBoxStore()
 const litegraphService = useLitegraphService()
+const { trackFeatureUsed } = useSurveyFeatureTracking('node-search')
 
 const { visible, newSearchBoxEnabled, useSearchBoxV2 } =
   storeToRefs(searchBoxStore)
@@ -165,6 +167,7 @@ function getFirstLink() {
 
 const nodeDefStore = useNodeDefStore()
 function showNewSearchBox(e: CanvasPointerEvent | null) {
+  trackFeatureUsed()
   const firstLink = getFirstLink()
   if (firstLink) {
     const filter =

--- a/src/platform/surveys/NightlySurveyPopover.vue
+++ b/src/platform/surveys/NightlySurveyPopover.vue
@@ -131,18 +131,10 @@ function handleOptOut() {
         />
 
         <div class="mt-3 flex items-center justify-center gap-2">
-          <Button
-            variant="textonly"
-            size="sm"
-            @click="handleDismiss"
-          >
+          <Button variant="textonly" size="sm" @click="handleDismiss">
             {{ t('nightlySurvey.notNow') }}
           </Button>
-          <Button
-            variant="muted-textonly"
-            size="sm"
-            @click="handleOptOut"
-          >
+          <Button variant="muted-textonly" size="sm" @click="handleOptOut">
             {{ t('nightlySurvey.dontAskAgain') }}
           </Button>
         </div>

--- a/src/platform/surveys/NightlySurveyPopover.vue
+++ b/src/platform/surveys/NightlySurveyPopover.vue
@@ -54,6 +54,7 @@ watch(
 
     showTimeout = setTimeout(() => {
       showTimeout = null
+      if (!isValidTypeformId.value) return
       isVisible.value = true
       markSurveyShown()
       emit('shown')

--- a/src/platform/surveys/NightlySurveyPopover.vue
+++ b/src/platform/surveys/NightlySurveyPopover.vue
@@ -55,6 +55,7 @@ watch(
     showTimeout = setTimeout(() => {
       showTimeout = null
       isVisible.value = true
+      markSurveyShown()
       emit('shown')
     }, delayMs.value)
   },
@@ -78,10 +79,6 @@ whenever(typeformRef, () => {
   }
   document.head.appendChild(scriptEl)
 })
-
-function handleAccept() {
-  markSurveyShown()
-}
 
 function handleDismiss() {
   isVisible.value = false
@@ -110,24 +107,18 @@ function handleOptOut() {
         data-testid="nightly-survey-popover"
         class="fixed right-4 bottom-4 z-10000 w-80 rounded-lg border border-border-subtle bg-base-background p-4 shadow-lg"
       >
-        <div class="mb-3 flex items-start justify-between">
-          <h3 class="text-sm font-medium text-text-primary">
-            {{ t('nightlySurvey.title') }}
-          </h3>
-          <button
-            class="text-text-muted hover:text-text-primary"
+        <div class="mb-2 flex items-center justify-end">
+          <Button
+            variant="muted-textonly"
+            size="icon-sm"
             :aria-label="t('g.close')"
             @click="handleDismiss"
           >
             <i class="icon-[lucide--x] size-4" />
-          </button>
+          </Button>
         </div>
 
-        <p class="mb-4 text-sm text-text-secondary">
-          {{ t('nightlySurvey.description') }}
-        </p>
-
-        <div v-if="typeformError" class="text-danger mb-4 text-sm">
+        <div v-if="typeformError" class="text-danger text-sm">
           {{ t('nightlySurvey.loadError') }}
         </div>
 
@@ -139,26 +130,21 @@ function handleOptOut() {
           class="min-h-[300px]"
         />
 
-        <div class="mt-4 flex flex-col gap-2">
-          <Button variant="primary" class="w-full" @click="handleAccept">
-            {{ t('nightlySurvey.accept') }}
+        <div class="mt-3 flex items-center justify-center gap-2">
+          <Button
+            variant="textonly"
+            size="sm"
+            @click="handleDismiss"
+          >
+            {{ t('nightlySurvey.notNow') }}
           </Button>
-          <div class="flex gap-2">
-            <Button
-              variant="textonly"
-              class="flex-1 text-xs"
-              @click="handleDismiss"
-            >
-              {{ t('nightlySurvey.notNow') }}
-            </Button>
-            <Button
-              variant="muted-textonly"
-              class="flex-1 text-xs"
-              @click="handleOptOut"
-            >
-              {{ t('nightlySurvey.dontAskAgain') }}
-            </Button>
-          </div>
+          <Button
+            variant="muted-textonly"
+            size="sm"
+            @click="handleOptOut"
+          >
+            {{ t('nightlySurvey.dontAskAgain') }}
+          </Button>
         </div>
       </div>
     </Transition>

--- a/src/platform/surveys/surveyRegistry.ts
+++ b/src/platform/surveys/surveyRegistry.ts
@@ -4,7 +4,14 @@ import type { FeatureSurveyConfig } from './useSurveyEligibility'
  * Registry of all feature surveys.
  * Add new surveys here when targeting specific features for feedback.
  */
-export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {}
+export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {
+  'node-search': {
+    featureId: 'node-search',
+    typeformId: 'goZLqjKL',
+    triggerThreshold: 3,
+    delayMs: 5000
+  }
+}
 
 export function getSurveyConfig(
   featureId: string


### PR DESCRIPTION
## WIP — waiting on Typeform ID from Alex Tov (Monday)

Pre-wires `trackFeatureUsed('node-search')` in `NodeSearchBoxPopover.vue`. Increments a localStorage counter each time the user opens node search. Currently a no-op because the `FEATURE_SURVEYS` registry is empty.

**Monday**: Alex provides Typeform ID → add registry entry → survey goes live on nightly builds.

### What this PR does
- Imports `useSurveyFeatureTracking` composable
- Calls `trackFeatureUsed()` in `showNewSearchBox()`

### What's still needed (will update this PR)
- [x] Add `node-search` entry to `FEATURE_SURVEYS` in `surveyRegistry.ts` with Typeform ID
- [x] Set up Typeform → Slack webhook to `#frontend-nightly-user-feedback`
- [ ] Test end-to-end on nightly build

### How the survey system works
After 3 uses of node search on a nightly build, a Typeform survey popover slides in (once per user, 4-day global cooldown between surveys). Eligibility: nightly + localhost only, respects opt-out.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9934-WIP-Track-node-search-usage-for-nightly-survey-3246d73d365081308847dd4c0085f21c) by [Unito](https://www.unito.io)
