### PR TITLE
Also promote children of promoted dynamic widgets

### DIFF
--- a/src/core/graph/subgraph/promotedWidgetView.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.ts
@@ -1,3 +1,6 @@
+import { intersectionWith, differenceWith } from 'es-toolkit'
+
+import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
@@ -9,6 +12,7 @@ import type { BaseWidget } from '@/lib/litegraph/src/widgets/BaseWidget'
 import { toConcreteWidget } from '@/lib/litegraph/src/widgets/widgetMap'
 import { t } from '@/i18n'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { usePromotionStore } from '@/stores/promotionStore'
 import {
   stripGraphPrefix,
   useWidgetValueStore
@@ -90,6 +94,7 @@ class PromotedWidgetView implements IPromotedWidgetView {
   private projectedWidget?: BaseWidget
   private cachedDeepestByFrame?: { node: LGraphNode; widget: IBaseWidget }
   private cachedDeepestFrame = -1
+  private hasDependents = false
 
   /** Cached reference to the bound subgraph slot, set at construction. */
   private _boundSlot?: SubgraphSlotRef
@@ -106,6 +111,7 @@ class PromotedWidgetView implements IPromotedWidgetView {
     this.sourceNodeId = nodeId
     this.sourceWidgetName = widgetName
     this.graphId = subgraphNode.rootGraph.id
+    //this.updateDependents()
   }
 
   get node(): SubgraphNode {
@@ -349,6 +355,7 @@ class PromotedWidgetView implements IPromotedWidgetView {
     e?: CanvasPointerEvent
   ) {
     this.resolveAtHost()?.widget.callback?.(value, canvas, node, pos, e)
+    if (this.hasDependents) this.updateDependents()
   }
 
   private resolveAtHost():
@@ -540,6 +547,49 @@ class PromotedWidgetView implements IPromotedWidgetView {
       widget: this
     })
   }
+
+  private updateDependents() {
+    const parent = this.node
+    const { demote, promote } = usePromotionStore()
+    const child = this.node.subgraph.getNodeById(this.sourceNodeId)
+    if (!child) return
+
+    const key = this.sourceWidgetName + '.'
+    const existing = parent.widgets
+      .filter((w) => w.name.startsWith(key))
+      .map((w) => getSource(parent, w))
+    const candidate =
+      child.widgets
+        ?.filter((w) => w.name.startsWith(key))
+        .map((w) => getSource(child, w)) ?? []
+
+    const overlap = intersectionWith(existing, candidate, sourcesEqual)
+    const toPrune = differenceWith(existing, overlap, sourcesEqual)
+    const toAdd = differenceWith(candidate, overlap, sourcesEqual)
+
+    this.hasDependents ||= !!candidate.length
+    for (const source of toPrune) demote(parent.rootGraph.id, parent.id, source)
+    for (const source of toAdd) promote(parent.rootGraph.id, parent.id, source)
+  }
+}
+
+function getSource(node: LGraphNode, wid: IBaseWidget): PromotedWidgetSource {
+  return isPromotedWidgetView(wid)
+    ? {
+        sourceNodeId: String(node.id),
+        sourceWidgetName: wid.sourceWidgetName,
+        disambiguatingSourceNodeId:
+          wid.disambiguatingSourceNodeId ?? wid.sourceNodeId
+      }
+    : { sourceNodeId: String(node.id), sourceWidgetName: wid.name }
+}
+
+function sourcesEqual(a: PromotedWidgetSource, b: PromotedWidgetSource) {
+  return (
+    a.sourceWidgetName === b.sourceWidgetName &&
+    (a.disambiguatingSourceNodeId ?? a.sourceNodeId) ===
+      (b.disambiguatingSourceNodeId ?? b.sourceNodeId)
+  )
 }
 
 /** Checks if a widget is a BaseDOMWidget (DOMWidget or ComponentWidget). */

--- a/src/core/graph/subgraph/promotedWidgetView.ts
+++ b/src/core/graph/subgraph/promotedWidgetView.ts
@@ -1,4 +1,5 @@
 import { intersectionWith, differenceWith } from 'es-toolkit'
+import { watch } from 'vue'
 
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { LGraphNode, NodeId } from '@/lib/litegraph/src/LGraphNode'
@@ -94,7 +95,6 @@ class PromotedWidgetView implements IPromotedWidgetView {
   private projectedWidget?: BaseWidget
   private cachedDeepestByFrame?: { node: LGraphNode; widget: IBaseWidget }
   private cachedDeepestFrame = -1
-  private hasDependents = false
 
   /** Cached reference to the bound subgraph slot, set at construction. */
   private _boundSlot?: SubgraphSlotRef
@@ -111,7 +111,14 @@ class PromotedWidgetView implements IPromotedWidgetView {
     this.sourceNodeId = nodeId
     this.sourceWidgetName = widgetName
     this.graphId = subgraphNode.rootGraph.id
-    //this.updateDependents()
+
+    if (this.resolveDeepest()?.widget?.hasDynamicChildren) {
+      watch(
+        () => this.value,
+        () => this.updateDependents()
+      )
+      this.updateDependents(true)
+    }
   }
 
   get node(): SubgraphNode {
@@ -355,7 +362,6 @@ class PromotedWidgetView implements IPromotedWidgetView {
     e?: CanvasPointerEvent
   ) {
     this.resolveAtHost()?.widget.callback?.(value, canvas, node, pos, e)
-    if (this.hasDependents) this.updateDependents()
   }
 
   private resolveAtHost():
@@ -548,16 +554,18 @@ class PromotedWidgetView implements IPromotedWidgetView {
     })
   }
 
-  private updateDependents() {
+  private updateDependents(skipExisting?: boolean) {
     const parent = this.node
     const { demote, promote } = usePromotionStore()
     const child = this.node.subgraph.getNodeById(this.sourceNodeId)
     if (!child) return
 
     const key = this.sourceWidgetName + '.'
-    const existing = parent.widgets
-      .filter((w) => w.name.startsWith(key))
-      .map((w) => getSource(parent, w))
+    const existing = skipExisting
+      ? []
+      : parent.widgets
+          .filter((w) => w.name.startsWith(key))
+          .map((w) => getSource(parent, w))
     const candidate =
       child.widgets
         ?.filter((w) => w.name.startsWith(key))
@@ -567,7 +575,6 @@ class PromotedWidgetView implements IPromotedWidgetView {
     const toPrune = differenceWith(existing, overlap, sourcesEqual)
     const toAdd = differenceWith(candidate, overlap, sourcesEqual)
 
-    this.hasDependents ||= !!candidate.length
     for (const source of toPrune) demote(parent.rootGraph.id, parent.id, source)
     for (const source of toAdd) promote(parent.rootGraph.id, parent.id, source)
   }
@@ -576,10 +583,9 @@ class PromotedWidgetView implements IPromotedWidgetView {
 function getSource(node: LGraphNode, wid: IBaseWidget): PromotedWidgetSource {
   return isPromotedWidgetView(wid)
     ? {
-        sourceNodeId: String(node.id),
+        sourceNodeId: wid.sourceNodeId,
         sourceWidgetName: wid.sourceWidgetName,
-        disambiguatingSourceNodeId:
-          wid.disambiguatingSourceNodeId ?? wid.sourceNodeId
+        disambiguatingSourceNodeId: wid.disambiguatingSourceNodeId
       }
     : { sourceNodeId: String(node.id), sourceWidgetName: wid.name }
 }

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -22,6 +22,7 @@ import {
 import { useLitegraphService } from '@/services/litegraphService'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 const INLINE_INPUTS = false
 
@@ -88,6 +89,7 @@ function dynamicComboWidget(
     appArg,
     widgetName
   )
+  widget.hasDynamicChildren = true
   function isInGroup(e: { name: string }): boolean {
     return e.name.startsWith(inputName + '.')
   }
@@ -184,17 +186,25 @@ function dynamicComboWidget(
   }
   //A little hacky, but onConfigure won't work.
   //It fires too late and is overly disruptive
-  let widgetValue = widget.value
   Object.defineProperty(widget, 'value', {
     get() {
-      return widgetValue
+      return useWidgetValueStore().getWidget(
+        app.rootGraph.id,
+        node.id,
+        widget.name
+      )?.value
     },
     set(value) {
-      widgetValue = value
+      const state = useWidgetValueStore().getWidget(
+        app.rootGraph.id,
+        node.id,
+        widget.name
+      )
+      if (state) state.value = value
       updateWidgets(value)
     }
   })
-  widget.value = widgetValue
+  widget.value = widget.value
   return { widget, minWidth, minHeight }
 }
 

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -424,6 +424,7 @@ export interface IBaseWidget<
   hidden?: boolean
   advanced?: boolean
   tooltip?: string
+  hasDynamicChildren?: boolean
 
   // TODO: Confirm this format
   callback?(


### PR DESCRIPTION
Changing the value of a DynamicCombo will cause widgets to be added or removed from a node. When a DynamicCombo is promoted, these dynamically added children will now also be promoted and any previously promoted children will be demoted.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10534-Also-promote-children-of-promoted-dynamic-widgets-32e6d73d36508177954ff5dd64e28864) by [Unito](https://www.unito.io)
