### PR TITLE
revert: fix: prevent survey popup when surveyed feature is inactive (#10360)

### DIFF
--- a/src/platform/surveys/surveyRegistry.ts
+++ b/src/platform/surveys/surveyRegistry.ts
@@ -1,5 +1,3 @@
-import { useSettingStore } from '@/platform/settings/settingStore'
-
 import type { FeatureSurveyConfig } from './useSurveyEligibility'
 
 /**
@@ -11,13 +9,7 @@ export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {
     featureId: 'node-search',
     typeformId: 'goZLqjKL',
     triggerThreshold: 3,
-    delayMs: 5000,
-    isFeatureActive: () => {
-      const settingStore = useSettingStore()
-      return (
-        settingStore.get('Comfy.NodeSearchBoxImpl') !== 'litegraph (legacy)'
-      )
-    }
+    delayMs: 5000
   }
 }
 

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -181,17 +181,6 @@ describe('useSurveyEligibility', () => {
 
       expect(isEligible.value).toBe(false)
     })
-
-    it('is not eligible when isFeatureActive returns false', () => {
-      setFeatureUsage('test-feature', 5)
-
-      const { isEligible } = useSurveyEligibility({
-        ...defaultConfig,
-        isFeatureActive: () => false
-      })
-
-      expect(isEligible.value).toBe(false)
-    })
   })
 
   describe('actions', () => {

--- a/src/platform/surveys/useSurveyEligibility.ts
+++ b/src/platform/surveys/useSurveyEligibility.ts
@@ -13,7 +13,6 @@ export interface FeatureSurveyConfig {
   triggerThreshold?: number
   delayMs?: number
   enabled?: boolean
-  isFeatureActive?: () => boolean
 }
 
 interface SurveyState {
@@ -62,13 +61,8 @@ export function useSurveyEligibility(
 
   const hasOptedOut = computed(() => state.value.optedOut)
 
-  const isFeatureActive = computed(
-    () => resolvedConfig.value.isFeatureActive?.() ?? true
-  )
-
   const isEligible = computed(() => {
     if (!isSurveyEnabled.value) return false
-    if (!isFeatureActive.value) return false
     if (!isNightlyLocalhost.value) return false
     if (!hasReachedThreshold.value) return false
     if (hasSeenSurvey.value) return false


### PR DESCRIPTION
## Summary

Reverts #10360

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10393-revert-fix-prevent-survey-popup-when-surveyed-feature-is-inactive-10360-32b6d73d36508132aff9c0e21529efac) by [Unito](https://www.unito.io)
