### PR TITLE
fix: store 3d viewer config in standalone mode

### DIFF
--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -104,7 +104,8 @@ describe('useLoad3dViewer', () => {
       }),
       forceRender: vi.fn(),
       remove: vi.fn(),
-      setTargetSize: vi.fn()
+      setTargetSize: vi.fn(),
+      loadModel: vi.fn().mockResolvedValue(undefined)
     }
 
     mockSourceLoad3d = {
@@ -652,6 +653,59 @@ describe('useLoad3dViewer', () => {
       await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
 
       expect(viewer.lightIntensity.value).toBe(1) // Default value
+    })
+  })
+
+  describe('standalone mode persistence', () => {
+    it('should save and restore configuration in standalone mode', async () => {
+      const viewer = useLoad3dViewer()
+      const containerRef = document.createElement('div')
+      const model1 = 'model1.glb'
+      const model2 = 'model2.glb'
+
+      // Initialize with model1
+      await viewer.initializeStandaloneViewer(containerRef, model1)
+      expect(viewer.isStandaloneMode.value).toBe(true)
+
+      // Change some state for model1
+      viewer.backgroundColor.value = '#ff0000'
+      viewer.showGrid.value = false
+      await nextTick()
+
+      // Load model2 - should save model1 config and restore model2 defaults
+      await viewer.initializeStandaloneViewer(containerRef, model2)
+      expect(viewer.backgroundColor.value).toBe('#282828') // Default
+      expect(viewer.showGrid.value).toBe(true) // Default
+
+      // Change some state for model2
+      viewer.backgroundColor.value = '#00ff00'
+      await nextTick()
+
+      // Load model1 again - should restore model1 config
+      await viewer.initializeStandaloneViewer(containerRef, model1)
+      expect(viewer.backgroundColor.value).toBe('#ff0000')
+      expect(viewer.showGrid.value).toBe(false)
+
+      // Load model2 again - should restore model2 config
+      await viewer.initializeStandaloneViewer(containerRef, model2)
+      expect(viewer.backgroundColor.value).toBe('#00ff00')
+    })
+
+    it('should save configuration during cleanup in standalone mode', async () => {
+      const viewer = useLoad3dViewer()
+      const containerRef = document.createElement('div')
+      const modelUrl = 'model_cleanup.glb'
+
+      await viewer.initializeStandaloneViewer(containerRef, modelUrl)
+      viewer.backgroundColor.value = '#0000ff'
+      await nextTick()
+
+      viewer.cleanup()
+
+      // Re-initialize and check if config was restored from cache
+      const newViewer = useLoad3dViewer()
+      await newViewer.initializeStandaloneViewer(containerRef, modelUrl)
+      expect(newViewer.backgroundColor.value).toBe('#0000ff')
     })
   })
 })

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -596,6 +596,18 @@ describe('useLoad3dViewer', () => {
         'toastMessages.failedToUploadBackgroundImage'
       )
     })
+
+    it('should work in standalone mode without a node', async () => {
+      const viewer = useLoad3dViewer()
+      const containerRef = document.createElement('div')
+      await viewer.initializeStandaloneViewer(containerRef, 'model.glb')
+
+      const file = new File([''], 'test.jpg', { type: 'image/jpeg' })
+      await viewer.handleBackgroundImageUpdate(file)
+
+      expect(Load3dUtils.uploadFile).toHaveBeenCalledWith(file, '3d')
+      expect(viewer.backgroundImage.value).toBe('uploaded-image.jpg')
+    })
   })
 
   describe('cleanup', () => {
@@ -690,7 +702,7 @@ describe('useLoad3dViewer', () => {
       expect(viewer.lightIntensity.value).toBe(2)
       expect(viewer.backgroundImage.value).toBe('test.jpg')
       expect(viewer.hasBackgroundImage.value).toBe(true)
-      expect(viewer.backgroundRenderMode.value).toBe('contain')
+      expect(viewer.backgroundRenderMode.value).toBe('tiled')
       expect(viewer.upDirection.value).toBe('+y')
       expect(viewer.materialMode.value).toBe('wireframe')
 

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -534,7 +534,9 @@ describe('useLoad3dViewer', () => {
 
   describe('handleBackgroundImageUpdate', () => {
     it('should upload and set background image', async () => {
-      vi.mocked(Load3dUtils.uploadFile).mockResolvedValue('uploaded-image.jpg')
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValueOnce(
+        'uploaded-image.jpg'
+      )
 
       const viewer = useLoad3dViewer(mockNode)
       const containerRef = document.createElement('div')
@@ -551,7 +553,9 @@ describe('useLoad3dViewer', () => {
 
     it('should use resource folder for upload', async () => {
       mockNode.properties['Resource Folder'] = 'subfolder'
-      vi.mocked(Load3dUtils.uploadFile).mockResolvedValue('uploaded-image.jpg')
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValueOnce(
+        'uploaded-image.jpg'
+      )
 
       const viewer = useLoad3dViewer(mockNode)
       const containerRef = document.createElement('div')
@@ -598,6 +602,9 @@ describe('useLoad3dViewer', () => {
     })
 
     it('should work in standalone mode without a node', async () => {
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValueOnce(
+        'uploaded-image.jpg'
+      )
       const viewer = useLoad3dViewer()
       const containerRef = document.createElement('div')
       await viewer.initializeStandaloneViewer(containerRef, 'model.glb')

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -105,7 +105,12 @@ describe('useLoad3dViewer', () => {
       forceRender: vi.fn(),
       remove: vi.fn(),
       setTargetSize: vi.fn(),
-      loadModel: vi.fn().mockResolvedValue(undefined)
+      loadModel: vi.fn().mockResolvedValue(undefined),
+      setCameraState: vi.fn(),
+      addEventListener: vi.fn(),
+      hasAnimations: vi.fn().mockReturnValue(false),
+      isSplatModel: vi.fn().mockReturnValue(false),
+      isPlyModel: vi.fn().mockReturnValue(false)
     }
 
     mockSourceLoad3d = {

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -668,21 +668,34 @@ describe('useLoad3dViewer', () => {
 
       viewer.backgroundColor.value = '#ff0000'
       viewer.showGrid.value = false
+      viewer.cameraType.value = 'orthographic'
+      viewer.fov.value = 45
+      viewer.lightIntensity.value = 2
+      viewer.backgroundImage.value = 'test.jpg'
+      viewer.backgroundRenderMode.value = 'tiled'
+      viewer.upDirection.value = '+y'
+      viewer.materialMode.value = 'wireframe'
       await nextTick()
 
       await viewer.initializeStandaloneViewer(containerRef, model2)
       expect(viewer.backgroundColor.value).toBe('#282828')
       expect(viewer.showGrid.value).toBe(true)
-
-      viewer.backgroundColor.value = '#00ff00'
-      await nextTick()
+      expect(viewer.backgroundImage.value).toBe('')
 
       await viewer.initializeStandaloneViewer(containerRef, model1)
       expect(viewer.backgroundColor.value).toBe('#ff0000')
       expect(viewer.showGrid.value).toBe(false)
+      expect(viewer.cameraType.value).toBe('orthographic')
+      expect(viewer.fov.value).toBe(45)
+      expect(viewer.lightIntensity.value).toBe(2)
+      expect(viewer.backgroundImage.value).toBe('test.jpg')
+      expect(viewer.hasBackgroundImage.value).toBe(true)
+      expect(viewer.backgroundRenderMode.value).toBe('contain')
+      expect(viewer.upDirection.value).toBe('+y')
+      expect(viewer.materialMode.value).toBe('wireframe')
 
       await viewer.initializeStandaloneViewer(containerRef, model2)
-      expect(viewer.backgroundColor.value).toBe('#00ff00')
+      expect(viewer.backgroundColor.value).toBe('#282828')
     })
 
     it('should save configuration during cleanup in standalone mode', async () => {

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -663,30 +663,24 @@ describe('useLoad3dViewer', () => {
       const model1 = 'model1.glb'
       const model2 = 'model2.glb'
 
-      // Initialize with model1
       await viewer.initializeStandaloneViewer(containerRef, model1)
       expect(viewer.isStandaloneMode.value).toBe(true)
 
-      // Change some state for model1
       viewer.backgroundColor.value = '#ff0000'
       viewer.showGrid.value = false
       await nextTick()
 
-      // Load model2 - should save model1 config and restore model2 defaults
       await viewer.initializeStandaloneViewer(containerRef, model2)
-      expect(viewer.backgroundColor.value).toBe('#282828') // Default
-      expect(viewer.showGrid.value).toBe(true) // Default
+      expect(viewer.backgroundColor.value).toBe('#282828')
+      expect(viewer.showGrid.value).toBe(true)
 
-      // Change some state for model2
       viewer.backgroundColor.value = '#00ff00'
       await nextTick()
 
-      // Load model1 again - should restore model1 config
       await viewer.initializeStandaloneViewer(containerRef, model1)
       expect(viewer.backgroundColor.value).toBe('#ff0000')
       expect(viewer.showGrid.value).toBe(false)
 
-      // Load model2 again - should restore model2 config
       await viewer.initializeStandaloneViewer(containerRef, model2)
       expect(viewer.backgroundColor.value).toBe('#00ff00')
     })
@@ -702,7 +696,6 @@ describe('useLoad3dViewer', () => {
 
       viewer.cleanup()
 
-      // Re-initialize and check if config was restored from cache
       const newViewer = useLoad3dViewer()
       await newViewer.initializeStandaloneViewer(containerRef, modelUrl)
       expect(newViewer.backgroundColor.value).toBe('#0000ff')

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -33,6 +33,21 @@ interface Load3dViewerState {
   materialMode: MaterialMode
 }
 
+const DEFAULT_STANDALONE_CONFIG: Load3dViewerState = {
+  backgroundColor: '#282828',
+  showGrid: true,
+  cameraType: 'perspective',
+  fov: 75,
+  lightIntensity: 1,
+  cameraState: null,
+  backgroundImage: '',
+  backgroundRenderMode: 'tiled',
+  upDirection: 'original',
+  materialMode: 'original'
+}
+
+const standaloneConfigCache = new Map<string, Load3dViewerState>()
+
 /**
  * @param node Optional node - if provided, viewer works in node mode with apply/restore
  *             If not provided, viewer works in standalone mode for asset preview
@@ -64,6 +79,7 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
 
   let load3d: Load3d | null = null
   let sourceLoad3d: Load3d | null = null
+  let currentModelUrl: string | null = null
 
   const initialState = ref<Load3dViewerState>({
     backgroundColor: '#282828',
@@ -381,15 +397,8 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
       })
 
       await load3d.loadModel(modelUrl)
-
-      backgroundColor.value = '#282828'
-      showGrid.value = true
-      cameraType.value = 'perspective'
-      fov.value = 75
-      lightIntensity.value = 1
-      backgroundRenderMode.value = 'tiled'
-      upDirection.value = 'original'
-      materialMode.value = 'original'
+      currentModelUrl = modelUrl
+      restoreStandaloneConfig(modelUrl)
       isSplatModel.value = load3d.isSplatModel()
       isPlyModel.value = load3d.isPlyModel()
 
@@ -410,12 +419,47 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     if (!load3d) return
 
     try {
+      saveStandaloneConfig()
       await load3d.loadModel(modelUrl)
+      currentModelUrl = modelUrl
+      restoreStandaloneConfig(modelUrl)
       isSplatModel.value = load3d.isSplatModel()
       isPlyModel.value = load3d.isPlyModel()
     } catch (error) {
       console.error('Error loading model in standalone viewer:', error)
       useToastStore().addAlert('Failed to load 3D model')
+    }
+  }
+
+  function saveStandaloneConfig() {
+    if (!currentModelUrl) return
+    standaloneConfigCache.set(currentModelUrl, {
+      backgroundColor: backgroundColor.value,
+      showGrid: showGrid.value,
+      cameraType: cameraType.value,
+      fov: fov.value,
+      lightIntensity: lightIntensity.value,
+      cameraState: load3d?.getCameraState() ?? null,
+      backgroundImage: backgroundImage.value,
+      backgroundRenderMode: backgroundRenderMode.value,
+      upDirection: upDirection.value,
+      materialMode: materialMode.value
+    })
+  }
+
+  function restoreStandaloneConfig(modelUrl: string) {
+    const cached = standaloneConfigCache.get(modelUrl)
+    const config = cached ?? DEFAULT_STANDALONE_CONFIG
+    backgroundColor.value = config.backgroundColor
+    showGrid.value = config.showGrid
+    cameraType.value = config.cameraType
+    fov.value = config.fov
+    lightIntensity.value = config.lightIntensity
+    backgroundRenderMode.value = config.backgroundRenderMode
+    upDirection.value = config.upDirection
+    materialMode.value = config.materialMode
+    if (cached?.cameraState && load3d) {
+      load3d.setCameraState(cached.cameraState)
     }
   }
 
@@ -609,9 +653,13 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
   }
 
   const cleanup = () => {
+    if (isStandaloneMode.value) {
+      saveStandaloneConfig()
+    }
     load3d?.remove()
     load3d = null
     sourceLoad3d = null
+    currentModelUrl = null
   }
 
   return {

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -584,25 +584,32 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     if (!file) {
       backgroundImage.value = ''
       hasBackgroundImage.value = false
+      if (isStandaloneMode.value) {
+        saveStandaloneConfig()
+      }
       return
     }
 
-    if (!node) {
+    if (!load3d) {
+      useToastStore().addAlert(t('toastMessages.no3dScene'))
       return
     }
+
+    const resourceFolder =
+      (node?.properties?.['Resource Folder'] as string) || ''
+    const subfolder = resourceFolder.trim()
+      ? `3d/${resourceFolder.trim()}`
+      : '3d'
 
     try {
-      const resourceFolder =
-        (node.properties['Resource Folder'] as string) || ''
-      const subfolder = resourceFolder.trim()
-        ? `3d/${resourceFolder.trim()}`
-        : '3d'
-
       const uploadPath = await Load3dUtils.uploadFile(file, subfolder)
 
       if (uploadPath) {
         backgroundImage.value = uploadPath
         hasBackgroundImage.value = true
+        if (isStandaloneMode.value) {
+          saveStandaloneConfig()
+        }
       }
     } catch (error) {
       console.error('Error uploading background image:', error)
@@ -616,17 +623,13 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
       return
     }
 
-    if (!node) {
-      return
-    }
+    const resourceFolder =
+      (node?.properties?.['Resource Folder'] as string) || ''
+    const subfolder = resourceFolder.trim()
+      ? `3d/${resourceFolder.trim()}`
+      : '3d'
 
     try {
-      const resourceFolder =
-        (node.properties['Resource Folder'] as string) || ''
-      const subfolder = resourceFolder.trim()
-        ? `3d/${resourceFolder.trim()}`
-        : '3d'
-
       const uploadedPath = await Load3dUtils.uploadFile(file, subfolder)
 
       if (!uploadedPath) {
@@ -643,7 +646,7 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
 
       await load3d.loadModel(modelUrl)
 
-      const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
+      const modelWidget = node?.widgets?.find((w) => w.name === 'model_file')
       if (modelWidget) {
         const options = modelWidget.options as { values?: string[] } | undefined
         if (options?.values && !options.values.includes(uploadedPath)) {

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -1,4 +1,5 @@
 import { ref, toRaw, watch } from 'vue'
+import QuickLRU from '@alloc/quick-lru'
 
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
@@ -46,7 +47,9 @@ const DEFAULT_STANDALONE_CONFIG: Load3dViewerState = {
   materialMode: 'original'
 }
 
-const standaloneConfigCache = new Map<string, Load3dViewerState>()
+const standaloneConfigCache = new QuickLRU<string, Load3dViewerState>({
+  maxSize: 50
+})
 
 /**
  * @param node Optional node - if provided, viewer works in node mode with apply/restore
@@ -455,6 +458,8 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     cameraType.value = config.cameraType
     fov.value = config.fov
     lightIntensity.value = config.lightIntensity
+    backgroundImage.value = config.backgroundImage
+    hasBackgroundImage.value = !!config.backgroundImage
     backgroundRenderMode.value = config.backgroundRenderMode
     upDirection.value = config.upDirection
     materialMode.value = config.materialMode

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -52,8 +52,11 @@ const standaloneConfigCache = new QuickLRU<string, Load3dViewerState>({
 })
 
 /**
- * @param node Optional node - if provided, viewer works in node mode with apply/restore
- *             If not provided, viewer works in standalone mode for asset preview
+ * Composable for managing a 3D viewer instance.
+ * Supports both node-based mode (applied to a LiteGraph node)
+ * and standalone mode (for asset previews).
+ *
+ * @param node Optional LiteGraph node to sync state with
  */
 export const useLoad3dViewer = (node?: LGraphNode) => {
   const backgroundColor = ref('')
@@ -225,6 +228,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   })
 
+  /**
+   * Seeks to a specific progress point in the current animation.
+   *
+   * @param progress Progress percentage (0-100)
+   */
   const handleSeek = (progress: number) => {
     if (load3d && animationDuration.value > 0) {
       const time = (progress / 100) * animationDuration.value
@@ -232,6 +240,9 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Sets up event listeners for animation-related events from the Load3d instance.
+   */
   const setupAnimationEvents = () => {
     if (!load3d) return
 
@@ -262,7 +273,10 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
   }
 
   /**
-   * Initialize viewer in node mode (with source Load3d)
+   * Initializes the viewer in node mode using a source Load3d instance.
+   *
+   * @param containerRef The HTML element to mount the viewer in
+   * @param source The source Load3d instance to copy state from
    */
   const initializeViewer = async (
     containerRef: HTMLElement,
@@ -376,8 +390,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
   }
 
   /**
-   * Initialize viewer in standalone mode (for asset preview).
+   * Initializes the viewer in standalone mode for asset preview.
    * Creates the Load3d instance once; subsequent calls reuse it.
+   *
+   * @param containerRef The HTML element to mount the viewer in
+   * @param modelUrl URL of the model to load
    */
   const initializeStandaloneViewer = async (
     containerRef: HTMLElement,
@@ -434,6 +451,9 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Saves the current viewer configuration to the standalone cache.
+   */
   function saveStandaloneConfig() {
     if (!currentModelUrl) return
     standaloneConfigCache.set(currentModelUrl, {
@@ -450,6 +470,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     })
   }
 
+  /**
+   * Restores the viewer configuration from the standalone cache for the given model URL.
+   *
+   * @param modelUrl URL of the model to restore config for
+   */
   function restoreStandaloneConfig(modelUrl: string) {
     const cached = standaloneConfigCache.get(modelUrl)
     const config = cached ?? DEFAULT_STANDALONE_CONFIG
@@ -468,6 +493,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Exports the current model in the specified format.
+   *
+   * @param format The export format (e.g., 'glb', 'obj')
+   */
   const exportModel = async (format: string) => {
     if (!load3d) return
 
@@ -481,18 +511,30 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Handles resizing the 3D viewer.
+   */
   const handleResize = () => {
     load3d?.handleResize()
   }
 
+  /**
+   * Notifies the viewer that the mouse has entered the viewer area.
+   */
   const handleMouseEnter = () => {
     load3d?.updateStatusMouseOnViewer(true)
   }
 
+  /**
+   * Notifies the viewer that the mouse has left the viewer area.
+   */
   const handleMouseLeave = () => {
     load3d?.updateStatusMouseOnViewer(false)
   }
 
+  /**
+   * Restores the viewer state to its initial values when the viewer was opened.
+   */
   const restoreInitialState = () => {
     if (!node) return
 
@@ -532,6 +574,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Applies the current viewer changes back to the source node and its properties.
+   *
+   * @returns Promise resolving to true if changes were applied successfully
+   */
   const applyChanges = async () => {
     if (!node || !sourceLoad3d || !load3d) return false
 
@@ -576,10 +623,18 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     return true
   }
 
+  /**
+   * Refreshes the viewport of the current Load3d instance.
+   */
   const refreshViewport = () => {
     useLoad3dService().handleViewportRefresh(load3d)
   }
 
+  /**
+   * Returns the subfolder path for file uploads based on the node properties.
+   *
+   * @returns The subfolder string
+   */
   const getUploadSubfolder = () => {
     const resourceFolder = String(
       node?.properties?.['Resource Folder'] ?? ''
@@ -587,6 +642,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     return resourceFolder ? `3d/${resourceFolder}` : '3d'
   }
 
+  /**
+   * Handles updating the background image either by clearing it or uploading a new file.
+   *
+   * @param file The image file to upload, or null to clear the background
+   */
   const handleBackgroundImageUpdate = async (file: File | null) => {
     if (!file) {
       backgroundImage.value = ''
@@ -615,6 +675,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Handles dropping a new model file into the viewer.
+   *
+   * @param file The 3D model file to load
+   */
   const handleModelDrop = async (file: File) => {
     if (!load3d) {
       useToastStore().addAlert(t('toastMessages.no3dScene'))
@@ -655,6 +720,9 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     }
   }
 
+  /**
+   * Cleans up the viewer resources and saves the current standalone config if applicable.
+   */
   const cleanup = () => {
     if (isStandaloneMode.value) {
       saveStandaloneConfig()

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -580,13 +580,17 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
     useLoad3dService().handleViewportRefresh(load3d)
   }
 
+  const getUploadSubfolder = () => {
+    const resourceFolder = String(
+      node?.properties?.['Resource Folder'] ?? ''
+    ).trim()
+    return resourceFolder ? `3d/${resourceFolder}` : '3d'
+  }
+
   const handleBackgroundImageUpdate = async (file: File | null) => {
     if (!file) {
       backgroundImage.value = ''
       hasBackgroundImage.value = false
-      if (isStandaloneMode.value) {
-        saveStandaloneConfig()
-      }
       return
     }
 
@@ -595,21 +599,15 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
       return
     }
 
-    const resourceFolder =
-      (node?.properties?.['Resource Folder'] as string) || ''
-    const subfolder = resourceFolder.trim()
-      ? `3d/${resourceFolder.trim()}`
-      : '3d'
-
     try {
-      const uploadPath = await Load3dUtils.uploadFile(file, subfolder)
+      const uploadPath = await Load3dUtils.uploadFile(
+        file,
+        getUploadSubfolder()
+      )
 
       if (uploadPath) {
         backgroundImage.value = uploadPath
         hasBackgroundImage.value = true
-        if (isStandaloneMode.value) {
-          saveStandaloneConfig()
-        }
       }
     } catch (error) {
       console.error('Error uploading background image:', error)
@@ -623,14 +621,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
       return
     }
 
-    const resourceFolder =
-      (node?.properties?.['Resource Folder'] as string) || ''
-    const subfolder = resourceFolder.trim()
-      ? `3d/${resourceFolder.trim()}`
-      : '3d'
-
     try {
-      const uploadedPath = await Load3dUtils.uploadFile(file, subfolder)
+      const uploadedPath = await Load3dUtils.uploadFile(
+        file,
+        getUploadSubfolder()
+      )
 
       if (!uploadedPath) {
         useToastStore().addAlert(t('toastMessages.fileUploadFailed'))

--- a/src/services/load3dService.ts
+++ b/src/services/load3dService.ts
@@ -8,6 +8,13 @@
 import { toRaw } from 'vue'
 
 import type Load3d from '@/extensions/core/load3d/Load3d'
+import type {
+  AnimationItem,
+  BackgroundRenderModeType,
+  CameraType,
+  MaterialMode,
+  UpDirection
+} from '@/extensions/core/load3d/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { NodeId } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { Object3D } from 'three'
@@ -15,6 +22,28 @@ import type { Object3D } from 'three'
 // Type for the useLoad3dViewer composable function
 // Using explicit type to avoid import() type annotations (lint rule)
 type UseLoad3dViewerFn = (node?: LGraphNode) => {
+  backgroundColor: { value: string }
+  showGrid: { value: boolean }
+  cameraType: { value: CameraType }
+  fov: { value: number }
+  lightIntensity: { value: number }
+  backgroundImage: { value: string }
+  hasBackgroundImage: { value: boolean }
+  backgroundRenderMode: { value: BackgroundRenderModeType }
+  upDirection: { value: UpDirection }
+  materialMode: { value: MaterialMode }
+  needApplyChanges: { value: boolean }
+  isPreview: { value: boolean }
+  isStandaloneMode: { value: boolean }
+  isSplatModel: { value: boolean }
+  isPlyModel: { value: boolean }
+  animations: { value: AnimationItem[] }
+  playing: { value: boolean }
+  selectedSpeed: { value: number }
+  selectedAnimation: { value: number }
+  animationProgress: { value: number }
+  animationDuration: { value: number }
+
   initializeViewer: (containerRef: HTMLElement, source: Load3d) => Promise<void>
   initializeStandaloneViewer: (
     containerRef: HTMLElement,
@@ -31,7 +60,6 @@ type UseLoad3dViewerFn = (node?: LGraphNode) => {
   handleBackgroundImageUpdate: (file: File | null) => Promise<void>
   handleModelDrop: (file: File) => Promise<void>
   handleSeek: (progress: number) => void
-  needApplyChanges: { value: boolean }
 }
 
 // Type for SkeletonUtils module


### PR DESCRIPTION
## Summary

Adds settings persistence for the standalone 3D viewer (App Mode), ensuring custom configurations like background color and camera state are remembered across different models.

## Changes

URL-based Caching: Added a cache to store and restore viewer settings per model URL.
Unit Tests: Added coverage for configuration saving and restoration workflows.


## Screenshots
before

https://github.com/user-attachments/assets/5ba0e3a1-c876-4de6-879e-e77c42661267

after

https://github.com/user-attachments/assets/debc4fbd-b5ae-484e-aa67-d4c130722ab0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10126-fix-persistence-for-3d-viewer-config-in-standalone-mode-3266d73d365081e88438ca29d4db5640) by [Unito](https://www.unito.io)
