### PR TITLE
App Mode tests

### DIFF
--- a/browser_tests/fixtures/components/WidgetSelectDropdown.ts
+++ b/browser_tests/fixtures/components/WidgetSelectDropdown.ts
@@ -1,0 +1,12 @@
+import type { Locator } from '@playwright/test'
+
+export class WidgetSelectDropdownFixture {
+  public readonly selection: Locator
+
+  constructor(public readonly root: Locator) {
+    this.selection = root.locator('button span span')
+  }
+  async selectedItem(): Promise<string> {
+    return await this.selection.innerText()
+  }
+}

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -227,6 +227,17 @@ export class AppModeHelper {
     return this.page.getByTestId(TestIds.linear.mobile)
   }
 
+  get mobileWorkflows() {
+    return this.mobileView.getByTestId(TestIds.linear.mobileWorkflows)
+  }
+  get mobileActionmenu() {
+    return this.mobileView.getByTestId(TestIds.linear.mobileActionMenu)
+  }
+  async switchMobileWorkflow(workflowName: string) {
+    await this.mobileWorkflows.click()
+    await this.page.getByRole('menu').getByText(workflowName).click()
+  }
+
   /**
    * Get the actions menu trigger for a widget in the app mode widget list.
    * @param widgetName Text shown in the widget label (e.g. "seed").

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -11,11 +11,12 @@ import { BuilderSelectHelper } from '@e2e/fixtures/helpers/BuilderSelectHelper'
 import { BuilderStepsHelper } from '@e2e/fixtures/helpers/BuilderStepsHelper'
 
 export class AppModeHelper {
-  readonly steps: BuilderStepsHelper
   readonly footer: BuilderFooterHelper
+  readonly mobile: MobileAppHelper
   readonly saveAs: BuilderSaveAsHelper
   readonly select: BuilderSelectHelper
   readonly outputHistory: OutputHistoryComponent
+  readonly steps: BuilderStepsHelper
   readonly widgets: AppModeWidgetHelper
 
   /** The "Connect an output" popover shown when saving without outputs. */
@@ -62,11 +63,12 @@ export class AppModeHelper {
   public readonly vueNodeSwitchDontShowAgainCheckbox: Locator
 
   constructor(private readonly comfyPage: ComfyPage) {
-    this.steps = new BuilderStepsHelper(comfyPage)
+    this.mobile = new MobileAppHelper(comfyPage)
     this.footer = new BuilderFooterHelper(comfyPage)
     this.saveAs = new BuilderSaveAsHelper(comfyPage)
     this.select = new BuilderSelectHelper(comfyPage)
     this.outputHistory = new OutputHistoryComponent(comfyPage.page)
+    this.steps = new BuilderStepsHelper(comfyPage)
     this.widgets = new AppModeWidgetHelper(comfyPage)
 
     this.connectOutputPopover = this.page.getByTestId(
@@ -222,12 +224,6 @@ export class AppModeHelper {
 
   get centerPanel(): Locator {
     return this.page.getByTestId(TestIds.linear.centerPanel)
-  }
-  get mobileView(): Locator {
-    return this.page.getByTestId(TestIds.linear.mobile)
-  }
-  get mobileNavigation(): Locator {
-    return this.page.getByRole('tablist').filter({ hasText: 'Run' })
   }
 
   get mobileWorkflows() {

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -9,6 +9,7 @@ import { BuilderFooterHelper } from '@e2e/fixtures/helpers/BuilderFooterHelper'
 import { BuilderSaveAsHelper } from '@e2e/fixtures/helpers/BuilderSaveAsHelper'
 import { BuilderSelectHelper } from '@e2e/fixtures/helpers/BuilderSelectHelper'
 import { BuilderStepsHelper } from '@e2e/fixtures/helpers/BuilderStepsHelper'
+import { MobileAppHelper } from '@e2e/fixtures/helpers/MobileAppHelper'
 
 export class AppModeHelper {
   readonly footer: BuilderFooterHelper
@@ -224,20 +225,6 @@ export class AppModeHelper {
 
   get centerPanel(): Locator {
     return this.page.getByTestId(TestIds.linear.centerPanel)
-  }
-
-  get mobileWorkflows() {
-    return this.mobileView.getByTestId(TestIds.linear.mobileWorkflows)
-  }
-  get mobileActionmenu() {
-    return this.mobileView.getByTestId(TestIds.linear.mobileActionMenu)
-  }
-  async switchMobileWorkflow(workflowName: string) {
-    await this.mobileWorkflows.click()
-    await this.page.getByRole('menu').getByText(workflowName).click()
-  }
-  async mobileNavigateTab(name: 'run' | 'outputs' | 'assets') {
-    await this.mobileNavigation.getByRole('tab', { name }).click()
   }
 
   /**

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -220,6 +220,13 @@ export class AppModeHelper {
     await this.toggleAppMode()
   }
 
+  get centerPanel(): Locator {
+    return this.page.getByTestId(TestIds.linear.centerPanel)
+  }
+  get mobileView(): Locator {
+    return this.page.getByTestId(TestIds.linear.mobile)
+  }
+
   /**
    * Get the actions menu trigger for a widget in the app mode widget list.
    * @param widgetName Text shown in the widget label (e.g. "seed").

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -62,6 +62,8 @@ export class AppModeHelper {
   public readonly vueNodeSwitchDismissButton: Locator
   /** The "Don't show again" checkbox inside the Vue Node switch popup. */
   public readonly vueNodeSwitchDontShowAgainCheckbox: Locator
+  /** The main content area where outputs are displayed*/
+  public readonly centerPanel: Locator
 
   constructor(private readonly comfyPage: ComfyPage) {
     this.mobile = new MobileAppHelper(comfyPage)
@@ -128,6 +130,7 @@ export class AppModeHelper {
     this.vueNodeSwitchDontShowAgainCheckbox = this.page.getByTestId(
       TestIds.appMode.vueNodeSwitchDontShowAgain
     )
+    this.centerPanel = this.page.getByTestId(TestIds.linear.centerPanel)
   }
 
   private get page(): Page {
@@ -221,10 +224,6 @@ export class AppModeHelper {
     }, inputs)
     await this.comfyPage.nextFrame()
     await this.toggleAppMode()
-  }
-
-  get centerPanel(): Locator {
-    return this.page.getByTestId(TestIds.linear.centerPanel)
   }
 
   /**

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -226,6 +226,9 @@ export class AppModeHelper {
   get mobileView(): Locator {
     return this.page.getByTestId(TestIds.linear.mobile)
   }
+  get mobileNavigation(): Locator {
+    return this.page.getByRole('tablist').filter({ hasText: 'Run' })
+  }
 
   get mobileWorkflows() {
     return this.mobileView.getByTestId(TestIds.linear.mobileWorkflows)
@@ -236,6 +239,9 @@ export class AppModeHelper {
   async switchMobileWorkflow(workflowName: string) {
     await this.mobileWorkflows.click()
     await this.page.getByRole('menu').getByText(workflowName).click()
+  }
+  async mobileNavigateTab(name: 'run' | 'outputs' | 'assets') {
+    await this.mobileNavigation.getByRole('tab', { name }).click()
   }
 
   /**

--- a/browser_tests/fixtures/helpers/BuilderSelectHelper.ts
+++ b/browser_tests/fixtures/helpers/BuilderSelectHelper.ts
@@ -51,6 +51,10 @@ export class BuilderSelectHelper {
     return this.comfyPage.page
   }
 
+  get selectedItems(): Locator {
+    return this.page.getByTestId(TestIds.builder.ioItem)
+  }
+
   /**
    * Get the actions menu trigger for a builder IoItem (input-select sidebar).
    * @param title The widget title shown in the IoItem.

--- a/browser_tests/fixtures/helpers/BuilderSelectHelper.ts
+++ b/browser_tests/fixtures/helpers/BuilderSelectHelper.ts
@@ -51,10 +51,6 @@ export class BuilderSelectHelper {
     return this.comfyPage.page
   }
 
-  get selectedItems(): Locator {
-    return this.page.getByTestId(TestIds.builder.ioItem)
-  }
-
   /**
    * Get the actions menu trigger for a builder IoItem (input-select sidebar).
    * @param title The widget title shown in the IoItem.

--- a/browser_tests/fixtures/helpers/MobileAppHelper.ts
+++ b/browser_tests/fixtures/helpers/MobileAppHelper.ts
@@ -35,4 +35,7 @@ export class MobileAppHelper {
   private get page(): Page {
     return this.comfyPage.page
   }
+  async tap(locator: Locator, { count = 1 }: { count: number }) {
+    for (let i = 0; i < count; i++) await locator.tap()
+  }
 }

--- a/browser_tests/fixtures/helpers/MobileAppHelper.ts
+++ b/browser_tests/fixtures/helpers/MobileAppHelper.ts
@@ -1,28 +1,23 @@
 import type { Locator, Page } from '@playwright/test'
 
-import type { ComfyPage } from '../ComfyPage'
-import { TestIds } from '../selectors'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
 
 export class MobileAppHelper {
-  constructor(private readonly comfyPage: ComfyPage) {}
+  readonly actionmenu: Locator
+  readonly contentPanel: Locator
+  readonly navigation: Locator
+  readonly navigationTabs: Locator
+  readonly view: Locator
+  readonly workflows: Locator
 
-  get view(): Locator {
-    return this.page.getByTestId(TestIds.linear.mobile)
-  }
-  get navigation(): Locator {
-    return this.page.getByRole('tablist').filter({ hasText: 'Run' })
-  }
-  get workflows() {
-    return this.view.getByTestId(TestIds.linear.mobileWorkflows)
-  }
-  get actionmenu() {
-    return this.view.getByTestId(TestIds.linear.mobileActionMenu)
-  }
-  get navigationTabs() {
-    return this.navigation.getByRole('tab')
-  }
-  get contentPanel() {
-    return this.page.getByRole('tabpanel')
+  constructor(private readonly comfyPage: ComfyPage) {
+    this.view = this.page.getByTestId(TestIds.linear.mobile)
+    this.actionmenu = this.view.getByTestId(TestIds.linear.mobileActionMenu)
+    this.contentPanel = this.page.getByRole('tabpanel')
+    this.navigation = this.page.getByRole('tablist').filter({ hasText: 'Run' })
+    this.navigationTabs = this.navigation.getByRole('tab')
+    this.workflows = this.view.getByTestId(TestIds.linear.mobileWorkflows)
   }
 
   async switchWorkflow(workflowName: string) {

--- a/browser_tests/fixtures/helpers/MobileAppHelper.ts
+++ b/browser_tests/fixtures/helpers/MobileAppHelper.ts
@@ -35,7 +35,7 @@ export class MobileAppHelper {
   private get page(): Page {
     return this.comfyPage.page
   }
-  async tap(locator: Locator, { count = 1 }: { count: number }) {
+  async tap(locator: Locator, { count = 1 }: { count?: number } = {}) {
     for (let i = 0; i < count; i++) await locator.tap()
   }
 }

--- a/browser_tests/fixtures/helpers/MobileAppHelper.ts
+++ b/browser_tests/fixtures/helpers/MobileAppHelper.ts
@@ -1,0 +1,38 @@
+import type { Locator, Page } from '@playwright/test'
+
+import type { ComfyPage } from '../ComfyPage'
+import { TestIds } from '../selectors'
+
+export class MobileAppHelper {
+  constructor(private readonly comfyPage: ComfyPage) {}
+
+  get view(): Locator {
+    return this.page.getByTestId(TestIds.linear.mobile)
+  }
+  get navigation(): Locator {
+    return this.page.getByRole('tablist').filter({ hasText: 'Run' })
+  }
+  get workflows() {
+    return this.view.getByTestId(TestIds.linear.mobileWorkflows)
+  }
+  get actionmenu() {
+    return this.view.getByTestId(TestIds.linear.mobileActionMenu)
+  }
+  get navigationTabs() {
+    return this.navigation.getByRole('tab')
+  }
+  get contentPanel() {
+    return this.page.getByRole('tabpanel')
+  }
+
+  async switchWorkflow(workflowName: string) {
+    await this.workflows.click()
+    await this.page.getByRole('menu').getByText(workflowName).click()
+  }
+  async navigateTab(name: 'run' | 'outputs' | 'assets') {
+    await this.navigation.getByRole('tab', { name }).click()
+  }
+  private get page(): Page {
+    return this.comfyPage.page
+  }
+}

--- a/browser_tests/fixtures/helpers/MobileAppHelper.ts
+++ b/browser_tests/fixtures/helpers/MobileAppHelper.ts
@@ -4,16 +4,16 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 export class MobileAppHelper {
-  readonly actionmenu: Locator
+  private readonly page: Page
   readonly contentPanel: Locator
   readonly navigation: Locator
   readonly navigationTabs: Locator
   readonly view: Locator
   readonly workflows: Locator
 
-  constructor(private readonly comfyPage: ComfyPage) {
+  constructor(comfyPage: ComfyPage) {
+    this.page = comfyPage.page
     this.view = this.page.getByTestId(TestIds.linear.mobile)
-    this.actionmenu = this.view.getByTestId(TestIds.linear.mobileActionMenu)
     this.contentPanel = this.page.getByRole('tabpanel')
     this.navigation = this.page.getByRole('tablist').filter({ hasText: 'Run' })
     this.navigationTabs = this.navigation.getByRole('tab')
@@ -26,9 +26,6 @@ export class MobileAppHelper {
   }
   async navigateTab(name: 'run' | 'outputs' | 'assets') {
     await this.navigation.getByRole('tab', { name }).click()
-  }
-  private get page(): Page {
-    return this.comfyPage.page
   }
   async tap(locator: Locator, { count = 1 }: { count?: number } = {}) {
     for (let i = 0; i < count; i++) await locator.tap()

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -144,6 +144,13 @@ export const TestIds = {
     domWidgetTextarea: 'dom-widget-textarea',
     subgraphEnterButton: 'subgraph-enter-button'
   },
+  linear: {
+    centerPanel: 'linear-center-panel',
+    mobile: 'linear-mobile',
+    mobileNavigation: 'linear-mobile-navigation',
+    outputInfo: 'linear-output-info',
+    widgetContainer: 'linear-widgets'
+  },
   builder: {
     footerNav: 'builder-footer-nav',
     saveButton: 'builder-save-button',

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -148,6 +148,8 @@ export const TestIds = {
     centerPanel: 'linear-center-panel',
     mobile: 'linear-mobile',
     mobileNavigation: 'linear-mobile-navigation',
+    mobileActionMenu: 'linear-mobile-menu',
+    mobileWorkflows: 'linear-mobile-workflows',
     outputInfo: 'linear-output-info',
     widgetContainer: 'linear-widgets'
   },

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -148,7 +148,6 @@ export const TestIds = {
     centerPanel: 'linear-center-panel',
     mobile: 'linear-mobile',
     mobileNavigation: 'linear-mobile-navigation',
-    mobileActionMenu: 'linear-mobile-menu',
     mobileWorkflows: 'linear-mobile-workflows',
     outputInfo: 'linear-output-info',
     widgetContainer: 'linear-widgets'

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -13,6 +13,7 @@ export class VueNodeFixture {
   public readonly collapseButton: Locator
   public readonly collapseIcon: Locator
   public readonly root: Locator
+  public readonly widgets: Locator
 
   constructor(private readonly locator: Locator) {
     this.header = locator.locator('[data-testid^="node-header-"]')
@@ -23,10 +24,7 @@ export class VueNodeFixture {
     this.collapseButton = locator.getByTestId('node-collapse-button')
     this.collapseIcon = this.collapseButton.locator('i')
     this.root = locator
-  }
-
-  get widgets(): Locator {
-    return this.locator.locator('.lg-node-widget')
+    this.widgets = this.locator.locator('.lg-node-widget')
   }
 
   async getTitle(): Promise<string> {

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -25,6 +25,10 @@ export class VueNodeFixture {
     this.root = locator
   }
 
+  get widgets(): Locator {
+    return this.locator.locator('.lg-node-widget')
+  }
+
   async getTitle(): Promise<string> {
     return (await this.title.textContent()) ?? ''
   }

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -52,13 +52,16 @@ test.describe('App mode usage', () => {
 
       const steps = comfyPage.page.getByRole('spinbutton')
       await expect(steps).toHaveValue('20')
-      await comfyPage.page
-        .getByRole('button', { name: 'increment' })
-        .click({ clickCount: 5 })
+      await mobile.tap(
+        comfyPage.page.getByRole('button', { name: 'increment' }),
+        { count: 5 }
+      )
       await expect(steps).toHaveValue('25')
-      await comfyPage.page
-        .getByRole('button', { name: 'decrement' })
-        .click({ clickCount: 3 })
+      await mobile.tap(
+        comfyPage.page.getByRole('button', { name: 'decrement' }),
+        { count: 3 }
+      )
+
       await expect(steps).toHaveValue('22')
     })
 

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -35,19 +35,19 @@ test.describe('App mode usage', () => {
   })
   test.describe('Mobile', { tag: ['@mobile'] }, () => {
     test('panel navigation', async ({ comfyPage }) => {
-      const { mobileNavigation, mobileView } = comfyPage.appMode
+      const { mobile } = comfyPage.appMode
       await comfyPage.appMode.enterAppModeWithInputs([['3', 'steps']])
-      await expect(mobileView).toBeVisible()
+      await expect(mobile.view).toBeVisible()
+      await expect(mobile.navigation).toBeVisible()
 
-      const panel = comfyPage.page.getByRole('tabpanel')
-      await expect(mobileNavigation).toBeVisible()
-      await comfyPage.appMode.mobileNavigateTab('assets')
-      await expect(panel).toContainClass('left-[200vw]')
-      const buttons = await mobileNavigation.getByRole('tab').all()
+      await mobile.navigateTab('assets')
+      await expect(mobile.contentPanel).toContainClass('left-[200vw]')
+
+      const buttons = await mobile.navigationTabs.all()
       await buttons[0].dragTo(buttons[2], { steps: 5 })
-      await expect(panel).toContainClass('left-[100vw]')
+      await expect(mobile.contentPanel).toContainClass('left-[100vw]')
 
-      await comfyPage.appMode.mobileNavigateTab('run')
+      await mobile.navigateTab('run')
       await expect(comfyPage.appMode.linearWidgets).toBeInViewport({ ratio: 1 })
 
       const steps = comfyPage.page.getByRole('spinbutton')
@@ -66,13 +66,12 @@ test.describe('App mode usage', () => {
       const widgetNames = ['seed', 'steps', 'denoise', 'cfg']
       for (const name of widgetNames)
         await comfyPage.appMode.enterAppModeWithInputs([['3', name]])
-      await expect(comfyPage.appMode.mobileWorkflows).toBeVisible()
+      await expect(comfyPage.appMode.mobile.workflows).toBeVisible()
+
       const widgets = comfyPage.appMode.linearWidgets
-      await comfyPage.appMode.mobileView
-        .getByRole('tab', { name: 'Edit & Run' })
-        .click()
+      await comfyPage.appMode.mobile.navigateTab('run')
       for (let i = 0; i < widgetNames.length; i++) {
-        await comfyPage.appMode.switchMobileWorkflow(`(${i + 2})`)
+        await comfyPage.appMode.mobile.switchWorkflow(`(${i + 2})`)
         await expect(widgets.getByText(widgetNames[i])).toBeVisible()
       }
     })

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -35,7 +35,7 @@ test.describe('App mode usage', () => {
     ])
   })
   test.describe('Mobile', { tag: ['@mobile'] }, () => {
-    test('smoke', async ({ comfyPage }) => {
+    test('panel navigation', async ({ comfyPage }) => {
       const { mobileView } = comfyPage.appMode
       await comfyPage.appMode.enterAppModeWithInputs([['3', 'steps']])
       await expect(mobileView).toBeVisible()
@@ -67,11 +67,20 @@ test.describe('App mode usage', () => {
         .click({ clickCount: 3 })
       await expect(steps).toHaveValue('22')
     })
-    test('workflow selection', async ({ comfyPage }) => {
-      for (const w of ['default']) await comfyPage.workflow.loadWorkflow(w)
 
-      await comfyPage.appMode.enterAppModeWithInputs([['3', 'steps']])
-      await expect(comfyPage.appMode.mobileView).toBeVisible()
+    test('workflow selection', async ({ comfyPage }) => {
+      const widgetNames = ['seed', 'steps', 'denoise', 'cfg']
+      for (const name of widgetNames)
+        await comfyPage.appMode.enterAppModeWithInputs([['3', name]])
+      await expect(comfyPage.appMode.mobileWorkflows).toBeVisible()
+      const widgets = comfyPage.appMode.linearWidgets
+      await comfyPage.appMode.mobileView
+        .getByRole('tab', { name: 'Edit & Run' })
+        .click()
+      for (let i = 0; i < widgetNames.length; i++) {
+        await comfyPage.appMode.switchMobileWorkflow(`(${i + 2})`)
+        await expect(widgets.getByText(widgetNames[i])).toBeVisible()
+      }
     })
   })
 })

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -1,0 +1,60 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+import { TestIds } from '../fixtures/selectors'
+
+test.describe('App mode usage', () => {
+  test('Drag and Drop', async ({ comfyPage }) => {
+    const { centerPanel } = comfyPage.appMode
+    await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
+    await expect(centerPanel).toBeVisible()
+    //an app without an image input will load the workflow
+    await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
+    await expect(centerPanel).not.toBeVisible()
+
+    //prep a load image
+    await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
+    const loadImage = await comfyPage.vueNodes.getNodeLocator('12')
+    await expect(loadImage).toBeVisible()
+
+    await comfyPage.appMode.enterAppModeWithInputs([['12', 'image']])
+    await expect(centerPanel).toBeVisible()
+    //an app with an image input will upload the image to the input
+    await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
+    await expect(centerPanel).toBeVisible()
+    //an app with an image input can load from a uri-source
+    await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
+    await expect(centerPanel).toBeVisible()
+  })
+  test('Widget Interaction', async ({ comfyPage }) => {
+    await comfyPage.appMode.enterAppModeWithInputs([
+      ['4', 'seed'],
+      ['4', 'sampler_name'],
+      ['6', 'text']
+    ])
+  })
+  test.describe('Mobile', { tag: ['@mobile'] }, () => {
+    test('smoke', async ({ comfyPage }) => {
+      const { mobileView } = comfyPage.appMode
+      await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
+      await expect(mobileView).toBeVisible()
+
+      const navigation = comfyPage.page
+        .getByRole('tablist')
+        .filter({ hasText: 'Assets' })
+      const panel = comfyPage.page.getByRole('tabpanel')
+      await expect(navigation).toBeVisible()
+      const buttons = await navigation.getByRole('tab').all()
+      await buttons[2].click()
+      await expect(panel).toContainClass('left-[200vw]')
+      //expect
+      await buttons[0].dragTo(buttons[2], { steps: 5 })
+      await expect(panel).toContainClass('left-[100vw]')
+
+      await navigation.getByRole('tab', { name: 'Edit & Run' }).click()
+      const widgets = mobileView.getByTestId(TestIds.linear.widgetContainer)
+      await expect(widgets).toBeInViewport({ ratio: 1 })
+    })
+  })
+})

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -41,11 +41,11 @@ test.describe('App mode usage', () => {
       await expect(mobile.navigation).toBeVisible()
 
       await mobile.navigateTab('assets')
-      await expect(mobile.contentPanel).toContainClass('left-[200vw]')
+      await expect(mobile.contentPanel).toHaveAccessibleName('Assets')
 
       const buttons = await mobile.navigationTabs.all()
       await buttons[0].dragTo(buttons[2], { steps: 5 })
-      await expect(mobile.contentPanel).toContainClass('left-[100vw]')
+      await expect(mobile.contentPanel).toHaveAccessibleName('Outputs')
 
       await mobile.navigateTab('run')
       await expect(comfyPage.appMode.linearWidgets).toBeInViewport({ ratio: 1 })

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '../fixtures/ComfyPage'
-import { TestIds } from '../fixtures/selectors'
 
 test.describe('App mode usage', () => {
   test('Drag and Drop', async ({ comfyPage }) => {
@@ -49,8 +48,7 @@ test.describe('App mode usage', () => {
       await expect(panel).toContainClass('left-[100vw]')
 
       await comfyPage.appMode.mobileNavigateTab('run')
-      const widgets = mobileView.getByTestId(TestIds.linear.widgetContainer)
-      await expect(widgets).toBeInViewport({ ratio: 1 })
+      await expect(comfyPage.appMode.linearWidgets).toBeInViewport({ ratio: 1 })
 
       const steps = comfyPage.page.getByRole('spinbutton')
       await expect(steps).toHaveValue('20')

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -37,7 +37,7 @@ test.describe('App mode usage', () => {
   test.describe('Mobile', { tag: ['@mobile'] }, () => {
     test('smoke', async ({ comfyPage }) => {
       const { mobileView } = comfyPage.appMode
-      await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
+      await comfyPage.appMode.enterAppModeWithInputs([['3', 'steps']])
       await expect(mobileView).toBeVisible()
 
       const navigation = comfyPage.page
@@ -55,6 +55,23 @@ test.describe('App mode usage', () => {
       await navigation.getByRole('tab', { name: 'Edit & Run' }).click()
       const widgets = mobileView.getByTestId(TestIds.linear.widgetContainer)
       await expect(widgets).toBeInViewport({ ratio: 1 })
+
+      const steps = comfyPage.page.getByRole('spinbutton')
+      await expect(steps).toHaveValue('20')
+      await comfyPage.page
+        .getByRole('button', { name: 'increment' })
+        .click({ clickCount: 5 })
+      await expect(steps).toHaveValue('25')
+      await comfyPage.page
+        .getByRole('button', { name: 'decrement' })
+        .click({ clickCount: 3 })
+      await expect(steps).toHaveValue('22')
+    })
+    test('workflow selection', async ({ comfyPage }) => {
+      for (const w of ['default']) await comfyPage.workflow.loadWorkflow(w)
+
+      await comfyPage.appMode.enterAppModeWithInputs([['3', 'steps']])
+      await expect(comfyPage.appMode.mobileView).toBeVisible()
     })
   })
 })

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -36,23 +36,19 @@ test.describe('App mode usage', () => {
   })
   test.describe('Mobile', { tag: ['@mobile'] }, () => {
     test('panel navigation', async ({ comfyPage }) => {
-      const { mobileView } = comfyPage.appMode
+      const { mobileNavigation, mobileView } = comfyPage.appMode
       await comfyPage.appMode.enterAppModeWithInputs([['3', 'steps']])
       await expect(mobileView).toBeVisible()
 
-      const navigation = comfyPage.page
-        .getByRole('tablist')
-        .filter({ hasText: 'Assets' })
       const panel = comfyPage.page.getByRole('tabpanel')
-      await expect(navigation).toBeVisible()
-      const buttons = await navigation.getByRole('tab').all()
-      await buttons[2].click()
+      await expect(mobileNavigation).toBeVisible()
+      await comfyPage.appMode.mobileNavigateTab('assets')
       await expect(panel).toContainClass('left-[200vw]')
-      //expect
+      const buttons = await mobileNavigation.getByRole('tab').all()
       await buttons[0].dragTo(buttons[2], { steps: 5 })
       await expect(panel).toContainClass('left-[100vw]')
 
-      await navigation.getByRole('tab', { name: 'Edit & Run' }).click()
+      await comfyPage.appMode.mobileNavigateTab('run')
       const widgets = mobileView.getByTestId(TestIds.linear.widgetContainer)
       await expect(widgets).toBeInViewport({ ratio: 1 })
 

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -5,6 +5,7 @@ import {
 
 test.describe('App mode usage', () => {
   test('Drag and Drop', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     const { centerPanel } = comfyPage.appMode
     await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
     await expect(centerPanel).toBeVisible()

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -1,7 +1,7 @@
 import {
   comfyPageFixture as test,
   comfyExpect as expect
-} from '../fixtures/ComfyPage'
+} from '@e2e/fixtures/ComfyPage'
 
 test.describe('App mode usage', () => {
   test('Drag and Drop', async ({ comfyPage }) => {
@@ -11,7 +11,7 @@ test.describe('App mode usage', () => {
     await expect(centerPanel).toBeVisible()
     //an app without an image input will load the workflow
     await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
-    await expect(centerPanel).not.toBeVisible()
+    await expect(centerPanel).toBeHidden()
 
     //prep a load image
     await comfyPage.workflow.loadWorkflow('default')
@@ -28,6 +28,7 @@ test.describe('App mode usage', () => {
     await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
     await expect(centerPanel).toBeVisible()
   })
+
   test('Widet Interaction', async ({ comfyPage }) => {
     await comfyPage.appMode.enterAppModeWithInputs([
       ['3', 'seed'],
@@ -43,11 +44,11 @@ test.describe('App mode usage', () => {
 
     await seed.dragTo(incrementButton, { steps: 5 })
     const intermediateValue = Number(await input.inputValue())
-    await expect(intermediateValue).toBeGreaterThan(initialValue)
+    expect(intermediateValue).toBeGreaterThan(initialValue)
 
     await seed.dragTo(decrementButton, { steps: 5 })
     const endValue = Number(await input.inputValue())
-    await expect(endValue).toBeLessThan(intermediateValue)
+    expect(endValue).toBeLessThan(intermediateValue)
 
     const sampler = comfyPage.appMode.linearWidgets.getByLabel('sampler_name', {
       exact: true
@@ -61,6 +62,7 @@ test.describe('App mode usage', () => {
 
     //verify values are consistent with litegraph
   })
+
   test.describe('Mobile', { tag: ['@mobile'] }, () => {
     test('panel navigation', async ({ comfyPage }) => {
       const { mobile } = comfyPage.appMode

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -26,12 +26,38 @@ test.describe('App mode usage', () => {
     await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
     await expect(centerPanel).toBeVisible()
   })
-  test('Widget Interaction', async ({ comfyPage }) => {
+  test('Widet Interaction', async ({ comfyPage }) => {
     await comfyPage.appMode.enterAppModeWithInputs([
-      ['4', 'seed'],
-      ['4', 'sampler_name'],
+      ['3', 'seed'],
+      ['3', 'sampler_name'],
       ['6', 'text']
     ])
+    const seed = comfyPage.appMode.linearWidgets.getByLabel('seed', {
+      exact: true
+    })
+    const { input, incrementButton, decrementButton } =
+      comfyPage.vueNodes.getInputNumberControls(seed)
+    const initialValue = Number(await input.inputValue())
+
+    await seed.dragTo(incrementButton, { steps: 5 })
+    const intermediateValue = Number(await input.inputValue())
+    await expect(intermediateValue).toBeGreaterThan(initialValue)
+
+    await seed.dragTo(decrementButton, { steps: 5 })
+    const endValue = Number(await input.inputValue())
+    await expect(endValue).toBeLessThan(intermediateValue)
+
+    const sampler = comfyPage.appMode.linearWidgets.getByLabel('sampler_name', {
+      exact: true
+    })
+    await sampler.click()
+
+    await comfyPage.page.getByRole('searchbox').fill('uni')
+    await comfyPage.page.keyboard.press('ArrowDown')
+    await comfyPage.page.keyboard.press('Enter')
+    await expect(sampler).toHaveText('uni_pc')
+
+    //verify values are consistent with litegraph
   })
   test.describe('Mobile', { tag: ['@mobile'] }, () => {
     test('panel navigation', async ({ comfyPage }) => {

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -29,7 +29,7 @@ test.describe('App mode usage', () => {
     await expect(centerPanel).toBeVisible()
   })
 
-  test('Widet Interaction', async ({ comfyPage }) => {
+  test('Widget Interaction', async ({ comfyPage }) => {
     await comfyPage.appMode.enterAppModeWithInputs([
       ['3', 'seed'],
       ['3', 'sampler_name'],

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -14,11 +14,12 @@ test.describe('App mode usage', () => {
     await expect(centerPanel).not.toBeVisible()
 
     //prep a load image
+    await comfyPage.workflow.loadWorkflow('default')
     await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
-    const loadImage = await comfyPage.vueNodes.getNodeLocator('12')
+    const loadImage = await comfyPage.vueNodes.getNodeLocator('10')
     await expect(loadImage).toBeVisible()
 
-    await comfyPage.appMode.enterAppModeWithInputs([['12', 'image']])
+    await comfyPage.appMode.enterAppModeWithInputs([['10', 'image']])
     await expect(centerPanel).toBeVisible()
     //an app with an image input will upload the image to the input
     await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -9,41 +9,61 @@ test.describe('App mode usage', () => {
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     const { centerPanel } = comfyPage.appMode
     await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
-    await expect(centerPanel).toBeVisible()
+    await expect(centerPanel, 'Enter app mode').toBeVisible()
+
     //an app without an image input will load the workflow
-    await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
-    comfyFiles.deleteAfterTest({ filename: 'workflow.webp', type: 'input' })
-    await expect(centerPanel).toBeHidden()
+    await test.step('App without an image input loads workflow', async () => {
+      await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
+      await expect(centerPanel).toBeHidden()
+    })
 
     //prep a load image
-    await comfyPage.workflow.loadWorkflow('default')
-    await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
-    comfyFiles.deleteAfterTest({ filename: 'og-image.png', type: 'input' })
-    const loadImage = await comfyPage.vueNodes.getNodeLocator('10')
-    await expect(loadImage).toBeVisible()
-
-    await comfyPage.appMode.enterAppModeWithInputs([['10', 'image']])
-    await expect(centerPanel).toBeVisible()
+    await test.step('Add a load image node', async () => {
+      await comfyPage.workflow.loadWorkflow('default')
+      await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
+      comfyFiles.deleteAfterTest({ filename: 'og-image.png', type: 'input' })
+      const loadImage = await comfyPage.vueNodes.getNodeLocator('10')
+      await expect(loadImage).toBeVisible()
+    })
 
     const imageInput = new WidgetSelectDropdownFixture(
       comfyPage.appMode.linearWidgets.locator('.lg-node-widget')
     )
-    await expect(imageInput.root).toBeVisible()
-    const initialImage = await imageInput.selectedItem()
 
-    //an app with an image input will upload the image to the input
-    await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
-    comfyFiles.deleteAfterTest({ filename: 'workflow (2).webp', type: 'input' })
-    await expect(imageInput.selection).not.toHaveText(initialImage)
-    await expect(
-      centerPanel,
-      'A file with workflow should not open a new workflow'
-    ).toBeVisible()
+    await test.step('Enter app mode with image input', async () => {
+      await comfyPage.appMode.enterAppModeWithInputs([['10', 'image']])
+      await expect(centerPanel).toBeVisible()
 
-    const secondImage = await imageInput.selectedItem()
-    //an app with an image input can load from a uri-source
-    await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
-    await expect(imageInput.selection).not.toHaveText(secondImage)
+      await expect(imageInput.root).toBeVisible()
+    })
+
+    await test.step('Dragging an image redirects to image input', async () => {
+      const initialImage = await imageInput.selectedItem()
+
+      await comfyPage.dragDrop.dragAndDropExternalResource({
+        fileName: 'workflowInMedia/workflow.webp',
+        preserveNativePropagation: true
+      })
+      comfyFiles.deleteAfterTest({ filename: 'workflow.webp', type: 'input' })
+
+      await expect(imageInput.selection).not.toHaveText(initialImage)
+      await expect(
+        centerPanel,
+        'A file with workflow should not open a new workflow'
+      ).toBeVisible()
+    })
+
+    await test.step('Dragging a url redirects to image input', async () => {
+      const secondImage = await imageInput.selectedItem()
+      await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png', {
+        preserveNativePropagation: true
+      })
+      comfyFiles.deleteAfterTest({
+        filename: 'og-image (1).png',
+        type: 'input'
+      })
+      await expect(imageInput.selection).not.toHaveText(secondImage)
+    })
   })
 
   test('Widget Interaction', async ({ comfyPage }) => {

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -2,31 +2,48 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
+import { WidgetSelectDropdownFixture } from '@e2e/fixtures/components/WidgetSelectDropdown'
 
 test.describe('App mode usage', () => {
-  test('Drag and Drop', async ({ comfyPage }) => {
+  test('Drag and Drop', async ({ comfyPage, comfyFiles }) => {
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     const { centerPanel } = comfyPage.appMode
     await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
     await expect(centerPanel).toBeVisible()
     //an app without an image input will load the workflow
     await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
+    comfyFiles.deleteAfterTest({ filename: 'workflow.webp', type: 'input' })
     await expect(centerPanel).toBeHidden()
 
     //prep a load image
     await comfyPage.workflow.loadWorkflow('default')
     await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
+    comfyFiles.deleteAfterTest({ filename: 'og-image.png', type: 'input' })
     const loadImage = await comfyPage.vueNodes.getNodeLocator('10')
     await expect(loadImage).toBeVisible()
 
     await comfyPage.appMode.enterAppModeWithInputs([['10', 'image']])
     await expect(centerPanel).toBeVisible()
+
+    const imageInput = new WidgetSelectDropdownFixture(
+      comfyPage.appMode.linearWidgets.locator('.lg-node-widget')
+    )
+    await expect(imageInput.root).toBeVisible()
+    const initialImage = await imageInput.selectedItem()
+
     //an app with an image input will upload the image to the input
     await comfyPage.dragDrop.dragAndDropFile('workflowInMedia/workflow.webp')
-    await expect(centerPanel).toBeVisible()
+    comfyFiles.deleteAfterTest({ filename: 'workflow (2).webp', type: 'input' })
+    await expect(imageInput.selection).not.toHaveText(initialImage)
+    await expect(
+      centerPanel,
+      'A file with workflow should not open a new workflow'
+    ).toBeVisible()
+
+    const secondImage = await imageInput.selectedItem()
     //an app with an image input can load from a uri-source
     await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
-    await expect(centerPanel).toBeVisible()
+    await expect(imageInput.selection).not.toHaveText(secondImage)
   })
 
   test('Widget Interaction', async ({ comfyPage }) => {
@@ -81,18 +98,18 @@ test.describe('App mode usage', () => {
       await expect(comfyPage.appMode.linearWidgets).toBeInViewport({ ratio: 1 })
 
       const steps = comfyPage.page.getByRole('spinbutton')
-      await expect(steps).toHaveValue('20')
+      const initialValue = Number(await steps.inputValue())
       await mobile.tap(
         comfyPage.page.getByRole('button', { name: 'increment' }),
         { count: 5 }
       )
-      await expect(steps).toHaveValue('25')
+      await expect(steps).toHaveValue(String(initialValue + 5))
       await mobile.tap(
         comfyPage.page.getByRole('button', { name: 'decrement' }),
         { count: 3 }
       )
 
-      await expect(steps).toHaveValue('22')
+      await expect(steps).toHaveValue(String(initialValue + 2))
     })
 
     test('workflow selection', async ({ comfyPage }) => {

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -7,6 +7,10 @@ import { WidgetSelectDropdownFixture } from '@e2e/fixtures/components/WidgetSele
 test.describe('App mode usage', () => {
   test('Drag and Drop', async ({ comfyPage, comfyFiles }) => {
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.settings.setSetting(
+      'Comfy.NodeSearchBoxImpl',
+      'v1 (legacy)'
+    )
     const { centerPanel } = comfyPage.appMode
     await comfyPage.appMode.enterAppModeWithInputs([['3', 'seed']])
     await expect(centerPanel, 'Enter app mode').toBeVisible()
@@ -20,8 +24,8 @@ test.describe('App mode usage', () => {
     //prep a load image
     await test.step('Add a load image node', async () => {
       await comfyPage.workflow.loadWorkflow('default')
-      await comfyPage.dragDrop.dragAndDropURL('/assets/images/og-image.png')
-      comfyFiles.deleteAfterTest({ filename: 'og-image.png', type: 'input' })
+      await comfyPage.page.mouse.dblclick(200, 200, { delay: 5 })
+      await comfyPage.searchBox.fillAndSelectFirstNode('Load Image')
       const loadImage = await comfyPage.vueNodes.getNodeLocator('10')
       await expect(loadImage).toBeVisible()
     })
@@ -59,7 +63,7 @@ test.describe('App mode usage', () => {
         preserveNativePropagation: true
       })
       comfyFiles.deleteAfterTest({
-        filename: 'og-image (1).png',
+        filename: 'og-image.png',
         type: 'input'
       })
       await expect(imageInput.selection).not.toHaveText(secondImage)

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -45,7 +45,8 @@ test.describe('App mode usage', () => {
       const initialImage = await imageInput.selectedItem()
 
       await comfyPage.dragDrop.dragAndDropExternalResource({
-        fileName: 'workflowInMedia/workflow.webp',
+        fileName: 'workflow.webp',
+        filePath: './browser_tests/assets/workflowInMedia/workflow.webp',
         preserveNativePropagation: true
       })
       comfyFiles.deleteAfterTest({ filename: 'workflow.webp', type: 'input' })

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -1,8 +1,7 @@
 import {
   comfyPageFixture as test,
   comfyExpect as expect
-} from '../fixtures/ComfyPage'
-import { VueNodeFixture } from '../fixtures/utils/vueNodeFixtures'
+} from '@e2e/fixtures/ComfyPage'
 
 test.describe('App mode builder selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -21,7 +20,7 @@ test.describe('App mode builder selection', () => {
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
-    const prompts = await comfyPage.vueNodes
+    const prompts = comfyPage.vueNodes
       .getNodeByTitle('New Subgraph')
       .locator('.lg-node-widget')
     const count = await prompts.count()
@@ -31,6 +30,7 @@ test.describe('App mode builder selection', () => {
       await expect(items).toHaveCount(i + 1)
     }
   })
+
   test('Can drag and drop inputs', async ({ comfyPage }) => {
     const items = comfyPage.appMode.select.selectedItems
     await comfyPage.appMode.enterBuilder()
@@ -47,6 +47,7 @@ test.describe('App mode builder selection', () => {
     //dragTo doesn't cross the center point, so denoise is moved to position 2
     await expect(items.nth(1)).toContainText('denoise')
   })
+
   test('Can select outputs', async ({ comfyPage }) => {
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToOutputs()
@@ -60,28 +61,31 @@ test.describe('App mode builder selection', () => {
     const items = comfyPage.appMode.select.selectedItems
     await expect(items).toHaveCount(1)
   })
+
   test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     const items = comfyPage.appMode.select.selectedItems
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
-    await comfyPage.vueNodes
-      .getFixtureByTitle('Load Checkpoint')
-      .then((node) => node.widgets.click())
-
-    await expect.soft(items).toHaveCount(0)
+    await comfyPage.appMode.select.selectInputWidget(
+      'Load Checkpoint',
+      'ckpt_name'
+    )
+    //await expect.soft(items).toHaveCount(0)
 
     await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
-    for (const locator of await comfyPage.vueNodes.getNodeByTitle('Note').all())
-      await new VueNodeFixture(locator).widgets.click({ force: true })
+    await comfyPage.appMode.select.selectInputWidget('Note', 'text')
+    await comfyPage.appMode.select.selectInputWidget('Markdown Note', 'text')
 
     await expect(items).toHaveCount(0)
   })
+
   test('Marks canvas readOnly', async ({ comfyPage }) => {
     await comfyPage.settings.setSetting(
       'Comfy.NodeSearchBoxImpl',
@@ -104,8 +108,9 @@ test.describe('App mode builder selection', () => {
     await expect(comfyPage.searchBox.input).toHaveCount(0)
 
     const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    // oxlint-disable-next-line playwright/no-force-option -- Node container has conditional pointer-events:none that blocks actionability
     await ksampler.header.dblclick({ force: true })
-    await expect(ksampler.titleInput).not.toBeVisible()
+    await expect(ksampler.titleInput).toBeHidden()
 
     await comfyPage.page.keyboard.press('Escape')
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -1,0 +1,128 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+import { TestIds } from '../fixtures/selectors'
+
+test.describe('App mode builder selection', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.page.evaluate(() => {
+      window.app!.api.serverFeatureFlags.value = {
+        ...window.app!.api.serverFeatureFlags.value,
+        linear_toggle_enabled: true
+      }
+    })
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting(
+      'Comfy.AppBuilder.VueNodeSwitchDismissed',
+      true
+    )
+  })
+
+  test('Can independently select inputs of same name', async ({
+    comfyPage
+  }) => {
+    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+
+    await comfyPage.vueNodes.selectNodes(['6', '7'])
+    await comfyPage.command.executeCommand('Comfy.Graph.ConvertToSubgraph')
+
+    await comfyPage.appMode.enterBuilder()
+    await comfyPage.appMode.goToInputs()
+    await expect(items).toHaveCount(0)
+
+    const prompts = await comfyPage.vueNodes
+      .getNodeByTitle('New Subgraph')
+      .locator('.lg-node-widget')
+    const count = await prompts.count()
+    for (let i = 0; i < count; i++) {
+      await expect(prompts.nth(i)).toBeVisible()
+      await prompts.nth(i).click()
+      await expect(items).toHaveCount(i + 1)
+    }
+  })
+  test('Can drag and drop inputs', async ({ comfyPage }) => {
+    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    await comfyPage.appMode.enterBuilder()
+    await comfyPage.appMode.goToInputs()
+    await expect(items).toHaveCount(0)
+
+    const ksampler = await comfyPage.vueNodes.getNodeLocator('3')
+    for (const widget of await ksampler.locator('.lg-node-widget').all())
+      await widget.click()
+
+    await items.first().dragTo(items.last(), { steps: 5 })
+    await expect(items.first()).toContainText('steps')
+    await items.last().dragTo(items.first(), { steps: 5 })
+    //dragTo doesn't cross the center point, so denoise is moved to position 2
+    await expect(items.nth(1)).toContainText('denoise')
+  })
+  test('Can select outputs', async ({ comfyPage }) => {
+    await comfyPage.appMode.enterBuilder()
+    await comfyPage.appMode.goToOutputs()
+
+    await comfyPage.nodeOps
+      .getNodeRefById('9')
+      .then((ref) => ref.centerOnNode())
+    const saveImage = await comfyPage.vueNodes.getNodeLocator('9')
+    await saveImage.click()
+
+    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    await expect(items).toHaveCount(1)
+  })
+  test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
+    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    await comfyPage.appMode.enterBuilder()
+    await comfyPage.appMode.goToInputs()
+    await expect(items).toHaveCount(0)
+
+    await comfyPage.vueNodes
+      .getNodeLocator('4')
+      .locator('.lg-node-widget')
+      .click()
+    await expect.soft(items).toHaveCount(0)
+
+    await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
+    await comfyPage.appMode.enterBuilder()
+    await comfyPage.appMode.goToInputs()
+    await expect(items).toHaveCount(0)
+    await comfyPage.vueNodes
+      .getNodeLocator('1')
+      .locator('.lg-node-widget')
+      .click({ force: true })
+    await comfyPage.vueNodes
+      .getNodeLocator('2')
+      .locator('.lg-node-widget')
+      .click({ force: true })
+    await expect(items).toHaveCount(0)
+  })
+  test('Marks canvas readOnly', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting(
+      'Comfy.NodeSearchBoxImpl',
+      'v1 (legacy)'
+    )
+
+    await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
+    await expect(comfyPage.searchBox.input).toHaveCount(1)
+    await comfyPage.page.keyboard.press('Escape')
+
+    await comfyPage.appMode.enterBuilder()
+    await comfyPage.appMode.goToInputs()
+
+    await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
+    await expect(comfyPage.searchBox.input).toHaveCount(0)
+
+    //space toggles panning mode, canvas should remain readOnly after pressing
+    await comfyPage.page.keyboard.press('Space')
+    await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
+    await expect(comfyPage.searchBox.input).toHaveCount(0)
+
+    const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    await ksampler.header.dblclick({ force: true })
+    expect(ksampler.titleInput).not.toBeVisible()
+
+    await comfyPage.page.keyboard.press('Escape')
+    await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
+    await expect(comfyPage.searchBox.input).toHaveCount(1)
+  })
+})

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -106,7 +106,7 @@ test.describe('App mode builder selection', () => {
 
     const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
     await ksampler.header.dblclick({ force: true })
-    expect(ksampler.titleInput).not.toBeVisible()
+    await expect(ksampler.titleInput).not.toBeVisible()
 
     await comfyPage.page.keyboard.press('Escape')
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -6,8 +6,7 @@ import { VueNodeFixture } from '../fixtures/utils/vueNodeFixtures'
 
 test.describe('App mode builder selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.featureFlags.setFlag('linear_toggle_enabled', true)
-    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.appMode.enableLinearMode()
   })
 
   test('Can independently select inputs of same name', async ({

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -6,12 +6,7 @@ import { TestIds } from '../fixtures/selectors'
 
 test.describe('App mode builder selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.page.evaluate(() => {
-      window.app!.api.serverFeatureFlags.value = {
-        ...window.app!.api.serverFeatureFlags.value,
-        linear_toggle_enabled: true
-      }
-    })
+    await comfyPage.featureFlags.setFlag('linear_toggle_enabled', true)
     await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
     await comfyPage.settings.setSetting(
       'Comfy.AppBuilder.VueNodeSwitchDismissed',
@@ -28,7 +23,7 @@ test.describe('App mode builder selection', () => {
     await comfyPage.command.executeCommand('Comfy.Graph.ConvertToSubgraph')
 
     await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.goToInputs()
+    await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
     const prompts = await comfyPage.vueNodes
@@ -44,7 +39,7 @@ test.describe('App mode builder selection', () => {
   test('Can drag and drop inputs', async ({ comfyPage }) => {
     const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
     await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.goToInputs()
+    await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
     const ksampler = await comfyPage.vueNodes.getNodeLocator('3')
@@ -59,7 +54,7 @@ test.describe('App mode builder selection', () => {
   })
   test('Can select outputs', async ({ comfyPage }) => {
     await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.goToOutputs()
+    await comfyPage.appMode.steps.goToOutputs()
 
     await comfyPage.nodeOps
       .getNodeRefById('9')
@@ -73,7 +68,7 @@ test.describe('App mode builder selection', () => {
   test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
     const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
     await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.goToInputs()
+    await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
     await comfyPage.vueNodes
@@ -84,7 +79,7 @@ test.describe('App mode builder selection', () => {
 
     await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
     await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.goToInputs()
+    await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
     await comfyPage.vueNodes
       .getNodeLocator('1')
@@ -107,7 +102,7 @@ test.describe('App mode builder selection', () => {
     await comfyPage.page.keyboard.press('Escape')
 
     await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.goToInputs()
+    await comfyPage.appMode.steps.goToInputs()
 
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
     await expect(comfyPage.searchBox.input).toHaveCount(0)

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -2,6 +2,7 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '../fixtures/ComfyPage'
+import { VueNodeFixture } from '../fixtures/utils/vueNodeFixtures'
 
 test.describe('App mode builder selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -67,23 +68,19 @@ test.describe('App mode builder selection', () => {
     await expect(items).toHaveCount(0)
 
     await comfyPage.vueNodes
-      .getNodeLocator('4')
-      .locator('.lg-node-widget')
-      .click()
+      .getFixtureByTitle('Load Checkpoint')
+      .then((node) => node.widgets.click())
+
     await expect.soft(items).toHaveCount(0)
 
     await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
-    await comfyPage.vueNodes
-      .getNodeLocator('1')
-      .locator('.lg-node-widget')
-      .click({ force: true })
-    await comfyPage.vueNodes
-      .getNodeLocator('2')
-      .locator('.lg-node-widget')
-      .click({ force: true })
+
+    for (const locator of await comfyPage.vueNodes.getNodeByTitle('Note').all())
+      await new VueNodeFixture(locator).widgets.click({ force: true })
+
     await expect(items).toHaveCount(0)
   })
   test('Marks canvas readOnly', async ({ comfyPage }) => {

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -2,22 +2,17 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '../fixtures/ComfyPage'
-import { TestIds } from '../fixtures/selectors'
 
 test.describe('App mode builder selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.featureFlags.setFlag('linear_toggle_enabled', true)
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-    await comfyPage.settings.setSetting(
-      'Comfy.AppBuilder.VueNodeSwitchDismissed',
-      true
-    )
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
   })
 
   test('Can independently select inputs of same name', async ({
     comfyPage
   }) => {
-    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    const items = comfyPage.appMode.select.selectedItems
 
     await comfyPage.vueNodes.selectNodes(['6', '7'])
     await comfyPage.command.executeCommand('Comfy.Graph.ConvertToSubgraph')
@@ -37,7 +32,7 @@ test.describe('App mode builder selection', () => {
     }
   })
   test('Can drag and drop inputs', async ({ comfyPage }) => {
-    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    const items = comfyPage.appMode.select.selectedItems
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
@@ -62,11 +57,11 @@ test.describe('App mode builder selection', () => {
     const saveImage = await comfyPage.vueNodes.getNodeLocator('9')
     await saveImage.click()
 
-    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    const items = comfyPage.appMode.select.selectedItems
     await expect(items).toHaveCount(1)
   })
   test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
-    const items = comfyPage.page.getByTestId(TestIds.builder.ioItem)
+    const items = comfyPage.appMode.select.selectedItems
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -11,6 +11,7 @@ test.describe('App mode builder selection', () => {
   test('Can independently select inputs of same name', async ({
     comfyPage
   }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
     const items = comfyPage.appMode.select.selectedItems
 
     await comfyPage.vueNodes.selectNodes(['6', '7'])

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -111,7 +111,7 @@ test.describe('App mode builder selection', () => {
     const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
     // oxlint-disable-next-line playwright/no-force-option -- Node container has conditional pointer-events:none that blocks actionability
     await ksampler.header.dblclick({ force: true })
-    await expect(ksampler.titleInput).toBeHidden()
+    await expect(ksampler.titleEditor.input).toBeHidden()
 
     await comfyPage.page.keyboard.press('Escape')
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -12,7 +12,7 @@ test.describe('App mode builder selection', () => {
     comfyPage
   }) => {
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-    const items = comfyPage.appMode.select.selectedItems
+    const items = comfyPage.appMode.select.inputItems
 
     await comfyPage.vueNodes.selectNodes(['6', '7'])
     await comfyPage.command.executeCommand('Comfy.Graph.ConvertToSubgraph')
@@ -32,23 +32,6 @@ test.describe('App mode builder selection', () => {
     }
   })
 
-  test('Can drag and drop inputs', async ({ comfyPage }) => {
-    const items = comfyPage.appMode.select.selectedItems
-    await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.steps.goToInputs()
-    await expect(items).toHaveCount(0)
-
-    const ksampler = await comfyPage.vueNodes.getNodeLocator('3')
-    for (const widget of await ksampler.locator('.lg-node-widget').all())
-      await widget.click()
-
-    await items.first().dragTo(items.last(), { steps: 5 })
-    await expect(items.first()).toContainText('steps')
-    await items.last().dragTo(items.first(), { steps: 5 })
-    //dragTo doesn't cross the center point, so denoise is moved to position 2
-    await expect(items.nth(1)).toContainText('denoise')
-  })
-
   test('Can select outputs', async ({ comfyPage }) => {
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToOutputs()
@@ -59,17 +42,18 @@ test.describe('App mode builder selection', () => {
     const saveImage = await comfyPage.vueNodes.getNodeLocator('9')
     await saveImage.click()
 
-    const items = comfyPage.appMode.select.selectedItems
+    const items = comfyPage.appMode.select.inputItems
     await expect(items).toHaveCount(1)
   })
 
   test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-    const items = comfyPage.appMode.select.selectedItems
+    const items = comfyPage.appMode.select.inputItems
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
+    //On ci, no models exist, so Load Checkpoint is in an error state
     await comfyPage.appMode.select.selectInputWidget(
       'Load Checkpoint',
       'ckpt_name'

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -74,7 +74,7 @@ test.describe('App mode builder selection', () => {
       'Load Checkpoint',
       'ckpt_name'
     )
-    //await expect.soft(items).toHaveCount(0)
+    await expect(items).toHaveCount(0)
 
     await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
     await comfyPage.appMode.enterBuilder()
@@ -94,27 +94,41 @@ test.describe('App mode builder selection', () => {
     )
 
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
-    await expect(comfyPage.searchBox.input).toHaveCount(1)
+    await expect(
+      comfyPage.searchBox.input,
+      'Canvas is initially editable'
+    ).toHaveCount(1)
     await comfyPage.page.keyboard.press('Escape')
 
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
 
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
-    await expect(comfyPage.searchBox.input).toHaveCount(0)
+    await expect(
+      comfyPage.searchBox.input,
+      'Entering builder makes the canvas readonly'
+    ).toHaveCount(0)
 
-    //space toggles panning mode, canvas should remain readOnly after pressing
     await comfyPage.page.keyboard.press('Space')
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
-    await expect(comfyPage.searchBox.input).toHaveCount(0)
+    await expect(
+      comfyPage.searchBox.input,
+      'Canvas remains readonly after pressing space'
+    ).toHaveCount(0)
 
     const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
     // oxlint-disable-next-line playwright/no-force-option -- Node container has conditional pointer-events:none that blocks actionability
     await ksampler.header.dblclick({ force: true })
-    await expect(ksampler.titleEditor.input).toBeHidden()
+    await expect(
+      ksampler.titleEditor.input,
+      'Double clicking node titles will not initiate a rename'
+    ).toBeHidden()
 
     await comfyPage.page.keyboard.press('Escape')
     await comfyPage.page.mouse.dblclick(100, 100, { delay: 5 })
-    await expect(comfyPage.searchBox.input).toHaveCount(1)
+    await expect(
+      comfyPage.searchBox.input,
+      'Canvas is no longer readonly after exiting'
+    ).toHaveCount(1)
   })
 })

--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -47,13 +47,16 @@ test.describe('App mode builder selection', () => {
   })
 
   test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
+    //Manually set error state on checkpoint loader
+    //Shouldn't be needed on ci, but has spotty reliability
+    await comfyPage.page.evaluate(() => (graph!.nodes[6].has_errors = true))
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
     const items = comfyPage.appMode.select.inputItems
     await comfyPage.appMode.enterBuilder()
     await comfyPage.appMode.steps.goToInputs()
     await expect(items).toHaveCount(0)
 
-    //On ci, no models exist, so Load Checkpoint is in an error state
     await comfyPage.appMode.select.selectInputWidget(
       'Load Checkpoint',
       'ckpt_name'

--- a/src/composables/node/useNodeDragAndDrop.ts
+++ b/src/composables/node/useNodeDragAndDrop.ts
@@ -73,12 +73,14 @@ export const useNodeDragAndDrop = <T>(
       return true
     }
 
-    const uri = URL.parse(e?.dataTransfer?.getData('text/uri-list') ?? '')
+    const baseUri = e?.dataTransfer?.getData('text/uri-list') ?? ''
+    const uri = URL.parse(baseUri, location.href)
     if (!uri || uri.origin !== location.origin) return false
 
     try {
       const resp = await fetch(uri)
-      const fileName = uri?.searchParams?.get('filename')
+      const fileName =
+        uri?.searchParams?.get('filename') ?? baseUri.split('/').at(-1)
       if (!fileName || !resp.ok) return false
 
       const blob = await resp.blob()

--- a/src/renderer/extensions/linearMode/MobileDisplay.vue
+++ b/src/renderer/extensions/linearMode/MobileDisplay.vue
@@ -199,6 +199,7 @@ const menuEntries = computed<MenuItem[]>(() => [
           class="absolute h-full w-screen overflow-y-auto contain-size"
           role="tabpanel"
           :aria-hidden="activeIndex !== 0"
+          :aria-label="t(tabs[0][0])"
         >
           <LinearControls mobile @navigate-outputs="activeIndex = 1" />
         </div>
@@ -206,6 +207,7 @@ const menuEntries = computed<MenuItem[]>(() => [
           class="absolute top-0 left-[100vw] flex h-full w-screen flex-col bg-base-background"
           role="tabpanel"
           :aria-hidden="activeIndex !== 1"
+          :aria-label="t(tabs[1][0])"
         >
           <MobileError
             v-if="executionErrorStore.isErrorOverlayOpen"
@@ -217,6 +219,7 @@ const menuEntries = computed<MenuItem[]>(() => [
           class="absolute top-0 left-[200vw] h-full w-screen bg-base-background"
           role="tabpanel"
           :aria-hidden="activeIndex !== 2"
+          :aria-label="t(tabs[2][0])"
         />
       </div>
     </div>

--- a/src/renderer/extensions/linearMode/MobileDisplay.vue
+++ b/src/renderer/extensions/linearMode/MobileDisplay.vue
@@ -164,13 +164,14 @@ const menuEntries = computed<MenuItem[]>(() => [
       <DropdownMenu :entries="menuEntries" />
       <DropdownMenu
         :entries="workflowsEntries"
-        class="max-h-[40vh] w-(--reka-dropdown-menu-content-available-width)"
+        class="max-h-[40vh] w-(--reka-dropdown-menu-content-available-width) overflow-y-auto"
         :collision-padding="20"
       >
         <template #button>
           <!--TODO: Use button here? Probably too much work to destyle-->
           <div
             class="flex h-10 grow items-center gap-2 rounded-sm bg-secondary-background p-2"
+            data-testid="linear-mobile-workflows"
           >
             <i
               class="icon-[lucide--panels-top-left] shrink-0 bg-primary-background"

--- a/src/renderer/extensions/linearMode/MobileDisplay.vue
+++ b/src/renderer/extensions/linearMode/MobileDisplay.vue
@@ -154,7 +154,10 @@ const menuEntries = computed<MenuItem[]>(() => [
 ])
 </script>
 <template>
-  <section class="absolute flex size-full flex-col bg-secondary-background">
+  <section
+    class="absolute flex size-full flex-col bg-secondary-background"
+    data-testid="linear-mobile"
+  >
     <header
       class="flex h-16 w-full items-center gap-3 border-b border-border-subtle bg-base-background px-4 py-3"
     >
@@ -191,11 +194,17 @@ const menuEntries = computed<MenuItem[]>(() => [
         "
         :style="{ translate }"
       >
-        <div class="absolute h-full w-screen overflow-y-auto contain-size">
+        <div
+          class="absolute h-full w-screen overflow-y-auto contain-size"
+          role="tabpanel"
+          :aria-hidden="activeIndex !== 0"
+        >
           <LinearControls mobile @navigate-outputs="activeIndex = 1" />
         </div>
         <div
           class="absolute top-0 left-[100vw] flex h-full w-screen flex-col bg-base-background"
+          role="tabpanel"
+          :aria-hidden="activeIndex !== 1"
         >
           <MobileError
             v-if="executionErrorStore.isErrorOverlayOpen"
@@ -205,18 +214,23 @@ const menuEntries = computed<MenuItem[]>(() => [
         </div>
         <AssetsSidebarTab
           class="absolute top-0 left-[200vw] h-full w-screen bg-base-background"
+          role="tabpanel"
+          :aria-hidden="activeIndex !== 2"
         />
       </div>
     </div>
     <div
       ref="sliderPaneRef"
       class="flex h-22 w-full items-center justify-around gap-4 bg-secondary-background p-4"
+      role="tablist"
     >
       <Button
         v-for="([label, icon], index) in tabs"
         :key="label"
         :variant="index === activeIndex ? 'secondary' : 'muted-textonly'"
         class="h-14 grow flex-col"
+        role="tab"
+        :aria-selected="index === activeIndex"
         @click="onClick(index)"
       >
         <div class="relative size-4">

--- a/src/renderer/extensions/linearMode/MobileDisplay.vue
+++ b/src/renderer/extensions/linearMode/MobileDisplay.vue
@@ -23,9 +23,9 @@ import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const tabs = [
-  ['linearMode.mobileControls', 'icon-[lucide--play]'],
-  ['nodeHelpPage.outputs', 'icon-[comfy--image-ai-edit]'],
-  ['sideToolbar.assets', 'icon-[lucide--images]']
+  ['linearMode.mobileControls', 'icon-[lucide--play]', 'control'],
+  ['nodeHelpPage.outputs', 'icon-[comfy--image-ai-edit]', 'preview'],
+  ['sideToolbar.assets', 'icon-[lucide--images]', 'output']
 ]
 
 const canvasStore = useCanvasStore()
@@ -196,18 +196,22 @@ const menuEntries = computed<MenuItem[]>(() => [
         :style="{ translate }"
       >
         <div
+          id="mobile-app-control-panel"
           class="absolute h-full w-screen overflow-y-auto contain-size"
           role="tabpanel"
           :aria-hidden="activeIndex !== 0"
-          :aria-label="t(tabs[0][0])"
+          aria-labelledby="mobile-app-control-tab"
+          :inert="activeIndex !== 0"
         >
           <LinearControls mobile @navigate-outputs="activeIndex = 1" />
         </div>
         <div
+          id="mobile-app-preview-panel"
           class="absolute top-0 left-[100vw] flex h-full w-screen flex-col bg-base-background"
           role="tabpanel"
           :aria-hidden="activeIndex !== 1"
-          :aria-label="t(tabs[1][0])"
+          aria-labelledby="mobile-app-preview-tab"
+          :inert="activeIndex !== 1"
         >
           <MobileError
             v-if="executionErrorStore.isErrorOverlayOpen"
@@ -216,10 +220,12 @@ const menuEntries = computed<MenuItem[]>(() => [
           <LinearPreview v-else mobile @navigate-controls="activeIndex = 0" />
         </div>
         <AssetsSidebarTab
+          id="mobile-app-output-panel"
           class="absolute top-0 left-[200vw] h-full w-screen bg-base-background"
           role="tabpanel"
           :aria-hidden="activeIndex !== 2"
-          :aria-label="t(tabs[2][0])"
+          aria-labelledby="mobile-app-output-tab"
+          :inert="activeIndex !== 2"
         />
       </div>
     </div>
@@ -229,12 +235,14 @@ const menuEntries = computed<MenuItem[]>(() => [
       role="tablist"
     >
       <Button
-        v-for="([label, icon], index) in tabs"
+        v-for="([label, icon, id], index) in tabs"
+        :id="`mobile-app-${id}-tab`"
         :key="label"
         :variant="index === activeIndex ? 'secondary' : 'muted-textonly'"
         class="h-14 grow flex-col"
         role="tab"
         :aria-selected="index === activeIndex"
+        :aria-controls="`mobile-app-${id}-panel`"
         @click="onClick(index)"
       >
         <div class="relative size-4">

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="widget-markdown relative w-full" @dblclick="startEditing">
+  <div
+    :aria-label="widget.name"
+    class="widget-markdown relative w-full"
+    @dblclick="startEditing"
+  >
     <div
       class="comfy-markdown-content size-full min-h-[60px] overflow-y-auto rounded-lg text-sm"
       :class="isEditing ? 'invisible' : 'visible'"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -1,14 +1,13 @@
 <template>
-  <div
-    :aria-label="widget.name"
-    class="widget-markdown relative w-full"
-    @dblclick="startEditing"
-  >
+  <div class="widget-markdown relative w-full" @dblclick="startEditing">
     <div
       class="comfy-markdown-content size-full min-h-[60px] overflow-y-auto rounded-lg text-sm"
       :class="isEditing ? 'invisible' : 'visible'"
       tabindex="0"
       data-capture-wheel="true"
+      role="textarea"
+      :aria-label="widget.name || $t('g.markdown')"
+      aria-readonly="true"
       v-html="renderedHtml"
     />
 

--- a/src/views/LinearView.vue
+++ b/src/views/LinearView.vue
@@ -147,6 +147,7 @@ function dragDrop(e: DragEvent) {
       </SplitterPanel>
       <SplitterPanel
         id="linearCenterPanel"
+        data-testid="linear-center-panel"
         :size="CENTER_PANEL_SIZE"
         class="relative flex min-w-[20vw] flex-col gap-4 text-muted-foreground outline-none"
         @drop="dragDrop"


### PR DESCRIPTION
Adds tests for
- Mobile app mode.
- Drag and drop operations in app mode
- Basic widget interaction in app mode.
- The read only state when in builder mode.

This branch has been fairly long lived. Some of the tests implemented may have near duplicates.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10633-App-Mode-tests-3306d73d36508154aa25d8096119a32c) by [Unito](https://www.unito.io)
