### PR TITLE
fix: enforce canonical subgraph IO order after configure [PR 1 of 2]

### DIFF
--- a/browser_tests/tests/subgraphIOOrder.spec.ts
+++ b/browser_tests/tests/subgraphIOOrder.spec.ts
@@ -1,0 +1,75 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Subgraph IO canonical order', { tag: '@subgraph' }, () => {
+  test('SubgraphNode input order matches canonical subgraph definition after load', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            subgraph?: { inputNode: { slots: Array<{ name: string }> } }
+            inputs: Array<{ name: string }>
+          }
+        | undefined
+
+      if (!sgNode?.subgraph) return { error: 'No subgraph node' }
+
+      const canonicalOrder = sgNode.subgraph.inputNode.slots.map((s) => s.name)
+      const outerOrder = sgNode.inputs.map((i) => i.name)
+
+      return { canonicalOrder, outerOrder }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.outerOrder).toEqual(result.canonicalOrder)
+  })
+
+  test('SubgraphNode input order is stable across serialize/configure cycles', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            inputs: Array<{ name: string }>
+            serialize: () => unknown
+            configure: (data: unknown) => void
+          }
+        | undefined
+
+      if (!sgNode) return { error: 'No subgraph node' }
+
+      const orderBefore = sgNode.inputs.map((i) => i.name)
+
+      // Serialize and reconfigure three times
+      for (let i = 0; i < 3; i++) {
+        const data = sgNode.serialize()
+        sgNode.configure(data)
+      }
+
+      const orderAfter = sgNode.inputs.map((i) => i.name)
+
+      return { orderBefore, orderAfter }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.orderAfter).toEqual(result.orderBefore)
+  })
+})

--- a/browser_tests/tests/subgraphIOOrder.spec.ts
+++ b/browser_tests/tests/subgraphIOOrder.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Subgraph IO canonical order', { tag: '@subgraph' }, () => {
   test('SubgraphNode input order matches canonical subgraph definition after load', async ({

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -880,6 +880,99 @@ describe('SubgraphNode duplicate input pruning (#9977)', () => {
   })
 })
 
+describe('SubgraphNode canonical IO order (#10221)', () => {
+  it('should enforce canonical input order after configure with mismatched serialized order', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'first', type: 'STRING' },
+        { name: 'second', type: 'INT' },
+        { name: 'third', type: 'FLOAT' }
+      ]
+    })
+
+    const parentGraph = new LGraph()
+    const instanceData = {
+      id: 1 as const,
+      type: subgraph.id,
+      pos: [0, 0] as [number, number],
+      size: [200, 100] as [number, number],
+      inputs: [
+        { name: 'third', type: 'FLOAT', link: null },
+        { name: 'first', type: 'STRING', link: null },
+        { name: 'second', type: 'INT', link: null }
+      ],
+      outputs: [],
+      properties: {},
+      flags: {},
+      mode: 0,
+      order: 0
+    }
+
+    const node = new SubgraphNode(
+      parentGraph,
+      subgraph,
+      instanceData as ExportedSubgraphInstance
+    )
+
+    expect(node.inputs.map((i) => i.name)).toEqual(['first', 'second', 'third'])
+  })
+
+  it('should enforce canonical output order after configure', () => {
+    const subgraph = createTestSubgraph({
+      outputs: [
+        { name: 'out_a', type: 'STRING' },
+        { name: 'out_b', type: 'INT' }
+      ]
+    })
+
+    const parentGraph = new LGraph()
+    const instanceData = {
+      id: 1 as const,
+      type: subgraph.id,
+      pos: [0, 0] as [number, number],
+      size: [200, 100] as [number, number],
+      inputs: [],
+      outputs: [
+        { name: 'out_b', type: 'INT', links: null },
+        { name: 'out_a', type: 'STRING', links: null }
+      ],
+      properties: {},
+      flags: {},
+      mode: 0,
+      order: 0
+    }
+
+    const node = new SubgraphNode(
+      parentGraph,
+      subgraph,
+      instanceData as ExportedSubgraphInstance
+    )
+
+    expect(node.outputs.map((o) => o.name)).toEqual(['out_a', 'out_b'])
+  })
+
+  it('should preserve canonical order across serialize/configure cycles', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'alpha', type: 'STRING' },
+        { name: 'beta', type: 'INT' },
+        { name: 'gamma', type: 'FLOAT' }
+      ]
+    })
+
+    const node = createTestSubgraphNode(subgraph)
+    const expectedOrder = ['alpha', 'beta', 'gamma']
+
+    expect(node.inputs.map((i) => i.name)).toEqual(expectedOrder)
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const serialized = node.serialize()
+      node.configure(serialized)
+      expect(node.inputs.map((i) => i.name)).toEqual(expectedOrder)
+    }
+  })
+})
+
 describe('Nested SubgraphNode duplicate input prevention', () => {
   it('should not duplicate inputs when the referenced subgraph is reconfigured', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -937,6 +937,36 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     )
   }
 
+  private _sortSlotsToCanonicalOrder(): void {
+    const canonicalInputs = this.subgraph.inputNode.slots
+    this.inputs.sort((a, b) => {
+      const ai = canonicalInputs.indexOf(a._subgraphSlot!)
+      const bi = canonicalInputs.indexOf(b._subgraphSlot!)
+      return ai - bi
+    })
+    // Fix input link target_slot indices after reorder
+    for (const [i, input] of this.inputs.entries()) {
+      if (input.link == null) continue
+      const link = this.graph?._links.get(input.link)
+      if (link) link.target_slot = i
+    }
+
+    const canonicalOutputs = this.subgraph.outputNode.slots
+    this.outputs.sort((a, b) => {
+      const ai = canonicalOutputs.findIndex((s) => s.name === a.name)
+      const bi = canonicalOutputs.findIndex((s) => s.name === b.name)
+      return ai - bi
+    })
+    // Fix output link origin_slot indices after reorder
+    for (const [i, output] of this.outputs.entries()) {
+      if (!output.links?.length) continue
+      for (const linkId of output.links) {
+        const link = this.graph?._links.get(linkId)
+        if (link) link.origin_slot = i
+      }
+    }
+  }
+
   private _rebindInputSubgraphSlots(): void {
     this._invalidatePromotedViewsCache()
 
@@ -1051,6 +1081,11 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     // Prune inputs that don't map to any subgraph slot definition.
     // This prevents stale/duplicate serialized inputs from persisting (#9977).
     this.inputs = this.inputs.filter((input) => input._subgraphSlot)
+
+    // Enforce canonical order: sort inputs/outputs to match the subgraph
+    // definition arrays. Serialized data may have a different order, causing
+    // drift between inner pins, outer pins, and properties panel (#10221).
+    this._sortSlotsToCanonicalOrder()
 
     // Ensure proxyWidgets is initialized so it serializes
     this.properties.proxyWidgets ??= []


### PR DESCRIPTION
## Summary (Part 1 of 2)

Groundwork for subgraph IO ordering: enforce canonical order after configure so all views stay in sync.

This is the first of three PRs hardening subgraph widget/slot consistency:
- **PR 1** (this): Enforce canonical IO order so inner pins, outer pins, and properties panel stay in sync
- **PR 2** (#10232): Add drag-to-reorder for subgraph IO pins inside subgraph editing mode

## Changes

- Sort SubgraphNode inputs/outputs to match canonical subgraph definition order after rebinding and pruning
- Fix link slot indices after reorder to preserve connections
- Mismatched serialized workflows self-heal on load

## Problem

Subgraph IO order drifts between inner pins, outer pins, and properties panel. `super.configure()` replaces canonical-order inputs with serialized-order inputs, then `_rebindInputSubgraphSlots` heuristically re-matches them without enforcing order.

## Solution

New `_sortSlotsToCanonicalOrder()` method called in `_internalConfigureAfterSlots` after rebinding and pruning. Sorts `this.inputs` by `subgraph.inputNode.slots` index and `this.outputs` by `subgraph.outputNode.slots` index, then fixes `link.target_slot` / `link.origin_slot` references.

## Test plan

- [x] Unit test: mismatched serialized input order is normalized to canonical
- [x] Unit test: mismatched serialized output order is normalized
- [x] Unit test: serialize/configure cycles are idempotent (3 cycles)
- [ ] Manual: create subgraph with multiple inputs, save, reload, verify order matches

- Fixes #10221

## PR Chain

1. **#10227 — This PR: canonical subgraph IO order enforcement**
2. #10232 — Drag-to-reorder subgraph IO pins

1. **#10227 — This PR: canonical subgraph IO order enforcement**
2. #10232 — Drag-to-reorder subgraph IO pins