### PR TITLE
Fix snap offset for reroutes and subgraph IO

### DIFF
--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -7,7 +7,8 @@ import {
   LGraph,
   LGraphNode,
   LiteGraph,
-  LLink
+  LLink,
+  Reroute
 } from '@/lib/litegraph/src/litegraph'
 import type { SerialisableGraph } from '@/lib/litegraph/src/types/serialisation'
 import type { UUID } from '@/lib/litegraph/src/utils/uuid'
@@ -17,6 +18,7 @@ import {
   createTestSubgraphData,
   createTestSubgraphNode
 } from './subgraph/__fixtures__/subgraphHelpers'
+import { subgraphTest } from './subgraph/__fixtures__/subgraphFixtures'
 
 import {
   duplicateLinksRoot,
@@ -965,5 +967,41 @@ describe('deduplicateSubgraphNodeIds (via configure)', () => {
 
     expect(nodeIdSet(graph, SUBGRAPH_A)).toEqual(new Set([10, 11, 12]))
     expect(nodeIdSet(graph, SUBGRAPH_B)).toEqual(new Set([20, 21, 22]))
+  })
+  subgraphTest('should snap slots to same y-level', ({ emptySubgraph }) => {
+    const node = new LGraphNode('testname')
+    node.addInput('test', 'IMAGE')
+    emptySubgraph.add(node)
+
+    emptySubgraph.inputNode.pos = [0, 0]
+    //Reroute needs offset of ~20y to align with first slot
+    const reroute = new Reroute(1, emptySubgraph, [0, 20])
+
+    node.snapToGrid(10)
+    reroute.snapToGrid(10)
+    emptySubgraph.inputNode.snapToGrid(10)
+
+    node.arrange()
+    emptySubgraph.inputNode.arrange()
+
+    const yPos = node.getInputPos(0)[1]
+    expect(reroute.pos[1]).toBe(yPos)
+    expect(emptySubgraph.inputNode.emptySlot.pos[1]).toBe(yPos)
+
+    //Assign non-equal positions and repeat
+    emptySubgraph.inputNode.pos = [0, 43]
+    node.pos = [0, 50]
+    reroute.pos = [0, 63]
+
+    node.snapToGrid(10)
+    reroute.snapToGrid(10)
+    emptySubgraph.inputNode.snapToGrid(10)
+
+    node.arrange()
+    emptySubgraph.inputNode.arrange()
+
+    const yPos2 = node.getInputPos(0)[1]
+    expect(reroute.pos[1]).toBe(yPos2)
+    expect(emptySubgraph.inputNode.emptySlot.pos[1]).toBe(yPos2)
   })
 })

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -100,6 +100,42 @@ describe('LGraph', () => {
     const fromOldSchema = new LGraph(oldSchemaGraph)
     expect(fromOldSchema).toMatchSnapshot('oldSchemaGraph')
   })
+  subgraphTest('should snap slots to same y-level', ({ emptySubgraph }) => {
+    const node = new LGraphNode('testname')
+    node.addInput('test', 'IMAGE')
+    emptySubgraph.add(node)
+
+    emptySubgraph.inputNode.pos = [0, 0]
+    // Reroute needs offset of ~20y to align with first slot
+    const reroute = new Reroute(1, emptySubgraph, [0, 20])
+
+    node.snapToGrid(10)
+    reroute.snapToGrid(10)
+    emptySubgraph.inputNode.snapToGrid(10)
+
+    node.arrange()
+    emptySubgraph.inputNode.arrange()
+
+    const yPos = node.getInputPos(0)[1]
+    expect(reroute.pos[1]).toBe(yPos)
+    expect(emptySubgraph.inputNode.emptySlot.pos[1]).toBe(yPos)
+
+    // Assign non-equal positions and repeat
+    emptySubgraph.inputNode.pos = [0, 43]
+    node.pos = [0, 50]
+    reroute.pos = [0, 63]
+
+    node.snapToGrid(10)
+    reroute.snapToGrid(10)
+    emptySubgraph.inputNode.snapToGrid(10)
+
+    node.arrange()
+    emptySubgraph.inputNode.arrange()
+
+    const yPos2 = node.getInputPos(0)[1]
+    expect(reroute.pos[1]).toBe(yPos2)
+    expect(emptySubgraph.inputNode.emptySlot.pos[1]).toBe(yPos2)
+  })
 })
 
 describe('Floating Links / Reroutes', () => {
@@ -967,41 +1003,5 @@ describe('deduplicateSubgraphNodeIds (via configure)', () => {
 
     expect(nodeIdSet(graph, SUBGRAPH_A)).toEqual(new Set([10, 11, 12]))
     expect(nodeIdSet(graph, SUBGRAPH_B)).toEqual(new Set([20, 21, 22]))
-  })
-  subgraphTest('should snap slots to same y-level', ({ emptySubgraph }) => {
-    const node = new LGraphNode('testname')
-    node.addInput('test', 'IMAGE')
-    emptySubgraph.add(node)
-
-    emptySubgraph.inputNode.pos = [0, 0]
-    //Reroute needs offset of ~20y to align with first slot
-    const reroute = new Reroute(1, emptySubgraph, [0, 20])
-
-    node.snapToGrid(10)
-    reroute.snapToGrid(10)
-    emptySubgraph.inputNode.snapToGrid(10)
-
-    node.arrange()
-    emptySubgraph.inputNode.arrange()
-
-    const yPos = node.getInputPos(0)[1]
-    expect(reroute.pos[1]).toBe(yPos)
-    expect(emptySubgraph.inputNode.emptySlot.pos[1]).toBe(yPos)
-
-    //Assign non-equal positions and repeat
-    emptySubgraph.inputNode.pos = [0, 43]
-    node.pos = [0, 50]
-    reroute.pos = [0, 63]
-
-    node.snapToGrid(10)
-    reroute.snapToGrid(10)
-    emptySubgraph.inputNode.snapToGrid(10)
-
-    node.arrange()
-    emptySubgraph.inputNode.arrange()
-
-    const yPos2 = node.getInputPos(0)[1]
-    expect(reroute.pos[1]).toBe(yPos2)
-    expect(emptySubgraph.inputNode.emptySlot.pos[1]).toBe(yPos2)
   })
 })

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5882,7 +5882,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   drawSnapGuide(
     ctx: CanvasRenderingContext2D,
     item: Positionable,
-    shape = RenderShape.ROUND
+    shape = RenderShape.ROUND,
+    { offsetToSlot }: { offsetToSlot?: boolean } = {}
   ) {
     const snapGuide = temp
     snapGuide.set(item.boundingRect)
@@ -5890,7 +5891,10 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     // Not all items have pos equal to top-left of bounds
     const { pos } = item
     const offsetX = pos[0] - snapGuide[0]
-    const offsetY = pos[1] - snapGuide[1]
+    const offsetY =
+      pos[1] -
+      snapGuide[1] -
+      (offsetToSlot ? LiteGraph.NODE_SLOT_HEIGHT * 0.7 : 0)
 
     // Normalise boundingRect to pos to snap
     snapGuide[0] += offsetX
@@ -6067,7 +6071,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         this.isDragging &&
         this.selectedItems.has(reroute)
       ) {
-        this.drawSnapGuide(ctx, reroute, RenderShape.CIRCLE)
+        this.drawSnapGuide(ctx, reroute, RenderShape.CIRCLE, {
+          offsetToSlot: true
+        })
       }
       reroute.draw(ctx, this._pattern)
 

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -16,6 +16,7 @@ import type {
   ReadOnlyRect,
   ReadonlyLinkNetwork
 } from './interfaces'
+import { LiteGraph } from './litegraph'
 import { distance, isPointInRect } from './measure'
 import type { Serialisable, SerialisableReroute } from './types/serialisation'
 
@@ -428,9 +429,10 @@ export class Reroute
   snapToGrid(snapTo: number): boolean {
     if (!snapTo) return false
 
+    const offsetY = LiteGraph.NODE_SLOT_HEIGHT * 0.7
     const { pos } = this
     pos[0] = snapTo * Math.round(pos[0] / snapTo)
-    pos[1] = snapTo * Math.round(pos[1] / snapTo)
+    pos[1] = snapTo * Math.round((pos[1] - offsetY) / snapTo) + offsetY
     return true
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -36,7 +36,7 @@ export abstract class SubgraphIONodeBase<
 {
   static margin = 10
   static minWidth = 100
-  static roundedRadius = 4
+  static roundedRadius = 14
 
   private readonly _boundingRect: Rectangle = new Rectangle()
 

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -36,7 +36,7 @@ export abstract class SubgraphIONodeBase<
 {
   static margin = 10
   static minWidth = 100
-  static roundedRadius = 10
+  static roundedRadius = 4
 
   private readonly _boundingRect: Rectangle = new Rectangle()
 

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -36,7 +36,7 @@ export abstract class SubgraphIONodeBase<
 {
   static margin = 10
   static minWidth = 100
-  static roundedRadius = 14
+  static roundedRadius = 14 // Matches NODE_SLOT_HEIGHT * 0.7 for slot alignment
 
   private readonly _boundingRect: Rectangle = new Rectangle()
 


### PR DESCRIPTION
When snapping to grid, reroutes and subgraph IO would snap at an awful y offset.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/285cfd52-2242-4242-b031-926677575542"  /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/4920ef9b-8eb1-4330-8eea-9992ad662018" />|


Regretfully, the PR leaves more magic constants than I would like. There's a hardcoded `0.7` multiplier on `NODE_SLOT_HEIGHT` that isn't defined as a constant, and it seems circular imports prevent constants being used to declare the subgraphIO `roundedRadius`

See #8838 (Sorry for the delay. This change wound up being real simple)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10229-Fix-snap-offset-for-reroutes-and-subgraph-IO-3276d73d365081c2866dc388898a1be4) by [Unito](https://www.unito.io)
