### PR TITLE
fix: sync widget values to workflow metadata in graphToPrompt

### DIFF
--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -221,25 +221,32 @@ test.describe('Workflows sidebar', () => {
     await comfyPage.workflow.loadWorkflow('default')
 
     const snapshots = await comfyPage.page.evaluate(async () => {
-      const node = window.app!.graph.getNodeById(3)
-      const seedWidget = node?.widgets?.find((widget) => widget.name === 'seed')
+      const node = window.app!.graph.nodes.find(
+        (node) => node.type === 'KSampler'
+      )
+      if (!node) throw new Error('KSampler node not found in default workflow')
+
+      const seedWidget = node.widgets?.find((widget) => widget.name === 'seed')
       if (!seedWidget) throw new Error('KSampler seed widget not found')
+      const nodeId = String(node.id)
 
       const seeds = [1001, 2002, 3003]
       let callCount = 0
       seedWidget.serializeValue = () => seeds[callCount++]
 
-      const results: Array<{
-        apiSeed: unknown
-        workflowSeed: unknown
-      }> = []
+      const results = []
 
       for (let i = 0; i < seeds.length; i++) {
         const { output, workflow } = await window.app!.graphToPrompt()
-        const workflowNode = workflow.nodes.find((node) => node.id === 3)
+        const workflowNode = workflow.nodes.find(
+          (workflowNode) => String(workflowNode.id) === nodeId
+        )
+        if (!Array.isArray(workflowNode?.widgets_values)) {
+          throw new Error('KSampler workflow widget values not found')
+        }
         results.push({
-          apiSeed: output['3'].inputs.seed,
-          workflowSeed: workflowNode?.widgets_values?.[0]
+          apiSeed: output[nodeId].inputs.seed,
+          workflowSeed: workflowNode.widgets_values[0]
         })
       }
 

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -209,6 +209,50 @@ test.describe('Workflows sidebar', () => {
       .toBe('ok')
   })
 
+  test('Exported workflow metadata tracks serialized widget values', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'PR #10703 - graphToPrompt should sync widget serializeValue output to workflow metadata'
+    })
+
+    await comfyPage.workflow.loadWorkflow('default')
+
+    const snapshots = await comfyPage.page.evaluate(async () => {
+      const node = window.app!.graph.getNodeById(3)
+      const seedWidget = node?.widgets?.find((widget) => widget.name === 'seed')
+      if (!seedWidget) throw new Error('KSampler seed widget not found')
+
+      const seeds = [1001, 2002, 3003]
+      let callCount = 0
+      seedWidget.serializeValue = () => seeds[callCount++]
+
+      const results: Array<{
+        apiSeed: unknown
+        workflowSeed: unknown
+      }> = []
+
+      for (let i = 0; i < seeds.length; i++) {
+        const { output, workflow } = await window.app!.graphToPrompt()
+        const workflowNode = workflow.nodes.find((node) => node.id === 3)
+        results.push({
+          apiSeed: output['3'].inputs.seed,
+          workflowSeed: workflowNode?.widgets_values?.[0]
+        })
+      }
+
+      return results
+    })
+
+    expect(snapshots).toEqual([
+      { apiSeed: 1001, workflowSeed: 1001 },
+      { apiSeed: 2002, workflowSeed: 2002 },
+      { apiSeed: 3003, workflowSeed: 3003 }
+    ])
+  })
+
   test('Can export same workflow with different locales', async ({
     comfyPage
   }) => {

--- a/docs/WIDGET_SERIALIZATION.md
+++ b/docs/WIDGET_SERIALIZATION.md
@@ -1,12 +1,33 @@
-# Widget Serialization: `widget.serialize` vs `widget.options.serialize`
+# Widget Serialization Controls
 
-Two properties named `serialize` exist at different levels of a widget object. They control different serialization layers and are checked by completely different code paths.
+Two properties named `serialize` and the related `syncToWorkflow` property control different serialization layers.
 
 **`widget.serialize`** — Controls **workflow persistence**. Checked by `LGraphNode.serialize()` and `configure()` when reading/writing `widgets_values` in the workflow JSON. When `false`, the widget is skipped in both serialization and deserialization. Used for UI-only widgets (image previews, progress text, audio players). Typed as `IBaseWidget.serialize` in `src/lib/litegraph/src/types/widgets.ts`.
 
 **`widget.options.serialize`** — Controls **prompt/API serialization**. Checked by `executionUtil.ts` when building the API payload sent to the backend. When `false`, the widget is excluded from prompt inputs. Used for client-side-only controls (`control_after_generate`, combo filter lists) that the server doesn't need. Typed as `IWidgetOptions.serialize` in `src/lib/litegraph/src/types/widgets.ts`.
 
-These correspond to the two data formats in `ComfyMetadata` embedded in output files (PNG, GLTF, WebM, AVIF, etc.): `widget.serialize` → `ComfyMetadataTags.WORKFLOW`, `widget.options.serialize` → `ComfyMetadataTags.PROMPT`.
+**`widget.syncToWorkflow`** — Controls whether an explicit `widget.serializeValue()` result is copied into the execution workflow snapshot returned by `graphToPrompt()` and embedded in output metadata. It defaults to `true`. This does not mutate the live widget value or change workflow persistence through a normal `graph.serialize()` call.
+
+The two `serialize` properties correspond to the two data formats in `ComfyMetadata` embedded in output files (PNG, GLTF, WebM, AVIF, etc.): `widget.serialize` → `ComfyMetadataTags.WORKFLOW`, `widget.options.serialize` → `ComfyMetadataTags.PROMPT`.
+
+## Execution workflow synchronization
+
+`graphToPrompt()` first serializes the graph, then resolves widget values for execution. For widgets with an explicit `serializeValue()`, the resolved value is copied into that serialized execution snapshot by default. Set `syncToWorkflow = false` when the transform is only meaningful for the current execution.
+
+For example, `saveImageExtraOutput` keeps a `filename_prefix` template such as `ComfyUI_%date:yyyy-MM-dd%` in the workflow while sending a resolved value such as `ComfyUI_2026-07-24` in the prompt:
+
+```ts
+widget.serializeValue = () =>
+  typeof widget.value === 'string'
+    ? applyTextReplacements(app.graph, widget.value)
+    : widget.value
+widget.syncToWorkflow = false
+```
+
+Snapshot synchronization respects the existing `widgets_values` shape:
+
+- Array-based `widgets_values` are updated by widget index.
+- VHS-style record-based `widgets_values` are updated only when an existing key matches the widget name. Unrelated keys are preserved, and missing widget-name keys are not added.
 
 ## Permutation table
 
@@ -20,9 +41,10 @@ These correspond to the two data formats in `ComfyMetadata` embedded in output f
 ## Gotchas
 
 - `addWidget('combo', name, value, cb, { serialize: false })` puts `serialize` into `widget.options`, **not** onto `widget` directly. These are different properties consumed by different systems.
-- `LGraphNode.serialize()` checks `widget.serialize === false` (line 967). It does **not** check `widget.options.serialize`. A widget with `options.serialize = false` is still included in `widgets_values`.
+- `LGraphNode.serialize()` checks `widget.serialize === false`. It does **not** check `widget.options.serialize`. A widget with `options.serialize = false` is still included in `widgets_values`.
 - `LGraphNode.serialize()` only writes `widgets_values` if `this.widgets` is truthy. Nodes that create widgets dynamically (like `PrimitiveNode`) will have no `widgets_values` in serialized output if serialized before widget creation — even if `this.widgets_values` exists on the instance from a prior `configure()` call.
 - `widget.options.serialize` is typed as `IWidgetOptions.serialize` — both properties share the name `serialize` but live at different levels of the widget object.
+- `widget.syncToWorkflow` has no effect unless the widget defines `serializeValue()`.
 
 ## PrimitiveNode and copy/paste
 
@@ -50,7 +72,9 @@ See [ADR-0006](adr/0006-primitive-node-copy-paste-lifecycle.md) for proposed fix
 
 - `widget.serialize` checked: `src/lib/litegraph/src/LGraphNode.ts` serialize() and configure()
 - `widget.options.serialize` checked: `src/utils/executionUtil.ts`
+- `widget.syncToWorkflow` checked: `src/utils/executionUtil.ts`
 - `widget.options.serialize` set: `src/scripts/widgets.ts` addValueControlWidgets()
+- `widget.syncToWorkflow` set: `src/extensions/core/saveImageExtraOutput.ts`
 - `widget.serialize` set: `src/composables/node/useNodeImage.ts`, `src/extensions/core/previewAny.ts`, etc.
 - Metadata types: `src/types/metadataTypes.ts`
 - PrimitiveNode: `src/extensions/core/widgetInputs.ts`

--- a/src/extensions/core/saveImageExtraOutput.test.ts
+++ b/src/extensions/core/saveImageExtraOutput.test.ts
@@ -21,7 +21,8 @@ type BeforeRegisterNodeDef = NonNullable<
 interface FilenamePrefixWidget {
   name: string
   value: unknown
-  serializeValue?: () => string
+  serializeValue?: () => unknown
+  syncToWorkflow?: boolean
 }
 
 async function loadExtension(): Promise<ComfyExtension> {
@@ -33,7 +34,7 @@ async function loadExtension(): Promise<ComfyExtension> {
 
 async function createNodeWithFilenamePrefix(
   nodeName: string,
-  prefix: string
+  prefix: unknown
 ): Promise<FilenamePrefixWidget> {
   const ext = await loadExtension()
 
@@ -99,6 +100,61 @@ describe('Comfy.SaveImageExtraOutput', () => {
       )
 
       expect(widget.serializeValue!()).toBe('ComfyUI_12345')
+      expect(widget.syncToWorkflow).toBe(false)
     }
   )
+
+  it('leaves non-string filename_prefix values unchanged', async () => {
+    const widget = await createNodeWithFilenamePrefix('SaveImage', 123)
+
+    expect(widget.serializeValue!()).toBe(123)
+    expect(widget.syncToWorkflow).toBe(false)
+  })
+
+  it('allows save nodes without a filename_prefix widget', async () => {
+    const ext = await loadExtension()
+    const nodeType = {
+      prototype: {}
+    } as unknown as Parameters<BeforeRegisterNodeDef>[0]
+
+    await ext.beforeRegisterNodeDef!(
+      nodeType,
+      { name: 'SaveImage' } as ComfyNodeDef,
+      {} as Parameters<BeforeRegisterNodeDef>[2]
+    )
+
+    const proto = nodeType.prototype as { onNodeCreated?: () => void }
+    expect(() => proto.onNodeCreated!.call({ widgets: [] })).not.toThrow()
+  })
+
+  it('adds a search-and-replace alias to non-save nodes', async () => {
+    const ext = await loadExtension()
+    const onNodeCreated = vi.fn()
+    const nodeType = {
+      prototype: { onNodeCreated }
+    } as unknown as Parameters<BeforeRegisterNodeDef>[0]
+    const nodeData = { name: 'KSampler' } as ComfyNodeDef
+
+    await ext.beforeRegisterNodeDef!(
+      nodeType,
+      nodeData,
+      {} as Parameters<BeforeRegisterNodeDef>[2]
+    )
+
+    const addProperty = vi.fn()
+    const node = {
+      properties: {},
+      addProperty,
+      constructor: { type: 'KSampler' }
+    }
+    const proto = nodeType.prototype as { onNodeCreated?: () => void }
+    proto.onNodeCreated!.call(node)
+
+    expect(onNodeCreated).toHaveBeenCalledOnce()
+    expect(addProperty).toHaveBeenCalledWith(
+      'Node name for S&R',
+      'KSampler',
+      'string'
+    )
+  })
 })

--- a/src/extensions/core/saveImageExtraOutput.ts
+++ b/src/extensions/core/saveImageExtraOutput.ts
@@ -44,13 +44,15 @@ app.registerExtension({
             onNodeCreated.apply(this, arguments)
           : undefined
 
-        // @ts-expect-error fixme ts strict error
-        const widget = this.widgets.find((w) => w.name === 'filename_prefix')
-        // @ts-expect-error fixme ts strict error
+        const widget = this.widgets?.find((w) => w.name === 'filename_prefix')
+        if (!widget) return r
+
         widget.serializeValue = () => {
-          // @ts-expect-error fixme ts strict error
-          return applyTextReplacements(app.graph, widget.value)
+          return typeof widget.value === 'string'
+            ? applyTextReplacements(app.graph, widget.value)
+            : widget.value
         }
+        widget.syncToWorkflow = false
 
         return r
       }

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -54,6 +54,13 @@ declare module '@/lib/litegraph/src/types/widgets' {
     beforeQueued?(options?: WidgetCallbackOptions): unknown
     afterQueued?(options?: WidgetCallbackOptions): unknown
     serializeValue?(node: LGraphNode, index: number): Promise<unknown> | unknown
+    /**
+     * Whether {@link serializeValue} results should replace the persisted
+     * workflow value.
+     *
+     * @default true
+     */
+    syncToWorkflow?: boolean
 
     /**
      * Refreshes the widget's value or options from its remote source.

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -6,6 +6,10 @@ import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 import { graphToPrompt } from './executionUtil'
 
+function widgetValues(node: { widgets_values?: unknown }): unknown[] {
+  return node.widgets_values as unknown[]
+}
+
 describe('graphToPrompt', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -72,8 +76,8 @@ describe('graphToPrompt', () => {
       expect(output[nodeId].inputs.steps).toBe(20)
 
       // workflow widgets_values should match what was sent in the prompt
-      expect(wfNode.widgets_values![0]).toBe('cat')
-      expect(wfNode.widgets_values![1]).toBe(20)
+      expect(widgetValues(wfNode)[0]).toBe('cat')
+      expect(widgetValues(wfNode)[1]).toBe(20)
     })
 
     it('syncs async serializeValue results', async () => {
@@ -92,7 +96,7 @@ describe('graphToPrompt', () => {
       const nodeId = String(wfNode.id)
 
       expect(output[nodeId].inputs.data).toBe('resolved-async')
-      expect(wfNode.widgets_values![0]).toBe('resolved-async')
+      expect(widgetValues(wfNode)[0]).toBe('resolved-async')
     })
 
     it('keeps workflow in sync when widget.value changes between calls', async () => {
@@ -108,7 +112,7 @@ describe('graphToPrompt', () => {
       const nodeId = String(wfNode1.id)
 
       expect(result1.output[nodeId].inputs.seed).toBe(100)
-      expect(wfNode1.widgets_values![0]).toBe(100)
+      expect(widgetValues(wfNode1)[0]).toBe(100)
 
       // Simulate seed change (e.g. beforeQueued randomises the seed)
       node.widgets![0].value = 999
@@ -118,10 +122,10 @@ describe('graphToPrompt', () => {
       const wfNode2 = result2.workflow.nodes[0]
 
       expect(result2.output[nodeId].inputs.seed).toBe(999)
-      expect(wfNode2.widgets_values![0]).toBe(999)
+      expect(widgetValues(wfNode2)[0]).toBe(999)
 
       // Verify first call was not mutated
-      expect(wfNode1.widgets_values![0]).toBe(100)
+      expect(widgetValues(wfNode1)[0]).toBe(100)
     })
 
     it('does not sync widgets with options.serialize === false', async () => {
@@ -145,10 +149,10 @@ describe('graphToPrompt', () => {
       expect(output[nodeId].inputs.control).toBeUndefined()
 
       // seed should be synced, control should retain its serialized value
-      expect(wfNode.widgets_values![0]).toBe(42)
+      expect(widgetValues(wfNode)[0]).toBe(42)
       // control widget's workflow value should be its original value
       // (set by graph.serialize, not modified by sync)
-      expect(wfNode.widgets_values![1]).toBe('randomize')
+      expect(widgetValues(wfNode)[1]).toBe('randomize')
     })
 
     it('does not sync widgets with widget.serialize === false', async () => {
@@ -168,10 +172,10 @@ describe('graphToPrompt', () => {
       const wfNode = workflow.nodes[0]
 
       // visible widget should be synced
-      expect(wfNode.widgets_values![0]).toBe(10)
+      expect(widgetValues(wfNode)[0]).toBe(10)
       // hidden widget (serialize: false) should not appear in widgets_values
       // because LGraphNode.serialize() skips it
-      expect(wfNode.widgets_values![1]).toBeUndefined()
+      expect(widgetValues(wfNode)[1]).toBeUndefined()
     })
 
     it('handles object widget values by deep-cloning', async () => {
@@ -186,12 +190,21 @@ describe('graphToPrompt', () => {
         }
       ])
 
-      const { workflow } = await graphToPrompt(graph)
+      const { workflow, output } = await graphToPrompt(graph)
       const wfNode = workflow.nodes[0]
 
       // Should be deep-cloned, not a reference
-      const synced = wfNode.widgets_values![0] as Record<string, unknown>
+      const synced = widgetValues(wfNode)[0] as Record<string, unknown>
       expect(synced).toEqual({ key: 'modified', nested: { a: 2 } })
+
+      // Verify reference independence: mutating synced does not affect output
+      ;(synced.nested as Record<string, unknown>).a = 999
+      const nodeId = String(wfNode.id)
+      const outputValue = output[nodeId].inputs.config as Record<
+        string,
+        unknown
+      >
+      expect((outputValue.nested as Record<string, unknown>).a).toBe(2)
     })
   })
 
@@ -218,15 +231,15 @@ describe('graphToPrompt', () => {
       // Each iteration should have its own seed in both output and workflow
       for (const [idx, result] of results.entries()) {
         expect(result.output[nodeId].inputs.seed).toBe(seeds[idx])
-        expect(result.workflow.nodes[0].widgets_values![0]).toBe(seeds[idx])
+        expect(widgetValues(result.workflow.nodes[0])[0]).toBe(seeds[idx])
       }
 
       // Steps and cfg should be the same across all iterations
       for (const result of results) {
         expect(result.output[nodeId].inputs.steps).toBe(20)
         expect(result.output[nodeId].inputs.cfg).toBe(7.5)
-        expect(result.workflow.nodes[0].widgets_values![1]).toBe(20)
-        expect(result.workflow.nodes[0].widgets_values![2]).toBe(7.5)
+        expect(widgetValues(result.workflow.nodes[0])[1]).toBe(20)
+        expect(widgetValues(result.workflow.nodes[0])[2]).toBe(7.5)
       }
     })
 
@@ -257,9 +270,9 @@ describe('graphToPrompt', () => {
       expect(result3.output[nodeId].inputs.prompt).toBe('result-3')
 
       // Workflow metadata should match the output
-      expect(result1.workflow.nodes[0].widgets_values![0]).toBe('result-1')
-      expect(result2.workflow.nodes[0].widgets_values![0]).toBe('result-2')
-      expect(result3.workflow.nodes[0].widgets_values![0]).toBe('result-3')
+      expect(widgetValues(result1.workflow.nodes[0])[0]).toBe('result-1')
+      expect(widgetValues(result2.workflow.nodes[0])[0]).toBe('result-2')
+      expect(widgetValues(result3.workflow.nodes[0])[0]).toBe('result-3')
     })
   })
 })

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -1,0 +1,265 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { graphToPrompt } from './executionUtil'
+
+describe('graphToPrompt', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  function createNodeWithWidgets(
+    graph: LGraph,
+    title: string,
+    widgets: {
+      type: string
+      name: string
+      value: unknown
+      options?: Record<string, unknown>
+      serializeValue?: (
+        node: unknown,
+        index: number
+      ) => Promise<unknown> | unknown
+      serialize?: boolean
+    }[]
+  ): LGraphNode {
+    const node = new LGraphNode(title)
+    node.comfyClass = title
+    node.serialize_widgets = true
+    node.addOutput('output', 'IMAGE')
+
+    for (const w of widgets) {
+      const widget = node.addWidget(
+        w.type as 'number',
+        w.name,
+        w.value as number,
+        null,
+        w.options ?? {}
+      )
+      if (w.serializeValue) {
+        widget.serializeValue = w.serializeValue
+      }
+      if (w.serialize === false) {
+        widget.serialize = false
+      }
+    }
+
+    graph.add(node)
+    return node
+  }
+
+  describe('workflow metadata sync', () => {
+    it('syncs serializeValue results back to workflow widgets_values', async () => {
+      const graph = new LGraph()
+      createNodeWithWidgets(graph, 'DynamicNode', [
+        {
+          type: 'text',
+          name: 'prompt',
+          value: '{cat|dog}',
+          serializeValue: () => 'cat'
+        },
+        { type: 'number', name: 'steps', value: 20 }
+      ])
+
+      const { workflow, output } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+      const nodeId = String(wfNode.id)
+
+      expect(output[nodeId].inputs.prompt).toBe('cat')
+      expect(output[nodeId].inputs.steps).toBe(20)
+
+      // workflow widgets_values should match what was sent in the prompt
+      expect(wfNode.widgets_values![0]).toBe('cat')
+      expect(wfNode.widgets_values![1]).toBe(20)
+    })
+
+    it('syncs async serializeValue results', async () => {
+      const graph = new LGraph()
+      createNodeWithWidgets(graph, 'AsyncNode', [
+        {
+          type: 'text',
+          name: 'data',
+          value: 'original',
+          serializeValue: () => Promise.resolve('resolved-async')
+        }
+      ])
+
+      const { workflow, output } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+      const nodeId = String(wfNode.id)
+
+      expect(output[nodeId].inputs.data).toBe('resolved-async')
+      expect(wfNode.widgets_values![0]).toBe('resolved-async')
+    })
+
+    it('keeps workflow in sync when widget.value changes between calls', async () => {
+      const graph = new LGraph()
+      const node = createNodeWithWidgets(graph, 'SeedNode', [
+        { type: 'number', name: 'seed', value: 100 },
+        { type: 'number', name: 'steps', value: 20 }
+      ])
+
+      // First call — seed is 100
+      const result1 = await graphToPrompt(graph)
+      const wfNode1 = result1.workflow.nodes[0]
+      const nodeId = String(wfNode1.id)
+
+      expect(result1.output[nodeId].inputs.seed).toBe(100)
+      expect(wfNode1.widgets_values![0]).toBe(100)
+
+      // Simulate seed change (e.g. beforeQueued randomises the seed)
+      node.widgets![0].value = 999
+
+      // Second call — seed is 999
+      const result2 = await graphToPrompt(graph)
+      const wfNode2 = result2.workflow.nodes[0]
+
+      expect(result2.output[nodeId].inputs.seed).toBe(999)
+      expect(wfNode2.widgets_values![0]).toBe(999)
+
+      // Verify first call was not mutated
+      expect(wfNode1.widgets_values![0]).toBe(100)
+    })
+
+    it('does not sync widgets with options.serialize === false', async () => {
+      const graph = new LGraph()
+      createNodeWithWidgets(graph, 'ControlNode', [
+        { type: 'number', name: 'seed', value: 42 },
+        {
+          type: 'combo',
+          name: 'control',
+          value: 'randomize',
+          options: { serialize: false, values: ['fixed', 'randomize'] }
+        }
+      ])
+
+      const { workflow, output } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+      const nodeId = String(wfNode.id)
+
+      // control widget should not appear in output
+      expect(output[nodeId].inputs.seed).toBe(42)
+      expect(output[nodeId].inputs.control).toBeUndefined()
+
+      // seed should be synced, control should retain its serialized value
+      expect(wfNode.widgets_values![0]).toBe(42)
+      // control widget's workflow value should be its original value
+      // (set by graph.serialize, not modified by sync)
+      expect(wfNode.widgets_values![1]).toBe('randomize')
+    })
+
+    it('does not sync widgets with widget.serialize === false', async () => {
+      const graph = new LGraph()
+      createNodeWithWidgets(graph, 'PartialNode', [
+        { type: 'number', name: 'visible', value: 10 },
+        {
+          type: 'number',
+          name: 'hidden',
+          value: 99,
+          serialize: false,
+          serializeValue: () => 'transformed'
+        }
+      ])
+
+      const { workflow } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+
+      // visible widget should be synced
+      expect(wfNode.widgets_values![0]).toBe(10)
+      // hidden widget (serialize: false) should not appear in widgets_values
+      // because LGraphNode.serialize() skips it
+      expect(wfNode.widgets_values![1]).toBeUndefined()
+    })
+
+    it('handles object widget values by deep-cloning', async () => {
+      const objValue = { key: 'value', nested: { a: 1 } }
+      const graph = new LGraph()
+      createNodeWithWidgets(graph, 'ObjectNode', [
+        {
+          type: 'text',
+          name: 'config',
+          value: objValue,
+          serializeValue: () => ({ key: 'modified', nested: { a: 2 } })
+        }
+      ])
+
+      const { workflow } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+
+      // Should be deep-cloned, not a reference
+      const synced = wfNode.widgets_values![0] as Record<string, unknown>
+      expect(synced).toEqual({ key: 'modified', nested: { a: 2 } })
+    })
+  })
+
+  describe('batch count simulation', () => {
+    it('produces different workflow metadata when seed changes between calls', async () => {
+      const graph = new LGraph()
+      const node = createNodeWithWidgets(graph, 'KSampler', [
+        { type: 'number', name: 'seed', value: 1000 },
+        { type: 'number', name: 'steps', value: 20 },
+        { type: 'number', name: 'cfg', value: 7.5 }
+      ])
+
+      const results: Awaited<ReturnType<typeof graphToPrompt>>[] = []
+
+      // Simulate batch count = 3, with seed randomised before each call
+      const seeds = [1000, 2000, 3000]
+      for (const seed of seeds) {
+        node.widgets![0].value = seed
+        results.push(await graphToPrompt(graph))
+      }
+
+      const nodeId = String(results[0].workflow.nodes[0].id)
+
+      // Each iteration should have its own seed in both output and workflow
+      for (const [idx, result] of results.entries()) {
+        expect(result.output[nodeId].inputs.seed).toBe(seeds[idx])
+        expect(result.workflow.nodes[0].widgets_values![0]).toBe(seeds[idx])
+      }
+
+      // Steps and cfg should be the same across all iterations
+      for (const result of results) {
+        expect(result.output[nodeId].inputs.steps).toBe(20)
+        expect(result.output[nodeId].inputs.cfg).toBe(7.5)
+        expect(result.workflow.nodes[0].widgets_values![1]).toBe(20)
+        expect(result.workflow.nodes[0].widgets_values![2]).toBe(7.5)
+      }
+    })
+
+    it('produces different workflow metadata when serializeValue varies', async () => {
+      let callCount = 0
+      const graph = new LGraph()
+      createNodeWithWidgets(graph, 'DynamicPrompt', [
+        {
+          type: 'text',
+          name: 'prompt',
+          value: '{cat|dog|bird}',
+          serializeValue: () => {
+            callCount++
+            return `result-${callCount}`
+          }
+        }
+      ])
+
+      const result1 = await graphToPrompt(graph)
+      const result2 = await graphToPrompt(graph)
+      const result3 = await graphToPrompt(graph)
+
+      const nodeId = String(result1.workflow.nodes[0].id)
+
+      // Each call should produce a different resolved value
+      expect(result1.output[nodeId].inputs.prompt).toBe('result-1')
+      expect(result2.output[nodeId].inputs.prompt).toBe('result-2')
+      expect(result3.output[nodeId].inputs.prompt).toBe('result-3')
+
+      // Workflow metadata should match the output
+      expect(result1.workflow.nodes[0].widgets_values![0]).toBe('result-1')
+      expect(result2.workflow.nodes[0].widgets_values![0]).toBe('result-2')
+      expect(result3.workflow.nodes[0].widgets_values![0]).toBe('result-3')
+    })
+  })
+})

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -6,6 +6,9 @@ import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 import { graphToPrompt } from './executionUtil'
 
+/**
+ * Casts a serialized node's widget values for indexed assertions.
+ */
 function widgetValues(node: { widgets_values?: unknown }): unknown[] {
   return node.widgets_values as unknown[]
 }
@@ -15,6 +18,9 @@ describe('graphToPrompt', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
+  /**
+   * Creates a graph node with serialized widgets for graphToPrompt tests.
+   */
   function createNodeWithWidgets(
     graph: LGraph,
     title: string,

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -3,14 +3,31 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  IBaseWidget,
+  IWidgetOptions
+} from '@/lib/litegraph/src/types/widgets'
 
 import { graphToPrompt } from './executionUtil'
 
-/**
- * Casts a serialized node's widget values for indexed assertions.
- */
-function widgetValues(node: { widgets_values?: unknown }): unknown[] {
-  return node.widgets_values as unknown[]
+type WidgetFixture = {
+  name: string
+  options?: IWidgetOptions
+  serializeValue?: IBaseWidget['serializeValue']
+  serialize?: boolean
+  syncToWorkflow?: boolean
+} & (
+  | { type: 'number'; value: number }
+  | { type: 'text'; value: string }
+  | { type: 'combo'; value: string | number }
+  | { type: 'custom'; value: Record<string, unknown> }
+)
+
+function requireWidgetValues(node: { widgets_values?: unknown }): unknown[] {
+  if (!Array.isArray(node.widgets_values)) {
+    throw new TypeError('Expected serialized widget values to be an array')
+  }
+  return node.widgets_values
 }
 
 describe('graphToPrompt', () => {
@@ -18,23 +35,10 @@ describe('graphToPrompt', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  /**
-   * Creates a graph node with serialized widgets for graphToPrompt tests.
-   */
   function createNodeWithWidgets(
     graph: LGraph,
     title: string,
-    widgets: {
-      type: string
-      name: string
-      value: unknown
-      options?: Record<string, unknown>
-      serializeValue?: (
-        node: unknown,
-        index: number
-      ) => Promise<unknown> | unknown
-      serialize?: boolean
-    }[]
+    widgets: WidgetFixture[]
   ): LGraphNode {
     const node = new LGraphNode(title)
     node.comfyClass = title
@@ -42,18 +46,28 @@ describe('graphToPrompt', () => {
     node.addOutput('output', 'IMAGE')
 
     for (const w of widgets) {
-      const widget = node.addWidget(
-        w.type as 'number',
-        w.name,
-        w.value as number,
-        null,
-        w.options ?? {}
-      )
+      let widget: IBaseWidget
+      switch (w.type) {
+        case 'number':
+          widget = node.addWidget('number', w.name, w.value, null, w.options)
+          break
+        case 'text':
+          widget = node.addWidget('text', w.name, w.value, null, w.options)
+          break
+        case 'combo':
+          widget = node.addWidget('combo', w.name, w.value, null, w.options)
+          break
+        case 'custom':
+          widget = node.addWidget('custom', w.name, w.value, null, w.options)
+      }
       if (w.serializeValue) {
         widget.serializeValue = w.serializeValue
       }
       if (w.serialize === false) {
         widget.serialize = false
+      }
+      if (w.syncToWorkflow === false) {
+        widget.syncToWorkflow = false
       }
     }
 
@@ -82,8 +96,8 @@ describe('graphToPrompt', () => {
       expect(output[nodeId].inputs.steps).toBe(20)
 
       // workflow widgets_values should match what was sent in the prompt
-      expect(widgetValues(wfNode)[0]).toBe('cat')
-      expect(widgetValues(wfNode)[1]).toBe(20)
+      expect(requireWidgetValues(wfNode)[0]).toBe('cat')
+      expect(requireWidgetValues(wfNode)[1]).toBe(20)
     })
 
     it('syncs async serializeValue results', async () => {
@@ -102,7 +116,41 @@ describe('graphToPrompt', () => {
       const nodeId = String(wfNode.id)
 
       expect(output[nodeId].inputs.data).toBe('resolved-async')
-      expect(widgetValues(wfNode)[0]).toBe('resolved-async')
+      expect(requireWidgetValues(wfNode)[0]).toBe('resolved-async')
+    })
+
+    it('syncs existing name-keyed workflow widget values', async () => {
+      const graph = new LGraph()
+      const node = createNodeWithWidgets(graph, 'RecordNode', [
+        {
+          type: 'text',
+          name: 'prompt',
+          value: '{cat|dog}',
+          serializeValue: () => 'cat'
+        },
+        {
+          type: 'text',
+          name: 'unmapped',
+          value: 'original',
+          serializeValue: () => 'resolved'
+        }
+      ])
+      node.onSerialize = (serialized) => {
+        Object.assign(serialized, {
+          widgets_values: { prompt: 'original', preserved: 'value' }
+        })
+      }
+
+      const { workflow, output } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+      const nodeId = String(wfNode.id)
+
+      expect(output[nodeId].inputs.prompt).toBe('cat')
+      expect(output[nodeId].inputs.unmapped).toBe('resolved')
+      expect(wfNode.widgets_values).toEqual({
+        prompt: 'cat',
+        preserved: 'value'
+      })
     })
 
     it('keeps workflow in sync when widget.value changes between calls', async () => {
@@ -118,7 +166,7 @@ describe('graphToPrompt', () => {
       const nodeId = String(wfNode1.id)
 
       expect(result1.output[nodeId].inputs.seed).toBe(100)
-      expect(widgetValues(wfNode1)[0]).toBe(100)
+      expect(requireWidgetValues(wfNode1)[0]).toBe(100)
 
       // Simulate seed change (e.g. beforeQueued randomises the seed)
       node.widgets![0].value = 999
@@ -128,10 +176,10 @@ describe('graphToPrompt', () => {
       const wfNode2 = result2.workflow.nodes[0]
 
       expect(result2.output[nodeId].inputs.seed).toBe(999)
-      expect(widgetValues(wfNode2)[0]).toBe(999)
+      expect(requireWidgetValues(wfNode2)[0]).toBe(999)
 
       // Verify first call was not mutated
-      expect(widgetValues(wfNode1)[0]).toBe(100)
+      expect(requireWidgetValues(wfNode1)[0]).toBe(100)
     })
 
     it('does not sync widgets with options.serialize === false', async () => {
@@ -155,10 +203,10 @@ describe('graphToPrompt', () => {
       expect(output[nodeId].inputs.control).toBeUndefined()
 
       // seed should be synced, control should retain its serialized value
-      expect(widgetValues(wfNode)[0]).toBe(42)
+      expect(requireWidgetValues(wfNode)[0]).toBe(42)
       // control widget's workflow value should be its original value
       // (set by graph.serialize, not modified by sync)
-      expect(widgetValues(wfNode)[1]).toBe('randomize')
+      expect(requireWidgetValues(wfNode)[1]).toBe('randomize')
     })
 
     it('does not sync widgets with widget.serialize === false', async () => {
@@ -178,21 +226,47 @@ describe('graphToPrompt', () => {
       const wfNode = workflow.nodes[0]
 
       // visible widget should be synced
-      expect(widgetValues(wfNode)[0]).toBe(10)
+      expect(requireWidgetValues(wfNode)[0]).toBe(10)
       // hidden widget (serialize: false) should not appear in widgets_values
       // because LGraphNode.serialize() skips it
-      expect(widgetValues(wfNode)[1]).toBeUndefined()
+      expect(requireWidgetValues(wfNode)[1]).toBeUndefined()
+    })
+
+    it('preserves workflow values for execution-only transforms', async () => {
+      const graph = new LGraph()
+      const prefix = 'ComfyUI_%date:yyyy-MM-dd%'
+      createNodeWithWidgets(graph, 'SaveImage', [
+        {
+          type: 'text',
+          name: 'filename_prefix',
+          value: prefix,
+          serializeValue: () => 'ComfyUI_2026-07-24',
+          syncToWorkflow: false
+        }
+      ])
+
+      const { workflow, output } = await graphToPrompt(graph)
+      const wfNode = workflow.nodes[0]
+      const nodeId = String(wfNode.id)
+
+      expect(output[nodeId].inputs.filename_prefix).toBe('ComfyUI_2026-07-24')
+      expect(requireWidgetValues(wfNode)[0]).toBe(prefix)
     })
 
     it('handles object widget values by deep-cloning', async () => {
       const objValue = { key: 'value', nested: { a: 1 } }
+      const timestamp = new Date('2026-07-24T00:00:00.000Z')
       const graph = new LGraph()
       createNodeWithWidgets(graph, 'ObjectNode', [
         {
-          type: 'text',
+          type: 'custom',
           name: 'config',
           value: objValue,
-          serializeValue: () => ({ key: 'modified', nested: { a: 2 } })
+          serializeValue: () => ({
+            key: 'modified',
+            nested: { a: 2 },
+            timestamp
+          })
         }
       ])
 
@@ -200,8 +274,12 @@ describe('graphToPrompt', () => {
       const wfNode = workflow.nodes[0]
 
       // Should be deep-cloned, not a reference
-      const synced = widgetValues(wfNode)[0] as Record<string, unknown>
-      expect(synced).toEqual({ key: 'modified', nested: { a: 2 } })
+      const synced = requireWidgetValues(wfNode)[0] as Record<string, unknown>
+      expect(synced).toEqual({
+        key: 'modified',
+        nested: { a: 2 },
+        timestamp
+      })
 
       // Verify reference independence: mutating synced does not affect output
       ;(synced.nested as Record<string, unknown>).a = 999
@@ -237,15 +315,17 @@ describe('graphToPrompt', () => {
       // Each iteration should have its own seed in both output and workflow
       for (const [idx, result] of results.entries()) {
         expect(result.output[nodeId].inputs.seed).toBe(seeds[idx])
-        expect(widgetValues(result.workflow.nodes[0])[0]).toBe(seeds[idx])
+        expect(requireWidgetValues(result.workflow.nodes[0])[0]).toBe(
+          seeds[idx]
+        )
       }
 
       // Steps and cfg should be the same across all iterations
       for (const result of results) {
         expect(result.output[nodeId].inputs.steps).toBe(20)
         expect(result.output[nodeId].inputs.cfg).toBe(7.5)
-        expect(widgetValues(result.workflow.nodes[0])[1]).toBe(20)
-        expect(widgetValues(result.workflow.nodes[0])[2]).toBe(7.5)
+        expect(requireWidgetValues(result.workflow.nodes[0])[1]).toBe(20)
+        expect(requireWidgetValues(result.workflow.nodes[0])[2]).toBe(7.5)
       }
     })
 
@@ -276,9 +356,9 @@ describe('graphToPrompt', () => {
       expect(result3.output[nodeId].inputs.prompt).toBe('result-3')
 
       // Workflow metadata should match the output
-      expect(widgetValues(result1.workflow.nodes[0])[0]).toBe('result-1')
-      expect(widgetValues(result2.workflow.nodes[0])[0]).toBe('result-2')
-      expect(widgetValues(result3.workflow.nodes[0])[0]).toBe('result-3')
+      expect(requireWidgetValues(result1.workflow.nodes[0])[0]).toBe('result-1')
+      expect(requireWidgetValues(result2.workflow.nodes[0])[0]).toBe('result-2')
+      expect(requireWidgetValues(result3.workflow.nodes[0])[0]).toBe('result-3')
     })
   })
 })

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -1,9 +1,10 @@
+import { cloneDeep } from 'es-toolkit'
+
 import type {
   ExecutableLGraphNode,
   ExecutionId,
   LGraph
 } from '@/lib/litegraph/src/litegraph'
-import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import {
   ExecutableNodeDTO,
   LGraphEventMode
@@ -14,6 +15,32 @@ import type {
 } from '@/platform/workflow/validation/schemas/workflowSchema'
 
 import { compressWidgetInputSlots } from './litegraphUtil'
+
+function cloneWorkflowWidgetValue(value: unknown): unknown {
+  return value != null && typeof value === 'object'
+    ? cloneDeep(value)
+    : (value ?? null)
+}
+
+function isWidgetValueRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function syncWorkflowWidgetValue(
+  widgetValues: unknown,
+  widgetName: string,
+  widgetIndex: number,
+  value: unknown
+): void {
+  if (Array.isArray(widgetValues)) {
+    widgetValues[widgetIndex] = cloneWorkflowWidgetValue(value)
+  } else if (
+    isWidgetValueRecord(widgetValues) &&
+    Object.hasOwn(widgetValues, widgetName)
+  ) {
+    widgetValues[widgetName] = cloneWorkflowWidgetValue(value)
+  }
+}
 
 /**
  * Converts the current graph workflow for sending to the API.
@@ -57,13 +84,10 @@ export const graphToPrompt = async (
   workflow.extra ??= {}
   workflow.extra.frontendVersion = __COMFYUI_FRONTEND_VERSION__
 
-  // Build a lookup from node ID to serialized workflow node so that
-  // serializeValue results can be synced back into extra_pnginfo.
-  // Keys are stringified because ExecutableNodeDTO.id is always a string
-  // (e.g. "3") while workflow node IDs may be numbers.
-  const workflowNodeById = new Map<string, ISerialisedNode>()
-  for (const wfNode of workflow.nodes) {
-    workflowNodeById.set(String(wfNode.id), wfNode)
+  // DTO IDs are strings, while workflow node IDs may be numbers.
+  const workflowNodeById = new Map<string, { widgets_values?: unknown }>()
+  for (const workflowNode of workflow.nodes) {
+    workflowNodeById.set(String(workflowNode.id), workflowNode)
   }
 
   const nodeDtoMap = new Map<ExecutionId, ExecutableLGraphNode>()
@@ -107,10 +131,7 @@ export const graphToPrompt = async (
     // Note: widget.options.serialize controls prompt inclusion (checked here).
     // widget.serialize controls workflow persistence (checked by LGraphNode).
     if (widgets) {
-      // Find the matching workflow node to keep extra_pnginfo in sync.
-      // For root-graph nodes the DTO id is the plain node ID; subgraph
-      // inner nodes use a colon-separated path and are not present in the
-      // root workflow node list.
+      // Inner subgraph DTO IDs are absent from the root workflow snapshot.
       const wfNode = workflowNodeById.get(String(node.id))
 
       for (const [i, widget] of widgets.entries()) {
@@ -119,20 +140,21 @@ export const graphToPrompt = async (
         const widgetValue = widget.serializeValue
           ? await widget.serializeValue(node, i)
           : widget.value
+        const workflowWidgetValues = wfNode?.widgets_values
 
-        // Sync the resolved value back into the workflow metadata so that
-        // extra_pnginfo accurately reflects what was sent for execution.
-        // This covers widgets whose serializeValue transforms the value
-        // (e.g. dynamic prompts, randomised seeds) and also guards against
-        // any drift between widget.value and the serialized workflow
-        // snapshot captured earlier via graph.serialize().
-        // Only update widgets that are persisted in the workflow
-        // (widget.serialize !== false).
-        if (wfNode?.widgets_values && widget.serialize !== false) {
-          wfNode.widgets_values[i] =
-            widgetValue != null && typeof widgetValue === 'object'
-              ? JSON.parse(JSON.stringify(widgetValue))
-              : (widgetValue ?? null)
+        // graph.serialize() precedes DTO creation and value resolution, so
+        // patch its snapshot in place.
+        if (
+          widget.serializeValue &&
+          widget.serialize !== false &&
+          widget.syncToWorkflow !== false
+        ) {
+          syncWorkflowWidgetValue(
+            workflowWidgetValues,
+            widget.name,
+            i,
+            widgetValue
+          )
         }
 
         // By default, Array values are reserved to represent node connections.

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -3,6 +3,7 @@ import type {
   ExecutionId,
   LGraph
 } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import {
   ExecutableNodeDTO,
   LGraphEventMode
@@ -56,6 +57,15 @@ export const graphToPrompt = async (
   workflow.extra ??= {}
   workflow.extra.frontendVersion = __COMFYUI_FRONTEND_VERSION__
 
+  // Build a lookup from node ID to serialized workflow node so that
+  // serializeValue results can be synced back into extra_pnginfo.
+  // Keys are stringified because ExecutableNodeDTO.id is always a string
+  // (e.g. "3") while workflow node IDs may be numbers.
+  const workflowNodeById = new Map<string, ISerialisedNode>()
+  for (const wfNode of workflow.nodes) {
+    workflowNodeById.set(String(wfNode.id), wfNode)
+  }
+
   const nodeDtoMap = new Map<ExecutionId, ExecutableLGraphNode>()
   for (const node of graph.computeExecutionOrder(false)) {
     const dto: ExecutableLGraphNode = new ExecutableNodeDTO(
@@ -97,12 +107,34 @@ export const graphToPrompt = async (
     // Note: widget.options.serialize controls prompt inclusion (checked here).
     // widget.serialize controls workflow persistence (checked by LGraphNode).
     if (widgets) {
+      // Find the matching workflow node to keep extra_pnginfo in sync.
+      // For root-graph nodes the DTO id is the plain node ID; subgraph
+      // inner nodes use a colon-separated path and are not present in the
+      // root workflow node list.
+      const wfNode = workflowNodeById.get(String(node.id))
+
       for (const [i, widget] of widgets.entries()) {
         if (!widget.name || widget.options?.serialize === false) continue
 
         const widgetValue = widget.serializeValue
           ? await widget.serializeValue(node, i)
           : widget.value
+
+        // Sync the resolved value back into the workflow metadata so that
+        // extra_pnginfo accurately reflects what was sent for execution.
+        // This covers widgets whose serializeValue transforms the value
+        // (e.g. dynamic prompts, randomised seeds) and also guards against
+        // any drift between widget.value and the serialized workflow
+        // snapshot captured earlier via graph.serialize().
+        // Only update widgets that are persisted in the workflow
+        // (widget.serialize !== false).
+        if (wfNode?.widgets_values && widget.serialize !== false) {
+          wfNode.widgets_values[i] =
+            widgetValue != null && typeof widgetValue === 'object'
+              ? JSON.parse(JSON.stringify(widgetValue))
+              : (widgetValue ?? null)
+        }
+
         // By default, Array values are reserved to represent node connections.
         // We need to wrap the array as an object to avoid the misinterpretation
         // of the array as a node connection.


### PR DESCRIPTION
## Summary

When batch count > 1, saved images can embed stale workflow metadata even though
the prompt contains the current iteration's serialized widget values. This makes
later images non-reproducible from their embedded workflows.

`graphToPrompt()` now synchronizes explicit `serializeValue()` results into its
serialized execution workflow snapshot. Widgets whose transform is execution-only
can opt out with `syncToWorkflow = false`, which keeps filename templates such as
`ComfyUI_%date:yyyy-MM-dd%` intact in the persisted workflow.

## Changes

- Synchronize explicit `serializeValue()` results with execution workflow metadata.
- Support both array-based `widgets_values` and existing name-keyed record shapes
  used by extensions such as VHS.
- Add `widget.syncToWorkflow`, defaulting to `true`, and opt the save-node
  `filename_prefix` transform out of workflow synchronization.
- Use `es-toolkit`'s `cloneDeep` so values such as `Date` objects are preserved.
- Locate the KSampler dynamically in the browser regression test instead of
  relying on a hardcoded node ID.
- Document the workflow, prompt, and execution-snapshot serialization controls.

## Review Focus

- Synchronization only applies to widgets with an explicit `serializeValue()`.
- `widget.serialize === false`, `widget.options.serialize === false`, and
  `widget.syncToWorkflow === false` retain their distinct behaviors.
- Name-keyed records only update an existing widget-name key; unrelated fields are
  preserved and missing keys are not created.
- Values copied into workflow metadata are deep-cloned to avoid reference sharing.
- Subgraph inner nodes absent from the root workflow snapshot are safely skipped.

Fixes Comfy-Org/ComfyUI#1388

<details>
<summary>Before</summary>

```text
$ pnpm exec vitest run src/utils/executionUtil.test.ts

 RUN  v4.1.10 <repo>

stderr | src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > preserves workflow values for execution-only transforms
LiteGraph addWidget(...) without a callback or property assigned

stderr | src/utils/executionUtil.test.ts
[ComfyUI] The legacy queue/history menu is deprecated. Core functionality in this menu may break at any time. Issues and feature requests related to the legacy menu will not be addressed. To switch to the new menu: Settings → search "Use new menu" → change from "Disabled" to "Top".
[ComfyUI] The legacy queue/history menu is deprecated. Core functionality in this menu may break at any time. Issues and feature requests related to the legacy menu will not be addressed. To switch to the new menu: Settings → search "Use new menu" → change from "Disabled" to "Top".

 ❯ src/utils/executionUtil.test.ts (9 tests | 1 failed) 24ms
       × preserves workflow values for execution-only transforms 6ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > preserves workflow values for execution-only transforms
AssertionError: expected 'ComfyUI_2026-07-24' to be 'ComfyUI_%date:yyyy-MM-dd%' // Object.is equality

Expected: "ComfyUI_%date:yyyy-MM-dd%"
Received: "ComfyUI_2026-07-24"

 ❯ src/utils/executionUtil.test.ts:205:39
    203|
    204|       expect(output[nodeId].inputs.filename_prefix).toBe('ComfyUI_2026…
    205|       expect(widgetValues(wfNode)[0]).toBe(prefix)
       |                                       ^
    206|     })
    207|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
   Start at  12:11:34
   Duration  8.88s (transform 6.44s, setup 118ms, import 8.38s, tests 24ms, environment 226ms)
```

</details>

<details>
<summary>After</summary>

```text
$ pnpm exec vitest run src/utils/executionUtil.test.ts src/extensions/core/saveImageExtraOutput.test.ts --reporter=verbose

 RUN  v4.1.10 <repo>

 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveImage on serialize 30ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveImageAdvanced on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveSVGNode on serialize 3ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveVideo on serialize 3ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveAnimatedWEBP on serialize 3ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveWEBM on serialize 3ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveAudio on serialize 3ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveAudioMP3 on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveAudioOpus on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveAudioAdvanced on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveGLB on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of Save3DAdvanced on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveGaussianSplat on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SavePointCloud on serialize 1ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveAnimatedPNG on serialize 1ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of CLIPSave on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of VAESave on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of ModelSave on serialize 1ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of LoraSave on serialize 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > resolves text replacements in the filename_prefix of SaveLatent on serialize 1ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > leaves non-string filename_prefix values unchanged 7ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > allows save nodes without a filename_prefix widget 2ms
 ✓ src/extensions/core/saveImageExtraOutput.test.ts > Comfy.SaveImageExtraOutput > adds a search-and-replace alias to non-save nodes 2ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > syncs serializeValue results back to workflow widgets_values 8ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > syncs async serializeValue results 1ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > syncs existing name-keyed workflow widget values 2ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > keeps workflow in sync when widget.value changes between calls 1ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > does not sync widgets with options.serialize === false 1ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > does not sync widgets with widget.serialize === false 1ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > preserves workflow values for execution-only transforms 1ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > workflow metadata sync > handles object widget values by deep-cloning 1ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > batch count simulation > produces different workflow metadata when seed changes between calls 2ms
 ✓ src/utils/executionUtil.test.ts > graphToPrompt > batch count simulation > produces different workflow metadata when serializeValue varies 1ms

 Test Files  2 passed (2)
      Tests  33 passed (33)
   Start at  13:34:04
   Duration  9.29s (transform 7.85s, setup 256ms, import 10.49s, tests 103ms, environment 460ms)
```

</details>

## Test plan

- [x] Focused unit and integration tests: 33 passed
- [x] Coverage: 84.52% statements, 85% lines, 100% functions
- [x] Main and browser TypeScript checks
- [x] Production build
- [x] Formatting, lint (0 errors), `knip`, and `git diff --check`
- [x] Browser regression test discovered by Playwright
- [ ] Full browser execution requires a ComfyUI backend started with `--multi-user`
- [ ] Manual: set batch count to 3, queue, and drag each saved image back to
  confirm that each image reproduces its own result

Full pull-request workflows on this fork may require maintainer approval before
they run.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10703-fix-sync-widget-values-to-workflow-metadata-in-graphToPrompt-3326d73d365081bc9e95d8537f84a821) by [Unito](https://www.unito.io)

<!-- codex-update-pr-verification-start -->

Pushed head: `4adfed3d5a9cdb8ae11487b31c333c9d53c47703`

The branch was rebased onto `upstream/main`. All human inline review comments
have been addressed and replied to. No AI attribution trailers are present.

<!-- codex-update-pr-verification-end -->
