### PR TITLE
fix: prevent duplicate zip downloads when multiple tabs are open

### DIFF
--- a/src/stores/assetExportStore.test.ts
+++ b/src/stores/assetExportStore.test.ts
@@ -1,0 +1,196 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AssetExportWsMessage } from '@/schemas/apiSchema'
+import { useAssetExportStore } from '@/stores/assetExportStore'
+
+type ExportEventHandler = (e: CustomEvent<AssetExportWsMessage>) => void
+
+const eventHandler = vi.hoisted(() => {
+  const state: { current: ExportEventHandler | null } = { current: null }
+  return state
+})
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: vi.fn((_event: string, handler: ExportEventHandler) => {
+      eventHandler.current = handler
+    }),
+    removeEventListener: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    getExportDownloadUrl: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/tasks/services/taskService', () => ({
+  taskService: {
+    getTask: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: vi.fn() })
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+function createExportMessage(
+  overrides: Partial<AssetExportWsMessage> = {}
+): AssetExportWsMessage {
+  return {
+    task_id: 'task-123',
+    assets_total: 5,
+    assets_attempted: 0,
+    assets_failed: 0,
+    bytes_total: 1000,
+    bytes_processed: 0,
+    progress: 0,
+    status: 'running',
+    ...overrides
+  }
+}
+
+function dispatch(data: AssetExportWsMessage) {
+  if (!eventHandler.current) {
+    throw new Error(
+      'Event handler not registered. Call useAssetExportStore() first.'
+    )
+  }
+  eventHandler.current(new CustomEvent('asset_export', { detail: data }))
+}
+
+describe('useAssetExportStore', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+    vi.resetAllMocks()
+    eventHandler.current = null
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('handleAssetExport', () => {
+    it('ignores messages for exports not tracked by this tab', () => {
+      const store = useAssetExportStore()
+
+      dispatch(
+        createExportMessage({
+          status: 'completed',
+          export_name: 'export.zip',
+          progress: 1
+        })
+      )
+
+      expect(store.exportList).toHaveLength(0)
+    })
+
+    it('updates tracked exports on progress messages', () => {
+      const store = useAssetExportStore()
+      store.trackExport('task-123')
+
+      dispatch(
+        createExportMessage({
+          assets_attempted: 3,
+          bytes_processed: 500,
+          progress: 0.5
+        })
+      )
+
+      expect(store.activeExports).toHaveLength(1)
+      expect(store.activeExports[0].progress).toBe(0.5)
+      expect(store.activeExports[0].assetsAttempted).toBe(3)
+    })
+
+    it('moves export to finished on completion', () => {
+      const store = useAssetExportStore()
+      store.trackExport('task-123')
+
+      dispatch(createExportMessage({ status: 'running' }))
+      expect(store.activeExports).toHaveLength(1)
+
+      dispatch(
+        createExportMessage({
+          status: 'completed',
+          export_name: 'export.zip',
+          progress: 1
+        })
+      )
+
+      expect(store.activeExports).toHaveLength(0)
+      expect(store.finishedExports).toHaveLength(1)
+      expect(store.finishedExports[0].status).toBe('completed')
+    })
+
+    it('ignores duplicate completed messages after download triggered', () => {
+      const store = useAssetExportStore()
+      store.trackExport('task-123')
+
+      dispatch(
+        createExportMessage({
+          status: 'completed',
+          export_name: 'export.zip',
+          progress: 1
+        })
+      )
+
+      const before = store.finishedExports.length
+      dispatch(
+        createExportMessage({
+          status: 'completed',
+          export_name: 'export.zip',
+          progress: 1
+        })
+      )
+
+      expect(store.finishedExports).toHaveLength(before)
+    })
+  })
+
+  describe('trackExport', () => {
+    it('creates an initial export entry', () => {
+      const store = useAssetExportStore()
+      store.trackExport('task-abc')
+
+      expect(store.hasActiveExports).toBe(true)
+      expect(store.activeExports[0].taskId).toBe('task-abc')
+      expect(store.activeExports[0].status).toBe('created')
+      expect(store.activeExports[0].downloadTriggered).toBe(false)
+    })
+
+    it('does not duplicate if already tracked', () => {
+      const store = useAssetExportStore()
+      store.trackExport('task-abc')
+      store.trackExport('task-abc')
+
+      expect(store.exportList).toHaveLength(1)
+    })
+  })
+
+  describe('clearFinishedExports', () => {
+    it('removes all finished exports', () => {
+      const store = useAssetExportStore()
+      store.trackExport('task-123')
+
+      dispatch(
+        createExportMessage({
+          status: 'completed',
+          export_name: 'export.zip',
+          progress: 1
+        })
+      )
+      expect(store.finishedExports).toHaveLength(1)
+
+      store.clearFinishedExports()
+      expect(store.finishedExports).toHaveLength(0)
+    })
+  })
+})

--- a/src/stores/assetExportStore.test.ts
+++ b/src/stores/assetExportStore.test.ts
@@ -2,6 +2,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { assetService } from '@/platform/assets/services/assetService'
 import type { AssetExportWsMessage } from '@/schemas/apiSchema'
 import { useAssetExportStore } from '@/stores/assetExportStore'
 
@@ -70,8 +71,11 @@ describe('useAssetExportStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.useFakeTimers({ shouldAdvanceTime: false })
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     eventHandler.current = null
+    vi.mocked(assetService.getExportDownloadUrl).mockResolvedValue({
+      url: 'https://example.com/export.zip'
+    })
   })
 
   afterEach(() => {
@@ -91,6 +95,7 @@ describe('useAssetExportStore', () => {
       )
 
       expect(store.exportList).toHaveLength(0)
+      expect(assetService.getExportDownloadUrl).not.toHaveBeenCalled()
     })
 
     it('updates tracked exports on progress messages', () => {
@@ -128,6 +133,7 @@ describe('useAssetExportStore', () => {
       expect(store.activeExports).toHaveLength(0)
       expect(store.finishedExports).toHaveLength(1)
       expect(store.finishedExports[0].status).toBe('completed')
+      expect(assetService.getExportDownloadUrl).toHaveBeenCalledTimes(1)
     })
 
     it('ignores duplicate completed messages after download triggered', () => {
@@ -152,6 +158,7 @@ describe('useAssetExportStore', () => {
       )
 
       expect(store.finishedExports).toHaveLength(before)
+      expect(assetService.getExportDownloadUrl).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/stores/assetExportStore.ts
+++ b/src/stores/assetExportStore.ts
@@ -97,9 +97,13 @@ export const useAssetExportStore = defineStore('assetExport', () => {
   function handleAssetExport(data: AssetExportWsMessage) {
     const existing = exports.value.get(data.task_id)
 
+    // Ignore exports not tracked by this tab — the server broadcasts
+    // asset_export to every open tab, causing duplicate downloads otherwise.
+    if (!existing) return
+
     if (
-      (existing?.status === 'completed' || existing?.status === 'failed') &&
-      existing?.downloadTriggered
+      (existing.status === 'completed' || existing.status === 'failed') &&
+      existing.downloadTriggered
     ) {
       return
     }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fixes a bug where batch downloading cloud assets triggers repeated downloads of the same zip file (one per open browser tab).

## Problem

The `assetExportStore`'s WebSocket handler (`handleAssetExport`) was creating new export entries for **any** `asset_export` WebSocket message, including in tabs that did not initiate the download. Since the ingest service broadcasts `asset_export` messages to all WebSocket sessions (tabs) for a user within a workspace, every open tab would:

1. Receive the `completed` status message
2. Create a new export entry (since `existing` was undefined in that tab)
3. Independently trigger a browser download via `triggerDownload()`

With N tabs open, the user would get N simultaneous downloads of the same zip file.

## Fix

Add an early return in `handleAssetExport` when the export was not explicitly tracked by the current tab via `trackExport()`. Since `trackExport()` is only called by the tab that initiated the batch download (in `downloadMultipleAssetsAsZip`), only that tab will process WebSocket updates and trigger the download.

## Testing

- Added `assetExportStore.test.ts` with 7 tests covering the fix and existing store behavior
- Key test: `ignores messages for exports not tracked by this tab` — verifies that untracked WebSocket messages don't create entries or trigger downloads

## Manual verification note

This bug requires multiple browser tabs with independent Pinia stores to reproduce. The number of duplicate downloads equals the number of open tabs. Not feasible to test with a single Playwright session.

## Related issue

[Bug: Batch download of multiple cloud assets triggers repeated downloads of the same zip file](https://www.notion.so/Bug-Batch-download-of-multiple-cloud-assets-triggers-repeated-downloads-of-the-same-zip-file-3336d73d365081f78d8ef6b65c9fd9b3)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10753-fix-prevent-duplicate-zip-downloads-when-multiple-tabs-are-open-3336d73d365081ec936cd4006430243b) by [Unito](https://www.unito.io)
