### PR TITLE
[backport cloud/1.42] fix: prevent saving active workflow content to inactive tab on close

### DIFF
--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -136,7 +136,7 @@ export const useWorkflowService = () => {
       }
     }
 
-    workflow.changeTracker?.checkState()
+    if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
 
     if (isSelfOverwrite) {
       await saveWorkflow(workflow)
@@ -161,7 +161,7 @@ export const useWorkflowService = () => {
     if (workflow.isTemporary) {
       await saveWorkflowAs(workflow)
     } else {
-      workflow.changeTracker?.checkState()
+      if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
 
       const isApp = workflow.initialMode === 'app'
       const expectedPath =


### PR DESCRIPTION
Backport of #10745 to cloud/1.42.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10756-backport-cloud-1-42-fix-prevent-saving-active-workflow-content-to-inactive-tab-on-clo-3336d73d365081b386c2c3f9f52920c8) by [Unito](https://www.unito.io)
