### PR TITLE
fix: broken Firebase auth gate in API layer

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1,5 +1,6 @@
 import { promiseTimeout, until } from '@vueuse/core'
 import axios from 'axios'
+import { storeToRefs } from 'pinia'
 import { get } from 'es-toolkit/compat'
 import { trimEnd } from 'es-toolkit'
 import { ref } from 'vue'
@@ -414,9 +415,10 @@ export class ComfyApi extends EventTarget {
 
       if (authStore.isInitialized) return
 
+      const { isInitialized } = storeToRefs(authStore)
       try {
         await Promise.race([
-          until(authStore.isInitialized),
+          until(isInitialized).toBe(true),
           promiseTimeout(10000)
         ])
       } catch {


### PR DESCRIPTION
## Summary

- `waitForAuthInitialization` in `api.ts` was silently passing through without actually waiting for Firebase auth
- `authStore.isInitialized` is unwrapped by Pinia (plain boolean, not a ref), so `until()` received a static value
- `until()` without `.toBe()` returns a builder object, not a promise — `Promise.race` treated it as immediately resolved
- Fixed with `storeToRefs` to preserve the ref and `.toBe(true)` to return an actual promise

## Test plan

- [ ] Verify cloud mode API calls wait for Firebase initialization before firing
- [ ] Verify non-cloud mode is unaffected
- [ ] Verify no 401s on initial page load in cloud mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10115-fix-broken-Firebase-auth-gate-in-API-layer-3256d73d365081e39b0df4d644f38c84) by [Unito](https://www.unito.io)
