### PR TITLE
[backport cloud/1.42] feat: fire subscription_success telemetry on subscription activation (#10186)

### DIFF
--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -236,6 +236,7 @@ watch(
   () => isActiveSubscription.value,
   (isActive) => {
     if (isActive && showCustomPricingTable.value) {
+      telemetry?.trackMonthlySubscriptionSucceeded()
       emit('close', true)
     }
   }

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -90,6 +90,14 @@ describe('GtmTelemetryProvider', () => {
       expect(lastDataLayerEntry()).toMatchObject({ event: 'select_promotion' })
     })
 
+    it('pushes subscription_success for subscription activation', () => {
+      const provider = createInitializedProvider()
+      provider.trackMonthlySubscriptionSucceeded()
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'subscription_success'
+      })
+    })
+
     it('pushes run_workflow with trigger_source', () => {
       const provider = createInitializedProvider()
       provider.trackRunButton({ trigger_source: 'button' })

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -165,6 +165,10 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     this.pushEvent('signup_opened')
   }
 
+  trackMonthlySubscriptionSucceeded(): void {
+    this.pushEvent('subscription_success')
+  }
+
   trackRunButton(options?: {
     subscribe_to_run?: boolean
     trigger_source?: ExecutionTriggerSource

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -47,6 +47,14 @@ vi.mock('@/stores/dialogStore', () => ({
   })
 }))
 
+const mockTrackMonthlySubscriptionSucceeded = vi.fn()
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackMonthlySubscriptionSucceeded: mockTrackMonthlySubscriptionSucceeded
+  })
+}))
+
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingOperationStore } from './billingOperationStore'
@@ -157,6 +165,37 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.subscriptionSuccess',
         life: 5000
       })
+    })
+
+    it('fires purchase telemetry on subscription success', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      store.startOperation('op-1', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+    })
+
+    it('does not fire purchase telemetry on topup success', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      store.startOperation('op-1', 'topup')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockTrackMonthlySubscriptionSucceeded).not.toHaveBeenCalled()
     })
 
     it('shows topup success message for topup operations', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { t } from '@/i18n'
+import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
@@ -132,6 +133,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'succeeded', null)
     cleanup(opId)
+
+    if (operation.type === 'subscription') {
+      useTelemetry()?.trackMonthlySubscriptionSucceeded()
+    }
 
     const billingContext = useBillingContext()
     await Promise.all([


### PR DESCRIPTION
Backport of #10186 to cloud/1.42.

Fires a client-side `subscription_success` event to GTM when a subscription activates, enabling LinkedIn and Meta conversion tracking tags.

Cherry-picked from merge commit 6c14802.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10594-backport-cloud-1-42-feat-fire-subscription_success-telemetry-on-subscription-activati-3306d73d3650812b9e5adc34369146d2) by [Unito](https://www.unito.io)
