### PR TITLE
docs: add Fixture Data & Schemas section to Playwright test guidance

### DIFF
--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -87,6 +87,21 @@ Tags are respected by config:
 - Check `browser_tests/assets/` for test data and fixtures
 - Use realistic ComfyUI workflows for E2E tests
 
+## Fixture Data & Schemas
+
+When creating test fixture data, import or reference existing Zod schemas and TypeScript
+types from `src/` instead of inventing ad-hoc shapes. This keeps test data in sync with
+production types.
+
+Key schema locations:
+
+- `src/schemas/apiSchema.ts` — API response types (`PromptResponse`, `SystemStats`, `User`, `UserDataFullInfo`, WebSocket messages)
+- `src/schemas/nodeDefSchema.ts` — Node definition schema (`ComfyNodeDef`, `InputSpec`, `ComboInputSpec`)
+- `src/schemas/nodeDef/nodeDefSchemaV2.ts` — V2 node definition schema
+- `src/platform/remote/comfyui/jobs/jobTypes.ts` — Jobs API Zod schemas (`zJobDetail`, `zJobsListResponse`, `zRawJobListItem`)
+- `src/platform/workflow/validation/schemas/workflowSchema.ts` — Workflow validation (`ComfyWorkflowJSON`, `ComfyApiWorkflow`)
+- `src/types/metadataTypes.ts` — Asset metadata types
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary

Add a "Fixture Data & Schemas" section to `docs/guidance/playwright.md` so agents reference existing Zod schemas and TypeScript types when creating test fixture data.

## Changes

- **What**: New section listing key schema/type locations (`apiSchema`, `nodeDefSchema`, `jobTypes`, `workflowSchema`, etc.) to keep test fixtures in sync with production types.

## Review Focus

Documentation-only change; no runtime impact.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10642-docs-add-Fixture-Data-Schemas-section-to-Playwright-test-guidance-3316d73d365081f5a234e4672b3dc4b9) by [Unito](https://www.unito.io)
