### PR TITLE
fix: trigger Vue reactivity on output slot type changes in matchType

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -323,6 +323,10 @@ function withComfyMatchType(node: LGraphNode): asserts node is MatchTypeNode {
         if (!(outputGroups?.[idx] == matchKey)) return
         changeOutputType(this, output, outputType)
       })
+      // Force Vue reactivity update for output slot types.
+      // Outputs are wrapped in shallowReactive by useGraphNodeManager,
+      // so mutating output.type alone doesn't trigger re-render.
+      this.outputs = [...this.outputs]
       app.canvas?.setDirty(true, true)
     }
   )


### PR DESCRIPTION
## Summary

Fix VHS unbatch output slot color not updating when slot types change via matchType resolution in Vue renderer.

## Changes

- **What**: After `changeOutputType` mutates `output.type` on objects inside a `shallowReactive` array, spread-copy `this.outputs` to trigger the shallowReactive setter so `SlotConnectionDot` re-evaluates the slot color.

## Review Focus

The fix adds `this.outputs = [...this.outputs]` after the matchType resolution loop in `withComfyMatchType`. This forces Vue's shallowReactive proxy to fire, since mutating a property on an object inside the array doesn't trigger the setter. The spread is placed after all outputs are updated to batch the reactivity trigger.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9935-fix-trigger-Vue-reactivity-on-output-slot-type-changes-in-matchType-3246d73d365081c4a293f57931892c61) by [Unito](https://www.unito.io)
