### PR TITLE
fix(test): fix bulk context menu test using correct Playwright patterns

### DIFF
--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -527,20 +527,26 @@ test.describe('Assets sidebar - context menu', () => {
     // Dismiss any toasts that appeared after asset loading
     await tab.dismissToasts()
 
-    // Multi-select: click first, then Ctrl/Cmd+click second
+    // Multi-select: use keyboard.down/up so useKeyModifier('Control') detects
+    // the modifier — click({ modifiers }) only sets the mouse event flag and
+    // does not fire a keydown event that VueUse tracks.
     await cards.first().click()
-    await cards.nth(1).click({ modifiers: ['ControlOrMeta'] })
+    await comfyPage.page.keyboard.down('Control')
+    await cards.nth(1).click()
+    await comfyPage.page.keyboard.up('Control')
 
     // Verify multi-selection took effect and footer is stable before right-clicking
     await expect(tab.selectedCards).toHaveCount(2, { timeout: 3000 })
     await expect(tab.selectionFooter).toBeVisible({ timeout: 3000 })
 
-    // Right-click on a selected card (retry to let grid layout settle)
+    // Use dispatchEvent instead of click({ button: 'right' }) to avoid any
+    // overlay intercepting the event, and assert directly without toPass.
     const contextMenu = comfyPage.page.locator('.p-contextmenu')
-    await expect(async () => {
-      await cards.first().click({ button: 'right' })
-      await expect(contextMenu).toBeVisible()
-    }).toPass({ intervals: [300], timeout: 5000 })
+    await cards.first().dispatchEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true
+    })
+    await expect(contextMenu).toBeVisible()
 
     // Bulk menu should show bulk download action
     await expect(tab.contextMenuItem('Download all')).toBeVisible()

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -544,7 +544,8 @@ test.describe('Assets sidebar - context menu', () => {
     const contextMenu = comfyPage.page.locator('.p-contextmenu')
     await cards.first().dispatchEvent('contextmenu', {
       bubbles: true,
-      cancelable: true
+      cancelable: true,
+      button: 2
     })
     await expect(contextMenu).toBeVisible()
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fixes the `Bulk context menu shows when multiple assets selected` test that is failing on main.

**Root cause — two issues:**

1. `click({ modifiers: ['ControlOrMeta'] })` does not fire `keydown` events that VueUse's `useKeyModifier('Control')` tracks (used in `useAssetSelection.ts`). Multi-select silently fails because the composable never sees the Control key pressed. Fix: use `keyboard.down('Control')` / `keyboard.up('Control')` around the click.

2. `click({ button: 'right' })` can be intercepted by canvas overlays (documented gotcha in `browser_tests/AGENTS.md`). Fix: use `dispatchEvent('contextmenu', { bubbles: true, cancelable: true })` which bypasses overlay interception.

Also removed the `toPass()` retry wrapper since the root causes are now addressed directly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10762-fix-test-fix-bulk-context-menu-test-using-correct-Playwright-patterns-3346d73d3650811c843ee4a39d3ab305) by [Unito](https://www.unito.io)
