### PR TITLE
feat: drag-to-reorder subgraph IO pins [PR 2 of 2]

### DIFF
--- a/browser_tests/tests/subgraphIOOrder.spec.ts
+++ b/browser_tests/tests/subgraphIOOrder.spec.ts
@@ -1,0 +1,75 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Subgraph IO canonical order', { tag: '@subgraph' }, () => {
+  test('SubgraphNode input order matches canonical subgraph definition after load', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            subgraph?: { inputNode: { slots: Array<{ name: string }> } }
+            inputs: Array<{ name: string }>
+          }
+        | undefined
+
+      if (!sgNode?.subgraph) return { error: 'No subgraph node' }
+
+      const canonicalOrder = sgNode.subgraph.inputNode.slots.map((s) => s.name)
+      const outerOrder = sgNode.inputs.map((i) => i.name)
+
+      return { canonicalOrder, outerOrder }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.outerOrder).toEqual(result.canonicalOrder)
+  })
+
+  test('SubgraphNode input order is stable across serialize/configure cycles', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            inputs: Array<{ name: string }>
+            serialize: () => unknown
+            configure: (data: unknown) => void
+          }
+        | undefined
+
+      if (!sgNode) return { error: 'No subgraph node' }
+
+      const orderBefore = sgNode.inputs.map((i) => i.name)
+
+      // Serialize and reconfigure three times
+      for (let i = 0; i < 3; i++) {
+        const data = sgNode.serialize()
+        sgNode.configure(data)
+      }
+
+      const orderAfter = sgNode.inputs.map((i) => i.name)
+
+      return { orderBefore, orderAfter }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.orderAfter).toEqual(result.orderBefore)
+  })
+})

--- a/browser_tests/tests/subgraphIOReorder.spec.ts
+++ b/browser_tests/tests/subgraphIOReorder.spec.ts
@@ -50,6 +50,52 @@ test.describe('Subgraph IO reorder', { tag: '@subgraph' }, () => {
     expect(result.innerAfter).not.toEqual(result.innerBefore)
   })
 
+  test('reorderOutput updates inner slot order and outer SubgraphNode pins', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            subgraph?: {
+              outputs: Array<{ name: string }>
+              reorderOutput: (from: number, to: number) => void
+            }
+            outputs: Array<{ name: string }>
+          }
+        | undefined
+
+      if (!sgNode?.subgraph) return { error: 'No subgraph node' }
+      if (sgNode.subgraph.outputs.length < 2)
+        return { error: 'Need 2+ outputs to test reorder' }
+
+      const innerBefore = sgNode.subgraph.outputs.map((o) => o.name)
+      const outerBefore = sgNode.outputs.map((o) => o.name)
+
+      sgNode.subgraph.reorderOutput(0, 1)
+
+      const innerAfter = sgNode.subgraph.outputs.map((o) => o.name)
+      const outerAfter = sgNode.outputs.map((o) => o.name)
+
+      return { innerBefore, outerBefore, innerAfter, outerAfter }
+    })
+
+    if ('error' in result) {
+      test.skip(true, result.error as string)
+      return
+    }
+
+    expect(result.innerAfter).toEqual(result.outerAfter)
+    expect(result.innerAfter).not.toEqual(result.innerBefore)
+  })
+
   test('reorder is stable across serialize/configure cycle', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/subgraphIOReorder.spec.ts
+++ b/browser_tests/tests/subgraphIOReorder.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Subgraph IO reorder', { tag: '@subgraph' }, () => {
   test('reorderInput updates inner slot order and outer SubgraphNode pins', async ({
@@ -66,6 +66,7 @@ test.describe('Subgraph IO reorder', { tag: '@subgraph' }, () => {
         | {
             subgraph?: {
               outputs: Array<{ name: string }>
+              addOutput: (name: string, type: string) => void
               reorderOutput: (from: number, to: number) => void
             }
             outputs: Array<{ name: string }>
@@ -73,8 +74,14 @@ test.describe('Subgraph IO reorder', { tag: '@subgraph' }, () => {
         | undefined
 
       if (!sgNode?.subgraph) return { error: 'No subgraph node' }
-      if (sgNode.subgraph.outputs.length < 2)
-        return { error: 'Need 2+ outputs to test reorder' }
+
+      // Ensure at least two outputs exist so the reorder can be exercised
+      while (sgNode.subgraph.outputs.length < 2) {
+        sgNode.subgraph.addOutput(
+          `output_${sgNode.subgraph.outputs.length}`,
+          '*'
+        )
+      }
 
       const innerBefore = sgNode.subgraph.outputs.map((o) => o.name)
       const outerBefore = sgNode.outputs.map((o) => o.name)
@@ -87,11 +94,7 @@ test.describe('Subgraph IO reorder', { tag: '@subgraph' }, () => {
       return { innerBefore, outerBefore, innerAfter, outerAfter }
     })
 
-    if ('error' in result) {
-      test.skip(true, result.error as string)
-      return
-    }
-
+    expect(result).not.toHaveProperty('error')
     expect(result.innerAfter).toEqual(result.outerAfter)
     expect(result.innerAfter).not.toEqual(result.innerBefore)
   })

--- a/browser_tests/tests/subgraphIOReorder.spec.ts
+++ b/browser_tests/tests/subgraphIOReorder.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Subgraph IO reorder', { tag: '@subgraph' }, () => {
+  test('reorderInput updates inner slot order and outer SubgraphNode pins', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            subgraph?: {
+              inputs: Array<{ name: string }>
+              reorderInput: (from: number, to: number) => void
+            }
+            inputs: Array<{ name: string }>
+          }
+        | undefined
+
+      if (!sgNode?.subgraph) return { error: 'No subgraph node' }
+      if (sgNode.subgraph.inputs.length < 2)
+        return { error: 'Need 2+ inputs to test reorder' }
+
+      const innerBefore = sgNode.subgraph.inputs.map((i) => i.name)
+      const outerBefore = sgNode.inputs.map((i) => i.name)
+
+      // Swap first two inputs
+      sgNode.subgraph.reorderInput(0, 1)
+
+      const innerAfter = sgNode.subgraph.inputs.map((i) => i.name)
+      const outerAfter = sgNode.inputs.map((i) => i.name)
+
+      return { innerBefore, outerBefore, innerAfter, outerAfter }
+    })
+
+    expect(result).not.toHaveProperty('error')
+
+    // Inner and outer should match after reorder
+    expect(result.innerAfter).toEqual(result.outerAfter)
+
+    // Order should have changed
+    expect(result.innerAfter).not.toEqual(result.innerBefore)
+  })
+
+  test('reorder is stable across serialize/configure cycle', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    const result = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.canvas.graph!
+      const sgNode = graph._nodes.find(
+        (n: { isSubgraphNode?: () => boolean }) => n.isSubgraphNode?.()
+      ) as
+        | {
+            subgraph?: {
+              inputs: Array<{ name: string }>
+              reorderInput: (from: number, to: number) => void
+            }
+            inputs: Array<{ name: string }>
+            serialize: () => unknown
+            configure: (data: unknown) => void
+          }
+        | undefined
+
+      if (!sgNode?.subgraph) return { error: 'No subgraph node' }
+      if (sgNode.subgraph.inputs.length < 2) return { error: 'Need 2+ inputs' }
+
+      sgNode.subgraph.reorderInput(0, 1)
+      const afterReorder = sgNode.inputs.map((i) => i.name)
+
+      // Serialize and reconfigure
+      const data = sgNode.serialize()
+      sgNode.configure(data)
+      const afterCycle = sgNode.inputs.map((i) => i.name)
+
+      return { afterReorder, afterCycle }
+    })
+
+    expect(result).not.toHaveProperty('error')
+    expect(result.afterCycle).toEqual(result.afterReorder)
+  })
+})

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -3043,6 +3043,54 @@ export class Subgraph
   }
 
   /**
+   * Moves a subgraph input from one position to another, updating
+   * link origin_slot indices to keep connections intact.
+   */
+  reorderInput(fromIndex: number, toIndex: number): void {
+    if (fromIndex === toIndex) return
+    if (fromIndex < 0 || fromIndex >= this.inputs.length) return
+    if (toIndex < 0 || toIndex >= this.inputs.length) return
+
+    const [moved] = this.inputs.splice(fromIndex, 1)
+    this.inputs.splice(toIndex, 0, moved)
+
+    // Fix link origin_slot for all links from SubgraphInputNode
+    for (const [i, input] of this.inputs.entries()) {
+      for (const linkId of input.linkIds) {
+        const link = this._links.get(linkId)
+        if (link) link.origin_slot = i
+      }
+    }
+
+    this.events.dispatch('input-reordered', { fromIndex, toIndex })
+    this.setDirtyCanvas(true, true)
+  }
+
+  /**
+   * Moves a subgraph output from one position to another, updating
+   * link target_slot indices to keep connections intact.
+   */
+  reorderOutput(fromIndex: number, toIndex: number): void {
+    if (fromIndex === toIndex) return
+    if (fromIndex < 0 || fromIndex >= this.outputs.length) return
+    if (toIndex < 0 || toIndex >= this.outputs.length) return
+
+    const [moved] = this.outputs.splice(fromIndex, 1)
+    this.outputs.splice(toIndex, 0, moved)
+
+    // Fix link target_slot for all links to SubgraphOutputNode
+    for (const [i, output] of this.outputs.entries()) {
+      for (const linkId of output.linkIds) {
+        const link = this._links.get(linkId)
+        if (link) link.target_slot = i
+      }
+    }
+
+    this.events.dispatch('output-reordered', { fromIndex, toIndex })
+    this.setDirtyCanvas(true, true)
+  }
+
+  /**
    * Renames an input slot in the subgraph.
    * @param input The input slot to rename.
    * @param name The new name for the input slot.

--- a/src/lib/litegraph/src/infrastructure/SubgraphEventMap.ts
+++ b/src/lib/litegraph/src/infrastructure/SubgraphEventMap.ts
@@ -44,6 +44,15 @@ export interface SubgraphEventMap extends LGraphEventMap {
     newName: string
   }
 
+  'input-reordered': {
+    fromIndex: number
+    toIndex: number
+  }
+  'output-reordered': {
+    fromIndex: number
+    toIndex: number
+  }
+
   'widget-promoted': {
     widget: IBaseWidget
     subgraphNode: SubgraphNode

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -342,7 +342,8 @@ export abstract class SubgraphIONodeBase<
     if (!dragState) return
 
     dragState.cursorY = cursorY
-    dragState.toIndex = this._getSlotInsertIndex(cursorY, dragState.rowHeight)
+    const midY = cursorY - dragState.grabOffsetY + dragState.rowHeight / 2
+    dragState.toIndex = this._getSlotInsertIndex(midY, dragState.rowHeight)
     this.subgraph.setDirtyCanvas(true, true)
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -29,6 +29,23 @@ import type { Subgraph } from './Subgraph'
 import type { SubgraphInput } from './SubgraphInput'
 import type { SubgraphOutput } from './SubgraphOutput'
 
+interface SlotMeasurement<TSlot> {
+  slot: TSlot
+  width: number
+  height: number
+}
+
+interface SlotReorderDragState<TSlot> {
+  draggedSlot: TSlot
+  fromIndex: number
+  toIndex: number
+  cursorY: number
+  grabOffsetY: number
+  rowHeight: number
+  slotHeight: number
+  gapTop: number
+}
+
 export abstract class SubgraphIONodeBase<
   TSlot extends SubgraphInput | SubgraphOutput
 >
@@ -80,6 +97,9 @@ export abstract class SubgraphIONodeBase<
 
   abstract readonly slots: TSlot[]
   abstract get allSlots(): TSlot[]
+  protected abstract reorderSlot(fromIndex: number, toIndex: number): void
+
+  protected reorderDragState?: SlotReorderDragState<TSlot>
 
   constructor(
     /** The subgraph that this node belongs to. */
@@ -109,6 +129,10 @@ export abstract class SubgraphIONodeBase<
   }
 
   abstract get slotAnchorX(): number
+
+  protected get pinHitAreaWidth(): number {
+    return 12
+  }
 
   onPointerMove(e: CanvasPointerEvent): CanvasItem {
     const containsPoint = this.boundingRect.containsXy(e.canvasX, e.canvasY)
@@ -286,25 +310,169 @@ export abstract class SubgraphIONodeBase<
     )
   }
 
+  protected isConnectionDragHit(slot: TSlot, canvasX: number): boolean {
+    return Math.abs(canvasX - slot.pos[0]) <= this.pinHitAreaWidth
+  }
+
+  protected startSlotReorderDrag(slot: TSlot, cursorY: number): boolean {
+    const fromIndex = this.slots.indexOf(slot)
+    if (fromIndex === -1) return false
+
+    const [, slotHeight] = slot.measure()
+    const slotTop = slot.boundingRect[1]
+    const rowHeight = slot.boundingRect[3] || slotHeight
+
+    this.reorderDragState = {
+      draggedSlot: slot,
+      fromIndex,
+      toIndex: fromIndex,
+      cursorY,
+      grabOffsetY: cursorY - slotTop,
+      rowHeight,
+      slotHeight,
+      gapTop: slotTop
+    }
+
+    this.subgraph.setDirtyCanvas(true, true)
+    return true
+  }
+
+  protected updateSlotReorderDrag(cursorY: number): void {
+    const dragState = this.reorderDragState
+    if (!dragState) return
+
+    dragState.cursorY = cursorY
+    dragState.toIndex = this._getSlotInsertIndex(cursorY, dragState.rowHeight)
+    this.subgraph.setDirtyCanvas(true, true)
+  }
+
+  protected finishSlotReorderDrag():
+    | {
+        fromIndex: number
+        toIndex: number
+      }
+    | undefined {
+    const dragState = this.reorderDragState
+    if (!dragState) return
+
+    this.reorderDragState = undefined
+    this.subgraph.setDirtyCanvas(true, true)
+
+    return {
+      fromIndex: dragState.fromIndex,
+      toIndex: dragState.toIndex
+    }
+  }
+
+  protected clearSlotReorderDrag(): void {
+    if (!this.reorderDragState) return
+    this.reorderDragState = undefined
+    this.subgraph.setDirtyCanvas(true, true)
+  }
+
+  protected setDragCursor(cursor?: string): void {
+    this.subgraph.canvasAction((canvas) => {
+      canvas.canvas.style.cursor = cursor ?? ''
+    })
+  }
+
+  private _getSlotInsertIndex(cursorY: number, rowHeight: number): number {
+    return Math.max(
+      0,
+      Math.min(
+        this.slots.length - 1,
+        Math.floor((cursorY - this._getRailTop()) / rowHeight)
+      )
+    )
+  }
+
+  private _getRailTop(): number {
+    return this.boundingRect[1] + SubgraphIONodeBase.roundedRadius
+  }
+
+  private _measureSlots(): Array<
+    SlotMeasurement<TSlot | typeof this.emptySlot>
+  > {
+    return this.allSlots.map((slot) => {
+      const [width, height] = slot.measure()
+      return { slot, width, height }
+    })
+  }
+
   /** Arrange the slots in this node. */
   arrange(): void {
     const { minWidth, roundedRadius } = SubgraphIONodeBase
     const [, y] = this.boundingRect
-    const x = this.slotAnchorX
     const { size } = this
 
-    let maxWidth = minWidth
-    let currentY = y + roundedRadius
-
-    for (const slot of this.allSlots) {
-      const [slotWidth, slotHeight] = slot.measure()
-      slot.arrange([x, currentY, slotWidth, slotHeight])
-
-      currentY += slotHeight
-      if (slotWidth > maxWidth) maxWidth = slotWidth
-    }
+    const slotMeasurements = this._measureSlots()
+    const maxWidth = slotMeasurements.reduce(
+      (currentMax, { width }) => Math.max(currentMax, width),
+      minWidth
+    )
 
     size[0] = maxWidth + 2 * roundedRadius
+
+    const x = this.slotAnchorX
+    let currentY = this._getRailTop()
+    const dragState = this.reorderDragState
+
+    if (!dragState) {
+      for (const { slot, width, height } of slotMeasurements) {
+        slot.arrange([x, currentY, width, height])
+        currentY += height
+      }
+    } else {
+      const draggedMeasurement = slotMeasurements.find(
+        ({ slot }) => slot === dragState.draggedSlot
+      )
+      const emptyMeasurement = slotMeasurements.find(
+        ({ slot }) => slot === this.emptySlot
+      )
+
+      let gapInserted = false
+      let slotIndex = 0
+
+      for (const { slot, width, height } of slotMeasurements) {
+        if (slot === dragState.draggedSlot || slot === this.emptySlot) continue
+
+        if (!gapInserted && slotIndex === dragState.toIndex) {
+          dragState.gapTop = currentY
+          currentY += dragState.slotHeight
+          gapInserted = true
+          slotIndex += 1
+        }
+
+        slot.arrange([x, currentY, width, height])
+        currentY += height
+        slotIndex += 1
+      }
+
+      if (!gapInserted) {
+        dragState.gapTop = currentY
+        currentY += dragState.slotHeight
+      }
+
+      if (draggedMeasurement) {
+        dragState.draggedSlot.arrange([
+          x,
+          dragState.cursorY - dragState.grabOffsetY,
+          draggedMeasurement.width,
+          draggedMeasurement.height
+        ])
+      }
+
+      if (emptyMeasurement) {
+        this.emptySlot.arrange([
+          x,
+          currentY,
+          emptyMeasurement.width,
+          emptyMeasurement.height
+        ])
+        currentY += emptyMeasurement.height
+      }
+    }
+
     size[1] = currentY - y + roundedRadius
   }
 
@@ -356,9 +524,21 @@ export abstract class SubgraphIONodeBase<
     ctx.font = '12px Inter, sans-serif'
     ctx.textBaseline = 'middle'
 
+    const dragState = this.reorderDragState
+
     for (const slot of this.allSlots) {
+      if (slot === dragState?.draggedSlot) continue
       slot.draw({ ctx, colorContext, fromSlot, editorAlpha })
     }
+
+    if (!dragState) return
+
+    dragState.draggedSlot.draw({
+      ctx,
+      colorContext,
+      fromSlot,
+      editorAlpha: (editorAlpha ?? 1) * 0.85
+    })
   }
 
   configure(data: ExportedSubgraphIONode): void {

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -43,34 +43,65 @@ export class SubgraphInputNode
     return x + width - SubgraphIONodeBase.roundedRadius
   }
 
+  protected override reorderSlot(fromIndex: number, toIndex: number): void {
+    this.subgraph.reorderInput(fromIndex, toIndex)
+  }
+
   override onPointerDown(
     e: CanvasPointerEvent,
     pointer: CanvasPointer,
     linkConnector: LinkConnector
   ): void {
-    // Left-click handling for dragging connections
-    if (e.button === 0) {
-      for (const slot of this.allSlots) {
-        // Check if click is within the full slot area (including label)
-        if (slot.boundingRect.containsXy(e.canvasX, e.canvasY)) {
-          pointer.onDragStart = () => {
-            linkConnector.dragNewFromSubgraphInput(this.subgraph, this, slot)
-          }
-          pointer.onDragEnd = (eUp) => {
-            linkConnector.dropLinks(this.subgraph, eUp)
-          }
-          pointer.onDoubleClick = () => {
-            this.handleSlotDoubleClick(slot, e)
-          }
-          pointer.finally = () => {
-            linkConnector.reset(true)
-          }
-        }
-      }
-      // Check for right-click
-    } else if (e.button === 2) {
+    if (e.button === 2) {
       const slot = this.getSlotInPosition(e.canvasX, e.canvasY)
       if (slot) this.showSlotContextMenu(slot, e)
+      return
+    }
+
+    if (e.button !== 0) return
+
+    const slot = this.getSlotInPosition(e.canvasX, e.canvasY)
+    if (!slot) return
+
+    pointer.onDoubleClick = () => {
+      this.handleSlotDoubleClick(slot, e)
+    }
+
+    if (slot === this.emptySlot || this.isConnectionDragHit(slot, e.canvasX)) {
+      pointer.onDragStart = () => {
+        linkConnector.dragNewFromSubgraphInput(this.subgraph, this, slot)
+      }
+      pointer.onDragEnd = (eUp) => {
+        linkConnector.dropLinks(this.subgraph, eUp)
+      }
+      pointer.finally = () => {
+        linkConnector.reset(true)
+      }
+      return
+    }
+
+    pointer.onDragStart = (_, eMove) => {
+      const started = this.startSlotReorderDrag(
+        slot,
+        eMove?.canvasY ?? e.canvasY
+      )
+      if (!started) return
+
+      this.setDragCursor('grabbing')
+    }
+    pointer.onDrag = (eMove) => {
+      this.updateSlotReorderDrag(eMove.canvasY)
+      this.setDragCursor('grabbing')
+    }
+    pointer.onDragEnd = () => {
+      const dragState = this.finishSlotReorderDrag()
+      if (!dragState || dragState.fromIndex === dragState.toIndex) return
+
+      this.reorderSlot(dragState.fromIndex, dragState.toIndex)
+    }
+    pointer.finally = () => {
+      this.clearSlotReorderDrag()
+      this.setDragCursor()
     }
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -880,6 +880,99 @@ describe('SubgraphNode duplicate input pruning (#9977)', () => {
   })
 })
 
+describe('SubgraphNode canonical IO order (#10221)', () => {
+  it('should enforce canonical input order after configure with mismatched serialized order', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'first', type: 'STRING' },
+        { name: 'second', type: 'INT' },
+        { name: 'third', type: 'FLOAT' }
+      ]
+    })
+
+    const parentGraph = new LGraph()
+    const instanceData = {
+      id: 1 as const,
+      type: subgraph.id,
+      pos: [0, 0] as [number, number],
+      size: [200, 100] as [number, number],
+      inputs: [
+        { name: 'third', type: 'FLOAT', link: null },
+        { name: 'first', type: 'STRING', link: null },
+        { name: 'second', type: 'INT', link: null }
+      ],
+      outputs: [],
+      properties: {},
+      flags: {},
+      mode: 0,
+      order: 0
+    }
+
+    const node = new SubgraphNode(
+      parentGraph,
+      subgraph,
+      instanceData as ExportedSubgraphInstance
+    )
+
+    expect(node.inputs.map((i) => i.name)).toEqual(['first', 'second', 'third'])
+  })
+
+  it('should enforce canonical output order after configure', () => {
+    const subgraph = createTestSubgraph({
+      outputs: [
+        { name: 'out_a', type: 'STRING' },
+        { name: 'out_b', type: 'INT' }
+      ]
+    })
+
+    const parentGraph = new LGraph()
+    const instanceData = {
+      id: 1 as const,
+      type: subgraph.id,
+      pos: [0, 0] as [number, number],
+      size: [200, 100] as [number, number],
+      inputs: [],
+      outputs: [
+        { name: 'out_b', type: 'INT', links: null },
+        { name: 'out_a', type: 'STRING', links: null }
+      ],
+      properties: {},
+      flags: {},
+      mode: 0,
+      order: 0
+    }
+
+    const node = new SubgraphNode(
+      parentGraph,
+      subgraph,
+      instanceData as ExportedSubgraphInstance
+    )
+
+    expect(node.outputs.map((o) => o.name)).toEqual(['out_a', 'out_b'])
+  })
+
+  it('should preserve canonical order across serialize/configure cycles', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'alpha', type: 'STRING' },
+        { name: 'beta', type: 'INT' },
+        { name: 'gamma', type: 'FLOAT' }
+      ]
+    })
+
+    const node = createTestSubgraphNode(subgraph)
+    const expectedOrder = ['alpha', 'beta', 'gamma']
+
+    expect(node.inputs.map((i) => i.name)).toEqual(expectedOrder)
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const serialized = node.serialize()
+      node.configure(serialized)
+      expect(node.inputs.map((i) => i.name)).toEqual(expectedOrder)
+    }
+  })
+})
+
 describe('Nested SubgraphNode duplicate input prevention', () => {
   it('should not duplicate inputs when the referenced subgraph is reconfigured', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -937,6 +937,36 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     )
   }
 
+  private _sortSlotsToCanonicalOrder(): void {
+    const canonicalInputs = this.subgraph.inputNode.slots
+    this.inputs.sort((a, b) => {
+      const ai = canonicalInputs.indexOf(a._subgraphSlot!)
+      const bi = canonicalInputs.indexOf(b._subgraphSlot!)
+      return ai - bi
+    })
+    // Fix input link target_slot indices after reorder
+    for (const [i, input] of this.inputs.entries()) {
+      if (input.link == null) continue
+      const link = this.graph?._links.get(input.link)
+      if (link) link.target_slot = i
+    }
+
+    const canonicalOutputs = this.subgraph.outputNode.slots
+    this.outputs.sort((a, b) => {
+      const ai = canonicalOutputs.findIndex((s) => s.name === a.name)
+      const bi = canonicalOutputs.findIndex((s) => s.name === b.name)
+      return ai - bi
+    })
+    // Fix output link origin_slot indices after reorder
+    for (const [i, output] of this.outputs.entries()) {
+      if (!output.links?.length) continue
+      for (const linkId of output.links) {
+        const link = this.graph?._links.get(linkId)
+        if (link) link.origin_slot = i
+      }
+    }
+  }
+
   private _rebindInputSubgraphSlots(): void {
     this._invalidatePromotedViewsCache()
 
@@ -1051,6 +1081,11 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     // Prune inputs that don't map to any subgraph slot definition.
     // This prevents stale/duplicate serialized inputs from persisting (#9977).
     this.inputs = this.inputs.filter((input) => input._subgraphSlot)
+
+    // Enforce canonical order: sort inputs/outputs to match the subgraph
+    // definition arrays. Serialized data may have a different order, causing
+    // drift between inner pins, outer pins, and properties panel (#10221).
+    this._sortSlotsToCanonicalOrder()
 
     // Ensure proxyWidgets is initialized so it serializes
     this.properties.proxyWidgets ??= []

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -838,6 +838,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         }
         this._setConcreteSlots()
         this._invalidatePromotedViewsCache()
+        this._syncPromotions()
         this.setDirtyCanvas(true, true)
       },
       { signal }
@@ -990,8 +991,10 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     const canonicalOutputs = this.subgraph.outputNode.slots
     this.outputs.sort((a, b) => {
-      const ai = canonicalOutputs.findIndex((s) => s.name === a.name)
-      const bi = canonicalOutputs.findIndex((s) => s.name === b.name)
+      const aiRaw = canonicalOutputs.findIndex((s) => s.name === a.name)
+      const biRaw = canonicalOutputs.findIndex((s) => s.name === b.name)
+      const ai = aiRaw === -1 ? Number.MAX_SAFE_INTEGER : aiRaw
+      const bi = biRaw === -1 ? Number.MAX_SAFE_INTEGER : biRaw
       return ai - bi
     })
     // Fix output link origin_slot indices after reorder

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -836,6 +836,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
           const link = this.graph?._links.get(input.link)
           if (link) link.target_slot = i
         }
+        this._setConcreteSlots()
         this._invalidatePromotedViewsCache()
         this.setDirtyCanvas(true, true)
       },
@@ -855,6 +856,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
             if (link) link.origin_slot = i
           }
         }
+        this._setConcreteSlots()
         this.setDirtyCanvas(true, true)
       },
       { signal }

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -825,6 +825,41 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       { signal }
     )
 
+    subgraphEvents.addEventListener(
+      'input-reordered',
+      (e) => {
+        const { fromIndex, toIndex } = e.detail
+        const [moved] = this.inputs.splice(fromIndex, 1)
+        this.inputs.splice(toIndex, 0, moved)
+        for (const [i, input] of this.inputs.entries()) {
+          if (input.link == null) continue
+          const link = this.graph?._links.get(input.link)
+          if (link) link.target_slot = i
+        }
+        this._invalidatePromotedViewsCache()
+        this.setDirtyCanvas(true, true)
+      },
+      { signal }
+    )
+
+    subgraphEvents.addEventListener(
+      'output-reordered',
+      (e) => {
+        const { fromIndex, toIndex } = e.detail
+        const [moved] = this.outputs.splice(fromIndex, 1)
+        this.outputs.splice(toIndex, 0, moved)
+        for (const [i, output] of this.outputs.entries()) {
+          if (!output.links?.length) continue
+          for (const linkId of output.links) {
+            const link = this.graph?._links.get(linkId)
+            if (link) link.origin_slot = i
+          }
+        }
+        this.setDirtyCanvas(true, true)
+      },
+      { signal }
+    )
+
     this.type = subgraph.id
     this.configure(instanceData)
 

--- a/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
@@ -51,29 +51,54 @@ export class SubgraphOutputNode
     pointer: CanvasPointer,
     linkConnector: LinkConnector
   ): void {
-    // Left-click handling for dragging connections
-    if (e.button === 0) {
-      for (const slot of this.allSlots) {
-        // Check if click is within the full slot area (including label)
-        if (slot.boundingRect.containsXy(e.canvasX, e.canvasY)) {
-          pointer.onDragStart = () => {
-            linkConnector.dragNewFromSubgraphOutput(this.subgraph, this, slot)
-          }
-          pointer.onDragEnd = (eUp) => {
-            linkConnector.dropLinks(this.subgraph, eUp)
-          }
-          pointer.onDoubleClick = () => {
-            this.handleSlotDoubleClick(slot, e)
-          }
-          pointer.finally = () => {
-            linkConnector.reset(true)
-          }
-        }
-      }
-      // Check for right-click
-    } else if (e.button === 2) {
+    if (e.button === 2) {
       const slot = this.getSlotInPosition(e.canvasX, e.canvasY)
       if (slot) this.showSlotContextMenu(slot, e)
+      return
+    }
+
+    if (e.button !== 0) return
+
+    const slot = this.getSlotInPosition(e.canvasX, e.canvasY)
+    if (!slot) return
+
+    pointer.onDoubleClick = () => {
+      this.handleSlotDoubleClick(slot, e)
+    }
+
+    if (slot === this.emptySlot || this.isConnectionDragHit(slot, e.canvasX)) {
+      pointer.onDragStart = () => {
+        linkConnector.dragNewFromSubgraphOutput(this.subgraph, this, slot)
+      }
+      pointer.onDragEnd = (eUp) => {
+        linkConnector.dropLinks(this.subgraph, eUp)
+      }
+      pointer.finally = () => {
+        linkConnector.reset(true)
+      }
+      return
+    }
+
+    pointer.onDragStart = (_, eMove) => {
+      const started = this.startSlotReorderDrag(
+        slot,
+        eMove?.canvasY ?? e.canvasY
+      )
+      if (!started) return
+      this.setDragCursor('grabbing')
+    }
+    pointer.onDrag = (eMove) => {
+      this.updateSlotReorderDrag(eMove.canvasY)
+      this.setDragCursor('grabbing')
+    }
+    pointer.onDragEnd = () => {
+      const dragResult = this.finishSlotReorderDrag()
+      if (!dragResult || dragResult.fromIndex === dragResult.toIndex) return
+      this.reorderSlot(dragResult.fromIndex, dragResult.toIndex)
+    }
+    pointer.finally = () => {
+      this.clearSlotReorderDrag()
+      this.setDragCursor()
     }
   }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutputNode.ts
@@ -42,6 +42,10 @@ export class SubgraphOutputNode
     return x + SubgraphIONodeBase.roundedRadius
   }
 
+  protected override reorderSlot(fromIndex: number, toIndex: number): void {
+    this.subgraph.reorderOutput(fromIndex, toIndex)
+  }
+
   override onPointerDown(
     e: CanvasPointerEvent,
     pointer: CanvasPointer,

--- a/src/lib/litegraph/src/subgraph/SubgraphReorder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphReorder.test.ts
@@ -163,11 +163,13 @@ describe('SubgraphNode syncs on reorder events', () => {
     expect(subgraphNode.inputs[0].link).not.toBeNull()
     const linkId = subgraphNode.inputs[0].link!
 
-    // Reorder: swap positions
+    // Reorder: move 'a' from index 0 to index 1
     subgraph.reorderInput(0, 1)
 
-    // The link should now be on the input that was moved
-    const movedInput = subgraphNode.inputs.find((i) => i.link === linkId)
-    expect(movedInput).toBeDefined()
+    // 'b' should now be at index 0 (no link), 'a' at index 1 (with link)
+    expect(subgraphNode.inputs[0].name).toBe('b')
+    expect(subgraphNode.inputs[0].link).toBeNull()
+    expect(subgraphNode.inputs[1].name).toBe('a')
+    expect(subgraphNode.inputs[1].link).toBe(linkId)
   })
 })

--- a/src/lib/litegraph/src/subgraph/SubgraphReorder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphReorder.test.ts
@@ -96,6 +96,35 @@ describe('Subgraph.reorderOutput', () => {
 
     expect(subgraph.outputs.map((o) => o.name)).toEqual(['z', 'x', 'y'])
   })
+
+  it('fixes link target_slot indices after reorder', () => {
+    const subgraph = createTestSubgraph({
+      outputs: [
+        { name: 'x', type: 'STRING' },
+        { name: 'y', type: 'INT' },
+        { name: 'z', type: 'FLOAT' }
+      ]
+    })
+
+    const nodeX = new LGraphNode('NodeX')
+    nodeX.addOutput('value', 'STRING')
+    subgraph.add(nodeX)
+    subgraph.outputNode.slots[0].connect(nodeX.outputs[0], nodeX)
+
+    const nodeZ = new LGraphNode('NodeZ')
+    nodeZ.addOutput('value', 'FLOAT')
+    subgraph.add(nodeZ)
+    subgraph.outputNode.slots[2].connect(nodeZ.outputs[0], nodeZ)
+
+    subgraph.reorderOutput(0, 2)
+
+    for (const [i, output] of subgraph.outputs.entries()) {
+      for (const linkId of output.linkIds) {
+        const link = subgraph._links.get(linkId)
+        expect(link?.target_slot).toBe(i)
+      }
+    }
+  })
 })
 
 describe('SubgraphNode syncs on reorder events', () => {

--- a/src/lib/litegraph/src/subgraph/SubgraphReorder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphReorder.test.ts
@@ -1,0 +1,173 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import {
+  createTestSubgraph,
+  createTestSubgraphNode,
+  resetSubgraphFixtureState
+} from './__fixtures__/subgraphHelpers'
+
+beforeEach(() => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+  resetSubgraphFixtureState()
+})
+
+describe('Subgraph.reorderInput', () => {
+  it('moves an input from one position to another', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'a', type: 'STRING' },
+        { name: 'b', type: 'INT' },
+        { name: 'c', type: 'FLOAT' }
+      ]
+    })
+
+    expect(subgraph.inputs.map((i) => i.name)).toEqual(['a', 'b', 'c'])
+
+    subgraph.reorderInput(0, 2)
+
+    expect(subgraph.inputs.map((i) => i.name)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('is a no-op when from === to', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'a', type: 'STRING' },
+        { name: 'b', type: 'INT' }
+      ]
+    })
+
+    subgraph.reorderInput(1, 1)
+
+    expect(subgraph.inputs.map((i) => i.name)).toEqual(['a', 'b'])
+  })
+
+  it('fixes link origin_slot indices after reorder', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'a', type: 'STRING' },
+        { name: 'b', type: 'INT' },
+        { name: 'c', type: 'FLOAT' }
+      ]
+    })
+
+    // Connect interior nodes to subgraph inputs
+    const nodeA = new LGraphNode('NodeA')
+    nodeA.addInput('value', 'STRING')
+    nodeA.inputs[0].widget = { name: 'value' }
+    subgraph.add(nodeA)
+    subgraph.inputNode.slots[0].connect(nodeA.inputs[0], nodeA)
+
+    const nodeC = new LGraphNode('NodeC')
+    nodeC.addInput('value', 'FLOAT')
+    nodeC.inputs[0].widget = { name: 'value' }
+    subgraph.add(nodeC)
+    subgraph.inputNode.slots[2].connect(nodeC.inputs[0], nodeC)
+
+    // Reorder: move 'a' to position 2
+    subgraph.reorderInput(0, 2)
+
+    // Verify link origin_slot indices match new positions
+    for (const [i, input] of subgraph.inputs.entries()) {
+      for (const linkId of input.linkIds) {
+        const link = subgraph._links.get(linkId)
+        expect(link?.origin_slot).toBe(i)
+      }
+    }
+  })
+})
+
+describe('Subgraph.reorderOutput', () => {
+  it('moves an output from one position to another', () => {
+    const subgraph = createTestSubgraph({
+      outputs: [
+        { name: 'x', type: 'STRING' },
+        { name: 'y', type: 'INT' },
+        { name: 'z', type: 'FLOAT' }
+      ]
+    })
+
+    expect(subgraph.outputs.map((o) => o.name)).toEqual(['x', 'y', 'z'])
+
+    subgraph.reorderOutput(2, 0)
+
+    expect(subgraph.outputs.map((o) => o.name)).toEqual(['z', 'x', 'y'])
+  })
+})
+
+describe('SubgraphNode syncs on reorder events', () => {
+  it('reorders inputs when subgraph fires input-reordered', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'first', type: 'STRING' },
+        { name: 'second', type: 'INT' },
+        { name: 'third', type: 'FLOAT' }
+      ]
+    })
+
+    const subgraphNode = createTestSubgraphNode(subgraph)
+
+    expect(subgraphNode.inputs.map((i) => i.name)).toEqual([
+      'first',
+      'second',
+      'third'
+    ])
+
+    subgraph.reorderInput(0, 2)
+
+    expect(subgraphNode.inputs.map((i) => i.name)).toEqual([
+      'second',
+      'third',
+      'first'
+    ])
+  })
+
+  it('reorders outputs when subgraph fires output-reordered', () => {
+    const subgraph = createTestSubgraph({
+      outputs: [
+        { name: 'out_a', type: 'STRING' },
+        { name: 'out_b', type: 'INT' }
+      ]
+    })
+
+    const subgraphNode = createTestSubgraphNode(subgraph)
+
+    expect(subgraphNode.outputs.map((o) => o.name)).toEqual(['out_a', 'out_b'])
+
+    subgraph.reorderOutput(1, 0)
+
+    expect(subgraphNode.outputs.map((o) => o.name)).toEqual(['out_b', 'out_a'])
+  })
+
+  it('preserves links through reorder', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [
+        { name: 'a', type: 'STRING' },
+        { name: 'b', type: 'INT' }
+      ]
+    })
+
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    const parentGraph = subgraphNode.graph ?? subgraph.rootGraph
+    parentGraph.add(subgraphNode)
+
+    // Connect an external node to input 0
+    const extNode = new LGraphNode('External')
+    extNode.addOutput('out', 'STRING')
+    parentGraph.add(extNode)
+    extNode.connect(0, subgraphNode, 0)
+
+    expect(subgraphNode.inputs[0].link).not.toBeNull()
+    const linkId = subgraphNode.inputs[0].link!
+
+    // Reorder: swap positions
+    subgraph.reorderInput(0, 1)
+
+    // The link should now be on the input that was moved
+    const movedInput = subgraphNode.inputs.find((i) => i.link === linkId)
+    expect(movedInput).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary (Part 2 of 2)

Adds drag-to-reorder for subgraph IO pins inside subgraph editing mode, building on #10227 (canonical order enforcement).

## Changes

- `Subgraph.reorderInput()` / `reorderOutput()` with link index fixing and event dispatch
- `input-reordered` / `output-reordered` events on SubgraphEventMap
- SubgraphNode listens and syncs its inputs/outputs on reorder, rebuilds concrete slot caches
- Canvas drag UX on both SubgraphInputNode and SubgraphOutputNode:
  - Drag from label area to reorder, drag from pin dot to connect
  - Layout handled in `arrange()` — dragged item follows cursor, gap inserted at target
  - Grab cursor during drag, 85% opacity on dragged item
  - Empty slot excluded from reorder

## Review Focus

- `SubgraphIONodeBase.arrange()` — the drag layout with gap insertion
- `SubgraphInputNode.onPointerDown()` — pin-dot vs label-area hit detection split
- `Subgraph.reorderInput/Output()` — link index fixup after splice
- `SubgraphNode` event listeners — `_setConcreteSlots()` call after reorder

## Dependencies

- #10227 (canonical order enforcement) — provides `_sortSlotsToCanonicalOrder()` that normalizes order on load

## Breaking Changes

None. Existing workflows load and serialize identically. Reorder is a new user-initiated action only.

## Test plan

- [x] Unit: reorderInput moves slots and fixes link indices
- [x] Unit: reorderOutput moves slots
- [x] Unit: SubgraphNode syncs on reorder events
- [x] Unit: links preserved through reorder
- [x] E2E: inner and outer pin order sync after reorder
- [x] E2E: reorder stable across serialize/configure cycle
- [x] Manual: drag input labels to reorder
- [x] Manual: drag output labels to reorder
- [x] Manual: pin dot drag still creates connections

- Related to #10221

## PR Chain

1. #10227 — Canonical subgraph IO order enforcement
2. **#10232 — This PR: drag-to-reorder subgraph IO pins**

1. #10227 — Canonical subgraph IO order enforcement
2. **#10232 — This PR: drag-to-reorder subgraph IO pins**