### PR TITLE
feat: add Copy URL button to missing model rows for OSS

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3437,6 +3437,7 @@
       "customNodeDownloadDisabled": "Cloud environment does not support model imports for custom nodes in this section. Please use standard loader nodes or substitute with a model from the library below.",
       "importNotSupported": "Import Not Supported",
       "copyModelName": "Copy model name",
+      "copyUrl": "Copy URL",
       "confirmSelection": "Confirm selection",
       "locateNode": "Locate node on canvas",
       "cancelSelection": "Cancel selection",

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -31,6 +31,16 @@
       </div>
 
       <Button
+        v-if="!isCloud && model.representative.url && !isAssetSupported"
+        variant="secondary"
+        size="sm"
+        class="h-8 shrink-0 rounded-lg text-sm"
+        @click="copyToClipboard(model.representative.url!)"
+      >
+        {{ t('rightSidePanel.missingModels.copyUrl') }}
+      </Button>
+
+      <Button
         variant="textonly"
         size="icon-sm"
         :aria-label="t('rightSidePanel.missingModels.confirmSelection')"
@@ -133,7 +143,10 @@
             :type-mismatch="typeMismatch"
           />
         </div>
-        <div v-else-if="downloadable" class="flex w-full items-start py-1">
+        <div
+          v-else-if="!isCloud && downloadable"
+          class="flex w-full items-start py-1"
+        >
           <Button
             variant="secondary"
             size="md"
@@ -185,6 +198,7 @@ import {
 } from '@/platform/missingModel/composables/useMissingModelInteractions'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
+import { isCloud } from '@/platform/distribution/types'
 import {
   downloadModel,
   isModelDownloadable


### PR DESCRIPTION
## Summary
- Add a "Copy URL" text button in missing model row headers for non-asset-supported models in OSS
- Guard both Copy URL and Download buttons with `!isCloud` to prevent display in Cloud environments
- Button design matches the existing "Download All" button style (`variant="secondary" size="sm"`)

## Test plan
- [ ] Verify Copy URL button appears in OSS missing model rows when model has a URL
- [ ] Verify clicking Copy URL copies the download URL to clipboard
- [ ] Verify Copy URL and Download buttons do NOT appear in Cloud environments
- [ ] Verify no visual regression in Cloud missing model UI

<img width="336" height="119" alt="image" src="https://github.com/user-attachments/assets/1a6f0b5a-d401-4636-a33d-3afef5a437b8" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-9966-feat-add-Copy-URL-button-to-missing-model-rows-for-OSS-3246d73d365081fcb753cd07bf7c235d) by [Unito](https://www.unito.io)
