### PR TITLE
fix: prevent scroll event leak from text widgets to canvas

### DIFF
--- a/src/components/graph/widgets/TextPreviewWidget.vue
+++ b/src/components/graph/widgets/TextPreviewWidget.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="relative max-h-[200px] min-h-[28px] w-full overflow-y-auto rounded-lg px-4 py-2 text-xs"
+    data-capture-wheel="true"
   >
     <div class="flex items-center gap-2">
       <div class="flex flex-1 items-center gap-2 break-all">

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -46,12 +46,21 @@ function createMockPointerEvent(
   return mockEvent as PointerEvent
 }
 
-function createMockWheelEvent(ctrlKey = false, metaKey = false): WheelEvent {
+function createMockWheelEvent(
+  ctrlKey = false,
+  metaKey = false,
+  deltaY = 0,
+  target?: HTMLElement
+): WheelEvent {
   const mockEvent: Partial<WheelEvent> = {
     ctrlKey,
     metaKey,
+    deltaY,
     preventDefault: vi.fn(),
     stopPropagation: vi.fn()
+  }
+  if (target) {
+    Object.defineProperty(mockEvent, 'target', { value: target })
   }
   return mockEvent as WheelEvent
 }
@@ -221,6 +230,105 @@ describe('useCanvasInteractions', () => {
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
 
       document.body.removeChild(captureElement)
+    })
+
+    describe('scrollable capture-wheel elements', () => {
+      function createScrollableElement(): {
+        container: HTMLDivElement
+        inner: HTMLDivElement
+        cleanup: () => void
+      } {
+        const container = document.createElement('div')
+        container.setAttribute('data-capture-wheel', 'true')
+        // Simulate scrollable element with overflow content
+        Object.defineProperties(container, {
+          scrollHeight: { value: 200, configurable: true },
+          clientHeight: { value: 100, configurable: true },
+          scrollTop: { value: 50, writable: true, configurable: true }
+        })
+        const inner = document.createElement('div')
+        container.appendChild(inner)
+        document.body.appendChild(container)
+        return {
+          container,
+          inner,
+          cleanup: () => document.body.removeChild(container)
+        }
+      }
+
+      it('should NOT forward wheel when scrollable element has room to scroll', () => {
+        const { get } = useSettingStore()
+        vi.mocked(get).mockReturnValue('standard')
+
+        const { inner, cleanup } = createScrollableElement()
+        const { handleWheel } = useCanvasInteractions()
+        // scrollTop=50, scrolling down, not at bottom
+        const mockEvent = createMockWheelEvent(false, false, 100, inner)
+
+        handleWheel(mockEvent)
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled()
+        expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
+        cleanup()
+      })
+
+      it('should forward wheel when scrollable element is at top boundary scrolling up', () => {
+        const { get } = useSettingStore()
+        vi.mocked(get).mockReturnValue('legacy')
+
+        const { container, inner, cleanup } = createScrollableElement()
+        // At top
+        Object.defineProperty(container, 'scrollTop', {
+          value: 0,
+          configurable: true
+        })
+        const { handleWheel } = useCanvasInteractions()
+        // Scrolling up (deltaY < 0) while at top
+        const mockEvent = createMockWheelEvent(false, false, -100, inner)
+
+        handleWheel(mockEvent)
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled()
+        expect(mockEvent.stopPropagation).toHaveBeenCalled()
+        cleanup()
+      })
+
+      it('should forward wheel when scrollable element is at bottom boundary scrolling down', () => {
+        const { get } = useSettingStore()
+        vi.mocked(get).mockReturnValue('legacy')
+
+        const { container, inner, cleanup } = createScrollableElement()
+        // At bottom: scrollTop + clientHeight >= scrollHeight
+        Object.defineProperty(container, 'scrollTop', {
+          value: 100,
+          configurable: true
+        })
+        const { handleWheel } = useCanvasInteractions()
+        // Scrolling down (deltaY > 0) while at bottom
+        const mockEvent = createMockWheelEvent(false, false, 100, inner)
+
+        handleWheel(mockEvent)
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled()
+        expect(mockEvent.stopPropagation).toHaveBeenCalled()
+        cleanup()
+      })
+
+      it('should forward ctrl+wheel to canvas even when scrollable element has room', () => {
+        const { get } = useSettingStore()
+        vi.mocked(get).mockReturnValue('standard')
+
+        const { inner, cleanup } = createScrollableElement()
+        const { handleWheel } = useCanvasInteractions()
+        // Ctrl+wheel for zoom — should bypass scroll capture
+        const mockEvent = createMockWheelEvent(true, false, 100, inner)
+
+        handleWheel(mockEvent)
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled()
+        expect(mockEvent.stopPropagation).toHaveBeenCalled()
+        cleanup()
+      })
     })
   })
 })

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -41,9 +41,45 @@ export function useCanvasInteractions() {
     return !!(captureElement && active && captureElement.contains(active))
   }
 
-  const shouldForwardWheelEvent = (event: WheelEvent): boolean =>
-    !wheelCapturedByFocusedElement(event) ||
-    (isStandardNavMode.value && (event.ctrlKey || event.metaKey))
+  /**
+   * Returns true if the wheel event target is inside a scrollable
+   * capture-wheel element that can still scroll in the current direction.
+   * This prevents scroll events from leaking to the canvas when the user
+   * scrolls within a widget's content area, even when the widget is not focused.
+   */
+  const wheelCapturedByScrollableElement = (event: WheelEvent): boolean => {
+    const target = event.target as HTMLElement | null
+    const captureElement = target?.closest(
+      '[data-capture-wheel="true"]'
+    ) as HTMLElement | null
+    if (!captureElement) return false
+
+    const isScrollable =
+      captureElement.scrollHeight > captureElement.clientHeight
+    if (!isScrollable) return false
+
+    const { scrollTop, scrollHeight, clientHeight } = captureElement
+    const tolerance = 1
+    const atTop = scrollTop <= tolerance
+    const atBottom = scrollTop + clientHeight >= scrollHeight - tolerance
+
+    // At boundary scrolling further out — let canvas handle it
+    if (event.deltaY < 0 && atTop) return false
+    if (event.deltaY > 0 && atBottom) return false
+
+    return true
+  }
+
+  const shouldForwardWheelEvent = (event: WheelEvent): boolean => {
+    // Focused capture-wheel elements always block forwarding (except Ctrl+wheel zoom)
+    if (wheelCapturedByFocusedElement(event)) {
+      return isStandardNavMode.value && (event.ctrlKey || event.metaKey)
+    }
+    // Scrollable capture-wheel elements block forwarding when within scroll bounds
+    if (wheelCapturedByScrollableElement(event)) return false
+
+    return true
+  }
 
   /**
    * Handles wheel events from UI components that should be forwarded to canvas

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -76,7 +76,10 @@ export function useCanvasInteractions() {
       return isStandardNavMode.value && (event.ctrlKey || event.metaKey)
     }
     // Scrollable capture-wheel elements block forwarding when within scroll bounds
-    if (wheelCapturedByScrollableElement(event)) return false
+    // (except Ctrl/Cmd+wheel which should always reach canvas for zoom)
+    if (wheelCapturedByScrollableElement(event)) {
+      return isStandardNavMode.value && (event.ctrlKey || event.metaKey)
+    }
 
     return true
   }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
@@ -100,8 +100,8 @@ function addMarkdownWidget(
       return
     }
 
-    // Ctrl+wheel always goes to canvas for zoom
-    if (event.ctrlKey) {
+    // Ctrl+wheel (or Cmd+wheel on macOS) always goes to canvas for zoom
+    if (event.ctrlKey || event.metaKey) {
       event.preventDefault()
       event.stopPropagation()
       app.canvas.processMouseWheel(event)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
@@ -91,6 +91,39 @@ function addMarkdownWidget(
     event.stopPropagation()
   })
 
+  inputEl.addEventListener('wheel', (event: WheelEvent) => {
+    const canScrollY = inputEl.scrollHeight > inputEl.clientHeight
+    if (!canScrollY) {
+      // Not scrollable — forward to canvas
+      event.preventDefault()
+      app.canvas.processMouseWheel(event)
+      return
+    }
+
+    // Ctrl+wheel always goes to canvas for zoom
+    if (event.ctrlKey) {
+      event.preventDefault()
+      event.stopPropagation()
+      app.canvas.processMouseWheel(event)
+      return
+    }
+
+    const atTop = inputEl.scrollTop <= 0
+    const atBottom =
+      inputEl.scrollTop + inputEl.clientHeight >= inputEl.scrollHeight - 1
+
+    if ((event.deltaY < 0 && atTop) || (event.deltaY > 0 && atBottom)) {
+      // At boundary — forward to canvas
+      event.preventDefault()
+      event.stopPropagation()
+      app.canvas.processMouseWheel(event)
+      return
+    }
+
+    // Within scroll range — consume event
+    event.stopPropagation()
+  })
+
   inputEl.addEventListener('pointerdown', (event: PointerEvent) => {
     if (event.button === 1) {
       app.canvas.processMouseDown(event)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -79,8 +79,8 @@ function addMultilineWidget(
     const canScrollY = inputEl.scrollHeight > inputEl.clientHeight
     const isHorizontal = Math.abs(deltaX) > Math.abs(deltaY)
 
-    // Prevent pinch zoom from zooming the page
-    if (event.ctrlKey) {
+    // Prevent pinch zoom from zooming the page (Ctrl on Windows/Linux, Cmd on macOS)
+    if (event.ctrlKey || event.metaKey) {
       event.preventDefault()
       event.stopPropagation()
       app.canvas.processMouseWheel(event)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -111,6 +111,21 @@ function addMultilineWidget(
 
     // Vertical scrolling when gestures disabled: let textarea scroll if scrollable
     if (canScrollY) {
+      const atTop = inputEl.scrollTop <= 0
+      const atBottom =
+        inputEl.scrollTop + inputEl.clientHeight >= inputEl.scrollHeight - 1
+      const scrollingUp = deltaY < 0
+      const scrollingDown = deltaY > 0
+
+      if ((atTop && scrollingUp) || (atBottom && scrollingDown)) {
+        // At boundary — forward to canvas for zoom/pan
+        event.preventDefault()
+        event.stopPropagation()
+        app.canvas.processMouseWheel(event)
+        return
+      }
+
+      // Within scroll range — consume event, let textarea scroll natively
       event.stopPropagation()
       return
     }


### PR DESCRIPTION
## Summary

Fixes #3990 — scroll events from scrollable text widgets (textarea, markdown, text preview) were leaking to the canvas layer, causing unwanted zoom/pan when scrolling widget content.

## Root Cause

TransformPane's capture-phase wheel handler forwarded **all** wheel events to the canvas unless the widget element was both focused and marked with data-capture-wheel. This meant:

- **TextPreviewWidget** (used by Preview Any nodes): No data-capture-wheel attribute — events always forwarded — canvas zooms instead of text scrolling
- **Unfocused widgets**: Even widgets with data-capture-wheel had events forwarded when not focused — first scroll always went to canvas
- **useStringWidget** (legacy path): At scroll boundaries, events were silently consumed instead of forwarding to canvas
- **useMarkdownWidget** (legacy path): No wheel handler at all — all events leaked

## Changes

### 1. useCanvasInteractions.ts — Core fix
Added wheelCapturedByScrollableElement() to shouldForwardWheelEvent. This detects when a wheel event target is inside a scrollable data-capture-wheel element:
- **Within scroll bounds** — event stays in widget (not forwarded to canvas)
- **At scroll boundary** (top/bottom edge) — event passes through to canvas for zoom/pan
- **Not scrollable** — event forwards to canvas (existing behavior preserved)

This works regardless of focus state, fixing the issue where unfocused scrollable widgets had their scroll events stolen by the canvas.

### 2. TextPreviewWidget.vue
Added data-capture-wheel="true" to the scrollable container div.

### 3. useMarkdownWidget.ts — Legacy path
Added a complete wheel event handler (previously had none):
- Ctrl+wheel forwards to canvas for zoom
- Within scroll range consumes event (widget scrolls natively)
- At boundary forwards to canvas
- Not scrollable forwards to canvas

### 4. useStringWidget.ts — Legacy path
Added scroll boundary detection to the existing canScrollY branch. Previously, it only called stopPropagation() which silently consumed events at boundaries. Now:
- At boundary — explicitly forwards to canvas via processMouseWheel
- Within scroll range — existing behavior preserved (native scroll)

## Backward Compatibility

- All existing data-capture-wheel + focus behavior preserved
- Ctrl+wheel zoom through focused widgets still works in standard mode
- Non-scrollable elements still forward events to canvas
- Trackpad gesture handling unchanged

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10613-fix-prevent-scroll-event-leak-from-text-widgets-to-canvas-3306d73d36508143b36afb702ace42aa) by [Unito](https://www.unito.io)
