### PR TITLE
fix: cloud subscribe redirect hangs waiting for billing init

### DIFF
--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { until } from '@vueuse/core'
 import Button from 'primevue/button'
 import ProgressSpinner from 'primevue/progressspinner'
 import { computed, onMounted, ref } from 'vue'
@@ -20,7 +19,7 @@ const router = useRouter()
 const { reportError, accessBillingPortal } = useFirebaseAuthActions()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
 
-const { isActiveSubscription, isInitialized } = useBillingContext()
+const { isActiveSubscription, isInitialized, initialize } = useBillingContext()
 
 const selectedTierKey = ref<TierKey | null>(null)
 
@@ -76,7 +75,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
   }
 
   if (!isInitialized.value) {
-    await until(isInitialized).toBe(true)
+    await initialize()
   }
 
   if (isActiveSubscription.value) {


### PR DESCRIPTION
## Summary

Fix /cloud/subscribe route hanging indefinitely because billing context never initializes during the onboarding flow.

## Changes

- **What**: Replace passive `await until(isInitialized).toBe(true)` with explicit `await initialize()` in CloudSubscriptionRedirectView. Remove unused `until` import.


![Kapture 2026-03-15 at 23 16 22](https://github.com/user-attachments/assets/0a12487b-b39a-4f96-9a4c-96a01facfdd8)

## Review Focus

In the onboarding flow, `useTeamWorkspaceStore().activeWorkspace` is not set, so `useBillingContext`'s internal watch (which triggers `initialize()` on workspace change) enters the `!newWorkspaceId` branch — it resets `isInitialized` to `false` and returns without ever calling `initialize()`. The old code then awaited `isInitialized` becoming `true` forever.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9965-fix-cloud-subscribe-redirect-hangs-waiting-for-billing-init-3246d73d3650812d93ebd477c544fa0a) by [Unito](https://www.unito.io)
