### PR TITLE
test: add mask editor E2E tests for dialog lifecycle

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import type { ComfyPage } from '../../../../fixtures/ComfyPage'
@@ -36,6 +37,27 @@ test.describe('Vue Nodes Image Preview', () => {
     }
   }
 
+  async function openMaskEditorViaCommand(comfyPage: ComfyPage) {
+    const { nodeId } = await loadImageOnNode(comfyPage)
+    await comfyPage.vueNodes.selectNode(nodeId)
+    await comfyPage.command.executeCommand('Comfy.MaskEditor.OpenMaskEditor')
+    const dialog = comfyPage.page.locator('.mask-editor-dialog')
+    await expect(dialog).toBeVisible()
+    return dialog
+  }
+
+  async function drawStrokeOnMaskEditor(page: Page) {
+    const pointerZone = page.locator('.maskEditor-ui-container').first()
+    const box = await pointerZone.boundingBox()
+    if (!box) throw new Error('PointerZone not found')
+    await page.mouse.move(box.x + box.width * 0.3, box.y + box.height * 0.5)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width * 0.7, box.y + box.height * 0.5, {
+      steps: 10
+    })
+    await page.mouse.up()
+  }
+
   // TODO(#8143): Re-enable after image preview sync is working in CI
   test.fixme('opens mask editor from image preview button', async ({
     comfyPage
@@ -65,6 +87,71 @@ test.describe('Vue Nodes Image Preview', () => {
     await expect(contextMenu.getByText('Save Image')).toBeVisible()
     await expect(contextMenu.getByText('Open in Mask Editor')).toBeVisible()
   })
+
+  test(
+    'opens mask editor via command execution',
+    { tag: ['@smoke'] },
+    async ({ comfyPage }) => {
+      const dialog = await openMaskEditorViaCommand(comfyPage)
+
+      await expect(
+        comfyPage.page.locator('.maskEditor-ui-container')
+      ).toBeVisible()
+      await expect(dialog.getByText('Mask Editor')).toBeVisible()
+      await expect(dialog).toHaveScreenshot('mask-editor-open-via-command.png')
+    }
+  )
+
+  test(
+    'cancel closes mask editor dialog without uploading',
+    { tag: ['@smoke'] },
+    async ({ comfyPage }) => {
+      const uploadRequests: string[] = []
+      await comfyPage.page.route('**/upload/mask', (route) => {
+        uploadRequests.push('mask')
+        return route.continue()
+      })
+      await comfyPage.page.route('**/upload/image', (route) => {
+        uploadRequests.push('image')
+        return route.continue()
+      })
+
+      const dialog = await openMaskEditorViaCommand(comfyPage)
+      await dialog.getByRole('button', { name: /cancel/i }).click()
+
+      await expect(dialog).not.toBeVisible()
+      expect(uploadRequests).toHaveLength(0)
+    }
+  )
+
+  test(
+    'save closes mask editor dialog and uploads mask',
+    { tag: ['@smoke'] },
+    async ({ comfyPage }) => {
+      const uploadedPaths: string[] = []
+      await comfyPage.page.route('**/upload/mask', async (route) => {
+        const response = await route.fetch()
+        const body = await response.json()
+        if (body?.name) uploadedPaths.push(body.name)
+        return route.fulfill({ response })
+      })
+      await comfyPage.page.route('**/upload/image', async (route) => {
+        const response = await route.fetch()
+        const body = await response.json()
+        if (body?.name) uploadedPaths.push(body.name)
+        return route.fulfill({ response })
+      })
+
+      const dialog = await openMaskEditorViaCommand(comfyPage)
+      await drawStrokeOnMaskEditor(comfyPage.page)
+      await expect(dialog).toHaveScreenshot('mask-editor-after-stroke.png')
+
+      await dialog.getByRole('button', { name: /save/i }).click()
+
+      await expect(dialog).not.toBeVisible()
+      expect(uploadedPaths.length).toBeGreaterThan(0)
+    }
+  )
 
   test(
     'renders promoted image previews for each subgraph node',

--- a/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
@@ -117,10 +117,14 @@ test.describe('Vue Nodes Image Preview', () => {
       })
 
       const dialog = await openMaskEditorViaCommand(comfyPage)
+      await expect(dialog).toHaveScreenshot('mask-editor-before-cancel.png')
       await dialog.getByRole('button', { name: /cancel/i }).click()
 
       await expect(dialog).not.toBeVisible()
       expect(uploadRequests).toHaveLength(0)
+      await expect(comfyPage.canvas).toHaveScreenshot(
+        'mask-editor-cancelled-canvas-state.png'
+      )
     }
   )
 
@@ -150,6 +154,9 @@ test.describe('Vue Nodes Image Preview', () => {
 
       await expect(dialog).not.toBeVisible()
       expect(uploadedPaths.length).toBeGreaterThan(0)
+      await expect(comfyPage.canvas).toHaveScreenshot(
+        'mask-editor-saved-canvas-state.png'
+      )
     }
   )
 


### PR DESCRIPTION
## Summary

Adds Playwright smoke tests for mask editor dialog open-via-command, cancel, and save flows — the first working E2E coverage for the mask editor.

## Changes

- **What**: Three `@smoke` tests in `imagePreview.spec.ts` covering levels 1.3–1.5 of the mask editor E2E plan: open via command execution, cancel without uploading, save with stroke and upload verification. Two shared helpers (`openMaskEditorViaCommand`, `drawStrokeOnMaskEditor`) extracted for reuse by future levels.

## Review Focus

- Tests open the dialog via `Comfy.MaskEditor.OpenMaskEditor` command rather than the image preview hover button, avoiding the CI sync issue tracked in #8143.
- Screenshot expectations (`mask-editor-open-via-command.png`, `mask-editor-after-stroke.png`) are declared but not generated locally — CI will produce golden images on first run.
- Upload assertions in the save test intercept and fulfill actual network requests rather than mocking, so they exercise the real save path.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10622-test-add-mask-editor-E2E-tests-for-dialog-lifecycle-3306d73d36508127b802e5d44afd962f) by [Unito](https://www.unito.io)
