### PR TITLE
docs: add E2E testing gotchas for canvas overlay, context menus, and subgraph navigation

### DIFF
--- a/.claude/skills/writing-playwright-tests/SKILL.md
+++ b/.claude/skills/writing-playwright-tests/SKILL.md
@@ -44,18 +44,18 @@ await expect(node).toHaveClass(BYPASS_CLASS)
 
 These are frequent causes of flaky tests - check them first, but investigate if they don't apply:
 
-| Symptom                            | Common Cause              | Typical Fix                                                                            |
-| ---------------------------------- | ------------------------- | -------------------------------------------------------------------------------------- |
-| Test passes locally, fails in CI   | Missing nextFrame()       | Add `await comfyPage.nextFrame()` after canvas ops (not needed after `loadWorkflow()`) |
-| Keyboard shortcuts don't work      | Missing focus             | Add `await comfyPage.canvas.click()` first                                             |
-| Double-click doesn't trigger       | Timing too fast           | Add `{ delay: 5 }` option                                                              |
-| Elements end up in wrong position  | Drag animation incomplete | Use `{ steps: 10 }` not `{ steps: 1 }`                                                 |
-| Widget value wrong after drag-drop | Upload incomplete         | Add `{ waitForUpload: true }`                                                          |
-| Test fails when run with others    | Test pollution            | Add `afterEach` with `resetView()`                                                     |
-| Local screenshots don't match CI   | Platform differences      | Screenshots are Linux-only, use PR label                                               |
-| `subtree intercepts pointer events`| Canvas overlay (z-999)    | Use `dispatchEvent` on the DOM element to bypass overlay                               |
-| Context menu empty / wrong items   | Node not selected         | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`                 |
-| `navigateIntoSubgraph` timeout     | Node too small in asset   | Use node size `[400, 200]` minimum in test asset JSON                                  |
+| Symptom                             | Common Cause              | Typical Fix                                                                            |
+| ----------------------------------- | ------------------------- | -------------------------------------------------------------------------------------- |
+| Test passes locally, fails in CI    | Missing nextFrame()       | Add `await comfyPage.nextFrame()` after canvas ops (not needed after `loadWorkflow()`) |
+| Keyboard shortcuts don't work       | Missing focus             | Add `await comfyPage.canvas.click()` first                                             |
+| Double-click doesn't trigger        | Timing too fast           | Add `{ delay: 5 }` option                                                              |
+| Elements end up in wrong position   | Drag animation incomplete | Use `{ steps: 10 }` not `{ steps: 1 }`                                                 |
+| Widget value wrong after drag-drop  | Upload incomplete         | Add `{ waitForUpload: true }`                                                          |
+| Test fails when run with others     | Test pollution            | Add `afterEach` with `resetView()`                                                     |
+| Local screenshots don't match CI    | Platform differences      | Screenshots are Linux-only, use PR label                                               |
+| `subtree intercepts pointer events` | Canvas overlay (z-999)    | Use `dispatchEvent` on the DOM element to bypass overlay                               |
+| Context menu empty / wrong items    | Node not selected         | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`                 |
+| `navigateIntoSubgraph` timeout      | Node too small in asset   | Use node size `[400, 200]` minimum in test asset JSON                                  |
 
 ## Test Tags
 

--- a/.claude/skills/writing-playwright-tests/SKILL.md
+++ b/.claude/skills/writing-playwright-tests/SKILL.md
@@ -53,6 +53,9 @@ These are frequent causes of flaky tests - check them first, but investigate if 
 | Widget value wrong after drag-drop | Upload incomplete         | Add `{ waitForUpload: true }`                                                          |
 | Test fails when run with others    | Test pollution            | Add `afterEach` with `resetView()`                                                     |
 | Local screenshots don't match CI   | Platform differences      | Screenshots are Linux-only, use PR label                                               |
+| `subtree intercepts pointer events`| Canvas overlay (z-999)    | Use `dispatchEvent` on the DOM element to bypass overlay                               |
+| Context menu empty / wrong items   | Node not selected         | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`                 |
+| `navigateIntoSubgraph` timeout     | Node too small in asset   | Use node size `[400, 200]` minimum in test asset JSON                                  |
 
 ## Test Tags
 

--- a/browser_tests/AGENTS.md
+++ b/browser_tests/AGENTS.md
@@ -32,11 +32,11 @@ browser_tests/
 
 ## Gotchas
 
-| Symptom | Cause | Fix |
-| --- | --- | --- |
+| Symptom                                            | Cause                                       | Fix                                                                                |
+| -------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------- |
 | `subtree intercepts pointer events` on DOM widgets | Canvas `z-999` overlay intercepts `click()` | Use `dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 })` |
-| Context menu empty or wrong items | Node not selected | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')` |
-| `navigateIntoSubgraph` timeout | Node too small in test asset JSON | Use node size `[400, 200]` minimum |
+| Context menu empty or wrong items                  | Node not selected                           | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`             |
+| `navigateIntoSubgraph` timeout                     | Node too small in test asset JSON           | Use node size `[400, 200]` minimum                                                 |
 
 ## After Making Changes
 

--- a/browser_tests/AGENTS.md
+++ b/browser_tests/AGENTS.md
@@ -32,11 +32,11 @@ browser_tests/
 
 ## Gotchas
 
-| Symptom                                            | Cause                                       | Fix                                                                                |
-| -------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `subtree intercepts pointer events` on DOM widgets | Canvas `z-999` overlay intercepts `click()` | Use `dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 })` |
-| Context menu empty or wrong items                  | Node not selected                           | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`             |
-| `navigateIntoSubgraph` timeout                     | Node too small in test asset JSON           | Use node size `[400, 200]` minimum                                                 |
+| Symptom                                            | Cause                                       | Fix                                                                                                      |
+| -------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `subtree intercepts pointer events` on DOM widgets | Canvas `z-999` overlay intercepts `click()` | Use Playwright's `locator.dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 })` |
+| Context menu empty or wrong items                  | Node not selected                           | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`                                   |
+| `navigateIntoSubgraph` timeout                     | Node too small in test asset JSON           | Use node size `[400, 200]` minimum                                                                       |
 
 ## After Making Changes
 

--- a/browser_tests/AGENTS.md
+++ b/browser_tests/AGENTS.md
@@ -30,6 +30,14 @@ browser_tests/
 └── tests/            - Test files (*.spec.ts)
 ```
 
+## Gotchas
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `subtree intercepts pointer events` on DOM widgets | Canvas `z-999` overlay intercepts `click()` | Use `dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 })` |
+| Context menu empty or wrong items | Node not selected | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')` |
+| `navigateIntoSubgraph` timeout | Node too small in test asset JSON | Use node size `[400, 200]` minimum |
+
 ## After Making Changes
 
 - Run `pnpm typecheck:browser` after modifying TypeScript files in this directory

--- a/browser_tests/AGENTS.md
+++ b/browser_tests/AGENTS.md
@@ -32,11 +32,11 @@ browser_tests/
 
 ## Gotchas
 
-| Symptom                                            | Cause                                       | Fix                                                                                                      |
-| -------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Symptom                                            | Cause                                       | Fix                                                                                                     |
+| -------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `subtree intercepts pointer events` on DOM widgets | Canvas `z-999` overlay intercepts `click()` | Use Playwright's `locator.dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 })` |
-| Context menu empty or wrong items                  | Node not selected                           | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`                                   |
-| `navigateIntoSubgraph` timeout                     | Node too small in test asset JSON           | Use node size `[400, 200]` minimum                                                                       |
+| Context menu empty or wrong items                  | Node not selected                           | Select node first: `vueNodes.selectNode()` or `nodeRef.click('title')`                                  |
+| `navigateIntoSubgraph` timeout                     | Node too small in test asset JSON           | Use node size `[400, 200]` minimum                                                                      |
 
 ## After Making Changes
 


### PR DESCRIPTION
Documents 3 hard-learned gotchas from debugging subgraph context menu E2E tests across ~8 threads:

- Canvas `z-999` overlay intercepting `click()` on DOM widgets → use `dispatchEvent`
- Context menus requiring node selection before right-click
- Subgraph node sizing minimum for reliable `navigateIntoSubgraph()`

Added to both `browser_tests/AGENTS.md` (auto-loaded for agents working in that dir) and the Playwright test-writing skill's Common Issues table.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9951-docs-add-E2E-testing-gotchas-for-canvas-overlay-context-menus-and-subgraph-navigation-3246d73d3650819a928bf91d66e22c2c) by [Unito](https://www.unito.io)
