### PR TITLE
docs: add ADR compliance guardrails for agents and reviewers

### DIFF
--- a/.agents/checks/adr-compliance.md
+++ b/.agents/checks/adr-compliance.md
@@ -1,0 +1,111 @@
+---
+name: adr-compliance
+description: Checks code changes against Architecture Decision Records, with emphasis on ECS (ADR 0008) and command-pattern (ADR 0003) compliance
+severity-default: medium
+tools: [Read, Grep, glob]
+---
+
+Check that code changes are consistent with the project's Architecture Decision Records in `docs/adr/`.
+
+## Priority 1: ECS and Command-Pattern Compliance (ADR 0008 + ADR 0003)
+
+These are the primary architectural guardrails. Every entity/litegraph change must be checked against them.
+
+### Command Pattern (ADR 0003)
+
+All entity state mutations MUST be expressible as **serializable, idempotent, deterministic commands**. This is required for CRDT sync, undo/redo, cross-environment portability, and gateway backends.
+
+Flag:
+- **Direct spatial mutation** — `node.pos = ...`, `node.size = ...`, `group.pos = ...` outside of a store or command. All spatial data flows through `layoutStore` commands.
+- **Imperative fire-and-forget mutation** — Any new API that mutates entity state as a side effect rather than producing a serializable command object. Systems should produce command batches, not execute mutations directly.
+- **Void-returning mutation APIs** — New entity mutation functions that return `void` instead of a result type (`{ status: 'applied' | 'rejected' | 'no-op' }`). Commands need error/rejection semantics.
+- **Auto-incrementing IDs in new entity code** — New entity creation using auto-increment counters without acknowledging the CRDT collision problem. Concurrent environments need globally unique, stable identifiers.
+
+### ECS Architecture (ADR 0008)
+
+The graph domain model is migrating to ECS. New code must not make the migration harder.
+
+Flag:
+- **God-object growth** — New methods/properties added to `LGraphNode` (~4k lines), `LGraphCanvas` (~9k lines), `LGraph` (~3k lines), or `Subgraph`. Extract to systems, stores, or composables instead.
+- **Mixed data and behavior** — New component-like data structures that contain methods or back-references to parent entities. ECS components are plain data objects.
+- **New circular entity dependencies** — New circular imports between `LGraph` ↔ `Subgraph`, `LGraphNode` ↔ `LGraphCanvas`, or similar entity classes.
+- **Direct `graph._version++`** — Mutating the private version counter directly instead of through a public API. Extensions already depend on this side-channel; it must become a proper API.
+
+### Centralized Registries and ECS-Style Access
+
+All entity data access should move toward centralized query patterns, not instance property access.
+
+Flag:
+- **New instance method/property patterns** — Adding `node.someProperty` or `node.someMethod()` for data that should be a component in the World, queried via `world.getComponent(entityId, ComponentType)`.
+- **OOP inheritance for entity modeling** — Extending entity classes with new subclasses instead of composing behavior through components and systems.
+- **Scattered state** — New entity state stored in multiple locations (class properties, stores, local variables) instead of being consolidated in the World or in a single store.
+
+### Extension Ecosystem Impact
+
+Entity API changes affect 40+ custom node repos. Changes to these patterns require an extension migration path.
+
+Flag when changed without migration guidance:
+- `onConnectionsChange`, `onRemoved`, `onAdded`, `onConfigure` callbacks
+- `onConnectInput` / `onConnectOutput` validation hooks
+- `onWidgetChanged` handlers
+- `node.widgets.find(w => w.name === ...)` patterns
+- `node.serialize` overrides
+- `graph._version++` direct mutation
+- `getNodeById` usage patterns
+
+## Priority 2: General ADR Compliance
+
+For all other ADRs, iterate through each file in `docs/adr/` and extract the core lesson. Ensure changed code does not contradict accepted ADRs. Flag contradictions with proposed ADRs as directional guidance.
+
+### How to Apply
+
+1. Read `docs/adr/README.md` to get the full ADR index
+2. For each ADR, read the Decision and Consequences sections
+3. Check the diff against each ADR's constraints
+4. Only flag ACTUAL violations in changed code, not pre-existing patterns
+
+### Skip List
+
+These ADRs can be skipped for most reviews (they cover completed or narrow-scope decisions):
+- **ADR 0004** (Rejected — Fork PrimeVue) — only relevant if someone proposes forking PrimeVue again
+
+## How to Check
+
+1. Identify changed files in the entity/litegraph layer: `src/lib/litegraph/`, `src/ecs/`, `src/platform/`, entity-related stores
+2. For Priority 1 patterns, use targeted searches:
+   ```
+   # Direct position mutation
+   Grep: pattern="\.pos\s*=" path="src/lib/litegraph"
+   Grep: pattern="\.size\s*=" path="src/lib/litegraph"
+
+   # God object growth (new methods)
+   Grep: pattern="(class LGraphNode|class LGraphCanvas|class LGraph\b)" path="src/lib/litegraph"
+
+   # Version mutation
+   Grep: pattern="_version\+\+" path="src/lib/litegraph"
+
+   # Extension callback changes
+   Grep: pattern="on(ConnectionsChange|Removed|Added|Configure|ConnectInput|ConnectOutput|WidgetChanged)" path="src/lib/litegraph"
+   ```
+3. For Priority 2, read `docs/adr/` files and check for contradictions
+
+## Severity Guidelines
+
+| Issue | Severity |
+| --- | --- |
+| Imperative mutation API without command-pattern wrapper | high |
+| New god-object method on LGraphNode/LGraphCanvas/LGraph | high |
+| Breaking extension callback without migration path | high |
+| New circular entity dependency | high |
+| Direct spatial mutation bypassing command pattern | medium |
+| Mixed data/behavior in component-like structures | medium |
+| New OOP inheritance pattern for entities | medium |
+| Contradicts accepted ADR direction | medium |
+| Contradicts proposed ADR direction without justification | low |
+
+## Rules
+
+- Only flag ACTUAL violations in changed code, not pre-existing patterns
+- If a change explicitly acknowledges an ADR tradeoff in comments or PR description, lower severity
+- Proposed ADRs carry less weight than accepted ones — flag as directional guidance
+- Reference the specific ADR number in every finding

--- a/.agents/checks/adr-compliance.md
+++ b/.agents/checks/adr-compliance.md
@@ -16,6 +16,7 @@ These are the primary architectural guardrails. Every entity/litegraph change mu
 All entity state mutations MUST be expressible as **serializable, idempotent, deterministic commands**. This is required for CRDT sync, undo/redo, cross-environment portability, and gateway backends.
 
 Flag:
+
 - **Direct spatial mutation** — `node.pos = ...`, `node.size = ...`, `group.pos = ...` outside of a store or command. All spatial data flows through `layoutStore` commands.
 - **Imperative fire-and-forget mutation** — Any new API that mutates entity state as a side effect rather than producing a serializable command object. Systems should produce command batches, not execute mutations directly.
 - **Void-returning mutation APIs** — New entity mutation functions that return `void` instead of a result type (`{ status: 'applied' | 'rejected' | 'no-op' }`). Commands need error/rejection semantics.
@@ -26,6 +27,7 @@ Flag:
 The graph domain model is migrating to ECS. New code must not make the migration harder.
 
 Flag:
+
 - **God-object growth** — New methods/properties added to `LGraphNode` (~4k lines), `LGraphCanvas` (~9k lines), `LGraph` (~3k lines), or `Subgraph`. Extract to systems, stores, or composables instead.
 - **Mixed data and behavior** — New component-like data structures that contain methods or back-references to parent entities. ECS components are plain data objects.
 - **New circular entity dependencies** — New circular imports between `LGraph` ↔ `Subgraph`, `LGraphNode` ↔ `LGraphCanvas`, or similar entity classes.
@@ -36,6 +38,7 @@ Flag:
 All entity data access should move toward centralized query patterns, not instance property access.
 
 Flag:
+
 - **New instance method/property patterns** — Adding `node.someProperty` or `node.someMethod()` for data that should be a component in the World, queried via `world.getComponent(entityId, ComponentType)`.
 - **OOP inheritance for entity modeling** — Extending entity classes with new subclasses instead of composing behavior through components and systems.
 - **Scattered state** — New entity state stored in multiple locations (class properties, stores, local variables) instead of being consolidated in the World or in a single store.
@@ -45,6 +48,7 @@ Flag:
 Entity API changes affect 40+ custom node repos. Changes to these patterns require an extension migration path.
 
 Flag when changed without migration guidance:
+
 - `onConnectionsChange`, `onRemoved`, `onAdded`, `onConfigure` callbacks
 - `onConnectInput` / `onConnectOutput` validation hooks
 - `onWidgetChanged` handlers
@@ -67,12 +71,14 @@ For all other ADRs, iterate through each file in `docs/adr/` and extract the cor
 ### Skip List
 
 These ADRs can be skipped for most reviews (they cover completed or narrow-scope decisions):
+
 - **ADR 0004** (Rejected — Fork PrimeVue) — only relevant if someone proposes forking PrimeVue again
 
 ## How to Check
 
 1. Identify changed files in the entity/litegraph layer: `src/lib/litegraph/`, `src/ecs/`, `src/platform/`, entity-related stores
 2. For Priority 1 patterns, use targeted searches:
+
    ```
    # Direct position mutation
    Grep: pattern="\.pos\s*=" path="src/lib/litegraph"
@@ -87,21 +93,22 @@ These ADRs can be skipped for most reviews (they cover completed or narrow-scope
    # Extension callback changes
    Grep: pattern="on(ConnectionsChange|Removed|Added|Configure|ConnectInput|ConnectOutput|WidgetChanged)" path="src/lib/litegraph"
    ```
+
 3. For Priority 2, read `docs/adr/` files and check for contradictions
 
 ## Severity Guidelines
 
-| Issue | Severity |
-| --- | --- |
-| Imperative mutation API without command-pattern wrapper | high |
-| New god-object method on LGraphNode/LGraphCanvas/LGraph | high |
-| Breaking extension callback without migration path | high |
-| New circular entity dependency | high |
-| Direct spatial mutation bypassing command pattern | medium |
-| Mixed data/behavior in component-like structures | medium |
-| New OOP inheritance pattern for entities | medium |
-| Contradicts accepted ADR direction | medium |
-| Contradicts proposed ADR direction without justification | low |
+| Issue                                                    | Severity |
+| -------------------------------------------------------- | -------- |
+| Imperative mutation API without command-pattern wrapper  | high     |
+| New god-object method on LGraphNode/LGraphCanvas/LGraph  | high     |
+| Breaking extension callback without migration path       | high     |
+| New circular entity dependency                           | high     |
+| Direct spatial mutation bypassing command pattern        | medium   |
+| Mixed data/behavior in component-like structures         | medium   |
+| New OOP inheritance pattern for entities                 | medium   |
+| Contradicts accepted ADR direction                       | medium   |
+| Contradicts proposed ADR direction without justification | low      |
 
 ## Rules
 

--- a/.claude/commands/adr-compliance-audit.md
+++ b/.claude/commands/adr-compliance-audit.md
@@ -1,0 +1,90 @@
+# ADR Compliance Audit
+
+Audit the current changes (or a specified PR) for compliance with Architecture Decision Records.
+
+## Step 1: Gather the Diff
+
+- If a PR number is provided, run: `gh pr diff $PR_NUMBER`
+- Otherwise, run: `git diff main...HEAD` (or `git diff --cached` for staged changes)
+
+## Step 2: Priority 1 — ECS and Command-Pattern Compliance
+
+Read these documents for context:
+```
+docs/adr/0003-crdt-based-layout-system.md
+docs/adr/0008-entity-component-system.md
+docs/architecture/ecs-target-architecture.md
+docs/architecture/ecs-migration-plan.md
+docs/architecture/appendix-critical-analysis.md
+```
+
+### Check A: Command Pattern (ADR 0003)
+
+Every entity state mutation must be a **serializable, idempotent, deterministic command** — replayable, undoable, transmittable over CRDT.
+
+Flag:
+1. **Direct spatial mutation** — `node.pos = ...`, `node.size = ...`, `group.pos = ...` outside a store/command
+2. **Imperative fire-and-forget APIs** — Functions that mutate entity state as side effects rather than producing serializable command objects. Systems should produce command batches, not execute mutations directly.
+3. **Void-returning mutation APIs** — Entity mutations returning `void` instead of `{ status: 'applied' | 'rejected' | 'no-op' }`
+4. **Auto-increment IDs** — New entity creation via counters without addressing CRDT collision. Concurrent environments need globally unique identifiers.
+5. **Missing transaction semantics** — Multi-entity operations without atomic grouping (e.g., node removal = 10+ deletes with no rollback on failure)
+
+### Check B: ECS Architecture (ADR 0008)
+
+Flag:
+1. **God-object growth** — New methods/properties on `LGraphNode`, `LGraphCanvas`, `LGraph`, `Subgraph`
+2. **Mixed data/behavior** — Component-like structures with methods or back-references
+3. **OOP instance patterns** — New `node.someProperty` or `node.someMethod()` for data that should be a World component
+4. **OOP inheritance** — New entity subclasses instead of component composition
+5. **Circular entity deps** — New `LGraph` ↔ `Subgraph`, `LGraphNode` ↔ `LGraphCanvas` circular imports
+6. **Direct `_version++`** — Mutating private version counter instead of through public API
+
+### Check C: Extension Ecosystem Impact
+
+If any of these patterns are changed, flag and require migration guidance:
+- `onConnectionsChange`, `onRemoved`, `onAdded`, `onConfigure` callbacks
+- `onConnectInput` / `onConnectOutput` validation hooks
+- `onWidgetChanged` handlers
+- `node.widgets.find(w => w.name === ...)` access patterns
+- `node.serialize` overrides
+- `graph._version++` direct mutation
+
+Reference: 40+ custom node repos depend on these (rgthree-comfy, ComfyUI-Impact-Pack, cg-use-everywhere, etc.)
+
+## Step 3: Priority 2 — General ADR Compliance
+
+1. Read `docs/adr/README.md` for the full ADR index
+2. For each ADR (except skip list), read the Decision section
+3. Check the diff for contradictions
+4. Only flag ACTUAL violations in changed code
+
+**Skip list**: ADR 0004 (Rejected — Fork PrimeVue)
+
+## Step 4: Generate Report
+
+```
+## ADR Compliance Audit Report
+
+### Summary
+- Files audited: N
+- Priority 1 findings: N (command-pattern: N, ECS: N, ecosystem: N)
+- Priority 2 findings: N
+
+### Priority 1: Command Pattern & ECS
+(List each with ADR reference, file, line, description)
+
+### Priority 1: Extension Ecosystem Impact
+(List each changed callback/API with affected custom node repos)
+
+### Priority 2: General ADR Compliance
+(List each with ADR reference, file, line, description)
+
+### Compliant Patterns
+(Note changes that positively align with ADR direction)
+```
+
+## Severity
+
+- **Must fix**: Contradicts accepted ADR, or introduces imperative mutation API without command-pattern wrapper, or breaks extension callback without migration path
+- **Should discuss**: Contradicts proposed ADR direction — either align or propose ADR amendment
+- **Note**: Surfaces open architectural question not yet addressed by ADRs

--- a/.claude/commands/adr-compliance-audit.md
+++ b/.claude/commands/adr-compliance-audit.md
@@ -10,6 +10,7 @@ Audit the current changes (or a specified PR) for compliance with Architecture D
 ## Step 2: Priority 1 — ECS and Command-Pattern Compliance
 
 Read these documents for context:
+
 ```
 docs/adr/0003-crdt-based-layout-system.md
 docs/adr/0008-entity-component-system.md
@@ -23,6 +24,7 @@ docs/architecture/appendix-critical-analysis.md
 Every entity state mutation must be a **serializable, idempotent, deterministic command** — replayable, undoable, transmittable over CRDT.
 
 Flag:
+
 1. **Direct spatial mutation** — `node.pos = ...`, `node.size = ...`, `group.pos = ...` outside a store/command
 2. **Imperative fire-and-forget APIs** — Functions that mutate entity state as side effects rather than producing serializable command objects. Systems should produce command batches, not execute mutations directly.
 3. **Void-returning mutation APIs** — Entity mutations returning `void` instead of `{ status: 'applied' | 'rejected' | 'no-op' }`
@@ -32,6 +34,7 @@ Flag:
 ### Check B: ECS Architecture (ADR 0008)
 
 Flag:
+
 1. **God-object growth** — New methods/properties on `LGraphNode`, `LGraphCanvas`, `LGraph`, `Subgraph`
 2. **Mixed data/behavior** — Component-like structures with methods or back-references
 3. **OOP instance patterns** — New `node.someProperty` or `node.someMethod()` for data that should be a World component
@@ -42,6 +45,7 @@ Flag:
 ### Check C: Extension Ecosystem Impact
 
 If any of these patterns are changed, flag and require migration guidance:
+
 - `onConnectionsChange`, `onRemoved`, `onAdded`, `onConfigure` callbacks
 - `onConnectInput` / `onConnectOutput` validation hooks
 - `onWidgetChanged` handlers

--- a/.claude/commands/adr-compliance-audit.md
+++ b/.claude/commands/adr-compliance-audit.md
@@ -5,7 +5,7 @@ Audit the current changes (or a specified PR) for compliance with Architecture D
 ## Step 1: Gather the Diff
 
 - If a PR number is provided, run: `gh pr diff $PR_NUMBER`
-- Otherwise, run: `git diff main...HEAD` (or `git diff --cached` for staged changes)
+- Otherwise, run: `git diff origin/main...HEAD` (or `git diff --cached` for staged changes)
 
 ## Step 2: Priority 1 — ECS and Command-Pattern Compliance
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,3 +28,21 @@ reviews:
           3. The PR description includes a concrete, non-placeholder explanation of why an end-to-end regression test was not added.
 
           Fail otherwise. When failing, mention which bug-fix signal you found and ask the author to either add or update a Playwright regression test under `browser_tests/` or add a concrete explanation in the PR description of why an end-to-end regression test is not practical.
+      - name: ADR compliance for entity/litegraph changes
+        mode: warning
+        instructions: |
+          Use only PR metadata already available in the review context: the changed-file list relative to the PR base, the PR description, and the diff content. Do not rely on shell commands.
+
+          This check applies ONLY when the PR modifies files under `src/lib/litegraph/`, `src/ecs/`, or files related to graph entities (nodes, links, widgets, slots, reroutes, groups, subgraphs).
+
+          If none of those paths appear in the changed files, pass immediately.
+
+          When applicable, check for:
+          1. **Command pattern (ADR 0003)**: Entity state mutations must be serializable, idempotent, deterministic commands — not imperative fire-and-forget side effects. Flag direct spatial mutation (`node.pos =`, `node.size =`, `group.pos =`) outside of a store or command, and any new void-returning mutation API that should produce a command object.
+          2. **God-object growth (ADR 0008)**: New methods/properties added to `LGraphNode`, `LGraphCanvas`, `LGraph`, or `Subgraph` that add responsibilities rather than extracting/migrating existing ones.
+          3. **ECS data/behavior separation (ADR 0008)**: Component-like data structures that contain methods or back-references to parent entities. ECS components must be plain data. New OOP instance patterns (`node.someProperty`, `node.someMethod()`) for data that should be a World component.
+          4. **Extension ecosystem (ADR 0008)**: Changes to extension-facing callbacks (`onConnectionsChange`, `onRemoved`, `onAdded`, `onConfigure`, `onConnectInput/Output`, `onWidgetChanged`), `node.widgets` access, `node.serialize` overrides, or `graph._version++` without migration guidance. These affect 40+ custom node repos.
+
+          Pass if none of these patterns are found in the diff.
+
+          When warning, reference the specific ADR by number and link to `docs/adr/` for context. Frame findings as directional guidance since ADR 0003 and 0008 are in Proposed status.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,18 @@ See @docs/testing/\*.md for detailed patterns.
 - Nx: <https://nx.dev/docs/reference/nx-commands>
 - [Practical Test Pyramid](https://martinfowler.com/articles/practical-test-pyramid.html)
 
+## Architecture Decision Records
+
+All architectural decisions are documented in `docs/adr/`. Code changes must be consistent with accepted ADRs. Proposed ADRs indicate design direction and should be treated as guidance. See `.agents/checks/adr-compliance.md` for automated validation rules.
+
+### Entity Architecture Constraints (ADR 0003 + ADR 0008)
+
+1. **Command pattern for all mutations**: Every entity state change must be a serializable, idempotent, deterministic command — replayable, undoable, and transmittable over CRDT. No imperative fire-and-forget mutation APIs. Systems produce command batches, not direct side effects.
+2. **Centralized registries and ECS-style access**: Entity data lives in the World (centralized registry), queried via `world.getComponent(entityId, ComponentType)`. Do not add new instance properties/methods to entity classes. Do not use OOP inheritance for entity modeling.
+3. **No god-object growth**: Do not add methods to `LGraphNode`, `LGraphCanvas`, `LGraph`, or `Subgraph`. Extract to systems, stores, or composables.
+4. **Plain data components**: ECS components are plain data objects — no methods, no back-references to parent entities. Behavior belongs in systems (pure functions).
+5. **Extension ecosystem impact**: Changes to entity callbacks (`onConnectionsChange`, `onRemoved`, `onAdded`, `onConnectInput/Output`, `onConfigure`, `onWidgetChanged`), `node.widgets` access, `node.serialize`, or `graph._version++` affect 40+ custom node repos and require migration guidance.
+
 ## Project Philosophy
 
 - Follow good software engineering principles


### PR DESCRIPTION
## Summary

Adds automated guardrails to ensure future PRs are validated against the project's Architecture Decision Records, particularly ADR 0003 (CRDT command pattern) and ADR 0008 (ECS).

## Changes

### Agent check: `.agents/checks/adr-compliance.md`
Automated check that validates code changes against all accepted and proposed ADRs. Flags:
- New god-object methods on LGraphNode/LGraphCanvas/LGraph
- Direct spatial mutation bypassing command pattern
- Imperative entity APIs without command-pattern wrappers
- Mixed data/behavior in component-like structures
- Circular entity dependencies

### Claude command: `.claude/commands/adr-compliance-audit.md`
On-demand audit command that reads all ADRs and architecture docs, diffs the current changes, and generates a structured compliance report with hard violations, directional conflicts, and open questions.

### AGENTS.md update
Added "Architecture Decision Records" section with:
- Key ADR summaries (0003 and 0008)
- Architectural constraints (command pattern, no god-object growth, data/behavior separation, incremental migration)
- Cross-references to `docs/adr/` and `docs/architecture/`

### CodeRabbit check: `.coderabbit.yaml`
Added a warning-level pre-merge check that triggers on entity/litegraph file changes and validates against ADR 0003 and 0008 constraints.

Targets PR #10420

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10539-docs-add-ADR-compliance-guardrails-for-agents-and-reviewers-32e6d73d365081dc90d0ece0a55edb27) by [Unito](https://www.unito.io)
