### PR TITLE
feat: support histogram display in curve widget

### DIFF
--- a/src/components/curve/WidgetCurve.vue
+++ b/src/components/curve/WidgetCurve.vue
@@ -22,19 +22,21 @@
       :model-value="effectiveCurve.points"
       :disabled="isDisabled"
       :interpolation="effectiveCurve.interpolation"
+      :histogram="histogram"
       @update:model-value="onPointsChange"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 
 import {
   singleValueExtractor,
   useUpstreamValue
 } from '@/composables/useUpstreamValue'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
 import Select from '@/components/ui/select/Select.vue'
 import SelectContent from '@/components/ui/select/SelectContent.vue'
@@ -63,10 +65,26 @@ const modelValue = defineModel<CurveData>({
 
 const isDisabled = computed(() => !!widget.options?.disabled)
 
+const nodeOutputStore = useNodeOutputStore()
+const histogram = computed(() => {
+  const locatorId = widget.nodeLocatorId
+  if (!locatorId) return null
+  const output = nodeOutputStore.nodeOutputs[locatorId]
+  const data = output?.histogram
+  if (!Array.isArray(data) || data.length === 0) return null
+  return new Uint32Array(data)
+})
+
 const upstreamValue = useUpstreamValue(
   () => widget.linkedUpstream,
   singleValueExtractor(isCurveData)
 )
+
+watch(upstreamValue, (upstream) => {
+  if (isDisabled.value && upstream) {
+    modelValue.value = upstream
+  }
+})
 
 const effectiveCurve = computed(() =>
   isDisabled.value && upstreamValue.value

--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -150,21 +150,27 @@ export function createMonotoneInterpolator(
 }
 
 /**
- * Convert a 256-bin histogram into an SVG path string.
- * Normalizes using the 99.5th percentile to avoid outlier spikes.
+ * Convert a histogram (arbitrary number of bins) into an SVG path string.
+ * Applies square-root scaling and normalizes using the 99.5th percentile
+ * to avoid outlier spikes.
  */
 export function histogramToPath(histogram: Uint32Array): string {
-  if (!histogram.length) return ''
+  const len = histogram.length
+  if (len === 0) return ''
 
-  const sorted = Array.from(histogram).sort((a, b) => a - b)
-  const max = sorted[Math.floor(255 * 0.995)]
+  const sqrtValues = new Float32Array(len)
+  for (let i = 0; i < len; i++) sqrtValues[i] = Math.sqrt(histogram[i])
+
+  const sorted = Array.from(sqrtValues).sort((a, b) => a - b)
+  const max = sorted[Math.floor((len - 1) * 0.995)]
   if (max === 0) return ''
 
   const invMax = 1 / max
+  const lastIdx = len - 1
   const parts: string[] = ['M0,1']
-  for (let i = 0; i < 256; i++) {
-    const x = i / 255
-    const y = 1 - Math.min(1, histogram[i] * invMax)
+  for (let i = 0; i < len; i++) {
+    const x = lastIdx === 0 ? 0.5 : i / lastIdx
+    const y = 1 - Math.min(1, sqrtValues[i] * invMax)
     parts.push(`L${x},${y}`)
   }
   parts.push('L1,1 Z')

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -123,7 +123,10 @@ import type {
   WidgetValue
 } from '@/types/simplifiedWidget'
 import { cn } from '@/utils/tailwindUtil'
-import { getExecutionIdFromNodeData } from '@/utils/graphTraversalUtil'
+import {
+  getExecutionIdFromNodeData,
+  getLocatorIdFromNodeData
+} from '@/utils/graphTraversalUtil'
 import { app } from '@/scripts/app'
 
 import InputSlot from './InputSlot.vue'
@@ -405,6 +408,12 @@ const processedWidgets = computed((): ProcessedWidget[] => {
           }
         : undefined
 
+    const nodeLocatorId = widget.nodeId
+      ? widget.nodeId
+      : nodeData
+        ? getLocatorIdFromNodeData(nodeData)
+        : undefined
+
     const simplified: SimplifiedWidget = {
       name: widget.name,
       type: widget.type,
@@ -414,6 +423,7 @@ const processedWidgets = computed((): ProcessedWidget[] => {
       controlWidget: widget.controlWidget,
       label: widget.promotedLabel ?? widgetState?.label,
       linkedUpstream,
+      nodeLocatorId,
       options: widgetOptions,
       spec: widget.spec
     }

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -76,6 +76,9 @@ export interface SimplifiedWidget<
   /** Optional serialization method for custom value handling */
   serializeValue?: () => unknown
 
+  /** NodeLocatorId for the node that owns this widget's execution outputs */
+  nodeLocatorId?: string
+
   /** Optional input specification backing this widget */
   spec?: InputSpecV2
 


### PR DESCRIPTION
## Summary
- WidgetCurve reads histogram data from nodeOutputStore (sent by backend CurveEditor node via ui output) and passes it to CurveEditor
- histogramToPath now supports arbitrary-length bin arrays instead ofhardcoded 256

need BE changes

## Screenshots (if applicable)
<img width="2431" height="1022" alt="image" src="https://github.com/user-attachments/assets/8421d4a7-1bff-4269-8b55-649838f9d619" />

<img width="2462" height="979" alt="image" src="https://github.com/user-attachments/assets/191c9163-82ab-4eb2-bb74-0037b3ccd383" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10365-feat-support-histogram-display-in-curve-widget-32a6d73d3650816b9852d73309a0b35f) by [Unito](https://www.unito.io)
