### PR TITLE
feat: add outline button variant

### DIFF
--- a/src/components/ui/button/button.variants.ts
+++ b/src/components/ui/button/button.variants.ts
@@ -23,7 +23,9 @@ export const buttonVariants = cva({
       'overlay-white': 'bg-white text-gray-600 hover:bg-white/90',
       base: 'bg-base-background text-base-foreground hover:bg-secondary-background-hover',
       gradient:
-        'border-transparent bg-(image:--subscription-button-gradient) text-white hover:opacity-90'
+        'border-transparent bg-(image:--subscription-button-gradient) text-white hover:opacity-90',
+      outline:
+        'border border-solid border-border-subtle bg-transparent text-base-foreground hover:bg-secondary-background-hover'
     },
     size: {
       sm: 'h-6 rounded-sm px-2 py-1 text-xs',
@@ -55,7 +57,8 @@ const variants = [
   'link',
   'base',
   'overlay-white',
-  'gradient'
+  'gradient',
+  'outline'
 ] as const satisfies Array<ButtonVariants['variant']>
 const sizes = [
   'sm',


### PR DESCRIPTION
## Summary

Add an `outline` variant to the Button component — transparent background with a subtle border stroke, matching the Figma design system.

## Changes

- Add `outline` variant to `buttonVariants` in `button.variants.ts`
- Styling: `border-border-subtle`, transparent bg, `text-base-foreground`, hover fills with `bg-secondary-background-hover`
- Automatically reflected in Storybook AllVariants story via the `FOR_STORIES` export

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10389-feat-add-outline-button-variant-32b6d73d365081d39faccb3091db6af2) by [Unito](https://www.unito.io)
