### PR TITLE
fix: _removeDuplicateLinks incorrectly removes valid link when slot indices shift

### DIFF
--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -614,6 +614,87 @@ describe('_removeDuplicateLinks', () => {
     expect(graph._links.has(dupLink.id)).toBe(false)
   })
 
+  it('keeps the valid link when input.link is at a shifted slot index', () => {
+    LiteGraph.registerNodeType('test/DupTestNode', TestNode)
+    const graph = new LGraph()
+
+    const source = LiteGraph.createNode('test/DupTestNode', 'Source')!
+    const target = LiteGraph.createNode('test/DupTestNode', 'Target')!
+    graph.add(source)
+    graph.add(target)
+
+    // Connect source:0 -> target:0, establishing input.link on target
+    source.connect(0, target, 0)
+    const validLinkId = target.inputs[0].link!
+    expect(graph._links.has(validLinkId)).toBe(true)
+
+    // Simulate widget-to-input conversion shifting the slot: insert a new
+    // input BEFORE the connected one, moving it from index 0 to index 1.
+    target.addInput('extra_widget', 'number')
+    const connectedInput = target.inputs[0]
+    target.inputs[0] = target.inputs[1]
+    target.inputs[1] = connectedInput
+    // Now target.inputs[1].link === validLinkId, but target.inputs[0].link is null
+
+    // Add a duplicate link with the same connection tuple (target_slot=0
+    // in the LLink, matching the original slot before the shift).
+    const dupLink = new LLink(
+      ++graph.state.lastLinkId,
+      'number',
+      source.id,
+      0,
+      target.id,
+      0
+    )
+    graph._links.set(dupLink.id, dupLink)
+    source.outputs[0].links!.push(dupLink.id)
+
+    expect(graph._links.size).toBe(2)
+
+    graph._removeDuplicateLinks()
+
+    // The valid link (referenced by an actual input) must survive
+    expect(graph._links.size).toBe(1)
+    expect(graph._links.has(validLinkId)).toBe(true)
+    expect(graph._links.has(dupLink.id)).toBe(false)
+    expect(target.inputs[1].link).toBe(validLinkId)
+  })
+
+  it('repairs input.link when it points to a removed duplicate', () => {
+    LiteGraph.registerNodeType('test/DupTestNode', TestNode)
+    const graph = new LGraph()
+
+    const source = LiteGraph.createNode('test/DupTestNode', 'Source')!
+    const target = LiteGraph.createNode('test/DupTestNode', 'Target')!
+    graph.add(source)
+    graph.add(target)
+
+    source.connect(0, target, 0)
+
+    // Create a duplicate link
+    const dupLink = new LLink(
+      ++graph.state.lastLinkId,
+      'number',
+      source.id,
+      0,
+      target.id,
+      0
+    )
+    graph._links.set(dupLink.id, dupLink)
+    source.outputs[0].links!.push(dupLink.id)
+
+    // Point input.link to the duplicate (simulating corrupted state)
+    target.inputs[0].link = dupLink.id
+
+    graph._removeDuplicateLinks()
+
+    expect(graph._links.size).toBe(1)
+    // input.link must point to whichever link survived
+    const survivingId = graph._links.keys().next().value!
+    expect(target.inputs[0].link).toBe(survivingId)
+    expect(graph._links.has(target.inputs[0].link!)).toBe(true)
+  })
+
   it('is a no-op when no duplicates exist', () => {
     registerTestNodes()
     const graph = new LGraph()

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1625,42 +1625,66 @@ export class LGraph
    * output.links and the graph's _links map.
    */
   _removeDuplicateLinks(): void {
-    const seen = new Map<string, LinkId>()
-    const toRemove: LinkId[] = []
-
+    // Group all link IDs by their connection tuple.
+    const groups = new Map<string, LinkId[]>()
     for (const [id, link] of this._links) {
       const key = LGraph._linkTupleKey(link)
-      if (seen.has(key)) {
-        const existingId = seen.get(key)!
-        // Keep the link that the input side references
-        const node = this.getNodeById(link.target_id)
-        const input = node?.inputs?.[link.target_slot]
-        if (input?.link === id) {
-          toRemove.push(existingId)
-          seen.set(key, id)
-        } else {
-          toRemove.push(id)
-        }
-      } else {
-        seen.set(key, id)
+      let group = groups.get(key)
+      if (!group) {
+        group = []
+        groups.set(key, group)
       }
+      group.push(id)
     }
 
-    for (const id of toRemove) {
-      const link = this._links.get(id)
-      if (!link) continue
+    for (const [, ids] of groups) {
+      if (ids.length <= 1) continue
 
-      // Remove from origin node's output.links array
-      const originNode = this.getNodeById(link.origin_id)
-      if (originNode) {
-        const output = originNode.outputs?.[link.origin_slot]
-        if (output?.links) {
-          const idx = output.links.indexOf(id)
-          if (idx !== -1) output.links.splice(idx, 1)
+      const sampleLink = this._links.get(ids[0])!
+      const node = this.getNodeById(sampleLink.target_id)
+
+      // Find which link ID is actually referenced by any input on the target
+      // node. Cannot rely on target_slot index because widget-to-input
+      // conversions during configure() can shift slot indices.
+      let keepId: LinkId | undefined
+      if (node) {
+        for (const input of node.inputs ?? []) {
+          const match = ids.find((id) => input.link === id)
+          if (match != null) {
+            keepId = match
+            break
+          }
         }
       }
+      keepId ??= ids[0]
 
-      this._links.delete(id)
+      for (const id of ids) {
+        if (id === keepId) continue
+
+        const link = this._links.get(id)
+        if (!link) continue
+
+        // Remove from origin node's output.links array
+        const originNode = this.getNodeById(link.origin_id)
+        if (originNode) {
+          const output = originNode.outputs?.[link.origin_slot]
+          if (output?.links) {
+            const idx = output.links.indexOf(id)
+            if (idx !== -1) output.links.splice(idx, 1)
+          }
+        }
+
+        this._links.delete(id)
+      }
+
+      // Ensure input.link points to the surviving link
+      if (node) {
+        for (const input of node.inputs ?? []) {
+          if (ids.includes(input.link as LinkId) && input.link !== keepId) {
+            input.link = keepId
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v1.41.21 where `_removeDuplicateLinks()` (added by #9120 / backport #10045) incorrectly removes valid links during workflow loading when the target node has widget-to-input conversions that shift slot indices.

- Fixes https://github.com/Comfy-Org/workflow_templates/issues/715

## Root Cause

The `_removeDuplicateLinks()` method added in #9120 uses `node.inputs[link.target_slot]` to determine which duplicate link to keep. However, `target_slot` is the slot index recorded at serialization time. During `LGraphNode.configure()`, the `onConnectionsChange` callback triggers widget-to-input conversions (e.g., KSamplerAdvanced converting `steps`, `cfg`, `start_at_step`, etc.), which inserts new entries into the `inputs` array. This shifts indices so that `node.inputs[target_slot]` no longer points to the expected input.

**Concrete example with `video_wan2_2_14B_i2v.json`:**

The Wan2.2 Image-to-Video subgraph contains a Switch node (id=120) connected to KSamplerAdvanced (id=85) cfg input. The serialized data has two links with the same connection tuple `(origin_id=120, origin_slot=0, target_id=85, target_slot=5)`:

| Link ID | Connection | Status |
|---------|-----------|--------|
| 257 | 120:0 → 85:5 (FLOAT) | Orphaned duplicate (not referenced by any input.link) |
| 276 | 120:0 → 85:5 (FLOAT) | Valid (referenced by node 85 input.link=276) |

When `_removeDuplicateLinks()` runs after all nodes are configured:
1. KSamplerAdvanced is created with 4 default inputs, but after `configure()` with widget conversions, it has **13 inputs** (shifted indices)
2. The method checks `node.inputs[5].link` (target_slot=5 from the LLink), but index 5 is now a different input due to the shift
3. `node.inputs[5].link === null` → the method incorrectly decides link 276 is not referenced
4. **Link 276 (valid) is removed, link 257 (orphan) is kept** → connection lost

This worked correctly in v1.41.20 because `_removeDuplicateLinks()` did not exist.

## Changes

Replace the `target_slot`-based positional lookup with a full scan of the target node's inputs to find which duplicate link ID is actually referenced by `input.link`. Also repair `input.link` if it still points to a removed duplicate after cleanup.

## Test Plan

- [x] Added regression test: shifted slot index scenario (widget-to-input conversion)
- [x] Added regression test: `input.link` repair when pointing to removed duplicate
- [x] Existing `_removeDuplicateLinks` tests pass (45/45)
- [x] Full unit test suite passes (6885/6885)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] Manual verification: loaded `video_wan2_2_14B_i2v.json` in clean state — Switch→KSamplerAdvanced cfg link is now preserved
- [ ] E2E testing is difficult for this fix since it requires a workflow with duplicate links in a subgraph containing nodes with widget-to-input conversions (e.g., KSamplerAdvanced). The specific conditions — duplicate LLink entries + slot index shift from widget conversion — are hard to set up in Playwright without a pre-crafted fixture workflow and backend node type registration. The unit tests cover the core logic directly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10289-fix-_removeDuplicateLinks-incorrectly-removes-valid-link-when-slot-indices-shift-3286d73d36508140b053fd538163e383) by [Unito](https://www.unito.io)
