### PR TITLE
fix: sync advanced inputs button color with node header

### DIFF
--- a/src/renderer/extensions/vueNodes/components/NodeFooter.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.vue
@@ -28,7 +28,7 @@
           '-z-10 bg-node-component-header-surface'
         )
       "
-      :style="{ backgroundColor: headerColor }"
+      :style="headerColorStyle"
       @click.stop="$emit('enterSubgraph')"
     >
       <div class="ml-auto flex h-full w-1/2 items-center justify-center gap-2">
@@ -73,6 +73,7 @@
           '-z-10 bg-node-component-header-surface'
         )
       "
+      :style="headerColorStyle"
       @click.stop="$emit('toggleAdvanced')"
     >
       <div class="ml-auto flex h-full w-1/2 items-center justify-center gap-2">
@@ -124,7 +125,7 @@
           '-z-10 bg-node-component-header-surface'
         )
       "
-      :style="{ backgroundColor: headerColor }"
+      :style="headerColorStyle"
       @click.stop="$emit('enterSubgraph')"
     >
       <div class="flex size-full items-center justify-center gap-2">
@@ -145,6 +146,7 @@
         '-z-10 bg-node-component-header-surface'
       )
     "
+    :style="headerColorStyle"
     @click.stop="$emit('toggleAdvanced')"
   >
     <div class="flex size-full items-center justify-center gap-2">
@@ -232,6 +234,10 @@ const getTabStyles = (isBackground = false) => {
     props.hasAnyError ? '-translate-x-1 translate-y-0.5' : 'translate-y-0.5'
   )
 }
+
+const headerColorStyle = computed(() =>
+  props.headerColor ? { backgroundColor: props.headerColor } : undefined
+)
 
 // Case 1 context: Split widths
 const errorTabWidth = 'w-[calc(50%+4px)]'


### PR DESCRIPTION
## Summary
- The "Show Advanced Inputs" footer button was missing `headerColor` style binding, causing it to not sync with the node header color (unlike the "Enter Subgraph" button which already had it)
- Extracted the repeated `{ backgroundColor: headerColor }` inline style (4 occurrences) into a `headerColorStyle` computed

## Screenshots 
before 
<img width="211" height="286" alt="스크린샷 2026-03-24 154312" src="https://github.com/user-attachments/assets/edfd9480-04fa-4cd4-813d-a95adffbe2d3" />

after 
<img width="261" height="333" alt="스크린샷 2026-03-24 154622" src="https://github.com/user-attachments/assets/eab28717-889e-4a6b-8775-bfc08fa727ff" />

## Test plan
- [x] Set a custom color on a node with advanced inputs and verify the footer button matches the header color
- [x] Verify subgraph enter button still syncs correctly
- [x] Verify dual-tab layouts (error + advanced, error + subgraph) both show correct colors

### Why no E2E test
Node header color is applied as an inline style via `headerColor` prop, which is already passed and tested through the existing subgraph enter button path. This change simply extends the same binding to the advanced inputs buttons — no new data flow or interaction is introduced, so a screenshot-based E2E test would add maintenance cost without meaningful regression coverage.