### PR TITLE
fix: preserve promoted widget order on sidebar hide/show cycle / drag reorder

### DIFF
--- a/browser_tests/helpers/promotedWidgets.ts
+++ b/browser_tests/helpers/promotedWidgets.ts
@@ -2,7 +2,29 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 
 type PromotedWidgetEntry = [string, string]
 
-function isPromotedWidgetEntry(entry: unknown): entry is PromotedWidgetEntry {
+export interface PromotedWidgetSnapshot {
+  proxyWidgets: PromotedWidgetEntry[]
+  widgetNames: string[]
+}
+
+export function getPiniaStoreInBrowser(storeName: string) {
+  type StoreRecord = Record<string, (...args: unknown[]) => unknown>
+  const el = document.getElementById('vue-app') as HTMLElement & {
+    __vue_app__?: {
+      config: {
+        globalProperties: { $pinia?: { _s: Map<string, StoreRecord> } }
+      }
+    }
+  }
+  const store =
+    el.__vue_app__?.config?.globalProperties?.$pinia?._s.get(storeName)
+  if (!store) throw new Error(`Pinia store "${storeName}" not found`)
+  return store
+}
+
+export function isPromotedWidgetEntry(
+  entry: unknown
+): entry is PromotedWidgetEntry {
   return (
     Array.isArray(entry) &&
     entry.length === 2 &&

--- a/browser_tests/tests/subgraphPromotionOrder.spec.ts
+++ b/browser_tests/tests/subgraphPromotionOrder.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { TestIds } from '../fixtures/selectors'
 import { getPromotedWidgetNames } from '../helpers/promotedWidgets'
 
 test.describe(
@@ -40,19 +41,14 @@ test.describe(
       const subgraphVueNode = comfyPage.vueNodes.getNodeLocator(nodeId)
       await expect(subgraphVueNode).toBeVisible()
 
-      const nodeBody = subgraphVueNode.locator(
-        `[data-testid="node-body-${nodeId}"]`
+      const widgetsContainer = subgraphVueNode.getByTestId(
+        TestIds.widgets.container
       )
-      const widgetElements = nodeBody.locator('.lg-node-widgets > div')
-      await expect(widgetElements.first()).toBeVisible()
+      await expect(widgetsContainer).toBeVisible()
 
       // Get the initial promoted widget order
       const initialOrder = await getPromotedWidgetNames(comfyPage, nodeId)
       expect(initialOrder.length).toBeGreaterThanOrEqual(2)
-
-      // Verify widget count in the DOM matches
-      const domWidgetCount = await widgetElements.count()
-      expect(domWidgetCount).toBeGreaterThanOrEqual(initialOrder.length)
 
       // Demote then re-promote the first widget via the promotion store.
       // Pinia store access pattern: see getPiniaStoreInBrowser in

--- a/browser_tests/tests/subgraphPromotionOrder.spec.ts
+++ b/browser_tests/tests/subgraphPromotionOrder.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { getPromotedWidgetNames } from '../helpers/promotedWidgets'
+
+test.describe(
+  'Subgraph promoted widget ordering',
+  { tag: ['@subgraph', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    })
+
+    test('demote then re-promote preserves widget order', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+
+      // Create a subgraph from the KSampler node which has multiple
+      // auto-promoted widgets (seed, steps, cfg, etc.)
+      const ksampler = comfyPage.vueNodes.getNodeByTitle('KSampler')
+      await comfyPage.vueNodes.waitForNodes()
+      await expect(ksampler).toBeVisible()
+
+      // Select and convert to subgraph
+      const ksamplerRef = await comfyPage.nodeOps.getNodeRefById('3')
+      await ksamplerRef.click('title')
+      const subgraphNode = await ksamplerRef.convertToSubgraph()
+      await comfyPage.nextFrame()
+      await comfyPage.vueNodes.waitForNodes()
+
+      const nodeId = String(subgraphNode.id)
+
+      // Verify promoted widgets render in the Vue node body
+      const subgraphVueNode = comfyPage.vueNodes.getNodeLocator(nodeId)
+      await expect(subgraphVueNode).toBeVisible()
+
+      const nodeBody = subgraphVueNode.locator(
+        `[data-testid="node-body-${nodeId}"]`
+      )
+      const widgetElements = nodeBody.locator('.lg-node-widgets > div')
+      await expect(widgetElements.first()).toBeVisible()
+
+      // Get the initial promoted widget order
+      const initialOrder = await getPromotedWidgetNames(comfyPage, nodeId)
+      expect(initialOrder.length).toBeGreaterThanOrEqual(2)
+
+      // Verify widget count in the DOM matches
+      const domWidgetCount = await widgetElements.count()
+      expect(domWidgetCount).toBeGreaterThanOrEqual(initialOrder.length)
+
+      // Demote then re-promote the first widget via the promotion store
+      const finalOrder = await comfyPage.page.evaluate(
+        ([id, widgetName]) => {
+          const el = document.getElementById('vue-app') as HTMLElement & {
+            __vue_app__: {
+              config: {
+                globalProperties: {
+                  $pinia: {
+                    _s: Map<
+                      string,
+                      Record<string, (...args: unknown[]) => unknown>
+                    >
+                  }
+                }
+              }
+            }
+          }
+          const store =
+            el.__vue_app__.config.globalProperties.$pinia._s.get('promotion')
+          if (!store) throw new Error('promotionStore not found')
+
+          const node = window.app!.canvas.graph!.getNodeById(id)
+          if (!node) throw new Error(`Node "${id}" not found`)
+          const graphId = (node as { rootGraph?: { id: string } }).rootGraph?.id
+
+          const entries = store.getPromotions(graphId, node.id) as {
+            sourceWidgetName: string
+          }[]
+          const target = entries.find((e) => e.sourceWidgetName === widgetName)
+          if (!target) throw new Error(`Widget "${widgetName}" not found`)
+
+          store.demote(graphId, node.id, target)
+          node.computeSize(node.size)
+
+          store.promote(graphId, node.id, target)
+          node.computeSize(node.size)
+
+          return (node.widgets ?? []).map((w: { name: string }) => w.name)
+        },
+        [nodeId, initialOrder[0]]
+      )
+
+      expect(finalOrder).toEqual(initialOrder)
+    })
+  }
+)

--- a/browser_tests/tests/subgraphPromotionOrder.spec.ts
+++ b/browser_tests/tests/subgraphPromotionOrder.spec.ts
@@ -19,18 +19,22 @@ test.describe(
 
       // Create a subgraph from the KSampler node which has multiple
       // auto-promoted widgets (seed, steps, cfg, etc.)
-      const ksampler = comfyPage.vueNodes.getNodeByTitle('KSampler')
       await comfyPage.vueNodes.waitForNodes()
-      await expect(ksampler).toBeVisible()
 
-      // Select and convert to subgraph
-      const ksamplerRef = await comfyPage.nodeOps.getNodeRefById('3')
-      await ksamplerRef.click('title')
-      const subgraphNode = await ksamplerRef.convertToSubgraph()
+      // Select KSampler and convert to subgraph via evaluate
+      // (LG nodeRef helpers don't work reliably in Vue nodes mode)
+      const nodeId = await comfyPage.page.evaluate(() => {
+        const graph = window.app!.canvas.graph!
+        const ksampler = graph._nodes.find((n) => n.type === 'KSampler')
+        if (!ksampler) throw new Error('KSampler not found')
+
+        window.app!.canvas.selectNode(ksampler)
+        const result = graph.convertToSubgraph(new Set([ksampler]))
+        if (!result) throw new Error('convertToSubgraph failed')
+        return String(result.node.id)
+      })
       await comfyPage.nextFrame()
       await comfyPage.vueNodes.waitForNodes()
-
-      const nodeId = String(subgraphNode.id)
 
       // Verify promoted widgets render in the Vue node body
       const subgraphVueNode = comfyPage.vueNodes.getNodeLocator(nodeId)

--- a/browser_tests/tests/subgraphPromotionOrder.spec.ts
+++ b/browser_tests/tests/subgraphPromotionOrder.spec.ts
@@ -50,10 +50,12 @@ test.describe(
       const domWidgetCount = await widgetElements.count()
       expect(domWidgetCount).toBeGreaterThanOrEqual(initialOrder.length)
 
-      // Demote then re-promote the first widget via the promotion store
+      // Demote then re-promote the first widget via the promotion store.
+      // Pinia store access pattern: see getPiniaStoreInBrowser in
+      // browser_tests/helpers/promotedWidgets.ts
       const finalOrder = await comfyPage.page.evaluate(
         ([id, widgetName]) => {
-          const el = document.getElementById('vue-app') as HTMLElement & {
+          const el = document.getElementById('vue-app') as never as {
             __vue_app__: {
               config: {
                 globalProperties: {
@@ -73,7 +75,8 @@ test.describe(
 
           const node = window.app!.canvas.graph!.getNodeById(id)
           if (!node) throw new Error(`Node "${id}" not found`)
-          const graphId = (node as { rootGraph?: { id: string } }).rootGraph?.id
+          const graphId = (node as typeof node & { rootGraph?: { id: string } })
+            .rootGraph?.id
 
           const entries = store.getPromotions(graphId, node.id) as {
             sourceWidgetName: string

--- a/browser_tests/tests/subgraphPromotionOrder.spec.ts
+++ b/browser_tests/tests/subgraphPromotionOrder.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from '@playwright/test'
 
-import type { ComfyPage } from '../fixtures/ComfyPage'
-import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-import { TestIds } from '../fixtures/selectors'
-import { getPromotedWidgetNames } from '../helpers/promotedWidgets'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { getPromotedWidgetNames } from '@e2e/helpers/promotedWidgets'
 
 async function ensurePropertiesPanel(comfyPage: ComfyPage) {
   const panel = comfyPage.menu.propertiesPanel.root
@@ -41,13 +41,16 @@ test.describe(
       await comfyPage.workflow.loadWorkflow('default')
       await comfyPage.vueNodes.waitForNodes()
 
-      // Create a subgraph from KSampler (multiple auto-promoted widgets)
+      // Create a subgraph from KSampler + one CLIPTextEncode so we get at
+      // least 2 auto-promoted widgets: KSampler's "seed" (in recommendedWidgetNames)
+      // and CLIPTextEncode's "text" (CLIPTextEncode is in recommendedNodes).
       const nodeId = await comfyPage.page.evaluate(() => {
         const graph = window.app!.canvas.graph!
         const ksampler = graph._nodes.find((n) => n.type === 'KSampler')
+        const clipEncode = graph._nodes.find((n) => n.type === 'CLIPTextEncode')
         if (!ksampler) throw new Error('KSampler not found')
-        window.app!.canvas.selectNode(ksampler)
-        const result = graph.convertToSubgraph(new Set([ksampler]))
+        if (!clipEncode) throw new Error('CLIPTextEncode not found')
+        const result = graph.convertToSubgraph(new Set([ksampler, clipEncode]))
         if (!result) throw new Error('convertToSubgraph failed')
         return String(result.node.id)
       })
@@ -58,7 +61,7 @@ test.describe(
       await expect(subgraphVueNode).toBeVisible()
 
       // Select the subgraph node and open SubgraphEditor sidebar
-      await subgraphVueNode.click()
+      await comfyPage.vueNodes.selectNode(nodeId)
       const shownSection = await openSubgraphEditor(comfyPage)
 
       // Capture initial widget order from the sidebar labels
@@ -90,8 +93,7 @@ test.describe(
       await hiddenToggle.first().click()
 
       // Verify the shown section order is restored
-      const restoredLabels = await labels.allTextContents()
-      expect(restoredLabels).toEqual(initialLabels)
+      await expect(labels).toHaveText(initialLabels)
 
       // Also verify the promotion store order matches
       const finalOrder = await getPromotedWidgetNames(comfyPage, nodeId)

--- a/browser_tests/tests/subgraphPromotionOrder.spec.ts
+++ b/browser_tests/tests/subgraphPromotionOrder.spec.ts
@@ -1,34 +1,51 @@
 import { expect } from '@playwright/test'
 
+import type { ComfyPage } from '../fixtures/ComfyPage'
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
 import { TestIds } from '../fixtures/selectors'
 import { getPromotedWidgetNames } from '../helpers/promotedWidgets'
+
+async function ensurePropertiesPanel(comfyPage: ComfyPage) {
+  const panel = comfyPage.menu.propertiesPanel.root
+  if (!(await panel.isVisible())) {
+    await comfyPage.actionbar.propertiesButton.click()
+  }
+  await expect(panel).toBeVisible()
+  return panel
+}
+
+async function openSubgraphEditor(comfyPage: ComfyPage) {
+  await ensurePropertiesPanel(comfyPage)
+  const editorToggle = comfyPage.page.getByTestId(TestIds.subgraphEditor.toggle)
+  await expect(editorToggle).toBeVisible()
+  await editorToggle.click()
+  const shownSection = comfyPage.page.getByTestId(
+    TestIds.subgraphEditor.shownSection
+  )
+  await expect(shownSection).toBeVisible()
+  return shownSection
+}
 
 test.describe(
   'Subgraph promoted widget ordering',
   { tag: ['@subgraph', '@widget'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
       await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     })
 
-    test('demote then re-promote preserves widget order', async ({
+    test('demote then re-promote via sidebar preserves widget order', async ({
       comfyPage
     }) => {
       await comfyPage.workflow.loadWorkflow('default')
-
-      // Create a subgraph from the KSampler node which has multiple
-      // auto-promoted widgets (seed, steps, cfg, etc.)
       await comfyPage.vueNodes.waitForNodes()
 
-      // Select KSampler and convert to subgraph via evaluate
-      // (LG nodeRef helpers don't work reliably in Vue nodes mode)
+      // Create a subgraph from KSampler (multiple auto-promoted widgets)
       const nodeId = await comfyPage.page.evaluate(() => {
         const graph = window.app!.canvas.graph!
         const ksampler = graph._nodes.find((n) => n.type === 'KSampler')
         if (!ksampler) throw new Error('KSampler not found')
-
         window.app!.canvas.selectNode(ksampler)
         const result = graph.convertToSubgraph(new Set([ksampler]))
         if (!result) throw new Error('convertToSubgraph failed')
@@ -37,64 +54,47 @@ test.describe(
       await comfyPage.nextFrame()
       await comfyPage.vueNodes.waitForNodes()
 
-      // Verify promoted widgets render in the Vue node body
       const subgraphVueNode = comfyPage.vueNodes.getNodeLocator(nodeId)
       await expect(subgraphVueNode).toBeVisible()
 
-      const widgetsContainer = subgraphVueNode.getByTestId(
-        TestIds.widgets.container
-      )
-      await expect(widgetsContainer).toBeVisible()
+      // Select the subgraph node and open SubgraphEditor sidebar
+      await subgraphVueNode.click()
+      const shownSection = await openSubgraphEditor(comfyPage)
 
-      // Get the initial promoted widget order
+      // Capture initial widget order from the sidebar labels
+      const labels = shownSection.getByTestId(
+        TestIds.subgraphEditor.widgetLabel
+      )
+      const initialLabels = await labels.allTextContents()
+      expect(initialLabels.length).toBeGreaterThanOrEqual(2)
+
+      // Also capture initial order from the promotion store (source of truth)
       const initialOrder = await getPromotedWidgetNames(comfyPage, nodeId)
-      expect(initialOrder.length).toBeGreaterThanOrEqual(2)
 
-      // Demote then re-promote the first widget via the promotion store.
-      // Pinia store access pattern: see getPiniaStoreInBrowser in
-      // browser_tests/helpers/promotedWidgets.ts
-      const finalOrder = await comfyPage.page.evaluate(
-        ([id, widgetName]) => {
-          const el = document.getElementById('vue-app') as never as {
-            __vue_app__: {
-              config: {
-                globalProperties: {
-                  $pinia: {
-                    _s: Map<
-                      string,
-                      Record<string, (...args: unknown[]) => unknown>
-                    >
-                  }
-                }
-              }
-            }
-          }
-          const store =
-            el.__vue_app__.config.globalProperties.$pinia._s.get('promotion')
-          if (!store) throw new Error('promotionStore not found')
-
-          const node = window.app!.canvas.graph!.getNodeById(id)
-          if (!node) throw new Error(`Node "${id}" not found`)
-          const graphId = (node as typeof node & { rootGraph?: { id: string } })
-            .rootGraph?.id
-
-          const entries = store.getPromotions(graphId, node.id) as {
-            sourceWidgetName: string
-          }[]
-          const target = entries.find((e) => e.sourceWidgetName === widgetName)
-          if (!target) throw new Error(`Widget "${widgetName}" not found`)
-
-          store.demote(graphId, node.id, target)
-          node.computeSize(node.size)
-
-          store.promote(graphId, node.id, target)
-          node.computeSize(node.size)
-
-          return (node.widgets ?? []).map((w: { name: string }) => w.name)
-        },
-        [nodeId, initialOrder[0]]
+      // Hide the first widget via the sidebar toggle (demote)
+      const toggleButtons = shownSection.getByTestId(
+        TestIds.subgraphEditor.widgetToggle
       )
+      await toggleButtons.first().click()
 
+      // The hidden section should now contain the demoted widget
+      const hiddenSection = comfyPage.page.getByTestId(
+        TestIds.subgraphEditor.hiddenSection
+      )
+      await expect(hiddenSection).toBeVisible()
+
+      // Re-show the widget via the hidden section toggle (promote)
+      const hiddenToggle = hiddenSection.getByTestId(
+        TestIds.subgraphEditor.widgetToggle
+      )
+      await hiddenToggle.first().click()
+
+      // Verify the shown section order is restored
+      const restoredLabels = await labels.allTextContents()
+      expect(restoredLabels).toEqual(initialLabels)
+
+      // Also verify the promotion store order matches
+      const finalOrder = await getPromotedWidgetNames(comfyPage, nodeId)
       expect(finalOrder).toEqual(initialOrder)
     })
   }

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -802,14 +802,14 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
         // Force shallowReactive to detect the deep property change
         // by re-assigning the affected array through the defineProperty setter.
+        // This triggers safeWidgets recomputation, which picks up updated
+        // promotedLabel via safeWidgetMapper reading widget.label.
         if (slotLabelEvent.slotType !== NodeSlotType.OUTPUT && nodeRef.inputs) {
           nodeRef.inputs = [...nodeRef.inputs]
         }
         if (slotLabelEvent.slotType !== NodeSlotType.INPUT && nodeRef.outputs) {
           nodeRef.outputs = [...nodeRef.outputs]
         }
-        // Re-extract widget data so promotedLabel reflects the rename
-        vueNodeData.set(nodeId, extractVueNodeData(nodeRef))
       }
     }
 

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -24,6 +24,7 @@ import type { NodeId } from '@/renderer/core/layout/types'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { isDOMWidget } from '@/scripts/domWidget'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { usePromotionStore } from '@/stores/promotionStore'
 import type { WidgetValue, SafeControlWidget } from '@/types/simplifiedWidget'
 import { normalizeControlOption } from '@/types/simplifiedWidget'
 
@@ -473,6 +474,13 @@ export function extractVueNodeData(node: LGraphNode): VueNodeData {
   })
 
   const safeWidgets = reactiveComputed<SafeWidgetData[]>(() => {
+    // For SubgraphNodes, establish a reactive dependency on the promotion
+    // store so this computed re-evaluates when widgets are promoted/demoted.
+    if (existingWidgetsDescriptor?.get && node.isSubgraphNode()) {
+      const promotionStore = usePromotionStore()
+      promotionStore.getPromotionsRef(node.rootGraph.id, node.id)
+    }
+
     const widgetsSnapshot = node.widgets ?? []
 
     const freshMetadata = buildSlotMetadata(node.inputs, node.graph)

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/services/litegraphService', () => ({
 import {
   CANVAS_IMAGE_PREVIEW_WIDGET,
   getPromotableWidgets,
+  getSourceNodeId,
   hasUnpromotedWidgets,
   isLinkedPromotion,
   isPreviewPseudoWidget,
@@ -103,6 +104,31 @@ describe('isPreviewPseudoWidget', () => {
         widget({ name: 'text', serialize: false, type: 'customtext' })
       )
     ).toBe(false)
+  })
+})
+
+describe('getSourceNodeId', () => {
+  it('returns undefined for a regular widget', () => {
+    expect(getSourceNodeId(widget({ name: 'seed' }))).toBeUndefined()
+  })
+
+  it('returns undefined for a promoted widget without disambiguatingSourceNodeId', () => {
+    const promoted = {
+      ...widget({ name: 'seed' }),
+      sourceNodeId: '3',
+      sourceWidgetName: 'seed'
+    } as IBaseWidget
+    expect(getSourceNodeId(promoted)).toBeUndefined()
+  })
+
+  it('returns disambiguatingSourceNodeId when present', () => {
+    const promoted = {
+      ...widget({ name: 'seed' }),
+      sourceNodeId: '3',
+      sourceWidgetName: 'seed',
+      disambiguatingSourceNodeId: '99'
+    } as IBaseWidget
+    expect(getSourceNodeId(promoted)).toBe('99')
   })
 })
 

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -50,7 +50,7 @@ export function isLinkedPromotion(
 
 export function getSourceNodeId(w: IBaseWidget): string | undefined {
   if (!isPromotedWidgetView(w)) return undefined
-  return w.disambiguatingSourceNodeId ?? w.sourceNodeId
+  return w.disambiguatingSourceNodeId
 }
 
 function toPromotionSource(

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -15,6 +15,7 @@ import {
 } from '@/composables/node/canvasImagePreviewTypes'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLitegraphService } from '@/services/litegraphService'
+import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { usePromotionStore } from '@/stores/promotionStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
@@ -124,6 +125,13 @@ export function demoteWidget(
   for (const parent of parents) {
     store.demote(parent.rootGraph.id, parent.id, source)
   }
+
+  // Clear DOM position override so the legacy canvas stops rendering
+  // the interior widget on the subgraph node after demotion.
+  if ('id' in widget && ('element' in widget || 'component' in widget)) {
+    useDomWidgetStore().clearPositionOverride(String(widget.id))
+  }
+
   refreshPromotedWidgetRendering(parents)
   Sentry.addBreadcrumb({
     category: 'subgraph',

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -48,6 +48,9 @@ export function isLinkedPromotion(
   })
 }
 
+// Returns only the explicit disambiguatingSourceNodeId (for nested subgraphs).
+// Must NOT fall back to sourceNodeId — callers pass this to promotionStore
+// lookups where undefined must match stored entries without disambiguation.
 export function getSourceNodeId(w: IBaseWidget): string | undefined {
   if (!isPromotedWidgetView(w)) return undefined
   return w.disambiguatingSourceNodeId

--- a/src/stores/promotionStore.test.ts
+++ b/src/stores/promotionStore.test.ts
@@ -711,6 +711,148 @@ describe(usePromotionStore, () => {
     })
   })
 
+  describe('demote then re-promote preserves position', () => {
+    it('restores a middle entry to its original index', () => {
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '12',
+        sourceWidgetName: 'cfg'
+      })
+
+      store.demote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+
+      expect(store.getPromotions(graphA, nodeId)).toEqual([
+        { sourceNodeId: '10', sourceWidgetName: 'seed' },
+        { sourceNodeId: '11', sourceWidgetName: 'steps' },
+        { sourceNodeId: '12', sourceWidgetName: 'cfg' }
+      ])
+    })
+
+    it('restores the first entry to index 0', () => {
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+
+      store.demote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+
+      expect(store.getPromotions(graphA, nodeId)).toEqual([
+        { sourceNodeId: '10', sourceWidgetName: 'seed' },
+        { sourceNodeId: '11', sourceWidgetName: 'steps' }
+      ])
+    })
+
+    it('clamps index when list has shrunk', () => {
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '12',
+        sourceWidgetName: 'cfg'
+      })
+
+      // Demote last (index 2), then demote middle (index 1)
+      store.demote(graphA, nodeId, {
+        sourceNodeId: '12',
+        sourceWidgetName: 'cfg'
+      })
+      store.demote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+
+      // Re-promote cfg (was index 2, but list now has length 1)
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '12',
+        sourceWidgetName: 'cfg'
+      })
+
+      expect(store.getPromotions(graphA, nodeId)).toEqual([
+        { sourceNodeId: '10', sourceWidgetName: 'seed' },
+        { sourceNodeId: '12', sourceWidgetName: 'cfg' }
+      ])
+    })
+
+    it('appends when no prior position is remembered', () => {
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+
+      expect(store.getPromotions(graphA, nodeId)).toEqual([
+        { sourceNodeId: '10', sourceWidgetName: 'seed' },
+        { sourceNodeId: '11', sourceWidgetName: 'steps' }
+      ])
+    })
+
+    it('clearGraph resets remembered positions', () => {
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+
+      store.demote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+
+      store.clearGraph(graphA)
+
+      // Re-promote after clear — no remembered position, should append
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '11',
+        sourceWidgetName: 'steps'
+      })
+      store.promote(graphA, nodeId, {
+        sourceNodeId: '10',
+        sourceWidgetName: 'seed'
+      })
+
+      expect(store.getPromotions(graphA, nodeId)).toEqual([
+        { sourceNodeId: '11', sourceWidgetName: 'steps' },
+        { sourceNodeId: '10', sourceWidgetName: 'seed' }
+      ])
+    })
+  })
+
   describe('sourceNodeId disambiguation', () => {
     it('promote with disambiguatingSourceNodeId is found by matching isPromoted', () => {
       store.promote(graphA, nodeId, {

--- a/src/stores/promotionStore.test.ts
+++ b/src/stores/promotionStore.test.ts
@@ -803,7 +803,7 @@ describe(usePromotionStore, () => {
       ])
     })
 
-    it('appends when no prior position is remembered', () => {
+    it('initial promotes append in order', () => {
       store.promote(graphA, nodeId, {
         sourceNodeId: '10',
         sourceWidgetName: 'seed'

--- a/src/stores/promotionStore.ts
+++ b/src/stores/promotionStore.ts
@@ -19,6 +19,7 @@ export const usePromotionStore = defineStore('promotion', () => {
     new Map<UUID, Map<NodeId, PromotedWidgetSource[]>>()
   )
   const graphRefCounts = ref(new Map<UUID, Map<string, number>>())
+  const lastDemotedIndices = new Map<string, number>()
 
   function _getPromotionsForGraph(
     graphId: UUID
@@ -136,7 +137,19 @@ export const usePromotionStore = defineStore('promotion', () => {
     }
     if (source.disambiguatingSourceNodeId)
       entry.disambiguatingSourceNodeId = source.disambiguatingSourceNodeId
-    setPromotions(graphId, subgraphNodeId, [...entries, entry])
+
+    const positionKey = `${graphId}:${subgraphNodeId}:${makePromotionEntryKey(source)}`
+    const lastIndex = lastDemotedIndices.get(positionKey)
+    lastDemotedIndices.delete(positionKey)
+
+    const nextEntries = [...entries]
+    if (lastIndex !== undefined) {
+      const insertAt = Math.min(lastIndex, nextEntries.length)
+      nextEntries.splice(insertAt, 0, entry)
+    } else {
+      nextEntries.push(entry)
+    }
+    setPromotions(graphId, subgraphNodeId, nextEntries)
   }
 
   function demote(
@@ -145,17 +158,20 @@ export const usePromotionStore = defineStore('promotion', () => {
     source: PromotedWidgetSource
   ): void {
     const entries = getPromotionsRef(graphId, subgraphNodeId)
+    const index = entries.findIndex(
+      (e) =>
+        e.sourceNodeId === source.sourceNodeId &&
+        e.sourceWidgetName === source.sourceWidgetName &&
+        e.disambiguatingSourceNodeId === source.disambiguatingSourceNodeId
+    )
+    if (index !== -1) {
+      const positionKey = `${graphId}:${subgraphNodeId}:${makePromotionEntryKey(source)}`
+      lastDemotedIndices.set(positionKey, index)
+    }
     setPromotions(
       graphId,
       subgraphNodeId,
-      entries.filter(
-        (e) =>
-          !(
-            e.sourceNodeId === source.sourceNodeId &&
-            e.sourceWidgetName === source.sourceWidgetName &&
-            e.disambiguatingSourceNodeId === source.disambiguatingSourceNodeId
-          )
-      )
+      entries.filter((_, i) => i !== index)
     )
   }
 
@@ -188,6 +204,9 @@ export const usePromotionStore = defineStore('promotion', () => {
   function clearGraph(graphId: UUID): void {
     graphPromotions.value.delete(graphId)
     graphRefCounts.value.delete(graphId)
+    for (const key of lastDemotedIndices.keys()) {
+      if (key.startsWith(`${graphId}:`)) lastDemotedIndices.delete(key)
+    }
   }
 
   return {

--- a/src/stores/promotionStore.ts
+++ b/src/stores/promotionStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, triggerRef } from 'vue'
 
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
@@ -122,6 +122,7 @@ export const usePromotionStore = defineStore('promotion', () => {
     } else {
       promotions.set(subgraphNodeId, [...entries])
     }
+    triggerRef(graphPromotions)
   }
 
   function makePositionKey(

--- a/src/stores/promotionStore.ts
+++ b/src/stores/promotionStore.ts
@@ -20,7 +20,7 @@ export const usePromotionStore = defineStore('promotion', () => {
   )
   const graphRefCounts = ref(new Map<UUID, Map<string, number>>())
   // Non-reactive: ephemeral position cache consumed only by promote/demote
-  const lastDemotedIndices = new Map<string, number>()
+  const lastDemotedIndices = new Map<UUID, Map<string, number>>()
 
   function _getPromotionsForGraph(
     graphId: UUID
@@ -125,12 +125,19 @@ export const usePromotionStore = defineStore('promotion', () => {
     triggerRef(graphPromotions)
   }
 
-  function makePositionKey(
-    graphId: UUID,
+  function _positionKey(
     subgraphNodeId: NodeId,
     source: PromotedWidgetSource
   ): string {
-    return `${graphId}:${subgraphNodeId}:${makePromotionEntryKey(source)}`
+    return `${subgraphNodeId}:${makePromotionEntryKey(source)}`
+  }
+
+  function _getLastDemotedForGraph(graphId: UUID): Map<string, number> {
+    const existing = lastDemotedIndices.get(graphId)
+    if (existing) return existing
+    const next = new Map<string, number>()
+    lastDemotedIndices.set(graphId, next)
+    return next
   }
 
   function promote(
@@ -148,9 +155,10 @@ export const usePromotionStore = defineStore('promotion', () => {
     if (source.disambiguatingSourceNodeId)
       entry.disambiguatingSourceNodeId = source.disambiguatingSourceNodeId
 
-    const positionKey = makePositionKey(graphId, subgraphNodeId, source)
-    const lastIndex = lastDemotedIndices.get(positionKey)
-    lastDemotedIndices.delete(positionKey)
+    const positionKey = _positionKey(subgraphNodeId, source)
+    const graphCache = lastDemotedIndices.get(graphId)
+    const lastIndex = graphCache?.get(positionKey)
+    graphCache?.delete(positionKey)
 
     const nextEntries = [...entries]
     if (lastIndex !== undefined) {
@@ -176,8 +184,10 @@ export const usePromotionStore = defineStore('promotion', () => {
     )
     if (index === -1) return
 
-    const positionKey = makePositionKey(graphId, subgraphNodeId, source)
-    lastDemotedIndices.set(positionKey, index)
+    _getLastDemotedForGraph(graphId).set(
+      _positionKey(subgraphNodeId, source),
+      index
+    )
     setPromotions(
       graphId,
       subgraphNodeId,
@@ -214,9 +224,7 @@ export const usePromotionStore = defineStore('promotion', () => {
   function clearGraph(graphId: UUID): void {
     graphPromotions.value.delete(graphId)
     graphRefCounts.value.delete(graphId)
-    for (const key of Array.from(lastDemotedIndices.keys())) {
-      if (key.startsWith(`${graphId}:`)) lastDemotedIndices.delete(key)
-    }
+    lastDemotedIndices.delete(graphId)
   }
 
   return {

--- a/src/stores/promotionStore.ts
+++ b/src/stores/promotionStore.ts
@@ -19,6 +19,7 @@ export const usePromotionStore = defineStore('promotion', () => {
     new Map<UUID, Map<NodeId, PromotedWidgetSource[]>>()
   )
   const graphRefCounts = ref(new Map<UUID, Map<string, number>>())
+  // Non-reactive: ephemeral position cache consumed only by promote/demote
   const lastDemotedIndices = new Map<string, number>()
 
   function _getPromotionsForGraph(
@@ -123,6 +124,14 @@ export const usePromotionStore = defineStore('promotion', () => {
     }
   }
 
+  function makePositionKey(
+    graphId: UUID,
+    subgraphNodeId: NodeId,
+    source: PromotedWidgetSource
+  ): string {
+    return `${graphId}:${subgraphNodeId}:${makePromotionEntryKey(source)}`
+  }
+
   function promote(
     graphId: UUID,
     subgraphNodeId: NodeId,
@@ -138,7 +147,7 @@ export const usePromotionStore = defineStore('promotion', () => {
     if (source.disambiguatingSourceNodeId)
       entry.disambiguatingSourceNodeId = source.disambiguatingSourceNodeId
 
-    const positionKey = `${graphId}:${subgraphNodeId}:${makePromotionEntryKey(source)}`
+    const positionKey = makePositionKey(graphId, subgraphNodeId, source)
     const lastIndex = lastDemotedIndices.get(positionKey)
     lastDemotedIndices.delete(positionKey)
 
@@ -164,10 +173,10 @@ export const usePromotionStore = defineStore('promotion', () => {
         e.sourceWidgetName === source.sourceWidgetName &&
         e.disambiguatingSourceNodeId === source.disambiguatingSourceNodeId
     )
-    if (index !== -1) {
-      const positionKey = `${graphId}:${subgraphNodeId}:${makePromotionEntryKey(source)}`
-      lastDemotedIndices.set(positionKey, index)
-    }
+    if (index === -1) return
+
+    const positionKey = makePositionKey(graphId, subgraphNodeId, source)
+    lastDemotedIndices.set(positionKey, index)
     setPromotions(
       graphId,
       subgraphNodeId,
@@ -204,7 +213,7 @@ export const usePromotionStore = defineStore('promotion', () => {
   function clearGraph(graphId: UUID): void {
     graphPromotions.value.delete(graphId)
     graphRefCounts.value.delete(graphId)
-    for (const key of lastDemotedIndices.keys()) {
+    for (const key of Array.from(lastDemotedIndices.keys())) {
       if (key.startsWith(`${graphId}:`)) lastDemotedIndices.delete(key)
     }
   }


### PR DESCRIPTION
## Summary

Fix three bugs in the sidebar show/hide flow that caused promoted widget order to scramble and allowed duplicate promotions.

## Changes

- **What**: `promotionStore.promote()` now restores a widget to its original position when re-promoted after demotion. `getSourceNodeId()` no longer falls back to `sourceNodeId`, fixing broken `isPromoted` lookups for non-nested subgraphs. Removed non-idempotent `extractVueNodeData()` re-call from `node:slot-label:changed` handler.

## Review Focus

- `promotionStore.ts`: `demote()` records removed entry index in `lastDemotedIndices` map; `promote()` inserts at that index (clamped) instead of always appending. Map cleared on `clearGraph()`.
- `promotionUtils.ts`: One-line fix removing `?? w.sourceNodeId` fallback that caused `disambiguatingSourceNodeId` mismatch in all sidebar store lookups.
- `useGraphNodeManager.ts`: Removed `vueNodeData.set(nodeId, extractVueNodeData(nodeRef))` — the existing reactive array reassignment already triggers `safeWidgets` recomputation.

Fixes #9995

Related: #9841 (duplicate inputs + broken ordering), #10227 / #10232 (subgraph IO ordering — handled separately)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10584-fix-preserve-promoted-widget-order-on-sidebar-hide-show-cycle-drag-reorder-3306d73d365081d9be91f55494e5b00e) by [Unito](https://www.unito.io)
