### PR TITLE
fix: tighten date detection regex in formatJsonValue()

### DIFF
--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -123,12 +123,13 @@ export const useCustomerEventsService = () => {
 
   function formatJsonValue(value: unknown) {
     if (typeof value === 'number') {
-      // Format numbers with commas and decimals if needed
       return value.toLocaleString()
     }
-    if (typeof value === 'string' && value.match(/^\d{4}-\d{2}-\d{2}/)) {
-      // Format dates nicely
-      return new Date(value).toLocaleString()
+    if (typeof value === 'string') {
+      const date = new Date(value)
+      if (!Number.isNaN(date.getTime()) && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+        return d(date, { dateStyle: 'medium', timeStyle: 'short' })
+      }
     }
     return value
   }


### PR DESCRIPTION
`formatJsonValue()` uses a loose regex `^\d{4}-\d{2}-\d{2}` to detect date-like strings, which matches non-date strings like `"2024-01-01-beta"`.

Changes:
- Require ISO 8601 `T` separator: `/^\d{4}-\d{2}-\d{2}T/`
- Validate parse result with `!Number.isNaN(date.getTime())`
- Use `d()` i18n formatter for consistency with `formatDate()` in the same file

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10110-fix-tighten-date-detection-regex-in-formatJsonValue-3256d73d3650819793a7c7799fefac4e) by [Unito](https://www.unito.io)
