### PR TITLE
fix: show selected node help in node library v2

### DIFF
--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
@@ -1,8 +1,12 @@
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
+import type { TestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useNodeHelpStore } from '@/stores/workspace/nodeHelpStore'
 
 import NodeLibrarySidebarTabV2 from './NodeLibrarySidebarTabV2.vue'
 
@@ -68,6 +72,14 @@ vi.mock('./nodeLibrary/NodeDragPreview.vue', () => ({
   }
 }))
 
+vi.mock('@/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue', () => ({
+  default: {
+    name: 'NodeHelpPage',
+    template: '<div data-testid="node-help-page">{{ node.display_name }}</div>',
+    props: ['node']
+  }
+}))
+
 vi.mock('@/components/ui/search-input/SearchInput.vue', () => ({
   default: {
     name: 'SearchBox',
@@ -91,10 +103,16 @@ describe('NodeLibrarySidebarTabV2', () => {
     vi.clearAllMocks()
   })
 
-  function mountComponent() {
+  function createTestPinia(): TestingPinia {
+    const pinia = createTestingPinia({ stubActions: false })
+    setActivePinia(pinia)
+    return pinia
+  }
+
+  function mountComponent(pinia = createTestPinia()) {
     return mount(NodeLibrarySidebarTabV2, {
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [pinia, i18n],
         stubs: {
           teleport: true
         }
@@ -123,5 +141,22 @@ describe('NodeLibrarySidebarTabV2', () => {
     expect(wrapper.find('[data-testid="blueprints-panel"]').exists()).toBe(
       false
     )
+  })
+
+  it('should render node help instead of the node library when help is open', () => {
+    const pinia = createTestPinia()
+    const nodeHelpStore = useNodeHelpStore()
+    nodeHelpStore.openHelp({
+      nodePath: 'loaders/LoadImage',
+      display_name: 'Load Image'
+    } as Parameters<typeof nodeHelpStore.openHelp>[0])
+
+    const wrapper = mountComponent(pinia)
+
+    expect(wrapper.find('[data-testid="node-help-page"]').text()).toContain(
+      'Load Image'
+    )
+    expect(wrapper.find('[data-testid="search-box"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="essential-panel"]').exists()).toBe(false)
   })
 })

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.vue
@@ -1,159 +1,166 @@
 <template>
-  <SidebarTabTemplate :title="$t('sideToolbar.nodes')">
-    <template #header>
-      <SidebarTopArea bottom-divider>
-        <SearchInput
-          ref="searchBoxRef"
-          v-model="searchQuery"
-          :placeholder="$t('g.search') + '...'"
-          @search="handleSearch"
-        />
-        <template #actions>
-          <DropdownMenuRoot>
-            <DropdownMenuTrigger as-child>
-              <Button
-                variant="secondary"
-                size="icon"
-                :aria-label="$t('g.sort')"
-              >
-                <i class="icon-[lucide--arrow-up-down] size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuContent
-                class="z-9999 min-w-32 rounded-lg border border-border-default bg-comfy-menu-bg p-1 shadow-lg"
-                align="end"
-                :side-offset="4"
-              >
-                <DropdownMenuRadioGroup v-model="sortOrder">
-                  <DropdownMenuRadioItem
-                    v-for="option in sortingOptions"
-                    :key="option.id"
-                    :value="option.id"
+  <div class="h-full">
+    <SidebarTabTemplate v-if="!isHelpOpen" :title="$t('sideToolbar.nodes')">
+      <template #header>
+        <SidebarTopArea bottom-divider>
+          <SearchInput
+            ref="searchBoxRef"
+            v-model="searchQuery"
+            :placeholder="$t('g.search') + '...'"
+            @search="handleSearch"
+          />
+          <template #actions>
+            <DropdownMenuRoot>
+              <DropdownMenuTrigger as-child>
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  :aria-label="$t('g.sort')"
+                >
+                  <i class="icon-[lucide--arrow-up-down] size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuContent
+                  class="z-9999 min-w-32 rounded-lg border border-border-default bg-comfy-menu-bg p-1 shadow-lg"
+                  align="end"
+                  :side-offset="4"
+                >
+                  <DropdownMenuRadioGroup v-model="sortOrder">
+                    <DropdownMenuRadioItem
+                      v-for="option in sortingOptions"
+                      :key="option.id"
+                      :value="option.id"
+                      class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
+                    >
+                      <span class="flex-1">{{ $t(option.label) }}</span>
+                      <DropdownMenuItemIndicator class="w-4">
+                        <i class="icon-[lucide--check] size-4" />
+                      </DropdownMenuItemIndicator>
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
+            </DropdownMenuRoot>
+            <DropdownMenuRoot v-if="selectedTab === 'all'">
+              <DropdownMenuTrigger as-child>
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  :aria-label="$t('sideToolbar.nodeLibraryTab.filter')"
+                >
+                  <i class="icon-[lucide--list-filter] size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuContent
+                  class="z-9999 min-w-32 rounded-lg border border-border-default bg-comfy-menu-bg p-1 shadow-lg"
+                  align="end"
+                  :side-offset="4"
+                >
+                  <DropdownMenuCheckboxItem
+                    v-model="filterOptions.blueprints"
                     class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
                   >
-                    <span class="flex-1">{{ $t(option.label) }}</span>
+                    <span class="flex-1">{{
+                      $t('sideToolbar.nodeLibraryTab.filterOptions.blueprints')
+                    }}</span>
                     <DropdownMenuItemIndicator class="w-4">
                       <i class="icon-[lucide--check] size-4" />
                     </DropdownMenuItemIndicator>
-                  </DropdownMenuRadioItem>
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
-          </DropdownMenuRoot>
-          <DropdownMenuRoot v-if="selectedTab === 'all'">
-            <DropdownMenuTrigger as-child>
-              <Button
-                variant="secondary"
-                size="icon"
-                :aria-label="$t('sideToolbar.nodeLibraryTab.filter')"
-              >
-                <i class="icon-[lucide--list-filter] size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuContent
-                class="z-9999 min-w-32 rounded-lg border border-border-default bg-comfy-menu-bg p-1 shadow-lg"
-                align="end"
-                :side-offset="4"
-              >
-                <DropdownMenuCheckboxItem
-                  v-model="filterOptions.blueprints"
-                  class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
-                >
-                  <span class="flex-1">{{
-                    $t('sideToolbar.nodeLibraryTab.filterOptions.blueprints')
-                  }}</span>
-                  <DropdownMenuItemIndicator class="w-4">
-                    <i class="icon-[lucide--check] size-4" />
-                  </DropdownMenuItemIndicator>
-                </DropdownMenuCheckboxItem>
-                <DropdownMenuCheckboxItem
-                  v-model="filterOptions.partnerNodes"
-                  class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
-                >
-                  <span class="flex-1">{{
-                    $t('sideToolbar.nodeLibraryTab.filterOptions.partnerNodes')
-                  }}</span>
-                  <DropdownMenuItemIndicator class="w-4">
-                    <i class="icon-[lucide--check] size-4" />
-                  </DropdownMenuItemIndicator>
-                </DropdownMenuCheckboxItem>
-                <DropdownMenuCheckboxItem
-                  v-model="filterOptions.comfyNodes"
-                  class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
-                >
-                  <span class="flex-1">{{
-                    $t('sideToolbar.nodeLibraryTab.filterOptions.comfyNodes')
-                  }}</span>
-                  <DropdownMenuItemIndicator class="w-4">
-                    <i class="icon-[lucide--check] size-4" />
-                  </DropdownMenuItemIndicator>
-                </DropdownMenuCheckboxItem>
-                <DropdownMenuCheckboxItem
-                  v-model="filterOptions.extensions"
-                  class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
-                >
-                  <span class="flex-1">{{
-                    $t('sideToolbar.nodeLibraryTab.filterOptions.extensions')
-                  }}</span>
-                  <DropdownMenuItemIndicator class="w-4">
-                    <i class="icon-[lucide--check] size-4" />
-                  </DropdownMenuItemIndicator>
-                </DropdownMenuCheckboxItem>
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
-          </DropdownMenuRoot>
-        </template>
-      </SidebarTopArea>
-      <div class="border-b border-comfy-input p-2 2xl:px-4">
-        <TabList v-model="selectedTab">
-          <Tab v-for="tab in tabs" :key="tab.value" :value="tab.value">
-            {{ tab.label }}
-          </Tab>
-        </TabList>
-      </div>
-    </template>
-    <template #body>
-      <NodeDragPreview />
-      <div class="flex h-full flex-col">
-        <div class="min-h-0 flex-1 overflow-y-auto py-2">
-          <TabPanel
-            v-if="flags.nodeLibraryEssentialsEnabled"
-            :model-value="selectedTab"
-            value="essentials"
-          >
-            <EssentialNodesPanel
-              v-model:expanded-keys="expandedKeys"
-              :root="renderedEssentialRoot"
-              :flat-nodes="essentialFlatNodes"
-              @node-click="handleNodeClick"
-            />
-          </TabPanel>
-          <TabPanel :model-value="selectedTab" value="all">
-            <AllNodesPanel
-              v-model:expanded-keys="expandedKeys"
-              :sections="renderedSections"
-              :fill-node-info="fillNodeInfo"
-              :sort-order="sortOrder"
-              @node-click="handleNodeClick"
-            />
-          </TabPanel>
-          <TabPanel :model-value="selectedTab" value="blueprints">
-            <BlueprintsPanel
-              v-model:expanded-keys="expandedKeys"
-              :sections="renderedBlueprintsSections"
-              @node-click="handleNodeClick"
-            />
-          </TabPanel>
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    v-model="filterOptions.partnerNodes"
+                    class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
+                  >
+                    <span class="flex-1">{{
+                      $t(
+                        'sideToolbar.nodeLibraryTab.filterOptions.partnerNodes'
+                      )
+                    }}</span>
+                    <DropdownMenuItemIndicator class="w-4">
+                      <i class="icon-[lucide--check] size-4" />
+                    </DropdownMenuItemIndicator>
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    v-model="filterOptions.comfyNodes"
+                    class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
+                  >
+                    <span class="flex-1">{{
+                      $t('sideToolbar.nodeLibraryTab.filterOptions.comfyNodes')
+                    }}</span>
+                    <DropdownMenuItemIndicator class="w-4">
+                      <i class="icon-[lucide--check] size-4" />
+                    </DropdownMenuItemIndicator>
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    v-model="filterOptions.extensions"
+                    class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none hover:bg-comfy-input"
+                  >
+                    <span class="flex-1">{{
+                      $t('sideToolbar.nodeLibraryTab.filterOptions.extensions')
+                    }}</span>
+                    <DropdownMenuItemIndicator class="w-4">
+                      <i class="icon-[lucide--check] size-4" />
+                    </DropdownMenuItemIndicator>
+                  </DropdownMenuCheckboxItem>
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
+            </DropdownMenuRoot>
+          </template>
+        </SidebarTopArea>
+        <div class="border-b border-comfy-input p-2 2xl:px-4">
+          <TabList v-model="selectedTab">
+            <Tab v-for="tab in tabs" :key="tab.value" :value="tab.value">
+              {{ tab.label }}
+            </Tab>
+          </TabList>
         </div>
-      </div>
-    </template>
-  </SidebarTabTemplate>
+      </template>
+      <template #body>
+        <NodeDragPreview />
+        <div class="flex h-full flex-col">
+          <div class="min-h-0 flex-1 overflow-y-auto py-2">
+            <TabPanel
+              v-if="flags.nodeLibraryEssentialsEnabled"
+              :model-value="selectedTab"
+              value="essentials"
+            >
+              <EssentialNodesPanel
+                v-model:expanded-keys="expandedKeys"
+                :root="renderedEssentialRoot"
+                :flat-nodes="essentialFlatNodes"
+                @node-click="handleNodeClick"
+              />
+            </TabPanel>
+            <TabPanel :model-value="selectedTab" value="all">
+              <AllNodesPanel
+                v-model:expanded-keys="expandedKeys"
+                :sections="renderedSections"
+                :fill-node-info="fillNodeInfo"
+                :sort-order="sortOrder"
+                @node-click="handleNodeClick"
+              />
+            </TabPanel>
+            <TabPanel :model-value="selectedTab" value="blueprints">
+              <BlueprintsPanel
+                v-model:expanded-keys="expandedKeys"
+                :sections="renderedBlueprintsSections"
+                @node-click="handleNodeClick"
+              />
+            </TabPanel>
+          </div>
+        </div>
+      </template>
+    </SidebarTabTemplate>
+
+    <NodeHelpPage v-else :node="currentHelpNode!" @close="closeHelp" />
+  </div>
 </template>
 
 <script setup lang="ts">
 import { useLocalStorage } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
 import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -173,6 +180,7 @@ import TabList from '@/components/tab/TabList.vue'
 import TabPanel from '@/components/tab/TabPanel.vue'
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
+import NodeHelpPage from '@/components/sidebar/tabs/nodeLibrary/NodeHelpPage.vue'
 import SidebarTopArea from '@/components/sidebar/tabs/SidebarTopArea.vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useNodeDragToCanvas } from '@/composables/node/useNodeDragToCanvas'
@@ -182,6 +190,7 @@ import {
   DEFAULT_TAB_ID,
   nodeOrganizationService
 } from '@/services/nodeOrganizationService'
+import { useNodeHelpStore } from '@/stores/workspace/nodeHelpStore'
 import { getProviderIcon } from '@/utils/categoryUtil'
 import { flattenTree, sortedTree, unwrapTreeRoot } from '@/utils/treeUtil'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -256,7 +265,10 @@ const expandedKeysByTab = ref<Record<TabId, string[]>>({
 const expandedKeys = usePerTabState(selectedTab, expandedKeysByTab)
 
 const nodeDefStore = useNodeDefStore()
+const nodeHelpStore = useNodeHelpStore()
 const { startDrag } = useNodeDragToCanvas()
+const { currentHelpNode, isHelpOpen } = storeToRefs(nodeHelpStore)
+const { closeHelp } = nodeHelpStore
 
 const filteredNodeDefs = computed(() => {
   if (searchQuery.value.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the new node library sidebar so `Node Info` opens the selected node's help/details view instead of falling back to the generic node search/list.

## Changes

- **What**: `NodeLibrarySidebarTabV2` now honors `nodeHelpStore` and renders `NodeHelpPage` when help is open, matching the legacy node library behavior.
- **What**: Added a regression test covering the help-open state in the V2 sidebar tab.
- **Note**: Most of the large `.vue` diff is template reindent/formatting churn from wrapping the existing node library layout in a help-state `v-if`/`v-else`, not new UI logic.

## Review Focus

Check that the V2 node library flow now matches the legacy tab behavior:
- selecting a node and clicking `Node Info` opens that node's help page
- the back button returns to the normal node library browser
- switching selection and reopening `Node Info` shows the newly selected node

Fixes #9996

## Fix Demo

https://github.com/user-attachments/assets/627471bd-690c-4454-92bb-d0c19a1f82b7

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10112-fix-show-selected-node-help-in-node-library-v2-3256d73d365081779b86fd812e7b0e26) by [Unito](https://www.unito.io)
