### PR TITLE
docs: add convention for new assertions — prefer page objects over custom matchers

### DIFF
--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -101,20 +101,14 @@ expect(node.widgets).toHaveLength(4)
 
 ## Custom Assertions
 
-Existing `comfyExpect` matchers (`toBePinned`, `toBeBypassed`, `toBeCollapsed`, `toHaveFocus`) are fine to use in existing and new tests.
-
-**For NEW assertions**: Add assertion methods directly on the page object or helper class instead of extending `comfyExpect`. Page object methods are discoverable via IntelliSense without special imports.
+Add assertion methods directly on the page object or helper class instead of extending `comfyExpect`. Page object methods are discoverable via IntelliSense without special imports.
 
 ```typescript
-// ✅ Preferred for new assertions
+// ✅ Page object assertions
 await node.expectPinned()
 await node.expectBypassed()
 
-// ✅ Acceptable (existing matchers)
-import { comfyExpect as expect } from '../fixtures/ComfyPage'
-await expect(node).toBePinned()
-
-// ❌ Do not add new custom matchers to comfyExpect
+// ❌ Do not add custom matchers to comfyExpect
 ```
 
 ## Test Tags

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -99,6 +99,23 @@ expect(node.widgets).toHaveLength(4)
 - Use `expect.soft()` when you want to verify multiple invariants without aborting on the first failure
 - Prefer Playwright's built-in message parameter over custom error classes
 
+## Custom Assertions
+
+Existing `comfyExpect` matchers (`toBePinned`, `toBeBypassed`, `toBeCollapsed`, `toHaveFocus`) are fine to use in existing and new tests.
+
+**For NEW assertions**: Add assertion methods directly on the page object or helper class instead of extending `comfyExpect`. Page object methods are discoverable via IntelliSense without special imports.
+
+```typescript
+// ✅ Preferred for new assertions
+await node.expectPinned()
+await node.expectBypassed()
+
+// ✅ Acceptable (existing matchers)
+import { comfyExpect as expect } from '../fixtures/ComfyPage'
+await expect(node).toBePinned()
+
+// ❌ Do not add new custom matchers to comfyExpect
+```
 ## Test Tags
 
 Tags are respected by config:

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -116,6 +116,7 @@ await expect(node).toBePinned()
 
 // ❌ Do not add new custom matchers to comfyExpect
 ```
+
 ## Test Tags
 
 Tags are respected by config:


### PR DESCRIPTION
## Summary

Add guidance to `docs/guidance/playwright.md` that new node-specific assertions should be methods on page objects/helpers rather than new `comfyExpect` custom matchers.

## Changes

- **What**: New "Custom Assertions" section in Playwright guidance documenting that existing `comfyExpect` matchers are fine to use, but new assertions should go on the page object for IntelliSense discoverability.

## Review Focus

Documentation-only change. No code refactoring — this is a convention for new code only.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10660-docs-add-convention-for-new-assertions-prefer-page-objects-over-custom-matchers-3316d73d3650816d97a8fbbdc33f6b75) by [Unito](https://www.unito.io)
