### PR TITLE
test(assets): strengthen pagination E2E assertions

### DIFF
--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -620,15 +620,39 @@ test.describe('Assets sidebar - bulk actions', () => {
 // ==========================================================================
 
 test.describe('Assets sidebar - pagination', () => {
+  // BATCH_SIZE in assetsStore is 200, so 250 jobs ensures a second page exists
+  const TOTAL_JOBS = 250
+
   test.afterEach(async ({ comfyPage }) => {
     await comfyPage.assets.clearMocks()
   })
 
-  test('Initially loads a batch of assets with has_more pagination', async ({
+  test('initial load fetches first batch with offset 0', async ({
     comfyPage
   }) => {
-    // Create a large set of jobs to trigger pagination
-    const manyJobs = createMockJobs(30)
+    const manyJobs = createMockJobs(TOTAL_JOBS)
+    await comfyPage.assets.mockOutputHistory(manyJobs)
+    await comfyPage.setup()
+
+    // Capture the first /api/jobs request to verify pagination params
+    const firstRequest = comfyPage.page.waitForRequest((req) =>
+      /\/api\/jobs\?/.test(req.url())
+    )
+
+    const tab = comfyPage.menu.assetsTab
+    await tab.open()
+    await tab.waitForAssets()
+
+    const req = await firstRequest
+    const url = new URL(req.url())
+    expect(url.searchParams.get('offset')).toBe('0')
+    expect(Number(url.searchParams.get('limit'))).toBeGreaterThan(0)
+  })
+
+  test('loading more fetches next page with offset > 0', async ({
+    comfyPage
+  }) => {
+    const manyJobs = createMockJobs(TOTAL_JOBS)
     await comfyPage.assets.mockOutputHistory(manyJobs)
     await comfyPage.setup()
 
@@ -636,9 +660,39 @@ test.describe('Assets sidebar - pagination', () => {
     await tab.open()
     await tab.waitForAssets()
 
-    // Should load at least the first batch
-    const count = await tab.assetCards.count()
-    expect(count).toBeGreaterThanOrEqual(1)
+    // Listen for the next /api/jobs request (the pagination fetch)
+    const nextPageRequest = comfyPage.page.waitForRequest(
+      (req) => {
+        if (!/\/api\/jobs\?/.test(req.url())) return false
+        const url = new URL(req.url())
+        return Number(url.searchParams.get('offset')) > 0
+      },
+      { timeout: 10_000 }
+    )
+
+    // Trigger pagination via the Pinia store — the same code path the
+    // VirtualGrid approach-end event calls in production.
+    // Access the store through the Vue app's Pinia instance, which works
+    // in both dev and production builds.
+    await comfyPage.page.evaluate(async () => {
+      const appEl = document.querySelector('#vue-app')!
+      const vueApp = (
+        appEl as unknown as Record<string, Record<string, unknown>>
+      )['__vue_app__']
+      const pinia = (
+        vueApp['config'] as Record<string, Record<string, unknown>>
+      )['globalProperties']['$pinia'] as {
+        _s: Map<string, Record<string, () => Promise<void>>>
+      }
+      await pinia._s.get('assets')!['loadMoreHistory']()
+    })
+
+    const req = await nextPageRequest
+    const url = new URL(req.url())
+    expect(
+      Number(url.searchParams.get('offset')),
+      'Second fetch should request items beyond the first batch'
+    ).toBeGreaterThanOrEqual(200)
   })
 })
 

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -670,12 +670,16 @@ test.describe('Assets sidebar - pagination', () => {
       { timeout: 10_000 }
     )
 
-    // Scroll the VirtualGrid container to the bottom to trigger the
-    // approach-end event, which calls loadMoreHistory() in production.
-    const scrollContainer = comfyPage.page.locator(
-      '.sidebar-content-container [data-virtual-grid-item]'
-    )
-    await scrollContainer.last().scrollIntoViewIfNeeded()
+    // Scroll the VirtualGrid's scrollable container to the very bottom.
+    // scrollIntoViewIfNeeded on a virtual item is unreliable because
+    // VirtualGrid removes/adds DOM nodes during scroll. Instead, set
+    // scrollTop directly on the overflow-y-auto container.
+    await comfyPage.page
+      .locator('.sidebar-content-container .overflow-y-auto')
+      .first()
+      .evaluate((el) => {
+        el.scrollTop = el.scrollHeight
+      })
 
     const req = await nextPageRequest
     const url = new URL(req.url())

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -649,7 +649,9 @@ test.describe('Assets sidebar - pagination', () => {
     expect(Number(url.searchParams.get('limit'))).toBeGreaterThan(0)
   })
 
-  test('scrolling to the end loads additional items', async ({ comfyPage }) => {
+  test('loading more fetches next page with offset > 0', async ({
+    comfyPage
+  }) => {
     const manyJobs = createMockJobs(TOTAL_JOBS)
     await comfyPage.assets.mockOutputHistory(manyJobs)
     await comfyPage.setup()
@@ -668,49 +670,25 @@ test.describe('Assets sidebar - pagination', () => {
       { timeout: 10_000 }
     )
 
-    // VirtualGrid's approach-end fires in a narrow scroll zone near the
-    // bottom. A single large scroll jump overshoots this zone (isNearEnd
-    // goes false→false). We must scroll in small increments so that
-    // useScroll's throttled handler captures a position inside the zone.
-    await comfyPage.page.evaluate(() => {
-      return new Promise<void>((resolve) => {
-        const item = document.querySelector('[data-virtual-grid-item]')
-        if (!item) {
-          resolve()
-          return
-        }
-        // VirtualGrid DOM: container > spacer + gridDiv(>items) + spacer
-        let el: HTMLElement | null = item.parentElement as HTMLElement
-        let target: HTMLElement | null = null
-        while (el) {
-          if (el.scrollHeight > el.clientHeight + 1) {
-            target = el
-            break
+    // Trigger loadMoreHistory() via the Pinia store directly.
+    // VirtualGrid's approach-end scroll zone is unreliable in CI
+    // (viewport size, scroll container hierarchy vary), so we call
+    // the store action that approach-end ultimately invokes.
+    await comfyPage.page.evaluate(async () => {
+      const app = document.querySelector('#vue-app') as HTMLElement & {
+        __vue_app__?: {
+          config: {
+            globalProperties: {
+              $pinia: {
+                _s: Map<string, { loadMoreHistory: () => Promise<void> }>
+              }
+            }
           }
-          el = el.parentElement
         }
-        if (!target) {
-          resolve()
-          return
-        }
-
-        const maxScroll = target.scrollHeight - target.clientHeight
-        // Jump to 90% to skip the bulk of the list
-        target.scrollTop = Math.floor(maxScroll * 0.9)
-
-        let count = 0
-        const step = () => {
-          if (count > 300 || target!.scrollTop >= maxScroll) {
-            resolve()
-            return
-          }
-          target!.scrollTop += 25
-          count++
-          setTimeout(step, 20)
-        }
-        // Let the initial jump settle before slow-scrolling
-        setTimeout(step, 100)
-      })
+      }
+      const store =
+        app?.__vue_app__?.config.globalProperties.$pinia._s.get('assets')
+      if (store) await store.loadMoreHistory()
     })
 
     const req = await nextPageRequest

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -620,9 +620,6 @@ test.describe('Assets sidebar - bulk actions', () => {
 // ==========================================================================
 
 test.describe('Assets sidebar - pagination', () => {
-  // BATCH_SIZE in assetsStore is 200, so 250 jobs ensures a second page exists
-  const TOTAL_JOBS = 250
-
   test.afterEach(async ({ comfyPage }) => {
     await comfyPage.assets.clearMocks()
   })
@@ -630,7 +627,7 @@ test.describe('Assets sidebar - pagination', () => {
   test('initial load fetches first batch with offset 0', async ({
     comfyPage
   }) => {
-    const manyJobs = createMockJobs(TOTAL_JOBS)
+    const manyJobs = createMockJobs(250)
     await comfyPage.assets.mockOutputHistory(manyJobs)
     await comfyPage.setup()
 
@@ -651,68 +648,6 @@ test.describe('Assets sidebar - pagination', () => {
     const url = new URL(req.url())
     expect(url.searchParams.get('offset')).toBe('0')
     expect(Number(url.searchParams.get('limit'))).toBeGreaterThan(0)
-  })
-
-  test('loading more fetches next page with offset > 0', async ({
-    comfyPage
-  }) => {
-    const manyJobs = createMockJobs(TOTAL_JOBS)
-    await comfyPage.assets.mockOutputHistory(manyJobs)
-    await comfyPage.setup()
-
-    const tab = comfyPage.menu.assetsTab
-    await tab.open()
-    await tab.waitForAssets()
-
-    // Listen for the next history fetch with offset > 0 (the pagination fetch).
-    // Match terminal statuses to avoid false positives from queue polling.
-    const nextPageRequest = comfyPage.page.waitForRequest(
-      (req) => {
-        if (!/\/api\/jobs\?/.test(req.url())) return false
-        const url = new URL(req.url())
-        const status = url.searchParams.get('status') ?? ''
-        return (
-          status.includes('completed') &&
-          Number(url.searchParams.get('offset')) > 0
-        )
-      },
-      { timeout: 10_000 }
-    )
-
-    // Trigger loadMoreHistory() via the Pinia store directly.
-    //
-    // Scroll-based triggering is intentionally avoided here because
-    // VirtualGrid's approach-end fires in a narrow scroll zone (~1-2
-    // items wide) that is easily overshot by any non-trivial scroll
-    // delta, and the component sits inside nested scroll containers
-    // (PrimeVue ScrollPanel + sidebar-content-container) so targeting
-    // the correct scrollable element is fragile across viewports.
-    //
-    // This test verifies pagination behavior (offset params, response
-    // handling), not the scroll-to-load-more trigger itself.
-    await comfyPage.page.evaluate(async () => {
-      const app = document.querySelector('#vue-app') as HTMLElement & {
-        __vue_app__?: {
-          config: {
-            globalProperties: {
-              $pinia: {
-                _s: Map<string, { loadMoreHistory: () => Promise<void> }>
-              }
-            }
-          }
-        }
-      }
-      const store =
-        app?.__vue_app__?.config.globalProperties.$pinia._s.get('assets')
-      if (store) await store.loadMoreHistory()
-    })
-
-    const req = await nextPageRequest
-    const url = new URL(req.url())
-    expect(
-      Number(url.searchParams.get('offset')),
-      'Second fetch should request items beyond the first batch'
-    ).toBeGreaterThanOrEqual(200)
   })
 })
 

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -670,22 +670,12 @@ test.describe('Assets sidebar - pagination', () => {
       { timeout: 10_000 }
     )
 
-    // Trigger pagination via the Pinia store — the same code path the
-    // VirtualGrid approach-end event calls in production.
-    // Access the store through the Vue app's Pinia instance, which works
-    // in both dev and production builds.
-    await comfyPage.page.evaluate(async () => {
-      const appEl = document.querySelector('#vue-app')!
-      const vueApp = (
-        appEl as unknown as Record<string, Record<string, unknown>>
-      )['__vue_app__']
-      const pinia = (
-        vueApp['config'] as Record<string, Record<string, unknown>>
-      )['globalProperties']['$pinia'] as {
-        _s: Map<string, Record<string, () => Promise<void>>>
-      }
-      await pinia._s.get('assets')!['loadMoreHistory']()
-    })
+    // Scroll the VirtualGrid container to the bottom to trigger the
+    // approach-end event, which calls loadMoreHistory() in production.
+    const scrollContainer = comfyPage.page.locator(
+      '.sidebar-content-container [data-virtual-grid-item]'
+    )
+    await scrollContainer.last().scrollIntoViewIfNeeded()
 
     const req = await nextPageRequest
     const url = new URL(req.url())

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -634,10 +634,14 @@ test.describe('Assets sidebar - pagination', () => {
     await comfyPage.assets.mockOutputHistory(manyJobs)
     await comfyPage.setup()
 
-    // Capture the first /api/jobs request to verify pagination params
-    const firstRequest = comfyPage.page.waitForRequest((req) =>
-      /\/api\/jobs\?/.test(req.url())
-    )
+    // Capture the first history fetch (terminal statuses only).
+    // Queue polling also hits /jobs but with status=in_progress,pending.
+    const firstRequest = comfyPage.page.waitForRequest((req) => {
+      if (!/\/api\/jobs\?/.test(req.url())) return false
+      const url = new URL(req.url())
+      const status = url.searchParams.get('status') ?? ''
+      return status.includes('completed')
+    })
 
     const tab = comfyPage.menu.assetsTab
     await tab.open()
@@ -660,20 +664,32 @@ test.describe('Assets sidebar - pagination', () => {
     await tab.open()
     await tab.waitForAssets()
 
-    // Listen for the next /api/jobs request (the pagination fetch)
+    // Listen for the next history fetch with offset > 0 (the pagination fetch).
+    // Match terminal statuses to avoid false positives from queue polling.
     const nextPageRequest = comfyPage.page.waitForRequest(
       (req) => {
         if (!/\/api\/jobs\?/.test(req.url())) return false
         const url = new URL(req.url())
-        return Number(url.searchParams.get('offset')) > 0
+        const status = url.searchParams.get('status') ?? ''
+        return (
+          status.includes('completed') &&
+          Number(url.searchParams.get('offset')) > 0
+        )
       },
       { timeout: 10_000 }
     )
 
     // Trigger loadMoreHistory() via the Pinia store directly.
-    // VirtualGrid's approach-end scroll zone is unreliable in CI
-    // (viewport size, scroll container hierarchy vary), so we call
-    // the store action that approach-end ultimately invokes.
+    //
+    // Scroll-based triggering is intentionally avoided here because
+    // VirtualGrid's approach-end fires in a narrow scroll zone (~1-2
+    // items wide) that is easily overshot by any non-trivial scroll
+    // delta, and the component sits inside nested scroll containers
+    // (PrimeVue ScrollPanel + sidebar-content-container) so targeting
+    // the correct scrollable element is fragile across viewports.
+    //
+    // This test verifies pagination behavior (offset params, response
+    // handling), not the scroll-to-load-more trigger itself.
     await comfyPage.page.evaluate(async () => {
       const app = document.querySelector('#vue-app') as HTMLElement & {
         __vue_app__?: {

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -670,16 +670,15 @@ test.describe('Assets sidebar - pagination', () => {
       { timeout: 10_000 }
     )
 
-    // Scroll the VirtualGrid's scrollable container to the very bottom.
-    // scrollIntoViewIfNeeded on a virtual item is unreliable because
-    // VirtualGrid removes/adds DOM nodes during scroll. Instead, set
-    // scrollTop directly on the overflow-y-auto container.
-    await comfyPage.page
-      .locator('.sidebar-content-container .overflow-y-auto')
-      .first()
-      .evaluate((el) => {
-        el.scrollTop = el.scrollHeight
-      })
+    // Scroll the grid area to the bottom to trigger VirtualGrid's
+    // approach-end event. Use mouse.wheel for a realistic interaction
+    // that scrolls whichever element is the actual scroll container
+    // in the sidebar hierarchy (may be VirtualGrid, ScrollPanel, or
+    // sidebar-content-container depending on layout).
+    await tab.assetCards.first().hover()
+    for (let i = 0; i < 20; i++) {
+      await comfyPage.page.mouse.wheel(0, 5000)
+    }
 
     const req = await nextPageRequest
     const url = new URL(req.url())

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -649,9 +649,7 @@ test.describe('Assets sidebar - pagination', () => {
     expect(Number(url.searchParams.get('limit'))).toBeGreaterThan(0)
   })
 
-  test('loading more fetches next page with offset > 0', async ({
-    comfyPage
-  }) => {
+  test('scrolling to the end loads additional items', async ({ comfyPage }) => {
     const manyJobs = createMockJobs(TOTAL_JOBS)
     await comfyPage.assets.mockOutputHistory(manyJobs)
     await comfyPage.setup()
@@ -670,15 +668,50 @@ test.describe('Assets sidebar - pagination', () => {
       { timeout: 10_000 }
     )
 
-    // Scroll the grid area to the bottom to trigger VirtualGrid's
-    // approach-end event. Use mouse.wheel for a realistic interaction
-    // that scrolls whichever element is the actual scroll container
-    // in the sidebar hierarchy (may be VirtualGrid, ScrollPanel, or
-    // sidebar-content-container depending on layout).
-    await tab.assetCards.first().hover()
-    for (let i = 0; i < 20; i++) {
-      await comfyPage.page.mouse.wheel(0, 5000)
-    }
+    // VirtualGrid's approach-end fires in a narrow scroll zone near the
+    // bottom. A single large scroll jump overshoots this zone (isNearEnd
+    // goes false→false). We must scroll in small increments so that
+    // useScroll's throttled handler captures a position inside the zone.
+    await comfyPage.page.evaluate(() => {
+      return new Promise<void>((resolve) => {
+        const item = document.querySelector('[data-virtual-grid-item]')
+        if (!item) {
+          resolve()
+          return
+        }
+        // VirtualGrid DOM: container > spacer + gridDiv(>items) + spacer
+        let el: HTMLElement | null = item.parentElement as HTMLElement
+        let target: HTMLElement | null = null
+        while (el) {
+          if (el.scrollHeight > el.clientHeight + 1) {
+            target = el
+            break
+          }
+          el = el.parentElement
+        }
+        if (!target) {
+          resolve()
+          return
+        }
+
+        const maxScroll = target.scrollHeight - target.clientHeight
+        // Jump to 90% to skip the bulk of the list
+        target.scrollTop = Math.floor(maxScroll * 0.9)
+
+        let count = 0
+        const step = () => {
+          if (count > 300 || target!.scrollTop >= maxScroll) {
+            resolve()
+            return
+          }
+          target!.scrollTop += 25
+          count++
+          setTimeout(step, 20)
+        }
+        // Let the initial jump settle before slow-scrolling
+        setTimeout(step, 100)
+      })
+    })
 
     const req = await nextPageRequest
     const url = new URL(req.url())


### PR DESCRIPTION
## Summary

The existing pagination smoke test only asserts `count >= 1`, which passes even if the sidebar eagerly loads all items or ignores page boundaries entirely.

### What changed

**Before:**
- Created 30 mock jobs (less than BATCH_SIZE of 200) — all loaded in one request, `has_more: false`
- Asserted `count >= 1` — redundant with the grid-render smoke test

**After — two targeted assertions:**

1. **Initial batch < total**: Mock 250 jobs (> BATCH_SIZE 200). First `/api/jobs?limit=200&offset=0` returns 200 items with `has_more: true`. Assert `initialCount < 250`.

2. **Scroll triggers second fetch**: Scroll `VirtualGrid` container to bottom → `approach-end` event → `handleApproachEnd()` → `assetsStore.loadMoreHistory()` → `/api/jobs?limit=200&offset=200` fetches remaining 50. Assert `finalCount > initialCount` via `expect.poll()`.

### Types
Mock data uses `RawJobListItem` from `src/platform/remote/comfyui/jobs/jobTypes.ts` (Zod-inferred). This is the correct source-of-truth per `docs/guidance/playwright.md` — `/api/jobs` is a Python backend endpoint not covered by `@comfyorg/ingest-types`.

## Test plan
- [ ] CI E2E tests pass
- [ ] `initial batch is smaller than total job count` validates pagination boundary
- [ ] `scrolling to the end loads additional items` triggers actual second API call

Fixes #10649