### PR TITLE
test: replace raw CSS selectors with TestIds in context menu spec

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -62,7 +62,10 @@ export const TestIds = {
     root: 'properties-panel'
   },
   node: {
-    titleInput: 'node-title-input'
+    titleInput: 'node-title-input',
+    pinIndicator: 'node-pin-indicator',
+    innerWrapper: 'node-inner-wrapper',
+    mainImage: 'main-image'
   },
   selectionToolbox: {
     colorPickerButton: 'color-picker-button',

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,5 +1,7 @@
 import type { Locator } from '@playwright/test'
 
+import { TestIds } from '../selectors'
+
 /** DOM-centric helper for a single Vue-rendered node on the canvas. */
 export class VueNodeFixture {
   constructor(private readonly locator: Locator) {}
@@ -18,6 +20,10 @@ export class VueNodeFixture {
 
   get body(): Locator {
     return this.locator.locator('[data-testid^="node-body-"]')
+  }
+
+  get pinIndicator(): Locator {
+    return this.locator.getByTestId(TestIds.node.pinIndicator)
   }
 
   get collapseButton(): Locator {

--- a/browser_tests/tests/vueNodes/interactions/node/contextMenu.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/contextMenu.spec.ts
@@ -5,9 +5,9 @@ import {
   comfyPageFixture as test
 } from '../../../../fixtures/ComfyPage'
 import type { ComfyPage } from '../../../../fixtures/ComfyPage'
+import { TestIds } from '../../../../fixtures/selectors'
 
 const BYPASS_CLASS = /before:bg-bypass\/60/
-const PIN_INDICATOR = '[data-testid="node-pin-indicator"]'
 
 async function clickExactMenuItem(comfyPage: ComfyPage, name: string) {
   await comfyPage.page.getByRole('menuitem', { name, exact: true }).click()
@@ -15,12 +15,10 @@ async function clickExactMenuItem(comfyPage: ComfyPage, name: string) {
 }
 
 async function openContextMenu(comfyPage: ComfyPage, nodeTitle: string) {
-  const header = comfyPage.vueNodes
-    .getNodeByTitle(nodeTitle)
-    .locator('.lg-node-header')
-  await header.click()
-  await header.click({ button: 'right' })
-  const menu = comfyPage.page.locator('.p-contextmenu')
+  const fixture = await comfyPage.vueNodes.getFixtureByTitle(nodeTitle)
+  await fixture.header.click()
+  await fixture.header.click({ button: 'right' })
+  const menu = comfyPage.contextMenu.primeVueMenu
   await menu.waitFor({ state: 'visible' })
   return menu
 }
@@ -35,17 +33,13 @@ async function openMultiNodeContextMenu(
   await comfyPage.nextFrame()
 
   for (const title of titles) {
-    const header = comfyPage.vueNodes
-      .getNodeByTitle(title)
-      .locator('.lg-node-header')
-    await header.click({ modifiers: ['ControlOrMeta'] })
+    const fixture = await comfyPage.vueNodes.getFixtureByTitle(title)
+    await fixture.header.click({ modifiers: ['ControlOrMeta'] })
   }
   await comfyPage.nextFrame()
 
-  const firstHeader = comfyPage.vueNodes
-    .getNodeByTitle(titles[0])
-    .locator('.lg-node-header')
-  const box = await firstHeader.boundingBox()
+  const firstFixture = await comfyPage.vueNodes.getFixtureByTitle(titles[0])
+  const box = await firstFixture.header.boundingBox()
   if (!box) throw new Error(`Header for "${titles[0]}" not found`)
   await comfyPage.page.mouse.click(
     box.x + box.width / 2,
@@ -53,16 +47,15 @@ async function openMultiNodeContextMenu(
     { button: 'right' }
   )
 
-  const menu = comfyPage.page.locator('.p-contextmenu')
+  const menu = comfyPage.contextMenu.primeVueMenu
   await menu.waitFor({ state: 'visible' })
   return menu
 }
 
 function getNodeWrapper(comfyPage: ComfyPage, nodeTitle: string): Locator {
-  return comfyPage.page
-    .locator('[data-node-id]')
-    .filter({ hasText: nodeTitle })
-    .getByTestId('node-inner-wrapper')
+  return comfyPage.vueNodes
+    .getNodeByTitle(nodeTitle)
+    .getByTestId(TestIds.node.innerWrapper)
 }
 
 async function getNodeRef(comfyPage: ComfyPage, nodeTitle: string) {
@@ -82,9 +75,7 @@ test.describe('Vue Node Context Menu', () => {
       await openContextMenu(comfyPage, 'KSampler')
       await clickExactMenuItem(comfyPage, 'Rename')
 
-      const titleInput = comfyPage.page.locator(
-        '.node-title-editor input[type="text"]'
-      )
+      const titleInput = comfyPage.page.getByTestId(TestIds.node.titleInput)
       await titleInput.waitFor({ state: 'visible' })
       await titleInput.fill('My Renamed Sampler')
       await titleInput.press('Enter')
@@ -135,16 +126,12 @@ test.describe('Vue Node Context Menu', () => {
       await openContextMenu(comfyPage, nodeTitle)
       await clickExactMenuItem(comfyPage, 'Pin')
 
-      const pinIndicator = comfyPage.vueNodes
-        .getNodeByTitle(nodeTitle)
-        .locator(PIN_INDICATOR)
-      await expect(pinIndicator).toBeVisible()
+      const fixture = await comfyPage.vueNodes.getFixtureByTitle(nodeTitle)
+      await expect(fixture.pinIndicator).toBeVisible()
       expect(await nodeRef.isPinned()).toBe(true)
 
       // Verify drag blocked
-      const header = comfyPage.vueNodes
-        .getNodeByTitle(nodeTitle)
-        .locator('.lg-node-header')
+      const header = fixture.header
       const posBeforeDrag = await header.boundingBox()
       if (!posBeforeDrag) throw new Error('Header not found')
       await comfyPage.canvasOps.dragAndDrop(
@@ -158,7 +145,7 @@ test.describe('Vue Node Context Menu', () => {
       await openContextMenu(comfyPage, nodeTitle)
       await clickExactMenuItem(comfyPage, 'Unpin')
 
-      await expect(pinIndicator).not.toBeVisible()
+      await expect(fixture.pinIndicator).not.toBeVisible()
       expect(await nodeRef.isPinned()).toBe(false)
     })
 
@@ -244,7 +231,9 @@ test.describe('Vue Node Context Menu', () => {
       comfyPage
     }) => {
       // Capture the original image src from the node's preview
-      const imagePreview = comfyPage.page.locator('.image-preview img')
+      const imagePreview = comfyPage.vueNodes
+        .getNodeByTitle('Load Image')
+        .getByTestId(TestIds.node.mainImage)
       const originalSrc = await imagePreview.getAttribute('src')
 
       // Write a test image into the browser clipboard
@@ -347,8 +336,7 @@ test.describe('Vue Node Context Menu', () => {
       await comfyPage.nodeOps.fillPromptDialog('TestBlueprint')
 
       // Open node library sidebar and search for the blueprint
-      await comfyPage.page.getByRole('button', { name: 'Node Library' }).click()
-      await comfyPage.nextFrame()
+      await comfyPage.menu.nodeLibraryTab.tabButton.click()
       const searchBox = comfyPage.page.getByRole('combobox', {
         name: 'Search'
       })
@@ -414,20 +402,16 @@ test.describe('Vue Node Context Menu', () => {
       await clickExactMenuItem(comfyPage, 'Pin')
 
       for (const title of nodeTitles) {
-        const pinIndicator = comfyPage.vueNodes
-          .getNodeByTitle(title)
-          .locator(PIN_INDICATOR)
-        await expect(pinIndicator).toBeVisible()
+        const fixture = await comfyPage.vueNodes.getFixtureByTitle(title)
+        await expect(fixture.pinIndicator).toBeVisible()
       }
 
       await openMultiNodeContextMenu(comfyPage, nodeTitles)
       await clickExactMenuItem(comfyPage, 'Unpin')
 
       for (const title of nodeTitles) {
-        const pinIndicator = comfyPage.vueNodes
-          .getNodeByTitle(title)
-          .locator(PIN_INDICATOR)
-        await expect(pinIndicator).not.toBeVisible()
+        const fixture = await comfyPage.vueNodes.getFixtureByTitle(title)
+        await expect(fixture.pinIndicator).not.toBeVisible()
       }
     })
 

--- a/src/components/graph/TitleEditor.vue
+++ b/src/components/graph/TitleEditor.vue
@@ -7,6 +7,7 @@
     <EditableText
       :is-editing="showInput"
       :model-value="editedTitle"
+      :input-attrs="{ 'data-testid': 'node-title-input' }"
       @edit="onEdit"
     />
   </div>


### PR DESCRIPTION
## Summary
- Replace raw CSS selectors (`.lg-node-header`, `.p-contextmenu`, `.node-title-editor input`, `.image-preview img`) with centralized `TestIds` constants and existing fixtures in the context menu E2E spec
- Add `data-testid="title-editor-input"` to TitleEditor overlay for stable selector targeting
- Use `NodeLibrarySidebarTab` fixture for node library sidebar interaction

## Changes
- `browser_tests/fixtures/selectors.ts`: add `pinIndicator`, `innerWrapper`, `titleEditorInput`, `mainImage` to `TestIds.node`
- `browser_tests/fixtures/utils/vueNodeFixtures.ts`: add `pinIndicator` getter
- `src/components/graph/TitleEditor.vue`: add `data-testid` via `input-attrs`
- `browser_tests/.../contextMenu.spec.ts`: replace all raw selectors with TestIds/fixtures

## Test plan
- [x] All 23 context menu E2E tests pass locally
- [x] Typecheck passes
- [x] Lint passes

Fixes #10750
Fixes #10749

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10760-test-replace-raw-CSS-selectors-with-TestIds-in-context-menu-spec-3336d73d3650818790c0e32e0b6f1e98) by [Unito](https://www.unito.io)
