### PR TITLE
[backport core/1.41] fix: prevent saving active workflow content to inactive tab on close

### DIFF
--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -137,7 +137,7 @@ export const useWorkflowService = () => {
       }
     }
 
-    workflow.changeTracker?.checkState()
+    if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
 
     if (isSelfOverwrite) {
       await saveWorkflow(workflow)
@@ -160,7 +160,7 @@ export const useWorkflowService = () => {
     if (workflow.isTemporary) {
       await saveWorkflowAs(workflow)
     } else {
-      workflow.changeTracker?.checkState()
+      if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
 
       const isApp = workflow.initialMode === 'app'
       const expectedPath =


### PR DESCRIPTION
## Summary

Backport of #10745 to core/1.41.

- Guard `checkState()` in `saveWorkflow` and `saveWorkflowAs` to only run when the workflow being saved is active
- Prevents inactive tab content from being overwritten with active tab's graph data on close

## Linked Issues

- Fixes Comfy-Org/ComfyUI#13230
- Backport of #10745

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10752-backport-core-1-41-fix-prevent-saving-active-workflow-content-to-inactive-tab-on-clos-3336d73d36508189acd7d30c1d851d68) by [Unito](https://www.unito.io)
