### PR TITLE
fix: App mode - renaming widgets on subgraphs

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -33,6 +33,7 @@ import { FeatureFlagHelper } from './helpers/FeatureFlagHelper'
 import { KeyboardHelper } from './helpers/KeyboardHelper'
 import { NodeOperationsHelper } from './helpers/NodeOperationsHelper'
 import { SettingsHelper } from './helpers/SettingsHelper'
+import { AppModeHelper } from './helpers/AppModeHelper'
 import { SubgraphHelper } from './helpers/SubgraphHelper'
 import { ToastHelper } from './helpers/ToastHelper'
 import { WorkflowHelper } from './helpers/WorkflowHelper'
@@ -176,6 +177,7 @@ export class ComfyPage {
   public readonly settingDialog: SettingDialog
   public readonly confirmDialog: ConfirmDialog
   public readonly vueNodes: VueNodeHelpers
+  public readonly appMode: AppModeHelper
   public readonly subgraph: SubgraphHelper
   public readonly canvasOps: CanvasHelper
   public readonly nodeOps: NodeOperationsHelper
@@ -221,6 +223,7 @@ export class ComfyPage {
     this.settingDialog = new SettingDialog(page, this)
     this.confirmDialog = new ConfirmDialog(page)
     this.vueNodes = new VueNodeHelpers(page)
+    this.appMode = new AppModeHelper(this)
     this.subgraph = new SubgraphHelper(this)
     this.canvasOps = new CanvasHelper(page, this.canvas, this.resetViewButton)
     this.nodeOps = new NodeOperationsHelper(this)

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -1,0 +1,128 @@
+import type { Locator, Page } from '@playwright/test'
+
+import type { ComfyPage } from '../ComfyPage'
+import { TestIds } from '../selectors'
+
+export class AppModeHelper {
+  constructor(private readonly comfyPage: ComfyPage) {}
+
+  private get page(): Page {
+    return this.comfyPage.page
+  }
+
+  private get builderToolbar(): Locator {
+    return this.page.getByRole('navigation', { name: 'App Builder' })
+  }
+
+  /** Enter builder mode via the "Workflow actions" dropdown → "Build app". */
+  async enterBuilder() {
+    await this.page
+      .getByRole('button', { name: 'Workflow actions' })
+      .first()
+      .click()
+    await this.page.getByRole('menuitem', { name: 'Build app' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Exit builder mode via the footer "Exit app builder" button. */
+  async exitBuilder() {
+    await this.page.getByRole('button', { name: 'Exit app builder' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Click the "Inputs" step in the builder toolbar. */
+  async goToInputs() {
+    await this.builderToolbar.getByRole('button', { name: 'Inputs' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Click the "Outputs" step in the builder toolbar. */
+  async goToOutputs() {
+    await this.builderToolbar.getByRole('button', { name: 'Outputs' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Click the "Preview" step in the builder toolbar. */
+  async goToPreview() {
+    await this.builderToolbar.getByRole('button', { name: 'Preview' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Click the "Next" button in the builder footer. */
+  async next() {
+    await this.page.getByRole('button', { name: 'Next' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Click the "Back" button in the builder footer. */
+  async back() {
+    await this.page.getByRole('button', { name: 'Back' }).click()
+    await this.comfyPage.nextFrame()
+  }
+
+  /** Toggle app mode (linear view) on/off. */
+  async toggleAppMode() {
+    await this.page.evaluate(() => {
+      window.app!.extensionManager.command.execute('Comfy.ToggleLinear')
+    })
+    await this.comfyPage.nextFrame()
+  }
+
+  /** The linear-mode widget list container (visible in app mode). */
+  get linearWidgets(): Locator {
+    return this.page.locator('[data-testid="linear-widgets"]')
+  }
+
+  /**
+   * Get the actions menu trigger for a widget in the app mode widget list.
+   * @param widgetName Text shown in the widget label (e.g. "seed").
+   */
+  getAppModeWidgetMenu(widgetName: string): Locator {
+    return this.linearWidgets
+      .locator(`div:has(> div > span:text-is("${widgetName}"))`)
+      .getByTestId(TestIds.builder.widgetActionsMenu)
+      .first()
+  }
+
+  /**
+   * Get the actions menu trigger for a widget in the builder input-select
+   * sidebar (IoItem).
+   * @param title The widget title shown in the IoItem.
+   */
+  getBuilderInputItemMenu(title: string): Locator {
+    return this.page
+      .getByTestId(TestIds.builder.ioItem)
+      .filter({ hasText: title })
+      .getByTestId(TestIds.builder.widgetActionsMenu)
+  }
+
+  /**
+   * Get the actions menu trigger for a widget in the builder preview/arrange
+   * sidebar (AppModeWidgetList with builderMode).
+   * @param ariaLabel The aria-label on the widget row, e.g. "seed — KSampler".
+   */
+  getBuilderPreviewWidgetMenu(ariaLabel: string): Locator {
+    return this.page
+      .locator(`[aria-label="${ariaLabel}"]`)
+      .getByTestId(TestIds.builder.widgetActionsMenu)
+  }
+
+  /**
+   * Rename a widget by clicking its popover trigger, selecting "Rename",
+   * and filling in the dialog.
+   * @param popoverTrigger The button that opens the widget's actions popover.
+   * @param newName The new name to assign.
+   */
+  async renameWidget(popoverTrigger: Locator, newName: string) {
+    await popoverTrigger.click()
+    await this.page.getByText('Rename', { exact: true }).click()
+
+    const dialogInput = this.page.locator(
+      '.p-dialog-content input[type="text"]'
+    )
+    await dialogInput.fill(newName)
+    await this.page.keyboard.press('Enter')
+    await dialogInput.waitFor({ state: 'hidden' })
+    await this.comfyPage.nextFrame()
+  }
+}

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -58,6 +58,10 @@ export const TestIds = {
     domWidgetTextarea: 'dom-widget-textarea',
     subgraphEnterButton: 'subgraph-enter-button'
   },
+  builder: {
+    ioItem: 'builder-io-item',
+    widgetActionsMenu: 'widget-actions-menu'
+  },
   breadcrumb: {
     subgraph: 'subgraph-breadcrumb'
   },

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -88,6 +88,7 @@ export type TestIdValue =
   | (typeof TestIds.node)[keyof typeof TestIds.node]
   | (typeof TestIds.selectionToolbox)[keyof typeof TestIds.selectionToolbox]
   | (typeof TestIds.widgets)[keyof typeof TestIds.widgets]
+  | (typeof TestIds.builder)[keyof typeof TestIds.builder]
   | (typeof TestIds.breadcrumb)[keyof typeof TestIds.breadcrumb]
   | Exclude<
       (typeof TestIds.templates)[keyof typeof TestIds.templates],

--- a/browser_tests/tests/appModeWidgetRename.spec.ts
+++ b/browser_tests/tests/appModeWidgetRename.spec.ts
@@ -1,0 +1,106 @@
+import type { Page } from '@playwright/test'
+
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+
+async function injectLinearData(page: Page) {
+  await page.evaluate(async () => {
+    const graph = window.app!.graph
+    if (!graph) return
+
+    const outputNodeIds = graph.nodes
+      .filter(
+        (n: { type?: string }) =>
+          n.type === 'SaveImage' || n.type === 'PreviewImage'
+      )
+      .map((n: { id: number | string }) => String(n.id))
+
+    const ksampler = graph.nodes.find(
+      (n: { type?: string }) => n.type === 'KSampler'
+    )
+    const inputs: [string, string][] = ksampler
+      ? [[String(ksampler.id), 'seed']]
+      : []
+
+    const workflow = graph.serialize() as unknown as Record<string, unknown>
+    const extra = (workflow.extra ?? {}) as Record<string, unknown>
+    extra.linearData = { inputs, outputs: outputNodeIds }
+    workflow.extra = extra
+    await window.app!.loadGraphData(
+      workflow as unknown as Parameters<
+        NonNullable<typeof window.app>['loadGraphData']
+      >[0]
+    )
+  })
+}
+
+async function toggleLinearMode(page: Page) {
+  await page.evaluate(() => {
+    window.app!.extensionManager.command.execute('Comfy.ToggleLinear')
+  })
+}
+
+test.describe('App mode widget rename', { tag: '@ui' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+  })
+
+  test('Rename persists after saving and reloading workflow', async ({
+    comfyPage
+  }) => {
+    const { page } = comfyPage
+
+    // Enter app mode with KSampler seed widget as input
+    await injectLinearData(page)
+    await comfyPage.nextFrame()
+    await toggleLinearMode(page)
+    await comfyPage.nextFrame()
+
+    const widgetsContainer = page.locator('[data-testid="linear-widgets"]')
+    await expect(widgetsContainer).toBeVisible({ timeout: 5000 })
+
+    // Click the ellipsis button on the seed widget
+    const ellipsisButton = widgetsContainer
+      .locator('button:has(i.icon-\\[lucide--ellipsis\\])')
+      .first()
+    await ellipsisButton.click()
+
+    // Click "Rename" in the popover
+    await page.getByText('Rename', { exact: true }).click()
+
+    // Fill in the rename prompt dialog
+    const dialogInput = page.locator('.p-dialog-content input[type="text"]')
+    await dialogInput.fill('My Custom Seed')
+    await page.keyboard.press('Enter')
+    await dialogInput.waitFor({ state: 'hidden' })
+    await comfyPage.nextFrame()
+
+    // Verify the widget label is updated
+    await expect(widgetsContainer.getByText('My Custom Seed')).toBeVisible()
+
+    // Exit app mode to access topbar
+    await toggleLinearMode(page)
+    await comfyPage.nextFrame()
+
+    // Save workflow
+    const workflowName = `${new Date().getTime()} workflow`
+    await comfyPage.menu.topbar.saveWorkflow(workflowName)
+
+    // Open the saved workflow from the browse tree in a fresh tab
+    const { workflowsTab } = comfyPage.menu
+    await workflowsTab.open()
+    await workflowsTab.getPersistedItem(workflowName).dblclick()
+    await comfyPage.nextFrame()
+
+    // Re-enter app mode on the reloaded workflow
+    await toggleLinearMode(page)
+    await comfyPage.nextFrame()
+
+    // Verify the renamed label persisted
+    const reloadedWidgets = page.locator('[data-testid="linear-widgets"]')
+    await expect(reloadedWidgets).toBeVisible({ timeout: 5000 })
+    await expect(reloadedWidgets.getByText('My Custom Seed')).toBeVisible()
+  })
+})

--- a/browser_tests/tests/appModeWidgetRename.spec.ts
+++ b/browser_tests/tests/appModeWidgetRename.spec.ts
@@ -1,106 +1,149 @@
-import type { Page } from '@playwright/test'
-
+import type { ComfyPage } from '../fixtures/ComfyPage'
 import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '../fixtures/ComfyPage'
+import { fitToViewInstant } from '../helpers/fitToView'
+import { getPromotedWidgetNames } from '../helpers/promotedWidgets'
 
-async function injectLinearData(page: Page) {
-  await page.evaluate(async () => {
-    const graph = window.app!.graph
-    if (!graph) return
+/**
+ * Convert the KSampler (id 3) in the default workflow to a subgraph,
+ * enter builder, select the promoted seed widget as input and
+ * SaveImage/PreviewImage as output.
+ *
+ * Returns the subgraph node reference for further interaction.
+ */
+async function setupSubgraphBuilder(comfyPage: ComfyPage) {
+  const { page, appMode } = comfyPage
+  await comfyPage.workflow.loadWorkflow('default')
 
-    const outputNodeIds = graph.nodes
-      .filter(
+  const ksampler = await comfyPage.nodeOps.getNodeRefById('3')
+  await ksampler.click('title')
+  const subgraphNode = await ksampler.convertToSubgraph()
+  await comfyPage.nextFrame()
+
+  const subgraphNodeId = String(subgraphNode.id)
+  const promotedNames = await getPromotedWidgetNames(comfyPage, subgraphNodeId)
+  expect(promotedNames).toContain('seed')
+
+  await fitToViewInstant(comfyPage)
+  await appMode.enterBuilder()
+  await appMode.goToInputs()
+
+  // Click the promoted seed widget on the canvas to select it
+  const seedWidgetRef = await subgraphNode.getWidget(0)
+  const seedPos = await seedWidgetRef.getPosition()
+  await page.mouse.click(seedPos.x, seedPos.y)
+  await comfyPage.nextFrame()
+
+  // Select an output node
+  await appMode.goToOutputs()
+
+  const saveImageNodeId = await page.evaluate(() =>
+    String(
+      window.app!.rootGraph.nodes.find(
         (n: { type?: string }) =>
           n.type === 'SaveImage' || n.type === 'PreviewImage'
-      )
-      .map((n: { id: number | string }) => String(n.id))
-
-    const ksampler = graph.nodes.find(
-      (n: { type?: string }) => n.type === 'KSampler'
+      )?.id
     )
-    const inputs: [string, string][] = ksampler
-      ? [[String(ksampler.id), 'seed']]
-      : []
+  )
+  const saveImageRef = await comfyPage.nodeOps.getNodeRefById(saveImageNodeId)
+  const saveImagePos = await saveImageRef.getPosition()
+  // Click left edge — the right side is hidden by the builder panel
+  await page.mouse.click(saveImagePos.x + 10, saveImagePos.y - 10)
+  await comfyPage.nextFrame()
 
-    const workflow = graph.serialize() as unknown as Record<string, unknown>
-    const extra = (workflow.extra ?? {}) as Record<string, unknown>
-    extra.linearData = { inputs, outputs: outputNodeIds }
-    workflow.extra = extra
-    await window.app!.loadGraphData(
-      workflow as unknown as Parameters<
-        NonNullable<typeof window.app>['loadGraphData']
-      >[0]
-    )
-  })
+  return subgraphNode
 }
 
-async function toggleLinearMode(page: Page) {
-  await page.evaluate(() => {
-    window.app!.extensionManager.command.execute('Comfy.ToggleLinear')
-  })
+/** Save the workflow, reopen it, and enter app mode. */
+async function saveAndReopenInAppMode(
+  comfyPage: ComfyPage,
+  workflowName: string
+) {
+  await comfyPage.menu.topbar.saveWorkflow(workflowName)
+
+  const { workflowsTab } = comfyPage.menu
+  await workflowsTab.open()
+  await workflowsTab.getPersistedItem(workflowName).dblclick()
+  await comfyPage.nextFrame()
+
+  await comfyPage.appMode.toggleAppMode()
 }
 
-test.describe('App mode widget rename', { tag: '@ui' }, () => {
+test.describe('App mode widget rename', { tag: ['@ui', '@subgraph'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.page.evaluate(() => {
+      window.app!.api.serverFeatureFlags.value = {
+        ...window.app!.api.serverFeatureFlags.value,
+        linear_toggle_enabled: true
+      }
+    })
     await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
   })
 
-  test('Rename persists after saving and reloading workflow', async ({
-    comfyPage
-  }) => {
-    const { page } = comfyPage
+  test('Rename from builder input-select sidebar', async ({ comfyPage }) => {
+    const { appMode } = comfyPage
+    await setupSubgraphBuilder(comfyPage)
 
-    // Enter app mode with KSampler seed widget as input
-    await injectLinearData(page)
-    await comfyPage.nextFrame()
-    await toggleLinearMode(page)
-    await comfyPage.nextFrame()
+    // Go back to inputs step where IoItems are shown
+    await appMode.goToInputs()
 
-    const widgetsContainer = page.locator('[data-testid="linear-widgets"]')
-    await expect(widgetsContainer).toBeVisible({ timeout: 5000 })
+    const menu = appMode.getBuilderInputItemMenu('seed')
+    await expect(menu).toBeVisible({ timeout: 5000 })
+    await appMode.renameWidget(menu, 'Builder Input Seed')
 
-    // Click the ellipsis button on the seed widget
-    const ellipsisButton = widgetsContainer
-      .locator('button:has(i.icon-\\[lucide--ellipsis\\])')
-      .first()
-    await ellipsisButton.click()
+    // Verify in app mode after save/reload
+    await appMode.exitBuilder()
+    const workflowName = `${new Date().getTime()} builder-input`
+    await saveAndReopenInAppMode(comfyPage, workflowName)
 
-    // Click "Rename" in the popover
-    await page.getByText('Rename', { exact: true }).click()
+    await expect(appMode.linearWidgets).toBeVisible({ timeout: 5000 })
+    await expect(
+      appMode.linearWidgets.getByText('Builder Input Seed')
+    ).toBeVisible()
+  })
 
-    // Fill in the rename prompt dialog
-    const dialogInput = page.locator('.p-dialog-content input[type="text"]')
-    await dialogInput.fill('My Custom Seed')
-    await page.keyboard.press('Enter')
-    await dialogInput.waitFor({ state: 'hidden' })
-    await comfyPage.nextFrame()
+  test('Rename from builder preview sidebar', async ({ comfyPage }) => {
+    const { appMode } = comfyPage
+    await setupSubgraphBuilder(comfyPage)
 
-    // Verify the widget label is updated
-    await expect(widgetsContainer.getByText('My Custom Seed')).toBeVisible()
+    await appMode.goToPreview()
 
-    // Exit app mode to access topbar
-    await toggleLinearMode(page)
-    await comfyPage.nextFrame()
+    const menu = appMode.getBuilderPreviewWidgetMenu('seed — New Subgraph')
+    await expect(menu).toBeVisible({ timeout: 5000 })
+    await appMode.renameWidget(menu, 'Preview Seed')
 
-    // Save workflow
-    const workflowName = `${new Date().getTime()} workflow`
-    await comfyPage.menu.topbar.saveWorkflow(workflowName)
+    // Verify in app mode after save/reload
+    await appMode.exitBuilder()
+    const workflowName = `${new Date().getTime()} builder-preview`
+    await saveAndReopenInAppMode(comfyPage, workflowName)
 
-    // Open the saved workflow from the browse tree in a fresh tab
-    const { workflowsTab } = comfyPage.menu
-    await workflowsTab.open()
-    await workflowsTab.getPersistedItem(workflowName).dblclick()
-    await comfyPage.nextFrame()
+    await expect(appMode.linearWidgets).toBeVisible({ timeout: 5000 })
+    await expect(appMode.linearWidgets.getByText('Preview Seed')).toBeVisible()
+  })
 
-    // Re-enter app mode on the reloaded workflow
-    await toggleLinearMode(page)
-    await comfyPage.nextFrame()
+  test('Rename from app mode', async ({ comfyPage }) => {
+    const { appMode } = comfyPage
+    await setupSubgraphBuilder(comfyPage)
 
-    // Verify the renamed label persisted
-    const reloadedWidgets = page.locator('[data-testid="linear-widgets"]')
-    await expect(reloadedWidgets).toBeVisible({ timeout: 5000 })
-    await expect(reloadedWidgets.getByText('My Custom Seed')).toBeVisible()
+    // Enter app mode from builder
+    await appMode.exitBuilder()
+    await appMode.toggleAppMode()
+
+    await expect(appMode.linearWidgets).toBeVisible({ timeout: 5000 })
+
+    const menu = appMode.getAppModeWidgetMenu('seed')
+    await appMode.renameWidget(menu, 'App Mode Seed')
+
+    await expect(appMode.linearWidgets.getByText('App Mode Seed')).toBeVisible()
+
+    // Verify persistence after save/reload
+    await appMode.toggleAppMode()
+    const workflowName = `${new Date().getTime()} app-mode`
+    await saveAndReopenInAppMode(comfyPage, workflowName)
+
+    await expect(appMode.linearWidgets).toBeVisible({ timeout: 5000 })
+    await expect(appMode.linearWidgets.getByText('App Mode Seed')).toBeVisible()
   })
 })

--- a/src/components/builder/AppModeWidgetList.vue
+++ b/src/components/builder/AppModeWidgetList.vue
@@ -191,7 +191,11 @@ function nodeToNodeData(node: LGraphNode) {
         ]"
       >
         <template #button>
-          <Button variant="textonly" size="icon">
+          <Button
+            variant="textonly"
+            size="icon"
+            data-testid="widget-actions-menu"
+          >
             <i class="icon-[lucide--ellipsis]" />
           </Button>
         </template>

--- a/src/components/builder/IoItem.vue
+++ b/src/components/builder/IoItem.vue
@@ -63,7 +63,7 @@ const entries = computed(() => {
     </div>
     <Popover :entries>
       <template #button>
-        <Button variant="muted-textonly">
+        <Button variant="muted-textonly" data-testid="widget-actions-menu">
           <i class="icon-[lucide--ellipsis]" />
         </Button>
       </template>

--- a/src/utils/widgetUtil.test.ts
+++ b/src/utils/widgetUtil.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 
-import { getWidgetDefaultValue } from '@/utils/widgetUtil'
+import { getWidgetDefaultValue, renameWidget } from '@/utils/widgetUtil'
+
+vi.mock('@/core/graph/subgraph/resolvePromotedWidgetSource', () => ({
+  resolvePromotedWidgetSource: vi.fn()
+}))
+
+import { resolvePromotedWidgetSource } from '@/core/graph/subgraph/resolvePromotedWidgetSource'
+
+const mockedResolve = vi.mocked(resolvePromotedWidgetSource)
 
 describe('getWidgetDefaultValue', () => {
   it('returns undefined for undefined spec', () => {
@@ -35,5 +46,100 @@ describe('getWidgetDefaultValue', () => {
   it('returns undefined for unknown type without options', () => {
     const spec = { type: 'CUSTOM' } as InputSpec
     expect(getWidgetDefaultValue(spec)).toBeUndefined()
+  })
+})
+
+function makeWidget(overrides: Record<string, unknown> = {}): IBaseWidget {
+  return {
+    name: 'myWidget',
+    type: 'number',
+    value: 0,
+    label: undefined,
+    options: {},
+    ...overrides
+  } as unknown as IBaseWidget
+}
+
+function makeNode({
+  isSubgraph = false,
+  inputs = [] as INodeInputSlot[]
+}: {
+  isSubgraph?: boolean
+  inputs?: INodeInputSlot[]
+} = {}): LGraphNode {
+  return {
+    id: 1,
+    inputs,
+    isSubgraphNode: () => isSubgraph
+  } as unknown as LGraphNode
+}
+
+describe('renameWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renames a regular widget and its matching input', () => {
+    const widget = makeWidget({ name: 'seed' })
+    const input = { name: 'seed', widget: { name: 'seed' } } as INodeInputSlot
+    const node = makeNode({ inputs: [input] })
+
+    const result = renameWidget(widget, node, 'My Seed')
+
+    expect(result).toBe(true)
+    expect(widget.label).toBe('My Seed')
+    expect(input.label).toBe('My Seed')
+  })
+
+  it('clears label when given empty string', () => {
+    const widget = makeWidget({ name: 'seed', label: 'Old Label' })
+    const node = makeNode()
+
+    renameWidget(widget, node, '')
+
+    expect(widget.label).toBeUndefined()
+  })
+
+  it('renames promoted widget source when node is a subgraph without explicit parents', () => {
+    const sourceWidget = makeWidget({ name: 'innerSeed' })
+    const interiorInput = {
+      name: 'innerSeed',
+      widget: { name: 'innerSeed' }
+    } as INodeInputSlot
+    const interiorNode = makeNode({ inputs: [interiorInput] })
+
+    mockedResolve.mockReturnValue({
+      widget: sourceWidget,
+      node: interiorNode
+    })
+
+    const promotedWidget = makeWidget({
+      name: 'seed',
+      sourceNodeId: '5',
+      sourceWidgetName: 'innerSeed'
+    })
+    const subgraphNode = makeNode({ isSubgraph: true })
+
+    const result = renameWidget(promotedWidget, subgraphNode, 'Renamed')
+
+    expect(result).toBe(true)
+    expect(sourceWidget.label).toBe('Renamed')
+    expect(interiorInput.label).toBe('Renamed')
+    expect(promotedWidget.label).toBe('Renamed')
+  })
+
+  it('does not resolve promoted widget source for non-subgraph node without parents', () => {
+    const promotedWidget = makeWidget({
+      name: 'seed',
+      sourceNodeId: '5',
+      sourceWidgetName: 'innerSeed'
+    })
+    const node = makeNode({ isSubgraph: false })
+
+    const result = renameWidget(promotedWidget, node, 'Renamed')
+
+    expect(result).toBe(true)
+    expect(mockedResolve).not.toHaveBeenCalled()
+    expect(promotedWidget.label).toBe('Renamed')
   })
 })

--- a/src/utils/widgetUtil.ts
+++ b/src/utils/widgetUtil.ts
@@ -48,7 +48,10 @@ export function renameWidget(
   newLabel: string,
   parents?: SubgraphNode[]
 ): boolean {
-  if (isPromotedWidgetView(widget) && parents?.length) {
+  const resolvedParents =
+    parents ?? (node.isSubgraphNode() ? [node as SubgraphNode] : [])
+
+  if (isPromotedWidgetView(widget) && resolvedParents.length) {
     const sourceWidget = resolvePromotedWidgetSource(node, widget)
     if (!sourceWidget) {
       console.error('Could not resolve source widget for promoted widget')

--- a/src/utils/widgetUtil.ts
+++ b/src/utils/widgetUtil.ts
@@ -48,10 +48,10 @@ export function renameWidget(
   newLabel: string,
   parents?: SubgraphNode[]
 ): boolean {
-  const resolvedParents =
-    parents ?? (node.isSubgraphNode() ? [node as SubgraphNode] : [])
-
-  if (isPromotedWidgetView(widget) && resolvedParents.length) {
+  if (
+    isPromotedWidgetView(widget) &&
+    (parents?.length || node.isSubgraphNode())
+  ) {
     const sourceWidget = resolvePromotedWidgetSource(node, widget)
     if (!sourceWidget) {
       console.error('Could not resolve source widget for promoted widget')


### PR DESCRIPTION
## Summary

Fixes renaming of widgets from subgraph nodes in app builder/app mode.

## Changes

- **What**: If the widget is from a subgraph node and no parents passed, use the node as the subgraph parent.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10245-fix-App-mode-renaming-widgets-on-subgraphs-3276d73d3650815bb131c840df43cdf2) by [Unito](https://www.unito.io)
