### PR TITLE
fix: derive payment redirect URLs from getComfyPlatformBaseUrl()

### DIFF
--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -100,6 +100,7 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
@@ -218,8 +219,8 @@ async function handleAddCreditCard() {
     if (!planSlug) return
     const response = await subscribe(
       planSlug,
-      'https://www.comfy.org/payment/success',
-      'https://www.comfy.org/payment/failed'
+      `${getComfyPlatformBaseUrl()}/payment/success`,
+      `${getComfyPlatformBaseUrl()}/payment/failed`
     )
 
     if (!response) return
@@ -272,8 +273,8 @@ async function handleConfirmTransition() {
     if (!planSlug) return
     const response = await subscribe(
       planSlug,
-      'https://www.comfy.org/payment/success',
-      'https://www.comfy.org/payment/failed'
+      `${getComfyPlatformBaseUrl()}/payment/success`,
+      `${getComfyPlatformBaseUrl()}/payment/failed`
     )
 
     if (!response) return


### PR DESCRIPTION
Replaces hardcoded `https://www.comfy.org/payment/...` URLs with `getComfyPlatformBaseUrl()` so staging deploys no longer redirect users to production after payment.

fix #10456

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10600-fix-derive-payment-redirect-URLs-from-getComfyPlatformBaseUrl-3306d73d365081679ef4da840337bb81) by [Unito](https://www.unito.io)
