### PR TITLE
fix: normalize legacy prefixed proxyWidget entries on configure

### DIFF
--- a/browser_tests/assets/subgraphs/nested-subgraph-legacy-prefixed-proxy-widgets.json
+++ b/browser_tests/assets/subgraphs/nested-subgraph-legacy-prefixed-proxy-widgets.json
@@ -1,0 +1,599 @@
+{
+  "id": "legacy-prefix-test-workflow",
+  "revision": 0,
+  "last_node_id": 5,
+  "last_link_id": 5,
+  "nodes": [
+    {
+      "id": 5,
+      "type": "1e38d8ea-45e1-48a5-aa20-966584201867",
+      "pos": [788, 433.5],
+      "size": [400, 200],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "string_a",
+          "type": "STRING",
+          "widget": {
+            "name": "string_a"
+          },
+          "link": 4
+        }
+      ],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [5]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [["6", "6: 3: string_a"]]
+      },
+      "widgets_values": [""]
+    },
+    {
+      "id": 2,
+      "type": "PreviewAny",
+      "pos": [1335, 429],
+      "size": [250, 145.5],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 5
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, false]
+    },
+    {
+      "id": 1,
+      "type": "PrimitiveStringMultiline",
+      "pos": [356, 450],
+      "size": [225, 121.5],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [4]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PrimitiveStringMultiline"
+      },
+      "widgets_values": ["Outer\n"]
+    }
+  ],
+  "links": [
+    [4, 1, 0, 5, 0, "STRING"],
+    [5, 5, 0, 2, 0, "STRING"]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "1e38d8ea-45e1-48a5-aa20-966584201867",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 6,
+          "lastLinkId": 9,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Outer Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [351, 432.5, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1315, 432.5, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "7bf3e1d4-0521-4b5c-92f5-47ca598b7eb4",
+            "name": "string_a",
+            "type": "STRING",
+            "linkIds": [1],
+            "localized_name": "string_a",
+            "pos": [451, 452.5]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "fbe975ba-d7c2-471e-a99a-a1e2c6ab466d",
+            "name": "STRING",
+            "type": "STRING",
+            "linkIds": [9],
+            "localized_name": "STRING",
+            "pos": [1335, 452.5]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 3,
+            "type": "StringConcatenate",
+            "pos": [815, 373],
+            "size": [400, 200],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 1
+              },
+              {
+                "localized_name": "string_b",
+                "name": "string_b",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_b"
+                },
+                "link": 2
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [7]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringConcatenate"
+            },
+            "widgets_values": ["", "", ""]
+          },
+          {
+            "id": 6,
+            "type": "9be42452-056b-4c99-9f9f-7381d11c4454",
+            "pos": [955, 775],
+            "size": [400, 200],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 7
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [["-1", "string_a"]]
+            },
+            "widgets_values": [""]
+          },
+          {
+            "id": 4,
+            "type": "PrimitiveStringMultiline",
+            "pos": [313, 685],
+            "size": [400, 200],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [2]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": ["Inner 1\n"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 2,
+            "origin_id": 4,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 7,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 6,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 9,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          }
+        ],
+        "extra": {}
+      },
+      {
+        "id": "9be42452-056b-4c99-9f9f-7381d11c4454",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 9,
+          "lastLinkId": 12,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Inner Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [680, 774, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1320, 774, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "01c05c51-86b5-4bad-b32f-9c911683a13d",
+            "name": "string_a",
+            "type": "STRING",
+            "linkIds": [4],
+            "localized_name": "string_a",
+            "pos": [780, 794]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "a8bcf3bf-a66a-4c71-8d92-17a2a4d03686",
+            "name": "STRING",
+            "type": "STRING",
+            "linkIds": [12],
+            "localized_name": "STRING",
+            "pos": [1340, 794]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 5,
+            "type": "StringConcatenate",
+            "pos": [860, 719],
+            "size": [400, 200],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 4
+              },
+              {
+                "localized_name": "string_b",
+                "name": "string_b",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_b"
+                },
+                "link": 7
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [11]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringConcatenate"
+            },
+            "widgets_values": ["", "", ""]
+          },
+          {
+            "id": 6,
+            "type": "PrimitiveStringMultiline",
+            "pos": [401, 973],
+            "size": [400, 200],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [7]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": ["Inner 2\n"]
+          },
+          {
+            "id": 9,
+            "type": "7c2915a5-5eb8-4958-a8fd-4beb30f370ce",
+            "pos": [1046, 985],
+            "size": [400, 200],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 11
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [12]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [["-1", "string_a"]]
+            },
+            "widgets_values": [""]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 4,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 5,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 7,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 5,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 11,
+            "origin_id": 5,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 10,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 12,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          }
+        ],
+        "extra": {}
+      },
+      {
+        "id": "7c2915a5-5eb8-4958-a8fd-4beb30f370ce",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 8,
+          "lastLinkId": 10,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Innermost Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [262, 1222, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1330, 1222, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "934a8baa-d79c-428c-8ec9-814ad437d7c7",
+            "name": "string_a",
+            "type": "STRING",
+            "linkIds": [9],
+            "localized_name": "string_a",
+            "pos": [362, 1242]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "4c3d243b-9ff6-4dcd-9dbf-e4ec8e1fc879",
+            "name": "STRING",
+            "type": "STRING",
+            "linkIds": [10],
+            "localized_name": "STRING",
+            "pos": [1350, 1242]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 7,
+            "type": "StringConcatenate",
+            "pos": [870, 1038],
+            "size": [400, 200],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 9
+              },
+              {
+                "localized_name": "string_b",
+                "name": "string_b",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_b"
+                },
+                "link": 8
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [10]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringConcatenate"
+            },
+            "widgets_values": ["", "", ""]
+          },
+          {
+            "id": 8,
+            "type": "PrimitiveStringMultiline",
+            "pos": [442, 1296],
+            "size": [400, 200],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [8]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": ["Inner 3\n"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 8,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": 7,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 9,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 10,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "STRING"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [-7, 144]
+    },
+    "frontendVersion": "1.38.13"
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/subgraphLegacyPrefixedProxyWidgets.spec.ts
+++ b/browser_tests/tests/subgraphLegacyPrefixedProxyWidgets.spec.ts
@@ -1,0 +1,99 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+import { TestIds } from '../fixtures/selectors'
+
+/**
+ * Regression test for legacy-prefixed proxyWidget normalization.
+ *
+ * Older serialized workflows stored proxyWidget entries with prefixed widget
+ * names like "6: 3: string_a" instead of plain "string_a". This caused
+ * resolution failures during configure, resulting in missing promoted widgets.
+ *
+ * The fixture contains an outer SubgraphNode (id 5) whose proxyWidgets array
+ * has a legacy-prefixed entry: ["6", "6: 3: string_a"]. After normalization
+ * the promoted widget should render with the clean name "string_a".
+ *
+ * See: https://github.com/Comfy-Org/ComfyUI_frontend/pull/10573
+ */
+test.describe(
+  'Legacy prefixed proxyWidget normalization',
+  { tag: ['@subgraph', '@widget'] },
+  () => {
+    const WORKFLOW = 'subgraphs/nested-subgraph-legacy-prefixed-proxy-widgets'
+
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    })
+
+    test('Loads without console warnings about failed widget resolution', async ({
+      comfyPage
+    }) => {
+      const warnings: string[] = []
+      comfyPage.page.on('console', (msg) => {
+        const text = msg.text()
+        if (
+          text.includes('Failed to resolve legacy -1') ||
+          text.includes('No link found') ||
+          text.includes('No inner link found')
+        ) {
+          warnings.push(text)
+        }
+      })
+
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+      expect(warnings).toEqual([])
+    })
+
+    test('Promoted widget renders with normalized name, not legacy prefix', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+
+      const outerNode = comfyPage.vueNodes.getNodeLocator('5')
+      await expect(outerNode).toBeVisible()
+
+      // The promoted widget should render with the clean name "string_a",
+      // not the legacy-prefixed "6: 3: string_a".
+      const promotedWidget = outerNode
+        .getByLabel('string_a', { exact: true })
+        .first()
+      await expect(promotedWidget).toBeVisible()
+    })
+
+    test('No legacy-prefixed or disconnected widgets remain on the node', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+
+      const outerNode = comfyPage.vueNodes.getNodeLocator('5')
+      await expect(outerNode).toBeVisible()
+
+      // Both widget rows should be valid "string_a" widgets — no stale
+      // "Disconnected" placeholders from unresolved legacy entries.
+      const widgetRows = outerNode.getByTestId(TestIds.widgets.widget)
+      await expect(widgetRows).toHaveCount(2)
+
+      for (const row of await widgetRows.all()) {
+        await expect(row.getByLabel('string_a', { exact: true })).toBeVisible()
+      }
+    })
+
+    test('Promoted widget value is editable as a text input', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+
+      const outerNode = comfyPage.vueNodes.getNodeLocator('5')
+      const textarea = outerNode
+        .getByRole('textbox', { name: 'string_a' })
+        .first()
+      await expect(textarea).toBeVisible()
+    })
+  }
+)

--- a/src/core/graph/subgraph/legacyProxyWidgetNormalization.test.ts
+++ b/src/core/graph/subgraph/legacyProxyWidgetNormalization.test.ts
@@ -1,0 +1,122 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { normalizeLegacyProxyWidgetEntry } from '@/core/graph/subgraph/legacyProxyWidgetNormalization'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode,
+  resetSubgraphFixtureState
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+
+function createHostWithInnerWidget(widgetName: string) {
+  const rootGraph = createTestRootGraph()
+  const innerSubgraph = createTestSubgraph({
+    rootGraph,
+    inputs: [{ name: 'value', type: 'number' }]
+  })
+
+  const innerNode = new LGraphNode('InnerNode')
+  const input = innerNode.addInput('value', 'number')
+  innerNode.addWidget('number', widgetName, 0, () => {})
+  input.widget = { name: widgetName }
+  innerSubgraph.add(innerNode)
+  innerSubgraph.inputNode.slots[0].connect(innerNode.inputs[0], innerNode)
+
+  const hostNode = createTestSubgraphNode(innerSubgraph, {
+    parentGraph: rootGraph
+  })
+
+  return { rootGraph, innerSubgraph, innerNode, hostNode }
+}
+
+describe('normalizeLegacyProxyWidgetEntry', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    resetSubgraphFixtureState()
+  })
+
+  it('returns entry unchanged when it already resolves', () => {
+    const { hostNode, innerNode } = createHostWithInnerWidget('seed')
+
+    const result = normalizeLegacyProxyWidgetEntry(
+      hostNode,
+      String(innerNode.id),
+      'seed'
+    )
+
+    expect(result).toEqual({
+      sourceNodeId: String(innerNode.id),
+      sourceWidgetName: 'seed'
+    })
+  })
+
+  it('returns entry unchanged with disambiguator when it already resolves', () => {
+    const { hostNode, innerNode } = createHostWithInnerWidget('seed')
+
+    const result = normalizeLegacyProxyWidgetEntry(
+      hostNode,
+      String(innerNode.id),
+      'seed',
+      String(innerNode.id)
+    )
+
+    expect(result).toEqual({
+      sourceNodeId: String(innerNode.id),
+      sourceWidgetName: 'seed',
+      disambiguatingSourceNodeId: String(innerNode.id)
+    })
+  })
+
+  it('strips a single legacy prefix from widget name', () => {
+    const rootGraph = createTestRootGraph()
+    const innerSubgraph = createTestSubgraph({
+      rootGraph,
+      inputs: [{ name: 'seed', type: 'number' }]
+    })
+
+    const samplerNode = new LGraphNode('Sampler')
+    const samplerInput = samplerNode.addInput('seed', 'number')
+    samplerNode.addWidget('number', 'noise_seed', 42, () => {})
+    samplerInput.widget = { name: 'noise_seed' }
+    innerSubgraph.add(samplerNode)
+    innerSubgraph.inputNode.slots[0].connect(samplerNode.inputs[0], samplerNode)
+
+    const outerSubgraph = createTestSubgraph({ rootGraph })
+    const nestedNode = createTestSubgraphNode(innerSubgraph, {
+      parentGraph: outerSubgraph
+    })
+    outerSubgraph.add(nestedNode)
+
+    const hostNode = createTestSubgraphNode(outerSubgraph, {
+      parentGraph: rootGraph
+    })
+
+    const prefixedName = `${nestedNode.id}: ${samplerNode.id}: noise_seed`
+    const result = normalizeLegacyProxyWidgetEntry(
+      hostNode,
+      String(nestedNode.id),
+      prefixedName
+    )
+
+    expect(result.sourceWidgetName).toBe('noise_seed')
+    expect(result.disambiguatingSourceNodeId).toBe(String(samplerNode.id))
+  })
+
+  it('returns original entry when prefix cannot be resolved', () => {
+    const { hostNode, innerNode } = createHostWithInnerWidget('seed')
+
+    const result = normalizeLegacyProxyWidgetEntry(
+      hostNode,
+      String(innerNode.id),
+      '999: nonexistent_widget'
+    )
+
+    expect(result).toEqual({
+      sourceNodeId: String(innerNode.id),
+      sourceWidgetName: '999: nonexistent_widget'
+    })
+  })
+})

--- a/src/core/graph/subgraph/legacyProxyWidgetNormalization.ts
+++ b/src/core/graph/subgraph/legacyProxyWidgetNormalization.ts
@@ -1,0 +1,111 @@
+import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
+import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
+import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
+
+const LEGACY_PROXY_WIDGET_PREFIX_PATTERN = /^\s*(\d+)\s*:\s*(.+)$/
+
+type PromotedWidgetPatch = Omit<PromotedWidgetSource, 'sourceNodeId'>
+
+function canResolve(
+  hostNode: SubgraphNode,
+  sourceNodeId: string,
+  widgetName: string,
+  disambiguator?: string
+): boolean {
+  return (
+    resolveConcretePromotedWidget(
+      hostNode,
+      sourceNodeId,
+      widgetName,
+      disambiguator
+    ).status === 'resolved'
+  )
+}
+
+function tryResolveCandidate(
+  hostNode: SubgraphNode,
+  sourceNodeId: string,
+  widgetName: string,
+  disambiguator?: string
+): PromotedWidgetPatch | undefined {
+  if (!canResolve(hostNode, sourceNodeId, widgetName, disambiguator))
+    return undefined
+
+  return {
+    sourceWidgetName: widgetName,
+    ...(disambiguator && { disambiguatingSourceNodeId: disambiguator })
+  }
+}
+
+function resolveLegacyPrefixedEntry(
+  hostNode: SubgraphNode,
+  sourceNodeId: string,
+  sourceWidgetName: string,
+  disambiguatingSourceNodeId?: string
+): PromotedWidgetPatch | undefined {
+  let remaining = sourceWidgetName
+
+  while (true) {
+    const match = LEGACY_PROXY_WIDGET_PREFIX_PATTERN.exec(remaining)
+    if (!match) return undefined
+
+    const [, legacySourceNodeId, unprefixed] = match
+    remaining = unprefixed
+
+    const disambiguators = [
+      legacySourceNodeId,
+      ...(disambiguatingSourceNodeId ? [disambiguatingSourceNodeId] : []),
+      undefined
+    ]
+
+    for (const disambiguator of disambiguators) {
+      const resolved = tryResolveCandidate(
+        hostNode,
+        sourceNodeId,
+        remaining,
+        disambiguator
+      )
+      if (resolved) return resolved
+    }
+  }
+}
+
+export function normalizeLegacyProxyWidgetEntry(
+  hostNode: SubgraphNode,
+  sourceNodeId: string,
+  sourceWidgetName: string,
+  disambiguatingSourceNodeId?: string
+): PromotedWidgetSource {
+  if (
+    canResolve(
+      hostNode,
+      sourceNodeId,
+      sourceWidgetName,
+      disambiguatingSourceNodeId
+    )
+  ) {
+    return {
+      sourceNodeId,
+      sourceWidgetName,
+      ...(disambiguatingSourceNodeId && { disambiguatingSourceNodeId })
+    }
+  }
+
+  const patch = resolveLegacyPrefixedEntry(
+    hostNode,
+    sourceNodeId,
+    sourceWidgetName,
+    disambiguatingSourceNodeId
+  )
+
+  const patchDisambiguatingSourceNodeId =
+    patch?.disambiguatingSourceNodeId ?? disambiguatingSourceNodeId
+
+  return {
+    sourceNodeId,
+    sourceWidgetName: patch?.sourceWidgetName ?? sourceWidgetName,
+    ...(patchDisambiguatingSourceNodeId && {
+      disambiguatingSourceNodeId: patchDisambiguatingSourceNodeId
+    })
+  }
+}

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -34,6 +34,7 @@ import {
   createPromotedWidgetView,
   isPromotedWidgetView
 } from '@/core/graph/subgraph/promotedWidgetView'
+import { normalizeLegacyProxyWidgetEntry } from '@/core/graph/subgraph/legacyProxyWidgetNormalization'
 import type { PromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetView'
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
@@ -1078,20 +1079,22 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
           return null
         }
         if (!this.subgraph.getNodeById(nodeId)) return null
-        const entry: PromotedWidgetSource = {
-          sourceNodeId: nodeId,
-          sourceWidgetName: widgetName,
-          ...(sourceNodeId && { disambiguatingSourceNodeId: sourceNodeId })
-        }
-        return entry
+
+        return normalizeLegacyProxyWidgetEntry(
+          this,
+          nodeId,
+          widgetName,
+          sourceNodeId
+        )
       })
       .filter((e): e is NonNullable<typeof e> => e !== null)
 
     store.setPromotions(this.rootGraph.id, this.id, entries)
 
     // Write back resolved entries so legacy or stale entries don't persist
-    if (entries.length !== raw.length) {
-      this.properties.proxyWidgets = this._serializeEntries(entries)
+    const serialized = this._serializeEntries(entries)
+    if (JSON.stringify(serialized) !== JSON.stringify(raw)) {
+      this.properties.proxyWidgets = serialized
     }
 
     // Check all inputs for connected widgets

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -12,6 +12,7 @@ import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
 
 import {
   createEventCapture,
+  createTestRootGraph,
   createTestSubgraph,
   createTestSubgraphNode,
   resetSubgraphFixtureState
@@ -319,6 +320,63 @@ describe('SubgraphWidgetPromotion', () => {
       expect(widgetSourceIds).not.toContain('999')
       expect(widgetSourceIds).not.toContain('998')
       expect(widgetSourceIds).toContain(keptSamplerNodeId)
+    })
+
+    it('should normalize legacy prefixed proxyWidgets on configure', () => {
+      const rootGraph = createTestRootGraph()
+
+      const innerSubgraph = createTestSubgraph({
+        rootGraph,
+        inputs: [{ name: 'seed', type: 'number' }]
+      })
+
+      const samplerNode = new LGraphNode('Sampler')
+      const samplerInput = samplerNode.addInput('seed', 'number')
+      samplerNode.addWidget('number', 'noise_seed', 123, () => {})
+      samplerInput.widget = { name: 'noise_seed' }
+      innerSubgraph.add(samplerNode)
+      innerSubgraph.inputNode.slots[0].connect(
+        samplerNode.inputs[0],
+        samplerNode
+      )
+
+      const outerSubgraph = createTestSubgraph({ rootGraph })
+      const nestedNode = createTestSubgraphNode(innerSubgraph, {
+        parentGraph: outerSubgraph
+      })
+      outerSubgraph.add(nestedNode)
+
+      const hostNode = createTestSubgraphNode(outerSubgraph, {
+        parentGraph: rootGraph
+      })
+
+      const serializedHostNode = hostNode.serialize()
+      serializedHostNode.properties = {
+        ...serializedHostNode.properties,
+        proxyWidgets: [
+          [
+            String(nestedNode.id),
+            `${nestedNode.id}: ${samplerNode.id}: noise_seed`
+          ]
+        ]
+      }
+
+      hostNode.configure(serializedHostNode)
+
+      const promotedWidgets = hostNode.widgets
+        .filter(isPromotedWidgetView)
+        .filter((widget) => !widget.name.startsWith('$$'))
+
+      expect(promotedWidgets).toHaveLength(1)
+      expect(promotedWidgets[0].type).toBe('number')
+      expect(promotedWidgets[0].value).toBe(123)
+      expect(promotedWidgets[0].sourceWidgetName).toBe('noise_seed')
+      expect(promotedWidgets[0].disambiguatingSourceNodeId).toBe(
+        String(samplerNode.id)
+      )
+      expect(hostNode.properties.proxyWidgets).toStrictEqual([
+        [String(nestedNode.id), 'noise_seed', String(samplerNode.id)]
+      ])
     })
   })
 


### PR DESCRIPTION
## Summary

Normalize legacy prefixed proxyWidget entries during subgraph configure so nested subgraph widgets resolve correctly.

## Changes

- **What**: Extract `normalizeLegacyProxyWidgetEntry` to strip legacy `nodeId: innerNodeId: widgetName` prefixes from serialized proxyWidgets and resolve the correct `disambiguatingSourceNodeId`. Write-back comparison now checks serialized content (not just array length) so stale formats are cleaned up even when the entry count is unchanged.

## Review Focus

- The iterative prefix-stripping loop in `resolveLegacyPrefixedEntry` — it peels one `N: ` prefix per iteration and tries all disambiguator candidates at each level.
- The write-back condition change from length comparison to `JSON.stringify` equality.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10573-fix-normalize-legacy-prefixed-proxyWidget-entries-on-configure-32f6d73d365081e886e1c9b3939e3b9f) by [Unito](https://www.unito.io)
