### PR TITLE
fix: deprioritize API nodes in search results and sidebar

### DIFF
--- a/src/platform/surveys/surveyRegistry.test.ts
+++ b/src/platform/surveys/surveyRegistry.test.ts
@@ -43,6 +43,13 @@ describe('surveyRegistry', () => {
     })
   })
 
+  describe('node-search survey', () => {
+    it('should be disabled', () => {
+      const config = getSurveyConfig('node-search')
+      expect(config?.enabled).toBe(false)
+    })
+  })
+
   describe('getEnabledSurveys', () => {
     it('includes surveys with enabled: true', () => {
       const enabled = getEnabledSurveys()

--- a/src/platform/surveys/surveyRegistry.ts
+++ b/src/platform/surveys/surveyRegistry.ts
@@ -9,7 +9,8 @@ export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {
     featureId: 'node-search',
     typeformId: 'goZLqjKL',
     triggerThreshold: 3,
-    delayMs: 5000
+    delayMs: 5000,
+    enabled: false
   }
 }
 

--- a/src/services/nodeOrganizationService.test.ts
+++ b/src/services/nodeOrganizationService.test.ts
@@ -308,6 +308,55 @@ describe('nodeOrganizationService', () => {
     })
   })
 
+  describe('organizeNodesByTab section ordering', () => {
+    it('should place partner nodes after comfy nodes and extensions', () => {
+      const nodes = [
+        createMockNodeDef({
+          name: 'ApiNode',
+          api_node: true,
+          category: 'api node/provider',
+          nodeSource: {
+            type: NodeSourceType.Core,
+            className: 'comfy-core',
+            displayText: 'Core',
+            badgeText: 'C'
+          }
+        }),
+        createMockNodeDef({
+          name: 'CoreNode',
+          category: 'loaders',
+          python_module: 'nodes',
+          nodeSource: {
+            type: NodeSourceType.Core,
+            className: 'comfy-core',
+            displayText: 'Core',
+            badgeText: 'C'
+          }
+        }),
+        createMockNodeDef({
+          name: 'ExtensionNode',
+          category: 'custom',
+          nodeSource: {
+            type: NodeSourceType.CustomNodes,
+            className: 'comfy-custom',
+            displayText: 'Custom',
+            badgeText: 'E'
+          }
+        })
+      ]
+
+      const sections = nodeOrganizationService.organizeNodesByTab(nodes, 'all')
+      const categoryOrder = sections.map((s) => s.category)
+
+      const comfyIndex = categoryOrder.indexOf('comfyNodes')
+      const extensionsIndex = categoryOrder.indexOf('extensions')
+      const partnerIndex = categoryOrder.indexOf('partnerNodes')
+
+      expect(partnerIndex).toBeGreaterThan(comfyIndex)
+      expect(partnerIndex).toBeGreaterThan(extensionsIndex)
+    })
+  })
+
   describe('sorting comparison', () => {
     it('original sort should keep order', () => {
       const strategy = nodeOrganizationService.getSortingStrategy('original')

--- a/src/services/nodeOrganizationService.ts
+++ b/src/services/nodeOrganizationService.ts
@@ -230,16 +230,6 @@ class NodeOrganizationService {
     if (blueprintTree.children?.length) {
       sections.push({ category: 'blueprints', tree: blueprintTree })
     }
-    if (partnerNodes.length > 0) {
-      sections.push({
-        category: 'partnerNodes',
-        tree: unwrapTreeRoot(
-          buildNodeDefTree(partnerNodes, {
-            pathExtractor: categoryPathExtractor
-          })
-        )
-      })
-    }
     if (comfyNodes.length > 0) {
       sections.push({
         category: 'comfyNodes',
@@ -254,6 +244,16 @@ class NodeOrganizationService {
         tree: buildNodeDefTree(extensions, {
           pathExtractor: categoryPathExtractor
         })
+      })
+    }
+    if (partnerNodes.length > 0) {
+      sections.push({
+        category: 'partnerNodes',
+        tree: unwrapTreeRoot(
+          buildNodeDefTree(partnerNodes, {
+            pathExtractor: categoryPathExtractor
+          })
+        )
       })
     }
 

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -3,7 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 import type { NodeDefFilter } from '@/stores/nodeDefStore'
 
 describe('useNodeDefStore', () => {
@@ -328,6 +328,47 @@ describe('useNodeDefStore', () => {
       // allNodeDefsByName includes all
       expect(store.allNodeDefsByName).toHaveProperty('Normal')
       expect(store.allNodeDefsByName).toHaveProperty('Deprecated')
+    })
+  })
+
+  describe('postProcessSearchScores', () => {
+    const baseNodeDef: ComfyNodeDef = {
+      name: 'TestNode',
+      display_name: 'Test Node',
+      category: 'test',
+      python_module: 'nodes',
+      description: '',
+      input: {},
+      output: [],
+      output_is_list: [],
+      output_name: [],
+      output_node: false
+    }
+
+    it('should add penalty for API nodes', () => {
+      const apiNode = new ComfyNodeDefImpl({ ...baseNodeDef, api_node: true })
+      const localNode = new ComfyNodeDefImpl({
+        ...baseNodeDef,
+        api_node: false
+      })
+
+      const scores = [2, 0.5, 3, 0.1]
+      const apiScores = apiNode.postProcessSearchScores([...scores])
+      const localScores = localNode.postProcessSearchScores([...scores])
+
+      expect(apiScores[0]).toBeGreaterThan(localScores[0])
+    })
+
+    it('should not add penalty for non-API nodes', () => {
+      const localNode = new ComfyNodeDefImpl({
+        ...baseNodeDef,
+        api_node: false
+      })
+
+      const scores = [2, 0.5, 3, 0.1]
+      const result = localNode.postProcessSearchScores([...scores])
+
+      expect(result[0]).toBe(scores[0])
     })
   })
 

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -197,7 +197,8 @@ export class ComfyNodeDefImpl
   postProcessSearchScores(scores: SearchAuxScore): SearchAuxScore {
     const nodeFrequencyStore = useNodeFrequencyStore()
     const nodeFrequency = nodeFrequencyStore.getNodeFrequencyByName(this.name)
-    return [scores[0], -nodeFrequency, ...scores.slice(1)]
+    const apiNodePenalty = this.api_node ? 10 : 0
+    return [scores[0] + apiNodePenalty, -nodeFrequency, ...scores.slice(1)]
   }
 
   get nodeLifeCycleBadgeText(): string {


### PR DESCRIPTION
## Summary

Deprioritize API nodes so local/native nodes appear first in search results and the node library sidebar. Disable the node-search survey popup.

## Changes

- **What**: Add a score penalty for API nodes in `postProcessSearchScores` so they rank lower in search results. Reorder sidebar sections to place partner (API) nodes after core nodes and extensions. Disable the node-search survey popup by setting `enabled: false` in the survey registry.
- **Breaking**: None

## Review Focus

The search score penalty of 10 is intentionally large (the main score ranges 0-9) to ensure API nodes consistently sort below local nodes with equivalent relevance. The sidebar section reorder is a simple move of the `partnerNodes` push to after `comfyNodes` and `extensions`.

Fixes #10333