### PR TITLE
fix: keep promoted DOM widgets visible when inner node is collapsed

### DIFF
--- a/browser_tests/tests/subgraphCollapsedWidgets.spec.ts
+++ b/browser_tests/tests/subgraphCollapsedWidgets.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test'
 
-import type { ComfyPage } from '../fixtures/ComfyPage'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-import { getPromotedWidgetCount } from '../helpers/promotedWidgets'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { getPromotedWidgetCount } from '@e2e/helpers/promotedWidgets'
 
 /**
  * Navigate out of the current subgraph to its parent graph.
@@ -63,23 +63,34 @@ test.describe(
       const widgetCountAfter = await getPromotedWidgetCount(comfyPage, nodeId)
       expect(widgetCountAfter).toBe(widgetCountBefore)
 
-      // DOM widget overlays should be visible on the host node
-      // (v-show bound to widgetState.visible in DomWidget.vue)
+      // DOM widget overlays should be visible on the host node.
+      // DOM elements live on the inner nodes (PromotedWidgetView proxies on
+      // the host have no .element); check via the subgraph's inner nodes and
+      // the .dom-widget container's v-show state.
       await expect
         .poll(() =>
           comfyPage.page.evaluate((id) => {
-            const node = window.app!.canvas.graph!.getNodeById(Number(id))
-            if (!node?.widgets) return 0
-            return node.widgets.filter((w) => {
-              const element = (w as { element?: HTMLElement }).element
-              if (!(element instanceof HTMLElement)) return false
-              const style = window.getComputedStyle(element)
-              return (
-                element.isConnected &&
-                style.display !== 'none' &&
-                style.visibility !== 'hidden'
-              )
-            }).length
+            const hostNode = window.app!.canvas.graph!.getNodeById(Number(id))
+            const innerGraph = (
+              hostNode as unknown as {
+                subgraph?: { _nodes: Array<{ widgets?: unknown[] }> }
+              }
+            )?.subgraph
+            if (!innerGraph) return 0
+            let count = 0
+            for (const node of innerGraph._nodes) {
+              for (const w of node.widgets ?? []) {
+                const element = (w as { element?: HTMLElement }).element
+                if (!(element instanceof HTMLElement) || !element.isConnected)
+                  continue
+                const container = element.closest('.dom-widget')
+                if (!container) continue
+                const style = window.getComputedStyle(container)
+                if (style.display !== 'none' && style.visibility !== 'hidden')
+                  count++
+              }
+            }
+            return count
           }, nodeId)
         )
         .toBeGreaterThan(0)

--- a/browser_tests/tests/subgraphCollapsedWidgets.spec.ts
+++ b/browser_tests/tests/subgraphCollapsedWidgets.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test'
+
+import type { ComfyPage } from '../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { getPromotedWidgetCount } from '../helpers/promotedWidgets'
+
+/**
+ * Navigate out of the current subgraph to its parent graph.
+ */
+async function exitSubgraphToParent(comfyPage: ComfyPage): Promise<void> {
+  await comfyPage.page.evaluate(() => {
+    const canvas = window.app!.canvas
+    if (!canvas.graph) return
+    canvas.setGraph(canvas.graph.rootGraph)
+  })
+  await comfyPage.nextFrame()
+}
+
+test.describe(
+  'Promoted widgets survive inner node collapse',
+  { tag: ['@subgraph', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
+    })
+
+    test('DOM widgets stay visible on host when inner node is collapsed', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+
+      // Convert a CLIPTextEncode (has DOM text widget) to a subgraph
+      const clipNode = await comfyPage.nodeOps.getNodeRefById('6')
+      await clipNode.click('title')
+      const subgraphNode = await clipNode.convertToSubgraph()
+      await comfyPage.nextFrame()
+
+      const nodeId = String(subgraphNode.id)
+      const widgetCountBefore = await getPromotedWidgetCount(comfyPage, nodeId)
+      expect(widgetCountBefore).toBeGreaterThan(0)
+
+      // Navigate into the subgraph and collapse the inner node
+      await subgraphNode.navigateIntoSubgraph()
+      await comfyPage.nextFrame()
+
+      // Collapse all inner nodes via JS (they're inside the subgraph)
+      await comfyPage.page.evaluate(() => {
+        const graph = window.app!.canvas.graph!
+        for (const node of graph._nodes) {
+          if (!node.collapsed) {
+            node.flags.collapsed = true
+          }
+        }
+        graph._version++
+      })
+      await comfyPage.nextFrame()
+
+      // Navigate back to parent
+      await exitSubgraphToParent(comfyPage)
+      await comfyPage.nextFrame()
+
+      // Promoted widgets should still be present on the host
+      const widgetCountAfter = await getPromotedWidgetCount(comfyPage, nodeId)
+      expect(widgetCountAfter).toBe(widgetCountBefore)
+
+      // DOM widget overlays should be visible on the host node
+      // (v-show bound to widgetState.visible in DomWidget.vue)
+      await expect
+        .poll(() => comfyPage.page.locator('.dom-widget:visible').count())
+        .toBeGreaterThan(0)
+    })
+  }
+)

--- a/browser_tests/tests/subgraphCollapsedWidgets.spec.ts
+++ b/browser_tests/tests/subgraphCollapsedWidgets.spec.ts
@@ -66,7 +66,22 @@ test.describe(
       // DOM widget overlays should be visible on the host node
       // (v-show bound to widgetState.visible in DomWidget.vue)
       await expect
-        .poll(() => comfyPage.page.locator('.dom-widget:visible').count())
+        .poll(() =>
+          comfyPage.page.evaluate((id) => {
+            const node = window.app!.canvas.graph!.getNodeById(Number(id))
+            if (!node?.widgets) return 0
+            return node.widgets.filter((w) => {
+              const element = (w as { element?: HTMLElement }).element
+              if (!(element instanceof HTMLElement)) return false
+              const style = window.getComputedStyle(element)
+              return (
+                element.isConnected &&
+                style.display !== 'none' &&
+                style.visibility !== 'hidden'
+              )
+            }).length
+          }, nodeId)
+        )
         .toBeGreaterThan(0)
     })
   }

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -25,6 +25,7 @@ const overrideTransitionGrace = new Set<string>()
 
 const widgetStates = computed(() => [...domWidgetStore.widgetStates.values()])
 
+/** Syncs DOM widget position, size, and visibility each frame. */
 const updateWidgets = () => {
   const lgCanvas = canvasStore.canvas
   if (!lgCanvas) return
@@ -56,10 +57,14 @@ const updateWidgets = () => {
 
     // Early exit for non-visible widgets.
     // When a position override is active (widget promoted to SubgraphNode),
-    // the interior widget's `active` flag is false (its node is in the
-    // subgraph, not the current graph) — bypass that check.
+    // bypass isVisible() (which checks the inner node's collapsed state)
+    // but still respect explicit hidden flags.
+    const explicitlyHidden =
+      widget.hidden === true || widget.options?.hidden === true
+    const failsVisibility = useOverride ? explicitlyHidden : !widget.isVisible()
+
     if (
-      !widget.isVisible() ||
+      failsVisibility ||
       (!widgetState.active && !useOverride && !useTransitionGrace)
     ) {
       widgetState.visible = false


### PR DESCRIPTION
## Summary

Fix promoted DOM widgets (text fields, number inputs) disappearing from the host SubgraphNode when their inner node is collapsed.

## Problem

`DomWidgets.vue` checks `widget.isVisible()` to decide whether to render each DOM widget overlay. For promoted widgets, `isVisible()` delegates to the inner node's `isWidgetVisible()`, which returns `false` when `this.collapsed` is `true`. This check ran before the position override check, so promoted widgets on the host were hidden even though the host node itself was not collapsed.

Non-DOM widgets (canvas-drawn) were unaffected because `PromotedWidgetView.draw()` renders them directly via a projected widget copy without consulting the inner node's visibility.

## Fix

Skip the `isVisible()` check when a position override is active (`useOverride`). When a widget is promoted to a SubgraphNode, the host node governs display — the inner node's collapsed state is irrelevant.

```diff
-      !widget.isVisible() ||
+      (!useOverride && !widget.isVisible()) ||
```

## Screenshots
### Before
<img width="296" height="409" alt="Screenshot 2026-03-18 at 5 17 26 PM" src="https://github.com/user-attachments/assets/50011a5b-29d9-44d3-baa5-e750bbcfb6b4" />

### After

<img width="290" height="391" alt="Screenshot 2026-03-18 at 5 15 47 PM" src="https://github.com/user-attachments/assets/003aed95-565b-4f6f-99ca-fff4ae882078" />
<img width="623" height="376" alt="Screenshot 2026-03-18 at 5 15 43 PM" src="https://github.com/user-attachments/assets/c275c3a9-3290-40b3-9fa5-1ec74aea0929" />
<img width="662" height="423" alt="Screenshot 2026-03-18 at 5 15 37 PM" src="https://github.com/user-attachments/assets/2a0197e7-b924-43f5-a1c7-9d846697cebf" />
<img width="267" height="414" alt="Screenshot 2026-03-18 at 5 15 11 PM" src="https://github.com/user-attachments/assets/5e046b97-20be-40df-b3c6-12c42cc8d303" />

## Test plan

- [x] Manual: collapse all inner nodes in subgraph, promoted text fields stay visible on host
- [x] Manual: uncollapse inner nodes, widgets remain functional
- [x] Manual: collapse the host SubgraphNode itself, widgets correctly hide
- [x] Manual: non-promoted DOM widgets on regular nodes still hide when collapsed
- [x] Typecheck passes

- Fixes #10276
- Related: #9925, #9979
<!-- QA_REPORT_SECTION -->
---
## 🔍 Automated QA Report

| | |
|---|---|
| **Status** | ✅ Complete |
| **Report** | [sno-qa-10277.comfy-qa.pages.dev](https://sno-qa-10277.comfy-qa.pages.dev/) |
| **CI Run** | [View workflow](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/23373291281) |

Before/after video recordings with **Behavior Changes** and **Timeline Comparison** tables.