### PR TITLE
fix: use server response filename in WebcamCapture serialization

### DIFF
--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -145,9 +145,7 @@ app.registerExtension({
       const data = await resp.json()
       const serverName = data.name ?? name
       const subfolder = data.subfolder ?? 'webcam'
-      return subfolder
-        ? `${subfolder}/${serverName} [temp]`
-        : `${serverName} [temp]`
+      return `${subfolder}/${serverName} [temp]`
     }
 
     // @ts-expect-error fixme ts strict error

--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -142,7 +142,12 @@ app.registerExtension({
         useToastStore().addAlert(err)
         throw new Error(err)
       }
-      return `webcam/${name} [temp]`
+      const data = await resp.json()
+      const serverName = data.name ?? name
+      const subfolder = data.subfolder ?? 'webcam'
+      return subfolder
+        ? `${subfolder}/${serverName} [temp]`
+        : `${serverName} [temp]`
     }
 
     // @ts-expect-error fixme ts strict error


### PR DESCRIPTION
## Summary
- WebcamCapture's `serializeValue` was ignoring the `/upload/image` response and returning the original timestamp-based filename (`webcam/${timestamp}.png [temp]`)
- This breaks content-addressed storage backends (e.g. Comfy Cloud) where the server returns a different (hash-based) filename, causing `ImageDownloadError` at inference time
- Now reads `data.name` and `data.subfolder` from the upload response, matching the pattern already used by `useNodeImageUpload` and `useMaskEditorSaver`
- No behavioral change for local ComfyUI — the server already returns the same filename, it was just being ignored

## Test plan
- [x] WebcamCapture node captures and uploads an image successfully on local ComfyUI
- [x] WebcamCapture node works correctly on Comfy Cloud (no `ImageDownloadError`)
- [ ] Duplicate filename edge case: upload two captures with same timestamp — server-renamed file is used correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10220-fix-use-server-response-filename-in-WebcamCapture-serialization-3266d73d3650818aa9bdff8d27586180) by [Unito](https://www.unito.io)
