### PR TITLE
fix: use UI flow context for sign_up vs login telemetry

### DIFF
--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -186,13 +186,13 @@ const toggleState = () => {
 }
 
 const signInWithGoogle = async () => {
-  if (await authActions.signInWithGoogle()) {
+  if (await authActions.signInWithGoogle({ isNewUser: !isSignIn.value })) {
     onSuccess()
   }
 }
 
 const signInWithGithub = async () => {
-  if (await authActions.signInWithGithub()) {
+  if (await authActions.signInWithGithub({ isNewUser: !isSignIn.value })) {
     onSuccess()
   }
 }

--- a/src/composables/auth/useFirebaseAuthActions.ts
+++ b/src/composables/auth/useFirebaseAuthActions.ts
@@ -140,13 +140,19 @@ export const useFirebaseAuthActions = () => {
     return result
   }, reportError)
 
-  const signInWithGoogle = wrapWithErrorHandlingAsync(async () => {
-    return await authStore.loginWithGoogle()
-  }, reportError)
+  const signInWithGoogle = wrapWithErrorHandlingAsync(
+    async (options?: { isNewUser?: boolean }) => {
+      return await authStore.loginWithGoogle(options)
+    },
+    reportError
+  )
 
-  const signInWithGithub = wrapWithErrorHandlingAsync(async () => {
-    return await authStore.loginWithGithub()
-  }, reportError)
+  const signInWithGithub = wrapWithErrorHandlingAsync(
+    async (options?: { isNewUser?: boolean }) => {
+      return await authStore.loginWithGithub(options)
+    },
+    reportError
+  )
 
   const signInWithEmail = wrapWithErrorHandlingAsync(
     async (email: string, password: string) => {

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -182,14 +182,14 @@ const onSuccess = async () => {
 
 const signInWithGoogle = async () => {
   authError.value = ''
-  if (await authActions.signInWithGoogle()) {
+  if (await authActions.signInWithGoogle({ isNewUser: true })) {
     await onSuccess()
   }
 }
 
 const signInWithGithub = async () => {
   authError.value = ''
-  if (await authActions.signInWithGithub()) {
+  if (await authActions.signInWithGithub({ isNewUser: true })) {
     await onSuccess()
   }
 }

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -5,7 +5,7 @@ import {
   GoogleAuthProvider,
   browserLocalPersistence,
   createUserWithEmailAndPassword,
-  getAdditionalUserInfo,
+
   onAuthStateChanged,
   onIdTokenChanged,
   sendPasswordResetEmail,
@@ -378,18 +378,18 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     return result
   }
 
-  const loginWithGoogle = async (): Promise<UserCredential> => {
+  const loginWithGoogle = async (options?: {
+    isNewUser?: boolean
+  }): Promise<UserCredential> => {
     const result = await executeAuthAction(
       (authInstance) => signInWithPopup(authInstance, googleProvider),
       { createCustomer: true }
     )
 
     if (isCloud) {
-      const additionalUserInfo = getAdditionalUserInfo(result)
-      const isNewUser = additionalUserInfo?.isNewUser ?? false
       useTelemetry()?.trackAuth({
         method: 'google',
-        is_new_user: isNewUser,
+        is_new_user: options?.isNewUser ?? false,
         user_id: result.user.uid
       })
     }
@@ -397,18 +397,18 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     return result
   }
 
-  const loginWithGithub = async (): Promise<UserCredential> => {
+  const loginWithGithub = async (options?: {
+    isNewUser?: boolean
+  }): Promise<UserCredential> => {
     const result = await executeAuthAction(
       (authInstance) => signInWithPopup(authInstance, githubProvider),
       { createCustomer: true }
     )
 
     if (isCloud) {
-      const additionalUserInfo = getAdditionalUserInfo(result)
-      const isNewUser = additionalUserInfo?.isNewUser ?? false
       useTelemetry()?.trackAuth({
         method: 'github',
-        is_new_user: isNewUser,
+        is_new_user: options?.isNewUser ?? false,
         user_id: result.user.uid
       })
     }

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -5,7 +5,6 @@ import {
   GoogleAuthProvider,
   browserLocalPersistence,
   createUserWithEmailAndPassword,
-
   onAuthStateChanged,
   onIdTokenChanged,
   sendPasswordResetEmail,


### PR DESCRIPTION
## Problem

GA4 shows **zero** `sign_up` events from cloud.comfy.org. All new users (Google/GitHub) are tracked as `login` instead of `sign_up`.

**Root cause:** `getAdditionalUserInfo(result)?.isNewUser` from Firebase is unreliable for popup auth flows — it compares `creationDate` vs `lastSignInDate` timestamps, which can differ even for genuinely new users. When it returns `null` or `false`, the code defaults to pushing a `login` event instead of `sign_up`.

**Evidence:** GA4 Exploration filtered to `sign_up` + `cloud.comfy.org` shows 0 events, while `login` shows 8,804 Google users, 519 email, 193 GitHub — all new users are being misclassified as logins.

(Additionally, the ~300 `sign_up` events visible in GA4 are actually from `blog.comfy.org` — Substack newsletter subscriptions — not from the app at all.)

## Fix

Use the UI flow context to determine `is_new_user` instead of Firebase's unreliable API:
- `CloudSignupView.vue` → passes `{ isNewUser: true }` (user is on the sign-up page)
- `CloudLoginView.vue` → no flag needed, defaults to `false` (user is on the login page)
- `SignInContent.vue` → passes `{ isNewUser: !isSignIn.value }` (dialog toggles between sign-in/sign-up)
- Removes the unused `getAdditionalUserInfo` import

## Changes

- `firebaseAuthStore.ts`: `loginWithGoogle`/`loginWithGithub` accept optional `{ isNewUser }` parameter instead of calling `getAdditionalUserInfo`
- `useFirebaseAuthActions.ts`: passes the option through
- `CloudSignupView.vue`: passes `{ isNewUser: true }`
- `SignInContent.vue`: passes `{ isNewUser: !isSignIn.value }`

## Testing

- All 32 `firebaseAuthStore.test.ts` tests pass
- All 19 `GtmTelemetryProvider.test.ts` tests pass
- Typecheck passes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10388-fix-use-UI-flow-context-for-sign_up-vs-login-telemetry-32b6d73d3650811e96cec281108abbf3) by [Unito](https://www.unito.io)
