### PR TITLE
test: add vue renderer perf tests (idle, pan, zoom culling)

### DIFF
--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -222,78 +222,76 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     )
   })
 
-  test('vue renderer large graph idle', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
-    await comfyPage.vueNodes.waitForNodes()
-    await comfyPage.perf.startMeasuring()
+  test.describe('vue renderer large graph', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+      await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+      await comfyPage.vueNodes.waitForNodes()
+    })
 
-    for (let i = 0; i < 120; i++) {
-      await comfyPage.nextFrame()
-    }
+    test('idle', async ({ comfyPage }) => {
+      await comfyPage.perf.startMeasuring()
 
-    const m = await comfyPage.perf.stopMeasuring('vue-large-graph-idle')
-    recordMeasurement(m)
-    console.log(
-      `Vue large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.domNodes} DOM nodes`
-    )
-  })
+      for (let i = 0; i < 120; i++) {
+        await comfyPage.nextFrame()
+      }
 
-  test('vue renderer large graph pan', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
-    await comfyPage.vueNodes.waitForNodes()
+      const m = await comfyPage.perf.stopMeasuring('vue-large-graph-idle')
+      recordMeasurement(m)
+      console.log(
+        `Vue large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.domNodes} DOM nodes`
+      )
+    })
 
-    const canvas = comfyPage.canvas
-    const box = await canvas.boundingBox()
-    if (!box) throw new Error('Canvas bounding box not available')
+    test('pan', async ({ comfyPage }) => {
+      const canvas = comfyPage.canvas
+      const box = await canvas.boundingBox()
+      if (!box) throw new Error('Canvas bounding box not available')
 
-    await comfyPage.perf.startMeasuring()
+      await comfyPage.perf.startMeasuring()
 
-    const centerX = box.x + box.width / 2
-    const centerY = box.y + box.height / 2
-    await comfyPage.page.mouse.move(centerX, centerY)
-    await comfyPage.page.mouse.down({ button: 'middle' })
-    for (let i = 0; i < 60; i++) {
-      await comfyPage.page.mouse.move(centerX + i * 5, centerY + i * 2)
-      await comfyPage.nextFrame()
-    }
-    await comfyPage.page.mouse.up({ button: 'middle' })
+      const centerX = box.x + box.width / 2
+      const centerY = box.y + box.height / 2
+      await comfyPage.page.mouse.move(centerX, centerY)
+      await comfyPage.page.mouse.down({ button: 'middle' })
+      for (let i = 0; i < 60; i++) {
+        await comfyPage.page.mouse.move(centerX + i * 5, centerY + i * 2)
+        await comfyPage.nextFrame()
+      }
+      await comfyPage.page.mouse.up({ button: 'middle' })
 
-    const m = await comfyPage.perf.stopMeasuring('vue-large-graph-pan')
-    recordMeasurement(m)
-    console.log(
-      `Vue large graph pan: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
-    )
-  })
+      const m = await comfyPage.perf.stopMeasuring('vue-large-graph-pan')
+      recordMeasurement(m)
+      console.log(
+        `Vue large graph pan: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
+      )
+    })
 
-  test('vue renderer zoom out culling', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
-    await comfyPage.vueNodes.waitForNodes()
-    await comfyPage.perf.startMeasuring()
+    test('zoom out culling', async ({ comfyPage }) => {
+      await comfyPage.perf.startMeasuring()
 
-    // Zoom out far enough that nodes become < 4px screen size
-    // (triggers size-based culling in isNodeInViewport)
-    for (let i = 0; i < 20; i++) {
-      await comfyPage.canvasOps.zoom(100)
-    }
+      // Zoom out far enough that nodes become < 4px screen size
+      // (triggers size-based culling in isNodeInViewport)
+      for (let i = 0; i < 20; i++) {
+        await comfyPage.canvasOps.zoom(100)
+      }
 
-    // Idle at extreme zoom-out — most nodes should be culled
-    for (let i = 0; i < 60; i++) {
-      await comfyPage.nextFrame()
-    }
+      // Idle at extreme zoom-out — most nodes should be culled
+      for (let i = 0; i < 60; i++) {
+        await comfyPage.nextFrame()
+      }
 
-    // Zoom back in
-    for (let i = 0; i < 20; i++) {
-      await comfyPage.canvasOps.zoom(-100)
-    }
+      // Zoom back in
+      for (let i = 0; i < 20; i++) {
+        await comfyPage.canvasOps.zoom(-100)
+      }
 
-    const m = await comfyPage.perf.stopMeasuring('vue-zoom-culling')
-    recordMeasurement(m)
-    console.log(
-      `Vue zoom culling: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame`
-    )
+      const m = await comfyPage.perf.stopMeasuring('vue-zoom-culling')
+      recordMeasurement(m)
+      console.log(
+        `Vue zoom culling: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame`
+      )
+    })
   })
 
   test('workflow execution', async ({ comfyPage }) => {

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -277,7 +277,6 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     // (triggers size-based culling in isNodeInViewport)
     for (let i = 0; i < 20; i++) {
       await comfyPage.canvasOps.zoom(100)
-      await comfyPage.nextFrame()
     }
 
     // Idle at extreme zoom-out — most nodes should be culled
@@ -288,7 +287,6 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     // Zoom back in
     for (let i = 0; i < 20; i++) {
       await comfyPage.canvasOps.zoom(-100)
-      await comfyPage.nextFrame()
     }
 
     const m = await comfyPage.perf.stopMeasuring('vue-zoom-culling')

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -276,6 +276,12 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
         await comfyPage.canvasOps.zoom(100)
       }
 
+      // Verify we actually entered the culling regime.
+      // isNodeTooSmall triggers when max(width, height) * scale < 4px.
+      // Typical nodes are ~200px wide, so scale must be < 0.02.
+      const scale = await comfyPage.canvasOps.getScale()
+      expect(scale).toBeLessThan(0.02)
+
       // Idle at extreme zoom-out — most nodes should be culled
       for (let i = 0; i < 60; i++) {
         await comfyPage.nextFrame()

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -222,6 +222,82 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     )
   })
 
+  test('vue renderer large graph idle', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.vueNodes.waitForNodes()
+    await comfyPage.perf.startMeasuring()
+
+    for (let i = 0; i < 120; i++) {
+      await comfyPage.nextFrame()
+    }
+
+    const m = await comfyPage.perf.stopMeasuring('vue-large-graph-idle')
+    recordMeasurement(m)
+    console.log(
+      `Vue large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.domNodes} DOM nodes`
+    )
+  })
+
+  test('vue renderer large graph pan', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.vueNodes.waitForNodes()
+
+    const canvas = comfyPage.canvas
+    const box = await canvas.boundingBox()
+    if (!box) throw new Error('Canvas bounding box not available')
+
+    await comfyPage.perf.startMeasuring()
+
+    const centerX = box.x + box.width / 2
+    const centerY = box.y + box.height / 2
+    await comfyPage.page.mouse.move(centerX, centerY)
+    await comfyPage.page.mouse.down({ button: 'middle' })
+    for (let i = 0; i < 60; i++) {
+      await comfyPage.page.mouse.move(centerX + i * 5, centerY + i * 2)
+      await comfyPage.nextFrame()
+    }
+    await comfyPage.page.mouse.up({ button: 'middle' })
+
+    const m = await comfyPage.perf.stopMeasuring('vue-large-graph-pan')
+    recordMeasurement(m)
+    console.log(
+      `Vue large graph pan: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
+    )
+  })
+
+  test('vue renderer zoom out culling', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.vueNodes.waitForNodes()
+    await comfyPage.perf.startMeasuring()
+
+    // Zoom out far enough that nodes become < 4px screen size
+    // (triggers size-based culling in isNodeInViewport)
+    for (let i = 0; i < 20; i++) {
+      await comfyPage.canvasOps.zoom(100)
+      await comfyPage.nextFrame()
+    }
+
+    // Idle at extreme zoom-out — most nodes should be culled
+    for (let i = 0; i < 60; i++) {
+      await comfyPage.nextFrame()
+    }
+
+    // Zoom back in
+    for (let i = 0; i < 20; i++) {
+      await comfyPage.canvasOps.zoom(-100)
+      await comfyPage.nextFrame()
+    }
+
+    const m = await comfyPage.perf.stopMeasuring('vue-zoom-culling')
+    recordMeasurement(m)
+    console.log(
+      `Vue zoom culling: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame`
+    )
+  })
+
   test('workflow execution', async ({ comfyPage }) => {
     // Uses lightweight PrimitiveString → PreviewAny workflow (no GPU needed)
     await comfyPage.workflow.loadWorkflow('execution/partial_execution')


### PR DESCRIPTION
Add 3 perf tests exercising Vue renderer (Nodes 2.0) with the 245-node large-graph-workflow:

- **vue renderer large graph idle** — enables Vue nodes, idles 120 frames, measures style recalcs/layouts/DOM nodes. Catches containment regressions.
- **vue renderer large graph pan** — middle-click pans 60 frames, measures frameDurationMs/TBT. Catches TransformPane falling back to reactive style bindings.
- **vue renderer zoom out culling** — zooms out 20 steps (triggers size-based culling at <4px), idles 60 frames, zooms back in. Catches viewport culling regressions.

Complements existing LiteGraph renderer tests for direct A/B comparison in the perf report. Uses existing `large-graph-workflow.json` asset from #9940.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10001-test-add-vue-renderer-perf-tests-idle-pan-zoom-culling-3256d73d365081b4b714d8f3b396604c) by [Unito](https://www.unito.io)
