### PR TITLE
fix: restore Firebase getAdditionalUserInfo for sign-up telemetry OR logic

### DIFF
--- a/src/stores/firebaseAuthStore.test.ts
+++ b/src/stores/firebaseAuthStore.test.ts
@@ -85,9 +85,18 @@ vi.mock('firebase/auth', async (importOriginal) => {
       addScope = vi.fn()
       setCustomParameters = vi.fn()
     },
+    getAdditionalUserInfo: vi.fn(),
     setPersistence: vi.fn().mockResolvedValue(undefined)
   }
 })
+
+// Mock telemetry
+const mockTrackAuth = vi.fn()
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackAuth: mockTrackAuth
+  })
+}))
 
 // Mock useToastStore
 vi.mock('@/stores/toastStore', () => ({
@@ -571,6 +580,82 @@ describe('useFirebaseAuthStore', () => {
       await Promise.all([googleLoginPromise, githubLoginPromise])
 
       expect(store.loading).toBe(false)
+    })
+
+    describe('sign-up telemetry OR logic', () => {
+      const mockUserCredential = {
+        user: mockUser
+      } as Partial<UserCredential> as UserCredential
+
+      beforeEach(() => {
+        vi.mocked(firebaseAuth.signInWithPopup).mockResolvedValue(
+          mockUserCredential
+        )
+      })
+
+      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+        '%s should track is_new_user=true when Firebase says new user',
+        async (method) => {
+          vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
+            isNewUser: true,
+            providerId: 'google.com',
+            profile: null
+          })
+
+          await store[method]()
+
+          expect(mockTrackAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ is_new_user: true })
+          )
+        }
+      )
+
+      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+        '%s should track is_new_user=true when UI options say new user',
+        async (method) => {
+          vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
+            isNewUser: false,
+            providerId: 'google.com',
+            profile: null
+          })
+
+          await store[method]({ isNewUser: true })
+
+          expect(mockTrackAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ is_new_user: true })
+          )
+        }
+      )
+
+      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+        '%s should track is_new_user=false when neither source says new user',
+        async (method) => {
+          vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
+            isNewUser: false,
+            providerId: 'google.com',
+            profile: null
+          })
+
+          await store[method]()
+
+          expect(mockTrackAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ is_new_user: false })
+          )
+        }
+      )
+
+      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+        '%s should track is_new_user=false when getAdditionalUserInfo returns null',
+        async (method) => {
+          vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue(null)
+
+          await store[method]()
+
+          expect(mockTrackAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ is_new_user: false })
+          )
+        }
+      )
     })
   })
 

--- a/src/stores/firebaseAuthStore.ts
+++ b/src/stores/firebaseAuthStore.ts
@@ -5,6 +5,7 @@ import {
   GoogleAuthProvider,
   browserLocalPersistence,
   createUserWithEmailAndPassword,
+  getAdditionalUserInfo,
   onAuthStateChanged,
   onIdTokenChanged,
   sendPasswordResetEmail,
@@ -386,9 +387,11 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     )
 
     if (isCloud) {
+      const additionalUserInfo = getAdditionalUserInfo(result)
       useTelemetry()?.trackAuth({
         method: 'google',
-        is_new_user: options?.isNewUser ?? false,
+        is_new_user:
+          options?.isNewUser || additionalUserInfo?.isNewUser || false,
         user_id: result.user.uid
       })
     }
@@ -405,9 +408,11 @@ export const useFirebaseAuthStore = defineStore('firebaseAuth', () => {
     )
 
     if (isCloud) {
+      const additionalUserInfo = getAdditionalUserInfo(result)
       useTelemetry()?.trackAuth({
         method: 'github',
-        is_new_user: options?.isNewUser ?? false,
+        is_new_user:
+          options?.isNewUser || additionalUserInfo?.isNewUser || false,
         user_id: result.user.uid
       })
     }


### PR DESCRIPTION
## Summary

Restores `getAdditionalUserInfo` from Firebase Auth so sign-up telemetry fires when *either* Firebase or the UI context identifies a new user, fixing a regression from #10388.

## Changes

- **What**: In `loginWithGoogle` and `loginWithGithub`, call `getAdditionalUserInfo(result)` and OR it with the UI-provided `options?.isNewUser` flag: `is_new_user: options?.isNewUser || additionalUserInfo?.isNewUser || false`. Added 8 parameterized unit tests covering the OR truth table (Firebase true, UI true, both false, null result).

## Review Focus

The OR semantics: if either source says new user, we send `sign_up` telemetry. Previously only the UI flag was checked, which missed cases where the user lands directly on the OAuth provider without going through the sign-up view.

## Testing

Unit tests cover all branches of the OR logic. An e2e test is not feasible here because it would require completing a real OAuth flow with Google/GitHub (interactive popup, valid credentials, CAPTCHA) and intercepting the resulting `getAdditionalUserInfo` response from Firebase — none of which can be reliably automated in a headless Playwright environment without a live Firebase project seeded with disposable accounts.

Fixes #10447