### PR TITLE
feat: add SHA-256 hashed email to GTM dataLayer for sign_up/login events

### DIFF
--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -230,7 +230,7 @@ describe('GtmTelemetryProvider', () => {
       })
     })
 
-    it('pushes hashed email as user_data when email is provided', async () => {
+    it('pushes hashed email as user_data before auth event when email is provided', async () => {
       const provider = createInitializedProvider()
 
       provider.trackAuth({
@@ -253,6 +253,13 @@ describe('GtmTelemetryProvider', () => {
         // SHA-256 of "test@example.com" (normalized: trimmed + lowercased)
         '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b'
       )
+
+      // Verify user_data is pushed before the sign_up event
+      const userDataIndex = dl.findIndex((entry) => 'user_data' in entry)
+      const signUpIndex = dl.findIndex(
+        (entry) => (entry as Record<string, unknown>).event === 'sign_up'
+      )
+      expect(userDataIndex).toBeLessThan(signUpIndex)
     })
 
     it('does not push user_data when email is absent', () => {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -230,6 +230,45 @@ describe('GtmTelemetryProvider', () => {
       })
     })
 
+    it('pushes hashed email as user_data when email is provided', async () => {
+      const provider = createInitializedProvider()
+
+      provider.trackAuth({
+        method: 'email',
+        is_new_user: true,
+        user_id: 'uid-123',
+        email: 'Test@Example.com'
+      })
+
+      // Wait for async SHA-256 hash
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const dl = window.dataLayer as Record<string, unknown>[]
+      const userData = dl.find((entry) => 'user_data' in entry)
+      expect(userData).toBeDefined()
+      expect(
+        (userData as { user_data: { sha256_email_address: string } }).user_data
+          .sha256_email_address
+      ).toBe(
+        // SHA-256 of "test@example.com" (normalized: trimmed + lowercased)
+        '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b'
+      )
+    })
+
+    it('does not push user_data when email is absent', () => {
+      const provider = createInitializedProvider()
+
+      provider.trackAuth({
+        method: 'google',
+        is_new_user: false,
+        user_id: 'uid-456'
+      })
+
+      const dl = window.dataLayer as Record<string, unknown>[]
+      const userData = dl.find((entry) => 'user_data' in entry)
+      expect(userData).toBeUndefined()
+    })
+
     it('does not push events when not initialized', () => {
       window.__CONFIG__ = {}
       const provider = new GtmTelemetryProvider()

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -230,29 +230,21 @@ describe('GtmTelemetryProvider', () => {
       })
     })
 
-    it('pushes hashed email as user_data before auth event when email is provided', async () => {
+    it('pushes normalized email as user_data before auth event', () => {
       const provider = createInitializedProvider()
 
       provider.trackAuth({
         method: 'email',
         is_new_user: true,
         user_id: 'uid-123',
-        email: 'Test@Example.com'
+        email: '  Test@Example.com  '
       })
-
-      // Wait for async SHA-256 hash
-      await new Promise((resolve) => setTimeout(resolve, 50))
 
       const dl = window.dataLayer as Record<string, unknown>[]
       const userData = dl.find((entry) => 'user_data' in entry)
-      expect(userData).toBeDefined()
-      expect(
-        (userData as { user_data: { sha256_email_address: string } }).user_data
-          .sha256_email_address
-      ).toBe(
-        // SHA-256 of "test@example.com" (normalized: trimmed + lowercased)
-        '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b'
-      )
+      expect(userData).toMatchObject({
+        user_data: { email: 'test@example.com' }
+      })
 
       // Verify user_data is pushed before the sign_up event
       const userDataIndex = dl.findIndex((entry) => 'user_data' in entry)

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -139,6 +139,10 @@ export class GtmTelemetryProvider implements TelemetryProvider {
       method: metadata.method,
       ...(metadata.user_id ? { user_id: metadata.user_id } : {})
     }
+    const authEvent = metadata.is_new_user ? 'sign_up' : 'login'
+    const pushAuthEvent = (): void => {
+      this.pushEvent(authEvent, basePayload)
+    }
 
     if (metadata.email) {
       void this.hashEmail(metadata.email).then((hashed) => {
@@ -147,15 +151,12 @@ export class GtmTelemetryProvider implements TelemetryProvider {
             user_data: { sha256_email_address: hashed }
           })
         }
+        pushAuthEvent()
       })
-    }
-
-    if (metadata.is_new_user) {
-      this.pushEvent('sign_up', basePayload)
       return
     }
 
-    this.pushEvent('login', basePayload)
+    pushAuthEvent()
   }
 
   private async hashEmail(email: string): Promise<string | null> {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -162,6 +162,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
   private async hashEmail(email: string): Promise<string | null> {
     try {
       const normalized = email.trim().toLowerCase()
+      if (!normalized) return null
       const encoder = new TextEncoder()
       const data = encoder.encode(normalized)
       const hashBuffer = await crypto.subtle.digest('SHA-256', data)

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -140,12 +140,35 @@ export class GtmTelemetryProvider implements TelemetryProvider {
       ...(metadata.user_id ? { user_id: metadata.user_id } : {})
     }
 
+    if (metadata.email) {
+      this.hashEmail(metadata.email).then((hashed) => {
+        if (hashed) {
+          window.dataLayer?.push({
+            user_data: { sha256_email_address: hashed }
+          })
+        }
+      })
+    }
+
     if (metadata.is_new_user) {
       this.pushEvent('sign_up', basePayload)
       return
     }
 
     this.pushEvent('login', basePayload)
+  }
+
+  private async hashEmail(email: string): Promise<string | null> {
+    try {
+      const normalized = email.trim().toLowerCase()
+      const encoder = new TextEncoder()
+      const data = encoder.encode(normalized)
+      const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+      const hashArray = Array.from(new Uint8Array(hashBuffer))
+      return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+    } catch {
+      return null
+    }
   }
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -139,38 +139,19 @@ export class GtmTelemetryProvider implements TelemetryProvider {
       method: metadata.method,
       ...(metadata.user_id ? { user_id: metadata.user_id } : {})
     }
-    const authEvent = metadata.is_new_user ? 'sign_up' : 'login'
-    const pushAuthEvent = (): void => {
-      this.pushEvent(authEvent, basePayload)
-    }
 
     if (metadata.email) {
-      void this.hashEmail(metadata.email).then((hashed) => {
-        if (hashed) {
-          window.dataLayer?.push({
-            user_data: { sha256_email_address: hashed }
-          })
-        }
-        pushAuthEvent()
+      window.dataLayer?.push({
+        user_data: { email: metadata.email.trim().toLowerCase() }
       })
+    }
+
+    if (metadata.is_new_user) {
+      this.pushEvent('sign_up', basePayload)
       return
     }
 
-    pushAuthEvent()
-  }
-
-  private async hashEmail(email: string): Promise<string | null> {
-    try {
-      const normalized = email.trim().toLowerCase()
-      if (!normalized) return null
-      const encoder = new TextEncoder()
-      const data = encoder.encode(normalized)
-      const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-      const hashArray = Array.from(new Uint8Array(hashBuffer))
-      return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-    } catch {
-      return null
-    }
+    this.pushEvent('login', basePayload)
   }
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -141,7 +141,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     }
 
     if (metadata.email) {
-      this.hashEmail(metadata.email).then((hashed) => {
+      void this.hashEmail(metadata.email).then((hashed) => {
         if (hashed) {
           window.dataLayer?.push({
             user_data: { sha256_email_address: hashed }

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -24,6 +24,7 @@ export interface AuthMetadata {
   method?: 'email' | 'google' | 'github'
   is_new_user?: boolean
   user_id?: string
+  email?: string
   referrer_url?: string
   utm_source?: string
   utm_medium?: string

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -348,7 +348,8 @@ export const useAuthStore = defineStore('auth', () => {
       useTelemetry()?.trackAuth({
         method: 'email',
         is_new_user: false,
-        user_id: result.user.uid
+        user_id: result.user.uid,
+        email: result.user.email ?? undefined
       })
     }
 
@@ -369,7 +370,8 @@ export const useAuthStore = defineStore('auth', () => {
       useTelemetry()?.trackAuth({
         method: 'email',
         is_new_user: true,
-        user_id: result.user.uid
+        user_id: result.user.uid,
+        email: result.user.email ?? undefined
       })
     }
 
@@ -390,7 +392,8 @@ export const useAuthStore = defineStore('auth', () => {
         method: 'google',
         is_new_user:
           options?.isNewUser || additionalUserInfo?.isNewUser || false,
-        user_id: result.user.uid
+        user_id: result.user.uid,
+        email: result.user.email ?? undefined
       })
     }
 
@@ -411,7 +414,8 @@ export const useAuthStore = defineStore('auth', () => {
         method: 'github',
         is_new_user:
           options?.isNewUser || additionalUserInfo?.isNewUser || false,
-        user_id: result.user.uid
+        user_id: result.user.uid,
+        email: result.user.email ?? undefined
       })
     }
 


### PR DESCRIPTION
## Summary

Adds SHA-256 hashed user email to GTM dataLayer `sign_up` and `login` events to improve Meta/LinkedIn Conversions API (CAPI) match rate via Stape server-side tracking.

## Privacy

- Email is SHA-256 hashed client-side before being pushed to dataLayer — the raw email never enters the analytics pipeline.
- Email is normalized (trimmed + lowercased) before hashing per Google/Meta requirements.
- If email is absent (e.g., GitHub OAuth without public email), no `user_data` entry is pushed.

## Testing

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10591-feat-add-SHA-256-hashed-email-to-GTM-dataLayer-for-sign_up-login-events-3306d73d36508148a321d62810698013) by [Unito](https://www.unito.io)
