### PR TITLE
[backport core/1.41] fix: restore backend outputs_count for asset sidebar multi-output badge (#9627)

### DIFF
--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -70,7 +70,7 @@ function mapHistoryToAssets(historyItems: JobListItem[]): AssetItem[] {
 
     assetItem.user_metadata = {
       ...assetItem.user_metadata,
-      outputCount: task.previewableOutputs.length,
+      outputCount: task.outputsCount ?? task.previewableOutputs.length,
       allOutputs: task.previewableOutputs
     }
 


### PR DESCRIPTION
Backport of #9627 to core/1.41