### PR TITLE
test: migrate 8 hard-case component tests from VTU to VTL (Phase 3)

### DIFF
--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -61,7 +61,6 @@ const loginButtonText = enMessages.auth.login.loginButton
 
 describe('SignInForm', () => {
   beforeEach(() => {
-    vi.restoreAllMocks()
     mockSendPasswordReset.mockReset()
     mockToastAdd.mockReset()
     mockLoadingRef.value = false
@@ -99,13 +98,6 @@ describe('SignInForm', () => {
   }
 
   describe('Forgot Password Link', () => {
-    it('shows disabled style when email is empty', () => {
-      renderComponent()
-
-      const forgotPasswordLink = screen.getByText(forgotPasswordText)
-      expect(forgotPasswordLink).toHaveClass('cursor-not-allowed', 'opacity-50')
-    })
-
     it('shows toast and focuses email input when clicked while disabled', async () => {
       const { user } = renderComponent()
 
@@ -139,6 +131,17 @@ describe('SignInForm', () => {
         email: 'test@example.com',
         password: 'password123'
       })
+    })
+
+    it('does not emit submit event when form data is invalid', async () => {
+      const onSubmit = vi.fn()
+      const { user } = renderComponent({ onSubmit })
+
+      await user.type(getEmailInput(), 'invalid-email')
+      await user.type(getPasswordInput(), 'password123')
+      await user.click(screen.getByRole('button', { name: loginButtonText }))
+
+      expect(onSubmit).not.toHaveBeenCalled()
     })
   })
 

--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -1,21 +1,19 @@
 import { Form } from '@primevue/forms'
-import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import Button from '@/components/ui/button/Button.vue'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
 import ProgressSpinner from 'primevue/progressspinner'
 import ToastService from 'primevue/toastservice'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import SignInForm from './SignInForm.vue'
-
-type ComponentInstance = InstanceType<typeof SignInForm>
 
 // Mock firebase auth modules
 vi.mock('firebase/app', () => ({
@@ -41,11 +39,11 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
   }))
 }))
 
-let mockLoading = false
+const mockLoadingRef = ref(false)
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
     get loading() {
-      return mockLoading
+      return mockLoadingRef.value
     }
   }))
 }))
@@ -58,259 +56,142 @@ vi.mock('primevue/usetoast', () => ({
   }))
 }))
 
+const forgotPasswordText = enMessages.auth.login.forgotPassword
+const loginButtonText = enMessages.auth.login.loginButton
+
 describe('SignInForm', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.restoreAllMocks()
     mockSendPasswordReset.mockReset()
     mockToastAdd.mockReset()
-    mockLoading = false
+    mockLoadingRef.value = false
   })
 
-  const mountComponent = (
-    props = {},
-    options = {}
-  ): VueWrapper<ComponentInstance> => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function renderComponent(props: Record<string, unknown> = {}) {
     const i18n = createI18n({
       legacy: false,
       locale: 'en',
       messages: { en: enMessages }
     })
-
-    return mount(SignInForm, {
+    const user = userEvent.setup()
+    const result = render(SignInForm, {
       global: {
         plugins: [PrimeVue, i18n, ToastService],
-        components: {
-          Form,
-          Button,
-          InputText,
-          Password,
-          ProgressSpinner
-        }
+        components: { Form, Button, InputText, Password, ProgressSpinner }
       },
-      props,
-      ...options
+      props
     })
+    return { ...result, user }
+  }
+
+  function getEmailInput() {
+    return screen.getByPlaceholderText(enMessages.auth.login.emailPlaceholder)
+  }
+
+  function getPasswordInput() {
+    return screen.getByPlaceholderText(
+      enMessages.auth.login.passwordPlaceholder
+    )
   }
 
   describe('Forgot Password Link', () => {
-    it('shows disabled style when email is empty', async () => {
-      const wrapper = mountComponent()
-      await nextTick()
+    it('shows disabled style when email is empty', () => {
+      renderComponent()
 
-      const forgotPasswordSpan = wrapper.find(
-        'span.text-muted.text-base.font-medium.select-none'
-      )
-
-      expect(forgotPasswordSpan.classes()).toContain('cursor-not-allowed')
-      expect(forgotPasswordSpan.classes()).toContain('opacity-50')
+      const forgotPasswordLink = screen.getByText(forgotPasswordText)
+      expect(forgotPasswordLink).toHaveClass('cursor-not-allowed', 'opacity-50')
     })
 
     it('shows toast and focuses email input when clicked while disabled', async () => {
-      const wrapper = mountComponent()
-      const forgotPasswordSpan = wrapper.find(
-        'span.text-muted.text-base.font-medium.select-none'
-      )
+      const { user } = renderComponent()
 
-      // Mock getElementById to track focus
-      const mockFocus = vi.fn()
-      const mockElement: Partial<HTMLElement> = { focus: mockFocus }
-      vi.spyOn(document, 'getElementById').mockReturnValue(
-        mockElement as HTMLElement
-      )
+      const emailInput = getEmailInput()
+      const focusSpy = vi.spyOn(emailInput, 'focus')
 
-      // Click forgot password link while email is empty
-      await forgotPasswordSpan.trigger('click')
-      await nextTick()
+      await user.click(screen.getByText(forgotPasswordText))
 
-      // Should show toast warning
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'warn',
         summary: enMessages.auth.login.emailPlaceholder,
         life: 5000
       })
 
-      // Should focus email input
-      expect(document.getElementById).toHaveBeenCalledWith(
-        'comfy-org-sign-in-email'
-      )
-      expect(mockFocus).toHaveBeenCalled()
+      expect(focusSpy).toHaveBeenCalled()
 
-      // Should NOT call sendPasswordReset
       expect(mockSendPasswordReset).not.toHaveBeenCalled()
-    })
-
-    it('calls handleForgotPassword with email when link is clicked', async () => {
-      const wrapper = mountComponent()
-      const component = wrapper.vm as typeof wrapper.vm & {
-        handleForgotPassword: (email: string, valid: boolean) => void
-        onSubmit: (data: { valid: boolean; values: unknown }) => void
-      }
-
-      // Spy on handleForgotPassword
-      const handleForgotPasswordSpy = vi.spyOn(
-        component,
-        'handleForgotPassword'
-      )
-
-      const forgotPasswordSpan = wrapper.find(
-        'span.text-muted.text-base.font-medium.select-none'
-      )
-
-      // Click the forgot password link
-      await forgotPasswordSpan.trigger('click')
-
-      // Should call handleForgotPassword
-      expect(handleForgotPasswordSpy).toHaveBeenCalled()
     })
   })
 
   describe('Form Submission', () => {
-    it('emits submit event when onSubmit is called with valid data', async () => {
-      const wrapper = mountComponent()
-      const component = wrapper.vm as typeof wrapper.vm & {
-        handleForgotPassword: (email: string, valid: boolean) => void
-        onSubmit: (data: { valid: boolean; values: unknown }) => void
-      }
+    it('emits submit event when form is submitted with valid data', async () => {
+      const onSubmit = vi.fn()
+      const { user } = renderComponent({ onSubmit })
 
-      // Call onSubmit directly with valid data
-      component.onSubmit({
-        valid: true,
-        values: { email: 'test@example.com', password: 'password123' }
+      await user.type(getEmailInput(), 'test@example.com')
+      await user.type(getPasswordInput(), 'password123')
+      await user.click(screen.getByRole('button', { name: loginButtonText }))
+
+      expect(onSubmit).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123'
       })
-
-      // Check emitted event
-      expect(wrapper.emitted('submit')).toBeTruthy()
-      expect(wrapper.emitted('submit')?.[0]).toEqual([
-        {
-          email: 'test@example.com',
-          password: 'password123'
-        }
-      ])
-    })
-
-    it('does not emit submit event when form is invalid', async () => {
-      const wrapper = mountComponent()
-      const component = wrapper.vm as typeof wrapper.vm & {
-        handleForgotPassword: (email: string, valid: boolean) => void
-        onSubmit: (data: { valid: boolean; values: unknown }) => void
-      }
-
-      // Call onSubmit with invalid form
-      component.onSubmit({ valid: false, values: {} })
-
-      // Should not emit submit event
-      expect(wrapper.emitted('submit')).toBeFalsy()
     })
   })
 
   describe('Loading State', () => {
-    it('shows spinner when loading', async () => {
-      mockLoading = true
+    it('shows spinner when loading', () => {
+      mockLoadingRef.value = true
+      renderComponent()
 
-      try {
-        const wrapper = mountComponent()
-        await nextTick()
-
-        expect(wrapper.findComponent(ProgressSpinner).exists()).toBe(true)
-        expect(wrapper.findComponent(Button).exists()).toBe(false)
-      } catch (error) {
-        // Fallback test - check HTML content if component rendering fails
-        mockLoading = true
-        const wrapper = mountComponent()
-        expect(wrapper.html()).toContain('p-progressspinner')
-        expect(wrapper.html()).not.toContain('<button')
-      }
+      expect(screen.getByRole('progressbar')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: loginButtonText })
+      ).not.toBeInTheDocument()
     })
 
     it('shows button when not loading', () => {
-      mockLoading = false
+      renderComponent()
 
-      const wrapper = mountComponent()
-
-      expect(wrapper.findComponent(ProgressSpinner).exists()).toBe(false)
-      expect(wrapper.findComponent(Button).exists()).toBe(true)
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: loginButtonText })
+      ).toBeInTheDocument()
     })
   })
 
   describe('Component Structure', () => {
     it('renders email input with correct attributes', () => {
-      const wrapper = mountComponent()
-      const emailInput = wrapper.findComponent(InputText)
+      renderComponent()
 
-      expect(emailInput.attributes('id')).toBe('comfy-org-sign-in-email')
-      expect(emailInput.attributes('autocomplete')).toBe('email')
-      expect(emailInput.attributes('name')).toBe('email')
-      expect(emailInput.attributes('type')).toBe('text')
+      const emailInput = getEmailInput()
+      expect(emailInput).toHaveAttribute('id', 'comfy-org-sign-in-email')
+      expect(emailInput).toHaveAttribute('autocomplete', 'email')
+      expect(emailInput).toHaveAttribute('name', 'email')
+      expect(emailInput).toHaveAttribute('type', 'text')
     })
 
     it('renders password input with correct attributes', () => {
-      const wrapper = mountComponent()
-      const passwordInput = wrapper.findComponent(Password)
+      renderComponent()
 
-      // Check props instead of attributes for Password component
-      expect(passwordInput.props('inputId')).toBe('comfy-org-sign-in-password')
-      // Password component passes name as prop, not attribute
-      expect(passwordInput.props('name')).toBe('password')
-      expect(passwordInput.props('feedback')).toBe(false)
-      expect(passwordInput.props('toggleMask')).toBe(true)
-    })
-
-    it('renders form with correct resolver', () => {
-      const wrapper = mountComponent()
-      const form = wrapper.findComponent(Form)
-
-      expect(form.props('resolver')).toBeDefined()
+      const passwordInput = getPasswordInput()
+      expect(passwordInput).toHaveAttribute('id', 'comfy-org-sign-in-password')
+      expect(passwordInput).toHaveAttribute('name', 'password')
     })
   })
 
-  describe('Focus Behavior', () => {
-    it('focuses email input when handleForgotPassword is called with invalid email', async () => {
-      const wrapper = mountComponent()
-      const component = wrapper.vm as typeof wrapper.vm & {
-        handleForgotPassword: (email: string, valid: boolean) => void
-        onSubmit: (data: { valid: boolean; values: unknown }) => void
-      }
+  describe('Forgot Password with valid email', () => {
+    it('calls sendPasswordReset when email is valid', async () => {
+      const { user } = renderComponent()
 
-      // Mock getElementById to track focus
-      const mockFocus = vi.fn()
-      const mockElement: Partial<HTMLElement> = { focus: mockFocus }
-      vi.spyOn(document, 'getElementById').mockReturnValue(
-        mockElement as HTMLElement
-      )
+      await user.type(getEmailInput(), 'test@example.com')
+      await user.click(screen.getByText(forgotPasswordText))
 
-      // Call handleForgotPassword with no email
-      await component.handleForgotPassword('', false)
-
-      // Should focus email input
-      expect(document.getElementById).toHaveBeenCalledWith(
-        'comfy-org-sign-in-email'
-      )
-      expect(mockFocus).toHaveBeenCalled()
-    })
-
-    it('does not focus email input when valid email is provided', async () => {
-      const wrapper = mountComponent()
-      const component = wrapper.vm as typeof wrapper.vm & {
-        handleForgotPassword: (email: string, valid: boolean) => void
-        onSubmit: (data: { valid: boolean; values: unknown }) => void
-      }
-
-      // Mock getElementById
-      const mockFocus = vi.fn()
-      const mockElement: Partial<HTMLElement> = { focus: mockFocus }
-      vi.spyOn(document, 'getElementById').mockReturnValue(
-        mockElement as HTMLElement
-      )
-
-      // Call handleForgotPassword with valid email
-      await component.handleForgotPassword('test@example.com', true)
-
-      // Should NOT focus email input
-      expect(document.getElementById).not.toHaveBeenCalled()
-      expect(mockFocus).not.toHaveBeenCalled()
-
-      // Should call sendPasswordReset
       expect(mockSendPasswordReset).toHaveBeenCalledWith('test@example.com')
+      expect(mockToastAdd).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -130,6 +130,10 @@ describe('SelectionToolbox', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     canvasStore = useCanvasStore()
+    nodeDefMock = {
+      type: 'TestNode',
+      title: 'Test Node'
+    } as unknown
 
     // Mock the canvas to avoid "getCanvas: canvas is null" errors
     canvasStore.canvas = createMockCanvas()
@@ -369,8 +373,9 @@ describe('SelectionToolbox', () => {
       canvasStore.selectedItems = []
       const { container } = renderComponent()
 
-      const panel = container.querySelector('.panel')
-      expect(panel?.children.length).toBeGreaterThan(0) // At least MoreOptions should show
+      expect(
+        container.querySelector('[data-testid="more-options-button"]')
+      ).toBeTruthy()
     })
   })
 

--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils'
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+import { fireEvent, render } from '@testing-library/vue'
 import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -136,8 +137,8 @@ describe('SelectionToolbox', () => {
     vi.resetAllMocks()
   })
 
-  const mountComponent = (props = {}) => {
-    return mount(SelectionToolbox, {
+  function renderComponent(props = {}): { container: Element } {
+    const { container } = render(SelectionToolbox, {
       props,
       global: {
         plugins: [i18n, PrimeVue],
@@ -169,7 +170,9 @@ describe('SelectionToolbox', () => {
           Load3DViewerButton: {
             template: '<div class="load-3d-viewer-button" />'
           },
-          MaskEditorButton: { template: '<div class="mask-editor-button" />' },
+          MaskEditorButton: {
+            template: '<div class="mask-editor-button" />'
+          },
           DeleteButton: {
             template:
               '<button data-testid="delete-button" class="delete-button" />'
@@ -193,6 +196,7 @@ describe('SelectionToolbox', () => {
         }
       }
     })
+    return { container }
   }
 
   describe('Button Visibility Logic', () => {
@@ -204,91 +208,91 @@ describe('SelectionToolbox', () => {
     it('should show info button only for single selections', () => {
       // Single node selection
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('.info-button').exists()).toBe(true)
+      const { container } = renderComponent()
+      expect(container.querySelector('.info-button')).toBeTruthy()
 
-      // Multiple node selection
+      // Multiple node selection - render in separate test scope
       canvasStore.selectedItems = [
         createMockPositionable(),
         createMockPositionable()
       ]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
-      expect(wrapper2.find('.info-button').exists()).toBe(false)
+      const { container: container2 } = renderComponent()
+      expect(container2.querySelector('.info-button')).toBeFalsy()
     })
 
     it('should not show info button when node definition is not found', () => {
       canvasStore.selectedItems = [createMockPositionable()]
-      // mock nodedef and return null
       nodeDefMock = null
-      // remount component
-      const wrapper = mountComponent()
-      expect(wrapper.find('.info-button').exists()).toBe(false)
+      const { container } = renderComponent()
+      expect(container.querySelector('.info-button')).toBeFalsy()
     })
 
     it('should show color picker for all selections', () => {
       // Single node selection
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('[data-testid="color-picker-button"]').exists()).toBe(
-        true
-      )
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="color-picker-button"]')
+      ).toBeTruthy()
 
       // Multiple node selection
       canvasStore.selectedItems = [
         createMockPositionable(),
         createMockPositionable()
       ]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
+      const { container: container2 } = renderComponent()
       expect(
-        wrapper2.find('[data-testid="color-picker-button"]').exists()
-      ).toBe(true)
+        container2.querySelector('[data-testid="color-picker-button"]')
+      ).toBeTruthy()
     })
 
     it('should show frame nodes only for multiple selections', () => {
       // Single node selection
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('.frame-nodes').exists()).toBe(false)
+      const { container } = renderComponent()
+      expect(container.querySelector('.frame-nodes')).toBeFalsy()
 
       // Multiple node selection
       canvasStore.selectedItems = [
         createMockPositionable(),
         createMockPositionable()
       ]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
-      expect(wrapper2.find('.frame-nodes').exists()).toBe(true)
+      const { container: container2 } = renderComponent()
+      expect(container2.querySelector('.frame-nodes')).toBeTruthy()
     })
 
     it('should show bypass button for appropriate selections', () => {
       // Single node selection
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('[data-testid="bypass-button"]').exists()).toBe(true)
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="bypass-button"]')
+      ).toBeTruthy()
 
       // Multiple node selection
       canvasStore.selectedItems = [
         createMockPositionable(),
         createMockPositionable()
       ]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
-      expect(wrapper2.find('[data-testid="bypass-button"]').exists()).toBe(true)
+      const { container: container2 } = renderComponent()
+      expect(
+        container2.querySelector('[data-testid="bypass-button"]')
+      ).toBeTruthy()
     })
 
     it('should show common buttons for all selections', () => {
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      expect(wrapper.find('[data-testid="delete-button"]').exists()).toBe(true)
       expect(
-        wrapper.find('[data-testid="convert-to-subgraph-button"]').exists()
-      ).toBe(true)
-      expect(wrapper.find('[data-testid="more-options-button"]').exists()).toBe(
-        true
-      )
+        container.querySelector('[data-testid="delete-button"]')
+      ).toBeTruthy()
+      expect(
+        container.querySelector('[data-testid="convert-to-subgraph-button"]')
+      ).toBeTruthy()
+      expect(
+        container.querySelector('[data-testid="more-options-button"]')
+      ).toBeTruthy()
     })
 
     it('should show mask editor only for single image nodes', () => {
@@ -297,15 +301,14 @@ describe('SelectionToolbox', () => {
       // Single image node
       isImageNodeSpy.mockReturnValue(true)
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('.mask-editor-button').exists()).toBe(true)
+      const { container } = renderComponent()
+      expect(container.querySelector('.mask-editor-button')).toBeTruthy()
 
       // Single non-image node
       isImageNodeSpy.mockReturnValue(false)
       canvasStore.selectedItems = [createMockPositionable()]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
-      expect(wrapper2.find('.mask-editor-button').exists()).toBe(false)
+      const { container: container2 } = renderComponent()
+      expect(container2.querySelector('.mask-editor-button')).toBeFalsy()
     })
 
     it('should show Color picker button only for single Load3D nodes', () => {
@@ -314,15 +317,14 @@ describe('SelectionToolbox', () => {
       // Single Load3D node
       isLoad3dNodeSpy.mockReturnValue(true)
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('.load-3d-viewer-button').exists()).toBe(true)
+      const { container } = renderComponent()
+      expect(container.querySelector('.load-3d-viewer-button')).toBeTruthy()
 
       // Single non-Load3D node
       isLoad3dNodeSpy.mockReturnValue(false)
       canvasStore.selectedItems = [createMockPositionable()]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
-      expect(wrapper2.find('.load-3d-viewer-button').exists()).toBe(false)
+      const { container: container2 } = renderComponent()
+      expect(container2.querySelector('.load-3d-viewer-button')).toBeFalsy()
     })
 
     it('should show ExecuteButton only when output nodes are selected', () => {
@@ -335,22 +337,20 @@ describe('SelectionToolbox', () => {
         { type: 'SaveImage' }
       ] as LGraphNode[])
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-      expect(wrapper.find('.execute-button').exists()).toBe(true)
+      const { container } = renderComponent()
+      expect(container.querySelector('.execute-button')).toBeTruthy()
 
       // Without output node selected
       isOutputNodeSpy.mockReturnValue(false)
       filterOutputNodesSpy.mockReturnValue([])
       canvasStore.selectedItems = [createMockPositionable()]
-      wrapper.unmount()
-      const wrapper2 = mountComponent()
-      expect(wrapper2.find('.execute-button').exists()).toBe(false)
+      const { container: container2 } = renderComponent()
+      expect(container2.querySelector('.execute-button')).toBeFalsy()
 
       // No selection at all
       canvasStore.selectedItems = []
-      wrapper2.unmount()
-      const wrapper3 = mountComponent()
-      expect(wrapper3.find('.execute-button').exists()).toBe(false)
+      const { container: container3 } = renderComponent()
+      expect(container3.querySelector('.execute-button')).toBeFalsy()
     })
   })
 
@@ -358,19 +358,19 @@ describe('SelectionToolbox', () => {
     it('should show dividers between button groups when both groups have buttons', () => {
       // Setup single node to show info + other buttons
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      const dividers = wrapper.findAll('.vertical-divider')
+      const dividers = container.querySelectorAll('.vertical-divider')
       expect(dividers.length).toBeGreaterThan(0)
     })
 
     it('should not show dividers when adjacent groups are empty', () => {
       // No selection should show minimal buttons and dividers
       canvasStore.selectedItems = []
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      const buttons = wrapper.find('.panel').element.children
-      expect(buttons.length).toBeGreaterThan(0) // At least MoreOptions should show
+      const panel = container.querySelector('.panel')
+      expect(panel?.children.length).toBeGreaterThan(0) // At least MoreOptions should show
     })
   })
 
@@ -390,9 +390,9 @@ describe('SelectionToolbox', () => {
       } as ReturnType<typeof useExtensionService>)
 
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      expect(wrapper.find('.extension-command-button').exists()).toBe(true)
+      expect(container.querySelector('.extension-command-button')).toBeTruthy()
     })
 
     it('should not render extension commands when none available', () => {
@@ -400,47 +400,9 @@ describe('SelectionToolbox', () => {
       mockExtensionService.mockReturnValue(createMockExtensionService())
 
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      expect(wrapper.find('.extension-command-button').exists()).toBe(false)
-    })
-  })
-
-  describe('Container Styling', () => {
-    it('should apply minimap container styles', () => {
-      const mockExtensionService = vi.mocked(useExtensionService)
-      mockExtensionService.mockReturnValue(createMockExtensionService())
-
-      canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-
-      const panel = wrapper.find('.panel')
-      expect(panel.exists()).toBe(true)
-    })
-
-    it('should have correct CSS classes', () => {
-      const mockExtensionService = vi.mocked(useExtensionService)
-      mockExtensionService.mockReturnValue(createMockExtensionService())
-
-      canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-
-      const panel = wrapper.find('.panel')
-      expect(panel.classes()).toContain('selection-toolbox')
-      expect(panel.classes()).toContain('absolute')
-      expect(panel.classes()).toContain('left-1/2')
-      expect(panel.classes()).toContain('rounded-lg')
-    })
-
-    it('should handle animation class conditionally', () => {
-      const mockExtensionService = vi.mocked(useExtensionService)
-      mockExtensionService.mockReturnValue(createMockExtensionService())
-
-      canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
-
-      const panel = wrapper.find('.panel')
-      expect(panel.exists()).toBe(true)
+      expect(container.querySelector('.extension-command-button')).toBeFalsy()
     })
   })
 
@@ -461,10 +423,11 @@ describe('SelectionToolbox', () => {
       mockExtensionService.mockReturnValue(createMockExtensionService())
 
       canvasStore.selectedItems = [createMockPositionable()]
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      const panel = wrapper.find('.panel')
-      await panel.trigger('wheel')
+      const panel = container.querySelector('.panel')
+      expect(panel).toBeTruthy()
+      await fireEvent.wheel(panel!)
 
       expect(forwardEventToCanvasSpy).toHaveBeenCalled()
     })
@@ -478,12 +441,12 @@ describe('SelectionToolbox', () => {
 
     it('should hide most buttons when no items selected', () => {
       canvasStore.selectedItems = []
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
 
-      expect(wrapper.find('.info-button').exists()).toBe(false)
-      expect(wrapper.find('.color-picker-button').exists()).toBe(false)
-      expect(wrapper.find('.frame-nodes').exists()).toBe(false)
-      expect(wrapper.find('.bookmark-button').exists()).toBe(false)
+      expect(container.querySelector('.info-button')).toBeFalsy()
+      expect(container.querySelector('.color-picker-button')).toBeFalsy()
+      expect(container.querySelector('.frame-nodes')).toBeFalsy()
+      expect(container.querySelector('.bookmark-button')).toBeFalsy()
     })
   })
 })

--- a/src/components/queue/QueueOverlayExpanded.test.ts
+++ b/src/components/queue/QueueOverlayExpanded.test.ts
@@ -1,4 +1,6 @@
-import { mount } from '@vue/test-utils'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { JobListItem } from '@/composables/queue/useJobList'
@@ -25,61 +27,79 @@ const JobFiltersBarStub = {
   template: '<div />'
 }
 
-const JobAssetsListStub = {
-  name: 'JobAssetsList',
-  template: '<div class="job-assets-list-stub" />'
+const testJob: JobListItem = {
+  id: 'job-1',
+  title: 'Job 1',
+  meta: 'meta',
+  state: 'pending'
 }
+
+const JobAssetsListStub = defineComponent({
+  name: 'JobAssetsList',
+  setup(_, { emit }) {
+    return {
+      triggerCancel: () => emit('cancel-item', testJob),
+      triggerDelete: () => emit('delete-item', testJob),
+      triggerView: () => emit('view-item', testJob)
+    }
+  },
+  template: `
+    <div class="job-assets-list-stub">
+      <button data-testid="stub-cancel" @click="triggerCancel()" />
+      <button data-testid="stub-delete" @click="triggerDelete()" />
+      <button data-testid="stub-view" @click="triggerView()" />
+    </div>
+  `
+})
 
 const JobContextMenuStub = {
   template: '<div />'
 }
 
-const createJob = (): JobListItem => ({
-  id: 'job-1',
-  title: 'Job 1',
-  meta: 'meta',
-  state: 'pending'
-})
+const defaultProps = {
+  headerTitle: 'Jobs',
+  queuedCount: 1,
+  selectedJobTab: 'All' as const,
+  selectedWorkflowFilter: 'all' as const,
+  selectedSortMode: 'mostRecent' as const,
+  displayedJobGroups: [],
+  hasFailedJobs: false
+}
 
-const mountComponent = () =>
-  mount(QueueOverlayExpanded, {
-    props: {
-      headerTitle: 'Jobs',
-      queuedCount: 1,
-      selectedJobTab: 'All',
-      selectedWorkflowFilter: 'all',
-      selectedSortMode: 'mostRecent',
-      displayedJobGroups: [],
-      hasFailedJobs: false
-    },
-    global: {
-      stubs: {
-        QueueOverlayHeader: QueueOverlayHeaderStub,
-        JobFiltersBar: JobFiltersBarStub,
-        JobAssetsList: JobAssetsListStub,
-        JobContextMenu: JobContextMenuStub
-      }
-    }
-  })
+const stubs = {
+  QueueOverlayHeader: QueueOverlayHeaderStub,
+  JobFiltersBar: JobFiltersBarStub,
+  JobAssetsList: JobAssetsListStub,
+  JobContextMenu: JobContextMenuStub
+}
 
 describe('QueueOverlayExpanded', () => {
   it('renders JobAssetsList', () => {
-    const wrapper = mountComponent()
-    expect(wrapper.find('.job-assets-list-stub').exists()).toBe(true)
+    const { container } = render(QueueOverlayExpanded, {
+      props: defaultProps,
+      global: { stubs }
+    })
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('.job-assets-list-stub')).toBeTruthy()
   })
 
   it('re-emits list item actions from JobAssetsList', async () => {
-    const wrapper = mountComponent()
-    const job = createJob()
-    const jobAssetsList = wrapper.findComponent({ name: 'JobAssetsList' })
+    const user = userEvent.setup()
+    const onCancelItem = vi.fn<(item: JobListItem) => void>()
+    const onDeleteItem = vi.fn<(item: JobListItem) => void>()
+    const onViewItem = vi.fn<(item: JobListItem) => void>()
 
-    jobAssetsList.vm.$emit('cancel-item', job)
-    jobAssetsList.vm.$emit('delete-item', job)
-    jobAssetsList.vm.$emit('view-item', job)
-    await wrapper.vm.$nextTick()
+    render(QueueOverlayExpanded, {
+      props: { ...defaultProps, onCancelItem, onDeleteItem, onViewItem },
+      global: { stubs }
+    })
 
-    expect(wrapper.emitted('cancelItem')?.[0]).toEqual([job])
-    expect(wrapper.emitted('deleteItem')?.[0]).toEqual([job])
-    expect(wrapper.emitted('viewItem')?.[0]).toEqual([job])
+    await user.click(screen.getByTestId('stub-cancel'))
+    await user.click(screen.getByTestId('stub-delete'))
+    await user.click(screen.getByTestId('stub-view'))
+
+    expect(onCancelItem).toHaveBeenCalledWith(testJob)
+    expect(onDeleteItem).toHaveBeenCalledWith(testJob)
+    expect(onViewItem).toHaveBeenCalledWith(testJob)
   })
 })

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -1,4 +1,8 @@
-import { mount } from '@vue/test-utils'
+/* eslint-disable vue/one-component-per-file -- test stubs */
+/* eslint-disable testing-library/no-container, testing-library/no-node-access -- stubs lack ARIA roles; data attributes for props */
+/* eslint-disable testing-library/prefer-user-event -- fireEvent needed: fake timers require fireEvent for mouseEnter/mouseLeave */
+import { fireEvent, render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 
@@ -14,7 +18,36 @@ const JobDetailsPopoverStub = defineComponent({
     jobId: { type: String, required: true },
     workflowId: { type: String, default: undefined }
   },
-  template: '<div class="job-details-popover-stub" />'
+  template:
+    '<div class="job-details-popover-stub" :data-job-id="jobId" :data-workflow-id="workflowId" />'
+})
+
+const AssetsListItemStub = defineComponent({
+  name: 'AssetsListItem',
+  props: {
+    previewUrl: { type: String, default: undefined },
+    isVideoPreview: { type: Boolean, default: false },
+    previewAlt: { type: String, default: '' },
+    iconName: { type: String, default: undefined },
+    iconClass: { type: String, default: undefined },
+    primaryText: { type: String, default: undefined },
+    secondaryText: { type: String, default: undefined },
+    progressTotalPercent: { type: Number, default: undefined },
+    progressCurrentPercent: { type: Number, default: undefined }
+  },
+  setup(_, { emit }) {
+    return { emitPreviewClick: () => emit('preview-click') }
+  },
+  template: `
+    <div class="assets-list-item-stub"
+         :data-preview-url="previewUrl"
+         :data-is-video="isVideoPreview">
+      <span>{{ primaryText }}</span>
+      <button data-testid="preview-trigger" @click="emitPreviewClick" />
+      <i v-if="iconName && !previewUrl" :class="iconName" @click="emitPreviewClick" />
+      <slot name="actions" />
+    </div>
+  `
 })
 
 vi.mock('vue-i18n', () => {
@@ -72,7 +105,12 @@ const buildJob = (overrides: Partial<JobListItem> = {}): JobListItem => ({
   ...overrides
 })
 
-const mountJobAssetsList = (jobs: JobListItem[]) => {
+function renderJobAssetsList(
+  jobs: JobListItem[],
+  callbacks: {
+    onViewItem?: (item: JobListItem) => void
+  } = {}
+) {
   const displayedJobGroups: JobGroup[] = [
     {
       key: 'group-1',
@@ -81,15 +119,23 @@ const mountJobAssetsList = (jobs: JobListItem[]) => {
     }
   ]
 
-  return mount(JobAssetsList, {
-    props: { displayedJobGroups },
+  const user = userEvent.setup()
+
+  const result = render(JobAssetsList, {
+    props: {
+      displayedJobGroups,
+      ...(callbacks.onViewItem && { onViewItem: callbacks.onViewItem })
+    },
     global: {
       stubs: {
         teleport: true,
-        JobDetailsPopover: JobDetailsPopoverStub
+        JobDetailsPopover: JobDetailsPopoverStub,
+        AssetsListItem: AssetsListItemStub
       }
     }
   })
+
+  return { ...result, user }
 }
 
 function createDomRect({
@@ -124,24 +170,23 @@ afterEach(() => {
 describe('JobAssetsList', () => {
   it('emits viewItem on preview-click for completed jobs with preview', async () => {
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
+    const onViewItem = vi.fn()
+    const { user } = renderJobAssetsList([job], { onViewItem })
 
-    const listItem = wrapper.findComponent({ name: 'AssetsListItem' })
-    listItem.vm.$emit('preview-click')
-    await wrapper.vm.$nextTick()
+    await user.click(screen.getByTestId('preview-trigger'))
 
-    expect(wrapper.emitted('viewItem')).toEqual([[job]])
+    expect(onViewItem).toHaveBeenCalledWith(job)
   })
 
   it('emits viewItem on double-click for completed jobs with preview', async () => {
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
+    const onViewItem = vi.fn()
+    const { container, user } = renderJobAssetsList([job], { onViewItem })
 
-    const listItem = wrapper.findComponent({ name: 'AssetsListItem' })
-    await listItem.trigger('dblclick')
-    await wrapper.vm.$nextTick()
+    const stubRoot = container.querySelector('.assets-list-item-stub')!
+    await user.dblClick(stubRoot)
 
-    expect(wrapper.emitted('viewItem')).toEqual([[job]])
+    expect(onViewItem).toHaveBeenCalledWith(job)
   })
 
   it('emits viewItem on double-click for completed video jobs without icon image', async () => {
@@ -149,16 +194,18 @@ describe('JobAssetsList', () => {
       iconImageUrl: undefined,
       taskRef: createTaskRef(createResultItem('job-1.webm', 'video'))
     })
-    const wrapper = mountJobAssetsList([job])
+    const onViewItem = vi.fn()
+    const { container, user } = renderJobAssetsList([job], { onViewItem })
 
-    const listItem = wrapper.findComponent({ name: 'AssetsListItem' })
-    expect(listItem.props('previewUrl')).toBe('/api/view/job-1.webm')
-    expect(listItem.props('isVideoPreview')).toBe(true)
+    const stubRoot = container.querySelector('.assets-list-item-stub')!
+    expect(stubRoot.getAttribute('data-preview-url')).toBe(
+      '/api/view/job-1.webm'
+    )
+    expect(stubRoot.getAttribute('data-is-video')).toBe('true')
 
-    await listItem.trigger('dblclick')
-    await wrapper.vm.$nextTick()
+    await user.dblClick(stubRoot)
 
-    expect(wrapper.emitted('viewItem')).toEqual([[job]])
+    expect(onViewItem).toHaveBeenCalledWith(job)
   })
 
   it('emits viewItem on icon click for completed 3D jobs without preview tile', async () => {
@@ -166,14 +213,13 @@ describe('JobAssetsList', () => {
       iconImageUrl: undefined,
       taskRef: createTaskRef(createResultItem('job-1.glb', 'model'))
     })
-    const wrapper = mountJobAssetsList([job])
+    const onViewItem = vi.fn()
+    const { container, user } = renderJobAssetsList([job], { onViewItem })
 
-    const listItem = wrapper.findComponent({ name: 'AssetsListItem' })
+    const icon = container.querySelector('.assets-list-item-stub i')!
+    await user.click(icon)
 
-    await listItem.find('i').trigger('click')
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.emitted('viewItem')).toEqual([[job]])
+    expect(onViewItem).toHaveBeenCalledWith(job)
   })
 
   it('does not emit viewItem on double-click for non-completed jobs', async () => {
@@ -181,13 +227,13 @@ describe('JobAssetsList', () => {
       state: 'running',
       taskRef: createTaskRef(createResultItem('job-1.png'))
     })
-    const wrapper = mountJobAssetsList([job])
+    const onViewItem = vi.fn()
+    const { container, user } = renderJobAssetsList([job], { onViewItem })
 
-    const listItem = wrapper.findComponent({ name: 'AssetsListItem' })
-    await listItem.trigger('dblclick')
-    await wrapper.vm.$nextTick()
+    const stubRoot = container.querySelector('.assets-list-item-stub')!
+    await user.dblClick(stubRoot)
 
-    expect(wrapper.emitted('viewItem')).toBeUndefined()
+    expect(onViewItem).not.toHaveBeenCalled()
   })
 
   it('emits viewItem from the View button for completed jobs without preview output', async () => {
@@ -195,92 +241,90 @@ describe('JobAssetsList', () => {
       iconImageUrl: undefined,
       taskRef: createTaskRef()
     })
-    const wrapper = mountJobAssetsList([job])
-    const jobRow = wrapper.find(`[data-job-id="${job.id}"]`)
+    const onViewItem = vi.fn()
+    const { container } = renderJobAssetsList([job], { onViewItem })
 
-    await jobRow.trigger('mouseenter')
-    const viewButton = wrapper
-      .findAll('button')
-      .find((button) => button.text() === 'menuLabels.View')
-    expect(viewButton).toBeDefined()
+    const jobRow = container.querySelector(`[data-job-id="${job.id}"]`)!
+    await fireEvent.mouseEnter(jobRow)
 
-    await viewButton!.trigger('click')
+    await fireEvent.click(screen.getByText('menuLabels.View'))
     await nextTick()
 
-    expect(wrapper.emitted('viewItem')).toEqual([[job]])
+    expect(onViewItem).toHaveBeenCalledWith(job)
   })
 
   it('shows and hides the job details popover with hover delays', async () => {
     vi.useFakeTimers()
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
-    const jobRow = wrapper.find(`[data-job-id="${job.id}"]`)
+    const { container } = renderJobAssetsList([job])
 
-    await jobRow.trigger('mouseenter')
+    const jobRow = container.querySelector(`[data-job-id="${job.id}"]`)!
+
+    await fireEvent.mouseEnter(jobRow)
     await vi.advanceTimersByTimeAsync(199)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(false)
+    expect(container.querySelector('.job-details-popover-stub')).toBeNull()
 
     await vi.advanceTimersByTimeAsync(1)
     await nextTick()
 
-    const popover = wrapper.findComponent(JobDetailsPopoverStub)
-    expect(popover.exists()).toBe(true)
-    expect(popover.props()).toMatchObject({
-      jobId: job.id,
-      workflowId: 'workflow-1'
-    })
+    const popoverStub = container.querySelector('.job-details-popover-stub')!
+    expect(popoverStub).not.toBeNull()
+    expect(popoverStub.getAttribute('data-job-id')).toBe(job.id)
+    expect(popoverStub.getAttribute('data-workflow-id')).toBe('workflow-1')
 
-    await jobRow.trigger('mouseleave')
+    await fireEvent.mouseLeave(jobRow)
     await vi.advanceTimersByTimeAsync(149)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(true)
+    expect(container.querySelector('.job-details-popover-stub')).not.toBeNull()
 
     await vi.advanceTimersByTimeAsync(1)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(false)
+    expect(container.querySelector('.job-details-popover-stub')).toBeNull()
   })
 
   it('keeps the job details popover open while hovering the popover', async () => {
     vi.useFakeTimers()
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
-    const jobRow = wrapper.find(`[data-job-id="${job.id}"]`)
+    const { container } = renderJobAssetsList([job])
 
-    await jobRow.trigger('mouseenter')
+    const jobRow = container.querySelector(`[data-job-id="${job.id}"]`)!
+
+    await fireEvent.mouseEnter(jobRow)
     await vi.advanceTimersByTimeAsync(200)
     await nextTick()
 
-    await jobRow.trigger('mouseleave')
+    await fireEvent.mouseLeave(jobRow)
     await vi.advanceTimersByTimeAsync(100)
     await nextTick()
 
-    const popover = wrapper.find('.job-details-popover')
-    expect(popover.exists()).toBe(true)
+    const popoverWrapper = container.querySelector('.job-details-popover')!
+    expect(popoverWrapper).not.toBeNull()
 
-    await popover.trigger('mouseenter')
+    await fireEvent.mouseEnter(popoverWrapper)
     await vi.advanceTimersByTimeAsync(100)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(true)
+    expect(container.querySelector('.job-details-popover-stub')).not.toBeNull()
 
-    await popover.trigger('mouseleave')
+    await fireEvent.mouseLeave(popoverWrapper)
     await vi.advanceTimersByTimeAsync(149)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(true)
+    expect(container.querySelector('.job-details-popover-stub')).not.toBeNull()
 
     await vi.advanceTimersByTimeAsync(1)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(false)
+    expect(container.querySelector('.job-details-popover-stub')).toBeNull()
   })
 
   it('positions the popover to the right of rows near the left viewport edge', async () => {
     vi.useFakeTimers()
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
-    const jobRow = wrapper.find(`[data-job-id="${job.id}"]`)
+    const { container } = renderJobAssetsList([job])
+
+    const jobRow = container.querySelector(`[data-job-id="${job.id}"]`)!
 
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-    vi.spyOn(jobRow.element, 'getBoundingClientRect').mockReturnValue(
+    vi.spyOn(jobRow, 'getBoundingClientRect').mockReturnValue(
       createDomRect({
         top: 100,
         left: 40,
@@ -289,22 +333,23 @@ describe('JobAssetsList', () => {
       })
     )
 
-    await jobRow.trigger('mouseenter')
+    await fireEvent.mouseEnter(jobRow)
     await vi.advanceTimersByTimeAsync(200)
     await nextTick()
 
-    const popover = wrapper.find('.job-details-popover')
-    expect(popover.attributes('style')).toContain('left: 248px;')
+    const popover = container.querySelector('.job-details-popover')!
+    expect(popover.getAttribute('style')).toContain('left: 248px;')
   })
 
   it('positions the popover to the left of rows near the right viewport edge', async () => {
     vi.useFakeTimers()
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
-    const jobRow = wrapper.find(`[data-job-id="${job.id}"]`)
+    const { container } = renderJobAssetsList([job])
+
+    const jobRow = container.querySelector(`[data-job-id="${job.id}"]`)!
 
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-    vi.spyOn(jobRow.element, 'getBoundingClientRect').mockReturnValue(
+    vi.spyOn(jobRow, 'getBoundingClientRect').mockReturnValue(
       createDomRect({
         top: 100,
         left: 980,
@@ -313,83 +358,89 @@ describe('JobAssetsList', () => {
       })
     )
 
-    await jobRow.trigger('mouseenter')
+    await fireEvent.mouseEnter(jobRow)
     await vi.advanceTimersByTimeAsync(200)
     await nextTick()
 
-    const popover = wrapper.find('.job-details-popover')
-    expect(popover.attributes('style')).toContain('left: 672px;')
+    const popover = container.querySelector('.job-details-popover')!
+    expect(popover.getAttribute('style')).toContain('left: 672px;')
   })
+
   it('clears the previous popover when hovering a new row briefly and leaving the list', async () => {
     vi.useFakeTimers()
     const firstJob = buildJob({ id: 'job-1' })
     const secondJob = buildJob({ id: 'job-2', title: 'Job 2' })
-    const wrapper = mountJobAssetsList([firstJob, secondJob])
-    const firstRow = wrapper.find('[data-job-id="job-1"]')
-    const secondRow = wrapper.find('[data-job-id="job-2"]')
+    const { container } = renderJobAssetsList([firstJob, secondJob])
 
-    await firstRow.trigger('mouseenter')
+    const firstRow = container.querySelector('[data-job-id="job-1"]')!
+    const secondRow = container.querySelector('[data-job-id="job-2"]')!
+
+    await fireEvent.mouseEnter(firstRow)
     await vi.advanceTimersByTimeAsync(200)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).props('jobId')).toBe(
-      'job-1'
-    )
+    const popoverJobId = container
+      .querySelector('.job-details-popover-stub')
+      ?.getAttribute('data-job-id')
+    expect(popoverJobId).toBe('job-1')
 
-    await firstRow.trigger('mouseleave')
-    await secondRow.trigger('mouseenter')
+    await fireEvent.mouseLeave(firstRow)
+    await fireEvent.mouseEnter(secondRow)
     await vi.advanceTimersByTimeAsync(100)
     await nextTick()
-    await secondRow.trigger('mouseleave')
+    await fireEvent.mouseLeave(secondRow)
 
     await vi.advanceTimersByTimeAsync(150)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(false)
+    expect(container.querySelector('.job-details-popover-stub')).toBeNull()
   })
 
   it('shows the new popover after the previous row hides while the next row stays hovered', async () => {
     vi.useFakeTimers()
     const firstJob = buildJob({ id: 'job-1' })
     const secondJob = buildJob({ id: 'job-2', title: 'Job 2' })
-    const wrapper = mountJobAssetsList([firstJob, secondJob])
-    const firstRow = wrapper.find('[data-job-id="job-1"]')
-    const secondRow = wrapper.find('[data-job-id="job-2"]')
+    const { container } = renderJobAssetsList([firstJob, secondJob])
 
-    await firstRow.trigger('mouseenter')
+    const firstRow = container.querySelector('[data-job-id="job-1"]')!
+    const secondRow = container.querySelector('[data-job-id="job-2"]')!
+
+    await fireEvent.mouseEnter(firstRow)
     await vi.advanceTimersByTimeAsync(200)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).props('jobId')).toBe(
-      'job-1'
-    )
+    const firstPopoverJobId = container
+      .querySelector('.job-details-popover-stub')
+      ?.getAttribute('data-job-id')
+    expect(firstPopoverJobId).toBe('job-1')
 
-    await firstRow.trigger('mouseleave')
-    await secondRow.trigger('mouseenter')
+    await fireEvent.mouseLeave(firstRow)
+    await fireEvent.mouseEnter(secondRow)
 
     await vi.advanceTimersByTimeAsync(150)
     await nextTick()
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(false)
+    expect(container.querySelector('.job-details-popover-stub')).toBeNull()
 
     await vi.advanceTimersByTimeAsync(50)
     await nextTick()
 
-    const popover = wrapper.findComponent(JobDetailsPopoverStub)
-    expect(popover.exists()).toBe(true)
-    expect(popover.props('jobId')).toBe('job-2')
+    const popoverStub = container.querySelector('.job-details-popover-stub')!
+    expect(popoverStub).not.toBeNull()
+    expect(popoverStub.getAttribute('data-job-id')).toBe('job-2')
   })
 
   it('does not show details if the hovered row disappears before the show delay ends', async () => {
     vi.useFakeTimers()
     const job = buildJob()
-    const wrapper = mountJobAssetsList([job])
-    const jobRow = wrapper.find(`[data-job-id="${job.id}"]`)
+    const { container, rerender } = renderJobAssetsList([job])
 
-    await jobRow.trigger('mouseenter')
-    await wrapper.setProps({ displayedJobGroups: [] })
+    const jobRow = container.querySelector(`[data-job-id="${job.id}"]`)!
+
+    await fireEvent.mouseEnter(jobRow)
+    await rerender({ displayedJobGroups: [] })
     await nextTick()
 
     await vi.advanceTimersByTimeAsync(200)
     await nextTick()
 
-    expect(wrapper.findComponent(JobDetailsPopoverStub).exists()).toBe(false)
-    expect(wrapper.find('.job-details-popover').exists()).toBe(false)
+    expect(container.querySelector('.job-details-popover-stub')).toBeNull()
+    expect(container.querySelector('.job-details-popover')).toBeNull()
   })
 })

--- a/src/components/searchbox/NodeSearchBoxPopover.test.ts
+++ b/src/components/searchbox/NodeSearchBoxPopover.test.ts
@@ -1,8 +1,8 @@
-import { mount } from '@vue/test-utils'
+import { render } from '@testing-library/vue'
 import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { computed, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -68,12 +68,22 @@ vi.mock('@/stores/nodeDefStore', () => ({
   })
 }))
 
+let emitAddFilter:
+  | ((filter: FuseFilterWithValue<ComfyNodeDefImpl, string>) => void)
+  | null = null
+
 const NodeSearchBoxStub = defineComponent({
   name: 'NodeSearchBox',
   props: {
     filters: { type: Array, default: () => [] }
   },
-  template: '<div class="node-search-box" />'
+  emits: ['addFilter'],
+  setup(props, { emit }) {
+    emitAddFilter = (filter) => emit('addFilter', filter)
+    const filterCount = computed(() => props.filters.length)
+    return { filterCount }
+  },
+  template: '<div class="node-search-box" :data-filter-count="filterCount" />'
 })
 
 function createFilter(
@@ -96,10 +106,11 @@ describe('NodeSearchBoxPopover', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockStoreRefs.visible.value = false
+    emitAddFilter = null
   })
 
-  const mountComponent = () => {
-    return mount(NodeSearchBoxPopover, {
+  function renderComponent() {
+    return render(NodeSearchBoxPopover, {
       global: {
         plugins: [i18n, PrimeVue],
         stubs: {
@@ -115,59 +126,57 @@ describe('NodeSearchBoxPopover', () => {
 
   describe('addFilter duplicate prevention', () => {
     it('should add a filter when no duplicates exist', async () => {
-      const wrapper = mountComponent()
-      const searchBox = wrapper.findComponent(NodeSearchBoxStub)
+      const { container } = renderComponent()
 
-      searchBox.vm.$emit('addFilter', createFilter('outputType', 'IMAGE'))
-      await wrapper.vm.$nextTick()
+      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      await nextTick()
 
-      const filters = searchBox.props('filters') as FuseFilterWithValue<
-        ComfyNodeDefImpl,
-        string
-      >[]
-      expect(filters).toHaveLength(1)
-      expect(filters[0]).toEqual(
-        expect.objectContaining({
-          filterDef: expect.objectContaining({ id: 'outputType' }),
-          value: 'IMAGE'
-        })
-      )
+      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
+      const searchBox = container.querySelector('.node-search-box')
+      expect(searchBox).toHaveAttribute('data-filter-count', '1')
+      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
     })
 
     it('should not add a duplicate filter with same id and value', async () => {
-      const wrapper = mountComponent()
-      const searchBox = wrapper.findComponent(NodeSearchBoxStub)
+      const { container } = renderComponent()
 
-      searchBox.vm.$emit('addFilter', createFilter('outputType', 'IMAGE'))
-      await wrapper.vm.$nextTick()
-      searchBox.vm.$emit('addFilter', createFilter('outputType', 'IMAGE'))
-      await wrapper.vm.$nextTick()
+      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      await nextTick()
+      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      await nextTick()
 
-      expect(searchBox.props('filters')).toHaveLength(1)
+      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
+      const searchBox = container.querySelector('.node-search-box')
+      expect(searchBox).toHaveAttribute('data-filter-count', '1')
+      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
     })
 
     it('should allow filters with same id but different values', async () => {
-      const wrapper = mountComponent()
-      const searchBox = wrapper.findComponent(NodeSearchBoxStub)
+      const { container } = renderComponent()
 
-      searchBox.vm.$emit('addFilter', createFilter('outputType', 'IMAGE'))
-      await wrapper.vm.$nextTick()
-      searchBox.vm.$emit('addFilter', createFilter('outputType', 'MASK'))
-      await wrapper.vm.$nextTick()
+      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      await nextTick()
+      emitAddFilter!(createFilter('outputType', 'MASK'))
+      await nextTick()
 
-      expect(searchBox.props('filters')).toHaveLength(2)
+      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
+      const searchBox = container.querySelector('.node-search-box')
+      expect(searchBox).toHaveAttribute('data-filter-count', '2')
+      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
     })
 
     it('should allow filters with different ids but same value', async () => {
-      const wrapper = mountComponent()
-      const searchBox = wrapper.findComponent(NodeSearchBoxStub)
+      const { container } = renderComponent()
 
-      searchBox.vm.$emit('addFilter', createFilter('outputType', 'IMAGE'))
-      await wrapper.vm.$nextTick()
-      searchBox.vm.$emit('addFilter', createFilter('inputType', 'IMAGE'))
-      await wrapper.vm.$nextTick()
+      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      await nextTick()
+      emitAddFilter!(createFilter('inputType', 'IMAGE'))
+      await nextTick()
 
-      expect(searchBox.props('filters')).toHaveLength(2)
+      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
+      const searchBox = container.querySelector('.node-search-box')
+      expect(searchBox).toHaveAttribute('data-filter-count', '2')
+      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
     })
   })
 })

--- a/src/components/searchbox/NodeSearchBoxPopover.test.ts
+++ b/src/components/searchbox/NodeSearchBoxPopover.test.ts
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -10,27 +10,10 @@ import type { FuseFilter, FuseFilterWithValue } from '@/utils/fuseUtil'
 
 import NodeSearchBoxPopover from './NodeSearchBoxPopover.vue'
 
-const mockStoreRefs = vi.hoisted(() => ({
-  visible: { value: false },
-  newSearchBoxEnabled: { value: true }
-}))
-
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
     get: vi.fn()
   })
-}))
-
-vi.mock('pinia', async () => {
-  const actual = await vi.importActual('pinia')
-  return {
-    ...(actual as Record<string, unknown>),
-    storeToRefs: () => mockStoreRefs
-  }
-})
-
-vi.mock('@/stores/workspace/searchBoxStore', () => ({
-  useSearchBoxStore: () => ({})
 }))
 
 vi.mock('@/services/litegraphService', () => ({
@@ -68,23 +51,9 @@ vi.mock('@/stores/nodeDefStore', () => ({
   })
 }))
 
-let emitAddFilter:
-  | ((filter: FuseFilterWithValue<ComfyNodeDefImpl, string>) => void)
-  | null = null
-
-const NodeSearchBoxStub = defineComponent({
-  name: 'NodeSearchBox',
-  props: {
-    filters: { type: Array, default: () => [] }
-  },
-  emits: ['addFilter'],
-  setup(props, { emit }) {
-    emitAddFilter = (filter) => emit('addFilter', filter)
-    const filterCount = computed(() => props.filters.length)
-    return { filterCount }
-  },
-  template: '<div class="node-search-box" :data-filter-count="filterCount" />'
-})
+type EmitAddFilter = (
+  filter: FuseFilterWithValue<ComfyNodeDefImpl, string>
+) => void
 
 function createFilter(
   id: string,
@@ -103,16 +72,33 @@ describe('NodeSearchBoxPopover', () => {
     messages: { en: {} }
   })
 
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    mockStoreRefs.visible.value = false
-    emitAddFilter = null
-  })
-
   function renderComponent() {
-    return render(NodeSearchBoxPopover, {
+    let emitAddFilter: EmitAddFilter | null = null
+
+    const NodeSearchBoxStub = defineComponent({
+      name: 'NodeSearchBox',
+      props: {
+        filters: { type: Array, default: () => [] }
+      },
+      emits: ['addFilter'],
+      setup(props, { emit }) {
+        emitAddFilter = (filter) => emit('addFilter', filter)
+        const filterCount = computed(() => props.filters.length)
+        return { filterCount }
+      },
+      template: '<output aria-label="filter count">{{ filterCount }}</output>'
+    })
+
+    const pinia = createTestingPinia({
+      stubActions: false,
+      initialState: {
+        searchBox: { visible: false }
+      }
+    })
+
+    const result = render(NodeSearchBoxPopover, {
       global: {
-        plugins: [i18n, PrimeVue],
+        plugins: [i18n, PrimeVue, pinia],
         stubs: {
           NodeSearchBox: NodeSearchBoxStub,
           Dialog: {
@@ -122,61 +108,53 @@ describe('NodeSearchBoxPopover', () => {
         }
       }
     })
+
+    if (!emitAddFilter) throw new Error('NodeSearchBox stub did not mount')
+
+    return { ...result, emitAddFilter: emitAddFilter as EmitAddFilter }
   }
 
   describe('addFilter duplicate prevention', () => {
     it('should add a filter when no duplicates exist', async () => {
-      const { container } = renderComponent()
+      const { emitAddFilter } = renderComponent()
 
-      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
 
-      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
-      const searchBox = container.querySelector('.node-search-box')
-      expect(searchBox).toHaveAttribute('data-filter-count', '1')
-      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
+      expect(screen.getByLabelText('filter count')).toHaveTextContent('1')
     })
 
     it('should not add a duplicate filter with same id and value', async () => {
-      const { container } = renderComponent()
+      const { emitAddFilter } = renderComponent()
 
-      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
-      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
 
-      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
-      const searchBox = container.querySelector('.node-search-box')
-      expect(searchBox).toHaveAttribute('data-filter-count', '1')
-      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
+      expect(screen.getByLabelText('filter count')).toHaveTextContent('1')
     })
 
     it('should allow filters with same id but different values', async () => {
-      const { container } = renderComponent()
+      const { emitAddFilter } = renderComponent()
 
-      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
-      emitAddFilter!(createFilter('outputType', 'MASK'))
+      emitAddFilter(createFilter('outputType', 'MASK'))
       await nextTick()
 
-      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
-      const searchBox = container.querySelector('.node-search-box')
-      expect(searchBox).toHaveAttribute('data-filter-count', '2')
-      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
+      expect(screen.getByLabelText('filter count')).toHaveTextContent('2')
     })
 
     it('should allow filters with different ids but same value', async () => {
-      const { container } = renderComponent()
+      const { emitAddFilter } = renderComponent()
 
-      emitAddFilter!(createFilter('outputType', 'IMAGE'))
+      emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
-      emitAddFilter!(createFilter('inputType', 'IMAGE'))
+      emitAddFilter(createFilter('inputType', 'IMAGE'))
       await nextTick()
 
-      /* eslint-disable testing-library/no-node-access, testing-library/no-container -- Stub component requires direct DOM access */
-      const searchBox = container.querySelector('.node-search-box')
-      expect(searchBox).toHaveAttribute('data-filter-count', '2')
-      /* eslint-enable testing-library/no-node-access, testing-library/no-container */
+      expect(screen.getByLabelText('filter count')).toHaveTextContent('2')
     })
   })
 })

--- a/src/components/templates/thumbnails/BaseThumbnail.test.ts
+++ b/src/components/templates/thumbnails/BaseThumbnail.test.ts
@@ -1,12 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { describe, expect, it } from 'vitest'
 
 import BaseThumbnail from '@/components/templates/thumbnails/BaseThumbnail.vue'
 
 describe('BaseThumbnail', () => {
-  function renderThumbnail(props = {}) {
+  function renderThumbnail(
+    props: Partial<ComponentProps<typeof BaseThumbnail>> = {}
+  ) {
     return render(BaseThumbnail, {
-      props,
+      props: props as ComponentProps<typeof BaseThumbnail>,
       slots: {
         default: '<img src="/test.jpg" alt="test" />'
       }
@@ -19,24 +22,21 @@ describe('BaseThumbnail', () => {
   })
 
   it('applies hover zoom with correct style', () => {
-    const { container } = renderThumbnail({ isHovered: true })
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const contentDiv = container.querySelector('.transform-gpu')
+    renderThumbnail({ isHovered: true })
+    const contentDiv = screen.getByTestId('thumbnail-content')
     expect(contentDiv).toHaveStyle({ transform: 'scale(1.04)' })
   })
 
   it('applies custom hover zoom value', () => {
-    const { container } = renderThumbnail({ hoverZoom: 10, isHovered: true })
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const contentDiv = container.querySelector('.transform-gpu')
+    renderThumbnail({ hoverZoom: 10, isHovered: true })
+    const contentDiv = screen.getByTestId('thumbnail-content')
     expect(contentDiv).toHaveStyle({ transform: 'scale(1.1)' })
   })
 
   it('does not apply scale when not hovered', () => {
-    const { container } = renderThumbnail({ isHovered: false })
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const contentDiv = container.querySelector('.transform-gpu')
-    expect(contentDiv).not.toHaveStyle({ transform: expect.any(String) })
+    renderThumbnail({ isHovered: false })
+    const contentDiv = screen.getByTestId('thumbnail-content')
+    expect(contentDiv).not.toHaveAttribute('style')
   })
 
   it('shows error state when image fails to load', async () => {

--- a/src/components/templates/thumbnails/BaseThumbnail.test.ts
+++ b/src/components/templates/thumbnails/BaseThumbnail.test.ts
@@ -1,71 +1,51 @@
-import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import BaseThumbnail from '@/components/templates/thumbnails/BaseThumbnail.vue'
 
-type ComponentInstance = InstanceType<typeof BaseThumbnail> & {
-  error: boolean
-}
-
-vi.mock('@vueuse/core', () => ({
-  useEventListener: vi.fn()
-}))
-
 describe('BaseThumbnail', () => {
-  const mountThumbnail = (props = {}, slots = {}) => {
-    return mount(BaseThumbnail, {
+  function renderThumbnail(props = {}) {
+    return render(BaseThumbnail, {
       props,
       slots: {
-        default: '<img src="/test.jpg" alt="test" />',
-        ...slots
+        default: '<img src="/test.jpg" alt="test" />'
       }
     })
   }
 
   it('renders slot content', () => {
-    const wrapper = mountThumbnail()
-    expect(wrapper.find('img').exists()).toBe(true)
+    renderThumbnail()
+    expect(screen.getByAltText('test')).toBeTruthy()
   })
 
   it('applies hover zoom with correct style', () => {
-    const wrapper = mountThumbnail({ isHovered: true })
-    const contentDiv = wrapper.find('.transform-gpu')
-    expect(contentDiv.attributes('style')).toContain('transform')
-    expect(contentDiv.attributes('style')).toContain('scale')
+    const { container } = renderThumbnail({ isHovered: true })
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const contentDiv = container.querySelector('.transform-gpu')
+    expect(contentDiv).toHaveStyle({ transform: 'scale(1.04)' })
   })
 
   it('applies custom hover zoom value', () => {
-    const wrapper = mountThumbnail({ hoverZoom: 10, isHovered: true })
-    const contentDiv = wrapper.find('.transform-gpu')
-    expect(contentDiv.attributes('style')).toContain('scale(1.1)')
+    const { container } = renderThumbnail({ hoverZoom: 10, isHovered: true })
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const contentDiv = container.querySelector('.transform-gpu')
+    expect(contentDiv).toHaveStyle({ transform: 'scale(1.1)' })
   })
 
   it('does not apply scale when not hovered', () => {
-    const wrapper = mountThumbnail({ isHovered: false })
-    const contentDiv = wrapper.find('.transform-gpu')
-    expect(contentDiv.attributes('style')).toBeUndefined()
+    const { container } = renderThumbnail({ isHovered: false })
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const contentDiv = container.querySelector('.transform-gpu')
+    expect(contentDiv).not.toHaveStyle({ transform: expect.any(String) })
   })
 
   it('shows error state when image fails to load', async () => {
-    const wrapper = mountThumbnail()
-    const vm = wrapper.vm as ComponentInstance
-
-    // Manually set error since useEventListener is mocked
-    vm.error = true
-    await nextTick()
-
-    expect(
-      wrapper.find('img[src="/assets/images/default-template.png"]').exists()
-    ).toBe(true)
-  })
-
-  it('applies transition classes to content', () => {
-    const wrapper = mountThumbnail()
-    const contentDiv = wrapper.find('.transform-gpu')
-    expect(contentDiv.classes()).toContain('transform-gpu')
-    expect(contentDiv.classes()).toContain('transition-transform')
-    expect(contentDiv.classes()).toContain('duration-1000')
-    expect(contentDiv.classes()).toContain('ease-out')
+    renderThumbnail()
+    const img = screen.getByAltText('test')
+    await fireEvent.error(img)
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      '/assets/images/default-template.png'
+    )
   })
 })

--- a/src/components/templates/thumbnails/BaseThumbnail.vue
+++ b/src/components/templates/thumbnails/BaseThumbnail.vue
@@ -5,6 +5,7 @@
     <div
       v-if="!error"
       ref="contentRef"
+      data-testid="thumbnail-content"
       class="size-full transform-gpu transition-transform duration-1000 ease-out"
       :style="
         isHovered ? { transform: `scale(${1 + hoverZoom / 100})` } : undefined

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -1,8 +1,7 @@
-import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
-import Button from '@/components/ui/button/Button.vue'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { h } from 'vue'
+import { defineComponent, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -38,7 +37,7 @@ vi.mock('firebase/auth', () => ({
 
 // Mock pinia
 vi.mock('pinia', () => ({
-  storeToRefs: vi.fn((store) => store)
+  storeToRefs: vi.fn((store: Record<string, unknown>) => store)
 }))
 
 // Mock the useFeatureFlags composable
@@ -91,13 +90,25 @@ vi.mock('@/platform/workspace/components/WorkspaceProfilePic.vue', () => ({
 
 // Mock the CurrentUserPopoverLegacy component
 vi.mock('./CurrentUserPopoverLegacy.vue', () => ({
-  default: {
+  // eslint-disable-next-line vue/one-component-per-file
+  default: defineComponent({
     name: 'CurrentUserPopoverLegacyMock',
-    render() {
-      return h('div', 'Popover Content')
-    },
-    emits: ['close']
-  }
+    emits: ['close'],
+    setup(_, { emit }) {
+      return () =>
+        h('div', [
+          'Popover Content',
+          h(
+            'button',
+            {
+              'data-testid': 'close-popover',
+              onClick: () => emit('close')
+            },
+            'Close'
+          )
+        ])
+    }
+  })
 }))
 
 describe('CurrentUserButton', () => {
@@ -110,63 +121,66 @@ describe('CurrentUserButton', () => {
     mockIsCloud.value = false
   })
 
-  const mountComponent = (options?: { stubButton?: boolean }): VueWrapper => {
-    const { stubButton = true } = options ?? {}
+  function renderComponent() {
+    const user = userEvent.setup()
     const i18n = createI18n({
       legacy: false,
       locale: 'en',
       messages: { en: enMessages }
     })
 
-    return mount(CurrentUserButton, {
+    const result = render(CurrentUserButton, {
       global: {
         plugins: [i18n],
         stubs: {
-          // Use shallow mount for popover to make testing easier
-          Popover: {
-            template: '<div><slot></slot></div>',
-            methods: {
-              toggle: vi.fn(),
-              hide: vi.fn()
+          // eslint-disable-next-line vue/one-component-per-file
+          Popover: defineComponent({
+            setup(_, { slots, expose }) {
+              const shown = ref(false)
+              expose({
+                toggle: () => {
+                  shown.value = !shown.value
+                },
+                hide: () => {
+                  shown.value = false
+                }
+              })
+              return () => (shown.value ? h('div', slots.default?.()) : null)
             }
-          },
-          ...(stubButton ? { Button: true } : {})
+          })
         }
       }
     })
+
+    return { user, ...result }
   }
 
   it('renders correctly when user is logged in', () => {
-    const wrapper = mountComponent()
-    expect(wrapper.findComponent(Button).exists()).toBe(true)
+    renderComponent()
+    expect(
+      screen.getByRole('button', { name: 'Current user' })
+    ).toBeInTheDocument()
   })
 
   it('toggles popover on button click', async () => {
-    const wrapper = mountComponent()
-    const popoverToggleSpy = vi.fn()
+    const { user } = renderComponent()
 
-    // Override the ref with a mock implementation
-    // @ts-expect-error - accessing internal Vue component vm
-    wrapper.vm.popover = { toggle: popoverToggleSpy }
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument()
 
-    await wrapper.findComponent(Button).trigger('click')
-    expect(popoverToggleSpy).toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'Current user' }))
+
+    expect(screen.getByText('Popover Content')).toBeInTheDocument()
   })
 
   it('hides popover when closePopover is called', async () => {
-    const wrapper = mountComponent()
+    const { user } = renderComponent()
 
-    // Replace the popover.hide method with a spy
-    const popoverHideSpy = vi.fn()
-    // @ts-expect-error - accessing internal Vue component vm
-    wrapper.vm.popover = { hide: popoverHideSpy }
+    await user.click(screen.getByRole('button', { name: 'Current user' }))
+    expect(screen.getByText('Popover Content')).toBeInTheDocument()
 
-    // Directly call the closePopover method through the component instance
-    // @ts-expect-error - accessing internal Vue component vm
-    wrapper.vm.closePopover()
+    await user.click(screen.getByTestId('close-popover'))
 
-    // Verify that popover.hide was called
-    expect(popoverHideSpy).toHaveBeenCalled()
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument()
   })
 
   it('shows UserAvatar in personal workspace', () => {
@@ -175,9 +189,9 @@ describe('CurrentUserButton', () => {
     mockTeamWorkspaceStore.initState.value = 'ready'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = true
 
-    const wrapper = mountComponent({ stubButton: false })
-    expect(wrapper.html()).toContain('Avatar')
-    expect(wrapper.html()).not.toContain('WorkspaceProfilePic')
+    renderComponent()
+    expect(screen.getByText('Avatar')).toBeInTheDocument()
+    expect(screen.queryByText('WorkspaceProfilePic')).not.toBeInTheDocument()
   })
 
   it('shows WorkspaceProfilePic in team workspace', () => {
@@ -187,8 +201,8 @@ describe('CurrentUserButton', () => {
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
     mockTeamWorkspaceStore.workspaceName.value = 'My Team'
 
-    const wrapper = mountComponent({ stubButton: false })
-    expect(wrapper.html()).toContain('WorkspaceProfilePic')
-    expect(wrapper.html()).not.toContain('Avatar')
+    renderComponent()
+    expect(screen.getByText('WorkspaceProfilePic')).toBeInTheDocument()
+    expect(screen.queryByText('Avatar')).not.toBeInTheDocument()
   })
 })

--- a/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
@@ -1,7 +1,6 @@
-import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { createTestingPinia } from '@pinia/testing'
-import Button from '@/components/ui/button/Button.vue'
 import PrimeVue from 'primevue/config'
 import Listbox from 'primevue/listbox'
 import Select from 'primevue/select'
@@ -13,17 +12,7 @@ import { createI18n } from 'vue-i18n'
 import VerifiedIcon from '@/components/icons/VerifiedIcon.vue'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
-// SelectedVersion is now using direct strings instead of enum
-
 import PackVersionSelectorPopover from './PackVersionSelectorPopover.vue'
-
-interface PackVersionSelectorVM {
-  getVersionCompatibility: (version: string) => unknown
-}
-
-function getVM(wrapper: VueWrapper): PackVersionSelectorVM {
-  return wrapper.vm as Partial<PackVersionSelectorVM> as PackVersionSelectorVM
-}
 
 // Default mock versions for reference
 const defaultMockVersions = [
@@ -112,46 +101,47 @@ describe('PackVersionSelectorPopover', () => {
     mockGetInstalledPackVersion.mockReset().mockReturnValue(undefined)
   })
 
-  const mountComponent = ({
-    props = {}
-  }: { props?: Record<string, unknown> } = {}): VueWrapper => {
+  function renderComponent({
+    props = {},
+    onCancel,
+    onSubmit
+  }: {
+    props?: Record<string, unknown>
+    onCancel?: () => void
+    onSubmit?: () => void
+  } = {}) {
     const i18n = createI18n({
       legacy: false,
       locale: 'en',
       messages: { en: enMessages }
     })
-
-    return mount(PackVersionSelectorPopover, {
+    const user = userEvent.setup()
+    const result = render(PackVersionSelectorPopover, {
       props: {
         nodePack: mockNodePack,
-        ...props
+        ...props,
+        ...(onCancel ? { onCancel } : {}),
+        ...(onSubmit ? { onSubmit } : {})
       },
       global: {
         plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
-        components: {
-          Listbox,
-          VerifiedIcon,
-          Select
-        },
-        directives: {
-          tooltip: Tooltip
-        }
+        components: { Listbox, VerifiedIcon, Select },
+        directives: { tooltip: Tooltip }
       }
     })
+    return { ...result, user }
   }
 
   it('fetches versions on mount', async () => {
-    // Set up the mock for this specific test
     mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-    mountComponent()
+    renderComponent()
     await waitForPromises()
 
     expect(mockGetPackVersions).toHaveBeenCalledWith(mockNodePack.id)
   })
 
   it('shows loading state while fetching versions', async () => {
-    // Delay the promise resolution
     mockGetPackVersions.mockImplementationOnce(
       () =>
         new Promise((resolve) =>
@@ -159,63 +149,52 @@ describe('PackVersionSelectorPopover', () => {
         )
     )
 
-    const wrapper = mountComponent()
+    renderComponent()
 
-    expect(wrapper.text()).toContain('Loading versions...')
+    expect(screen.getByText('Loading versions...')).toBeInTheDocument()
   })
 
   it('displays special options and version options in the listbox', async () => {
-    // Set up the mock for this specific test
     mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-    const wrapper = mountComponent()
+    renderComponent()
     await waitForPromises()
 
-    const listbox = wrapper.findComponent(Listbox)
-    expect(listbox.exists()).toBe(true)
-
-    const options = listbox.props('options')!
-    // Check that we have both special options and version options
-    // Latest version (1.0.0) should be excluded from the version list to avoid duplication
-    expect(options.length).toBe(defaultMockVersions.length + 1) // 2 special options + version options minus 1 duplicate
-
-    // Check that special options exist
-    expect(options.some((o) => o.value === 'nightly')).toBe(true)
-    expect(options.some((o) => o.value === 'latest')).toBe(true)
-
-    // Check that version options exist (excluding latest version 1.0.0)
-    expect(options.some((o) => o.value === '1.0.0')).toBe(false) // Should be excluded as it's the latest
-    expect(options.some((o) => o.value === '0.9.0')).toBe(true)
-    expect(options.some((o) => o.value === '0.8.0')).toBe(true)
+    // Latest version (1.0.0) should be excluded from version list to avoid duplication
+    expect(screen.getByText(/Latest/)).toBeInTheDocument()
+    expect(screen.getByText('Nightly')).toBeInTheDocument()
+    expect(screen.getByText('0.9.0')).toBeInTheDocument()
+    expect(screen.getByText('0.8.0')).toBeInTheDocument()
+    // 1.0.0 appears only inside the "Latest (1.0.0)" label, not as a standalone option
+    expect(
+      screen.queryByRole('option', { name: '1.0.0' })
+    ).not.toBeInTheDocument()
   })
 
   it('emits cancel event when cancel button is clicked', async () => {
-    // Set up the mock for this specific test
     mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
+    const onCancel = vi.fn()
 
-    const wrapper = mountComponent()
+    const { user } = renderComponent({ onCancel })
     await waitForPromises()
 
-    const cancelButton = wrapper.findAllComponents(Button)[0]
-    await cancelButton.trigger('click')
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
-    expect(wrapper.emitted('cancel')).toBeTruthy()
+    expect(onCancel).toHaveBeenCalledOnce()
   })
 
   it('calls installPack and emits submit when install button is clicked', async () => {
-    // Set up the mock for this specific test
     mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
+    const onSubmit = vi.fn()
 
-    const wrapper = mountComponent()
+    const { user } = renderComponent({ onSubmit })
     await waitForPromises()
 
-    // Set the selected version
-    await wrapper.findComponent(Listbox).setValue('0.9.0')
+    // Select version 0.9.0 by clicking its option
+    await user.click(screen.getByText('0.9.0'))
 
-    const installButton = wrapper.findAllComponents(Button)[1]
-    await installButton.trigger('click')
+    await user.click(screen.getByRole('button', { name: 'Install' }))
 
-    // Check that installPack was called with the correct parameters
     expect(mockInstallPack).toHaveBeenCalledWith(
       expect.objectContaining({
         id: mockNodePack.id,
@@ -225,126 +204,117 @@ describe('PackVersionSelectorPopover', () => {
       })
     )
 
-    // Check that submit was emitted
-    expect(wrapper.emitted('submit')).toBeTruthy()
+    expect(onSubmit).toHaveBeenCalledOnce()
   })
 
   it('is reactive to nodePack prop changes', async () => {
-    // Set up the mock for the initial fetch
     mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-    const wrapper = mountComponent()
+    const { rerender } = renderComponent()
     await waitForPromises()
 
-    // Set up the mock for the second fetch after prop change
     mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-    // Update the nodePack prop
     const newNodePack = { ...mockNodePack, id: 'new-test-pack' }
-    await wrapper.setProps({ nodePack: newNodePack })
+    await rerender({ nodePack: newNodePack })
     await waitForPromises()
 
-    // Should fetch versions for the new nodePack
     expect(mockGetPackVersions).toHaveBeenCalledWith(newNodePack.id)
   })
 
   describe('nodePack.id changes', () => {
     it('re-fetches versions when nodePack.id changes', async () => {
-      // Set up the mock for the initial fetch
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      const wrapper = mountComponent()
+      const { rerender } = renderComponent()
       await waitForPromises()
 
-      // Verify initial fetch
       expect(mockGetPackVersions).toHaveBeenCalledTimes(1)
       expect(mockGetPackVersions).toHaveBeenCalledWith(mockNodePack.id)
 
-      // Set up the mock for the second fetch
       const newVersions = [
         { version: '2.0.0', createdAt: '2023-06-01' },
         { version: '1.9.0', createdAt: '2023-05-01' }
       ]
       mockGetPackVersions.mockResolvedValueOnce(newVersions)
 
-      // Update the nodePack with a new ID
       const newNodePack = {
         ...mockNodePack,
         id: 'different-pack',
         name: 'Different Pack'
       }
-      await wrapper.setProps({ nodePack: newNodePack })
+      await rerender({ nodePack: newNodePack })
       await waitForPromises()
 
-      // Should fetch versions for the new nodePack
       expect(mockGetPackVersions).toHaveBeenCalledTimes(2)
       expect(mockGetPackVersions).toHaveBeenLastCalledWith(newNodePack.id)
 
-      // Check that new versions are displayed
-      const listbox = wrapper.findComponent(Listbox)
-      const options = listbox.props('options')!
-      expect(options.some((o) => o.value === '2.0.0')).toBe(true)
-      expect(options.some((o) => o.value === '1.9.0')).toBe(true)
+      expect(screen.getByText('2.0.0')).toBeInTheDocument()
+      expect(screen.getByText('1.9.0')).toBeInTheDocument()
     })
 
     it('does not re-fetch when nodePack changes but id remains the same', async () => {
-      // Set up the mock for the initial fetch
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      const wrapper = mountComponent()
+      const { rerender } = renderComponent()
       await waitForPromises()
 
-      // Verify initial fetch
       expect(mockGetPackVersions).toHaveBeenCalledTimes(1)
 
-      // Update the nodePack with same ID but different properties
       const updatedNodePack = {
         ...mockNodePack,
         name: 'Updated Test Pack',
         description: 'New description'
       }
-      await wrapper.setProps({ nodePack: updatedNodePack })
+      await rerender({ nodePack: updatedNodePack })
       await waitForPromises()
 
-      // Should NOT fetch versions again
       expect(mockGetPackVersions).toHaveBeenCalledTimes(1)
     })
 
     it('maintains selected version when switching to a new pack', async () => {
-      // Set up the mock for the initial fetch
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      const wrapper = mountComponent()
+      const { user, container, rerender } = renderComponent()
       await waitForPromises()
 
-      // Select a specific version
-      const listbox = wrapper.findComponent(Listbox)
-      await listbox.setValue('0.9.0')
-      expect(listbox.props('modelValue')).toBe('0.9.0')
+      // Select version 0.9.0
+      await user.click(screen.getByText('0.9.0'))
 
-      // Set up the mock for the second fetch
+      // Verify 0.9.0 is selected via aria-selected
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- PrimeVue Listbox: checking aria-selected on option element
+      const selectedOption = container.querySelector(
+        '[role="option"][aria-selected="true"]'
+      )
+      expect(selectedOption).not.toBeNull()
+      expect(selectedOption?.textContent).toContain('0.9.0')
+
       mockGetPackVersions.mockResolvedValueOnce([
         { version: '3.0.0', createdAt: '2023-07-01' },
         { version: '0.9.0', createdAt: '2023-04-01' }
       ])
 
-      // Update to a new pack that also has version 0.9.0
       const newNodePack = {
         id: 'another-pack',
         name: 'Another Pack',
         latest_version: { version: '3.0.0' }
       }
-      await wrapper.setProps({ nodePack: newNodePack })
+      await rerender({ nodePack: newNodePack })
       await waitForPromises()
 
-      // Selected version should remain the same if available
-      expect(listbox.props('modelValue')).toBe('0.9.0')
+      // Selected version should remain 0.9.0 — verify via pi-check icon
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- PrimeVue Listbox: checking selected indicator icon
+      const checkIcons = container.querySelectorAll('.pi.pi-check')
+      const selectedTexts = Array.from(checkIcons).map(
+        // eslint-disable-next-line testing-library/no-node-access -- traversing to parent option element
+        (icon) => icon.closest('[role="option"]')?.textContent
+      )
+      expect(selectedTexts.some((text) => text?.includes('0.9.0'))).toBe(true)
     })
   })
 
   describe('Unclaimed GitHub packs handling', () => {
     it('falls back to nightly when no versions exist', async () => {
-      // Set up the mock to return versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
       const packWithRepo = {
@@ -352,20 +322,22 @@ describe('PackVersionSelectorPopover', () => {
         latest_version: undefined
       }
 
-      const wrapper = mountComponent({
-        props: {
-          nodePack: packWithRepo
-        }
+      const { container } = renderComponent({
+        props: { nodePack: packWithRepo }
       })
-
       await waitForPromises()
-      const listbox = wrapper.findComponent(Listbox)
-      expect(listbox.exists()).toBe(true)
-      expect(listbox.props('modelValue')).toBe('nightly')
+
+      // Nightly should be selected — verify via pi-check icon next to Nightly
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- PrimeVue Listbox: checking selected indicator icon
+      const checkIcons = container.querySelectorAll('.pi.pi-check')
+      const selectedTexts = Array.from(checkIcons).map(
+        // eslint-disable-next-line testing-library/no-node-access -- traversing to parent option element
+        (icon) => icon.closest('[role="option"]')?.textContent
+      )
+      expect(selectedTexts.some((text) => text?.includes('Nightly'))).toBe(true)
     })
 
     it('defaults to nightly when publisher name is "Unclaimed"', async () => {
-      // Set up the mock to return versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
       const unclaimedNodePack = {
@@ -373,25 +345,26 @@ describe('PackVersionSelectorPopover', () => {
         publisher: { name: 'Unclaimed' }
       }
 
-      const wrapper = mountComponent({
-        props: {
-          nodePack: unclaimedNodePack
-        }
+      const { container } = renderComponent({
+        props: { nodePack: unclaimedNodePack }
       })
-
       await waitForPromises()
-      const listbox = wrapper.findComponent(Listbox)
-      expect(listbox.exists()).toBe(true)
-      expect(listbox.props('modelValue')).toBe('nightly')
+
+      // Nightly should be selected
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- PrimeVue Listbox: checking selected indicator icon
+      const checkIcons = container.querySelectorAll('.pi.pi-check')
+      const selectedTexts = Array.from(checkIcons).map(
+        // eslint-disable-next-line testing-library/no-node-access -- traversing to parent option element
+        (icon) => icon.closest('[role="option"]')?.textContent
+      )
+      expect(selectedTexts.some((text) => text?.includes('Nightly'))).toBe(true)
     })
   })
 
   describe('version compatibility checking', () => {
     it('shows warning icon for incompatible versions', async () => {
-      // Set up the mock for versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      // Mock compatibility check to return conflict for specific version
       mockCheckNodeCompatibility.mockImplementation((versionData) => {
         if (versionData.supported_os?.includes('linux')) {
           return {
@@ -414,103 +387,41 @@ describe('PackVersionSelectorPopover', () => {
         supported_accelerators: ['CUDA']
       }
 
-      const wrapper = mountComponent({
+      const { container } = renderComponent({
         props: { nodePack: nodePackWithCompatibility }
       })
       await waitForPromises()
 
-      // Check that compatibility checking function was called
       expect(mockCheckNodeCompatibility).toHaveBeenCalled()
 
-      // The warning icon should be shown for incompatible versions
-      const warningIcons = wrapper.findAll('.icon-\\[lucide--triangle-alert\\]')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- icon class query not expressible via ARIA roles
+      const warningIcons = container.querySelectorAll(
+        '.icon-\\[lucide--triangle-alert\\]'
+      )
       expect(warningIcons.length).toBeGreaterThan(0)
     })
 
     it('shows verified icon for compatible versions', async () => {
-      // Set up the mock for versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      // Mock compatibility check to return no conflicts
       mockCheckNodeCompatibility.mockReturnValue({
         hasConflict: false,
         conflicts: []
       })
 
-      const wrapper = mountComponent()
+      const { container } = renderComponent()
       await waitForPromises()
 
-      // Check that compatibility checking function was called
       expect(mockCheckNodeCompatibility).toHaveBeenCalled()
 
-      // The verified icon should be shown for compatible versions
-      // Look for the VerifiedIcon component or SVG elements
-      const verifiedIcons = wrapper.findAll('svg')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- VerifiedIcon renders SVG without accessible role
+      const verifiedIcons = container.querySelectorAll('svg')
       expect(verifiedIcons.length).toBeGreaterThan(0)
     })
 
-    it('calls checkVersionCompatibility with correct version data', async () => {
-      // Set up the mock for versions with specific supported data
-      const versionsWithCompatibility = [
-        {
-          version: '1.0.0',
-          supported_os: ['windows', 'linux'],
-          supported_accelerators: ['CUDA', 'CPU'],
-          supported_comfyui_version: '>=0.1.0',
-          supported_comfyui_frontend_version: '>=1.0.0'
-        }
-      ]
-      mockGetPackVersions.mockResolvedValueOnce(versionsWithCompatibility)
-
-      const nodePackWithCompatibility = {
-        ...mockNodePack,
-        supported_os: ['windows'],
-        supported_accelerators: ['CPU'],
-        supported_comfyui_version: '>=0.1.0',
-        supported_comfyui_frontend_version: '>=1.0.0',
-        latest_version: {
-          version: '1.0.0',
-          supported_os: ['windows', 'linux'],
-          supported_accelerators: ['CPU'], // latest_version data takes precedence
-          supported_comfyui_version: '>=0.1.0',
-          supported_comfyui_frontend_version: '>=1.0.0',
-          supported_python_version: '>=3.8',
-          is_banned: false,
-          has_registry_data: true
-        }
-      }
-
-      const wrapper = mountComponent({
-        props: { nodePack: nodePackWithCompatibility }
-      })
-      await waitForPromises()
-
-      // Clear previous calls from component mounting/rendering
-      mockCheckNodeCompatibility.mockClear()
-
-      // Trigger compatibility check by accessing getVersionCompatibility
-      const vm = getVM(wrapper)
-      vm.getVersionCompatibility('1.0.0')
-
-      // Verify that checkNodeCompatibility was called with correct data
-      // Since 1.0.0 is the latest version, it should use latest_version data
-      expect(mockCheckNodeCompatibility).toHaveBeenCalledWith({
-        supported_os: ['windows', 'linux'],
-        supported_accelerators: ['CPU'], // latest_version data takes precedence
-        supported_comfyui_version: '>=0.1.0',
-        supported_comfyui_frontend_version: '>=1.0.0',
-        supported_python_version: '>=3.8',
-        is_banned: false,
-        has_registry_data: true,
-        version: '1.0.0'
-      })
-    })
-
     it('shows version conflict warnings for ComfyUI and frontend versions', async () => {
-      // Set up the mock for versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      // Mock compatibility check to return version conflicts
       mockCheckNodeCompatibility.mockImplementation((versionData) => {
         const conflicts = []
         if (versionData.supported_comfyui_version) {
@@ -539,94 +450,23 @@ describe('PackVersionSelectorPopover', () => {
         supported_comfyui_frontend_version: '>=2.0.0'
       }
 
-      const wrapper = mountComponent({
+      const { container } = renderComponent({
         props: { nodePack: nodePackWithVersionRequirements }
       })
       await waitForPromises()
 
-      // Check that compatibility checking function was called
       expect(mockCheckNodeCompatibility).toHaveBeenCalled()
 
-      // The warning icon should be shown for version incompatible packages
-      const warningIcons = wrapper.findAll('.icon-\\[lucide--triangle-alert\\]')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- icon class query not expressible via ARIA roles
+      const warningIcons = container.querySelectorAll(
+        '.icon-\\[lucide--triangle-alert\\]'
+      )
       expect(warningIcons.length).toBeGreaterThan(0)
     })
 
-    it('handles latest and nightly versions using nodePack data', async () => {
-      // Set up the mock for versions
-      mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
-
-      const nodePackWithCompatibility = {
-        ...mockNodePack,
-        supported_os: ['windows'],
-        supported_accelerators: ['CPU'],
-        supported_comfyui_version: '>=0.1.0',
-        supported_comfyui_frontend_version: '>=1.0.0',
-        latest_version: {
-          ...mockNodePack.latest_version,
-          supported_os: ['windows'], // Match nodePack data for test consistency
-          supported_accelerators: ['CPU'], // Match nodePack data for test consistency
-          supported_python_version: '>=3.8',
-          is_banned: false,
-          has_registry_data: true
-        }
-      }
-
-      const wrapper = mountComponent({
-        props: { nodePack: nodePackWithCompatibility }
-      })
-      await waitForPromises()
-
-      const vm = getVM(wrapper)
-
-      // Clear previous calls from component mounting/rendering
-      mockCheckNodeCompatibility.mockClear()
-
-      // Test latest version
-      vm.getVersionCompatibility('latest')
-      expect(mockCheckNodeCompatibility).toHaveBeenCalledWith({
-        supported_os: ['windows'],
-        supported_accelerators: ['CPU'],
-        supported_comfyui_version: '>=0.1.0',
-        supported_comfyui_frontend_version: '>=1.0.0',
-        supported_python_version: '>=3.8',
-        is_banned: false,
-        has_registry_data: true,
-        version: '1.0.0'
-      })
-
-      // Clear for next test call
-      mockCheckNodeCompatibility.mockClear()
-
-      // Test nightly version
-      vm.getVersionCompatibility('nightly')
-      expect(mockCheckNodeCompatibility).toHaveBeenCalledWith({
-        id: 'test-pack',
-        name: 'Test Pack',
-        supported_os: ['windows'],
-        supported_accelerators: ['CPU'],
-        supported_comfyui_version: '>=0.1.0',
-        supported_comfyui_frontend_version: '>=1.0.0',
-        repository: 'https://github.com/user/repo',
-        has_registry_data: true,
-        latest_version: {
-          supported_os: ['windows'],
-          supported_accelerators: ['CPU'],
-          supported_python_version: '>=3.8',
-          is_banned: false,
-          has_registry_data: true,
-          version: '1.0.0',
-          supported_comfyui_version: '>=0.1.0',
-          supported_comfyui_frontend_version: '>=1.0.0'
-        }
-      })
-    })
-
     it('shows banned package warnings', async () => {
-      // Set up the mock for versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      // Mock compatibility check to return banned conflicts
       mockCheckNodeCompatibility.mockImplementation((versionData) => {
         if (versionData.is_banned === true) {
           return {
@@ -652,37 +492,23 @@ describe('PackVersionSelectorPopover', () => {
         }
       }
 
-      const wrapper = mountComponent({
+      const { container } = renderComponent({
         props: { nodePack: bannedNodePack }
       })
       await waitForPromises()
 
-      // Check that compatibility checking function was called
       expect(mockCheckNodeCompatibility).toHaveBeenCalled()
 
-      // Open the dropdown to see the options
-      const select = wrapper.find('.p-select')
-      if (!select.exists()) {
-        // Try alternative selector
-        const selectButton = wrapper.find('[aria-haspopup="listbox"]')
-        if (selectButton.exists()) {
-          await selectButton.trigger('click')
-        }
-      } else {
-        await select.trigger('click')
-      }
-      await wrapper.vm.$nextTick()
-
-      // The warning icon should be shown for banned packages in the dropdown options
-      const warningIcons = wrapper.findAll('.icon-\\[lucide--triangle-alert\\]')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- icon class query not expressible via ARIA roles
+      const warningIcons = container.querySelectorAll(
+        '.icon-\\[lucide--triangle-alert\\]'
+      )
       expect(warningIcons.length).toBeGreaterThan(0)
     })
 
     it('shows security pending warnings', async () => {
-      // Set up the mock for versions
       mockGetPackVersions.mockResolvedValueOnce(defaultMockVersions)
 
-      // Mock compatibility check to return security pending conflicts
       mockCheckNodeCompatibility.mockImplementation((versionData) => {
         if (versionData.has_registry_data === false) {
           return {
@@ -708,16 +534,17 @@ describe('PackVersionSelectorPopover', () => {
         }
       }
 
-      const wrapper = mountComponent({
+      const { container } = renderComponent({
         props: { nodePack: securityPendingNodePack }
       })
       await waitForPromises()
 
-      // Check that compatibility checking function was called
       expect(mockCheckNodeCompatibility).toHaveBeenCalled()
 
-      // The warning icon should be shown for security pending packages
-      const warningIcons = wrapper.findAll('.icon-\\[lucide--triangle-alert\\]')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- icon class query not expressible via ARIA roles
+      const warningIcons = container.querySelectorAll(
+        '.icon-\\[lucide--triangle-alert\\]'
+      )
       expect(warningIcons.length).toBeGreaterThan(0)
     })
   })


### PR DESCRIPTION
## Summary

Phase 3 of the VTL migration: migrate 8 hard-case component tests from @vue/test-utils to @testing-library/vue (68 tests).

Stacked on #10490.

## Changes

- **What**: Migrate SignInForm, CurrentUserButton, NodeSearchBoxPopover, BaseThumbnail, JobAssetsList, SelectionToolbox, QueueOverlayExpanded, PackVersionSelectorPopover from VTU to VTL
- **`wrapper.vm` elimination**: 13 instances across 4 files (5 in SignInForm, 3 in CurrentUserButton, 3 in PackVersionSelectorPopover, 2 in BaseThumbnail) replaced with user interactions or removed
- **`vm.$emit()` on stubs**: Interactive stubs with `setup(_, { emit })` expose buttons or closure-based emit functions (QueueOverlayExpanded, NodeSearchBoxPopover, JobAssetsList)
- **Removed**: 6 change-detector/redundant tests, 3 `@ts-expect-error` annotations, `PackVersionSelectorVM` interface, `getVM` helper
- **BaseThumbnail**: Removed `useEventListener` mock — real event handler attaches, `fireEvent.error(img)` triggers error state

## Review Focus

- Interactive stub patterns: `JobAssetsListStub` and `NodeSearchBoxStub` use closure-based emit functions to trigger parent event handlers without `vm.$emit`
- SignInForm form submission test fills PrimeVue Form fields via `userEvent.type` and submits via button click (replaces `vm.onSubmit()` direct call)
- CurrentUserButton Popover stub tracks open/close state reactively
- JobAssetsList: file-level `eslint-disable` for `no-container`/`no-node-access`/`prefer-user-event` since stubs lack ARIA roles and hover tests need `fireEvent`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10493-test-migrate-8-hard-case-component-tests-from-VTU-to-VTL-Phase-3-32e6d73d365081f88097df634606d7e3) by [Unito](https://www.unito.io)
