### PR TITLE
fix: hide inaccurate resolution subtitle on cloud asset cards

### DIFF
--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -141,6 +141,7 @@ import { computed, defineAsyncComponent, provide, ref, toRef } from 'vue'
 import IconGroup from '@/components/button/IconGroup.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { isCloud } from '@/platform/distribution/types'
 import { useAssetsStore } from '@/stores/assetsStore'
 import {
   formatDuration,
@@ -279,7 +280,8 @@ const formattedDuration = computed(() => {
 // Get metadata info based on file kind
 const metaInfo = computed(() => {
   if (!asset) return ''
-  if (fileKind.value === 'image' && imageDimensions.value) {
+  // TODO(assets): Re-enable once /assets API returns original image dimensions in metadata (#10590)
+  if (fileKind.value === 'image' && imageDimensions.value && !isCloud) {
     return `${imageDimensions.value.width}x${imageDimensions.value.height}`
   }
   if (asset.size && ['video', 'audio', '3D'].includes(fileKind.value)) {


### PR DESCRIPTION
## Summary

Hide image resolution subtitle on cloud asset cards because thumbnails are downscaled to max 512px, causing `naturalWidth`/`naturalHeight` to report incorrect dimensions.

## Changes

- **What**: Gate the dimension display in `MediaAssetCard.vue` behind `!isCloud` so resolution is only shown on local (where full-res images are loaded). Added TODO referencing #10590 for re-enabling once `/assets` API returns original dimensions in metadata.

## Review Focus

One-line conditional change — the `isCloud` import from `@/platform/distribution/types` follows the established pattern used across the repo.

Fixes #10590

## Screenshots (if applicable)

N/A — this removes a subtitle that was displaying wrong values (e.g., showing 512x512 for a 1024x1024 image on cloud).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10602-fix-hide-inaccurate-resolution-subtitle-on-cloud-asset-cards-3306d73d36508186bd3ad704bd83bf14) by [Unito](https://www.unito.io)
