### PR TITLE
fix: make gradient_stops enumerable so it survives object spread

### DIFF
--- a/src/extensions/core/customWidgets.test.ts
+++ b/src/extensions/core/customWidgets.test.ts
@@ -30,6 +30,7 @@ describe('PrimitiveFloat widget type bridging', () => {
     })
 
     Object.defineProperty(widget.options, 'gradient_stops', {
+      enumerable: true,
       get: () => properties.gradient_stops,
       set: (v) => {
         properties.gradient_stops = v

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -169,6 +169,7 @@ function onCustomFloatCreated(this: LGraphNode) {
   })
 
   Object.defineProperty(valueWidget.options, 'gradient_stops', {
+    enumerable: true,
     get: () => this.properties.gradient_stops,
     set: (v) => {
       this.properties.gradient_stops = v


### PR DESCRIPTION
## Summary
Object.defineProperty defaults to enumerable: false for new properties. NodeWidgets.vue spreads widget options into a new object, dropping non-enumerable properties — gradient_stops was silently lost, causing the gradient slider to fall back to the default black-to-white gradient.

## Screenshots (if applicable)

before
<img width="1679" height="1271" alt="image" src="https://github.com/user-attachments/assets/60a20163-56e5-4438-9c36-ea42c23c7495" />

after
<img width="1686" height="1421" alt="image" src="https://github.com/user-attachments/assets/5057b3d4-32ee-4abc-9118-cc2c3f85ae85" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10406-fix-make-gradient_stops-enumerable-so-it-survives-object-spread-32c6d73d36508131b7c8c3ab3e93d221) by [Unito](https://www.unito.io)
