### PR TITLE
fix: prevent live preview dimension flicker between frames

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LivePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LivePreview.vue
@@ -40,8 +40,8 @@ const imageError = ref(false)
 watch(
   () => props.imageUrl,
   () => {
-    // Reset states when URL changes
-    actualDimensions.value = null
+    // Reset error state when URL changes, but keep previous dimensions
+    // to avoid flickering "Calculating dimensions" text during live preview
     imageError.value = false
   }
 )


### PR DESCRIPTION
## Summary

Fix "Calculating dimensions" text flickering during live sampling preview in Vue renderer.

## Changes

- **What**: Stop resetting `actualDimensions` to `null` on every `imageUrl` change. Previous dimensions are retained while the new frame loads, eliminating the flicker. Error state is still reset correctly.

## Review Focus

The watcher on `props.imageUrl` previously reset both `actualDimensions` and `imageError`. Now it only resets `imageError`, since `handleImageLoad` updates dimensions when the new frame actually loads. This means stale dimensions show briefly between frames, which is intentionally better than showing "Calculating dimensions" text.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9937-fix-prevent-live-preview-dimension-flicker-between-frames-3246d73d36508154a676e5996112354f) by [Unito](https://www.unito.io)
