### PR TITLE
Feat/glsl live preview

### DIFF
--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -192,3 +192,15 @@ export function curvesToLUT(
 
   return lut
 }
+
+export function curveDataToFloatLUT(
+  curve: CurveData,
+  size: number = 256
+): Float32Array {
+  const lut = new Float32Array(size)
+  const interpolate = createInterpolator(curve.points, curve.interpolation)
+  for (let i = 0; i < size; i++) {
+    lut[i] = interpolate(i / (size - 1))
+  }
+  return lut
+}

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -284,6 +284,7 @@ import { useTelemetry } from '@/platform/telemetry'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { useGLSLPreview } from '@/renderer/glsl/useGLSLPreview'
 import { usePromotedPreviews } from '@/composables/node/usePromotedPreviews'
 import NodeBadges from '@/renderer/extensions/vueNodes/components/NodeBadges.vue'
 import { LayoutSource } from '@/renderer/core/layout/types'
@@ -729,6 +730,8 @@ const lgraphNode = computed(() => {
 // TODO: Surface subgraph info more cleanly in VueNodeData instead of
 // reaching through lgraphNode for promoted preview resolution.
 const { promotedPreviews } = usePromotedPreviews(lgraphNode)
+
+useGLSLPreview(lgraphNode)
 
 const showAdvancedInputsButton = computed(() => {
   const node = lgraphNode.value

--- a/src/renderer/glsl/glslPreviewUtils.ts
+++ b/src/renderer/glsl/glslPreviewUtils.ts
@@ -1,0 +1,40 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
+
+export const GLSL_NODE_TYPE = 'GLSLShader'
+export const DEBOUNCE_MS = 50
+export const DEFAULT_SIZE = 512
+const MAX_PREVIEW_DIMENSION = 1024
+
+export function normalizeDimension(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SIZE
+  return parsed
+}
+
+export function clampResolution(w: number, h: number): [number, number] {
+  const maxDim = Math.max(w, h)
+  if (maxDim <= MAX_PREVIEW_DIMENSION) return [w, h]
+  const scale = MAX_PREVIEW_DIMENSION / maxDim
+  return [Math.round(w * scale), Math.round(h * scale)]
+}
+
+export function getImageThroughSubgraphBoundary(
+  node: LGraphNode,
+  slot: number,
+  ownerSubgraphNode: LGraphNode
+): HTMLImageElement | undefined {
+  const graph = node.graph
+  if (!graph) return undefined
+
+  const input = node.inputs[slot]
+  if (input?.link == null) return undefined
+
+  const link = graph._links.get(input.link)
+  if (!link || link.origin_id !== SUBGRAPH_INPUT_ID) return undefined
+
+  const outerUpstream = ownerSubgraphNode.getInputNode(link.origin_slot)
+  if (!outerUpstream?.imgs?.length) return undefined
+
+  return outerUpstream.imgs[0]
+}

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -227,4 +227,105 @@ describe('useGLSLPreview', () => {
       })
     })
   })
+
+  describe('render pipeline', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    async function setupAndRender(node: LGraphNode) {
+      mockNodeOutputs[String(node.id)] = {
+        images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
+      }
+      const store = useWidgetValueStore() as unknown as {
+        _widgetMap: Map<string, { value: unknown }>
+      }
+      store._widgetMap.set('fragment_shader', {
+        value: 'void main() {}'
+      })
+
+      const nodeRef = shallowRef<LGraphNode | null>(null)
+      const result = useGLSLPreview(nodeRef)
+
+      nodeRef.value = node
+      await nextTick()
+      vi.advanceTimersByTime(100)
+      await nextTick()
+      // Allow async renderPreview to complete
+      await nextTick()
+
+      return result
+    }
+
+    it('calls compileFragment, render, and toBlob in sequence', async () => {
+      const node = createMockNode()
+      await setupAndRender(node)
+
+      expect(mockRendererFactory.compileFragment).toHaveBeenCalledWith(
+        'void main() {}'
+      )
+      expect(mockRendererFactory.render).toHaveBeenCalled()
+      expect(mockRendererFactory.toBlob).toHaveBeenCalled()
+
+      const compileOrder =
+        mockRendererFactory.compileFragment.mock.invocationCallOrder[0]
+      const renderOrder = mockRendererFactory.render.mock.invocationCallOrder[0]
+      const toBlobOrder = mockRendererFactory.toBlob.mock.invocationCallOrder[0]
+      expect(compileOrder).toBeLessThan(renderOrder)
+      expect(renderOrder).toBeLessThan(toBlobOrder)
+    })
+
+    it('sets lastError on compilation failure', async () => {
+      mockRendererFactory.compileFragment.mockReturnValueOnce({
+        success: false,
+        log: 'syntax error at line 5'
+      })
+
+      const node = createMockNode()
+      const { lastError } = await setupAndRender(node)
+
+      expect(lastError.value).toBe('syntax error at line 5')
+    })
+
+    it('clears lastError on successful compilation', async () => {
+      const node = createMockNode()
+      const { lastError } = await setupAndRender(node)
+
+      expect(lastError.value).toBe(null)
+    })
+
+    it('skips render when shader source is unavailable', async () => {
+      const store = useWidgetValueStore() as unknown as {
+        _widgetMap: Map<string, { value: unknown }>
+      }
+      store._widgetMap.delete('fragment_shader')
+
+      const node = createMockNode()
+      mockNodeOutputs[String(node.id)] = {
+        images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
+      }
+
+      const nodeRef = shallowRef<LGraphNode | null>(null)
+      useGLSLPreview(nodeRef)
+      nodeRef.value = node
+      await nextTick()
+      vi.advanceTimersByTime(100)
+      await nextTick()
+
+      expect(mockRendererFactory.compileFragment).not.toHaveBeenCalled()
+    })
+
+    it('disposes renderer and cancels debounce on cleanup', async () => {
+      const node = createMockNode()
+      const { dispose } = await setupAndRender(node)
+
+      dispose()
+
+      expect(mockRendererFactory.dispose).toHaveBeenCalled()
+    })
+  })
 })

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -1,0 +1,230 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, reactive, ref, shallowRef } from 'vue'
+
+import { useGLSLPreview } from '@/renderer/glsl/useGLSLPreview'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+
+import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { MaybeRefOrGetter } from 'vue'
+
+const mockRendererFactory = vi.hoisted(() => {
+  const init = vi.fn(() => true)
+  const compileFragment = vi.fn(() => ({ success: true, log: '' }))
+  const setResolution = vi.fn()
+  const setFloatUniform = vi.fn()
+  const setIntUniform = vi.fn()
+  const setBoolUniform = vi.fn()
+  const bindCurveTexture = vi.fn()
+  const bindInputImage = vi.fn()
+  const render = vi.fn()
+  const toBlob = vi.fn(() => Promise.resolve(new Blob(['test'])))
+  const dispose = vi.fn()
+  const lastConfig = { value: undefined as GLSLRendererConfig | undefined }
+
+  return {
+    create: (config?: GLSLRendererConfig) => {
+      lastConfig.value = config
+      return {
+        init,
+        compileFragment,
+        setResolution,
+        setFloatUniform,
+        setIntUniform,
+        setBoolUniform,
+        bindCurveTexture,
+        bindInputImage,
+        render,
+        toBlob,
+        dispose
+      }
+    },
+    lastConfig,
+    init,
+    compileFragment,
+    setResolution,
+    setFloatUniform,
+    setIntUniform,
+    setBoolUniform,
+    bindCurveTexture,
+    bindInputImage,
+    render,
+    toBlob,
+    dispose
+  }
+})
+
+vi.mock('@/renderer/glsl/useGLSLRenderer', () => ({
+  useGLSLRenderer: (config?: GLSLRendererConfig) =>
+    mockRendererFactory.create(config)
+}))
+
+const mockSetNodePreviewsByNodeId = vi.fn()
+const mockNodeOutputs = reactive<Record<string, unknown>>({})
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({
+    setNodePreviewsByNodeId: mockSetNodePreviewsByNodeId,
+    setNodePreviewsByLocatorId: vi.fn(),
+    revokePreviewsByLocatorId: vi.fn(),
+    nodeOutputs: mockNodeOutputs
+  })
+}))
+
+vi.mock('@/stores/widgetValueStore', () => {
+  const widgetMap = new Map<string, { value: unknown }>()
+  const getWidget = vi.fn((_graphId: string, _nodeId: string, name: string) =>
+    widgetMap.get(name)
+  )
+  return {
+    useWidgetValueStore: () => ({
+      getWidget,
+      _widgetMap: widgetMap
+    })
+  }
+})
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    nodeIdToNodeLocatorId: (id: string | number) => String(id),
+    nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
+  })
+}))
+
+vi.mock('@/utils/objectUrlUtil', () => ({
+  createSharedObjectUrl: () => 'blob:test',
+  releaseSharedObjectUrl: vi.fn()
+}))
+
+function createMockNode(overrides: Record<string, unknown> = {}): LGraphNode {
+  const graph = { id: 'test-graph-id', rootGraph: { id: 'test-graph-id' } }
+  return {
+    id: 1,
+    type: 'GLSLShader',
+    inputs: [],
+    graph,
+    getInputNode: vi.fn(() => null),
+    isSubgraphNode: () => false,
+    ...overrides
+  } as unknown as LGraphNode
+}
+
+function wrapNode(
+  node: LGraphNode | null
+): MaybeRefOrGetter<LGraphNode | null> {
+  return ref(node) as MaybeRefOrGetter<LGraphNode | null>
+}
+
+describe('useGLSLPreview', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockRendererFactory.lastConfig.value = undefined
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:test')
+    globalThis.URL.revokeObjectURL = vi.fn()
+  })
+
+  it('does not activate for non-GLSLShader nodes', () => {
+    const node = createMockNode({ type: 'KSampler' })
+    const { isActive } = useGLSLPreview(wrapNode(node))
+    expect(isActive.value).toBe(false)
+  })
+
+  it('does not activate before first execution', () => {
+    const node = createMockNode()
+    Object.keys(mockNodeOutputs).forEach((k) => delete mockNodeOutputs[k])
+    const { isActive } = useGLSLPreview(wrapNode(node))
+    expect(isActive.value).toBe(false)
+  })
+
+  it('activates for GLSLShader nodes with execution output', () => {
+    const node = createMockNode()
+    mockNodeOutputs['1'] = {
+      images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
+    }
+    const { isActive } = useGLSLPreview(wrapNode(node))
+    expect(isActive.value).toBe(true)
+  })
+
+  it('exposes lastError as null initially', () => {
+    const node = createMockNode()
+    const { lastError } = useGLSLPreview(wrapNode(node))
+    expect(lastError.value).toBe(null)
+  })
+
+  it('does not activate for null node', () => {
+    const { isActive } = useGLSLPreview(wrapNode(null))
+    expect(isActive.value).toBe(false)
+  })
+
+  it('cleans up on dispose', () => {
+    const node = createMockNode()
+    const { dispose } = useGLSLPreview(wrapNode(node))
+    expect(() => dispose()).not.toThrow()
+  })
+
+  describe('autogrow config extraction', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    async function triggerRender(node: LGraphNode) {
+      mockNodeOutputs[String(node.id)] = {
+        images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
+      }
+      const store = useWidgetValueStore() as unknown as {
+        _widgetMap: Map<string, { value: unknown }>
+      }
+      store._widgetMap.set('fragment_shader', {
+        value: 'void main() {}'
+      })
+
+      const nodeRef = shallowRef<LGraphNode | null>(null)
+      useGLSLPreview(nodeRef)
+
+      nodeRef.value = node
+      await nextTick()
+      vi.advanceTimersByTime(100)
+      await nextTick()
+    }
+
+    it('passes default config when node has no comfyDynamic', async () => {
+      const node = createMockNode()
+      await triggerRender(node)
+
+      expect(mockRendererFactory.lastConfig.value).toEqual({
+        maxInputs: 5,
+        maxFloatUniforms: 20,
+        maxIntUniforms: 20,
+        maxBoolUniforms: 10,
+        maxCurves: 4
+      })
+    })
+
+    it('extracts autogrow limits from node comfyDynamic', async () => {
+      const node = createMockNode({
+        comfyDynamic: {
+          autogrow: {
+            images: { min: 1, max: 3 },
+            floats: { min: 0, max: 8 },
+            ints: { min: 0, max: 4 }
+          }
+        }
+      })
+      await triggerRender(node)
+
+      expect(mockRendererFactory.lastConfig.value).toEqual({
+        maxInputs: 3,
+        maxFloatUniforms: 8,
+        maxIntUniforms: 4,
+        maxBoolUniforms: 10,
+        maxCurves: 4
+      })
+    })
+  })
+})

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -3,155 +3,33 @@ import { computed, effectScope, onScopeDispose, ref, toValue, watch } from 'vue'
 
 import type { ComputedRef, EffectScope, MaybeRefOrGetter, Ref } from 'vue'
 import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
-import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { UUID } from '@/lib/litegraph/src/utils/uuid'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
-import type { CurveData } from '@/components/curve/types'
-import { createInterpolator, isCurveData } from '@/components/curve/curveUtils'
+import { curveDataToFloatLUT } from '@/components/curve/curveUtils'
 import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
 import { useGLSLRenderer } from '@/renderer/glsl/useGLSLRenderer'
+import {
+  extractUniformSources,
+  getAutogrowLimits,
+  useGLSLUniforms
+} from '@/renderer/glsl/useGLSLUniforms'
 import {
   createSharedObjectUrl,
   releaseSharedObjectUrl
 } from '@/utils/objectUrlUtil'
 
-const GLSL_NODE_TYPE = 'GLSLShader'
-const DEBOUNCE_MS = 50
-const DEFAULT_SIZE = 512
-const MAX_PREVIEW_DIMENSION = 1024
-const CURVE_LUT_SIZE = 256
-
-interface AutogrowGroup {
-  max: number
-  min: number
-  prefix?: string
-}
-
-interface UniformSource {
-  nodeId: NodeId
-  widgetName: string
-}
-
-function getAutogrowLimits(node: LGraphNode): GLSLRendererConfig {
-  const defaults: GLSLRendererConfig = {
-    maxInputs: 5,
-    maxFloatUniforms: 20,
-    maxIntUniforms: 20,
-    maxBoolUniforms: 10,
-    maxCurves: 4
-  }
-
-  if (!('comfyDynamic' in node)) return defaults
-
-  const dynamic = node.comfyDynamic
-  if (
-    typeof dynamic !== 'object' ||
-    dynamic === null ||
-    !('autogrow' in dynamic)
-  )
-    return defaults
-
-  const groups = dynamic.autogrow as Record<string, AutogrowGroup> | undefined
-  if (!groups) return defaults
-
-  return {
-    maxInputs: groups['images']?.max ?? defaults.maxInputs,
-    maxFloatUniforms: groups['floats']?.max ?? defaults.maxFloatUniforms,
-    maxIntUniforms: groups['ints']?.max ?? defaults.maxIntUniforms,
-    maxBoolUniforms: groups['bools']?.max ?? defaults.maxBoolUniforms,
-    maxCurves: groups['curves']?.max ?? defaults.maxCurves
-  }
-}
-
-function normalizeDimension(value: unknown): number {
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SIZE
-  return parsed
-}
-
-function clampResolution(w: number, h: number): [number, number] {
-  const maxDim = Math.max(w, h)
-  if (maxDim <= MAX_PREVIEW_DIMENSION) return [w, h]
-  const scale = MAX_PREVIEW_DIMENSION / maxDim
-  return [Math.round(w * scale), Math.round(h * scale)]
-}
-
-function curveDataToLUT(curve: CurveData): Float32Array {
-  const lut = new Float32Array(CURVE_LUT_SIZE)
-  const interpolate = createInterpolator(curve.points, curve.interpolation)
-  for (let i = 0; i < CURVE_LUT_SIZE; i++) {
-    lut[i] = interpolate(i / (CURVE_LUT_SIZE - 1))
-  }
-  return lut
-}
-
-function getImageThroughSubgraphBoundary(
-  node: LGraphNode,
-  slot: number,
-  ownerSubgraphNode: LGraphNode
-): HTMLImageElement | undefined {
-  const graph = node.graph
-  if (!graph) return undefined
-
-  const input = node.inputs[slot]
-  if (input?.link == null) return undefined
-
-  const link = graph._links.get(input.link)
-  if (!link || link.origin_id !== SUBGRAPH_INPUT_ID) return undefined
-
-  const outerUpstream = ownerSubgraphNode.getInputNode(link.origin_slot)
-  if (!outerUpstream?.imgs?.length) return undefined
-
-  return outerUpstream.imgs[0]
-}
-
-function extractUniformSources(
-  glslNode: LGraphNode,
-  subgraph: Subgraph
-): {
-  floats: UniformSource[]
-  ints: UniformSource[]
-  bools: UniformSource[]
-  curves: UniformSource[]
-} {
-  const floats: UniformSource[] = []
-  const ints: UniformSource[] = []
-  const bools: UniformSource[] = []
-  const curves: UniformSource[] = []
-
-  if (!glslNode.inputs) return { floats, ints, bools, curves }
-
-  for (const input of glslNode.inputs) {
-    if (input.link == null) continue
-
-    const link = subgraph.getLink(input.link)
-    if (!link || link.origin_id === SUBGRAPH_INPUT_ID) continue
-
-    const sourceNode = subgraph.getNodeById(link.origin_id)
-    if (!sourceNode?.widgets?.[0]) continue
-
-    const inputName = input.name ?? ''
-    const dotIndex = inputName.indexOf('.')
-    if (dotIndex === -1) continue
-
-    const prefix = inputName.slice(0, dotIndex)
-    const source: UniformSource = {
-      nodeId: sourceNode.id as NodeId,
-      widgetName: sourceNode.widgets[0].name
-    }
-
-    if (prefix === 'floats') floats.push(source)
-    else if (prefix === 'ints') ints.push(source)
-    else if (prefix === 'bools') bools.push(source)
-    else if (prefix === 'curves') curves.push(source)
-  }
-
-  return { floats, ints, bools, curves }
-}
+import {
+  clampResolution,
+  DEBOUNCE_MS,
+  DEFAULT_SIZE,
+  getImageThroughSubgraphBoundary,
+  GLSL_NODE_TYPE,
+  normalizeDimension
+} from '@/renderer/glsl/glslPreviewUtils'
 
 /**
  * Two-tier composable for GLSL live preview.
@@ -251,14 +129,14 @@ function createInnerPreview(
   let rendererReady = false
   let renderRequestId = 0
 
-  const innerGLSLNode = computed(() => {
+  const innerGLSLNode = (() => {
     const node = nodeRef.value
     if (!node?.isSubgraphNode()) return null
     const subgraph = node.subgraph as Subgraph | undefined
     return subgraph?.nodes.find((n) => n.type === GLSL_NODE_TYPE) ?? null
-  })
+  })()
 
-  const ownerSubgraphNode = computed(() => {
+  const ownerSubgraphNode = (() => {
     const node = nodeRef.value
     const graph = node?.graph
     if (!graph) return null
@@ -266,11 +144,11 @@ function createInnerPreview(
     if (!rootGraph || graph === rootGraph) return null
 
     return (
-      rootGraph._nodes.find(
+      rootGraph._nodes?.find(
         (n) => n.isSubgraphNode() && n.subgraph === graph
       ) ?? null
     )
-  })
+  })()
 
   const graphId = computed(
     () => nodeRef.value?.graph?.rootGraph?.id as UUID | undefined
@@ -287,7 +165,7 @@ function createInnerPreview(
     const locatorId = nodeToNodeLocatorId(node)
     if (outputs[locatorId]?.images?.length) return true
 
-    const inner = innerGLSLNode.value
+    const inner = innerGLSLNode
     if (inner) {
       const innerLocatorId = nodeToNodeLocatorId(inner)
       if (outputs[innerLocatorId]?.images?.length) return true
@@ -296,13 +174,13 @@ function createInnerPreview(
     return false
   })
 
-  const isActive = computed(
+  const shouldRender = computed(
     () =>
       (isGLSLNode.value || isGLSLSubgraphNode.value) && hasExecutionOutput.value
   )
 
   watch(
-    isActive,
+    shouldRender,
     (v) => {
       isActiveOut.value = v
     },
@@ -321,7 +199,7 @@ function createInnerPreview(
         | undefined
     }
 
-    const inner = innerGLSLNode.value
+    const inner = innerGLSLNode
     if (inner) {
       return widgetValueStore.getWidget(
         gId,
@@ -334,7 +212,7 @@ function createInnerPreview(
   })
 
   const rendererConfig = computed(() => {
-    const inner = innerGLSLNode.value
+    const inner = innerGLSLNode
     if (inner) return getAutogrowLimits(inner)
 
     const node = nodeRef.value
@@ -351,169 +229,18 @@ function createInnerPreview(
 
   const uniformSources = computed(() => {
     const node = nodeRef.value
-    const inner = innerGLSLNode.value
+    const inner = innerGLSLNode
     if (!node?.isSubgraphNode() || !inner) return null
     return extractUniformSources(inner, node.subgraph as Subgraph)
   })
 
-  function collectUniformValues(
-    subgraphSources: UniformSource[] | undefined,
-    groupName: string,
-    uniformPrefix: string,
-    maxCount: number
-  ): number[] {
-    const gId = graphId.value
-    if (!gId) return []
-
-    if (subgraphSources) {
-      return subgraphSources.map(({ nodeId: nId, widgetName }) => {
-        const widget = widgetValueStore.getWidget(gId, nId, widgetName)
-        return Number(widget?.value ?? 0) || 0
-      })
-    }
-
-    const nId = nodeId.value
-    const node = nodeRef.value
-    if (nId == null || !node) return []
-
-    const values: number[] = []
-    for (let i = 0; i < maxCount; i++) {
-      const inputName = `${groupName}.${uniformPrefix}${i}`
-      const widget = widgetValueStore.getWidget(gId, nId, inputName)
-      if (widget !== undefined) {
-        values.push(Number(widget.value) || 0)
-        continue
-      }
-
-      const slot = node.inputs?.findIndex((inp) => inp.name === inputName)
-      if (slot == null || slot < 0) break
-
-      const upstreamNode = node.getInputNode(slot)
-      if (!upstreamNode) break
-      const upstreamWidgets = widgetValueStore.getNodeWidgets(
-        gId,
-        upstreamNode.id as NodeId
-      )
-      if (upstreamWidgets.length === 0) break
-      values.push(Number(upstreamWidgets[0].value) || 0)
-    }
-    return values
-  }
-
-  const floatValues = computed(() =>
-    collectUniformValues(
-      uniformSources.value?.floats,
-      'floats',
-      'u_float',
-      rendererConfig.value.maxFloatUniforms
-    )
+  const { floatValues, intValues, boolValues, curveValues } = useGLSLUniforms(
+    graphId,
+    nodeId,
+    nodeRef,
+    uniformSources,
+    rendererConfig
   )
-
-  const intValues = computed(() =>
-    collectUniformValues(
-      uniformSources.value?.ints,
-      'ints',
-      'u_int',
-      rendererConfig.value.maxIntUniforms
-    )
-  )
-
-  function collectBoolValues(
-    subgraphSources: UniformSource[] | undefined,
-    maxCount: number
-  ): boolean[] {
-    const gId = graphId.value
-    if (!gId) return []
-
-    if (subgraphSources) {
-      return subgraphSources.map(({ nodeId: nId, widgetName }) => {
-        const widget = widgetValueStore.getWidget(gId, nId, widgetName)
-        return Boolean(widget?.value ?? false)
-      })
-    }
-
-    const nId = nodeId.value
-    const node = nodeRef.value
-    if (nId == null || !node) return []
-
-    const values: boolean[] = []
-    for (let i = 0; i < maxCount; i++) {
-      const inputName = `bools.u_bool${i}`
-      const widget = widgetValueStore.getWidget(gId, nId, inputName)
-      if (widget !== undefined) {
-        values.push(Boolean(widget.value))
-        continue
-      }
-
-      const slot = node.inputs?.findIndex((inp) => inp.name === inputName)
-      if (slot == null || slot < 0) break
-
-      const upstreamNode = node.getInputNode(slot)
-      if (!upstreamNode) break
-      const upstreamWidgets = widgetValueStore.getNodeWidgets(
-        gId,
-        upstreamNode.id as NodeId
-      )
-      if (upstreamWidgets.length === 0) break
-      values.push(Boolean(upstreamWidgets[0].value))
-    }
-    return values
-  }
-
-  const boolValues = computed(() =>
-    collectBoolValues(
-      uniformSources.value?.bools,
-      rendererConfig.value.maxBoolUniforms
-    )
-  )
-
-  const curveValues = computed((): CurveData[] => {
-    const gId = graphId.value
-    if (!gId) return []
-
-    const sources = uniformSources.value?.curves
-    if (sources && sources.length > 0) {
-      return sources
-        .map(({ nodeId: nId, widgetName }) => {
-          const widget = widgetValueStore.getWidget(gId, nId, widgetName)
-          return widget && isCurveData(widget.value)
-            ? (widget.value as CurveData)
-            : null
-        })
-        .filter((v): v is CurveData => v !== null)
-    }
-
-    const node = nodeRef.value
-    const nId = nodeId.value
-    if (nId == null || !node?.inputs) return []
-
-    const values: CurveData[] = []
-    const max = rendererConfig.value.maxCurves
-    for (let i = 0; i < max; i++) {
-      const inputName = `curves.u_curve${i}`
-
-      const widget = widgetValueStore.getWidget(gId, nId, inputName)
-      if (widget && isCurveData(widget.value)) {
-        values.push(widget.value as CurveData)
-        continue
-      }
-
-      const slot = node.inputs.findIndex((inp) => inp.name === inputName)
-      if (slot < 0) break
-
-      const upstreamNode = node.getInputNode(slot)
-      if (!upstreamNode) break
-
-      const upstreamWidgets = widgetValueStore.getNodeWidgets(
-        gId,
-        upstreamNode.id as NodeId
-      )
-      const curveWidget = upstreamWidgets.find((w) => isCurveData(w.value))
-      if (!curveWidget) break
-      values.push(curveWidget.value as CurveData)
-    }
-    return values
-  })
 
   function loadInputImages(): void {
     const node = nodeRef.value
@@ -544,7 +271,7 @@ function createInnerPreview(
         continue
       }
 
-      const owner = ownerSubgraphNode.value
+      const owner = ownerSubgraphNode
       if (owner) {
         const img = getImageThroughSubgraphBoundary(node, slot, owner)
         if (img) {
@@ -586,7 +313,7 @@ function createInnerPreview(
         )
       }
 
-      const owner = ownerSubgraphNode.value
+      const owner = ownerSubgraphNode
       if (owner) {
         const img = getImageThroughSubgraphBoundary(node, slot, owner)
         if (img) {
@@ -650,7 +377,7 @@ function createInnerPreview(
   async function renderPreview(): Promise<void> {
     const requestId = ++renderRequestId
     const source = shaderSource.value
-    if (!source || !isActive.value) return
+    if (!source || !shouldRender.value) return
 
     const r = ensureRenderer()
 
@@ -687,7 +414,7 @@ function createInnerPreview(
       }
       const curves = curveValues.value
       for (let i = 0; i < curves.length; i++) {
-        r.bindCurveTexture(i, curveDataToLUT(curves[i]))
+        r.bindCurveTexture(i, curveDataToFloatLUT(curves[i]))
       }
 
       r.render()
@@ -695,19 +422,20 @@ function createInnerPreview(
       const blob = await r.toBlob()
       if (requestId !== renderRequestId || disposed) return
       const blobUrl = createSharedObjectUrl(blob)
-
-      const inner = innerGLSLNode.value
-      if (inner) {
-        const innerLocatorId = nodeToNodeLocatorId(inner)
-        nodeOutputStore.setNodePreviewsByLocatorId(innerLocatorId, [blobUrl])
-      } else {
-        const nId = nodeId.value
-        if (nId != null) {
-          nodeOutputStore.setNodePreviewsByNodeId(nId, [blobUrl])
+      try {
+        const inner = innerGLSLNode
+        if (inner) {
+          const innerLocatorId = nodeToNodeLocatorId(inner)
+          nodeOutputStore.setNodePreviewsByLocatorId(innerLocatorId, [blobUrl])
+        } else {
+          const nId = nodeId.value
+          if (nId != null) {
+            nodeOutputStore.setNodePreviewsByNodeId(nId, [blobUrl])
+          }
         }
+      } finally {
+        releaseSharedObjectUrl(blobUrl)
       }
-
-      releaseSharedObjectUrl(blobUrl)
     } catch (error) {
       if (requestId !== renderRequestId) return
       lastError.value =
@@ -720,7 +448,7 @@ function createInnerPreview(
   }, DEBOUNCE_MS)
 
   watch(
-    isActive,
+    shouldRender,
     (active) => {
       if (isGLSLNode.value) {
         const node = nodeRef.value
@@ -740,13 +468,13 @@ function createInnerPreview(
         curveValues.value
       ] as const,
     () => {
-      if (isActive.value) debouncedRender()
+      if (shouldRender.value) debouncedRender()
     },
     { deep: true }
   )
 
   watch(shaderSource, () => {
-    if (isActive.value) debouncedRender()
+    if (shouldRender.value) debouncedRender()
   })
 
   // Return dispose function for the inner tier
@@ -757,7 +485,7 @@ function createInnerPreview(
     renderer = null
 
     // Revoke preview blob URLs to avoid memory leaks
-    const inner = innerGLSLNode.value
+    const inner = innerGLSLNode
     if (inner) {
       const locatorId = nodeToNodeLocatorId(inner)
       nodeOutputStore.revokePreviewsByLocatorId(locatorId)

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -1,0 +1,772 @@
+import { debounce } from 'es-toolkit/compat'
+import { computed, effectScope, onScopeDispose, ref, toValue, watch } from 'vue'
+
+import type { ComputedRef, EffectScope, MaybeRefOrGetter, Ref } from 'vue'
+import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
+import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
+import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
+import type { UUID } from '@/lib/litegraph/src/utils/uuid'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+
+import type { CurveData } from '@/components/curve/types'
+import { createInterpolator, isCurveData } from '@/components/curve/curveUtils'
+import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
+import { useGLSLRenderer } from '@/renderer/glsl/useGLSLRenderer'
+import {
+  createSharedObjectUrl,
+  releaseSharedObjectUrl
+} from '@/utils/objectUrlUtil'
+
+const GLSL_NODE_TYPE = 'GLSLShader'
+const DEBOUNCE_MS = 50
+const DEFAULT_SIZE = 512
+const MAX_PREVIEW_DIMENSION = 1024
+const CURVE_LUT_SIZE = 256
+
+interface AutogrowGroup {
+  max: number
+  min: number
+  prefix?: string
+}
+
+interface UniformSource {
+  nodeId: NodeId
+  widgetName: string
+}
+
+function getAutogrowLimits(node: LGraphNode): GLSLRendererConfig {
+  const defaults: GLSLRendererConfig = {
+    maxInputs: 5,
+    maxFloatUniforms: 20,
+    maxIntUniforms: 20,
+    maxBoolUniforms: 10,
+    maxCurves: 4
+  }
+
+  if (!('comfyDynamic' in node)) return defaults
+
+  const dynamic = node.comfyDynamic
+  if (
+    typeof dynamic !== 'object' ||
+    dynamic === null ||
+    !('autogrow' in dynamic)
+  )
+    return defaults
+
+  const groups = dynamic.autogrow as Record<string, AutogrowGroup> | undefined
+  if (!groups) return defaults
+
+  return {
+    maxInputs: groups['images']?.max ?? defaults.maxInputs,
+    maxFloatUniforms: groups['floats']?.max ?? defaults.maxFloatUniforms,
+    maxIntUniforms: groups['ints']?.max ?? defaults.maxIntUniforms,
+    maxBoolUniforms: groups['bools']?.max ?? defaults.maxBoolUniforms,
+    maxCurves: groups['curves']?.max ?? defaults.maxCurves
+  }
+}
+
+function normalizeDimension(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SIZE
+  return parsed
+}
+
+function clampResolution(w: number, h: number): [number, number] {
+  const maxDim = Math.max(w, h)
+  if (maxDim <= MAX_PREVIEW_DIMENSION) return [w, h]
+  const scale = MAX_PREVIEW_DIMENSION / maxDim
+  return [Math.round(w * scale), Math.round(h * scale)]
+}
+
+function curveDataToLUT(curve: CurveData): Float32Array {
+  const lut = new Float32Array(CURVE_LUT_SIZE)
+  const interpolate = createInterpolator(curve.points, curve.interpolation)
+  for (let i = 0; i < CURVE_LUT_SIZE; i++) {
+    lut[i] = interpolate(i / (CURVE_LUT_SIZE - 1))
+  }
+  return lut
+}
+
+function getImageThroughSubgraphBoundary(
+  node: LGraphNode,
+  slot: number,
+  ownerSubgraphNode: LGraphNode
+): HTMLImageElement | undefined {
+  const graph = node.graph
+  if (!graph) return undefined
+
+  const input = node.inputs[slot]
+  if (input?.link == null) return undefined
+
+  const link = graph._links.get(input.link)
+  if (!link || link.origin_id !== SUBGRAPH_INPUT_ID) return undefined
+
+  const outerUpstream = ownerSubgraphNode.getInputNode(link.origin_slot)
+  if (!outerUpstream?.imgs?.length) return undefined
+
+  return outerUpstream.imgs[0]
+}
+
+function extractUniformSources(
+  glslNode: LGraphNode,
+  subgraph: Subgraph
+): {
+  floats: UniformSource[]
+  ints: UniformSource[]
+  bools: UniformSource[]
+  curves: UniformSource[]
+} {
+  const floats: UniformSource[] = []
+  const ints: UniformSource[] = []
+  const bools: UniformSource[] = []
+  const curves: UniformSource[] = []
+
+  if (!glslNode.inputs) return { floats, ints, bools, curves }
+
+  for (const input of glslNode.inputs) {
+    if (input.link == null) continue
+
+    const link = subgraph.getLink(input.link)
+    if (!link || link.origin_id === SUBGRAPH_INPUT_ID) continue
+
+    const sourceNode = subgraph.getNodeById(link.origin_id)
+    if (!sourceNode?.widgets?.[0]) continue
+
+    const inputName = input.name ?? ''
+    const dotIndex = inputName.indexOf('.')
+    if (dotIndex === -1) continue
+
+    const prefix = inputName.slice(0, dotIndex)
+    const source: UniformSource = {
+      nodeId: sourceNode.id as NodeId,
+      widgetName: sourceNode.widgets[0].name
+    }
+
+    if (prefix === 'floats') floats.push(source)
+    else if (prefix === 'ints') ints.push(source)
+    else if (prefix === 'bools') bools.push(source)
+    else if (prefix === 'curves') curves.push(source)
+  }
+
+  return { floats, ints, bools, curves }
+}
+
+/**
+ * Two-tier composable for GLSL live preview.
+ *
+ * Outer tier (always created): only 2 cheap computed refs to detect
+ * whether the node is GLSL-related. For non-GLSL nodes this is the
+ * only cost — no watchers, store subscriptions, or renderer.
+ *
+ * Inner tier (lazy): created via effectScope when the node is detected
+ * as a GLSLShader or a subgraph containing one. Contains all the
+ * expensive logic: store reads, watchers, debounce, WebGL renderer.
+ */
+export function useGLSLPreview(
+  nodeMaybe: MaybeRefOrGetter<LGraphNode | null | undefined>
+) {
+  const lastError = ref<string | null>(null)
+
+  const nodeRef = computed(() => toValue(nodeMaybe) ?? null)
+
+  const isGLSLNode = computed(() => nodeRef.value?.type === GLSL_NODE_TYPE)
+
+  const isGLSLSubgraphNode = computed(() => {
+    const node = nodeRef.value
+    if (!node?.isSubgraphNode()) return false
+    const subgraph = node.subgraph as Subgraph | undefined
+    return subgraph?.nodes.some((n) => n.type === GLSL_NODE_TYPE) ?? false
+  })
+
+  const isGLSLRelated = computed(
+    () => isGLSLNode.value || isGLSLSubgraphNode.value
+  )
+
+  let innerScope: EffectScope | null = null
+  let innerDispose: (() => void) | null = null
+  const isActive = ref(false)
+
+  watch(
+    isGLSLRelated,
+    (related) => {
+      if (related && !innerScope) {
+        innerScope = effectScope()
+        innerDispose = innerScope.run(() =>
+          createInnerPreview(
+            nodeRef,
+            isGLSLNode,
+            isGLSLSubgraphNode,
+            lastError,
+            isActive
+          )
+        )!
+      } else if (!related && innerScope) {
+        innerDispose?.()
+        innerScope.stop()
+        innerScope = null
+        innerDispose = null
+        isActive.value = false
+      }
+    },
+    { immediate: true }
+  )
+
+  onScopeDispose(() => {
+    innerDispose?.()
+    innerScope?.stop()
+  })
+
+  return {
+    isActive: computed(() => isActive.value),
+    lastError,
+    dispose() {
+      innerDispose?.()
+      innerScope?.stop()
+      innerScope = null
+      innerDispose = null
+    }
+  }
+}
+
+/**
+ * Inner tier: all expensive GLSL preview logic.
+ * Runs inside its own effectScope so it can be created/destroyed
+ * independently of the component lifecycle.
+ * Returns a dispose function.
+ */
+function createInnerPreview(
+  nodeRef: ComputedRef<LGraphNode | null>,
+  isGLSLNode: ComputedRef<boolean>,
+  isGLSLSubgraphNode: ComputedRef<boolean>,
+  lastError: Ref<string | null>,
+  isActiveOut: Ref<boolean>
+): () => void {
+  const widgetValueStore = useWidgetValueStore()
+  const nodeOutputStore = useNodeOutputStore()
+  const { nodeToNodeLocatorId } = useWorkflowStore()
+
+  let renderer: ReturnType<typeof useGLSLRenderer> | null = null
+  let rendererReady = false
+  let renderRequestId = 0
+
+  const innerGLSLNode = computed(() => {
+    const node = nodeRef.value
+    if (!node?.isSubgraphNode()) return null
+    const subgraph = node.subgraph as Subgraph | undefined
+    return subgraph?.nodes.find((n) => n.type === GLSL_NODE_TYPE) ?? null
+  })
+
+  const ownerSubgraphNode = computed(() => {
+    const node = nodeRef.value
+    const graph = node?.graph
+    if (!graph) return null
+    const rootGraph = graph.rootGraph
+    if (!rootGraph || graph === rootGraph) return null
+
+    return (
+      rootGraph._nodes.find(
+        (n) => n.isSubgraphNode() && n.subgraph === graph
+      ) ?? null
+    )
+  })
+
+  const graphId = computed(
+    () => nodeRef.value?.graph?.rootGraph?.id as UUID | undefined
+  )
+
+  const nodeId = computed(() => nodeRef.value?.id as NodeId | undefined)
+
+  const hasExecutionOutput = computed(() => {
+    const node = nodeRef.value
+    if (!node) return false
+
+    const outputs = nodeOutputStore.nodeOutputs
+
+    const locatorId = nodeToNodeLocatorId(node)
+    if (outputs[locatorId]?.images?.length) return true
+
+    const inner = innerGLSLNode.value
+    if (inner) {
+      const innerLocatorId = nodeToNodeLocatorId(inner)
+      if (outputs[innerLocatorId]?.images?.length) return true
+    }
+
+    return false
+  })
+
+  const isActive = computed(
+    () =>
+      (isGLSLNode.value || isGLSLSubgraphNode.value) && hasExecutionOutput.value
+  )
+
+  watch(
+    isActive,
+    (v) => {
+      isActiveOut.value = v
+    },
+    { immediate: true }
+  )
+
+  const shaderSource = computed(() => {
+    const gId = graphId.value
+    if (!gId) return undefined
+
+    if (isGLSLNode.value) {
+      const nId = nodeId.value
+      if (nId == null) return undefined
+      return widgetValueStore.getWidget(gId, nId, 'fragment_shader')?.value as
+        | string
+        | undefined
+    }
+
+    const inner = innerGLSLNode.value
+    if (inner) {
+      return widgetValueStore.getWidget(
+        gId,
+        inner.id as NodeId,
+        'fragment_shader'
+      )?.value as string | undefined
+    }
+
+    return undefined
+  })
+
+  const rendererConfig = computed(() => {
+    const inner = innerGLSLNode.value
+    if (inner) return getAutogrowLimits(inner)
+
+    const node = nodeRef.value
+    if (!node)
+      return {
+        maxInputs: 5,
+        maxFloatUniforms: 20,
+        maxIntUniforms: 20,
+        maxBoolUniforms: 10,
+        maxCurves: 4
+      }
+    return getAutogrowLimits(node)
+  })
+
+  const uniformSources = computed(() => {
+    const node = nodeRef.value
+    const inner = innerGLSLNode.value
+    if (!node?.isSubgraphNode() || !inner) return null
+    return extractUniformSources(inner, node.subgraph as Subgraph)
+  })
+
+  function collectUniformValues(
+    subgraphSources: UniformSource[] | undefined,
+    groupName: string,
+    uniformPrefix: string,
+    maxCount: number
+  ): number[] {
+    const gId = graphId.value
+    if (!gId) return []
+
+    if (subgraphSources) {
+      return subgraphSources.map(({ nodeId: nId, widgetName }) => {
+        const widget = widgetValueStore.getWidget(gId, nId, widgetName)
+        return Number(widget?.value ?? 0) || 0
+      })
+    }
+
+    const nId = nodeId.value
+    const node = nodeRef.value
+    if (nId == null || !node) return []
+
+    const values: number[] = []
+    for (let i = 0; i < maxCount; i++) {
+      const inputName = `${groupName}.${uniformPrefix}${i}`
+      const widget = widgetValueStore.getWidget(gId, nId, inputName)
+      if (widget !== undefined) {
+        values.push(Number(widget.value) || 0)
+        continue
+      }
+
+      const slot = node.inputs?.findIndex((inp) => inp.name === inputName)
+      if (slot == null || slot < 0) break
+
+      const upstreamNode = node.getInputNode(slot)
+      if (!upstreamNode) break
+      const upstreamWidgets = widgetValueStore.getNodeWidgets(
+        gId,
+        upstreamNode.id as NodeId
+      )
+      if (upstreamWidgets.length === 0) break
+      values.push(Number(upstreamWidgets[0].value) || 0)
+    }
+    return values
+  }
+
+  const floatValues = computed(() =>
+    collectUniformValues(
+      uniformSources.value?.floats,
+      'floats',
+      'u_float',
+      rendererConfig.value.maxFloatUniforms
+    )
+  )
+
+  const intValues = computed(() =>
+    collectUniformValues(
+      uniformSources.value?.ints,
+      'ints',
+      'u_int',
+      rendererConfig.value.maxIntUniforms
+    )
+  )
+
+  function collectBoolValues(
+    subgraphSources: UniformSource[] | undefined,
+    maxCount: number
+  ): boolean[] {
+    const gId = graphId.value
+    if (!gId) return []
+
+    if (subgraphSources) {
+      return subgraphSources.map(({ nodeId: nId, widgetName }) => {
+        const widget = widgetValueStore.getWidget(gId, nId, widgetName)
+        return Boolean(widget?.value ?? false)
+      })
+    }
+
+    const nId = nodeId.value
+    const node = nodeRef.value
+    if (nId == null || !node) return []
+
+    const values: boolean[] = []
+    for (let i = 0; i < maxCount; i++) {
+      const inputName = `bools.u_bool${i}`
+      const widget = widgetValueStore.getWidget(gId, nId, inputName)
+      if (widget !== undefined) {
+        values.push(Boolean(widget.value))
+        continue
+      }
+
+      const slot = node.inputs?.findIndex((inp) => inp.name === inputName)
+      if (slot == null || slot < 0) break
+
+      const upstreamNode = node.getInputNode(slot)
+      if (!upstreamNode) break
+      const upstreamWidgets = widgetValueStore.getNodeWidgets(
+        gId,
+        upstreamNode.id as NodeId
+      )
+      if (upstreamWidgets.length === 0) break
+      values.push(Boolean(upstreamWidgets[0].value))
+    }
+    return values
+  }
+
+  const boolValues = computed(() =>
+    collectBoolValues(
+      uniformSources.value?.bools,
+      rendererConfig.value.maxBoolUniforms
+    )
+  )
+
+  const curveValues = computed((): CurveData[] => {
+    const gId = graphId.value
+    if (!gId) return []
+
+    const sources = uniformSources.value?.curves
+    if (sources && sources.length > 0) {
+      return sources
+        .map(({ nodeId: nId, widgetName }) => {
+          const widget = widgetValueStore.getWidget(gId, nId, widgetName)
+          return widget && isCurveData(widget.value)
+            ? (widget.value as CurveData)
+            : null
+        })
+        .filter((v): v is CurveData => v !== null)
+    }
+
+    const node = nodeRef.value
+    const nId = nodeId.value
+    if (nId == null || !node?.inputs) return []
+
+    const values: CurveData[] = []
+    const max = rendererConfig.value.maxCurves
+    for (let i = 0; i < max; i++) {
+      const inputName = `curves.u_curve${i}`
+
+      const widget = widgetValueStore.getWidget(gId, nId, inputName)
+      if (widget && isCurveData(widget.value)) {
+        values.push(widget.value as CurveData)
+        continue
+      }
+
+      const slot = node.inputs.findIndex((inp) => inp.name === inputName)
+      if (slot < 0) break
+
+      const upstreamNode = node.getInputNode(slot)
+      if (!upstreamNode) break
+
+      const upstreamWidgets = widgetValueStore.getNodeWidgets(
+        gId,
+        upstreamNode.id as NodeId
+      )
+      const curveWidget = upstreamWidgets.find((w) => isCurveData(w.value))
+      if (!curveWidget) break
+      values.push(curveWidget.value as CurveData)
+    }
+    return values
+  })
+
+  function loadInputImages(): void {
+    const node = nodeRef.value
+    if (!node?.inputs || !renderer) return
+
+    if (isGLSLSubgraphNode.value) {
+      let imageSlotIndex = 0
+      for (let slot = 0; slot < node.inputs.length; slot++) {
+        if (node.inputs[slot].type !== 'IMAGE') continue
+        const upstreamNode = node.getInputNode(slot)
+        if (upstreamNode?.imgs?.length) {
+          renderer.bindInputImage(imageSlotIndex, upstreamNode.imgs[0])
+        }
+        imageSlotIndex++
+      }
+      return
+    }
+
+    let imageSlotIndex = 0
+    for (let slot = 0; slot < node.inputs.length; slot++) {
+      const input = node.inputs[slot]
+      if (!input.name.startsWith('images.image')) continue
+
+      const upstreamNode = node.getInputNode(slot)
+      if (upstreamNode?.imgs?.length) {
+        renderer.bindInputImage(imageSlotIndex, upstreamNode.imgs[0])
+        imageSlotIndex++
+        continue
+      }
+
+      const owner = ownerSubgraphNode.value
+      if (owner) {
+        const img = getImageThroughSubgraphBoundary(node, slot, owner)
+        if (img) {
+          renderer.bindInputImage(imageSlotIndex, img)
+        }
+      }
+      imageSlotIndex++
+    }
+  }
+
+  function getResolution(): [number, number] {
+    const node = nodeRef.value
+    if (!node?.inputs) return [DEFAULT_SIZE, DEFAULT_SIZE]
+
+    if (isGLSLSubgraphNode.value) {
+      for (let slot = 0; slot < node.inputs.length; slot++) {
+        if (node.inputs[slot].type !== 'IMAGE') continue
+        const upstreamNode = node.getInputNode(slot)
+        if (!upstreamNode?.imgs?.length) continue
+        const img = upstreamNode.imgs[0]
+        return clampResolution(
+          img.naturalWidth || DEFAULT_SIZE,
+          img.naturalHeight || DEFAULT_SIZE
+        )
+      }
+      return [DEFAULT_SIZE, DEFAULT_SIZE]
+    }
+
+    for (let slot = 0; slot < node.inputs.length; slot++) {
+      const input = node.inputs[slot]
+      if (!input.name.startsWith('images.image')) continue
+
+      const upstreamNode = node.getInputNode(slot)
+      if (upstreamNode?.imgs?.length) {
+        const img = upstreamNode.imgs[0]
+        return clampResolution(
+          img.naturalWidth || DEFAULT_SIZE,
+          img.naturalHeight || DEFAULT_SIZE
+        )
+      }
+
+      const owner = ownerSubgraphNode.value
+      if (owner) {
+        const img = getImageThroughSubgraphBoundary(node, slot, owner)
+        if (img) {
+          return clampResolution(
+            img.naturalWidth || DEFAULT_SIZE,
+            img.naturalHeight || DEFAULT_SIZE
+          )
+        }
+      }
+    }
+
+    const gId = graphId.value
+    const nId = nodeId.value
+    if (gId && nId != null) {
+      const widthWidget = widgetValueStore.getWidget(
+        gId,
+        nId,
+        'size_mode.width'
+      )
+      const heightWidget = widgetValueStore.getWidget(
+        gId,
+        nId,
+        'size_mode.height'
+      )
+      if (widthWidget && heightWidget) {
+        return clampResolution(
+          normalizeDimension(widthWidget.value),
+          normalizeDimension(heightWidget.value)
+        )
+      }
+    }
+
+    return [DEFAULT_SIZE, DEFAULT_SIZE]
+  }
+
+  let disposed = false
+  let lastRendererConfig: GLSLRendererConfig | null = null
+
+  function ensureRenderer(): ReturnType<typeof useGLSLRenderer> {
+    const config = rendererConfig.value
+    if (renderer && lastRendererConfig) {
+      const changed =
+        config.maxInputs !== lastRendererConfig.maxInputs ||
+        config.maxFloatUniforms !== lastRendererConfig.maxFloatUniforms ||
+        config.maxIntUniforms !== lastRendererConfig.maxIntUniforms ||
+        config.maxBoolUniforms !== lastRendererConfig.maxBoolUniforms ||
+        config.maxCurves !== lastRendererConfig.maxCurves
+      if (changed) {
+        renderer.dispose()
+        renderer = null
+        rendererReady = false
+      }
+    }
+    if (!renderer) {
+      renderer = useGLSLRenderer(config)
+      lastRendererConfig = { ...config }
+    }
+    return renderer
+  }
+
+  async function renderPreview(): Promise<void> {
+    const requestId = ++renderRequestId
+    const source = shaderSource.value
+    if (!source || !isActive.value) return
+
+    const r = ensureRenderer()
+
+    try {
+      if (!rendererReady) {
+        const [w, h] = getResolution()
+        if (!r.init(w, h)) {
+          lastError.value = 'WebGL2 not available'
+          return
+        }
+        rendererReady = true
+      }
+
+      const result = r.compileFragment(source)
+      if (!result.success) {
+        lastError.value = result.log
+        return
+      }
+      lastError.value = null
+
+      const [w, h] = getResolution()
+      r.setResolution(w, h)
+
+      loadInputImages()
+
+      for (let i = 0; i < floatValues.value.length; i++) {
+        r.setFloatUniform(i, floatValues.value[i])
+      }
+      for (let i = 0; i < intValues.value.length; i++) {
+        r.setIntUniform(i, intValues.value[i])
+      }
+      for (let i = 0; i < boolValues.value.length; i++) {
+        r.setBoolUniform(i, boolValues.value[i])
+      }
+      const curves = curveValues.value
+      for (let i = 0; i < curves.length; i++) {
+        r.bindCurveTexture(i, curveDataToLUT(curves[i]))
+      }
+
+      r.render()
+
+      const blob = await r.toBlob()
+      if (requestId !== renderRequestId || disposed) return
+      const blobUrl = createSharedObjectUrl(blob)
+
+      const inner = innerGLSLNode.value
+      if (inner) {
+        const innerLocatorId = nodeToNodeLocatorId(inner)
+        nodeOutputStore.setNodePreviewsByLocatorId(innerLocatorId, [blobUrl])
+      } else {
+        const nId = nodeId.value
+        if (nId != null) {
+          nodeOutputStore.setNodePreviewsByNodeId(nId, [blobUrl])
+        }
+      }
+
+      releaseSharedObjectUrl(blobUrl)
+    } catch (error) {
+      if (requestId !== renderRequestId) return
+      lastError.value =
+        error instanceof Error ? error.message : 'Failed to render preview'
+    }
+  }
+
+  const debouncedRender = debounce((): void => {
+    void renderPreview()
+  }, DEBOUNCE_MS)
+
+  watch(
+    isActive,
+    (active) => {
+      if (isGLSLNode.value) {
+        const node = nodeRef.value
+        if (node) node.hideOutputImages = active
+      }
+      if (active) debouncedRender()
+    },
+    { immediate: true }
+  )
+
+  watch(
+    () =>
+      [
+        floatValues.value,
+        intValues.value,
+        boolValues.value,
+        curveValues.value
+      ] as const,
+    () => {
+      if (isActive.value) debouncedRender()
+    },
+    { deep: true }
+  )
+
+  watch(shaderSource, () => {
+    if (isActive.value) debouncedRender()
+  })
+
+  // Return dispose function for the inner tier
+  return () => {
+    disposed = true
+    debouncedRender.cancel()
+    renderer?.dispose()
+    renderer = null
+
+    // Revoke preview blob URLs to avoid memory leaks
+    const inner = innerGLSLNode.value
+    if (inner) {
+      const locatorId = nodeToNodeLocatorId(inner)
+      nodeOutputStore.revokePreviewsByLocatorId(locatorId)
+    } else {
+      const nId = nodeId.value
+      if (nId != null) {
+        const locatorId = nodeToNodeLocatorId(nodeRef.value!)
+        nodeOutputStore.revokePreviewsByLocatorId(locatorId)
+      }
+    }
+  }
+}

--- a/src/renderer/glsl/useGLSLRenderer.test.ts
+++ b/src/renderer/glsl/useGLSLRenderer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    onScopeDispose: vi.fn()
+  }
+})
+
+describe('useGLSLRenderer', () => {
+  it('returns renderer API with expected methods', async () => {
+    const { useGLSLRenderer } = await import('@/renderer/glsl/useGLSLRenderer')
+    const renderer = useGLSLRenderer()
+
+    expect(renderer).toHaveProperty('init')
+    expect(renderer).toHaveProperty('compileFragment')
+    expect(renderer).toHaveProperty('setResolution')
+    expect(renderer).toHaveProperty('setFloatUniform')
+    expect(renderer).toHaveProperty('setIntUniform')
+    expect(renderer).toHaveProperty('bindInputImage')
+    expect(renderer).toHaveProperty('render')
+    expect(renderer).toHaveProperty('readPixels')
+    expect(renderer).toHaveProperty('toBlob')
+    expect(renderer).toHaveProperty('dispose')
+  })
+
+  it('init returns false when WebGL2 is unavailable', async () => {
+    const { useGLSLRenderer } = await import('@/renderer/glsl/useGLSLRenderer')
+    const renderer = useGLSLRenderer()
+    expect(renderer.init(256, 256)).toBe(false)
+  })
+
+  it('compileFragment reports error before initialization', async () => {
+    const { useGLSLRenderer } = await import('@/renderer/glsl/useGLSLRenderer')
+    const renderer = useGLSLRenderer()
+    const result = renderer.compileFragment('void main() {}')
+    expect(result.success).toBe(false)
+  })
+
+  it('toBlob rejects before initialization', async () => {
+    const { useGLSLRenderer } = await import('@/renderer/glsl/useGLSLRenderer')
+    const renderer = useGLSLRenderer()
+    await expect(renderer.toBlob()).rejects.toThrow('Renderer not initialized')
+  })
+
+  it('accepts custom config without error', async () => {
+    const { useGLSLRenderer } = await import('@/renderer/glsl/useGLSLRenderer')
+    const config: GLSLRendererConfig = {
+      maxInputs: 3,
+      maxFloatUniforms: 2,
+      maxIntUniforms: 1,
+      maxBoolUniforms: 1,
+      maxCurves: 2
+    }
+    const renderer = useGLSLRenderer(config)
+    expect(renderer.init(256, 256)).toBe(false)
+  })
+})

--- a/src/renderer/glsl/useGLSLRenderer.ts
+++ b/src/renderer/glsl/useGLSLRenderer.ts
@@ -1,5 +1,3 @@
-import { onScopeDispose } from 'vue'
-
 import { detectPassCount } from '@/renderer/glsl/glslUtils'
 
 const VERTEX_SHADER_SOURCE = `#version 300 es
@@ -17,12 +15,16 @@ export interface GLSLRendererConfig {
   maxInputs: number
   maxFloatUniforms: number
   maxIntUniforms: number
+  maxBoolUniforms: number
+  maxCurves: number
 }
 
 const DEFAULT_CONFIG: GLSLRendererConfig = {
   maxInputs: 5,
-  maxFloatUniforms: 5,
-  maxIntUniforms: 5
+  maxFloatUniforms: 20,
+  maxIntUniforms: 20,
+  maxBoolUniforms: 10,
+  maxCurves: 4
 }
 
 interface CompileResult {
@@ -50,15 +52,22 @@ function compileShader(
 }
 
 export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
-  const { maxInputs, maxFloatUniforms, maxIntUniforms } = config
+  const {
+    maxInputs,
+    maxFloatUniforms,
+    maxIntUniforms,
+    maxBoolUniforms,
+    maxCurves
+  } = config
 
   const uniformNames = [
     'u_resolution',
     'u_pass',
-    'u_prevPass',
     ...Array.from({ length: maxInputs }, (_, i) => `u_image${i}`),
     ...Array.from({ length: maxFloatUniforms }, (_, i) => `u_float${i}`),
-    ...Array.from({ length: maxIntUniforms }, (_, i) => `u_int${i}`)
+    ...Array.from({ length: maxIntUniforms }, (_, i) => `u_int${i}`),
+    ...Array.from({ length: maxBoolUniforms }, (_, i) => `u_bool${i}`),
+    ...Array.from({ length: maxCurves }, (_, i) => `u_curve${i}`)
   ]
 
   let canvas: OffscreenCanvas | null = null
@@ -72,9 +81,13 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
   const inputTextures: (WebGLTexture | null)[] = Array.from<null>({
     length: maxInputs
   }).fill(null)
+  const curveTextures: (WebGLTexture | null)[] = Array.from<null>({
+    length: maxCurves
+  }).fill(null)
   const uniformLocations = new Map<string, WebGLUniformLocation | null>()
   let passCount = 1
   let disposed = false
+  let lastCompiledSource: string | null = null
 
   function initPingPongFBOs(
     ctx: WebGL2RenderingContext,
@@ -92,12 +105,12 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
         ctx.texImage2D(
           ctx.TEXTURE_2D,
           0,
-          ctx.RGBA8,
+          ctx.RGBA16F,
           width,
           height,
           0,
           ctx.RGBA,
-          ctx.UNSIGNED_BYTE,
+          ctx.HALF_FLOAT,
           null
         )
         ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MIN_FILTER, ctx.LINEAR)
@@ -191,6 +204,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
       if (!ctx) return false
 
       gl = ctx
+      gl.getExtension('EXT_color_buffer_float')
       gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
       vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE)
       initPingPongFBOs(gl, width, height)
@@ -205,6 +219,11 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     if (disposed || !gl) return { success: false, log: 'Engine disposed' }
 
     passCount = Math.min(detectPassCount(source), MAX_PASSES)
+
+    if (source === lastCompiledSource && program) {
+      return { success: true, log: '' }
+    }
+    lastCompiledSource = source
 
     if (fragmentShader) {
       gl.deleteShader(fragmentShader)
@@ -270,6 +289,49 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     }
   }
 
+  function setBoolUniform(index: number, value: boolean): void {
+    if (disposed || !program || !gl) return
+    const loc = uniformLocations.get(`u_bool${index}`)
+    if (loc != null) {
+      gl.useProgram(program)
+      gl.uniform1i(loc, value ? 1 : 0)
+    }
+  }
+
+  function bindCurveTexture(index: number, lut: Float32Array): void {
+    if (disposed || !gl) return
+    if (index < 0 || index >= maxCurves) return
+
+    if (curveTextures[index]) {
+      gl.deleteTexture(curveTextures[index])
+      curveTextures[index] = null
+    }
+
+    const texture = gl.createTexture()
+    if (!texture) return
+
+    const unit = maxInputs + index
+    gl.activeTexture(gl.TEXTURE0 + unit)
+    gl.bindTexture(gl.TEXTURE_2D, texture)
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R16F,
+      lut.length,
+      1,
+      0,
+      gl.RED,
+      gl.FLOAT,
+      lut
+    )
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+
+    curveTextures[index] = texture
+  }
+
   function bindInputImage(
     index: number,
     image: HTMLImageElement | ImageBitmap
@@ -304,6 +366,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     if (disposed || !program || !pingPongFBOs || !gl || !canvas) return
 
     gl.useProgram(program)
+    gl.disable(gl.BLEND)
 
     const resLoc = uniformLocations.get('u_resolution')
     if (resLoc != null) {
@@ -319,8 +382,15 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
       }
     }
 
-    const prevPassUnit = maxInputs
-    const prevPassLoc = uniformLocations.get('u_prevPass')
+    for (let i = 0; i < maxCurves; i++) {
+      const loc = uniformLocations.get(`u_curve${i}`)
+      if (loc != null && curveTextures[i]) {
+        const unit = maxInputs + i
+        gl.activeTexture(gl.TEXTURE0 + unit)
+        gl.bindTexture(gl.TEXTURE_2D, curveTextures[i])
+        gl.uniform1i(loc, unit)
+      }
+    }
 
     for (let pass = 0; pass < passCount; pass++) {
       const passLoc = uniformLocations.get('u_pass')
@@ -328,31 +398,26 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
 
       const isLastPass = pass === passCount - 1
       const writeIdx = pass % 2
-      const readIdx = 1 - writeIdx
 
       if (isLastPass) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null)
-      } else {
-        gl.bindFramebuffer(gl.FRAMEBUFFER, pingPongFBOs[writeIdx])
-      }
-
-      // Note: u_prevPass uses ping-pong FBOs rather than overwriting the input
-      // texture in-place as the backend does for single-input iteration.
-      if (pass > 0 && prevPassLoc != null) {
-        gl.activeTexture(gl.TEXTURE0 + prevPassUnit)
-        gl.bindTexture(gl.TEXTURE_2D, pingPongTextures![readIdx])
-        gl.uniform1i(prevPassLoc, prevPassUnit)
-      }
-
-      // Ping-pong FBOs have a single color attachment, so intermediate
-      // passes always target COLOR_ATTACHMENT0. MRT is only possible on
-      // the default framebuffer (last pass).
-      if (isLastPass) {
         gl.drawBuffers([gl.BACK])
       } else {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, pingPongFBOs[writeIdx])
         gl.drawBuffers([gl.COLOR_ATTACHMENT0])
       }
 
+      // Match backend behavior: pass > 0 binds previous pass output to
+      // texture unit 0, overriding u_image0 so shaders read the previous
+      // pass result via the same sampler.
+      if (pass > 0) {
+        const sourceTexture = pingPongTextures![(pass - 1) % 2]
+        gl.activeTexture(gl.TEXTURE0)
+        gl.bindTexture(gl.TEXTURE_2D, sourceTexture)
+      }
+
+      gl.clearColor(0, 0, 0, 0)
+      gl.clear(gl.COLOR_BUFFER_BIT)
       gl.drawArrays(gl.TRIANGLES, 0, 3)
     }
   }
@@ -384,6 +449,11 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     }
     inputTextures.fill(null)
 
+    for (const tex of curveTextures) {
+      if (tex) gl.deleteTexture(tex)
+    }
+    curveTextures.fill(null)
+
     if (fallbackTexture) {
       gl.deleteTexture(fallbackTexture)
       fallbackTexture = null
@@ -411,14 +481,14 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     ext?.loseContext()
   }
 
-  onScopeDispose(dispose)
-
   return {
     init,
     compileFragment,
     setResolution,
     setFloatUniform,
     setIntUniform,
+    setBoolUniform,
+    bindCurveTexture,
     bindInputImage,
     render,
     readPixels,

--- a/src/renderer/glsl/useGLSLRenderer.ts
+++ b/src/renderer/glsl/useGLSLRenderer.ts
@@ -204,7 +204,9 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
       if (!ctx) return false
 
       gl = ctx
-      gl.getExtension('EXT_color_buffer_float')
+
+      if (!gl.getExtension('EXT_color_buffer_float')) return false
+
       gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
       vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE)
       initPingPongFBOs(gl, width, height)
@@ -313,6 +315,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     const unit = maxInputs + index
     gl.activeTexture(gl.TEXTURE0 + unit)
     gl.bindTexture(gl.TEXTURE_2D, texture)
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false)
     gl.texImage2D(
       gl.TEXTURE_2D,
       0,
@@ -324,6 +327,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
       gl.FLOAT,
       lut
     )
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
@@ -436,7 +440,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
 
   async function toBlob(): Promise<Blob> {
     if (!canvas) throw new Error('Renderer not initialized')
-    return canvas.convertToBlob({ type: 'image/jpeg', quality: 0.92 })
+    return canvas.convertToBlob({ type: 'image/webp', quality: 0.92 })
   }
 
   function dispose(): void {

--- a/src/renderer/glsl/useGLSLUniforms.ts
+++ b/src/renderer/glsl/useGLSLUniforms.ts
@@ -1,0 +1,247 @@
+import { computed } from 'vue'
+
+import type { ComputedRef } from 'vue'
+import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
+import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
+import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
+import type { UUID } from '@/lib/litegraph/src/utils/uuid'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+
+import { isCurveData } from '@/components/curve/curveUtils'
+import type { CurveData } from '@/components/curve/types'
+import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
+
+interface AutogrowGroup {
+  max: number
+  min: number
+  prefix?: string
+}
+
+export interface UniformSource {
+  nodeId: NodeId
+  widgetName: string
+}
+
+export interface UniformSources {
+  floats: UniformSource[]
+  ints: UniformSource[]
+  bools: UniformSource[]
+  curves: UniformSource[]
+}
+
+export function getAutogrowLimits(node: LGraphNode): GLSLRendererConfig {
+  const defaults: GLSLRendererConfig = {
+    maxInputs: 5,
+    maxFloatUniforms: 20,
+    maxIntUniforms: 20,
+    maxBoolUniforms: 10,
+    maxCurves: 4
+  }
+
+  if (!('comfyDynamic' in node)) return defaults
+
+  const dynamic = node.comfyDynamic
+  if (
+    typeof dynamic !== 'object' ||
+    dynamic === null ||
+    !('autogrow' in dynamic)
+  )
+    return defaults
+
+  const groups = dynamic.autogrow as Record<string, AutogrowGroup> | undefined
+  if (!groups) return defaults
+
+  return {
+    maxInputs: groups['images']?.max ?? defaults.maxInputs,
+    maxFloatUniforms: groups['floats']?.max ?? defaults.maxFloatUniforms,
+    maxIntUniforms: groups['ints']?.max ?? defaults.maxIntUniforms,
+    maxBoolUniforms: groups['bools']?.max ?? defaults.maxBoolUniforms,
+    maxCurves: groups['curves']?.max ?? defaults.maxCurves
+  }
+}
+
+export function extractUniformSources(
+  glslNode: LGraphNode,
+  subgraph: Subgraph
+): UniformSources {
+  const floats: UniformSource[] = []
+  const ints: UniformSource[] = []
+  const bools: UniformSource[] = []
+  const curves: UniformSource[] = []
+
+  if (!glslNode.inputs) return { floats, ints, bools, curves }
+
+  for (const input of glslNode.inputs) {
+    if (input.link == null) continue
+
+    const link = subgraph.getLink(input.link)
+    if (!link || link.origin_id === SUBGRAPH_INPUT_ID) continue
+
+    const sourceNode = subgraph.getNodeById(link.origin_id)
+    if (!sourceNode?.widgets?.[0]) continue
+
+    const inputName = input.name ?? ''
+    const dotIndex = inputName.indexOf('.')
+    if (dotIndex === -1) continue
+
+    const prefix = inputName.slice(0, dotIndex)
+    const source: UniformSource = {
+      nodeId: sourceNode.id as NodeId,
+      widgetName: sourceNode.widgets[0].name
+    }
+
+    if (prefix === 'floats') floats.push(source)
+    else if (prefix === 'ints') ints.push(source)
+    else if (prefix === 'bools') bools.push(source)
+    else if (prefix === 'curves') curves.push(source)
+  }
+
+  return { floats, ints, bools, curves }
+}
+
+export function useGLSLUniforms(
+  graphId: ComputedRef<UUID | undefined>,
+  nodeId: ComputedRef<NodeId | undefined>,
+  nodeRef: ComputedRef<LGraphNode | null>,
+  uniformSources: ComputedRef<UniformSources | null>,
+  rendererConfig: ComputedRef<GLSLRendererConfig>
+) {
+  const widgetValueStore = useWidgetValueStore()
+
+  function collectValues<T>(
+    subgraphSources: UniformSource[] | undefined,
+    groupName: string,
+    uniformPrefix: string,
+    maxCount: number,
+    coerce: (value: unknown) => T,
+    defaultValue: T
+  ): T[] {
+    const gId = graphId.value
+    if (!gId) return []
+
+    if (subgraphSources) {
+      return subgraphSources.map(({ nodeId: nId, widgetName }) => {
+        const widget = widgetValueStore.getWidget(gId, nId, widgetName)
+        return coerce(widget?.value ?? defaultValue)
+      })
+    }
+
+    const nId = nodeId.value
+    const node = nodeRef.value
+    if (nId == null || !node) return []
+
+    const values: T[] = []
+    for (let i = 0; i < maxCount; i++) {
+      const inputName = `${groupName}.${uniformPrefix}${i}`
+      const widget = widgetValueStore.getWidget(gId, nId, inputName)
+      if (widget !== undefined) {
+        values.push(coerce(widget.value))
+        continue
+      }
+
+      const slot = node.inputs?.findIndex((inp) => inp.name === inputName)
+      if (slot == null || slot < 0) break
+
+      const upstreamNode = node.getInputNode(slot)
+      if (!upstreamNode) break
+      const upstreamWidgets = widgetValueStore.getNodeWidgets(
+        gId,
+        upstreamNode.id as NodeId
+      )
+      if (upstreamWidgets.length === 0) break
+      values.push(coerce(upstreamWidgets[0].value))
+    }
+    return values
+  }
+
+  const toNumber = (v: unknown): number => Number(v) || 0
+  const toBool = (v: unknown): boolean => Boolean(v)
+
+  const floatValues = computed(() =>
+    collectValues(
+      uniformSources.value?.floats,
+      'floats',
+      'u_float',
+      rendererConfig.value.maxFloatUniforms,
+      toNumber,
+      0
+    )
+  )
+
+  const intValues = computed(() =>
+    collectValues(
+      uniformSources.value?.ints,
+      'ints',
+      'u_int',
+      rendererConfig.value.maxIntUniforms,
+      toNumber,
+      0
+    )
+  )
+
+  const boolValues = computed(() =>
+    collectValues(
+      uniformSources.value?.bools,
+      'bools',
+      'u_bool',
+      rendererConfig.value.maxBoolUniforms,
+      toBool,
+      false
+    )
+  )
+
+  const curveValues = computed((): CurveData[] => {
+    const gId = graphId.value
+    if (!gId) return []
+
+    const sources = uniformSources.value?.curves
+    if (sources && sources.length > 0) {
+      return sources
+        .map(({ nodeId: nId, widgetName }) => {
+          const widget = widgetValueStore.getWidget(gId, nId, widgetName)
+          return widget && isCurveData(widget.value)
+            ? (widget.value as CurveData)
+            : null
+        })
+        .filter((v): v is CurveData => v !== null)
+    }
+
+    const node = nodeRef.value
+    const nId = nodeId.value
+    if (nId == null || !node?.inputs) return []
+
+    const values: CurveData[] = []
+    const max = rendererConfig.value.maxCurves
+    for (let i = 0; i < max; i++) {
+      const inputName = `curves.u_curve${i}`
+
+      const widget = widgetValueStore.getWidget(gId, nId, inputName)
+      if (widget && isCurveData(widget.value)) {
+        values.push(widget.value as CurveData)
+        continue
+      }
+
+      const slot = node.inputs.findIndex((inp) => inp.name === inputName)
+      if (slot < 0) break
+
+      const upstreamNode = node.getInputNode(slot)
+      if (!upstreamNode) break
+
+      const upstreamWidgets = widgetValueStore.getNodeWidgets(
+        gId,
+        upstreamNode.id as NodeId
+      )
+      const curveWidget = upstreamWidgets.find((w) => isCurveData(w.value))
+      if (!curveWidget) break
+      values.push(curveWidget.value as CurveData)
+    }
+    return values
+  })
+
+  return {
+    floatValues,
+    intValues,
+    boolValues,
+    curveValues
+  }
+}

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -261,6 +261,17 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
   ) {
     const nodeLocatorId = executionIdToNodeLocatorId(app.rootGraph, executionId)
     if (!nodeLocatorId) return
+    setNodePreviewsByLocatorId(nodeLocatorId, previewImages)
+    latestPreview.value = previewImages
+  }
+
+  /**
+   * Set node preview images by NodeLocatorId directly.
+   */
+  function setNodePreviewsByLocatorId(
+    nodeLocatorId: NodeLocatorId,
+    previewImages: string[]
+  ) {
     const existingPreviews = app.nodePreviewImages[nodeLocatorId]
     if (scheduledRevoke[nodeLocatorId]) {
       scheduledRevoke[nodeLocatorId].stop()
@@ -274,7 +285,6 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     for (const url of previewImages) {
       retainSharedObjectUrl(url)
     }
-    latestPreview.value = previewImages
     app.nodePreviewImages[nodeLocatorId] = previewImages
     nodePreviewImages.value[nodeLocatorId] = previewImages
   }
@@ -290,22 +300,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     nodeId: string | number,
     previewImages: string[]
   ) {
-    const nodeLocatorId = nodeIdToNodeLocatorId(nodeId)
-    const existingPreviews = app.nodePreviewImages[nodeLocatorId]
-    if (scheduledRevoke[nodeLocatorId]) {
-      scheduledRevoke[nodeLocatorId].stop()
-      delete scheduledRevoke[nodeLocatorId]
-    }
-    if (existingPreviews?.[Symbol.iterator]) {
-      for (const url of existingPreviews) {
-        releaseSharedObjectUrl(url)
-      }
-    }
-    for (const url of previewImages) {
-      retainSharedObjectUrl(url)
-    }
-    app.nodePreviewImages[nodeLocatorId] = previewImages
-    nodePreviewImages.value[nodeLocatorId] = previewImages
+    setNodePreviewsByLocatorId(nodeIdToNodeLocatorId(nodeId), previewImages)
   }
 
   /**
@@ -486,6 +481,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     setNodeOutputs,
     setNodeOutputsByExecutionId,
     setNodePreviewsByExecutionId,
+    setNodePreviewsByLocatorId,
     setNodePreviewsByNodeId,
     updateNodeImages,
     refreshNodeOutputs,
@@ -493,6 +489,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
 
     // Cleanup
     revokePreviewsByExecutionId,
+    revokePreviewsByLocatorId,
     revokeAllPreviews,
     revokeSubgraphPreviews,
     removeNodeOutputs,


### PR DESCRIPTION
## Summary
replacement for https://github.com/Comfy-Org/ComfyUI_frontend/pull/9201

the first commit squashed https://github.com/Comfy-Org/ComfyUI_frontend/pull/9201 and fixed conflict.

the second commit change needed by:
 - Enable GLSL live preview on SubgraphNodes by detecting the inner GLSLShader and rendering its preview directly on the parent SubgraphNode                                                  
- Previously, SubgraphNodes containing a GLSLShader showed no live preview at all To achieve this:                                                                                                                                                                           
   - Read shader source, uniform values, and renderer config from the inner GLSLShader's widgets                                                                                              
   - Trace IMAGE inputs through the subgraph boundary so the inner shader can use images connected to the SubgraphNode's outer inputs                                                         
   - Set preview output using the inner node's locator ID so the promoted preview system picks it up on the SubgraphNode                                                                      
   - Extract setNodePreviewsByLocatorId from nodeOutputStore to support setting previews by locator ID directly                                                                               
- Fix graphId to use rootGraph.id for widget store lookups (was using graph.id, which broke lookups for nodes inside subgraphs)                                                              
- Read uniform values from connected upstream nodes, not just local widgets                                                                                                                  
- Fix blob URL lifecycle: use the store's createSharedObjectUrl/releaseSharedObjectUrl reference-counting system instead of manual revoke, preventing leaks on composable re-creation        
        

## Screenshot

https://github.com/user-attachments/assets/9623fa32-de39-4a3a-b8b3-28688851390b

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10349-Feat-glsl-live-preview-3296d73d3650814b83aef52ab1962a77) by [Unito](https://www.unito.io)
