### PR TITLE
perf: disable Sentry event target wrapping to reduce DOM event overhead

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,14 @@ Sentry.init({
   replaysOnErrorSampleRate: 0,
   // Only set these for non-cloud builds
   ...(isCloud
-    ? {}
+    ? {
+        integrations: [
+          // Disable event target wrapping to reduce overhead on high-frequency
+          // DOM events (pointermove, mousemove, wheel). Sentry still captures
+          // errors via window.onerror and unhandledrejection.
+          Sentry.browserApiErrorsIntegration({ eventTarget: false })
+        ]
+      }
     : {
         integrations: [],
         autoSessionTracking: false,


### PR DESCRIPTION
## Summary

Disable Sentry `browserApiErrorsIntegration` event target wrapping for cloud builds to eliminate 231.7ms of `sentryWrapped` overhead during canvas interaction.

## Changes

- **What**: Configure `browserApiErrorsIntegration({ eventTarget: false })` in the cloud Sentry init path. This prevents Sentry from wrapping every `addEventListener` callback in try/catch, which was the #1 hot function during multi-cluster panning (100 profiling samples). Error capturing still works via `window.onerror` and `unhandledrejection`.

## Review Focus

- Confirm that disabling event target wrapping is acceptable for cloud error monitoring — Sentry still captures unhandled errors, just not errors thrown inside individual event handler callbacks.
- Non-cloud builds already had `integrations: []` / `defaultIntegrations: false`, so no change there.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10472-perf-disable-Sentry-event-target-wrapping-to-reduce-DOM-event-overhead-32d6d73d365081cdb455e47aee34dcc6) by [Unito](https://www.unito.io)
