### PR TITLE
test: add perf test for fast-pan memory pressure

### DIFF
--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -351,7 +351,7 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     })
   })
 
-test(
+  test(
     'subgraph transition (enter and exit)',
     { tag: ['@vue-nodes'] },
     async ({ comfyPage }, testInfo) => {

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -391,7 +391,9 @@ test(
   )
 
   test('fast pan memory pressure', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.vueNodes.waitForNodes()
 
     const canvas = comfyPage.canvas
     const box = await canvas.boundingBox()

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -351,7 +351,7 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
     })
   })
 
-  test(
+test(
     'subgraph transition (enter and exit)',
     { tag: ['@vue-nodes'] },
     async ({ comfyPage }, testInfo) => {
@@ -389,6 +389,56 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       )
     }
   )
+
+  test('fast pan memory pressure', async ({ comfyPage }) => {
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+
+    const canvas = comfyPage.canvas
+    const box = await canvas.boundingBox()
+    if (!box) throw new Error('Canvas bounding box not available')
+
+    await comfyPage.perf.startMeasuring()
+
+    // Rapidly pan back and forth across the large graph (245 nodes).
+    // Each pan pass triggers reactive node instrumentation as nodes
+    // enter/leave the viewport. Without idempotent instrumentation,
+    // each pass leaks ComputedRefImpl, Link, Dep, and EventListener
+    // objects (~198K ComputedRefImpl and 1.5M Link objects observed
+    // in the original heap snapshot analysis).
+    const centerX = box.x + box.width / 2
+    const centerY = box.y + box.height / 2
+
+    for (let pass = 0; pass < 5; pass++) {
+      await comfyPage.page.mouse.move(centerX, centerY)
+      await comfyPage.page.mouse.down({ button: 'middle' })
+      for (let i = 0; i < 60; i++) {
+        await comfyPage.page.mouse.move(
+          centerX + i * 8,
+          centerY + (i % 2 === 0 ? i * 3 : -i * 3)
+        )
+        await comfyPage.nextFrame()
+      }
+      await comfyPage.page.mouse.up({ button: 'middle' })
+
+      // Return to center for next pass
+      await comfyPage.page.mouse.move(centerX, centerY)
+      await comfyPage.page.mouse.down({ button: 'middle' })
+      for (let i = 0; i < 60; i++) {
+        await comfyPage.page.mouse.move(
+          centerX - i * 8,
+          centerY - (i % 2 === 0 ? i * 3 : -i * 3)
+        )
+        await comfyPage.nextFrame()
+      }
+      await comfyPage.page.mouse.up({ button: 'middle' })
+    }
+
+    const m = await comfyPage.perf.stopMeasuring('fast-pan-memory')
+    recordMeasurement(m)
+    console.log(
+      `Fast pan memory: ${(m.heapDeltaBytes / 1024 / 1024).toFixed(1)}MB heap delta, ${m.eventListeners} event listeners, ${m.taskDurationMs.toFixed(1)}ms task`
+    )
+  })
 
   test('workflow execution', async ({ comfyPage }) => {
     // Uses lightweight PrimitiveString → PreviewAny workflow (no GPU needed)

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -57,6 +57,7 @@ type MetricKey =
   | 'frameDurationMs'
   | 'p95FrameDurationMs'
   | 'heapUsedBytes'
+  | 'heapDeltaBytes'
 
 interface MetricDef {
   key: MetricKey
@@ -86,6 +87,7 @@ const REPORTED_METRICS: MetricDef[] = [
   { key: 'scriptDurationMs', label: 'script duration', unit: 'ms' },
   { key: 'totalBlockingTimeMs', label: 'TBT', unit: 'ms' },
   { key: 'heapUsedBytes', label: 'heap used', unit: 'bytes' },
+  { key: 'heapDeltaBytes', label: 'heap delta', unit: 'bytes' },
   { key: 'domNodes', label: 'DOM nodes', unit: '', minAbsDelta: 5 },
   { key: 'eventListeners', label: 'event listeners', unit: '', minAbsDelta: 5 }
 ]


### PR DESCRIPTION
Adds a `@perf` test to establish a baseline for the fast-pan memory leak.

This is **PR 1 of 2**. The fix will follow in a separate PR once this baseline is established on main.

## What

Adds `fast pan memory pressure` to the performance test suite measuring `heapDeltaBytes`, `eventListeners`, and `taskDurationMs` during rapid back-and-forth panning across a 245-node graph (5 passes × 60 frames each direction = 600 frame interactions).

## Why

Heap snapshot analysis showed the fast-pan scenario accumulates 1.9GB (3.6× the 514MB baseline) with 198K ComputedRefImpl, 1.5M Link, 591K Dep, and 112K EventListener objects leaked from non-idempotent node instrumentation. This test captures the memory pressure so the upcoming fix PR can prove the improvement via CI delta.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10495-test-add-perf-test-for-fast-pan-memory-pressure-32e6d73d36508156b09fdf3cee4f2b7d) by [Unito](https://www.unito.io)
