### PR TITLE
refactor: clean up essentials node organization logic

### DIFF
--- a/src/constants/essentialsNodes.ts
+++ b/src/constants/essentialsNodes.ts
@@ -108,6 +108,27 @@ export const ESSENTIALS_CATEGORY_CANONICAL: ReadonlyMap<
 > = new Map(ESSENTIALS_CATEGORIES.map((c) => [c.toLowerCase(), c]))
 
 /**
+ * Precomputed rank map: category → display order index.
+ * Used for sorting essentials folders in their canonical order.
+ */
+export const ESSENTIALS_CATEGORY_RANK: ReadonlyMap<string, number> = new Map(
+  ESSENTIALS_CATEGORIES.map((c, i) => [c, i])
+)
+
+/**
+ * Precomputed rank maps: category → (node name → display order index).
+ * Used for sorting nodes within each essentials folder.
+ */
+export const ESSENTIALS_NODE_RANK: Partial<
+  Record<EssentialsCategory, ReadonlyMap<string, number>>
+> = Object.fromEntries(
+  Object.entries(ESSENTIALS_NODES).map(([category, nodes]) => [
+    category,
+    new Map(nodes.map((name, i) => [name, i]))
+  ])
+)
+
+/**
  * "Novel" toolkit nodes for telemetry — basics excluded.
  * Derived from ESSENTIALS_NODES minus the 'basics' category.
  */

--- a/src/services/nodeOrganizationService.ts
+++ b/src/services/nodeOrganizationService.ts
@@ -1,8 +1,9 @@
 import { resolveBlueprintEssentialsCategory } from '@/constants/essentialsDisplayNames'
 import type { EssentialsCategory } from '@/constants/essentialsNodes'
 import {
-  ESSENTIALS_CATEGORIES,
-  ESSENTIALS_NODES
+  ESSENTIALS_CATEGORY_CANONICAL,
+  ESSENTIALS_CATEGORY_RANK,
+  ESSENTIALS_NODE_RANK
 } from '@/constants/essentialsNodes'
 import { t } from '@/i18n'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -19,6 +20,34 @@ import type { TreeNode } from '@/types/treeExplorerTypes'
 import { sortedTree, unwrapTreeRoot } from '@/utils/treeUtil'
 
 const DEFAULT_ICON = 'pi pi-sort'
+const UNKNOWN_RANK = Number.MAX_SAFE_INTEGER
+
+function resolveEssentialsCategory(
+  nodeDef: ComfyNodeDefImpl
+): EssentialsCategory | undefined {
+  if (!nodeDef.isCoreNode) return undefined
+
+  if (nodeDef.essentials_category) {
+    return (
+      ESSENTIALS_CATEGORY_CANONICAL.get(
+        nodeDef.essentials_category.toLowerCase()
+      ) ?? (nodeDef.essentials_category as EssentialsCategory)
+    )
+  }
+  return resolveBlueprintEssentialsCategory(nodeDef.name)
+}
+
+function sortByKnownOrder<T>(
+  items: T[],
+  getKey: (item: T) => string | undefined,
+  rankMap: ReadonlyMap<string, number>
+): void {
+  items.sort(
+    (a, b) =>
+      (rankMap.get(getKey(a) ?? '') ?? UNKNOWN_RANK) -
+      (rankMap.get(getKey(b) ?? '') ?? UNKNOWN_RANK)
+  )
+}
 
 function categoryPathExtractor(nodeDef: ComfyNodeDefImpl): string[] {
   const category = nodeDef.category || ''
@@ -147,44 +176,39 @@ class NodeOrganizationService {
   }
 
   private organizeEssentials(nodes: ComfyNodeDefImpl[]): NodeSection[] {
-    const essentialNodes = nodes.filter(
-      (nodeDef) =>
-        !!nodeDef.essentials_category ||
-        !!resolveBlueprintEssentialsCategory(nodeDef.name)
-    )
-    const tree = buildNodeDefTree(essentialNodes, {
-      pathExtractor: (nodeDef) => {
-        const folder =
-          nodeDef.essentials_category ||
-          resolveBlueprintEssentialsCategory(nodeDef.name) ||
-          ''
-        return folder ? [folder, nodeDef.name] : [nodeDef.name]
-      }
+    const categoryByNode = new Map<ComfyNodeDefImpl, EssentialsCategory>()
+    const essentialNodes = nodes.filter((node) => {
+      const category = resolveEssentialsCategory(node)
+      if (!category) return false
+      categoryByNode.set(node, category)
+      return true
     })
-    this.sortEssentialsFolders(tree)
+
+    const tree = buildNodeDefTree(essentialNodes, {
+      pathExtractor: (node) => [categoryByNode.get(node)!, node.name]
+    })
+    this.sortEssentialsTree(tree)
     return [{ tree }]
   }
 
-  private sortEssentialsFolders(tree: TreeNode): void {
+  private sortEssentialsTree(tree: TreeNode): void {
     if (!tree.children) return
 
-    const catLen = ESSENTIALS_CATEGORIES.length
-    tree.children.sort((a, b) => {
-      const ai = ESSENTIALS_CATEGORIES.indexOf(a.label as EssentialsCategory)
-      const bi = ESSENTIALS_CATEGORIES.indexOf(b.label as EssentialsCategory)
-      return (ai === -1 ? catLen : ai) - (bi === -1 ? catLen : bi)
-    })
+    sortByKnownOrder(
+      tree.children,
+      (node) => node.label,
+      ESSENTIALS_CATEGORY_RANK
+    )
 
     for (const folder of tree.children) {
       if (!folder.children) continue
-      const order = ESSENTIALS_NODES[folder.label as EssentialsCategory]
-      if (!order) continue
-      const orderLen = order.length
-      folder.children.sort((a, b) => {
-        const ai = order.indexOf(a.data?.name ?? a.label ?? '')
-        const bi = order.indexOf(b.data?.name ?? b.label ?? '')
-        return (ai === -1 ? orderLen : ai) - (bi === -1 ? orderLen : bi)
-      })
+      const rankMap = ESSENTIALS_NODE_RANK[folder.label as EssentialsCategory]
+      if (!rankMap) continue
+      sortByKnownOrder(
+        folder.children,
+        (node) => node.data?.name ?? node.label,
+        rankMap
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

Refactor essentials tab node organization to eliminate duplicated logic and restrict essentials to core nodes only.

## Changes

- **What**: 
  - Extract `resolveEssentialsCategory` to centralize category resolution (was duplicated between filter and pathExtractor).
  - Add `isCoreNode` guard so third-party nodes never appear in essentials. 
  - Replace `indexOf`-based sorting with precomputed rank maps (`ESSENTIALS_CATEGORY_RANK`, `ESSENTIALS_NODE_RANK`). 

<img width="589" height="769" alt="image" src="https://github.com/user-attachments/assets/66f41f35-aef5-4e12-97d5-0f33baf0ac45" />


## Review Focus

- The `isCoreNode` guard in `resolveEssentialsCategory` — ensures only core nodes can appear in essentials even if a custom node sets `essentials_category`.
- Rank map precomputation vs previous `indexOf` — functionally equivalent but O(1) lookup.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10433-refactor-clean-up-essentials-node-organization-logic-32d6d73d36508193a4d1f7f9c18fcef7) by [Unito](https://www.unito.io)
