### PR TITLE
fix: prevent asset browser from hijacking CogVideo HF-download dropdowns

### DIFF
--- a/src/stores/modelToNodeStore.ts
+++ b/src/stores/modelToNodeStore.ts
@@ -75,8 +75,8 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
 
   /**
    * Find providers for modelType with hierarchical fallback.
-   * Tries exact match first, then falls back to top-level segment (e.g., "parent/child" → "parent").
-   * Note: Only falls back one level; "a/b/c" tries "a/b/c" then "a", not "a/b".
+   * Tries exact match first, then progressively shorter parent paths.
+   * e.g., "a/b/c" tries "a/b/c" → "a/b" → "a".
    */
   function findProvidersWithFallback(
     modelType: string
@@ -88,12 +88,13 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
     const exactMatch = modelToNodeMap.value[modelType]
     if (exactMatch && exactMatch.length > 0) return exactMatch
 
-    const topLevel = modelType.split('/')[0]
-    if (topLevel === modelType) return undefined
-
-    const fallback = modelToNodeMap.value[topLevel]
-
-    if (fallback && fallback.length > 0) return fallback
+    // Try progressively shorter parent paths
+    const segments = modelType.split('/')
+    for (let i = segments.length - 1; i >= 1; i--) {
+      const parentPath = segments.slice(0, i).join('/')
+      const fallback = modelToNodeMap.value[parentPath]
+      if (fallback && fallback.length > 0) return fallback
+    }
 
     return undefined
   }
@@ -361,10 +362,11 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
 
     // CogVideoX models (comfyui-cogvideoxwrapper)
     quickRegister('CogVideo/GGUF', 'DownloadAndLoadCogVideoGGUFModel', 'model')
+    // Empty key: HF-download node — don't activate asset browser for the combo widget
     quickRegister(
       'CogVideo/ControlNet',
       'DownloadAndLoadCogVideoControlNet',
-      'model'
+      ''
     )
 
     // DynamiCrafter models (ComfyUI-DynamiCrafterWrapper)
@@ -386,7 +388,8 @@ export const useModelToNodeStore = defineStore('modelToNode', () => {
     quickRegister('lama', 'LaMa', 'lama_model')
 
     // CogVideoX video generation models (comfyui-cogvideoxwrapper)
-    quickRegister('CogVideo', 'DownloadAndLoadCogVideoModel', 'model')
+    // Empty key: HF-download node — don't activate asset browser for the combo widget
+    quickRegister('CogVideo', 'DownloadAndLoadCogVideoModel', '')
 
     // Inpaint models (comfyui-inpaint-nodes)
     quickRegister('inpaint', 'INPAINT_LoadInpaintModel', 'model_name')


### PR DESCRIPTION
# DO NOT MERGE: AWAITING BACKEND DEPLOY

Dependent on a backend infrastructure change that must be deployed first.

## Summary
- Use empty key `''` for `DownloadAndLoadCogVideoControlNet` and `DownloadAndLoadCogVideoModel` registrations so `shouldUseAssetBrowser` returns false — these nodes use HuggingFace repo names, not file-based assets, so the asset browser finds nothing and shows an empty dropdown
- Fix `findProvidersWithFallback` to try all intermediate path levels (`a/b/c` → `a/b` → `a`) so clicking "Use" on a `CogVideo/ControlNet/*` model creates the correct `DownloadAndLoadCogVideoControlNet` node instead of falling back to `DownloadAndLoadCogVideoModel`

## How has this been tested?
- All 46 existing `modelToNodeStore` tests pass
- Hierarchical fallback still works for existing registrations (checkpoints, ultralytics, etc.)

## Documentation
- [x] No documentation changes needed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10236-fix-prevent-asset-browser-from-hijacking-CogVideo-HF-download-dropdowns-3276d73d3650812292eede9ac32db973) by [Unito](https://www.unito.io)
