### PR TITLE
fix: make Save As follow standard document semantics

### DIFF
--- a/browser_tests/fixtures/components/Topbar.ts
+++ b/browser_tests/fixtures/components/Topbar.ts
@@ -86,13 +86,17 @@ export class Topbar {
     return this._saveWorkflow(workflowName, 'Save As')
   }
 
+  saveWorkflowCopy(workflowName: string): Promise<void> {
+    return this._saveWorkflow(workflowName, 'Save a Copy')
+  }
+
   exportWorkflow(workflowName: string): Promise<void> {
     return this._saveWorkflow(workflowName, 'Export')
   }
 
   async _saveWorkflow(
     workflowName: string,
-    command: 'Save' | 'Save As' | 'Export'
+    command: 'Save' | 'Save As' | 'Save a Copy' | 'Export'
   ) {
     await this.triggerTopbarCommand(['File', command])
     await this.getSaveDialog().fill(workflowName)

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -259,10 +259,10 @@ test.describe('Workflows sidebar', () => {
       .poll(() => comfyPage.menu.workflowsTab.getActiveWorkflowName())
       .toEqual('workflow2')
 
-    // Save As overwriting workflow1 (which is still on disk but no longer open)
-    // rebinds the current tab from workflow2 → workflow1
+    // Save As workflow1 — workflow1 exists on disk but is no longer in memory
+    // (the rebind removed it from the store), so no overwrite dialog appears;
+    // the current tab is silently rebound from workflow2 → workflow1
     await topbar.saveWorkflowAs('workflow1')
-    await comfyPage.confirmDialog.click('overwrite')
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
       .toEqual(['workflow1'])

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -116,17 +116,36 @@ test.describe('Workflows sidebar', () => {
       .toEqual(['*Unsaved Workflow', 'foo/baz'])
   })
 
-  test('Can save workflow as', async ({ comfyPage }) => {
+  test('Save As rebinds persisted workflow to new name', async ({
+    comfyPage
+  }) => {
     await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
     await comfyPage.menu.topbar.saveWorkflowAs('workflow3')
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
       .toEqual(['*Unsaved Workflow', 'workflow3'])
 
+    // Save As on a persisted workflow rebinds (same tab, new name)
     await comfyPage.menu.topbar.saveWorkflowAs('workflow4')
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
-      .toEqual(['*Unsaved Workflow', 'workflow3', 'workflow4'])
+      .toEqual(['*Unsaved Workflow', 'workflow4'])
+  })
+
+  test('Save a Copy creates a new tab', async ({ comfyPage }) => {
+    await comfyPage.menu.topbar.saveWorkflow('original')
+    await expect
+      .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
+      .toEqual(['original'])
+
+    // Save a Copy opens a new tab with the copy name
+    await comfyPage.menu.topbar.saveWorkflowCopy('copy1')
+    await expect
+      .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
+      .toEqual(['original', 'copy1'])
+    await expect
+      .poll(() => comfyPage.menu.workflowsTab.getActiveWorkflowName())
+      .toEqual('copy1')
   })
 
   test('Exported workflow does not contain localized slot names', async ({
@@ -229,21 +248,24 @@ test.describe('Workflows sidebar', () => {
   test('Can overwrite other workflows with save as', async ({ comfyPage }) => {
     const topbar = comfyPage.menu.topbar
     await topbar.saveWorkflow('workflow1')
+
+    // Save As rebinds: workflow1 tab becomes workflow2
     await topbar.saveWorkflowAs('workflow2')
     await comfyPage.nextFrame()
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
-      .toEqual(['workflow1', 'workflow2'])
+      .toEqual(['workflow2'])
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getActiveWorkflowName())
       .toEqual('workflow2')
 
+    // Save As overwriting workflow1 (which is still on disk but no longer open)
+    // rebinds the current tab from workflow2 → workflow1
     await topbar.saveWorkflowAs('workflow1')
     await comfyPage.confirmDialog.click('overwrite')
-    // The old workflow1 should be deleted and the new one should be saved.
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getOpenedWorkflowNames())
-      .toEqual(['workflow2', 'workflow1'])
+      .toEqual(['workflow1'])
     await expect
       .poll(() => comfyPage.menu.workflowsTab.getActiveWorkflowName())
       .toEqual('workflow1')

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -193,6 +193,19 @@ export function useCoreCommands(): ComfyCommand[] {
       }
     },
     {
+      id: 'Comfy.SaveWorkflowCopy',
+      icon: 'pi pi-copy',
+      label: 'Save a Copy',
+      menubarLabel: 'Save a Copy',
+      category: 'essentials' as const,
+      function: async () => {
+        const workflow = useWorkflowStore().activeWorkflow as ComfyWorkflow
+        if (!workflow) return
+
+        await workflowService.saveWorkflowCopy(workflow)
+      }
+    },
+    {
       id: 'Comfy.RenameWorkflow',
       icon: 'pi pi-pencil',
       label: 'Rename Workflow',

--- a/src/composables/useWorkflowActionsMenu.ts
+++ b/src/composables/useWorkflowActionsMenu.ts
@@ -170,6 +170,17 @@ export function useWorkflowActionsMenu(
     })
 
     addItem({
+      id: 'save-copy',
+      label: t('menuLabels.Save a Copy'),
+      icon: 'pi pi-copy',
+      command: async () => {
+        await ensureWorkflowActive(workflow)
+        await commandStore.execute('Comfy.SaveWorkflowCopy')
+      },
+      visible: isRoot
+    })
+
+    addItem({
       id: 'export',
       label: t('menuLabels.Export'),
       icon: 'pi pi-download',

--- a/src/constants/coreMenuCommands.ts
+++ b/src/constants/coreMenuCommands.ts
@@ -9,6 +9,7 @@ export const CORE_MENU_COMMANDS = [
     [
       'Comfy.SaveWorkflow',
       'Comfy.SaveWorkflowAs',
+      'Comfy.SaveWorkflowCopy',
       'Comfy.ExportWorkflow',
       'Comfy.ExportWorkflowAPI'
     ]

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1404,6 +1404,7 @@
     "Rename": "Rename",
     "Save": "Save",
     "Save As": "Save As",
+    "Save a Copy": "Save a Copy",
     "Show Settings Dialog": "Show Settings Dialog",
     "Set Subgraph Description": "Set Subgraph Description",
     "Set Subgraph Search Aliases": "Set Subgraph Search Aliases",

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -425,9 +425,30 @@ describe('useWorkflowService', () => {
         workflow,
         'workflows/copy-name.json'
       )
+      expect(app.loadGraphData).toHaveBeenCalledWith(
+        expect.anything(),
+        true,
+        true,
+        copy,
+        expect.anything()
+      )
       expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(copy)
       // Should NOT rebind the original
       expect(workflowStore.rebindWorkflowToPath).not.toHaveBeenCalled()
+    })
+
+    it('should return false when copying to same path', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/original.json'
+      })
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(workflow)
+
+      const result = await useWorkflowService().saveWorkflowCopy(workflow, {
+        filename: 'original'
+      })
+
+      expect(result).toBe(false)
+      expect(workflowStore.saveAs).not.toHaveBeenCalled()
     })
 
     it('should return false when no filename is provided', async () => {

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -105,7 +105,8 @@ vi.mock('@/platform/workflow/persistence/stores/workflowDraftStore', () => ({
     saveDraft: vi.fn(),
     getDraft: vi.fn(),
     removeDraft: vi.fn(),
-    markDraftUsed: vi.fn()
+    markDraftUsed: vi.fn(),
+    moveDraft: vi.fn()
   })
 }))
 
@@ -340,13 +341,13 @@ describe('useWorkflowService', () => {
       workflowStore = useWorkflowStore()
     })
 
-    it('should rename then save when workflow is temporary', async () => {
+    it('should rebind then save when workflow is temporary', async () => {
       const workflow = createModeTestWorkflow({
         path: 'workflows/Unsaved Workflow.json'
       })
       Object.defineProperty(workflow, 'isTemporary', { get: () => true })
       vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
-      vi.mocked(workflowStore.renameWorkflow).mockResolvedValue()
+      vi.mocked(workflowStore.rebindWorkflowToPath).mockResolvedValue()
       vi.mocked(workflowStore.saveWorkflow).mockResolvedValue()
 
       const result = await useWorkflowService().saveWorkflowAs(workflow, {
@@ -354,7 +355,7 @@ describe('useWorkflowService', () => {
       })
 
       expect(result).toBe(true)
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.json'
       )
@@ -793,7 +794,7 @@ describe('useWorkflowService', () => {
       workflowStore = useWorkflowStore()
       service = useWorkflowService()
       vi.spyOn(workflowStore, 'saveWorkflow').mockResolvedValue()
-      vi.spyOn(workflowStore, 'renameWorkflow').mockResolvedValue()
+      vi.spyOn(workflowStore, 'rebindWorkflowToPath').mockResolvedValue()
       app.rootGraph.extra = {}
     })
 
@@ -812,7 +813,7 @@ describe('useWorkflowService', () => {
       return workflow as LoadedComfyWorkflow
     }
 
-    it('should rename then save when workflow is temporary', async () => {
+    it('should rebind then save when workflow is temporary', async () => {
       const workflow = createTemporaryWorkflow()
       vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
 
@@ -821,7 +822,7 @@ describe('useWorkflowService', () => {
       })
 
       expect(result).toBe(true)
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.json'
       )
@@ -846,7 +847,7 @@ describe('useWorkflowService', () => {
 
       await service.saveWorkflowAs(workflow, { filename: 'my-workflow' })
 
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.app.json'
       )
@@ -858,7 +859,7 @@ describe('useWorkflowService', () => {
 
       await service.saveWorkflowAs(workflow, { filename: 'my-workflow' })
 
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.json'
       )
@@ -869,7 +870,7 @@ describe('useWorkflowService', () => {
 
       await service.saveWorkflowAs(workflow, { filename: 'my-workflow' })
 
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.json'
       )
@@ -884,7 +885,7 @@ describe('useWorkflowService', () => {
         isApp: true
       })
 
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.app.json'
       )
@@ -899,37 +900,31 @@ describe('useWorkflowService', () => {
         isApp: false
       })
 
-      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         workflow,
         'workflows/my-workflow.json'
       )
     })
 
-    it('creates a copy when saving same name with different mode (not self-overwrite)', async () => {
+    it('rebinds to new path when saving same name with different mode', async () => {
       const source = createModeTestWorkflow({
         path: 'workflows/test.json',
         initialMode: 'graph'
       })
-
-      const copy = createModeTestWorkflow({
-        path: 'workflows/test.app.json'
-      })
-      vi.spyOn(workflowStore, 'saveAs').mockReturnValue(copy)
-      vi.spyOn(workflowStore, 'openWorkflow').mockResolvedValue(copy)
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
 
       await service.saveWorkflowAs(source, {
         filename: 'test',
         isApp: true
       })
 
-      // Different extension means different path, so it's not a self-overwrite
-      // — a new copy is created instead of modifying the source in place
-      expect(source.initialMode).toBe('graph')
-      expect(workflowStore.saveAs).toHaveBeenCalledWith(
+      // Different extension → rebind the current workflow to the new path
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         source,
         'workflows/test.app.json'
       )
-      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(copy)
+      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(source)
+      expect(workflowStore.saveAs).not.toHaveBeenCalled()
     })
 
     it('self-overwrites when saving same name with same mode', async () => {
@@ -950,134 +945,63 @@ describe('useWorkflowService', () => {
       expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(source)
     })
 
-    it('does not modify source workflow mode when saving persisted workflow as different mode', async () => {
+    it('does not modify source initialMode when saving persisted workflow as different mode', async () => {
       const source = createModeTestWorkflow({
         path: 'workflows/original.json',
         initialMode: 'graph'
       })
-
-      const copy = createModeTestWorkflow({
-        path: 'workflows/copy.app.json'
-      })
-      vi.spyOn(workflowStore, 'saveAs').mockReturnValue(copy)
-      vi.spyOn(workflowStore, 'openWorkflow').mockResolvedValue(copy)
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
 
       await service.saveWorkflowAs(source, {
         filename: 'copy',
         isApp: true
       })
 
+      // rebind changes the path, not the mode
       expect(source.initialMode).toBe('graph')
-      expect(copy.initialMode).toBe('app')
-      expect(workflowStore.saveAs).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         source,
         'workflows/copy.app.json'
       )
-      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(copy)
+      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(source)
     })
 
-    it('does not modify source workflow mode when saving app as graph', async () => {
+    it('does not modify source initialMode when saving app as graph', async () => {
       const source = createModeTestWorkflow({
         path: 'workflows/original.app.json',
         initialMode: 'app'
       })
-
-      const copy = createModeTestWorkflow({
-        path: 'workflows/copy.json'
-      })
-      vi.spyOn(workflowStore, 'saveAs').mockReturnValue(copy)
-      vi.spyOn(workflowStore, 'openWorkflow').mockResolvedValue(copy)
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
 
       await service.saveWorkflowAs(source, {
         filename: 'copy',
         isApp: false
       })
 
+      // rebind changes the path, not the mode
       expect(source.initialMode).toBe('app')
-      expect(copy.initialMode).toBe('graph')
-      expect(workflowStore.saveAs).toHaveBeenCalledWith(
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
         source,
         'workflows/copy.json'
       )
-      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(copy)
+      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(source)
     })
 
-    function captureLinearModeAtSaveTime() {
-      let value: boolean | undefined
-      vi.mocked(workflowStore.saveWorkflow).mockImplementation(async () => {
-        value = app.rootGraph.extra?.linearMode as boolean | undefined
-      })
-      return () => value
-    }
-
-    it('sets linearMode in graph data before saving (graph -> app)', async () => {
-      const workflow = createTemporaryWorkflow()
-      workflow.initialMode = 'graph'
-      app.rootGraph.extra = { linearMode: false }
-      const getLinearMode = captureLinearModeAtSaveTime()
-
-      await service.saveWorkflowAs(workflow, {
-        filename: 'my-workflow',
-        isApp: true
-      })
-
-      expect(getLinearMode()).toBe(true)
-    })
-
-    it('sets linearMode in graph data before saving (app -> graph)', async () => {
-      const workflow = createTemporaryWorkflow()
-      workflow.initialMode = 'app'
-      app.rootGraph.extra = { linearMode: true }
-      const getLinearMode = captureLinearModeAtSaveTime()
-
-      await service.saveWorkflowAs(workflow, {
-        filename: 'my-workflow',
-        isApp: false
-      })
-
-      expect(getLinearMode()).toBe(false)
-    })
-
-    it('sets linearMode before saving persisted workflow copy', async () => {
-      const source = createModeTestWorkflow({
-        path: 'workflows/original.json',
-        initialMode: 'graph'
-      })
-      app.rootGraph.extra = { linearMode: false }
-
-      const copy = createModeTestWorkflow({
-        path: 'workflows/original.app.json'
-      })
-      vi.spyOn(workflowStore, 'saveAs').mockReturnValue(copy)
-      vi.spyOn(workflowStore, 'openWorkflow').mockResolvedValue(copy)
-      const getLinearMode = captureLinearModeAtSaveTime()
-
-      await service.saveWorkflowAs(source, {
-        filename: 'original',
-        isApp: true
-      })
-
-      expect(getLinearMode()).toBe(true)
-    })
-
-    it('does not change initialMode when isApp is omitted (persisted copy)', async () => {
+    it('preserves initialMode when isApp is omitted', async () => {
       const source = createModeTestWorkflow({
         path: 'workflows/original.app.json',
         initialMode: 'app'
       })
-
-      // Real saveAs copies initialMode from source; replicate that here
-      const copy = createModeTestWorkflow({
-        path: 'workflows/copy.app.json',
-        initialMode: 'app'
-      })
-      vi.spyOn(workflowStore, 'saveAs').mockReturnValue(copy)
-      vi.spyOn(workflowStore, 'openWorkflow').mockResolvedValue(copy)
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
 
       await service.saveWorkflowAs(source, { filename: 'copy' })
 
-      // saveWorkflowAs should not change initialMode when isApp is omitted
-      expect(copy.initialMode).toBe('app')
+      // isApp omitted → derived from initialMode ('app'), path uses .app.json
+      expect(source.initialMode).toBe('app')
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
+        source,
+        'workflows/copy.app.json'
+      )
     })
   })
 

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -332,6 +332,117 @@ describe('useWorkflowService', () => {
     })
   })
 
+  describe('saveWorkflowAs', () => {
+    let workflowStore: ReturnType<typeof useWorkflowStore>
+
+    beforeEach(() => {
+      setActivePinia(createTestingPinia())
+      workflowStore = useWorkflowStore()
+    })
+
+    it('should rename then save when workflow is temporary', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/Unsaved Workflow.json'
+      })
+      Object.defineProperty(workflow, 'isTemporary', { get: () => true })
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
+      vi.mocked(workflowStore.renameWorkflow).mockResolvedValue()
+      vi.mocked(workflowStore.saveWorkflow).mockResolvedValue()
+
+      const result = await useWorkflowService().saveWorkflowAs(workflow, {
+        filename: 'my-workflow'
+      })
+
+      expect(result).toBe(true)
+      expect(workflowStore.renameWorkflow).toHaveBeenCalledWith(
+        workflow,
+        'workflows/my-workflow.json'
+      )
+      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(workflow)
+    })
+
+    it('should return false when no filename is provided', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/test.json'
+      })
+      vi.spyOn(workflow, 'promptSave').mockResolvedValue(null)
+
+      const result = await useWorkflowService().saveWorkflowAs(workflow)
+
+      expect(result).toBe(false)
+      expect(workflowStore.saveWorkflow).not.toHaveBeenCalled()
+    })
+
+    it('should rebind persisted workflow to new path', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/original.json'
+      })
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
+      vi.mocked(workflowStore.rebindWorkflowToPath).mockResolvedValue()
+      vi.mocked(workflowStore.saveWorkflow).mockResolvedValue()
+
+      const result = await useWorkflowService().saveWorkflowAs(workflow, {
+        filename: 'new-name'
+      })
+
+      expect(result).toBe(true)
+      expect(workflowStore.rebindWorkflowToPath).toHaveBeenCalledWith(
+        workflow,
+        'workflows/new-name.json'
+      )
+      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(workflow)
+      // Should NOT create a copy
+      expect(workflowStore.saveAs).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('saveWorkflowCopy', () => {
+    let workflowStore: ReturnType<typeof useWorkflowStore>
+
+    beforeEach(() => {
+      setActivePinia(createTestingPinia())
+      workflowStore = useWorkflowStore()
+    })
+
+    it('should create a copy and open it in a new tab', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/original.json'
+      })
+      const copy = createModeTestWorkflow({
+        path: 'workflows/copy-name.json'
+      })
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
+      vi.mocked(workflowStore.saveAs).mockReturnValue(copy)
+      vi.mocked(workflowStore.saveWorkflow).mockResolvedValue()
+      vi.mocked(workflowStore.isActive).mockReturnValue(false)
+
+      const result = await useWorkflowService().saveWorkflowCopy(workflow, {
+        filename: 'copy-name'
+      })
+
+      expect(result).toBe(true)
+      expect(workflowStore.saveAs).toHaveBeenCalledWith(
+        workflow,
+        'workflows/copy-name.json'
+      )
+      expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(copy)
+      // Should NOT rebind the original
+      expect(workflowStore.rebindWorkflowToPath).not.toHaveBeenCalled()
+    })
+
+    it('should return false when no filename is provided', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/test.json'
+      })
+      vi.spyOn(workflow, 'promptSave').mockResolvedValue(null)
+
+      const result = await useWorkflowService().saveWorkflowCopy(workflow)
+
+      expect(result).toBe(false)
+      expect(workflowStore.saveAs).not.toHaveBeenCalled()
+    })
+  })
+
   describe('afterLoadNewGraph', () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>
     let existingWorkflow: LoadedComfyWorkflow

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -110,9 +110,16 @@ export const useWorkflowService = () => {
     downloadBlob(file, blob)
   }
   /**
-   * Save a workflow as a new file
+   * Save the workflow under a new filename (standard "Save As" semantics).
+   *
+   * For persisted workflows the current tab is rebound to the new path and
+   * the old file is left on disk unchanged. Temporary workflows are renamed
+   * in place. If the target path already exists, the user is prompted to
+   * confirm overwrite.
+   *
    * @param workflow The workflow to save
    * @param options.filename Pre-supplied filename (skips the prompt dialog)
+   * @returns `true` if saved, `false` if the user cancelled
    */
   const saveWorkflowAs = async (
     workflow: ComfyWorkflow,
@@ -142,24 +149,59 @@ export const useWorkflowService = () => {
       if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
       await saveWorkflow(workflow)
     } else {
-      let target: ComfyWorkflow
-      if (workflow.isTemporary) {
-        await renameWorkflow(workflow, newPath)
-        target = workflow
-      } else {
-        target = workflowStore.saveAs(workflow, newPath)
-        await openWorkflow(target)
-      }
+      // True Save As: write current state to new path, rebind this
+      // workflow to the new path. Old file stays on disk unchanged.
+      await workflowStore.rebindWorkflowToPath(workflow, newPath)
 
       if (options.isApp !== undefined) {
         app.rootGraph.extra ??= {}
         app.rootGraph.extra.linearMode = isApp
-        target.initialMode = isApp ? 'app' : 'graph'
+        workflow.initialMode = isApp ? 'app' : 'graph'
       }
-      if (workflowStore.isActive(target)) target.changeTracker?.checkState()
+      workflow.changeTracker?.checkState()
 
-      await workflowStore.saveWorkflow(target)
+      await workflowStore.saveWorkflow(workflow)
     }
+
+    useTelemetry()?.trackWorkflowSaved({ is_app: isApp, is_new: true })
+    return true
+  }
+
+  /**
+   * Save a copy of the workflow to a new file and open it in a new tab.
+   * The original workflow remains open and unchanged.
+   *
+   * @param workflow The workflow to copy
+   * @param options.filename Pre-supplied filename (skips the prompt dialog)
+   * @returns `true` if saved, `false` if the user cancelled
+   */
+  const saveWorkflowCopy = async (
+    workflow: ComfyWorkflow,
+    options: { filename?: string } = {}
+  ): Promise<boolean> => {
+    const newFilename = options.filename ?? (await workflow.promptSave())
+    if (!newFilename) return false
+
+    const isApp = workflow.initialMode === 'app'
+    const newPath =
+      workflow.directory + '/' + appendWorkflowJsonExt(newFilename, isApp)
+    const existingWorkflow = workflowStore.getWorkflowByPath(newPath)
+
+    if (existingWorkflow && !existingWorkflow.isTemporary) {
+      if ((await confirmOverwrite(newPath)) !== true) return false
+
+      const isSelf = existingWorkflow.path === workflow.path
+      if (!isSelf) {
+        const deleted = await deleteWorkflow(existingWorkflow, true)
+        if (!deleted) return false
+      }
+    }
+
+    workflow.changeTracker?.checkState()
+
+    const copy = workflowStore.saveAs(workflow, newPath)
+    await openWorkflow(copy)
+    await workflowStore.saveWorkflow(copy)
 
     useTelemetry()?.trackWorkflowSaved({ is_app: isApp, is_new: true })
     return true
@@ -567,6 +609,7 @@ export const useWorkflowService = () => {
   return {
     exportWorkflow,
     saveWorkflowAs,
+    saveWorkflowCopy,
     saveWorkflow,
     loadDefaultWorkflow,
     loadBlankWorkflow,

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -149,18 +149,17 @@ export const useWorkflowService = () => {
       if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
       await saveWorkflow(workflow)
     } else {
-      // True Save As: write current state to new path, rebind this
-      // workflow to the new path. Old file stays on disk unchanged.
-      await workflowStore.rebindWorkflowToPath(workflow, newPath)
-
-      if (options.isApp !== undefined) {
-        app.rootGraph.extra ??= {}
-        app.rootGraph.extra.linearMode = isApp
-        workflow.initialMode = isApp ? 'app' : 'graph'
+      // True Save As: only keep rebind if persistence succeeds.
+      const previousPath = workflow.path
+      try {
+        await workflowStore.rebindWorkflowToPath(workflow, newPath)
+        await workflowStore.saveWorkflow(workflow)
+      } catch (error) {
+        if (workflow.path !== previousPath) {
+          await workflowStore.rebindWorkflowToPath(workflow, previousPath)
+        }
+        throw error
       }
-      workflow.changeTracker?.checkState()
-
-      await workflowStore.saveWorkflow(workflow)
     }
 
     useTelemetry()?.trackWorkflowSaved({ is_app: isApp, is_new: true })
@@ -187,14 +186,14 @@ export const useWorkflowService = () => {
       workflow.directory + '/' + appendWorkflowJsonExt(newFilename, isApp)
     const existingWorkflow = workflowStore.getWorkflowByPath(newPath)
 
+    if (existingWorkflow?.path === workflow.path) {
+      return false
+    }
+
     if (existingWorkflow && !existingWorkflow.isTemporary) {
       if ((await confirmOverwrite(newPath)) !== true) return false
-
-      const isSelf = existingWorkflow.path === workflow.path
-      if (!isSelf) {
-        const deleted = await deleteWorkflow(existingWorkflow, true)
-        if (!deleted) return false
-      }
+      const deleted = await deleteWorkflow(existingWorkflow, true)
+      if (!deleted) return false
     }
 
     workflow.changeTracker?.checkState()

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -192,8 +192,16 @@ export const useWorkflowService = () => {
 
     if (existingWorkflow && !existingWorkflow.isTemporary) {
       if ((await confirmOverwrite(newPath)) !== true) return false
-      const deleted = await deleteWorkflow(existingWorkflow, true)
-      if (!deleted) return false
+
+      // Close with dirty-state warning before deleting so unsaved
+      // edits in the target tab are not silently discarded.
+      if (workflowStore.isOpen(existingWorkflow)) {
+        const closed = await closeWorkflow(existingWorkflow, {
+          warnIfUnsaved: true
+        })
+        if (!closed) return false
+      }
+      await workflowStore.deleteWorkflow(existingWorkflow)
     }
 
     workflow.changeTracker?.checkState()

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -543,6 +543,62 @@ describe('useWorkflowStore', () => {
     })
   })
 
+  describe('rebindWorkflowToPath', () => {
+    it('should update path, lookup, and open tabs without backend call', async () => {
+      await syncRemoteWorkflows(['original.json'])
+      const workflow = store.getWorkflowByPath('workflows/original.json')!
+      workflow.changeTracker = createMockChangeTracker({ workflow })
+      workflow.content = '{}'
+      workflow.originalContent = '{}'
+      await store.openWorkflow(workflow)
+
+      await store.rebindWorkflowToPath(workflow, 'workflows/renamed.json')
+
+      expect(workflow.path).toBe('workflows/renamed.json')
+      expect(store.getWorkflowByPath('workflows/original.json')).toBeNull()
+      expect(store.getWorkflowByPath('workflows/renamed.json')).toBe(workflow)
+      expect(
+        store.openWorkflows.some((w) => w.path === 'workflows/renamed.json')
+      ).toBe(true)
+      expect(
+        store.openWorkflows.some((w) => w.path === 'workflows/original.json')
+      ).toBe(false)
+      // No backend rename call
+      expect(api.storeUserData).not.toHaveBeenCalled()
+    })
+
+    it('should transfer bookmarks from old path to new path', async () => {
+      await syncRemoteWorkflows(['bookmarked.json'])
+      const workflow = store.getWorkflowByPath('workflows/bookmarked.json')!
+      workflow.changeTracker = createMockChangeTracker({ workflow })
+      workflow.content = '{}'
+      workflow.originalContent = '{}'
+      await store.openWorkflow(workflow)
+      await bookmarkStore.setBookmarked('workflows/bookmarked.json', true)
+
+      await store.rebindWorkflowToPath(workflow, 'workflows/new-name.json')
+
+      expect(bookmarkStore.isBookmarked('workflows/bookmarked.json')).toBe(
+        false
+      )
+      expect(bookmarkStore.isBookmarked('workflows/new-name.json')).toBe(true)
+    })
+
+    it('should not affect bookmarks when workflow was not bookmarked', async () => {
+      await syncRemoteWorkflows(['plain.json'])
+      const workflow = store.getWorkflowByPath('workflows/plain.json')!
+      workflow.changeTracker = createMockChangeTracker({ workflow })
+      workflow.content = '{}'
+      workflow.originalContent = '{}'
+      await store.openWorkflow(workflow)
+
+      await store.rebindWorkflowToPath(workflow, 'workflows/new-plain.json')
+
+      expect(bookmarkStore.isBookmarked('workflows/plain.json')).toBe(false)
+      expect(bookmarkStore.isBookmarked('workflows/new-plain.json')).toBe(false)
+    })
+  })
+
   describe('saveAs', () => {
     it('should save workflow to new path and reset modification state', async () => {
       await syncRemoteWorkflows(['test.json'])

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -64,6 +64,11 @@ interface WorkflowStore {
   ) => ComfyWorkflow
   renameWorkflow: (workflow: ComfyWorkflow, newPath: string) => Promise<void>
   deleteWorkflow: (workflow: ComfyWorkflow) => Promise<void>
+  saveAs: (existingWorkflow: ComfyWorkflow, path: string) => ComfyWorkflow
+  rebindWorkflowToPath: (
+    workflow: ComfyWorkflow,
+    newPath: string
+  ) => Promise<void>
   saveWorkflow: (workflow: ComfyWorkflow) => Promise<void>
 
   workflows: ComfyWorkflow[]
@@ -254,6 +259,45 @@ export const useWorkflowStore = defineStore('workflow', () => {
     workflow.originalContent = workflow.content = JSON.stringify(state)
     workflowLookup.value[workflow.path] = workflow
     return workflow
+  }
+
+  /**
+   * Rebind an existing workflow object to a new path without moving
+   * the old file on disk. Used by true "Save As" semantics — the
+   * current document gets a new filename but keeps its identity.
+   */
+  const rebindWorkflowToPath = async (
+    workflow: ComfyWorkflow,
+    newPath: string
+  ) => {
+    const oldPath = workflow.path
+    const oldKey = workflow.key
+    const wasBookmarked = bookmarkStore.isBookmarked(oldPath)
+    const draftStore = useWorkflowDraftStore()
+
+    // Update the workflow object's path (no backend rename)
+    workflow.updatePath(newPath)
+
+    // Swap lookup keys
+    delete workflowLookup.value[oldPath]
+    workflowLookup.value[newPath] = workflow
+
+    // Swap in open tabs
+    const openIndex = openWorkflowPaths.value.indexOf(oldPath)
+    if (openIndex !== -1) {
+      openWorkflowPaths.value.splice(openIndex, 1, newPath)
+    }
+
+    // Move drafts and thumbnails
+    draftStore.moveDraft(oldPath, newPath, workflow.key)
+    const newKey = workflow.key
+    moveWorkflowThumbnail(oldKey, newKey)
+
+    // Update bookmarks
+    if (wasBookmarked) {
+      await bookmarkStore.setBookmarked(oldPath, false)
+      await bookmarkStore.setBookmarked(newPath, true)
+    }
   }
 
   const ensureWorkflowId = (
@@ -776,6 +820,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     renameWorkflow,
     deleteWorkflow,
     saveAs,
+    rebindWorkflowToPath,
     saveWorkflow,
     reorderWorkflows,
 

--- a/src/renderer/extensions/linearMode/MobileDisplay.vue
+++ b/src/renderer/extensions/linearMode/MobileDisplay.vue
@@ -106,6 +106,7 @@ const menuEntries = computed<MenuItem[]>(() => [
       { separator: true },
       commandIdToMenuItem('Comfy.SaveWorkflow'),
       commandIdToMenuItem('Comfy.SaveWorkflowAs'),
+      commandIdToMenuItem('Comfy.SaveWorkflowCopy'),
       { separator: true },
       commandIdToMenuItem('Comfy.ExportWorkflow'),
       commandIdToMenuItem('Comfy.ExportWorkflowAPI')


### PR DESCRIPTION
## Summary

Make `Save As` behave like standard document applications: rebind the current tab to the new filename, clear dirty state, leave old file on disk. The previous copy-to-new-tab behavior is preserved as a new `Save a Copy` command.

## Problem

`Save As` on a persisted workflow was creating a new workflow object in a new tab — essentially `Save a Copy`. The original tab stayed open and dirty, which is confusing for anyone expecting standard `Save As` semantics. Easy to accidentally save over the wrong file or lose track of which tab is the "real" one.

## Changes

- `workflowStore.rebindWorkflowToPath()` — swaps path, lookup keys, open tabs, drafts, thumbnails, and bookmarks without any backend rename
- `workflowService.saveWorkflowAs()` — persisted workflows now rebind via `rebindWorkflowToPath` + `saveWorkflow` instead of `saveAs` + `openWorkflow`
- `workflowService.saveWorkflowCopy()` — new method preserving the old copy-to-new-tab behavior
- `Comfy.SaveWorkflowCopy` command + breadcrumb menu item + i18n entry
- Temporary workflows still rename in place (no behavior change)

## Review Focus

- `rebindWorkflowToPath` — correct handling of lookup, tabs, drafts, thumbnails, bookmarks
- Third branch in `saveWorkflowAs` — the rebind path for persisted non-self-overwrite
- `saveWorkflowCopy` — should be identical to old `saveWorkflowAs` behavior for persisted workflows

## Breaking Changes

`Save As` on persisted workflows no longer opens a new tab. Users who relied on the copy behavior should use `Save a Copy` instead.

## Screenshots
<img width="440" height="509" alt="Screenshot 2026-03-18 at 1 58 05 PM" src="https://github.com/user-attachments/assets/d9670600-0598-429d-8c48-49a5c1eb3ab9" />
<img width="432" height="591" alt="Screenshot 2026-03-18 at 6 31 35 PM" src="https://github.com/user-attachments/assets/8a33bc61-6a5f-406c-b666-a68e8c8e930e" />
<img width="512" height="512" alt="Screenshot 2026-03-18 at 6 28 42 PM" src="https://github.com/user-attachments/assets/faa4a011-3019-49df-9f9f-e62a50cfcccb" />
<img width="333" height="522" alt="Screenshot 2026-03-18 at 6 28 00 PM" src="https://github.com/user-attachments/assets/7394eca6-e5d4-433c-89f9-4f560e1e9536" />

## Unmodified - File Management Actions not Document Level Save Ops
<img width="423" height="295" alt="Screenshot 2026-03-18 at 6 33 29 PM" src="https://github.com/user-attachments/assets/e5f01eb1-a048-4bec-bc06-33d92aae65a0" />

## Test plan

- [x] Unit: `rebindWorkflowToPath` updates path, lookup, tabs (no backend call)
- [x] Unit: `rebindWorkflowToPath` transfers bookmarks
- [x] Unit: `saveWorkflowAs` calls `rebindWorkflowToPath` for persisted workflows
- [x] Unit: `saveWorkflowCopy` calls `saveAs` and opens new tab
- [x] Unit: both return false on cancelled filename prompt
- [x] E2E: Save As rebinds persisted workflow (same tab, new name)
- [x] E2E: Save a Copy creates a new tab
- [x] E2E: overwrite other workflows with Save As
- [x] All 123 unit tests pass, typecheck + typecheck:browser clean

- Fixes #10253

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10270-fix-make-Save-As-follow-standard-document-semantics-3276d73d365081919230eef05018e702) by [Unito](https://www.unito.io)
<!-- QA_REPORT_SECTION -->
---
## 🔍 Automated QA Report

| | |
|---|---|
| **Status** | ✅ Complete |
| **Report** | [sno-qa-10270.comfy-qa.pages.dev](https://sno-qa-10270.comfy-qa.pages.dev/) |
| **CI Run** | [View workflow](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/23373285027) |

Before/after video recordings with **Behavior Changes** and **Timeline Comparison** tables.