### PR TITLE
feat: add FPS percentile measurement and M2 scoreboard to perf reports

### DIFF
--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -166,8 +166,14 @@ export class PerformanceHelper {
               resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
               return
             }
-            const fps = frameDurations.map((d) => 1000 / d)
+            const fps = frameDurations
+              .map((d) => 1000 / d)
+              .filter((f) => Number.isFinite(f))
             fps.sort((a, b) => a - b)
+            if (fps.length === 0) {
+              resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
+              return
+            }
             function percentile(p: number): number {
               const rank = p * (fps.length - 1)
               const lo = Math.floor(rank)

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -14,6 +14,14 @@ interface PerfSnapshot {
   JSEventListeners: number
 }
 
+export interface FPSResult {
+  p5: number
+  p50: number
+  p95: number
+  mean: number
+  frameCount: number
+}
+
 export interface PerfMeasurement {
   name: string
   durationMs: number
@@ -29,6 +37,9 @@ export interface PerfMeasurement {
   eventListeners: number
   totalBlockingTimeMs: number
   frameDurationMs: number
+  fpsP5?: number
+  fpsP50?: number
+  fpsMean?: number
 }
 
 export class PerformanceHelper {
@@ -127,6 +138,41 @@ export class PerformanceHelper {
         requestAnimationFrame(tick)
       })
     }, sampleFrames)
+  }
+
+  async measureFPS(durationMs: number): Promise<FPSResult> {
+    return this.page.evaluate((duration) => {
+      return new Promise<FPSResult>((resolve) => {
+        const frameDurations: number[] = []
+        let lastTime = 0
+        const start = performance.now()
+
+        function tick(now: number) {
+          if (lastTime > 0) frameDurations.push(now - lastTime)
+          lastTime = now
+          if (now - start < duration) {
+            requestAnimationFrame(tick)
+          } else {
+            if (frameDurations.length === 0) {
+              resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
+              return
+            }
+            const fps = frameDurations.map((d) => 1000 / d)
+            fps.sort((a, b) => a - b)
+            const percentile = (p: number) =>
+              fps[Math.floor(fps.length * p)] ?? 0
+            resolve({
+              p5: percentile(0.05),
+              p50: percentile(0.5),
+              p95: percentile(0.95),
+              mean: fps.reduce((a, b) => a + b, 0) / fps.length,
+              frameCount: fps.length
+            })
+          }
+        }
+        requestAnimationFrame(tick)
+      })
+    }, durationMs)
   }
 
   async startMeasuring(): Promise<void> {

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -146,21 +146,37 @@ export class PerformanceHelper {
         const frameDurations: number[] = []
         let lastTime = 0
         const start = performance.now()
+        let settled = false
+        const timeout = setTimeout(() => {
+          if (settled) return
+          settled = true
+          resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
+        }, duration + 5000)
 
         function tick(now: number) {
+          if (settled) return
           if (lastTime > 0) frameDurations.push(now - lastTime)
           lastTime = now
           if (now - start < duration) {
             requestAnimationFrame(tick)
           } else {
+            settled = true
+            clearTimeout(timeout)
             if (frameDurations.length === 0) {
               resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
               return
             }
             const fps = frameDurations.map((d) => 1000 / d)
             fps.sort((a, b) => a - b)
-            const percentile = (p: number) =>
-              fps[Math.floor(fps.length * p)] ?? 0
+            function percentile(p: number): number {
+              const rank = p * (fps.length - 1)
+              const lo = Math.floor(rank)
+              const hi = Math.ceil(rank)
+              const weight = rank - lo
+              const loVal = fps[lo] ?? 0
+              const hiVal = fps[hi] ?? loVal
+              return loVal + (hiVal - loVal) * weight
+            }
             resolve({
               p5: percentile(0.05),
               p50: percentile(0.5),

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -14,6 +14,14 @@ interface PerfSnapshot {
   JSEventListeners: number
 }
 
+export interface FPSResult {
+  p5: number
+  p50: number
+  p95: number
+  mean: number
+  frameCount: number
+}
+
 export interface PerfMeasurement {
   name: string
   durationMs: number
@@ -32,6 +40,9 @@ export interface PerfMeasurement {
   frameDurationMs: number
   p95FrameDurationMs: number
   allFrameDurationsMs: number[]
+  fpsP5?: number
+  fpsP50?: number
+  fpsMean?: number
 }
 
 export class PerformanceHelper {
@@ -133,6 +144,41 @@ export class PerformanceHelper {
         requestAnimationFrame(tick)
       })
     }, sampleFrames)
+  }
+
+  async measureFPS(durationMs: number): Promise<FPSResult> {
+    return this.page.evaluate((duration) => {
+      return new Promise<FPSResult>((resolve) => {
+        const frameDurations: number[] = []
+        let lastTime = 0
+        const start = performance.now()
+
+        function tick(now: number) {
+          if (lastTime > 0) frameDurations.push(now - lastTime)
+          lastTime = now
+          if (now - start < duration) {
+            requestAnimationFrame(tick)
+          } else {
+            if (frameDurations.length === 0) {
+              resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
+              return
+            }
+            const fps = frameDurations.map((d) => 1000 / d)
+            fps.sort((a, b) => a - b)
+            const percentile = (p: number) =>
+              fps[Math.floor(fps.length * p)] ?? 0
+            resolve({
+              p5: percentile(0.05),
+              p50: percentile(0.5),
+              p95: percentile(0.95),
+              mean: fps.reduce((a, b) => a + b, 0) / fps.length,
+              frameCount: fps.length
+            })
+          }
+        }
+        requestAnimationFrame(tick)
+      })
+    }, durationMs)
   }
 
   async startMeasuring(): Promise<void> {

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -152,21 +152,37 @@ export class PerformanceHelper {
         const frameDurations: number[] = []
         let lastTime = 0
         const start = performance.now()
+        let settled = false
+        const timeout = setTimeout(() => {
+          if (settled) return
+          settled = true
+          resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
+        }, duration + 5000)
 
         function tick(now: number) {
+          if (settled) return
           if (lastTime > 0) frameDurations.push(now - lastTime)
           lastTime = now
           if (now - start < duration) {
             requestAnimationFrame(tick)
           } else {
+            settled = true
+            clearTimeout(timeout)
             if (frameDurations.length === 0) {
               resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
               return
             }
             const fps = frameDurations.map((d) => 1000 / d)
             fps.sort((a, b) => a - b)
-            const percentile = (p: number) =>
-              fps[Math.floor(fps.length * p)] ?? 0
+            function percentile(p: number): number {
+              const rank = p * (fps.length - 1)
+              const lo = Math.floor(rank)
+              const hi = Math.ceil(rank)
+              const weight = rank - lo
+              const loVal = fps[lo] ?? 0
+              const hiVal = fps[hi] ?? loVal
+              return loVal + (hiVal - loVal) * weight
+            }
             resolve({
               p5: percentile(0.05),
               p50: percentile(0.5),

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -172,8 +172,14 @@ export class PerformanceHelper {
               resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
               return
             }
-            const fps = frameDurations.map((d) => 1000 / d)
+            const fps = frameDurations
+              .map((d) => 1000 / d)
+              .filter((f) => Number.isFinite(f))
             fps.sort((a, b) => a - b)
+            if (fps.length === 0) {
+              resolve({ p5: 0, p50: 0, p95: 0, mean: 0, frameCount: 0 })
+              return
+            }
             function percentile(p: number): number {
               const rank = p * (fps.length - 1)
               const lo = Math.floor(rank)

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -42,6 +42,7 @@ export interface PerfMeasurement {
   allFrameDurationsMs: number[]
   fpsP5?: number
   fpsP50?: number
+  fpsP95?: number
   fpsMean?: number
 }
 

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -120,9 +120,16 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     }
 
     const m = await comfyPage.perf.stopMeasuring('large-graph-idle')
+
+    // M2 milestone metric: P5 FPS on 245-node workflow (target: ≥52)
+    const fps = await comfyPage.perf.measureFPS(3000)
+    m.fpsP5 = fps.p5
+    m.fpsP50 = fps.p50
+    m.fpsMean = fps.mean
+
     recordMeasurement(m)
     console.log(
-      `Large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts`
+      `Large graph idle: ${m.styleRecalcs} recalcs, ${m.layouts} layouts | FPS P5=${fps.p5.toFixed(0)} P50=${fps.p50.toFixed(0)} mean=${fps.mean.toFixed(0)} (${fps.frameCount} frames)`
     )
   })
 

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -123,9 +123,16 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     }
 
     const m = await comfyPage.perf.stopMeasuring('large-graph-idle')
+
+    // M2 milestone metric: P5 FPS on 245-node workflow (target: ≥52)
+    const fps = await comfyPage.perf.measureFPS(3000)
+    m.fpsP5 = fps.p5
+    m.fpsP50 = fps.p50
+    m.fpsMean = fps.mean
+
     recordMeasurement(m)
     console.log(
-      `Large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts`
+      `Large graph idle: ${m.styleRecalcs} recalcs, ${m.layouts} layouts | FPS P5=${fps.p5.toFixed(0)} P50=${fps.p50.toFixed(0)} mean=${fps.mean.toFixed(0)} (${fps.frameCount} frames)`
     )
   })
 

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -128,11 +128,12 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     const fps = await comfyPage.perf.measureFPS(3000)
     m.fpsP5 = fps.p5
     m.fpsP50 = fps.p50
+    m.fpsP95 = fps.p95
     m.fpsMean = fps.mean
 
     recordMeasurement(m)
     console.log(
-      `Large graph idle: ${m.styleRecalcs} recalcs, ${m.layouts} layouts | FPS P5=${fps.p5.toFixed(0)} P50=${fps.p50.toFixed(0)} mean=${fps.mean.toFixed(0)} (${fps.frameCount} frames)`
+      `Large graph idle: ${m.styleRecalcs} recalcs, ${m.layouts} layouts | FPS P5=${fps.p5.toFixed(0)} P50=${fps.p50.toFixed(0)} P95=${fps.p95.toFixed(0)} mean=${fps.mean.toFixed(0)} (${fps.frameCount} frames)`
     )
   })
 

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -176,8 +176,7 @@ function renderM2Scoreboard(
       : null
 
   const tbtValues = samples.map((s) => s.totalBlockingTimeMs)
-  const avgTBT =
-    tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
+  const avgTBT = tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
   const tbtPassed = avgTBT <= M2_TARGET_TBT_MS
   const tbtIcon = tbtPassed ? '✅' : '🔴'
 
@@ -197,8 +196,7 @@ function renderM2Scoreboard(
     `| **TBT** | **${avgTBT.toFixed(0)}ms** | ≤${M2_TARGET_TBT_MS}ms | ${tbtIcon} ${tbtPassed ? 'PASS' : 'FAIL'} |`,
     `| **Frame Duration** | **${avgFD.toFixed(1)}ms** | ≤${M2_TARGET_FRAME_DURATION_MS}ms | ${fdIcon} ${fdPassed ? 'PASS' : 'FAIL'} |`
   ]
-  if (avgP50 !== null)
-    lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
+  if (avgP50 !== null) lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
   if (avgMean !== null)
     lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
   lines.push(

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -25,7 +25,15 @@ interface PerfMeasurement {
   eventListeners: number
   totalBlockingTimeMs: number
   frameDurationMs: number
+  fpsP5?: number
+  fpsP50?: number
+  fpsMean?: number
 }
+
+const M2_TARGET_FPS = 52
+const M2_TARGET_TBT_MS = 200
+const M2_TARGET_FRAME_DURATION_MS = 20
+const M2_TEST_NAME = 'large-graph-idle'
 
 interface PerfReport {
   timestamp: string
@@ -136,6 +144,70 @@ function formatBytes(bytes: number): string {
   if (Math.abs(bytes) < 1024) return `${bytes} B`
   if (Math.abs(bytes) < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function renderM2Scoreboard(
+  prGroups: Map<string, PerfMeasurement[]>
+): string[] {
+  const samples = prGroups.get(M2_TEST_NAME)
+  if (!samples?.length) return []
+
+  const fpsValues = samples
+    .map((s) => s.fpsP5)
+    .filter((v): v is number => v != null && v > 0)
+  if (fpsValues.length === 0) return []
+
+  const avgP5 = fpsValues.reduce((a, b) => a + b, 0) / fpsValues.length
+  const passed = avgP5 >= M2_TARGET_FPS
+  const icon = passed ? '✅' : '🔴'
+  const p50Values = samples
+    .map((s) => s.fpsP50)
+    .filter((v): v is number => v != null && v > 0)
+  const avgP50 =
+    p50Values.length > 0
+      ? p50Values.reduce((a, b) => a + b, 0) / p50Values.length
+      : null
+  const meanValues = samples
+    .map((s) => s.fpsMean)
+    .filter((v): v is number => v != null && v > 0)
+  const avgMean =
+    meanValues.length > 0
+      ? meanValues.reduce((a, b) => a + b, 0) / meanValues.length
+      : null
+
+  const tbtValues = samples.map((s) => s.totalBlockingTimeMs)
+  const avgTBT =
+    tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
+  const tbtPassed = avgTBT <= M2_TARGET_TBT_MS
+  const tbtIcon = tbtPassed ? '✅' : '🔴'
+
+  const fdValues = samples.map((s) => s.frameDurationMs)
+  const avgFD = fdValues.reduce((a, b) => a + b, 0) / fdValues.length
+  const fdPassed = avgFD <= M2_TARGET_FRAME_DURATION_MS
+  const fdIcon = fdPassed ? '✅' : '🔴'
+
+  const allPassed = passed && tbtPassed && fdPassed
+
+  const lines: string[] = [
+    `### ${allPassed ? '✅' : '🔴'} M2 Perf Target — 245-node workflow`,
+    '',
+    `| Metric | Value | Target | Status |`,
+    `|--------|-------|--------|--------|`,
+    `| **P5 FPS** | **${avgP5.toFixed(0)}** | ≥${M2_TARGET_FPS} | ${icon} ${passed ? 'PASS' : 'FAIL'} |`,
+    `| **TBT** | **${avgTBT.toFixed(0)}ms** | ≤${M2_TARGET_TBT_MS}ms | ${tbtIcon} ${tbtPassed ? 'PASS' : 'FAIL'} |`,
+    `| **Frame Duration** | **${avgFD.toFixed(1)}ms** | ≤${M2_TARGET_FRAME_DURATION_MS}ms | ${fdIcon} ${fdPassed ? 'PASS' : 'FAIL'} |`
+  ]
+  if (avgP50 !== null)
+    lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
+  if (avgMean !== null)
+    lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
+  lines.push(
+    `| Samples | ${fpsValues.length} | — | — |`,
+    '',
+    `> Legacy baseline: ~60 FPS idle, ~70 FPS zoom. Target = <25% regression.`,
+    ''
+  )
+  return lines
 }
 
 function renderFullReport(
@@ -328,6 +400,8 @@ function main() {
 
   const lines: string[] = []
   lines.push('## ⚡ Performance Report\n')
+
+  lines.push(...renderM2Scoreboard(prGroups))
 
   if (baseline && historical.length >= 2) {
     lines.push(...renderFullReport(prGroups, baseline, historical))

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -152,35 +152,36 @@ function renderM2Scoreboard(
   const samples = prGroups.get(M2_TEST_NAME)
   if (!samples?.length) return []
 
-  const fpsValues = samples
-    .map((s) => s.fpsP5)
-    .filter((v): v is number => v != null && v > 0)
-  if (fpsValues.length === 0) return []
+  const scoredSamples = samples.filter(
+    (s): s is PerfMeasurement & { fpsP5: number } => Number.isFinite(s.fpsP5)
+  )
+  if (scoredSamples.length === 0) return []
 
+  const fpsValues = scoredSamples.map((s) => s.fpsP5)
   const avgP5 = fpsValues.reduce((a, b) => a + b, 0) / fpsValues.length
   const passed = avgP5 >= M2_TARGET_FPS
   const icon = passed ? '✅' : '🔴'
-  const p50Values = samples
+  const p50Values = scoredSamples
     .map((s) => s.fpsP50)
-    .filter((v): v is number => v != null && v > 0)
+    .filter((v): v is number => Number.isFinite(v))
   const avgP50 =
     p50Values.length > 0
       ? p50Values.reduce((a, b) => a + b, 0) / p50Values.length
       : null
-  const meanValues = samples
+  const meanValues = scoredSamples
     .map((s) => s.fpsMean)
-    .filter((v): v is number => v != null && v > 0)
+    .filter((v): v is number => Number.isFinite(v))
   const avgMean =
     meanValues.length > 0
       ? meanValues.reduce((a, b) => a + b, 0) / meanValues.length
       : null
 
-  const tbtValues = samples.map((s) => s.totalBlockingTimeMs)
+  const tbtValues = scoredSamples.map((s) => s.totalBlockingTimeMs)
   const avgTBT = tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
   const tbtPassed = avgTBT <= M2_TARGET_TBT_MS
   const tbtIcon = tbtPassed ? '✅' : '🔴'
 
-  const fdValues = samples.map((s) => s.frameDurationMs)
+  const fdValues = scoredSamples.map((s) => s.frameDurationMs)
   const avgFD = fdValues.reduce((a, b) => a + b, 0) / fdValues.length
   const fdPassed = avgFD <= M2_TARGET_FRAME_DURATION_MS
   const fdIcon = fdPassed ? '✅' : '🔴'
@@ -200,7 +201,7 @@ function renderM2Scoreboard(
   if (avgMean !== null)
     lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
   lines.push(
-    `| Samples | ${fpsValues.length} | — | — |`,
+    `| Samples | ${scoredSamples.length} | — | — |`,
     '',
     `> Legacy baseline: ~60 FPS idle, ~70 FPS zoom. Target = <25% regression.`,
     ''

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -31,7 +31,15 @@ interface PerfMeasurement {
   frameDurationMs: number
   p95FrameDurationMs: number
   allFrameDurationsMs?: number[]
+  fpsP5?: number
+  fpsP50?: number
+  fpsMean?: number
 }
+
+const M2_TARGET_FPS = 52
+const M2_TARGET_TBT_MS = 200
+const M2_TARGET_FRAME_DURATION_MS = 20
+const M2_TEST_NAME = 'large-graph-idle'
 
 interface PerfReport {
   timestamp: string
@@ -251,6 +259,70 @@ function renderHeadlineSummary(
     lines.push('> ' + summaries.join('\n> '), '')
   }
 
+  return lines
+}
+
+function renderM2Scoreboard(
+  prGroups: Map<string, PerfMeasurement[]>
+): string[] {
+  const samples = prGroups.get(M2_TEST_NAME)
+  if (!samples?.length) return []
+
+  const fpsValues = samples
+    .map((s) => s.fpsP5)
+    .filter((v): v is number => v != null && v > 0)
+  if (fpsValues.length === 0) return []
+
+  const avgP5 = fpsValues.reduce((a, b) => a + b, 0) / fpsValues.length
+  const passed = avgP5 >= M2_TARGET_FPS
+  const icon = passed ? '✅' : '🔴'
+  const p50Values = samples
+    .map((s) => s.fpsP50)
+    .filter((v): v is number => v != null && v > 0)
+  const avgP50 =
+    p50Values.length > 0
+      ? p50Values.reduce((a, b) => a + b, 0) / p50Values.length
+      : null
+  const meanValues = samples
+    .map((s) => s.fpsMean)
+    .filter((v): v is number => v != null && v > 0)
+  const avgMean =
+    meanValues.length > 0
+      ? meanValues.reduce((a, b) => a + b, 0) / meanValues.length
+      : null
+
+  const tbtValues = samples.map((s) => s.totalBlockingTimeMs)
+  const avgTBT =
+    tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
+  const tbtPassed = avgTBT <= M2_TARGET_TBT_MS
+  const tbtIcon = tbtPassed ? '✅' : '🔴'
+
+  const fdValues = samples.map((s) => s.frameDurationMs)
+  const avgFD = fdValues.reduce((a, b) => a + b, 0) / fdValues.length
+  const fdPassed = avgFD <= M2_TARGET_FRAME_DURATION_MS
+  const fdIcon = fdPassed ? '✅' : '🔴'
+
+  const allPassed = passed && tbtPassed && fdPassed
+
+  const lines: string[] = [
+    `### ${allPassed ? '✅' : '🔴'} M2 Perf Target — 245-node workflow`,
+    '',
+    `| Metric | Value | Target | Status |`,
+    `|--------|-------|--------|--------|`,
+    `| **P5 FPS** | **${avgP5.toFixed(0)}** | ≥${M2_TARGET_FPS} | ${icon} ${passed ? 'PASS' : 'FAIL'} |`,
+    `| **TBT** | **${avgTBT.toFixed(0)}ms** | ≤${M2_TARGET_TBT_MS}ms | ${tbtIcon} ${tbtPassed ? 'PASS' : 'FAIL'} |`,
+    `| **Frame Duration** | **${avgFD.toFixed(1)}ms** | ≤${M2_TARGET_FRAME_DURATION_MS}ms | ${fdIcon} ${fdPassed ? 'PASS' : 'FAIL'} |`
+  ]
+  if (avgP50 !== null)
+    lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
+  if (avgMean !== null)
+    lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
+  lines.push(
+    `| Samples | ${fpsValues.length} | — | — |`,
+    '',
+    `> Legacy baseline: ~60 FPS idle, ~70 FPS zoom. Target = <25% regression.`,
+    ''
+  )
   return lines
 }
 
@@ -482,6 +554,8 @@ function main() {
   const lines: string[] = []
   lines.push('## ⚡ Performance Report\n')
   lines.push(...renderHeadlineSummary(prGroups))
+
+  lines.push(...renderM2Scoreboard(prGroups))
 
   if (baseline && historical.length >= 2) {
     lines.push(...renderFullReport(prGroups, baseline, historical))

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -292,8 +292,7 @@ function renderM2Scoreboard(
       : null
 
   const tbtValues = samples.map((s) => s.totalBlockingTimeMs)
-  const avgTBT =
-    tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
+  const avgTBT = tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
   const tbtPassed = avgTBT <= M2_TARGET_TBT_MS
   const tbtIcon = tbtPassed ? '✅' : '🔴'
 
@@ -313,8 +312,7 @@ function renderM2Scoreboard(
     `| **TBT** | **${avgTBT.toFixed(0)}ms** | ≤${M2_TARGET_TBT_MS}ms | ${tbtIcon} ${tbtPassed ? 'PASS' : 'FAIL'} |`,
     `| **Frame Duration** | **${avgFD.toFixed(1)}ms** | ≤${M2_TARGET_FRAME_DURATION_MS}ms | ${fdIcon} ${fdPassed ? 'PASS' : 'FAIL'} |`
   ]
-  if (avgP50 !== null)
-    lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
+  if (avgP50 !== null) lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
   if (avgMean !== null)
     lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
   lines.push(

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -268,35 +268,36 @@ function renderM2Scoreboard(
   const samples = prGroups.get(M2_TEST_NAME)
   if (!samples?.length) return []
 
-  const fpsValues = samples
-    .map((s) => s.fpsP5)
-    .filter((v): v is number => v != null && v > 0)
-  if (fpsValues.length === 0) return []
+  const scoredSamples = samples.filter(
+    (s): s is PerfMeasurement & { fpsP5: number } => Number.isFinite(s.fpsP5)
+  )
+  if (scoredSamples.length === 0) return []
 
+  const fpsValues = scoredSamples.map((s) => s.fpsP5)
   const avgP5 = fpsValues.reduce((a, b) => a + b, 0) / fpsValues.length
   const passed = avgP5 >= M2_TARGET_FPS
   const icon = passed ? '✅' : '🔴'
-  const p50Values = samples
+  const p50Values = scoredSamples
     .map((s) => s.fpsP50)
-    .filter((v): v is number => v != null && v > 0)
+    .filter((v): v is number => Number.isFinite(v))
   const avgP50 =
     p50Values.length > 0
       ? p50Values.reduce((a, b) => a + b, 0) / p50Values.length
       : null
-  const meanValues = samples
+  const meanValues = scoredSamples
     .map((s) => s.fpsMean)
-    .filter((v): v is number => v != null && v > 0)
+    .filter((v): v is number => Number.isFinite(v))
   const avgMean =
     meanValues.length > 0
       ? meanValues.reduce((a, b) => a + b, 0) / meanValues.length
       : null
 
-  const tbtValues = samples.map((s) => s.totalBlockingTimeMs)
+  const tbtValues = scoredSamples.map((s) => s.totalBlockingTimeMs)
   const avgTBT = tbtValues.reduce((a, b) => a + b, 0) / tbtValues.length
   const tbtPassed = avgTBT <= M2_TARGET_TBT_MS
   const tbtIcon = tbtPassed ? '✅' : '🔴'
 
-  const fdValues = samples.map((s) => s.frameDurationMs)
+  const fdValues = scoredSamples.map((s) => s.frameDurationMs)
   const avgFD = fdValues.reduce((a, b) => a + b, 0) / fdValues.length
   const fdPassed = avgFD <= M2_TARGET_FRAME_DURATION_MS
   const fdIcon = fdPassed ? '✅' : '🔴'
@@ -316,7 +317,7 @@ function renderM2Scoreboard(
   if (avgMean !== null)
     lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
   lines.push(
-    `| Samples | ${fpsValues.length} | — | — |`,
+    `| Samples | ${scoredSamples.length} | — | — |`,
     '',
     `> Legacy baseline: ~60 FPS idle, ~70 FPS zoom. Target = <25% regression.`,
     ''

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -33,6 +33,7 @@ interface PerfMeasurement {
   allFrameDurationsMs?: number[]
   fpsP5?: number
   fpsP50?: number
+  fpsP95?: number
   fpsMean?: number
 }
 
@@ -284,6 +285,13 @@ function renderM2Scoreboard(
     p50Values.length > 0
       ? p50Values.reduce((a, b) => a + b, 0) / p50Values.length
       : null
+  const p95Values = scoredSamples
+    .map((s) => s.fpsP95)
+    .filter((v): v is number => Number.isFinite(v))
+  const avgP95 =
+    p95Values.length > 0
+      ? p95Values.reduce((a, b) => a + b, 0) / p95Values.length
+      : null
   const meanValues = scoredSamples
     .map((s) => s.fpsMean)
     .filter((v): v is number => Number.isFinite(v))
@@ -314,6 +322,7 @@ function renderM2Scoreboard(
     `| **Frame Duration** | **${avgFD.toFixed(1)}ms** | ≤${M2_TARGET_FRAME_DURATION_MS}ms | ${fdIcon} ${fdPassed ? 'PASS' : 'FAIL'} |`
   ]
   if (avgP50 !== null) lines.push(`| P50 FPS | ${avgP50.toFixed(0)} | — | — |`)
+  if (avgP95 !== null) lines.push(`| P95 FPS | ${avgP95.toFixed(0)} | — | — |`)
   if (avgMean !== null)
     lines.push(`| Mean FPS | ${avgMean.toFixed(0)} | — | — |`)
   lines.push(

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -38,6 +38,11 @@ interface PerfMeasurement {
 }
 
 const M2_TARGET_FPS = 52
+const M2_IDLE_BASELINE_FPS = 60
+const M2_ALLOWED_DROP_PCT = (
+  ((M2_IDLE_BASELINE_FPS - M2_TARGET_FPS) / M2_IDLE_BASELINE_FPS) *
+  100
+).toFixed(0)
 const M2_TARGET_TBT_MS = 200
 const M2_TARGET_FRAME_DURATION_MS = 20
 const M2_TEST_NAME = 'large-graph-idle'
@@ -328,7 +333,7 @@ function renderM2Scoreboard(
   lines.push(
     `| Samples | ${scoredSamples.length} | — | — |`,
     '',
-    `> Legacy baseline: ~60 FPS idle, ~70 FPS zoom. Target = <25% regression.`,
+    `> Legacy baseline: ~${M2_IDLE_BASELINE_FPS} FPS idle, ~70 FPS zoom. P5 target of ${M2_TARGET_FPS} FPS allows at most a ${M2_ALLOWED_DROP_PCT}% drop from the idle baseline.`,
     ''
   )
   return lines


### PR DESCRIPTION
## Summary

Add P5/P50/P95 FPS measurement to perf tests and display M2 milestone scoreboard with 3 threshold metrics at the top of every PR performance comment.

## Changes

- **What**: `measureFPS(durationMs)` on PerformanceHelper for RAF-loop FPS collection with P5/P50/P95 percentile computation. `renderM2Scoreboard()` in perf-report.ts with 3 gated metrics: P5 FPS ≥52 (jank), TBT ≤200ms (idle blocking), Frame Duration ≤20ms (sustained rate floor).
- **Dependencies**: None

## Review Focus

- RAF-loop measurement runs 3s after idle measurement completes
- TBT/Frame Duration thresholds from CI baseline: legacy=0ms TBT/16.7ms frame; Vue=0-910ms TBT/18-20ms frame

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10003-feat-add-FPS-percentile-measurement-and-M2-scoreboard-to-perf-reports-3256d73d36508146802ff6cd30c7da05) by [Unito](https://www.unito.io)
