### PR TITLE
test: add copy/paste node and image paste e2e tests

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -226,7 +226,7 @@ export class ComfyPage {
     this.nodeOps = new NodeOperationsHelper(this)
     this.settings = new SettingsHelper(page)
     this.keyboard = new KeyboardHelper(page, this.canvas)
-    this.clipboard = new ClipboardHelper(this.keyboard)
+    this.clipboard = new ClipboardHelper(this.keyboard, page)
     this.workflow = new WorkflowHelper(this)
     this.contextMenu = new ContextMenu(page)
     this.toast = new ToastHelper(page)

--- a/browser_tests/fixtures/helpers/ClipboardHelper.ts
+++ b/browser_tests/fixtures/helpers/ClipboardHelper.ts
@@ -1,9 +1,27 @@
-import type { Locator } from '@playwright/test'
+import { readFileSync } from 'fs'
+import { basename } from 'path'
+
+import type { Locator, Page } from '@playwright/test'
 
 import type { KeyboardHelper } from './KeyboardHelper'
 
+function getMimeType(fileName: string): string {
+  if (fileName.endsWith('.png')) return 'image/png'
+  if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg'))
+    return 'image/jpeg'
+  if (fileName.endsWith('.webp')) return 'image/webp'
+  if (fileName.endsWith('.svg')) return 'image/svg+xml'
+  if (fileName.endsWith('.avif')) return 'image/avif'
+  if (fileName.endsWith('.webm')) return 'video/webm'
+  if (fileName.endsWith('.mp4')) return 'video/mp4'
+  return 'application/octet-stream'
+}
+
 export class ClipboardHelper {
-  constructor(private readonly keyboard: KeyboardHelper) {}
+  constructor(
+    private readonly keyboard: KeyboardHelper,
+    private readonly page: Page
+  ) {}
 
   async copy(locator?: Locator | null): Promise<void> {
     await this.keyboard.ctrlSend('KeyC', locator ?? null)
@@ -11,5 +29,27 @@ export class ClipboardHelper {
 
   async paste(locator?: Locator | null): Promise<void> {
     await this.keyboard.ctrlSend('KeyV', locator ?? null)
+  }
+
+  async pasteFile(filePath: string): Promise<void> {
+    const buffer = readFileSync(filePath)
+    const bufferArray = [...new Uint8Array(buffer)]
+    const fileName = basename(filePath)
+    const fileType = getMimeType(fileName)
+
+    await this.page.evaluate(
+      ({ buf, name, type }) => {
+        const file = new File([new Uint8Array(buf)], name, { type })
+        const dataTransfer = new DataTransfer()
+        dataTransfer.items.add(file)
+        const event = new ClipboardEvent('paste', {
+          clipboardData: dataTransfer,
+          bubbles: true,
+          cancelable: true
+        })
+        document.dispatchEvent(event)
+      },
+      { buf: bufferArray, name: fileName, type: fileType }
+    )
   }
 }

--- a/browser_tests/fixtures/helpers/ClipboardHelper.ts
+++ b/browser_tests/fixtures/helpers/ClipboardHelper.ts
@@ -4,18 +4,7 @@ import { basename } from 'path'
 import type { Locator, Page } from '@playwright/test'
 
 import type { KeyboardHelper } from './KeyboardHelper'
-
-function getMimeType(fileName: string): string {
-  const name = fileName.toLowerCase()
-  if (name.endsWith('.png')) return 'image/png'
-  if (name.endsWith('.jpg') || name.endsWith('.jpeg')) return 'image/jpeg'
-  if (name.endsWith('.webp')) return 'image/webp'
-  if (name.endsWith('.svg')) return 'image/svg+xml'
-  if (name.endsWith('.avif')) return 'image/avif'
-  if (name.endsWith('.webm')) return 'video/webm'
-  if (name.endsWith('.mp4')) return 'video/mp4'
-  return 'application/octet-stream'
-}
+import { getMimeType } from './mimeTypeUtil'
 
 export class ClipboardHelper {
   constructor(
@@ -37,19 +26,37 @@ export class ClipboardHelper {
     const fileName = basename(filePath)
     const fileType = getMimeType(fileName)
 
+    // Register a one-time capturing-phase listener that intercepts the next
+    // paste event and injects file data onto clipboardData.
     await this.page.evaluate(
-      ({ buf, name, type }) => {
-        const file = new File([new Uint8Array(buf)], name, { type })
-        const dataTransfer = new DataTransfer()
-        dataTransfer.items.add(file)
-        const event = new ClipboardEvent('paste', {
-          clipboardData: dataTransfer,
-          bubbles: true,
-          cancelable: true
-        })
-        document.dispatchEvent(event)
+      ({ bufferArray, fileName, fileType }) => {
+        document.addEventListener(
+          'paste',
+          (e: ClipboardEvent) => {
+            e.preventDefault()
+            e.stopImmediatePropagation()
+
+            const file = new File([new Uint8Array(bufferArray)], fileName, {
+              type: fileType
+            })
+            const dataTransfer = new DataTransfer()
+            dataTransfer.items.add(file)
+
+            const syntheticEvent = new ClipboardEvent('paste', {
+              clipboardData: dataTransfer,
+              bubbles: true,
+              cancelable: true
+            })
+            document.dispatchEvent(syntheticEvent)
+          },
+          { capture: true, once: true }
+        )
       },
-      { buf: bufferArray, name: fileName, type: fileType }
+      { bufferArray, fileName, fileType }
     )
+
+    // Trigger a real Ctrl+V keystroke — the capturing listener above will
+    // intercept it and re-dispatch with file data attached.
+    await this.paste()
   }
 }

--- a/browser_tests/fixtures/helpers/ClipboardHelper.ts
+++ b/browser_tests/fixtures/helpers/ClipboardHelper.ts
@@ -6,14 +6,14 @@ import type { Locator, Page } from '@playwright/test'
 import type { KeyboardHelper } from './KeyboardHelper'
 
 function getMimeType(fileName: string): string {
-  if (fileName.endsWith('.png')) return 'image/png'
-  if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg'))
-    return 'image/jpeg'
-  if (fileName.endsWith('.webp')) return 'image/webp'
-  if (fileName.endsWith('.svg')) return 'image/svg+xml'
-  if (fileName.endsWith('.avif')) return 'image/avif'
-  if (fileName.endsWith('.webm')) return 'video/webm'
-  if (fileName.endsWith('.mp4')) return 'video/mp4'
+  const name = fileName.toLowerCase()
+  if (name.endsWith('.png')) return 'image/png'
+  if (name.endsWith('.jpg') || name.endsWith('.jpeg')) return 'image/jpeg'
+  if (name.endsWith('.webp')) return 'image/webp'
+  if (name.endsWith('.svg')) return 'image/svg+xml'
+  if (name.endsWith('.avif')) return 'image/avif'
+  if (name.endsWith('.webm')) return 'video/webm'
+  if (name.endsWith('.mp4')) return 'video/mp4'
   return 'application/octet-stream'
 }
 

--- a/browser_tests/fixtures/helpers/DragDropHelper.ts
+++ b/browser_tests/fixtures/helpers/DragDropHelper.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs'
 import type { Page } from '@playwright/test'
 
 import type { Position } from '../types'
+import { getMimeType } from './mimeTypeUtil'
 
 export class DragDropHelper {
   constructor(
@@ -48,19 +49,8 @@ export class DragDropHelper {
       const filePath = this.assetPath(fileName)
       const buffer = readFileSync(filePath)
 
-      const getFileType = (fileName: string) => {
-        if (fileName.endsWith('.png')) return 'image/png'
-        if (fileName.endsWith('.svg')) return 'image/svg+xml'
-        if (fileName.endsWith('.webp')) return 'image/webp'
-        if (fileName.endsWith('.webm')) return 'video/webm'
-        if (fileName.endsWith('.json')) return 'application/json'
-        if (fileName.endsWith('.glb')) return 'model/gltf-binary'
-        if (fileName.endsWith('.avif')) return 'image/avif'
-        return 'application/octet-stream'
-      }
-
       evaluateParams.fileName = fileName
-      evaluateParams.fileType = getFileType(fileName)
+      evaluateParams.fileType = getMimeType(fileName)
       evaluateParams.buffer = [...new Uint8Array(buffer)]
     }
 

--- a/browser_tests/fixtures/helpers/mimeTypeUtil.ts
+++ b/browser_tests/fixtures/helpers/mimeTypeUtil.ts
@@ -1,0 +1,13 @@
+export function getMimeType(fileName: string): string {
+  const name = fileName.toLowerCase()
+  if (name.endsWith('.png')) return 'image/png'
+  if (name.endsWith('.jpg') || name.endsWith('.jpeg')) return 'image/jpeg'
+  if (name.endsWith('.webp')) return 'image/webp'
+  if (name.endsWith('.svg')) return 'image/svg+xml'
+  if (name.endsWith('.avif')) return 'image/avif'
+  if (name.endsWith('.webm')) return 'video/webm'
+  if (name.endsWith('.mp4')) return 'video/mp4'
+  if (name.endsWith('.json')) return 'application/json'
+  if (name.endsWith('.glb')) return 'model/gltf-binary'
+  return 'application/octet-stream'
+}

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -1,31 +1,7 @@
-import { readFileSync } from 'fs'
-
-import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 import { DefaultGraphPositions } from '../fixtures/constants/defaultGraphPositions'
-
-async function simulateImagePaste(
-  page: Page,
-  assetPath: string
-): Promise<void> {
-  const buffer = readFileSync(assetPath)
-  const bufferArray = [...new Uint8Array(buffer)]
-  await page.evaluate((buf) => {
-    const file = new File([new Uint8Array(buf)], 'image32x32.webp', {
-      type: 'image/webp'
-    })
-    const dataTransfer = new DataTransfer()
-    dataTransfer.items.add(file)
-    const event = new ClipboardEvent('paste', {
-      clipboardData: dataTransfer,
-      bubbles: true,
-      cancelable: true
-    })
-    document.dispatchEvent(event)
-  }, bufferArray)
-}
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
@@ -168,8 +144,9 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
       await comfyPage.canvas.click({ position: { x: 50, y: 500 } })
       await comfyPage.nextFrame()
       await comfyPage.clipboard.paste()
-      await comfyPage.nextFrame()
-      expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
+      await expect(async () => {
+        expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
+      }).toPass({ timeout: 5000 })
 
       // Step 2: Paste image onto selected LoadImage node
       const loadImageNodes =
@@ -181,16 +158,16 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
         (resp) => resp.url().includes('/upload/') && resp.status() === 200,
         { timeout: 10000 }
       )
-      await simulateImagePaste(
-        comfyPage.page,
+      await comfyPage.clipboard.pasteFile(
         comfyPage.assetPath('image32x32.webp')
       )
       await uploadPromise
-      await comfyPage.nextFrame()
 
-      const fileWidget = await loadImageNodes[0].getWidget(0)
-      const filename = await fileWidget.getValue()
-      expect(filename).toBe('image32x32.webp')
+      await expect(async () => {
+        const fileWidget = await loadImageNodes[0].getWidget(0)
+        const filename = await fileWidget.getValue()
+        expect(filename).toContain('image32x32')
+      }).toPass({ timeout: 5000 })
       expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
 
       // Step 3: Click empty canvas area, paste image → creates new LoadImage
@@ -201,14 +178,14 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
         (resp) => resp.url().includes('/upload/') && resp.status() === 200,
         { timeout: 10000 }
       )
-      await simulateImagePaste(
-        comfyPage.page,
+      await comfyPage.clipboard.pasteFile(
         comfyPage.assetPath('image32x32.webp')
       )
       await uploadPromise2
-      await comfyPage.nextFrame()
 
-      expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(4)
+      await expect(async () => {
+        expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(4)
+      }).toPass({ timeout: 5000 })
       const allLoadImageNodes =
         await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
       expect(allLoadImageNodes).toHaveLength(2)

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -144,9 +144,11 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
       await comfyPage.canvas.click({ position: { x: 50, y: 500 } })
       await comfyPage.nextFrame()
       await comfyPage.clipboard.paste()
-      await expect(async () => {
-        expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
-      }).toPass({ timeout: 5000 })
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount(), {
+          timeout: 5_000
+        })
+        .toBe(3)
 
       // Step 2: Paste image onto selected LoadImage node
       const loadImageNodes =
@@ -156,18 +158,22 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
 
       const uploadPromise = comfyPage.page.waitForResponse(
         (resp) => resp.url().includes('/upload/') && resp.status() === 200,
-        { timeout: 10000 }
+        { timeout: 10_000 }
       )
       await comfyPage.clipboard.pasteFile(
         comfyPage.assetPath('image32x32.webp')
       )
       await uploadPromise
 
-      await expect(async () => {
-        const fileWidget = await loadImageNodes[0].getWidget(0)
-        const filename = await fileWidget.getValue()
-        expect(filename).toContain('image32x32')
-      }).toPass({ timeout: 5000 })
+      await expect
+        .poll(
+          async () => {
+            const fileWidget = await loadImageNodes[0].getWidget(0)
+            return fileWidget.getValue()
+          },
+          { timeout: 5_000 }
+        )
+        .toContain('image32x32')
       expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
 
       // Step 3: Click empty canvas area, paste image → creates new LoadImage
@@ -176,16 +182,18 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
 
       const uploadPromise2 = comfyPage.page.waitForResponse(
         (resp) => resp.url().includes('/upload/') && resp.status() === 200,
-        { timeout: 10000 }
+        { timeout: 10_000 }
       )
       await comfyPage.clipboard.pasteFile(
         comfyPage.assetPath('image32x32.webp')
       )
       await uploadPromise2
 
-      await expect(async () => {
-        expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(4)
-      }).toPass({ timeout: 5000 })
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount(), {
+          timeout: 5_000
+        })
+        .toBe(4)
       const allLoadImageNodes =
         await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
       expect(allLoadImageNodes).toHaveLength(2)

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -1,7 +1,31 @@
+import { readFileSync } from 'fs'
+
+import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 import { DefaultGraphPositions } from '../fixtures/constants/defaultGraphPositions'
+
+async function simulateImagePaste(
+  page: Page,
+  assetPath: string
+): Promise<void> {
+  const buffer = readFileSync(assetPath)
+  const bufferArray = [...new Uint8Array(buffer)]
+  await page.evaluate((buf) => {
+    const file = new File([new Uint8Array(buf)], 'image32x32.webp', {
+      type: 'image/webp'
+    })
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(file)
+    const event = new ClipboardEvent('paste', {
+      clipboardData: dataTransfer,
+      bubbles: true,
+      cancelable: true
+    })
+    document.dispatchEvent(event)
+  }, bufferArray)
+}
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
@@ -129,4 +153,65 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
     const undoCount = await comfyPage.nodeOps.getGraphNodesCount()
     expect(undoCount).toBe(initialCount)
   })
+
+  test(
+    'Copy paste node, image paste onto LoadImage, image paste on empty canvas',
+    { tag: ['@node'] },
+    async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/load_image_with_ksampler')
+      expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(2)
+
+      // Step 1: Copy a KSampler node with Ctrl+C and paste with Ctrl+V
+      const ksamplerNodes =
+        await comfyPage.nodeOps.getNodeRefsByType('KSampler')
+      await ksamplerNodes[0].copy()
+      await comfyPage.canvas.click({ position: { x: 50, y: 500 } })
+      await comfyPage.nextFrame()
+      await comfyPage.clipboard.paste()
+      await comfyPage.nextFrame()
+      expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
+
+      // Step 2: Paste image onto selected LoadImage node
+      const loadImageNodes =
+        await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+      await loadImageNodes[0].click('title')
+      await comfyPage.nextFrame()
+
+      const uploadPromise = comfyPage.page.waitForResponse(
+        (resp) => resp.url().includes('/upload/') && resp.status() === 200,
+        { timeout: 10000 }
+      )
+      await simulateImagePaste(
+        comfyPage.page,
+        comfyPage.assetPath('image32x32.webp')
+      )
+      await uploadPromise
+      await comfyPage.nextFrame()
+
+      const fileWidget = await loadImageNodes[0].getWidget(0)
+      const filename = await fileWidget.getValue()
+      expect(filename).toBe('image32x32.webp')
+      expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(3)
+
+      // Step 3: Click empty canvas area, paste image → creates new LoadImage
+      await comfyPage.canvas.click({ position: { x: 50, y: 500 } })
+      await comfyPage.nextFrame()
+
+      const uploadPromise2 = comfyPage.page.waitForResponse(
+        (resp) => resp.url().includes('/upload/') && resp.status() === 200,
+        { timeout: 10000 }
+      )
+      await simulateImagePaste(
+        comfyPage.page,
+        comfyPage.assetPath('image32x32.webp')
+      )
+      await uploadPromise2
+      await comfyPage.nextFrame()
+
+      expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(4)
+      const allLoadImageNodes =
+        await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+      expect(allLoadImageNodes).toHaveLength(2)
+    }
+  )
 })


### PR DESCRIPTION
## Summary
- Add e2e test covering node copy/paste (Ctrl+C/V), image paste onto a selected LoadImage node, and image paste on empty canvas creating a new LoadImage node
- Extract `simulateImagePaste` into reusable `ClipboardHelper.pasteFile()` with auto-detected filename and MIME type
- Add test workflow asset `load_image_with_ksampler.json` and `image32x32.webp` image asset

## Test plan
- [ ] `pnpm typecheck:browser` passes
- [ ] `pnpm exec eslint browser_tests/tests/copyPaste.spec.ts` passes
- [ ] New test passes in CI: `Copy paste node, image paste onto LoadImage, image paste on empty canvas`
- [ ] Existing copy/paste tests unaffected

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10233-test-add-copy-paste-node-and-image-paste-e2e-tests-3276d73d365081e78bb9f3f1bf34389f) by [Unito](https://www.unito.io)
