### PR TITLE
refactor: replace inline getByRole('dialog') with page objects in E2E tests

### DIFF
--- a/browser_tests/fixtures/components/ComfyNodeSearchBox.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBox.ts
@@ -1,11 +1,14 @@
 import type { Locator, Page } from '@playwright/test'
 
 export class ComfyNodeSearchFilterSelectionPanel {
-  constructor(public readonly page: Page) {}
+  readonly root: Locator
+
+  constructor(public readonly page: Page) {
+    this.root = page.getByRole('dialog')
+  }
 
   get header() {
-    return this.page
-      .getByRole('dialog')
+    return this.root
       .locator('div')
       .filter({ hasText: 'Add node filter condition' })
   }

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -83,6 +83,14 @@ export class AppModeHelper {
     return this.page.locator('[data-testid="linear-widgets"]')
   }
 
+  /** The PrimeVue Popover for the image picker (renders with role="dialog"). */
+  get imagePickerPopover(): Locator {
+    return this.page
+      .getByRole('dialog')
+      .filter({ has: this.page.getByRole('button', { name: 'All' }) })
+      .first()
+  }
+
   /**
    * Get the actions menu trigger for a widget in the app mode widget list.
    * @param widgetName Text shown in the widget label (e.g. "seed").

--- a/browser_tests/tests/appModeDropdownClipping.spec.ts
+++ b/browser_tests/tests/appModeDropdownClipping.spec.ts
@@ -145,10 +145,7 @@ test.describe('App mode dropdown clipping', { tag: '@ui' }, () => {
 
     // The unstyled PrimeVue Popover renders with role="dialog".
     // Locate the one containing the image grid (filter buttons like "All", "Inputs").
-    const popover = comfyPage.page
-      .getByRole('dialog')
-      .filter({ has: comfyPage.page.getByRole('button', { name: 'All' }) })
-      .first()
+    const popover = comfyPage.appMode.imagePickerPopover
     await expect(popover).toBeVisible({ timeout: 5000 })
 
     const isInViewport = await popover.evaluate((el) => {


### PR DESCRIPTION
## Summary

Replace remaining inline `getByRole('dialog')` calls in E2E tests with page object accessors, following the pattern from PR #10586.

**Note:** The original scope covered 9 calls across 5 files. Three of those refactors (ConfirmDialog, MediaLightbox, TemplatesDialog) were already merged into main via other PRs, so this PR now covers only the remaining 3 files.

## Changes

- **ComfyNodeSearchBox.ts**: Extract a `root` locator on `ComfyNodeSearchFilterSelectionPanel` so `header` getter uses `this.root` instead of an inline `page.getByRole('dialog')`
- **AppModeHelper.ts**: Add `imagePickerPopover` getter that locates the PrimeVue Popover (`role="dialog"`) filtered by a button named "All"
- **appModeDropdownClipping.spec.ts**: Replace 4-line inline `getByRole('dialog')` chain with `comfyPage.appMode.imagePickerPopover`

## Review Focus

Pure test infrastructure refactor — no production code changes. Each page object follows existing conventions.

Fixes #10723