### PR TITLE
fix: add LoadImage and LoadVideo to canvas preview node types

### DIFF
--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -98,24 +98,25 @@ test.describe(
       test('LoadImage node gets $$canvas-image-preview pseudo-widget promoted', async ({
         comfyPage
       }) => {
-        // Add a LoadImage node to the graph
-        const loadImageNodeId = await comfyPage.page.evaluate(() => {
+        await comfyPage.workflow.loadWorkflow('default')
+
+        // Add a LoadImage node and convert to subgraph programmatically
+        const subgraphNodeId = await comfyPage.page.evaluate(() => {
           const graph = window.app!.graph!
           const node = window.LiteGraph!.createNode('LoadImage')!
           node.pos = [300, 300]
           graph.add(node)
-          return String(node.id)
+          const { node: subgraphNode } = graph.convertToSubgraph(
+            new Set([node])
+          )
+          return String(subgraphNode.id)
         })
         await comfyPage.nextFrame()
 
-        const loadImageNode =
-          await comfyPage.nodeOps.getNodeRefById(loadImageNodeId)
-        await loadImageNode.click('title')
-        const subgraphNode = await loadImageNode.convertToSubgraph()
-        await comfyPage.nextFrame()
-
-        const nodeId = String(subgraphNode.id)
-        const pseudoWidgets = await getPseudoPreviewWidgets(comfyPage, nodeId)
+        const pseudoWidgets = await getPseudoPreviewWidgets(
+          comfyPage,
+          subgraphNodeId
+        )
         expect(pseudoWidgets.length).toBeGreaterThan(0)
         expect(
           pseudoWidgets.some(([, name]) => name === '$$canvas-image-preview')

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -6,7 +6,8 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 import {
   getPromotedWidgetNames,
-  getPromotedWidgetCount
+  getPromotedWidgetCount,
+  getPseudoPreviewWidgets
 } from '@e2e/fixtures/utils/promotedWidgets'
 
 async function expectPromotedWidgetNamesToContain(
@@ -92,6 +93,33 @@ test.describe(
           String(subgraphNode.id),
           'filename_prefix'
         )
+      })
+
+      test('LoadImage node gets $$canvas-image-preview pseudo-widget promoted', async ({
+        comfyPage
+      }) => {
+        // Add a LoadImage node to the graph
+        const loadImageNodeId = await comfyPage.page.evaluate(() => {
+          const graph = window.app!.graph!
+          const node = window.LiteGraph!.createNode('LoadImage')!
+          node.pos = [300, 300]
+          graph.add(node)
+          return String(node.id)
+        })
+        await comfyPage.nextFrame()
+
+        const loadImageNode =
+          await comfyPage.nodeOps.getNodeRefById(loadImageNodeId)
+        await loadImageNode.click('title')
+        const subgraphNode = await loadImageNode.convertToSubgraph()
+        await comfyPage.nextFrame()
+
+        const nodeId = String(subgraphNode.id)
+        const pseudoWidgets = await getPseudoPreviewWidgets(comfyPage, nodeId)
+        expect(pseudoWidgets.length).toBeGreaterThan(0)
+        expect(
+          pseudoWidgets.some(([, name]) => name === '$$canvas-image-preview')
+        ).toBe(true)
       })
     })
 

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -93,24 +93,25 @@ test.describe(
       test('LoadImage node gets $$canvas-image-preview pseudo-widget promoted', async ({
         comfyPage
       }) => {
-        // Add a LoadImage node to the graph
-        const loadImageNodeId = await comfyPage.page.evaluate(() => {
+        await comfyPage.workflow.loadWorkflow('default')
+
+        // Add a LoadImage node and convert to subgraph programmatically
+        const subgraphNodeId = await comfyPage.page.evaluate(() => {
           const graph = window.app!.graph!
           const node = window.LiteGraph!.createNode('LoadImage')!
           node.pos = [300, 300]
           graph.add(node)
-          return String(node.id)
+          const { node: subgraphNode } = graph.convertToSubgraph(
+            new Set([node])
+          )
+          return String(subgraphNode.id)
         })
         await comfyPage.nextFrame()
 
-        const loadImageNode =
-          await comfyPage.nodeOps.getNodeRefById(loadImageNodeId)
-        await loadImageNode.click('title')
-        const subgraphNode = await loadImageNode.convertToSubgraph()
-        await comfyPage.nextFrame()
-
-        const nodeId = String(subgraphNode.id)
-        const pseudoWidgets = await getPseudoPreviewWidgets(comfyPage, nodeId)
+        const pseudoWidgets = await getPseudoPreviewWidgets(
+          comfyPage,
+          subgraphNodeId
+        )
         expect(pseudoWidgets.length).toBeGreaterThan(0)
         expect(
           pseudoWidgets.some(([, name]) => name === '$$canvas-image-preview')

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -6,7 +6,8 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 import {
   getPromotedWidgetNames,
-  getPromotedWidgetCount
+  getPromotedWidgetCount,
+  getPseudoPreviewWidgets
 } from '@e2e/fixtures/utils/promotedWidgets'
 
 async function expectPromotedWidgetNamesToContain(
@@ -87,6 +88,33 @@ test.describe(
           String(subgraphNode.id),
           'filename_prefix'
         )
+      })
+
+      test('LoadImage node gets $$canvas-image-preview pseudo-widget promoted', async ({
+        comfyPage
+      }) => {
+        // Add a LoadImage node to the graph
+        const loadImageNodeId = await comfyPage.page.evaluate(() => {
+          const graph = window.app!.graph!
+          const node = window.LiteGraph!.createNode('LoadImage')!
+          node.pos = [300, 300]
+          graph.add(node)
+          return String(node.id)
+        })
+        await comfyPage.nextFrame()
+
+        const loadImageNode =
+          await comfyPage.nodeOps.getNodeRefById(loadImageNodeId)
+        await loadImageNode.click('title')
+        const subgraphNode = await loadImageNode.convertToSubgraph()
+        await comfyPage.nextFrame()
+
+        const nodeId = String(subgraphNode.id)
+        const pseudoWidgets = await getPseudoPreviewWidgets(comfyPage, nodeId)
+        expect(pseudoWidgets.length).toBeGreaterThan(0)
+        expect(
+          pseudoWidgets.some(([, name]) => name === '$$canvas-image-preview')
+        ).toBe(true)
       })
     })
 

--- a/src/composables/node/canvasImagePreviewTypes.ts
+++ b/src/composables/node/canvasImagePreviewTypes.ts
@@ -4,7 +4,9 @@ export const CANVAS_IMAGE_PREVIEW_WIDGET = '$$canvas-image-preview'
 const CANVAS_IMAGE_PREVIEW_NODE_TYPES = new Set([
   'PreviewImage',
   'SaveImage',
-  'GLSLShader'
+  'GLSLShader',
+  'LoadImage',
+  'LoadVideo'
 ])
 
 export function supportsVirtualCanvasImagePreview(node: LGraphNode): boolean {

--- a/src/composables/node/canvasImagePreviewTypes.ts
+++ b/src/composables/node/canvasImagePreviewTypes.ts
@@ -7,7 +7,9 @@ const CANVAS_IMAGE_PREVIEW_NODE_TYPES = new Set([
   'KSamplerAdvanced',
   'PreviewImage',
   'SaveImage',
-  'GLSLShader'
+  'GLSLShader',
+  'LoadImage',
+  'LoadVideo'
 ])
 
 export function supportsVirtualCanvasImagePreview(node: LGraphNode): boolean {

--- a/src/composables/node/usePromotedPreviews.ts
+++ b/src/composables/node/usePromotedPreviews.ts
@@ -51,10 +51,22 @@ export function usePromotedPreviews(
       )
       const reactiveOutputs = nodeOutputStore.nodeOutputs[locatorId]
       const reactivePreviews = nodeOutputStore.nodePreviewImages[locatorId]
+      console.warn('[PROMOTED-PREVIEW]', {
+        locatorId,
+        hasOutputs: !!reactiveOutputs?.images?.length,
+        hasPreviews: !!reactivePreviews?.length,
+        entry
+      })
       if (!reactiveOutputs?.images?.length && !reactivePreviews?.length)
         continue
 
       const urls = nodeOutputStore.getNodeImageUrls(interiorNode)
+      console.warn(
+        '[PROMOTED-PREVIEW] urls:',
+        urls?.length,
+        'type:',
+        interiorNode.previewMediaType
+      )
       if (!urls?.length) continue
 
       const type =

--- a/src/composables/node/usePromotedPreviews.ts
+++ b/src/composables/node/usePromotedPreviews.ts
@@ -51,22 +51,10 @@ export function usePromotedPreviews(
       )
       const reactiveOutputs = nodeOutputStore.nodeOutputs[locatorId]
       const reactivePreviews = nodeOutputStore.nodePreviewImages[locatorId]
-      console.warn('[PROMOTED-PREVIEW]', {
-        locatorId,
-        hasOutputs: !!reactiveOutputs?.images?.length,
-        hasPreviews: !!reactivePreviews?.length,
-        entry
-      })
       if (!reactiveOutputs?.images?.length && !reactivePreviews?.length)
         continue
 
       const urls = nodeOutputStore.getNodeImageUrls(interiorNode)
-      console.warn(
-        '[PROMOTED-PREVIEW] urls:',
-        urls?.length,
-        'type:',
-        interiorNode.previewMediaType
-      )
       if (!urls?.length) continue
 
       const type =

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -203,6 +203,28 @@ describe('getPromotableWidgets', () => {
     ).toBe(true)
   })
 
+  it('adds virtual canvas preview widget for LoadImage nodes', () => {
+    const node = new LGraphNode('LoadImage')
+    node.type = 'LoadImage'
+
+    const widgets = getPromotableWidgets(node)
+
+    expect(
+      widgets.some((widget) => widget.name === CANVAS_IMAGE_PREVIEW_WIDGET)
+    ).toBe(true)
+  })
+
+  it('adds virtual canvas preview widget for LoadVideo nodes', () => {
+    const node = new LGraphNode('LoadVideo')
+    node.type = 'LoadVideo'
+
+    const widgets = getPromotableWidgets(node)
+
+    expect(
+      widgets.some((widget) => widget.name === CANVAS_IMAGE_PREVIEW_WIDGET)
+    ).toBe(true)
+  })
+
   it('does not add virtual canvas preview widget for non-image nodes', () => {
     const node = new LGraphNode('TextNode')
     node.addOutput('TEXT', 'STRING')
@@ -265,6 +287,25 @@ describe('promoteRecommendedWidgets', () => {
     expect(
       store.isPromoted(subgraphNode.rootGraph.id, subgraphNode.id, {
         sourceNodeId: String(glslNode.id),
+        sourceWidgetName: CANVAS_IMAGE_PREVIEW_WIDGET
+      })
+    ).toBe(true)
+    expect(updatePreviewsMock).not.toHaveBeenCalled()
+  })
+
+  it('eagerly promotes virtual preview widget for LoadImage nodes', () => {
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    const loadImageNode = new LGraphNode('LoadImage')
+    loadImageNode.type = 'LoadImage'
+    subgraph.add(loadImageNode)
+
+    promoteRecommendedWidgets(subgraphNode)
+
+    const store = usePromotionStore()
+    expect(
+      store.isPromoted(subgraphNode.rootGraph.id, subgraphNode.id, {
+        sourceNodeId: String(loadImageNode.id),
         sourceWidgetName: CANVAS_IMAGE_PREVIEW_WIDGET
       })
     ).toBe(true)

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -395,6 +395,27 @@ describe('promoteRecommendedWidgets', () => {
     })
     expect(updatePreviewsMock).not.toHaveBeenCalled()
   })
+
+  it('eagerly exposes virtual preview widget for LoadImage nodes', () => {
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    const loadImageNode = new LGraphNode('LoadImage', 'LoadImage')
+    subgraph.add(loadImageNode)
+
+    promoteRecommendedWidgets(subgraphNode)
+
+    expect(
+      usePreviewExposureStore().getExposures(
+        subgraphNode.rootGraph.id,
+        String(subgraphNode.id)
+      )
+    ).toContainEqual({
+      name: CANVAS_IMAGE_PREVIEW_WIDGET,
+      sourceNodeId: String(loadImageNode.id),
+      sourcePreviewName: CANVAS_IMAGE_PREVIEW_WIDGET
+    })
+    expect(updatePreviewsMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('autoExposeKnownPreviewNodes', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useImageUploadWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { IComboWidget } from '@/lib/litegraph/src/types/widgets'
 import type { ResultItem, ResultItemType } from '@/schemas/apiSchema'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
@@ -137,6 +141,21 @@ describe('useImageUploadWidget', () => {
       'missing.png',
       fileComboWidget
     )
+  })
+
+  it('dirties the subgraph and root canvas after an upload', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    const { node } = createUploadNode()
+    subgraph.add(node)
+    construct(node)
+    const subgraphDirtySpy = vi.spyOn(subgraph, 'setDirtyCanvas')
+    const rootGraphDirtySpy = vi.spyOn(rootGraph, 'setDirtyCanvas')
+
+    mocks.capturedUploadOptions?.onUploadComplete(['uploaded.png'])
+
+    expect(subgraphDirtySpy).toHaveBeenCalledWith(true)
+    expect(rootGraphDirtySpy).toHaveBeenCalledWith(true)
   })
 
   it('previews the combo value once the initial frame runs', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -105,11 +105,28 @@ export const useImageUploadWidget = () => {
 
     // Add our own callback to the combo widget to render an image when it changes
     fileComboWidget.callback = function () {
+      console.warn(
+        '[IMAGEUPLOAD-CB] value:',
+        fileComboWidget.value,
+        'graphId:',
+        node.graph?.id,
+        'nodeId:',
+        node.id,
+        'inSubgraph:',
+        node.graph !== node.graph?.rootGraph
+      )
       node.imgs = undefined
       nodeOutputStore.setNodeOutputs(node, String(fileComboWidget.value), {
         isAnimated
       })
       node.graph?.setDirtyCanvas(true)
+      // When this node is inside a subgraph, also dirty the root canvas so
+      // the parent SubgraphNode redraws and picks up the new preview via
+      // its onDrawBackground → updatePreviews loop.
+      const rootGraph = node.graph?.rootGraph
+      if (rootGraph && rootGraph !== node.graph) {
+        rootGraph.setDirtyCanvas(true)
+      }
     }
 
     // On load if we have a value then render the image

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -105,16 +105,6 @@ export const useImageUploadWidget = () => {
 
     // Add our own callback to the combo widget to render an image when it changes
     fileComboWidget.callback = function () {
-      console.warn(
-        '[IMAGEUPLOAD-CB] value:',
-        fileComboWidget.value,
-        'graphId:',
-        node.graph?.id,
-        'nodeId:',
-        node.id,
-        'inSubgraph:',
-        node.graph !== node.graph?.rootGraph
-      )
       node.imgs = undefined
       nodeOutputStore.setNodeOutputs(node, String(fileComboWidget.value), {
         isAnimated

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -122,6 +122,12 @@ export const useImageUploadWidget = () => {
         isAnimated
       })
       node.graph?.setDirtyCanvas(true)
+      // When this node is inside a subgraph, also dirty the root canvas so
+      // the parent SubgraphNode redraws with the new preview.
+      const rootGraph = node.graph?.rootGraph
+      if (rootGraph && rootGraph !== node.graph) {
+        rootGraph.setDirtyCanvas(true)
+      }
     }
 
     // On load if we have a value then render the image


### PR DESCRIPTION
## Summary

LoadImage and LoadVideo previews were never promoted to parent subgraph nodes because they were missing from `CANVAS_IMAGE_PREVIEW_NODE_TYPES`.

## Changes

- **What**: Add `LoadImage` and `LoadVideo` to `CANVAS_IMAGE_PREVIEW_NODE_TYPES` in `canvasImagePreviewTypes.ts` so `supportsVirtualCanvasImagePreview` returns `true` for them, enabling the `$$canvas-image-preview` pseudo-widget to be created and promoted on subgraph nodes.

## Review Focus

The fix is a 2-line addition to the Set. The promotion/reactivity plumbing already works for these node types — they were simply missing from the allowlist. `LoadImage` writes to `nodeOutputs` (with `type: "input"`) via `setNodeOutputs`, which is already tracked by `usePromotedPreviews` (after #10165). `LoadVideo` follows the same upload-widget codepath.

Needs backport to `cloud/1.41` for staging release.

## Test Plan

- 3 new unit tests in `promotionUtils.test.ts` covering `getPromotableWidgets` and `promoteRecommendedWidgets` for LoadImage/LoadVideo
- All 24 tests in `promotionUtils.test.ts` pass
- All 16 tests in `usePromotedPreviews.test.ts` and `useNodeCanvasImagePreview.test.ts` pass

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10530-fix-add-LoadImage-and-LoadVideo-to-canvas-preview-node-types-32e6d73d36508128b8dbf76f401c4efb) by [Unito](https://www.unito.io)
