### PR TITLE
fix: bring cloned/pasted nodes to front in Vue renderer

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4271,6 +4271,28 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     if (newPositions.length) layoutStore.setSource(LayoutSource.Canvas)
     layoutStore.batchUpdateNodeBounds(newPositions)
 
+    // Bring cloned/pasted nodes to front so they appear above existing nodes
+    if (newPositions.length) {
+      const allNodes = layoutStore.getAllNodes().value
+      let maxZIndex = 0
+      for (const [, layout] of allNodes) {
+        if (layout.zIndex > maxZIndex) maxZIndex = layout.zIndex
+      }
+
+      for (const { nodeId } of newPositions) {
+        layoutStore.applyOperation({
+          type: 'setNodeZIndex',
+          entity: 'node',
+          nodeId,
+          zIndex: ++maxZIndex,
+          previousZIndex: 0,
+          timestamp: Date.now(),
+          source: LayoutSource.Canvas,
+          actor: layoutStore.getCurrentActor()
+        })
+      }
+    }
+
     this.selectItems(created)
     forEachNode(graph, (n) => n.onGraphConfigured?.())
     forEachNode(graph, (n) => n.onAfterGraphConfigured?.())


### PR DESCRIPTION
## Summary

Cloned/pasted nodes now appear above existing nodes in Node 2.0 (Vue renderer) mode instead of behind them.

## Changes

- **What**: After `_deserializeItems` creates new nodes via clone or paste, their z-index is set above all existing nodes so they render on top and are immediately accessible.

## Review Focus

The fix follows the same pattern as `bringNodeToFront` in `layoutMutations.ts` and the existing alt-click clone handler in `LGraphNode.vue`. It applies to both context menu "Clone" and paste operations.

Fixes #10307