### PR TITLE
refactor: [Option B] inline node footer layout with onBounding + vueBoundsOverrides

### DIFF
--- a/browser_tests/assets/selection/subgraph-with-regular-node.json
+++ b/browser_tests/assets/selection/subgraph-with-regular-node.json
@@ -1,0 +1,116 @@
+{
+  "id": "selection-bbox-test",
+  "revision": 0,
+  "last_node_id": 3,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 2,
+      "type": "e5fb1765-9323-4548-801a-5aead34d879e",
+      "pos": [300, 200],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [1]
+        }
+      ],
+      "properties": {},
+      "widgets_values": []
+    },
+    {
+      "id": 3,
+      "type": "EmptyLatentImage",
+      "pos": [800, 200],
+      "size": [400, 200],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {},
+      "widgets_values": [512, 512, 1]
+    }
+  ],
+  "links": [[1, 2, 0, 3, 0, "LATENT"]],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "e5fb1765-9323-4548-801a-5aead34d879e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 1,
+          "lastLinkId": 0,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Test Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [100, 200, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [500, 200, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "c5cc99d8-a2b6-4bf3-8be7-d4949ef736cd",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [],
+            "pos": { "0": 200, "1": 220 }
+          }
+        ],
+        "outputs": [
+          {
+            "id": "9bd488b9-e907-4c95-a7a4-85c5597a87af",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [],
+            "pos": { "0": 520, "1": 220 }
+          }
+        ],
+        "widgets": [],
+        "nodes": [],
+        "groups": [],
+        "links": [],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -114,25 +114,25 @@ export class NodeOperationsHelper {
     }
   }
 
-  async loadWithPositions(
+  async getSerializedGraph(): Promise<ComfyWorkflowJSON> {
+    return this.page.evaluate(
+      () => window.app!.graph.serialize() as ComfyWorkflowJSON
+    )
+  }
+
+  async loadGraph(data: ComfyWorkflowJSON): Promise<void> {
+    await this.page.evaluate(
+      (d) => window.app!.loadGraphData(d, true, true, null),
+      data
+    )
+  }
+
+  async repositionNodes(
     positions: Record<string, [number, number]>
   ): Promise<void> {
-    await this.page.evaluate(
-      async ({ positions }) => {
-        const data = window.app!.graph.serialize()
-        for (const node of data.nodes) {
-          const pos = positions[String(node.id)]
-          if (pos) node.pos = pos
-        }
-        await window.app!.loadGraphData(
-          data as ComfyWorkflowJSON,
-          true,
-          true,
-          null
-        )
-      },
-      { positions }
-    )
+    const data = await this.getSerializedGraph()
+    applyNodePositions(data, positions)
+    await this.loadGraph(data)
   }
 
   async resizeNode(
@@ -207,5 +207,15 @@ export class NodeOperationsHelper {
     await dialogInput.fill('128')
     await dialogInput.press('Enter')
     await this.comfyPage.nextFrame()
+  }
+}
+
+function applyNodePositions(
+  data: ComfyWorkflowJSON,
+  positions: Record<string, [number, number]>
+): void {
+  for (const node of data.nodes) {
+    const pos = positions[String(node.id)]
+    if (pos) node.pos = pos
   }
 }

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -4,7 +4,10 @@ import type {
   LGraph,
   LGraphNode
 } from '../../../src/lib/litegraph/src/litegraph'
-import type { NodeId } from '../../../src/platform/workflow/validation/schemas/workflowSchema'
+import type {
+  ComfyWorkflowJSON,
+  NodeId
+} from '../../../src/platform/workflow/validation/schemas/workflowSchema'
 import type { ComfyPage } from '../ComfyPage'
 import { DefaultGraphPositions } from '../constants/defaultGraphPositions'
 import type { Position, Size } from '../types'
@@ -109,6 +112,27 @@ export class NodeOperationsHelper {
       await this.page.keyboard.up('Control')
       await this.comfyPage.nextFrame()
     }
+  }
+
+  async loadWithPositions(
+    positions: Record<string, [number, number]>
+  ): Promise<void> {
+    await this.page.evaluate(
+      async ({ positions }) => {
+        const data = window.app!.graph.serialize()
+        for (const node of data.nodes) {
+          const pos = positions[String(node.id)]
+          if (pos) node.pos = pos
+        }
+        await window.app!.loadGraphData(
+          data as ComfyWorkflowJSON,
+          true,
+          true,
+          null
+        )
+      },
+      { positions }
+    )
   }
 
   async resizeNode(

--- a/browser_tests/fixtures/utils/boundsUtils.ts
+++ b/browser_tests/fixtures/utils/boundsUtils.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@playwright/test'
+
+export interface CanvasRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface MeasureResult {
+  selectionBounds: CanvasRect | null
+  nodeVisualBounds: Record<string, CanvasRect>
+}
+
+// Must match the padding value passed to createBounds() in selectionBorder.ts
+const SELECTION_PADDING = 10
+
+export async function measureSelectionBounds(
+  page: Page,
+  nodeIds: string[]
+): Promise<MeasureResult> {
+  return page.evaluate(
+    ({ ids, padding }) => {
+      const canvas = window.app!.canvas
+      const ds = canvas.ds
+
+      const selectedItems = canvas.selectedItems
+      let minX = Infinity
+      let minY = Infinity
+      let maxX = -Infinity
+      let maxY = -Infinity
+      for (const item of selectedItems) {
+        const rect = item.boundingRect
+        minX = Math.min(minX, rect[0])
+        minY = Math.min(minY, rect[1])
+        maxX = Math.max(maxX, rect[0] + rect[2])
+        maxY = Math.max(maxY, rect[1] + rect[3])
+      }
+      const selectionBounds =
+        selectedItems.size > 0
+          ? {
+              x: minX - padding,
+              y: minY - padding,
+              w: maxX - minX + 2 * padding,
+              h: maxY - minY + 2 * padding
+            }
+          : null
+
+      const canvasEl = canvas.canvas as HTMLCanvasElement
+      const canvasRect = canvasEl.getBoundingClientRect()
+      const nodeVisualBounds: Record<
+        string,
+        { x: number; y: number; w: number; h: number }
+      > = {}
+
+      for (const id of ids) {
+        const nodeEl = document.querySelector(
+          `[data-node-id="${id}"]`
+        ) as HTMLElement | null
+        if (!nodeEl) continue
+
+        const domRect = nodeEl.getBoundingClientRect()
+        const footerEls = nodeEl.querySelectorAll(
+          '[data-testid="subgraph-enter-button"], [data-testid="node-footer"]'
+        )
+        let bottom = domRect.bottom
+        for (const footerEl of footerEls) {
+          bottom = Math.max(bottom, footerEl.getBoundingClientRect().bottom)
+        }
+
+        nodeVisualBounds[id] = {
+          x: (domRect.left - canvasRect.left) / ds.scale - ds.offset[0],
+          y: (domRect.top - canvasRect.top) / ds.scale - ds.offset[1],
+          w: domRect.width / ds.scale,
+          h: (bottom - domRect.top) / ds.scale
+        }
+      }
+
+      return { selectionBounds, nodeVisualBounds }
+    },
+    { ids: nodeIds, padding: SELECTION_PADDING }
+  ) as Promise<MeasureResult>
+}

--- a/browser_tests/fixtures/utils/litegraphUtils.ts
+++ b/browser_tests/fixtures/utils/litegraphUtils.ts
@@ -332,6 +332,16 @@ export class NodeReference {
   async isCollapsed() {
     return !!(await this.getFlags()).collapsed
   }
+  async setCollapsed(collapsed: boolean) {
+    await this.comfyPage.page.evaluate(
+      ([id, collapsed]) => {
+        const node = window.app!.canvas.graph!.getNodeById(id)
+        if (!node) throw new Error('Node not found')
+        if (node.collapsed !== collapsed) node.collapse(true)
+      },
+      [this.id, collapsed] as const
+    )
+  }
   async isBypassed() {
     return (await this.getProperty<number | null | undefined>('mode')) === 4
   }

--- a/browser_tests/fixtures/utils/litegraphUtils.ts
+++ b/browser_tests/fixtures/utils/litegraphUtils.ts
@@ -332,6 +332,7 @@ export class NodeReference {
   async isCollapsed() {
     return !!(await this.getFlags()).collapsed
   }
+  /** Deterministic setter using node.collapse() API (not a toggle). */
   async setCollapsed(collapsed: boolean) {
     await this.comfyPage.page.evaluate(
       ([id, collapsed]) => {

--- a/browser_tests/tests/selectionBoundingBox.spec.ts
+++ b/browser_tests/tests/selectionBoundingBox.spec.ts
@@ -1,86 +1,7 @@
 import { expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
-
-interface CanvasRect {
-  x: number
-  y: number
-  w: number
-  h: number
-}
-
-interface MeasureResult {
-  selectionBounds: CanvasRect | null
-  nodeVisualBounds: Record<string, CanvasRect>
-}
-
-// Must match the padding value passed to createBounds() in selectionBorder.ts
-const SELECTION_PADDING = 10
-
-async function measureBounds(
-  page: Page,
-  nodeIds: string[]
-): Promise<MeasureResult> {
-  return page.evaluate(
-    ({ ids, padding }) => {
-      const canvas = window.app!.canvas
-      const ds = canvas.ds
-
-      const selectedItems = canvas.selectedItems
-      let minX = Infinity
-      let minY = Infinity
-      let maxX = -Infinity
-      let maxY = -Infinity
-      for (const item of selectedItems) {
-        const rect = item.boundingRect
-        minX = Math.min(minX, rect[0])
-        minY = Math.min(minY, rect[1])
-        maxX = Math.max(maxX, rect[0] + rect[2])
-        maxY = Math.max(maxY, rect[1] + rect[3])
-      }
-      const selectionBounds =
-        selectedItems.size > 0
-          ? {
-              x: minX - padding,
-              y: minY - padding,
-              w: maxX - minX + 2 * padding,
-              h: maxY - minY + 2 * padding
-            }
-          : null
-
-      const canvasEl = canvas.canvas as HTMLCanvasElement
-      const canvasRect = canvasEl.getBoundingClientRect()
-      const nodeVisualBounds: Record<string, CanvasRect> = {}
-
-      for (const id of ids) {
-        const nodeEl = document.querySelector(
-          `[data-node-id="${id}"]`
-        ) as HTMLElement | null
-        if (!nodeEl) continue
-
-        const domRect = nodeEl.getBoundingClientRect()
-        const footerEls = nodeEl.querySelectorAll(
-          '[data-testid="subgraph-enter-button"], [data-testid="node-footer"]'
-        )
-        let bottom = domRect.bottom
-        for (const footerEl of footerEls) {
-          bottom = Math.max(bottom, footerEl.getBoundingClientRect().bottom)
-        }
-
-        nodeVisualBounds[id] = {
-          x: (domRect.left - canvasRect.left) / ds.scale - ds.offset[0],
-          y: (domRect.top - canvasRect.top) / ds.scale - ds.offset[1],
-          w: domRect.width / ds.scale,
-          h: (bottom - domRect.top) / ds.scale
-        }
-      }
-
-      return { selectionBounds, nodeVisualBounds }
-    },
-    { ids: nodeIds, padding: SELECTION_PADDING }
-  ) as Promise<MeasureResult>
-}
+import { measureSelectionBounds } from '../fixtures/utils/boundsUtils'
 
 const SUBGRAPH_ID = '2'
 const REGULAR_ID = '3'
@@ -129,7 +50,7 @@ test.describe('Selection bounding box', { tag: ['@canvas', '@node'] }, () => {
           const targetId = getTargetId(type)
           const refId = getRefId(type)
 
-          await comfyPage.nodeOps.loadWithPositions({
+          await comfyPage.nodeOps.repositionNodes({
             [refId]: REF_POS,
             [targetId]: TARGET_POSITIONS[pos]
           })
@@ -148,7 +69,7 @@ test.describe('Selection bounding box', { tag: ['@canvas', '@node'] }, () => {
             .toBe(2)
           await comfyPage.nextFrame()
 
-          const result = await measureBounds(page, [refId, targetId])
+          const result = await measureSelectionBounds(page, [refId, targetId])
           expect(result.selectionBounds).not.toBeNull()
 
           const sel = result.selectionBounds!

--- a/browser_tests/tests/selectionBoundingBox.spec.ts
+++ b/browser_tests/tests/selectionBoundingBox.spec.ts
@@ -1,0 +1,171 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+interface CanvasRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+interface MeasureResult {
+  selectionBounds: CanvasRect | null
+  nodeVisualBounds: Record<string, CanvasRect>
+}
+
+// Must match the padding value passed to createBounds() in selectionBorder.ts
+const SELECTION_PADDING = 10
+
+async function measureBounds(
+  page: Page,
+  nodeIds: string[]
+): Promise<MeasureResult> {
+  return page.evaluate(
+    ({ ids, padding }) => {
+      const canvas = window.app!.canvas
+      const ds = canvas.ds
+
+      const selectedItems = canvas.selectedItems
+      let minX = Infinity
+      let minY = Infinity
+      let maxX = -Infinity
+      let maxY = -Infinity
+      for (const item of selectedItems) {
+        const rect = item.boundingRect
+        minX = Math.min(minX, rect[0])
+        minY = Math.min(minY, rect[1])
+        maxX = Math.max(maxX, rect[0] + rect[2])
+        maxY = Math.max(maxY, rect[1] + rect[3])
+      }
+      const selectionBounds =
+        selectedItems.size > 0
+          ? {
+              x: minX - padding,
+              y: minY - padding,
+              w: maxX - minX + 2 * padding,
+              h: maxY - minY + 2 * padding
+            }
+          : null
+
+      const canvasEl = canvas.canvas as HTMLCanvasElement
+      const canvasRect = canvasEl.getBoundingClientRect()
+      const nodeVisualBounds: Record<string, CanvasRect> = {}
+
+      for (const id of ids) {
+        const nodeEl = document.querySelector(
+          `[data-node-id="${id}"]`
+        ) as HTMLElement | null
+        if (!nodeEl) continue
+
+        const domRect = nodeEl.getBoundingClientRect()
+        const footerEls = nodeEl.querySelectorAll(
+          '[data-testid="subgraph-enter-button"], [data-testid="node-footer"]'
+        )
+        let bottom = domRect.bottom
+        for (const footerEl of footerEls) {
+          bottom = Math.max(bottom, footerEl.getBoundingClientRect().bottom)
+        }
+
+        nodeVisualBounds[id] = {
+          x: (domRect.left - canvasRect.left) / ds.scale - ds.offset[0],
+          y: (domRect.top - canvasRect.top) / ds.scale - ds.offset[1],
+          w: domRect.width / ds.scale,
+          h: (bottom - domRect.top) / ds.scale
+        }
+      }
+
+      return { selectionBounds, nodeVisualBounds }
+    },
+    { ids: nodeIds, padding: SELECTION_PADDING }
+  ) as Promise<MeasureResult>
+}
+
+const SUBGRAPH_ID = '2'
+const REGULAR_ID = '3'
+const WORKFLOW = 'selection/subgraph-with-regular-node'
+
+const REF_POS: [number, number] = [100, 100]
+const TARGET_POSITIONS: Record<string, [number, number]> = {
+  'bottom-left': [50, 500],
+  'bottom-right': [600, 500]
+}
+
+type NodeType = 'subgraph' | 'regular'
+type NodeState = 'expanded' | 'collapsed'
+type Position = 'bottom-left' | 'bottom-right'
+
+function getTargetId(type: NodeType): string {
+  return type === 'subgraph' ? SUBGRAPH_ID : REGULAR_ID
+}
+
+function getRefId(type: NodeType): string {
+  return type === 'subgraph' ? REGULAR_ID : SUBGRAPH_ID
+}
+
+test.describe('Selection bounding box', { tag: ['@canvas', '@node'] }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow(WORKFLOW)
+    await comfyPage.vueNodes.waitForNodes()
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.canvasOps.resetView()
+  })
+
+  const nodeTypes: NodeType[] = ['subgraph', 'regular']
+  const nodeStates: NodeState[] = ['expanded', 'collapsed']
+  const positions: Position[] = ['bottom-left', 'bottom-right']
+
+  for (const type of nodeTypes) {
+    for (const state of nodeStates) {
+      for (const pos of positions) {
+        test(`${type} node (${state}) at ${pos}: selection bounds encompass node`, async ({
+          comfyPage
+        }) => {
+          const page = comfyPage.page
+          const targetId = getTargetId(type)
+          const refId = getRefId(type)
+
+          await comfyPage.nodeOps.loadWithPositions({
+            [refId]: REF_POS,
+            [targetId]: TARGET_POSITIONS[pos]
+          })
+          await comfyPage.vueNodes.waitForNodes()
+          await comfyPage.vueNodes.getNodeLocator(targetId).waitFor()
+          await comfyPage.vueNodes.getNodeLocator(refId).waitFor()
+
+          if (state === 'collapsed') {
+            const nodeRef = await comfyPage.nodeOps.getNodeRefById(targetId)
+            await nodeRef.setCollapsed(true)
+          }
+
+          await comfyPage.canvas.press('Control+a')
+          await expect
+            .poll(() => comfyPage.nodeOps.getSelectedGraphNodesCount())
+            .toBe(2)
+          await comfyPage.nextFrame()
+
+          const result = await measureBounds(page, [refId, targetId])
+          expect(result.selectionBounds).not.toBeNull()
+
+          const sel = result.selectionBounds!
+          const vis = result.nodeVisualBounds[targetId]
+          expect(vis).toBeDefined()
+
+          const selRight = sel.x + sel.w
+          const selBottom = sel.y + sel.h
+          const visRight = vis.x + vis.w
+          const visBottom = vis.y + vis.h
+
+          expect(sel.x).toBeLessThanOrEqual(vis.x)
+          expect(selRight).toBeGreaterThanOrEqual(visRight)
+          expect(sel.y).toBeLessThanOrEqual(vis.y)
+          expect(selBottom).toBeGreaterThanOrEqual(visBottom)
+        })
+      }
+    }
+  }
+})

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -423,6 +423,16 @@ export class LGraphNode
    */
   _collapsed_width?: number
   /**
+   * The height of the node when collapsed (including footer).
+   * Set by ResizeObserver in Vue nodes mode.
+   */
+  _collapsed_height?: number
+  /**
+   * The footer height in Vue nodes mode.
+   * Set by ResizeObserver, used by measure() to extend boundingRect.
+   */
+  _footerHeight?: number
+  /**
    * Called once at the start of every frame.  Caller may change the values in {@link out}, which will be reflected in {@link boundingRect}.
    * WARNING: Making changes to boundingRect via onBounding is poorly supported, and will likely result in strange behaviour.
    */
@@ -2090,18 +2100,18 @@ export class LGraphNode
     out[1] = this.pos[1] + -titleHeight
     if (!this.flags?.collapsed) {
       out[2] = this.size[0]
-      out[3] = this.size[1] + titleHeight
+      out[3] = this.size[1] + titleHeight + (this._footerHeight ?? 0)
     } else {
-      if (ctx) ctx.font = this.innerFontStyle
-      this._collapsed_width = Math.min(
-        this.size[0],
-        ctx
-          ? cachedMeasureText(ctx, this.getTitle() ?? '') +
-              LiteGraph.NODE_TITLE_HEIGHT * 2
-          : 0
-      )
+      if (ctx && !LiteGraph.vueNodesMode) {
+        ctx.font = this.innerFontStyle
+        this._collapsed_width = Math.min(
+          this.size[0],
+          cachedMeasureText(ctx, this.getTitle() ?? '') +
+            LiteGraph.NODE_TITLE_HEIGHT * 2
+        )
+      }
       out[2] = this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH
-      out[3] = LiteGraph.NODE_TITLE_HEIGHT
+      out[3] = this._collapsed_height || LiteGraph.NODE_TITLE_HEIGHT
     }
   }
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -423,16 +423,6 @@ export class LGraphNode
    */
   _collapsed_width?: number
   /**
-   * The height of the node when collapsed (including footer).
-   * Set by ResizeObserver in Vue nodes mode.
-   */
-  _collapsed_height?: number
-  /**
-   * The footer height in Vue nodes mode.
-   * Set by ResizeObserver, used by measure() to extend boundingRect.
-   */
-  _footerHeight?: number
-  /**
    * Called once at the start of every frame.  Caller may change the values in {@link out}, which will be reflected in {@link boundingRect}.
    * WARNING: Making changes to boundingRect via onBounding is poorly supported, and will likely result in strange behaviour.
    */
@@ -2100,18 +2090,18 @@ export class LGraphNode
     out[1] = this.pos[1] + -titleHeight
     if (!this.flags?.collapsed) {
       out[2] = this.size[0]
-      out[3] = this.size[1] + titleHeight + (this._footerHeight ?? 0)
+      out[3] = this.size[1] + titleHeight
     } else {
-      if (ctx && !LiteGraph.vueNodesMode) {
-        ctx.font = this.innerFontStyle
-        this._collapsed_width = Math.min(
-          this.size[0],
-          cachedMeasureText(ctx, this.getTitle() ?? '') +
-            LiteGraph.NODE_TITLE_HEIGHT * 2
-        )
-      }
+      if (ctx) ctx.font = this.innerFontStyle
+      this._collapsed_width = Math.min(
+        this.size[0],
+        ctx
+          ? cachedMeasureText(ctx, this.getTitle() ?? '') +
+              LiteGraph.NODE_TITLE_HEIGHT * 2
+          : 0
+      )
       out[2] = this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH
-      out[3] = this._collapsed_height || LiteGraph.NODE_TITLE_HEIGHT
+      out[3] = LiteGraph.NODE_TITLE_HEIGHT
     }
   }
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -212,13 +212,8 @@ describe('LGraphNode', () => {
 
     const wrapper = mountLGraphNode({ nodeData: mockNodeData })
 
-    // Root div should have the selection class
+    // Root div should have the selection outline
     expect(wrapper.classes()).toContain('outline-node-component-outline')
-
-    // The layered outline overlay should be present
-    const overlay = wrapper.find('[data-testid="node-state-outline-overlay"]')
-    expect(overlay.exists()).toBe(true)
-    expect(overlay.classes()).toContain('border-node-component-outline')
   })
 
   it('should render progress indicator when executing prop is true', () => {
@@ -226,13 +221,8 @@ describe('LGraphNode', () => {
 
     const wrapper = mountLGraphNode({ nodeData: mockNodeData })
 
-    // Root div should have the executing class
+    // Root div should have the executing outline
     expect(wrapper.classes()).toContain('outline-node-stroke-executing')
-
-    // The layered outline overlay should be present
-    const overlay = wrapper.find('[data-testid="node-state-outline-overlay"]')
-    expect(overlay.exists()).toBe(true)
-    expect(overlay.classes()).toContain('border-node-stroke-executing')
   })
 
   it('should initialize height CSS vars for collapsed nodes', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -55,8 +55,7 @@
           hasAnyError ? '-inset-[7px]' : '-inset-[3px]',
           isSelected
             ? 'border-node-component-outline'
-            : 'border-node-stroke-executing',
-          footerStateOutlineBottomClass
+            : 'border-node-stroke-executing'
         )
       "
     />
@@ -64,10 +63,9 @@
     <div
       :class="
         cn(
-          'pointer-events-none absolute border border-solid border-component-node-border',
+          'pointer-events-none absolute z-0 border-solid border-component-node-border',
           rootBorderShapeClass,
-          hasAnyError ? '-inset-1' : 'inset-0',
-          footerRootBorderBottomClass
+          hasAnyError ? '-inset-[5px] border' : '-inset-px border-2'
         )
       "
     />
@@ -75,7 +73,7 @@
       data-testid="node-inner-wrapper"
       :class="
         cn(
-          'flex flex-1 flex-col border border-solid border-transparent bg-node-component-header-surface',
+          'relative z-5 flex flex-1 flex-col border border-solid border-transparent bg-node-component-header-surface',
           'w-(--node-width)',
           !isRerouteNode && 'min-h-(--node-height) min-w-(--min-node-width)',
           shapeClass,
@@ -190,6 +188,49 @@
           />
         </div>
       </template>
+      <template
+        v-if="
+          !isCollapsed &&
+          !isRerouteNode &&
+          nodeData.resizable !== false &&
+          !isSelectMode
+        "
+      >
+        <div
+          v-for="handle in RESIZE_HANDLES"
+          :key="handle.corner"
+          role="button"
+          :aria-label="t(handle.i18nKey)"
+          :class="
+            cn(
+              baseResizeHandleClasses,
+              handle.positionClasses,
+              handle.cursorClass,
+              'group-hover/node:opacity-100'
+            )
+          "
+          @pointerdown.stop="handleResizePointerDown($event, handle.corner)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 12 12"
+            :class="cn('absolute size-2/5', handle.svgPositionClasses)"
+            :style="
+              handle.svgTransform
+                ? { transform: handle.svgTransform }
+                : undefined
+            "
+          >
+            <path
+              d="M11 1L1 11M11 6L6 11"
+              stroke="var(--color-muted-foreground)"
+              stroke-width="0.975"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+      </template>
     </div>
     <NodeFooter
       v-if="!isRerouteNode"
@@ -205,49 +246,6 @@
       @open-errors="handleOpenErrors"
       @toggle-advanced="handleToggleAdvanced"
     />
-    <template
-      v-if="
-        !isCollapsed &&
-        !isRerouteNode &&
-        nodeData.resizable !== false &&
-        !isSelectMode
-      "
-    >
-      <div
-        v-for="handle in RESIZE_HANDLES"
-        :key="handle.corner"
-        role="button"
-        :aria-label="t(handle.i18nKey)"
-        :class="
-          cn(
-            baseResizeHandleClasses,
-            handle.positionClasses,
-            (handle.corner === 'SE' || handle.corner === 'SW') &&
-              footerResizeHandleBottomClass,
-            handle.cursorClass,
-            'group-hover/node:opacity-100'
-          )
-        "
-        @pointerdown.stop="handleResizePointerDown($event, handle.corner)"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 12 12"
-          :class="cn('absolute size-2/5', handle.svgPositionClasses)"
-          :style="
-            handle.svgTransform ? { transform: handle.svgTransform } : undefined
-          "
-        >
-          <path
-            d="M11 1L1 11M11 6L6 11"
-            stroke="var(--color-muted-foreground)"
-            stroke-width="0.975"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </div>
-    </template>
   </div>
 </template>
 
@@ -565,30 +563,6 @@ const { latestPreviewUrl, shouldShowPreviewImg } = useNodePreviewState(
   }
 )
 
-const hasFooter = computed(() => {
-  return !!(
-    (hasAnyError.value && showErrorsTabEnabled.value) ||
-    lgraphNode.value?.isSubgraphNode() ||
-    (!lgraphNode.value?.isSubgraphNode() &&
-      (showAdvancedState.value || showAdvancedInputsButton.value))
-  )
-})
-
-// Footer offset computed classes
-
-const footerStateOutlineBottomClass = computed(() =>
-  hasFooter.value ? '-bottom-[35px]' : ''
-)
-
-const footerRootBorderBottomClass = computed(() =>
-  hasFooter.value ? '-bottom-8' : ''
-)
-
-const footerResizeHandleBottomClass = computed(() => {
-  if (!hasFooter.value) return ''
-  return hasAnyError.value ? 'bottom-[-31px]' : 'bottom-[-35px]'
-})
-
 const cursorClass = computed(() => {
   if (nodeData.flags?.pinned) return 'cursor-default'
   return layoutStore.isDraggingVueNodes.value
@@ -612,9 +586,9 @@ const shapeClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-tl-2xl rounded-br-2xl'
+      return 'rounded-tl-[16px] rounded-br-[17px]'
     default:
-      return 'rounded-2xl'
+      return 'rounded-t-[16px] rounded-b-[17px]'
   }
 })
 
@@ -634,10 +608,10 @@ const rootBorderShapeClass = computed(() => {
       return ''
     case RenderShape.CARD:
       return isExpanded
-        ? 'rounded-tl-[20px] rounded-br-[20px]'
-        : 'rounded-tl-2xl rounded-br-2xl'
+        ? 'rounded-tl-[21px] rounded-br-[21px]'
+        : 'rounded-tl-[17px] rounded-br-[18px]'
     default:
-      return isExpanded ? 'rounded-[20px]' : 'rounded-2xl'
+      return isExpanded ? 'rounded-[21px]' : 'rounded-t-[17px] rounded-b-[18px]'
   }
 })
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -49,7 +49,7 @@
       data-testid="node-inner-wrapper"
       :class="
         cn(
-          'relative z-5 flex flex-1 flex-col border border-solid border-transparent bg-node-component-header-surface',
+          'relative z-5 flex flex-1 flex-col bg-node-component-header-surface',
           'w-(--node-width)',
           !isRerouteNode && 'min-h-(--node-height) min-w-(--min-node-width)',
           shapeClass,

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -174,6 +174,9 @@
       >
         <div
           v-for="handle in RESIZE_HANDLES"
+          v-show="
+            handle.corner === 'NE' || handle.corner === 'NW' || !hasFooter
+          "
           :key="handle.corner"
           role="button"
           :aria-label="t(handle.i18nKey)"
@@ -221,6 +224,50 @@
       @open-errors="handleOpenErrors"
       @toggle-advanced="handleToggleAdvanced"
     />
+    <template
+      v-if="
+        hasFooter &&
+        !isCollapsed &&
+        !isRerouteNode &&
+        nodeData.resizable !== false &&
+        !isSelectMode
+      "
+    >
+      <div
+        v-for="handle in RESIZE_HANDLES.filter(
+          (h) => h.corner === 'SE' || h.corner === 'SW'
+        )"
+        :key="`footer-${handle.corner}`"
+        role="button"
+        :aria-label="t(handle.i18nKey)"
+        :class="
+          cn(
+            baseResizeHandleClasses,
+            handle.positionClasses,
+            handle.cursorClass,
+            'group-hover/node:opacity-100'
+          )
+        "
+        @pointerdown.stop="handleResizePointerDown($event, handle.corner)"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 12 12"
+          :class="cn('absolute size-2/5', handle.svgPositionClasses)"
+          :style="
+            handle.svgTransform ? { transform: handle.svgTransform } : undefined
+          "
+        >
+          <path
+            d="M11 1L1 11M11 6L6 11"
+            stroke="var(--color-muted-foreground)"
+            stroke-width="0.975"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -477,7 +524,7 @@ onUnmounted(() => {
 })
 
 const baseResizeHandleClasses =
-  'absolute h-5 w-5 opacity-0 pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-white/40'
+  'absolute z-10 h-5 w-5 opacity-0 pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-white/40'
 
 const mutations = useLayoutMutations()
 
@@ -555,6 +602,15 @@ const outlineClass = computed(() => {
         ? 'rounded-tl-[16px] rounded-br-[16px]'
         : 'rounded-[16px]'
   return cn('outline-4 outline-offset-[3px]', errorRadius, color)
+})
+
+const hasFooter = computed(() => {
+  return !!(
+    (hasAnyError.value && showErrorsTabEnabled.value) ||
+    lgraphNode.value?.isSubgraphNode() ||
+    (!lgraphNode.value?.isSubgraphNode() &&
+      (showAdvancedState.value || showAdvancedInputsButton.value))
+  )
 })
 
 const cursorClass = computed(() => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -281,7 +281,8 @@ import {
   onMounted,
   onUnmounted,
   ref,
-  watch
+  watch,
+  watchEffect
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -314,7 +315,10 @@ import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables
 import { useNodePointerInteractions } from '@/renderer/extensions/vueNodes/composables/useNodePointerInteractions'
 import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
 import { usePartitionedBadges } from '@/renderer/extensions/vueNodes/composables/usePartitionedBadges'
-import { useVueElementTracking } from '@/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking'
+import {
+  useVueElementTracking,
+  vueBoundsOverrides
+} from '@/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking'
 import { useNodeExecutionState } from '@/renderer/extensions/vueNodes/execution/useNodeExecutionState'
 import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
 import { useNodeLayout } from '@/renderer/extensions/vueNodes/layout/useNodeLayout'
@@ -784,6 +788,32 @@ const showAdvancedState = customRef((track, trigger) => {
       trigger()
     }
   }
+})
+
+watchEffect((onCleanup) => {
+  const node = lgraphNode.value
+  if (!node) return
+
+  const nodeId = String(nodeData.id)
+  const collapsed = isCollapsed.value
+  const previousOnBounding = node.onBounding
+
+  node.onBounding = function (out) {
+    previousOnBounding?.call(this, out)
+    const overrides = vueBoundsOverrides.get(nodeId)
+    if (!overrides) return
+
+    if (collapsed) {
+      if (overrides.collapsedWidth) out[2] = overrides.collapsedWidth
+      if (overrides.collapsedHeight) out[3] = overrides.collapsedHeight
+    } else if (overrides.footerHeight) {
+      out[3] += overrides.footerHeight
+    }
+  }
+
+  onCleanup(() => {
+    node.onBounding = previousOnBounding
+  })
 })
 
 const hasVideoInput = computed(() => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -10,7 +10,7 @@
     :data-collapsed="isCollapsed || undefined"
     :class="
       cn(
-        'group/node lg-node absolute isolate flex flex-col border border-solid text-sm contain-layout contain-style',
+        'group/node lg-node absolute isolate box-border flex flex-col border border-solid text-sm contain-layout contain-style',
         hasAnyError ? 'border-transparent' : 'border-component-node-border',
         rootBorderShapeClass,
         outlineClass,

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -10,12 +10,12 @@
     :data-collapsed="isCollapsed || undefined"
     :class="
       cn(
-        'group/node lg-node absolute isolate text-sm',
-        'flex flex-col contain-layout contain-style',
+        'group/node lg-node absolute isolate flex flex-col border border-solid text-sm contain-layout contain-style',
+        hasAnyError ? 'border-transparent' : 'border-component-node-border',
+        rootBorderShapeClass,
+        outlineClass,
         isRerouteNode ? 'h-(--node-height)' : 'min-w-(--min-node-width)',
         cursorClass,
-        isSelected && 'outline-node-component-outline',
-        executing && 'outline-node-stroke-executing',
         shouldHandleNodePointerEvents && !nodeData.flags?.ghost
           ? 'pointer-events-auto'
           : 'pointer-events-none'
@@ -44,30 +44,6 @@
         !nodeData.hasErrors
       "
       :id="nodeData.id"
-    />
-    <div
-      v-if="isSelected || executing"
-      data-testid="node-state-outline-overlay"
-      :class="
-        cn(
-          'pointer-events-none absolute z-0 border-3 outline-none',
-          selectionShapeClass,
-          hasAnyError ? '-inset-[7px]' : '-inset-[3px]',
-          isSelected
-            ? 'border-node-component-outline'
-            : 'border-node-stroke-executing'
-        )
-      "
-    />
-    <!-- Root Border Overlay -->
-    <div
-      :class="
-        cn(
-          'pointer-events-none absolute z-0 border-solid border-component-node-border',
-          rootBorderShapeClass,
-          hasAnyError ? '-inset-[5px] border' : '-inset-px border-2'
-        )
-      "
     />
     <div
       data-testid="node-inner-wrapper"
@@ -237,7 +213,6 @@
       :is-subgraph="!!lgraphNode?.isSubgraphNode()"
       :has-any-error="hasAnyError"
       :show-errors-tab-enabled="showErrorsTabEnabled"
-      :is-collapsed="isCollapsed"
       :show-advanced-inputs-button="showAdvancedInputsButton"
       :show-advanced-state="showAdvancedState"
       :header-color="applyLightThemeColor(nodeData?.color)"
@@ -563,6 +538,25 @@ const { latestPreviewUrl, shouldShowPreviewImg } = useNodePreviewState(
   }
 )
 
+const outlineClass = computed(() => {
+  const color = isSelected.value
+    ? 'outline-node-component-outline'
+    : executing.value
+      ? 'outline-node-stroke-executing'
+      : null
+  if (!color) return ''
+
+  if (!hasAnyError.value) return cn('outline-3', color)
+
+  const errorRadius =
+    nodeData.shape === RenderShape.BOX
+      ? ''
+      : nodeData.shape === RenderShape.CARD
+        ? 'rounded-tl-[16px] rounded-br-[16px]'
+        : 'rounded-[16px]'
+  return cn('outline-4 outline-offset-[3px]', errorRadius, color)
+})
+
 const cursorClass = computed(() => {
   if (nodeData.flags?.pinned) return 'cursor-default'
   return layoutStore.isDraggingVueNodes.value
@@ -575,9 +569,9 @@ const bodyRoundingClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-br-2xl'
+      return 'rounded-br-[15px]'
     default:
-      return 'rounded-b-2xl'
+      return 'rounded-b-[15px]'
   }
 })
 
@@ -586,9 +580,9 @@ const shapeClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-tl-[16px] rounded-br-[17px]'
+      return 'rounded-tl-[15px] rounded-br-[15px]'
     default:
-      return 'rounded-t-[16px] rounded-b-[17px]'
+      return 'rounded-[15px]'
   }
 })
 
@@ -601,33 +595,15 @@ const isTransparentHeaderless = computed(
 
 const rootBorderShapeClass = computed(() => {
   if (isTransparentHeaderless.value) return 'border-0'
-
-  const isExpanded = hasAnyError.value
   switch (nodeData.shape) {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return isExpanded
+      return hasAnyError.value
         ? 'rounded-tl-[21px] rounded-br-[21px]'
-        : 'rounded-tl-[17px] rounded-br-[18px]'
+        : 'rounded-tl-[16px] rounded-br-[16px]'
     default:
-      return isExpanded ? 'rounded-[21px]' : 'rounded-t-[17px] rounded-b-[18px]'
-  }
-})
-
-const selectionShapeClass = computed(() => {
-  if (isTransparentHeaderless.value) return 'border-0'
-
-  const isExpanded = hasAnyError.value
-  switch (nodeData.shape) {
-    case RenderShape.BOX:
-      return ''
-    case RenderShape.CARD:
-      return isExpanded
-        ? 'rounded-tl-[23px] rounded-br-[23px]'
-        : 'rounded-tl-[19px] rounded-br-[19px]'
-    default:
-      return isExpanded ? 'rounded-[23px]' : 'rounded-[19px]'
+      return hasAnyError.value ? 'rounded-[21px]' : 'rounded-[16px]'
   }
 })
 

--- a/src/renderer/extensions/vueNodes/components/NodeFooter.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.vue
@@ -2,14 +2,14 @@
   <!-- Case 1: Subgraph + Error (Dual Tabs) -->
   <div
     v-if="isSubgraph && hasAnyError && showErrorsTabEnabled"
-    class="-mx-1 -mt-18 -mb-2 box-border flex w-[calc(100%+8px)] pt-7 pb-1"
+    class="-mx-1 -mt-4 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
   >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(false),
-          'box-border w-1/2 rounded-none bg-destructive-background pt-16 pb-4 text-white hover:bg-destructive-background-hover',
+          'box-border w-1/2 rounded-none bg-destructive-background pt-9 pb-4 text-white hover:bg-destructive-background-hover',
           errorRadiusClass
         )
       "
@@ -27,7 +27,7 @@
       :class="
         cn(
           getTabStyles(true),
-          '-ml-5·box-border·w-[calc(50%+20px)]·rounded-none·bg-node-component-header-surface·pt-16·pb-4·pl-5',
+          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-9 pb-4 pl-5 ring-1 ring-component-node-border ring-inset',
           enterRadiusClass
         )
       "
@@ -49,14 +49,14 @@
       showErrorsTabEnabled &&
       (showAdvancedInputsButton || showAdvancedState)
     "
-    class="-mx-1 -mt-18 -mb-2 box-border flex w-[calc(100%+8px)] pt-7 pb-1"
+    class="-mx-1 -mt-4 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
   >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(false),
-          'box-border w-1/2 rounded-none bg-destructive-background pt-16 pb-4 text-white hover:bg-destructive-background-hover',
+          'box-border w-1/2 rounded-none bg-destructive-background pt-9 pb-4 text-white hover:bg-destructive-background-hover',
           errorRadiusClass
         )
       "
@@ -73,7 +73,7 @@
       :class="
         cn(
           getTabStyles(true),
-          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-16 pb-4 pl-5',
+          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-9 pb-4 pl-5 ring-1 ring-component-node-border ring-inset',
           enterRadiusClass
         )
       "
@@ -100,14 +100,14 @@
   <!-- Case 2: Error Only (Full Width) -->
   <div
     v-else-if="hasAnyError && showErrorsTabEnabled"
-    class="-mx-1 -mt-18 -mb-2 box-border flex w-[calc(100%+8px)] pt-7 pb-1"
+    class="-mx-1 -mt-4 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
   >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(false),
-          'box-border w-full rounded-none bg-destructive-background pt-16 pb-4 text-white hover:bg-destructive-background-hover',
+          'box-border w-full rounded-none bg-destructive-background pt-9 pb-4 text-white hover:bg-destructive-background-hover',
           footerRadiusClass
         )
       "
@@ -121,14 +121,25 @@
   </div>
 
   <!-- Case 3: Subgraph only (Full Width) -->
-  <div v-else-if="isSubgraph" class="-mt-18 box-border flex w-full pt-7">
+  <div
+    v-else-if="isSubgraph"
+    :class="
+      cn(
+        '-mt-4 box-border flex',
+        hasAnyError ? '-mx-1 -mb-2 w-[calc(100%+8px)] pb-1' : 'w-full'
+      )
+    "
+  >
     <Button
       variant="textonly"
       data-testid="subgraph-enter-button"
       :class="
         cn(
           getTabStyles(true),
-          'box-border w-full rounded-none bg-node-component-header-surface pt-15 pb-4',
+          'box-border w-full rounded-none bg-node-component-header-surface',
+          hasAnyError
+            ? 'pt-9 pb-4 ring-1 ring-component-node-border ring-inset'
+            : 'pt-8 pb-4',
           footerRadiusClass
         )
       "
@@ -145,14 +156,22 @@
   <!-- Case 4: Advanced Footer (Regular Nodes) -->
   <div
     v-else-if="showAdvancedInputsButton || showAdvancedState"
-    class="-mt-18 box-border flex w-full pt-7"
+    :class="
+      cn(
+        '-mt-4 box-border flex',
+        hasAnyError ? '-mx-1 -mb-2 w-[calc(100%+8px)] pb-1' : 'w-full'
+      )
+    "
   >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(true),
-          'box-border w-full rounded-none bg-node-component-header-surface pt-15 pb-4',
+          'box-border w-full rounded-none bg-node-component-header-surface',
+          hasAnyError
+            ? 'pt-9 pb-4 ring-1 ring-component-node-border ring-inset'
+            : 'pt-8 pb-4',
           footerRadiusClass
         )
       "
@@ -190,7 +209,6 @@ interface Props {
   isSubgraph: boolean
   hasAnyError: boolean
   showErrorsTabEnabled: boolean
-  isCollapsed: boolean
   showAdvancedInputsButton?: boolean
   showAdvancedState?: boolean
   headerColor?: string
@@ -211,9 +229,9 @@ const footerRadiusClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return isError ? 'rounded-br-[20px]' : 'rounded-br-[17px]'
+      return isError ? 'rounded-br-[19px]' : 'rounded-br-[15px]'
     default:
-      return isError ? 'rounded-b-[20px]' : 'rounded-b-[17px]'
+      return isError ? 'rounded-b-[19px]' : 'rounded-b-[15px]'
   }
 })
 
@@ -222,9 +240,9 @@ const errorRadiusClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-bl-[20px]'
+      return 'rounded-br-[19px]'
     default:
-      return 'rounded-b-[20px]'
+      return 'rounded-b-[19px]'
   }
 })
 
@@ -233,18 +251,13 @@ const enterRadiusClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-br-[20px]'
     default:
-      return 'rounded-br-[20px]'
+      return 'rounded-br-[19px]'
   }
 })
 
 const getTabStyles = (isBackground = false) => {
-  return cn(
-    'pointer-events-auto text-xs',
-    isBackground ? 'z-0' : 'z-2',
-    props.isCollapsed ? 'h-8' : 'h-9'
-  )
+  return cn('pointer-events-auto h-9 text-xs', isBackground ? 'z-0' : 'z-2')
 }
 
 const headerColorStyle = computed(() =>

--- a/src/renderer/extensions/vueNodes/components/NodeFooter.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.vue
@@ -1,13 +1,16 @@
 <template>
   <!-- Case 1: Subgraph + Error (Dual Tabs) -->
-  <template v-if="isSubgraph && hasAnyError && showErrorsTabEnabled">
+  <div
+    v-if="isSubgraph && hasAnyError && showErrorsTabEnabled"
+    class="-mx-1 -mt-18 -mb-2 box-border flex w-[calc(100%+8px)] pt-7 pb-1"
+  >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(false),
-          errorTabWidth,
-          '-z-5 bg-destructive-background text-white hover:bg-destructive-background-hover'
+          'box-border w-1/2 rounded-none bg-destructive-background pt-16 pb-4 text-white hover:bg-destructive-background-hover',
+          errorRadiusClass
         )
       "
       @click.stop="$emit('openErrors')"
@@ -24,36 +27,37 @@
       :class="
         cn(
           getTabStyles(true),
-          enterTabFullWidth,
-          '-z-10 bg-node-component-header-surface'
+          '-ml-5·box-border·w-[calc(50%+20px)]·rounded-none·bg-node-component-header-surface·pt-16·pb-4·pl-5',
+          enterRadiusClass
         )
       "
       :style="headerColorStyle"
       @click.stop="$emit('enterSubgraph')"
     >
-      <div class="ml-auto flex h-full w-1/2 items-center justify-center gap-2">
+      <div class="flex size-full items-center justify-center gap-2">
         <span class="truncate">{{ t('g.enter') }}</span>
         <i class="icon-[comfy--workflow] size-4 shrink-0" />
       </div>
     </Button>
-  </template>
+  </div>
 
   <!-- Case 1b: Advanced + Error (Dual Tabs, Regular Nodes) -->
-  <template
+  <div
     v-else-if="
       !isSubgraph &&
       hasAnyError &&
       showErrorsTabEnabled &&
       (showAdvancedInputsButton || showAdvancedState)
     "
+    class="-mx-1 -mt-18 -mb-2 box-border flex w-[calc(100%+8px)] pt-7 pb-1"
   >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(false),
-          errorTabWidth,
-          '-z-5 bg-destructive-background text-white hover:bg-destructive-background-hover'
+          'box-border w-1/2 rounded-none bg-destructive-background pt-16 pb-4 text-white hover:bg-destructive-background-hover',
+          errorRadiusClass
         )
       "
       @click.stop="$emit('openErrors')"
@@ -69,14 +73,14 @@
       :class="
         cn(
           getTabStyles(true),
-          enterTabFullWidth,
-          '-z-10 bg-node-component-header-surface'
+          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-16 pb-4 pl-5',
+          enterRadiusClass
         )
       "
       :style="headerColorStyle"
       @click.stop="$emit('toggleAdvanced')"
     >
-      <div class="ml-auto flex h-full w-1/2 items-center justify-center gap-2">
+      <div class="flex size-full items-center justify-center gap-2">
         <span class="truncate">{{
           showAdvancedState
             ? t('rightSidePanel.hideAdvancedShort')
@@ -91,17 +95,20 @@
         />
       </div>
     </Button>
-  </template>
+  </div>
 
   <!-- Case 2: Error Only (Full Width) -->
-  <template v-else-if="hasAnyError && showErrorsTabEnabled">
+  <div
+    v-else-if="hasAnyError && showErrorsTabEnabled"
+    class="-mx-1 -mt-18 -mb-2 box-border flex w-[calc(100%+8px)] pt-7 pb-1"
+  >
     <Button
       variant="textonly"
       :class="
         cn(
           getTabStyles(false),
-          enterTabFullWidth,
-          '-z-5 bg-destructive-background text-white hover:bg-destructive-background-hover'
+          'box-border w-full rounded-none bg-destructive-background pt-16 pb-4 text-white hover:bg-destructive-background-hover',
+          footerRadiusClass
         )
       "
       @click.stop="$emit('openErrors')"
@@ -111,18 +118,18 @@
         <i class="icon-[lucide--info] size-4 shrink-0" />
       </div>
     </Button>
-  </template>
+  </div>
 
   <!-- Case 3: Subgraph only (Full Width) -->
-  <template v-else-if="isSubgraph">
+  <div v-else-if="isSubgraph" class="-mt-18 box-border flex w-full pt-7">
     <Button
       variant="textonly"
       data-testid="subgraph-enter-button"
       :class="
         cn(
           getTabStyles(true),
-          hasAnyError ? 'w-[calc(100%+8px)]' : 'w-full',
-          '-z-10 bg-node-component-header-surface'
+          'box-border w-full rounded-none bg-node-component-header-surface pt-15 pb-4',
+          footerRadiusClass
         )
       "
       :style="headerColorStyle"
@@ -133,37 +140,41 @@
         <i class="icon-[comfy--workflow] size-4 shrink-0" />
       </div>
     </Button>
-  </template>
+  </div>
 
   <!-- Case 4: Advanced Footer (Regular Nodes) -->
-  <Button
+  <div
     v-else-if="showAdvancedInputsButton || showAdvancedState"
-    variant="textonly"
-    :class="
-      cn(
-        getTabStyles(true),
-        hasAnyError ? 'w-[calc(100%+8px)]' : 'w-full',
-        '-z-10 bg-node-component-header-surface'
-      )
-    "
-    :style="headerColorStyle"
-    @click.stop="$emit('toggleAdvanced')"
+    class="-mt-18 box-border flex w-full pt-7"
   >
-    <div class="flex size-full items-center justify-center gap-2">
-      <template v-if="showAdvancedState">
-        <span class="truncate">{{
-          t('rightSidePanel.hideAdvancedInputsButton')
-        }}</span>
-        <i class="icon-[lucide--chevron-up] size-4 shrink-0" />
-      </template>
-      <template v-else>
-        <span class="truncate">{{
-          t('rightSidePanel.showAdvancedInputsButton')
-        }}</span>
-        <i class="icon-[lucide--settings-2] size-4 shrink-0" />
-      </template>
-    </div>
-  </Button>
+    <Button
+      variant="textonly"
+      :class="
+        cn(
+          getTabStyles(true),
+          'box-border w-full rounded-none bg-node-component-header-surface pt-15 pb-4',
+          footerRadiusClass
+        )
+      "
+      :style="headerColorStyle"
+      @click.stop="$emit('toggleAdvanced')"
+    >
+      <div class="flex size-full items-center justify-center gap-2">
+        <template v-if="showAdvancedState">
+          <span class="truncate">{{
+            t('rightSidePanel.hideAdvancedInputsButton')
+          }}</span>
+          <i class="icon-[lucide--chevron-up] size-4 shrink-0" />
+        </template>
+        <template v-else>
+          <span class="truncate">{{
+            t('rightSidePanel.showAdvancedInputsButton')
+          }}</span>
+          <i class="icon-[lucide--settings-2] size-4 shrink-0" />
+        </template>
+      </div>
+    </Button>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -195,51 +206,48 @@ defineEmits<{
 }>()
 
 const footerRadiusClass = computed(() => {
-  const isExpanded = props.hasAnyError
-
+  const isError = props.hasAnyError
   switch (props.shape) {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return isExpanded ? 'rounded-br-[20px]' : 'rounded-br-2xl'
+      return isError ? 'rounded-br-[20px]' : 'rounded-br-[17px]'
     default:
-      return isExpanded ? 'rounded-b-[20px]' : 'rounded-b-2xl'
+      return isError ? 'rounded-b-[20px]' : 'rounded-b-[17px]'
   }
 })
 
-/**
- * Returns shared size/position classes for footer tabs
- * @param isBackground If true, calculates styles for the background/right tab (Enter Subgraph)
- */
-const getTabStyles = (isBackground = false) => {
-  let sizeClasses = ''
-  if (props.isCollapsed) {
-    let pt = 'pt-10'
-    if (isBackground) {
-      pt = props.hasAnyError ? 'pt-10.5' : 'pt-9'
-    }
-    sizeClasses = cn('-mt-7.5 h-15', pt)
-  } else {
-    let pt = 'pt-12.5'
-    if (isBackground) {
-      pt = props.hasAnyError ? 'pt-12.5' : 'pt-11.5'
-    }
-    sizeClasses = cn('-mt-10 h-17.5', pt)
+const errorRadiusClass = computed(() => {
+  switch (props.shape) {
+    case RenderShape.BOX:
+      return ''
+    case RenderShape.CARD:
+      return 'rounded-bl-[20px]'
+    default:
+      return 'rounded-b-[20px]'
   }
+})
 
+const enterRadiusClass = computed(() => {
+  switch (props.shape) {
+    case RenderShape.BOX:
+      return ''
+    case RenderShape.CARD:
+      return 'rounded-br-[20px]'
+    default:
+      return 'rounded-br-[20px]'
+  }
+})
+
+const getTabStyles = (isBackground = false) => {
   return cn(
-    'pointer-events-auto absolute top-full left-0 text-xs',
-    footerRadiusClass.value,
-    sizeClasses,
-    props.hasAnyError ? '-translate-x-1 translate-y-0.5' : 'translate-y-0.5'
+    'pointer-events-auto text-xs',
+    isBackground ? 'z-0' : 'z-2',
+    props.isCollapsed ? 'h-8' : 'h-9'
   )
 }
 
 const headerColorStyle = computed(() =>
   props.headerColor ? { backgroundColor: props.headerColor } : undefined
 )
-
-// Case 1 context: Split widths
-const errorTabWidth = 'w-[calc(50%+4px)]'
-const enterTabFullWidth = 'w-[calc(100%+8px)]'
 </script>

--- a/src/renderer/extensions/vueNodes/components/NodeFooter.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.vue
@@ -2,7 +2,7 @@
   <!-- Case 1: Subgraph + Error (Dual Tabs) -->
   <div
     v-if="isSubgraph && hasAnyError && showErrorsTabEnabled"
-    class="-mx-1 -mt-4 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
+    class="-mx-1 -mt-5 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
   >
     <Button
       variant="textonly"
@@ -49,7 +49,7 @@
       showErrorsTabEnabled &&
       (showAdvancedInputsButton || showAdvancedState)
     "
-    class="-mx-1 -mt-4 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
+    class="-mx-1 -mt-5 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
   >
     <Button
       variant="textonly"
@@ -100,7 +100,7 @@
   <!-- Case 2: Error Only (Full Width) -->
   <div
     v-else-if="hasAnyError && showErrorsTabEnabled"
-    class="-mx-1 -mt-4 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
+    class="-mx-1 -mt-5 -mb-2 box-border flex w-[calc(100%+8px)] pb-1"
   >
     <Button
       variant="textonly"
@@ -125,7 +125,7 @@
     v-else-if="isSubgraph"
     :class="
       cn(
-        '-mt-4 box-border flex',
+        '-mt-5 box-border flex',
         hasAnyError ? '-mx-1 -mb-2 w-[calc(100%+8px)] pb-1' : 'w-full'
       )
     "
@@ -158,7 +158,7 @@
     v-else-if="showAdvancedInputsButton || showAdvancedState"
     :class="
       cn(
-        '-mt-4 box-border flex',
+        '-mt-5 box-border flex',
         hasAnyError ? '-mx-1 -mb-2 w-[calc(100%+8px)] pb-1' : 'w-full'
       )
     "

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -47,7 +47,8 @@ const testState = vi.hoisted(() => ({
 }))
 
 vi.mock('@vueuse/core', () => ({
-  useDocumentVisibility: () => ref<'visible' | 'hidden'>('visible')
+  useDocumentVisibility: () => ref<'visible' | 'hidden'>('visible'),
+  createSharedComposable: <T>(fn: T) => fn
 }))
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
@@ -99,6 +100,8 @@ function createResizeEntry(options?: {
   if (collapsed) {
     element.dataset.collapsed = ''
   }
+  Object.defineProperty(element, 'offsetWidth', { value: width })
+  Object.defineProperty(element, 'offsetHeight', { value: height })
   const rectSpy = vi.fn(() => new DOMRect(left, top, width, height))
   element.getBoundingClientRect = rectSpy
   const boxSizes = [{ inlineSize: width, blockSize: height }]

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
@@ -15,8 +15,9 @@ import { useDocumentVisibility } from '@vueuse/core'
 
 import { useSharedCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { app } from '@/scripts/app'
 import type { Bounds, NodeId } from '@/renderer/core/layout/types'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import {
@@ -139,25 +140,44 @@ const resizeObserver = new ResizeObserver((entries) => {
     const nodeId: NodeId | undefined =
       elementType === 'node' ? elementId : undefined
 
-    // Skip collapsed nodes — their DOM height is just the header, and writing
-    // that back to the layout store would overwrite the stored expanded size.
+    // Collapsed nodes: don't update layoutStore (preserve expanded size),
+    // but sync the collapsed DOM width to litegraph for boundingRect.
     if (elementType === 'node' && element.dataset.collapsed != null) {
       if (nodeId) {
+        const lgNode = app.graph?.getNodeById(nodeId)
+        if (lgNode) {
+          const body = element.querySelector(
+            '[data-testid^="node-inner-wrapper"]'
+          )
+          lgNode._collapsed_width =
+            body instanceof HTMLElement ? body.offsetWidth : element.offsetWidth
+          lgNode._collapsed_height = element.offsetHeight
+        }
         nodesNeedingSlotResync.add(nodeId)
       }
       continue
     }
 
-    // Use borderBoxSize when available; fall back to contentRect for older engines/tests
-    // Border box is the border included FULL wxh DOM value.
-    const borderBox = Array.isArray(entry.borderBoxSize)
-      ? entry.borderBoxSize[0]
-      : {
-          inlineSize: entry.contentRect.width,
-          blockSize: entry.contentRect.height
+    // Measure body (node-inner-wrapper) for node.size to exclude footer,
+    // but store the full height (with footer) for boundingRect.
+    const bodyEl = element.querySelector('[data-testid^="node-inner-wrapper"]')
+    const measuredEl = bodyEl instanceof HTMLElement ? bodyEl : element
+    const width = Math.max(0, measuredEl.offsetWidth)
+    const height = Math.max(0, measuredEl.offsetHeight)
+    const fullHeight = Math.max(0, element.offsetHeight)
+
+    // Store footer-inclusive height for boundingRect calculation
+    if (nodeId) {
+      const lgNode = app.graph?.getNodeById(nodeId)
+      if (lgNode) {
+        const footerExtra = fullHeight - measuredEl.offsetHeight
+        if (footerExtra > 0) {
+          lgNode._footerHeight = footerExtra
+        } else {
+          lgNode._footerHeight = undefined
         }
-    const width = Math.max(0, borderBox.inlineSize)
-    const height = Math.max(0, borderBox.blockSize)
+      }
+    }
     const nodeLayout = nodeId
       ? layoutStore.getNodeLayoutRef(nodeId).value
       : null

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
@@ -17,7 +17,6 @@ import { useSharedCanvasPositionConversion } from '@/composables/element/useCanv
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
-import { app } from '@/scripts/app'
 import type { Bounds, NodeId } from '@/renderer/core/layout/types'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import {
@@ -27,6 +26,14 @@ import {
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
 
 import { syncNodeSlotLayoutsFromDOM } from './useSlotElementTracking'
+
+interface VueBoundsOverride {
+  footerHeight?: number
+  collapsedWidth?: number
+  collapsedHeight?: number
+}
+
+export const vueBoundsOverrides = new Map<NodeId, VueBoundsOverride>()
 
 /**
  * Generic update item for element bounds tracking
@@ -141,42 +148,40 @@ const resizeObserver = new ResizeObserver((entries) => {
       elementType === 'node' ? elementId : undefined
 
     // Collapsed nodes: don't update layoutStore (preserve expanded size),
-    // but sync the collapsed DOM width to litegraph for boundingRect.
+    // but store collapsed dimensions in the shared WeakMap for onBounding.
     if (elementType === 'node' && element.dataset.collapsed != null) {
       if (nodeId) {
-        const lgNode = app.graph?.getNodeById(nodeId)
-        if (lgNode) {
-          const body = element.querySelector(
-            '[data-testid^="node-inner-wrapper"]'
-          )
-          lgNode._collapsed_width =
-            body instanceof HTMLElement ? body.offsetWidth : element.offsetWidth
-          lgNode._collapsed_height = element.offsetHeight
-        }
+        const body = element.querySelector(
+          '[data-testid^="node-inner-wrapper"]'
+        )
+        const collapsedWidth =
+          body instanceof HTMLElement ? body.offsetWidth : element.offsetWidth
+        vueBoundsOverrides.set(nodeId, {
+          ...vueBoundsOverrides.get(nodeId),
+          collapsedWidth,
+          collapsedHeight: element.offsetHeight
+        })
         nodesNeedingSlotResync.add(nodeId)
       }
       continue
     }
 
-    // Measure body (node-inner-wrapper) for node.size to exclude footer,
-    // but store the full height (with footer) for boundingRect.
+    // Measure body (node-inner-wrapper) for node.size to exclude footer.
+    // Store footer height in WeakMap for onBounding to extend boundingRect.
     const bodyEl = element.querySelector('[data-testid^="node-inner-wrapper"]')
     const measuredEl = bodyEl instanceof HTMLElement ? bodyEl : element
     const width = Math.max(0, measuredEl.offsetWidth)
     const height = Math.max(0, measuredEl.offsetHeight)
     const fullHeight = Math.max(0, element.offsetHeight)
 
-    // Store footer-inclusive height for boundingRect calculation
     if (nodeId) {
-      const lgNode = app.graph?.getNodeById(nodeId)
-      if (lgNode) {
-        const footerExtra = fullHeight - measuredEl.offsetHeight
-        if (footerExtra > 0) {
-          lgNode._footerHeight = footerExtra
-        } else {
-          lgNode._footerHeight = undefined
-        }
-      }
+      const footerExtra = fullHeight - measuredEl.offsetHeight
+      vueBoundsOverrides.set(nodeId, {
+        ...vueBoundsOverrides.get(nodeId),
+        footerHeight: footerExtra > 0 ? footerExtra : 0,
+        collapsedWidth: vueBoundsOverrides.get(nodeId)?.collapsedWidth,
+        collapsedHeight: vueBoundsOverrides.get(nodeId)?.collapsedHeight
+      })
     }
     const nodeLayout = nodeId
       ? layoutStore.getNodeLayoutRef(nodeId).value

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
@@ -51,7 +51,10 @@ export function useNodeResize(
     const nodeId = nodeElement.dataset.nodeId
     if (!nodeId) return
 
-    const rect = nodeElement.getBoundingClientRect()
+    const bodyElement =
+      nodeElement.querySelector('[data-testid^="node-inner-wrapper"]') ??
+      nodeElement
+    const rect = bodyElement.getBoundingClientRect()
     const scale = transformState.camera.z
 
     const startSize: Size = {
@@ -61,7 +64,7 @@ export function useNodeResize(
 
     const savedNodeHeight = nodeElement.style.getPropertyValue('--node-height')
     nodeElement.style.setProperty('--node-height', '0px')
-    const minContentHeight = nodeElement.getBoundingClientRect().height / scale
+    const minContentHeight = bodyElement.getBoundingClientRect().height / scale
     nodeElement.style.setProperty('--node-height', savedNodeHeight || '')
 
     const nodeLayout = layoutStore.getNodeLayoutRef(nodeId).value


### PR DESCRIPTION
## Summary

Fix selection bounding box not encompassing node footer, and refactor footer from absolute overlay to inline flow layout. **Option B** uses `onBounding` callback with a `vueBoundsOverrides` Map in the Vue layer — no core `LGraphNode.ts` changes.

See also: **Option A** — Comfy-Org/ComfyUI_frontend#10711 (uses core `_footerHeight`/`_collapsedHeight` properties)

## Background

The node footer (Enter Subgraph, Advanced, Error buttons) was previously rendered as an absolute overlay (`absolute top-full`) outside the node body. This caused the selection bounding box, resize handles, and border/outline overlays to not account for the footer height, requiring multiple hardcoded pixel offsets (32px, 34px) to compensate.

## Changes

### Footer inline layout (shared with Option A)
- Replace absolute overlay footer with inline flow layout using z-index layering (body `z-5` > footer `z-0`/`z-2`)
- Footer buttons use negative margin (`-mt-5`) to slide behind the body's rounded bottom edge
- Enter/Advanced buttons tuck behind Error button with `-ml-5` overlap
- Shape-aware radius classes for all footer button combinations

### Border/outline unification (shared with Option A)
- Remove two separate overlay divs (selection border + root border)
- Move border directly to root element
- Selection/execution indicator uses `outline` on root (no layout shift)
- Error state hides root border since `ring-4` covers it

### Resize handles (shared with Option A)
- Split SE/SW handles: body handles hide when footer exists, footer-level handles render after NodeFooter
- Use body element (`node-inner-wrapper`) for resize start size to exclude footer height
- Add `z-10` to resize handles so they appear above footer buttons

### Accurate bounding rect (Option B approach)
- `vueBoundsOverrides` Map in Vue layer stores DOM-measured footer height, collapsed width/height
- `onBounding` callback reads from the Map to extend `boundingRect` — no hardcoded pixel values
- `LGraphNode.ts` is completely unchanged (no new properties, no `vueNodesMode` guard)
- `selectionBorder.ts` unchanged — uses `createBounds` as before, no per-frame DOM queries
- Preserves existing `onBounding` callbacks via chaining (`previousOnBounding`)

### Limitations of Option B
- Uses `onBounding` callback which Christian noted as "reaching across the boundary from Vue into litegraph's internal callback system"
- However: no magic numbers (DOM-measured values), proper callback chaining, and `onBounding` is the designed extension point
- `vueBoundsOverrides` Map must stay in sync with ResizeObserver lifecycle

### Tests (shared with Option A)
- 8 parameterized E2E tests for selection bounding box
- Shared test helpers: `repositionNodes`, `NodeReference.setCollapsed`, `measureSelectionBounds`

## Review Focus

- `onBounding` with DOM-measured values vs core `_footerHeight` property (see Option A: #10711)
- Is `onBounding` acceptable when values come from DOM measurement rather than hardcoded offsets?
- `vueBoundsOverrides` Map lifecycle — populated by ResizeObserver, consumed by `onBounding`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10712-refactor-Option-B-inline-node-footer-layout-with-onBounding-vueBoundsOverrides-3326d73d365081cbb6e1ff02033adac3) by [Unito](https://www.unito.io)
