### PR TITLE
feat: resolveVirtualOutput for cross-subgraph virtual nodes (eg. Set/Get)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1208,6 +1208,14 @@ export class LGraphNode
   }
 
   /**
+   * Resolves the output source for cross-graph virtual nodes (e.g. Set/Get),
+   * bypassing {@link getInputLink} when the source lives in a different graph.
+   */
+  resolveVirtualOutput?(
+    slot: number
+  ): { node: LGraphNode; slot: number } | undefined
+
+  /**
    * Returns the link info in the connection of an input slot
    * @returns object or null
    */

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
@@ -382,6 +382,102 @@ describe('ALWAYS mode node output resolution', () => {
   })
 })
 
+describe('Virtual node resolveVirtualOutput', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('should resolve through resolveVirtualOutput when implemented', () => {
+    const graph = new LGraph()
+
+    const sourceNode = new LGraphNode('Source')
+    sourceNode.addOutput('out', 'IMAGE')
+    graph.add(sourceNode)
+
+    const virtualNode = new LGraphNode('Virtual Get')
+    virtualNode.addOutput('out', 'IMAGE')
+    virtualNode.isVirtualNode = true
+    virtualNode.resolveVirtualOutput = () => ({ node: sourceNode, slot: 0 })
+    graph.add(virtualNode)
+
+    const nodeDtoMap = new Map()
+    const sourceDto = new ExecutableNodeDTO(
+      sourceNode,
+      [],
+      nodeDtoMap,
+      undefined
+    )
+    nodeDtoMap.set(sourceDto.id, sourceDto)
+
+    const virtualDto = new ExecutableNodeDTO(
+      virtualNode,
+      [],
+      nodeDtoMap,
+      undefined
+    )
+    nodeDtoMap.set(virtualDto.id, virtualDto)
+
+    const resolved = virtualDto.resolveOutput(0, 'IMAGE', new Set())
+    expect(resolved).toBeDefined()
+    expect(resolved?.node).toBe(sourceDto)
+    expect(resolved?.origin_slot).toBe(0)
+  })
+
+  it('should throw when resolveVirtualOutput returns a node with no matching DTO', () => {
+    const graph = new LGraph()
+
+    const unmappedNode = new LGraphNode('Unmapped Source')
+    unmappedNode.addOutput('out', 'IMAGE')
+    graph.add(unmappedNode)
+
+    const virtualNode = new LGraphNode('Virtual Get')
+    virtualNode.addOutput('out', 'IMAGE')
+    virtualNode.isVirtualNode = true
+    virtualNode.resolveVirtualOutput = () => ({
+      node: unmappedNode,
+      slot: 0
+    })
+    graph.add(virtualNode)
+
+    const nodeDtoMap = new Map()
+    const virtualDto = new ExecutableNodeDTO(
+      virtualNode,
+      [],
+      nodeDtoMap,
+      undefined
+    )
+    nodeDtoMap.set(virtualDto.id, virtualDto)
+
+    expect(() => virtualDto.resolveOutput(0, 'IMAGE', new Set())).toThrow(
+      'No DTO found for virtual source node'
+    )
+  })
+
+  it('should fall through to getInputLink when resolveVirtualOutput returns undefined', () => {
+    const graph = new LGraph()
+
+    const virtualNode = new LGraphNode('Virtual Passthrough')
+    virtualNode.addOutput('out', 'IMAGE')
+    virtualNode.isVirtualNode = true
+    virtualNode.resolveVirtualOutput = () => undefined
+    graph.add(virtualNode)
+
+    const nodeDtoMap = new Map()
+    const virtualDto = new ExecutableNodeDTO(
+      virtualNode,
+      [],
+      nodeDtoMap,
+      undefined
+    )
+    nodeDtoMap.set(virtualDto.id, virtualDto)
+
+    const spy = vi.spyOn(virtualNode, 'getInputLink')
+    const resolved = virtualDto.resolveOutput(0, 'IMAGE', new Set())
+    expect(resolved).toBeUndefined()
+    expect(spy).toHaveBeenCalledWith(0)
+  })
+})
+
 describe.skip('ExecutableNodeDTO Properties', () => {
   it('should provide access to basic properties', () => {
     const graph = new LGraph()

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -291,6 +291,20 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
       return this._resolveSubgraphOutput(slot, type, visited)
 
     if (node.isVirtualNode) {
+      // Cross-graph virtual nodes (e.g. Set/Get) resolve their source directly.
+      const virtualSource = this.node.resolveVirtualOutput?.(slot)
+      if (virtualSource) {
+        const inputNodeDto = [...this.nodesByExecutionId.values()].find(
+          (dto) =>
+            dto instanceof ExecutableNodeDTO && dto.node === virtualSource.node
+        )
+        if (!inputNodeDto)
+          throw new Error(
+            `No DTO found for virtual source node [${virtualSource.node.id}]`
+          )
+
+        return inputNodeDto.resolveOutput(virtualSource.slot, type, visited)
+      }
       const virtualLink = this.node.getInputLink(slot)
       if (virtualLink) {
         const { inputNode } = virtualLink.resolve(this.graph)


### PR DESCRIPTION
## Summary

Enable virtual nodes (e.g. Set/Get) to resolve their output source directly when the source lives in a different subgraph.

## Changes

- **What**: Added optional resolveVirtualOutput method on LGraphNode and a new resolution path in ExecutableNodeDTO.resolveOutput that checks it before falling through to the existing getInputLink path. Includes unit tests for the three code paths (happy path, missing DTO, fallthrough).

## Review Focus

- Fully backwards compatible — no existing node implements resolveVirtualOutput, so the new path is always skipped for current virtual nodes (Reroute, PrimitiveNode, etc.).

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots

Simple example in actual use, combined with new changes in KJNodes allows using Get nodes inside subgraphs:

<img width="2242" height="1434" alt="image" src="https://github.com/user-attachments/assets/cc940a95-e0bb-4adf-91b6-9adc43a74aa2" />

<img width="1436" height="440" alt="image" src="https://github.com/user-attachments/assets/62044af5-0d6e-4c4e-b34c-d33e85f2b969" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10111-feat-resolveVirtualOutput-for-cross-subgraph-virtual-nodes-eg-Set-Get-3256d73d3650816a9f20e28029561c58) by [Unito](https://www.unito.io)
