### PR TITLE
test: move getNodeDefs spec into src/scripts

### DIFF
--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -65,7 +65,6 @@ describe('ComfyApp.getNodeDefs', () => {
 
     const result = await comfyApp.getNodeDefs()
 
-    // When display_name is empty, should fall back to name
     expect(result.TestNode.display_name).toBe('TestNode')
   })
 
@@ -84,7 +83,6 @@ describe('ComfyApp.getNodeDefs', () => {
     }
 
     vi.mocked(api.getNodeDefs).mockResolvedValue(mockNodeDefs)
-    // Mock st to return a translation instead of fallback
     vi.mocked(st).mockReturnValue('Translated Display Name')
 
     const result = await comfyApp.getNodeDefs()


### PR DESCRIPTION
## Summary

Move the `getNodeDefs` unit test out of deprecated `tests-ui` and into `src/scripts` so Vitest discovers and runs it.

## Changes

- **What**: Renamed `tests-ui/tests/scripts/app.getNodeDefs.test.ts` to `src/scripts/app.getNodeDefs.test.ts`

## Review Focus

Confirm the spec now follows the colocated test convention and is included by the existing Vitest `include` globs.

## Screenshots (if applicable)

N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10503-test-move-getNodeDefs-spec-into-src-scripts-32e6d73d3650816f9211dc4c20daba4b) by [Unito](https://www.unito.io)
