### PR TITLE
fix: add visual feedback for subgraph IO drag interactions

### DIFF
--- a/browser_tests/tests/subgraphIODragBridge.spec.ts
+++ b/browser_tests/tests/subgraphIODragBridge.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyPageFixture as test,
   comfyExpect as expect
-} from '../fixtures/ComfyPage'
+} from '@e2e/fixtures/ComfyPage'
 
 const WORKFLOW = 'subgraphs/test-values-input-subgraph'
 
@@ -87,8 +87,8 @@ test.describe(
       const snapTargets = page.locator('.lg-slot--snap-target')
       await expect(snapTargets).toHaveCount(0)
 
-      // Start drag, simulate pointer move over a compatible input slot,
-      // and verify the snap-target class appears.
+      // Start drag without any pointer movement and confirm no snap-target
+      // is applied spuriously (the class only appears on actual hover).
       const hasSnapTarget = await page.evaluate(async () => {
         const canvas = window.app!.canvas!
         const graph = canvas.graph as {

--- a/browser_tests/tests/subgraphIODragBridge.spec.ts
+++ b/browser_tests/tests/subgraphIODragBridge.spec.ts
@@ -32,10 +32,10 @@ test.describe(
 
       // Before drag: no slots should be dimmed
       const outputSlots = page.locator('.lg-slot--output')
-      const dimmeBefore = await outputSlots.evaluateAll((els) =>
+      const dimmedBefore = await outputSlots.evaluateAll((els) =>
         els.some((el) => el.classList.contains('opacity-40'))
       )
-      expect(dimmeBefore).toBe(false)
+      expect(dimmedBefore).toBe(false)
 
       // Start a drag from the seed SubgraphInput (INT type)
       await page.evaluate(() => {

--- a/browser_tests/tests/subgraphIODragBridge.spec.ts
+++ b/browser_tests/tests/subgraphIODragBridge.spec.ts
@@ -73,7 +73,7 @@ test.describe(
       expect(dimmedAfter).toBe(false)
     })
 
-    test('Snap-target class is applied to compatible slot on hover', async ({
+    test('Snap-target class is not applied without pointer hover', async ({
       comfyPage
     }) => {
       const { page } = comfyPage

--- a/browser_tests/tests/subgraphIODragBridge.spec.ts
+++ b/browser_tests/tests/subgraphIODragBridge.spec.ts
@@ -1,0 +1,168 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+
+const WORKFLOW = 'subgraphs/test-values-input-subgraph'
+
+/**
+ * Tests for the subgraph IO drag bridge — verifying that canvas-drawn
+ * SubgraphInput drags produce correct visual feedback on Vue-rendered
+ * slots (dimming incompatible, highlighting compatible).
+ *
+ * See: https://github.com/Comfy-Org/ComfyUI_frontend/pull/10224
+ */
+test.describe(
+  'Subgraph IO drag bridge visual feedback',
+  { tag: ['@subgraph', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    })
+
+    test('Dragging from SubgraphInput dims incompatible Vue slots', async ({
+      comfyPage
+    }) => {
+      const { page } = comfyPage
+
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+      await comfyPage.vueNodes.enterSubgraph('19')
+      await comfyPage.vueNodes.waitForNodes()
+
+      // Before drag: no slots should be dimmed
+      const outputSlots = page.locator('.lg-slot--output')
+      const dimmeBefore = await outputSlots.evaluateAll((els) =>
+        els.some((el) => el.classList.contains('opacity-40'))
+      )
+      expect(dimmeBefore).toBe(false)
+
+      // Start a drag from the seed SubgraphInput (INT type)
+      await page.evaluate(() => {
+        const canvas = window.app!.canvas
+        const graph = canvas!.graph as {
+          inputNode: { slots: Array<{ name: string }> }
+        }
+        const seedSlot = graph.inputNode.slots.find((s) => s.name === 'seed')
+
+        canvas!.linkConnector['dragNewFromSubgraphInput'](
+          canvas!.graph!,
+          graph.inputNode as never,
+          seedSlot as never
+        )
+      })
+      await comfyPage.nextFrame()
+
+      // During drag: incompatible output slots should be dimmed
+      // (seed is INT, so CLIP/LATENT/CONDITIONING outputs won't match)
+      const dimmedDuring = await outputSlots.evaluateAll((els) =>
+        els.some((el) => el.classList.contains('opacity-40'))
+      )
+      expect(dimmedDuring).toBe(true)
+
+      // Clean up the drag
+      await page.evaluate(() => {
+        window.app!.canvas!.linkConnector.reset()
+      })
+      await comfyPage.nextFrame()
+
+      // After reset: dimming should be cleared
+      const dimmedAfter = await outputSlots.evaluateAll((els) =>
+        els.some((el) => el.classList.contains('opacity-40'))
+      )
+      expect(dimmedAfter).toBe(false)
+    })
+
+    test('Snap-target class is applied to compatible slot on hover', async ({
+      comfyPage
+    }) => {
+      const { page } = comfyPage
+
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+      await comfyPage.vueNodes.enterSubgraph('19')
+      await comfyPage.vueNodes.waitForNodes()
+
+      // No snap targets initially
+      const snapTargets = page.locator('.lg-slot--snap-target')
+      await expect(snapTargets).toHaveCount(0)
+
+      // Start drag, simulate pointer move over a compatible input slot,
+      // and verify the snap-target class appears.
+      const hasSnapTarget = await page.evaluate(async () => {
+        const canvas = window.app!.canvas!
+        const graph = canvas.graph as {
+          inputNode: { slots: Array<{ name: string }> }
+        }
+        const seedSlot = graph.inputNode.slots.find((s) => s.name === 'seed')
+
+        canvas.linkConnector['dragNewFromSubgraphInput'](
+          canvas.graph!,
+          graph.inputNode as never,
+          seedSlot as never
+        )
+
+        // Wait a frame for the bridge to activate
+        await new Promise((r) => requestAnimationFrame(r))
+
+        // Check if any snap targets exist (the bridge adds them on pointer move)
+        const snapCount = document.querySelectorAll(
+          '.lg-slot--snap-target'
+        ).length
+
+        canvas.linkConnector.reset()
+        return snapCount
+      })
+
+      // The snap-target is only applied when the pointer hovers over a
+      // compatible slot during drag. Without actual pointer movement,
+      // we verify the class doesn't appear spuriously.
+      expect(hasSnapTarget).toBe(0)
+    })
+
+    test('Drag state resets when the LinkConnector resets', async ({
+      comfyPage
+    }) => {
+      const { page } = comfyPage
+
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+      await comfyPage.vueNodes.enterSubgraph('19')
+      await comfyPage.vueNodes.waitForNodes()
+
+      // Start and immediately reset a drag
+      const result = await page.evaluate(() => {
+        const canvas = window.app!.canvas!
+        const graph = canvas.graph as {
+          inputNode: { slots: Array<{ name: string }> }
+        }
+        const seedSlot = graph.inputNode.slots.find((s) => s.name === 'seed')
+
+        let resetFired = false
+        canvas.linkConnector.events.addEventListener('reset', () => {
+          resetFired = true
+        })
+
+        canvas.linkConnector['dragNewFromSubgraphInput'](
+          canvas.graph!,
+          graph.inputNode as never,
+          seedSlot as never
+        )
+
+        const wasDragging = canvas.linkConnector.isConnecting
+        canvas.linkConnector.reset()
+        const isDraggingAfter = canvas.linkConnector.isConnecting
+
+        return { wasDragging, isDraggingAfter, resetFired }
+      })
+
+      expect(result.wasDragging).toBe(true)
+      expect(result.isDraggingAfter).toBe(false)
+      expect(result.resetFired).toBe(true)
+
+      // Verify no dimmed slots remain
+      const dimmedSlots = page.locator('.lg-slot.opacity-40')
+      await expect(dimmedSlots).toHaveCount(0)
+    })
+  }
+)

--- a/browser_tests/tests/subgraphIODragFeedback.spec.ts
+++ b/browser_tests/tests/subgraphIODragFeedback.spec.ts
@@ -59,21 +59,25 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
         return origTrigger(event, data)
       }
 
-      // Connect SubgraphInput to interior node's widget input
-      const widgetInput = interiorNode.inputs?.find(
-        (inp: { widget?: unknown }) => inp.widget
-      )
-      if (!widgetInput) return { error: 'No widget input found on Int node' }
+      try {
+        // Connect SubgraphInput to interior node's widget input
+        const widgetInput = interiorNode.inputs?.find(
+          (inp: { widget?: unknown }) => inp.widget
+        )
+        if (!widgetInput) return { error: 'No widget input found on Int node' }
 
-      const inputIndex = interiorNode.inputs.indexOf(widgetInput)
-      const newSlot = subgraph.inputNode.slots.find(
-        (s: { name: string }) => s.name === 'test_int'
-      )
-      if (!newSlot) return { error: 'Could not find test_int slot' }
+        const inputIndex = interiorNode.inputs.indexOf(widgetInput)
+        const newSlot = subgraph.inputNode.slots.find(
+          (s: { name: string }) => s.name === 'test_int'
+        )
+        if (!newSlot) return { error: 'Could not find test_int slot' }
 
-      newSlot.connect(interiorNode.inputs[inputIndex], interiorNode)
+        newSlot.connect(interiorNode.inputs[inputIndex], interiorNode)
 
-      return { eventFired, eventConnected }
+        return { eventFired, eventConnected }
+      } finally {
+        subgraph.trigger = origTrigger
+      }
     })
 
     expect(result).not.toHaveProperty('error')

--- a/browser_tests/tests/subgraphIODragFeedback.spec.ts
+++ b/browser_tests/tests/subgraphIODragFeedback.spec.ts
@@ -91,21 +91,28 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
     )
     await comfyPage.nextFrame()
 
+    interface TestSubgraph {
+      inputNode: { slots: Array<unknown> }
+    }
+    interface TestSubgraphNode {
+      subgraph?: TestSubgraph
+    }
+
     const result = await comfyPage.page.evaluate(() => {
       const canvas = window.app!.canvas
       if (!canvas) return { error: 'No canvas' }
 
-      // Navigate into the subgraph
       const sgNode = canvas.graph!._nodes.find(
         (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
-      ) as { subgraph?: { inputNode: { slots: Array<unknown> } } } | undefined
+      ) as unknown as TestSubgraphNode | undefined
       if (!sgNode?.subgraph) return { error: 'No subgraph node found' }
 
-      canvas.openSubgraph(sgNode.subgraph as never, sgNode as never)
+      canvas.openSubgraph(
+        sgNode.subgraph as unknown as Parameters<typeof canvas.openSubgraph>[0],
+        sgNode as unknown as Parameters<typeof canvas.openSubgraph>[1]
+      )
 
-      const subgraph = canvas.graph as unknown as {
-        inputNode: { slots: Array<unknown> }
-      } | null
+      const subgraph = canvas.graph as unknown as TestSubgraph | null
       if (!subgraph || !('inputNode' in subgraph))
         return { error: 'Not in subgraph' }
 
@@ -119,15 +126,15 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
 
       canvas.linkConnector.events.addEventListener('connecting', onConnecting)
 
-      // Trigger an actual drag from the subgraph input node
       const inputSlot = subgraph.inputNode.slots[0]
       if (!inputSlot) return { error: 'No input slot' }
 
+      type DragFn = typeof canvas.linkConnector.dragNewFromSubgraphInput
       try {
-        canvas.linkConnector.dragNewFromSubgraphInput(
-          subgraph as never,
-          subgraph.inputNode as never,
-          inputSlot as never
+        ;(canvas.linkConnector.dragNewFromSubgraphInput as DragFn)(
+          subgraph as unknown as Parameters<DragFn>[0],
+          subgraph.inputNode as unknown as Parameters<DragFn>[1],
+          inputSlot as unknown as Parameters<DragFn>[2]
         )
       } finally {
         canvas.linkConnector.events.removeEventListener(

--- a/browser_tests/tests/subgraphIODragFeedback.spec.ts
+++ b/browser_tests/tests/subgraphIODragFeedback.spec.ts
@@ -1,0 +1,120 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
+  test('SubgraphInput.connect fires node:slot-links:changed for widget inputs', async ({
+    comfyPage
+  }) => {
+    // Verify that connecting a widget-backed input inside a subgraph
+    // dispatches the slot-links:changed event, which drives Vue
+    // reactivity for slot visual feedback.
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const LiteGraph = window.LiteGraph!
+
+      // Create a subgraph with an INT input
+      const subgraphData = {
+        version: 1,
+        revision: 0,
+        state: {
+          lastNodeId: 0,
+          lastLinkId: 0,
+          lastGroupId: 0,
+          lastRerouteId: 0
+        },
+        nodes: [],
+        links: [],
+        groups: [],
+        config: {},
+        definitions: { subgraphs: [] },
+        id: crypto.randomUUID(),
+        name: 'Drag Test Subgraph',
+        inputNode: {
+          id: -10,
+          bounding: [10, 100, 150, 126],
+          pinned: false
+        },
+        outputNode: {
+          id: -20,
+          bounding: [400, 100, 140, 126],
+          pinned: false
+        },
+        inputs: [],
+        outputs: [],
+        widgets: []
+      }
+
+      const subgraph = graph.createSubgraph(subgraphData as never)
+      subgraph.addInput('value', 'INT')
+
+      // Add an interior node with a widget input
+      const interiorNode = LiteGraph.createNode('Int')
+      if (!interiorNode) return { error: 'Could not create Int node' }
+      subgraph.add(interiorNode)
+
+      // Listen for slot-links:changed events via LiteGraph's trigger system
+      let eventFired = false
+      let eventConnected: boolean | null = null
+      const origTrigger = subgraph.trigger.bind(subgraph)
+      subgraph.trigger = (event: string, data: unknown) => {
+        if (event === 'node:slot-links:changed') {
+          eventFired = true
+          eventConnected = (data as { connected: boolean }).connected
+        }
+        return origTrigger(event, data)
+      }
+
+      // Connect SubgraphInput to interior node's widget input
+      const widgetInput = interiorNode.inputs?.find(
+        (inp: { widget?: unknown }) => inp.widget
+      )
+      if (!widgetInput) return { error: 'No widget input found on Int node' }
+
+      const inputIndex = interiorNode.inputs.indexOf(widgetInput)
+      subgraph.inputNode.slots[0].connect(
+        interiorNode.inputs[inputIndex],
+        interiorNode
+      )
+
+      return { eventFired, eventConnected }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.eventFired).toBe(true)
+    expect(result.eventConnected).toBe(true)
+  })
+
+  test('LinkConnector dispatches connecting event on subgraph IO drag', async ({
+    comfyPage
+  }) => {
+    // Verify that the connecting event is dispatched when starting
+    // a link drag, enabling the bridge composable to activate.
+    const result = await comfyPage.page.evaluate(() => {
+      const canvas = window.app!.canvas
+      if (!canvas) return { error: 'No canvas' }
+
+      let connectingFired = false
+      let connectingTo: string | null = null
+
+      canvas.linkConnector.events.addEventListener(
+        'connecting',
+        (e: CustomEvent<{ connectingTo: string }>) => {
+          connectingFired = true
+          connectingTo = e.detail.connectingTo
+        }
+      )
+
+      // Trigger a link drag programmatically
+      canvas.linkConnector.events.dispatch('connecting', {
+        connectingTo: 'input'
+      })
+
+      return { connectingFired, connectingTo }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.connectingFired).toBe(true)
+    expect(result.connectingTo).toBe('input')
+  })
+})

--- a/browser_tests/tests/subgraphIODragFeedback.spec.ts
+++ b/browser_tests/tests/subgraphIODragFeedback.spec.ts
@@ -120,6 +120,9 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
       if (!subgraph || !('inputNode' in subgraph))
         return { error: 'Not in subgraph' }
 
+      const inputSlot = subgraph.inputNode.slots[0]
+      if (!inputSlot) return { error: 'No input slot' }
+
       let connectingFired = false
       let connectingTo: string | null = null
 
@@ -129,9 +132,6 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
       }
 
       canvas.linkConnector.events.addEventListener('connecting', onConnecting)
-
-      const inputSlot = subgraph.inputNode.slots[0]
-      if (!inputSlot) return { error: 'No input slot' }
 
       type DragFn = typeof canvas.linkConnector.dragNewFromSubgraphInput
       try {

--- a/browser_tests/tests/subgraphIODragFeedback.spec.ts
+++ b/browser_tests/tests/subgraphIODragFeedback.spec.ts
@@ -6,54 +6,48 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
   test('SubgraphInput.connect fires node:slot-links:changed for widget inputs', async ({
     comfyPage
   }) => {
-    // Verify that connecting a widget-backed input inside a subgraph
-    // dispatches the slot-links:changed event, which drives Vue
-    // reactivity for slot visual feedback.
+    // Load a workflow with a subgraph that has a promoted text widget,
+    // then connect a new interior node to verify the event fires.
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
     const result = await comfyPage.page.evaluate(() => {
       const graph = window.app!.canvas.graph!
+
+      // Find the SubgraphNode and navigate into its subgraph
+      const subgraphNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            subgraph?: {
+              addInput: (name: string, type: string) => void
+              add: (node: unknown) => void
+              inputNode: {
+                slots: Array<{
+                  name: string
+                  connect: (...args: unknown[]) => void
+                }>
+              }
+              trigger: (event: string, data: unknown) => unknown
+            }
+          }
+        | undefined
+      if (!subgraphNode?.subgraph) return { error: 'No subgraph node found' }
+
+      const subgraph = subgraphNode.subgraph
       const LiteGraph = window.LiteGraph!
 
-      // Create a subgraph with an INT input
-      const subgraphData = {
-        version: 1,
-        revision: 0,
-        state: {
-          lastNodeId: 0,
-          lastLinkId: 0,
-          lastGroupId: 0,
-          lastRerouteId: 0
-        },
-        nodes: [],
-        links: [],
-        groups: [],
-        config: {},
-        definitions: { subgraphs: [] },
-        id: crypto.randomUUID(),
-        name: 'Drag Test Subgraph',
-        inputNode: {
-          id: -10,
-          bounding: [10, 100, 150, 126],
-          pinned: false
-        },
-        outputNode: {
-          id: -20,
-          bounding: [400, 100, 140, 126],
-          pinned: false
-        },
-        inputs: [],
-        outputs: [],
-        widgets: []
-      }
-
-      const subgraph = graph.createSubgraph(subgraphData as never)
-      subgraph.addInput('value', 'INT')
+      // Add a new INT input to the subgraph
+      subgraph.addInput('test_int', 'INT')
 
       // Add an interior node with a widget input
       const interiorNode = LiteGraph.createNode('Int')
       if (!interiorNode) return { error: 'Could not create Int node' }
       subgraph.add(interiorNode)
 
-      // Listen for slot-links:changed events via LiteGraph's trigger system
+      // Listen for slot-links:changed
       let eventFired = false
       let eventConnected: boolean | null = null
       const origTrigger = subgraph.trigger.bind(subgraph)
@@ -72,10 +66,12 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
       if (!widgetInput) return { error: 'No widget input found on Int node' }
 
       const inputIndex = interiorNode.inputs.indexOf(widgetInput)
-      subgraph.inputNode.slots[0].connect(
-        interiorNode.inputs[inputIndex],
-        interiorNode
+      const newSlot = subgraph.inputNode.slots.find(
+        (s: { name: string }) => s.name === 'test_int'
       )
+      if (!newSlot) return { error: 'Could not find test_int slot' }
+
+      newSlot.connect(interiorNode.inputs[inputIndex], interiorNode)
 
       return { eventFired, eventConnected }
     })
@@ -85,14 +81,33 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
     expect(result.eventConnected).toBe(true)
   })
 
-  test('LinkConnector dispatches connecting event on subgraph IO drag', async ({
+  test('dragNewFromSubgraphInput dispatches connecting event', async ({
     comfyPage
   }) => {
-    // Verify that the connecting event is dispatched when starting
-    // a link drag, enabling the bridge composable to activate.
+    // Verify that starting a link drag from a SubgraphInput slot
+    // dispatches the 'connecting' event on the LinkConnector.
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
     const result = await comfyPage.page.evaluate(() => {
       const canvas = window.app!.canvas
       if (!canvas) return { error: 'No canvas' }
+
+      // Navigate into the subgraph
+      const sgNode = canvas.graph!._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as { subgraph?: { inputNode: { slots: Array<unknown> } } } | undefined
+      if (!sgNode?.subgraph) return { error: 'No subgraph node found' }
+
+      canvas.openSubgraph(sgNode.subgraph as never, sgNode as never)
+
+      const subgraph = canvas.graph as unknown as {
+        inputNode: { slots: Array<unknown> }
+      } | null
+      if (!subgraph || !('inputNode' in subgraph))
+        return { error: 'Not in subgraph' }
 
       let connectingFired = false
       let connectingTo: string | null = null
@@ -105,10 +120,18 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
         }
       )
 
-      // Trigger a link drag programmatically
-      canvas.linkConnector.events.dispatch('connecting', {
-        connectingTo: 'input'
-      })
+      // Trigger an actual drag from the subgraph input node
+      const inputSlot = subgraph.inputNode.slots[0]
+      if (!inputSlot) return { error: 'No input slot' }
+
+      canvas.linkConnector.dragNewFromSubgraphInput(
+        subgraph as never,
+        subgraph.inputNode as never,
+        inputSlot as never
+      )
+
+      // Clean up the drag
+      canvas.linkConnector.reset()
 
       return { connectingFired, connectingTo }
     })

--- a/browser_tests/tests/subgraphIODragFeedback.spec.ts
+++ b/browser_tests/tests/subgraphIODragFeedback.spec.ts
@@ -112,26 +112,30 @@ test.describe('Subgraph IO drag visual feedback', { tag: '@subgraph' }, () => {
       let connectingFired = false
       let connectingTo: string | null = null
 
-      canvas.linkConnector.events.addEventListener(
-        'connecting',
-        (e: CustomEvent<{ connectingTo: string }>) => {
-          connectingFired = true
-          connectingTo = e.detail.connectingTo
-        }
-      )
+      function onConnecting(e: CustomEvent<{ connectingTo: string }>) {
+        connectingFired = true
+        connectingTo = e.detail.connectingTo
+      }
+
+      canvas.linkConnector.events.addEventListener('connecting', onConnecting)
 
       // Trigger an actual drag from the subgraph input node
       const inputSlot = subgraph.inputNode.slots[0]
       if (!inputSlot) return { error: 'No input slot' }
 
-      canvas.linkConnector.dragNewFromSubgraphInput(
-        subgraph as never,
-        subgraph.inputNode as never,
-        inputSlot as never
-      )
-
-      // Clean up the drag
-      canvas.linkConnector.reset()
+      try {
+        canvas.linkConnector.dragNewFromSubgraphInput(
+          subgraph as never,
+          subgraph.inputNode as never,
+          inputSlot as never
+        )
+      } finally {
+        canvas.linkConnector.events.removeEventListener(
+          'connecting',
+          onConnecting
+        )
+        canvas.linkConnector.reset()
+      }
 
       return { connectingFired, connectingTo }
     })

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -165,6 +165,7 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { useWorkflowAutoSave } from '@/platform/workflow/persistence/composables/useWorkflowAutoSave'
 import { useWorkflowPersistenceV2 as useWorkflowPersistence } from '@/platform/workflow/persistence/composables/useWorkflowPersistenceV2'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSubgraphDragBridge } from '@/renderer/core/canvas/links/useSubgraphDragBridge'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import TransformPane from '@/renderer/core/layout/transform/TransformPane.vue'
@@ -468,6 +469,7 @@ useContextMenuTranslation()
 useCopy()
 usePaste()
 useWorkflowAutoSave()
+useSubgraphDragBridge()
 
 // Start watching for locale change after the initial value is loaded.
 watch(

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -267,6 +267,7 @@ export class LinkConnector {
     state.draggingExistingLinks = true
 
     this._setLegacyLinks(false)
+    this.events.dispatch('connecting', { connectingTo: 'input' })
   }
 
   /** Drag all links from an output to a new output. */
@@ -378,6 +379,7 @@ export class LinkConnector {
     state.connectingTo = 'output'
 
     this._setLegacyLinks(true)
+    this.events.dispatch('connecting', { connectingTo: 'output' })
   }
 
   /**

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -445,6 +445,7 @@ export class LinkConnector {
     this.state.connectingTo = 'input'
 
     this._setLegacyLinks(false)
+    this.events.dispatch('connecting', { connectingTo: 'input' })
   }
 
   dragNewFromSubgraphOutput(
@@ -466,6 +467,7 @@ export class LinkConnector {
     this.state.connectingTo = 'output'
 
     this._setLegacyLinks(true)
+    this.events.dispatch('connecting', { connectingTo: 'output' })
   }
 
   /**
@@ -878,7 +880,10 @@ export class LinkConnector {
       (link) => link instanceof MovingInputLink && link.disconnectOnDrop
     ).forEach((link) => (link as MovingLinkBase).disconnect())
     if (this.renderLinks.length === 0) return
-    // For external event only.
+
+    const intercepted = this.events.dispatch('before-drop-on-canvas', event)
+    if (intercepted === false) return
+
     const mayContinue = this.events.dispatch('dropped-on-canvas', event)
     if (mayContinue === false) return
 

--- a/src/lib/litegraph/src/canvas/LinkConnectorDropEvents.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorDropEvents.test.ts
@@ -5,6 +5,7 @@ import {
   createMockCanvasPointerEvent,
   createMockLGraphNode,
   createMockLinkNetwork,
+  createMockNodeInputSlot,
   createMockNodeOutputSlot
 } from '@/utils/__tests__/litegraphTestUtils'
 
@@ -83,5 +84,74 @@ describe('LinkConnector.dropOnNothing event dispatch', () => {
 
     expect(beforeListener).not.toHaveBeenCalled()
     expect(droppedListener).not.toHaveBeenCalled()
+  })
+})
+
+describe('LinkConnector rewire flows dispatch connecting event', () => {
+  let connector: LinkConnector
+
+  beforeEach(() => {
+    connector = new LinkConnector(mockSetConnectingLinks)
+    vi.clearAllMocks()
+  })
+
+  test('moveInputLink dispatches connecting with connectingTo: input', () => {
+    const connectingListener = vi.fn()
+    connector.events.addEventListener('connecting', connectingListener)
+
+    // Use a floating link path (no link ID, has _floatingLinks) which is
+    // simpler to mock than the full link resolution path.
+    const floatingLink = {
+      id: 1,
+      parentId: 'reroute-1',
+      _dragging: false
+    }
+    const reroute = { id: 'reroute-1' }
+    const reroutes = new Map([['reroute-1', reroute]])
+    const network = createMockLinkNetwork({
+      links: new Map(),
+      reroutes,
+      getReroute: (id: string) => reroutes.get(id)
+    } as never)
+
+    const floatingLinks = new Set([floatingLink])
+    const input = createMockNodeInputSlot({
+      link: null,
+      _floatingLinks: floatingLinks
+    } as never)
+
+    connector.moveInputLink(network, input)
+
+    expect(connectingListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { connectingTo: 'input' }
+      })
+    )
+  })
+
+  test('moveOutputLink dispatches connecting with connectingTo: output', () => {
+    const connectingListener = vi.fn()
+    connector.events.addEventListener('connecting', connectingListener)
+
+    // Inject a render link directly so moveOutputLink reaches the dispatch
+    // without needing full link resolution mocking.
+    connector.renderLinks.push(createMockRenderLink())
+
+    const network = createMockLinkNetwork({
+      links: new Map(),
+      reroutes: new Map()
+    } as never)
+
+    // Empty output (no links/floating) — the method will find renderLinks
+    // already populated from our injection and proceed to dispatch.
+    const output = createMockNodeOutputSlot({ links: [] })
+
+    connector.moveOutputLink(network, output)
+
+    expect(connectingListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { connectingTo: 'output' }
+      })
+    )
   })
 })

--- a/src/lib/litegraph/src/canvas/LinkConnectorDropEvents.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorDropEvents.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { LinkConnector } from '@/lib/litegraph/src/litegraph'
+import {
+  createMockCanvasPointerEvent,
+  createMockLGraphNode,
+  createMockLinkNetwork,
+  createMockNodeOutputSlot
+} from '@/utils/__tests__/litegraphTestUtils'
+
+const mockSetConnectingLinks = vi.fn()
+
+type RenderLinkItem = LinkConnector['renderLinks'][number]
+
+function createMockRenderLink(): RenderLinkItem {
+  const partial: Partial<RenderLinkItem> = {
+    toType: 'input',
+    fromPos: [0, 0],
+    fromSlotIndex: 0,
+    fromDirection: 0,
+    network: createMockLinkNetwork(),
+    node: createMockLGraphNode(),
+    fromSlot: createMockNodeOutputSlot(),
+    dragDirection: 0,
+    canConnectToInput: vi.fn().mockReturnValue(false),
+    canConnectToOutput: vi.fn().mockReturnValue(false),
+    canConnectToReroute: vi.fn().mockReturnValue(false),
+    connectToInput: vi.fn(),
+    connectToOutput: vi.fn(),
+    connectToSubgraphInput: vi.fn(),
+    connectToRerouteOutput: vi.fn(),
+    connectToSubgraphOutput: vi.fn(),
+    connectToRerouteInput: vi.fn()
+  }
+  return partial as RenderLinkItem
+}
+
+describe('LinkConnector.dropOnNothing event dispatch', () => {
+  let connector: LinkConnector
+
+  beforeEach(() => {
+    connector = new LinkConnector(mockSetConnectingLinks)
+    vi.clearAllMocks()
+  })
+
+  test('dispatches before-drop-on-canvas before dropped-on-canvas', () => {
+    connector.renderLinks.push(createMockRenderLink())
+
+    const callOrder: string[] = []
+    connector.events.addEventListener('before-drop-on-canvas', () => {
+      callOrder.push('before-drop-on-canvas')
+    })
+    connector.events.addEventListener('dropped-on-canvas', () => {
+      callOrder.push('dropped-on-canvas')
+    })
+
+    connector.dropOnNothing(createMockCanvasPointerEvent(100, 100))
+
+    expect(callOrder).toEqual(['before-drop-on-canvas', 'dropped-on-canvas'])
+  })
+
+  test('skips dropped-on-canvas when before-drop-on-canvas is intercepted', () => {
+    connector.renderLinks.push(createMockRenderLink())
+
+    const droppedListener = vi.fn()
+    connector.events.addEventListener('before-drop-on-canvas', (e) => {
+      e.preventDefault()
+    })
+    connector.events.addEventListener('dropped-on-canvas', droppedListener)
+
+    connector.dropOnNothing(createMockCanvasPointerEvent(100, 100))
+
+    expect(droppedListener).not.toHaveBeenCalled()
+  })
+
+  test('does not dispatch events when renderLinks is empty', () => {
+    const beforeListener = vi.fn()
+    const droppedListener = vi.fn()
+    connector.events.addEventListener('before-drop-on-canvas', beforeListener)
+    connector.events.addEventListener('dropped-on-canvas', droppedListener)
+
+    connector.dropOnNothing(createMockCanvasPointerEvent(100, 100))
+
+    expect(beforeListener).not.toHaveBeenCalled()
+    expect(droppedListener).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/litegraph/src/canvas/LinkConnectorDropEvents.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorDropEvents.test.ts
@@ -41,7 +41,6 @@ describe('LinkConnector.dropOnNothing event dispatch', () => {
 
   beforeEach(() => {
     connector = new LinkConnector(mockSetConnectingLinks)
-    vi.clearAllMocks()
   })
 
   test('dispatches before-drop-on-canvas before dropped-on-canvas', () => {
@@ -92,7 +91,6 @@ describe('LinkConnector rewire flows dispatch connecting event', () => {
 
   beforeEach(() => {
     connector = new LinkConnector(mockSetConnectingLinks)
-    vi.clearAllMocks()
   })
 
   test('moveInputLink dispatches connecting with connectingTo: input', () => {

--- a/src/lib/litegraph/src/infrastructure/LinkConnectorEventMap.ts
+++ b/src/lib/litegraph/src/infrastructure/LinkConnectorEventMap.ts
@@ -15,6 +15,7 @@ import type { IWidget } from '@/lib/litegraph/src/types/widgets'
 export interface LinkConnectorEventMap {
   reset: boolean
 
+  /** Fired when a new link drag begins from a slot or subgraph IO node. */
   connecting: {
     connectingTo: 'input' | 'output'
   }
@@ -48,6 +49,7 @@ export interface LinkConnectorEventMap {
     node: SubgraphInputNode | SubgraphOutputNode
     event: CanvasPointerEvent
   }
+  /** Fired before a link is dropped on empty canvas. Return false to intercept. */
   'before-drop-on-canvas': CanvasPointerEvent
   'dropped-on-canvas': CanvasPointerEvent
 

--- a/src/lib/litegraph/src/infrastructure/LinkConnectorEventMap.ts
+++ b/src/lib/litegraph/src/infrastructure/LinkConnectorEventMap.ts
@@ -49,7 +49,7 @@ export interface LinkConnectorEventMap {
     node: SubgraphInputNode | SubgraphOutputNode
     event: CanvasPointerEvent
   }
-  /** Fired before a link is dropped on empty canvas. Return false to intercept. */
+  /** Fired before a link is dropped on empty canvas. Call event.preventDefault() to intercept; dispatch() returns false when prevented. */
   'before-drop-on-canvas': CanvasPointerEvent
   'dropped-on-canvas': CanvasPointerEvent
 

--- a/src/lib/litegraph/src/infrastructure/LinkConnectorEventMap.ts
+++ b/src/lib/litegraph/src/infrastructure/LinkConnectorEventMap.ts
@@ -15,6 +15,10 @@ import type { IWidget } from '@/lib/litegraph/src/types/widgets'
 export interface LinkConnectorEventMap {
   reset: boolean
 
+  connecting: {
+    connectingTo: 'input' | 'output'
+  }
+
   'before-drop-links': {
     renderLinks: RenderLink[]
     event: CanvasPointerEvent
@@ -44,6 +48,7 @@ export interface LinkConnectorEventMap {
     node: SubgraphInputNode | SubgraphOutputNode
     event: CanvasPointerEvent
   }
+  'before-drop-on-canvas': CanvasPointerEvent
   'dropped-on-canvas': CanvasPointerEvent
 
   'dropped-on-widget': {

--- a/src/lib/litegraph/src/subgraph/SubgraphIOSlotLinks.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIOSlotLinks.test.ts
@@ -41,9 +41,8 @@ describe('SubgraphInput.connect triggers node:slot-links:changed', () => {
 
       subgraph.inputNode.slots[0].connect(node.inputs[0], node)
 
-      expect(triggerSpy).not.toHaveBeenCalledWith(
-        'node:slot-links:changed',
-        expect.anything()
+      expect(triggerSpy.mock.calls.map((c) => c[0])).not.toContain(
+        'node:slot-links:changed'
       )
     }
   )
@@ -93,9 +92,8 @@ describe('SubgraphInputNode._disconnectNodeInput triggers node:slot-links:change
 
       subgraph.inputNode._disconnectNodeInput(node, node.inputs[0], link!)
 
-      expect(triggerSpy).not.toHaveBeenCalledWith(
-        'node:slot-links:changed',
-        expect.anything()
+      expect(triggerSpy.mock.calls.map((c) => c[0])).not.toContain(
+        'node:slot-links:changed'
       )
     }
   )

--- a/src/lib/litegraph/src/subgraph/SubgraphIOSlotLinks.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIOSlotLinks.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
+
+import { subgraphTest } from './__fixtures__/subgraphFixtures'
+
+describe('SubgraphInput.connect triggers node:slot-links:changed', () => {
+  subgraphTest(
+    'fires connected event when connecting to a widget input',
+    ({ simpleSubgraph }) => {
+      const subgraph = simpleSubgraph
+      const triggerSpy = vi.spyOn(subgraph, 'trigger')
+
+      const node = new LGraphNode('Target')
+      node.addInput('prompt', 'STRING')
+      node.inputs[0].widget = { name: 'prompt' }
+      subgraph.add(node)
+
+      subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+
+      expect(triggerSpy).toHaveBeenCalledWith('node:slot-links:changed', {
+        nodeId: node.id,
+        slotType: NodeSlotType.INPUT,
+        slotIndex: 0,
+        connected: true,
+        linkId: expect.any(Number)
+      })
+    }
+  )
+
+  subgraphTest(
+    'does not fire event when connecting to a non-widget input',
+    ({ simpleSubgraph }) => {
+      const subgraph = simpleSubgraph
+      const triggerSpy = vi.spyOn(subgraph, 'trigger')
+
+      const node = new LGraphNode('Target')
+      node.addInput('in', 'number')
+      subgraph.add(node)
+
+      subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+
+      expect(triggerSpy).not.toHaveBeenCalledWith(
+        'node:slot-links:changed',
+        expect.anything()
+      )
+    }
+  )
+})
+
+describe('SubgraphInputNode._disconnectNodeInput triggers node:slot-links:changed', () => {
+  subgraphTest(
+    'fires disconnected event when disconnecting a widget input',
+    ({ simpleSubgraph }) => {
+      const subgraph = simpleSubgraph
+
+      const node = new LGraphNode('Target')
+      node.addInput('prompt', 'STRING')
+      node.inputs[0].widget = { name: 'prompt' }
+      subgraph.add(node)
+
+      const link = subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+      expect(link).toBeDefined()
+
+      const triggerSpy = vi.spyOn(subgraph, 'trigger')
+
+      subgraph.inputNode._disconnectNodeInput(node, node.inputs[0], link!)
+
+      expect(triggerSpy).toHaveBeenCalledWith('node:slot-links:changed', {
+        nodeId: node.id,
+        slotType: NodeSlotType.INPUT,
+        slotIndex: 0,
+        connected: false,
+        linkId: link!.id
+      })
+    }
+  )
+
+  subgraphTest(
+    'does not fire event when disconnecting a non-widget input',
+    ({ simpleSubgraph }) => {
+      const subgraph = simpleSubgraph
+
+      const node = new LGraphNode('Target')
+      node.addInput('in', 'number')
+      subgraph.add(node)
+
+      const link = subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+      expect(link).toBeDefined()
+
+      const triggerSpy = vi.spyOn(subgraph, 'trigger')
+
+      subgraph.inputNode._disconnectNodeInput(node, node.inputs[0], link!)
+
+      expect(triggerSpy).not.toHaveBeenCalledWith(
+        'node:slot-links:changed',
+        expect.anything()
+      )
+    }
+  )
+})

--- a/src/lib/litegraph/src/subgraph/SubgraphInput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInput.ts
@@ -136,6 +136,16 @@ export class SubgraphInput extends SubgraphSlot {
     }
     subgraph._version++
 
+    if (slot.widget) {
+      subgraph.trigger('node:slot-links:changed', {
+        nodeId: node.id,
+        slotType: NodeSlotType.INPUT,
+        slotIndex: inputIndex,
+        connected: true,
+        linkId: link.id
+      })
+    }
+
     node.onConnectionsChange?.(NodeSlotType.INPUT, inputIndex, true, link, slot)
 
     subgraph.afterChange()

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -182,7 +182,7 @@ export class SubgraphInputNode
 
     const linkId = input.link
     input.link = null
-    if (input.widget) {
+    if (input.widget && linkId != null) {
       subgraph.trigger('node:slot-links:changed', {
         nodeId: node.id,
         slotType: NodeSlotType.INPUT,

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -180,7 +180,17 @@ export class SubgraphInputNode
       }
     }
 
+    const linkId = input.link
     input.link = null
+    if (input.widget) {
+      subgraph.trigger('node:slot-links:changed', {
+        nodeId: node.id,
+        slotType: NodeSlotType.INPUT,
+        slotIndex: node.inputs.indexOf(input),
+        connected: false,
+        linkId: linkId
+      })
+    }
     subgraph.setDirtyCanvas(false, true)
 
     if (!link) return

--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -140,7 +140,6 @@ export class LinkConnectorAdapter {
 
   /** Drops moving links onto the canvas (no target). */
   dropOnCanvas(event: CanvasPointerEvent): void {
-    //Add extra check for connection to subgraphInput/subgraphOutput
     if (isSubgraph(this.network)) {
       const { canvasX, canvasY } = event
       const ioNode = this.network.getIoNodeOnPos?.(canvasX, canvasY)

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -172,6 +172,7 @@ export function useSubgraphDragBridge() {
     let pendingMove: { clientX: number; clientY: number } | null = null
     let highlightedSlotEl: HTMLElement | null = null
 
+    /** Resolves the Vue slot under the pointer and updates snap/highlight state. */
     const processFrame = () => {
       const data = pendingMove
       if (!data) return
@@ -293,6 +294,7 @@ export function useSubgraphDragBridge() {
 
     const raf = createRafBatch(processFrame)
 
+    /** Buffers the latest pointer position and schedules a RAF frame. */
     const onPointerMove = (e: PointerEvent) => {
       pendingMove = { clientX: e.clientX, clientY: e.clientY }
       raf.schedule()

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -1,0 +1,353 @@
+import { tryOnScopeDispose, whenever } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
+
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
+import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
+import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
+import type { SlotDropCandidate } from '@/renderer/core/canvas/links/slotLinkDragUIState'
+import { LinkDirection } from '@/lib/litegraph/src/types/globalEnums'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { createLinkConnectorAdapter } from '@/renderer/core/canvas/links/linkConnectorAdapter'
+import {
+  resolveNodeSurfaceSlotCandidate,
+  resolveSlotTargetCandidate
+} from '@/renderer/core/canvas/links/linkDropOrchestrator'
+import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
+import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { createSlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
+import { resolvePointerTarget } from '@/renderer/extensions/vueNodes/composables/useSlotLinkInteraction'
+import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
+import { app } from '@/scripts/app'
+import { createRafBatch } from '@/utils/rafBatch'
+
+const SNAP_CLASS = 'lg-slot--snap-target'
+
+/**
+ * Bridges canvas-initiated subgraph IO drags to Vue slot drag state.
+ *
+ * When a drag starts from a SubgraphInput or SubgraphOutput node
+ * (canvas-drawn), the Vue slot components need to know about it so they
+ * can dim incompatible slots, snap links, and highlight compatible targets.
+ */
+export function useSubgraphDragBridge() {
+  const canvasStore = useCanvasStore()
+  const { canvas } = storeToRefs(canvasStore)
+  const {
+    state: dragState,
+    beginDrag,
+    endDrag,
+    setCandidate,
+    setCompatibleForKey
+  } = useSlotLinkDragUIState()
+  let cleanup: (() => void) | undefined
+
+  whenever(canvas, (lgCanvas) => {
+    cleanup?.()
+    cleanup = setupBridge(lgCanvas)
+  })
+
+  tryOnScopeDispose(() => {
+    cleanup?.()
+    cleanup = undefined
+  })
+
+  /** Wires up LinkConnector event listeners and returns a cleanup function. */
+  function setupBridge(lgCanvas: LGraphCanvas): () => void {
+    const linkConnector: LinkConnector = lgCanvas.linkConnector
+    let teardownDrag: (() => void) | undefined
+    let isBridgeDrag = false
+
+    const onConnecting = (
+      event: CustomEvent<{ connectingTo: 'input' | 'output' }>
+    ) => {
+      teardownDrag?.()
+      teardownDrag = undefined
+
+      const { connectingTo } = event.detail
+
+      const adapter = createLinkConnectorAdapter()
+      if (!adapter) return
+
+      const renderLink = adapter.renderLinks[0]
+      if (!renderLink) return
+
+      const sourceType: 'input' | 'output' =
+        connectingTo === 'input' ? 'output' : 'input'
+
+      isBridgeDrag = true
+      beginDrag(
+        {
+          nodeId: String(renderLink.node.id),
+          slotIndex: renderLink.fromSlotIndex,
+          type: sourceType,
+          direction: renderLink.fromDirection ?? LinkDirection.RIGHT,
+          position: {
+            x: renderLink.fromPos[0],
+            y: renderLink.fromPos[1]
+          }
+        },
+        -1
+      )
+
+      const allKeys = layoutStore.getAllSlotKeys()
+      for (const key of allKeys) {
+        const slotLayout = layoutStore.getSlotLayout(key)
+        if (!slotLayout) continue
+        if (slotLayout.type !== connectingTo) continue
+
+        const ok =
+          connectingTo === 'input'
+            ? adapter.isInputValidDrop(slotLayout.nodeId, slotLayout.index)
+            : adapter.isOutputValidDrop(slotLayout.nodeId, slotLayout.index)
+
+        setCompatibleForKey(key, ok)
+      }
+
+      teardownDrag = startPointerTracking(lgCanvas, linkConnector)
+    }
+
+    const onBeforeDropOnCanvas = (event: CustomEvent) => {
+      if (!isBridgeDrag) return
+
+      const candidate = dragState.candidate
+      if (!candidate?.compatible) return
+
+      const adapter = createLinkConnectorAdapter()
+      if (!adapter) return
+
+      const connected = connectToCandidate(
+        adapter.renderLinks,
+        adapter.network,
+        candidate,
+        linkConnector
+      )
+      if (connected) event.preventDefault()
+    }
+
+    const onReset = () => {
+      if (!isBridgeDrag) return
+      teardownDrag?.()
+      teardownDrag = undefined
+      isBridgeDrag = false
+      endDrag()
+    }
+
+    linkConnector.events.addEventListener('connecting', onConnecting)
+    linkConnector.events.addEventListener(
+      'before-drop-on-canvas',
+      onBeforeDropOnCanvas
+    )
+    linkConnector.events.addEventListener('reset', onReset)
+
+    return () => {
+      linkConnector.events.removeEventListener('connecting', onConnecting)
+      linkConnector.events.removeEventListener(
+        'before-drop-on-canvas',
+        onBeforeDropOnCanvas
+      )
+      linkConnector.events.removeEventListener('reset', onReset)
+      teardownDrag?.()
+      teardownDrag = undefined
+      if (isBridgeDrag) {
+        isBridgeDrag = false
+        endDrag()
+      }
+    }
+  }
+
+  /**
+   * Tracks pointer movement during a bridge drag to resolve Vue slot
+   * candidates, update snap positions, and toggle snap-target highlights.
+   * Returns a cleanup function that removes the listener and RAF batch.
+   */
+  function startPointerTracking(
+    lgCanvas: LGraphCanvas,
+    linkConnector: LinkConnector
+  ): () => void {
+    const ownerDoc = lgCanvas.getCanvasWindow().document
+    const session = createSlotLinkDragContext()
+    const slotRegistry = useNodeSlotRegistryStore()
+    let pendingMove: { clientX: number; clientY: number } | null = null
+    let highlightedSlotEl: HTMLElement | null = null
+
+    const processFrame = () => {
+      const data = pendingMove
+      if (!data) return
+      pendingMove = null
+
+      const adapter = createLinkConnectorAdapter()
+      if (!adapter) return
+      const graph = adapter.network
+
+      const target = resolvePointerTarget(data.clientX, data.clientY, null)
+
+      let hoveredSlotKey: string | null = null
+      let hoveredNodeId: NodeId | null = null
+      if (target === session.lastPointerEventTarget) {
+        hoveredSlotKey = session.lastPointerTargetSlotKey
+        hoveredNodeId = session.lastPointerTargetNodeId
+      } else if (target instanceof HTMLElement) {
+        const elWithSlot = target
+          .closest('.lg-slot, .lg-node-widget')
+          ?.querySelector<HTMLElement>('[data-slot-key]')
+        const elWithNode = target.closest<HTMLElement>('[data-node-id]')
+        hoveredSlotKey = elWithSlot?.dataset['slotKey'] ?? null
+        hoveredNodeId = elWithNode?.dataset['nodeId'] ?? null
+        session.lastPointerEventTarget = target
+        session.lastPointerTargetSlotKey = hoveredSlotKey
+        session.lastPointerTargetNodeId = hoveredNodeId
+      }
+
+      const hoverChanged =
+        hoveredSlotKey !== session.lastHoverSlotKey ||
+        hoveredNodeId !== session.lastHoverNodeId
+
+      let candidate = dragState.candidate
+
+      if (hoverChanged) {
+        const context = { adapter, graph, session }
+        const slotCandidate = resolveSlotTargetCandidate(target, context)
+        const nodeCandidate = resolveNodeSurfaceSlotCandidate(target, context)
+        candidate = slotCandidate?.compatible ? slotCandidate : nodeCandidate
+        session.lastHoverSlotKey = hoveredSlotKey
+        session.lastHoverNodeId = hoveredNodeId
+
+        if (slotCandidate) {
+          const key = getSlotKey(
+            slotCandidate.layout.nodeId,
+            slotCandidate.layout.index,
+            slotCandidate.layout.type === 'input'
+          )
+          setCompatibleForKey(key, !!slotCandidate.compatible)
+        }
+        if (nodeCandidate && !slotCandidate?.compatible) {
+          const key = getSlotKey(
+            nodeCandidate.layout.nodeId,
+            nodeCandidate.layout.index,
+            nodeCandidate.layout.type === 'input'
+          )
+          setCompatibleForKey(key, !!nodeCandidate.compatible)
+        }
+      }
+
+      const newCandidate = candidate?.compatible ? candidate : null
+      const newCandidateKey = newCandidate
+        ? getSlotKey(
+            newCandidate.layout.nodeId,
+            newCandidate.layout.index,
+            newCandidate.layout.type === 'input'
+          )
+        : null
+
+      const candidateChanged = newCandidateKey !== session.lastCandidateKey
+      if (candidateChanged) {
+        setCandidate(newCandidate)
+        session.lastCandidateKey = newCandidateKey
+        updateSnapTargetHighlight(newCandidate)
+      }
+
+      const snapPos = newCandidate
+        ? ([newCandidate.layout.position.x, newCandidate.layout.position.y] as [
+            number,
+            number
+          ])
+        : undefined
+      const currentSnap = linkConnector.state.snapLinksPos
+      const snapPosChanged = snapPos
+        ? !currentSnap ||
+          currentSnap[0] !== snapPos[0] ||
+          currentSnap[1] !== snapPos[1]
+        : !!currentSnap
+      if (snapPosChanged) {
+        linkConnector.state.snapLinksPos = snapPos
+      }
+
+      if (candidateChanged || snapPosChanged) {
+        app.canvas?.setDirty(true, true)
+      }
+    }
+
+    /** Toggles the `lg-slot--snap-target` CSS class on the candidate's slot element. */
+    function updateSnapTargetHighlight(candidate: SlotDropCandidate | null) {
+      if (highlightedSlotEl) {
+        highlightedSlotEl.classList.remove(SNAP_CLASS)
+        highlightedSlotEl = null
+      }
+      if (!candidate) return
+      const key = getSlotKey(
+        candidate.layout.nodeId,
+        candidate.layout.index,
+        candidate.layout.type === 'input'
+      )
+      const entry = slotRegistry
+        .getNode(candidate.layout.nodeId)
+        ?.slots.get(key)
+      const groupEl = entry?.el?.parentElement
+      if (groupEl) {
+        groupEl.classList.add(SNAP_CLASS)
+        highlightedSlotEl = groupEl
+      }
+    }
+
+    const raf = createRafBatch(processFrame)
+
+    const onPointerMove = (e: PointerEvent) => {
+      pendingMove = { clientX: e.clientX, clientY: e.clientY }
+      raf.schedule()
+    }
+
+    ownerDoc.addEventListener('pointermove', onPointerMove, { capture: true })
+
+    return () => {
+      ownerDoc.removeEventListener('pointermove', onPointerMove, {
+        capture: true
+      })
+      raf.cancel()
+      if (highlightedSlotEl) {
+        highlightedSlotEl.classList.remove(SNAP_CLASS)
+        highlightedSlotEl = null
+      }
+      session.dispose()
+    }
+  }
+}
+
+/**
+ * Connects render links to the snapped Vue slot candidate.
+ * Returns `true` if at least one link was connected.
+ */
+function connectToCandidate(
+  links: ReadonlyArray<RenderLink>,
+  network: { getNodeById(id: NodeId): LGraphNode | null },
+  candidate: SlotDropCandidate,
+  linkConnector: LinkConnector
+): boolean {
+  const node = network.getNodeById(candidate.layout.nodeId)
+  if (!node) return false
+
+  let connected = false
+
+  if (candidate.layout.type === 'input') {
+    const input = node.inputs?.[candidate.layout.index]
+    if (!input) return false
+    for (const link of links) {
+      if (link.toType !== 'input') continue
+      if (!link.canConnectToInput(node, input)) continue
+      link.connectToInput(node, input, linkConnector.events)
+      connected = true
+    }
+  } else {
+    const output = node.outputs?.[candidate.layout.index]
+    if (!output) return false
+    for (const link of links) {
+      if (link.toType !== 'output') continue
+      if (!link.canConnectToOutput(node, output)) continue
+      link.connectToOutput(node, output, linkConnector.events)
+      connected = true
+    }
+  }
+
+  return connected
+}

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -19,7 +19,6 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { createSlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
 import { resolvePointerTarget } from '@/renderer/extensions/vueNodes/composables/useSlotLinkInteraction'
 import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
-import { app } from '@/scripts/app'
 import { createRafBatch } from '@/utils/rafBatch'
 
 const SNAP_CLASS = 'lg-slot--snap-target'
@@ -276,7 +275,7 @@ export function useSubgraphDragBridge() {
       }
 
       if (candidateChanged || snapPosChanged) {
-        app.canvas?.setDirty(true, true)
+        lgCanvas.setDirty(true, true)
       }
     }
 

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -167,6 +167,7 @@ export function useSubgraphDragBridge() {
     linkConnector: LinkConnector
   ): { cleanup: () => void; flush: () => void } {
     const ownerDoc = lgCanvas.getCanvasWindow().document
+    const ownerView = ownerDoc.defaultView
     const session = createSlotLinkDragContext()
     const slotRegistry = useNodeSlotRegistryStore()
     let pendingMove: { clientX: number; clientY: number } | null = null
@@ -182,14 +183,19 @@ export function useSubgraphDragBridge() {
       if (!adapter) return
       const graph = adapter.network
 
-      const target = resolvePointerTarget(data.clientX, data.clientY, null)
+      const target = resolvePointerTarget(
+        data.clientX,
+        data.clientY,
+        null,
+        ownerDoc
+      )
 
       let hoveredSlotKey: string | null = null
       let hoveredNodeId: NodeId | null = null
       if (target === session.lastPointerEventTarget) {
         hoveredSlotKey = session.lastPointerTargetSlotKey
         hoveredNodeId = session.lastPointerTargetNodeId
-      } else if (target instanceof HTMLElement) {
+      } else if (ownerView && target instanceof ownerView.HTMLElement) {
         const elWithSlot = target
           .closest('.lg-slot, .lg-node-widget')
           ?.querySelector<HTMLElement>('[data-slot-key]')

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -285,7 +285,9 @@ export function useSubgraphDragBridge() {
       const entry = slotRegistry
         .getNode(candidate.layout.nodeId)
         ?.slots.get(key)
-      const groupEl = entry?.el?.parentElement
+      const groupEl =
+        (entry?.el?.closest('.group\\/slot') as HTMLElement | null) ??
+        entry?.el?.parentElement
       if (groupEl) {
         groupEl.classList.add(SNAP_CLASS)
         highlightedSlotEl = groupEl

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -56,14 +56,14 @@ export function useSubgraphDragBridge() {
   /** Wires up LinkConnector event listeners and returns a cleanup function. */
   function setupBridge(lgCanvas: LGraphCanvas): () => void {
     const linkConnector: LinkConnector = lgCanvas.linkConnector
-    let teardownDrag: (() => void) | undefined
+    let pointerTracking: { cleanup: () => void; flush: () => void } | undefined
     let isBridgeDrag = false
 
     const onConnecting = (
       event: CustomEvent<{ connectingTo: 'input' | 'output' }>
     ) => {
-      teardownDrag?.()
-      teardownDrag = undefined
+      pointerTracking?.cleanup()
+      pointerTracking = undefined
 
       const { connectingTo } = event.detail
 
@@ -105,12 +105,13 @@ export function useSubgraphDragBridge() {
         setCompatibleForKey(key, ok)
       }
 
-      teardownDrag = startPointerTracking(lgCanvas, linkConnector)
+      pointerTracking = startPointerTracking(lgCanvas, linkConnector)
     }
 
     const onBeforeDropOnCanvas = (event: CustomEvent) => {
       if (!isBridgeDrag) return
 
+      pointerTracking?.flush()
       const candidate = dragState.candidate
       if (!candidate?.compatible) return
 
@@ -128,8 +129,8 @@ export function useSubgraphDragBridge() {
 
     const onReset = () => {
       if (!isBridgeDrag) return
-      teardownDrag?.()
-      teardownDrag = undefined
+      pointerTracking?.cleanup()
+      pointerTracking = undefined
       isBridgeDrag = false
       endDrag()
     }
@@ -148,8 +149,8 @@ export function useSubgraphDragBridge() {
         onBeforeDropOnCanvas
       )
       linkConnector.events.removeEventListener('reset', onReset)
-      teardownDrag?.()
-      teardownDrag = undefined
+      pointerTracking?.cleanup()
+      pointerTracking = undefined
       if (isBridgeDrag) {
         isBridgeDrag = false
         endDrag()
@@ -160,12 +161,11 @@ export function useSubgraphDragBridge() {
   /**
    * Tracks pointer movement during a bridge drag to resolve Vue slot
    * candidates, update snap positions, and toggle snap-target highlights.
-   * Returns a cleanup function that removes the listener and RAF batch.
    */
   function startPointerTracking(
     lgCanvas: LGraphCanvas,
     linkConnector: LinkConnector
-  ): () => void {
+  ): { cleanup: () => void; flush: () => void } {
     const ownerDoc = lgCanvas.getCanvasWindow().document
     const session = createSlotLinkDragContext()
     const slotRegistry = useNodeSlotRegistryStore()
@@ -304,16 +304,19 @@ export function useSubgraphDragBridge() {
 
     ownerDoc.addEventListener('pointermove', onPointerMove, { capture: true })
 
-    return () => {
-      ownerDoc.removeEventListener('pointermove', onPointerMove, {
-        capture: true
-      })
-      raf.cancel()
-      if (highlightedSlotEl) {
-        highlightedSlotEl.classList.remove(SNAP_CLASS)
-        highlightedSlotEl = null
+    return {
+      flush: () => raf.flush(),
+      cleanup: () => {
+        ownerDoc.removeEventListener('pointermove', onPointerMove, {
+          capture: true
+        })
+        raf.cancel()
+        if (highlightedSlotEl) {
+          highlightedSlotEl.classList.remove(SNAP_CLASS)
+          highlightedSlotEl = null
+        }
+        session.dispose()
       }
-      session.dispose()
     }
   }
 }

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -204,10 +204,14 @@ export function useSubgraphDragBridge() {
       const hoverChanged =
         hoveredSlotKey !== session.lastHoverSlotKey ||
         hoveredNodeId !== session.lastHoverNodeId
+      // Recompute node-surface candidates even without a hover change when
+      // the pointer is on a node background (no specific slot hovered).
+      const shouldResolveCandidate =
+        hoverChanged || (hoveredSlotKey == null && hoveredNodeId != null)
 
       let candidate = dragState.candidate
 
-      if (hoverChanged) {
+      if (shouldResolveCandidate) {
         const context = { adapter, graph, session }
         const slotCandidate = resolveSlotTargetCandidate(target, context)
         const nodeCandidate = resolveNodeSurfaceSlotCandidate(target, context)

--- a/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
+++ b/src/renderer/core/canvas/links/useSubgraphDragBridge.ts
@@ -37,6 +37,7 @@ export function useSubgraphDragBridge() {
     state: dragState,
     beginDrag,
     endDrag,
+    clearCompatible,
     setCandidate,
     setCompatibleForKey
   } = useSlotLinkDragUIState()
@@ -58,11 +59,20 @@ export function useSubgraphDragBridge() {
     let pointerTracking: { cleanup: () => void; flush: () => void } | undefined
     let isBridgeDrag = false
 
+    function resetBridgeDrag() {
+      pointerTracking?.cleanup()
+      pointerTracking = undefined
+      if (isBridgeDrag) {
+        endDrag()
+      }
+      clearCompatible()
+      isBridgeDrag = false
+    }
+
     const onConnecting = (
       event: CustomEvent<{ connectingTo: 'input' | 'output' }>
     ) => {
-      pointerTracking?.cleanup()
-      pointerTracking = undefined
+      resetBridgeDrag()
 
       const { connectingTo } = event.detail
 
@@ -128,10 +138,7 @@ export function useSubgraphDragBridge() {
 
     const onReset = () => {
       if (!isBridgeDrag) return
-      pointerTracking?.cleanup()
-      pointerTracking = undefined
-      isBridgeDrag = false
-      endDrag()
+      resetBridgeDrag()
     }
 
     linkConnector.events.addEventListener('connecting', onConnecting)
@@ -148,12 +155,7 @@ export function useSubgraphDragBridge() {
         onBeforeDropOnCanvas
       )
       linkConnector.events.removeEventListener('reset', onReset)
-      pointerTracking?.cleanup()
-      pointerTracking = undefined
-      if (isBridgeDrag) {
-        isBridgeDrag = false
-        endDrag()
-      }
+      resetBridgeDrag()
     }
   }
 

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -52,7 +52,7 @@ const slotClass = computed(() =>
     'border border-solid border-node-component-slot-dot-outline',
     props.multi
       ? 'h-6 w-3'
-      : 'size-3 cursor-crosshair group-hover/slot:scale-125 group-hover/slot:[--node-component-slot-dot-outline-opacity-mult:5] group-[.lg-slot--snap-target]/slot:[--node-component-slot-dot-outline-opacity-mult:5] group-[.lg-slot--snap-target]/slot:scale-125'
+      : 'size-3 cursor-crosshair group-hover/slot:scale-125 group-hover/slot:[--node-component-slot-dot-outline-opacity-mult:5] group-[.lg-slot--snap-target]/slot:scale-125 group-[.lg-slot--snap-target]/slot:[--node-component-slot-dot-outline-opacity-mult:5]'
   )
 )
 </script>

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -52,7 +52,7 @@ const slotClass = computed(() =>
     'border border-solid border-node-component-slot-dot-outline',
     props.multi
       ? 'h-6 w-3'
-      : 'size-3 cursor-crosshair group-hover/slot:scale-125 group-hover/slot:[--node-component-slot-dot-outline-opacity-mult:5]'
+      : 'size-3 cursor-crosshair group-hover/slot:scale-125 group-hover/slot:[--node-component-slot-dot-outline-opacity-mult:5] group-[.lg-slot--snap-target]/slot:[--node-component-slot-dot-outline-opacity-mult:5] group-[.lg-slot--snap-target]/slot:scale-125'
   )
 )
 </script>

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -405,7 +405,7 @@ export function useSlotLinkInteraction({
         const wasPointerOver = node.isPointerOver
         node.onPointerMove(pointerEvent)
 
-        if (wasPointerOver !== node.isPointerOver || node.isPointerOver) {
+        if (wasPointerOver !== node.isPointerOver) {
           subgraphIOHoverChanged = true
         }
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -550,8 +550,6 @@ export function useSlotLinkInteraction({
 
     raf.flush()
 
-    raf.flush()
-
     if (!state.source) {
       cleanupInteraction()
       app.canvas?.setDirty(true, true)

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -12,6 +12,7 @@ import type {
   INodeInputSlot,
   INodeOutputSlot
 } from '@/lib/litegraph/src/interfaces'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { LinkDirection } from '@/lib/litegraph/src/types/globalEnums'
 import {
   clearCanvasPointerHistory,
@@ -33,6 +34,7 @@ import { createSlotLinkDragContext } from '@/renderer/extensions/vueNodes/compos
 import { augmentToCanvasPointerEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
 import { app } from '@/scripts/app'
 import { createRafBatch } from '@/utils/rafBatch'
+import { isSubgraph } from '@/utils/typeGuardUtil'
 
 interface SlotInteractionOptions {
   nodeId: string
@@ -390,14 +392,44 @@ export function useSlotLinkInteraction({
       dragContext.lastCandidateKey = newCandidateKey
     }
 
+    let subgraphIOSnapPos: [number, number] | null = null
+    let subgraphIOHoverChanged = false
+
+    const graph = app.canvas?.graph
+    if (isSubgraph(graph)) {
+      const pointerEvent = { canvasX, canvasY } as CanvasPointerEvent
+
+      for (const node of [graph.inputNode, graph.outputNode]) {
+        if (!node) continue
+
+        const wasPointerOver = node.isPointerOver
+        node.onPointerMove(pointerEvent)
+
+        if (wasPointerOver !== node.isPointerOver || node.isPointerOver) {
+          subgraphIOHoverChanged = true
+        }
+
+        if (node.isPointerOver) {
+          const slot = node.getSlotInPosition(canvasX, canvasY)
+          if (slot && slot.isPointerOver) {
+            subgraphIOSnapPos = slot.pos
+          }
+        }
+      }
+    }
+
     let snapPosChanged = false
     if (activeAdapter) {
-      const snapX = newCandidate
-        ? newCandidate.layout.position.x
-        : state.pointer.canvas.x
-      const snapY = newCandidate
-        ? newCandidate.layout.position.y
-        : state.pointer.canvas.y
+      const snapX = subgraphIOSnapPos
+        ? subgraphIOSnapPos[0]
+        : newCandidate
+          ? newCandidate.layout.position.x
+          : state.pointer.canvas.x
+      const snapY = subgraphIOSnapPos
+        ? subgraphIOSnapPos[1]
+        : newCandidate
+          ? newCandidate.layout.position.y
+          : state.pointer.canvas.y
       const currentSnap = activeAdapter.linkConnector.state.snapLinksPos
       snapPosChanged =
         !currentSnap || currentSnap[0] !== snapX || currentSnap[1] !== snapY
@@ -406,7 +438,8 @@ export function useSlotLinkInteraction({
       }
     }
 
-    const shouldRedraw = candidateChanged || snapPosChanged
+    const shouldRedraw =
+      candidateChanged || snapPosChanged || subgraphIOHoverChanged
     if (shouldRedraw) app.canvas?.setDirty(true, true)
   }
   const raf = createRafBatch(processPointerMoveFrame)

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -105,9 +105,10 @@ function createPointerSession(): PointerSession {
 export function resolvePointerTarget(
   clientX: number,
   clientY: number,
-  fallback: EventTarget | null
+  fallback: EventTarget | null,
+  ownerDoc: Document = document
 ): EventTarget | null {
-  return document.elementFromPoint(clientX, clientY) ?? fallback
+  return ownerDoc.elementFromPoint(clientX, clientY) ?? fallback
 }
 
 export function useSlotLinkInteraction({
@@ -287,6 +288,12 @@ export function useSlotLinkInteraction({
   }
 
   const cleanupInteraction = () => {
+    // Clear synthetic hover state on subgraph IO nodes
+    const graph = app.canvas?.graph
+    if (isSubgraph(graph)) {
+      graph.inputNode?.onPointerLeave()
+      graph.outputNode?.onPointerLeave()
+    }
     autoPan?.stop()
     autoPan = null
     if (state.pointerId != null) {
@@ -409,7 +416,7 @@ export function useSlotLinkInteraction({
           subgraphIOHoverChanged = true
         }
 
-        if (node.isPointerOver) {
+        if (node.isPointerOver && newCandidate?.compatible) {
           const slot = node.getSlotInPosition(canvasX, canvasY)
           if (slot && slot.isPointerOver) {
             subgraphIOSnapPos = slot.pos


### PR DESCRIPTION
Rebases and continues #9281 (by @artokun) and #9838 (by @christian-byrne) on latest main.

## Summary

- New `useSubgraphDragBridge` composable bridging LiteGraph canvas pointer state to Vue slot interaction state
- Fire `node:slot-links:changed` events from SubgraphInput/SubgraphInputNode for widget-backed inputs
- Add `before-drop-on-canvas` event to LinkConnector for interception

Fixes #9010

## Changes

- Bridge canvas-initiated subgraph IO drags to Vue slot drag state, restoring slot dimming, proximity snap, dot highlights, and drop-to-connect across the canvas/Vue rendering boundary
- SubgraphInput.connect and SubgraphInputNode._disconnectNodeInput now dispatch `node:slot-links:changed` so Vue components reactively update

## Credit

- Original implementation: @artokun (#9281)
- Rebase, CodeRabbit fixes, cleanup: @christian-byrne (#9838)

## Demo

https://github.com/user-attachments/assets/1f1a0864-12b3-47d8-ad8e-10e009ce16d5

## Test plan

- [x] Unit tests: LinkConnectorDropEvents (3 tests), SubgraphIOSlotLinks (4 tests)
- [ ] Manual: drag from canvas node output to subgraph IO input — verify slot dimming, snap, dot highlights
- [ ] Manual: drag from subgraph IO output to canvas node input — verify same visual feedback

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10224-fix-add-visual-feedback-for-subgraph-IO-drag-interactions-3266d73d36508142bc36ce27b3a4f9b1) by [Unito](https://www.unito.io)
