### PR TITLE
test: add e2e tests for subgraph promoted widget panel regressions

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -52,6 +52,13 @@ export const TestIds = {
   propertiesPanel: {
     root: 'properties-panel'
   },
+  subgraphEditor: {
+    toggle: 'subgraph-editor-toggle',
+    shownSection: 'subgraph-editor-shown-section',
+    hiddenSection: 'subgraph-editor-hidden-section',
+    widgetToggle: 'subgraph-widget-toggle',
+    widgetLabel: 'subgraph-widget-label'
+  },
   node: {
     titleInput: 'node-title-input'
   },

--- a/browser_tests/tests/subgraphPromotedWidgetPanel.spec.ts
+++ b/browser_tests/tests/subgraphPromotedWidgetPanel.spec.ts
@@ -1,0 +1,146 @@
+import type { Locator } from '@playwright/test'
+import type { ComfyPage } from '../fixtures/ComfyPage'
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+import { TestIds } from '../fixtures/selectors'
+
+async function ensurePropertiesPanel(comfyPage: ComfyPage) {
+  const panel = comfyPage.menu.propertiesPanel.root
+  if (!(await panel.isVisible())) {
+    await comfyPage.actionbar.propertiesButton.click()
+  }
+  await expect(panel).toBeVisible()
+  return panel
+}
+
+async function selectSubgraphAndOpenEditor(
+  comfyPage: ComfyPage,
+  nodeTitle: string
+) {
+  const subgraphNode = (
+    await comfyPage.nodeOps.getNodeRefsByTitle(nodeTitle)
+  )[0]
+  await subgraphNode.click('title')
+
+  await ensurePropertiesPanel(comfyPage)
+
+  const editorToggle = comfyPage.page.getByTestId(TestIds.subgraphEditor.toggle)
+  await expect(editorToggle).toBeVisible()
+  await editorToggle.click()
+
+  const shownSection = comfyPage.page.getByTestId(
+    TestIds.subgraphEditor.shownSection
+  )
+  await expect(shownSection).toBeVisible()
+  return shownSection
+}
+
+async function collectWidgetLabels(shownSection: Locator) {
+  const labels = shownSection.getByTestId(TestIds.subgraphEditor.widgetLabel)
+  const count = await labels.count()
+  const texts: string[] = []
+  for (let i = 0; i < count; i++) {
+    const text = await labels.nth(i).textContent()
+    if (text) texts.push(text.trim())
+  }
+  return texts
+}
+
+test.describe(
+  'Subgraph promoted widget panel',
+  { tag: ['@node', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    })
+
+    test.describe('SubgraphEditor (Settings panel)', () => {
+      test('linked promoted widgets have hide toggle disabled', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-nested-promotion'
+        )
+        const shownSection = await selectSubgraphAndOpenEditor(
+          comfyPage,
+          'Sub 0'
+        )
+
+        const toggleButtons = shownSection.getByTestId(
+          TestIds.subgraphEditor.widgetToggle
+        )
+        const count = await toggleButtons.count()
+        expect(count).toBeGreaterThan(0)
+
+        for (let i = 0; i < count; i++) {
+          await expect(toggleButtons.nth(i)).toBeDisabled()
+        }
+      })
+
+      test('linked promoted widgets show link icon instead of eye icon', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-nested-promotion'
+        )
+        const shownSection = await selectSubgraphAndOpenEditor(
+          comfyPage,
+          'Sub 0'
+        )
+
+        const linkIcons = shownSection.locator('.icon-\\[lucide--link\\]')
+        await expect(linkIcons.first()).toBeVisible()
+
+        const eyeIcons = shownSection.locator('.icon-\\[lucide--eye\\]')
+        await expect(eyeIcons).toHaveCount(0)
+      })
+
+      test('widget labels display renamed values instead of raw names', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/test-values-input-subgraph'
+        )
+        const shownSection = await selectSubgraphAndOpenEditor(
+          comfyPage,
+          'Input Test Subgraph'
+        )
+
+        const allTexts = await collectWidgetLabels(shownSection)
+        expect(allTexts.length).toBeGreaterThan(0)
+
+        // The fixture has a widget with name="text" but
+        // label="renamed_from_sidepanel". The panel should show the
+        // renamed label, not the raw widget name.
+        expect(allTexts).toContain('renamed_from_sidepanel')
+        expect(allTexts).not.toContain('text')
+      })
+    })
+
+    test.describe('Parameters tab (WidgetActions menu)', () => {
+      test('linked promoted widget menu should not show Hide/Show input', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-nested-promotion'
+        )
+        const subgraphNode = (
+          await comfyPage.nodeOps.getNodeRefsByTitle('Sub 0')
+        )[0]
+        await subgraphNode.click('title')
+
+        const panel = await ensurePropertiesPanel(comfyPage)
+
+        const moreButtons = panel.locator('.icon-\\[lucide--more-vertical\\]')
+        await expect(moreButtons.first()).toBeVisible()
+        await moreButtons.first().click()
+
+        await expect(comfyPage.page.getByText('Hide input')).toHaveCount(0)
+        await expect(comfyPage.page.getByText('Show input')).toHaveCount(0)
+        await expect(comfyPage.page.getByText('Rename')).toBeVisible()
+      })
+    })
+  }
+)

--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -303,6 +303,7 @@ function handleTitleCancel() {
             v-if="isSingleSubgraphNode"
             variant="secondary"
             size="icon"
+            data-testid="subgraph-editor-toggle"
             :class="cn(isEditingSubgraph && 'bg-secondary-background-selected')"
             @click="
               rightSidePanelStore.openPanel(

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -223,6 +223,7 @@ onMounted(() => {
 
       <div
         v-if="filteredActive.length"
+        data-testid="subgraph-editor-shown-section"
         class="flex flex-col border-b border-interface-stroke"
       >
         <div
@@ -254,6 +255,7 @@ onMounted(() => {
 
       <div
         v-if="filteredCandidates.length"
+        data-testid="subgraph-editor-hidden-section"
         class="flex flex-col border-b border-interface-stroke"
       >
         <div

--- a/src/components/rightSidePanel/subgraph/SubgraphNodeWidget.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphNodeWidget.vue
@@ -38,11 +38,14 @@ function getIcon() {
       <div class="line-clamp-1 text-xs text-text-secondary">
         {{ nodeTitle }}
       </div>
-      <div class="line-clamp-1 text-sm/8">{{ widgetName }}</div>
+      <div class="line-clamp-1 text-sm/8" data-testid="subgraph-widget-label">
+        {{ widgetName }}
+      </div>
     </div>
     <Button
       variant="muted-textonly"
       size="sm"
+      data-testid="subgraph-widget-toggle"
       :disabled="isPhysical"
       @click.stop="$emit('toggleVisibility')"
     >


### PR DESCRIPTION
## Summary

- Add Playwright regression tests that expose three bugs in the subgraph promoted widget panel introduced by the proxy-widget-v2 refactor (#8856)
- Add `data-testid` attributes to `SubgraphEditor`, `SubgraphNodeWidget`, and `RightSidePanel` for stable test selectors

## Tests added

| Test | Expected on main | Bug |
|---|---|---|
| Linked promoted widgets have hide toggle disabled | FAIL | Hide button is enabled for linked widgets that cannot be demoted |
| Linked promoted widgets show link icon instead of eye | FAIL | Eye icon shown instead of link icon |
| Widget labels display renamed values instead of raw names | FAIL | `widget.name` shown instead of `widget.label` |
| Linked promoted widget menu should not show Hide/Show input | FAIL | Hide/Show input option exposed in three-dot menu |

## Test plan

- [ ] All 4 tests fail on `main` (confirming bugs exist)
- [ ] Tests pass after fix PR is applied

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10502-test-add-e2e-tests-for-subgraph-promoted-widget-panel-regressions-32e6d73d36508159b650ede3638bca06) by [Unito](https://www.unito.io)
