### PR TITLE
fix: show webcam capture button in Vue renderer

### DIFF
--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -108,7 +108,7 @@ app.registerExtension({
       'waiting for camera...',
       'capture',
       capture,
-      { canvasOnly: true }
+      {}
     )
     btn.disabled = true
     btn.serializeValue = () => undefined


### PR DESCRIPTION
## Summary

Fix missing capture button on WebcamCapture node in Vue renderer mode.

## Changes

- **What**: Remove `canvasOnly: true` from the capture button widget options. This flag prevented `WidgetButton.vue` from rendering the button. The WEBCAM DOM widget (video feed) already renders correctly via `WidgetDOM.vue`.

## Review Focus

Single-line change: `{ canvasOnly: true }` → `{}`. The button's label, callback, disabled state, and serializeValue behavior are all handled by WidgetButton.vue already.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9936-fix-show-webcam-capture-button-in-Vue-renderer-3246d73d36508173a6e5ca59d9fb7af1) by [Unito](https://www.unito.io)
