### PR TITLE
fix: prevent survey popup when surveyed feature is inactive

### DIFF
--- a/src/platform/surveys/surveyRegistry.ts
+++ b/src/platform/surveys/surveyRegistry.ts
@@ -1,3 +1,5 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+
 import type { FeatureSurveyConfig } from './useSurveyEligibility'
 
 /**
@@ -9,7 +11,13 @@ export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {
     featureId: 'node-search',
     typeformId: 'goZLqjKL',
     triggerThreshold: 3,
-    delayMs: 5000
+    delayMs: 5000,
+    isFeatureActive: () => {
+      const settingStore = useSettingStore()
+      return (
+        settingStore.get('Comfy.NodeSearchBoxImpl') !== 'litegraph (legacy)'
+      )
+    }
   }
 }
 

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -181,6 +181,17 @@ describe('useSurveyEligibility', () => {
 
       expect(isEligible.value).toBe(false)
     })
+
+    it('is not eligible when isFeatureActive returns false', () => {
+      setFeatureUsage('test-feature', 5)
+
+      const { isEligible } = useSurveyEligibility({
+        ...defaultConfig,
+        isFeatureActive: () => false
+      })
+
+      expect(isEligible.value).toBe(false)
+    })
   })
 
   describe('actions', () => {

--- a/src/platform/surveys/useSurveyEligibility.ts
+++ b/src/platform/surveys/useSurveyEligibility.ts
@@ -13,6 +13,7 @@ export interface FeatureSurveyConfig {
   triggerThreshold?: number
   delayMs?: number
   enabled?: boolean
+  isFeatureActive?: () => boolean
 }
 
 interface SurveyState {
@@ -61,8 +62,13 @@ export function useSurveyEligibility(
 
   const hasOptedOut = computed(() => state.value.optedOut)
 
+  const isFeatureActive = computed(
+    () => resolvedConfig.value.isFeatureActive?.() ?? true
+  )
+
   const isEligible = computed(() => {
     if (!isSurveyEnabled.value) return false
+    if (!isFeatureActive.value) return false
     if (!isNightlyLocalhost.value) return false
     if (!hasReachedThreshold.value) return false
     if (hasSeenSurvey.value) return false


### PR DESCRIPTION
## Summary

Prevent the nightly survey popup from appearing when the feature being surveyed is currently disabled.

## Root Cause

`useSurveyEligibility` checks the feature usage count from localStorage but does not verify whether the surveyed feature is currently active. When a user uses the new node search 3+ times (reaching the survey threshold), then switches back to legacy search, the usage count persists in localStorage and the survey popup still appears despite the feature being off.

## Steps to Reproduce

1. Enable new node search (Settings > Node Search Box Implementation > "default")
2. Use node search 3+ times (double-click canvas, search for nodes)
3. Switch back to legacy search (Settings > Node Search Box Implementation > "litegraph (legacy)")
4. Wait 5 seconds on a nightly localhost build
5. **Expected**: No survey popup appears (feature is disabled)
6. **Actual**: Survey popup appears because eligibility only checks stored usage count, not current feature state

## Changes

1. Added optional `isFeatureActive` callback to `FeatureSurveyConfig` interface
2. Added `isFeatureActive` guard in `useSurveyEligibility` eligibility computation
3. Configured `node-search` survey with `isFeatureActive` that checks the current search box setting

## Red-Green Verification

| Commit | Result | Description |
|---|---|---|
| `99e7d7fe9` `test:` | RED | Asserts `isEligible` is false when `isFeatureActive` returns false. Fails on current code. |
| `01df9af12` `fix:` | GREEN | Adds `isFeatureActive` check to eligibility. Test passes. |

Fixes #10333