### PR TITLE
fix: resolve no-unused-expressions lint violations on core/1.42

### DIFF
--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -165,8 +165,7 @@ export function useMoreOptionsMenu() {
 
   const menuOptions = computed((): MenuOption[] => {
     // Reference selection flags to ensure re-computation when they change
-
-    optionsVersion.value
+    void optionsVersion.value
     const states = computeSelectionFlags()
 
     // Detect single group selection context (and no nodes explicitly selected)

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -264,7 +264,7 @@ describe('useJobList', () => {
     const { jobItems } = initComposable()
     await flush()
 
-    jobItems.value
+    void jobItems.value
     expect(buildJobDisplay).toHaveBeenCalledWith(
       expect.anything(),
       'pending',
@@ -275,7 +275,7 @@ describe('useJobList', () => {
     await vi.advanceTimersByTimeAsync(3000)
     await flush()
 
-    jobItems.value
+    void jobItems.value
     expect(buildJobDisplay).toHaveBeenCalledWith(
       expect.anything(),
       'pending',
@@ -292,7 +292,7 @@ describe('useJobList', () => {
 
     const { jobItems } = initComposable()
     await flush()
-    jobItems.value
+    void jobItems.value
 
     queueStoreMock.pendingTasks = []
     await flush()
@@ -303,7 +303,7 @@ describe('useJobList', () => {
       createTask({ jobId: taskId, job: { priority: 2 }, mockState: 'pending' })
     ]
     await flush()
-    jobItems.value
+    void jobItems.value
     expect(buildJobDisplay).toHaveBeenCalledWith(
       expect.anything(),
       'pending',

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -470,7 +470,8 @@ function handleSubscribeWorkspace() {
 }
 
 function handleUpgrade() {
-  isFreeTierPlan.value ? showPricingTable() : showSubscriptionDialog()
+  if (isFreeTierPlan.value) showPricingTable()
+  else showSubscriptionDialog()
 }
 
 function handleUpgradeToAddCredits() {


### PR DESCRIPTION
## Summary

Cherry-picks the 3-file lint fixes from #10114 (b696b2f2e) to unblock backport PRs on `core/1.42`.

PR #10114 upgraded `eslint-plugin-oxlint` on main, which changed rule ownership and fixed `no-unused-expressions` violations. Those fixes were never backported to 1.42 branches, causing all backport PRs (e.g. #10732) to fail CI: Lint Format.

### Files fixed
- `src/composables/graph/useMoreOptionsMenu.ts` — add `void` prefix
- `src/composables/queue/useJobList.test.ts` — add `void` prefix (4 sites)
- `src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue` — convert ternary to if/else

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10776-fix-resolve-no-unused-expressions-lint-violations-on-core-1-42-3346d73d3650813b93aaed6824436e4b) by [Unito](https://www.unito.io)
