### PR TITLE
ci: pass CODECOV_TOKEN and add codecov.yml for PR comments

### DIFF
--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -31,4 +31,5 @@ jobs:
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:
           files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 comment:
-  layout: "header, diff, flags, files"
+  layout: 'header, diff, flags, files'
   behavior: default
   require_changes: false
   require_base: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true


### PR DESCRIPTION
## What

Follow-up to #10575. Pass `CODECOV_TOKEN` secret to codecov upload action and add `codecov.yml` config so Codecov posts coverage diff comments on PRs.

## Changes

- `ci-tests-unit.yaml`: add `token: ${{ secrets.CODECOV_TOKEN }}`
- `codecov.yml`: configure PR comment layout (header, diff, flags, files)

## Manual Step Required

An admin needs to add the `CODECOV_TOKEN` secret to the repo:

1. Go to [codecov.io](https://app.codecov.io) → sign in → find `Comfy-Org/ComfyUI_frontend` → Settings → General → copy the Repository Upload Token
2. Go to [repo secrets](https://github.com/Comfy-Org/ComfyUI_frontend/settings/secrets/actions) → New repository secret → name: `CODECOV_TOKEN`, value: the token

## Testing

Config-only change. Once the secret is added, the next PR will get a Codecov coverage comment.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10774-ci-pass-CODECOV_TOKEN-and-add-codecov-yml-for-PR-comments-3346d73d36508169bac5e61eecc94063) by [Unito](https://www.unito.io)
