### PR TITLE
refactor: replace PrimeVue Chip with design system (Reka UI)

### DIFF
--- a/src/components/searchbox/NodeSearchItem.vue
+++ b/src/components/searchbox/NodeSearchItem.vue
@@ -37,18 +37,17 @@
         :value="formatNumberWithSuffix(nodeFrequency, { roundToInt: true })"
         severity="secondary"
       />
-      <Chip
+      <span
         v-if="nodeDef.nodeSource.type !== NodeSourceType.Unknown"
-        class="text-sm font-light"
+        class="inline-flex items-center rounded-2xl bg-surface-700 px-2 py-0.5 text-sm font-light"
       >
         {{ nodeDef.nodeSource.displayText }}
-      </Chip>
+      </span>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import Chip from 'primevue/chip'
 import Tag from 'primevue/tag'
 import { computed } from 'vue'
 

--- a/src/components/sidebar/tabs/modelLibrary/DownloadItem.vue
+++ b/src/components/sidebar/tabs/modelLibrary/DownloadItem.vue
@@ -4,13 +4,19 @@
       {{ getDownloadLabel(download.savePath ?? '') }}
     </div>
     <div v-if="['cancelled', 'error'].includes(download.status ?? '')">
-      <Chip
-        class="mt-2 h-6 bg-red-700 text-sm font-light"
-        removable
-        @remove="handleRemoveDownload"
+      <span
+        class="mt-2 inline-flex h-6 items-center gap-1 rounded-2xl bg-red-700 py-0.5 pr-1 pl-2 text-sm font-light"
       >
         {{ t('electronFileDownload.cancelled') }}
-      </Chip>
+        <button
+          type="button"
+          :aria-label="$t('g.remove')"
+          class="inline-flex cursor-pointer items-center justify-center rounded-full p-0.5 hover:bg-red-600"
+          @click="handleRemoveDownload"
+        >
+          <i class="icon-[lucide--x] size-3 text-white/70" aria-hidden="true" />
+        </button>
+      </span>
     </div>
     <div
       v-if="
@@ -67,7 +73,6 @@
 </template>
 
 <script setup lang="ts">
-import Chip from 'primevue/chip'
 import ProgressBar from 'primevue/progressbar'
 import { useI18n } from 'vue-i18n'
 


### PR DESCRIPTION
## Summary
- Replace PrimeVue `Chip` with native HTML in `NodeSearchItem` (text-only chip for node source display)
- Replace PrimeVue `Chip` with native HTML + remove button in `DownloadItem` (removable cancelled download chip)

Continues the PrimeVue component removal effort from #10580 and #10582.

## Test plan
- [ ] Node search results show source chip correctly (e.g. "built-in", custom node name)
- [ ] Cancelled downloads show "Cancelled" chip with dismiss button
- [ ] Dismiss button removes the cancelled download entry

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10646-refactor-replace-PrimeVue-Chip-with-native-HTML-3316d73d365081488b70db8d06ec38cf) by [Unito](https://www.unito.io)
