### PR TITLE
fix: block missing e2e regression coverage in CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
   pre_merge_checks:
     custom_checks:
       - name: End-to-end regression coverage for fixes
-        mode: warning
+        mode: error
         instructions: |
           Pass if at least one of the following is true:
           1. Neither the PR title nor any commit subject in the PR uses bug-fix language such as `fix`, `fixed`, `fixes`, `fixing`, `bugfix`, or `hotfix`.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,6 +3,7 @@ issue_enrichment:
     enabled: true
 reviews:
   high_level_summary: false
+  request_changes_workflow: true
   auto_review:
     drafts: true
     ignore_title_keywords:
@@ -13,6 +14,7 @@ reviews:
       - github-actions
       - github-actions[bot]
   pre_merge_checks:
+    override_requested_reviewers_only: true
     custom_checks:
       - name: End-to-end regression coverage for fixes
         mode: error

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,6 +19,9 @@ reviews:
       - name: End-to-end regression coverage for fixes
         mode: error
         instructions: |
+          Use only PR metadata already available in the review context: the PR title, commit subjects in this PR, the files changed in this PR relative to the PR base (equivalent to `base...head`), and the PR description.
+          Do not rely on shell commands. Do not inspect reverse diffs, files changed only on the base branch, or files outside this PR. If the changed-file list or commit subjects are unavailable, mark the check inconclusive instead of guessing.
+
           Pass if at least one of the following is true:
           1. Neither the PR title nor any commit subject in the PR uses bug-fix language such as `fix`, `fixed`, `fixes`, `fixing`, `bugfix`, or `hotfix`.
           2. The PR changes at least one file under `browser_tests/`.


### PR DESCRIPTION
## Summary

Make the CodeRabbit end-to-end regression coverage check actually block fix-like PRs until it is resolved or explicitly overridden by a requested reviewer, and harden the prompt so it evaluates only PR-local metadata.

## Changes

- **What**: Set the `End-to-end regression coverage for fixes` custom check mode from `warning` to `error`
- **What**: Enable `reviews.request_changes_workflow` so CodeRabbit can block on failed `error` pre-merge checks
- **What**: Set `reviews.pre_merge_checks.override_requested_reviewers_only` to `true` so only requested reviewers can bypass a failed check
- **What**: Tighten the custom check instructions to use only PR metadata in review context, avoid shell commands, and avoid reverse-diff or base-branch file evaluation

## Review Focus

Confirm this is the intended CodeRabbit enforcement model for missing Playwright regression coverage on fix-like PRs and that the prompt wording is strict enough to avoid false positives from reversed diffs.
