### PR TITLE
fix: add missing fields to publish workflow API request

### DIFF
--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -46,11 +46,15 @@ vi.mock(
         name: '',
         description: '',
         tags: [],
+        models: [],
+        customNodes: [],
         thumbnailType: 'image',
         thumbnailFile: null,
         comparisonBeforeFile: null,
         comparisonAfterFile: null,
-        exampleImages: []
+        exampleImages: [],
+        tutorialUrl: '',
+        metadata: {}
       }),
       isFirstStep: ref(false),
       isLastStep: ref(true),

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishWizardContent.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishWizardContent.test.ts
@@ -47,11 +47,15 @@ function createDefaultFormData(): ComfyHubPublishFormData {
     name: 'Test Workflow',
     description: '',
     tags: [],
+    models: [],
+    customNodes: [],
     thumbnailType: 'image',
     thumbnailFile: null,
     comparisonBeforeFile: null,
     comparisonAfterFile: null,
-    exampleImages: []
+    exampleImages: [],
+    tutorialUrl: '',
+    metadata: {}
   }
 }
 

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
@@ -54,11 +54,15 @@ function createFormData(
     name: 'Demo workflow',
     description: 'A demo workflow',
     tags: ['demo'],
+    models: [],
+    customNodes: [],
     thumbnailType: 'image',
     thumbnailFile: null,
     comparisonBeforeFile: null,
     comparisonAfterFile: null,
     exampleImages: [],
+    tutorialUrl: '',
+    metadata: {},
     ...overrides
   }
 }

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.ts
@@ -108,10 +108,18 @@ export function useComfyHubPublishSubmission() {
       assetIds,
       description: formData.description || undefined,
       tags: formData.tags.length > 0 ? normalizeTags(formData.tags) : undefined,
+      models: formData.models.length > 0 ? formData.models : undefined,
+      customNodes:
+        formData.customNodes.length > 0 ? formData.customNodes : undefined,
       thumbnailType,
       thumbnailTokenOrUrl,
       thumbnailComparisonTokenOrUrl,
-      sampleImageTokensOrUrls
+      sampleImageTokensOrUrls,
+      tutorialUrl: formData.tutorialUrl || undefined,
+      metadata:
+        Object.keys(formData.metadata).length > 0
+          ? formData.metadata
+          : undefined
     })
   }
 

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.ts
@@ -27,11 +27,15 @@ function createDefaultFormData(): ComfyHubPublishFormData {
     name: workflowStore.activeWorkflow?.filename ?? '',
     description: '',
     tags: [],
+    models: [],
+    customNodes: [],
     thumbnailType: 'image',
     thumbnailFile: null,
     comparisonBeforeFile: null,
     comparisonAfterFile: null,
-    exampleImages: []
+    exampleImages: [],
+    tutorialUrl: '',
+    metadata: {}
   }
 }
 

--- a/src/platform/workflow/sharing/services/comfyHubService.ts
+++ b/src/platform/workflow/sharing/services/comfyHubService.ts
@@ -25,10 +25,14 @@ interface PublishWorkflowInput {
   assetIds: string[]
   description?: string
   tags?: string[]
+  models?: string[]
+  customNodes?: string[]
   thumbnailType?: ThumbnailTypeInput
   thumbnailTokenOrUrl?: string
   thumbnailComparisonTokenOrUrl?: string
   sampleImageTokensOrUrls?: string[]
+  tutorialUrl?: string
+  metadata?: Record<string, unknown>
 }
 
 function normalizeThumbnailType(type: ThumbnailTypeInput): HubThumbnailType {
@@ -174,12 +178,16 @@ export function useComfyHubService() {
       asset_ids: input.assetIds,
       description: input.description,
       tags: input.tags,
+      models: input.models,
+      custom_nodes: input.customNodes,
       thumbnail_type: input.thumbnailType
         ? normalizeThumbnailType(input.thumbnailType)
         : undefined,
       thumbnail_token_or_url: input.thumbnailTokenOrUrl,
       thumbnail_comparison_token_or_url: input.thumbnailComparisonTokenOrUrl,
-      sample_image_tokens_or_urls: input.sampleImageTokensOrUrls
+      sample_image_tokens_or_urls: input.sampleImageTokensOrUrls,
+      tutorial_url: input.tutorialUrl,
+      metadata: input.metadata
     }
 
     const response = await api.fetchApi('/hub/workflows', {

--- a/src/platform/workflow/sharing/types/comfyHubTypes.ts
+++ b/src/platform/workflow/sharing/types/comfyHubTypes.ts
@@ -12,9 +12,13 @@ export interface ComfyHubPublishFormData {
   name: string
   description: string
   tags: string[]
+  models: string[]
+  customNodes: string[]
   thumbnailType: ThumbnailType
   thumbnailFile: File | null
   comparisonBeforeFile: File | null
   comparisonAfterFile: File | null
   exampleImages: ExampleImage[]
+  tutorialUrl: string
+  metadata: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary
- Add `models`, `custom_nodes`, `tutorial_url`, and `metadata` fields to the publish workflow request body
- These optional fields were missing from `PublishWorkflowInput` and `ComfyHubPublishFormData`, causing them to never be sent to `POST /api/hub/workflows`
- Aligns frontend with the backend API spec documented in the ComfyHub Backend API Summary

## Test plan
- [x] All 160 sharing tests pass (15 test files)
- [x] Typecheck passes
- [x] Lint passes
- [x] E2E manual test


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10306-fix-add-missing-fields-to-publish-workflow-API-request-3286d73d365081268ae0f9775e5049fd) by [Unito](https://www.unito.io)
