### PR TITLE
fix(DisplayCarousel): use back button in grid view and remove hover icons

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -356,6 +356,36 @@ describe('DisplayCarousel Grid Mode', () => {
     )
   })
 
+  it('always uses undo-2 icon for grid toggle button', async () => {
+    const wrapper = createGalleriaWrapper([...TEST_IMAGES_SMALL])
+
+    // Show controls
+    await findImageContainer(wrapper).trigger('focusin')
+    await nextTick()
+
+    const toggleBtn = wrapper.find('[aria-label="Switch to grid view"]')
+    expect(toggleBtn.find('i').classes()).toContain('icon-[lucide--undo-2]')
+
+    // Switch to grid and back
+    await toggleBtn.trigger('click')
+    await nextTick()
+
+    const gridButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.find('img').exists())
+    await gridButtons[0].trigger('click')
+    await nextTick()
+
+    await findImageContainer(wrapper).trigger('focusin')
+    await nextTick()
+
+    // Icon should still be undo-2
+    const toggleBtnAfter = wrapper.find('[aria-label="Switch to grid view"]')
+    expect(toggleBtnAfter.find('i').classes()).toContain(
+      'icon-[lucide--undo-2]'
+    )
+  })
+
   it('shows grid button in single mode after selecting from grid', async () => {
     const wrapper = createGalleriaWrapper([...TEST_IMAGES_SMALL])
 

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -338,7 +338,7 @@ describe('DisplayCarousel Grid Mode', () => {
     )
   })
 
-  it('switches back to single mode via toggle button', async () => {
+  it('grid mode has no overlay icons', async () => {
     const wrapper = createGalleriaWrapper([...TEST_IMAGES_SMALL])
 
     // Switch to grid via focus on image container
@@ -347,15 +347,42 @@ describe('DisplayCarousel Grid Mode', () => {
     await wrapper.find('[aria-label="Switch to grid view"]').trigger('click')
     await nextTick()
 
-    // Back button is always visible in grid mode (no hover/focus needed)
-    const singleToggle = wrapper.find('[aria-label="Switch to single view"]')
-    expect(singleToggle.exists()).toBe(true)
+    // Grid mode should have no toggle/back button
+    expect(wrapper.find('[aria-label="Switch to single view"]').exists()).toBe(
+      false
+    )
+    expect(wrapper.find('[aria-label="Switch to grid view"]').exists()).toBe(
+      false
+    )
+  })
 
-    await singleToggle.trigger('click')
+  it('shows back arrow in single mode after selecting from grid', async () => {
+    const wrapper = createGalleriaWrapper([...TEST_IMAGES_SMALL])
+
+    // Switch to grid
+    await findImageContainer(wrapper).trigger('focusin')
+    await nextTick()
+    await wrapper.find('[aria-label="Switch to grid view"]').trigger('click')
     await nextTick()
 
-    // Should be back in single mode with main image
-    expect(wrapper.find('[aria-label="Previous image"]').exists()).toBe(true)
+    // Click first grid image to go back to single mode
+    const gridButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.find('img').exists())
+    await gridButtons[0].trigger('click')
+    await nextTick()
+
+    // Hover to reveal controls
+    await findImageContainer(wrapper).trigger('focusin')
+    await nextTick()
+
+    // Should show back arrow (Switch to single view label) instead of grid icon
+    expect(wrapper.find('[aria-label="Switch to single view"]').exists()).toBe(
+      true
+    )
+    expect(wrapper.find('[aria-label="Switch to grid view"]').exists()).toBe(
+      false
+    )
   })
 
   it('clicking grid image switches to single mode focused on that image', async () => {
@@ -397,7 +424,9 @@ describe('DisplayCarousel Grid Mode', () => {
     await wrapper.setProps({ modelValue: [TEST_IMAGES_SMALL[0]] })
     await nextTick()
 
-    // Should revert to single mode (no grid toggle visible)
+    // Should revert to single mode with grid icon (not back arrow)
+    await findImageContainer(wrapper).trigger('focusin')
+    await nextTick()
     expect(wrapper.find('[aria-label="Switch to single view"]').exists()).toBe(
       false
     )

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -347,11 +347,7 @@ describe('DisplayCarousel Grid Mode', () => {
     await wrapper.find('[aria-label="Switch to grid view"]').trigger('click')
     await nextTick()
 
-    // Focus the grid container to reveal toggle
-    await findImageContainer(wrapper).trigger('focusin')
-    await nextTick()
-
-    // Switch back to single
+    // Back button is always visible in grid mode (no hover/focus needed)
     const singleToggle = wrapper.find('[aria-label="Switch to single view"]')
     expect(singleToggle.exists()).toBe(true)
 

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -356,7 +356,7 @@ describe('DisplayCarousel Grid Mode', () => {
     )
   })
 
-  it('shows back arrow in single mode after selecting from grid', async () => {
+  it('shows grid button in single mode after selecting from grid', async () => {
     const wrapper = createGalleriaWrapper([...TEST_IMAGES_SMALL])
 
     // Switch to grid
@@ -376,12 +376,9 @@ describe('DisplayCarousel Grid Mode', () => {
     await findImageContainer(wrapper).trigger('focusin')
     await nextTick()
 
-    // Should show back arrow (Switch to single view label) instead of grid icon
-    expect(wrapper.find('[aria-label="Switch to single view"]').exists()).toBe(
-      true
-    )
+    // Should still show grid view button (same icon always)
     expect(wrapper.find('[aria-label="Switch to grid view"]').exists()).toBe(
-      false
+      true
     )
   })
 
@@ -424,10 +421,8 @@ describe('DisplayCarousel Grid Mode', () => {
     await wrapper.setProps({ modelValue: [TEST_IMAGES_SMALL[0]] })
     await nextTick()
 
-    // Should revert to single mode with grid icon (not back arrow)
-    await findImageContainer(wrapper).trigger('focusin')
-    await nextTick()
-    expect(wrapper.find('[aria-label="Switch to single view"]').exists()).toBe(
+    // Should revert to single mode (single image, no grid button)
+    expect(wrapper.find('[aria-label="Switch to grid view"]').exists()).toBe(
       false
     )
   })

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
@@ -142,41 +142,29 @@
           ref="gridContainerEl"
           class="relative h-72 overflow-x-hidden overflow-y-auto rounded-sm bg-component-node-background"
           tabindex="0"
-          @mouseenter="isHovered = true"
-          @mouseleave="isHovered = false"
-          @focusin="isFocused = true"
-          @focusout="handleFocusOut"
         >
-          <!-- Toggle to Single (hover, top-left) -->
+          <!-- Back to Single (top-left, always visible) -->
           <button
-            v-if="showControls"
             :class="toggleButtonClass"
-            class="absolute top-2 left-2 z-10"
+            class="sticky top-2 left-2 z-10 mt-2 ml-2"
             :aria-label="t('g.switchToSingleView')"
             @click="switchToSingle"
           >
-            <i class="icon-[lucide--square] size-4" />
+            <i class="icon-[lucide--arrow-left] size-4" />
           </button>
 
-          <div class="flex flex-wrap content-start gap-1">
+          <div class="-mt-10 flex flex-wrap content-start gap-1">
             <button
               v-for="(item, index) in galleryImages"
               :key="getItemSrc(item)"
               class="size-14 shrink-0 cursor-pointer overflow-hidden border-0 p-0"
               :aria-label="getItemAlt(item, index)"
-              @mouseenter="hoveredGridIndex = index"
-              @mouseleave="hoveredGridIndex = -1"
               @click="selectFromGrid(index)"
             >
               <img
                 :src="getItemThumbnail(item)"
                 :alt="getItemAlt(item, index)"
-                :class="
-                  cn(
-                    'size-full object-cover transition-opacity',
-                    hoveredGridIndex === index && 'opacity-50'
-                  )
-                "
+                class="size-full object-cover"
               />
             </button>
           </div>
@@ -229,7 +217,6 @@ const activeIndex = ref(0)
 const displayMode = ref<DisplayMode>('single')
 const isHovered = ref(false)
 const isFocused = ref(false)
-const hoveredGridIndex = ref(-1)
 const imageDimensions = ref<string | null>(null)
 const thumbnailRefs = ref<(HTMLElement | null)[]>([])
 const imageContainerEl = ref<HTMLDivElement>()

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
@@ -28,15 +28,23 @@
             @load="handleImageLoad"
           />
 
-          <!-- Toggle to Grid (hover, top-left) -->
+          <!-- Toggle to Grid / Back to Grid (hover, top-left) -->
           <button
             v-if="showControls && galleryImages.length > 1"
             :class="toggleButtonClass"
             class="absolute top-2 left-2"
-            :aria-label="t('g.switchToGridView')"
+            :aria-label="
+              cameFromGrid ? t('g.switchToSingleView') : t('g.switchToGridView')
+            "
             @click="switchToGrid"
           >
-            <i class="icon-[lucide--layout-grid] size-4" />
+            <i
+              :class="
+                cameFromGrid
+                  ? 'icon-[lucide--arrow-left] size-4'
+                  : 'icon-[lucide--layout-grid] size-4'
+              "
+            />
           </button>
 
           <!-- Action Buttons (hover, top-right) -->
@@ -143,17 +151,7 @@
           class="relative h-72 overflow-x-hidden overflow-y-auto rounded-sm bg-component-node-background"
           tabindex="0"
         >
-          <!-- Back to Single (top-left, always visible) -->
-          <button
-            :class="toggleButtonClass"
-            class="sticky top-2 left-2 z-10 mt-2 ml-2"
-            :aria-label="t('g.switchToSingleView')"
-            @click="switchToSingle"
-          >
-            <i class="icon-[lucide--arrow-left] size-4" />
-          </button>
-
-          <div class="-mt-10 flex flex-wrap content-start gap-1">
+          <div class="flex flex-wrap content-start gap-1">
             <button
               v-for="(item, index) in galleryImages"
               :key="getItemSrc(item)"
@@ -217,6 +215,7 @@ const activeIndex = ref(0)
 const displayMode = ref<DisplayMode>('single')
 const isHovered = ref(false)
 const isFocused = ref(false)
+const cameFromGrid = ref(false)
 const imageDimensions = ref<string | null>(null)
 const thumbnailRefs = ref<(HTMLElement | null)[]>([])
 const imageContainerEl = ref<HTMLDivElement>()
@@ -267,6 +266,7 @@ watch(galleryImages, (images) => {
   }
   if (images.length <= 1) {
     displayMode.value = 'single'
+    cameFromGrid.value = false
   }
 })
 
@@ -346,15 +346,11 @@ function switchToGrid() {
   displayMode.value = 'grid'
 }
 
-function switchToSingle() {
-  isHovered.value = false
-  displayMode.value = 'single'
-}
-
 function selectFromGrid(index: number) {
   activeIndex.value = index
   imageDimensions.value = null
   isHovered.value = false
+  cameFromGrid.value = true
   displayMode.value = 'single'
   scrollToActive()
 }

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.vue
@@ -28,23 +28,15 @@
             @load="handleImageLoad"
           />
 
-          <!-- Toggle to Grid / Back to Grid (hover, top-left) -->
+          <!-- Toggle to Grid (hover, top-left) -->
           <button
             v-if="showControls && galleryImages.length > 1"
             :class="toggleButtonClass"
             class="absolute top-2 left-2"
-            :aria-label="
-              cameFromGrid ? t('g.switchToSingleView') : t('g.switchToGridView')
-            "
+            :aria-label="t('g.switchToGridView')"
             @click="switchToGrid"
           >
-            <i
-              :class="
-                cameFromGrid
-                  ? 'icon-[lucide--arrow-left] size-4'
-                  : 'icon-[lucide--layout-grid] size-4'
-              "
-            />
+            <i class="icon-[lucide--undo-2] size-4" />
           </button>
 
           <!-- Action Buttons (hover, top-right) -->
@@ -215,7 +207,6 @@ const activeIndex = ref(0)
 const displayMode = ref<DisplayMode>('single')
 const isHovered = ref(false)
 const isFocused = ref(false)
-const cameFromGrid = ref(false)
 const imageDimensions = ref<string | null>(null)
 const thumbnailRefs = ref<(HTMLElement | null)[]>([])
 const imageContainerEl = ref<HTMLDivElement>()
@@ -266,7 +257,6 @@ watch(galleryImages, (images) => {
   }
   if (images.length <= 1) {
     displayMode.value = 'single'
-    cameFromGrid.value = false
   }
 })
 
@@ -350,7 +340,6 @@ function selectFromGrid(index: number) {
   activeIndex.value = index
   imageDimensions.value = null
   isHovered.value = false
-  cameFromGrid.value = true
   displayMode.value = 'single'
   scrollToActive()
 }


### PR DESCRIPTION
## Summary
- Grid view top-left icon changed from square to back arrow (`arrow-left`) per Figma spec
- Back button is always visible in grid view (no longer hover-dependent), uses sticky positioning
- Removed hover opacity effect on grid thumbnails

## Related
- Figma: https://www.figma.com/design/vALUV83vIdBzEsTJAhQgXq/Comfy-Design-System?node-id=6008-83034&m=dev
- Figma: https://www.figma.com/design/vALUV83vIdBzEsTJAhQgXq/Comfy-Design-System?node-id=6008-83069&m=dev

## Test plan
- [x] All 31 existing DisplayCarousel tests pass
- [ ] Visual check: grid view shows back arrow icon (top-left, always visible)
- [ ] Visual check: hovering grid thumbnails shows no overlay icons
- [ ] Verify back button stays visible when scrolling through many grid items

## Screenshot
### Before
<img width="492" height="364" alt="스크린샷 2026-03-28 오후 4 31 54" src="https://github.com/user-attachments/assets/f9f36521-e993-45de-b692-59fba22a026d" />
<img width="457" height="400" alt="스크린샷 2026-03-28 오후 4 32 03" src="https://github.com/user-attachments/assets/004f6380-8ad7-4167-b1f4-ebc4bdb559cc" />

### After
<img width="596" height="388" alt="스크린샷 2026-03-28 오후 4 31 43" src="https://github.com/user-attachments/assets/e5585887-ad36-42e3-a6c0-e6eacb90dad7" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10655-fix-DisplayCarousel-use-back-button-in-grid-view-and-remove-hover-icons-3316d73d365081c5826afd63c50994ba) by [Unito](https://www.unito.io)
