### PR TITLE
fix: address review feedback for ComfyHub publish wizard

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3185,7 +3185,9 @@
     "shareAs": "Share as",
     "additionalInfo": "Additional information",
     "createProfileToPublish": "Create a profile to publish to ComfyHub",
-    "createProfileCta": "Create a profile"
+    "createProfileCta": "Create a profile",
+    "publishFailedTitle": "Publish failed",
+    "publishFailedDescription": "Something went wrong while publishing your workflow. Please try again."
   },
   "comfyHubProfile": {
     "checkingAccess": "Checking your publishing access...",

--- a/src/platform/workflow/sharing/components/publish/ComfyHubFinishStep.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubFinishStep.vue
@@ -57,17 +57,18 @@
 
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
+import { computed, watch } from 'vue'
 
 import type { ComfyHubProfile } from '@/schemas/apiSchema'
 import ShareAssetWarningBox from '@/platform/workflow/sharing/components/ShareAssetWarningBox.vue'
 import { useWorkflowShareService } from '@/platform/workflow/sharing/services/workflowShareService'
-import { computed } from 'vue'
 
 const { profile } = defineProps<{
   profile: ComfyHubProfile
 }>()
 
 const acknowledged = defineModel<boolean>('acknowledged', { default: false })
+const ready = defineModel<boolean>('ready', { default: false })
 
 const shareService = useWorkflowShareService()
 
@@ -82,5 +83,11 @@ const isReady = computed(
     !isLoadingAssets.value && (!hasPrivateAssets.value || acknowledged.value)
 )
 
-defineExpose({ isReady })
+watch(
+  isReady,
+  (val) => {
+    ready.value = val
+  },
+  { immediate: true }
+)
 </script>

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue
@@ -214,6 +214,13 @@ async function handlePublish(): Promise<void> {
       cachePublishPrefill(path, formData.value)
     }
     onClose()
+  } catch (error) {
+    console.error('Failed to publish workflow:', error)
+    toast.add({
+      severity: 'error',
+      summary: t('comfyHubPublish.publishFailedTitle'),
+      detail: t('comfyHubPublish.publishFailedDescription')
+    })
   } finally {
     isPublishing.value = false
   }
@@ -235,7 +242,8 @@ async function fetchPublishPrefill() {
     if (prefill) {
       applyPrefill(prefill)
     }
-  } catch {
+  } catch (error) {
+    console.warn('Failed to fetch publish prefill:', error)
     const cached = getCachedPrefill(path)
     if (cached) {
       applyPrefill(cached)

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishWizardContent.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishWizardContent.test.ts
@@ -119,9 +119,13 @@ describe('ComfyHubPublishWizardContent', () => {
           },
           ComfyHubFinishStep: {
             template: '<div data-testid="finish-step" />',
-            props: ['profile', 'acknowledged'],
-            setup() {
-              return { isReady: true }
+            props: ['profile', 'acknowledged', 'ready'],
+            emits: ['update:ready', 'update:acknowledged'],
+            setup(
+              _: unknown,
+              { emit }: { emit: (e: string, v: boolean) => void }
+            ) {
+              emit('update:ready', true)
             }
           },
           ComfyHubExamplesStep: {
@@ -289,9 +293,10 @@ describe('ComfyHubPublishWizardContent', () => {
       expect(footer.attributes('data-publish-disabled')).toBe('true')
     })
 
-    it('enables publish when gate enabled and hasProfile is true', () => {
+    it('enables publish when gate enabled and hasProfile is true', async () => {
       mockHasProfile.value = true
       const wrapper = createWrapper()
+      await flushPromises()
 
       const footer = wrapper.find('[data-testid="publish-footer"]')
       expect(footer.attributes('data-publish-disabled')).toBe('false')

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishWizardContent.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishWizardContent.vue
@@ -47,7 +47,7 @@
         </div>
         <ComfyHubFinishStep
           v-else-if="currentStep === 'finish' && hasProfile && profile"
-          ref="finishStepRef"
+          v-model:ready="finishStepReady"
           v-model:acknowledged="assetsAcknowledged"
           :profile
         />
@@ -121,17 +121,23 @@ const { checkProfile, hasProfile, isFetchingProfile, profile } =
 const isProfileLoading = computed(
   () => hasProfile.value === null || isFetchingProfile.value
 )
-const finishStepRef = ref<InstanceType<typeof ComfyHubFinishStep> | null>(null)
+const finishStepReady = ref(false)
 const assetsAcknowledged = ref(false)
 const isResolvingPublishAccess = ref(false)
 const isPublishInFlight = computed(
   () => isPublishing || isResolvingPublishAccess.value
 )
+const isFinishStepVisible = computed(
+  () =>
+    currentStep === 'finish' &&
+    hasProfile.value === true &&
+    profile.value !== null
+)
 const isPublishDisabled = computed(
   () =>
     isPublishInFlight.value ||
     (flags.comfyHubProfileGateEnabled && hasProfile.value !== true) ||
-    (finishStepRef.value !== null && !finishStepRef.value.isReady)
+    (isFinishStepVisible.value && !finishStepReady.value)
 )
 
 async function handlePublish() {

--- a/src/platform/workflow/sharing/composables/useComfyHubProfileGate.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubProfileGate.test.ts
@@ -98,6 +98,16 @@ describe('useComfyHubProfileGate', () => {
       expect(mockGetMyProfile).toHaveBeenCalledTimes(2)
     })
 
+    it('sets hasProfile to false when fetch throws', async () => {
+      mockGetMyProfile.mockRejectedValue(new Error('Network error'))
+
+      await gate.fetchProfile()
+
+      expect(gate.hasProfile.value).toBe(false)
+      expect(gate.profile.value).toBe(null)
+      expect(mockToastErrorHandler).toHaveBeenCalledOnce()
+    })
+
     it('sets isFetchingProfile during fetch', async () => {
       let resolvePromise: (v: ComfyHubProfile | null) => void
       mockGetMyProfile.mockReturnValue(

--- a/src/platform/workflow/sharing/composables/useComfyHubProfileGate.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubProfileGate.ts
@@ -77,6 +77,7 @@ export function useComfyHubProfileGate() {
       profile.value = nextProfile
       return nextProfile
     } catch (error) {
+      hasProfile.value = false
       toastErrorHandler(error)
       return null
     } finally {

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.ts
@@ -36,6 +36,15 @@ function getAssetIds(assets: AssetInfo[]): string[] {
   return assets.map((asset) => asset.id)
 }
 
+function resolveThumbnailFile(
+  formData: ComfyHubPublishFormData
+): File | undefined {
+  if (formData.thumbnailType === 'imageComparison') {
+    return formData.comparisonBeforeFile ?? undefined
+  }
+  return formData.thumbnailFile ?? undefined
+}
+
 export function useComfyHubPublishSubmission() {
   const { profile } = useComfyHubProfileGate()
   const workflowStore = useWorkflowStore()
@@ -69,12 +78,10 @@ export function useComfyHubPublishSubmission() {
       await workflowShareService.getShareableAssets()
     )
 
-    const thumbnailTokenOrUrl =
-      formData.thumbnailFile && formData.thumbnailType !== 'imageComparison'
-        ? await uploadFileAndGetToken(formData.thumbnailFile)
-        : formData.comparisonBeforeFile
-          ? await uploadFileAndGetToken(formData.comparisonBeforeFile)
-          : undefined
+    const thumbnailFile = resolveThumbnailFile(formData)
+    const thumbnailTokenOrUrl = thumbnailFile
+      ? await uploadFileAndGetToken(thumbnailFile)
+      : undefined
     const thumbnailComparisonTokenOrUrl =
       formData.thumbnailType === 'imageComparison' &&
       formData.comparisonAfterFile


### PR DESCRIPTION
## Summary
Addresses review feedback from @christian-byrne on #10128 ([review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/10128#pullrequestreview-3986833156)):

- **fix: infinite loading on profile fetch error** — Set `hasProfile.value = false` in catch block of `performFetch()` so the profile-creation form appears instead of an infinite spinner
- **fix: unhandled publish error** — Add catch block to `handlePublish` with toast error feedback, matching the existing save handler pattern
- **refactor: extract `resolveThumbnailFile` helper** — Replace fragile nested ternary with explicit function that correctly resolves thumbnail file by type
- **refactor: replace `defineExpose`/template-ref with `v-model:ready`** — FinishStep now communicates readiness via `v-model:ready` instead of breaking unidirectional data flow with `defineExpose({ isReady })`
- **fix: silent prefill error** — Add `console.warn` in `fetchPublishPrefill` catch block for debuggability

### Deferred to follow-up PRs
- Extract `useWorkflowSaveGate()` composable for duplicated save-before-proceed logic
- Pass pre-fetched `getShareableAssets()` result to avoid redundant call in `submitToComfyHub`
- Add `useTelemetry()` instrumentation for publish flow
- `insertImagesAt` naming refactor (tracked in #10372)

## Test plan
- [x] Unit tests pass for all changed files
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] New test: `sets hasProfile to false when fetch throws`

Fixes #10128 (review feedback)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10377-fix-address-review-feedback-for-ComfyHub-publish-wizard-32a6d73d36508165823cda52758e7db9) by [Unito](https://www.unito.io)
