### PR TITLE
fix: App mode - workaround for alt+m producing alt+μ on mac

### DIFF
--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -63,6 +63,13 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
+      alt: true,
+      key: 'μ'
+    },
+    commandId: 'Comfy.ToggleLinear'
+  },
+  {
+    combo: {
       key: 's',
       ctrl: true
     },

--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -64,7 +64,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   {
     combo: {
       alt: true,
-      key: 'μ'
+      key: 'µ'
     },
     commandId: 'Comfy.ToggleLinear'
   },


### PR DESCRIPTION
## Summary

Adds a second keybinding for app mode as on Mac Alt+M produces Alt+μ

## Changes

- **What**: add extra binding entry

## Screenshots (if applicable)

Still shows alt + m in the keybinding panel
<img width="840" height="206" alt="image" src="https://github.com/user-attachments/assets/f1906bc2-e7c2-4eac-b3ca-5a8a207cc93c" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10528-fix-App-mode-workaround-for-alt-m-producing-alt-on-mac-32e6d73d36508176b7d6d918c5bb88f3) by [Unito](https://www.unito.io)
