### PR TITLE
feat: add getNodesByTitle and getNodeByTitleNth helpers to VueNodeHelpers

### DIFF
--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -31,10 +31,27 @@ export class VueNodeHelpers {
   }
 
   /**
-   * Get locator for a Vue node by the node's title (displayed name in the header)
+   * Get locator for a Vue node by the node's title (displayed name in the header).
+   * Returns all matching nodes — use only when the title is unique.
+   * For non-unique titles, use {@link getNodesByTitle} with `.nth(n)`.
    */
   getNodeByTitle(title: string): Locator {
     return this.page.locator(`[data-node-id]`).filter({ hasText: title })
+  }
+
+  /**
+   * Get locator matching ALL Vue nodes with the given title.
+   * Callers should use `.nth(0)`, `.nth(1)`, etc. to pick a specific one.
+   */
+  getNodesByTitle(title: string): Locator {
+    return this.page.locator(`[data-node-id]`).filter({ hasText: title })
+  }
+
+  /**
+   * Get locator for the nth Vue node matching the given title (0-indexed).
+   */
+  getNodeByTitleNth(title: string, index: number): Locator {
+    return this.getNodesByTitle(title).nth(index)
   }
 
   /**

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -31,27 +31,14 @@ export class VueNodeHelpers {
   }
 
   /**
-   * Get locator for a Vue node by the node's title (displayed name in the header).
-   * Returns all matching nodes — use only when the title is unique.
-   * For non-unique titles, use {@link getNodesByTitle} with `.nth(n)`.
+   * Get locator for Vue nodes by the node's title (displayed name in the header).
+   * Matches against the actual title element, not the full node body.
+   * Use `.first()` for unique titles, `.nth(n)` for duplicates.
    */
   getNodeByTitle(title: string): Locator {
-    return this.page.locator(`[data-node-id]`).filter({ hasText: title })
-  }
-
-  /**
-   * Get locator matching ALL Vue nodes with the given title.
-   * Callers should use `.nth(0)`, `.nth(1)`, etc. to pick a specific one.
-   */
-  getNodesByTitle(title: string): Locator {
-    return this.page.locator(`[data-node-id]`).filter({ hasText: title })
-  }
-
-  /**
-   * Get locator for the nth Vue node matching the given title (0-indexed).
-   */
-  getNodeByTitleNth(title: string, index: number): Locator {
-    return this.getNodesByTitle(title).nth(index)
+    return this.page.locator('[data-node-id]').filter({
+      has: this.page.locator('[data-testid="node-title"]', { hasText: title })
+    })
   }
 
   /**

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -86,6 +86,7 @@ Tags are respected by config:
 
 - Check `browser_tests/assets/` for test data and fixtures
 - Use realistic ComfyUI workflows for E2E tests
+- When multiple nodes can share the same name (e.g. two "CLIP Text Encode" nodes), use `vueNodes.getNodesByTitle(name).nth(n)` or `vueNodes.getNodeByTitleNth(name, n)`. Never use `getNodeByTitle` for non-unique names — Playwright strict mode will fail.
 
 ## Running Tests
 

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -86,7 +86,7 @@ Tags are respected by config:
 
 - Check `browser_tests/assets/` for test data and fixtures
 - Use realistic ComfyUI workflows for E2E tests
-- When multiple nodes can share the same name (e.g. two "CLIP Text Encode" nodes), use `vueNodes.getNodesByTitle(name).nth(n)` or `vueNodes.getNodeByTitleNth(name, n)`. Never use `getNodeByTitle` for non-unique names — Playwright strict mode will fail.
+- When multiple nodes share the same title (e.g. two "CLIP Text Encode" nodes), use `vueNodes.getNodeByTitle(name).nth(n)` to pick a specific one. Never interact with the bare locator when titles are non-unique — Playwright strict mode will fail.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary

Add helpers for safely interacting with nodes that share the same title without hitting Playwright strict mode.

## Changes

- **What**: Added `getNodesByTitle(title)` and `getNodeByTitleNth(title, index)` to `VueNodeHelpers`. Updated `docs/guidance/playwright.md` with a gotcha note about duplicate node names.

## Review Focus

These are purely additive helpers — no existing behavior changes. `getNodesByTitle` returns all matching nodes (callers use `.nth()` to pick), and `getNodeByTitleNth` is a convenience wrapper. The existing `selectNodes(nodeIds)` by-ID method is unchanged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10666-feat-add-getNodesByTitle-and-getNodeByTitleNth-helpers-to-VueNodeHelpers-3316d73d3650812eabe6e56a768a34d2) by [Unito](https://www.unito.io)
