### PR TITLE
tool: add layer architecture boundary lint rule

### DIFF
--- a/.claude/skills/layer-audit/SKILL.md
+++ b/.claude/skills/layer-audit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: layer-audit
+description: 'Detect violations of the layered architecture import rules (base -> platform -> workbench -> renderer). Runs ESLint with the import-x/no-restricted-paths rule and generates a grouped report.'
+---
+
+# Layer Architecture Audit
+
+Finds imports that violate the layered architecture boundary rules enforced by `import-x/no-restricted-paths` in `eslint.config.ts`.
+
+## Layer Hierarchy (bottom to top)
+
+```
+renderer  (top -- can import from all lower layers)
+   ^
+workbench
+   ^
+platform
+   ^
+  base    (bottom -- cannot import from any upper layer)
+```
+
+Each layer may only import from layers below it.
+
+## How to Run
+
+```bash
+# Run ESLint filtering for just the layer boundary rule violations
+pnpm lint 2>&1 | grep 'import-x/no-restricted-paths' -B1 | head -200
+```
+
+To get a full structured report, run:
+
+```bash
+# Collect all violations from base/, platform/, workbench/ layers
+pnpm eslint src/base/ src/platform/ src/workbench/ --no-error-on-unmatched-pattern --rule '{"import-x/no-restricted-paths": "warn"}' --format compact 2>&1 | grep 'no-restricted-paths' | sort
+```
+
+## How to Read Results
+
+Each violation line shows:
+- The **file** containing the bad import
+- The **import path** crossing the boundary
+- The **message** identifying which layer pair is violated
+
+### Grouping by Layer Pair
+
+After collecting violations, group them by the layer pair pattern:
+
+| Layer pair | Meaning |
+|---|---|
+| base -> platform | base/ importing from platform/ |
+| base -> workbench | base/ importing from workbench/ |
+| base -> renderer | base/ importing from renderer/ |
+| platform -> workbench | platform/ importing from workbench/ |
+| platform -> renderer | platform/ importing from renderer/ |
+| workbench -> renderer | workbench/ importing from renderer/ |
+
+## When to Use
+
+- Before creating a PR that adds imports between `src/base/`, `src/platform/`, `src/workbench/`, or `src/renderer/`
+- When auditing the codebase to find and plan migration of existing violations
+- After moving files between layers to verify no new violations were introduced
+
+## Fixing Violations
+
+Common strategies to resolve a layer violation:
+
+1. **Move the import target down** -- if the imported module doesn't depend on upper-layer concepts, move it to a lower layer
+2. **Introduce an interface** -- define an interface/type in the lower layer and implement it in the upper layer via dependency injection or a registration pattern
+3. **Move the importing file up** -- if the file logically belongs in a higher layer, relocate it
+4. **Extract shared logic** -- pull the shared functionality into `base/` or a shared utility
+
+## Reference
+
+| Resource | Path |
+|---|---|
+| ESLint config (rule definition) | `eslint.config.ts` |
+| Base layer | `src/base/` |
+| Platform layer | `src/platform/` |
+| Workbench layer | `src/workbench/` |
+| Renderer layer | `src/renderer/` |

--- a/.claude/skills/layer-audit/SKILL.md
+++ b/.claude/skills/layer-audit/SKILL.md
@@ -38,6 +38,7 @@ pnpm eslint src/base/ src/platform/ src/workbench/ --no-error-on-unmatched-patte
 ## How to Read Results
 
 Each violation line shows:
+
 - The **file** containing the bad import
 - The **import path** crossing the boundary
 - The **message** identifying which layer pair is violated
@@ -46,13 +47,13 @@ Each violation line shows:
 
 After collecting violations, group them by the layer pair pattern:
 
-| Layer pair | Meaning |
-|---|---|
-| base -> platform | base/ importing from platform/ |
-| base -> workbench | base/ importing from workbench/ |
-| base -> renderer | base/ importing from renderer/ |
+| Layer pair            | Meaning                             |
+| --------------------- | ----------------------------------- |
+| base -> platform      | base/ importing from platform/      |
+| base -> workbench     | base/ importing from workbench/     |
+| base -> renderer      | base/ importing from renderer/      |
 | platform -> workbench | platform/ importing from workbench/ |
-| platform -> renderer | platform/ importing from renderer/ |
+| platform -> renderer  | platform/ importing from renderer/  |
 | workbench -> renderer | workbench/ importing from renderer/ |
 
 ## When to Use
@@ -72,10 +73,10 @@ Common strategies to resolve a layer violation:
 
 ## Reference
 
-| Resource | Path |
-|---|---|
+| Resource                        | Path               |
+| ------------------------------- | ------------------ |
 | ESLint config (rule definition) | `eslint.config.ts` |
-| Base layer | `src/base/` |
-| Platform layer | `src/platform/` |
-| Workbench layer | `src/workbench/` |
-| Renderer layer | `src/renderer/` |
+| Base layer                      | `src/base/`        |
+| Platform layer                  | `src/platform/`    |
+| Workbench layer                 | `src/workbench/`   |
+| Renderer layer                  | `src/renderer/`    |

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -308,7 +308,7 @@ export default defineConfig([
   // Layer architecture boundary enforcement
   // Layers (bottom to top): base → platform → workbench → renderer
   // Each layer may only import from layers below it.
-  // Set to 'warn' because there are existing violations being migrated gradually.
+  // Existing violations are suppressed with eslint-disable comments.
   {
     files: [
       'src/base/**/*.{ts,vue}',
@@ -317,42 +317,25 @@ export default defineConfig([
     ],
     rules: {
       'import-x/no-restricted-paths': [
-        'warn',
+        'error',
         {
           zones: [
-            // base cannot import from platform, workbench, or renderer
             {
               target: './src/base/**',
-              from: './src/platform/**',
+              from: [
+                './src/platform/**',
+                './src/workbench/**',
+                './src/renderer/**'
+              ],
               message:
-                'base/ cannot import from platform/ (violates layer architecture: base → platform → workbench → renderer)'
-            },
-            {
-              target: './src/base/**',
-              from: './src/workbench/**',
-              message:
-                'base/ cannot import from workbench/ (violates layer architecture: base → platform → workbench → renderer)'
-            },
-            {
-              target: './src/base/**',
-              from: './src/renderer/**',
-              message:
-                'base/ cannot import from renderer/ (violates layer architecture: base → platform → workbench → renderer)'
-            },
-            // platform cannot import from workbench or renderer
-            {
-              target: './src/platform/**',
-              from: './src/workbench/**',
-              message:
-                'platform/ cannot import from workbench/ (violates layer architecture: base → platform → workbench → renderer)'
+                'base/ cannot import from upper layers (violates layer architecture: base → platform → workbench → renderer)'
             },
             {
               target: './src/platform/**',
-              from: './src/renderer/**',
+              from: ['./src/workbench/**', './src/renderer/**'],
               message:
-                'platform/ cannot import from renderer/ (violates layer architecture: base → platform → workbench → renderer)'
+                'platform/ cannot import from upper layers (violates layer architecture: base → platform → workbench → renderer)'
             },
-            // workbench cannot import from renderer
             {
               target: './src/workbench/**',
               from: './src/renderer/**',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -305,6 +305,66 @@ export default defineConfig([
     }
   },
 
+  // Layer architecture boundary enforcement
+  // Layers (bottom to top): base → platform → workbench → renderer
+  // Each layer may only import from layers below it.
+  // Set to 'warn' because there are existing violations being migrated gradually.
+  {
+    files: [
+      'src/base/**/*.{ts,vue}',
+      'src/platform/**/*.{ts,vue}',
+      'src/workbench/**/*.{ts,vue}'
+    ],
+    rules: {
+      'import-x/no-restricted-paths': [
+        'warn',
+        {
+          zones: [
+            // base cannot import from platform, workbench, or renderer
+            {
+              target: './src/base/**',
+              from: './src/platform/**',
+              message:
+                'base/ cannot import from platform/ (violates layer architecture: base → platform → workbench → renderer)'
+            },
+            {
+              target: './src/base/**',
+              from: './src/workbench/**',
+              message:
+                'base/ cannot import from workbench/ (violates layer architecture: base → platform → workbench → renderer)'
+            },
+            {
+              target: './src/base/**',
+              from: './src/renderer/**',
+              message:
+                'base/ cannot import from renderer/ (violates layer architecture: base → platform → workbench → renderer)'
+            },
+            // platform cannot import from workbench or renderer
+            {
+              target: './src/platform/**',
+              from: './src/workbench/**',
+              message:
+                'platform/ cannot import from workbench/ (violates layer architecture: base → platform → workbench → renderer)'
+            },
+            {
+              target: './src/platform/**',
+              from: './src/renderer/**',
+              message:
+                'platform/ cannot import from renderer/ (violates layer architecture: base → platform → workbench → renderer)'
+            },
+            // workbench cannot import from renderer
+            {
+              target: './src/workbench/**',
+              from: './src/renderer/**',
+              message:
+                'workbench/ cannot import from renderer/ (violates layer architecture: base → platform → workbench → renderer)'
+            }
+          ]
+        }
+      ]
+    }
+  },
+
   // i18n import enforcement
   // Vue components must use the useI18n() composable, not the global t/d/st/te
   {

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -2,7 +2,9 @@
  * Utility functions for downloading files
  */
 import { t } from '@/i18n'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { isCloud } from '@/platform/distribution/types'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 // Constants

--- a/src/platform/missingModel/missingModelScan.ts
+++ b/src/platform/missingModel/missingModelScan.ts
@@ -10,6 +10,7 @@ import type {
 } from './types'
 import { getAssetFilename } from '@/platform/assets/utils/assetMetadataUtils'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { getSelectedModelsMetadata } from '@/workbench/utils/modelMetadataUtil'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type {

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, onScopeDispose, ref } from 'vue'
 
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -48,6 +48,7 @@ import {
   collectAllNodes,
   getExecutionIdByNode
 } from '@/utils/graphTraversalUtil'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { getCnrIdFromNode } from '@/workbench/extensions/manager/utils/missingNodeErrorUtil'
 import { useNodeReplacementStore } from '@/platform/nodeReplacement/nodeReplacementStore'
 import { rescanAndSurfaceMissingNodes } from './missingNodeScan'

--- a/src/platform/nodeReplacement/missingNodeScan.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.ts
@@ -7,6 +7,7 @@ import {
   collectAllNodes,
   getExecutionIdByNode
 } from '@/utils/graphTraversalUtil'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { getCnrIdFromNode } from '@/workbench/extensions/manager/utils/missingNodeErrorUtil'
 
 /** Scan the live graph for unregistered node types and build a full MissingNodeType list. */

--- a/src/platform/settings/composables/useLitegraphSettings.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.ts
@@ -6,6 +6,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 /**

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -13,6 +13,7 @@ import {
 } from '@/platform/workflow/management/stores/workflowStore'
 import { useTelemetry } from '@/platform/telemetry'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useWorkflowThumbnail } from '@/renderer/core/thumbnail/useWorkflowThumbnail'
 import { app } from '@/scripts/app'
 import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -14,6 +14,7 @@ import type {
   NodeId
 } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { useWorkflowDraftStore } from '@/platform/workflow/persistence/stores/workflowDraftStore'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useWorkflowThumbnail } from '@/renderer/core/thumbnail/useWorkflowThumbnail'
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -5,6 +5,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useTelemetry } from '@/platform/telemetry'
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import { useTemplateWorkflows } from './useTemplateWorkflows'

--- a/src/workbench/eventHelpers.ts
+++ b/src/workbench/eventHelpers.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import-x/no-restricted-paths
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 /**
  * Utility functions for handling workbench events


### PR DESCRIPTION
## Summary
- Add `import-x/no-restricted-paths` ESLint rule enforcing the `base → platform → workbench → renderer` layer hierarchy
- Set to `error` with eslint-disable comments on existing violations (~11 suppressions)
- Consolidate zone definitions using array syntax for `from`/`target`
- Add `layer-audit` Claude skill for auditing violations
- Fix knip false positive for `zod` dependency in ingest-types

## Context
Ref: https://github.com/Comfy-Org/ComfyUI_frontend/pull/10021#discussion_r2939392141

The codebase is migrating toward a layered architecture. This adds static enforcement so new violations are caught in PR CI.

### Layer rules
| Layer | Can import from |
|---|---|
| `base/` | nothing |
| `platform/` | `base/` |
| `workbench/` | `platform/`, `base/` |
| `renderer/` | `workbench/`, `platform/`, `base/` |

### Current violations (pre-existing, suppressed with eslint-disable)
| Direction | Count |
|---|---|
| base → platform | 2 |
| platform → workbench | 3 |
| platform → renderer | 5 |
| workbench → renderer | 1 |

## Test plan
- [x] `pnpm lint` passes (0 errors, 0 warnings)
- [x] `pnpm typecheck` passes
- [x] `pnpm knip` passes
- [ ] CI green