### PR TITLE
fix(DisplayCarousel): use back button in grid view and remove hover icons

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -347,11 +347,7 @@ describe('DisplayCarousel Grid Mode', () => {
     await wrapper.find('[aria-label="Switch to grid view"]').trigger('click')
     await nextTick()
 
-    // Focus the grid container to reveal toggle
-    await findImageContainer(wrapper).trigger('focusin')
-    await nextTick()
-
-    // Switch back to single
+    // Back button is always visible in grid mode (no hover/focus needed)
     const singleToggle = wrapper.find('[aria-label="Switch to single view"]')
     expect(singleToggle.exists()).toBe(true)
 

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
@@ -142,41 +142,29 @@
           ref="gridContainerEl"
           class="relative h-72 overflow-x-hidden overflow-y-auto rounded-sm bg-component-node-background"
           tabindex="0"
-          @mouseenter="isHovered = true"
-          @mouseleave="isHovered = false"
-          @focusin="isFocused = true"
-          @focusout="handleFocusOut"
         >
-          <!-- Toggle to Single (hover, top-left) -->
+          <!-- Back to Single (top-left, always visible) -->
           <button
-            v-if="showControls"
             :class="toggleButtonClass"
-            class="absolute top-2 left-2 z-10"
+            class="sticky top-2 left-2 z-10 mt-2 ml-2"
             :aria-label="t('g.switchToSingleView')"
             @click="switchToSingle"
           >
-            <i class="icon-[lucide--square] size-4" />
+            <i class="icon-[lucide--arrow-left] size-4" />
           </button>
 
-          <div class="flex flex-wrap content-start gap-1">
+          <div class="-mt-10 flex flex-wrap content-start gap-1">
             <button
               v-for="(item, index) in galleryImages"
               :key="getItemSrc(item)"
               class="size-14 shrink-0 cursor-pointer overflow-hidden border-0 p-0"
               :aria-label="getItemAlt(item, index)"
-              @mouseenter="hoveredGridIndex = index"
-              @mouseleave="hoveredGridIndex = -1"
               @click="selectFromGrid(index)"
             >
               <img
                 :src="getItemThumbnail(item)"
                 :alt="getItemAlt(item, index)"
-                :class="
-                  cn(
-                    'size-full object-cover transition-opacity',
-                    hoveredGridIndex === index && 'opacity-50'
-                  )
-                "
+                class="size-full object-cover"
               />
             </button>
           </div>
@@ -229,7 +217,6 @@ const activeIndex = ref(0)
 const displayMode = ref<DisplayMode>('single')
 const isHovered = ref(false)
 const isFocused = ref(false)
-const hoveredGridIndex = ref(-1)
 const imageDimensions = ref<string | null>(null)
 const thumbnailRefs = ref<(HTMLElement | null)[]>([])
 const imageContainerEl = ref<HTMLDivElement>()


### PR DESCRIPTION


## Summary
- Grid view top-left icon changed from square to back arrow (`arrow-left`) per Figma spec
- Back button is always visible in grid view (no longer hover-dependent), uses sticky positioning
- Removed hover opacity effect on grid thumbnails

## Related
- Figma: https://www.figma.com/design/vALUV83vIdBzEsTJAhQgXq/Comfy-Design-System?node-id=6008-83034&m=dev
- Figma: https://www.figma.com/design/vALUV83vIdBzEsTJAhQgXq/Comfy-Design-System?node-id=6008-83069&m=dev

## Test plan
- [x] All 31 existing DisplayCarousel tests pass
- [ ] Visual check: grid view shows back arrow icon (top-left, always visible)
- [ ] Visual check: hovering grid thumbnails shows no overlay icons
- [ ] Verify back button stays visible when scrolling through many grid items

## Screenshot
### Before
<img width="492" height="364" alt="스크린샷 2026-03-28 오후 4 31 54" src="https://github.com/user-attachments/assets/f9f36521-e993-45de-b692-59fba22a026d" />
<img width="457" height="400" alt="스크린샷 2026-03-28 오후 4 32 03" src="https://github.com/user-attachments/assets/004f6380-8ad7-4167-b1f4-ebc4bdb559cc" />

### After
<img width="596" height="388" alt="스크린샷 2026-03-28 오후 4 31 43" src="https://github.com/user-attachments/assets/e5585887-ad36-42e3-a6c0-e6eacb90dad7" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10654-fix-DisplayCarousel-use-back-button-in-grid-view-and-remove-hover-icons-3316d73d3650819594c7f16d1012323c) by [Unito](https://www.unito.io)
