### PR TITLE
fix: don't resurface missing node warnings on workflow tab switch

### DIFF
--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -240,7 +240,7 @@ export const useWorkflowService = () => {
       workflow,
       {
         showMissingModels: loadFromRemote,
-        showMissingNodes: true,
+        showMissingNodes: loadFromRemote,
         checkForRerouteMigration: false,
         deferWarnings: true
       }


### PR DESCRIPTION
## Problem

The E2E test "Does not report warning when switching between opened workflows" (`tests/sidebar/workflows.spec.ts:235`) is flaky because the error overlay for missing nodes re-appears after being dismissed when switching back to a workflow with missing nodes.

## Root Cause

`openWorkflow()` always passed `showMissingNodes: true` to `loadGraphData`. This caused `runMissingModelPipeline` to re-set `pendingWarnings` on every workflow switch, and then `showPendingWarnings()` would re-surface the error overlay — even though the user had already dismissed it.

## Fix

Gate `showMissingNodes` by `loadFromRemote` (same pattern already used for `showMissingModels`). When switching between already-opened workflows (`loadFromRemote === false`), missing node warnings are not re-surfaced. This matches the existing behavior for undo/redo, where `changeTracker.ts` already passes `showMissingNodes: false`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10188-fix-don-t-resurface-missing-node-warnings-on-workflow-tab-switch-3266d73d3650811b933ddf67db137b7e) by [Unito](https://www.unito.io)
