### PR TITLE
fix(assets): centralize model tag parsing

### DIFF
--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -386,5 +386,23 @@ describe('AssetBrowserModal', () => {
         'assetBrowser.allCategory:{"category":"Checkpoints"}'
       )
     })
+
+    it('ignores non-model assets when deriving the default title', async () => {
+      const assets = [
+        {
+          ...createTestAsset('asset1', 'Input Image', 'checkpoints'),
+          tags: ['input', 'images']
+        }
+      ]
+      mockAssetsByKey.set('CheckpointLoaderSimple', assets)
+
+      const wrapper = createWrapper({ nodeType: 'CheckpointLoaderSimple' })
+      await flushPromises()
+
+      const layout = wrapper.findComponent({ name: 'BaseModalLayout' })
+      expect(layout.props('contentTitle')).toBe(
+        'assetBrowser.allCategory:{"category":"Checkpoints"}'
+      )
+    })
   })
 })

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -101,6 +101,7 @@ import { useModelTypes } from '@/platform/assets/composables/useModelTypes'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { formatCategoryLabel } from '@/platform/assets/utils/categoryLabel'
+import { getAssetModelType } from '@/platform/assets/utils/assetMetadataUtils'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { OnCloseKey } from '@/types/widgetTypes'
@@ -173,7 +174,7 @@ const isRightPanelOpen = ref(false)
 const primaryCategoryTag = computed(() => {
   const assets = fetchedAssets.value ?? []
   const tagFromAssets = assets
-    .map((asset) => asset.tags?.find((tag) => tag !== 'models'))
+    .map((asset) => getAssetModelType(asset))
     .find((tag): tag is string => typeof tag === 'string' && tag.length > 0)
 
   if (tagFromAssets) return tagFromAssets

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -151,6 +151,38 @@ describe('useAssetBrowser', () => {
         type: 'type'
       })
     })
+
+    it('creates model type badges regardless of tag order', () => {
+      const apiAsset = createApiAsset({
+        tags: ['checkpoints', 'models']
+      })
+
+      const { filteredAssets } = useAssetBrowser(ref([apiAsset]))
+      const result = filteredAssets.value[0]
+
+      expect(result.badges).toContainEqual({
+        label: 'checkpoints',
+        type: 'type'
+      })
+    })
+
+    it('does not create model type badges for non-model assets', () => {
+      const apiAsset = createApiAsset({
+        tags: ['input', 'images']
+      })
+
+      const { filteredAssets } = useAssetBrowser(ref([apiAsset]))
+      const result = filteredAssets.value[0]
+
+      expect(result.badges).not.toContainEqual({
+        label: 'input',
+        type: 'type'
+      })
+      expect(result.badges).not.toContainEqual({
+        label: 'images',
+        type: 'type'
+      })
+    })
   })
 
   describe('Tag-Based Filtering', () => {

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -19,9 +19,10 @@ import {
 } from '@/platform/assets/utils/assetFilterUtils'
 import {
   getAssetBaseModels,
-  getAssetFilename
+  getAssetFilename,
+  getAssetModelCategory,
+  getAssetModelType
 } from '@/platform/assets/utils/assetMetadataUtils'
-import { MODELS_TAG } from '@/platform/assets/services/assetService'
 import { sortAssets } from '@/platform/assets/utils/assetSortUtils'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import type { NavGroupData, NavItemData } from '@/types/navTypes'
@@ -88,7 +89,7 @@ export function useAssetBrowser(
 
     const badges: AssetBadge[] = []
 
-    const typeTag = asset.tags.find((tag) => tag !== 'models')
+    const typeTag = getAssetModelType(asset)
     // Type badge from non-root tag
     if (typeTag) {
       // Remove category prefix from badge label (e.g. "checkpoint/model" → "model")
@@ -124,11 +125,8 @@ export function useAssetBrowser(
 
   const typeCategories = computed<NavItemData[]>(() => {
     const categories = assets.value
-      .filter((asset) => asset.tags.includes(MODELS_TAG))
-      .flatMap((asset) =>
-        asset.tags.filter((tag) => tag !== MODELS_TAG && tag.length > 0)
-      )
-      .map((tag) => tag.split('/')[0])
+      .map((asset) => getAssetModelCategory(asset))
+      .filter((tag): tag is string => typeof tag === 'string' && tag.length > 0)
 
     return Array.from(new Set(categories))
       .sort()

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -7,6 +7,7 @@ import {
   getAssetBaseModels,
   getAssetDescription,
   getAssetDisplayName,
+  getAssetModelCategory,
   getAssetModelType,
   getAssetSourceUrl,
   getAssetTriggerPhrases,
@@ -243,6 +244,11 @@ describe('assetMetadataUtils', () => {
         expected: 'checkpoints'
       },
       {
+        name: 'returns model type regardless of tag order',
+        tags: ['checkpoints', 'models'],
+        expected: 'checkpoints'
+      },
+      {
         name: 'returns full path for path-style tags',
         tags: ['models', 'diffusers/Kolors/text_encoder'],
         expected: 'diffusers/Kolors/text_encoder'
@@ -252,10 +258,38 @@ describe('assetMetadataUtils', () => {
         tags: ['models'],
         expected: null
       },
-      { name: 'returns null when tags empty', tags: [], expected: null }
+      { name: 'returns null when tags empty', tags: [], expected: null },
+      {
+        name: 'returns null when asset is not in the models root',
+        tags: ['input', 'images'],
+        expected: null
+      }
     ])('$name', ({ tags, expected }) => {
       const asset = { ...mockAsset, tags }
       expect(getAssetModelType(asset)).toBe(expected)
+    })
+  })
+
+  describe('getAssetModelCategory', () => {
+    it.for([
+      {
+        name: 'returns top-level category from model type',
+        tags: ['models', 'diffusers/Kolors/text_encoder'],
+        expected: 'diffusers'
+      },
+      {
+        name: 'returns category regardless of tag order',
+        tags: ['checkpoints', 'models'],
+        expected: 'checkpoints'
+      },
+      {
+        name: 'returns null for non-model assets',
+        tags: ['input', 'images'],
+        expected: null
+      }
+    ])('$name', ({ tags, expected }) => {
+      const asset = { ...mockAsset, tags }
+      expect(getAssetModelCategory(asset)).toBe(expected)
     })
   })
 

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -137,8 +137,20 @@ export function getSourceName(url: string): string {
  * @returns The model type string or null if not present
  */
 export function getAssetModelType(asset: AssetItem): string | null {
+  if (!asset.tags?.includes('models')) return null
   const typeTag = asset.tags?.find((tag) => tag && tag !== 'models')
   return typeTag ?? null
+}
+
+/**
+ * Extracts the top-level model category from asset tags.
+ * @param asset - The asset to extract the model category from
+ * @returns The top-level model category string or null if not present
+ */
+export function getAssetModelCategory(asset: AssetItem): string | null {
+  const modelType = getAssetModelType(asset)
+  if (!modelType) return null
+  return modelType.split('/')[0] || null
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize model tag parsing in shared asset metadata helpers
- reuse the helpers in the asset browser and asset browser modal
- add coverage for reversed tag order and non-model assets

## Testing
- COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run src/platform/assets/utils/assetMetadataUtils.test.ts src/platform/assets/composables/useAssetBrowser.test.ts src/platform/assets/components/AssetBrowserModal.test.ts
- COREPACK_ENABLE_AUTO_PIN=0 pnpm typecheck

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10386-fix-assets-centralize-model-tag-parsing-32b6d73d3650819fbddffda9191e2ff3) by [Unito](https://www.unito.io)
