### PR TITLE
test(infra): AssetHelper with builder pattern + deterministic fixtures

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -29,7 +29,8 @@ import {
 } from '@e2e/fixtures/components/SidebarTab'
 import { Topbar } from '@e2e/fixtures/components/Topbar'
 import { AppModeHelper } from '@e2e/fixtures/helpers/AppModeHelper'
-import { AssetHelper } from '@e2e/fixtures/helpers/AssetHelper'
+import type { AssetHelper } from '@e2e/fixtures/helpers/AssetHelper'
+import { createAssetHelper } from '@e2e/fixtures/helpers/AssetHelper'
 import { AssetsHelper } from '@e2e/fixtures/helpers/AssetsHelper'
 import { CanvasHelper } from '@e2e/fixtures/helpers/CanvasHelper'
 import { ClipboardHelper } from '@e2e/fixtures/helpers/ClipboardHelper'
@@ -229,7 +230,7 @@ export class ComfyPage {
     this.queuePanel = new QueuePanel(page)
     this.perf = new PerformanceHelper(page)
     this.assets = new AssetsHelper(page)
-    this.assetApi = new AssetHelper(page)
+    this.assetApi = createAssetHelper(page)
     this.modelLibrary = new ModelLibraryHelper(page)
   }
 
@@ -451,6 +452,7 @@ export const comfyPageFixture = base.extend<{
 
     await use(comfyPage)
 
+    await comfyPage.assetApi.clearMocks()
     if (needsPerf) await comfyPage.perf.dispose()
   },
   comfyMouse: async ({ comfyPage }, use) => {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -29,6 +29,7 @@ import {
 } from '@e2e/fixtures/components/SidebarTab'
 import { Topbar } from '@e2e/fixtures/components/Topbar'
 import { AppModeHelper } from '@e2e/fixtures/helpers/AppModeHelper'
+import { AssetHelper } from '@e2e/fixtures/helpers/AssetHelper'
 import { AssetsHelper } from '@e2e/fixtures/helpers/AssetsHelper'
 import { CanvasHelper } from '@e2e/fixtures/helpers/CanvasHelper'
 import { ClipboardHelper } from '@e2e/fixtures/helpers/ClipboardHelper'
@@ -177,6 +178,7 @@ export class ComfyPage {
   public readonly queuePanel: QueuePanel
   public readonly perf: PerformanceHelper
   public readonly assets: AssetsHelper
+  public readonly assetApi: AssetHelper
   public readonly modelLibrary: ModelLibraryHelper
 
   /** Worker index to test user ID */
@@ -227,6 +229,7 @@ export class ComfyPage {
     this.queuePanel = new QueuePanel(page)
     this.perf = new PerformanceHelper(page)
     this.assets = new AssetsHelper(page)
+    this.assetApi = new AssetHelper(page)
     this.modelLibrary = new ModelLibraryHelper(page)
   }
 

--- a/browser_tests/fixtures/data/assetFixtures.ts
+++ b/browser_tests/fixtures/data/assetFixtures.ts
@@ -1,7 +1,4 @@
 import type { Asset } from '@comfyorg/ingest-types'
-
-// ─── Factory Helpers ───────────────────────────────────────────────────────────
-
 function createModelAsset(overrides: Partial<Asset> = {}): Asset {
   return {
     id: 'test-model-001',
@@ -50,9 +47,6 @@ function createOutputAsset(overrides: Partial<Asset> = {}): Asset {
     ...overrides
   }
 }
-
-// ─── Stable Fixtures (deterministic for screenshot tests) ──────────────────────
-
 export const STABLE_CHECKPOINT: Asset = createModelAsset({
   id: 'test-checkpoint-001',
   name: 'sd_xl_base_1.0.safetensors',
@@ -181,9 +175,6 @@ export const STABLE_OUTPUT_2: Asset = createOutputAsset({
   created_at: '2025-03-10T12:05:00Z',
   updated_at: '2025-03-10T12:05:00Z'
 })
-
-// ─── Preset Collections ────────────────────────────────────────────────────────
-
 export const ALL_MODEL_FIXTURES: Asset[] = [
   STABLE_CHECKPOINT,
   STABLE_CHECKPOINT_2,
@@ -200,9 +191,6 @@ export const ALL_INPUT_FIXTURES: Asset[] = [
 ]
 
 export const ALL_OUTPUT_FIXTURES: Asset[] = [STABLE_OUTPUT, STABLE_OUTPUT_2]
-
-// ─── Factories for generating N deterministic assets ───────────────────────────
-
 const CHECKPOINT_NAMES = [
   'sd_xl_base_1.0.safetensors',
   'v1-5-pruned-emaonly.safetensors',

--- a/browser_tests/fixtures/data/assetFixtures.ts
+++ b/browser_tests/fixtures/data/assetFixtures.ts
@@ -1,0 +1,307 @@
+import type { AssetItem } from '../../../src/platform/assets/schemas/assetSchema'
+
+// ─── Factory Helpers ───────────────────────────────────────────────────────────
+
+function createModelAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'test-model-001',
+    name: 'model.safetensors',
+    asset_hash:
+      'blake3:0000000000000000000000000000000000000000000000000000000000000000',
+    size: 2_147_483_648,
+    mime_type: 'application/octet-stream',
+    tags: ['models', 'checkpoints'],
+    created_at: '2025-01-15T10:00:00Z',
+    updated_at: '2025-01-15T10:00:00Z',
+    last_access_time: '2025-01-15T10:00:00Z',
+    user_metadata: { base_model: 'sd15' },
+    ...overrides
+  }
+}
+
+function createInputAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'test-input-001',
+    name: 'input.png',
+    asset_hash:
+      'blake3:1111111111111111111111111111111111111111111111111111111111111111',
+    size: 2_048_576,
+    mime_type: 'image/png',
+    tags: ['input'],
+    created_at: '2025-03-01T09:00:00Z',
+    updated_at: '2025-03-01T09:00:00Z',
+    last_access_time: '2025-03-01T09:00:00Z',
+    ...overrides
+  }
+}
+
+function createOutputAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'test-output-001',
+    name: 'output_00001.png',
+    asset_hash:
+      'blake3:2222222222222222222222222222222222222222222222222222222222222222',
+    size: 4_194_304,
+    mime_type: 'image/png',
+    tags: ['output'],
+    created_at: '2025-03-10T12:00:00Z',
+    updated_at: '2025-03-10T12:00:00Z',
+    last_access_time: '2025-03-10T12:00:00Z',
+    ...overrides
+  }
+}
+
+// ─── Stable Fixtures (deterministic for screenshot tests) ──────────────────────
+
+export const STABLE_CHECKPOINT: AssetItem = createModelAsset({
+  id: 'test-checkpoint-001',
+  name: 'sd_xl_base_1.0.safetensors',
+  size: 6_938_078_208,
+  tags: ['models', 'checkpoints'],
+  user_metadata: {
+    base_model: 'sdxl',
+    description: 'Stable Diffusion XL Base 1.0'
+  },
+  created_at: '2025-01-15T10:30:00Z',
+  updated_at: '2025-01-15T10:30:00Z'
+})
+
+export const STABLE_CHECKPOINT_2: AssetItem = createModelAsset({
+  id: 'test-checkpoint-002',
+  name: 'v1-5-pruned-emaonly.safetensors',
+  size: 4_265_146_304,
+  tags: ['models', 'checkpoints'],
+  user_metadata: {
+    base_model: 'sd15',
+    description: 'Stable Diffusion 1.5 Pruned EMA-Only'
+  },
+  created_at: '2025-01-20T08:00:00Z',
+  updated_at: '2025-01-20T08:00:00Z'
+})
+
+export const STABLE_LORA: AssetItem = createModelAsset({
+  id: 'test-lora-001',
+  name: 'detail_enhancer_v1.2.safetensors',
+  size: 184_549_376,
+  tags: ['models', 'loras'],
+  user_metadata: {
+    base_model: 'sdxl',
+    description: 'Detail Enhancement LoRA'
+  },
+  created_at: '2025-02-20T14:00:00Z',
+  updated_at: '2025-02-20T14:00:00Z'
+})
+
+export const STABLE_LORA_2: AssetItem = createModelAsset({
+  id: 'test-lora-002',
+  name: 'add_detail_v2.safetensors',
+  size: 226_492_416,
+  tags: ['models', 'loras'],
+  user_metadata: {
+    base_model: 'sd15',
+    description: 'Add Detail LoRA v2'
+  },
+  created_at: '2025-02-25T11:00:00Z',
+  updated_at: '2025-02-25T11:00:00Z'
+})
+
+export const STABLE_VAE: AssetItem = createModelAsset({
+  id: 'test-vae-001',
+  name: 'sdxl_vae.safetensors',
+  size: 334_641_152,
+  tags: ['models', 'vae'],
+  user_metadata: {
+    base_model: 'sdxl',
+    description: 'SDXL VAE'
+  },
+  created_at: '2025-01-18T16:00:00Z',
+  updated_at: '2025-01-18T16:00:00Z'
+})
+
+export const STABLE_EMBEDDING: AssetItem = createModelAsset({
+  id: 'test-embedding-001',
+  name: 'bad_prompt_v2.pt',
+  size: 32_768,
+  mime_type: 'application/x-pytorch',
+  tags: ['models', 'embeddings'],
+  user_metadata: {
+    base_model: 'sd15',
+    description: 'Negative Embedding: Bad Prompt v2'
+  },
+  created_at: '2025-02-01T09:30:00Z',
+  updated_at: '2025-02-01T09:30:00Z'
+})
+
+export const STABLE_INPUT_IMAGE: AssetItem = createInputAsset({
+  id: 'test-input-001',
+  name: 'reference_photo.png',
+  size: 2_048_576,
+  mime_type: 'image/png',
+  tags: ['input'],
+  created_at: '2025-03-01T09:00:00Z',
+  updated_at: '2025-03-01T09:00:00Z'
+})
+
+export const STABLE_INPUT_IMAGE_2: AssetItem = createInputAsset({
+  id: 'test-input-002',
+  name: 'mask_layer.png',
+  size: 1_048_576,
+  mime_type: 'image/png',
+  tags: ['input'],
+  created_at: '2025-03-05T10:00:00Z',
+  updated_at: '2025-03-05T10:00:00Z'
+})
+
+export const STABLE_INPUT_VIDEO: AssetItem = createInputAsset({
+  id: 'test-input-003',
+  name: 'clip_720p.mp4',
+  size: 15_728_640,
+  mime_type: 'video/mp4',
+  tags: ['input'],
+  created_at: '2025-03-08T14:30:00Z',
+  updated_at: '2025-03-08T14:30:00Z'
+})
+
+export const STABLE_OUTPUT: AssetItem = createOutputAsset({
+  id: 'test-output-001',
+  name: 'ComfyUI_00001_.png',
+  size: 4_194_304,
+  mime_type: 'image/png',
+  tags: ['output'],
+  created_at: '2025-03-10T12:00:00Z',
+  updated_at: '2025-03-10T12:00:00Z'
+})
+
+export const STABLE_OUTPUT_2: AssetItem = createOutputAsset({
+  id: 'test-output-002',
+  name: 'ComfyUI_00002_.png',
+  size: 3_670_016,
+  mime_type: 'image/png',
+  tags: ['output'],
+  created_at: '2025-03-10T12:05:00Z',
+  updated_at: '2025-03-10T12:05:00Z'
+})
+
+// ─── Preset Collections ────────────────────────────────────────────────────────
+
+export const ALL_MODEL_FIXTURES: AssetItem[] = [
+  STABLE_CHECKPOINT,
+  STABLE_CHECKPOINT_2,
+  STABLE_LORA,
+  STABLE_LORA_2,
+  STABLE_VAE,
+  STABLE_EMBEDDING
+]
+
+export const ALL_INPUT_FIXTURES: AssetItem[] = [
+  STABLE_INPUT_IMAGE,
+  STABLE_INPUT_IMAGE_2,
+  STABLE_INPUT_VIDEO
+]
+
+export const ALL_OUTPUT_FIXTURES: AssetItem[] = [STABLE_OUTPUT, STABLE_OUTPUT_2]
+
+// ─── Factories for generating N deterministic assets ───────────────────────────
+
+const CHECKPOINT_NAMES = [
+  'sd_xl_base_1.0.safetensors',
+  'v1-5-pruned-emaonly.safetensors',
+  'sd_xl_refiner_1.0.safetensors',
+  'dreamshaper_8.safetensors',
+  'realisticVision_v51.safetensors',
+  'deliberate_v3.safetensors',
+  'anything_v5.safetensors',
+  'counterfeit_v3.safetensors',
+  'revAnimated_v122.safetensors',
+  'majicmixRealistic_v7.safetensors'
+]
+
+const LORA_NAMES = [
+  'detail_enhancer_v1.2.safetensors',
+  'add_detail_v2.safetensors',
+  'epi_noiseoffset_v2.safetensors',
+  'lcm_lora_sdxl.safetensors',
+  'film_grain_v1.safetensors',
+  'sharpness_fix_v2.safetensors',
+  'better_hands_v1.safetensors',
+  'smooth_skin_v3.safetensors',
+  'color_pop_v1.safetensors',
+  'bokeh_effect_v2.safetensors'
+]
+
+const INPUT_NAMES = [
+  'reference_photo.png',
+  'mask_layer.png',
+  'clip_720p.mp4',
+  'depth_map.png',
+  'control_pose.png',
+  'sketch_input.jpg',
+  'inpainting_mask.png',
+  'style_reference.png',
+  'batch_001.png',
+  'batch_002.png'
+]
+
+const INPUT_MIMES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.mp4': 'video/mp4'
+}
+
+/**
+ * Generate N deterministic model assets of a given category.
+ * Uses sequential IDs and fixed names for screenshot stability.
+ */
+export function generateModels(
+  count: number,
+  category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
+): AssetItem[] {
+  const names = category === 'loras' ? LORA_NAMES : CHECKPOINT_NAMES
+  return Array.from({ length: Math.min(count, names.length) }, (_, i) =>
+    createModelAsset({
+      id: `gen-${category}-${String(i + 1).padStart(3, '0')}`,
+      name: names[i % names.length],
+      size: 2_000_000_000 + i * 500_000_000,
+      tags: ['models', category],
+      user_metadata: { base_model: i % 2 === 0 ? 'sdxl' : 'sd15' },
+      created_at: `2025-01-${String(15 + i).padStart(2, '0')}T10:00:00Z`,
+      updated_at: `2025-01-${String(15 + i).padStart(2, '0')}T10:00:00Z`
+    })
+  )
+}
+
+/**
+ * Generate N deterministic input file assets.
+ */
+export function generateInputFiles(count: number): AssetItem[] {
+  return Array.from({ length: Math.min(count, INPUT_NAMES.length) }, (_, i) => {
+    const name = INPUT_NAMES[i % INPUT_NAMES.length]
+    const ext = name.substring(name.lastIndexOf('.'))
+    return createInputAsset({
+      id: `gen-input-${String(i + 1).padStart(3, '0')}`,
+      name,
+      size: 1_000_000 + i * 500_000,
+      mime_type: INPUT_MIMES[ext] ?? 'application/octet-stream',
+      tags: ['input'],
+      created_at: `2025-03-${String(1 + i).padStart(2, '0')}T09:00:00Z`,
+      updated_at: `2025-03-${String(1 + i).padStart(2, '0')}T09:00:00Z`
+    })
+  })
+}
+
+/**
+ * Generate N deterministic output assets.
+ */
+export function generateOutputAssets(count: number): AssetItem[] {
+  return Array.from({ length: count }, (_, i) =>
+    createOutputAsset({
+      id: `gen-output-${String(i + 1).padStart(3, '0')}`,
+      name: `ComfyUI_${String(i + 1).padStart(5, '0')}_.png`,
+      size: 3_000_000 + i * 200_000,
+      mime_type: 'image/png',
+      tags: ['output'],
+      created_at: `2025-03-10T${String(12 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`,
+      updated_at: `2025-03-10T${String(12 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`
+    })
+  )
+}

--- a/browser_tests/fixtures/data/assetFixtures.ts
+++ b/browser_tests/fixtures/data/assetFixtures.ts
@@ -1,8 +1,8 @@
-import type { AssetItem } from '../../../src/platform/assets/schemas/assetSchema'
+import type { Asset } from '@comfyorg/ingest-types'
 
 // ─── Factory Helpers ───────────────────────────────────────────────────────────
 
-function createModelAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+function createModelAsset(overrides: Partial<Asset> = {}): Asset {
   return {
     id: 'test-model-001',
     name: 'model.safetensors',
@@ -19,7 +19,7 @@ function createModelAsset(overrides: Partial<AssetItem> = {}): AssetItem {
   }
 }
 
-function createInputAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+function createInputAsset(overrides: Partial<Asset> = {}): Asset {
   return {
     id: 'test-input-001',
     name: 'input.png',
@@ -35,7 +35,7 @@ function createInputAsset(overrides: Partial<AssetItem> = {}): AssetItem {
   }
 }
 
-function createOutputAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+function createOutputAsset(overrides: Partial<Asset> = {}): Asset {
   return {
     id: 'test-output-001',
     name: 'output_00001.png',
@@ -53,7 +53,7 @@ function createOutputAsset(overrides: Partial<AssetItem> = {}): AssetItem {
 
 // ─── Stable Fixtures (deterministic for screenshot tests) ──────────────────────
 
-export const STABLE_CHECKPOINT: AssetItem = createModelAsset({
+export const STABLE_CHECKPOINT: Asset = createModelAsset({
   id: 'test-checkpoint-001',
   name: 'sd_xl_base_1.0.safetensors',
   size: 6_938_078_208,
@@ -66,7 +66,7 @@ export const STABLE_CHECKPOINT: AssetItem = createModelAsset({
   updated_at: '2025-01-15T10:30:00Z'
 })
 
-export const STABLE_CHECKPOINT_2: AssetItem = createModelAsset({
+export const STABLE_CHECKPOINT_2: Asset = createModelAsset({
   id: 'test-checkpoint-002',
   name: 'v1-5-pruned-emaonly.safetensors',
   size: 4_265_146_304,
@@ -79,7 +79,7 @@ export const STABLE_CHECKPOINT_2: AssetItem = createModelAsset({
   updated_at: '2025-01-20T08:00:00Z'
 })
 
-export const STABLE_LORA: AssetItem = createModelAsset({
+export const STABLE_LORA: Asset = createModelAsset({
   id: 'test-lora-001',
   name: 'detail_enhancer_v1.2.safetensors',
   size: 184_549_376,
@@ -92,7 +92,7 @@ export const STABLE_LORA: AssetItem = createModelAsset({
   updated_at: '2025-02-20T14:00:00Z'
 })
 
-export const STABLE_LORA_2: AssetItem = createModelAsset({
+export const STABLE_LORA_2: Asset = createModelAsset({
   id: 'test-lora-002',
   name: 'add_detail_v2.safetensors',
   size: 226_492_416,
@@ -105,7 +105,7 @@ export const STABLE_LORA_2: AssetItem = createModelAsset({
   updated_at: '2025-02-25T11:00:00Z'
 })
 
-export const STABLE_VAE: AssetItem = createModelAsset({
+export const STABLE_VAE: Asset = createModelAsset({
   id: 'test-vae-001',
   name: 'sdxl_vae.safetensors',
   size: 334_641_152,
@@ -118,7 +118,7 @@ export const STABLE_VAE: AssetItem = createModelAsset({
   updated_at: '2025-01-18T16:00:00Z'
 })
 
-export const STABLE_EMBEDDING: AssetItem = createModelAsset({
+export const STABLE_EMBEDDING: Asset = createModelAsset({
   id: 'test-embedding-001',
   name: 'bad_prompt_v2.pt',
   size: 32_768,
@@ -132,7 +132,7 @@ export const STABLE_EMBEDDING: AssetItem = createModelAsset({
   updated_at: '2025-02-01T09:30:00Z'
 })
 
-export const STABLE_INPUT_IMAGE: AssetItem = createInputAsset({
+export const STABLE_INPUT_IMAGE: Asset = createInputAsset({
   id: 'test-input-001',
   name: 'reference_photo.png',
   size: 2_048_576,
@@ -142,7 +142,7 @@ export const STABLE_INPUT_IMAGE: AssetItem = createInputAsset({
   updated_at: '2025-03-01T09:00:00Z'
 })
 
-export const STABLE_INPUT_IMAGE_2: AssetItem = createInputAsset({
+export const STABLE_INPUT_IMAGE_2: Asset = createInputAsset({
   id: 'test-input-002',
   name: 'mask_layer.png',
   size: 1_048_576,
@@ -152,7 +152,7 @@ export const STABLE_INPUT_IMAGE_2: AssetItem = createInputAsset({
   updated_at: '2025-03-05T10:00:00Z'
 })
 
-export const STABLE_INPUT_VIDEO: AssetItem = createInputAsset({
+export const STABLE_INPUT_VIDEO: Asset = createInputAsset({
   id: 'test-input-003',
   name: 'clip_720p.mp4',
   size: 15_728_640,
@@ -162,7 +162,7 @@ export const STABLE_INPUT_VIDEO: AssetItem = createInputAsset({
   updated_at: '2025-03-08T14:30:00Z'
 })
 
-export const STABLE_OUTPUT: AssetItem = createOutputAsset({
+export const STABLE_OUTPUT: Asset = createOutputAsset({
   id: 'test-output-001',
   name: 'ComfyUI_00001_.png',
   size: 4_194_304,
@@ -172,7 +172,7 @@ export const STABLE_OUTPUT: AssetItem = createOutputAsset({
   updated_at: '2025-03-10T12:00:00Z'
 })
 
-export const STABLE_OUTPUT_2: AssetItem = createOutputAsset({
+export const STABLE_OUTPUT_2: Asset = createOutputAsset({
   id: 'test-output-002',
   name: 'ComfyUI_00002_.png',
   size: 3_670_016,
@@ -184,7 +184,7 @@ export const STABLE_OUTPUT_2: AssetItem = createOutputAsset({
 
 // ─── Preset Collections ────────────────────────────────────────────────────────
 
-export const ALL_MODEL_FIXTURES: AssetItem[] = [
+export const ALL_MODEL_FIXTURES: Asset[] = [
   STABLE_CHECKPOINT,
   STABLE_CHECKPOINT_2,
   STABLE_LORA,
@@ -193,13 +193,13 @@ export const ALL_MODEL_FIXTURES: AssetItem[] = [
   STABLE_EMBEDDING
 ]
 
-export const ALL_INPUT_FIXTURES: AssetItem[] = [
+export const ALL_INPUT_FIXTURES: Asset[] = [
   STABLE_INPUT_IMAGE,
   STABLE_INPUT_IMAGE_2,
   STABLE_INPUT_VIDEO
 ]
 
-export const ALL_OUTPUT_FIXTURES: AssetItem[] = [STABLE_OUTPUT, STABLE_OUTPUT_2]
+export const ALL_OUTPUT_FIXTURES: Asset[] = [STABLE_OUTPUT, STABLE_OUTPUT_2]
 
 // ─── Factories for generating N deterministic assets ───────────────────────────
 
@@ -255,7 +255,7 @@ const INPUT_MIMES: Record<string, string> = {
 export function generateModels(
   count: number,
   category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
-): AssetItem[] {
+): Asset[] {
   const names = category === 'loras' ? LORA_NAMES : CHECKPOINT_NAMES
   return Array.from({ length: Math.min(count, names.length) }, (_, i) =>
     createModelAsset({
@@ -273,7 +273,7 @@ export function generateModels(
 /**
  * Generate N deterministic input file assets.
  */
-export function generateInputFiles(count: number): AssetItem[] {
+export function generateInputFiles(count: number): Asset[] {
   return Array.from({ length: Math.min(count, INPUT_NAMES.length) }, (_, i) => {
     const name = INPUT_NAMES[i % INPUT_NAMES.length]
     const ext = name.substring(name.lastIndexOf('.'))
@@ -292,7 +292,7 @@ export function generateInputFiles(count: number): AssetItem[] {
 /**
  * Generate N deterministic output assets.
  */
-export function generateOutputAssets(count: number): AssetItem[] {
+export function generateOutputAssets(count: number): Asset[] {
   return Array.from({ length: count }, (_, i) =>
     createOutputAsset({
       id: `gen-output-${String(i + 1).padStart(3, '0')}`,

--- a/browser_tests/fixtures/data/assetFixtures.ts
+++ b/browser_tests/fixtures/data/assetFixtures.ts
@@ -242,10 +242,22 @@ const INPUT_NAMES = [
   'batch_002.png'
 ]
 
-const INPUT_MIMES: Record<string, string> = {
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.mp4': 'video/mp4'
+const EXTENSION_MIME_MAP: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac'
+}
+
+function getMimeType(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+  return EXTENSION_MIME_MAP[ext] ?? 'application/octet-stream'
 }
 
 /**
@@ -276,12 +288,11 @@ export function generateModels(
 export function generateInputFiles(count: number): Asset[] {
   return Array.from({ length: Math.min(count, INPUT_NAMES.length) }, (_, i) => {
     const name = INPUT_NAMES[i % INPUT_NAMES.length]
-    const ext = name.substring(name.lastIndexOf('.'))
     return createInputAsset({
       id: `gen-input-${String(i + 1).padStart(3, '0')}`,
       name,
       size: 1_000_000 + i * 500_000,
-      mime_type: INPUT_MIMES[ext] ?? 'application/octet-stream',
+      mime_type: getMimeType(name),
       tags: ['input'],
       created_at: `2025-03-${String(1 + i).padStart(2, '0')}T09:00:00Z`,
       updated_at: `2025-03-${String(1 + i).padStart(2, '0')}T09:00:00Z`

--- a/browser_tests/fixtures/data/assetFixtures.ts
+++ b/browser_tests/fixtures/data/assetFixtures.ts
@@ -300,8 +300,8 @@ export function generateOutputAssets(count: number): AssetItem[] {
       size: 3_000_000 + i * 200_000,
       mime_type: 'image/png',
       tags: ['output'],
-      created_at: `2025-03-10T${String(12 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`,
-      updated_at: `2025-03-10T${String(12 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`
+      created_at: `2025-03-10T${String((12 + Math.floor(i / 60)) % 24).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`,
+      updated_at: `2025-03-10T${String((12 + Math.floor(i / 60)) % 24).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`
     })
   )
 }

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -1,9 +1,9 @@
 import type { Page, Route } from '@playwright/test'
 
 import type {
-  AssetItem,
-  AssetResponse
-} from '../../../src/platform/assets/schemas/assetSchema'
+  Asset,
+  ListAssetsResponse
+} from '@comfyorg/ingest-types'
 import {
   generateModels,
   generateInputFiles,
@@ -24,7 +24,7 @@ interface PaginationOptions {
 }
 
 export class AssetHelper {
-  private store: Map<string, AssetItem> = new Map()
+  private store: Map<string, Asset> = new Map()
   private paginationOptions: PaginationOptions | null = null
   private routeHandlers: Array<{
     pattern: string
@@ -42,7 +42,7 @@ export class AssetHelper {
    * Accepts a count (generates deterministic fixtures) or an array of assets.
    */
   withModels(
-    countOrAssets: number | AssetItem[],
+    countOrAssets: number | Asset[],
     category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
   ): this {
     const assets =
@@ -58,7 +58,7 @@ export class AssetHelper {
   /**
    * Add input file assets to the mock store.
    */
-  withInputFiles(countOrAssets: number | AssetItem[]): this {
+  withInputFiles(countOrAssets: number | Asset[]): this {
     const assets =
       typeof countOrAssets === 'number'
         ? generateInputFiles(countOrAssets)
@@ -72,7 +72,7 @@ export class AssetHelper {
   /**
    * Add output assets to the mock store.
    */
-  withOutputAssets(countOrAssets: number | AssetItem[]): this {
+  withOutputAssets(countOrAssets: number | Asset[]): this {
     const assets =
       typeof countOrAssets === 'number'
         ? generateOutputAssets(countOrAssets)
@@ -86,7 +86,7 @@ export class AssetHelper {
   /**
    * Add a single specific asset to the mock store.
    */
-  withAsset(asset: AssetItem): this {
+  withAsset(asset: Asset): this {
     this.store.set(asset.id, asset)
     return this
   }
@@ -150,7 +150,7 @@ export class AssetHelper {
           filtered = filtered.slice(offset, offset + limit)
         }
 
-        const response: AssetResponse = {
+        const response: ListAssetsResponse = {
           assets: filtered,
           total: this.paginationOptions?.total ?? this.store.size,
           has_more: this.paginationOptions?.hasMore ?? false
@@ -264,14 +264,14 @@ export class AssetHelper {
   /**
    * Get the current assets in the mock store.
    */
-  getAssets(): AssetItem[] {
+  getAssets(): Asset[] {
     return [...this.store.values()]
   }
 
   /**
    * Get a single asset from the mock store by ID.
    */
-  getAsset(id: string): AssetItem | undefined {
+  getAsset(id: string): Asset | undefined {
     return this.store.get(id)
   }
 
@@ -300,7 +300,7 @@ export class AssetHelper {
 
   // ─── Internal ─────────────────────────────────────────────────────────────
 
-  private getFilteredAssets(tags: string[]): AssetItem[] {
+  private getFilteredAssets(tags: string[]): Asset[] {
     const assets = [...this.store.values()]
     if (tags.length === 0) return assets
 

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -201,13 +201,11 @@ export class AssetHelper {
       // POST /assets — upload
       if (method === 'POST' && /\/assets\/?$/.test(path)) {
         const response = this.uploadResponse ?? {
-          type: 'sync',
-          asset: {
-            id: `upload-${Date.now()}`,
-            name: 'uploaded_file.safetensors',
-            tags: ['models', 'checkpoints'],
-            created_at: new Date().toISOString()
-          }
+          id: `upload-${Date.now()}`,
+          name: 'uploaded_file.safetensors',
+          tags: ['models', 'checkpoints'],
+          created_at: new Date().toISOString(),
+          created_new: true
         }
         return route.fulfill({ status: 201, json: response })
       }
@@ -235,6 +233,8 @@ export class AssetHelper {
 
   /**
    * Mock a specific error response for any asset endpoint.
+   * Note: Call this before mock() or use clearMocks() first, as Playwright
+   * executes route handlers in LIFO registration order.
    */
   async mockError(
     statusCode: number,
@@ -305,7 +305,7 @@ export class AssetHelper {
     if (tags.length === 0) return assets
 
     return assets.filter((asset) =>
-      tags.every((tag) => asset.tags.includes(tag))
+      tags.every((tag) => (asset.tags ?? []).includes(tag))
     )
   }
 }

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -165,6 +165,36 @@ export class AssetHelper {
     this.routeHandlers.push({ pattern, handler })
     await this.page.route(pattern, handler)
   }
+  async fetch(
+    path: string,
+    init?: RequestInit
+  ): Promise<{ status: number; body: unknown }> {
+    return this.page.evaluate(
+      async ([fetchUrl, fetchInit]) => {
+        const res = await fetch(fetchUrl, fetchInit)
+        const text = await res.text()
+        let body: unknown
+        try {
+          body = JSON.parse(text)
+        } catch {
+          body = text
+        }
+        return { status: res.status, body }
+      },
+      [path, init] as const
+    )
+  }
+
+  configure(...operators: AssetOperator[]): void {
+    const config = operators.reduce<AssetConfig>(
+      (cfg, op) => op(cfg),
+      emptyConfig()
+    )
+    this.store = new Map(config.assets)
+    this.paginationOptions = config.pagination
+    this.uploadResponse = config.uploadResponse
+  }
+
   getMutations(): MutationRecord[] {
     return [...this.mutations]
   }

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -1,0 +1,311 @@
+import type { Page, Route } from '@playwright/test'
+
+import type {
+  AssetItem,
+  AssetResponse
+} from '../../../src/platform/assets/schemas/assetSchema'
+import {
+  generateModels,
+  generateInputFiles,
+  generateOutputAssets
+} from '../data/assetFixtures'
+
+export interface MutationRecord {
+  endpoint: string
+  method: string
+  url: string
+  body: unknown
+  timestamp: number
+}
+
+interface PaginationOptions {
+  total: number
+  hasMore: boolean
+}
+
+export class AssetHelper {
+  private store: Map<string, AssetItem> = new Map()
+  private paginationOptions: PaginationOptions | null = null
+  private routeHandlers: Array<{
+    pattern: string
+    handler: (route: Route) => Promise<void>
+  }> = []
+  private mutations: MutationRecord[] = []
+  private uploadResponse: Record<string, unknown> | null = null
+
+  constructor(private readonly page: Page) {}
+
+  // ─── Builder Methods (return `this` for chaining) ─────────────────────────
+
+  /**
+   * Add model assets to the mock store.
+   * Accepts a count (generates deterministic fixtures) or an array of assets.
+   */
+  withModels(
+    countOrAssets: number | AssetItem[],
+    category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
+  ): this {
+    const assets =
+      typeof countOrAssets === 'number'
+        ? generateModels(countOrAssets, category)
+        : countOrAssets
+    for (const asset of assets) {
+      this.store.set(asset.id, asset)
+    }
+    return this
+  }
+
+  /**
+   * Add input file assets to the mock store.
+   */
+  withInputFiles(countOrAssets: number | AssetItem[]): this {
+    const assets =
+      typeof countOrAssets === 'number'
+        ? generateInputFiles(countOrAssets)
+        : countOrAssets
+    for (const asset of assets) {
+      this.store.set(asset.id, asset)
+    }
+    return this
+  }
+
+  /**
+   * Add output assets to the mock store.
+   */
+  withOutputAssets(countOrAssets: number | AssetItem[]): this {
+    const assets =
+      typeof countOrAssets === 'number'
+        ? generateOutputAssets(countOrAssets)
+        : countOrAssets
+    for (const asset of assets) {
+      this.store.set(asset.id, asset)
+    }
+    return this
+  }
+
+  /**
+   * Add a single specific asset to the mock store.
+   */
+  withAsset(asset: AssetItem): this {
+    this.store.set(asset.id, asset)
+    return this
+  }
+
+  /**
+   * Set empty state (no assets). Clears any previously added assets.
+   */
+  withEmptyState(): this {
+    this.store.clear()
+    return this
+  }
+
+  /**
+   * Configure pagination behavior for the list response.
+   */
+  withPagination(options: PaginationOptions): this {
+    this.paginationOptions = options
+    return this
+  }
+
+  /**
+   * Configure a custom upload response for POST /assets.
+   */
+  withUploadResponse(response: Record<string, unknown>): this {
+    this.uploadResponse = response
+    return this
+  }
+
+  // ─── Activation ───────────────────────────────────────────────────────────
+
+  /**
+   * Install all route handlers based on current builder state.
+   * Must be called before page.goto().
+   */
+  async mock(): Promise<void> {
+    const handler = async (route: Route) => {
+      const url = new URL(route.request().url())
+      const method = route.request().method()
+      const path = url.pathname
+
+      // Track mutations
+      if (['POST', 'PUT', 'DELETE'].includes(method)) {
+        this.mutations.push({
+          endpoint: path,
+          method,
+          url: route.request().url(),
+          body: route.request().postDataJSON(),
+          timestamp: Date.now()
+        })
+      }
+
+      // GET /assets — list assets
+      if (method === 'GET' && /\/assets\/?$/.test(path)) {
+        const includeTags =
+          url.searchParams.get('include_tags')?.split(',') ?? []
+        const limit = parseInt(url.searchParams.get('limit') ?? '0', 10)
+        const offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
+
+        let filtered = this.getFilteredAssets(includeTags)
+        if (limit > 0) {
+          filtered = filtered.slice(offset, offset + limit)
+        }
+
+        const response: AssetResponse = {
+          assets: filtered,
+          total: this.paginationOptions?.total ?? this.store.size,
+          has_more: this.paginationOptions?.hasMore ?? false
+        }
+        return route.fulfill({ json: response })
+      }
+
+      // GET /assets/:id — single asset details
+      if (method === 'GET' && /\/assets\/[^/]+$/.test(path)) {
+        const id = path.split('/').pop()!
+        const asset = this.store.get(id)
+        if (asset) {
+          return route.fulfill({ json: asset })
+        }
+        return route.fulfill({
+          status: 404,
+          json: { error: 'Not found' }
+        })
+      }
+
+      // PUT /assets/:id — update asset
+      if (method === 'PUT' && /\/assets\/[^/]+$/.test(path)) {
+        const id = path.split('/').pop()!
+        const asset = this.store.get(id)
+        if (asset) {
+          const body = route.request().postDataJSON()
+          const updated = {
+            ...asset,
+            ...body,
+            updated_at: new Date().toISOString()
+          }
+          this.store.set(id, updated)
+          return route.fulfill({ json: updated })
+        }
+        return route.fulfill({
+          status: 404,
+          json: { error: 'Not found' }
+        })
+      }
+
+      // DELETE /assets/:id — delete asset
+      if (method === 'DELETE' && /\/assets\/[^/]+$/.test(path)) {
+        const id = path.split('/').pop()!
+        this.store.delete(id)
+        return route.fulfill({ status: 204, body: '' })
+      }
+
+      // POST /assets — upload
+      if (method === 'POST' && /\/assets\/?$/.test(path)) {
+        const response = this.uploadResponse ?? {
+          type: 'sync',
+          asset: {
+            id: `upload-${Date.now()}`,
+            name: 'uploaded_file.safetensors',
+            tags: ['models', 'checkpoints'],
+            created_at: new Date().toISOString()
+          }
+        }
+        return route.fulfill({ status: 201, json: response })
+      }
+
+      // POST /assets/download — async download
+      if (method === 'POST' && path.endsWith('/assets/download')) {
+        return route.fulfill({
+          status: 202,
+          json: {
+            task_id: 'download-task-001',
+            status: 'created',
+            message: 'Download started'
+          }
+        })
+      }
+
+      // Fallback — let unhandled requests through
+      return route.fallback()
+    }
+
+    const pattern = '**/assets**'
+    this.routeHandlers.push({ pattern, handler })
+    await this.page.route(pattern, handler)
+  }
+
+  /**
+   * Mock a specific error response for any asset endpoint.
+   */
+  async mockError(
+    statusCode: number,
+    error: string = 'Internal Server Error'
+  ): Promise<void> {
+    const handler = async (route: Route) => {
+      return route.fulfill({
+        status: statusCode,
+        json: { error }
+      })
+    }
+
+    const pattern = '**/assets**'
+    this.routeHandlers.push({ pattern, handler })
+    await this.page.route(pattern, handler)
+  }
+
+  // ─── Inspection ───────────────────────────────────────────────────────────
+
+  /**
+   * Get all recorded mutations (POST, PUT, DELETE requests).
+   */
+  getMutations(): MutationRecord[] {
+    return [...this.mutations]
+  }
+
+  /**
+   * Get the current assets in the mock store.
+   */
+  getAssets(): AssetItem[] {
+    return [...this.store.values()]
+  }
+
+  /**
+   * Get a single asset from the mock store by ID.
+   */
+  getAsset(id: string): AssetItem | undefined {
+    return this.store.get(id)
+  }
+
+  /**
+   * Get the number of assets currently in the mock store.
+   */
+  get assetCount(): number {
+    return this.store.size
+  }
+
+  // ─── Cleanup ──────────────────────────────────────────────────────────────
+
+  /**
+   * Clear all route mocks and reset internal state.
+   */
+  async clearMocks(): Promise<void> {
+    for (const { pattern, handler } of this.routeHandlers) {
+      await this.page.unroute(pattern, handler)
+    }
+    this.routeHandlers = []
+    this.store.clear()
+    this.mutations = []
+    this.paginationOptions = null
+    this.uploadResponse = null
+  }
+
+  // ─── Internal ─────────────────────────────────────────────────────────────
+
+  private getFilteredAssets(tags: string[]): AssetItem[] {
+    const assets = [...this.store.values()]
+    if (tags.length === 0) return assets
+
+    return assets.filter((asset) =>
+      tags.every((tag) => asset.tags.includes(tag))
+    )
+  }
+}

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -1,9 +1,6 @@
 import type { Page, Route } from '@playwright/test'
 
-import type {
-  Asset,
-  ListAssetsResponse
-} from '@comfyorg/ingest-types'
+import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
 import {
   generateModels,
   generateInputFiles,
@@ -34,10 +31,7 @@ function emptyConfig(): AssetConfig {
 
 export type AssetOperator = (config: AssetConfig) => AssetConfig
 
-function addAssets(
-  config: AssetConfig,
-  newAssets: Asset[]
-): AssetConfig {
+function addAssets(config: AssetConfig, newAssets: Asset[]): AssetConfig {
   const merged = new Map(config.assets)
   for (const asset of newAssets) {
     merged.set(asset.id, asset)
@@ -57,9 +51,7 @@ export function withModels(
   }
 }
 
-export function withInputFiles(
-  countOrAssets: number | Asset[]
-): AssetOperator {
+export function withInputFiles(countOrAssets: number | Asset[]): AssetOperator {
   return (config) => {
     const assets =
       typeof countOrAssets === 'number'

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -109,103 +109,33 @@ export class AssetHelper {
       const url = new URL(route.request().url())
       const method = route.request().method()
       const path = url.pathname
+      const body = ['POST', 'PUT', 'DELETE'].includes(method)
+        ? route.request().postDataJSON()
+        : null
 
-      // Track mutations
-      if (['POST', 'PUT', 'DELETE'].includes(method)) {
+      if (body !== null) {
         this.mutations.push({
           endpoint: path,
           method,
           url: route.request().url(),
-          body: route.request().postDataJSON(),
+          body,
           timestamp: Date.now()
         })
       }
 
-      // GET /assets — list assets
-      if (method === 'GET' && /\/assets\/?$/.test(path)) {
-        const includeTags =
-          url.searchParams.get('include_tags')?.split(',') ?? []
-        const limit = parseInt(url.searchParams.get('limit') ?? '0', 10)
-        const offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
+      if (method === 'GET' && /\/assets\/?$/.test(path))
+        return this.handleListAssets(route, url)
+      if (method === 'GET' && /\/assets\/[^/]+$/.test(path))
+        return this.handleGetAsset(route, path)
+      if (method === 'PUT' && /\/assets\/[^/]+$/.test(path))
+        return this.handleUpdateAsset(route, path, body)
+      if (method === 'DELETE' && /\/assets\/[^/]+$/.test(path))
+        return this.handleDeleteAsset(route, path)
+      if (method === 'POST' && /\/assets\/?$/.test(path))
+        return this.handleUploadAsset(route)
+      if (method === 'POST' && path.endsWith('/assets/download'))
+        return this.handleDownloadAsset(route)
 
-        let filtered = this.getFilteredAssets(includeTags)
-        if (limit > 0) {
-          filtered = filtered.slice(offset, offset + limit)
-        }
-
-        const response: ListAssetsResponse = {
-          assets: filtered,
-          total: this.paginationOptions?.total ?? this.store.size,
-          has_more: this.paginationOptions?.hasMore ?? false
-        }
-        return route.fulfill({ json: response })
-      }
-
-      // GET /assets/:id — single asset details
-      if (method === 'GET' && /\/assets\/[^/]+$/.test(path)) {
-        const id = path.split('/').pop()!
-        const asset = this.store.get(id)
-        if (asset) {
-          return route.fulfill({ json: asset })
-        }
-        return route.fulfill({
-          status: 404,
-          json: { error: 'Not found' }
-        })
-      }
-
-      // PUT /assets/:id — update asset
-      if (method === 'PUT' && /\/assets\/[^/]+$/.test(path)) {
-        const id = path.split('/').pop()!
-        const asset = this.store.get(id)
-        if (asset) {
-          const body = route.request().postDataJSON()
-          const updated = {
-            ...asset,
-            ...body,
-            updated_at: new Date().toISOString()
-          }
-          this.store.set(id, updated)
-          return route.fulfill({ json: updated })
-        }
-        return route.fulfill({
-          status: 404,
-          json: { error: 'Not found' }
-        })
-      }
-
-      // DELETE /assets/:id — delete asset
-      if (method === 'DELETE' && /\/assets\/[^/]+$/.test(path)) {
-        const id = path.split('/').pop()!
-        this.store.delete(id)
-        return route.fulfill({ status: 204, body: '' })
-      }
-
-      // POST /assets — upload
-      if (method === 'POST' && /\/assets\/?$/.test(path)) {
-        const response = this.uploadResponse ?? {
-          id: `upload-${Date.now()}`,
-          name: 'uploaded_file.safetensors',
-          tags: ['models', 'checkpoints'],
-          created_at: new Date().toISOString(),
-          created_new: true
-        }
-        return route.fulfill({ status: 201, json: response })
-      }
-
-      // POST /assets/download — async download
-      if (method === 'POST' && path.endsWith('/assets/download')) {
-        return route.fulfill({
-          status: 202,
-          json: {
-            task_id: 'download-task-001',
-            status: 'created',
-            message: 'Download started'
-          }
-        })
-      }
-
-      // Fallback — let unhandled requests through
       return route.fallback()
     }
 
@@ -244,6 +174,74 @@ export class AssetHelper {
   get assetCount(): number {
     return this.store.size
   }
+  private handleListAssets(route: Route, url: URL) {
+    const includeTags = url.searchParams.get('include_tags')?.split(',') ?? []
+    const limit = parseInt(url.searchParams.get('limit') ?? '0', 10)
+    const offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
+
+    let filtered = this.getFilteredAssets(includeTags)
+    if (limit > 0) {
+      filtered = filtered.slice(offset, offset + limit)
+    }
+
+    const response: ListAssetsResponse = {
+      assets: filtered,
+      total: this.paginationOptions?.total ?? this.store.size,
+      has_more: this.paginationOptions?.hasMore ?? false
+    }
+    return route.fulfill({ json: response })
+  }
+
+  private handleGetAsset(route: Route, path: string) {
+    const id = path.split('/').pop()!
+    const asset = this.store.get(id)
+    if (asset) return route.fulfill({ json: asset })
+    return route.fulfill({ status: 404, json: { error: 'Not found' } })
+  }
+
+  private handleUpdateAsset(route: Route, path: string, body: unknown) {
+    const id = path.split('/').pop()!
+    const asset = this.store.get(id)
+    if (asset) {
+      const updated = {
+        ...asset,
+        ...(body as Record<string, unknown>),
+        updated_at: new Date().toISOString()
+      }
+      this.store.set(id, updated)
+      return route.fulfill({ json: updated })
+    }
+    return route.fulfill({ status: 404, json: { error: 'Not found' } })
+  }
+
+  private handleDeleteAsset(route: Route, path: string) {
+    const id = path.split('/').pop()!
+    this.store.delete(id)
+    return route.fulfill({ status: 204, body: '' })
+  }
+
+  private handleUploadAsset(route: Route) {
+    const response = this.uploadResponse ?? {
+      id: `upload-${Date.now()}`,
+      name: 'uploaded_file.safetensors',
+      tags: ['models', 'checkpoints'],
+      created_at: new Date().toISOString(),
+      created_new: true
+    }
+    return route.fulfill({ status: 201, json: response })
+  }
+
+  private handleDownloadAsset(route: Route) {
+    return route.fulfill({
+      status: 202,
+      json: {
+        task_id: 'download-task-001',
+        status: 'created',
+        message: 'Download started'
+      }
+    })
+  }
+
   async clearMocks(): Promise<void> {
     for (const { pattern, handler } of this.routeHandlers) {
       await this.page.unroute(pattern, handler)

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -109,11 +109,17 @@ export class AssetHelper {
       const url = new URL(route.request().url())
       const method = route.request().method()
       const path = url.pathname
-      const body = ['POST', 'PUT', 'DELETE'].includes(method)
-        ? route.request().postDataJSON()
-        : null
+      const isMutation = ['POST', 'PUT', 'DELETE'].includes(method)
+      let body: Record<string, unknown> | null = null
+      if (isMutation) {
+        try {
+          body = route.request().postDataJSON()
+        } catch {
+          body = null
+        }
+      }
 
-      if (body !== null) {
+      if (isMutation) {
         this.mutations.push({
           endpoint: path,
           method,

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -23,104 +23,107 @@ interface PaginationOptions {
   hasMore: boolean
 }
 
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+export interface AssetConfig {
+  readonly assets: ReadonlyMap<string, Asset>
+  readonly pagination: PaginationOptions | null
+  readonly uploadResponse: Record<string, unknown> | null
+}
+
+function emptyConfig(): AssetConfig {
+  return { assets: new Map(), pagination: null, uploadResponse: null }
+}
+
+export type AssetOperator = (config: AssetConfig) => AssetConfig
+
+function addAssets(
+  config: AssetConfig,
+  newAssets: Asset[]
+): AssetConfig {
+  const merged = new Map(config.assets)
+  for (const asset of newAssets) {
+    merged.set(asset.id, asset)
+  }
+  return { ...config, assets: merged }
+}
+
+// ─── Operators ──────────────────────────────────────────────────────────────
+
+export function withModels(
+  countOrAssets: number | Asset[],
+  category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
+): AssetOperator {
+  return (config) => {
+    const assets =
+      typeof countOrAssets === 'number'
+        ? generateModels(countOrAssets, category)
+        : countOrAssets
+    return addAssets(config, assets)
+  }
+}
+
+export function withInputFiles(
+  countOrAssets: number | Asset[]
+): AssetOperator {
+  return (config) => {
+    const assets =
+      typeof countOrAssets === 'number'
+        ? generateInputFiles(countOrAssets)
+        : countOrAssets
+    return addAssets(config, assets)
+  }
+}
+
+export function withOutputAssets(
+  countOrAssets: number | Asset[]
+): AssetOperator {
+  return (config) => {
+    const assets =
+      typeof countOrAssets === 'number'
+        ? generateOutputAssets(countOrAssets)
+        : countOrAssets
+    return addAssets(config, assets)
+  }
+}
+
+export function withAsset(asset: Asset): AssetOperator {
+  return (config) => addAssets(config, [asset])
+}
+
+export function withPagination(options: PaginationOptions): AssetOperator {
+  return (config) => ({ ...config, pagination: options })
+}
+
+export function withUploadResponse(
+  response: Record<string, unknown>
+): AssetOperator {
+  return (config) => ({ ...config, uploadResponse: response })
+}
+
+// ─── Helper Class ───────────────────────────────────────────────────────────
+
 export class AssetHelper {
-  private store: Map<string, Asset> = new Map()
-  private paginationOptions: PaginationOptions | null = null
+  private store: Map<string, Asset>
+  private paginationOptions: PaginationOptions | null
   private routeHandlers: Array<{
     pattern: string
     handler: (route: Route) => Promise<void>
   }> = []
   private mutations: MutationRecord[] = []
-  private uploadResponse: Record<string, unknown> | null = null
+  private uploadResponse: Record<string, unknown> | null
 
-  constructor(private readonly page: Page) {}
-
-  // ─── Builder Methods (return `this` for chaining) ─────────────────────────
-
-  /**
-   * Add model assets to the mock store.
-   * Accepts a count (generates deterministic fixtures) or an array of assets.
-   */
-  withModels(
-    countOrAssets: number | Asset[],
-    category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
-  ): this {
-    const assets =
-      typeof countOrAssets === 'number'
-        ? generateModels(countOrAssets, category)
-        : countOrAssets
-    for (const asset of assets) {
-      this.store.set(asset.id, asset)
-    }
-    return this
+  constructor(
+    private readonly page: Page,
+    config: AssetConfig = emptyConfig()
+  ) {
+    this.store = new Map(config.assets)
+    this.paginationOptions = config.pagination
+    this.uploadResponse = config.uploadResponse
   }
 
-  /**
-   * Add input file assets to the mock store.
-   */
-  withInputFiles(countOrAssets: number | Asset[]): this {
-    const assets =
-      typeof countOrAssets === 'number'
-        ? generateInputFiles(countOrAssets)
-        : countOrAssets
-    for (const asset of assets) {
-      this.store.set(asset.id, asset)
-    }
-    return this
-  }
+  // ─── Activation ─────────────────────────────────────────────────────────
 
-  /**
-   * Add output assets to the mock store.
-   */
-  withOutputAssets(countOrAssets: number | Asset[]): this {
-    const assets =
-      typeof countOrAssets === 'number'
-        ? generateOutputAssets(countOrAssets)
-        : countOrAssets
-    for (const asset of assets) {
-      this.store.set(asset.id, asset)
-    }
-    return this
-  }
-
-  /**
-   * Add a single specific asset to the mock store.
-   */
-  withAsset(asset: Asset): this {
-    this.store.set(asset.id, asset)
-    return this
-  }
-
-  /**
-   * Set empty state (no assets). Clears any previously added assets.
-   */
-  withEmptyState(): this {
-    this.store.clear()
-    return this
-  }
-
-  /**
-   * Configure pagination behavior for the list response.
-   */
-  withPagination(options: PaginationOptions): this {
-    this.paginationOptions = options
-    return this
-  }
-
-  /**
-   * Configure a custom upload response for POST /assets.
-   */
-  withUploadResponse(response: Record<string, unknown>): this {
-    this.uploadResponse = response
-    return this
-  }
-
-  // ─── Activation ───────────────────────────────────────────────────────────
-
-  /**
-   * Install all route handlers based on current builder state.
-   * Must be called before page.goto().
-   */
   async mock(): Promise<void> {
     const handler = async (route: Route) => {
       const url = new URL(route.request().url())
@@ -231,11 +234,6 @@ export class AssetHelper {
     await this.page.route(pattern, handler)
   }
 
-  /**
-   * Mock a specific error response for any asset endpoint.
-   * Note: Call this before mock() or use clearMocks() first, as Playwright
-   * executes route handlers in LIFO registration order.
-   */
   async mockError(
     statusCode: number,
     error: string = 'Internal Server Error'
@@ -252,41 +250,26 @@ export class AssetHelper {
     await this.page.route(pattern, handler)
   }
 
-  // ─── Inspection ───────────────────────────────────────────────────────────
+  // ─── Inspection ─────────────────────────────────────────────────────────
 
-  /**
-   * Get all recorded mutations (POST, PUT, DELETE requests).
-   */
   getMutations(): MutationRecord[] {
     return [...this.mutations]
   }
 
-  /**
-   * Get the current assets in the mock store.
-   */
   getAssets(): Asset[] {
     return [...this.store.values()]
   }
 
-  /**
-   * Get a single asset from the mock store by ID.
-   */
   getAsset(id: string): Asset | undefined {
     return this.store.get(id)
   }
 
-  /**
-   * Get the number of assets currently in the mock store.
-   */
   get assetCount(): number {
     return this.store.size
   }
 
-  // ─── Cleanup ──────────────────────────────────────────────────────────────
+  // ─── Cleanup ────────────────────────────────────────────────────────────
 
-  /**
-   * Clear all route mocks and reset internal state.
-   */
   async clearMocks(): Promise<void> {
     for (const { pattern, handler } of this.routeHandlers) {
       await this.page.unroute(pattern, handler)
@@ -298,7 +281,7 @@ export class AssetHelper {
     this.uploadResponse = null
   }
 
-  // ─── Internal ─────────────────────────────────────────────────────────────
+  // ─── Internal ───────────────────────────────────────────────────────────
 
   private getFilteredAssets(tags: string[]): Asset[] {
     const assets = [...this.store.values()]
@@ -308,4 +291,17 @@ export class AssetHelper {
       tags.every((tag) => (asset.tags ?? []).includes(tag))
     )
   }
+}
+
+// ─── Factory ────────────────────────────────────────────────────────────────
+
+export function createAssetHelper(
+  page: Page,
+  ...operators: AssetOperator[]
+): AssetHelper {
+  const config = operators.reduce<AssetConfig>(
+    (cfg, op) => op(cfg),
+    emptyConfig()
+  )
+  return new AssetHelper(page, config)
 }

--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -22,9 +22,6 @@ interface PaginationOptions {
   total: number
   hasMore: boolean
 }
-
-// ─── Configuration ──────────────────────────────────────────────────────────
-
 export interface AssetConfig {
   readonly assets: ReadonlyMap<string, Asset>
   readonly pagination: PaginationOptions | null
@@ -47,9 +44,6 @@ function addAssets(
   }
   return { ...config, assets: merged }
 }
-
-// ─── Operators ──────────────────────────────────────────────────────────────
-
 export function withModels(
   countOrAssets: number | Asset[],
   category: 'checkpoints' | 'loras' | 'vae' | 'embeddings' = 'checkpoints'
@@ -100,9 +94,6 @@ export function withUploadResponse(
 ): AssetOperator {
   return (config) => ({ ...config, uploadResponse: response })
 }
-
-// ─── Helper Class ───────────────────────────────────────────────────────────
-
 export class AssetHelper {
   private store: Map<string, Asset>
   private paginationOptions: PaginationOptions | null
@@ -121,9 +112,6 @@ export class AssetHelper {
     this.paginationOptions = config.pagination
     this.uploadResponse = config.uploadResponse
   }
-
-  // ─── Activation ─────────────────────────────────────────────────────────
-
   async mock(): Promise<void> {
     const handler = async (route: Route) => {
       const url = new URL(route.request().url())
@@ -249,9 +237,6 @@ export class AssetHelper {
     this.routeHandlers.push({ pattern, handler })
     await this.page.route(pattern, handler)
   }
-
-  // ─── Inspection ─────────────────────────────────────────────────────────
-
   getMutations(): MutationRecord[] {
     return [...this.mutations]
   }
@@ -267,9 +252,6 @@ export class AssetHelper {
   get assetCount(): number {
     return this.store.size
   }
-
-  // ─── Cleanup ────────────────────────────────────────────────────────────
-
   async clearMocks(): Promise<void> {
     for (const { pattern, handler } of this.routeHandlers) {
       await this.page.unroute(pattern, handler)
@@ -280,9 +262,6 @@ export class AssetHelper {
     this.paginationOptions = null
     this.uploadResponse = null
   }
-
-  // ─── Internal ───────────────────────────────────────────────────────────
-
   private getFilteredAssets(tags: string[]): Asset[] {
     const assets = [...this.store.values()]
     if (tags.length === 0) return assets
@@ -292,9 +271,6 @@ export class AssetHelper {
     )
   }
 }
-
-// ─── Factory ────────────────────────────────────────────────────────────────
-
 export function createAssetHelper(
   page: Page,
   ...operators: AssetOperator[]

--- a/browser_tests/tests/assetHelper.spec.ts
+++ b/browser_tests/tests/assetHelper.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
@@ -16,6 +17,32 @@ import {
   STABLE_INPUT_IMAGE,
   STABLE_OUTPUT
 } from '../fixtures/data/assetFixtures'
+
+/**
+ * Helper to make fetch calls from the page context so page.route()
+ * interception works. page.request (APIRequestContext) bypasses route
+ * interception because it's an independent HTTP client.
+ */
+async function pageFetch(
+  page: Page,
+  url: string,
+  init?: RequestInit
+): Promise<{ status: number; body: unknown }> {
+  return page.evaluate(
+    async ([fetchUrl, fetchInit]) => {
+      const res = await fetch(fetchUrl, fetchInit)
+      const text = await res.text()
+      let body: unknown
+      try {
+        body = JSON.parse(text)
+      } catch {
+        body = text
+      }
+      return { status: res.status, body }
+    },
+    [url, init] as const
+  )
+}
 
 test.describe('AssetHelper', () => {
   test.describe('operators and configuration', () => {
@@ -74,12 +101,13 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const response = await comfyPage.page.request.get(
+      const { status, body } = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets`
       )
-      expect(response.ok()).toBe(true)
+      expect(status).toBe(200)
 
-      const data = await response.json()
+      const data = body as { assets: unknown[]; total: number; has_more: boolean }
       expect(data.assets).toHaveLength(2)
       expect(data.total).toBe(2)
       expect(data.has_more).toBe(false)
@@ -95,10 +123,11 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const response = await comfyPage.page.request.get(
+      const { body } = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets?limit=2&offset=0`
       )
-      const data = await response.json()
+      const data = body as { assets: unknown[]; total: number; has_more: boolean }
       expect(data.assets).toHaveLength(2)
       expect(data.total).toBe(10)
       expect(data.has_more).toBe(true)
@@ -115,10 +144,11 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const response = await comfyPage.page.request.get(
+      const { body } = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets?include_tags=models,checkpoints`
       )
-      const data = await response.json()
+      const data = body as { assets: Array<{ id: string }> }
       expect(data.assets).toHaveLength(1)
       expect(data.assets[0].id).toBe(STABLE_CHECKPOINT.id)
 
@@ -134,17 +164,19 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const found = await comfyPage.page.request.get(
+      const found = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
       )
-      expect(found.ok()).toBe(true)
-      const asset = await found.json()
+      expect(found.status).toBe(200)
+      const asset = found.body as { id: string }
       expect(asset.id).toBe(STABLE_CHECKPOINT.id)
 
-      const notFound = await comfyPage.page.request.get(
+      const notFound = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets/nonexistent-id`
       )
-      expect(notFound.status()).toBe(404)
+      expect(notFound.status).toBe(404)
 
       await helper.clearMocks()
     })
@@ -156,13 +188,18 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const response = await comfyPage.page.request.put(
+      const { status, body } = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
-        { data: { name: 'renamed.safetensors' } }
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'renamed.safetensors' })
+        }
       )
-      expect(response.ok()).toBe(true)
+      expect(status).toBe(200)
 
-      const updated = await response.json()
+      const updated = body as { name: string }
       expect(updated.name).toBe('renamed.safetensors')
       expect(helper.getAsset(STABLE_CHECKPOINT.id)?.name).toBe(
         'renamed.safetensors'
@@ -181,10 +218,12 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const response = await comfyPage.page.request.delete(
-        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
+      const { status } = await pageFetch(
+        comfyPage.page,
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
+        { method: 'DELETE' }
       )
-      expect(response.status()).toBe(204)
+      expect(status).toBe(204)
       expect(helper.assetCount).toBe(1)
       expect(helper.getAsset(STABLE_CHECKPOINT.id)).toBeUndefined()
 
@@ -205,11 +244,13 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      const response = await comfyPage.page.request.post(
-        `${comfyPage.url}/api/assets`
+      const { status, body } = await pageFetch(
+        comfyPage.page,
+        `${comfyPage.url}/api/assets`,
+        { method: 'POST' }
       )
-      expect(response.status()).toBe(201)
-      const data = await response.json()
+      expect(status).toBe(201)
+      const data = body as { id: string; name: string }
       expect(data.id).toBe('custom-upload-001')
       expect(data.name).toBe('custom.safetensors')
 
@@ -222,11 +263,13 @@ test.describe('AssetHelper', () => {
       const helper = createAssetHelper(comfyPage.page)
       await helper.mock()
 
-      const response = await comfyPage.page.request.post(
-        `${comfyPage.url}/api/assets/download`
+      const { status, body } = await pageFetch(
+        comfyPage.page,
+        `${comfyPage.url}/api/assets/download`,
+        { method: 'POST' }
       )
-      expect(response.status()).toBe(202)
-      const data = await response.json()
+      expect(status).toBe(202)
+      const data = body as { task_id: string; status: string }
       expect(data.task_id).toBe('download-task-001')
       expect(data.status).toBe('created')
 
@@ -242,13 +285,22 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      await comfyPage.page.request.post(`${comfyPage.url}/api/assets`)
-      await comfyPage.page.request.put(
+      await pageFetch(comfyPage.page, `${comfyPage.url}/api/assets`, {
+        method: 'POST'
+      })
+      await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
-        { data: { name: 'updated.safetensors' } }
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'updated.safetensors' })
+        }
       )
-      await comfyPage.page.request.delete(
-        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
+      await pageFetch(
+        comfyPage.page,
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
+        { method: 'DELETE' }
       )
 
       const mutations = helper.getMutations()
@@ -267,8 +319,9 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      await comfyPage.page.request.get(`${comfyPage.url}/api/assets`)
-      await comfyPage.page.request.get(
+      await pageFetch(comfyPage.page, `${comfyPage.url}/api/assets`)
+      await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
       )
 
@@ -283,11 +336,12 @@ test.describe('AssetHelper', () => {
       const helper = createAssetHelper(comfyPage.page)
       await helper.mockError(503, 'Service Unavailable')
 
-      const response = await comfyPage.page.request.get(
+      const { status, body } = await pageFetch(
+        comfyPage.page,
         `${comfyPage.url}/api/assets`
       )
-      expect(response.status()).toBe(503)
-      const data = await response.json()
+      expect(status).toBe(503)
+      const data = body as { error: string }
       expect(data.error).toBe('Service Unavailable')
 
       await helper.clearMocks()
@@ -304,7 +358,9 @@ test.describe('AssetHelper', () => {
       )
       await helper.mock()
 
-      await comfyPage.page.request.post(`${comfyPage.url}/api/assets`)
+      await pageFetch(comfyPage.page, `${comfyPage.url}/api/assets`, {
+        method: 'POST'
+      })
       expect(helper.getMutations()).toHaveLength(1)
       expect(helper.assetCount).toBe(1)
 

--- a/browser_tests/tests/assetHelper.spec.ts
+++ b/browser_tests/tests/assetHelper.spec.ts
@@ -260,9 +260,7 @@ test.describe('AssetHelper', () => {
       await helper.clearMocks()
     })
 
-    test('GET requests are not tracked as mutations', async ({
-      comfyPage
-    }) => {
+    test('GET requests are not tracked as mutations', async ({ comfyPage }) => {
       const helper = createAssetHelper(
         comfyPage.page,
         withAsset(STABLE_CHECKPOINT)
@@ -281,9 +279,7 @@ test.describe('AssetHelper', () => {
   })
 
   test.describe('mockError', () => {
-    test('returns error status for all asset routes', async ({
-      comfyPage
-    }) => {
+    test('returns error status for all asset routes', async ({ comfyPage }) => {
       const helper = createAssetHelper(comfyPage.page)
       await helper.mockError(503, 'Service Unavailable')
 

--- a/browser_tests/tests/assetHelper.spec.ts
+++ b/browser_tests/tests/assetHelper.spec.ts
@@ -1,0 +1,381 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import {
+  createAssetHelper,
+  withModels,
+  withInputFiles,
+  withOutputAssets,
+  withAsset,
+  withPagination,
+  withUploadResponse
+} from '../fixtures/helpers/AssetHelper'
+import {
+  STABLE_CHECKPOINT,
+  STABLE_LORA,
+  STABLE_INPUT_IMAGE,
+  STABLE_OUTPUT
+} from '../fixtures/data/assetFixtures'
+
+test.describe('AssetHelper', () => {
+  test.describe('operators and configuration', () => {
+    test('creates helper with models via withModels operator', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withModels(3, 'checkpoints')
+      )
+      expect(helper.assetCount).toBe(3)
+      expect(
+        helper.getAssets().every((a) => a.tags?.includes('checkpoints'))
+      ).toBe(true)
+    })
+
+    test('composes multiple operators', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withModels(2, 'checkpoints'),
+        withInputFiles(2),
+        withOutputAssets(1)
+      )
+      expect(helper.assetCount).toBe(5)
+    })
+
+    test('adds individual assets via withAsset', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT),
+        withAsset(STABLE_LORA)
+      )
+      expect(helper.assetCount).toBe(2)
+      expect(helper.getAsset(STABLE_CHECKPOINT.id)).toMatchObject({
+        id: STABLE_CHECKPOINT.id,
+        name: STABLE_CHECKPOINT.name
+      })
+    })
+
+    test('withPagination sets pagination options', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withModels(2),
+        withPagination({ total: 100, hasMore: true })
+      )
+      expect(helper.assetCount).toBe(2)
+    })
+  })
+
+  test.describe('mock API routes', () => {
+    test('GET /assets returns all assets', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT),
+        withAsset(STABLE_INPUT_IMAGE)
+      )
+      await helper.mock()
+
+      const response = await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets`
+      )
+      expect(response.ok()).toBe(true)
+
+      const data = await response.json()
+      expect(data.assets).toHaveLength(2)
+      expect(data.total).toBe(2)
+      expect(data.has_more).toBe(false)
+
+      await helper.clearMocks()
+    })
+
+    test('GET /assets respects pagination params', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withModels(5),
+        withPagination({ total: 10, hasMore: true })
+      )
+      await helper.mock()
+
+      const response = await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets?limit=2&offset=0`
+      )
+      const data = await response.json()
+      expect(data.assets).toHaveLength(2)
+      expect(data.total).toBe(10)
+      expect(data.has_more).toBe(true)
+
+      await helper.clearMocks()
+    })
+
+    test('GET /assets filters by include_tags', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT),
+        withAsset(STABLE_LORA),
+        withAsset(STABLE_INPUT_IMAGE)
+      )
+      await helper.mock()
+
+      const response = await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets?include_tags=models,checkpoints`
+      )
+      const data = await response.json()
+      expect(data.assets).toHaveLength(1)
+      expect(data.assets[0].id).toBe(STABLE_CHECKPOINT.id)
+
+      await helper.clearMocks()
+    })
+
+    test('GET /assets/:id returns single asset or 404', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT)
+      )
+      await helper.mock()
+
+      const found = await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
+      )
+      expect(found.ok()).toBe(true)
+      const asset = await found.json()
+      expect(asset.id).toBe(STABLE_CHECKPOINT.id)
+
+      const notFound = await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets/nonexistent-id`
+      )
+      expect(notFound.status()).toBe(404)
+
+      await helper.clearMocks()
+    })
+
+    test('PUT /assets/:id updates asset in store', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT)
+      )
+      await helper.mock()
+
+      const response = await comfyPage.page.request.put(
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
+        { data: { name: 'renamed.safetensors' } }
+      )
+      expect(response.ok()).toBe(true)
+
+      const updated = await response.json()
+      expect(updated.name).toBe('renamed.safetensors')
+      expect(helper.getAsset(STABLE_CHECKPOINT.id)?.name).toBe(
+        'renamed.safetensors'
+      )
+
+      await helper.clearMocks()
+    })
+
+    test('DELETE /assets/:id removes asset from store', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT),
+        withAsset(STABLE_LORA)
+      )
+      await helper.mock()
+
+      const response = await comfyPage.page.request.delete(
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
+      )
+      expect(response.status()).toBe(204)
+      expect(helper.assetCount).toBe(1)
+      expect(helper.getAsset(STABLE_CHECKPOINT.id)).toBeUndefined()
+
+      await helper.clearMocks()
+    })
+
+    test('POST /assets returns upload response', async ({ comfyPage }) => {
+      const customUpload = {
+        id: 'custom-upload-001',
+        name: 'custom.safetensors',
+        tags: ['models'],
+        created_at: '2025-01-01T00:00:00Z',
+        created_new: true
+      }
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withUploadResponse(customUpload)
+      )
+      await helper.mock()
+
+      const response = await comfyPage.page.request.post(
+        `${comfyPage.url}/api/assets`
+      )
+      expect(response.status()).toBe(201)
+      const data = await response.json()
+      expect(data.id).toBe('custom-upload-001')
+      expect(data.name).toBe('custom.safetensors')
+
+      await helper.clearMocks()
+    })
+
+    test('POST /assets/download returns async download response', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(comfyPage.page)
+      await helper.mock()
+
+      const response = await comfyPage.page.request.post(
+        `${comfyPage.url}/api/assets/download`
+      )
+      expect(response.status()).toBe(202)
+      const data = await response.json()
+      expect(data.task_id).toBe('download-task-001')
+      expect(data.status).toBe('created')
+
+      await helper.clearMocks()
+    })
+  })
+
+  test.describe('mutation tracking', () => {
+    test('tracks POST, PUT, DELETE mutations', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT)
+      )
+      await helper.mock()
+
+      await comfyPage.page.request.post(`${comfyPage.url}/api/assets`)
+      await comfyPage.page.request.put(
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
+        { data: { name: 'updated.safetensors' } }
+      )
+      await comfyPage.page.request.delete(
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
+      )
+
+      const mutations = helper.getMutations()
+      expect(mutations).toHaveLength(3)
+      expect(mutations[0].method).toBe('POST')
+      expect(mutations[1].method).toBe('PUT')
+      expect(mutations[2].method).toBe('DELETE')
+
+      await helper.clearMocks()
+    })
+
+    test('GET requests are not tracked as mutations', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT)
+      )
+      await helper.mock()
+
+      await comfyPage.page.request.get(`${comfyPage.url}/api/assets`)
+      await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
+      )
+
+      expect(helper.getMutations()).toHaveLength(0)
+
+      await helper.clearMocks()
+    })
+  })
+
+  test.describe('mockError', () => {
+    test('returns error status for all asset routes', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(comfyPage.page)
+      await helper.mockError(503, 'Service Unavailable')
+
+      const response = await comfyPage.page.request.get(
+        `${comfyPage.url}/api/assets`
+      )
+      expect(response.status()).toBe(503)
+      const data = await response.json()
+      expect(data.error).toBe('Service Unavailable')
+
+      await helper.clearMocks()
+    })
+  })
+
+  test.describe('clearMocks', () => {
+    test('resets store, mutations, and unroutes handlers', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT)
+      )
+      await helper.mock()
+
+      await comfyPage.page.request.post(`${comfyPage.url}/api/assets`)
+      expect(helper.getMutations()).toHaveLength(1)
+      expect(helper.assetCount).toBe(1)
+
+      await helper.clearMocks()
+      expect(helper.getMutations()).toHaveLength(0)
+      expect(helper.assetCount).toBe(0)
+    })
+  })
+
+  test.describe('fixture generators', () => {
+    test('generateModels produces deterministic assets', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(comfyPage.page, withModels(3, 'loras'))
+      const assets = helper.getAssets()
+
+      expect(assets).toHaveLength(3)
+      expect(assets.every((a) => a.tags?.includes('loras'))).toBe(true)
+      expect(assets.every((a) => a.tags?.includes('models'))).toBe(true)
+
+      const ids = assets.map((a) => a.id)
+      expect(new Set(ids).size).toBe(3)
+    })
+
+    test('generateInputFiles produces deterministic input assets', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(comfyPage.page, withInputFiles(3))
+      const assets = helper.getAssets()
+
+      expect(assets).toHaveLength(3)
+      expect(assets.every((a) => a.tags?.includes('input'))).toBe(true)
+    })
+
+    test('generateOutputAssets produces deterministic output assets', async ({
+      comfyPage
+    }) => {
+      const helper = createAssetHelper(comfyPage.page, withOutputAssets(5))
+      const assets = helper.getAssets()
+
+      expect(assets).toHaveLength(5)
+      expect(assets.every((a) => a.tags?.includes('output'))).toBe(true)
+      expect(assets.every((a) => a.name.startsWith('ComfyUI_'))).toBe(true)
+    })
+
+    test('stable fixtures have expected properties', async ({ comfyPage }) => {
+      const helper = createAssetHelper(
+        comfyPage.page,
+        withAsset(STABLE_CHECKPOINT),
+        withAsset(STABLE_LORA),
+        withAsset(STABLE_INPUT_IMAGE),
+        withAsset(STABLE_OUTPUT)
+      )
+
+      const checkpoint = helper.getAsset(STABLE_CHECKPOINT.id)!
+      expect(checkpoint.tags).toContain('checkpoints')
+      expect(checkpoint.size).toBeGreaterThan(0)
+      expect(checkpoint.created_at).toBeTruthy()
+
+      const lora = helper.getAsset(STABLE_LORA.id)!
+      expect(lora.tags).toContain('loras')
+
+      const input = helper.getAsset(STABLE_INPUT_IMAGE.id)!
+      expect(input.tags).toContain('input')
+
+      const output = helper.getAsset(STABLE_OUTPUT.id)!
+      expect(output.tags).toContain('output')
+    })
+  })
+})

--- a/browser_tests/tests/assetHelper.spec.ts
+++ b/browser_tests/tests/assetHelper.spec.ts
@@ -1,4 +1,3 @@
-import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
@@ -17,32 +16,6 @@ import {
   STABLE_INPUT_IMAGE,
   STABLE_OUTPUT
 } from '../fixtures/data/assetFixtures'
-
-/**
- * Helper to make fetch calls from the page context so page.route()
- * interception works. page.request (APIRequestContext) bypasses route
- * interception because it's an independent HTTP client.
- */
-async function pageFetch(
-  page: Page,
-  url: string,
-  init?: RequestInit
-): Promise<{ status: number; body: unknown }> {
-  return page.evaluate(
-    async ([fetchUrl, fetchInit]) => {
-      const res = await fetch(fetchUrl, fetchInit)
-      const text = await res.text()
-      let body: unknown
-      try {
-        body = JSON.parse(text)
-      } catch {
-        body = text
-      }
-      return { status: res.status, body }
-    },
-    [url, init] as const
-  )
-}
 
 test.describe('AssetHelper', () => {
   test.describe('operators and configuration', () => {
@@ -94,15 +67,14 @@ test.describe('AssetHelper', () => {
 
   test.describe('mock API routes', () => {
     test('GET /assets returns all assets', async ({ comfyPage }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
+      const { assetApi } = comfyPage
+      assetApi.configure(
         withAsset(STABLE_CHECKPOINT),
         withAsset(STABLE_INPUT_IMAGE)
       )
-      await helper.mock()
+      await assetApi.mock()
 
-      const { status, body } = await pageFetch(
-        comfyPage.page,
+      const { status, body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets`
       )
       expect(status).toBe(200)
@@ -116,19 +88,18 @@ test.describe('AssetHelper', () => {
       expect(data.total).toBe(2)
       expect(data.has_more).toBe(false)
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('GET /assets respects pagination params', async ({ comfyPage }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
+      const { assetApi } = comfyPage
+      assetApi.configure(
         withModels(5),
         withPagination({ total: 10, hasMore: true })
       )
-      await helper.mock()
+      await assetApi.mock()
 
-      const { body } = await pageFetch(
-        comfyPage.page,
+      const { body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets?limit=2&offset=0`
       )
       const data = body as {
@@ -140,64 +111,56 @@ test.describe('AssetHelper', () => {
       expect(data.total).toBe(10)
       expect(data.has_more).toBe(true)
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('GET /assets filters by include_tags', async ({ comfyPage }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
+      const { assetApi } = comfyPage
+      assetApi.configure(
         withAsset(STABLE_CHECKPOINT),
         withAsset(STABLE_LORA),
         withAsset(STABLE_INPUT_IMAGE)
       )
-      await helper.mock()
+      await assetApi.mock()
 
-      const { body } = await pageFetch(
-        comfyPage.page,
+      const { body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets?include_tags=models,checkpoints`
       )
       const data = body as { assets: Array<{ id: string }> }
       expect(data.assets).toHaveLength(1)
       expect(data.assets[0].id).toBe(STABLE_CHECKPOINT.id)
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('GET /assets/:id returns single asset or 404', async ({
       comfyPage
     }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
-        withAsset(STABLE_CHECKPOINT)
-      )
-      await helper.mock()
+      const { assetApi } = comfyPage
+      assetApi.configure(withAsset(STABLE_CHECKPOINT))
+      await assetApi.mock()
 
-      const found = await pageFetch(
-        comfyPage.page,
+      const found = await assetApi.fetch(
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
       )
       expect(found.status).toBe(200)
       const asset = found.body as { id: string }
       expect(asset.id).toBe(STABLE_CHECKPOINT.id)
 
-      const notFound = await pageFetch(
-        comfyPage.page,
+      const notFound = await assetApi.fetch(
         `${comfyPage.url}/api/assets/nonexistent-id`
       )
       expect(notFound.status).toBe(404)
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('PUT /assets/:id updates asset in store', async ({ comfyPage }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
-        withAsset(STABLE_CHECKPOINT)
-      )
-      await helper.mock()
+      const { assetApi } = comfyPage
+      assetApi.configure(withAsset(STABLE_CHECKPOINT))
+      await assetApi.mock()
 
-      const { status, body } = await pageFetch(
-        comfyPage.page,
+      const { status, body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
         {
           method: 'PUT',
@@ -209,33 +172,32 @@ test.describe('AssetHelper', () => {
 
       const updated = body as { name: string }
       expect(updated.name).toBe('renamed.safetensors')
-      expect(helper.getAsset(STABLE_CHECKPOINT.id)?.name).toBe(
+      expect(assetApi.getAsset(STABLE_CHECKPOINT.id)?.name).toBe(
         'renamed.safetensors'
       )
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('DELETE /assets/:id removes asset from store', async ({
       comfyPage
     }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
+      const { assetApi } = comfyPage
+      assetApi.configure(
         withAsset(STABLE_CHECKPOINT),
         withAsset(STABLE_LORA)
       )
-      await helper.mock()
+      await assetApi.mock()
 
-      const { status } = await pageFetch(
-        comfyPage.page,
+      const { status } = await assetApi.fetch(
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
         { method: 'DELETE' }
       )
       expect(status).toBe(204)
-      expect(helper.assetCount).toBe(1)
-      expect(helper.getAsset(STABLE_CHECKPOINT.id)).toBeUndefined()
+      expect(assetApi.assetCount).toBe(1)
+      expect(assetApi.getAsset(STABLE_CHECKPOINT.id)).toBeUndefined()
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('POST /assets returns upload response', async ({ comfyPage }) => {
@@ -246,14 +208,11 @@ test.describe('AssetHelper', () => {
         created_at: '2025-01-01T00:00:00Z',
         created_new: true
       }
-      const helper = createAssetHelper(
-        comfyPage.page,
-        withUploadResponse(customUpload)
-      )
-      await helper.mock()
+      const { assetApi } = comfyPage
+      assetApi.configure(withUploadResponse(customUpload))
+      await assetApi.mock()
 
-      const { status, body } = await pageFetch(
-        comfyPage.page,
+      const { status, body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets`,
         { method: 'POST' }
       )
@@ -262,17 +221,16 @@ test.describe('AssetHelper', () => {
       expect(data.id).toBe('custom-upload-001')
       expect(data.name).toBe('custom.safetensors')
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
     test('POST /assets/download returns async download response', async ({
       comfyPage
     }) => {
-      const helper = createAssetHelper(comfyPage.page)
-      await helper.mock()
+      const { assetApi } = comfyPage
+      await assetApi.mock()
 
-      const { status, body } = await pageFetch(
-        comfyPage.page,
+      const { status, body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets/download`,
         { method: 'POST' }
       )
@@ -281,23 +239,18 @@ test.describe('AssetHelper', () => {
       expect(data.task_id).toBe('download-task-001')
       expect(data.status).toBe('created')
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
   })
 
   test.describe('mutation tracking', () => {
     test('tracks POST, PUT, DELETE mutations', async ({ comfyPage }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
-        withAsset(STABLE_CHECKPOINT)
-      )
-      await helper.mock()
+      const { assetApi } = comfyPage
+      assetApi.configure(withAsset(STABLE_CHECKPOINT))
+      await assetApi.mock()
 
-      await pageFetch(comfyPage.page, `${comfyPage.url}/api/assets`, {
-        method: 'POST'
-      })
-      await pageFetch(
-        comfyPage.page,
+      await assetApi.fetch(`${comfyPage.url}/api/assets`, { method: 'POST' })
+      await assetApi.fetch(
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
         {
           method: 'PUT',
@@ -305,54 +258,53 @@ test.describe('AssetHelper', () => {
           body: JSON.stringify({ name: 'updated.safetensors' })
         }
       )
-      await pageFetch(
-        comfyPage.page,
+      await assetApi.fetch(
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`,
         { method: 'DELETE' }
       )
 
-      const mutations = helper.getMutations()
+      const mutations = assetApi.getMutations()
       expect(mutations).toHaveLength(3)
       expect(mutations[0].method).toBe('POST')
       expect(mutations[1].method).toBe('PUT')
       expect(mutations[2].method).toBe('DELETE')
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
 
-    test('GET requests are not tracked as mutations', async ({ comfyPage }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
-        withAsset(STABLE_CHECKPOINT)
-      )
-      await helper.mock()
+    test('GET requests are not tracked as mutations', async ({
+      comfyPage
+    }) => {
+      const { assetApi } = comfyPage
+      assetApi.configure(withAsset(STABLE_CHECKPOINT))
+      await assetApi.mock()
 
-      await pageFetch(comfyPage.page, `${comfyPage.url}/api/assets`)
-      await pageFetch(
-        comfyPage.page,
+      await assetApi.fetch(`${comfyPage.url}/api/assets`)
+      await assetApi.fetch(
         `${comfyPage.url}/api/assets/${STABLE_CHECKPOINT.id}`
       )
 
-      expect(helper.getMutations()).toHaveLength(0)
+      expect(assetApi.getMutations()).toHaveLength(0)
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
   })
 
   test.describe('mockError', () => {
-    test('returns error status for all asset routes', async ({ comfyPage }) => {
-      const helper = createAssetHelper(comfyPage.page)
-      await helper.mockError(503, 'Service Unavailable')
+    test('returns error status for all asset routes', async ({
+      comfyPage
+    }) => {
+      const { assetApi } = comfyPage
+      await assetApi.mockError(503, 'Service Unavailable')
 
-      const { status, body } = await pageFetch(
-        comfyPage.page,
+      const { status, body } = await assetApi.fetch(
         `${comfyPage.url}/api/assets`
       )
       expect(status).toBe(503)
       const data = body as { error: string }
       expect(data.error).toBe('Service Unavailable')
 
-      await helper.clearMocks()
+      await assetApi.clearMocks()
     })
   })
 
@@ -360,21 +312,17 @@ test.describe('AssetHelper', () => {
     test('resets store, mutations, and unroutes handlers', async ({
       comfyPage
     }) => {
-      const helper = createAssetHelper(
-        comfyPage.page,
-        withAsset(STABLE_CHECKPOINT)
-      )
-      await helper.mock()
+      const { assetApi } = comfyPage
+      assetApi.configure(withAsset(STABLE_CHECKPOINT))
+      await assetApi.mock()
 
-      await pageFetch(comfyPage.page, `${comfyPage.url}/api/assets`, {
-        method: 'POST'
-      })
-      expect(helper.getMutations()).toHaveLength(1)
-      expect(helper.assetCount).toBe(1)
+      await assetApi.fetch(`${comfyPage.url}/api/assets`, { method: 'POST' })
+      expect(assetApi.getMutations()).toHaveLength(1)
+      expect(assetApi.assetCount).toBe(1)
 
-      await helper.clearMocks()
-      expect(helper.getMutations()).toHaveLength(0)
-      expect(helper.assetCount).toBe(0)
+      await assetApi.clearMocks()
+      expect(assetApi.getMutations()).toHaveLength(0)
+      expect(assetApi.assetCount).toBe(0)
     })
   })
 

--- a/browser_tests/tests/assetHelper.spec.ts
+++ b/browser_tests/tests/assetHelper.spec.ts
@@ -183,10 +183,7 @@ test.describe('AssetHelper', () => {
       comfyPage
     }) => {
       const { assetApi } = comfyPage
-      assetApi.configure(
-        withAsset(STABLE_CHECKPOINT),
-        withAsset(STABLE_LORA)
-      )
+      assetApi.configure(withAsset(STABLE_CHECKPOINT), withAsset(STABLE_LORA))
       await assetApi.mock()
 
       const { status } = await assetApi.fetch(
@@ -272,9 +269,7 @@ test.describe('AssetHelper', () => {
       await assetApi.clearMocks()
     })
 
-    test('GET requests are not tracked as mutations', async ({
-      comfyPage
-    }) => {
+    test('GET requests are not tracked as mutations', async ({ comfyPage }) => {
       const { assetApi } = comfyPage
       assetApi.configure(withAsset(STABLE_CHECKPOINT))
       await assetApi.mock()
@@ -291,9 +286,7 @@ test.describe('AssetHelper', () => {
   })
 
   test.describe('mockError', () => {
-    test('returns error status for all asset routes', async ({
-      comfyPage
-    }) => {
+    test('returns error status for all asset routes', async ({ comfyPage }) => {
       const { assetApi } = comfyPage
       await assetApi.mockError(503, 'Service Unavailable')
 

--- a/browser_tests/tests/assetHelper.spec.ts
+++ b/browser_tests/tests/assetHelper.spec.ts
@@ -107,7 +107,11 @@ test.describe('AssetHelper', () => {
       )
       expect(status).toBe(200)
 
-      const data = body as { assets: unknown[]; total: number; has_more: boolean }
+      const data = body as {
+        assets: unknown[]
+        total: number
+        has_more: boolean
+      }
       expect(data.assets).toHaveLength(2)
       expect(data.total).toBe(2)
       expect(data.has_more).toBe(false)
@@ -127,7 +131,11 @@ test.describe('AssetHelper', () => {
         comfyPage.page,
         `${comfyPage.url}/api/assets?limit=2&offset=0`
       )
-      const data = body as { assets: unknown[]; total: number; has_more: boolean }
+      const data = body as {
+        assets: unknown[]
+        total: number
+        has_more: boolean
+      }
       expect(data.assets).toHaveLength(2)
       expect(data.total).toBe(10)
       expect(data.has_more).toBe(true)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "catalog:",
     "@comfyorg/design-system": "workspace:*",
-    "@comfyorg/ingest-types": "workspace:*",
     "@comfyorg/registry-types": "workspace:*",
     "@comfyorg/shared-frontend-utils": "workspace:*",
     "@comfyorg/tailwind-utils": "workspace:*",
@@ -123,6 +122,7 @@
     "zod-validation-error": "catalog:"
   },
   "devDependencies": {
+    "@comfyorg/ingest-types": "workspace:*",
     "@eslint/js": "catalog:",
     "@intlify/eslint-plugin-vue-i18n": "catalog:",
     "@lobehub/i18n-cli": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9578,9 +9578,6 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
-  vue-component-type-helpers@3.2.6:
-    resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
-
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -19870,8 +19867,6 @@ snapshots:
       typescript: 5.9.3
 
   vue-component-type-helpers@2.2.12: {}
-
-  vue-component-type-helpers@3.2.6: {}
 
   vue-component-type-helpers@3.2.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9578,6 +9578,9 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
+  vue-component-type-helpers@3.2.6:
+    resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -19867,6 +19870,8 @@ snapshots:
       typescript: 5.9.3
 
   vue-component-type-helpers@2.2.12: {}
+
+  vue-component-type-helpers@3.2.6: {}
 
   vue-component-type-helpers@3.2.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,9 +416,6 @@ importers:
       '@comfyorg/design-system':
         specifier: workspace:*
         version: link:packages/design-system
-      '@comfyorg/ingest-types':
-        specifier: workspace:*
-        version: link:packages/ingest-types
       '@comfyorg/registry-types':
         specifier: workspace:*
         version: link:packages/registry-types
@@ -606,6 +603,9 @@ importers:
         specifier: 'catalog:'
         version: 3.3.0(zod@3.25.76)
     devDependencies:
+      '@comfyorg/ingest-types':
+        specifier: workspace:*
+        version: link:packages/ingest-types
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.1


### PR DESCRIPTION
## What

Adds `AssetHelper` — a builder-pattern helper for mocking asset-related API endpoints in Playwright E2E tests, plus deterministic fixture data.

## Why

12+ asset-related API endpoints need mocking for asset browser tests (PNL-02), cloud dialog testing (DLG-08), and other asset-dependent E2E scenarios. Random mock data from existing `createMockAssets()` is unsuitable for deterministic E2E assertions.

## What's included

### `AssetHelper.ts` (307 LOC)
- Fluent builder API: `assetHelper.withModels(3).withImages(5).mock()`
- Stateful mock store (Map) for upload→verify→delete flows
- Endpoint coverage: GET/POST/PUT/DELETE `/assets`, download progress
- `mockError()` for error state testing
- `clearMocks()` cleanup matching QueueHelper/FeatureFlagHelper pattern

### `assetFixtures.ts` (304 LOC)
- 11 stable named constants (checkpoints, loras, VAE, embedding, inputs, outputs)
- Factory functions: `generateModels()`, `generateInputFiles()`, `generateOutputAssets()`
- Fixed IDs/dates/sizes — no randomness, safe for screenshot comparisons

### ComfyPage integration
- Available as `comfyPage.assets` in all tests

## Testing
- TypeScript compiles clean
- Follows existing QueueHelper/FeatureFlagHelper conventions

## Unblocks
- PNL-02: Asset browser tests (@Jaewon Yoon)
- DLG-08: Assets modal / cloud dialog testing

Part of: Test Coverage Q2 Overhaul

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10545-test-infra-AssetHelper-with-builder-pattern-deterministic-fixtures-32f6d73d365081d3985ef079ff3dbede) by [Unito](https://www.unito.io)
