### PR TITLE
fix: mask editor save shows blank image in Load Image node

### DIFF
--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -1,0 +1,183 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { app } from '@/scripts/app'
+import { api } from '@/scripts/api'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useMaskEditorSaver } from './useMaskEditorSaver'
+
+// ---- Module Mocks ----
+
+const mockDataStore: Record<string, unknown> = {
+  sourceNode: null,
+  inputData: null,
+  outputData: null
+}
+
+vi.mock('@/stores/maskEditorDataStore', () => ({
+  useMaskEditorDataStore: vi.fn(() => mockDataStore)
+}))
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    drawImage: vi.fn(),
+    getImageData: vi.fn(() => ({
+      data: new Uint8ClampedArray(4 * 4 * 4),
+      width: 4,
+      height: 4
+    })),
+    putImageData: vi.fn(),
+    globalCompositeOperation: 'source-over'
+  } as unknown as CanvasRenderingContext2D
+}
+
+function createMockCanvas(): HTMLCanvasElement {
+  return {
+    width: 4,
+    height: 4,
+    getContext: vi.fn(() => createMockCtx()),
+    toBlob: vi.fn((cb: BlobCallback) => {
+      cb(new Blob(['x'], { type: 'image/png' }))
+    }),
+    toDataURL: vi.fn(() => 'data:image/png;base64,mock')
+  } as unknown as HTMLCanvasElement
+}
+
+const mockEditorStore: Record<string, HTMLCanvasElement | null> = {
+  maskCanvas: null,
+  rgbCanvas: null,
+  imgCanvas: null
+}
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: vi.fn(() => mockEditorStore)
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn(),
+    apiURL: vi.fn((route: string) => `http://localhost:8188${route}`)
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: { setDirty: vi.fn() },
+    nodeOutputs: {} as Record<string, unknown>,
+    nodePreviewImages: {} as Record<string, string[]>,
+    getPreviewFormatParam: vi.fn(() => ''),
+    getRandParam: vi.fn(() => '')
+  }
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: vi.fn(() => ({
+    nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
+    nodeToNodeLocatorId: vi.fn((node: { id: number }) => String(node.id))
+  }))
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  executionIdToNodeLocatorId: vi.fn((_rootGraph: unknown, id: string) => id)
+}))
+
+describe('useMaskEditorSaver', () => {
+  let mockNode: LGraphNode
+  const originalCreateElement = document.createElement.bind(document)
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+
+    app.nodeOutputs = {}
+    app.nodePreviewImages = {}
+
+    mockNode = {
+      id: 42,
+      type: 'LoadImage',
+      images: [],
+      imgs: undefined,
+      widgets: [
+        { name: 'image', value: 'original.png [input]', callback: vi.fn() }
+      ],
+      widgets_values: ['original.png [input]'],
+      properties: { image: 'original.png [input]' },
+      graph: { setDirtyCanvas: vi.fn() }
+    } as unknown as LGraphNode
+
+    mockDataStore.sourceNode = mockNode
+    mockDataStore.inputData = {
+      baseLayer: { image: {} as HTMLImageElement, url: 'base.png' },
+      maskLayer: { image: {} as HTMLImageElement, url: 'mask.png' },
+      sourceRef: { filename: 'original.png', subfolder: '', type: 'input' },
+      nodeId: 42
+    }
+    mockDataStore.outputData = null
+
+    mockEditorStore.maskCanvas = createMockCanvas()
+    mockEditorStore.rgbCanvas = createMockCanvas()
+    mockEditorStore.imgCanvas = createMockCanvas()
+
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          name: 'clipspace-painted-masked-123.png',
+          subfolder: 'clipspace',
+          type: 'input'
+        })
+    } as Response)
+
+    vi.spyOn(document, 'createElement').mockImplementation(
+      (tagName: string, options?: ElementCreationOptions) => {
+        if (tagName === 'canvas')
+          return createMockCanvas() as unknown as HTMLCanvasElement
+        return originalCreateElement(tagName, options)
+      }
+    )
+
+    // Mock Image constructor so loadImageFromUrl resolves
+    vi.stubGlobal(
+      'Image',
+      class MockImage {
+        crossOrigin = ''
+        onload: ((ev: Event) => void) | null = null
+        onerror: ((ev: unknown) => void) | null = null
+        private _src = ''
+        get src() {
+          return this._src
+        }
+        set src(value: string) {
+          this._src = value
+          queueMicrotask(() => this.onload?.(new Event('load')))
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('registers node outputs in store after save for node without prior execution outputs', async () => {
+    const store = useNodeOutputStore()
+    const locatorId = String(mockNode.id)
+
+    // Precondition: node has never been executed, no outputs exist
+    expect(app.nodeOutputs[locatorId]).toBeUndefined()
+
+    const { save } = useMaskEditorSaver()
+    await save()
+
+    // After mask editor save, the node must have outputs in the store
+    // so the image preview displays correctly (not blank).
+    // Bug: the old code used updateNodeImages which silently no-ops
+    // when there are no pre-existing outputs for the node.
+    expect(store.nodeOutputs[locatorId]).toBeDefined()
+    expect(store.nodeOutputs[locatorId]?.images?.length).toBeGreaterThan(0)
+  })
+})

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -9,6 +9,7 @@ import type {
 import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import { createAnnotatedPath } from '@/utils/createAnnotatedPath'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 // Private layer filename functions
@@ -347,11 +348,15 @@ export function useMaskEditorSaver() {
           node.widgets_values[widgetIndex] = widgetValue
         }
       }
-
-      imageWidget.callback?.(widgetValue)
     }
 
-    nodeOutputStore.updateNodeImages(node)
+    node.imgs = undefined
+    const annotatedPath = createAnnotatedPath(mainRef.filename, {
+      subfolder: mainRef.subfolder,
+      rootFolder: mainRef.type
+    })
+    nodeOutputStore.setNodeOutputs(node, annotatedPath, { folder: 'input' })
+    node.graph?.setDirtyCanvas(true)
   }
 
   function loadImageFromUrl(url: string): Promise<HTMLImageElement> {


### PR DESCRIPTION
## Summary

Mask editor save was showing a blank image in the Load Image node (legacy nodes mode, not Nodes 2.0) because `updateNodeWithServerReferences` called `updateNodeImages`, which silently no-ops when the node has no pre-existing execution outputs. Replaced with `setNodeOutputs` which properly creates output entries regardless of prior state.

**Affects:** Legacy nodes mode only. Nodes 2.0 (Vue Nodes) renders images via Vue components and is not affected.

- Fixes #9983
- Fixes #9782
- Fixes #9952

## Red-Green Verification

| Commit | SHA | CI Status | Run | Purpose |
|--------|-----|-----------|-----|---------|
| `test: add failing test for mask editor save showing blank image` | `0ab66e8` | :red_circle: [Red](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/23125427860) | CI: Tests Unit **failure** | Proves the test catches the bug |
| `fix: mask editor save shows blank image in Load Image node` | `564cc9c` | :green_circle: [Green](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/23127289891) | CI: Tests Unit **success** | Proves the fix resolves the bug |

## manual testing

### as is 


https://github.com/user-attachments/assets/8d5c36ce-2c5e-4609-b246-dcf896c4a8e7


### to be

https://github.com/user-attachments/assets/c8ae4f0e-3da0-40f2-a543-d1d5a6bce795



## Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [ ] E2E regression test not added: mask editor save requires canvas pixel manipulation + server upload round-trip which is covered by the existing unit test mocking the full `save()` flow. The Playwright test infrastructure does not currently support mask editor interactions (draw + save).
- [x] Manual verification (legacy nodes mode): Load Image → upload → mask editor → draw → save → verify image refreshes