### PR TITLE
test: add mock data fixtures for backend API responses

### DIFF
--- a/.github/workflows/ci-oss-assets-validation.yaml
+++ b/.github/workflows/ci-oss-assets-validation.yaml
@@ -95,7 +95,7 @@ jobs:
           if npx license-checker-rseidelsohn@4 \
             --production \
             --summary \
-            --excludePackages '@comfyorg/comfyui-frontend;@comfyorg/design-system;@comfyorg/registry-types;@comfyorg/shared-frontend-utils;@comfyorg/tailwind-utils;@comfyorg/comfyui-electron-types' \
+            --excludePackages '@comfyorg/comfyui-frontend;@comfyorg/design-system;@comfyorg/ingest-types;@comfyorg/registry-types;@comfyorg/shared-frontend-utils;@comfyorg/tailwind-utils;@comfyorg/comfyui-electron-types' \
             --clarificationsFile .github/license-clarifications.json \
             --onlyAllow 'MIT;MIT*;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;BlueOak-1.0.0;Python-2.0;CC0-1.0;Unlicense;(MIT OR Apache-2.0);(MIT OR GPL-3.0);(Apache-2.0 OR MIT);(MPL-2.0 OR Apache-2.0);CC-BY-4.0;CC-BY-3.0;GPL-3.0-only'; then
             echo ''

--- a/browser_tests/fixtures/data/README.md
+++ b/browser_tests/fixtures/data/README.md
@@ -1,0 +1,30 @@
+# Mock Data Fixtures
+
+Deterministic mock data for browser (Playwright) tests. Each fixture
+exports typed objects that conform to the Zod schemas defined in
+`src/schemas/`.
+
+## Usage with `page.route()`
+
+```ts
+import { mockNodeDefinitions } from '../fixtures/data/nodeDefinitions'
+import { mockSystemStats } from '../fixtures/data/systemStats'
+
+// Intercept the object_info API call
+await page.route('**/api/object_info', (route) =>
+  route.fulfill({ json: mockNodeDefinitions })
+)
+
+// Intercept the system_stats API call
+await page.route('**/api/system_stats', (route) =>
+  route.fulfill({ json: mockSystemStats })
+)
+```
+
+## Adding new fixtures
+
+1. Locate the Zod schema in `src/schemas/` for the endpoint you need.
+2. Create a new `.ts` file here that imports and satisfies the
+   corresponding TypeScript type.
+3. Keep values realistic but stable — avoid dates, random IDs, or
+   values that would cause test flakiness.

--- a/browser_tests/fixtures/data/README.md
+++ b/browser_tests/fixtures/data/README.md
@@ -1,8 +1,8 @@
 # Mock Data Fixtures
 
 Deterministic mock data for browser (Playwright) tests. Each fixture
-exports typed objects that conform to the Zod schemas defined in
-`src/schemas/`.
+exports typed objects that conform to generated types from
+`packages/ingest-types` or Zod schemas in `src/schemas/`.
 
 ## Usage with `page.route()`
 
@@ -33,7 +33,8 @@ await page.route('**/api/system_stats', (route) =>
 
 ## Adding new fixtures
 
-1. Locate the Zod schema in `src/schemas/` for the endpoint you need.
+1. Locate the generated type in `packages/ingest-types` or Zod schema
+   in `src/schemas/` for the endpoint you need.
 2. Create a new `.ts` file here that imports and satisfies the
    corresponding TypeScript type.
 3. Keep values realistic but stable — avoid dates, random IDs, or

--- a/browser_tests/fixtures/data/README.md
+++ b/browser_tests/fixtures/data/README.md
@@ -6,16 +6,24 @@ exports typed objects that conform to the Zod schemas defined in
 
 ## Usage with `page.route()`
 
+> **Note:** `comfyPageFixture` navigates to the app during `setup()`,
+> before the test body runs. Routes must be registered before navigation
+> to intercept initial page-load requests. Set up routes in a custom
+> fixture or `test.beforeEach` that runs before `comfyPage.setup()`.
+
 ```ts
-import { mockNodeDefinitions } from '../fixtures/data/nodeDefinitions'
+import { createMockNodeDefinitions } from '../fixtures/data/nodeDefinitions'
 import { mockSystemStats } from '../fixtures/data/systemStats'
 
-// Intercept the object_info API call
+// Extend the base set with test-specific nodes
+const nodeDefs = createMockNodeDefinitions({
+  MyCustomNode: { /* ... */ }
+})
+
 await page.route('**/api/object_info', (route) =>
-  route.fulfill({ json: mockNodeDefinitions })
+  route.fulfill({ json: nodeDefs })
 )
 
-// Intercept the system_stats API call
 await page.route('**/api/system_stats', (route) =>
   route.fulfill({ json: mockSystemStats })
 )

--- a/browser_tests/fixtures/data/README.md
+++ b/browser_tests/fixtures/data/README.md
@@ -17,7 +17,9 @@ import { mockSystemStats } from '../fixtures/data/systemStats'
 
 // Extend the base set with test-specific nodes
 const nodeDefs = createMockNodeDefinitions({
-  MyCustomNode: { /* ... */ }
+  MyCustomNode: {
+    /* ... */
+  }
 })
 
 await page.route('**/api/object_info', (route) =>

--- a/browser_tests/fixtures/data/nodeDefinitions.ts
+++ b/browser_tests/fixtures/data/nodeDefinitions.ts
@@ -1,0 +1,83 @@
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+export const mockNodeDefinitions: Record<string, ComfyNodeDef> = {
+  KSampler: {
+    input: {
+      required: {
+        model: ['MODEL', {}],
+        seed: [
+          'INT',
+          {
+            default: 0,
+            min: 0,
+            max: 0xfffffffffffff,
+            control_after_generate: true
+          }
+        ],
+        steps: ['INT', { default: 20, min: 1, max: 10000 }],
+        cfg: ['FLOAT', { default: 8.0, min: 0.0, max: 100.0, step: 0.1 }],
+        sampler_name: [['euler', 'euler_ancestral', 'heun', 'dpm_2'], {}],
+        scheduler: [['normal', 'karras', 'exponential', 'simple'], {}],
+        positive: ['CONDITIONING', {}],
+        negative: ['CONDITIONING', {}],
+        latent_image: ['LATENT', {}]
+      },
+      optional: {
+        denoise: ['FLOAT', { default: 1.0, min: 0.0, max: 1.0, step: 0.01 }]
+      }
+    },
+    output: ['LATENT'],
+    output_is_list: [false],
+    output_name: ['LATENT'],
+    name: 'KSampler',
+    display_name: 'KSampler',
+    description: 'Samples latents using the provided model and conditioning.',
+    category: 'sampling',
+    output_node: false,
+    python_module: 'nodes',
+    deprecated: false,
+    experimental: false
+  },
+
+  CheckpointLoaderSimple: {
+    input: {
+      required: {
+        ckpt_name: [
+          ['v1-5-pruned.safetensors', 'sd_xl_base_1.0.safetensors'],
+          {}
+        ]
+      }
+    },
+    output: ['MODEL', 'CLIP', 'VAE'],
+    output_is_list: [false, false, false],
+    output_name: ['MODEL', 'CLIP', 'VAE'],
+    name: 'CheckpointLoaderSimple',
+    display_name: 'Load Checkpoint',
+    description: 'Loads a diffusion model checkpoint.',
+    category: 'loaders',
+    output_node: false,
+    python_module: 'nodes',
+    deprecated: false,
+    experimental: false
+  },
+
+  CLIPTextEncode: {
+    input: {
+      required: {
+        text: ['STRING', { multiline: true, dynamicPrompts: true }],
+        clip: ['CLIP', {}]
+      }
+    },
+    output: ['CONDITIONING'],
+    output_is_list: [false],
+    output_name: ['CONDITIONING'],
+    name: 'CLIPTextEncode',
+    display_name: 'CLIP Text Encode (Prompt)',
+    description: 'Encodes a text prompt using a CLIP model.',
+    category: 'conditioning',
+    output_node: false,
+    python_module: 'nodes',
+    deprecated: false,
+    experimental: false
+  }
+}

--- a/browser_tests/fixtures/data/nodeDefinitions.ts
+++ b/browser_tests/fixtures/data/nodeDefinitions.ts
@@ -1,6 +1,10 @@
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 
-export const mockNodeDefinitions: Record<string, ComfyNodeDef> = {
+/**
+ * Base node definitions covering the default workflow.
+ * Use {@link createMockNodeDefinitions} to extend with per-test overrides.
+ */
+const baseNodeDefinitions: Record<string, ComfyNodeDef> = {
   KSampler: {
     input: {
       required: {
@@ -79,5 +83,74 @@ export const mockNodeDefinitions: Record<string, ComfyNodeDef> = {
     python_module: 'nodes',
     deprecated: false,
     experimental: false
+  },
+
+  EmptyLatentImage: {
+    input: {
+      required: {
+        width: ['INT', { default: 512, min: 16, max: 16384, step: 8 }],
+        height: ['INT', { default: 512, min: 16, max: 16384, step: 8 }],
+        batch_size: ['INT', { default: 1, min: 1, max: 4096 }]
+      }
+    },
+    output: ['LATENT'],
+    output_is_list: [false],
+    output_name: ['LATENT'],
+    name: 'EmptyLatentImage',
+    display_name: 'Empty Latent Image',
+    description: 'Creates an empty latent image of the specified dimensions.',
+    category: 'latent',
+    output_node: false,
+    python_module: 'nodes',
+    deprecated: false,
+    experimental: false
+  },
+
+  VAEDecode: {
+    input: {
+      required: {
+        samples: ['LATENT', {}],
+        vae: ['VAE', {}]
+      }
+    },
+    output: ['IMAGE'],
+    output_is_list: [false],
+    output_name: ['IMAGE'],
+    name: 'VAEDecode',
+    display_name: 'VAE Decode',
+    description: 'Decodes latent images back into pixel space.',
+    category: 'latent',
+    output_node: false,
+    python_module: 'nodes',
+    deprecated: false,
+    experimental: false
+  },
+
+  SaveImage: {
+    input: {
+      required: {
+        images: ['IMAGE', {}],
+        filename_prefix: ['STRING', { default: 'ComfyUI' }]
+      }
+    },
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    name: 'SaveImage',
+    display_name: 'Save Image',
+    description: 'Saves images to the output directory.',
+    category: 'image',
+    output_node: true,
+    python_module: 'nodes',
+    deprecated: false,
+    experimental: false
   }
 }
+
+export function createMockNodeDefinitions(
+  overrides?: Record<string, ComfyNodeDef>
+): Record<string, ComfyNodeDef> {
+  return { ...baseNodeDefinitions, ...overrides }
+}
+
+export const mockNodeDefinitions = baseNodeDefinitions

--- a/browser_tests/fixtures/data/nodeDefinitions.ts
+++ b/browser_tests/fixtures/data/nodeDefinitions.ts
@@ -150,7 +150,6 @@ const baseNodeDefinitions: Record<string, ComfyNodeDef> = {
 export function createMockNodeDefinitions(
   overrides?: Record<string, ComfyNodeDef>
 ): Record<string, ComfyNodeDef> {
-  return { ...baseNodeDefinitions, ...overrides }
+  const base = structuredClone(baseNodeDefinitions)
+  return overrides ? { ...base, ...overrides } : base
 }
-
-export const mockNodeDefinitions = baseNodeDefinitions

--- a/browser_tests/fixtures/data/systemStats.ts
+++ b/browser_tests/fixtures/data/systemStats.ts
@@ -1,0 +1,25 @@
+import type { SystemStats } from '@/schemas/apiSchema'
+
+export const mockSystemStats: SystemStats = {
+  system: {
+    os: 'posix',
+    python_version: '3.11.9 (main, Apr  2 2024, 08:25:04) [GCC 13.2.0]',
+    embedded_python: false,
+    comfyui_version: '0.3.10',
+    pytorch_version: '2.4.0+cu124',
+    argv: ['main.py', '--listen', '0.0.0.0'],
+    ram_total: 67108864000,
+    ram_free: 52428800000
+  },
+  devices: [
+    {
+      name: 'NVIDIA GeForce RTX 4090',
+      type: 'cuda',
+      index: 0,
+      vram_total: 25769803776,
+      vram_free: 23622320128,
+      torch_vram_total: 25769803776,
+      torch_vram_free: 24696061952
+    }
+  ]
+}

--- a/browser_tests/fixtures/data/systemStats.ts
+++ b/browser_tests/fixtures/data/systemStats.ts
@@ -1,6 +1,6 @@
-import type { SystemStats } from '@/schemas/apiSchema'
+import type { SystemStatsResponse } from '@comfyorg/ingest-types'
 
-export const mockSystemStats: SystemStats = {
+export const mockSystemStats: SystemStatsResponse = {
   system: {
     os: 'posix',
     python_version: '3.11.9 (main, Apr  2 2024, 08:25:04) [GCC 13.2.0]',
@@ -15,11 +15,8 @@ export const mockSystemStats: SystemStats = {
     {
       name: 'NVIDIA GeForce RTX 4090',
       type: 'cuda',
-      index: 0,
       vram_total: 25769803776,
-      vram_free: 23622320128,
-      torch_vram_total: 25769803776,
-      torch_vram_free: 24696061952
+      vram_free: 23622320128
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
     "@comfyorg/comfyui-electron-types": "catalog:",
     "@comfyorg/design-system": "workspace:*",
+    "@comfyorg/ingest-types": "workspace:*",
     "@comfyorg/registry-types": "workspace:*",
     "@comfyorg/shared-frontend-utils": "workspace:*",
     "@comfyorg/tailwind-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@comfyorg/design-system':
         specifier: workspace:*
         version: link:packages/design-system
+      '@comfyorg/ingest-types':
+        specifier: workspace:*
+        version: link:packages/ingest-types
       '@comfyorg/registry-types':
         specifier: workspace:*
         version: link:packages/registry-types


### PR DESCRIPTION
## Summary

Add deterministic mock data fixtures for browser tests so they can use `page.route()` to intercept API calls without depending on a live backend.

## Changes

- **`browser_tests/fixtures/data/nodeDefinitions.ts`** — Mock `ComfyNodeDef` objects for KSampler, CheckpointLoaderSimple, and CLIPTextEncode
- **`browser_tests/fixtures/data/systemStats.ts`** — Mock `SystemStats` with realistic RTX 4090 GPU info
- **`browser_tests/fixtures/data/README.md`** — Usage guide for `page.route()` interception

All fixtures are typed against the Zod schemas in `src/schemas/` and pass `pnpm typecheck:browser`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10662-test-add-mock-data-fixtures-for-backend-API-responses-3316d73d3650813ea5c8c1faa215db63) by [Unito](https://www.unito.io)
