### PR TITLE
test: Expand node search box V2 e2e coverage

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -204,7 +204,7 @@ export class ComfyPage {
     this.workflowUploadInput = page.locator('#comfy-file-input')
 
     this.searchBox = new ComfyNodeSearchBox(page)
-    this.searchBoxV2 = new ComfyNodeSearchBoxV2(page)
+    this.searchBoxV2 = new ComfyNodeSearchBoxV2(this)
     this.menu = new ComfyMenu(page)
     this.actionbar = new ComfyActionbar(page)
     this.templates = new ComfyTemplates(page)

--- a/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test'
+import type { Locator } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 
@@ -8,13 +8,18 @@ export class ComfyNodeSearchBoxV2 {
   readonly filterSearch: Locator
   readonly results: Locator
   readonly filterOptions: Locator
+  readonly filterChips: Locator
+  readonly noResults: Locator
 
-  constructor(readonly page: Page) {
+  constructor(private comfyPage: ComfyPage) {
+    const page = comfyPage.page
     this.dialog = page.getByRole('search')
     this.input = this.dialog.getByRole('combobox')
     this.filterSearch = this.dialog.getByRole('textbox', { name: 'Search' })
     this.results = this.dialog.getByTestId('result-item')
     this.filterOptions = this.dialog.getByTestId('filter-option')
+    this.filterChips = this.dialog.getByTestId('filter-chip')
+    this.noResults = this.dialog.getByTestId('no-results')
   }
 
   categoryButton(categoryId: string): Locator {
@@ -25,7 +30,37 @@ export class ComfyNodeSearchBoxV2 {
     return this.dialog.getByRole('button', { name })
   }
 
-  async reload(comfyPage: ComfyPage) {
-    await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+  async applyTypeFilter(
+    filterName: 'Input' | 'Output',
+    typeName: string
+  ): Promise<void> {
+    await this.filterBarButton(filterName).click()
+    await this.filterOptions.first().waitFor({ state: 'visible' })
+    await this.filterSearch.fill(typeName)
+    await this.filterOptions.filter({ hasText: typeName }).first().click()
+    // Close the popover by clicking the trigger button again
+    await this.filterBarButton(filterName).click()
+    await this.filterOptions.first().waitFor({ state: 'hidden' })
+  }
+
+  async removeFilterChip(index: number = 0): Promise<void> {
+    await this.filterChips.nth(index).getByTestId('chip-delete').click()
+  }
+
+  async getResultCount(): Promise<number> {
+    await this.results.first().waitFor({ state: 'visible' })
+    return this.results.count()
+  }
+
+  async open(): Promise<void> {
+    await this.comfyPage.command.executeCommand('Workspace.SearchBox.Toggle')
+    await this.input.waitFor({ state: 'visible' })
+  }
+
+  async enableV2Search(): Promise<void> {
+    await this.comfyPage.settings.setSetting(
+      'Comfy.NodeSearchBoxImpl',
+      'default'
+    )
   }
 }

--- a/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
@@ -1,6 +1,17 @@
 import type { Locator } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+const { searchBoxV2 } = TestIds
+
+export type RootCategoryId =
+  | 'favorites'
+  | 'comfy'
+  | 'custom'
+  | 'essentials'
+  | 'partner-nodes'
+  | 'blueprints'
 
 export class ComfyNodeSearchBoxV2 {
   readonly dialog: Locator
@@ -10,50 +21,66 @@ export class ComfyNodeSearchBoxV2 {
   readonly filterOptions: Locator
   readonly filterChips: Locator
   readonly noResults: Locator
+  readonly nodeIdBadge: Locator
 
   constructor(private comfyPage: ComfyPage) {
     const page = comfyPage.page
     this.dialog = page.getByRole('search')
     this.input = this.dialog.getByRole('combobox')
     this.filterSearch = this.dialog.getByRole('textbox', { name: 'Search' })
-    this.results = this.dialog.getByTestId('result-item')
-    this.filterOptions = this.dialog.getByTestId('filter-option')
-    this.filterChips = this.dialog.getByTestId('filter-chip')
-    this.noResults = this.dialog.getByTestId('no-results')
+    this.results = this.dialog.getByTestId(searchBoxV2.resultItem)
+    this.filterOptions = this.dialog.getByTestId(searchBoxV2.filterOption)
+    this.filterChips = this.dialog.getByTestId(searchBoxV2.filterChip)
+    this.noResults = this.dialog.getByTestId(searchBoxV2.noResults)
+    this.nodeIdBadge = this.dialog.getByTestId(searchBoxV2.nodeIdBadge)
   }
 
+  /** Sidebar category tree button (e.g. `sampling`, `sampling/custom_sampling`). */
   categoryButton(categoryId: string): Locator {
-    return this.dialog.getByTestId(`category-${categoryId}`)
+    return this.dialog.getByTestId(searchBoxV2.category(categoryId))
   }
 
-  filterBarButton(name: string): Locator {
-    return this.dialog.getByRole('button', { name })
+  /** Top filter-bar root category chip (e.g. `comfy`, `essentials`). */
+  rootCategoryButton(id: RootCategoryId): Locator {
+    return this.dialog.getByTestId(searchBoxV2.rootCategory(id))
+  }
+
+  /** Top filter-bar input/output type popover trigger. */
+  typeFilterButton(key: 'input' | 'output'): Locator {
+    return this.dialog.getByTestId(searchBoxV2.typeFilter(key))
   }
 
   async applyTypeFilter(
-    filterName: 'Input' | 'Output',
+    key: 'input' | 'output',
     typeName: string
   ): Promise<void> {
-    await this.filterBarButton(filterName).click()
+    const trigger = this.typeFilterButton(key)
+    await trigger.click()
     await this.filterOptions.first().waitFor({ state: 'visible' })
     await this.filterSearch.fill(typeName)
     await this.filterOptions.filter({ hasText: typeName }).first().click()
-    // Close the popover by clicking the trigger button again
-    await this.filterBarButton(filterName).click()
+    // The popover does not auto-close on selection — toggle the trigger.
+    await trigger.click()
     await this.filterOptions.first().waitFor({ state: 'hidden' })
   }
 
   async removeFilterChip(index: number = 0): Promise<void> {
-    await this.filterChips.nth(index).getByTestId('chip-delete').click()
-  }
-
-  async getResultCount(): Promise<number> {
-    await this.results.first().waitFor({ state: 'visible' })
-    return this.results.count()
+    await this.filterChips
+      .nth(index)
+      .getByTestId(searchBoxV2.chipDelete)
+      .click()
   }
 
   async open(): Promise<void> {
     await this.comfyPage.command.executeCommand('Workspace.SearchBox.Toggle')
+    await this.input.waitFor({ state: 'visible' })
+  }
+
+  async openByDoubleClickCanvas(): Promise<void> {
+    // Use page.mouse.dblclick (not canvas.dblclick) so the z-999 Vue overlay
+    // does not intercept; coords target a viewport spot that is on the canvas
+    // and clear of both the side toolbar and any default-graph nodes.
+    await this.comfyPage.page.mouse.dblclick(200, 200, { delay: 5 })
     await this.input.waitFor({ state: 'visible' })
   }
 

--- a/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
@@ -1,17 +1,12 @@
 import type { Locator } from '@playwright/test'
 
+import type { RootCategoryId } from '@/components/searchbox/v2/rootCategories'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 const { searchBoxV2 } = TestIds
 
-export type RootCategoryId =
-  | 'favorites'
-  | 'comfy'
-  | 'custom'
-  | 'essentials'
-  | 'partner-nodes'
-  | 'blueprints'
+export type { RootCategoryId }
 
 export class ComfyNodeSearchBoxV2 {
   readonly dialog: Locator
@@ -64,15 +59,20 @@ export class ComfyNodeSearchBoxV2 {
     await this.filterOptions.first().waitFor({ state: 'hidden' })
   }
 
-  async removeFilterChip(index: number = 0): Promise<void> {
+  async removeFilterChip(index = 0): Promise<void> {
     await this.filterChips
       .nth(index)
       .getByTestId(searchBoxV2.chipDelete)
       .click()
   }
 
-  async open(): Promise<void> {
+  async toggle(): Promise<void> {
     await this.comfyPage.command.executeCommand('Workspace.SearchBox.Toggle')
+  }
+
+  async open(): Promise<void> {
+    if (await this.input.isVisible()) return
+    await this.toggle()
     await this.input.waitFor({ state: 'visible' })
   }
 
@@ -81,13 +81,24 @@ export class ComfyNodeSearchBoxV2 {
     // does not intercept; coords target a viewport spot that is on the canvas
     // and clear of both the side toolbar and any default-graph nodes.
     await this.comfyPage.page.mouse.dblclick(200, 200, { delay: 5 })
-    await this.input.waitFor({ state: 'visible' })
   }
 
-  async enableV2Search(): Promise<void> {
+  async ensureV2Search(): Promise<void> {
     await this.comfyPage.settings.setSetting(
       'Comfy.NodeSearchBoxImpl',
       'default'
+    )
+  }
+
+  async setup(): Promise<void> {
+    await this.ensureV2Search()
+    await this.comfyPage.settings.setSetting(
+      'Comfy.LinkRelease.Action',
+      'search box'
+    )
+    await this.comfyPage.settings.setSetting(
+      'Comfy.LinkRelease.ActionShift',
+      'search box'
     )
   }
 }

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -33,12 +33,6 @@ export class NodeOperationsHelper {
     })
   }
 
-  async getLinkCount(): Promise<number> {
-    return await this.page.evaluate(() => {
-      return window.app?.rootGraph?.links?.size ?? 0
-    })
-  }
-
   async getSelectedGraphNodesCount(): Promise<number> {
     return await this.page.evaluate(() => {
       return (

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -33,6 +33,12 @@ export class NodeOperationsHelper {
     })
   }
 
+  async getLinkCount(): Promise<number> {
+    return await this.page.evaluate(() => {
+      return window.app?.rootGraph?.links?.size ?? 0
+    })
+  }
+
   async getSelectedGraphNodesCount(): Promise<number> {
     return await this.page.evaluate(() => {
       return (

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -234,6 +234,17 @@ export const TestIds = {
     batchCounter: 'batch-counter',
     batchNext: 'batch-next',
     batchPrev: 'batch-prev'
+  },
+  searchBoxV2: {
+    resultItem: 'result-item',
+    filterOption: 'filter-option',
+    filterChip: 'filter-chip',
+    chipDelete: 'chip-delete',
+    noResults: 'no-results',
+    nodeIdBadge: 'node-id-badge',
+    category: (id: string) => `category-${id}`,
+    rootCategory: (id: string) => `search-category-${id}`,
+    typeFilter: (key: 'input' | 'output') => `search-filter-${key}`
   }
 } as const
 

--- a/browser_tests/tests/nodeGhostPlacement.spec.ts
+++ b/browser_tests/tests/nodeGhostPlacement.spec.ts
@@ -201,12 +201,10 @@ for (const mode of ['litegraph', 'vue'] as const) {
       'subgraph blueprint added from search box enters ghost mode',
       { tag: ['@subgraph'] },
       async ({ comfyPage }) => {
-        await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
         await comfyPage.settings.setSetting(
           'Comfy.NodeSearchBoxImpl',
           'default'
         )
-        await comfyPage.searchBoxV2.reload(comfyPage)
 
         // Convert a node to a subgraph and publish it as a blueprint
         const nodeRef = await comfyPage.nodeOps.getNodeRefById('3')
@@ -231,9 +229,8 @@ for (const mode of ['litegraph', 'vue'] as const) {
         const nodeCountBefore = await comfyPage.nodeOps.getGraphNodesCount()
 
         // Open v2 search box and search for the published blueprint
-        await comfyPage.canvasOps.doubleClick()
         const { searchBoxV2 } = comfyPage
-        await expect(searchBoxV2.input).toBeVisible()
+        await searchBoxV2.open()
 
         await searchBoxV2.input.fill(blueprintName)
         await expect(searchBoxV2.results.first()).toBeVisible()

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -21,13 +21,11 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
     await searchBoxV2.open()
-
     await searchBoxV2.input.fill('KSampler')
     await expect(searchBoxV2.results.first()).toBeVisible()
 
     await comfyPage.page.keyboard.press('Enter')
     await expect(searchBoxV2.input).toBeHidden()
-
     await expect
       .poll(() => comfyPage.nodeOps.getGraphNodesCount())
       .toBe(initialCount + 1)
@@ -38,14 +36,11 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
     await searchBoxV2.open()
-
-    // Default results should be visible without typing
+    // Default results should be visible without typing.
     await expect(searchBoxV2.results.first()).toBeVisible()
 
-    // Enter should add the first (selected) result
     await comfyPage.page.keyboard.press('Enter')
     await expect(searchBoxV2.input).toBeHidden()
-
     await expect
       .poll(() => comfyPage.nodeOps.getGraphNodesCount())
       .toBe(initialCount + 1)
@@ -59,9 +54,9 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       await comfyPage.settings.setSetting('Comfy.NodeLibrary.Bookmarks.V2', [
         'KSampler'
       ])
-      await searchBoxV2.open()
 
-      await searchBoxV2.filterBarButton('Bookmarked').click()
+      await searchBoxV2.open()
+      await searchBoxV2.rootCategoryButton('favorites').click()
 
       await expect(searchBoxV2.results).toHaveCount(1)
       await expect(searchBoxV2.results.first()).toContainText('KSampler')
@@ -73,11 +68,9 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       const { searchBoxV2 } = comfyPage
 
       await searchBoxV2.open()
-
       await searchBoxV2.categoryButton('sampling').click()
 
       await expect(searchBoxV2.results.first()).toBeVisible()
-      await expect.poll(() => searchBoxV2.results.count()).toBeGreaterThan(0)
     })
   })
 
@@ -87,23 +80,21 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      // Click "Input" filter chip in the filter bar
-      await searchBoxV2.filterBarButton('Input').click()
+      await test.step('Open Input filter popover', async () => {
+        await searchBoxV2.typeFilterButton('input').click()
+        await expect(searchBoxV2.filterOptions.first()).toBeVisible()
+      })
 
-      // Filter options should appear
-      await expect(searchBoxV2.filterOptions.first()).toBeVisible()
+      await test.step('Select MODEL type', async () => {
+        await searchBoxV2.filterSearch.fill('MODEL')
+        await searchBoxV2.filterOptions
+          .filter({ hasText: 'MODEL' })
+          .first()
+          .click()
+      })
 
-      // Type to narrow and select MODEL
-      await searchBoxV2.filterSearch.fill('MODEL')
-      await searchBoxV2.filterOptions
-        .filter({ hasText: 'MODEL' })
-        .first()
-        .click()
-
-      // Filter chip should appear and results should be filtered
-      await expect(
-        searchBoxV2.dialog.getByText('Input:', { exact: false }).locator('..')
-      ).toContainText('MODEL')
+      await expect(searchBoxV2.filterChips).toHaveCount(1)
+      await expect(searchBoxV2.filterChips.first()).toContainText('MODEL')
       await expect(searchBoxV2.results.first()).toBeVisible()
     })
   })
@@ -114,30 +105,32 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
       await searchBoxV2.open()
-
       await searchBoxV2.input.fill('KSampler')
       const results = searchBoxV2.results
       await expect(results.first()).toBeVisible()
 
-      // First result selected by default
-      await expect(results.first()).toHaveAttribute('aria-selected', 'true')
+      await test.step('First result is selected by default', async () => {
+        await expect(results.first()).toHaveAttribute('aria-selected', 'true')
+      })
 
-      // ArrowDown moves selection
-      await comfyPage.page.keyboard.press('ArrowDown')
-      await expect(results.nth(1)).toHaveAttribute('aria-selected', 'true')
-      await expect(results.first()).toHaveAttribute('aria-selected', 'false')
+      await test.step('ArrowDown moves selection to next result', async () => {
+        await comfyPage.page.keyboard.press('ArrowDown')
+        await expect(results.nth(1)).toHaveAttribute('aria-selected', 'true')
+        await expect(results.first()).toHaveAttribute('aria-selected', 'false')
+      })
 
-      // ArrowUp moves back
-      await comfyPage.page.keyboard.press('ArrowUp')
-      await expect(results.first()).toHaveAttribute('aria-selected', 'true')
+      await test.step('ArrowUp moves selection back', async () => {
+        await comfyPage.page.keyboard.press('ArrowUp')
+        await expect(results.first()).toHaveAttribute('aria-selected', 'true')
+      })
 
-      // Enter selects and adds node
-      await comfyPage.page.keyboard.press('Enter')
-      await expect(searchBoxV2.input).toBeHidden()
-
-      await expect
-        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
-        .toBe(initialCount + 1)
+      await test.step('Enter selects and adds the node', async () => {
+        await comfyPage.page.keyboard.press('Enter')
+        await expect(searchBoxV2.input).toBeHidden()
+        await expect
+          .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+          .toBe(initialCount + 1)
+      })
     })
   })
 })

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -5,8 +5,7 @@ import {
 
 test.describe('Node search box V2', { tag: '@node' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
-    await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+    await comfyPage.searchBoxV2.enableV2Search()
     await comfyPage.settings.setSetting(
       'Comfy.LinkRelease.Action',
       'search box'
@@ -15,15 +14,13 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       'Comfy.LinkRelease.ActionShift',
       'search box'
     )
-    await comfyPage.searchBoxV2.reload(comfyPage)
   })
 
   test('Can open search and add node', async ({ comfyPage }) => {
     const { searchBoxV2 } = comfyPage
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    await comfyPage.canvasOps.doubleClick()
-    await expect(searchBoxV2.input).toBeVisible()
+    await searchBoxV2.open()
 
     await searchBoxV2.input.fill('KSampler')
     await expect(searchBoxV2.results.first()).toBeVisible()
@@ -40,8 +37,7 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     const { searchBoxV2 } = comfyPage
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    await comfyPage.canvasOps.doubleClick()
-    await expect(searchBoxV2.input).toBeVisible()
+    await searchBoxV2.open()
 
     // Default results should be visible without typing
     await expect(searchBoxV2.results.first()).toBeVisible()
@@ -63,10 +59,7 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       await comfyPage.settings.setSetting('Comfy.NodeLibrary.Bookmarks.V2', [
         'KSampler'
       ])
-      await searchBoxV2.reload(comfyPage)
-
-      await comfyPage.canvasOps.doubleClick()
-      await expect(searchBoxV2.input).toBeVisible()
+      await searchBoxV2.open()
 
       await searchBoxV2.filterBarButton('Bookmarked').click()
 
@@ -79,8 +72,7 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     }) => {
       const { searchBoxV2 } = comfyPage
 
-      await comfyPage.canvasOps.doubleClick()
-      await expect(searchBoxV2.input).toBeVisible()
+      await searchBoxV2.open()
 
       await searchBoxV2.categoryButton('sampling').click()
 
@@ -93,8 +85,7 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     test('Can filter by input type via filter bar', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
 
-      await comfyPage.canvasOps.doubleClick()
-      await expect(searchBoxV2.input).toBeVisible()
+      await searchBoxV2.open()
 
       // Click "Input" filter chip in the filter bar
       await searchBoxV2.filterBarButton('Input').click()
@@ -122,8 +113,7 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       const { searchBoxV2 } = comfyPage
       const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-      await comfyPage.canvasOps.doubleClick()
-      await expect(searchBoxV2.input).toBeVisible()
+      await searchBoxV2.open()
 
       await searchBoxV2.input.fill('KSampler')
       const results = searchBoxV2.results

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -5,15 +5,7 @@ import {
 
 test.describe('Node search box V2', { tag: '@node' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.searchBoxV2.enableV2Search()
-    await comfyPage.settings.setSetting(
-      'Comfy.LinkRelease.Action',
-      'search box'
-    )
-    await comfyPage.settings.setSetting(
-      'Comfy.LinkRelease.ActionShift',
-      'search box'
-    )
+    await comfyPage.searchBoxV2.setup()
   })
 
   test('Can open search and add node', async ({ comfyPage }) => {

--- a/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
@@ -19,8 +19,7 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
   test('Double-click on empty canvas opens search', async ({ comfyPage }) => {
     const { searchBoxV2 } = comfyPage
 
-    await comfyPage.page.mouse.dblclick(200, 200, { delay: 5 })
-    await expect(searchBoxV2.input).toBeVisible()
+    await searchBoxV2.openByDoubleClickCanvas()
     await expect(searchBoxV2.dialog).toBeVisible()
   })
 
@@ -31,13 +30,11 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
     await searchBoxV2.open()
-
     await searchBoxV2.input.fill('KSampler')
     await expect(searchBoxV2.results.first()).toBeVisible()
 
     await comfyPage.page.keyboard.press('Escape')
     await expect(searchBoxV2.input).toBeHidden()
-
     await expect
       .poll(() => comfyPage.nodeOps.getGraphNodesCount())
       .toBe(initialCount)
@@ -87,7 +84,6 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.categoryButton('loaders').click()
       await expect(searchBoxV2.results.first()).toBeVisible()
-
       await expect
         .poll(() => searchBoxV2.results.allTextContents())
         .not.toEqual(samplingResults)
@@ -100,23 +96,24 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      // Search first to get a result set below the 64-item cap
+      // Search first to keep the result set under the 64-item cap.
       await searchBoxV2.input.fill('Load')
-      const unfilteredCount = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const unfilteredCount = await searchBoxV2.results.count()
 
-      // Apply Input filter with MODEL type
-      await searchBoxV2.applyTypeFilter('Input', 'MODEL')
-      await expect(searchBoxV2.filterChips.first()).toBeVisible()
-      const filteredCount = await searchBoxV2.getResultCount()
-      expect(filteredCount).not.toBe(unfilteredCount)
+      await test.step('Apply Input/MODEL filter', async () => {
+        await searchBoxV2.applyTypeFilter('input', 'MODEL')
+        await expect(searchBoxV2.filterChips).toHaveCount(1)
+        await expect
+          .poll(() => searchBoxV2.results.count())
+          .not.toBe(unfilteredCount)
+      })
 
-      // Remove filter by clicking the chip delete button
-      await searchBoxV2.removeFilterChip()
-
-      // Filter chip should be removed and count restored
-      await expect(searchBoxV2.filterChips).toHaveCount(0)
-      const restoredCount = await searchBoxV2.getResultCount()
-      expect(restoredCount).toBe(unfilteredCount)
+      await test.step('Remove the filter chip', async () => {
+        await searchBoxV2.removeFilterChip()
+        await expect(searchBoxV2.filterChips).toHaveCount(0)
+        await expect(searchBoxV2.results).toHaveCount(unfilteredCount)
+      })
     })
   })
 
@@ -129,31 +126,48 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       await comfyPage.canvasOps.disconnectEdge()
       await expect(searchBoxV2.input).toBeVisible()
 
-      // disconnectEdge pulls a CLIP link - should have a filter chip
+      // disconnectEdge pulls a CLIP link → expect a single CLIP filter chip.
       await expect(searchBoxV2.filterChips).toHaveCount(1)
       await expect(searchBoxV2.filterChips.first()).toContainText('CLIP')
     })
 
     test('Link release auto-connects added node', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
-      const nodeCountBefore = await comfyPage.nodeOps.getGraphNodesCount()
+      const NODE_TYPE = 'CLIPTextEncode'
+      const refsBefore = await comfyPage.nodeOps.getNodeRefsByType(NODE_TYPE)
+      const idsBefore = new Set(refsBefore.map((n) => n.id))
       const linkCountBefore = await comfyPage.nodeOps.getLinkCount()
 
       await comfyPage.canvasOps.disconnectEdge()
       await expect(searchBoxV2.input).toBeVisible()
 
-      // Search for a node that accepts CLIP input and select it
       await searchBoxV2.input.fill('CLIP Text Encode')
       await expect(searchBoxV2.results.first()).toBeVisible()
       await comfyPage.page.keyboard.press('Enter')
       await expect(searchBoxV2.input).toBeHidden()
 
-      // A new node should have been added and auto-connected
-      const nodeCountAfter = await comfyPage.nodeOps.getGraphNodesCount()
-      expect(nodeCountAfter).toBe(nodeCountBefore + 1)
+      // A new CLIPTextEncode node should have been added.
+      await expect
+        .poll(() =>
+          comfyPage.nodeOps
+            .getNodeRefsByType(NODE_TYPE)
+            .then((refs) => refs.length)
+        )
+        .toBe(refsBefore.length + 1)
 
-      const linkCountAfter = await comfyPage.nodeOps.getLinkCount()
-      expect(linkCountAfter).toBe(linkCountBefore)
+      // Net link count is unchanged: original release dropped a link, the
+      // selected node re-attached one.
+      await expect
+        .poll(() => comfyPage.nodeOps.getLinkCount())
+        .toBe(linkCountBefore)
+
+      // Verify the auto-connect: the newly-added node's CLIP input must be
+      // connected (proves the release wasn't just dropped).
+      const refsAfter = await comfyPage.nodeOps.getNodeRefsByType(NODE_TYPE)
+      const newNode = refsAfter.find((n) => !idsBefore.has(n.id))
+      if (!newNode) throw new Error('Expected a new CLIPTextEncode node')
+      const clipInput = await newNode.getInput(0)
+      await expect.poll(() => clipInput.getLinkCount()).toBe(1)
     })
   })
 
@@ -163,15 +177,15 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      // Search first so both counts use the search service path
       await searchBoxV2.input.fill('Load')
-      const unfilteredCount = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const unfilteredCount = await searchBoxV2.results.count()
 
-      await searchBoxV2.applyTypeFilter('Output', 'IMAGE')
+      await searchBoxV2.applyTypeFilter('output', 'IMAGE')
       await expect(searchBoxV2.filterChips).toHaveCount(1)
-      const filteredCount = await searchBoxV2.getResultCount()
-
-      expect(filteredCount).not.toBe(unfilteredCount)
+      await expect
+        .poll(() => searchBoxV2.results.count())
+        .not.toBe(unfilteredCount)
     })
 
     test('Multiple type filters (Input + Output) narrows results', async ({
@@ -181,15 +195,16 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      await searchBoxV2.applyTypeFilter('Input', 'MODEL')
+      await searchBoxV2.applyTypeFilter('input', 'MODEL')
       await expect(searchBoxV2.filterChips).toHaveCount(1)
-      const singleFilterCount = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const singleFilterCount = await searchBoxV2.results.count()
 
-      await searchBoxV2.applyTypeFilter('Output', 'LATENT')
+      await searchBoxV2.applyTypeFilter('output', 'LATENT')
       await expect(searchBoxV2.filterChips).toHaveCount(2)
-      const dualFilterCount = await searchBoxV2.getResultCount()
-
-      expect(dualFilterCount).toBeLessThan(singleFilterCount)
+      await expect
+        .poll(() => searchBoxV2.results.count())
+        .toBeLessThan(singleFilterCount)
     })
 
     test('Root filter + search query narrows results', async ({
@@ -198,18 +213,15 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       const { searchBoxV2 } = comfyPage
 
       await searchBoxV2.open()
-
-      // Search without root filter
       await searchBoxV2.input.fill('Sampler')
-      const unfilteredCount = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const unfilteredCount = await searchBoxV2.results.count()
 
-      // Apply Comfy root filter on top of search
-      await searchBoxV2.filterBarButton('Comfy').click()
-      const filteredCount = await searchBoxV2.getResultCount()
-
-      // Root filter should narrow or maintain the result set
-      expect(filteredCount).toBeLessThan(unfilteredCount)
-      expect(filteredCount).toBeGreaterThan(0)
+      await searchBoxV2.rootCategoryButton('comfy').click()
+      await expect
+        .poll(() => searchBoxV2.results.count())
+        .toBeLessThan(unfilteredCount)
+      await expect.poll(() => searchBoxV2.results.count()).toBeGreaterThan(0)
     })
 
     test('Root filter + category selection', async ({ comfyPage }) => {
@@ -217,15 +229,15 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      // Click "Comfy" root filter
-      await searchBoxV2.filterBarButton('Comfy').click()
-      const comfyCount = await searchBoxV2.getResultCount()
+      await searchBoxV2.rootCategoryButton('comfy').click()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const comfyCount = await searchBoxV2.results.count()
 
-      // Under root filter, categories are prefixed (e.g. comfy/sampling)
+      // Under root filter, categories are prefixed (e.g. comfy/sampling).
       await searchBoxV2.categoryButton('comfy/sampling').click()
-      const comfySamplingCount = await searchBoxV2.getResultCount()
-
-      expect(comfySamplingCount).toBeLessThan(comfyCount)
+      await expect
+        .poll(() => searchBoxV2.results.count())
+        .toBeLessThan(comfyCount)
     })
   })
 
@@ -235,17 +247,18 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      // Click a parent category to expand it
       const samplingBtn = searchBoxV2.categoryButton('sampling')
-      await samplingBtn.click()
-
-      // Look for subcategories (e.g. sampling/custom_sampling)
       const subcategory = searchBoxV2.categoryButton('sampling/custom_sampling')
-      await expect(subcategory).toBeVisible()
 
-      // Click sampling again to collapse
-      await samplingBtn.click()
-      await expect(subcategory).toBeHidden()
+      await test.step('Expanding sampling reveals its subcategories', async () => {
+        await samplingBtn.click()
+        await expect(subcategory).toBeVisible()
+      })
+
+      await test.step('Collapsing sampling hides its subcategories', async () => {
+        await samplingBtn.click()
+        await expect(subcategory).toBeHidden()
+      })
     })
 
     test('Subcategory narrows results to subset', async ({ comfyPage }) => {
@@ -253,34 +266,33 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       await searchBoxV2.open()
 
-      // Select parent category
       await searchBoxV2.categoryButton('sampling').click()
-      const parentCount = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const parentCount = await searchBoxV2.results.count()
 
-      // Select subcategory
       const subcategory = searchBoxV2.categoryButton('sampling/custom_sampling')
       await expect(subcategory).toBeVisible()
       await subcategory.click()
-      const childCount = await searchBoxV2.getResultCount()
 
-      expect(childCount).toBeLessThan(parentCount)
+      await expect
+        .poll(() => searchBoxV2.results.count())
+        .toBeLessThan(parentCount)
     })
 
     test('Most relevant resets category filter', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
 
       await searchBoxV2.open()
-      const defaultCount = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const defaultCount = await searchBoxV2.results.count()
 
-      // Select a category
       await searchBoxV2.categoryButton('sampling').click()
-      const samplingCount = await searchBoxV2.getResultCount()
-      expect(samplingCount).not.toBe(defaultCount)
+      await expect
+        .poll(() => searchBoxV2.results.count())
+        .not.toBe(defaultCount)
 
-      // Click "Most relevant" to reset
       await searchBoxV2.categoryButton('most-relevant').click()
-      const resetCount = await searchBoxV2.getResultCount()
-      expect(resetCount).toBe(defaultCount)
+      await expect(searchBoxV2.results).toHaveCount(defaultCount)
     })
   })
 
@@ -290,41 +302,40 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
       await searchBoxV2.open()
-
       await searchBoxV2.input.fill('KSampler')
       await expect(searchBoxV2.results.first()).toBeVisible()
 
       await searchBoxV2.results.first().click()
       await expect(searchBoxV2.input).toBeHidden()
-
-      const newCount = await comfyPage.nodeOps.getGraphNodesCount()
-      expect(newCount).toBe(initialCount + 1)
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+        .toBe(initialCount + 1)
     })
 
     test('Search narrows results progressively', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
+      const getCount = () => searchBoxV2.results.count()
 
       await searchBoxV2.open()
 
       await searchBoxV2.input.fill('S')
-      const count1 = await searchBoxV2.getResultCount()
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      const count1 = await getCount()
 
       await searchBoxV2.input.fill('Sa')
-      const count2 = await searchBoxV2.getResultCount()
+      await expect.poll(getCount).toBeLessThan(count1)
+      const count2 = await getCount()
 
       await searchBoxV2.input.fill('Sampler')
-      const count3 = await searchBoxV2.getResultCount()
-
-      expect(count2).toBeLessThan(count1)
-      expect(count3).toBeLessThan(count2)
+      await expect.poll(getCount).toBeLessThan(count2)
     })
 
     test('No results shown for nonsensical query', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
 
       await searchBoxV2.open()
-
       await searchBoxV2.input.fill('zzzxxxyyy_nonexistent_node')
+
       await expect(searchBoxV2.noResults).toBeVisible()
       await expect(searchBoxV2.results).toHaveCount(0)
     })
@@ -335,9 +346,8 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       const { searchBoxV2 } = comfyPage
 
       await searchBoxV2.open()
-
-      await searchBoxV2.applyTypeFilter('Input', 'MODEL')
-      await searchBoxV2.applyTypeFilter('Output', 'LATENT')
+      await searchBoxV2.applyTypeFilter('input', 'MODEL')
+      await searchBoxV2.applyTypeFilter('output', 'LATENT')
 
       await expect(searchBoxV2.filterChips).toHaveCount(2)
       await expect(searchBoxV2.filterChips.first()).toContainText('MODEL')
@@ -354,14 +364,11 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       const { searchBoxV2 } = comfyPage
 
       await searchBoxV2.open()
-
       await searchBoxV2.input.fill('VAE Decode')
       await expect(searchBoxV2.results.first()).toBeVisible()
 
-      const firstResult = searchBoxV2.results.first()
-      const idBadge = firstResult.getByTestId('node-id-badge')
-      await expect(idBadge).toBeVisible()
-      await expect(idBadge).toContainText('VAEDecode')
+      await expect(searchBoxV2.nodeIdBadge.first()).toBeVisible()
+      await expect(searchBoxV2.nodeIdBadge.first()).toContainText('VAEDecode')
     })
   })
 })

--- a/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
@@ -2,18 +2,11 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import { RootCategory } from '@/components/searchbox/v2/rootCategories'
 
 test.describe('Node search box V2 extended', { tag: '@node' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.searchBoxV2.enableV2Search()
-    await comfyPage.settings.setSetting(
-      'Comfy.LinkRelease.Action',
-      'search box'
-    )
-    await comfyPage.settings.setSetting(
-      'Comfy.LinkRelease.ActionShift',
-      'search box'
-    )
+    await comfyPage.searchBoxV2.setup()
   })
 
   test('Double-click on empty canvas opens search', async ({ comfyPage }) => {
@@ -40,37 +33,23 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       .toBe(initialCount)
   })
 
-  test('Reopening search after Enter has no persisted state', async ({
-    comfyPage
-  }) => {
-    const { searchBoxV2 } = comfyPage
+  for (const closeKey of ['Enter', 'Escape'] as const) {
+    test(`Reopening search after ${closeKey} has no persisted state`, async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
 
-    await searchBoxV2.open()
-    await searchBoxV2.input.fill('KSampler')
-    await expect(searchBoxV2.results.first()).toBeVisible()
-    await comfyPage.page.keyboard.press('Enter')
-    await expect(searchBoxV2.input).toBeHidden()
+      await searchBoxV2.open()
+      await searchBoxV2.input.fill('KSampler')
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      await comfyPage.page.keyboard.press(closeKey)
+      await expect(searchBoxV2.input).toBeHidden()
 
-    await searchBoxV2.open()
-    await expect(searchBoxV2.input).toHaveValue('')
-    await expect(searchBoxV2.filterChips).toHaveCount(0)
-  })
-
-  test('Reopening search after Escape has no persisted state', async ({
-    comfyPage
-  }) => {
-    const { searchBoxV2 } = comfyPage
-
-    await searchBoxV2.open()
-    await searchBoxV2.input.fill('KSampler')
-    await expect(searchBoxV2.results.first()).toBeVisible()
-    await comfyPage.page.keyboard.press('Escape')
-    await expect(searchBoxV2.input).toBeHidden()
-
-    await searchBoxV2.open()
-    await expect(searchBoxV2.input).toHaveValue('')
-    await expect(searchBoxV2.filterChips).toHaveCount(0)
-  })
+      await searchBoxV2.open()
+      await expect(searchBoxV2.input).toHaveValue('')
+      await expect(searchBoxV2.filterChips).toHaveCount(0)
+    })
+  }
 
   test.describe('Category navigation', () => {
     test('Category navigation updates results', async ({ comfyPage }) => {
@@ -136,7 +115,6 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       const NODE_TYPE = 'CLIPTextEncode'
       const refsBefore = await comfyPage.nodeOps.getNodeRefsByType(NODE_TYPE)
       const idsBefore = new Set(refsBefore.map((n) => n.id))
-      const linkCountBefore = await comfyPage.nodeOps.getLinkCount()
 
       await comfyPage.canvasOps.disconnectEdge()
       await expect(searchBoxV2.input).toBeVisible()
@@ -155,18 +133,12 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
         )
         .toBe(refsBefore.length + 1)
 
-      // Net link count is unchanged: original release dropped a link, the
-      // selected node re-attached one.
-      await expect
-        .poll(() => comfyPage.nodeOps.getLinkCount())
-        .toBe(linkCountBefore)
-
       // Verify the auto-connect: the newly-added node's CLIP input must be
       // connected (proves the release wasn't just dropped).
       const refsAfter = await comfyPage.nodeOps.getNodeRefsByType(NODE_TYPE)
       const newNode = refsAfter.find((n) => !idsBefore.has(n.id))
-      if (!newNode) throw new Error('Expected a new CLIPTextEncode node')
-      const clipInput = await newNode.getInput(0)
+      expect(newNode, 'expected a new CLIPTextEncode node').toBeDefined()
+      const clipInput = await newNode!.getInput(0)
       await expect.poll(() => clipInput.getLinkCount()).toBe(1)
     })
   })
@@ -294,24 +266,50 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       await searchBoxV2.categoryButton('most-relevant').click()
       await expect(searchBoxV2.results).toHaveCount(defaultCount)
     })
+
+    test(
+      'Blueprint root chip filters to published blueprints',
+      { tag: ['@subgraph'] },
+      async ({ comfyPage }) => {
+        const blueprintName = `chip-test-${crypto.randomUUID().slice(0, 8)}`
+        const nodeRef = await comfyPage.nodeOps.getNodeRefById('3')
+        await nodeRef.click('title')
+        await comfyPage.command.executeCommand('Comfy.Graph.ConvertToSubgraph')
+        await expect
+          .poll(() =>
+            comfyPage.nodeOps
+              .getNodeRefsByTitle('New Subgraph')
+              .then((refs) => refs.length)
+          )
+          .toBe(1)
+        const subgraphNodes =
+          await comfyPage.nodeOps.getNodeRefsByTitle('New Subgraph')
+        await subgraphNodes[0].click('title')
+        await comfyPage.command.executeCommand('Comfy.PublishSubgraph', {
+          name: blueprintName
+        })
+        await expect(comfyPage.visibleToasts).toHaveCount(1, { timeout: 5000 })
+        await comfyPage.toast.closeToasts(1)
+
+        const { searchBoxV2 } = comfyPage
+        await searchBoxV2.open()
+
+        const blueprintsChip = searchBoxV2.rootCategoryButton(
+          RootCategory.Blueprint
+        )
+        await expect(blueprintsChip).toBeVisible()
+        await blueprintsChip.click()
+
+        // Blueprints persist across tests on the same worker; filter by the
+        // unique name we just published rather than asserting the full list.
+        await expect(
+          searchBoxV2.results.filter({ hasText: blueprintName })
+        ).toHaveCount(1)
+      }
+    )
   })
 
   test.describe('Search behavior', () => {
-    test('Click on result item adds node', async ({ comfyPage }) => {
-      const { searchBoxV2 } = comfyPage
-      const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
-
-      await searchBoxV2.open()
-      await searchBoxV2.input.fill('KSampler')
-      await expect(searchBoxV2.results.first()).toBeVisible()
-
-      await searchBoxV2.results.first().click()
-      await expect(searchBoxV2.input).toBeHidden()
-      await expect
-        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
-        .toBe(initialCount + 1)
-    })
-
     test('Search narrows results progressively', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
       const getCount = () => searchBoxV2.results.count()
@@ -350,8 +348,9 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       await searchBoxV2.applyTypeFilter('output', 'LATENT')
 
       await expect(searchBoxV2.filterChips).toHaveCount(2)
-      await expect(searchBoxV2.filterChips.first()).toContainText('MODEL')
-      await expect(searchBoxV2.filterChips.nth(1)).toContainText('LATENT')
+      const chipTexts = await searchBoxV2.filterChips.allTextContents()
+      expect(chipTexts.some((t) => t.includes('MODEL'))).toBe(true)
+      expect(chipTexts.some((t) => t.includes('LATENT'))).toBe(true)
     })
   })
 

--- a/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
@@ -52,7 +52,7 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
     await searchBoxV2.input.fill('KSampler')
     await expect(searchBoxV2.results.first()).toBeVisible()
     await comfyPage.page.keyboard.press('Enter')
-    await expect(searchBoxV2.input).not.toBeVisible()
+    await expect(searchBoxV2.input).toBeHidden()
 
     await searchBoxV2.open()
     await expect(searchBoxV2.input).toHaveValue('')
@@ -146,7 +146,7 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       await searchBoxV2.input.fill('CLIP Text Encode')
       await expect(searchBoxV2.results.first()).toBeVisible()
       await comfyPage.page.keyboard.press('Enter')
-      await expect(searchBoxV2.input).not.toBeVisible()
+      await expect(searchBoxV2.input).toBeHidden()
 
       // A new node should have been added and auto-connected
       const nodeCountAfter = await comfyPage.nodeOps.getGraphNodesCount()
@@ -245,7 +245,7 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
 
       // Click sampling again to collapse
       await samplingBtn.click()
-      await expect(subcategory).not.toBeVisible()
+      await expect(subcategory).toBeHidden()
     })
 
     test('Subcategory narrows results to subset', async ({ comfyPage }) => {
@@ -295,7 +295,7 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       await expect(searchBoxV2.results.first()).toBeVisible()
 
       await searchBoxV2.results.first().click()
-      await expect(searchBoxV2.input).not.toBeVisible()
+      await expect(searchBoxV2.input).toBeHidden()
 
       const newCount = await comfyPage.nodeOps.getGraphNodesCount()
       expect(newCount).toBe(initialCount + 1)

--- a/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
@@ -5,8 +5,7 @@ import {
 
 test.describe('Node search box V2 extended', { tag: '@node' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
-    await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'default')
+    await comfyPage.searchBoxV2.enableV2Search()
     await comfyPage.settings.setSetting(
       'Comfy.LinkRelease.Action',
       'search box'
@@ -15,13 +14,12 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       'Comfy.LinkRelease.ActionShift',
       'search box'
     )
-    await comfyPage.searchBoxV2.reload(comfyPage)
   })
 
   test('Double-click on empty canvas opens search', async ({ comfyPage }) => {
     const { searchBoxV2 } = comfyPage
 
-    await comfyPage.canvasOps.doubleClick()
+    await comfyPage.page.mouse.dblclick(200, 200, { delay: 5 })
     await expect(searchBoxV2.input).toBeVisible()
     await expect(searchBoxV2.dialog).toBeVisible()
   })
@@ -32,8 +30,7 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
     const { searchBoxV2 } = comfyPage
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    await comfyPage.canvasOps.doubleClick()
-    await expect(searchBoxV2.input).toBeVisible()
+    await searchBoxV2.open()
 
     await searchBoxV2.input.fill('KSampler')
     await expect(searchBoxV2.results.first()).toBeVisible()
@@ -46,29 +43,43 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       .toBe(initialCount)
   })
 
-  test('Search clears when reopening', async ({ comfyPage }) => {
+  test('Reopening search after Enter has no persisted state', async ({
+    comfyPage
+  }) => {
     const { searchBoxV2 } = comfyPage
 
-    await comfyPage.canvasOps.doubleClick()
-    await expect(searchBoxV2.input).toBeVisible()
-
+    await searchBoxV2.open()
     await searchBoxV2.input.fill('KSampler')
     await expect(searchBoxV2.results.first()).toBeVisible()
+    await comfyPage.page.keyboard.press('Enter')
+    await expect(searchBoxV2.input).not.toBeVisible()
 
+    await searchBoxV2.open()
+    await expect(searchBoxV2.input).toHaveValue('')
+    await expect(searchBoxV2.filterChips).toHaveCount(0)
+  })
+
+  test('Reopening search after Escape has no persisted state', async ({
+    comfyPage
+  }) => {
+    const { searchBoxV2 } = comfyPage
+
+    await searchBoxV2.open()
+    await searchBoxV2.input.fill('KSampler')
+    await expect(searchBoxV2.results.first()).toBeVisible()
     await comfyPage.page.keyboard.press('Escape')
     await expect(searchBoxV2.input).toBeHidden()
 
-    await comfyPage.canvasOps.doubleClick()
-    await expect(searchBoxV2.input).toBeVisible()
+    await searchBoxV2.open()
     await expect(searchBoxV2.input).toHaveValue('')
+    await expect(searchBoxV2.filterChips).toHaveCount(0)
   })
 
   test.describe('Category navigation', () => {
     test('Category navigation updates results', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
 
-      await comfyPage.canvasOps.doubleClick()
-      await expect(searchBoxV2.input).toBeVisible()
+      await searchBoxV2.open()
 
       await searchBoxV2.categoryButton('sampling').click()
       await expect(searchBoxV2.results.first()).toBeVisible()
@@ -87,58 +98,270 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
     test('Filter chip removal restores results', async ({ comfyPage }) => {
       const { searchBoxV2 } = comfyPage
 
-      await comfyPage.canvasOps.doubleClick()
-      await expect(searchBoxV2.input).toBeVisible()
+      await searchBoxV2.open()
 
-      // Record initial result text for comparison
-      await expect(searchBoxV2.results.first()).toBeVisible()
-      const unfilteredResults = await searchBoxV2.results.allTextContents()
+      // Search first to get a result set below the 64-item cap
+      await searchBoxV2.input.fill('Load')
+      const unfilteredCount = await searchBoxV2.getResultCount()
 
       // Apply Input filter with MODEL type
-      await searchBoxV2.filterBarButton('Input').click()
-      await expect(searchBoxV2.filterOptions.first()).toBeVisible()
-      await searchBoxV2.filterSearch.fill('MODEL')
-      await searchBoxV2.filterOptions
-        .filter({ hasText: 'MODEL' })
-        .first()
-        .click()
-
-      // Verify filter chip appeared and results changed
-      const filterChip = searchBoxV2.dialog.getByTestId('filter-chip')
-      await expect(filterChip).toBeVisible()
-      await expect(searchBoxV2.results.first()).toBeVisible()
-      await expect
-        .poll(() => searchBoxV2.results.allTextContents())
-        .not.toEqual(unfilteredResults)
+      await searchBoxV2.applyTypeFilter('Input', 'MODEL')
+      await expect(searchBoxV2.filterChips.first()).toBeVisible()
+      const filteredCount = await searchBoxV2.getResultCount()
+      expect(filteredCount).not.toBe(unfilteredCount)
 
       // Remove filter by clicking the chip delete button
-      await filterChip.getByTestId('chip-delete').click()
+      await searchBoxV2.removeFilterChip()
 
-      // Filter chip should be removed
-      await expect(filterChip).toBeHidden()
-      await expect(searchBoxV2.results.first()).toBeVisible()
+      // Filter chip should be removed and count restored
+      await expect(searchBoxV2.filterChips).toHaveCount(0)
+      const restoredCount = await searchBoxV2.getResultCount()
+      expect(restoredCount).toBe(unfilteredCount)
     })
   })
 
-  test.describe('Keyboard navigation', () => {
-    test('ArrowUp on first item keeps first selected', async ({
+  test.describe('Link release', () => {
+    test('Link release opens search with pre-applied type filter', async ({
       comfyPage
     }) => {
       const { searchBoxV2 } = comfyPage
 
-      await comfyPage.canvasOps.doubleClick()
+      await comfyPage.canvasOps.disconnectEdge()
       await expect(searchBoxV2.input).toBeVisible()
 
+      // disconnectEdge pulls a CLIP link - should have a filter chip
+      await expect(searchBoxV2.filterChips).toHaveCount(1)
+      await expect(searchBoxV2.filterChips.first()).toContainText('CLIP')
+    })
+
+    test('Link release auto-connects added node', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+      const nodeCountBefore = await comfyPage.nodeOps.getGraphNodesCount()
+      const linkCountBefore = await comfyPage.nodeOps.getLinkCount()
+
+      await comfyPage.canvasOps.disconnectEdge()
+      await expect(searchBoxV2.input).toBeVisible()
+
+      // Search for a node that accepts CLIP input and select it
+      await searchBoxV2.input.fill('CLIP Text Encode')
+      await expect(searchBoxV2.results.first()).toBeVisible()
+      await comfyPage.page.keyboard.press('Enter')
+      await expect(searchBoxV2.input).not.toBeVisible()
+
+      // A new node should have been added and auto-connected
+      const nodeCountAfter = await comfyPage.nodeOps.getGraphNodesCount()
+      expect(nodeCountAfter).toBe(nodeCountBefore + 1)
+
+      const linkCountAfter = await comfyPage.nodeOps.getLinkCount()
+      expect(linkCountAfter).toBe(linkCountBefore)
+    })
+  })
+
+  test.describe('Filter combinations', () => {
+    test('Output type filter filters results', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      // Search first so both counts use the search service path
+      await searchBoxV2.input.fill('Load')
+      const unfilteredCount = await searchBoxV2.getResultCount()
+
+      await searchBoxV2.applyTypeFilter('Output', 'IMAGE')
+      await expect(searchBoxV2.filterChips).toHaveCount(1)
+      const filteredCount = await searchBoxV2.getResultCount()
+
+      expect(filteredCount).not.toBe(unfilteredCount)
+    })
+
+    test('Multiple type filters (Input + Output) narrows results', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      await searchBoxV2.applyTypeFilter('Input', 'MODEL')
+      await expect(searchBoxV2.filterChips).toHaveCount(1)
+      const singleFilterCount = await searchBoxV2.getResultCount()
+
+      await searchBoxV2.applyTypeFilter('Output', 'LATENT')
+      await expect(searchBoxV2.filterChips).toHaveCount(2)
+      const dualFilterCount = await searchBoxV2.getResultCount()
+
+      expect(dualFilterCount).toBeLessThan(singleFilterCount)
+    })
+
+    test('Root filter + search query narrows results', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      // Search without root filter
+      await searchBoxV2.input.fill('Sampler')
+      const unfilteredCount = await searchBoxV2.getResultCount()
+
+      // Apply Comfy root filter on top of search
+      await searchBoxV2.filterBarButton('Comfy').click()
+      const filteredCount = await searchBoxV2.getResultCount()
+
+      // Root filter should narrow or maintain the result set
+      expect(filteredCount).toBeLessThan(unfilteredCount)
+      expect(filteredCount).toBeGreaterThan(0)
+    })
+
+    test('Root filter + category selection', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      // Click "Comfy" root filter
+      await searchBoxV2.filterBarButton('Comfy').click()
+      const comfyCount = await searchBoxV2.getResultCount()
+
+      // Under root filter, categories are prefixed (e.g. comfy/sampling)
+      await searchBoxV2.categoryButton('comfy/sampling').click()
+      const comfySamplingCount = await searchBoxV2.getResultCount()
+
+      expect(comfySamplingCount).toBeLessThan(comfyCount)
+    })
+  })
+
+  test.describe('Category sidebar', () => {
+    test('Category tree expand and collapse', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      // Click a parent category to expand it
+      const samplingBtn = searchBoxV2.categoryButton('sampling')
+      await samplingBtn.click()
+
+      // Look for subcategories (e.g. sampling/custom_sampling)
+      const subcategory = searchBoxV2.categoryButton('sampling/custom_sampling')
+      await expect(subcategory).toBeVisible()
+
+      // Click sampling again to collapse
+      await samplingBtn.click()
+      await expect(subcategory).not.toBeVisible()
+    })
+
+    test('Subcategory narrows results to subset', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      // Select parent category
+      await searchBoxV2.categoryButton('sampling').click()
+      const parentCount = await searchBoxV2.getResultCount()
+
+      // Select subcategory
+      const subcategory = searchBoxV2.categoryButton('sampling/custom_sampling')
+      await expect(subcategory).toBeVisible()
+      await subcategory.click()
+      const childCount = await searchBoxV2.getResultCount()
+
+      expect(childCount).toBeLessThan(parentCount)
+    })
+
+    test('Most relevant resets category filter', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+      const defaultCount = await searchBoxV2.getResultCount()
+
+      // Select a category
+      await searchBoxV2.categoryButton('sampling').click()
+      const samplingCount = await searchBoxV2.getResultCount()
+      expect(samplingCount).not.toBe(defaultCount)
+
+      // Click "Most relevant" to reset
+      await searchBoxV2.categoryButton('most-relevant').click()
+      const resetCount = await searchBoxV2.getResultCount()
+      expect(resetCount).toBe(defaultCount)
+    })
+  })
+
+  test.describe('Search behavior', () => {
+    test('Click on result item adds node', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+      const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+
+      await searchBoxV2.open()
+
       await searchBoxV2.input.fill('KSampler')
-      const results = searchBoxV2.results
-      await expect(results.first()).toBeVisible()
+      await expect(searchBoxV2.results.first()).toBeVisible()
 
-      // First result should be selected by default
-      await expect(results.first()).toHaveAttribute('aria-selected', 'true')
+      await searchBoxV2.results.first().click()
+      await expect(searchBoxV2.input).not.toBeVisible()
 
-      // ArrowUp on first item should keep first selected
-      await comfyPage.page.keyboard.press('ArrowUp')
-      await expect(results.first()).toHaveAttribute('aria-selected', 'true')
+      const newCount = await comfyPage.nodeOps.getGraphNodesCount()
+      expect(newCount).toBe(initialCount + 1)
+    })
+
+    test('Search narrows results progressively', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      await searchBoxV2.input.fill('S')
+      const count1 = await searchBoxV2.getResultCount()
+
+      await searchBoxV2.input.fill('Sa')
+      const count2 = await searchBoxV2.getResultCount()
+
+      await searchBoxV2.input.fill('Sampler')
+      const count3 = await searchBoxV2.getResultCount()
+
+      expect(count2).toBeLessThan(count1)
+      expect(count3).toBeLessThan(count2)
+    })
+
+    test('No results shown for nonsensical query', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      await searchBoxV2.input.fill('zzzxxxyyy_nonexistent_node')
+      await expect(searchBoxV2.noResults).toBeVisible()
+      await expect(searchBoxV2.results).toHaveCount(0)
+    })
+  })
+
+  test.describe('Filter chip interaction', () => {
+    test('Multiple filter chips displayed', async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      await searchBoxV2.applyTypeFilter('Input', 'MODEL')
+      await searchBoxV2.applyTypeFilter('Output', 'LATENT')
+
+      await expect(searchBoxV2.filterChips).toHaveCount(2)
+      await expect(searchBoxV2.filterChips.first()).toContainText('MODEL')
+      await expect(searchBoxV2.filterChips.nth(1)).toContainText('LATENT')
+    })
+  })
+
+  test.describe('Settings-driven behavior', () => {
+    test('Node ID name shown when setting enabled', async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.NodeSearchBoxImpl.ShowIdName',
+        true
+      )
+      const { searchBoxV2 } = comfyPage
+
+      await searchBoxV2.open()
+
+      await searchBoxV2.input.fill('VAE Decode')
+      await expect(searchBoxV2.results.first()).toBeVisible()
+
+      const firstResult = searchBoxV2.results.first()
+      const idBadge = firstResult.getByTestId('node-id-badge')
+      await expect(idBadge).toBeVisible()
+      await expect(idBadge).toContainText('VAEDecode')
     })
   })
 })

--- a/src/components/searchbox/v2/NodeSearchContent.vue
+++ b/src/components/searchbox/v2/NodeSearchContent.vue
@@ -84,6 +84,7 @@
           </div>
           <div
             v-if="displayedResults.length === 0"
+            data-testid="no-results"
             class="px-4 py-8 text-center text-muted-foreground"
           >
             {{ $t('g.noResults') }}

--- a/src/components/searchbox/v2/NodeSearchFilterBar.vue
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.vue
@@ -62,8 +62,8 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import NodeSearchTypeFilterPopover from '@/components/searchbox/v2/NodeSearchTypeFilterPopover.vue'
+import { RootCategory } from '@/components/searchbox/v2/rootCategories'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
-import { BLUEPRINT_CATEGORY } from '@/types/nodeSource'
 import type { FuseFilterWithValue } from '@/utils/fuseUtil'
 import { getLinkTypeColor } from '@/utils/litegraphUtil'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -101,20 +101,20 @@ const MAX_VISIBLE_DOTS = 4
 const categoryButtons = computed(() => {
   const buttons: { id: string; label: string }[] = []
   if (hasFavorites) {
-    buttons.push({ id: 'favorites', label: t('g.bookmarked') })
+    buttons.push({ id: RootCategory.Favorites, label: t('g.bookmarked') })
   }
   if (hasBlueprintNodes) {
-    buttons.push({ id: BLUEPRINT_CATEGORY, label: t('g.blueprints') })
+    buttons.push({ id: RootCategory.Blueprint, label: t('g.blueprints') })
   }
   if (hasPartnerNodes) {
-    buttons.push({ id: 'partner-nodes', label: t('g.partner') })
+    buttons.push({ id: RootCategory.PartnerNodes, label: t('g.partner') })
   }
   if (hasEssentialNodes) {
-    buttons.push({ id: 'essentials', label: t('g.essentials') })
+    buttons.push({ id: RootCategory.Essentials, label: t('g.essentials') })
   }
-  buttons.push({ id: 'comfy', label: t('g.comfy') })
+  buttons.push({ id: RootCategory.Comfy, label: t('g.comfy') })
   if (hasCustomNodes) {
-    buttons.push({ id: 'custom', label: t('g.extensions') })
+    buttons.push({ id: RootCategory.Custom, label: t('g.extensions') })
   }
   return buttons
 })

--- a/src/components/searchbox/v2/NodeSearchFilterBar.vue
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.vue
@@ -5,6 +5,7 @@
       v-for="btn in categoryButtons"
       :key="btn.id"
       type="button"
+      :data-testid="`search-category-${btn.id}`"
       :aria-pressed="activeCategory === btn.id"
       :class="chipClass(activeCategory === btn.id)"
       @click="emit('selectCategory', btn.id)"
@@ -24,7 +25,11 @@
       @clear="emit('clearFilterGroup', tf.chip.filter.id)"
       @escape-close="emit('focusSearch')"
     >
-      <button type="button" :class="chipClass(false, tf.values.length > 0)">
+      <button
+        type="button"
+        :data-testid="`search-filter-${tf.chip.key}`"
+        :class="chipClass(false, tf.values.length > 0)"
+      >
         <span v-if="tf.values.length > 0" class="flex items-center">
           <span
             v-for="val in tf.values.slice(0, MAX_VISIBLE_DOTS)"

--- a/src/components/searchbox/v2/NodeSearchListItem.vue
+++ b/src/components/searchbox/v2/NodeSearchListItem.vue
@@ -18,6 +18,7 @@
         />
         <span
           v-if="showIdName"
+          data-testid="node-id-badge"
           class="shrink-0 rounded-sm bg-secondary-background px-1.5 py-0.5 text-xs text-muted-foreground"
           v-html="highlightQuery(nodeDef.name, currentQuery)"
         />

--- a/src/components/searchbox/v2/rootCategories.ts
+++ b/src/components/searchbox/v2/rootCategories.ts
@@ -1,0 +1,12 @@
+import { BLUEPRINT_CATEGORY } from '@/types/nodeSource'
+
+export const RootCategory = {
+  Favorites: 'favorites',
+  Comfy: 'comfy',
+  Custom: 'custom',
+  Essentials: 'essentials',
+  PartnerNodes: 'partner-nodes',
+  Blueprint: BLUEPRINT_CATEGORY
+} as const
+
+export type RootCategoryId = (typeof RootCategory)[keyof typeof RootCategory]


### PR DESCRIPTION
## Summary

Adds additional browser test coverage to the v2 node search

## Changes

- **What**:  
- extend search v2 fixtures
   - add additional tests
   - add data-testid for targeting elements
   - rework tests to work with new menu UI

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10620-test-Expand-node-search-box-V2-e2e-coverage-3306d73d365081b6bad3f73daab1194f) by [Unito](https://www.unito.io)
