### PR TITLE
[backport cloud/1.41] feat: differentiate personal/team pricing table with two-stage team workspace flow (#9901)

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -193,6 +193,7 @@ import { forEachNode } from '@/utils/graphTraversalUtil'
 import SelectionRectangle from './SelectionRectangle.vue'
 import { isCloud } from '@/platform/distribution/types'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
 import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
 
 const { t } = useI18n()
@@ -471,8 +472,9 @@ useEventListener(
 const comfyAppReady = ref(false)
 const workflowPersistence = useWorkflowPersistence()
 const { flags } = useFeatureFlags()
-// Set up invite loader during setup phase so useRoute/useRouter work correctly
+// Set up URL loaders during setup phase so useRoute/useRouter work correctly
 const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
+const createWorkspaceUrlLoader = isCloud ? useCreateWorkspaceUrlLoader() : null
 useCanvasDrop(canvasRef)
 useLitegraphSettings()
 useNodeBadge()
@@ -582,6 +584,18 @@ onMounted(async () => {
   // WorkspaceAuthGate ensures flag state is resolved before GraphCanvas mounts
   if (inviteUrlLoader && flags.teamWorkspacesEnabled) {
     await inviteUrlLoader.loadInviteFromUrl()
+  }
+
+  // Open create workspace dialog from URL if present (e.g., ?create_workspace=1)
+  if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
+    try {
+      await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
+    } catch (error) {
+      console.error(
+        '[GraphCanvas] Failed to load create workspace from URL:',
+        error
+      )
+    }
   }
 
   // Initialize release store to fetch releases from comfy-api (fire-and-forget)

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -2826,7 +2826,6 @@
       "title": "تم إلغاء اشتراكك"
     },
     "changeTo": "تغيير إلى {plan}",
-    "chooseBestPlanWorkspace": "اختر أفضل خطة لمساحة العمل الخاصة بك",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "شعار Comfy Cloud",
     "contactOwnerToSubscribe": "يرجى التواصل مع مالك مساحة العمل للاشتراك",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2222,7 +2222,12 @@
     "topupTimeout": "Top-up verification timed out"
   },
   "subscription": {
-    "chooseBestPlanWorkspace": "Choose the best plan for your workspace",
+    "plansForWorkspace": "Plans for {workspace}",
+    "personalWorkspace": "Personal Workspace",
+    "teamWorkspace": "Team Workspace",
+    "soloUseOnly": "Solo use only",
+    "needTeamWorkspace": "Need team workspace?",
+    "inviteUpTo": "Invite up to",
     "title": "Subscription",
     "titleUnsubscribed": "Subscribe to Comfy Cloud",
     "comfyCloud": "Comfy Cloud",
@@ -2534,6 +2539,18 @@
       "failedToFetchWorkspaces": "Failed to load workspaces"
     }
   },
+  "teamWorkspacesDialog": {
+    "title": "Team Workspaces",
+    "subtitle": "Switch to an existing one or create a new workspace",
+    "subtitleNoWorkspaces": "Create a new team workspace to share credits",
+    "confirmCallbackFailed": "Workspace created but setup incomplete",
+    "yourTeamWorkspaces": "Your team workspaces",
+    "switch": "Switch",
+    "newWorkspace": "New workspace",
+    "namePlaceholder": "e.g. Marketing Team",
+    "createWorkspace": "Create workspace",
+    "nameValidationError": "Name must be 1–50 characters using letters, numbers, spaces, or common punctuation."
+  },
   "workspaceSwitcher": {
     "switchWorkspace": "Switch workspace",
     "subscribe": "Subscribe",
@@ -2541,7 +2558,8 @@
     "roleOwner": "Owner",
     "roleMember": "Member",
     "createWorkspace": "Create new workspace",
-    "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one."
+    "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one.",
+    "failedToSwitch": "Failed to switch workspace"
   },
   "selectionToolbox": {
     "executeButton": {

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -2826,7 +2826,6 @@
       "title": "Tu suscripción ha sido cancelada"
     },
     "changeTo": "Cambiar a {plan}",
-    "chooseBestPlanWorkspace": "Elige el mejor plan para tu espacio de trabajo",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Logo de Comfy Cloud",
     "contactOwnerToSubscribe": "Contacta al propietario del espacio de trabajo para suscribirte",

--- a/src/locales/fa/main.json
+++ b/src/locales/fa/main.json
@@ -2838,7 +2838,6 @@
       "title": "اشتراک شما لغو شده است"
     },
     "changeTo": "تغییر به {plan}",
-    "chooseBestPlanWorkspace": "بهترین طرح را برای فضای کاری خود انتخاب کنید",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "لوگوی Comfy Cloud",
     "contactOwnerToSubscribe": "برای فعال‌سازی اشتراک با مالک محیط کاری تماس بگیرید",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -2826,7 +2826,6 @@
       "title": "Votre abonnement a été annulé"
     },
     "changeTo": "Changer pour {plan}",
-    "chooseBestPlanWorkspace": "Choisissez la meilleure offre pour votre espace de travail",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Logo Comfy Cloud",
     "contactOwnerToSubscribe": "Contactez le propriétaire de l’espace de travail pour vous abonner",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -2826,7 +2826,6 @@
       "title": "サブスクリプションはキャンセルされました"
     },
     "changeTo": "{plan}に変更",
-    "chooseBestPlanWorkspace": "ワークスペースに最適なプランを選択してください",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud ロゴ",
     "contactOwnerToSubscribe": "サブスクリプションのためにワークスペースのオーナーに連絡してください",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -2826,7 +2826,6 @@
       "title": "구독이 취소되었습니다"
     },
     "changeTo": "{plan}로 변경",
-    "chooseBestPlanWorkspace": "워크스페이스에 가장 적합한 플랜을 선택하세요",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud 로고",
     "contactOwnerToSubscribe": "워크스페이스 소유자에게 구독을 요청하세요",

--- a/src/locales/pt-BR/main.json
+++ b/src/locales/pt-BR/main.json
@@ -2838,7 +2838,6 @@
       "title": "Sua assinatura foi cancelada"
     },
     "changeTo": "Mudar para {plan}",
-    "chooseBestPlanWorkspace": "Escolha o melhor plano para seu workspace",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Logo do Comfy Cloud",
     "contactOwnerToSubscribe": "Entre em contato com o proprietário do espaço de trabalho para assinar",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -2826,7 +2826,6 @@
       "title": "Ваша подписка отменена"
     },
     "changeTo": "Перейти на {plan}",
-    "chooseBestPlanWorkspace": "Выберите лучший тариф для вашего рабочего пространства",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Логотип Comfy Cloud",
     "contactOwnerToSubscribe": "Свяжитесь с владельцем рабочего пространства для оформления подписки",

--- a/src/locales/tr/main.json
+++ b/src/locales/tr/main.json
@@ -2826,7 +2826,6 @@
       "title": "Aboneliğiniz iptal edildi"
     },
     "changeTo": "{plan} planına geç",
-    "chooseBestPlanWorkspace": "Çalışma alanınız için en iyi planı seçin",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud Logosu",
     "contactOwnerToSubscribe": "Abone olmak için çalışma alanı sahibiyle iletişime geçin",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -2826,7 +2826,6 @@
       "title": "您的訂閱已取消"
     },
     "changeTo": "切換至 {plan}",
-    "chooseBestPlanWorkspace": "為您的工作區選擇最佳方案",
     "comfyCloud": "Comfy Cloud",
     "comfyCloudLogo": "Comfy Cloud 標誌",
     "contactOwnerToSubscribe": "請聯絡工作區擁有者以訂閱",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -2838,7 +2838,6 @@
       "title": "您的订阅已被取消"
     },
     "changeTo": "更改为 {plan}",
-    "chooseBestPlanWorkspace": "为您的工作区选择最佳方案",
     "comfyCloud": "Comfy 云",
     "comfyCloudLogo": "Comfy Cloud Logo",
     "contactOwnerToSubscribe": "请联系工作区所有者进行订阅",

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -107,6 +107,8 @@ const i18n = createI18n({
         videoEstimateHelp: 'How is this calculated?',
         videoEstimateExplanation: 'Based on average usage.',
         videoEstimateTryTemplate: 'Try template',
+        soloUseOnly: 'Solo use only',
+        needTeamWorkspace: 'Need team workspace?',
         maxDuration: {
           standard: '30 min',
           creator: '30 min',
@@ -294,6 +296,22 @@ describe('PricingTable', () => {
       await flushPromises()
 
       expect(mockAccessBillingPortal).toHaveBeenCalledWith('standard-yearly')
+    })
+  })
+
+  describe('team workspace link', () => {
+    it('should emit chooseTeamWorkspace when clicking "Need team workspace?" link', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+
+      const teamLink = wrapper
+        .findAll('button')
+        .find((btn) => btn.text().includes('Need team workspace?'))
+
+      expect(teamLink).toBeDefined()
+      await teamLink?.trigger('click')
+
+      expect(wrapper.emitted('chooseTeamWorkspace')).toHaveLength(1)
     })
   })
 })

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-8">
+  <div class="flex flex-col gap-6">
     <div class="flex justify-center">
       <SelectButton
         v-model="currentBillingCycle"
@@ -38,7 +38,7 @@
         </template>
       </SelectButton>
     </div>
-    <div class="flex flex-col items-stretch gap-6 xl:flex-row">
+    <div class="flex flex-col items-stretch gap-4 xl:flex-row">
       <div
         v-for="tier in tiers"
         :key="tier.id"
@@ -49,7 +49,7 @@
           )
         "
       >
-        <div class="flex flex-col gap-8 p-8 pb-0">
+        <div class="flex flex-col gap-4 p-6 pb-0">
           <div class="flex flex-row items-center justify-between gap-2">
             <span
               class="font-inter text-base/normal font-bold text-base-foreground"
@@ -67,7 +67,7 @@
             <div class="flex flex-col gap-2">
               <div class="flex flex-row items-baseline gap-2">
                 <span
-                  class="font-inter text-[32px] leading-normal font-semibold text-base-foreground"
+                  class="font-inter text-[28px] leading-normal font-semibold text-base-foreground"
                 >
                   <span
                     v-show="currentBillingCycle === 'yearly'"
@@ -95,7 +95,22 @@
             </div>
           </div>
 
-          <div class="flex flex-1 flex-col gap-4 pb-0">
+          <p
+            role="note"
+            :aria-label="t('subscription.soloUseOnly')"
+            class="m-0 flex h-10 items-center rounded-lg bg-muted-foreground/30 px-3 text-sm text-muted-foreground"
+          >
+            {{ t('subscription.soloUseOnly') }}
+            <span class="mx-1 text-muted-foreground">–</span>
+            <button
+              class="text-primary-foreground cursor-pointer border-none bg-transparent p-0 text-sm font-medium underline hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
+              @click="emit('chooseTeamWorkspace')"
+            >
+              {{ t('subscription.needTeamWorkspace') }}
+            </button>
+          </p>
+
+          <div class="flex flex-1 flex-col gap-3 pb-0">
             <div class="flex flex-row items-center justify-between">
               <span
                 class="text-foreground font-inter text-sm/normal font-normal"
@@ -179,7 +194,7 @@
             </div>
           </div>
         </div>
-        <div class="flex flex-col p-8">
+        <div class="flex flex-col p-6">
           <Button
             :variant="getButtonSeverity(tier)"
             :disabled="isLoading || isCurrentPlan(tier.key)"
@@ -302,6 +317,10 @@ interface PricingTierConfig {
   customLoRAs: boolean
   isPopular?: boolean
 }
+
+const emit = defineEmits<{
+  chooseTeamWorkspace: []
+}>()
 
 const { t, n } = useI18n()
 

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="showCustomPricingTable"
-    class="relative flex h-full flex-col gap-8 overflow-y-auto! p-4 pt-8 md:p-16"
+    class="relative flex h-full flex-col gap-6 overflow-y-auto p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
       size="icon"
@@ -10,15 +10,30 @@
       :aria-label="$t('g.close')"
       @click="handleClose"
     >
-      <i class="pi pi-times text-xl" />
+      <i class="pi pi-times text-xl" aria-hidden="true" />
     </Button>
-    <div class="text-center">
-      <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
-        {{ $t('subscription.description') }}
-      </h2>
+    <div class="flex flex-col items-center gap-3">
+      <div
+        class="flex size-10 items-center justify-center rounded-xl bg-muted-foreground/30 text-lg font-semibold text-white"
+        aria-hidden="true"
+      >
+        <!-- Decorative initial for "Personal" workspace icon; not user-facing text -->
+        P
+      </div>
+      <i18n-t
+        keypath="subscription.plansForWorkspace"
+        tag="h2"
+        class="m-0 font-inter text-2xl font-semibold text-base-foreground"
+      >
+        <template #workspace>
+          <span class="text-muted-foreground">
+            {{ $t('subscription.personalWorkspace') }}
+          </span>
+        </template>
+      </i18n-t>
     </div>
 
-    <PricingTable class="flex-1" />
+    <PricingTable class="flex-1" @choose-team-workspace="handleChooseTeam" />
 
     <!-- Contact and Enterprise Links -->
     <div class="flex flex-col items-center gap-2">
@@ -55,7 +70,7 @@
       :aria-label="$t('g.close')"
       @click="handleClose"
     >
-      <i class="pi pi-times" />
+      <i class="pi pi-times" aria-hidden="true" />
     </Button>
 
     <div
@@ -144,9 +159,10 @@ import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
-const { onClose, reason } = defineProps<{
+const { onClose, reason, onChooseTeam } = defineProps<{
   onClose: () => void
   reason?: SubscriptionDialogReason
+  onChooseTeam?: () => void
 }>()
 
 const emit = defineEmits<{
@@ -243,6 +259,15 @@ watch(
 
 const handleSubscribed = () => {
   emit('close', true)
+}
+
+const handleChooseTeam = () => {
+  stopPolling()
+  if (onChooseTeam) {
+    onChooseTeam()
+  } else {
+    onClose()
+  }
 }
 
 const handleClose = () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSubscriptionDialog } from './useSubscriptionDialog'
+
+const mockCloseDialog = vi.fn()
+const mockShowLayoutDialog = vi.fn()
+const mockShowTeamWorkspacesDialog = vi.fn()
+const mockIsInPersonalWorkspace = vi.hoisted(() => ({ value: true }))
+const mockIsFreeTier = vi.hoisted(() => ({ value: false }))
+const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: false }))
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
+
+vi.mock('vue', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    defineAsyncComponent: vi.fn((loader) => loader)
+  }
+})
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: mockCloseDialog
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showLayoutDialog: mockShowLayoutDialog,
+    showTeamWorkspacesDialog: mockShowTeamWorkspacesDialog
+  })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get teamWorkspacesEnabled() {
+        return mockTeamWorkspacesEnabled.value
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
+  useSubscription: () => ({
+    isFreeTier: mockIsFreeTier
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    get isInPersonalWorkspace() {
+      return mockIsInPersonalWorkspace.value
+    }
+  })
+}))
+
+describe('useSubscriptionDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsCloud.value = true
+    mockIsInPersonalWorkspace.value = true
+    mockIsFreeTier.value = false
+    mockTeamWorkspacesEnabled.value = false
+
+    try {
+      sessionStorage.clear()
+    } catch {
+      // noop
+    }
+  })
+
+  describe('showPricingTable', () => {
+    it('does not open dialog on non-cloud', () => {
+      mockIsCloud.value = false
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('opens dialog on cloud', () => {
+      mockIsCloud.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalled()
+    })
+  })
+
+  describe('startTeamWorkspaceUpgradeFlow', () => {
+    it('closes existing dialogs before opening team workspace dialog', () => {
+      mockShowTeamWorkspacesDialog.mockResolvedValue(undefined)
+      const { startTeamWorkspaceUpgradeFlow } = useSubscriptionDialog()
+
+      startTeamWorkspaceUpgradeFlow()
+
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'subscription-required'
+      })
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'free-tier-info'
+      })
+      expect(mockShowTeamWorkspacesDialog).toHaveBeenCalledWith(
+        expect.any(Function)
+      )
+    })
+
+    it('persists resume intent to sessionStorage via onConfirm callback', () => {
+      mockShowTeamWorkspacesDialog.mockResolvedValue(undefined)
+      const { startTeamWorkspaceUpgradeFlow } = useSubscriptionDialog()
+
+      startTeamWorkspaceUpgradeFlow()
+
+      const onConfirm = mockShowTeamWorkspacesDialog.mock.calls[0][0]
+      onConfirm()
+
+      expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBe('1')
+    })
+
+    it('reopens pricing table on dialog rejection', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockShowTeamWorkspacesDialog.mockRejectedValue(new Error('dialog error'))
+
+      const { startTeamWorkspaceUpgradeFlow } = useSubscriptionDialog()
+      startTeamWorkspaceUpgradeFlow()
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          '[useSubscriptionDialog] Failed to open team workspaces dialog:',
+          expect.any(Error)
+        )
+      })
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'subscription-required' })
+      )
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('resumePendingPricingFlow', () => {
+    it('does nothing when no resume intent is stored', () => {
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+
+      resumePendingPricingFlow()
+
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('shows pricing table and clears intent when in team workspace', () => {
+      sessionStorage.setItem('comfy:resume-team-pricing', '1')
+      mockIsInPersonalWorkspace.value = false
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      resumePendingPricingFlow()
+
+      expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'subscription-required' })
+      )
+    })
+
+    it('clears intent but does not show pricing if still in personal workspace', () => {
+      sessionStorage.setItem('comfy:resume-team-pricing', '1')
+      mockIsInPersonalWorkspace.value = true
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      resumePendingPricingFlow()
+
+      expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('consumes intent so second call is a no-op', () => {
+      sessionStorage.setItem('comfy:resume-team-pricing', '1')
+      mockIsInPersonalWorkspace.value = false
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      resumePendingPricingFlow()
+      mockShowLayoutDialog.mockClear()
+
+      resumePendingPricingFlow()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -3,10 +3,12 @@ import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { isCloud } from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const DIALOG_KEY = 'subscription-required'
 const FREE_TIER_DIALOG_KEY = 'free-tier-info'
+const RESUME_PRICING_KEY = 'comfy:resume-team-pricing'
 
 export type SubscriptionDialogReason =
   | 'subscription_required'
@@ -26,6 +28,8 @@ export const useSubscriptionDialog = () => {
   }
 
   function showPricingTable(options?: { reason?: SubscriptionDialogReason }) {
+    if (!isCloud) return
+
     const useWorkspaceVariant =
       flags.teamWorkspacesEnabled && !workspaceStore.isInPersonalWorkspace
 
@@ -39,13 +43,20 @@ export const useSubscriptionDialog = () => {
             import('@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue')
         )
 
+    const personalProps = {
+      onClose: hide,
+      reason: options?.reason,
+      onChooseTeam: () => startTeamWorkspaceUpgradeFlow()
+    }
+    const workspaceProps = {
+      onClose: hide,
+      reason: options?.reason
+    }
+
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
       component,
-      props: {
-        onClose: hide,
-        reason: options?.reason
-      },
+      props: useWorkspaceVariant ? workspaceProps : personalProps,
       dialogComponentProps: {
         style: 'width: min(1328px, 95vw); max-height: 958px;',
         pt: {
@@ -98,9 +109,58 @@ export const useSubscriptionDialog = () => {
     showPricingTable(options)
   }
 
+  /**
+   * Start the two-stage team workspace upgrade flow:
+   * 1. Close the current pricing dialog
+   * 2. Open the create workspace dialog
+   * 3. On successful creation, persist a resume intent so the team pricing
+   *    dialog reopens automatically after the page reload
+   *
+   * Uses sessionStorage (not a store) because the intent must survive
+   * a full page reload triggered by workspace switching.
+   */
+  function startTeamWorkspaceUpgradeFlow() {
+    hide()
+    dialogService
+      .showTeamWorkspacesDialog(() => {
+        try {
+          sessionStorage.setItem(RESUME_PRICING_KEY, '1')
+        } catch {
+          // sessionStorage may be unavailable
+        }
+      })
+      .catch((error) => {
+        console.error(
+          '[useSubscriptionDialog] Failed to open team workspaces dialog:',
+          error
+        )
+        showPricingTable()
+      })
+  }
+
+  /**
+   * Check for and consume a pending team pricing resume intent.
+   * Call once after workspace initialization on app boot.
+   */
+  function resumePendingPricingFlow() {
+    try {
+      const pending = sessionStorage.getItem(RESUME_PRICING_KEY)
+      if (!pending) return
+      sessionStorage.removeItem(RESUME_PRICING_KEY)
+
+      if (!workspaceStore.isInPersonalWorkspace) {
+        showPricingTable()
+      }
+    } catch {
+      // sessionStorage may be unavailable
+    }
+  }
+
   return {
     show,
     showPricingTable,
-    hide
+    hide,
+    startTeamWorkspaceUpgradeFlow,
+    resumePendingPricingFlow
   }
 }

--- a/src/platform/navigation/preservedQueryNamespaces.ts
+++ b/src/platform/navigation/preservedQueryNamespaces.ts
@@ -1,5 +1,6 @@
 export const PRESERVED_QUERY_NAMESPACES = {
   TEMPLATE: 'template',
   INVITE: 'invite',
-  SHARE: 'share'
+  SHARE: 'share',
+  CREATE_WORKSPACE: 'create_workspace'
 } as const

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -51,6 +51,20 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
+const mockResumePendingPricingFlow = vi.fn()
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({
+      show: vi.fn(),
+      showPricingTable: vi.fn(),
+      hide: vi.fn(),
+      startTeamWorkspaceUpgradeFlow: vi.fn(),
+      resumePendingPricingFlow: mockResumePendingPricingFlow
+    })
+  })
+)
+
 describe('WorkspaceAuthGate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -142,6 +156,16 @@ describe('WorkspaceAuthGate', () => {
 
       expect(mockWorkspaceStoreInitialize).toHaveBeenCalled()
       expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+    })
+
+    it('calls resumePendingPricingFlow after successful workspace init', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockWorkspaceStoreInitState.value = 'ready'
+
+      mountComponent()
+      await flushPromises()
+
+      expect(mockResumePendingPricingFlow).toHaveBeenCalled()
     })
 
     it('skips workspace init when store is already initialized', async () => {

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -27,6 +27,7 @@ import { onMounted, ref } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useFirebaseAuthStore } from '@/stores/firebaseAuthStore'
@@ -36,6 +37,7 @@ const FIREBASE_INIT_TIMEOUT_MS = 16_000
 const CONFIG_REFRESH_TIMEOUT_MS = 10_000
 
 const isReady = ref(!isCloud)
+const subscriptionDialog = useSubscriptionDialog()
 
 async function initialize(): Promise<void> {
   if (!isCloud) return
@@ -90,6 +92,14 @@ async function initialize(): Promise<void> {
 
     // Step 5: WORKSPACE MODE - Full initialization
     await initializeWorkspaceMode()
+
+    // Step 6: Resume any pending pricing flow from team workspace creation
+    // Only safe after workspace store initialized successfully — the pricing
+    // dialog reads workspace state to decide which variant to show.
+    const workspaceStore = useTeamWorkspaceStore()
+    if (workspaceStore.initState === 'ready') {
+      subscriptionDialog.resumePendingPricingFlow()
+    }
   } catch (error) {
     console.error('[WorkspaceAuthGate] Initialization failed:', error)
   } finally {

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -1,9 +1,5 @@
 <template>
-  <div class="flex flex-col gap-8">
-    <h2 class="m-0 text-center text-xl text-muted-foreground lg:text-2xl">
-      {{ t('subscription.chooseBestPlanWorkspace') }}
-    </h2>
-
+  <div class="flex flex-col gap-6">
     <div class="flex justify-center">
       <SelectButton
         v-model="currentBillingCycle"
@@ -42,18 +38,18 @@
         </template>
       </SelectButton>
     </div>
-    <div class="flex flex-col items-stretch gap-6 xl:flex-row">
+    <div class="flex flex-col items-stretch gap-4 xl:flex-row">
       <div
         v-for="tier in tiers"
         :key="tier.id"
         :class="
           cn(
             'flex flex-1 flex-col rounded-2xl border border-border-default bg-base-background shadow-[0_0_12px_rgba(0,0,0,0.1)]',
-            tier.isPopular ? 'border-muted-foreground' : ''
+            tier.isPopular ? 'border-emerald-500' : ''
           )
         "
       >
-        <div class="flex flex-col gap-8 p-8 pb-0">
+        <div class="flex flex-col gap-4 p-6 pb-0">
           <div class="flex flex-row items-center justify-between gap-2">
             <span
               class="font-inter text-base/normal font-bold text-base-foreground"
@@ -71,7 +67,7 @@
             <div class="flex flex-col gap-2">
               <div class="flex flex-row items-baseline gap-2">
                 <span
-                  class="font-inter text-[32px] leading-normal font-semibold text-base-foreground"
+                  class="font-inter text-[28px] leading-normal font-semibold text-base-foreground"
                 >
                   <span
                     v-show="currentBillingCycle === 'yearly'"
@@ -99,7 +95,35 @@
             </div>
           </div>
 
-          <div class="flex flex-1 flex-col gap-4 pb-0">
+          <div
+            :class="
+              cn(
+                'flex h-10 items-center justify-between rounded-lg px-3',
+                maxMembersByTier[tier.key] > 1 ? 'bg-emerald-500/20' : ''
+              )
+            "
+          >
+            <template v-if="maxMembersByTier[tier.key] > 1">
+              <div class="flex items-center gap-2">
+                <i
+                  class="pi pi-users text-xs text-emerald-400"
+                  aria-hidden="true"
+                />
+                <span class="text-sm text-emerald-400">
+                  {{ t('subscription.inviteUpTo') }}
+                </span>
+              </div>
+              <span class="text-sm font-bold text-base-foreground">
+                {{
+                  t('subscription.memberCount', {
+                    count: maxMembersByTier[tier.key]
+                  })
+                }}
+              </span>
+            </template>
+          </div>
+
+          <div class="flex flex-1 flex-col gap-3 pb-0">
             <div class="flex flex-row items-center justify-between">
               <span class="text-foreground text-sm font-normal">
                 {{ t('subscription.monthlyCreditsPerMemberLabel') }}
@@ -121,7 +145,7 @@
               <span
                 class="font-inter text-sm/normal font-bold text-base-foreground"
               >
-                {{ getMaxMembers(tier) }}
+                {{ maxMembersByTier[tier.key] }}
               </span>
             </div>
 
@@ -188,7 +212,7 @@
             </div>
           </div>
         </div>
-        <div class="flex flex-col p-8">
+        <div class="flex flex-col p-6">
           <Button
             :variant="getButtonSeverity(tier)"
             :disabled="isButtonDisabled(tier)"
@@ -198,7 +222,7 @@
                 'h-10 w-full',
                 getButtonTextClass(tier),
                 tier.key === 'creator'
-                  ? 'border-transparent bg-base-foreground hover:bg-inverted-background-hover'
+                  ? 'border-transparent bg-success-background hover:bg-success-background/80'
                   : 'border-transparent bg-secondary-background hover:bg-secondary-background-hover focus:bg-secondary-background-selected'
               )
             "
@@ -482,7 +506,13 @@ const getAnnualTotal = (tier: PricingTierConfig): number => {
   return plan ? plan.price_cents / 100 : tier.pricing.yearly * 12
 }
 
-const getMaxMembers = (tier: PricingTierConfig): number => getMaxSeats(tier.key)
+const maxMembersByTier = computed(
+  () =>
+    Object.fromEntries(tiers.map((t) => [t.key, getMaxSeats(t.key)])) as Record<
+      CheckoutTierKey,
+      number
+    >
+)
 
 const getMonthlyCreditsPerMember = (tier: PricingTierConfig): number =>
   tier.pricing.credits

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative flex h-full flex-col gap-8 overflow-y-auto! p-4 pt-8 md:p-16"
+    class="relative flex h-full flex-col gap-6 overflow-y-auto p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
       v-if="checkoutStep === 'preview'"
@@ -22,6 +22,27 @@
     >
       <i class="pi pi-times text-xl" />
     </Button>
+
+    <div class="flex flex-col items-center gap-3">
+      <!-- Decorative initial for "Team" workspace icon; not user-facing text -->
+      <div
+        class="flex size-10 items-center justify-center rounded-xl bg-primary-background text-lg font-semibold text-white"
+        aria-hidden="true"
+      >
+        T
+      </div>
+      <i18n-t
+        keypath="subscription.plansForWorkspace"
+        tag="h2"
+        class="m-0 font-inter text-2xl font-semibold text-base-foreground"
+      >
+        <template #workspace>
+          <span class="text-emerald-400">
+            {{ $t('subscription.teamWorkspace') }}
+          </span>
+        </template>
+      </i18n-t>
+    </div>
 
     <div v-if="reason === 'out_of_credits'" class="text-center">
       <h2 class="m-0 text-xl text-muted-foreground lg:text-2xl">
@@ -106,7 +127,6 @@ const { t } = useI18n()
 const toast = useToast()
 const { subscribe, previewSubscribe, plans, fetchStatus, fetchBalance } =
   useBillingContext()
-
 const billingOperationStore = useBillingOperationStore()
 const isPolling = computed(() => billingOperationStore.hasPendingOperations)
 

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -47,10 +47,10 @@
                       }}
                     </span>
                     <span
-                      v-if="getTierLabel(workspace)"
+                      v-if="resolveTierLabel(workspace)"
                       class="rounded-full bg-base-foreground px-1 py-0.5 text-[10px] font-bold text-base-background uppercase"
                     >
-                      {{ getTierLabel(workspace) }}
+                      {{ resolveTierLabel(workspace) }}
                     </span>
                   </div>
                   <span class="text-xs text-muted-foreground">
@@ -115,6 +115,7 @@ import { useI18n } from 'vue-i18n'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
+import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
 import type {
   SubscriptionTier,
   WorkspaceRole,
@@ -141,27 +142,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { switchWorkspace } = useWorkspaceSwitch()
 const { subscription } = useBillingContext()
-
-const tierKeyMap: Record<string, string> = {
-  FREE: 'free',
-  STANDARD: 'standard',
-  CREATOR: 'creator',
-  PRO: 'pro',
-  FOUNDER: 'founder',
-  FOUNDERS_EDITION: 'founder'
-}
-
-function formatTierName(
-  tier: string | null | undefined,
-  isYearly: boolean
-): string {
-  if (!tier) return ''
-  const key = tierKeyMap[tier] ?? 'standard'
-  const baseName = t(`subscription.tiers.${key}.name`)
-  return isYearly
-    ? t('subscription.tierNameYearly', { name: baseName })
-    : baseName
-}
+const { formatTierName, getTierLabel } = useWorkspaceTierLabel()
 
 const currentSubscriptionTierName = computed(() => {
   const tier = subscription.value?.tier
@@ -196,33 +177,12 @@ function getRoleLabel(role: AvailableWorkspace['role']): string {
   return ''
 }
 
-function getTierLabel(workspace: AvailableWorkspace): string | null {
-  // For the current/active workspace, use billing context directly
-  // This ensures we always have the most up-to-date subscription info
+function resolveTierLabel(workspace: AvailableWorkspace): string | null {
   if (isCurrentWorkspace(workspace)) {
     return currentSubscriptionTierName.value || null
   }
 
-  // For non-active workspaces, use cached store data
-  if (!workspace.isSubscribed) return null
-
-  if (workspace.subscriptionTier) {
-    return formatTierName(workspace.subscriptionTier, false)
-  }
-
-  if (!workspace.subscriptionPlan) return null
-
-  // Parse plan slug (format: TIER_DURATION, e.g. "CREATOR_MONTHLY", "PRO_YEARLY")
-  const planSlug = workspace.subscriptionPlan
-
-  // Extract tier from plan slug (e.g., "CREATOR_MONTHLY" -> "CREATOR")
-  const tierMatch = Object.keys(tierKeyMap).find((tier) =>
-    planSlug.startsWith(tier)
-  )
-  if (!tierMatch) return null
-
-  const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
-  return formatTierName(tierMatch, isYearly)
+  return getTierLabel(workspace)
 }
 
 async function handleSelectWorkspace(workspace: AvailableWorkspace) {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -1,0 +1,316 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { nextTick } from 'vue'
+
+import TeamWorkspacesDialogContent from './TeamWorkspacesDialogContent.vue'
+
+const mockCloseDialog = vi.fn()
+const mockToastAdd = vi.fn()
+const mockSwitchWorkspace = vi.fn()
+const mockCreateWorkspace = vi.fn()
+const mockSharedWorkspaces = vi.hoisted(() => ({
+  value: [] as Array<{
+    id: string
+    name: string
+    role: string
+    isSubscribed: boolean
+    subscriptionPlan: string | null
+    subscriptionTier: string | null
+  }>
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: mockToastAdd
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: mockCloseDialog
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceSwitch', () => ({
+  useWorkspaceSwitch: () => ({
+    switchWorkspace: mockSwitchWorkspace
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceTierLabel', () => ({
+  useWorkspaceTierLabel: () => ({
+    getTierLabel: (w: { subscriptionTier: string | null }) =>
+      w.subscriptionTier === 'PRO' ? 'Pro' : null
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    sharedWorkspaces: mockSharedWorkspaces,
+    createWorkspace: mockCreateWorkspace
+  })
+}))
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const ButtonStub = {
+  name: 'Button',
+  template:
+    '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+  props: ['disabled', 'loading', 'variant', 'size']
+}
+
+function mountComponent(props: Record<string, unknown> = {}) {
+  return mount(TeamWorkspacesDialogContent, {
+    props,
+    shallow: true,
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Button: ButtonStub,
+        WorkspaceProfilePic: true
+      }
+    }
+  })
+}
+
+function findCreateButton(wrapper: ReturnType<typeof mountComponent>) {
+  return wrapper.findComponent(ButtonStub)
+}
+
+function setOwnedWorkspaces() {
+  mockSharedWorkspaces.value = [
+    {
+      id: 'ws-1',
+      name: 'Team Alpha',
+      role: 'owner',
+      isSubscribed: true,
+      subscriptionPlan: null,
+      subscriptionTier: 'PRO'
+    },
+    {
+      id: 'ws-2',
+      name: 'Team Beta',
+      role: 'member',
+      isSubscribed: false,
+      subscriptionPlan: null,
+      subscriptionTier: null
+    }
+  ]
+}
+
+describe('TeamWorkspacesDialogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSharedWorkspaces.value = []
+  })
+
+  describe('workspace listing', () => {
+    it('displays only owned workspaces', () => {
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+      const items = wrapper.findAll('li')
+      expect(items).toHaveLength(1)
+      expect(wrapper.text()).toContain('Team Alpha')
+      expect(wrapper.text()).not.toContain('Team Beta')
+    })
+
+    it('shows tier label for subscribed workspaces', () => {
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+      expect(wrapper.text()).toContain('Pro')
+    })
+
+    it('hides workspace list section when no owned workspaces', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.findAll('li')).toHaveLength(0)
+    })
+
+    it('shows create-only subtitle when no owned workspaces', () => {
+      const wrapper = mountComponent()
+      const subtitle = wrapper.find('header p')
+      expect(subtitle.text()).toBe('teamWorkspacesDialog.subtitleNoWorkspaces')
+    })
+
+    it('shows switch-or-create subtitle when owned workspaces exist', () => {
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+      const subtitle = wrapper.find('header p')
+      expect(subtitle.text()).toBe('teamWorkspacesDialog.subtitle')
+    })
+  })
+
+  describe('workspace switching', () => {
+    it('calls switchWorkspace with workspace id and closes dialog on success', async () => {
+      mockSwitchWorkspace.mockResolvedValue(true)
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+
+      const switchButton = wrapper.find('li button')
+      await switchButton.trigger('click')
+      await flushPromises()
+
+      expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+
+    it('shows error toast and keeps dialog open when switch fails', async () => {
+      mockSwitchWorkspace.mockRejectedValue(new Error('Network error'))
+      setOwnedWorkspaces()
+      const wrapper = mountComponent()
+
+      const switchButton = wrapper.find('li button')
+      await switchButton.trigger('click')
+      await flushPromises()
+
+      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'Network error'
+        })
+      )
+    })
+  })
+
+  describe('name validation', () => {
+    it('disables create button for empty name', () => {
+      const wrapper = mountComponent()
+      expect(findCreateButton(wrapper).props('disabled')).toBe(true)
+    })
+
+    it('enables create button for valid name', async () => {
+      const wrapper = mountComponent()
+      const input = wrapper.find('#workspace-name-input')
+      await input.setValue('My Team')
+      await nextTick()
+
+      expect(findCreateButton(wrapper).props('disabled')).toBe(false)
+    })
+
+    it('disables create button for name with special characters', async () => {
+      const wrapper = mountComponent()
+      const input = wrapper.find('#workspace-name-input')
+      await input.setValue('!@#$%')
+      await nextTick()
+
+      expect(findCreateButton(wrapper).props('disabled')).toBe(true)
+    })
+
+    it('disables create button for name exceeding 50 characters', async () => {
+      const wrapper = mountComponent()
+      const input = wrapper.find('#workspace-name-input')
+      await input.setValue('a'.repeat(51))
+      await nextTick()
+
+      expect(findCreateButton(wrapper).props('disabled')).toBe(true)
+    })
+  })
+
+  describe('workspace creation', () => {
+    async function typeAndCreate(
+      wrapper: ReturnType<typeof mountComponent>,
+      name: string
+    ) {
+      await wrapper.find('#workspace-name-input').setValue(name)
+      await nextTick()
+      findCreateButton(wrapper).vm.$emit('click')
+      await flushPromises()
+    }
+
+    it('calls createWorkspace and onConfirm on success', async () => {
+      mockCreateWorkspace.mockResolvedValue({ id: 'new-ws' })
+      const onConfirm = vi.fn()
+      const wrapper = mountComponent({ onConfirm })
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(mockCreateWorkspace).toHaveBeenCalledWith('New Team')
+      expect(onConfirm).toHaveBeenCalledWith('New Team')
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+
+    it('shows error toast when creation fails', async () => {
+      mockCreateWorkspace.mockRejectedValue(new Error('Limit reached'))
+      const wrapper = mountComponent()
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'Limit reached'
+        })
+      )
+      expect(mockCloseDialog).not.toHaveBeenCalled()
+    })
+
+    it('shows separate toast when onConfirm fails but still closes dialog', async () => {
+      mockCreateWorkspace.mockResolvedValue({ id: 'new-ws' })
+      const onConfirm = vi.fn().mockRejectedValue(new Error('Setup failed'))
+      const wrapper = mountComponent({ onConfirm })
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(mockCreateWorkspace).toHaveBeenCalledWith('New Team')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'Setup failed'
+        })
+      )
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+
+    it('does not call onConfirm when createWorkspace fails', async () => {
+      mockCreateWorkspace.mockRejectedValue(new Error('Limit reached'))
+      const onConfirm = vi.fn()
+      const wrapper = mountComponent({ onConfirm })
+
+      await typeAndCreate(wrapper, 'New Team')
+
+      expect(onConfirm).not.toHaveBeenCalled()
+    })
+
+    it('does not call createWorkspace when name is invalid', async () => {
+      const wrapper = mountComponent()
+      findCreateButton(wrapper).vm.$emit('click')
+      await nextTick()
+
+      expect(mockCreateWorkspace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('close button', () => {
+    it('closes dialog on close button click', async () => {
+      const wrapper = mountComponent()
+      const closeBtn = wrapper.find('header button')
+      await closeBtn.trigger('click')
+
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'team-workspaces'
+      })
+    })
+  })
+})

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue
@@ -1,0 +1,228 @@
+<template>
+  <section
+    class="flex w-full max-w-[480px] flex-col rounded-2xl border border-border-default bg-base-background"
+  >
+    <!-- Header -->
+    <header class="flex items-start gap-3 p-5 pb-0">
+      <div
+        class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary-background text-white"
+        aria-hidden="true"
+      >
+        <i class="icon-[lucide--users] text-lg" />
+      </div>
+      <div class="flex min-w-0 flex-1 flex-col">
+        <h2 class="m-0 text-lg font-semibold text-base-foreground">
+          {{ $t('teamWorkspacesDialog.title') }}
+        </h2>
+        <p class="m-0 text-sm text-muted-foreground">
+          {{
+            ownedTeamWorkspaces.length > 0
+              ? $t('teamWorkspacesDialog.subtitle')
+              : $t('teamWorkspacesDialog.subtitleNoWorkspaces')
+          }}
+        </p>
+      </div>
+      <button
+        class="focus-visible:ring-secondary-foreground -mt-1 cursor-pointer rounded-sm border-none bg-transparent p-2 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
+        :aria-label="$t('g.close')"
+        @click="onCancel"
+      >
+        <i class="pi pi-times size-4" aria-hidden="true" />
+      </button>
+    </header>
+
+    <!-- Existing team workspaces -->
+    <section
+      v-if="ownedTeamWorkspaces.length > 0"
+      class="flex flex-col px-5 pt-5"
+    >
+      <h3
+        class="m-0 mb-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase"
+      >
+        {{ $t('teamWorkspacesDialog.yourTeamWorkspaces') }}
+      </h3>
+      <ul
+        class="m-0 flex max-h-52 list-none flex-col gap-2 overflow-y-auto p-0"
+      >
+        <li v-for="workspace in ownedTeamWorkspaces" :key="workspace.id">
+          <button
+            class="focus-visible:ring-secondary-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border-default bg-transparent px-4 py-3 transition-colors hover:bg-secondary-background-hover focus-visible:ring-1 focus-visible:outline-none"
+            @click="handleSwitch(workspace.id)"
+          >
+            <WorkspaceProfilePic
+              class="size-9 shrink-0 text-sm"
+              :workspace-name="workspace.name"
+            />
+            <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
+              <div class="flex items-center gap-1.5">
+                <span
+                  class="truncate text-left text-sm font-medium text-base-foreground"
+                >
+                  {{ workspace.name }}
+                </span>
+                <span
+                  v-if="tierLabels.get(workspace.id)"
+                  class="shrink-0 rounded-full bg-base-foreground px-1 py-0.5 text-[10px] font-bold text-base-background uppercase"
+                >
+                  {{ tierLabels.get(workspace.id) }}
+                </span>
+              </div>
+            </div>
+            <span class="text-primary-foreground shrink-0 text-sm font-medium">
+              {{ $t('teamWorkspacesDialog.switch') }}
+              <i class="pi pi-arrow-right text-xs" aria-hidden="true" />
+            </span>
+          </button>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Divider -->
+    <hr
+      v-if="ownedTeamWorkspaces.length > 0"
+      class="mx-5 my-4 border-border-default"
+    />
+
+    <!-- New workspace section -->
+    <section
+      class="flex flex-col gap-3 px-5 pb-5"
+      :class="{ 'pt-5': ownedTeamWorkspaces.length === 0 }"
+    >
+      <h3
+        class="m-0 text-xs font-semibold tracking-wider text-muted-foreground uppercase"
+      >
+        {{ $t('teamWorkspacesDialog.newWorkspace') }}
+      </h3>
+      <div class="flex flex-col gap-2">
+        <label for="workspace-name-input" class="text-sm text-base-foreground">
+          {{ $t('workspacePanel.createWorkspaceDialog.nameLabel') }}
+        </label>
+        <input
+          id="workspace-name-input"
+          v-model="workspaceName"
+          type="text"
+          class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
+          :placeholder="$t('teamWorkspacesDialog.namePlaceholder')"
+          :aria-invalid="workspaceName.length > 0 && !isValidName"
+          :aria-describedby="
+            workspaceName.length > 0 && !isValidName
+              ? 'workspace-name-error'
+              : undefined
+          "
+          @keydown.enter="isValidName && !loading && onCreate()"
+        />
+        <p
+          v-if="workspaceName.length > 0 && !isValidName"
+          id="workspace-name-error"
+          class="text-danger m-0 text-xs"
+        >
+          {{ $t('teamWorkspacesDialog.nameValidationError') }}
+        </p>
+      </div>
+      <Button
+        variant="secondary"
+        size="lg"
+        class="w-full"
+        :loading
+        :disabled="!isValidName || loading"
+        @click="onCreate"
+      >
+        <i class="pi pi-plus text-xs" aria-hidden="true" />
+        {{ $t('teamWorkspacesDialog.createWorkspace') }}
+      </Button>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useToast } from 'primevue/usetoast'
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
+import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
+import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const { onConfirm } = defineProps<{
+  onConfirm?: (name: string) => void | Promise<void>
+}>()
+
+const DIALOG_KEY = 'team-workspaces'
+const SAFE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9\s\-_'.,()&+]*$/
+
+const { t } = useI18n()
+const dialogStore = useDialogStore()
+const toast = useToast()
+const workspaceStore = useTeamWorkspaceStore()
+const { switchWorkspace } = useWorkspaceSwitch()
+const { getTierLabel } = useWorkspaceTierLabel()
+const { sharedWorkspaces } = storeToRefs(workspaceStore)
+
+const loading = ref(false)
+const workspaceName = ref('')
+
+const ownedTeamWorkspaces = computed(() =>
+  sharedWorkspaces.value.filter((w) => w.role === 'owner')
+)
+
+const tierLabels = computed(
+  () =>
+    new Map(
+      ownedTeamWorkspaces.value.map((w) => [w.id, getTierLabel(w)] as const)
+    )
+)
+
+const isValidName = computed(() => {
+  const name = workspaceName.value.trim()
+  return name.length >= 1 && name.length <= 50 && SAFE_NAME_REGEX.test(name)
+})
+
+function onCancel() {
+  dialogStore.closeDialog({ key: DIALOG_KEY })
+}
+
+async function handleSwitch(workspaceId: string) {
+  try {
+    await switchWorkspace(workspaceId)
+    dialogStore.closeDialog({ key: DIALOG_KEY })
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: t('workspaceSwitcher.failedToSwitch'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
+  }
+}
+
+async function onCreate() {
+  if (!isValidName.value || loading.value) return
+  loading.value = true
+  const name = workspaceName.value.trim()
+  try {
+    await workspaceStore.createWorkspace(name)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: t('workspacePanel.toast.failedToCreateWorkspace'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
+    loading.value = false
+    return
+  }
+  try {
+    await onConfirm?.(name)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: t('teamWorkspacesDialog.confirmCallbackFailed'),
+      detail: error instanceof Error ? error.message : t('g.unknownError')
+    })
+  }
+  dialogStore.closeDialog({ key: DIALOG_KEY })
+  loading.value = false
+}
+</script>

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCreateWorkspaceUrlLoader } from './useCreateWorkspaceUrlLoader'
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  clearPreservedQuery: vi.fn(),
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn()
+}))
+
+vi.mock(
+  '@/platform/navigation/preservedQueryManager',
+  () => preservedQueryMocks
+)
+
+const mockRouteQuery = vi.hoisted(() => ({
+  value: {} as Record<string, string>
+}))
+const mockRouterReplace = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: mockRouteQuery.value
+  }),
+  useRouter: () => ({
+    replace: mockRouterReplace
+  })
+}))
+
+const mockShowTeamWorkspacesDialog = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
+)
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showTeamWorkspacesDialog: mockShowTeamWorkspacesDialog
+  })
+}))
+
+describe('useCreateWorkspaceUrlLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('loadCreateWorkspaceFromUrl', () => {
+    it('does nothing when no create_workspace param present', async () => {
+      mockRouteQuery.value = {}
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowTeamWorkspacesDialog).not.toHaveBeenCalled()
+      expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+
+    it('opens create workspace dialog when param is present', async () => {
+      mockRouteQuery.value = { create_workspace: '1' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowTeamWorkspacesDialog).toHaveBeenCalledOnce()
+    })
+
+    it('restores preserved query and opens dialog', async () => {
+      mockRouteQuery.value = {}
+      preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+        create_workspace: '1'
+      })
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
+        'create_workspace'
+      )
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        query: { create_workspace: '1' }
+      })
+      expect(mockShowTeamWorkspacesDialog).toHaveBeenCalledOnce()
+    })
+
+    it('cleans up URL after processing', async () => {
+      mockRouteQuery.value = { create_workspace: '1', other: 'param' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        query: { other: 'param' }
+      })
+    })
+
+    it('clears preserved query after processing', async () => {
+      mockRouteQuery.value = { create_workspace: '1' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+        'create_workspace'
+      )
+    })
+
+    it('ignores empty param', async () => {
+      mockRouteQuery.value = { create_workspace: '' }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowTeamWorkspacesDialog).not.toHaveBeenCalled()
+    })
+
+    it('ignores non-string param', async () => {
+      mockRouteQuery.value = {
+        create_workspace: ['array'] as unknown as string
+      }
+
+      const { loadCreateWorkspaceFromUrl } = useCreateWorkspaceUrlLoader()
+      await loadCreateWorkspaceFromUrl()
+
+      expect(mockShowTeamWorkspacesDialog).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
+++ b/src/platform/workspace/composables/useCreateWorkspaceUrlLoader.ts
@@ -1,0 +1,71 @@
+import { useRoute, useRouter } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  hydratePreservedQuery,
+  mergePreservedQueryIntoQuery
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { useDialogService } from '@/services/dialogService'
+
+const NAMESPACE = PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE
+
+/**
+ * Composable for opening the team workspaces dialog via URL query parameter.
+ *
+ * Supports URLs like:
+ * - /?create_workspace=1 (opens the team workspaces dialog)
+ *
+ * The parameter is preserved through login redirects via the
+ * preserved query system (sessionStorage), following the same pattern
+ * as the invite URL loader.
+ */
+export function useCreateWorkspaceUrlLoader() {
+  const route = useRoute()
+  const router = useRouter()
+  const dialogService = useDialogService()
+
+  /**
+   * Opens the team workspaces dialog if `?create_workspace=1` is present.
+   *
+   * Flow:
+   * 1. Restore preserved query (for post-login redirect)
+   * 2. Check for create_workspace param in route.query
+   * 3. Open the team workspaces dialog
+   * 4. Clean up URL and preserved query
+   */
+  async function loadCreateWorkspaceFromUrl() {
+    hydratePreservedQuery(NAMESPACE)
+    const mergedQuery = mergePreservedQueryIntoQuery(NAMESPACE, route.query)
+    if (mergedQuery) {
+      await router.replace({ query: mergedQuery })
+    }
+
+    const query = mergedQuery ?? route.query
+    const param = query.create_workspace
+    if (!param || typeof param !== 'string') return
+
+    const newQuery = { ...route.query }
+    delete newQuery.create_workspace
+    router.replace({ query: newQuery }).catch((error) => {
+      console.warn(
+        '[useCreateWorkspaceUrlLoader] Failed to clean URL params:',
+        error
+      )
+    })
+    clearPreservedQuery(NAMESPACE)
+
+    try {
+      await dialogService.showTeamWorkspacesDialog()
+    } catch (error) {
+      console.error(
+        '[useCreateWorkspaceUrlLoader] Failed to open create workspace dialog:',
+        error
+      )
+    }
+  }
+
+  return {
+    loadCreateWorkspaceFromUrl
+  }
+}

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useWorkspaceTierLabel } from './useWorkspaceTierLabel'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: vi.fn((key: string, params?: Record<string, unknown>) => {
+      if (key === 'subscription.tierNameYearly') return `${params?.name} Yearly`
+
+      const tierNames: Record<string, string> = {
+        'subscription.tiers.free.name': 'Free',
+        'subscription.tiers.standard.name': 'Standard',
+        'subscription.tiers.creator.name': 'Creator',
+        'subscription.tiers.pro.name': 'Pro',
+        'subscription.tiers.founder.name': "Founder's Edition"
+      }
+      return tierNames[key] ?? key
+    })
+  })
+}))
+
+describe('useWorkspaceTierLabel', () => {
+  let formatTierName: ReturnType<typeof useWorkspaceTierLabel>['formatTierName']
+  let getTierLabel: ReturnType<typeof useWorkspaceTierLabel>['getTierLabel']
+
+  beforeEach(() => {
+    const composable = useWorkspaceTierLabel()
+    formatTierName = composable.formatTierName
+    getTierLabel = composable.getTierLabel
+  })
+
+  describe('formatTierName', () => {
+    it('returns empty string for null tier', () => {
+      expect(formatTierName(null, false)).toBe('')
+    })
+
+    it('returns empty string for undefined tier', () => {
+      expect(formatTierName(undefined, false)).toBe('')
+    })
+
+    it('returns base name for monthly plan', () => {
+      expect(formatTierName('PRO', false)).toBe('Pro')
+    })
+
+    it('appends yearly suffix for yearly plan', () => {
+      expect(formatTierName('PRO', true)).toBe('Pro Yearly')
+    })
+
+    it('maps FOUNDERS_EDITION to founder label', () => {
+      expect(formatTierName('FOUNDERS_EDITION', false)).toBe(
+        "Founder's Edition"
+      )
+    })
+
+    it('falls back to standard for unknown tier', () => {
+      expect(formatTierName('UNKNOWN_TIER', false)).toBe('')
+    })
+  })
+
+  describe('getTierLabel', () => {
+    it('returns null when workspace is not subscribed', () => {
+      const result = getTierLabel({
+        isSubscribed: false,
+        subscriptionPlan: 'PRO_MONTHLY',
+        subscriptionTier: 'PRO'
+      })
+      expect(result).toBeNull()
+    })
+
+    it('uses subscriptionTier when available', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: null,
+        subscriptionTier: 'CREATOR'
+      })
+      expect(result).toBe('Creator')
+    })
+
+    it('ignores plan slug yearly when subscriptionTier is present', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'PRO_YEARLY',
+        subscriptionTier: 'PRO'
+      })
+      expect(result).toBe('Pro')
+    })
+
+    it('falls back to parsing subscriptionPlan when tier is null', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'CREATOR_MONTHLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe('Creator')
+    })
+
+    it('returns null when subscribed but both tier and plan are null', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: null,
+        subscriptionTier: null
+      })
+      expect(result).toBeNull()
+    })
+
+    it('returns null when plan slug does not match any known tier', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'ENTERPRISE_CUSTOM',
+        subscriptionTier: null
+      })
+      expect(result).toBeNull()
+    })
+
+    it('handles FOUNDERS_EDITION tier', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: null,
+        subscriptionTier: 'FOUNDERS_EDITION'
+      })
+      expect(result).toBe("Founder's Edition")
+    })
+
+    it('parses yearly suffix from plan slug fallback', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'STANDARD_YEARLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe('Standard Yearly')
+    })
+
+    it('parses FOUNDERS_EDITION from plan slug fallback', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'FOUNDERS_EDITION_MONTHLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe("Founder's Edition")
+    })
+  })
+})

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -1,0 +1,56 @@
+import { useI18n } from 'vue-i18n'
+
+import type { SubscriptionTier } from '@/platform/workspace/api/workspaceApi'
+
+const tierKeyMap: Record<string, string> = {
+  FREE: 'free',
+  STANDARD: 'standard',
+  CREATOR: 'creator',
+  PRO: 'pro',
+  FOUNDER: 'founder',
+  FOUNDERS_EDITION: 'founder'
+}
+
+interface WorkspaceSubscriptionInfo {
+  isSubscribed: boolean
+  subscriptionPlan: string | null
+  subscriptionTier: SubscriptionTier | null
+}
+
+export function useWorkspaceTierLabel() {
+  const { t } = useI18n()
+
+  function formatTierName(
+    tier: string | null | undefined,
+    isYearly: boolean
+  ): string {
+    if (!tier) return ''
+    const key = tierKeyMap[tier]
+    if (!key) return ''
+    const baseName = t(`subscription.tiers.${key}.name`)
+    return isYearly
+      ? t('subscription.tierNameYearly', { name: baseName })
+      : baseName
+  }
+
+  function getTierLabel(workspace: WorkspaceSubscriptionInfo): string | null {
+    if (!workspace.isSubscribed) return null
+
+    if (workspace.subscriptionTier) {
+      return formatTierName(workspace.subscriptionTier, false)
+    }
+
+    if (!workspace.subscriptionPlan) return null
+
+    const planSlug = workspace.subscriptionPlan
+    const tierMatch = Object.keys(tierKeyMap)
+      .sort((a, b) => b.length - a.length)
+      .find((tier) => planSlug === tier || planSlug.startsWith(`${tier}_`))
+    if (!tierMatch) return null
+
+    const isYearly = planSlug.includes('YEARLY') || planSlug.includes('ANNUAL')
+    return formatTierName(tierMatch, isYearly)
+  }
+
+  return { formatTierName, getTierLabel }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -106,6 +106,10 @@ installPreservedQueryTracker(router, [
   {
     namespace: PRESERVED_QUERY_NAMESPACES.INVITE,
     keys: ['invite']
+  },
+  {
+    namespace: PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE,
+    keys: ['create_workspace']
   }
 ])
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -452,6 +452,25 @@ export const useDialogService = () => {
     })
   }
 
+  /**
+   * Show the team workspaces dialog for creating or switching workspaces.
+   * Optionally calls `onConfirm` after a workspace is successfully created.
+   */
+  async function showTeamWorkspacesDialog(
+    onConfirm?: (name: string) => void | Promise<void>
+  ) {
+    const { default: component } =
+      await import('@/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.vue')
+    return dialogStore.showDialog({
+      key: 'team-workspaces',
+      component,
+      props: { onConfirm },
+      dialogComponentProps: {
+        ...workspaceDialogPt
+      }
+    })
+  }
+
   async function showLeaveWorkspaceDialog() {
     const { default: component } =
       await import('@/platform/workspace/components/dialogs/LeaveWorkspaceDialogContent.vue')
@@ -566,6 +585,7 @@ export const useDialogService = () => {
     showSmallLayoutDialog,
     showDeleteWorkspaceDialog,
     showCreateWorkspaceDialog,
+    showTeamWorkspacesDialog,
     showLeaveWorkspaceDialog,
     showEditWorkspaceDialog,
     showRemoveMemberDialog,


### PR DESCRIPTION
Backport of #9901 to cloud/1.41.

Cherry-picked merge commit cd45efa983fae85de97ff382f7cfc9c4b7114e96.

**Conflict resolution:**
- `src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts`: modify/delete — file was new in the PR, kept PR version (git add).
- `src/platform/cloud/subscription/composables/useSubscriptionDialog.ts`: auto-merge dropped the `isCloud` import and early-return guard; restored both to match the main branch version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10401-backport-cloud-1-41-feat-differentiate-personal-team-pricing-table-with-two-stage-tea-32c6d73d365081328accfa6e0a410219) by [Unito](https://www.unito.io)
