### PR TITLE
refactor: extract auth-routing from workspaceApi to auth domain

### DIFF
--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -290,10 +290,6 @@ async function getAuthHeaderOrThrow() {
   return useAuthStore().getAuthHeaderOrThrow()
 }
 
-async function getFirebaseHeaderOrThrow() {
-  return useAuthStore().getFirebaseAuthHeaderOrThrow()
-}
-
 function handleAxiosError(err: unknown): never {
   if (axios.isAxiosError(err)) {
     const status = err.response?.status
@@ -483,7 +479,7 @@ export const workspaceApi = {
    * Uses Firebase auth (user identity) since the user isn't yet a workspace member.
    */
   async acceptInvite(token: string): Promise<AcceptInviteResponse> {
-    const headers = await getFirebaseHeaderOrThrow()
+    const headers = await useAuthStore().getFirebaseAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<AcceptInviteResponse>(
         api.apiURL(`/invites/${token}/accept`),

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 
-import { t } from '@/i18n'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -288,27 +287,11 @@ const workspaceApiClient = axios.create({
 })
 
 async function getAuthHeaderOrThrow() {
-  const authHeader = await useAuthStore().getAuthHeader()
-  if (!authHeader) {
-    throw new WorkspaceApiError(
-      t('toastMessages.userNotAuthenticated'),
-      401,
-      'NOT_AUTHENTICATED'
-    )
-  }
-  return authHeader
+  return useAuthStore().getAuthHeaderOrThrow()
 }
 
 async function getFirebaseHeaderOrThrow() {
-  const authHeader = await useAuthStore().getFirebaseAuthHeader()
-  if (!authHeader) {
-    throw new WorkspaceApiError(
-      t('toastMessages.userNotAuthenticated'),
-      401,
-      'NOT_AUTHENTICATED'
-    )
-  }
-  return authHeader
+  return useAuthStore().getFirebaseAuthHeaderOrThrow()
 }
 
 function handleAxiosError(err: unknown): never {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -730,6 +730,37 @@ describe('useAuthStore', () => {
     })
   })
 
+  describe('getAuthHeaderOrThrow', () => {
+    it('returns auth header when authenticated', async () => {
+      const header = await store.getAuthHeaderOrThrow()
+      expect(header).toEqual({ Authorization: 'Bearer mock-id-token' })
+    })
+
+    it('throws AuthStoreError when not authenticated', async () => {
+      authStateCallback(null)
+      mockApiKeyGetAuthHeader.mockReturnValue(null)
+
+      await expect(store.getAuthHeaderOrThrow()).rejects.toThrow(
+        'toastMessages.userNotAuthenticated'
+      )
+    })
+  })
+
+  describe('getFirebaseAuthHeaderOrThrow', () => {
+    it('returns Firebase auth header when authenticated', async () => {
+      const header = await store.getFirebaseAuthHeaderOrThrow()
+      expect(header).toEqual({ Authorization: 'Bearer mock-id-token' })
+    })
+
+    it('throws AuthStoreError when not authenticated', async () => {
+      authStateCallback(null)
+
+      await expect(store.getFirebaseAuthHeaderOrThrow()).rejects.toThrow(
+        'toastMessages.userNotAuthenticated'
+      )
+    })
+  })
+
   describe('createCustomer', () => {
     it('should succeed with API key auth when no Firebase user is present', async () => {
       authStateCallback(null)

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -740,9 +740,10 @@ describe('useAuthStore', () => {
       authStateCallback(null)
       mockApiKeyGetAuthHeader.mockReturnValue(null)
 
-      await expect(store.getAuthHeaderOrThrow()).rejects.toThrow(
-        'toastMessages.userNotAuthenticated'
-      )
+      await expect(store.getAuthHeaderOrThrow()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        message: 'toastMessages.userNotAuthenticated'
+      })
     })
   })
 
@@ -755,9 +756,10 @@ describe('useAuthStore', () => {
     it('throws AuthStoreError when not authenticated', async () => {
       authStateCallback(null)
 
-      await expect(store.getFirebaseAuthHeaderOrThrow()).rejects.toThrow(
-        'toastMessages.userNotAuthenticated'
-      )
+      await expect(store.getFirebaseAuthHeaderOrThrow()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        message: 'toastMessages.userNotAuthenticated'
+      })
     })
   })
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -236,6 +236,22 @@ export const useAuthStore = defineStore('auth', () => {
     return await getIdToken()
   }
 
+  const getAuthHeaderOrThrow = async (): Promise<AuthHeader> => {
+    const authHeader = await getAuthHeader()
+    if (!authHeader) {
+      throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
+    }
+    return authHeader
+  }
+
+  const getFirebaseAuthHeaderOrThrow = async (): Promise<AuthHeader> => {
+    const authHeader = await getFirebaseAuthHeader()
+    if (!authHeader) {
+      throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
+    }
+    return authHeader
+  }
+
   const fetchBalance = async (): Promise<GetCustomerBalanceResponse | null> => {
     isFetchingBalance.value = true
     try {
@@ -538,7 +554,9 @@ export const useAuthStore = defineStore('auth', () => {
     sendPasswordReset,
     updatePassword: _updatePassword,
     getAuthHeader,
+    getAuthHeaderOrThrow,
     getFirebaseAuthHeader,
+    getFirebaseAuthHeaderOrThrow,
     getAuthToken
   }
 })


### PR DESCRIPTION
## Summary

Extract auth-routing logic (`getAuthHeaderOrThrow`, `getFirebaseAuthHeaderOrThrow`) from `workspaceApi.ts` into `authStore.ts`, eliminating a layering violation where the workspace API re-implemented auth header resolution.

## Changes

- **What**: Moved `getAuthHeaderOrThrow` and `getFirebaseAuthHeaderOrThrow` from `workspaceApi.ts` to `authStore.ts`. `workspaceApi.ts` now calls through `useAuthStore()` instead of re-implementing token resolution. Added tests for the new methods in `authStore.test.ts`. Updated `authStoreMock.ts` with the new methods.
- **Files**: 4 files changed

## Review Focus

- The `getAuthHeaderOrThrow` / `getFirebaseAuthHeaderOrThrow` methods throw `AuthStoreError` (auth domain error) — callers in workspace can catch and re-wrap if needed
- `workspaceApi.ts` is simplified by ~19 lines

## Stack

PR 2/5: #10483 → **→ This PR** → #10485 → #10486 → #10487
