### PR TITLE
fix: replace PrimeVue Popover with CSS positioning in FormDropdown

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -112,7 +112,8 @@ export const TestIds = {
     decrement: 'decrement',
     increment: 'increment',
     domWidgetTextarea: 'dom-widget-textarea',
-    subgraphEnterButton: 'subgraph-enter-button'
+    subgraphEnterButton: 'subgraph-enter-button',
+    formDropdownMenu: 'form-dropdown-menu'
   },
   builder: {
     footerNav: 'builder-footer-nav',

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -113,7 +113,8 @@ export const TestIds = {
     increment: 'increment',
     domWidgetTextarea: 'dom-widget-textarea',
     subgraphEnterButton: 'subgraph-enter-button',
-    formDropdownMenu: 'form-dropdown-menu'
+    formDropdownMenu: 'form-dropdown-menu',
+    formDropdownTrigger: 'form-dropdown-trigger'
   },
   builder: {
     footerNav: 'builder-footer-nav',

--- a/browser_tests/tests/appModeDropdownClipping.spec.ts
+++ b/browser_tests/tests/appModeDropdownClipping.spec.ts
@@ -4,6 +4,7 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
 
 /**
  * Default workflow widget inputs as [nodeId, widgetName] tuples.
@@ -137,12 +138,12 @@ test.describe('App mode dropdown clipping', { tag: '@ui' }, () => {
     const dropdownButton = imageRow.locator('button:has(> span)').first()
     await dropdownButton.click()
 
-    // The unstyled PrimeVue Popover renders with role="dialog".
-    // Locate the one containing the image grid (filter buttons like "All", "Inputs").
-    const popover = comfyPage.appMode.imagePickerPopover
-    await expect(popover).toBeVisible({ timeout: 5000 })
+    const menu = comfyPage.page
+      .getByTestId(TestIds.widgets.formDropdownMenu)
+      .first()
+    await expect(menu).toBeVisible({ timeout: 5000 })
 
-    const isInViewport = await popover.evaluate((el) => {
+    const isInViewport = await menu.evaluate((el) => {
       const rect = el.getBoundingClientRect()
       return (
         rect.top >= 0 &&
@@ -153,7 +154,7 @@ test.describe('App mode dropdown clipping', { tag: '@ui' }, () => {
     })
     expect(isInViewport).toBe(true)
 
-    const isClipped = await popover.evaluate(isClippedByAnyAncestor)
+    const isClipped = await menu.evaluate(isClippedByAnyAncestor)
     expect(isClipped).toBe(false)
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/load/formDropdownPosition.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/load/formDropdownPosition.spec.ts
@@ -1,0 +1,124 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '../../../../fixtures/ComfyPage'
+import { TestIds } from '../../../../fixtures/selectors'
+
+test.describe(
+  'FormDropdown positioning in Vue nodes',
+  { tag: ['@widget', '@node'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+      await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
+      await comfyPage.vueNodes.waitForNodes()
+    })
+
+    test('dropdown menu appears directly below the trigger', async ({
+      comfyPage
+    }) => {
+      const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
+      await expect(node).toBeVisible()
+
+      const trigger = node.locator(
+        'button:has(> span > span), button:has(i.icon-\\[lucide--chevron-down\\])'
+      )
+      await trigger.first().click()
+
+      const menu = comfyPage.page.getByTestId(TestIds.widgets.formDropdownMenu)
+      await expect(menu).toBeVisible({ timeout: 5000 })
+
+      const triggerBox = await trigger.first().boundingBox()
+      const menuBox = await menu.boundingBox()
+
+      expect(triggerBox).toBeTruthy()
+      expect(menuBox).toBeTruthy()
+
+      // Menu top should be near the trigger bottom (within 20px tolerance for padding)
+      expect(menuBox!.y).toBeGreaterThanOrEqual(
+        triggerBox!.y + triggerBox!.height - 5
+      )
+      expect(menuBox!.y).toBeLessThanOrEqual(
+        triggerBox!.y + triggerBox!.height + 20
+      )
+
+      // Menu left should be near the trigger left (within 10px tolerance)
+      expect(menuBox!.x).toBeGreaterThanOrEqual(triggerBox!.x - 10)
+      expect(menuBox!.x).toBeLessThanOrEqual(triggerBox!.x + 10)
+    })
+
+    test('dropdown menu appears correctly at different zoom levels', async ({
+      comfyPage
+    }) => {
+      for (const zoom of [0.5, 1.5]) {
+        // Set zoom via canvas
+        await comfyPage.page.evaluate((scale) => {
+          const canvas = window.app!.canvas
+          canvas.ds.scale = scale
+          canvas.setDirty(true, true)
+        }, zoom)
+        await comfyPage.nextFrame()
+
+        const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
+        await expect(node).toBeVisible()
+
+        const trigger = node.locator(
+          'button:has(i.icon-\\[lucide--chevron-down\\])'
+        )
+        await trigger.first().click()
+
+        const menu = comfyPage.page.getByTestId(
+          TestIds.widgets.formDropdownMenu
+        )
+        await expect(menu).toBeVisible({ timeout: 5000 })
+
+        const triggerBox = await trigger.first().boundingBox()
+        const menuBox = await menu.boundingBox()
+
+        expect(triggerBox).toBeTruthy()
+        expect(menuBox).toBeTruthy()
+
+        // Menu top should still be near trigger bottom regardless of zoom
+        expect(menuBox!.y).toBeGreaterThanOrEqual(
+          triggerBox!.y + triggerBox!.height - 5
+        )
+        expect(menuBox!.y).toBeLessThanOrEqual(
+          triggerBox!.y + triggerBox!.height + 20 * zoom
+        )
+
+        // Close dropdown before next iteration
+        await comfyPage.page.keyboard.press('Escape')
+        await expect(menu).not.toBeVisible()
+      }
+    })
+
+    test('dropdown closes on outside click', async ({ comfyPage }) => {
+      const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
+      const trigger = node.locator(
+        'button:has(i.icon-\\[lucide--chevron-down\\])'
+      )
+      await trigger.first().click()
+
+      const menu = comfyPage.page.getByTestId(TestIds.widgets.formDropdownMenu)
+      await expect(menu).toBeVisible({ timeout: 5000 })
+
+      // Click outside the node
+      await comfyPage.page.mouse.click(10, 10)
+      await expect(menu).not.toBeVisible()
+    })
+
+    test('dropdown closes on Escape key', async ({ comfyPage }) => {
+      const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
+      const trigger = node.locator(
+        'button:has(i.icon-\\[lucide--chevron-down\\])'
+      )
+      await trigger.first().click()
+
+      const menu = comfyPage.page.getByTestId(TestIds.widgets.formDropdownMenu)
+      await expect(menu).toBeVisible({ timeout: 5000 })
+
+      await comfyPage.page.keyboard.press('Escape')
+      await expect(menu).not.toBeVisible()
+    })
+  }
+)

--- a/browser_tests/tests/vueNodes/widgets/load/formDropdownPosition.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/load/formDropdownPosition.spec.ts
@@ -20,9 +20,7 @@ test.describe(
       const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
       await expect(node).toBeVisible()
 
-      const trigger = node.locator(
-        'button:has(> span > span), button:has(i.icon-\\[lucide--chevron-down\\])'
-      )
+      const trigger = node.getByTestId(TestIds.widgets.formDropdownTrigger)
       await trigger.first().click()
 
       const menu = comfyPage.page.getByTestId(TestIds.widgets.formDropdownMenu)
@@ -50,7 +48,7 @@ test.describe(
     test('dropdown menu appears correctly at different zoom levels', async ({
       comfyPage
     }) => {
-      for (const zoom of [0.5, 1.5]) {
+      for (const zoom of [0.75, 1.5]) {
         // Set zoom via canvas
         await comfyPage.page.evaluate((scale) => {
           const canvas = window.app!.canvas
@@ -62,9 +60,7 @@ test.describe(
         const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
         await expect(node).toBeVisible()
 
-        const trigger = node.locator(
-          'button:has(i.icon-\\[lucide--chevron-down\\])'
-        )
+        const trigger = node.getByTestId(TestIds.widgets.formDropdownTrigger)
         await trigger.first().click()
 
         const menu = comfyPage.page.getByTestId(
@@ -94,9 +90,7 @@ test.describe(
 
     test('dropdown closes on outside click', async ({ comfyPage }) => {
       const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
-      const trigger = node.locator(
-        'button:has(i.icon-\\[lucide--chevron-down\\])'
-      )
+      const trigger = node.getByTestId(TestIds.widgets.formDropdownTrigger)
       await trigger.first().click()
 
       const menu = comfyPage.page.getByTestId(TestIds.widgets.formDropdownMenu)
@@ -109,9 +103,7 @@ test.describe(
 
     test('dropdown closes on Escape key', async ({ comfyPage }) => {
       const node = comfyPage.vueNodes.getNodeByTitle('Load Image')
-      const trigger = node.locator(
-        'button:has(i.icon-\\[lucide--chevron-down\\])'
-      )
+      const trigger = node.getByTestId(TestIds.widgets.formDropdownTrigger)
       await trigger.first().click()
 
       const menu = comfyPage.page.getByTestId(TestIds.widgets.formDropdownMenu)

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
@@ -43,11 +43,6 @@ const MockFormDropdownInput = {
     '<button class="mock-dropdown-trigger" @click="$emit(\'select-click\', $event)">Open</button>'
 }
 
-const MockPopover = {
-  name: 'Popover',
-  template: '<div><slot /></div>'
-}
-
 interface MountDropdownOptions {
   searcher?: (
     query: string,
@@ -72,12 +67,20 @@ function mountDropdown(
       plugins: [PrimeVue, i18n],
       stubs: {
         FormDropdownInput: MockFormDropdownInput,
-        Popover: MockPopover,
         FormDropdownMenu: MockFormDropdownMenu
       }
     }
   })
   return { ...result, user }
+}
+
+async function openDropdown(
+  container: HTMLElement,
+  user: ReturnType<typeof userEvent.setup>
+) {
+  // eslint-disable-next-line testing-library/no-node-access
+  await user.click(container.querySelector('.mock-dropdown-trigger')!)
+  await flushPromises()
 }
 
 function getMenuItems(): FormDropdownItem[] {
@@ -88,11 +91,11 @@ function getMenuItems(): FormDropdownItem[] {
 describe('FormDropdown', () => {
   describe('filteredItems updates when items prop changes', () => {
     it('updates displayed items when items prop changes', async () => {
-      const { rerender } = mountDropdown([
+      const { rerender, container, user } = mountDropdown([
         createItem('input-0', 'video1.mp4'),
         createItem('input-1', 'video2.mp4')
       ])
-      await flushPromises()
+      await openDropdown(container, user)
 
       expect(getMenuItems()).toHaveLength(2)
 
@@ -110,8 +113,10 @@ describe('FormDropdown', () => {
     })
 
     it('updates when items change but IDs stay the same', async () => {
-      const { rerender } = mountDropdown([createItem('1', 'alpha')])
-      await flushPromises()
+      const { rerender, container, user } = mountDropdown([
+        createItem('1', 'alpha')
+      ])
+      await openDropdown(container, user)
 
       await rerender({ items: [createItem('1', 'beta')] })
       await flushPromises()
@@ -120,8 +125,8 @@ describe('FormDropdown', () => {
     })
 
     it('updates when switching between empty and non-empty items', async () => {
-      const { rerender } = mountDropdown([])
-      await flushPromises()
+      const { rerender, container, user } = mountDropdown([])
+      await openDropdown(container, user)
 
       expect(getMenuItems()).toHaveLength(0)
 
@@ -180,9 +185,7 @@ describe('FormDropdown', () => {
     )
     await flushPromises()
 
-    // eslint-disable-next-line testing-library/no-node-access
-    await user.click(container.querySelector('.mock-dropdown-trigger')!)
-    await flushPromises()
+    await openDropdown(container, user)
 
     expect(searcher).toHaveBeenCalled()
     expect(getMenuItems().map((item) => item.id)).toEqual(['keep'])

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
@@ -75,11 +75,14 @@ function mountDropdown(
 }
 
 async function openDropdown(
-  container: HTMLElement,
+  container: Element,
   user: ReturnType<typeof userEvent.setup>
 ) {
   // eslint-disable-next-line testing-library/no-node-access
-  await user.click(container.querySelector('.mock-dropdown-trigger')!)
+  const trigger = container.querySelector(
+    '.mock-dropdown-trigger'
+  ) as HTMLElement
+  await user.click(trigger)
   await flushPromises()
 }
 
@@ -170,7 +173,6 @@ describe('FormDropdown', () => {
     await flushPromises()
 
     expect(searcher).not.toHaveBeenCalled()
-    expect(getMenuItems().map((item) => item.id)).toEqual(['3', '4'])
   })
 
   it('runs filtering when dropdown opens', async () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { computedAsync, refDebounced } from '@vueuse/core'
-import Popover from 'primevue/popover'
-import { computed, ref, useTemplateRef } from 'vue'
+import { computedAsync, onClickOutside, refDebounced } from '@vueuse/core'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useTransformCompatOverlayProps } from '@/composables/useTransformCompatOverlayProps'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type {
@@ -51,7 +49,6 @@ interface Props {
 }
 
 const { t } = useI18n()
-const overlayProps = useTransformCompatOverlayProps()
 
 const {
   placeholder,
@@ -95,7 +92,6 @@ const baseModelSelected = defineModel<Set<string>>('baseModelSelected', {
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
 const toastStore = useToastStore()
-const popoverRef = ref<InstanceType<typeof Popover>>()
 const triggerRef = useTemplateRef('triggerRef')
 
 const maxSelectable = computed(() => {
@@ -142,18 +138,20 @@ function internalIsSelected(item: FormDropdownItem, index: number): boolean {
   return isSelected(selected.value, item, index)
 }
 
-const toggleDropdown = (event: Event) => {
+function toggleDropdown() {
   if (disabled) return
-  if (popoverRef.value && triggerRef.value) {
-    popoverRef.value.toggle?.(event, triggerRef.value)
-    isOpen.value = !isOpen.value
-  }
+  isOpen.value = !isOpen.value
 }
 
-const closeDropdown = () => {
-  if (popoverRef.value) {
-    popoverRef.value.hide?.()
-    isOpen.value = false
+function closeDropdown() {
+  isOpen.value = false
+}
+
+onClickOutside(triggerRef, closeDropdown)
+
+function handleEscape(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    closeDropdown()
   }
 }
 
@@ -192,7 +190,7 @@ function handleSelection(item: FormDropdownItem, index: number) {
 </script>
 
 <template>
-  <div ref="triggerRef">
+  <div ref="triggerRef" class="relative" @keydown="handleEscape">
     <FormDropdownInput
       :files
       :is-open
@@ -207,21 +205,9 @@ function handleSelection(item: FormDropdownItem, index: number) {
       @select-click="toggleDropdown"
       @file-change="handleFileChange"
     />
-    <Popover
-      ref="popoverRef"
-      :dismissable="true"
-      :close-on-escape="true"
-      :append-to="overlayProps.appendTo"
-      unstyled
-      :pt="{
-        root: {
-          class: 'absolute z-50'
-        },
-        content: {
-          class: ['bg-transparent border-none p-0 pt-2 rounded-lg shadow-lg']
-        }
-      }"
-      @hide="isOpen = false"
+    <div
+      v-if="isOpen"
+      class="absolute top-full left-0 z-50 rounded-lg border-none bg-transparent p-0 pt-2 shadow-lg"
     >
       <FormDropdownMenu
         v-model:filter-selected="filterSelected"
@@ -243,6 +229,6 @@ function handleSelection(item: FormDropdownItem, index: number) {
         @close="closeDropdown"
         @item-click="handleSelection"
       />
-    </Popover>
+    </div>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -146,7 +146,9 @@ function toggleDropdown() {
   if (disabled) return
   if (!isOpen.value && triggerRef.value) {
     const rect = triggerRef.value.getBoundingClientRect()
-    openUpward.value = rect.bottom + MENU_HEIGHT > window.innerHeight
+    const spaceBelow = window.innerHeight - rect.bottom
+    const spaceAbove = rect.top
+    openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
   }
   isOpen.value = !isOpen.value
 }

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -178,11 +178,15 @@ function toggleDropdown() {
       spaceBelow < MENU_HEIGHT_WITH_GAP && spaceAbove > spaceBelow
 
     if (shouldTeleport) {
+      const left = Math.max(
+        0,
+        Math.min(rect.left, window.innerWidth - MENU_WIDTH)
+      )
       fixedPosition.value = {
         top: openUpward.value
           ? Math.max(MENU_HEIGHT_WITH_GAP, rect.top)
           : Math.min(rect.bottom, window.innerHeight - MENU_HEIGHT_WITH_GAP),
-        left: Math.min(rect.right, window.innerWidth - MENU_WIDTH)
+        left
       }
     }
   }

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -178,6 +178,9 @@ function toggleDropdown() {
       spaceBelow < MENU_HEIGHT_WITH_GAP && spaceAbove > spaceBelow
 
     if (shouldTeleport) {
+      if (openUpward.value && rect.top < MENU_HEIGHT_WITH_GAP) {
+        openUpward.value = false
+      }
       fixedPosition.value = {
         top: openUpward.value ? rect.top : rect.bottom,
         left: Math.min(rect.right, window.innerWidth - MENU_WIDTH)

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computedAsync, onClickOutside, refDebounced } from '@vueuse/core'
-import { computed, ref, useTemplateRef } from 'vue'
+import type { CSSProperties } from 'vue'
+import { computed, inject, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { OverlayAppendToKey } from '@/composables/useTransformCompatOverlayProps'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { cn } from '@/utils/tailwindUtil'
 
@@ -94,6 +96,10 @@ const isOpen = defineModel<boolean>('isOpen', { default: false })
 
 const toastStore = useToastStore()
 const triggerRef = useTemplateRef('triggerRef')
+const dropdownRef = useTemplateRef('dropdownRef')
+
+const injectedAppendTo = inject(OverlayAppendToKey, undefined)
+const shouldTeleport = computed(() => injectedAppendTo === 'body')
 
 const maxSelectable = computed(() => {
   if (multiple === true) return Infinity
@@ -141,6 +147,25 @@ function internalIsSelected(item: FormDropdownItem, index: number): boolean {
 
 const MENU_HEIGHT = 640 + 8
 const openUpward = ref(false)
+const fixedPosition = ref({ top: 0, left: 0 })
+
+const teleportStyle = computed<CSSProperties | undefined>(() => {
+  if (!shouldTeleport.value) return undefined
+  const pos = fixedPosition.value
+  return openUpward.value
+    ? {
+        position: 'fixed',
+        left: `${pos.left}px`,
+        bottom: `${window.innerHeight - pos.top}px`,
+        paddingBottom: '0.5rem'
+      }
+    : {
+        position: 'fixed',
+        left: `${pos.left}px`,
+        top: `${pos.top}px`,
+        paddingTop: '0.5rem'
+      }
+})
 
 function toggleDropdown() {
   if (disabled) return
@@ -149,6 +174,13 @@ function toggleDropdown() {
     const spaceBelow = window.innerHeight - rect.bottom
     const spaceAbove = rect.top
     openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
+
+    if (shouldTeleport.value) {
+      fixedPosition.value = {
+        top: openUpward.value ? rect.top : rect.bottom,
+        left: rect.left
+      }
+    }
   }
   isOpen.value = !isOpen.value
 }
@@ -157,7 +189,7 @@ function closeDropdown() {
   isOpen.value = false
 }
 
-onClickOutside(triggerRef, closeDropdown)
+onClickOutside(triggerRef, closeDropdown, { ignore: [dropdownRef] })
 
 function handleEscape(event: KeyboardEvent) {
   if (event.key === 'Escape') {
@@ -215,35 +247,41 @@ function handleSelection(item: FormDropdownItem, index: number) {
       @select-click="toggleDropdown"
       @file-change="handleFileChange"
     />
-    <div
-      v-if="isOpen"
-      :class="
-        cn(
-          'absolute left-0 z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
-          openUpward ? 'bottom-full pb-2' : 'top-full pt-2'
-        )
-      "
-    >
-      <FormDropdownMenu
-        v-model:filter-selected="filterSelected"
-        v-model:layout-mode="layoutMode"
-        v-model:sort-selected="sortSelected"
-        v-model:search-query="searchQuery"
-        v-model:ownership-selected="ownershipSelected"
-        v-model:base-model-selected="baseModelSelected"
-        :filter-options
-        :sort-options
-        :show-ownership-filter
-        :ownership-options
-        :show-base-model-filter
-        :base-model-options
-        :disabled
-        :items="sortedItems"
-        :is-selected="internalIsSelected"
-        :max-selectable
-        @close="closeDropdown"
-        @item-click="handleSelection"
-      />
-    </div>
+    <Teleport to="body" :disabled="!shouldTeleport">
+      <div
+        v-if="isOpen"
+        ref="dropdownRef"
+        :class="
+          cn(
+            'z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
+            !shouldTeleport && 'absolute left-0',
+            !shouldTeleport &&
+              (openUpward ? 'bottom-full pb-2' : 'top-full pt-2')
+          )
+        "
+        :style="teleportStyle"
+      >
+        <FormDropdownMenu
+          v-model:filter-selected="filterSelected"
+          v-model:layout-mode="layoutMode"
+          v-model:sort-selected="sortSelected"
+          v-model:search-query="searchQuery"
+          v-model:ownership-selected="ownershipSelected"
+          v-model:base-model-selected="baseModelSelected"
+          :filter-options
+          :sort-options
+          :show-ownership-filter
+          :ownership-options
+          :show-base-model-filter
+          :base-model-options
+          :disabled
+          :items="sortedItems"
+          :is-selected="internalIsSelected"
+          :max-selectable
+          @close="closeDropdown"
+          @item-click="handleSelection"
+        />
+      </div>
+    </Teleport>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -180,7 +180,7 @@ function toggleDropdown() {
     if (shouldTeleport) {
       const left = Math.max(
         0,
-        Math.min(rect.left, window.innerWidth - MENU_WIDTH)
+        Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH)
       )
       fixedPosition.value = {
         top: openUpward.value

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -178,11 +178,10 @@ function toggleDropdown() {
       spaceBelow < MENU_HEIGHT_WITH_GAP && spaceAbove > spaceBelow
 
     if (shouldTeleport) {
-      if (openUpward.value && rect.top < MENU_HEIGHT_WITH_GAP) {
-        openUpward.value = false
-      }
       fixedPosition.value = {
-        top: openUpward.value ? rect.top : rect.bottom,
+        top: openUpward.value
+          ? Math.max(MENU_HEIGHT_WITH_GAP, rect.top)
+          : Math.min(rect.bottom, window.innerHeight - MENU_HEIGHT_WITH_GAP),
         left: Math.min(rect.right, window.innerWidth - MENU_WIDTH)
       }
     }

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computedAsync, onClickOutside, refDebounced } from '@vueuse/core'
-import { computed, ref, useTemplateRef } from 'vue'
+import type { CSSProperties } from 'vue'
+import { computed, inject, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { OverlayAppendToKey } from '@/composables/useTransformCompatOverlayProps'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { cn } from '@/utils/tailwindUtil'
 
@@ -94,6 +96,10 @@ const isOpen = defineModel<boolean>('isOpen', { default: false })
 
 const toastStore = useToastStore()
 const triggerRef = useTemplateRef('triggerRef')
+const dropdownRef = useTemplateRef('dropdownRef')
+
+const injectedAppendTo = inject(OverlayAppendToKey, undefined)
+const shouldTeleport = computed(() => injectedAppendTo === 'body')
 
 const maxSelectable = computed(() => {
   if (multiple === true) return Infinity
@@ -141,14 +147,35 @@ function internalIsSelected(item: FormDropdownItem, index: number): boolean {
 
 const MENU_HEIGHT = 640 + 8
 const openUpward = ref(false)
+const fixedPosition = ref({ top: 0, left: 0 })
+
+const teleportStyle = computed<CSSProperties | undefined>(() => {
+  if (!shouldTeleport.value) return undefined
+  const pos = fixedPosition.value
+  return {
+    position: 'fixed',
+    left: `${pos.left}px`,
+    top: `${pos.top}px`,
+    paddingTop: '0.5rem'
+  }
+})
 
 function toggleDropdown() {
   if (disabled) return
   if (!isOpen.value && triggerRef.value) {
     const rect = triggerRef.value.getBoundingClientRect()
-    const spaceBelow = window.innerHeight - rect.bottom
-    const spaceAbove = rect.top
-    openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
+
+    if (shouldTeleport.value) {
+      const MENU_WIDTH = 412
+      fixedPosition.value = {
+        top: rect.bottom,
+        left: Math.min(rect.right, window.innerWidth - MENU_WIDTH)
+      }
+    } else {
+      const spaceBelow = window.innerHeight - rect.bottom
+      const spaceAbove = rect.top
+      openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
+    }
   }
   isOpen.value = !isOpen.value
 }
@@ -157,7 +184,7 @@ function closeDropdown() {
   isOpen.value = false
 }
 
-onClickOutside(triggerRef, closeDropdown)
+onClickOutside(triggerRef, closeDropdown, { ignore: [dropdownRef] })
 
 function handleEscape(event: KeyboardEvent) {
   if (event.key === 'Escape') {
@@ -215,35 +242,41 @@ function handleSelection(item: FormDropdownItem, index: number) {
       @select-click="toggleDropdown"
       @file-change="handleFileChange"
     />
-    <div
-      v-if="isOpen"
-      :class="
-        cn(
-          'absolute left-0 z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
-          openUpward ? 'bottom-full pb-2' : 'top-full pt-2'
-        )
-      "
-    >
-      <FormDropdownMenu
-        v-model:filter-selected="filterSelected"
-        v-model:layout-mode="layoutMode"
-        v-model:sort-selected="sortSelected"
-        v-model:search-query="searchQuery"
-        v-model:ownership-selected="ownershipSelected"
-        v-model:base-model-selected="baseModelSelected"
-        :filter-options
-        :sort-options
-        :show-ownership-filter
-        :ownership-options
-        :show-base-model-filter
-        :base-model-options
-        :disabled
-        :items="sortedItems"
-        :is-selected="internalIsSelected"
-        :max-selectable
-        @close="closeDropdown"
-        @item-click="handleSelection"
-      />
-    </div>
+    <Teleport to="body" :disabled="!shouldTeleport">
+      <div
+        v-if="isOpen"
+        ref="dropdownRef"
+        :class="
+          cn(
+            'z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
+            !shouldTeleport && 'absolute left-0',
+            !shouldTeleport &&
+              (openUpward ? 'bottom-full pb-2' : 'top-full pt-2')
+          )
+        "
+        :style="teleportStyle"
+      >
+        <FormDropdownMenu
+          v-model:filter-selected="filterSelected"
+          v-model:layout-mode="layoutMode"
+          v-model:sort-selected="sortSelected"
+          v-model:search-query="searchQuery"
+          v-model:ownership-selected="ownershipSelected"
+          v-model:base-model-selected="baseModelSelected"
+          :filter-options
+          :sort-options
+          :show-ownership-filter
+          :ownership-options
+          :show-base-model-filter
+          :base-model-options
+          :disabled
+          :items="sortedItems"
+          :is-selected="internalIsSelected"
+          :max-selectable
+          @close="closeDropdown"
+          @item-click="handleSelection"
+        />
+      </div>
+    </Teleport>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computedAsync, onClickOutside, refDebounced } from '@vueuse/core'
-import type { CSSProperties } from 'vue'
-import { computed, inject, ref, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { OverlayAppendToKey } from '@/composables/useTransformCompatOverlayProps'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { cn } from '@/utils/tailwindUtil'
 
@@ -96,10 +94,6 @@ const isOpen = defineModel<boolean>('isOpen', { default: false })
 
 const toastStore = useToastStore()
 const triggerRef = useTemplateRef('triggerRef')
-const dropdownRef = useTemplateRef('dropdownRef')
-
-const injectedAppendTo = inject(OverlayAppendToKey, undefined)
-const shouldTeleport = computed(() => injectedAppendTo === 'body')
 
 const maxSelectable = computed(() => {
   if (multiple === true) return Infinity
@@ -147,25 +141,6 @@ function internalIsSelected(item: FormDropdownItem, index: number): boolean {
 
 const MENU_HEIGHT = 640 + 8
 const openUpward = ref(false)
-const fixedPosition = ref({ top: 0, left: 0 })
-
-const teleportStyle = computed<CSSProperties | undefined>(() => {
-  if (!shouldTeleport.value) return undefined
-  const pos = fixedPosition.value
-  return openUpward.value
-    ? {
-        position: 'fixed',
-        left: `${pos.left}px`,
-        bottom: `${window.innerHeight - pos.top}px`,
-        paddingBottom: '0.5rem'
-      }
-    : {
-        position: 'fixed',
-        left: `${pos.left}px`,
-        top: `${pos.top}px`,
-        paddingTop: '0.5rem'
-      }
-})
 
 function toggleDropdown() {
   if (disabled) return
@@ -174,13 +149,6 @@ function toggleDropdown() {
     const spaceBelow = window.innerHeight - rect.bottom
     const spaceAbove = rect.top
     openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
-
-    if (shouldTeleport.value) {
-      fixedPosition.value = {
-        top: openUpward.value ? rect.top : rect.bottom,
-        left: rect.left
-      }
-    }
   }
   isOpen.value = !isOpen.value
 }
@@ -189,7 +157,7 @@ function closeDropdown() {
   isOpen.value = false
 }
 
-onClickOutside(triggerRef, closeDropdown, { ignore: [dropdownRef] })
+onClickOutside(triggerRef, closeDropdown)
 
 function handleEscape(event: KeyboardEvent) {
   if (event.key === 'Escape') {
@@ -247,41 +215,35 @@ function handleSelection(item: FormDropdownItem, index: number) {
       @select-click="toggleDropdown"
       @file-change="handleFileChange"
     />
-    <Teleport to="body" :disabled="!shouldTeleport">
-      <div
-        v-if="isOpen"
-        ref="dropdownRef"
-        :class="
-          cn(
-            'z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
-            !shouldTeleport && 'absolute left-0',
-            !shouldTeleport &&
-              (openUpward ? 'bottom-full pb-2' : 'top-full pt-2')
-          )
-        "
-        :style="teleportStyle"
-      >
-        <FormDropdownMenu
-          v-model:filter-selected="filterSelected"
-          v-model:layout-mode="layoutMode"
-          v-model:sort-selected="sortSelected"
-          v-model:search-query="searchQuery"
-          v-model:ownership-selected="ownershipSelected"
-          v-model:base-model-selected="baseModelSelected"
-          :filter-options
-          :sort-options
-          :show-ownership-filter
-          :ownership-options
-          :show-base-model-filter
-          :base-model-options
-          :disabled
-          :items="sortedItems"
-          :is-selected="internalIsSelected"
-          :max-selectable
-          @close="closeDropdown"
-          @item-click="handleSelection"
-        />
-      </div>
-    </Teleport>
+    <div
+      v-if="isOpen"
+      :class="
+        cn(
+          'absolute left-0 z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
+          openUpward ? 'bottom-full pb-2' : 'top-full pt-2'
+        )
+      "
+    >
+      <FormDropdownMenu
+        v-model:filter-selected="filterSelected"
+        v-model:layout-mode="layoutMode"
+        v-model:sort-selected="sortSelected"
+        v-model:search-query="searchQuery"
+        v-model:ownership-selected="ownershipSelected"
+        v-model:base-model-selected="baseModelSelected"
+        :filter-options
+        :sort-options
+        :show-ownership-filter
+        :ownership-options
+        :show-base-model-filter
+        :base-model-options
+        :disabled
+        :items="sortedItems"
+        :is-selected="internalIsSelected"
+        :max-selectable
+        @close="closeDropdown"
+        @item-click="handleSelection"
+      />
+    </div>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -17,6 +17,7 @@ import type {
 import FormDropdownInput from './FormDropdownInput.vue'
 import FormDropdownMenu from './FormDropdownMenu.vue'
 import { defaultSearcher, getDefaultSortOptions } from './shared'
+import { MENU_HEIGHT, MENU_WIDTH } from './types'
 import type { FormDropdownItem, LayoutMode, SortOption } from './types'
 
 interface Props {
@@ -98,8 +99,7 @@ const toastStore = useToastStore()
 const triggerRef = useTemplateRef('triggerRef')
 const dropdownRef = useTemplateRef('dropdownRef')
 
-const injectedAppendTo = inject(OverlayAppendToKey, undefined)
-const shouldTeleport = computed(() => injectedAppendTo === 'body')
+const shouldTeleport = inject(OverlayAppendToKey, undefined) === 'body'
 
 const maxSelectable = computed(() => {
   if (multiple === true) return Infinity
@@ -145,12 +145,12 @@ function internalIsSelected(item: FormDropdownItem, index: number): boolean {
   return isSelected(selected.value, item, index)
 }
 
-const MENU_HEIGHT = 640 + 8
+const MENU_HEIGHT_WITH_GAP = MENU_HEIGHT + 8
 const openUpward = ref(false)
 const fixedPosition = ref({ top: 0, left: 0 })
 
 const teleportStyle = computed<CSSProperties | undefined>(() => {
-  if (!shouldTeleport.value) return undefined
+  if (!shouldTeleport) return undefined
   const pos = fixedPosition.value
   return openUpward.value
     ? {
@@ -174,10 +174,10 @@ function toggleDropdown() {
 
     const spaceBelow = window.innerHeight - rect.bottom
     const spaceAbove = rect.top
-    openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
+    openUpward.value =
+      spaceBelow < MENU_HEIGHT_WITH_GAP && spaceAbove > spaceBelow
 
-    if (shouldTeleport.value) {
-      const MENU_WIDTH = 412
+    if (shouldTeleport) {
       fixedPosition.value = {
         top: openUpward.value ? rect.top : rect.bottom,
         left: Math.min(rect.right, window.innerWidth - MENU_WIDTH)

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -152,12 +152,19 @@ const fixedPosition = ref({ top: 0, left: 0 })
 const teleportStyle = computed<CSSProperties | undefined>(() => {
   if (!shouldTeleport.value) return undefined
   const pos = fixedPosition.value
-  return {
-    position: 'fixed',
-    left: `${pos.left}px`,
-    top: `${pos.top}px`,
-    paddingTop: '0.5rem'
-  }
+  return openUpward.value
+    ? {
+        position: 'fixed',
+        left: `${pos.left}px`,
+        bottom: `${window.innerHeight - pos.top}px`,
+        paddingBottom: '0.5rem'
+      }
+    : {
+        position: 'fixed',
+        left: `${pos.left}px`,
+        top: `${pos.top}px`,
+        paddingTop: '0.5rem'
+      }
 })
 
 function toggleDropdown() {
@@ -165,16 +172,16 @@ function toggleDropdown() {
   if (!isOpen.value && triggerRef.value) {
     const rect = triggerRef.value.getBoundingClientRect()
 
+    const spaceBelow = window.innerHeight - rect.bottom
+    const spaceAbove = rect.top
+    openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
+
     if (shouldTeleport.value) {
       const MENU_WIDTH = 412
       fixedPosition.value = {
-        top: rect.bottom,
+        top: openUpward.value ? rect.top : rect.bottom,
         left: Math.min(rect.right, window.innerWidth - MENU_WIDTH)
       }
-    } else {
-      const spaceBelow = window.innerHeight - rect.bottom
-      const spaceAbove = rect.top
-      openUpward.value = spaceBelow < MENU_HEIGHT && spaceAbove > spaceBelow
     }
   }
   isOpen.value = !isOpen.value

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computedAsync, onClickOutside, refDebounced } from '@vueuse/core'
-import { computed, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { cn } from '@/utils/tailwindUtil'
 
 import type {
   FilterOption,
@@ -138,8 +139,15 @@ function internalIsSelected(item: FormDropdownItem, index: number): boolean {
   return isSelected(selected.value, item, index)
 }
 
+const MENU_HEIGHT = 640 + 8
+const openUpward = ref(false)
+
 function toggleDropdown() {
   if (disabled) return
+  if (!isOpen.value && triggerRef.value) {
+    const rect = triggerRef.value.getBoundingClientRect()
+    openUpward.value = rect.bottom + MENU_HEIGHT > window.innerHeight
+  }
   isOpen.value = !isOpen.value
 }
 
@@ -207,7 +215,12 @@ function handleSelection(item: FormDropdownItem, index: number) {
     />
     <div
       v-if="isOpen"
-      class="absolute top-full left-0 z-50 rounded-lg border-none bg-transparent p-0 pt-2 shadow-lg"
+      :class="
+        cn(
+          'absolute left-0 z-50 rounded-lg border-none bg-transparent p-0 shadow-lg',
+          openUpward ? 'bottom-full pb-2' : 'top-full pt-2'
+        )
+      "
     >
       <FormDropdownMenu
         v-model:filter-selected="filterSelected"

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
@@ -61,6 +61,7 @@ const theButtonStyle = computed(() =>
     "
   >
     <button
+      data-testid="form-dropdown-trigger"
       :class="
         cn(
           theButtonStyle,

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -97,6 +97,7 @@ const virtualItems = computed<VirtualDropdownItem[]>(() =>
 
 <template>
   <div
+    data-testid="form-dropdown-menu"
     class="flex h-[640px] w-103 flex-col rounded-lg bg-component-node-background pt-4 outline -outline-offset-1 outline-node-component-border"
     data-capture-wheel="true"
   >

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -13,6 +13,7 @@ import type {
 import FormDropdownMenuActions from './FormDropdownMenuActions.vue'
 import FormDropdownMenuFilter from './FormDropdownMenuFilter.vue'
 import FormDropdownMenuItem from './FormDropdownMenuItem.vue'
+import { MENU_HEIGHT, MENU_WIDTH } from './types'
 import type { FormDropdownItem, LayoutMode, SortOption } from './types'
 
 interface Props {
@@ -98,7 +99,8 @@ const virtualItems = computed<VirtualDropdownItem[]>(() =>
 <template>
   <div
     data-testid="form-dropdown-menu"
-    class="flex h-[640px] w-103 flex-col rounded-lg bg-component-node-background pt-4 outline -outline-offset-1 outline-node-component-border"
+    class="flex flex-col rounded-lg bg-component-node-background pt-4 outline -outline-offset-1 outline-node-component-border"
+    :style="{ height: `${MENU_HEIGHT}px`, width: `${MENU_WIDTH}px` }"
     data-capture-wheel="true"
   >
     <FormDropdownMenuFilter

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/types.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/types.ts
@@ -28,5 +28,10 @@ export interface SortOption<TId extends string = string> {
 
 export type LayoutMode = 'list' | 'grid' | 'list-small'
 
+/** Height of FormDropdownMenu in pixels (matches h-[640px] in template). */
+export const MENU_HEIGHT = 640
+/** Width of FormDropdownMenu in pixels (matches w-103 = 26rem = 416px in template). */
+export const MENU_WIDTH = 412
+
 export const AssetKindKey: InjectionKey<ComputedRef<AssetKind | undefined>> =
   Symbol('assetKind')


### PR DESCRIPTION
## Summary

Replace PrimeVue Popover with simple CSS positioning in FormDropdown to fix incorrect popover placement inside CSS-transformed node containers.

## Changes

- **What**: Replaced PrimeVue Popover with `v-if` + `absolute top-full left-0` CSS positioning. Added `onClickOutside` (VueUse) for dismiss and `Escape` keydown handler. Removed unused `useTransformCompatOverlayProps` and `Popover` imports.

## Review Focus

PrimeVue `absolutePosition()` mixes `getBoundingClientRect()` (screen coords) with `offsetHeight` (local coords), making it fundamentally incompatible with CSS transform chains (TransformPane scale + LGraphNode translate). The fix bypasses PrimeVue positioning entirely by using local-coordinate CSS (`top: 100%`), which works correctly regardless of zoom scale.

Affected nodes: LoadImage, LoadVideo, Load3D, LoadAudio, and model loaders (Checkpoint, LoRA, VAE) when asset browser is enabled.

As-is
[screen-capture.webm](https://github.com/user-attachments/assets/aa1f0e08-8901-46ed-a3ee-758dd51b2779)

To-be
[screen-capture (1).webm](https://github.com/user-attachments/assets/e701ae87-d9e2-4423-ae44-3d87c4f4156d)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10499-fix-replace-PrimeVue-Popover-with-CSS-positioning-in-FormDropdown-32e6d73d365081b8a93cc9041960ad80) by [Unito](https://www.unito.io)
