### PR TITLE
test: add perf test for PrimeVue dialog style recalculations

### DIFF
--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -252,9 +252,7 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       await comfyPage.nextFrame()
     }
 
-    const m = await comfyPage.perf.stopMeasuring(
-      'primevue-dialog-open-close'
-    )
+    const m = await comfyPage.perf.stopMeasuring('primevue-dialog-open-close')
     recordMeasurement(m)
     console.log(
       `PrimeVue dialog: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.styleRecalcDurationMs.toFixed(1)}ms recalc time`

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -222,6 +222,45 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     )
   })
 
+  test('PrimeVue dialog open style recalculations', async ({ comfyPage }) => {
+    // Load workflow first so the page is settled
+    await comfyPage.workflow.loadWorkflow('default')
+
+    // Wait for initial load to stabilize
+    for (let i = 0; i < 30; i++) {
+      await comfyPage.nextFrame()
+    }
+
+    await comfyPage.perf.startMeasuring()
+
+    // Open the settings dialog — triggers mounting of many PrimeVue
+    // components (Dialog, InputText, Select, ToggleSwitch, etc.),
+    // each of which injects <style> tags via PrimeVue's useStyle.
+    await comfyPage.command.executeCommand('Comfy.ShowSettingsDialog')
+    await comfyPage.page
+      .getByTestId('settings-dialog')
+      .waitFor({ state: 'visible', timeout: 5000 })
+
+    // Let it settle so all component styles are injected
+    for (let i = 0; i < 30; i++) {
+      await comfyPage.nextFrame()
+    }
+
+    // Close the dialog
+    await comfyPage.page.keyboard.press('Escape')
+    for (let i = 0; i < 10; i++) {
+      await comfyPage.nextFrame()
+    }
+
+    const m = await comfyPage.perf.stopMeasuring(
+      'primevue-dialog-open-close'
+    )
+    recordMeasurement(m)
+    console.log(
+      `PrimeVue dialog: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.styleRecalcDurationMs.toFixed(1)}ms recalc time`
+    )
+  })
+
   test('workflow execution', async ({ comfyPage }) => {
     // Uses lightweight PrimitiveString → PreviewAny workflow (no GPU needed)
     await comfyPage.workflow.loadWorkflow('execution/partial_execution')


### PR DESCRIPTION
Adds a `@perf` test to establish a baseline for PrimeVue `useStyle` style injection overhead (backlog #7).

This is PR 1 of 2. The fix will follow in a separate PR once this baseline is established on main.

## What

Adds `primevue-dialog-open-close` to the performance test suite measuring style recalculations during settings dialog open/close.

## Why

PrimeVue's `useStyle` composable injects `<style>` tags at runtime for each component mount. Firefox profiling showed 4,555 style invalidation markers from this mechanism. Opening a dialog that mounts many PrimeVue components (Dialog, InputText, Select, ToggleSwitch, etc.) triggers a burst of style injections.

Needed to prove the improvement from the upcoming fix for backlog item #7.

## How

The test:
1. Loads default workflow and waits for stabilization
2. Opens the settings dialog (triggers PrimeVue component mounts + style injections)
3. Waits for settlement
4. Closes the dialog
5. Records style recalc count, layout count, and recalc duration

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10017-test-add-perf-test-for-PrimeVue-dialog-style-recalculations-3256d73d365081dcba00e168ae486cc4) by [Unito](https://www.unito.io)
