### PR TITLE
feat: add model-to-node mappings for 10 node packs

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -170,5 +170,35 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
     'LLM/Florence-2-large-PromptGen-v2.0',
     'LTXVPromptEnhancerLoader',
     'image_captioner_name'
-  ]
+  ],
+
+  // ---- BiRefNet background removal (comfyui_layerstyle) ----
+  ['BiRefNet', 'LayerMask: LoadBiRefNetModelV2', 'version'],
+
+  // ---- EVF-SAM segmentation (comfyui_layerstyle) ----
+  ['EVF-SAM', 'LayerMask: EVFSAMUltra', 'model'],
+
+  // ---- Florence2 vision-language (comfyui-florence2) ----
+  ['florence2', 'DownloadAndLoadFlorence2Model', 'model'],
+
+  // ---- GIMM-VFI frame interpolation (ComfyUI-GIMM-VFI) ----
+  ['interpolation', 'DownloadAndLoadGIMMVFIModel', 'model'],
+
+  // ---- RMBG background removal (comfyui-rmbg) ----
+  ['rmbg', 'RMBG', 'model'],
+
+  // ---- SmolLM2/SmolVLM language models (comfyui_layerstyle) ----
+  ['smol', 'LayerUtility: LoadSmolLM2Model', 'model'],
+
+  // ---- Transparent background removal (comfyui_layerstyle) ----
+  ['transparent-background', 'LayerMask: TransparentBackgroundUltra', 'model'],
+
+  // ---- YOLO object detection (comfyui_layerstyle) ----
+  ['yolo', 'LayerMask: ObjectDetectorYOLO8', 'yolo_model'],
+
+  // ---- MediaPipe face detection (comfyui-liveportrait) ----
+  ['mediapipe', 'LivePortraitLoadMediaPipeCropper', ''],
+
+  // ---- Superprompt text enhancement ----
+  ['superprompt-v1', 'Superprompt', '']
 ] as const satisfies ReadonlyArray<readonly [string, string, string]>


### PR DESCRIPTION
## Summary
Add `MODEL_NODE_MAPPINGS` entries for 10 model directories missing UI backlinks.

### New mappings
- `BiRefNet` → `LayerMask: LoadBiRefNetModelV2` (`version`)
- `EVF-SAM` → `LayerMask: EVFSAMUltra` (`model`)
- `florence2` → `DownloadAndLoadFlorence2Model` (`model`)
- `interpolation` → `DownloadAndLoadGIMMVFIModel` (`model`)
- `rmbg` → `RMBG` (`model`)
- `smol` → `LayerUtility: LoadSmolLM2Model` (`model`)
- `transparent-background` → `LayerMask: TransparentBackgroundUltra` (`model`)
- `yolo` → `LayerMask: ObjectDetectorYOLO8` (`yolo_model`)
- `mediapipe` → `LivePortraitLoadMediaPipeCropper` (auto-load)
- `superprompt-v1` → `Superprompt` (auto-load)

These mappings ensure the "Use" button in the model browser correctly creates the appropriate loader node.

## Test plan
- [ ] Verify "Use" button works for models in each new directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10560-feat-add-model-to-node-mappings-for-10-node-packs-32f6d73d365081d18b6acda078e7fe0b) by [Unito](https://www.unito.io)
