### PR TITLE
fix: make gradient_stops enumerable so it survives object spread

### DIFF
--- a/src/extensions/core/customWidgets.test.ts
+++ b/src/extensions/core/customWidgets.test.ts
@@ -30,6 +30,7 @@ describe('PrimitiveFloat widget type bridging', () => {
     })
 
     Object.defineProperty(widget.options, 'gradient_stops', {
+      enumerable: true,
       get: () => properties.gradient_stops,
       set: (v) => {
         properties.gradient_stops = v
@@ -80,6 +81,20 @@ describe('PrimitiveFloat widget type bridging', () => {
     ]
     properties.gradient_stops = stops
     expect(widget.options.gradient_stops).toBe(stops)
+  })
+
+  it('gradient_stops survives object spread', () => {
+    const { properties, widget } = createMockNodeAndWidget()
+    applyFloatPropertyBridges(properties, widget)
+
+    const stops = [
+      { offset: 0, color: [0, 255, 255] },
+      { offset: 1, color: [255, 0, 0] }
+    ]
+    properties.gradient_stops = stops
+
+    const spread = { ...widget.options }
+    expect(spread.gradient_stops).toBe(stops)
   })
 
   it('writes gradient_stops back to properties', () => {

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -169,6 +169,7 @@ function onCustomFloatCreated(this: LGraphNode) {
   })
 
   Object.defineProperty(valueWidget.options, 'gradient_stops', {
+    enumerable: true,
     get: () => this.properties.gradient_stops,
     set: (v) => {
       this.properties.gradient_stops = v


### PR DESCRIPTION
## Summary
Object.defineProperty defaults to enumerable: false for new properties. NodeWidgets.vue spreads widget options into a new object, dropping non-enumerable properties — gradient_stops was silently lost, causing the gradient slider to fall back to the default black-to-white gradient.

## Screenshots (if applicable)
before
<img width="1679" height="1271" alt="image" src="https://github.com/user-attachments/assets/60a20163-56e5-4438-9c36-ea42c23c7495" />

after
<img width="1686" height="1421" alt="image" src="https://github.com/user-attachments/assets/5057b3d4-32ee-4abc-9118-cc2c3f85ae85" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10403-fix-make-gradient_stops-enumerable-so-it-survives-object-spread-32c6d73d365081f98e00d2e87022c679) by [Unito](https://www.unito.io)
