### PR TITLE
[backport core/1.41] fix: update PostHog api_host fallback domain (#9733)

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -81,7 +81,7 @@ describe('PostHogTelemetryProvider', () => {
       await vi.dynamicImportSettled()
 
       expect(hoisted.mockInit).toHaveBeenCalledWith('phc_test_token', {
-        api_host: 'https://ph.comfy.org',
+        api_host: 'https://t.comfy.org',
         autocapture: false,
         capture_pageview: false,
         capture_pageleave: false,

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -100,7 +100,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
             this.posthog = posthogModule.default
             this.posthog!.init(apiKey, {
               api_host:
-                window.__CONFIG__?.posthog_api_host || 'https://ph.comfy.org',
+                window.__CONFIG__?.posthog_api_host || 'https://t.comfy.org',
               autocapture: false,
               capture_pageview: false,
               capture_pageleave: false,


### PR DESCRIPTION
Backport of #9733 to core/1.41