### PR TITLE
feat: add model-to-node mappings for LTX Video prompt enhancer

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -393,6 +393,18 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
 
     // LayerDiffuse transparent image generation (comfyui-layerdiffuse)
     quickRegister('layer_model', 'LayeredDiffusionApply', 'config')
+
+    // LTX Video prompt enhancer models (ComfyUI-LTXTricks)
+    quickRegister(
+      'LLM/Llama-3.2-3B-Instruct',
+      'LTXVPromptEnhancerLoader',
+      'llm_name'
+    )
+    quickRegister(
+      'LLM/Florence-2-large-PromptGen-v2.0',
+      'LTXVPromptEnhancerLoader',
+      'image_captioner_name'
+    )
   }
 
   return {


### PR DESCRIPTION
## Summary
- Add `quickRegister()` entries for LTX Video prompt enhancer models:
  - `LLM/Llama-3.2-3B-Instruct` → `LTXVPromptEnhancerLoader` (`llm_name`)
  - `LLM/Florence-2-large-PromptGen-v2.0` → `LTXVPromptEnhancerLoader` (`image_captioner_name`)

These mappings ensure the "Use" button in the model browser correctly creates
the appropriate loader node when users click on these LLM models.

## Test plan
- [x] Verify "Use" button works for LLM/Llama-3.2-3B-Instruct in model browser
- [x] Verify "Use" button works for LLM/Florence-2-large-PromptGen-v2.0 in model browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10234-feat-add-model-to-node-mappings-for-LTX-Video-prompt-enhancer-3276d73d36508154847cdbae8c6e9bf1) by [Unito](https://www.unito.io)
