### PR TITLE
test: type asset helper update payload

### DIFF
--- a/browser_tests/fixtures/helpers/AssetHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetHelper.ts
@@ -1,6 +1,10 @@
 import type { Page, Route } from '@playwright/test'
 
-import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
+import type {
+  Asset,
+  ListAssetsResponse,
+  UpdateAssetData
+} from '@comfyorg/ingest-types'
 import {
   generateModels,
   generateInputFiles,
@@ -235,13 +239,17 @@ export class AssetHelper {
     return route.fulfill({ status: 404, json: { error: 'Not found' } })
   }
 
-  private handleUpdateAsset(route: Route, path: string, body: unknown) {
+  private handleUpdateAsset(
+    route: Route,
+    path: string,
+    body: UpdateAssetData['body'] | null
+  ) {
     const id = path.split('/').pop()!
     const asset = this.store.get(id)
     if (asset) {
       const updated = {
         ...asset,
-        ...(body as Record<string, unknown>),
+        ...(body ?? {}),
         updated_at: new Date().toISOString()
       }
       this.store.set(id, updated)


### PR DESCRIPTION
What changed

- Typed the `PUT /assets/:id` mock body in `AssetHelper` as `AssetUpdatePayload` instead of treating it as an untyped record.

Why

- Keeps the mock aligned with the frontend update contract used by the asset service.
- Narrows the helper without changing behavior, so follow-up typing work can build on a smaller base.

Validation

- `pnpm typecheck`
- `pnpm typecheck:browser`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10751-test-type-asset-helper-update-payload-3336d73d365081fd8f1bc0c7c49c5ddb) by [Unito](https://www.unito.io)
