### PR TITLE
feat: ban useVirtualList from @vueuse/core via ESLint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -344,5 +344,25 @@ export default defineConfig([
         }
       ]
     }
+  },
+
+  // Ban useVirtualList — use TanStack Virtual instead
+  {
+    files: ['**/*.{ts,vue}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@vueuse/core',
+              importNames: ['useVirtualList'],
+              message:
+                'useVirtualList requires uniform item heights. Use TanStack Virtual (via Reka UI virtualizer or @tanstack/vue-virtual) instead.'
+            }
+          ]
+        }
+      ]
+    }
   }
 ])

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -63,6 +63,13 @@ const commonParserOptions = {
   extraFileExtensions
 } as const
 
+const useVirtualListRestriction = {
+  name: '@vueuse/core',
+  importNames: ['useVirtualList'],
+  message:
+    'useVirtualList requires uniform item heights. Use TanStack Virtual (via Reka UI virtualizer or @tanstack/vue-virtual) instead.'
+} as const
+
 export default defineConfig([
   {
     ignores: [
@@ -319,7 +326,8 @@ export default defineConfig([
               importNames: ['t', 'd', 'te'],
               message:
                 "In Vue components, use `const { t } = useI18n()` instead of importing from '@/i18n'."
-            }
+            },
+            useVirtualListRestriction
           ]
         }
       ]
@@ -339,28 +347,21 @@ export default defineConfig([
               importNames: ['useI18n'],
               message:
                 "useI18n() requires Vue setup context. Use `import { t } from '@/i18n'` instead."
-            }
+            },
+            useVirtualListRestriction
           ]
         }
       ]
     }
   },
-
-  // Ban useVirtualList — use TanStack Virtual instead
+  // Preserve the useVirtualList ban for files excluded from the useI18n rule.
   {
-    files: ['**/*.{ts,vue}'],
+    files: ['**/use[A-Z]*.ts', '**/*.test.ts', 'src/i18n.ts'],
     rules: {
       'no-restricted-imports': [
         'error',
         {
-          paths: [
-            {
-              name: '@vueuse/core',
-              importNames: ['useVirtualList'],
-              message:
-                'useVirtualList requires uniform item heights. Use TanStack Virtual (via Reka UI virtualizer or @tanstack/vue-virtual) instead.'
-            }
-          ]
+          paths: [useVirtualListRestriction]
         }
       ]
     }


### PR DESCRIPTION
## Summary

Add ESLint `no-restricted-imports` rule to prevent usage of `useVirtualList` from `@vueuse/core`.

## Changes

- **What**: New ESLint config block banning `useVirtualList` in `**/*.{ts,vue}` files. The team standardized on TanStack Virtual (via Reka UI virtualizer or `@tanstack/vue-virtual`) for all virtualization. `useVirtualList` requires uniform item heights and is no longer desired. This is a preventive ban — no existing usage exists.

## Review Focus

Straightforward lint rule addition following the existing `no-restricted-imports` pattern in `eslint.config.ts`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10643-feat-ban-useVirtualList-from-vueuse-core-via-ESLint-3316d73d365081d5adf0ec926aab6e28) by [Unito](https://www.unito.io)
