### PR TITLE
feat: add BaseTooltip component using Reka UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,15 @@
 <template>
-  <router-view />
-  <GlobalDialog />
-  <BlockUI full-screen :blocked="isLoading" />
+  <TooltipProvider :delay-duration="300" disable-hoverable-content>
+    <router-view />
+    <GlobalDialog />
+    <BlockUI full-screen :blocked="isLoading" />
+  </TooltipProvider>
 </template>
 
 <script setup lang="ts">
 import { captureException } from '@sentry/vue'
 import BlockUI from 'primevue/blockui'
+import { TooltipProvider } from 'reka-ui'
 import { computed, onMounted, onUnmounted, watch } from 'vue'
 
 import { useI18n } from 'vue-i18n'

--- a/src/components/ui/tooltip/BaseTooltip.stories.ts
+++ b/src/components/ui/tooltip/BaseTooltip.stories.ts
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { TooltipProvider } from 'reka-ui'
+
+import Button from '@/components/ui/button/Button.vue'
+import BaseTooltip from './BaseTooltip.vue'
+
+const meta: Meta<typeof BaseTooltip> = {
+  title: 'Components/Tooltip/BaseTooltip',
+  component: BaseTooltip,
+  tags: ['autodocs'],
+  decorators: [
+    (story) => ({
+      components: { TooltipProvider, story },
+      template:
+        '<TooltipProvider :delay-duration="0"><story /></TooltipProvider>'
+    })
+  ],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'small', 'large']
+    },
+    side: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'left', 'right']
+    },
+    sideOffset: { control: { type: 'number' } },
+    disabled: { control: { type: 'boolean' } },
+    text: { control: { type: 'text' } }
+  },
+  args: {
+    variant: 'default',
+    side: 'top',
+    sideOffset: 4,
+    disabled: false,
+    text: 'Tooltip text'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const SingleTooltip: Story = {
+  render: (args) => ({
+    components: { BaseTooltip, Button },
+    setup() {
+      return { args }
+    },
+    template: `
+      <div class="flex items-center justify-center p-20">
+        <BaseTooltip v-bind="args">
+          <Button variant="secondary">Hover me</Button>
+        </BaseTooltip>
+      </div>
+    `
+  })
+}
+
+export const AllVariants: Story = {
+  render: () => ({
+    components: { BaseTooltip, Button },
+    template: `
+      <div class="flex items-center justify-center gap-8 p-20">
+        <BaseTooltip text="Default tooltip" variant="default">
+          <Button variant="secondary">Default</Button>
+        </BaseTooltip>
+        <BaseTooltip text="Small tooltip" variant="small">
+          <Button variant="secondary">Small</Button>
+        </BaseTooltip>
+        <BaseTooltip text="Large tooltip with longer text that demonstrates the max-width constraint of the large variant" variant="large">
+          <Button variant="secondary">Large</Button>
+        </BaseTooltip>
+      </div>
+    `
+  })
+}
+
+export const AllSides: Story = {
+  render: () => ({
+    components: { BaseTooltip, Button },
+    template: `
+      <div class="flex items-center justify-center gap-8 p-20">
+        <BaseTooltip text="Top tooltip" side="top" variant="small">
+          <Button variant="secondary">Top</Button>
+        </BaseTooltip>
+        <BaseTooltip text="Bottom tooltip" side="bottom" variant="small">
+          <Button variant="secondary">Bottom</Button>
+        </BaseTooltip>
+        <BaseTooltip text="Left tooltip" side="left" variant="small">
+          <Button variant="secondary">Left</Button>
+        </BaseTooltip>
+        <BaseTooltip text="Right tooltip" side="right" variant="small">
+          <Button variant="secondary">Right</Button>
+        </BaseTooltip>
+      </div>
+    `
+  })
+}
+
+export const Disabled: Story = {
+  args: {
+    text: 'This tooltip is disabled',
+    disabled: true
+  },
+  render: (args) => ({
+    components: { BaseTooltip, Button },
+    setup() {
+      return { args }
+    },
+    template: `
+      <div class="flex items-center justify-center p-20">
+        <BaseTooltip v-bind="args">
+          <Button variant="secondary">No tooltip (disabled)</Button>
+        </BaseTooltip>
+      </div>
+    `
+  })
+}
+
+export const LongText: Story = {
+  render: () => ({
+    components: { BaseTooltip, Button },
+    template: `
+      <div class="flex items-center justify-center p-20">
+        <BaseTooltip
+          text="Encodes a text prompt using a CLIP model into an embedding that can be used to guide the diffusion model towards generating specific images."
+          variant="large"
+        >
+          <Button variant="secondary">Hover for long text</Button>
+        </BaseTooltip>
+      </div>
+    `
+  })
+}

--- a/src/components/ui/tooltip/BaseTooltip.vue
+++ b/src/components/ui/tooltip/BaseTooltip.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import {
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  TooltipRoot,
+  TooltipTrigger
+} from 'reka-ui'
+
+import type { TooltipVariants } from '@/components/ui/tooltip/tooltip.variants'
+import { tooltipVariants } from '@/components/ui/tooltip/tooltip.variants'
+import { cn } from '@/utils/tailwindUtil'
+
+const {
+  text = '',
+  side = 'top',
+  sideOffset = 4,
+  variant = 'default',
+  delayDuration,
+  disabled = false,
+  class: className
+} = defineProps<{
+  text?: string
+  side?: 'top' | 'bottom' | 'left' | 'right'
+  sideOffset?: number
+  variant?: NonNullable<TooltipVariants['variant']>
+  delayDuration?: number
+  disabled?: boolean
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <TooltipRoot :delay-duration="delayDuration" :disabled="disabled || !text">
+    <TooltipTrigger as-child>
+      <slot />
+    </TooltipTrigger>
+    <TooltipPortal>
+      <TooltipContent
+        :side="side"
+        :side-offset="sideOffset"
+        :class="cn(tooltipVariants({ variant }), className)"
+      >
+        {{ text }}
+        <TooltipArrow
+          v-if="variant !== 'default'"
+          :width="8"
+          :height="5"
+          class="fill-node-component-tooltip-surface"
+        />
+      </TooltipContent>
+    </TooltipPortal>
+  </TooltipRoot>
+</template>

--- a/src/components/ui/tooltip/tooltip.variants.ts
+++ b/src/components/ui/tooltip/tooltip.variants.ts
@@ -1,0 +1,20 @@
+import type { VariantProps } from 'cva'
+import { cva } from 'cva'
+
+export const tooltipVariants = cva({
+  base: 'z-50 select-none',
+  variants: {
+    variant: {
+      default: 'rounded-md bg-[#3f3f46] px-3 py-2 text-sm text-white shadow-sm',
+      small:
+        'rounded-lg border border-node-component-tooltip-border bg-node-component-tooltip-surface px-4 py-2 text-xs text-node-component-tooltip shadow-none',
+      large:
+        'max-w-75 rounded-sm border border-node-component-tooltip-border bg-node-component-tooltip-surface px-4 py-2 text-sm/tight font-normal text-node-component-tooltip shadow-none'
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+})
+
+export type TooltipVariants = VariantProps<typeof tooltipVariants>


### PR DESCRIPTION
## Summary

Add foundational BaseTooltip component built on Reka UI as the first PR in the tooltip migration series.

## Changes

- **What**: New `BaseTooltip` component with three variants (`default`, `small`, `large`), four positioning sides, configurable delay and disabled state. App-wide `TooltipProvider` added to `App.vue`. Storybook stories for all variants, sides, disabled, and long text scenarios.
- **Dependencies**: Uses existing `reka-ui` (already a project dependency)

## Review Focus

- Variant styling classes in `tooltip.variants.ts` (semantic token usage for `small`/`large` vs hardcoded colors for `default`)
- `TooltipProvider` placement in `App.vue` wrapping all content with 300ms delay and `disable-hoverable-content`
- Arrow visibility conditional on non-default variants

Fixes #9700

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10362-feat-add-BaseTooltip-component-using-Reka-UI-32a6d73d365081cba343fa80f0f1c40e) by [Unito](https://www.unito.io)
