### PR TITLE
fix: search media assets by display_name in addition to name

### DIFF
--- a/src/platform/assets/composables/useMediaAssetFiltering.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.ts
@@ -37,7 +37,7 @@ export function useMediaAssetFiltering(assets: Ref<AssetItem[]>) {
   const mediaTypeFilters = ref<string[]>([])
 
   const fuseOptions = {
-    keys: ['name'],
+    keys: ['display_name', 'name'],
     threshold: 0.4,
     includeScore: true
   }


### PR DESCRIPTION
## Description

On cloud, asset filenames are content hashes (e.g. `16bcbbe5...png`) while the UI shows `display_name` (e.g. `ComfyUI_00011_`). Fuse.js was only searching the `name` field, so typing the visible name in the Media Assets search returned no results.

## Changes

### What
- Add `display_name` to the Fuse.js search keys in `useMediaAssetFiltering`, so users can search by the name they actually see in the panel.


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10254-fix-search-media-assets-by-display_name-in-addition-to-name-3276d73d3650813dbaf0ccd9d57ccfa3) by [Unito](https://www.unito.io/)