### PR TITLE
fix: create initial workflow tab when persistence is disabled

### DIFF
--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -10,6 +10,7 @@ import type { ComfyPage } from '../fixtures/ComfyPage'
 import { DefaultGraphPositions } from '../fixtures/constants/defaultGraphPositions'
 import { TestIds } from '../fixtures/selectors'
 import type { NodeReference } from '../fixtures/utils/litegraphUtils'
+import type { WorkspaceStore } from '../types/globals'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
@@ -718,6 +719,19 @@ test.describe('Load workflow', { tag: '@screenshot' }, () => {
   }) => {
     await comfyPage.workflow.loadWorkflow('inputs/string_input')
     await expect(comfyPage.canvas).toHaveScreenshot('string_input.png')
+  })
+
+  test('Creates initial workflow tab when persistence is disabled', async ({
+    comfyPage
+  }) => {
+    await comfyPage.settings.setSetting('Comfy.Workflow.Persist', false)
+    await comfyPage.setup()
+
+    const openCount = await comfyPage.page.evaluate(() => {
+      return (window.app!.extensionManager as WorkspaceStore).workflow
+        .openWorkflows.length
+    })
+    expect(openCount).toBeGreaterThanOrEqual(1)
   })
 
   test('Restore workflow on reload (switch workflow)', async ({

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -171,7 +171,7 @@ export function useWorkflowPersistenceV2() {
   }
 
   const initializeWorkflow = async () => {
-    if (!workflowPersistenceEnabled.value) return
+    if (!workflowPersistenceEnabled.value) return loadDefaultWorkflow()
 
     try {
       const restored = await loadPreviousWorkflowFromStorage()

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -171,7 +171,10 @@ export function useWorkflowPersistenceV2() {
   }
 
   const initializeWorkflow = async () => {
-    if (!workflowPersistenceEnabled.value) return loadDefaultWorkflow()
+    if (!workflowPersistenceEnabled.value) {
+      await loadDefaultWorkflow()
+      return
+    }
 
     try {
       const restored = await loadPreviousWorkflowFromStorage()


### PR DESCRIPTION
## Summary

- When `Comfy.Workflow.Persist` is OFF and storage is empty, `initializeWorkflow()` returned without creating any workflow tab — leaving users with no tab and no way to save
- Now falls through to `loadDefaultWorkflow()` so a default temporary workflow is always created

## Root Cause

In `useWorkflowPersistenceV2.ts`, `initializeWorkflow()` had an early return when persistence was disabled:

```ts
if (!workflowPersistenceEnabled.value) return
```

This skipped `loadDefaultWorkflow()`, which is responsible for creating the initial temporary workflow tab via `comfyApp.loadGraphData()` → `afterLoadNewGraph()` → `workflowStore.createNewTemporary()`.

## Fix

One-line change: `return` → `return loadDefaultWorkflow()`.

## Test plan

- [x] E2E test: verifies `openWorkflows.length >= 1` after reload with persistence OFF

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10565-fix-create-initial-workflow-tab-when-persistence-is-disabled-32f6d73d365081d5a681c3e019d373c3) by [Unito](https://www.unito.io)
