### PR TITLE
feat: add assertHasItems and openFor to ContextMenu page object

### DIFF
--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import type { Locator, Page } from '@playwright/test'
 
 export class ContextMenu {
@@ -31,6 +32,20 @@ export class ContextMenu {
       .isVisible()
       .catch(() => false)
     return primeVueVisible || litegraphVisible
+  }
+
+  async assertHasItems(items: string[]): Promise<void> {
+    for (const item of items) {
+      await expect
+        .soft(this.page.getByRole('menuitem', { name: item }))
+        .toBeVisible()
+    }
+  }
+
+  async openFor(locator: Locator): Promise<this> {
+    await locator.click({ button: 'right' })
+    await expect(this.primeVueMenu.or(this.litegraphMenu).first()).toBeVisible()
+    return this
   }
 
   async waitForHidden(): Promise<void> {

--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -44,7 +44,7 @@ export class ContextMenu {
 
   async openFor(locator: Locator): Promise<this> {
     await locator.click({ button: 'right' })
-    await expect(this.primeVueMenu.or(this.litegraphMenu).first()).toBeVisible()
+    await expect.poll(() => this.isVisible()).toBe(true)
     return this
   }
 


### PR DESCRIPTION
## Summary

Add composite assertion and scoped opening methods to the `ContextMenu` Playwright page object.

## Changes

- **What**: Added `assertHasItems(items: string[])` using `expect.soft()` per item, and `openFor(locator: Locator)` which right-clicks and waits for menu visibility. Fully backward-compatible.

## Review Focus

Both methods reuse existing locators (`primeVueMenu`, `litegraphMenu`, `getByRole("menuitem")`). `openFor` uses `.or()` to handle both menu types.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10659-feat-add-assertHasItems-and-openFor-to-ContextMenu-page-object-3316d73d36508193af45da7d3af4f50c) by [Unito](https://www.unito.io)
