### PR TITLE
[core/1.41] fix: invalidate promoted widget cache on subgraph input rename

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -692,6 +692,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
           nodeId: this.id,
           slotType: NodeSlotType.INPUT
         })
+        this._invalidatePromotedViewsCache()
       },
       { signal }
     )


### PR DESCRIPTION
Adds missing `_invalidatePromotedViewsCache()` call in the `renaming-input` event handler.

Without this, renaming a subgraph input does not update promoted widget view names because the cache returns stale entries.

- Fixes failing test: 'renaming an input updates linked promoted view display names'
- The cache system only exists on 1.41 (removed on main by #8856 store refactor), so this fix is branch-specific.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10151-core-1-41-fix-invalidate-promoted-widget-cache-on-subgraph-input-rename-3266d73d3650811faaaccaa357889238) by [Unito](https://www.unito.io)
