### PR TITLE
test: add E2E tests for settings dialog

### DIFF
--- a/browser_tests/tests/dialogs/settingsDialog.spec.ts
+++ b/browser_tests/tests/dialogs/settingsDialog.spec.ts
@@ -42,4 +42,100 @@ test.describe('Settings dialog', { tag: '@ui' }, () => {
     await dialog.close()
     await expect(dialog.root).not.toBeVisible()
   })
+
+  test('Escape key closes dialog', async ({ comfyPage }) => {
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+    await expect(dialog.root).toBeVisible()
+
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(dialog.root).not.toBeVisible()
+  })
+
+  test('Search filters settings list', async ({ comfyPage }) => {
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+
+    const settingItems = dialog.root.locator('[data-setting-id]')
+    const countBeforeSearch = await settingItems.count()
+
+    await dialog.searchBox.fill('Validate workflows')
+    await expect
+      .poll(() => settingItems.count())
+      .toBeLessThan(countBeforeSearch)
+  })
+
+  test('Search can be cleared to restore all settings', async ({
+    comfyPage
+  }) => {
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+
+    const settingItems = dialog.root.locator('[data-setting-id]')
+    const countBeforeSearch = await settingItems.count()
+
+    await dialog.searchBox.fill('Validate workflows')
+    await expect
+      .poll(() => settingItems.count())
+      .toBeLessThan(countBeforeSearch)
+
+    await dialog.searchBox.clear()
+    await expect.poll(() => settingItems.count()).toBe(countBeforeSearch)
+  })
+
+  test('Category navigation changes content area', async ({ comfyPage }) => {
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+
+    const firstCategory = dialog.categories.first()
+    const firstCategoryName = await firstCategory.textContent()
+    await firstCategory.click()
+    const firstContent = await dialog.contentArea.textContent()
+
+    // Find a different category to click
+    const categoryCount = await dialog.categories.count()
+    for (let i = 1; i < categoryCount; i++) {
+      const cat = dialog.categories.nth(i)
+      const catName = await cat.textContent()
+      if (catName !== firstCategoryName) {
+        await cat.click()
+        await expect
+          .poll(() => dialog.contentArea.textContent())
+          .not.toBe(firstContent)
+        return
+      }
+    }
+  })
+
+  test('Dropdown setting can be changed and persists', async ({
+    comfyPage
+  }) => {
+    const settingId = 'Comfy.UseNewMenu'
+    const initialValue = await comfyPage.settings.getSetting<string>(settingId)
+
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+
+    await dialog.searchBox.fill('Use new menu')
+    const settingRow = dialog.root.locator(`[data-setting-id="${settingId}"]`)
+    await expect(settingRow).toBeVisible()
+
+    // Click the PrimeVue Select to open the dropdown
+    await settingRow.locator('.p-select').click()
+    const overlay = comfyPage.page.locator('.p-select-overlay')
+    await expect(overlay).toBeVisible()
+
+    // Pick the option that is not the current value
+    const targetValue = initialValue === 'Top' ? 'Disabled' : 'Top'
+    await overlay
+      .locator(`.p-select-option-label:text-is("${targetValue}")`)
+      .click()
+
+    await expect
+      .poll(() => comfyPage.settings.getSetting<string>(settingId))
+      .toBe(targetValue)
+
+    // Restore original value
+    await comfyPage.settings.setSetting(settingId, initialValue)
+  })
 })

--- a/browser_tests/tests/dialogs/settingsDialog.spec.ts
+++ b/browser_tests/tests/dialogs/settingsDialog.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+
+test.describe('Settings dialog', { tag: '@ui' }, () => {
+  test('About panel shows version badges', async ({ comfyPage }) => {
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+    await dialog.goToAboutPanel()
+
+    const aboutPanel = comfyPage.page.getByTestId('about-panel')
+    await expect(aboutPanel).toBeVisible()
+    await expect(aboutPanel.locator('.about-badge').first()).toBeVisible()
+    await expect(aboutPanel).toContainText('ComfyUI_frontend')
+  })
+
+  test('Toggling a boolean setting through UI persists the value', async ({
+    comfyPage
+  }) => {
+    const settingId = 'Comfy.Validation.Workflows'
+    const initialValue = await comfyPage.settings.getSetting<boolean>(settingId)
+
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+
+    await dialog.searchBox.fill('Validate workflows')
+    const settingRow = dialog.root.locator(`[data-setting-id="${settingId}"]`)
+    await expect(settingRow).toBeVisible()
+
+    await settingRow.locator('.p-toggleswitch').click()
+
+    await expect
+      .poll(() => comfyPage.settings.getSetting<boolean>(settingId))
+      .toBe(!initialValue)
+  })
+
+  test('Can be closed via close button', async ({ comfyPage }) => {
+    const dialog = comfyPage.settingDialog
+    await dialog.open()
+    await expect(dialog.root).toBeVisible()
+
+    await dialog.close()
+    await expect(dialog.root).not.toBeVisible()
+  })
+})

--- a/browser_tests/tests/dialogs/settingsDialog.spec.ts
+++ b/browser_tests/tests/dialogs/settingsDialog.spec.ts
@@ -1,16 +1,33 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+import { mockSystemStats } from '../../fixtures/data/systemStats'
+
+const MOCK_COMFYUI_VERSION = '9.99.0-e2e-test'
 
 test.describe('Settings dialog', { tag: '@ui' }, () => {
-  test('About panel shows version badges', async ({ comfyPage }) => {
+  test('About panel renders mocked version from server', async ({
+    comfyPage
+  }) => {
+    const stats = {
+      ...mockSystemStats,
+      system: {
+        ...mockSystemStats.system,
+        comfyui_version: MOCK_COMFYUI_VERSION
+      }
+    }
+    await comfyPage.page.route('**/system_stats**', async (route) => {
+      await route.fulfill({ json: stats })
+    })
+    await comfyPage.setup()
+
     const dialog = comfyPage.settingDialog
     await dialog.open()
     await dialog.goToAboutPanel()
 
     const aboutPanel = comfyPage.page.getByTestId('about-panel')
     await expect(aboutPanel).toBeVisible()
-    await expect(aboutPanel.locator('.about-badge').first()).toBeVisible()
+    await expect(aboutPanel).toContainText(MOCK_COMFYUI_VERSION)
     await expect(aboutPanel).toContainText('ComfyUI_frontend')
   })
 

--- a/browser_tests/tests/dialogs/settingsDialog.spec.ts
+++ b/browser_tests/tests/dialogs/settingsDialog.spec.ts
@@ -40,15 +40,19 @@ test.describe('Settings dialog', { tag: '@ui' }, () => {
     const dialog = comfyPage.settingDialog
     await dialog.open()
 
-    await dialog.searchBox.fill('Validate workflows')
-    const settingRow = dialog.root.locator(`[data-setting-id="${settingId}"]`)
-    await expect(settingRow).toBeVisible()
+    try {
+      await dialog.searchBox.fill('Validate workflows')
+      const settingRow = dialog.root.locator(`[data-setting-id="${settingId}"]`)
+      await expect(settingRow).toBeVisible()
 
-    await settingRow.locator('.p-toggleswitch').click()
+      await settingRow.locator('.p-toggleswitch').click()
 
-    await expect
-      .poll(() => comfyPage.settings.getSetting<boolean>(settingId))
-      .toBe(!initialValue)
+      await expect
+        .poll(() => comfyPage.settings.getSetting<boolean>(settingId))
+        .toBe(!initialValue)
+    } finally {
+      await comfyPage.settings.setSetting(settingId, initialValue)
+    }
   })
 
   test('Can be closed via close button', async ({ comfyPage }) => {
@@ -111,6 +115,7 @@ test.describe('Settings dialog', { tag: '@ui' }, () => {
 
     // Find a different category to click
     const categoryCount = await dialog.categories.count()
+    let switched = false
     for (let i = 1; i < categoryCount; i++) {
       const cat = dialog.categories.nth(i)
       const catName = await cat.textContent()
@@ -119,9 +124,11 @@ test.describe('Settings dialog', { tag: '@ui' }, () => {
         await expect
           .poll(() => dialog.contentArea.textContent())
           .not.toBe(firstContent)
-        return
+        switched = true
+        break
       }
     }
+    expect(switched).toBe(true)
   })
 
   test('Dropdown setting can be changed and persists', async ({
@@ -133,26 +140,27 @@ test.describe('Settings dialog', { tag: '@ui' }, () => {
     const dialog = comfyPage.settingDialog
     await dialog.open()
 
-    await dialog.searchBox.fill('Use new menu')
-    const settingRow = dialog.root.locator(`[data-setting-id="${settingId}"]`)
-    await expect(settingRow).toBeVisible()
+    try {
+      await dialog.searchBox.fill('Use new menu')
+      const settingRow = dialog.root.locator(`[data-setting-id="${settingId}"]`)
+      await expect(settingRow).toBeVisible()
 
-    // Click the PrimeVue Select to open the dropdown
-    await settingRow.locator('.p-select').click()
-    const overlay = comfyPage.page.locator('.p-select-overlay')
-    await expect(overlay).toBeVisible()
+      // Click the PrimeVue Select to open the dropdown
+      await settingRow.locator('.p-select').click()
+      const overlay = comfyPage.page.locator('.p-select-overlay')
+      await expect(overlay).toBeVisible()
 
-    // Pick the option that is not the current value
-    const targetValue = initialValue === 'Top' ? 'Disabled' : 'Top'
-    await overlay
-      .locator(`.p-select-option-label:text-is("${targetValue}")`)
-      .click()
+      // Pick the option that is not the current value
+      const targetValue = initialValue === 'Top' ? 'Disabled' : 'Top'
+      await overlay
+        .locator(`.p-select-option-label:text-is("${targetValue}")`)
+        .click()
 
-    await expect
-      .poll(() => comfyPage.settings.getSetting<string>(settingId))
-      .toBe(targetValue)
-
-    // Restore original value
-    await comfyPage.settings.setSetting(settingId, initialValue)
+      await expect
+        .poll(() => comfyPage.settings.getSetting<string>(settingId))
+        .toBe(targetValue)
+    } finally {
+      await comfyPage.settings.setSetting(settingId, initialValue)
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Adds Playwright E2E tests for the Settings dialog covering behaviors not tested elsewhere:
  - About panel displays version badges (navigates to About, verifies content)
  - Boolean setting toggle through the UI persists the value (uses search + ToggleSwitch click, verifies via API)
  - Dialog can be closed via the close button (complements existing Escape-key test)

## Test plan
- [ ] `pnpm test:browser:local -- --grep "Settings dialog"` passes
- [ ] No overlap with existing tests in `dialog.spec.ts` or `useSettingSearch.spec.ts`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10797-test-add-E2E-tests-for-settings-dialog-3356d73d365081e4a3adcd3979048444) by [Unito](https://www.unito.io)
