### PR TITLE
fix: block workflow queue when file input nodes have empty selections

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1889,7 +1889,9 @@
     "extensionFileHint": "This may be due to the following script",
     "promptExecutionError": "Prompt execution failed",
     "accessRestrictedTitle": "Access Restricted",
-    "accessRestrictedMessage": "Your account is not authorized for this feature."
+    "accessRestrictedMessage": "Your account is not authorized for this feature.",
+    "emptyFileInputTitle": "Missing File Inputs",
+    "emptyFileInputMessage": "The following nodes require a file to be selected: {nodeList}. Please upload or select files before running."
   },
   "apiNodesSignInDialog": {
     "title": "Sign In Required to Use API Nodes",

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -146,7 +146,7 @@ import {
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
-export const FILE_INPUT_FIELDS = {
+const FILE_INPUT_FIELDS = {
   LoadImage: 'image',
   LoadAudio: 'audio',
   Load3D: 'model_file',
@@ -159,11 +159,17 @@ function isEmptyFileValue(value: unknown): boolean {
   return value == null
 }
 
+interface EmptyFileInputNode {
+  nodeId: string
+  classType: string
+  title: string
+}
+
 export function findEmptyFileInputNodes(
   output: ComfyApiWorkflow,
   nodeIds?: Set<string>
-): { nodeId: string; classType: string; title: string }[] {
-  const result: { nodeId: string; classType: string; title: string }[] = []
+): EmptyFileInputNode[] {
+  const result: EmptyFileInputNode[] = []
   for (const [nodeId, node] of Object.entries(output)) {
     if (nodeIds && !nodeIds.has(nodeId)) continue
     const field =

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -146,20 +146,29 @@ import {
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
-export const FILE_INPUT_FIELDS: Record<string, string> = {
+export const FILE_INPUT_FIELDS = {
   LoadImage: 'image',
   LoadAudio: 'audio',
   Load3D: 'model_file',
   LoadVideo: 'video'
+} as const
+
+function isEmptyFileValue(value: unknown): boolean {
+  if (Array.isArray(value)) return false // linked input from another node
+  if (typeof value === 'string') return value.trim() === ''
+  return value == null
 }
 
 export function findEmptyFileInputNodes(
-  output: ComfyApiWorkflow
+  output: ComfyApiWorkflow,
+  nodeIds?: Set<string>
 ): { nodeId: string; classType: string; title: string }[] {
   const result: { nodeId: string; classType: string; title: string }[] = []
   for (const [nodeId, node] of Object.entries(output)) {
-    const field = FILE_INPUT_FIELDS[node.class_type]
-    if (field && node.inputs[field] === '') {
+    if (nodeIds && !nodeIds.has(nodeId)) continue
+    const field =
+      FILE_INPUT_FIELDS[node.class_type as keyof typeof FILE_INPUT_FIELDS]
+    if (field && isEmptyFileValue(node.inputs[field])) {
       result.push({
         nodeId,
         classType: node.class_type,
@@ -1640,7 +1649,13 @@ export class ComfyApp {
             .activeWorkflow as ComfyWorkflow
           const p = await this.graphToPrompt(this.rootGraph)
 
-          const emptyFileInputNodes = findEmptyFileInputNodes(p.output)
+          const targetNodeIds = isPartialExecution
+            ? new Set(queueNodeIds!)
+            : undefined
+          const emptyFileInputNodes = findEmptyFileInputNodes(
+            p.output,
+            targetNodeIds
+          )
           if (emptyFileInputNodes.length) {
             const nodeList = emptyFileInputNodes
               .map((n) => `#${n.nodeId} ${n.title}`)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1667,9 +1667,7 @@ export class ComfyApp {
               .map((n) => `#${n.nodeId} ${n.title}`)
               .join(', ')
             useDialogService().showErrorDialog(
-              new Error(
-                t('errorDialog.emptyFileInputMessage', { nodeList })
-              ),
+              new Error(t('errorDialog.emptyFileInputMessage', { nodeList })),
               { title: t('errorDialog.emptyFileInputTitle') }
             )
             break

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -146,6 +146,30 @@ import {
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
 
+export const FILE_INPUT_FIELDS: Record<string, string> = {
+  LoadImage: 'image',
+  LoadAudio: 'audio',
+  Load3D: 'model_file',
+  LoadVideo: 'video'
+}
+
+export function findEmptyFileInputNodes(
+  output: ComfyApiWorkflow
+): { nodeId: string; classType: string; title: string }[] {
+  const result: { nodeId: string; classType: string; title: string }[] = []
+  for (const [nodeId, node] of Object.entries(output)) {
+    const field = FILE_INPUT_FIELDS[node.class_type]
+    if (field && node.inputs[field] === '') {
+      result.push({
+        nodeId,
+        classType: node.class_type,
+        title: node._meta?.title ?? node.class_type
+      })
+    }
+  }
+  return result
+}
+
 export function sanitizeNodeName(string: string) {
   let entityMap = {
     '&': '',
@@ -1615,6 +1639,21 @@ export class ComfyApp {
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
           const p = await this.graphToPrompt(this.rootGraph)
+
+          const emptyFileInputNodes = findEmptyFileInputNodes(p.output)
+          if (emptyFileInputNodes.length) {
+            const nodeList = emptyFileInputNodes
+              .map((n) => `#${n.nodeId} ${n.title}`)
+              .join(', ')
+            useDialogService().showErrorDialog(
+              new Error(
+                t('errorDialog.emptyFileInputMessage', { nodeList })
+              ),
+              { title: t('errorDialog.emptyFileInputTitle') }
+            )
+            break
+          }
+
           const queuedNodes = collectAllNodes(this.rootGraph)
           try {
             api.authToken = comfyOrgAuthToken

--- a/src/scripts/findEmptyFileInputNodes.test.ts
+++ b/src/scripts/findEmptyFileInputNodes.test.ts
@@ -70,4 +70,51 @@ describe('findEmptyFileInputNodes', () => {
       { nodeId: '5', classType: 'Load3D', title: 'Load3D' }
     ])
   })
+
+  it('detects null file input values', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: null })
+    }
+    expect(findEmptyFileInputNodes(output)).toHaveLength(1)
+  })
+
+  it('detects undefined file input values', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: undefined })
+    }
+    expect(findEmptyFileInputNodes(output)).toHaveLength(1)
+  })
+
+  it('detects whitespace-only file input values', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: '   ' })
+    }
+    expect(findEmptyFileInputNodes(output)).toHaveLength(1)
+  })
+
+  it('skips linked inputs (array references to other nodes)', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: ['5', 0] })
+    }
+    expect(findEmptyFileInputNodes(output)).toEqual([])
+  })
+
+  it('filters to only specified node IDs when provided', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: '' }),
+      '2': makeNode('LoadAudio', { audio: '' }),
+      '3': makeNode('KSampler', { seed: 42 })
+    }
+    const result = findEmptyFileInputNodes(output, new Set(['2', '3']))
+    expect(result).toEqual([
+      { nodeId: '2', classType: 'LoadAudio', title: 'LoadAudio' }
+    ])
+  })
+
+  it('detects missing file input field entirely', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', {})
+    }
+    expect(findEmptyFileInputNodes(output)).toHaveLength(1)
+  })
 })

--- a/src/scripts/findEmptyFileInputNodes.test.ts
+++ b/src/scripts/findEmptyFileInputNodes.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { findEmptyFileInputNodes } from './app'
+
+function makeNode(
+  classType: string,
+  inputs: Record<string, unknown>,
+  title?: string
+) {
+  return {
+    class_type: classType,
+    inputs,
+    _meta: { title: title ?? classType }
+  }
+}
+
+describe('findEmptyFileInputNodes', () => {
+  it('detects LoadImage with empty image field', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: '' }),
+      '2': makeNode('KSampler', { seed: 42 })
+    }
+    expect(findEmptyFileInputNodes(output)).toEqual([
+      { nodeId: '1', classType: 'LoadImage', title: 'LoadImage' }
+    ])
+  })
+
+  it('detects multiple empty file input nodes', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: '' }, 'My Image'),
+      '2': makeNode('LoadAudio', { audio: '' }),
+      '3': makeNode('LoadVideo', { video: 'file.mp4' })
+    }
+    const result = findEmptyFileInputNodes(output)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      nodeId: '1',
+      classType: 'LoadImage',
+      title: 'My Image'
+    })
+    expect(result[1]).toEqual({
+      nodeId: '2',
+      classType: 'LoadAudio',
+      title: 'LoadAudio'
+    })
+  })
+
+  it('returns empty array when all file inputs are populated', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('LoadImage', { image: 'photo.png' }),
+      '2': makeNode('Load3D', { model_file: 'model.glb' })
+    }
+    expect(findEmptyFileInputNodes(output)).toEqual([])
+  })
+
+  it('returns empty array when no file input nodes exist', () => {
+    const output: ComfyApiWorkflow = {
+      '1': makeNode('KSampler', { seed: 42 }),
+      '2': makeNode('CLIPTextEncode', { text: 'hello' })
+    }
+    expect(findEmptyFileInputNodes(output)).toEqual([])
+  })
+
+  it('detects Load3D with empty model_file', () => {
+    const output: ComfyApiWorkflow = {
+      '5': makeNode('Load3D', { model_file: '' })
+    }
+    expect(findEmptyFileInputNodes(output)).toEqual([
+      { nodeId: '5', classType: 'Load3D', title: 'Load3D' }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Validates file-input nodes (LoadImage, LoadAudio, Load3D, LoadVideo) before submitting workflows
- Shows a localized error dialog listing affected nodes when required file fields are empty
- Prevents round-trip to backend for an error the user can fix locally

Fixes COM-17398

## Related
- Parent bug: COM-17391
- Backend fix: https://github.com/Comfy-Org/cloud/pull/2946

## Test plan
- [ ] Import a shared workflow with a LoadImage node missing its image → localized "Missing File Inputs" dialog appears
- [ ] Run a workflow with all file inputs populated → works normally
- [ ] Run a workflow with no file-input nodes → works normally

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10418-fix-block-workflow-queue-when-file-input-nodes-have-empty-selections-32d6d73d365081a78756f00d7cad7fd3) by [Unito](https://www.unito.io)
