### PR TITLE
fix: load initial locale before mounting desktop-ui app

### DIFF
--- a/apps/desktop-ui/src/main.ts
+++ b/apps/desktop-ui/src/main.ts
@@ -10,7 +10,7 @@ import { createApp } from 'vue'
 
 import App from './App.vue'
 import './assets/css/style.css'
-import { i18n } from './i18n'
+import { i18n, loadLocale } from './i18n'
 import router from './router'
 
 const ComfyUIPreset = definePreset(Aura, {
@@ -19,6 +19,9 @@ const ComfyUIPreset = definePreset(Aura, {
     primary: Aura['primitive'].blue
   }
 })
+
+// Load the initial locale before mounting to avoid rendering with missing translations
+await loadLocale(i18n.global.locale.value)
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/apps/desktop-ui/src/main.ts
+++ b/apps/desktop-ui/src/main.ts
@@ -20,8 +20,10 @@ const ComfyUIPreset = definePreset(Aura, {
   }
 })
 
-// Load the initial locale before mounting to avoid rendering with missing translations
-await loadLocale(i18n.global.locale.value)
+// Load the initial locale before mounting to avoid rendering with missing translations.
+// Errors are caught to prevent a failed locale fetch from bricking startup; the app
+// falls back to English in that case.
+await loadLocale(i18n.global.locale.value).catch(() => {})
 
 const app = createApp(App)
 const pinia = createPinia()


### PR DESCRIPTION
## Problem

On startup, the desktop-ui app initialized vue-i18n with the correct locale code (detected from `navigator.language`, e.g. `ja`) but only English messages were bundled. Non-English translations are lazy-loaded and must be explicitly fetched via `loadLocale()` — which was never called at startup.

Result: the UI rendered in English even when the language switcher correctly displayed e.g. "日本語" (the switcher uses hardcoded fallback strings, not translations).

Manually switching language worked because `LanguageSelector.vue` already calls `await loadLocale(nextLocale)` in `onLocaleChange`.

## Fix

Call `await loadLocale(i18n.global.locale.value)` before mounting the app in `main.ts`. This ensures translations are loaded before the first render.

For English users this is a no-op — `'en'` is pre-seeded in `loadedLocales` so `loadLocale` returns immediately.

## Changes

- `apps/desktop-ui/src/main.ts`: await initial locale load before `createApp` mount

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10239-fix-load-initial-locale-before-mounting-desktop-ui-app-3276d73d36508138955dfc1e82f4b30a) by [Unito](https://www.unito.io)
