### PR TITLE
test: verify gradient_stops survives object spread

### DIFF
--- a/src/extensions/core/customWidgets.test.ts
+++ b/src/extensions/core/customWidgets.test.ts
@@ -83,6 +83,20 @@ describe('PrimitiveFloat widget type bridging', () => {
     expect(widget.options.gradient_stops).toBe(stops)
   })
 
+  it('gradient_stops survives object spread', () => {
+    const { properties, widget } = createMockNodeAndWidget()
+    applyFloatPropertyBridges(properties, widget)
+
+    const stops = [
+      { offset: 0, color: [0, 255, 255] },
+      { offset: 1, color: [255, 0, 0] }
+    ]
+    properties.gradient_stops = stops
+
+    const spread = { ...widget.options }
+    expect(spread.gradient_stops).toBe(stops)
+  })
+
   it('writes gradient_stops back to properties', () => {
     const { properties, widget } = createMockNodeAndWidget()
     applyFloatPropertyBridges(properties, widget)


### PR DESCRIPTION
## Summary
follow up https://github.com/Comfy-Org/ComfyUI_frontend/pull/10406 to add test

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10408-test-verify-gradient_stops-survives-object-spread-32c6d73d3650815da123c88f4b9b86ce) by [Unito](https://www.unito.io)
