### PR TITLE
fix: tree explorer row height and width overflow

### DIFF
--- a/src/components/common/TreeExplorerV2.vue
+++ b/src/components/common/TreeExplorerV2.vue
@@ -8,7 +8,7 @@
         :get-children="
           (item) => (item.children?.length ? item.children : undefined)
         "
-        class="m-0 min-w-0 p-0 pb-2"
+        class="m-0 min-w-0 p-0 px-2 pb-2"
       >
         <TreeVirtualizer
           v-slot="{ item }"

--- a/src/components/common/TreeExplorerV2Node.vue
+++ b/src/components/common/TreeExplorerV2Node.vue
@@ -28,7 +28,7 @@
       <button
         :class="
           cn(
-            'hover:text-foreground flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent text-muted-foreground',
+            'hover:text-foreground flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent text-muted-foreground',
             'opacity-0 group-hover/tree-node:opacity-100'
           )
         "
@@ -105,7 +105,7 @@ defineOptions({
 })
 
 const ROW_CLASS =
-  'group/tree-node flex w-[calc(100%-var(--spacing)*4)] min-w-0 cursor-pointer select-none items-center gap-3 overflow-hidden py-2 outline-none hover:bg-comfy-input mx-2 rounded'
+  'group/tree-node flex w-full min-w-0 cursor-pointer select-none items-center gap-3 overflow-hidden py-2 outline-none hover:bg-comfy-input rounded'
 
 const { item } = defineProps<{
   item: FlattenedItem<RenderedTreeExplorerNode<ComfyNodeDefImpl>>

--- a/src/components/common/TreeExplorerV2Node.vue
+++ b/src/components/common/TreeExplorerV2Node.vue
@@ -28,7 +28,7 @@
       <button
         :class="
           cn(
-            'hover:text-foreground flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent text-muted-foreground',
+            'hover:text-foreground flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent text-muted-foreground',
             'opacity-0 group-hover/tree-node:opacity-100'
           )
         "
@@ -105,7 +105,7 @@ defineOptions({
 })
 
 const ROW_CLASS =
-  'group/tree-node flex w-full min-w-0 cursor-pointer select-none items-center gap-3 overflow-hidden py-2 outline-none hover:bg-comfy-input mx-2 rounded'
+  'group/tree-node flex w-[calc(100%-var(--spacing)*4)] min-w-0 cursor-pointer select-none items-center gap-3 overflow-hidden py-2 outline-none hover:bg-comfy-input mx-2 rounded'
 
 const { item } = defineProps<{
   item: FlattenedItem<RenderedTreeExplorerNode<ComfyNodeDefImpl>>


### PR DESCRIPTION
## Summary

Fix tree explorer row sizing: consistent row height and prevent horizontal overflow.

## Changes

- **What**:
  1. Reduce node bookmark button from `size-6` (24px) to `size-5` (20px) so node and folder rows both have 36px height, matching `TreeVirtualizer` estimate-size and fixing tree list overlap.
  2. Change row width from `w-full` to `w-[calc(100%-var(--spacing)*4)]` to prevent horizontal overflow while keeping `mx-2` margin.

## Review Focus

Pure UI change — no test coverage needed. Verify tree rows render at consistent height and no horizontal overflow occurs.

## Screenshots (if applicable)

| Before    | After |
| -------- | ------- |
|<img width="1218" height="1662" alt="image" src="https://github.com/user-attachments/assets/89c799ab-cef3-40ee-88ca-900f5d3c7890" />|<img width="407" height="758" alt="image" src="https://github.com/user-attachments/assets/f9aa4569-aaf8-467f-9dde-a187151af9aa" />|

N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10501-fix-tree-explorer-row-height-and-width-overflow-32e6d73d3650819aa645c2262693ec62) by [Unito](https://www.unito.io)
