### PR TITLE
fix: replace queue virtualizer with tanstack

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@primevue/themes": "catalog:",
     "@sentry/vue": "catalog:",
     "@sparkjsdev/spark": "catalog:",
+    "@tanstack/vue-virtual": "catalog:",
     "@tiptap/core": "catalog:",
     "@tiptap/extension-link": "catalog:",
     "@tiptap/extension-table": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ catalogs:
     '@tailwindcss/vite':
       specifier: ^4.2.0
       version: 4.2.0
+    '@tanstack/vue-virtual':
+      specifier: ^3.13.12
+      version: 3.13.12
     '@testing-library/jest-dom':
       specifier: ^6.9.1
       version: 6.9.1
@@ -452,6 +455,9 @@ importers:
       '@sparkjsdev/spark':
         specifier: 'catalog:'
         version: 0.1.10
+      '@tanstack/vue-virtual':
+        specifier: 'catalog:'
+        version: 3.13.12(vue@3.5.13(typescript@5.9.3))
       '@tiptap/core':
         specifier: 'catalog:'
         version: 2.27.2(@tiptap/pm@2.27.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@sentry/vite-plugin': ^4.6.0
   '@sentry/vue': ^10.32.1
   '@sparkjsdev/spark': ^0.1.10
+  '@tanstack/vue-virtual': ^3.13.12
   '@storybook/addon-docs': ^10.2.10
   '@storybook/addon-mcp': 0.1.6
   '@storybook/vue3': ^10.2.10

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -2,35 +2,13 @@ import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 
+import './testUtils/mockTanstackVirtualizer'
+
 import type { JobGroup, JobListItem } from '@/composables/queue/useJobList'
 import type { JobListItem as ApiJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
 
 import JobAssetsList from './JobAssetsList.vue'
-
-vi.mock('@vueuse/core', async () => {
-  const actual = await vi.importActual<Record<string, unknown>>('@vueuse/core')
-  const vue = await import('vue')
-
-  return {
-    ...actual,
-    useVirtualList: (rows: unknown) => ({
-      list: vue.computed(() =>
-        vue.unref(rows as readonly unknown[]).map((data: unknown, index) => ({
-          data,
-          index
-        }))
-      ),
-      scrollTo: vi.fn(),
-      containerProps: {
-        ref: vue.ref(null),
-        onScroll: vi.fn(),
-        style: {}
-      },
-      wrapperProps: vue.computed(() => ({ style: {} }))
-    })
-  }
-})
 
 const JobDetailsPopoverStub = defineComponent({
   name: 'JobDetailsPopover',

--- a/src/components/queue/job/JobAssetsList.vue
+++ b/src/components/queue/job/JobAssetsList.vue
@@ -1,25 +1,24 @@
 <template>
   <div
+    ref="scrollContainer"
     v-bind="$attrs"
-    :ref="containerProps.ref"
-    :style="containerProps.style"
     data-testid="job-assets-list"
     class="h-full overflow-y-auto"
     @scroll="onListScroll"
   >
     <div :style="virtualWrapperStyle">
-      <template v-for="{ data: row } in virtualRows" :key="row.key">
+      <template v-for="{ row, virtualItem } in virtualRows" :key="row.key">
         <div
           v-if="row.type === 'header'"
           class="box-border px-3 pb-2 text-xs leading-none text-text-secondary"
-          :style="{ height: `${row.height}px` }"
+          :style="getVirtualRowStyle(virtualItem)"
         >
           {{ row.label }}
         </div>
         <div
           v-else-if="row.type === 'job'"
           class="box-border px-3"
-          :style="{ height: `${row.height}px` }"
+          :style="getVirtualRowStyle(virtualItem)"
         >
           <div
             :data-job-id="row.job.id"
@@ -111,7 +110,9 @@
 </template>
 
 <script setup lang="ts">
-import { useVirtualList } from '@vueuse/core'
+import type { VirtualItem } from '@tanstack/vue-virtual'
+import type { CSSProperties } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
 import { useI18n } from 'vue-i18n'
 import { computed, nextTick, ref } from 'vue'
 
@@ -125,11 +126,13 @@ import { cn } from '@/utils/tailwindUtil'
 import { iconForJobState } from '@/utils/queueDisplay'
 import { isActiveJobState } from '@/utils/queueUtil'
 
-import {
-  buildVirtualJobRows,
-  JOB_ROW_HEIGHT,
-  VIRTUAL_JOB_LIST_BOTTOM_PADDING
-} from './buildVirtualJobRows'
+import { buildVirtualJobRows } from './buildVirtualJobRows'
+import type { VirtualJobRow } from './buildVirtualJobRows'
+
+const HEADER_ROW_HEIGHT = 20
+const GROUP_ROW_GAP = 16
+const JOB_ROW_HEIGHT = 48
+const VIRTUAL_JOB_LIST_BOTTOM_PADDING = 16
 
 defineOptions({
   inheritAttrs: false
@@ -145,25 +148,42 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const scrollContainer = ref<HTMLElement | null>(null)
 const hoveredJobId = ref<string | null>(null)
 const activeRowElement = ref<HTMLElement | null>(null)
 const popoverPosition = ref<{ top: number; left: number } | null>(null)
 const flatRows = computed(() => buildVirtualJobRows(displayedJobGroups))
-const {
-  list: virtualRows,
-  containerProps,
-  wrapperProps
-} = useVirtualList(flatRows, {
-  itemHeight: (index) => flatRows.value[index]?.height ?? JOB_ROW_HEIGHT,
+const virtualizer = useVirtualizer({
+  get count(): number {
+    return flatRows.value.length
+  },
+  getItemKey(index: number) {
+    return flatRows.value[index]?.key ?? index
+  },
+  estimateSize(index: number) {
+    const row = flatRows.value[index]
+    return row ? getRowHeight(row, index, flatRows.value) : JOB_ROW_HEIGHT
+  },
+  getScrollElement() {
+    return scrollContainer.value
+  },
   overscan: 12
 })
-const virtualWrapperStyle = computed(() => ({
-  ...wrapperProps.value.style,
+const virtualRows = computed(() => {
+  const rows = flatRows.value
+  return virtualizer.value
+    .getVirtualItems()
+    .flatMap((virtualItem: VirtualItem) => {
+      const row = rows[virtualItem.index]
+      return row ? [{ row, virtualItem }] : []
+    })
+})
+const virtualWrapperStyle = computed<CSSProperties>(() => ({
+  position: 'relative',
   width: '100%',
-  paddingBottom:
-    flatRows.value.length > 0
-      ? `${VIRTUAL_JOB_LIST_BOTTOM_PADDING}px`
-      : undefined
+  ...(flatRows.value.length > 0 && {
+    height: `${virtualizer.value.getTotalSize() + VIRTUAL_JOB_LIST_BOTTOM_PADDING}px`
+  })
 }))
 const {
   activeDetails,
@@ -177,8 +197,33 @@ const {
   onReset: clearPopoverAnchor
 })
 
+function getVirtualRowStyle(virtualItem: VirtualItem): CSSProperties {
+  return {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: `${virtualItem.size}px`,
+    transform: `translateY(${virtualItem.start}px)`,
+    overflowAnchor: 'none'
+  }
+}
+
+function getRowHeight(
+  row: VirtualJobRow,
+  index: number,
+  rows: VirtualJobRow[]
+): number {
+  if (row.type === 'header') {
+    return HEADER_ROW_HEIGHT
+  }
+
+  return (
+    JOB_ROW_HEIGHT + (rows[index + 1]?.type === 'header' ? GROUP_ROW_GAP : 0)
+  )
+}
+
 function onListScroll() {
-  containerProps.onScroll()
   hoveredJobId.value = null
   resetActiveDetails()
 }

--- a/src/components/queue/job/buildVirtualJobRows.test.ts
+++ b/src/components/queue/job/buildVirtualJobRows.test.ts
@@ -32,37 +32,32 @@ describe('buildVirtualJobRows', () => {
       {
         key: 'header-today',
         type: 'header',
-        label: 'Today',
-        height: 20
+        label: 'Today'
       },
       {
         key: 'job-job-1',
         type: 'job',
-        job: displayedJobGroups[0].items[0],
-        height: 48
+        job: displayedJobGroups[0].items[0]
       },
       {
         key: 'job-job-2',
         type: 'job',
-        job: displayedJobGroups[0].items[1],
-        height: 64
+        job: displayedJobGroups[0].items[1]
       },
       {
         key: 'header-yesterday',
         type: 'header',
-        label: 'Yesterday',
-        height: 20
+        label: 'Yesterday'
       },
       {
         key: 'job-job-3',
         type: 'job',
-        job: displayedJobGroups[1].items[0],
-        height: 48
+        job: displayedJobGroups[1].items[0]
       }
     ])
   })
 
-  it('keeps the last group rows at the base job height', () => {
+  it('keeps a single group flattened without extra row metadata', () => {
     const displayedJobGroups: JobGroup[] = [
       {
         key: 'today',
@@ -75,14 +70,12 @@ describe('buildVirtualJobRows', () => {
       {
         key: 'header-today',
         type: 'header',
-        label: 'Today',
-        height: 20
+        label: 'Today'
       },
       {
         key: 'job-job-1',
         type: 'job',
-        job: displayedJobGroups[0].items[0],
-        height: 48
+        job: displayedJobGroups[0].items[0]
       }
     ])
   })

--- a/src/components/queue/job/buildVirtualJobRows.ts
+++ b/src/components/queue/job/buildVirtualJobRows.ts
@@ -1,49 +1,34 @@
 import type { JobGroup, JobListItem } from '@/composables/queue/useJobList'
 
-const HEADER_ROW_HEIGHT = 20
-const GROUP_ROW_GAP = 16
-export const JOB_ROW_HEIGHT = 48
-export const VIRTUAL_JOB_LIST_BOTTOM_PADDING = 16
-
 export type VirtualJobRow =
   | {
       key: string
       type: 'header'
       label: string
-      height: number
     }
   | {
       key: string
       type: 'job'
       job: JobListItem
-      height: number
     }
 
 export function buildVirtualJobRows(
   displayedJobGroups: JobGroup[]
 ): VirtualJobRow[] {
   const rows: VirtualJobRow[] = []
-  const lastGroupIndex = displayedJobGroups.length - 1
 
-  displayedJobGroups.forEach((group, groupIndex) => {
+  displayedJobGroups.forEach((group) => {
     rows.push({
       key: `header-${group.key}`,
       type: 'header',
-      label: group.label,
-      height: HEADER_ROW_HEIGHT
+      label: group.label
     })
 
-    group.items.forEach((job, jobIndex) => {
-      const isLastJobInGroup = jobIndex === group.items.length - 1
-      const isLastGroup = groupIndex === lastGroupIndex
-
+    group.items.forEach((job) => {
       rows.push({
         key: `job-${job.id}`,
         type: 'job',
-        job,
-        height:
-          JOB_ROW_HEIGHT +
-          (isLastJobInGroup && !isLastGroup ? GROUP_ROW_GAP : 0)
+        job
       })
     })
   })

--- a/src/components/queue/job/testUtils/mockTanstackVirtualizer.ts
+++ b/src/components/queue/job/testUtils/mockTanstackVirtualizer.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 
 vi.mock('@tanstack/vue-virtual', async () => {
-  const vue = await import('vue')
+  const { computed } = await import('vue')
 
   return {
     useVirtualizer: (options: {
@@ -9,7 +9,7 @@ vi.mock('@tanstack/vue-virtual', async () => {
       estimateSize: (index: number) => number
       getItemKey?: (index: number) => number | string
     }) =>
-      vue.computed(() => {
+      computed(() => {
         let start = 0
         const items = Array.from({ length: options.count }, (_, index) => {
           const size = options.estimateSize(index)

--- a/src/components/queue/job/testUtils/mockTanstackVirtualizer.ts
+++ b/src/components/queue/job/testUtils/mockTanstackVirtualizer.ts
@@ -1,0 +1,33 @@
+import { vi } from 'vitest'
+
+vi.mock('@tanstack/vue-virtual', async () => {
+  const vue = await import('vue')
+
+  return {
+    useVirtualizer: (options: {
+      count: number
+      estimateSize: (index: number) => number
+      getItemKey?: (index: number) => number | string
+    }) =>
+      vue.computed(() => {
+        let start = 0
+        const items = Array.from({ length: options.count }, (_, index) => {
+          const size = options.estimateSize(index)
+          const item = {
+            key: options.getItemKey?.(index) ?? index,
+            index,
+            start,
+            size
+          }
+
+          start += size
+          return item
+        })
+
+        return {
+          getVirtualItems: () => items,
+          getTotalSize: () => start
+        }
+      })
+  }
+})

--- a/src/components/sidebar/tabs/JobHistorySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/JobHistorySidebarTab.test.ts
@@ -3,31 +3,9 @@ import { createI18n } from 'vue-i18n'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 
+import '../../queue/job/testUtils/mockTanstackVirtualizer'
+
 import JobHistorySidebarTab from './JobHistorySidebarTab.vue'
-
-vi.mock('@vueuse/core', async () => {
-  const actual = await vi.importActual<Record<string, unknown>>('@vueuse/core')
-  const vue = await import('vue')
-
-  return {
-    ...actual,
-    useVirtualList: (rows: unknown) => ({
-      list: vue.computed(() =>
-        vue.unref(rows as readonly unknown[]).map((data: unknown, index) => ({
-          data,
-          index
-        }))
-      ),
-      scrollTo: vi.fn(),
-      containerProps: {
-        ref: vue.ref(null),
-        onScroll: vi.fn(),
-        style: {}
-      },
-      wrapperProps: vue.computed(() => ({ style: {} }))
-    })
-  }
-})
 
 const JobDetailsPopoverStub = defineComponent({
   name: 'JobDetailsPopover',


### PR DESCRIPTION
## Summary

Replace the queue/history virtualization change from VueUse with TanStack virtualizer so the implementation matches the virtualizer layer Reka already builds on.

## Changes

- **What**: Swapped `JobAssetsList` from `useVirtualList` to `@tanstack/vue-virtual`, made flattened job rows semantic-only, and centralized the shared virtualizer test mock.
- **Dependencies**: Added a direct `@tanstack/vue-virtual` dependency that was already present transitively through existing Reka tree virtualization.

## Review Focus

- Verify the stacked diff cleanly replaces the VueUse virtualizer API from #10592 without changing queue/history behavior.
- Verify row-height derivation stays aligned with the rendered layout now that sizing lives in `JobAssetsList.vue`.

## Screenshots (if applicable)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10682-fix-replace-queue-virtualizer-with-tanstack-3316d73d365081b8bdb7d286738b1ed3) by [Unito](https://www.unito.io)
